### PR TITLE
Update worker_manager library official for isolate

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -170,10 +170,7 @@ dependencies:
   percent_indicator: 4.2.2
 
   # Isolate
-  worker_manager:
-    git:
-      url: https://github.com/dab246/worker_manager.git
-      ref: improvement
+  worker_manager: 4.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- My [worker_manager](https://github.com/Renesanse/worker_manager/pull/58) improvement PR has been merged
- We can use the latest version of [worker_manager](https://pub.dev/packages/worker_manager) `4.4.0 ` on [pub.dev](https://pub.dev) to use.