### PR TITLE
Configure cache settings for Nginx

### DIFF
--- a/server/nginx.conf
+++ b/server/nginx.conf
@@ -22,6 +22,8 @@ http {
     #tcp_nopush     on;
 
     keepalive_timeout  65;
+    expires 86400;
+    etag on;
 
     include /etc/nginx/conf.d/*.conf;
 


### PR DESCRIPTION
solve https://github.com/linagora/tmail-flutter/issues/1518

Cache expires after 24h.
After cache is expired, browser can compare ETag to the server to check if the file has changed. If the server returns the same token, then the file is the same, and there's no need to re-download it.