### PR TITLE
Should not build web image on release branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,6 @@ pipeline {
       when {
         anyOf {
           branch 'master'
-          branch 'release'
           buildingTag()
         }
       }
@@ -21,8 +20,6 @@ pipeline {
           env.DOCKER_TAG = 'master'
           if (env.TAG_NAME) {
             env.DOCKER_TAG = env.TAG_NAME
-          } else {
-            env.DOCKER_TAG = env.BRANCH_NAME
           }
 
           echo "Docker tag: ${env.DOCKER_TAG}"


### PR DESCRIPTION
As I understood after talking with @chibenwa we should:
* build on master branch and tags
* not build on release branch

If you want to have a web image build proper to a release version you should push a tag with the version number (like `0.3.0`) then it will build you the image `linagora/tmail-web:0.3.0`. The release branch will NOT build anything. 