### PR TITLE
TF-1469 Fix [Reply/Responding] Reply screen is display not smoothly, it's lagging

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,7 +59,7 @@ class TMailApp extends StatelessWidget {
         }
       },
       unknownRoute: AppPages.unknownRoutePage,
-      defaultTransition: Transition.fade,
+      defaultTransition: Transition.noTransition,
       initialRoute: AppRoutes.home,
       getPages: AppPages.pages);
   }


### PR DESCRIPTION
### Issues

#1469 

### Root causes

- Due to default `animation` transition when navigate to page.

### Resolved

- `Android`


https://user-images.githubusercontent.com/80730648/223356340-f128c9e9-7699-4000-9930-a7856a01e054.mov


- `iOS`


https://user-images.githubusercontent.com/80730648/223356685-074108a0-04ee-4977-ba21-21ceb8b98ee2.mp4

