### PR TITLE
TF-1284 Fix some view blank when reload web

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,7 +20,7 @@ void main() async {
     await HiveCacheConfig().setUp();
     await HiveCacheConfig.initializeEncryptionKey();
     await Executor().warmUp();
-    AppUtils.loadEnvFile();
+    await AppUtils.loadEnvFile();
     runApp(const TMailApp());
   });
 }


### PR DESCRIPTION
#1284 

### Causes

- Because `dotenv.load()` has not been initialized but already used.

### Resolved


https://user-images.githubusercontent.com/80730648/206169099-f40fed96-800d-4dae-92c8-a6e888053b20.mov

