### PR TITLE
TF-1440 Fix user can not sign again after click back browser button in OIDC

### DIFF
--- a/lib/features/login/data/repository/credential_repository_impl.dart
+++ b/lib/features/login/data/repository/credential_repository_impl.dart
@@ -2,7 +2,7 @@
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tmail_ui_user/features/login/data/local/authentication_info_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/model/authentication_info_cache.dart';
-import 'package:tmail_ui_user/features/login/data/utils/login_constant.dart';
+import 'package:tmail_ui_user/features/login/domain/model/login_constants.dart';
 import 'package:tmail_ui_user/features/login/domain/repository/credential_repository.dart';
 
 class CredentialRepositoryImpl extends CredentialRepository {
@@ -17,17 +17,17 @@ class CredentialRepositoryImpl extends CredentialRepository {
 
   @override
   Future<Uri> getBaseUrl() async {
-    return Uri.parse(sharedPreferences.getString(LoginConstant.keyBaseUrl) ?? '');
+    return Uri.parse(sharedPreferences.getString(LoginConstants.KEY_BASE_URL) ?? '');
   }
 
   @override
   Future saveBaseUrl(Uri baseUrl) async {
-    await sharedPreferences.setString(LoginConstant.keyBaseUrl, baseUrl.toString());
+    await sharedPreferences.setString(LoginConstants.KEY_BASE_URL, baseUrl.toString());
   }
 
   @override
   Future removeBaseUrl() async {
-    await sharedPreferences.remove(LoginConstant.keyBaseUrl);
+    await sharedPreferences.remove(LoginConstants.KEY_BASE_URL);
   }
 
   @override

--- a/lib/features/login/data/utils/login_constant.dart
+++ b/lib/features/login/data/utils/login_constant.dart
@@ -1,4 +1,0 @@
-
-class LoginConstant {
-  static const String keyBaseUrl = 'KEY_BASE_URL';
-}

--- a/lib/features/login/domain/model/login_constants.dart
+++ b/lib/features/login/domain/model/login_constants.dart
@@ -1,0 +1,5 @@
+
+class LoginConstants {
+  static const String KEY_BASE_URL = 'KEY_BASE_URL';
+  static const String AUTH_DESTINATION_KEY = "auth_destination_url";
+}

--- a/lib/features/login/presentation/login_controller.dart
+++ b/lib/features/login/presentation/login_controller.dart
@@ -16,6 +16,7 @@ import 'package:model/oidc/request/oidc_request.dart';
 import 'package:model/oidc/response/oidc_response.dart';
 import 'package:model/oidc/token_oidc.dart';
 import 'package:tmail_ui_user/features/base/reloadable/reloadable_controller.dart';
+import 'package:tmail_ui_user/features/login/domain/model/login_constants.dart';
 import 'package:tmail_ui_user/features/login/domain/model/recent_login_url.dart';
 import 'package:tmail_ui_user/features/login/domain/model/recent_login_username.dart';
 import 'package:tmail_ui_user/features/login/domain/state/authenticate_oidc_on_browser_state.dart';
@@ -53,6 +54,7 @@ import 'package:tmail_ui_user/main/routes/navigation_router.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:tmail_ui_user/main/routes/route_utils.dart';
 import 'package:tmail_ui_user/main/utils/app_config.dart';
+import 'package:universal_html/html.dart' as html;
 
 class LoginController extends ReloadableController {
 
@@ -69,7 +71,6 @@ class LoginController extends ReloadableController {
   final GetAllRecentLoginUrlOnMobileInteractor _getAllRecentLoginUrlOnMobileInteractor;
   final SaveLoginUsernameOnMobileInteractor _saveLoginUsernameOnMobileInteractor;
   final GetAllRecentLoginUsernameOnMobileInteractor _getAllRecentLoginUsernameOnMobileInteractor;
-
 
   final TextEditingController urlInputController = TextEditingController();
   final TextEditingController usernameInputController = TextEditingController();
@@ -277,6 +278,7 @@ class LoginController extends ReloadableController {
   }
 
   void _getOIDCConfigurationSuccess(GetOIDCConfigurationSuccess success) {
+    log('LoginController::_getOIDCConfigurationSuccess():success: $success');
     loginState.value = LoginState(Right(success));
     if (BuildUtils.isWeb) {
       _authenticateOidcOnBrowserAction(success.oidcConfiguration);
@@ -295,11 +297,20 @@ class LoginController extends ReloadableController {
   }
 
   void _authenticateOidcOnBrowserAction(OIDCConfiguration config) async {
+    _removeAuthDestinationUrlInSessionStorage();
+
     final baseUri = _parseUri(AppConfig.baseUrl);
     if (baseUri != null) {
       consumeState(_authenticateOidcOnBrowserInteractor.execute(baseUri, config));
     } else {
       loginState.value = LoginState(Left(LoginCanNotAuthenticationSSOAction()));
+    }
+  }
+
+  void _removeAuthDestinationUrlInSessionStorage() {
+    final authDestinationUrlExist = html.window.sessionStorage.containsKey(LoginConstants.AUTH_DESTINATION_KEY);
+    if (authDestinationUrlExist) {
+      html.window.sessionStorage.remove(LoginConstants.AUTH_DESTINATION_KEY);
     }
   }
 


### PR DESCRIPTION
### Issue

#1440 

### Root cause

- `auth_destination_url`: Is our current page path (Here is `LoginView` with path: `https://domain.com#/login`)
- Because `auth_destination_url` already exists in `SessionStorage`. The authentication method always checks if `auth_destination_url` is present on storage. If so, you cannot continue.

<img width="894" alt="Screenshot 2023-03-24 at 16 33 25" src="https://user-images.githubusercontent.com/80730648/227481760-8c03c515-3a81-49c1-9a42-6d270849dbc1.png">


### Resolved

https://user-images.githubusercontent.com/80730648/227429967-edc46c4a-cc61-48c3-9056-d51defb129db.mov


