### PR TITLE
[HOT] Fix cannot show push notification on android

### DIFF
--- a/lib/features/push_notification/presentation/notification/local_notification_manager.dart
+++ b/lib/features/push_notification/presentation/notification/local_notification_manager.dart
@@ -88,6 +88,8 @@ class LocalNotificationManager {
       final granted = await _isAndroidPermissionGranted();
       if (!granted) {
         _notificationsEnabled = await _requestPermissions();
+      } else {
+        _notificationsEnabled = granted;
       }
     } else {
       _notificationsEnabled = await _requestPermissions();
@@ -131,9 +133,6 @@ class LocalNotificationManager {
     EmailAddress? emailAddress,
     String? payload
   }) async {
-    if (!_notificationsEnabled) {
-      return;
-    }
     final inboxStyleInformation = InboxStyleInformation(
       [message?.addBlockTag('p', attribute: 'style="color:#6D7885;"') ?? ''],
       htmlFormatLines: true,


### PR DESCRIPTION
### Root cause

- Do not assign a value to `_notificationsEnabled` when the permission is checked `_isAndroidPermissionGranted`

### Resolved


https://user-images.githubusercontent.com/80730648/228790101-9cc64acc-0ce0-45e9-8c8b-613509d267e7.mov


