### PR TITLE
TF-778 Fix text is cut after `-` symbol in web

### DIFF
--- a/lib/features/thread/presentation/widgets/email_tile_web_builder.dart
+++ b/lib/features/thread/presentation/widgets/email_tile_web_builder.dart
@@ -145,9 +145,11 @@ class EmailTileBuilder {
                                   fontWeight: _buildFontForReadEmail())).build()
                           : Text(
                               _getInformationSender(),
+                              softWrap: false,
                               maxLines: 1,
                               style: TextStyle(
                                   fontSize: 15,
+                                  overflow: TextOverflow.fade,
                                   color: _buildTextColorForReadEmail(),
                                   fontWeight: _buildFontForReadEmail()))
                   ),
@@ -316,9 +318,11 @@ class EmailTileBuilder {
                                     fontWeight: _buildFontForReadEmail())).build()
                             : Text(
                                 _getInformationSender(),
+                                softWrap: false,
                                 maxLines: 1,
                                 style: TextStyle(
                                     fontSize: 15,
+                                    overflow: TextOverflow.fade,
                                     color: _buildTextColorForReadEmail(),
                                     fontWeight: _buildFontForReadEmail()))
                       ),
@@ -500,9 +504,11 @@ class EmailTileBuilder {
                            backgroundColor: AppColor.bgWordSearch)).build()
                   : Text(_getInformationSender(),
                       maxLines: 1,
+                      softWrap: false,
                       style: TextStyle(
                           fontSize: 15,
                           color: _buildTextColorForReadEmail(),
+                          overflow: TextOverflow.fade,
                           fontWeight: _buildFontForReadEmail())),
             ),
             const SizedBox(width: 24),


### PR DESCRIPTION
#778 
### Issue:
<img width="1316" alt="Screen Shot 2022-08-02 at 19 48 44" src="https://user-images.githubusercontent.com/6462404/182378505-cec9786a-315b-43d7-a4d1-e3087f0c1579.png">

### Resolved:

https://user-images.githubusercontent.com/6462404/182378202-c0ccda86-d47b-42dc-a0b3-ee8d718230c8.mov

<img width="1382" alt="Screen Shot 2022-08-02 at 19 39 17" src="https://user-images.githubusercontent.com/6462404/182378239-965ec059-2489-4e59-9f53-3e30f75e77dc.png">
