### PR TITLE
TF-991 Fix link problem on my JIRA notifications

### DIFF
--- a/core/lib/presentation/utils/html_transformer/text/convert_url_string_to_html_links_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/text/convert_url_string_to_html_links_transformers.dart
@@ -1,6 +1,5 @@
 
 import 'package:core/presentation/utils/html_transformer/base/text_transformer.dart';
-import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/linkify_html.dart';
 
 class ConvertUrlStringToHtmlLinksTransformers extends TextTransformer {
@@ -9,9 +8,7 @@ class ConvertUrlStringToHtmlLinksTransformers extends TextTransformer {
 
   @override
   String process(String text) {
-    log('ConvertUrlStringToHtmlLinksTransformers::process(): BEFORE: $text');
     final texValid = LinkifyHtml().generateLinkify(text);
-    log('ConvertUrlStringToHtmlLinksTransformers::process(): AFTER: $texValid');
     return texValid;
   }
 }

--- a/core/lib/utils/linkify_html.dart
+++ b/core/lib/utils/linkify_html.dart
@@ -1,5 +1,4 @@
 
-import 'package:collection/collection.dart';
 import 'package:core/utils/app_logger.dart';
 
 class LinkifyHtml {
@@ -20,38 +19,29 @@ class LinkifyHtml {
 
     // URLs starting with http://, https://, ftp://
     final regexLinkWithHttp = _generateRegExp(r'(\b(https?|ftp):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])');
-
-    final listUrlMatch = regexLinkWithHttp.allMatches(replacedText)
-        .map((regexMatch) => regexMatch.group(1))
-        .whereNotNull()
-        .toSet();
-
-    log('ConvertUrlStringToHtmlLinksTransformers::_linkifyUrlAddress(): listUrlMatch: $listUrlMatch');
-
-    if (listUrlMatch.isNotEmpty) {
-      listUrlMatch.forEach((link) {
-        replacedText = replacedText.replaceAll(
-            link,
-            '<a href="$link" target="_blank">$link</a>');
-      });
-    }
+    final newReplacedTextWithHttp = replacedText.replaceAllMapped(regexLinkWithHttp, (regexMatch) {
+      final link = regexMatch.group(1);
+      final newLinkWithHttp = link?.isNotEmpty == true
+          ? '<a href="$link" target="_blank">$link</a>'
+          : '';
+      log('ConvertUrlStringToHtmlLinksTransformers::_linkifyUrlAddress(): newLinkWithHttp: $newLinkWithHttp');
+      return newLinkWithHttp;
+    });
+    replacedText = newReplacedTextWithHttp;
 
     // URLs starting with "www." without // before it or it'd re-link the ones done above.
     final regexLinkWithWWW = _generateRegExp(r'(^|[^\/])(www\.[\S]+(\b|\$))');
-
-    final listLinkMatch = regexLinkWithWWW.allMatches(replacedText)
-        .map((regexMatch) => regexMatch.group(2))
-        .whereNotNull()
-        .toSet();
-    log('ConvertUrlStringToHtmlLinksTransformers::_linkifyUrlAddress(): listLinkMatch: $listLinkMatch');
-
-    if (listLinkMatch.isNotEmpty) {
-      listLinkMatch.forEach((link) {
-        replacedText = replacedText.replaceAll(
-            link,
-            '<a href="https://$link" target="_blank">$link</a>');
-      });
-    }
+    final newReplacedTextWithWWW = replacedText.replaceAllMapped(regexLinkWithWWW, (regexMatch) {
+      final previousChar = regexMatch.group(1);
+      log('LinkifyHtml::_linkifyUrlAddress(): previousChar: $previousChar');
+      final link = regexMatch.group(2);
+      final newLinkWithWWW = link?.isNotEmpty == true
+          ? '$previousChar<a href="https://$link" target="_blank">$link</a>'
+          : '';
+      log('ConvertUrlStringToHtmlLinksTransformers::_linkifyUrlAddress(): newLinkWithWWW: $newLinkWithWWW');
+      return newLinkWithWWW;
+    });
+    replacedText = newReplacedTextWithWWW;
 
     return replacedText;
   }
@@ -60,20 +50,15 @@ class LinkifyHtml {
   String _linkifyMailToAddress(String inputText) {
     final regexMailTo = _generateRegExp(r'(([a-zA-Z0-9\-\_\.])+@[a-zA-Z\_]+?(\.[a-zA-Z]{2,6})+)');
 
-    final listEmailAddressMatch = regexMailTo.allMatches(inputText)
-        .map((regexMatch) => regexMatch.group(1))
-        .whereNotNull()
-        .toSet();
+    final newReplacedTextWitMailTo = inputText.replaceAllMapped(regexMailTo, (regexMatch) {
+      final emailAddress = regexMatch.group(1);
+      final newMailToLink = emailAddress?.isNotEmpty == true
+        ? '<a href="mailto:$emailAddress">$emailAddress</a>'
+        : '';
+      log('ConvertUrlStringToHtmlLinksTransformers::_linkifyUrlAddress(): newMailToLink: $newMailToLink');
+      return newMailToLink;
+    });
 
-    log('ConvertUrlStringToHtmlLinksTransformers::generateLinkifyHtml(): listEmailAddressMatch: $listEmailAddressMatch');
-
-    if (listEmailAddressMatch.isNotEmpty) {
-      listEmailAddressMatch.forEach((emailAddress) {
-        inputText = inputText.replaceAll(
-            emailAddress,
-            '<a href="mailto:$emailAddress">$emailAddress</a>');
-      });
-    }
-    return inputText;
+    return newReplacedTextWitMailTo;
   }
 }


### PR DESCRIPTION
#991 

### Root Cause

- Because there are many similar links in an email body. So `replace` string is incorrect.

### Resolved

- Before fixed



https://user-images.githubusercontent.com/80730648/194454282-bccebce5-5998-43b1-95fa-ecdcbd46e992.mov



- After fixed

https://user-images.githubusercontent.com/80730648/194461778-a8b122f0-a996-4d11-8ce4-411924d541d4.mov


