### PR TITLE
TF-220 Sort list of mailboxes by SortOrder before display

### DIFF
--- a/lib/features/mailbox/data/datasource_impl/mailbox_cache_datasource_impl.dart
+++ b/lib/features/mailbox/data/datasource_impl/mailbox_cache_datasource_impl.dart
@@ -5,6 +5,7 @@ import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:tmail_ui_user/features/mailbox/data/datasource/mailbox_datasource.dart';
 import 'package:tmail_ui_user/features/mailbox/data/model/mailbox_change_response.dart';
 import 'package:tmail_ui_user/features/mailbox/data/local/mailbox_cache_manager.dart';
+import 'package:tmail_ui_user/features/mailbox/data/extensions/mailbox_extension.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/model/mailbox_response.dart';
 
 class MailboxCacheDataSourceImpl extends MailboxDataSource {
@@ -35,7 +36,9 @@ class MailboxCacheDataSourceImpl extends MailboxDataSource {
   @override
   Future<List<Mailbox>> getAllMailboxCache() {
     return Future.sync(() async {
-      return await _mailboxCacheManager.getAllMailbox();
+      final listMailboxes = await _mailboxCacheManager.getAllMailbox();
+      listMailboxes.sort((mailboxA, mailboxB) => mailboxA.compareTo(mailboxB));
+      return listMailboxes;
     }).catchError((error) {
       throw error;
     });

--- a/lib/features/mailbox/data/extensions/mailbox_extension.dart
+++ b/lib/features/mailbox/data/extensions/mailbox_extension.dart
@@ -19,4 +19,8 @@ extension MailboxExtension on Mailbox {
       isSubscribed: isSubscribed?.value
     );
   }
+
+  int compareTo(Mailbox other) {
+    return this.sortOrder!.value.value.compareTo(other.sortOrder!.value.value);
+  }
 }


### PR DESCRIPTION
Doing a sort using SortOrder on the list of mailboxes before display.

INBOX has always the lowest SortOrder, followed gradually by other system mailboxes and then finally the other folders. We should use the SortOrder in the jmap mailbox object, it's for this kind of purpose I think. 

I could reproduce the issue on preprod with user `firstname1.surname1`.

Master branch:
![mailboxLIstMaster](https://user-images.githubusercontent.com/9005025/141446798-a570307f-f826-4b47-9f72-c73008fa24e9.png)

This fix:
![listMailboxesFix](https://user-images.githubusercontent.com/9005025/141446863-1b121bbe-0a9a-4040-bdce-b86aad0bb283.png)