### PR TITLE
Specific runner per OS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,12 +15,14 @@ jobs:
     name: Build app
     needs:
       - analyze-test
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        os:
-          - android
-          - ios
+        include:
+          - os: android
+            runner: ubuntu-latest
+          - os: ios
+            runner: macos-latest
     environment: dev
 
     steps:
@@ -44,8 +46,8 @@ jobs:
           PLAY_STORE_KEY_INFO_BASE64: ${{ secrets.PLAY_STORE_KEY_INFO_BASE64 }}
         run: |
           # echo "$GOOGLE_SERVICES_JSON" > app/google-services.json
-          echo "$PLAY_STORE_UPLOAD_KEY_BASE64" | base64 --decode --output app/keystore.jks
-          echo "$PLAY_STORE_KEY_INFO_BASE64" | base64 --decode --output key.properties
+          echo "$PLAY_STORE_UPLOAD_KEY_BASE64" | base64 --decode > app/keystore.jks
+          echo "$PLAY_STORE_KEY_INFO_BASE64" | base64 --decode > key.properties
         working-directory: ${{ matrix.os }}
 
       - name: Setup Java

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,12 +15,14 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs:
       - analyze-test
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        os:
-          - android
-          - ios
+        include:
+          - os: android
+            runner: ubuntu-latest
+          - os: ios
+            runner: macos-latest
     environment: prod
 
     steps:
@@ -42,8 +44,8 @@ jobs:
           PLAY_STORE_UPLOAD_KEY_BASE64: ${{ secrets.PLAY_STORE_UPLOAD_KEY_BASE64 }}
           PLAY_STORE_KEY_INFO_BASE64: ${{ secrets.PLAY_STORE_KEY_INFO_BASE64 }}
         run: |
-          echo "$PLAY_STORE_UPLOAD_KEY_BASE64" | base64 --decode --output app/keystore.jks
-          echo "$PLAY_STORE_KEY_INFO_BASE64" | base64 --decode --output key.properties
+          echo "$PLAY_STORE_UPLOAD_KEY_BASE64" | base64 --decode > app/keystore.jks
+          echo "$PLAY_STORE_KEY_INFO_BASE64" | base64 --decode > key.properties
         working-directory: ${{ matrix.os }}
 
       - name: Setup Java


### PR DESCRIPTION
This should free up macos runners for ios builds, and use ubuntu for android builds