### PR TITLE
Upgrade Flutter sdk version to 2.5.3

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -35,7 +35,7 @@ android {
     defaultConfig {
         applicationId "com.linagora.android.teammail"
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         // The number of method references in a .dex file cannot exceed 64K

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   cupertino_icons: ^1.0.4
 
   # flutter_svg
-  flutter_svg: 0.22.0
+  flutter_svg: 0.23.0+1
 
   # Http client
   dio: 4.0.0

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -67,7 +67,7 @@ dependencies:
       url: https://github.com/robert-virkus/flutter_inappwebview.git
 
   # url_launcher
-  url_launcher: 6.0.6
+  url_launcher: 6.0.12
 
 dev_dependencies:
   flutter_test:

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -20,7 +20,7 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
+  cupertino_icons: ^1.0.4
 
   # flutter_svg
   flutter_svg: 0.22.0

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   sqflite: 2.0.0+4
 
   # GetX
-  get: 4.1.4
+  get: 4.3.8
 
   # device_info
   device_info: 2.0.2

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -73,7 +73,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  test: 1.16.8
+  test: 1.17.10
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -56,7 +56,7 @@ dependencies:
   get: 4.3.8
 
   # device_info
-  device_info: 2.0.2
+  device_info: 2.0.3
 
   # getwidget
   getwidget: 2.0.4

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   # equatable
   equatable: 2.0.3
 
-  built_collection: 5.1.0
+  built_collection: 5.1.1
 
   html: 0.15.0
 

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   flutter_svg: 0.23.0+1
 
   # Http client
-  dio: 4.0.0
+  dio: 4.0.1
 
   # dartz
   dartz: 0.10.0-nullsafety.2

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   dio: 4.0.1
 
   # dartz
-  dartz: 0.10.0-nullsafety.2
+  dartz: 0.10.0
 
   # equatable
   equatable: 2.0.3

--- a/model/pubspec.yaml
+++ b/model/pubspec.yaml
@@ -20,7 +20,7 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/model/pubspec.yaml
+++ b/model/pubspec.yaml
@@ -63,7 +63,7 @@ dev_dependencies:
 
   build_runner: 2.1.5
 
-  json_serializable: 4.1.3
+  json_serializable: 6.0.1
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 

--- a/model/pubspec.yaml
+++ b/model/pubspec.yaml
@@ -45,8 +45,8 @@ dependencies:
   # jmap_dart_client
   jmap_dart_client:
     git:
-      url: git://github.com/linagora/jmap-dart-client.git
-      ref: master
+      url: git://github.com/Arsnael/jmap-dart-client.git
+      ref: upgrade-flutter-version
 
   # uri
   uri: 1.0.0

--- a/model/pubspec.yaml
+++ b/model/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   equatable: 2.0.3
 
   # quiver
-  quiver: 3.0.1
+  quiver: 3.0.1+1
 
   # intl
   intl: 0.17.0

--- a/model/pubspec.yaml
+++ b/model/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
+  cupertino_icons: ^1.0.4
 
   # equatable
   equatable: 2.0.3

--- a/model/pubspec.yaml
+++ b/model/pubspec.yaml
@@ -61,7 +61,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  build_runner: 2.0.5
+  build_runner: 2.1.5
 
   json_serializable: 4.1.3
 # For information on the generic Dart part of this file, see the

--- a/model/pubspec.yaml
+++ b/model/pubspec.yaml
@@ -52,7 +52,7 @@ dependencies:
   uri: 1.0.0
 
   # json_annotation
-  json_annotation: 4.0.1
+  json_annotation: 4.3.0
 
   # http_parser
   http_parser: 4.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,7 @@ dependencies:
   flutter_svg: 0.23.0+1
 
   # Http client
-  dio: 4.0.0
+  dio: 4.0.1
 
   # equatable
   equatable: 2.0.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -96,7 +96,7 @@ dependencies:
   path_provider: 2.0.3
 
   # device_info
-  device_info: 2.0.2
+  device_info: 2.0.3
 
   # permission_handler
   permission_handler: 8.1.6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,7 +56,7 @@ dependencies:
   shared_preferences: 2.0.8
 
   # either
-  dartz: 0.10.0-nullsafety.2
+  dartz: 0.10.0
 
   # flutter_typeahead
   flutter_typeahead: 3.2.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -111,7 +111,7 @@ dependencies:
       ref: master
 
   # file_picker
-  file_picker: 4.2.1
+  file_picker: 4.2.2+1
 
   # hive
   hive: 2.0.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.0+1
+version: 1.1.0
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
+  cupertino_icons: ^1.0.4
 
   # GetX
   get: 4.1.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   get: 4.3.8
 
   # intl
-  intl_generator: 0.2.0+0
+  intl_generator: 0.2.1
 
   # flutter_svg
   flutter_svg: 0.23.0+1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,7 +61,7 @@ dependencies:
   # flutter_typeahead
   flutter_typeahead: 3.2.1
 
-  built_collection: 5.1.0
+  built_collection: 5.1.1
 
   # jmap_dart_client
   jmap_dart_client:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,7 +84,7 @@ dependencies:
       ref: master
 
   # uuid
-  uuid: 3.0.4
+  uuid: 3.0.5
 
   # flutter_downloader
   flutter_downloader: 1.7.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -135,7 +135,7 @@ dev_dependencies:
 
   test: 1.17.10
 
-  mockito: 5.0.10
+  mockito: 5.0.16
 
   hive_generator: 1.1.1
 # For information on the generic Dart part of this file, see the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -93,7 +93,7 @@ dependencies:
   external_path: 1.0.1
 
   # path_provider
-  path_provider: 2.0.3
+  path_provider: 2.0.6
 
   # device_info
   device_info: 2.0.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,7 +87,7 @@ dependencies:
   uuid: 3.0.5
 
   # flutter_downloader
-  flutter_downloader: 1.7.0
+  flutter_downloader: 1.7.1
 
   # external_path
   external_path: 1.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -99,7 +99,7 @@ dependencies:
   device_info: 2.0.3
 
   # permission_handler
-  permission_handler: 8.1.6
+  permission_handler: 8.2.6
 
   # share
   share: 2.0.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -53,7 +53,7 @@ dependencies:
   equatable: 2.0.3
 
   # shared_preferences
-  shared_preferences: 2.0.5
+  shared_preferences: 2.0.8
 
   # either
   dartz: 0.10.0-nullsafety.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,7 +59,7 @@ dependencies:
   dartz: 0.10.0-nullsafety.2
 
   # flutter_typeahead
-  flutter_typeahead: 3.1.1
+  flutter_typeahead: 3.2.1
 
   built_collection: 5.1.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,8 +66,8 @@ dependencies:
   # jmap_dart_client
   jmap_dart_client:
     git:
-      url: git://github.com/linagora/jmap-dart-client.git
-      ref: master
+      url: git://github.com/Arsnael/jmap-dart-client.git
+      ref: upgrade-flutter-version
 
   # http_parser
   http_parser: 4.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   cupertino_icons: ^1.0.4
 
   # GetX
-  get: 4.1.4
+  get: 4.3.8
 
   # intl
   intl_generator: 0.2.0+0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   intl_generator: 0.2.0+0
 
   # flutter_svg
-  flutter_svg: 0.22.0
+  flutter_svg: 0.23.0+1
 
   # Http client
   dio: 4.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -131,7 +131,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  build_runner: 2.0.5
+  build_runner: 2.1.5
 
   test: 1.17.10
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -111,7 +111,7 @@ dependencies:
       ref: master
 
   # file_picker
-  file_picker: 3.0.2+2
+  file_picker: 4.2.1
 
   # hive
   hive: 2.0.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
 
 dependencies:
   flutter:
-    sdk: flutter
+    sdk: flutter # 2.5.3
 
   flutter_localizations:
     sdk: flutter
@@ -122,13 +122,18 @@ dependencies:
       url: git://github.com/dab246/enough_html_editor.git
       ref: fix_bug_enough_platform_widgets
 
+dependency_overrides:
+  # From what could find on the web, it seems some lib is using flutter_colorpicker to 0.4.0
+  # which conflicts with flutter sdk 2.5.3. Will see when upgradings libs if it's still present
+  flutter_colorpicker: ^0.6.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
   build_runner: 2.0.5
 
-  test: 1.16.8
+  test: 1.17.10
 
   mockito: 5.0.10
 


### PR DESCRIPTION
Took a bit of time today to try myself on Flutter :)

I guess I expect this to fail on the CI, as it should use the 2.2.3 version of the sdk :)

I did the work to upgrade to flutter sdk 2.5.3 (using dart sdk 2.14) and I upgraded some dart deps as well. 

Some dart deps bumps are depending on dart 2.14 which made me bump the android compileSdkVersion to 31 as well.

There is a few other deps I tried to upgrade, but I got conflicts with jmap_dart_client. How do you deal with deps update synced between your main project and submodules?

@hoangdat Well let me know if it interests you or not, or if there is more fixes needed to it. I could compile and launch the app in an emulated android device but I didn't test much, I'm not sure if it generated some issues or not.