### PR TITLE
Add hint text to avoid show null in editor

### DIFF
--- a/lib/features/composer/presentation/composer_view.dart
+++ b/lib/features/composer/presentation/composer_view.dart
@@ -1,11 +1,11 @@
 import 'package:core/core.dart';
 import 'package:enough_html_editor/enough_html_editor.dart';
-import 'package:html_editor_enhanced/html_editor.dart' as HtmlEditorBrowser;
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
+import 'package:html_editor_enhanced/html_editor.dart' as HtmlEditorBrowser;
 import 'package:model/model.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/upload_attachment_state.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
@@ -249,6 +249,7 @@ class ComposerView extends GetWidget<ComposerController> {
           controller: controller.htmlControllerBrowser,
           htmlEditorOptions: HtmlEditorBrowser.HtmlEditorOptions(
             shouldEnsureVisible: true,
+            hint: '',
             initialText: controller.getContentEmail(),
             autoAdjustHeight: controller.getContentEmail().isNotEmpty,
           ),


### PR DESCRIPTION
it is not a crash on composer. if  `initialText` is empty, editor will put `hint` on.

https://github.com/tneotia/html-editor-enhanced/blob/31406a4c0d6df0e9e8833057828dd8bf116df355/lib/src/widgets/html_editor_widget_web.dart#L212
```
            placeholder: "${widget.htmlEditorOptions.hint}",
```

<img width="875" alt="image" src="https://user-images.githubusercontent.com/6462404/156143738-6a39d016-8bbd-4b1b-b0ae-0e5a970b14ba.png">

@dab246 please review