### PR TITLE
TF-1628 Remove `HyperLink` of mailbox avoid conflict `WebView` of email on browser

### DIFF
--- a/lib/features/mailbox/presentation/widgets/mailbox_folder_tile_builder.dart
+++ b/lib/features/mailbox/presentation/widgets/mailbox_folder_tile_builder.dart
@@ -11,7 +11,6 @@ import 'package:model/email/presentation_email.dart';
 import 'package:model/mailbox/expand_mode.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:model/mailbox/select_mode.dart';
-import 'package:tmail_ui_user/features/base/widget/link_browser_widget.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/extensions/presentation_mailbox_extension.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_actions.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_displayed.dart';
@@ -84,21 +83,11 @@ class MailBoxFolderTileBuilder {
   Widget build() {
     if (responsiveUtils?.isWebDesktop(_context) == true && mailboxDisplayed == MailboxDisplayed.mailbox) {
       return DragTarget<List<PresentationEmail>>(
-        builder: (_, __, ___) => LinkBrowserWidget(
-          uri: _mailboxNode.item.mailboxRouteWeb,
-          child: _buildMailboxItem(_context)
-        ),
+        builder: (_, __, ___) => _buildMailboxItem(_context),
         onAccept: (emails) => _onDragItemAccepted?.call(emails, _mailboxNode.item),
       );
     } else {
-      if (BuildUtils.isWeb && mailboxDisplayed == MailboxDisplayed.mailbox) {
-        return LinkBrowserWidget(
-          uri: _mailboxNode.item.mailboxRouteWeb,
-          child: _buildMailboxItem(_context)
-        );
-      } else {
-        return _buildMailboxItem(_context);
-      }
+      return _buildMailboxItem(_context);
     }
   }
 

--- a/lib/features/search/mailbox/presentation/widgets/mailbox_searched_item_builder.dart
+++ b/lib/features/search/mailbox/presentation/widgets/mailbox_searched_item_builder.dart
@@ -10,7 +10,6 @@ import 'package:focused_menu_custom/focused_menu.dart';
 import 'package:focused_menu_custom/modals.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
-import 'package:tmail_ui_user/features/base/widget/link_browser_widget.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/extensions/presentation_mailbox_extension.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/utils/mailbox_method_action_define.dart';
 import 'package:tmail_ui_user/features/search/mailbox/presentation/utils/search_mailbox_utils.dart';
@@ -53,16 +52,7 @@ class _MailboxSearchedItemBuilderState extends State<MailboxSearchedItemBuilder>
   Widget build(BuildContext context) {
     if (BuildUtils.isWeb) {
       return DragTarget<List<PresentationEmail>>(
-        builder: (_, __, ___) {
-          if (widget._presentationMailbox.allowedToDisplay) {
-            return LinkBrowserWidget(
-              uri: widget._presentationMailbox.mailboxRouteWeb,
-              child: _buildMailboxItem(context)
-            );
-          } else {
-            return _buildMailboxItem(context);
-          }
-        },
+        builder: (_, __, ___) => _buildMailboxItem(context),
         onAccept: (emails) {
           widget.onDragEmailToMailboxAccepted?.call(emails, widget._presentationMailbox);
         }


### PR DESCRIPTION
### Issues

- #1628 
- #1629 

### Root cause

- Existing `HtmlElement` is overwritten. `html.Element` of `Link` widget in `url_launcher` and `WebView` of `EmailView`

### Resolved

- Remove `HyperLink` of mailbox

https://user-images.githubusercontent.com/80730648/226538610-1125e0b9-b0af-4f85-b738-b0041eb04caf.mov
