### PR TITLE
TF-940, 949 Using `apiUrl` in session to set up path for `jmap-dart-client`

### DIFF
--- a/contact/test/contact/autocomplete_tmail_contact_method_test.dart
+++ b/contact/test/contact/autocomplete_tmail_contact_method_test.dart
@@ -29,10 +29,10 @@ void main() {
     test('autocomplete_tmail_contact method and response parsing', () async {
       final baseOption  = BaseOptions(method: 'POST');
       final dio = Dio(baseOption)
-        ..options.baseUrl = 'http://domain.com';
+        ..options.baseUrl = 'http://domain.com/jmap';
       final dioAdapter = DioAdapter(dio: dio);
       dioAdapter.onPost(
-          '/jmap',
+          '',
           (server) => server.reply(200, {
                 "sessionState": "2c9f1b12-b35a-43e6-9af2-0106fb53a943",
                 "methodResponses": [

--- a/forward/test/forward/get_forward_method_test.dart
+++ b/forward/test/forward/get_forward_method_test.dart
@@ -20,10 +20,10 @@ void main() {
 
     test('get forward method and response parsing', () async {
       final baseOption = BaseOptions(method: 'POST');
-      final dio = Dio(baseOption)..options.baseUrl = 'http://domain.com';
+      final dio = Dio(baseOption)..options.baseUrl = 'http://domain.com/jmap';
       final dioAdapter = DioAdapter(dio: dio);
       dioAdapter.onPost(
-          '/jmap',
+          '',
           (server) => server.reply(200, {
                 "sessionState": "abcdefghij",
                 "methodResponses": [

--- a/forward/test/forward/set_forward_method_test.dart
+++ b/forward/test/forward/set_forward_method_test.dart
@@ -22,10 +22,10 @@ void main() {
     test('set forward method and response parsing', () async {
       final baseOption  = BaseOptions(method: 'POST');
       final dio = Dio(baseOption)
-        ..options.baseUrl = 'http://domain.com';
+        ..options.baseUrl = 'http://domain.com/jmap';
       final dioAdapter = DioAdapter(dio: dio);
       dioAdapter.onPost(
-        '/jmap',
+        '',
         (server) => server.reply(200, {
           "sessionState": "2c9f1b12-b35a-43e6-9af2-0106fb53a943",
           "methodResponses": [

--- a/lib/features/base/reloadable/reloadable_controller.dart
+++ b/lib/features/base/reloadable/reloadable_controller.dart
@@ -132,7 +132,13 @@ abstract class ReloadableController extends BaseController {
   }
 
   void _handleGetSessionSuccess(GetSessionSuccess success) {
-    handleReloaded(success.session);
+    final apiUrl = success.session.apiUrl.toString();
+    if (apiUrl.isNotEmpty) {
+      _dynamicUrlInterceptors.changeBaseUrl(apiUrl);
+      handleReloaded(success.session);
+    } else {
+      _handleGetSessionFailure();
+    }
   }
 
   void handleReloaded(Session session) {}

--- a/lib/features/email/domain/usecases/download_attachments_interactor.dart
+++ b/lib/features/email/domain/usecases/download_attachments_interactor.dart
@@ -32,39 +32,36 @@ class DownloadAttachmentsInteractor {
       String baseDownloadUrl
   ) async* {
     try {
-      final account = await _accountRepository.getCurrentAccount();
+      final currentAccount = await _accountRepository.getCurrentAccount();
 
-      log('ExportAttachmentInteractor::execute(): account: $account');
+      AccountRequest? accountRequest;
 
-      final taskIds = await Future.wait([
-        if (account.authenticationType == AuthenticationType.oidc)
-          _authenticationOIDCRepository.getStoredTokenOIDC(account.id)
-        else
-          credentialRepository.getAuthenticationInfoStored()
-      ], eagerError: true
-      ).then((List responses) async {
-        AccountRequest accountRequest;
-
-        if (account.authenticationType == AuthenticationType.oidc) {
-          final tokenOidc = responses.first as TokenOIDC;
+      if (currentAccount.authenticationType == AuthenticationType.oidc) {
+        final tokenOidc = await _authenticationOIDCRepository.getStoredTokenOIDC(currentAccount.id);
+        accountRequest = AccountRequest(
+            token: tokenOidc.toToken(),
+            authenticationType: AuthenticationType.oidc);
+      } else {
+        final authenticationInfoCache = await credentialRepository.getAuthenticationInfoStored();
+        if (authenticationInfoCache != null) {
           accountRequest = AccountRequest(
-              token: tokenOidc.toToken(),
-              authenticationType: AuthenticationType.oidc);
-        } else {
-          accountRequest = AccountRequest(
-              userName: responses.first as UserName,
-              password: responses.last as Password,
+              userName: UserName(authenticationInfoCache.username),
+              password: Password(authenticationInfoCache.password),
               authenticationType: AuthenticationType.basic);
         }
+      }
 
-        return await emailRepository.downloadAttachments(
+      if (accountRequest != null) {
+        final taskIds = await emailRepository.downloadAttachments(
             attachments,
             accountId,
             baseDownloadUrl,
             accountRequest);
-      });
 
-      yield Right<Failure, Success>(DownloadAttachmentsSuccess(taskIds));
+        yield Right<Failure, Success>(DownloadAttachmentsSuccess(taskIds));
+      } else {
+        yield Left<Failure, Success>(DownloadAttachmentsFailure(null));
+      }
     } catch (exception) {
       log('DownloadAttachmentsInteractor::execute(): $exception');
       if (exception is DownloadAttachmentHasTokenExpiredException) {

--- a/lib/features/session/domain/state/get_session_state.dart
+++ b/lib/features/session/domain/state/get_session_state.dart
@@ -11,7 +11,7 @@ class GetSessionSuccess extends UIState {
 }
 
 class GetSessionFailure extends FeatureFailure {
-  final exception;
+  final dynamic exception;
 
   GetSessionFailure(this.exception);
 

--- a/lib/features/session/presentation/session_controller.dart
+++ b/lib/features/session/presentation/session_controller.dart
@@ -1,3 +1,4 @@
+import 'package:core/data/network/config/dynamic_url_interceptors.dart';
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/utils/app_toast.dart';
 import 'package:core/domain/exceptions/remote_exception.dart';
@@ -20,6 +21,7 @@ class SessionController extends GetxController {
   final DeleteAuthorityOidcInteractor _deleteAuthorityOidcInteractor;
   final AuthorizationInterceptors _authorizationInterceptors;
   final AppToast _appToast;
+  final DynamicUrlInterceptors _dynamicUrlInterceptors;
 
   SessionController(
     this._getSessionInteractor,
@@ -27,7 +29,9 @@ class SessionController extends GetxController {
     this._cachingManager,
     this._deleteAuthorityOidcInteractor,
     this._authorizationInterceptors,
-    this._appToast);
+    this._appToast,
+    this._dynamicUrlInterceptors,
+  );
 
   @override
   void onReady() {
@@ -76,7 +80,13 @@ class SessionController extends GetxController {
     pushAndPopAll(AppRoutes.LOGIN);
   }
 
-  void _goToMailboxDashBoard(GetSessionSuccess getSessionSuccess) {
-    pushAndPop(AppRoutes.MAILBOX_DASHBOARD, arguments: getSessionSuccess.session);
+  void _goToMailboxDashBoard(GetSessionSuccess success) {
+    final apiUrl = success.session.apiUrl.toString();
+    if (apiUrl.isNotEmpty) {
+      _dynamicUrlInterceptors.changeBaseUrl(apiUrl);
+      pushAndPop(AppRoutes.MAILBOX_DASHBOARD, arguments: success.session);
+    } else {
+      _goToLogin();
+    }
   }
 }

--- a/lib/features/session/presentation/session_page_bindings.dart
+++ b/lib/features/session/presentation/session_page_bindings.dart
@@ -1,3 +1,4 @@
+import 'package:core/data/network/config/dynamic_url_interceptors.dart';
 import 'package:core/presentation/utils/app_toast.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/base_bindings.dart';
@@ -28,6 +29,7 @@ class SessionPageBindings extends BaseBindings {
       Get.find<DeleteAuthorityOidcInteractor>(),
       Get.find<AuthorizationInterceptors>(),
       Get.find<AppToast>(),
+      Get.find<DynamicUrlInterceptors>(),
     ));
   }
 

--- a/rule_filter/test/rule_filter/get_rule_filter_method_test.dart
+++ b/rule_filter/test/rule_filter/get_rule_filter_method_test.dart
@@ -40,10 +40,10 @@ void main() {
 
     test('get rule_filter method and response parsing', () async {
       final baseOption = BaseOptions(method: 'POST');
-      final dio = Dio(baseOption)..options.baseUrl = 'http://domain.com';
+      final dio = Dio(baseOption)..options.baseUrl = 'http://domain.com/jmap';
       final dioAdapter = DioAdapter(dio: dio);
       dioAdapter.onPost(
-          '/jmap',
+          '',
           (server) => server.reply(200, {
                 "sessionState": "2c9f1b12-b35a-43e6-9af2-0106fb53a943",
                 "methodResponses": [

--- a/rule_filter/test/rule_filter/set_rule_filter_method_test.dart
+++ b/rule_filter/test/rule_filter/set_rule_filter_method_test.dart
@@ -36,10 +36,10 @@ void main() {
 
     test('set rule_filter method and response parsing', () async {
       final baseOption = BaseOptions(method: 'POST');
-      final dio = Dio(baseOption)..options.baseUrl = 'http://domain.com';
+      final dio = Dio(baseOption)..options.baseUrl = 'http://domain.com/jmap';
       final dioAdapter = DioAdapter(dio: dio);
       dioAdapter.onPost(
-          '/jmap',
+          '',
           (server) => server.reply(200, {
                 "sessionState": "2c9f1b12-b35a-43e6-9af2-0106fb53a943",
                 "methodResponses": [


### PR DESCRIPTION
#940 
#949 

### Dependency

- [https://github.com/linagora/jmap-dart-client/pull/37]( https://github.com/linagora/jmap-dart-client/pull/37)

### Resolved

- With domain of `Fastmail`


https://user-images.githubusercontent.com/80730648/191583055-784cd8ae-7b7e-465d-8fed-4014532d59b7.mov


- With domain of `Jmap Linagrora`


https://user-images.githubusercontent.com/80730648/191583247-4b729669-2500-4ad4-a410-a6aec26c048a.mov


