### PR TITLE
Hotfix : Fix don't open Spam Mailbox

### DIFF
--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -256,6 +256,8 @@ class MailboxController extends BaseMailboxController {
     ever(mailboxDashBoardController.dashBoardAction, (action) {
       if (action is ClearSearchEmailAction) {
         _switchBackToMailboxDefault();
+      } else if (action is OpenSpamMailboxAction) {
+        openMailbox(action.context, action.presentationMailbox);
       }
     });
 
@@ -270,8 +272,6 @@ class MailboxController extends BaseMailboxController {
           refreshMailboxChanges();
         }
         mailboxDashBoardController.clearMailboxUIAction();
-      } else if (action is OpenSpamMailboxAction){
-        openMailbox(action.context, action.presentationMailbox);
       }
     });
   }


### PR DESCRIPTION
Fix don't open Spam Mailbox when clicking to showDetail in SpamReportBanner

https://user-images.githubusercontent.com/99852347/212885686-67692cdc-88f2-4b90-9c09-8ab6d09f677f.mov


https://user-images.githubusercontent.com/99852347/212885731-43ba76ad-017a-47ff-a92a-876169120fb9.mov

