### PR TITLE
Disable unnecessary permissions for iOS

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -37,5 +37,51 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+    target.build_configurations.each do |config|
+      config.build_settings['EXPANDED_CODE_SIGN_IDENTITY'] = ""
+      config.build_settings['CODE_SIGNING_REQUIRED'] = "NO"
+      config.build_settings['CODE_SIGNING_ALLOWED'] = "NO"
+
+      # disable unused permissions by remove # character
+      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+          '$(inherited)',
+
+          ## dart: PermissionGroup.calendar
+          'PERMISSION_EVENTS=0',
+
+          ## dart: PermissionGroup.reminders
+          'PERMISSION_REMINDERS=0',
+
+          ## dart: PermissionGroup.contacts
+          # 'PERMISSION_CONTACTS=0',
+
+          ## dart: PermissionGroup.camera
+          'PERMISSION_CAMERA=0',
+
+          ## dart: PermissionGroup.microphone
+          'PERMISSION_MICROPHONE=0',
+
+          ## dart: PermissionGroup.speech
+          'PERMISSION_SPEECH_RECOGNIZER=0',
+
+          ## dart: PermissionGroup.photos
+          # 'PERMISSION_PHOTOS=0',
+
+          ## dart: [PermissionGroup.location, PermissionGroup.locationAlways, PermissionGroup.locationWhenInUse]
+          'PERMISSION_LOCATION=0',
+
+          ## dart: PermissionGroup.notification
+          'PERMISSION_NOTIFICATIONS=0',
+
+          ## dart: PermissionGroup.mediaLibrary
+          'PERMISSION_MEDIA_LIBRARY=0',
+
+          ## dart: PermissionGroup.sensors
+          'PERMISSION_SENSORS=0',
+
+          ## dart: PermissionGroup.bluetooth
+          'PERMISSION_BLUETOOTH=0'
+      ]
+    end
   end
 end


### PR DESCRIPTION
We only use contact and photo permission, so I disable all unnecessary permissions for iOS. This configuration related to `permission_handler`. You can reference in: https://github.com/Baseflow/flutter-permission-handler/blob/master/permission_handler/README.md.

@dab246 please review it. Thanks.