### PR TITLE
TF-501 Set TeamMail app to be default mail app in iOS

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -65,5 +65,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 </dict>
 </plist>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -6,6 +6,7 @@
 	<array>
 		<string>https</string>
 		<string>http</string>
+		<string>mailto</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>


### PR DESCRIPTION
-  Set `CADisableMinimumFrameDurationOnPhone` to true for support high frame rate for newer devices (>= iPhone 13 Pro)  [https://github.com/flutter/flutter/issues/94508](https://github.com/flutter/flutter/issues/94508)