### PR TITLE
TF1528: Auto down one line when typing

### DIFF
--- a/lib/features/composer/presentation/composer_view_web.dart
+++ b/lib/features/composer/presentation/composer_view_web.dart
@@ -792,7 +792,6 @@ class ComposerView extends GetWidget<ComposerController>
             otherOptions: const OtherOptions(height: 550),
             callbacks: Callbacks(onBeforeCommand: (currentHtml) {
               log('ComposerView::_buildHtmlEditor(): onBeforeCommand : $currentHtml');
-              controller.richTextWebController.setFullScreenEditor();
               controller.setTextEditorWeb(currentHtml);
             }, onChangeContent: (changed) {
               log('ComposerView::_buildHtmlEditor(): onChangeContent : $changed');
@@ -800,7 +799,6 @@ class ComposerView extends GetWidget<ComposerController>
             }, onInit: () {
               log('ComposerView::_buildHtmlEditor(): onInit');
               controller.setTextEditorWeb(initContent);
-              controller.richTextWebController.setFullScreenEditor();
               controller.richTextWebController.setEnableCodeView();
             }, onFocus: () {
               log('ComposerView::_buildHtmlEditor(): onFocus');

--- a/lib/features/composer/presentation/composer_view_web.dart
+++ b/lib/features/composer/presentation/composer_view_web.dart
@@ -781,6 +781,7 @@ class ComposerView extends GetWidget<ComposerController>
             key: const Key('composer_editor_web'),
             controller: controller.richTextWebController.editorController,
             htmlEditorOptions: const HtmlEditorOptions(
+              shouldEnsureVisible: true,
               hint: '',
               darkMode: false,
               customBodyCssStyle: bodyCssStyleForEditor),
@@ -791,6 +792,7 @@ class ComposerView extends GetWidget<ComposerController>
             otherOptions: const OtherOptions(height: 550),
             callbacks: Callbacks(onBeforeCommand: (currentHtml) {
               log('ComposerView::_buildHtmlEditor(): onBeforeCommand : $currentHtml');
+              controller.richTextWebController.setFullScreenEditor();
               controller.setTextEditorWeb(currentHtml);
             }, onChangeContent: (changed) {
               log('ComposerView::_buildHtmlEditor(): onChangeContent : $changed');

--- a/lib/features/composer/presentation/controller/rich_text_web_controller.dart
+++ b/lib/features/composer/presentation/controller/rich_text_web_controller.dart
@@ -174,10 +174,6 @@ class RichTextWebController extends BaseRichTextController {
 
   Future<bool> get isActivatedCodeView => editorController.isActivatedCodeView();
 
-  void setFullScreenEditor() {
-    editorController.setFullScreen();
-  }
-
   void setEnableCodeView() async {
     final isActivated = await isActivatedCodeView;
     if (codeViewEnabled && !isActivated) {
@@ -191,7 +187,6 @@ class RichTextWebController extends BaseRichTextController {
     codeViewState.value = newCodeViewState;
     editorController.toggleCodeView();
     if (isActivated) {
-      setFullScreenEditor();
       editorController.setFullScreen();
     }
   }

--- a/lib/features/identity_creator/presentation/identity_creator_view.dart
+++ b/lib/features/identity_creator/presentation/identity_creator_view.dart
@@ -267,7 +267,6 @@ class IdentityCreatorView extends GetWidget<IdentityCreatorController> {
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(12),
               border: Border.all(color: AppColor.colorInputBorderCreateMailbox),
-              color: Colors.white,
             ),
             child: _buildSignatureHtmlTemplate(context),
           ),
@@ -426,7 +425,6 @@ class IdentityCreatorView extends GetWidget<IdentityCreatorController> {
         }, onInit: () {
           log('IdentityCreatorView::_buildHtmlEditorWeb(): onInit');
           controller.updateContentHtmlEditor(initContent);
-          controller.richTextWebController.setFullScreenEditor();
           controller.richTextWebController.setEnableCodeView();
         }, onFocus: () {
           log('IdentityCreatorView::_buildHtmlEditorWeb(): onFocus');

--- a/lib/features/manage_account/presentation/vacation/vacation_view.dart
+++ b/lib/features/manage_account/presentation/vacation/vacation_view.dart
@@ -450,9 +450,7 @@ class VacationView extends GetWidget<VacationController> with RichTextButtonMixi
             defaultToolbarButtons: []),
         otherOptions: const html_editor_browser.OtherOptions(height: 150),
         callbacks: html_editor_browser.Callbacks(
-          onInit: () {
-            controller.richTextControllerForWeb.setFullScreenEditor();
-          }, onChangeSelection: (settings) {
+          onChangeSelection: (settings) {
             controller.richTextControllerForWeb.onEditorSettingsChange(settings);
           }, onChangeContent: (String? changed) {
             controller.updateMessageHtmlText(changed);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -300,10 +300,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "5be16bf1707658e4c03078d4a9b90208ded217fb02c163e207d334082412f2fb"
+      sha256: "6d691edde054969f0e0f26abb1b30834b5138b963793e56f69d3a9a4435e6352"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.5"
+    version: "2.3.0"
   dartz:
     dependency: "direct main"
     description:
@@ -867,7 +867,7 @@ packages:
     description:
       path: "."
       ref: email_supported
-      resolved-ref: b0791598dfdc4fb89fc9a88554d838b61370100a
+      resolved-ref: "750fc01e09b5a98b06463e336a4b30851d90fa70"
       url: "https://github.com/linagora/html-editor-enhanced.git"
     source: git
     version: "2.5.1"


### PR DESCRIPTION
Issue: 
#1528 

When we use func `setFullScreenEditor ` it sets the html editor widget to a fixed height and then it cannot scroll automatically. The library already supports this so we shouldn't use func `setFullScreenEditor ` to set height during initialization.


- RESOLVE

[https://pub.dev/packages/html_editor_enhanced](url)
```
shouldEnsureVisible
Default value: false

This option parameter will scroll the editor container into view whenever the webview is focused or text is typed into the editor.

You can only use this parameter if your HtmlEditor is inside a Scrollview, otherwise it does nothing.

This is useful in cases where the page is a SingleChildScrollView or something similar with multiple widgets (eg a form). When the user is going through the different fields, it will pop the webview into view, just like a TextField would scroll into in view if text is being typed inside it.
```


`New composer`

https://user-images.githubusercontent.com/99852347/224885666-e7491c77-3c7e-4a8c-bdba-a76cdf819720.mov

`REPLY AND FORWARD`

https://user-images.githubusercontent.com/99852347/224885747-cd296220-6c58-4af8-b70a-1cecaa184c3c.mov

`Vacation`

https://user-images.githubusercontent.com/99852347/224925145-0978d158-d6e5-48ff-9f2f-d5e51928bf5c.mov

`Identity`

https://user-images.githubusercontent.com/99852347/224925185-6a62d4ba-5fb9-4249-a189-2c69a55102e3.mov

