### PR TITLE
[HOT-FIX] Fix wrong screen response on mobile

### DIFF
--- a/core/lib/presentation/views/responsive/responsive_widget.dart
+++ b/core/lib/presentation/views/responsive/responsive_widget.dart
@@ -27,9 +27,8 @@ class ResponsiveWidget extends StatelessWidget {
     log('ResponsiveWidget::build(): WIDTH_SIZE: ${responsiveUtils.getDeviceWidth(context)}');
 
     if (BuildUtils.isWeb) {
-
       if (responsiveUtils.isMobile(context)) {
-        return tablet ?? mobile;
+        return mobile;
       }
 
       if (responsiveUtils.isTablet(context)) {
@@ -55,7 +54,7 @@ class ResponsiveWidget extends StatelessWidget {
       }
 
       if (responsiveUtils.isMobile(context)) {
-        return tablet ?? mobile;
+        return mobile;
       }
 
       if (responsiveUtils.isTablet(context)) {


### PR DESCRIPTION
### Issues

<table>
  <tr>
    <td><img width="353" alt="Screen Shot 2022-07-08 at 15 46 58" src="https://user-images.githubusercontent.com/80730648/177954961-c99b4a56-94a5-4f35-a40f-0010720ae0ba.png"></td>
    <td><img width="353" alt="Screen Shot 2022-07-08 at 15 46 53" src="https://user-images.githubusercontent.com/80730648/177954987-7d3bfa46-f244-4cd9-a876-e8670e94f908.png"></td>
  </tr>
</table>

### Resolve

<table>
  <tr>
    <td><img width="353" alt="Screen Shot 2022-07-08 at 15 46 58" src="https://user-images.githubusercontent.com/80730648/177955689-a223b527-36b7-43b9-a00d-34d9e96916ae.png"></td>
    <td><img width="353" alt="Screen Shot 2022-07-08 at 15 46 53" src="https://user-images.githubusercontent.com/80730648/177955781-b781f3f3-0a4a-4ea9-831a-b5e68839a68f.png"></td>
  </tr>
</table>
