### PR TITLE
[Temporary] Fix error with inconsistency in cache and add ReSync function

### DIFF
--- a/lib/features/caching/account_cache_client.dart
+++ b/lib/features/caching/account_cache_client.dart
@@ -125,4 +125,9 @@ class AccountCacheClient extends HiveCacheClient<AccountCache> {
       throw error;
     });
   }
+
+  @override
+  Future<void> deleteWhere(bool Function(AccountCache data) validate) {
+    throw UnimplementedError();
+  }
 }

--- a/lib/features/caching/config/hive_cache_client.dart
+++ b/lib/features/caching/config/hive_cache_client.dart
@@ -32,4 +32,6 @@ abstract class HiveCacheClient<T> {
   }
 
   Future<void> clearAllData();
+
+  Future<void> deleteWhere(bool Function(T data) validate);
 }

--- a/lib/features/caching/email_cache_client.dart
+++ b/lib/features/caching/email_cache_client.dart
@@ -141,4 +141,15 @@ class EmailCacheClient extends HiveCacheClient<EmailCache> {
       throw error;
     });
   }
+
+  @override
+  Future<void> deleteWhere(bool Function(EmailCache data) validate) {
+    return Future.sync(() async {
+      final boxEmail = await openBox();
+      final emailIds = boxEmail.values.where(validate).map((email) => email.id);
+      boxEmail.deleteAll(emailIds);
+    }).catchError((error) {
+      throw error;
+    });
+  }
 }

--- a/lib/features/caching/mailbox_cache_client.dart
+++ b/lib/features/caching/mailbox_cache_client.dart
@@ -124,4 +124,9 @@ class MailboxCacheClient extends HiveCacheClient<MailboxCache> {
       throw error;
     });
   }
+
+  @override
+  Future<void> deleteWhere(bool Function(MailboxCache data) validate) {
+    throw UnimplementedError();
+  }
 }

--- a/lib/features/caching/recent_search_cache_client.dart
+++ b/lib/features/caching/recent_search_cache_client.dart
@@ -124,4 +124,9 @@ class RecentSearchCacheClient extends HiveCacheClient<RecentSearchCache> {
       throw error;
     });
   }
+
+  @override
+  Future<void> deleteWhere(bool Function(RecentSearchCache data) validate) {
+    throw UnimplementedError();
+  }
 }

--- a/lib/features/caching/state_cache_client.dart
+++ b/lib/features/caching/state_cache_client.dart
@@ -124,4 +124,9 @@ class StateCacheClient extends HiveCacheClient<StateCache> {
       throw error;
     });
   }
+
+  @override
+  Future<void> deleteWhere(bool Function(StateCache data) validate) {
+    throw UnimplementedError();
+  }
 }

--- a/lib/features/caching/token_oidc_cache_client.dart
+++ b/lib/features/caching/token_oidc_cache_client.dart
@@ -124,4 +124,9 @@ class TokenOidcCacheClient extends HiveCacheClient<TokenOidcCache> {
     });
   }
 
+  @override
+  Future<void> deleteWhere(bool Function(TokenOidcCache data) validate) {
+    throw UnimplementedError();
+  }
+
 }

--- a/lib/features/mailbox_dashboard/presentation/action/dashboard_action.dart
+++ b/lib/features/mailbox_dashboard/presentation/action/dashboard_action.dart
@@ -14,9 +14,8 @@ class DashBoardAction extends UIAction {
   List<Object?> get props => [];
 }
 
-class RefreshAllEmailAction extends DashBoardAction {
-
-  RefreshAllEmailAction();
+class ReSyncThreadAction extends DashBoardAction {
+  ReSyncThreadAction();
 
   @override
   List<Object?> get props => [];

--- a/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart
+++ b/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart
@@ -246,7 +246,7 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
           ..size(16)
           ..radiusSplash(10)
           ..padding(const EdgeInsets.symmetric(horizontal: 8, vertical: 8))
-          ..onPressActionClick(() => controller.dispatchAction(RefreshAllEmailAction())))
+          ..onPressActionClick(() => controller.dispatchAction(ReSyncThreadAction())))
         .build(),
       const SizedBox(width: 16),
       (ButtonBuilder(imagePaths.icSelectAll)

--- a/lib/features/thread/data/datasource/thread_datasource.dart
+++ b/lib/features/thread/data/datasource/thread_datasource.dart
@@ -34,6 +34,8 @@ abstract class ThreadDataSource {
 
   Future<List<Email>> getAllEmailCache({MailboxId? inMailboxId, Set<Comparator>? sort, FilterMessageOption? filterOption});
 
+  Future<void> deleteEmails({MailboxId? inMailboxId});
+
   Future<void> update({List<Email>? updated, List<Email>? created, List<EmailId>? destroyed});
 
   Future<List<EmailId>> emptyTrashFolder(

--- a/lib/features/thread/data/datasource_impl/local_thread_datasource_impl.dart
+++ b/lib/features/thread/data/datasource_impl/local_thread_datasource_impl.dart
@@ -55,6 +55,19 @@ class LocalThreadDataSourceImpl extends ThreadDataSource {
   }
 
   @override
+  Future<void> deleteEmails({MailboxId? inMailboxId}) {
+    if (inMailboxId == null) {
+      return _emailCacheManager.clearAll();
+    }
+    return _emailCacheManager
+      .deleteWhere((emailCache) {
+        return emailCache.mailboxIds != null
+          && emailCache.mailboxIds!.containsKey(inMailboxId.id.value)
+          && emailCache.mailboxIds![inMailboxId.id.value] == true;
+      });
+  }
+
+  @override
   Future<void> update({List<Email>? updated, List<Email>? created, List<EmailId>? destroyed}) {
     return Future.sync(() async {
       return await _emailCacheManager.update(updated: updated, created: created, destroyed: destroyed);

--- a/lib/features/thread/data/datasource_impl/thread_datasource_impl.dart
+++ b/lib/features/thread/data/datasource_impl/thread_datasource_impl.dart
@@ -10,9 +10,9 @@ import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:tmail_ui_user/features/thread/data/datasource/thread_datasource.dart';
 import 'package:tmail_ui_user/features/thread/data/model/email_change_response.dart';
+import 'package:tmail_ui_user/features/thread/data/network/thread_api.dart';
 import 'package:tmail_ui_user/features/thread/data/network/thread_isolate_worker.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/email_response.dart';
-import 'package:tmail_ui_user/features/thread/data/network/thread_api.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
 
 class ThreadDataSourceImpl extends ThreadDataSource {
@@ -85,5 +85,10 @@ class ThreadDataSourceImpl extends ThreadDataSource {
     }).catchError((error) {
       throw error;
     });
+  }
+
+  @override
+  Future<void> deleteEmails({MailboxId? inMailboxId}) {
+    throw UnimplementedError();
   }
 }

--- a/lib/features/thread/data/local/email_cache_manager.dart
+++ b/lib/features/thread/data/local/email_cache_manager.dart
@@ -1,15 +1,16 @@
 
 import 'package:core/core.dart';
-import 'package:model/model.dart';
+import 'package:flutter/foundation.dart';
+import 'package:jmap_dart_client/jmap/core/sort/comparator.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/model.dart';
 import 'package:tmail_ui_user/features/caching/email_cache_client.dart';
 import 'package:tmail_ui_user/features/cleanup/domain/model/email_cleanup_rule.dart';
 import 'package:tmail_ui_user/features/thread/data/extensions/email_cache_extension.dart';
 import 'package:tmail_ui_user/features/thread/data/extensions/email_extension.dart';
 import 'package:tmail_ui_user/features/thread/data/extensions/list_email_cache_extension.dart';
 import 'package:tmail_ui_user/features/thread/data/model/email_cache.dart';
-import 'package:jmap_dart_client/jmap/core/sort/comparator.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
 
 class EmailCacheManager {
@@ -72,6 +73,21 @@ class EmailCacheManager {
         .map((emailCache) => emailCache.id)
         .toList();
       await _emailCacheClient.deleteMultipleItem(listEmailIdCacheExpire);
+    }
+  }
+
+  Future<void> deleteWhere(bool Function(EmailCache emailCache) validate) async {
+    final emailCacheExist = await _emailCacheClient.isExistTable();
+    if (emailCacheExist) {
+      await _emailCacheClient.deleteWhere(validate);
+    }
+  }
+
+  Future<void> clearAll() async {
+    if (kIsWeb) {
+      await _emailCacheClient.clearAllData();
+    } else {
+      await _emailCacheClient.deleteBox();
     }
   }
 }

--- a/lib/features/thread/domain/repository/thread_repository.dart
+++ b/lib/features/thread/domain/repository/thread_repository.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
 
-import 'package:core/presentation/state/failure.dart';
-import 'package:core/presentation/state/success.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/filter/filter.dart';
 import 'package:jmap_dart_client/jmap/core/properties/properties.dart';
@@ -14,7 +12,6 @@ import 'package:tmail_ui_user/features/thread/domain/model/email_filter.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/email_response.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/get_email_request.dart';
-import 'package:dartz/dartz.dart' as dartz;
 
 abstract class ThreadRepository {
   Stream<EmailsResponse> getAllEmail(
@@ -37,6 +34,17 @@ abstract class ThreadRepository {
       Properties? propertiesUpdated,
       MailboxId? inMailboxId,
       FilterMessageOption? filterOption,
+    }
+  );
+
+  Stream<EmailsResponse> reSyncEmails(
+    AccountId accountId,
+    {
+      UnsignedInt? limit,
+      Set<Comparator>? sort,
+      EmailFilter? emailFilter,
+      Properties? propertiesCreated,
+      Properties? propertiesUpdated,
     }
   );
 

--- a/lib/features/thread/domain/state/re_sync_thread_state.dart
+++ b/lib/features/thread/domain/state/re_sync_thread_state.dart
@@ -1,0 +1,22 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:tmail_ui_user/features/thread/domain/state/get_all_email_state.dart';
+
+class ReSyncThreadSuccess extends GetAllEmailSuccess {
+
+  ReSyncThreadSuccess(
+    emailList,
+    currentEmailState
+  ) : super(emailList: emailList, currentEmailState: currentEmailState);
+
+  @override
+  List<Object?> get props => [emailList, currentEmailState];
+}
+
+class ReSyncThreadFailure extends FeatureFailure {
+  final dynamic exception;
+
+  ReSyncThreadFailure(this.exception);
+
+  @override
+  List<Object?> get props => [exception];
+}

--- a/lib/features/thread/domain/usecases/resync_thread_interactor.dart
+++ b/lib/features/thread/domain/usecases/resync_thread_interactor.dart
@@ -1,0 +1,55 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/properties/properties.dart';
+import 'package:jmap_dart_client/jmap/core/sort/comparator.dart';
+import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
+import 'package:model/extensions/email_extension.dart';
+import 'package:tmail_ui_user/features/thread/domain/model/email_filter.dart';
+import 'package:tmail_ui_user/features/thread/domain/model/email_response.dart';
+import 'package:tmail_ui_user/features/thread/domain/repository/thread_repository.dart';
+import 'package:tmail_ui_user/features/thread/domain/state/re_sync_thread_state.dart';
+
+class ReSyncThreadInteractor {
+  final ThreadRepository _threadRepository;
+
+  ReSyncThreadInteractor(this._threadRepository);
+
+  Stream<Either<Failure, Success>> execute(
+    AccountId accountId,
+    {
+      UnsignedInt? limit,
+      Set<Comparator>? sort,
+      EmailFilter? emailFilter,
+      Properties? propertiesCreated,
+      Properties? propertiesUpdated,
+    }
+  ) async* {
+    try {
+      yield Right<Failure, Success>(LoadingState());
+
+      yield* _threadRepository
+        .reSyncEmails(
+          accountId,
+          limit: limit,
+          sort: sort,
+          emailFilter: emailFilter,
+          propertiesCreated: propertiesCreated,
+          propertiesUpdated: propertiesUpdated)
+        .map(_toGetEmailState);
+
+    } catch(e) {
+      yield Left(ReSyncThreadFailure(e));
+    }
+  }
+
+  Either<Failure, Success> _toGetEmailState(EmailsResponse emailResponse) {
+    final presentationEmailList = emailResponse.emailList
+      ?.map((email) => email.toPresentationEmail()).toList() ?? List.empty();
+
+    return Right<Failure, Success>(
+      ReSyncThreadSuccess(presentationEmailList, emailResponse.state)
+    );
+  }
+}

--- a/lib/features/thread/presentation/thread_bindings.dart
+++ b/lib/features/thread/presentation/thread_bindings.dart
@@ -39,6 +39,7 @@ import 'package:tmail_ui_user/features/thread/domain/usecases/mark_as_multiple_e
 import 'package:tmail_ui_user/features/thread/domain/usecases/mark_as_star_multiple_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/move_multiple_email_to_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor.dart';
+import 'package:tmail_ui_user/features/thread/domain/usecases/resync_thread_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_more_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
@@ -61,6 +62,7 @@ class ThreadBindings extends BaseBindings {
       Get.find<EmptyTrashFolderInteractor>(),
       Get.find<MarkAsEmailReadInteractor>(),
       Get.find<MoveToMailboxInteractor>(),
+      Get.find<ReSyncThreadInteractor>()
     ));
   }
 
@@ -121,6 +123,9 @@ class ThreadBindings extends BaseBindings {
     Get.lazyPut(() => MoveToMailboxInteractor(
         Get.find<EmailRepository>(),
         Get.find<MailboxRepository>()));
+    Get.lazyPut(() => ReSyncThreadInteractor(
+        Get.find<ThreadRepository>()
+    ));
   }
 
   @override

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -374,30 +374,36 @@ class ThreadController extends BaseController {
     ));
   }
 
-  EmailFilterCondition _getFilterCondition({bool isLoadMore = false}) {
+  EmailFilterCondition _getFilterCondition() {
+    return EmailFilterCondition(
+      inMailbox: mailboxDashBoardController.selectedMailbox.value?.id
+    );
+  }
+
+  EmailFilterCondition _getLoadMoreFilterCondition() {
     switch(mailboxDashBoardController.filterMessageOption.value) {
       case FilterMessageOption.all:
         return EmailFilterCondition(
           inMailbox: mailboxDashBoardController.selectedMailbox.value?.id,
-          before: isLoadMore ? emailList.last.receivedAt : null
+          before: emailList.last.receivedAt
         );
       case FilterMessageOption.unread:
         return EmailFilterCondition(
-            inMailbox: mailboxDashBoardController.selectedMailbox.value?.id,
-            notKeyword: KeyWordIdentifier.emailSeen.value,
-            before: isLoadMore ? emailList.last.receivedAt : null
+          inMailbox: mailboxDashBoardController.selectedMailbox.value?.id,
+          notKeyword: KeyWordIdentifier.emailSeen.value,
+          before: emailList.last.receivedAt
         );
       case FilterMessageOption.attachments:
         return EmailFilterCondition(
-            inMailbox: mailboxDashBoardController.selectedMailbox.value?.id,
-            hasAttachment: true,
-            before: isLoadMore ? emailList.last.receivedAt : null
+          inMailbox: mailboxDashBoardController.selectedMailbox.value?.id,
+          hasAttachment: true,
+          before: emailList.last.receivedAt
         );
       case FilterMessageOption.starred:
         return EmailFilterCondition(
-            inMailbox: mailboxDashBoardController.selectedMailbox.value?.id,
-            hasKeyword: KeyWordIdentifier.emailFlagged.value,
-            before: isLoadMore ? emailList.last.receivedAt : null
+          inMailbox: mailboxDashBoardController.selectedMailbox.value?.id,
+          hasKeyword: KeyWordIdentifier.emailFlagged.value,
+          before: emailList.last.receivedAt
         );
     }
   }
@@ -446,7 +452,7 @@ class ThreadController extends BaseController {
             _accountId!,
             limit: ThreadConstants.defaultLimit,
             sort: _sortOrder,
-            filter: _getFilterCondition(isLoadMore: true),
+            filter: _getLoadMoreFilterCondition(),
             properties: ThreadConstants.propertiesDefault,
             lastEmailId: emailList.last.id)
       ));


### PR DESCRIPTION
### Problem:
- When set the `filterAction` (Fx: Unread), then open a mailbox A in the first time, all and only `UnRead emails` are cache.
- Then, Go to other mailbox, un-select `filterAction`, then back to A, cache will show unread, other read mail is not loaded.

### Fix:
- Reload from the network 
And add `ReSync` to fix the cache inconsistency 