### PR TITLE
Added compose file for quick local setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,23 +23,7 @@ WORKDIR /app
 COPY . .
 
 # Precompile tmail flutter
-RUN cd core \
-  && flutter pub get \
-  && cd ../model \
-  && flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs \
-  && cd ../contact \
-  && flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs \
-  && cd ../rule_filter \
-  && flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs \
-  && cd ../forward \
-  && flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs \
-  && cd ../fcm \
-  && flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs \
-  && cd .. \
-  && flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs \
-  && flutter pub get && flutter pub run intl_generator:extract_to_arb --output-dir=./lib/l10n lib/main/localizations/app_localizations.dart \
-  && flutter pub get && flutter pub run intl_generator:generate_from_arb --output-dir=lib/l10n --no-use-deferred-loading lib/main/localizations/app_localizations.dart lib/l10n/intl*.arb \
-  && flutter build web --profile
+RUN bash prebuild.sh && flutter build web --profile
 
 # Stage 2 - Create the run-time image
 FROM nginx:mainline
@@ -51,4 +35,5 @@ COPY --from=build-env /app/build/web /usr/share/nginx/html
 EXPOSE 80
 
 # Before stating NGinx, re-zip all the content to ensure customizations are propagated
-CMD gzip -k -r /usr/share/nginx/html/ && nginx -g 'daemon off;'
+RUN gzip -k -f -r /usr/share/nginx/html/ 
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,4 @@ COPY --from=build-env /app/build/web /usr/share/nginx/html
 EXPOSE 80
 
 # Before stating NGinx, re-zip all the content to ensure customizations are propagated
-RUN gzip -k -f -r /usr/share/nginx/html/ 
-CMD ["nginx", "-g", "daemon off;"]
+CMD gzip -k -r /usr/share/nginx/html/ && nginx -g 'daemon off;'

--- a/README.md
+++ b/README.md
@@ -154,7 +154,33 @@ No we do not plan to support such extensions, that are currently not standardize
   docker run -d -ti -p 8080:80 --mount type=bind,source="$(pwd)"/env.dev.file,target=/usr/share/nginx/html/assets/env.file --name web tmail-web:latest
   ```
 
-  Then go to http://localhost:8080 and you should be able to login against your JMAP backend using the Team Mail web-app.
+  Then go to http://localhost:8080 and you should be able to login against your JMAP backend using the TMail web-app.
+
+  #### Using the docker-compose file
+
+  We also include a [docker-compose.yaml](docker-compose.yaml) file so you can get a testing environment up quickly. This use our [tmail-backend](https://hub.docker.com/r/linagora/tmail-backend) image for the JMAP server.
+
+  Here are the steps to setup:
+
+  1. Generate JWT keys for `tmail-backend`:
+  ```bash
+  openssl genpkey -algorithm rsa -pkeyopt rsa_keygen_bits:4096 -out jwt_privatekey
+  openssl rsa -in jwt_privatekey -pubout -out jwt_publickey
+  ```
+  2. Edit the `env.file` and set `SERVER_URL` to `http://localhost/` (with the trailing slash)
+  3. Run `docker compose up -d` to bring up both the frontend and the backend.
+  4. Run `docker compose exec tmail-backend /root/provisioning/provisioning.sh` to provision some demo accounts (you don't have to let it run all the way).
+  5. The TMail web-app should be available at `http://localhost:8080`. The credentials for demo accounts are:
+  ```
+  User: alice@localhost
+  Password: aliceSecret
+
+  User: bob@localhost
+  Password: bobSecret
+
+  User: empty@localhost
+  Password: emptrySecret
+  ```
   
   #### More configurations for Team Mail web
   

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,28 @@
+version: "3"
+
+services:
+  tmail-frontend:
+    image: linagora/tmail-web:master
+    container_name: tmail-frontend
+    ports:
+      - "8080:80"
+    volumes:
+      - ./env.file:/usr/share/nginx/html/assets/env.file
+    networks:
+      - tmail
+    depends_on:
+      - tmail-backend
+
+  tmail-backend:
+    image: linagora/tmail-backend:memory-branch-master
+    container_name: tmail-backend
+    volumes:
+      - ./jwt_publickey:/root/conf/jwt_publickey
+      - ./jwt_privatekey:/root/conf/jwt_privatekey
+    ports:
+      - "80:80"
+    networks:
+      - tmail
+
+networks:
+  tmail:

--- a/env.file
+++ b/env.file
@@ -1,4 +1,4 @@
-SERVER_URL=http://localhost
+SERVER_URL=http://localhost/
 DOMAIN_REDIRECT_URL=http://localhost:3000
 WEB_OIDC_CLIENT_ID=teammail-web
 APP_GRID_AVAILABLE=supported


### PR DESCRIPTION
Also simplified the Dockerfile and moved `gzip` to a seperate `RUN` so the container can be restarted.

This compose file uses the `linagora/tmail-backend:memory-branch-master`image.