### PR TITLE
TF-1323 Fix can not attach image on mobile and web

### DIFF
--- a/lib/features/composer/data/repository/composer_repository_impl.dart
+++ b/lib/features/composer/data/repository/composer_repository_impl.dart
@@ -16,7 +16,7 @@ class ComposerRepositoryImpl extends ComposerRepository {
     this._composerDataSource);
 
   @override
-  UploadAttachment uploadAttachment(FileInfo fileInfo, Uri uploadUri, {CancelToken? cancelToken}) {
+  Future<UploadAttachment> uploadAttachment(FileInfo fileInfo, Uri uploadUri, {CancelToken? cancelToken}) {
     return _attachmentUploadDataSource.uploadAttachment(fileInfo, uploadUri, cancelToken: cancelToken);
   }
 

--- a/lib/features/composer/domain/repository/composer_repository.dart
+++ b/lib/features/composer/domain/repository/composer_repository.dart
@@ -1,9 +1,9 @@
 import 'package:dio/dio.dart';
-import 'package:model/model.dart';
+import 'package:model/upload/file_info.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_attachment.dart';
 
 abstract class ComposerRepository {
-  UploadAttachment uploadAttachment(FileInfo fileInfo, Uri uploadUri, {CancelToken? cancelToken});
+  Future<UploadAttachment> uploadAttachment(FileInfo fileInfo, Uri uploadUri, {CancelToken? cancelToken});
 
   Future<String?> downloadImageAsBase64(String url, String cid, FileInfo fileInfo, {double? maxWidth, bool? compress});
 }

--- a/lib/features/composer/domain/state/upload_attachment_state.dart
+++ b/lib/features/composer/domain/state/upload_attachment_state.dart
@@ -1,0 +1,25 @@
+
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:tmail_ui_user/features/upload/domain/model/upload_attachment.dart';
+
+class UploadAttachmentSuccess extends UIState {
+
+  final UploadAttachment uploadAttachment;
+  final bool isInline;
+
+  UploadAttachmentSuccess(this.uploadAttachment, {this.isInline = false});
+
+  @override
+  List<Object?> get props => [uploadAttachment, isInline];
+}
+
+class UploadAttachmentFailure extends FeatureFailure {
+  final dynamic exception;
+  final bool isInline;
+
+  UploadAttachmentFailure(this.exception, {this.isInline = false});
+
+  @override
+  List<Object> get props => [exception, isInline];
+}

--- a/lib/features/composer/domain/usecases/upload_attachment_interactor.dart
+++ b/lib/features/composer/domain/usecases/upload_attachment_interactor.dart
@@ -1,14 +1,31 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
 import 'package:dio/dio.dart';
-import 'package:model/model.dart';
+import 'package:model/upload/file_info.dart';
 import 'package:tmail_ui_user/features/composer/domain/repository/composer_repository.dart';
-import 'package:tmail_ui_user/features/upload/domain/model/upload_attachment.dart';
+import 'package:tmail_ui_user/features/composer/domain/state/upload_attachment_state.dart';
 
 class UploadAttachmentInteractor {
   final ComposerRepository _composerRepository;
 
   UploadAttachmentInteractor(this._composerRepository);
 
-  UploadAttachment execute(FileInfo fileInfo, Uri uploadUri, {CancelToken? cancelToken}) {
-    return _composerRepository.uploadAttachment(fileInfo, uploadUri, cancelToken: cancelToken);
+  Stream<Either<Failure, Success>> execute(
+    FileInfo fileInfo,
+    Uri uploadUri, {
+    CancelToken? cancelToken,
+    bool isInline = false
+  }) async* {
+    try {
+      final uploadAttachment = await _composerRepository.uploadAttachment(
+        fileInfo,
+        uploadUri,
+        cancelToken: cancelToken
+      );
+      yield Right<Failure, Success>(UploadAttachmentSuccess(uploadAttachment, isInline: isInline));
+    } catch (e) {
+      yield Left<Failure, Success>(UploadAttachmentFailure(e, isInline: isInline));
+    }
   }
 }

--- a/lib/features/composer/presentation/composer_bindings.dart
+++ b/lib/features/composer/presentation/composer_bindings.dart
@@ -51,6 +51,7 @@ import 'package:tmail_ui_user/features/upload/presentation/controller/upload_con
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
 import 'package:tmail_ui_user/main/exceptions/cache_exception_thrower.dart';
 import 'package:tmail_ui_user/main/exceptions/remote_exception_thrower.dart';
+import 'package:uuid/uuid.dart';
 import 'package:worker_manager/worker_manager.dart';
 
 class ComposerBindings extends BaseBindings {
@@ -67,7 +68,11 @@ class ComposerBindings extends BaseBindings {
 
   @override
   void bindingsDataSourceImpl() {
-    Get.lazyPut(() => AttachmentUploadDataSourceImpl(Get.find<FileUploader>()));
+    Get.lazyPut(() => AttachmentUploadDataSourceImpl(
+      Get.find<FileUploader>(),
+      Get.find<Uuid>(),
+      Get.find<RemoteExceptionThrower>()
+    ));
     Get.lazyPut(() => ComposerDataSourceImpl(Get.find<DownloadClient>(), Get.find<RemoteExceptionThrower>()));
     Get.lazyPut(() => ContactDataSourceImpl(Get.find<CacheExceptionThrower>()));
     Get.lazyPut(() => MailboxDataSourceImpl(

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1445,7 +1445,7 @@ class ComposerController extends BaseController {
       final accountId = mailboxDashBoardController.accountId.value;
       if (session != null && accountId != null) {
         final uploadUri = session.getUploadUri(accountId);
-        uploadController.uploadInlineImage(pickedFile, uploadUri);
+        uploadController.uploadFileAction(pickedFile, uploadUri, isInline: true);
       }
     } else {
       if (currentContext != null) {

--- a/lib/features/upload/data/datasource/attachment_upload_datasource.dart
+++ b/lib/features/upload/data/datasource/attachment_upload_datasource.dart
@@ -4,5 +4,5 @@ import 'package:model/upload/file_info.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_attachment.dart';
 
 abstract class AttachmentUploadDataSource {
-  UploadAttachment uploadAttachment(FileInfo fileInfo, Uri uploadUri, {CancelToken? cancelToken});
+  Future<UploadAttachment> uploadAttachment(FileInfo fileInfo, Uri uploadUri, {CancelToken? cancelToken});
 }

--- a/lib/features/upload/data/datasource_impl/attachment_upload_datasource_impl.dart
+++ b/lib/features/upload/data/datasource_impl/attachment_upload_datasource_impl.dart
@@ -5,29 +5,29 @@ import 'package:tmail_ui_user/features/upload/data/datasource/attachment_upload_
 import 'package:tmail_ui_user/features/upload/data/network/file_uploader.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_attachment.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
+import 'package:tmail_ui_user/main/exceptions/exception_thrower.dart';
 import 'package:uuid/uuid.dart';
 
 class AttachmentUploadDataSourceImpl extends AttachmentUploadDataSource {
 
   final FileUploader _fileUploader;
+  final Uuid _uuid;
+  final ExceptionThrower _exceptionThrower;
 
-  AttachmentUploadDataSourceImpl(this._fileUploader);
+  AttachmentUploadDataSourceImpl(this._fileUploader, this._uuid, this._exceptionThrower);
 
   @override
-  UploadAttachment uploadAttachment(FileInfo fileInfo, Uri uploadUri, {CancelToken? cancelToken}) {
-    final attachmentUploadId = _generateAttachmentUploadId();
-    final uploadAttachment = UploadAttachment(
-          attachmentUploadId,
-          fileInfo,
-          uploadUri,
-          _fileUploader,
-          cancelToken: cancelToken)
-      ..upload();
-
-    return uploadAttachment;
-  }
-
-  UploadTaskId _generateAttachmentUploadId() {
-    return UploadTaskId(const Uuid().v4());
+  Future<UploadAttachment> uploadAttachment(FileInfo fileInfo, Uri uploadUri, {CancelToken? cancelToken}) {
+    return Future.sync(() {
+      return UploadAttachment(
+        UploadTaskId(_uuid.v4()),
+        fileInfo,
+        uploadUri,
+        _fileUploader,
+        cancelToken: cancelToken
+      )..upload();
+    }).catchError((error) {
+      _exceptionThrower.throwException(error);
+    });
   }
 }

--- a/lib/features/upload/data/network/file_uploader.dart
+++ b/lib/features/upload/data/network/file_uploader.dart
@@ -3,13 +3,18 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:core/core.dart';
+import 'package:core/data/network/dio_client.dart';
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:core/utils/app_logger.dart';
+import 'package:core/utils/build_utils.dart';
 import 'package:dartz/dartz.dart';
 import 'package:dio/dio.dart';
 import 'package:model/email/attachment.dart';
 import 'package:model/upload/file_info.dart';
 import 'package:model/upload/upload_response.dart';
 import 'package:tmail_ui_user/features/upload/data/model/upload_file_arguments.dart';
+import 'package:tmail_ui_user/features/upload/domain/exceptions/upload_exception.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
 import 'package:tmail_ui_user/features/upload/domain/state/attachment_upload_state.dart';
 import 'package:worker_manager/worker_manager.dart' as worker;
@@ -36,21 +41,24 @@ class FileUploader {
           uploadUri,
           cancelToken: cancelToken);
     } else {
-      final attachmentUploaded = await _isolateExecutor.execute(
-          arg1: UploadFileArguments(
-              _dioClient,
-              uploadId,
-              fileInfo,
-              uploadUri,
-              cancelToken: cancelToken),
-          fun1: _handleUploadAttachmentAction,
-          notification: (value) {
-            if (value is Success) {
-              log('FileUploader::uploadAttachment(): onUpdateProgress: $value');
-              onSendController.add(Right(value));
-            }
-          });
-      return attachmentUploaded;
+      return await _isolateExecutor.execute(
+        arg1: UploadFileArguments(
+          _dioClient,
+          uploadId,
+          fileInfo,
+          uploadUri,
+          cancelToken: cancelToken
+        ),
+        fun1: _handleUploadAttachmentAction,
+        notification: (value) {
+          if (value is Success) {
+            log('FileUploader::uploadAttachment(): onUpdateProgress: $value');
+            onSendController.add(Right(value));
+          }
+        }
+      )
+      .then((value) => value)
+      .catchError((error) => throw error);
     }
   }
 
@@ -58,80 +66,107 @@ class FileUploader {
       UploadFileArguments argsUpload,
       worker.TypeSendPort sendPort
   ) async {
-    try {
-      final dioClient = argsUpload.dioClient;
-      final fileInfo = argsUpload.fileInfo;
-      final uploadUri = argsUpload.uploadUri;
-      final cancelToken = argsUpload.cancelToken;
+    final dioClient = argsUpload.dioClient;
+    final fileInfo = argsUpload.fileInfo;
+    final uploadUri = argsUpload.uploadUri;
+    final cancelToken = argsUpload.cancelToken;
 
-      final headerParam = dioClient.getHeaders();
-      headerParam[HttpHeaders.contentTypeHeader] = fileInfo.mimeType;
-      headerParam[HttpHeaders.contentLengthHeader] = fileInfo.fileSize;
-
-      final resultJson = await argsUpload.dioClient.post(
-          Uri.decodeFull(uploadUri.toString()),
-          options: Options(headers: headerParam),
-          data: fileInfo.readStream ?? File(fileInfo.filePath).openRead(),
-          cancelToken: cancelToken,
-          onSendProgress: (progress, total) {
-            log('FileUploader::_handleUploadAttachmentAction():onSendProgress: [${argsUpload.uploadId.id}] = $progress');
-            sendPort.send(UploadingAttachmentUploadState(
-                argsUpload.uploadId,
-                progress,
-                fileInfo.fileSize));
-          });
-
-      if (cancelToken?.isCancelled == true) {
-        log('FileUploader::_handleUploadAttachmentAction(): cancelToken');
-        return null;
+    final resultJson = await _invokeRequestToServer(
+      dioClient,
+      uploadUri,
+      fileInfo,
+      cancelToken: cancelToken,
+      onSendProgress: (count, total) {
+        log('FileUploader::_handleUploadAttachmentAction():onSendProgress: [${argsUpload.uploadId.id}] = $count');
+        sendPort.send(
+          UploadingAttachmentUploadState(
+            argsUpload.uploadId,
+            count,
+            fileInfo.fileSize
+          )
+        );
       }
-
-      final decodeJson = resultJson is Map ? resultJson : jsonDecode(resultJson);
-      final uploadResponse = UploadResponse.fromJson(decodeJson);
-      log('FileUploader::_handleUploadAttachmentAction(): ${uploadResponse.toString()}');
-      return uploadResponse.toAttachment(fileInfo.fileName);
-    } catch (e) {
-      log('FileUploader::_handleUploadAttachmentAction(): ERROR: $e');
+    );
+    log('FileUploader::_handleUploadAttachmentAction():resultJson: $resultJson');
+    if (cancelToken?.isCancelled == true) {
+      log('FileUploader::_handleUploadAttachmentAction(): upload is cancelled');
       return null;
     }
+
+    return _parsingResponse(resultJson: resultJson, fileName: fileInfo.fileName);
   }
 
   Future<Attachment?> _handleUploadAttachmentActionOnWeb(
-      UploadTaskId uploadId,
-      StreamController<Either<Failure, Success>> onSendController,
-      FileInfo fileInfo,
-      Uri uploadUri,
-      {CancelToken? cancelToken}
+    UploadTaskId uploadId,
+    StreamController<Either<Failure, Success>> onSendController,
+    FileInfo fileInfo,
+    Uri uploadUri,
+    {CancelToken? cancelToken}
   ) async {
-    try {
-      final headerParam = _dioClient.getHeaders();
-      headerParam[HttpHeaders.contentTypeHeader] = fileInfo.mimeType;
-      headerParam[HttpHeaders.contentLengthHeader] = fileInfo.fileSize;
-
-      final resultJson = await _dioClient.post(
-          Uri.decodeFull(uploadUri.toString()),
-          options: Options(headers: headerParam),
-          data: fileInfo.readStream,
-          cancelToken: cancelToken,
-          onSendProgress: (progress, total) {
-            log('FileUploader::_handleUploadAttachmentActionOnWeb():onSendProgress: [$uploadId] = $progress');
-            onSendController.add(Right(UploadingAttachmentUploadState(
-                uploadId, progress, fileInfo.fileSize)));
-          }
-      );
-
-      if (cancelToken?.isCancelled == true) {
-        log('FileUploader::_handleUploadAttachmentAction(): cancelToken');
-        return null;
+    final resultJson = await _invokeRequestToServer(
+      _dioClient,
+      uploadUri,
+      fileInfo,
+      cancelToken: cancelToken,
+      onSendProgress: (count, total) {
+        log('FileUploader::_handleUploadAttachmentActionOnWeb():onSendProgress: [${uploadId.id}] = $count');
+        onSendController.add(
+          Right(UploadingAttachmentUploadState(
+            uploadId,
+            count,
+            fileInfo.fileSize
+          ))
+        );
       }
+    );
 
+    log('FileUploader::_handleUploadAttachmentActionOnWeb():resultJson: $resultJson');
+
+    if (cancelToken?.isCancelled == true) {
+      log('FileUploader::_handleUploadAttachmentActionOnWeb(): upload is cancelled');
+      return null;
+    }
+
+    return _parsingResponse(resultJson: resultJson, fileName: fileInfo.fileName);
+  }
+
+  static Future<dynamic> _invokeRequestToServer(
+    DioClient dioClient,
+    Uri uploadUri,
+    FileInfo fileInfo, {
+    CancelToken? cancelToken,
+    ProgressCallback? onSendProgress
+  }) {
+    final headerParam = dioClient.getHeaders();
+    headerParam[HttpHeaders.contentTypeHeader] = fileInfo.mimeType;
+    headerParam[HttpHeaders.contentLengthHeader] = fileInfo.fileSize;
+
+    final data = fileInfo.readStream ?? File(fileInfo.filePath).openRead();
+
+    if (cancelToken?.isCancelled == true) {
+      log('FileUploader::_invokeRequestToServer(): upload is cancelled');
+      return Future.value();
+    }
+
+    return dioClient.post(
+      Uri.decodeFull(uploadUri.toString()),
+      options: Options(headers: headerParam),
+      data: data,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress
+    );
+  }
+
+  static Attachment? _parsingResponse({dynamic resultJson, required String fileName}) {
+    log('FileUploader::_parsingResponse():resultJson: $resultJson');
+    if (resultJson != null) {
       final decodeJson = resultJson is Map ? resultJson : jsonDecode(resultJson);
       final uploadResponse = UploadResponse.fromJson(decodeJson);
-      log('FileUploader::_handleUploadAttachmentActionOnWeb(): ${uploadResponse.toString()}');
-      return uploadResponse.toAttachment(fileInfo.fileName);
-    } catch (e) {
-      log('FileUploader::_handleUploadAttachmentActionOnWeb(): $e');
-      return null;
+      log('FileUploader::_parsingResponse():uploadResponse: ${uploadResponse.toString()}');
+      return uploadResponse.toAttachment(fileName);
+    } else {
+      logError('FileUploader::_parsingResponse(): DataResponseIsNullException');
+      throw DataResponseIsNullException();
     }
   }
 }

--- a/lib/features/upload/domain/exceptions/upload_exception.dart
+++ b/lib/features/upload/domain/exceptions/upload_exception.dart
@@ -1,0 +1,1 @@
+class DataResponseIsNullException implements Exception {}

--- a/lib/features/upload/presentation/extensions/upload_attachment_extension.dart
+++ b/lib/features/upload/presentation/extensions/upload_attachment_extension.dart
@@ -1,0 +1,14 @@
+
+import 'package:tmail_ui_user/features/upload/domain/model/upload_attachment.dart';
+import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_state.dart';
+
+extension UploadAttachmentExtension on UploadAttachment {
+
+  UploadFileState toUploadFileState() {
+    return UploadFileState(
+      uploadTaskId,
+      file: fileInfo,
+      cancelToken: cancelToken
+    );
+  }
+}

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2023-02-03T11:24:09.273116",
+  "@@last_modified": "2023-02-03T16:28:53.514637",
   "initializing_data": "Initializing data...",
   "@initializing_data": {
     "type": "text",
@@ -2676,6 +2676,12 @@
   },
   "saveEmailAsDraftFailureWithSetErrorTypeOverQuota": "Failure to save your message as drafts, because it is over quota.",
   "@saveEmailAsDraftFailureWithSetErrorTypeOverQuota": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "thisImageCannotBeAdded": "This image cannot be added.",
+  "@thisImageCannotBeAdded": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -2754,7 +2754,7 @@ class AppLocalizations {
       name: 'saveEmailAsDraftFailureWithSetErrorTypeOverQuota',
     );
   }
-  
+
   String get mailBoxes {
     return Intl.message(
       'Mailboxes',
@@ -2771,5 +2771,12 @@ class AppLocalizations {
     return Intl.message(
       'Hide mailbox',
       name: 'hideMailBoxes');
+  }
+
+  String get thisImageCannotBeAdded {
+    return Intl.message(
+      'This image cannot be added.',
+      name: 'thisImageCannotBeAdded'
+    );
   }
 }

--- a/lib/main/routes/route_utils.dart
+++ b/lib/main/routes/route_utils.dart
@@ -1,8 +1,8 @@
 
-import 'package:core/core.dart';
 import 'package:core/data/model/query/query_parameter.dart';
 import 'package:core/data/network/config/service_path.dart';
 import 'package:core/utils/app_logger.dart';
+import 'package:core/utils/build_utils.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';


### PR DESCRIPTION
#1323 

### Root causes

- Because server `preprod` returned error `500 Internal Server Error`

<img width="1067" alt="Screenshot 2023-02-02 at 15 38 55" src="https://user-images.githubusercontent.com/80730648/216313906-e41ace01-50d9-4274-b086-fdb42b1a34a0.png">

- Works well on `prod` . server

### Resolved

- `Try/catch` the error and show toast error message on the screen 
- Log the error in `debug` mode
