### PR TITLE
[HOT] Fix can not refresh change list mailbox and email

### DIFF
--- a/lib/features/email/domain/state/delete_multiple_emails_permanently_state.dart
+++ b/lib/features/email/domain/state/delete_multiple_emails_permanently_state.dart
@@ -3,6 +3,8 @@ import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:tmail_ui_user/features/base/state/ui_action_state.dart';
 
+class LoadingDeleteMultipleEmailsPermanentlyAll extends UIState {}
+
 class DeleteMultipleEmailsPermanentlyAllSuccess extends UIActionState {
 
   List<EmailId> emailIds;

--- a/lib/features/email/domain/state/move_to_mailbox_state.dart
+++ b/lib/features/email/domain/state/move_to_mailbox_state.dart
@@ -6,6 +6,8 @@ import 'package:model/model.dart';
 import 'package:tmail_ui_user/features/base/state/ui_action_state.dart';
 import 'package:tmail_ui_user/features/email/domain/model/move_action.dart';
 
+class LoadingMoveToMailbox extends UIState {}
+
 class MoveToMailboxSuccess extends UIActionState {
   final EmailId emailId;
   final MailboxId currentMailboxId;

--- a/lib/features/email/domain/usecases/delete_multiple_emails_permanently_interactor.dart
+++ b/lib/features/email/domain/usecases/delete_multiple_emails_permanently_interactor.dart
@@ -14,6 +14,8 @@ class DeleteMultipleEmailsPermanentlyInteractor {
 
   Stream<Either<Failure, Success>> execute(AccountId accountId, List<EmailId> emailIds) async* {
     try {
+      yield Right<Failure, Success>(LoadingDeleteMultipleEmailsPermanentlyAll());
+
       final listState = await Future.wait([
         _mailboxRepository.getMailboxState(),
         _emailRepository.getEmailState(),

--- a/lib/features/email/domain/usecases/move_to_mailbox_interactor.dart
+++ b/lib/features/email/domain/usecases/move_to_mailbox_interactor.dart
@@ -14,6 +14,8 @@ class MoveToMailboxInteractor {
 
   Stream<Either<Failure, Success>> execute(AccountId accountId, MoveToMailboxRequest moveRequest) async* {
     try {
+      yield Right(LoadingMoveToMailbox());
+
       final listState = await Future.wait([
         _mailboxRepository.getMailboxState(),
         _emailRepository.getEmailState(),

--- a/lib/features/mailbox/domain/state/create_new_mailbox_state.dart
+++ b/lib/features/mailbox/domain/state/create_new_mailbox_state.dart
@@ -3,6 +3,8 @@ import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:tmail_ui_user/features/base/state/ui_action_state.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 
+class LoadingCreateNewMailbox extends UIState {}
+
 class CreateNewMailboxSuccess extends UIActionState {
 
   final Mailbox newMailbox;

--- a/lib/features/mailbox/domain/state/delete_multiple_mailbox_state.dart
+++ b/lib/features/mailbox/domain/state/delete_multiple_mailbox_state.dart
@@ -1,7 +1,10 @@
 import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 import 'package:tmail_ui_user/features/base/state/ui_action_state.dart';
+
+class LoadingDeleteMultipleMailboxAll extends UIState {}
 
 class DeleteMultipleMailboxAllSuccess extends UIActionState {
 

--- a/lib/features/mailbox/domain/state/move_mailbox_state.dart
+++ b/lib/features/mailbox/domain/state/move_mailbox_state.dart
@@ -4,13 +4,7 @@ import 'package:tmail_ui_user/features/base/state/ui_action_state.dart';
 import 'package:tmail_ui_user/features/email/domain/model/move_action.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 
-class MoveMailboxLoading extends UIState {
-
-  MoveMailboxLoading();
-
-  @override
-  List<Object?> get props => [];
-}
+class LoadingMoveMailbox extends UIState {}
 
 class MoveMailboxSuccess extends UIActionState {
 

--- a/lib/features/mailbox/domain/state/rename_mailbox_state.dart
+++ b/lib/features/mailbox/domain/state/rename_mailbox_state.dart
@@ -2,6 +2,8 @@ import 'package:core/core.dart';
 import 'package:tmail_ui_user/features/base/state/ui_action_state.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 
+class LoadingRenameMailbox extends UIState {}
+
 class RenameMailboxSuccess extends UIActionState {
 
   RenameMailboxSuccess({

--- a/lib/features/mailbox/domain/state/search_mailbox_state.dart
+++ b/lib/features/mailbox/domain/state/search_mailbox_state.dart
@@ -1,6 +1,8 @@
 import 'package:core/core.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 
+class LoadingSearchMailbox extends UIState {}
+
 class SearchMailboxSuccess extends UIState {
 
   final List<PresentationMailbox> mailboxesSearched;

--- a/lib/features/mailbox/domain/usecases/create_new_mailbox_interactor.dart
+++ b/lib/features/mailbox/domain/usecases/create_new_mailbox_interactor.dart
@@ -12,6 +12,8 @@ class CreateNewMailboxInteractor {
 
   Stream<Either<Failure, Success>> execute(AccountId accountId, CreateNewMailboxRequest newMailboxRequest) async* {
     try {
+      yield Right<Failure, Success>(LoadingCreateNewMailbox());
+
       final currentMailboxState = await _mailboxRepository.getMailboxState();
       final newMailbox = await _mailboxRepository.createNewMailbox(accountId, newMailboxRequest);
       if (newMailbox != null) {

--- a/lib/features/mailbox/domain/usecases/delete_multiple_mailbox_interactor.dart
+++ b/lib/features/mailbox/domain/usecases/delete_multiple_mailbox_interactor.dart
@@ -20,6 +20,8 @@ class DeleteMultipleMailboxInteractor {
       List<MailboxId> listMailboxIdToDelete
   ) async* {
     try {
+      yield Right<Failure, Success>(LoadingDeleteMultipleMailboxAll());
+
       final currentMailboxState = await _mailboxRepository.getMailboxState();
 
       final listResult = await Future.wait(

--- a/lib/features/mailbox/domain/usecases/move_mailbox_interactor.dart
+++ b/lib/features/mailbox/domain/usecases/move_mailbox_interactor.dart
@@ -12,6 +12,8 @@ class MoveMailboxInteractor {
 
   Stream<Either<Failure, Success>> execute(AccountId accountId, MoveMailboxRequest request) async* {
     try {
+      yield Right<Failure, Success>(LoadingMoveMailbox());
+
       final currentMailboxState = await _mailboxRepository.getMailboxState();
       final result = await _mailboxRepository.moveMailbox(accountId, request);
       if (result) {

--- a/lib/features/mailbox/domain/usecases/rename_mailbox_interactor.dart
+++ b/lib/features/mailbox/domain/usecases/rename_mailbox_interactor.dart
@@ -12,6 +12,8 @@ class RenameMailboxInteractor {
 
   Stream<Either<Failure, Success>> execute(AccountId accountId, RenameMailboxRequest request) async* {
     try {
+      yield Right<Failure, Success>(LoadingRenameMailbox());
+
       final currentMailboxState = await _mailboxRepository.getMailboxState();
 
       final result = await _mailboxRepository.renameMailbox(accountId, request);

--- a/lib/features/mailbox/domain/usecases/search_mailbox_interactor.dart
+++ b/lib/features/mailbox/domain/usecases/search_mailbox_interactor.dart
@@ -9,6 +9,8 @@ class SearchMailboxInteractor {
 
   Stream<Either<Failure, Success>> execute(List<PresentationMailbox> mailboxes, SearchQuery searchQuery) async* {
     try {
+      yield Right<Failure, Success>(LoadingSearchMailbox());
+
       final resultList = mailboxes
         .where((mailbox) => mailbox.name?.name.toLowerCase().contains(searchQuery.value.toLowerCase()) == true)
         .toList();

--- a/lib/features/thread/domain/state/mark_as_multiple_email_read_state.dart
+++ b/lib/features/thread/domain/state/mark_as_multiple_email_read_state.dart
@@ -3,6 +3,8 @@ import 'package:model/email/read_actions.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 import 'package:tmail_ui_user/features/base/state/ui_action_state.dart';
 
+class LoadingMarkAsMultipleEmailReadAll extends UIState {}
+
 class MarkAsMultipleEmailReadAllSuccess extends UIActionState {
   final int countMarkAsReadSuccess;
   final ReadActions readActions;

--- a/lib/features/thread/domain/state/mark_as_star_multiple_email_state.dart
+++ b/lib/features/thread/domain/state/mark_as_star_multiple_email_state.dart
@@ -3,6 +3,8 @@ import 'package:model/model.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 import 'package:tmail_ui_user/features/base/state/ui_action_state.dart';
 
+class LoadingMarkAsStarMultipleEmailAll extends UIState {}
+
 class MarkAsStarMultipleEmailAllSuccess extends UIActionState {
   final int countMarkStarSuccess;
   final MarkStarAction markStarAction;

--- a/lib/features/thread/domain/state/move_multiple_email_to_mailbox_state.dart
+++ b/lib/features/thread/domain/state/move_multiple_email_to_mailbox_state.dart
@@ -6,6 +6,8 @@ import 'package:model/email/email_action_type.dart';
 import 'package:tmail_ui_user/features/base/state/ui_action_state.dart';
 import 'package:tmail_ui_user/features/email/domain/model/move_action.dart';
 
+class LoadingMoveMultipleEmailToMailboxAll extends UIState {}
+
 class MoveMultipleEmailToMailboxAllSuccess extends UIActionState {
   final List<EmailId> movedListEmailId;
   final MailboxId currentMailboxId;

--- a/lib/features/thread/domain/usecases/mark_as_multiple_email_read_interactor.dart
+++ b/lib/features/thread/domain/usecases/mark_as_multiple_email_read_interactor.dart
@@ -19,6 +19,8 @@ class MarkAsMultipleEmailReadInteractor {
       ReadActions readAction
   ) async* {
     try {
+      yield Right(LoadingMarkAsMultipleEmailReadAll());
+
       final listState = await Future.wait([
         _mailboxRepository.getMailboxState(),
         _emailRepository.getEmailState(),

--- a/lib/features/thread/domain/usecases/mark_as_star_multiple_email_interactor.dart
+++ b/lib/features/thread/domain/usecases/mark_as_star_multiple_email_interactor.dart
@@ -17,6 +17,8 @@ class MarkAsStarMultipleEmailInteractor {
       MarkStarAction markStarAction
   ) async* {
     try {
+      yield Right(LoadingMarkAsStarMultipleEmailAll());
+
       final currentEmailState = await _emailRepository.getEmailState();
 
       final listEmailNeedMarkStar = emails

--- a/lib/features/thread/domain/usecases/move_multiple_email_to_mailbox_interactor.dart
+++ b/lib/features/thread/domain/usecases/move_multiple_email_to_mailbox_interactor.dart
@@ -16,6 +16,8 @@ class MoveMultipleEmailToMailboxInteractor {
 
   Stream<Either<Failure, Success>> execute(AccountId accountId, MoveToMailboxRequest moveRequest) async* {
     try {
+      yield Right(LoadingMoveMultipleEmailToMailboxAll());
+
       final listState = await Future.wait([
         _mailboxRepository.getMailboxState(),
         _emailRepository.getEmailState(),


### PR DESCRIPTION
### Issues

- [x] Can not refresh change list mailbox and email after take actions with email in succession


https://user-images.githubusercontent.com/80730648/213106567-005e5137-2ee6-446e-a44a-2661ee16fa9b.mov


### Causes

- Since the `ViewState` variable of `Mailbox Dashboard` is the `Obx` variable that received the same value in a short period of time, the `listen` function was not called.

### Resolved


https://user-images.githubusercontent.com/80730648/213106935-8177ea21-1847-4ef3-b2d3-2d62913e1c7f.mov

