### PR TITLE
[HOT-FIX] TF-1356 Fix `Env.file` data lost after logout and login again

### DIFF
--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -11,6 +11,7 @@ import 'package:dartz/dartz.dart';
 import 'package:fcm/model/firebase_capability.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:forward/forward/capability_forward.dart';
 import 'package:get/get.dart';
@@ -161,7 +162,8 @@ abstract class BaseController extends GetxController
     try {
       requireCapability(session!, accountId!, [FirebaseCapability.fcmIdentifier]);
       if (AppConfig.fcmAvailable) {
-        await AppUtils.loadFcmConfigFile();
+        final mapEnvData = Map<String, String>.from(dotenv.env);
+        await AppUtils.loadFcmConfigFileToEnv(currentMapEnvData: mapEnvData);
         FcmConfiguration.initialize();
         if (!kIsWeb) {
           await LocalNotificationManager.instance.setUp();

--- a/lib/main/utils/app_utils.dart
+++ b/lib/main/utils/app_utils.dart
@@ -10,8 +10,11 @@ class AppUtils {
     return dotenv.load(fileName: envFileName);
   }
 
-  static Future<void> loadFcmConfigFile()  {
-    return dotenv.load(fileName: AppConfig.appFCMConfigurationPath);
+  static Future<void> loadFcmConfigFileToEnv({Map<String, String>? currentMapEnvData})  {
+    return dotenv.load(
+      fileName: AppConfig.appFCMConfigurationPath,
+      mergeWith: currentMapEnvData ?? {}
+    );
   }
 
   static Future<void> launchLink(String url, {bool isNewTab = true}) async {


### PR DESCRIPTION
#1356 

### Causes

- Because every time the `env` file loads, the `clean` function is called.

<img width="949" alt="Screenshot 2022-12-27 at 16 55 42" src="https://user-images.githubusercontent.com/80730648/209650669-6273ecde-ed7d-4ffa-b75d-a6e7867833cb.png">


<img width="540" alt="Screenshot 2022-12-27 at 16 55 58" src="https://user-images.githubusercontent.com/80730648/209650805-80e3a125-2b2f-4f2a-9a55-4c787aab1027.png">


### Resolved

- Use the `mergeWith` parameter in the `load` . function


