### PR TITLE
TF-904 Clicking mailbox name redirects to mailbox

### DIFF
--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -108,28 +108,26 @@ class EmailView extends GetWidget<EmailController> with NetworkConnectionMixin {
   Widget _buildAppBar(BuildContext context) {
     return Obx(() => Padding(
       padding: const EdgeInsets.only(top: 6),
-      child: (AppBarMailWidgetBuilder(
-              context,
-              imagePaths,
-              responsiveUtils,
-              controller.currentEmail,
-              controller.currentMailbox)
-          ..onBackActionClick(() => controller.closeEmailView(context))
-          ..addOnEmailActionClick((email, action) =>
-              controller.handleEmailAction(context, email, action))
-          ..addOnMoreActionClick((email, position) {
-            if (responsiveUtils.isMobile(context)) {
-              controller.openContextMenuAction(
-                  context,
-                  _emailActionMoreActionTile(context, email));
-            } else {
-              controller.openPopupMenuAction(
-                  context,
-                  position,
-                  _popupMenuEmailActionTile(context, email));
-            }
-          }))
-        .build()));
+      child: AppBarMailWidgetBuilder(
+        controller.currentEmail,
+        controller.currentMailbox,
+        onBackActionClick: () => controller.closeEmailView(context),
+        onEmailActionClick: (email, action) =>
+            controller.handleEmailAction(context, email, action),
+        onMoreActionClick: (email, position) {
+          if (responsiveUtils.isMobile(context)) {
+            controller.openContextMenuAction(
+                context,
+                _emailActionMoreActionTile(context, email));
+          } else {
+            controller.openPopupMenuAction(
+                context,
+                position,
+                _popupMenuEmailActionTile(context, email));
+          }
+        }
+      )
+    ));
   }
 
   Widget _buildBottomBar(BuildContext context) {

--- a/lib/features/email/presentation/widgets/app_bar_mail_widget_builder.dart
+++ b/lib/features/email/presentation/widgets/app_bar_mail_widget_builder.dart
@@ -2,6 +2,7 @@
 import 'package:core/core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:get/get.dart';
 import 'package:model/model.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
@@ -9,118 +10,132 @@ typedef OnBackActionClick = void Function();
 typedef OnEmailActionClick = void Function(PresentationEmail, EmailActionType);
 typedef OnMoreActionClick = void Function(PresentationEmail, RelativeRect?);
 
-class AppBarMailWidgetBuilder {
-  OnBackActionClick? _onBackActionClick;
-  OnEmailActionClick? _onEmailActionClick;
-  OnMoreActionClick? _onMoreActionClick;
+class AppBarMailWidgetBuilder extends StatelessWidget {
+  final _imagePaths = Get.find<ImagePaths>();
+  final _responsiveUtils = Get.find<ResponsiveUtils>();
 
-  final BuildContext _context;
-  final ImagePaths _imagePaths;
-  final ResponsiveUtils _responsiveUtils;
   final PresentationEmail? _presentationEmail;
   final PresentationMailbox? _currentMailbox;
+  final OnBackActionClick? onBackActionClick;
+  final OnEmailActionClick? onEmailActionClick;
+  final OnMoreActionClick? onMoreActionClick;
 
   AppBarMailWidgetBuilder(
-    this._context,
-    this._imagePaths,
-    this._responsiveUtils,
     this._presentationEmail,
     this._currentMailbox,
-  );
+    {
+      Key? key,
+      this.onBackActionClick,
+      this.onEmailActionClick,
+      this.onMoreActionClick
+    }
+  ) : super(key: key);
 
-  void onBackActionClick(OnBackActionClick onBackActionClick) {
-    _onBackActionClick = onBackActionClick;
-  }
-
-  void addOnEmailActionClick(OnEmailActionClick onEmailActionClick) {
-    _onEmailActionClick = onEmailActionClick;
-  }
-
-  void addOnMoreActionClick(OnMoreActionClick onMoreActionClick) {
-    _onMoreActionClick = onMoreActionClick;
-  }
-
-  Widget build() {
+  @override
+  Widget build(BuildContext context) {
     return Container(
       key: const Key('app_bar_messenger_widget'),
       alignment: Alignment.center,
-      padding: EdgeInsets.zero,
-      margin: EdgeInsets.zero,
-      child: MediaQuery(
-        data: const MediaQueryData(padding: EdgeInsets.zero),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.end,
-          children: [
-            if (_responsiveUtils.mailboxDashboardHasMailboxAndEmailView(_context))
-              _buildBackButton(),
-            if (_responsiveUtils.mailboxDashboardHasMailboxAndEmailView(_context))
-              Expanded(child: _buildMailboxName()),
-            if (_presentationEmail != null) _buildListOptionButton(),
-          ]
-        )
-      )
+      color: Colors.transparent,
+      padding: const EdgeInsets.only(left: 8),
+      child: Row(children: [
+        if (_responsiveUtils.mailboxDashboardHasMailboxAndEmailView(context))
+          Material(
+            color: Colors.transparent,
+            child: InkWell(
+              onTap: () => onBackActionClick?.call(),
+              borderRadius: BorderRadius.circular(15),
+              child: Tooltip(
+                message: AppLocalizations.of(context).back,
+                child: Container(
+                  color: Colors.transparent,
+                  height: 40,
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: Row(mainAxisSize: MainAxisSize.min, children: [
+                    SvgPicture.asset(
+                        _imagePaths.icBack,
+                        width: 18,
+                        height: 18,
+                        color: AppColor.colorTextButton,
+                        fit: BoxFit.fill),
+                    Container(
+                      margin: const EdgeInsets.only(left: 8),
+                      constraints: BoxConstraints(
+                          maxWidth: _responsiveUtils.getSizeScreenWidth(context) - 250),
+                      child: Text(
+                          _currentMailbox?.name?.name.capitalizeFirstEach ?? '',
+                          maxLines: 1,
+                          overflow: CommonTextStyle.defaultTextOverFlow,
+                          softWrap: CommonTextStyle.defaultSoftWrap,
+                          style: const TextStyle(fontSize: 17, color: AppColor.colorTextButton)),
+                    ),
+                  ]),
+                ),
+              ),
+            ),
+          ),
+        const Spacer(),
+        if (_presentationEmail != null) _buildListOptionButton(context),
+      ])
     );
   }
 
-  Widget _buildBackButton() {
-    return buildIconWeb(
-        icon: SvgPicture.asset(_imagePaths.icBack, width: 18, height: 18, color: AppColor.colorTextButton, fit: BoxFit.fill),
-        tooltip: AppLocalizations.of(_context).back,
-        onTap: () => _onBackActionClick?.call()
-    );
-  }
-
-  Widget _buildMailboxName() {
-    return Transform(
-      transform: Matrix4.translationValues(-10.0, 0.0, 0.0),
-      child: Text(
-        _currentMailbox?.name?.name.capitalizeFirstEach ?? '',
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-        style: const TextStyle(fontSize: 17, color: AppColor.colorTextButton))
-    );
-  }
-
-  Widget _buildListOptionButton() {
+  Widget _buildListOptionButton(BuildContext context) {
     return Row(
       children: [
         buildIconWeb(
             icon: SvgPicture.asset(_imagePaths.icMoveEmail, fit: BoxFit.fill),
-            tooltip: AppLocalizations.of(_context).move_message,
-            onTap: () => _onEmailActionClick?.call(_presentationEmail!, EmailActionType.moveToMailbox)),
+            tooltip: AppLocalizations.of(context).move_message,
+            onTap: () => onEmailActionClick?.call(
+                _presentationEmail!,
+                EmailActionType.moveToMailbox)),
         buildIconWeb(
-          icon: SvgPicture.asset(_presentationEmail!.hasStarred ? _imagePaths.icStar : _imagePaths.icUnStar, fit: BoxFit.fill),
-          tooltip: _presentationEmail!.hasStarred ? AppLocalizations.of(_context).not_starred : AppLocalizations.of(_context).mark_as_starred,
-          onTap: () => _onEmailActionClick?.call(_presentationEmail!,
-              _presentationEmail!.hasStarred ? EmailActionType.unMarkAsStarred : EmailActionType.markAsStarred)),
+          icon: SvgPicture.asset(
+              _presentationEmail!.hasStarred
+                ? _imagePaths.icStar
+                : _imagePaths.icUnStar,
+              fit: BoxFit.fill),
+          tooltip: _presentationEmail!.hasStarred
+              ? AppLocalizations.of(context).not_starred
+              : AppLocalizations.of(context).mark_as_starred,
+          onTap: () => onEmailActionClick?.call(_presentationEmail!,
+              _presentationEmail!.hasStarred
+                  ? EmailActionType.unMarkAsStarred
+                  : EmailActionType.markAsStarred)),
         buildIconWeb(
             icon: SvgPicture.asset(_imagePaths.icDeleteEmail, fit: BoxFit.fill),
             tooltip: _currentMailbox?.role != PresentationMailbox.roleTrash
-                ? AppLocalizations.of(_context).move_to_trash
-                : AppLocalizations.of(_context).delete_permanently,
+                ? AppLocalizations.of(context).move_to_trash
+                : AppLocalizations.of(context).delete_permanently,
             onTap: () {
               if (_currentMailbox?.role != PresentationMailbox.roleTrash) {
-                _onEmailActionClick?.call(_presentationEmail!, EmailActionType.moveToTrash);
+                onEmailActionClick?.call(
+                    _presentationEmail!,
+                    EmailActionType.moveToTrash);
               } else {
-                _onEmailActionClick?.call(_presentationEmail!, EmailActionType.deletePermanently);
+                onEmailActionClick?.call(
+                    _presentationEmail!,
+                    EmailActionType.deletePermanently);
               }
             }),
         Padding(
           padding: const EdgeInsets.only(left: 10, right: 16),
           child: buildIconWebHasPosition(
-              _context,
-              tooltip: AppLocalizations.of(_context).more,
-              icon: SvgPicture.asset(_imagePaths.icMore, fit: BoxFit.fill),
-              onTap: () {
-                if (_presentationEmail != null && _responsiveUtils.isMobile(_context)) {
-                  _onMoreActionClick?.call(_presentationEmail!, null);
-                }
-              },
-              onTapDown: (position) {
-                if (_presentationEmail != null && !_responsiveUtils.isMobile(_context)) {
-                  _onMoreActionClick?.call(_presentationEmail!, position);
-                }
-              })),
+            context,
+            tooltip: AppLocalizations.of(context).more,
+            icon: SvgPicture.asset(_imagePaths.icMore, fit: BoxFit.fill),
+            onTap: () {
+              if (_presentationEmail != null && _responsiveUtils.isMobile(context)) {
+                onMoreActionClick?.call(_presentationEmail!, null);
+              }
+            },
+            onTapDown: (position) {
+              if (_presentationEmail != null && !_responsiveUtils.isMobile(context)) {
+                onMoreActionClick?.call(_presentationEmail!, position);
+              }
+            }
+          )
+        ),
       ]
     );
   }


### PR DESCRIPTION
Related issue #904

When clicking on the line with the mailbox name, it goes back to the mailbox.
The link "size" is very wide, until the "move message" button, so licking on the "white space" also redirects to mailbox, but I don't think it is a problem.
Feel free to test or suggest changes.