### PR TITLE
TF-884 [Bug] Crash when open email 

### DIFF
--- a/core/lib/presentation/utils/html_transformer/html_template.dart
+++ b/core/lib/presentation/utils/html_transformer/html_template.dart
@@ -26,7 +26,7 @@ String generateHtml(String content, {
   double? minWidth,
   String? styleCSS,
   String? javaScripts,
-  bool? hideScrollBar
+  bool hideScrollBar = true,
 }) {
   return '''
     <!DOCTYPE html>
@@ -40,7 +40,7 @@ String generateHtml(String content, {
         min-width: ${minWidth ?? 0}px;
         overflow: auto;
       }
-      ${hideScrollBar == true ? '''
+      ${hideScrollBar ? '''
         .tmail-content::-webkit-scrollbar {
           display: none;
         }

--- a/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
+++ b/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:ui';
 
 import 'package:core/core.dart';
 import 'package:flutter/cupertino.dart';
@@ -44,7 +45,7 @@ class _HtmlContentViewState extends State<HtmlContentViewer> {
   late double actualHeight;
   double minHeight = 100;
   double minWidth = 300;
-  final double maxHeightForAndroid = 6000;
+  late double maxHeightForAndroid;
   String? _htmlData;
   late WebViewController _webViewController;
   bool _isLoading = true;
@@ -53,6 +54,8 @@ class _HtmlContentViewState extends State<HtmlContentViewer> {
   void initState() {
     super.initState();
     actualHeight = widget.heightContent;
+    maxHeightForAndroid = window.physicalSize.height;
+    log('_HtmlContentViewState::initState(): maxHeightForAndroid: $maxHeightForAndroid');
     _htmlData = _generateHtmlDocument(widget.contentHtml);
   }
 
@@ -64,7 +67,6 @@ class _HtmlContentViewState extends State<HtmlContentViewer> {
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, constraints) {
-      log('_HtmlContentViewState::build(): maxWidth: ${constraints.maxWidth}');
       return Stack(
         children: [
           SizedBox(
@@ -109,7 +111,7 @@ class _HtmlContentViewState extends State<HtmlContentViewer> {
             if (scrollHeightWithBuffer > minHeight) {
               setState(() {
                 //TODO: It hotfix for web_view crash on android device and waiting lib web_view update to fix this issue
-                if(Platform.isAndroid && scrollHeightWithBuffer > maxHeightForAndroid){
+                if (Platform.isAndroid && scrollHeightWithBuffer > maxHeightForAndroid){
                   actualHeight = maxHeightForAndroid;
                 } else {
                   actualHeight = scrollHeightWithBuffer;

--- a/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
+++ b/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
@@ -128,6 +128,7 @@ class _HtmlContentViewState extends State<HtmlContentViewer> {
       navigationDelegate: _onNavigation,
       gestureRecognizers: {
         Factory<LongPressGestureRecognizer>(() => LongPressGestureRecognizer()),
+        Factory<ScaleGestureRecognizer>(() => ScaleGestureRecognizer()),
       },
     );
   }

--- a/docs/adr/0010-crash-app-when-open-webview-on-android-device.md
+++ b/docs/adr/0010-crash-app-when-open-webview-on-android-device.md
@@ -8,23 +8,21 @@ Open
 
 ## Context
 
-- When using a webview inside of a scrollview,
-some content renders a completely distorted page and some content even crashes the app.
-This problem only affects Android the same app, on iOS the same code results in a correclty rendered web page.
-Rendering the same content also works fine on Android, when not embedding the webview inside of a scrollview.
+- When using a `WebView` inside of a `Scrollview`, some content renders a completely distorted page and some content even crashes the app.
+This problem only affects Android the same app, on iOS the same code results in a correctly rendered web page.
+Rendering the same content also works fine on Android, when not embedding the `WebView` inside of a scrollview.
 
-- Flutter version has problem: 3.0.3
+- Flutter version has problem: >= `3.0.0`
+- Library `webview_flutter` version used: `3.0.0`
 
 ## Decision
 
-- When using a webview inside of a scrollview,
-some content renders a completely distorted page and some content even crashes the app.
-This problem only affects Android the same app, on iOS the same code results in a correclty rendered web page.
-Rendering the same content also works fine on Android, when not embedding the webview inside of a scrollview.
+- Temporary solution: Set maximum height of `WebView` on `Android` device equal to device physical size height
 
 ## Consequences
 
-- From now we waiting web_view lib update and for android device if content of web_view has max height is 6000,
+- Email content is displayed well on `Android` devices. No more distortion and crashes
+- The content scroll bar appears inside the email detail display.
 
 ## Reference
 

--- a/model/lib/email/presentation_email.dart
+++ b/model/lib/email/presentation_email.dart
@@ -76,9 +76,9 @@ class PresentationEmail with EquatableMixin {
     return '';
   }
 
-  String getEmailTitle() => subject ?? '';
+  String getEmailTitle() => subject?.trim() ?? '';
 
-  String getPartialContent() => preview ?? '';
+  String getPartialContent() => preview?.trim() ?? '';
 
   bool get hasRead => keywords?.containsKey(KeyWordIdentifier.emailSeen) == true;
 


### PR DESCRIPTION
### Issues
- #884 
- Email title has too many spaces
<img width="360" alt="Screen Shot 2022-09-07 at 15 56 56" src="https://user-images.githubusercontent.com/80730648/188869573-b7141018-b60a-4dd1-8fa9-07da6f80c035.png">


### Dependency
- [https://github.com/linagora/enough_html_editor/pull/6](https://github.com/linagora/enough_html_editor/pull/6)


### Resolved
- Trim email title: 
<img width="360" alt="Screen Shot 2022-09-07 at 15 57 37" src="https://user-images.githubusercontent.com/80730648/188869731-8c4e9ae5-724e-4b9a-9eba-b8cd90d633e4.png">

- 

https://user-images.githubusercontent.com/80730648/188869872-9f9c9ffa-7cee-4aea-993f-f02b34663784.mp4

