### PR TITLE
Fix a git issue between root and flutter during the docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ENV PATH "$PATH:$FLUTTER_HOME/bin"
 # Prerequisites
 RUN apt update && apt install -y curl git unzip xz-utils zip gzip libglu1-mesa \
  && mkdir -p $FLUTTER_HOME \
+ && git config --global --add safe.directory /opt/flutter \
  && curl -o flutter.tar.xz $FLUTTER_URL \
  && tar xf flutter.tar.xz -C /opt \
  && rm flutter.tar.xz \


### PR DESCRIPTION
https://stackoverflow.com/questions/72978485/git-submodule-update-failed-with-fatal-detected-dubious-ownership-in-repositor

https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory

Some issue with git now... My guess is when executing `flutter doctor`, it does a git command to check newer versions of flutter... somehow the user that owns the directory and the one doing the git are different, thus it fails (I would think it's both root but there might be some flutter schenanigans going on that I'm not aware about)

Adding this as a safe directory for git allows us to bypass this check. It's safe I think as we use this on the pre-stage build that is just there to build tmail-flutter webapp before being trashed away on the final image (we only keep the compiled result of the flutter build that we copy into the nginx image)