### PR TITLE
#1045 Remove wrong conditions to append more items after loading more

### DIFF
--- a/lib/features/thread/data/repository/thread_repository_impl.dart
+++ b/lib/features/thread/data/repository/thread_repository_impl.dart
@@ -241,9 +241,6 @@ class ThreadRepositoryImpl extends ThreadRepository {
             properties: emailRequest.properties)
         .then((response) {
             var listEmails = response.emailList;
-            if (listEmails != null && listEmails.isNotEmpty) {
-              listEmails = listEmails.where((email) => email.id != emailRequest.lastEmailId).toList();
-            }
             return EmailsResponse(emailList: listEmails, state: response.state);
         });
 


### PR DESCRIPTION
### Root cause:
- wrong condition: if `moreItems` have any item in `emailList` will be ignored to append.

### Problem:


https://user-images.githubusercontent.com/6462404/194032802-7ba98576-853e-45bd-aa9a-e233f4725838.mov

### Solved:


https://user-images.githubusercontent.com/6462404/194032821-b573138a-d002-456e-9a54-9ccb47238f16.mov

