### PR TITLE
Hot fix cannot expand default mailbox

### DIFF
--- a/lib/features/base/base_mailbox_controller.dart
+++ b/lib/features/base/base_mailbox_controller.dart
@@ -99,7 +99,7 @@ abstract class BaseMailboxController extends BaseController {
     teamMailboxesTree.value = tupleTree.value3;
   }
 
-  void toggleMailboxFolder(MailboxNode selectedMailboxNode,ScrollController scrollController) {
+  void toggleMailboxFolder(MailboxNode selectedMailboxNode, ScrollController scrollController) {
     final newExpandMode = selectedMailboxNode.expandMode == ExpandMode.COLLAPSE
         ? ExpandMode.EXPAND
         : ExpandMode.COLLAPSE;

--- a/lib/features/base/base_mailbox_controller.dart
+++ b/lib/features/base/base_mailbox_controller.dart
@@ -99,7 +99,7 @@ abstract class BaseMailboxController extends BaseController {
     teamMailboxesTree.value = tupleTree.value3;
   }
 
-  void toggleMailboxFolder(MailboxNode selectedMailboxNode) {
+  void toggleMailboxFolder(MailboxNode selectedMailboxNode,ScrollController scrollController) {
     final newExpandMode = selectedMailboxNode.expandMode == ExpandMode.COLLAPSE
         ? ExpandMode.EXPAND
         : ExpandMode.COLLAPSE;
@@ -112,11 +112,45 @@ abstract class BaseMailboxController extends BaseController {
     if (personalMailboxTree.value.updateExpandedNode(selectedMailboxNode, newExpandMode) != null) {
       log('toggleMailboxFolder() refresh folderMailboxTree');
       personalMailboxTree.refresh();
+      final _childrenItems = personalMailboxTree.value.root.childrenItems ?? [];
+      _triggerScrollWhenExpandMailboxFolder(
+        _childrenItems,
+        selectedMailboxNode,
+        scrollController);
     }
 
     if (teamMailboxesTree.value.updateExpandedNode(selectedMailboxNode, newExpandMode) != null) {
       log('toggleMailboxFolder() refresh teamMailboxesTree');
       teamMailboxesTree.refresh();
+      final _childrenItems = teamMailboxesTree.value.root.childrenItems ?? [];
+      _triggerScrollWhenExpandMailboxFolder(
+          _childrenItems,
+          selectedMailboxNode,
+          scrollController);
+    }
+  }
+
+  void _triggerScrollWhenExpandMailboxFolder(
+      List<MailboxNode> childrenItems,
+      MailboxNode selectedMailboxNode,
+      ScrollController scrollController) async {
+    await Future.delayed(const Duration(milliseconds: 200));
+    final _lastItem = childrenItems.last;
+
+    if (selectedMailboxNode.expandMode == ExpandMode.COLLAPSE) {
+      return;
+    }
+
+    if (_lastItem.mailboxNameAsString.contains(selectedMailboxNode.mailboxNameAsString)) {
+      scrollController.animateTo(
+          scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeInToLinear);
+    } else {
+      scrollController.animateTo(
+          scrollController.offset + 100,
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeInToLinear);
     }
   }
 

--- a/lib/features/destination_picker/presentation/destination_picker_controller.dart
+++ b/lib/features/destination_picker/presentation/destination_picker_controller.dart
@@ -16,8 +16,6 @@ import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
-import 'package:model/mailbox/expand_mode.dart';
-import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:model/model.dart';
 import 'package:tmail_ui_user/features/base/base_mailbox_controller.dart';
 import 'package:tmail_ui_user/features/destination_picker/presentation/model/destination_picker_arguments.dart';
@@ -79,6 +77,8 @@ class DestinationPickerController extends BaseMailboxController {
   VoidCallback? onDismissDestinationPicker;
 
   List<String> listMailboxNameAsStringExist = <String>[];
+
+  final destinationListScrollController = ScrollController();
 
   DestinationPickerController(
     this._searchMailboxInteractor,

--- a/lib/features/destination_picker/presentation/destination_picker_controller.dart
+++ b/lib/features/destination_picker/presentation/destination_picker_controller.dart
@@ -159,6 +159,7 @@ class DestinationPickerController extends BaseMailboxController {
   @override
   void onClose() {
     _disposeWidget();
+    destinationListScrollController.dispose();
     super.onClose();
   }
 

--- a/lib/features/destination_picker/presentation/destination_picker_view.dart
+++ b/lib/features/destination_picker/presentation/destination_picker_view.dart
@@ -207,6 +207,7 @@ class DestinationPickerView extends GetWidget<DestinationPickerController>
   ) {
     return SingleChildScrollView(
         physics: const ClampingScrollPhysics(),
+        controller: controller.destinationListScrollController,
         child: Column(children: [
           if (actions?.canSearch() == true &&
             controller.destinationScreenType.value == DestinationScreenType.destinationPicker)
@@ -378,7 +379,8 @@ class DestinationPickerView extends GetWidget<DestinationPickerController>
                     mailboxIdAlreadySelected: mailboxIdSelected,
                     mailboxDisplayed: MailboxDisplayed.destinationPicker)
                 ..addOnClickOpenMailboxNodeAction((node) => _pickMailboxNode(context, node))
-                ..addOnClickExpandMailboxNodeAction((mailboxNode) => controller.toggleMailboxFolder(mailboxNode))
+                ..addOnClickExpandMailboxNodeAction((mailboxNode) =>
+                  controller.toggleMailboxFolder(mailboxNode, controller.destinationListScrollController))
               ).build(),
             children: _buildListChildTileWidget(
                 context,

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -196,6 +196,11 @@ class MailboxController extends BaseMailboxController with MailboxActionHandlerM
         ? ExpandMode.EXPAND
         : ExpandMode.COLLAPSE;
 
+    if (defaultMailboxTree.value.updateExpandedNode(selectedMailboxNode, newExpandMode) != null) {
+      log('toggleMailboxFolder() refresh defaultMailboxTree');
+      defaultMailboxTree.refresh();
+    }
+
     if (personalMailboxTree.value.updateExpandedNode(selectedMailboxNode, newExpandMode) != null) {
       log('toggleMailboxFolder() refresh folderMailboxTree');
       personalMailboxTree.refresh();

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -190,55 +190,6 @@ class MailboxController extends BaseMailboxController with MailboxActionHandlerM
     );
   }
 
-  @override
-  Future<void> toggleMailboxFolder(MailboxNode selectedMailboxNode) async {
-    final newExpandMode = selectedMailboxNode.expandMode == ExpandMode.COLLAPSE
-        ? ExpandMode.EXPAND
-        : ExpandMode.COLLAPSE;
-
-    if (defaultMailboxTree.value.updateExpandedNode(selectedMailboxNode, newExpandMode) != null) {
-      log('toggleMailboxFolder() refresh defaultMailboxTree');
-      defaultMailboxTree.refresh();
-      final _childrenItems = defaultMailboxTree.value.root.childrenItems ?? [];
-      _triggerScrollWhenExpandMailboxFolder(_childrenItems, selectedMailboxNode);
-    }
-
-    if (personalMailboxTree.value.updateExpandedNode(selectedMailboxNode, newExpandMode) != null) {
-      log('toggleMailboxFolder() refresh folderMailboxTree');
-      personalMailboxTree.refresh();
-      final _childrenItems = personalMailboxTree.value.root.childrenItems ?? [];
-      _triggerScrollWhenExpandMailboxFolder(_childrenItems, selectedMailboxNode);
-    }
-
-    if (teamMailboxesTree.value.updateExpandedNode(selectedMailboxNode, newExpandMode) != null) {
-      log('toggleMailboxFolder() refresh teamMailboxesTree');
-      teamMailboxesTree.refresh();
-      final _childrenItems = teamMailboxesTree.value.root.childrenItems ?? [];
-      _triggerScrollWhenExpandMailboxFolder(_childrenItems, selectedMailboxNode);
-    }
-  }
-
-  void _triggerScrollWhenExpandMailboxFolder(List<MailboxNode> childrenItems, MailboxNode selectedMailboxNode) async {
-    await Future.delayed(const Duration(milliseconds: 200));
-    final _lastItem = childrenItems.last;
-
-    if (selectedMailboxNode.expandMode == ExpandMode.COLLAPSE) {
-      return;
-    }
-
-    if (_lastItem.mailboxNameAsString.contains(selectedMailboxNode.mailboxNameAsString)) {
-      mailboxListScrollController.animateTo(
-        mailboxListScrollController.position.maxScrollExtent,
-        duration: const Duration(milliseconds: 200),
-        curve: Curves.easeInToLinear);
-    } else {
-      mailboxListScrollController.animateTo(
-        mailboxListScrollController.offset + 100,
-        duration: const Duration(milliseconds: 200),
-        curve: Curves.easeInToLinear);
-    }
-  }
-
   void handleScrollEnable() {
     isMailboxListScrollable.value = mailboxListScrollController.hasClients && mailboxListScrollController.position.maxScrollExtent > 0;
   }

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -199,6 +199,8 @@ class MailboxController extends BaseMailboxController with MailboxActionHandlerM
     if (defaultMailboxTree.value.updateExpandedNode(selectedMailboxNode, newExpandMode) != null) {
       log('toggleMailboxFolder() refresh defaultMailboxTree');
       defaultMailboxTree.refresh();
+      final _childrenItems = defaultMailboxTree.value.root.childrenItems ?? [];
+      _triggerScrollWhenExpandMailboxFolder(_childrenItems, selectedMailboxNode);
     }
 
     if (personalMailboxTree.value.updateExpandedNode(selectedMailboxNode, newExpandMode) != null) {

--- a/lib/features/mailbox/presentation/mailbox_view.dart
+++ b/lib/features/mailbox/presentation/mailbox_view.dart
@@ -345,7 +345,8 @@ class MailboxView extends GetWidget<MailboxController>
                   );
                 })
                 ..addOnClickOpenMailboxNodeAction((mailboxNode) => controller.openMailbox(context, mailboxNode.item))
-                ..addOnClickExpandMailboxNodeAction((mailboxNode) => controller.toggleMailboxFolder(mailboxNode))
+                ..addOnClickExpandMailboxNodeAction((mailboxNode) =>
+                  controller.toggleMailboxFolder(mailboxNode, controller.mailboxListScrollController))
                 ..addOnSelectMailboxNodeAction((mailboxNode) => controller.selectMailboxNode(mailboxNode))
               ).build()),
               children: _buildListChildTileWidget(context, mailboxNode)

--- a/lib/features/mailbox/presentation/mailbox_view_web.dart
+++ b/lib/features/mailbox/presentation/mailbox_view_web.dart
@@ -299,7 +299,8 @@ class MailboxView extends GetWidget<MailboxController>
                 lastNode: lastNode,
                 mailboxNodeSelected: controller.mailboxDashBoardController.selectedMailbox.value)
             ..addOnClickOpenMailboxNodeAction((mailboxNode) => controller.openMailbox(context, mailboxNode.item))
-            ..addOnClickExpandMailboxNodeAction((mailboxNode) => controller.toggleMailboxFolder(mailboxNode))
+            ..addOnClickExpandMailboxNodeAction((mailboxNode) =>
+              controller.toggleMailboxFolder(mailboxNode, controller.mailboxListScrollController))
             ..addOnClickOpenMenuMailboxNodeAction((position, mailboxNode) {
               openMailboxMenuActionOnWeb(
                 context,

--- a/lib/features/manage_account/presentation/mailbox_visibility/mailbox_visibility_view.dart
+++ b/lib/features/manage_account/presentation/mailbox_visibility/mailbox_visibility_view.dart
@@ -141,14 +141,18 @@ class MailboxVisibilityView extends GetWidget<MailboxVisibilityController>
             parent: MailBoxVisibilityFolderTileBuilder(
               _imagePaths,
               mailboxNode,
-              onClickExpandMailboxNodeAction: controller.toggleMailboxFolder,
+              onClickExpandMailboxNodeAction: (mailboxNode) {
+                controller.toggleMailboxFolder(mailboxNode, controller.mailboxListScrollController);
+              },
               onClickSubscribeMailboxAction: controller.subscribeMailbox
             ),
             children: _buildListChildTileWidget(context, mailboxNode)).build()
         : MailBoxVisibilityFolderTileBuilder(
             _imagePaths,
             mailboxNode,
-            onClickExpandMailboxNodeAction: controller.toggleMailboxFolder,
+            onClickExpandMailboxNodeAction: (mailboxNode) {
+              controller.toggleMailboxFolder(mailboxNode, controller.mailboxListScrollController);
+            },
             onClickSubscribeMailboxAction: controller.subscribeMailbox
           ))
       .toList() ?? <Widget>[];


### PR DESCRIPTION
Fixed cannot expand default mailbox

`Mobile`

https://user-images.githubusercontent.com/99852347/221460248-a6cf79bf-5321-4e40-a165-447febdcd002.mp4

`Web`

https://user-images.githubusercontent.com/99852347/221457630-280d0d55-a7a6-4741-9e89-899b487ef24d.mov

Support for auto scroll when expand folder on `Destination Picker` and `Mailbox visibility`

`Mobile`

https://user-images.githubusercontent.com/99852347/221498543-fc79853b-a62f-49ac-b814-28907c827a51.mp4

`Web`

https://user-images.githubusercontent.com/99852347/221498607-35c1772f-5d58-4a95-a0e3-6017c2518d34.mov


