### PR TITLE
TF-263 Fix bug can not paste text in the composer on android

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -122,7 +122,9 @@ dependencies:
   # enough_html_editor: Compose email for Mobile & Tablet
   enough_html_editor:
     git:
-      url: https://github.com/Enough-Software/enough_html_editor.git
+#      url: https://github.com/Enough-Software/enough_html_editor.git
+      url: https://github.com/dab246/enough_html_editor.git
+      ref: enable_on_long_gesture
 
   # html_editor_enhanced: Compose email for Web Browser
   html_editor_enhanced: 2.4.0+1


### PR DESCRIPTION
### Reason

WebView flutter has not integrated `LongPressGestureRecognizer` into `gestureRecognizers`

### Solve

Fixed `enough_html_editor` library at [https://github.com/dab246/enough_html_editor/commit/e676db31c58028e37f64fb4a9b81d01038411d0b](https://github.com/dab246/enough_html_editor/commit/e676db31c58028e37f64fb4a9b81d01038411d0b)

**PR of the original library**
[https://github.com/Enough-Software/enough_html_editor/pull/30](https://github.com/Enough-Software/enough_html_editor/pull/30)

### Demo

https://user-images.githubusercontent.com/80730648/156747447-3eb6c76c-0d99-4dfb-9463-ecf91abb4766.mov
