### PR TITLE
Change label "username" to "Email" in login form

### DIFF
--- a/lib/features/login/presentation/login_view.dart
+++ b/lib/features/login/presentation/login_view.dart
@@ -95,7 +95,7 @@ class LoginView extends GetWidget<LoginController> {
             ..key(Key('login_url_input'))
             ..onChange((value) => loginController.setUrlText(value))
             ..textInputAction(TextInputAction.next)
-            ..keyboardType(TextInputType.emailAddress)
+            ..keyboardType(TextInputType.url)
             ..textDecoration(LoginInputDecorationBuilder()
                 .setLabelText(AppLocalizations.of(context).prefix_https)
                 .setPrefixText(AppLocalizations.of(context).prefix_https)

--- a/lib/features/login/presentation/login_view.dart
+++ b/lib/features/login/presentation/login_view.dart
@@ -114,8 +114,8 @@ class LoginView extends GetWidget<LoginController> {
             ..textInputAction(TextInputAction.next)
             ..keyboardType(TextInputType.emailAddress)
             ..textDecoration(LoginInputDecorationBuilder()
-                .setLabelText(AppLocalizations.of(context).username)
-                .setHintText(AppLocalizations.of(context).username)
+                .setLabelText(AppLocalizations.of(context).email)
+                .setHintText(AppLocalizations.of(context).email)
                 .build()))
           .build()));
   }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -18,8 +18,8 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "username": "username",
-  "@username": {
+  "email": "email",
+  "@email": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -18,8 +18,8 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "username": "username",
-  "@username": {
+  "email": "email",
+  "@email": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2021-10-26T14:38:31.924635",
+  "@@last_modified": "2021-11-12T11:15:02.318577",
   "initializing_data": "Initializing data...",
   "@initializing_data": {
     "type": "text",
@@ -18,8 +18,8 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "username": "username",
-  "@username": {
+  "email": "email",
+  "@email": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -18,8 +18,8 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "username": "username",
-  "@username": {
+  "email": "email",
+  "@email": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/l10n/intl_vi.arb
+++ b/lib/l10n/intl_vi.arb
@@ -18,8 +18,8 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "username": "username",
-  "@username": {
+  "email": "email",
+  "@email": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -34,9 +34,9 @@ class AppLocalizations {
         name: 'prefix_https');
   }
 
-  String get username {
-    return Intl.message('username',
-        name: 'username');
+  String get email {
+    return Intl.message('email',
+        name: 'email');
   }
 
   String get password {


### PR DESCRIPTION
That has been in some feedbacks that it was confusing.

I also saw that the text input type for the url in the login form was emailAddress, which is wrong (I think), so I changed it to url type.

![email-label](https://user-images.githubusercontent.com/9005025/141276038-e396867e-8a8f-4982-8b63-6f865dbf3a83.png)