### PR TITLE
TF-1663 Fix user cannot click to compose after system display an error message

### DIFF
--- a/core/lib/presentation/views/toast/tmail_toast.dart
+++ b/core/lib/presentation/views/toast/tmail_toast.dart
@@ -166,6 +166,10 @@ class ToastView {
 
     _isVisible = true;
     overlayState!.insert(_overlayEntry!);
+    if (toastDuration != null) {
+      await Future.delayed(Duration(seconds: toastDuration));
+      await dismiss();
+    }
   }
 
   static Positioned _showWidgetBasedOnPosition(


### PR DESCRIPTION
### Issue

#1663 

### Root cause

- `ToastMessageView` after being displayed is not `dismissed' from the screen but only dimmed (opacity) so overriding composer button

### Resolved


https://user-images.githubusercontent.com/80730648/227911637-70d6b678-6f68-417d-981e-fe04b45707ee.mp4

