### PR TITLE
[HOT-FIX] Fix device id null after register new token successful

### DIFF
--- a/lib/features/push_notification/data/datasource_impl/fcm_datasource_impl.dart
+++ b/lib/features/push_notification/data/datasource_impl/fcm_datasource_impl.dart
@@ -3,6 +3,7 @@ import 'package:fcm/model/type_name.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 import 'package:tmail_ui_user/features/push_notification/data/datasource/fcm_datasource.dart';
 import 'package:tmail_ui_user/features/push_notification/data/network/fcm_api.dart';
+import 'package:tmail_ui_user/features/push_notification/domain/extensions/firebase_subscription_extension.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/model/register_new_token_request.dart';
 import 'package:tmail_ui_user/main/exceptions/exception_thrower.dart';
 
@@ -45,7 +46,8 @@ class FcmDatasourceImpl extends FCMDatasource {
   @override
   Future<FirebaseSubscription> registerNewToken(RegisterNewTokenRequest newTokenRequest) {
     return Future.sync(() async {
-      return await _fcmApi.registerNewToken(newTokenRequest);
+      final firebaseSubscription = await _fcmApi.registerNewToken(newTokenRequest);
+      return firebaseSubscription.fromDeviceId(newDeviceId: newTokenRequest.firebaseSubscription.deviceClientId);
     }).catchError((error) {
       _exceptionThrower.throwException(error);
     });

--- a/lib/features/push_notification/domain/extensions/firebase_subscription_extension.dart
+++ b/lib/features/push_notification/domain/extensions/firebase_subscription_extension.dart
@@ -1,0 +1,16 @@
+
+import 'package:fcm/model/device_client_id.dart';
+import 'package:fcm/model/firebase_subscription.dart';
+
+extension FirebaseSubscriptionExtension on FirebaseSubscription {
+
+  FirebaseSubscription fromDeviceId({DeviceClientId? newDeviceId}) {
+    return FirebaseSubscription(
+      id: id,
+      token: token,
+      deviceClientId: newDeviceId ?? deviceClientId,
+      expires: expires,
+      types: types
+    );
+  }
+}


### PR DESCRIPTION
### Causes

- Because `response` from `FirebaseRegistration/set` does not contain `deviceId`

### Resolved

- Mappings `deviceId` from `request` to use