### PR TITLE
TF-1278 Hide notification on background web browser when support FCM

### DIFF
--- a/web/firebase-messaging-sw.js
+++ b/web/firebase-messaging-sw.js
@@ -11,3 +11,9 @@ firebase.initializeApp({
     appId: "...",
 });
 const messaging = firebase.messaging();
+
+messaging.setBackgroundMessageHandler(function(payload) {
+    console.log('[firebase-messaging-sw.js] Received background message ', payload);
+    self.registration.hideNotification();
+    return null;
+});


### PR DESCRIPTION
#1278 

### Root causes

- The browser always automatically shows the default notification every time it receives a message from `push notification` in the `background/terminated` state. If we don't customize it.


### Solution

- Hide notification in `setBackgroundMessageHandler` method

### Backlog problem 

- Not reproduced. More research is needed.