### PR TITLE
TF-753 Migrate composer editor library to Linagora

### DIFF
--- a/docs/adr/0013-migrate-composer-editor-repository-to-linagora.md
+++ b/docs/adr/0013-migrate-composer-editor-repository-to-linagora.md
@@ -1,0 +1,20 @@
+# 13. Migrate composer editor repository to Linagora
+
+Date: 2022-08-08
+
+## Status
+
+Accepted
+
+## Context
+
+Migrate composer editor repository to Linagora
+
+## Decision
+
+- Migrate [enough_html_editor](https://github.com/Enough-Software/enough_html_editor) repository to [Linagora](https://github.com/linagora/enough_html_editor) with branch [email_supported](https://github.com/linagora/enough_html_editor/tree/email_supported)
+- Migrate [html_editor_enhanced](https://github.com/tneotia/html-editor-enhanced) repository to [Linagora](https://github.com/linagora/html-editor-enhanced) with branch [email_supported](https://github.com/linagora/html-editor-enhanced/tree/email_supported)
+
+## Consequences
+
+- For easy management, upgrades and maintenance

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -141,9 +141,6 @@ class ComposerController extends BaseController {
       return newContentHtml;
     } else {
       String contentHtml = await htmlEditorApi?.getText() ?? '';
-      if(Platform.isAndroid) {
-        contentHtml = contentHtml.replaceAll('&quot;', '"');
-      }
       log('ComposerController::_getEmailBodyText():MOBILE: $contentHtml');
       final newContentHtml = contentHtml.removeEditorStartTag();
       if (changedEmail) {

--- a/lib/features/composer/presentation/composer_view.dart
+++ b/lib/features/composer/presentation/composer_view.dart
@@ -670,6 +670,7 @@ class ComposerView extends GetWidget<ComposerController>
       child: HtmlEditor(
           key: const Key('composer_editor'),
           minHeight: 550,
+          addDefaultSelectionMenuItems: false,
           initialContent: initialContent,
           onCreated: (editorApi) {
             richTextMobileTabletController.htmlEditorApi = editorApi;

--- a/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
+++ b/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
@@ -148,15 +148,41 @@ class RichTextMobileTabletController extends BaseRichTextController {
     htmlEditorApi?.formatHeader(styleSelected.styleValue);
   }
 
-  void applyParagraphType(ParagraphType newParagraph) {
+  void applyParagraphType(ParagraphType newParagraph) async {
     selectedParagraph.value = newParagraph;
-    htmlEditorApi?.execCommand(newParagraph.commandAction);
+    switch(newParagraph) {
+      case ParagraphType.alignLeft:
+        await htmlEditorApi?.formatAlignLeft();
+        break;
+      case ParagraphType.alignRight:
+        await htmlEditorApi?.formatAlignRight();
+        break;
+      case ParagraphType.alignCenter:
+        await htmlEditorApi?.formatAlignCenter();
+        break;
+      case ParagraphType.justify:
+        await htmlEditorApi?.formatAlignJustify();
+        break;
+      case ParagraphType.indent:
+        await htmlEditorApi?.formatIndent();
+        break;
+      case ParagraphType.outdent:
+        await htmlEditorApi?.formatOutent();
+        break;
+    }
     menuParagraphController.hideMenu();
   }
 
-  void applyOrderListType(OrderListType newOrderList) {
+  void applyOrderListType(OrderListType newOrderList) async {
     selectedOrderList.value = newOrderList;
-    htmlEditorApi?.execCommand(newOrderList.commandAction);
+    switch(newOrderList) {
+      case OrderListType.bulletedList:
+        await htmlEditorApi?.insertUnorderedList();
+        break;
+      case OrderListType.numberedList:
+        await htmlEditorApi?.insertOrderedList();
+        break;
+    }
     menuOrderListController.hideMenu();
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -124,8 +124,8 @@ dependencies:
   # enough_html_editor: Compose email for Mobile & Tablet
   enough_html_editor:
     git:
-      url: https://github.com/ManhNTX/enough_html_editor.git
-      ref: improvements_for_use_tmail
+      url: https://github.com/linagora/enough_html_editor.git
+      ref: email_supported
 
   # html_editor_enhanced: Compose email for Web Browser
   html_editor_enhanced:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -130,8 +130,8 @@ dependencies:
   # html_editor_enhanced: Compose email for Web Browser
   html_editor_enhanced:
     git:
-      url: https://github.com/dab246/html-editor-enhanced.git
-      ref: improvements_for_use_tmail
+      url: https://github.com/linagora/html-editor-enhanced.git
+      ref: email_supported
 
   # fk_user_agent
   fk_user_agent: 2.1.0


### PR DESCRIPTION
#753 

### Dependence

- Merge [https://github.com/linagora/html-editor-enhanced/pull/2](https://github.com/linagora/html-editor-enhanced/pull/2)

### Resolved

- Migrate [enough_html_editor](https://github.com/ManhNTX/enough_html_editor) library to [Linagora](https://github.com/linagora/enough_html_editor) with branch [email_supported](https://github.com/linagora/enough_html_editor/tree/email_supported) 
- Migrate [html_editor_enhanced](https://github.com/dab246/html-editor-enhanced) library to [Linagora](https://github.com/linagora/html-editor-enhanced) with branch [email_supported](https://github.com/linagora/html-editor-enhanced/tree/email_supported) 