### PR TITLE
TF-358 Reduce `main.dart.js` file size at web browser startup

### DIFF
--- a/docs/adr/0003-reduce-main-file-size-on-web-browser.md
+++ b/docs/adr/0003-reduce-main-file-size-on-web-browser.md
@@ -1,0 +1,19 @@
+# 3. Reduce main file size on Web Browser
+
+Date: 2022-04-04
+
+## Status
+
+Accepted
+
+## Context
+
+- Reduce `main.dart.js` file size at web browser startup
+
+## Decision
+
+- We use [Lazily loading](https://dart.dev/guides/language/language-tour#lazily-loading-a-library) which could split your code in multiple JavaScript files
+
+## Consequences
+
+- Significantly reduce the size of the generated `main.dart.js` file.

--- a/lib/main/pages/app_pages.dart
+++ b/lib/main/pages/app_pages.dart
@@ -1,22 +1,21 @@
+import 'package:get/get.dart';
 import 'package:get/get_navigation/src/routes/get_route.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_bindings.dart';
-import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart'
-    if (dart.library.html) 'package:tmail_ui_user/features/composer/presentation/composer_view_web.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart' deferred as composer;
 import 'package:tmail_ui_user/features/destination_picker/presentation/destination_picker_bindings.dart';
-import 'package:tmail_ui_user/features/destination_picker/presentation/destination_picker_view.dart';
-import 'package:tmail_ui_user/features/email/presentation/email_view.dart';
+import 'package:tmail_ui_user/features/destination_picker/presentation/destination_picker_view.dart' deferred as destination_picker;
+import 'package:tmail_ui_user/features/email/presentation/email_view.dart' deferred as email;
 import 'package:tmail_ui_user/features/home/presentation/home_bindings.dart';
 import 'package:tmail_ui_user/features/home/presentation/home_view.dart';
 import 'package:tmail_ui_user/features/login/presentation/login_bindings.dart';
-import 'package:tmail_ui_user/features/login/presentation/login_view.dart';
-import 'package:tmail_ui_user/features/mailbox/presentation/mailbox_view.dart';
+import 'package:tmail_ui_user/features/login/presentation/login_view.dart' deferred as login;
 import 'package:tmail_ui_user/features/mailbox_creator/presentation/mailbox_creator_bindings.dart';
-import 'package:tmail_ui_user/features/mailbox_creator/presentation/mailbox_creator_view.dart';
+import 'package:tmail_ui_user/features/mailbox_creator/presentation/mailbox_creator_view.dart' deferred as mailbox_creator;
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/mailbox_dashboard_bindings.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/mailbox_dashboard_view.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/mailbox_dashboard_view.dart' deferred as mailbox_dashBoard;
 import 'package:tmail_ui_user/features/session/presentation/session_page_bindings.dart';
-import 'package:tmail_ui_user/features/session/presentation/session_view.dart';
-import 'package:tmail_ui_user/features/thread/presentation/thread_view.dart';
+import 'package:tmail_ui_user/features/session/presentation/session_view.dart' deferred as session;
+import 'package:tmail_ui_user/main/pages/deferred_widget.dart';
 import 'package:tmail_ui_user/main/routes/app_routes.dart';
 
 class AppPages {
@@ -27,39 +26,33 @@ class AppPages {
       binding: HomeBindings()),
     GetPage(
       name: AppRoutes.LOGIN,
-      page: () => LoginView(),
+      page: () => DeferredWidget(login.loadLibrary, () => login.LoginView()),
       binding: LoginBindings()),
     GetPage(
       name: AppRoutes.SESSION,
-      page: () => SessionView(),
+      page: () => DeferredWidget(session.loadLibrary, () => session.SessionView()),
       binding: SessionPageBindings()),
     GetPage(
-      name: AppRoutes.MAILBOX,
-      page: () => MailboxView()),
-    GetPage(
       name: AppRoutes.MAILBOX_DASHBOARD,
-      page: () => MailboxDashBoardView(),
+      page: () => DeferredWidget(mailbox_dashBoard.loadLibrary, () => mailbox_dashBoard.MailboxDashBoardView()),
       binding: MailboxDashBoardBindings()),
     GetPage(
-      name: AppRoutes.THREAD,
-      page: () => ThreadView()),
-    GetPage(
       name: AppRoutes.EMAIL,
-      page: () => EmailView()),
+      page: () => DeferredWidget(email.loadLibrary, () => email.EmailView())),
     GetPage(
       name: AppRoutes.COMPOSER,
       opaque: false,
-      page: () => ComposerView(),
+      page: () => DeferredWidget(composer.loadLibrary, () => composer.ComposerView()),
       binding: ComposerBindings()),
     GetPage(
       name: AppRoutes.DESTINATION_PICKER,
       opaque: false,
-      page: () => DestinationPickerView(),
+      page: () => DeferredWidget(destination_picker.loadLibrary, () => destination_picker.DestinationPickerView()),
       binding: DestinationPickerBindings()),
     GetPage(
       name: AppRoutes.MAILBOX_CREATOR,
       opaque: false,
-      page: () => MailboxCreatorView(),
+      page: () => DeferredWidget(mailbox_creator.loadLibrary, () => mailbox_creator.MailboxCreatorView()),
       binding: MailboxCreatorBindings()),
   ];
 }

--- a/lib/main/pages/deferred_widget.dart
+++ b/lib/main/pages/deferred_widget.dart
@@ -1,0 +1,73 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+
+typedef LibraryLoader = Future<void> Function();
+typedef DeferredWidgetBuilder = Widget Function();
+
+/// Wraps the child inside a deferred module loader.
+///
+/// The child is created and a single instance of the Widget is maintained in
+/// state as long as closure to create widget stays the same.
+///
+class DeferredWidget extends StatefulWidget {
+  DeferredWidget(
+      this.libraryLoader,
+      this.createWidget,
+      {Key? key, Widget? placeholder}
+  ) : placeholder = placeholder ?? Container(), super(key: key);
+
+  final LibraryLoader libraryLoader;
+  final DeferredWidgetBuilder createWidget;
+  final Widget placeholder;
+  static final Map<LibraryLoader, Future<void>> _moduleLoaders = {};
+  static final Set<LibraryLoader> _loadedModules = {};
+
+  static Future<void> preload(LibraryLoader loader) {
+    if (!_moduleLoaders.containsKey(loader)) {
+      _moduleLoaders[loader] = loader().then((dynamic _) {
+        _loadedModules.add(loader);
+      });
+    }
+    return _moduleLoaders[loader]!;
+  }
+
+  @override
+  State<DeferredWidget> createState() => _DeferredWidgetState();
+}
+
+class _DeferredWidgetState extends State<DeferredWidget> {
+  _DeferredWidgetState();
+
+  Widget? _loadedChild;
+  DeferredWidgetBuilder? _loadedCreator;
+
+  @override
+  void initState() {
+    /// If module was already loaded immediately create widget instead of
+    /// waiting for future or zone turn.
+    if (DeferredWidget._loadedModules.contains(widget.libraryLoader)) {
+      _onLibraryLoaded();
+    } else {
+      DeferredWidget.preload(widget.libraryLoader).then((dynamic _) => _onLibraryLoaded());
+    }
+    super.initState();
+  }
+
+  void _onLibraryLoaded() {
+    setState(() {
+      _loadedCreator = widget.createWidget;
+      _loadedChild = _loadedCreator!();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    /// If closure to create widget changed, create new instance, otherwise
+    /// treat as const Widget.
+    if (_loadedCreator != widget.createWidget && _loadedCreator != null) {
+      _loadedCreator = widget.createWidget;
+      _loadedChild = _loadedCreator!();
+    }
+    return _loadedChild ?? widget.placeholder;
+  }
+}


### PR DESCRIPTION
- Issues:  
    - The file size `main.dart.js` generated when building the web is too large.
    - This issue is discussed [here](https://github.com/flutter/flutter/issues/46589)

**Current `main.dart.js` file size : 3.8MB** 

<img width="1440" alt="Screen Shot 2022-04-04 at 12 23 55" src="https://user-images.githubusercontent.com/80730648/161482051-3077d733-6e6d-46fe-b8e6-ea24349292e6.png">

- Cause: Simultaneous download of all pages 
- Solve: Use [Lazily loading](https://dart.dev/guides/language/language-tour#lazily-loading-a-library) which could split your code in multiple JavaScript files
- Result: 

**After implement Lazily loading. File `main.dart.js` has size : 3.4MB** 

<img width="1440" alt="Screen Shot 2022-04-04 at 12 26 05" src="https://user-images.githubusercontent.com/80730648/161482558-8f60a553-a349-48f1-942d-2ecd769c6e3b.png">




