### PR TITLE
[WIP] TF-1088 build desktop for linux, windows, and macOS

### DIFF
--- a/core/lib/presentation/views/html_viewer/html_content_viewer_on_windows.dart
+++ b/core/lib/presentation/views/html_viewer/html_content_viewer_on_windows.dart
@@ -1,0 +1,117 @@
+import 'dart:developer';
+import 'dart:ui';
+
+import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/html_transformer/html_template.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:webview_windows/webview_windows.dart';
+
+class HtmlContentViewerForWindows extends StatefulWidget {
+  final String contentHtml;
+  final double heightContent;
+
+  final void Function(WebviewController controller)? onCreated;
+
+  final Future Function(Uri mailto)? mailtoDelegate;
+
+  /// Handler for any non-media URLs that the user taps on the website.
+  ///
+  /// Returns `true` when the given `url` was handled.
+  final Future<bool> Function(Uri url)? urlLauncherDelegate;
+
+  const HtmlContentViewerForWindows({
+    Key? key,
+    required this.contentHtml,
+    required this.heightContent,
+    this.onCreated,
+    this.urlLauncherDelegate,
+    this.mailtoDelegate,
+  }) : super(key: key);
+
+  
+  @override
+  State<StatefulWidget> createState() => _HtmlContentViewState();
+}
+
+class _HtmlContentViewState extends State<HtmlContentViewerForWindows> {
+  
+  late double actualHeight;
+  double minHeight = 100;
+  double minWidth = 300;
+  late double maxHeightForWindows;
+  late WebviewController _webviewController;
+  bool _isLoading = true;
+  late final ValueNotifier<String> _htmlDataNotifier;
+
+    @override
+  void initState() {
+    super.initState();
+    actualHeight = widget.heightContent;
+    maxHeightForWindows = window.physicalSize.height;
+    log('_HtmlContentViewState::initState(): maxHeightForWindows: $maxHeightForWindows');
+    _htmlDataNotifier = ValueNotifier(widget.contentHtml);
+    _webviewController = WebviewController();
+    initPlatformState();
+  }
+
+  Future<void> initPlatformState() async {
+    try {
+      await _webviewController.initialize();
+      await _webviewController.setBackgroundColor(Colors.white);
+      await  _webviewController.loadStringContent("");
+
+      if (!mounted) return;
+      setState(() {});
+    } on PlatformException catch (e) {
+      log(e.code);
+      if(e.message != null) {
+        log(e.message!);
+      }
+    }
+  }
+
+  String _generateHtmlDocument(String content) {
+    final htmlTemplate = generateHtml(content);
+    return htmlTemplate;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(builder: (context, constraints) {
+      return Stack(
+        children: [
+          SizedBox(
+            height: actualHeight,
+            width: constraints.maxWidth,
+            child: ValueListenableBuilder<String>(
+              valueListenable: _htmlDataNotifier,
+              builder: ((context, contentHtml, child) {
+                final htmlTemplate = _generateHtmlDocument(contentHtml);
+                if(!_webviewController.value.isInitialized) {
+                  return _buildLoadingView();
+                }
+                _webviewController.loadStringContent(htmlTemplate);
+                return child!;
+              }),
+              child: Webview(_webviewController),
+            ),
+            ),
+          if (_isLoading) Align(alignment: Alignment.center, child: _buildLoadingView())
+        ],
+      );
+    });
+  }
+
+  Widget _buildLoadingView() {
+    return const Padding(
+        padding: EdgeInsets.all(16),
+        child: SizedBox(
+          width: 30,
+          height: 30,
+          child: CupertinoActivityIndicator(color: AppColor.colorLoading)));
+  }
+
+}

--- a/core/pubspec.lock
+++ b/core/pubspec.lock
@@ -511,6 +511,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.9.5"
+  webview_windows:
+    dependency: "direct main"
+    description:
+      name: webview_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.1"
   win32:
     dependency: transitive
     description:

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -78,6 +78,8 @@ dependencies:
   flex_color_picker: 2.5.0
 
   flutter_image_compress: 1.1.0
+  
+  webview_windows: ^0.2.1
 
 dev_dependencies:
   flutter_test:

--- a/lib/features/composer/presentation/composer_view.dart
+++ b/lib/features/composer/presentation/composer_view.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:core/core.dart';
 import 'package:dropdown_button2/dropdown_button2.dart';
 import 'package:enough_html_editor/enough_html_editor.dart';
@@ -21,6 +23,7 @@ import 'package:tmail_ui_user/features/upload/presentation/extensions/list_uploa
 import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/get_email_content_state.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:html_editor_windows/html_editor_windows.dart' as htmlEditorWindow;
 
 class ComposerView extends GetWidget<ComposerController>
     with AppLoaderMixin, RichTextButtonMixin, ComposerLoadingMixin {
@@ -596,18 +599,23 @@ class ComposerView extends GetWidget<ComposerController>
     final richTextMobileTabletController = controller.richTextMobileTabletController;
     return Padding(
       padding: const EdgeInsets.only(left: 16, right: 16, bottom: 20),
-      child: HtmlEditor(
-        key: const Key('composer_editor'),
-        minHeight: 550,
-        addDefaultSelectionMenuItems: false,
-        initialContent: initialContent ?? '',
-        onCreated: (editorApi) {
-          richTextMobileTabletController.htmlEditorApi = editorApi;
-            controller.keyboardRichTextController.onCreateHTMLEditor(
-              editorApi,
-              onEnterKeyDown: controller.onEnterKeyDown,
-              context: context,
-            );
+      child: Platform.isWindows 
+        ? htmlEditorWindow.HtmlEditor(
+          key: const Key('composer_editor'), 
+          initialContent: initialContent ?? '',
+          height: 550,) 
+        : HtmlEditor(
+          key: const Key('composer_editor'),
+          minHeight: 550,
+          addDefaultSelectionMenuItems: false,
+          initialContent: initialContent ?? '',
+          onCreated: (editorApi) {
+            richTextMobileTabletController.htmlEditorApi = editorApi;
+              controller.keyboardRichTextController.onCreateHTMLEditor(
+                editorApi,
+                onEnterKeyDown: controller.onEnterKeyDown,
+                context: context,
+              );
         },
       ),
     );

--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -1,4 +1,7 @@
+import 'dart:io';
+
 import 'package:core/core.dart';
+import 'package:core/presentation/views/html_viewer/html_content_viewer_on_windows.dart';
 import 'package:filesize/filesize.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -746,6 +749,11 @@ class EmailView extends GetWidget<SingleEmailController>
               contentHtml: allEmailContents,
               controller: HtmlViewerControllerForWeb(),
               mailtoDelegate: (uri) => controller.openMailToLink(uri));
+        } else if(Platform.isWindows) {
+          return HtmlContentViewerForWindows(
+            contentHtml: allEmailContents, 
+            heightContent: responsiveUtils.getSizeScreenHeight(context), 
+            mailtoDelegate: (uri) async => controller.openMailToLink(uri));
         } else {
           return HtmlContentViewer(
               heightContent: responsiveUtils.getSizeScreenHeight(context),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.4"
+    version: "3.3.5"
   args:
     dependency: transitive
     description:
@@ -35,7 +35,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   better_open_file:
     dependency: "direct main"
     description:
@@ -119,7 +119,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   charcode:
     dependency: transitive
     description:
@@ -140,7 +140,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   code_builder:
     dependency: transitive
     description:
@@ -219,7 +219,7 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   core:
     dependency: "direct main"
     description:
@@ -396,7 +396,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   fcm:
     dependency: "direct main"
     description:
@@ -578,7 +578,7 @@ packages:
       name: flutter_platform_widgets
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.20.0"
+    version: "1.12.1"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -696,6 +696,15 @@ packages:
       url: "https://github.com/linagora/html-editor-enhanced.git"
     source: git
     version: "2.5.0"
+  html_editor_windows:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: main
+      resolved-ref: fb424dd62c41ea319a9e10df9a0048062b44c6ea
+      url: "https://github.com/sherlockvn/html_editor_windows.git"
+    source: git
+    version: "1.0.0+1"
   http:
     dependency: transitive
     description:
@@ -816,21 +825,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   mime:
     dependency: transitive
     description:
@@ -921,7 +930,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   path_drawing:
     dependency: transitive
     description:
@@ -1033,7 +1042,7 @@ packages:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "5.1.0"
   platform:
     dependency: transitive
     description:
@@ -1224,7 +1233,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   sqflite:
     dependency: transitive
     description:
@@ -1238,7 +1247,7 @@ packages:
       name: sqflite_common
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.0+2"
   stack_trace:
     dependency: transitive
     description:
@@ -1266,7 +1275,7 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   super_tag_editor:
     dependency: "direct main"
     description:
@@ -1280,7 +1289,7 @@ packages:
       name: syncfusion_flutter_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "20.3.57"
+    version: "20.3.59"
   syncfusion_flutter_datepicker:
     dependency: transitive
     description:
@@ -1301,14 +1310,14 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   textfield_tags:
     dependency: "direct main"
     description:
@@ -1371,7 +1380,7 @@ packages:
       name: url_launcher_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.21"
+    version: "6.0.22"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1477,6 +1486,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.9.5"
+  webview_windows:
+    dependency: transitive
+    description:
+      name: webview_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.2"
   win32:
     dependency: transitive
     description:
@@ -1513,5 +1529,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
-  flutter: ">=3.0.0"
+  dart: ">=2.18.5 <3.0.0"
+  flutter: ">=3.3.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -140,6 +140,10 @@ dependencies:
       url: https://github.com/linagora/html-editor-enhanced.git
       ref: email_supported
 
+  html_editor_windows:
+    git:
+      url: https://github.com/sherlockvn/html_editor_windows.git
+      ref: main
   # fk_user_agent
   fk_user_agent: 2.1.0
 
@@ -179,7 +183,7 @@ dependencies:
   # Isolate
   worker_manager: 4.4.0
 
-  async: 2.8.2
+  async: 2.9.0
 
   # HTML5 parser
   html: 0.15.0


### PR DESCRIPTION
#1088 
- Run and login, get session and build success.

### Package is not supported for desktop(linux, macos, windows):
- `flutter_downloader` is not supported in desktop and web
- `receive sharing intent` is not supported in desktop and web
- `webview_flutter` is not supported in desktop, but it have an interface package `webview_flutter_platform_interface`
- `fk_user_agent` is not supported in desktop and web
- `appToast` have supported some methods only for mobile, not desktop,  but it can work by using with context
- `permission_handler` is not supported in desktop,  but it have an interface package `permission_handler_plaform_interface`, and some people have do permission handler in window https://pub.dev/packages/permission_handler_windows

### Error
- All desktop platform currently can't see the content of email, can't compose a new email
- In linux, some button can't be clicked

https://user-images.githubusercontent.com/43041967/198192534-3ef2559a-c85e-46b9-b82d-73e4cfc38e72.mov

https://user-images.githubusercontent.com/43041967/198195739-b291f851-fdb7-494a-b7e3-907c8be1e163.mp4


https://user-images.githubusercontent.com/43041967/198215366-5c9620c8-58f1-491e-8b8e-4ccd58b8aad8.mp4



