### PR TITLE
Workaround solution for junitreport

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         jcenter()

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -75,6 +75,9 @@ workflows:
             flutter pub get && flutter pub run intl_generator:extract_to_arb --output-dir=./lib/l10n lib/main/localizations/app_localizations.dart
 
             flutter pub get && flutter pub run intl_generator:generate_from_arb --output-dir=lib/l10n --no-use-deferred-loading lib/main/localizations/app_localizations.dart lib/l10n/intl*.arb
+
+            # Workaround solution for issue: https://github.com/bitrise-steplib/bitrise-step-flutter-test/issues/34
+            dart pub global activate junitreport
         is_always_run: true
     - flutter-analyze@0:
         inputs:


### PR DESCRIPTION
the same issue: https://github.com/bitrise-steplib/bitrise-step-flutter-test/issues/34

Add the workaround solution to script before `flutter test`: 
```
dart pub global activate junitreport
```