### PR TITLE
TF-1657 Fix infinite scroll is broken

### DIFF
--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -493,7 +493,7 @@ class ThreadController extends BaseController with EmailActionController {
           limit: ThreadConstants.defaultLimit,
           sort: _sortOrder,
           filterOption: mailboxDashBoardController.filterMessageOption.value,
-          filter: _getFilterCondition(oldestEmail: oldestEmail),
+          filter: _getFilterCondition(oldestEmail: oldestEmail, mailboxIdSelected: _currentMailboxId),
           properties: ThreadConstants.propertiesDefault,
           lastEmailId: oldestEmail?.id
         )


### PR DESCRIPTION
### Issue

#1657 

### Root cause

- Because `Load More` misses the `mailboxId` property.

### Resolved



