### PR TITLE
Hot fix: Fix duplicate fcm token when login

### DIFF
--- a/lib/features/push_notification/presentation/config/fcm_configuration.dart
+++ b/lib/features/push_notification/presentation/config/fcm_configuration.dart
@@ -1,4 +1,5 @@
 
+import 'package:core/utils/build_utils.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/config/firebase_options.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/services/fcm_receiver.dart';
@@ -13,7 +14,7 @@ class FcmConfiguration {
   static void _initMessageListener() {
     FcmReceiver.instance.onForegroundMessage();
     FcmReceiver.instance.onBackgroundMessage();
-    FcmReceiver.instance.getFcmToken();
+    BuildUtils.isWeb ? FcmReceiver.instance.getFcmToken() : null;
     FcmReceiver.instance.onRefreshFcmToken();
   }
 }


### PR DESCRIPTION
Issue: When the user login after that call `getFcmToken` and `onRefreshFcmToken` to fcm token has duplicated.

![signal-2023-01-05-150011_002](https://user-images.githubusercontent.com/99852347/210736744-db1baf8a-5421-4405-a1ba-47923b8d6f72.jpeg)

Solution:  Delete `getFcmToken` func and keep `onRefreshFcmToken`

Android: 
after solving
<img width="1443" alt="Screenshot 2023-01-05 at 15 41 27" src="https://user-images.githubusercontent.com/99852347/210737687-c7c59eab-cdc4-4dfc-a0f3-2852b39696fa.png">
