### PR TITLE
Fix search and auto-complete don't input the final email

### DIFF
--- a/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/text_field_auto_complete_email_adress.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/text_field_auto_complete_email_adress.dart
@@ -106,7 +106,7 @@ class _TextFieldAutoCompleteEmailAddressState
         return widget.optionsBuilder.call(textEditingValue.text.toLowerCase());
       },
       onSelected: (EmailAddress selectedTag) {
-        _controller.addTag = selectedTag.asString();
+        _controller.addTag = selectedTag.emailAddress;
       },
       fieldViewBuilder: (context, ttec, tfn, onFieldSubmitted) {
         return TextFieldTags(

--- a/lib/features/manage_account/presentation/mailbox_visibility/mailbox_visibility_view.dart
+++ b/lib/features/manage_account/presentation/mailbox_visibility/mailbox_visibility_view.dart
@@ -1,4 +1,3 @@
-import 'package:core/core.dart';
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/state/success.dart';


### PR DESCRIPTION
Fix search and auto-complete don't input the final email

Issue :
GIVEN I type the name 
AND select the email address suggestion
WHEN I launch the search and sent it as text, not an email address
THEN there is no result

Solution :
- After choosing an email address, the suggestion should be sent to the email address
Demo 

https://user-images.githubusercontent.com/99852347/218955251-1cc6eccc-7872-4f78-ab5e-9242fad0f484.mov

