### PR TITLE
TF-1759: Check when replying and all replies will include me in the recipient

### DIFF
--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -535,13 +535,22 @@ class ComposerController extends BaseController {
   void _initEmailAddress(ComposerArguments arguments) {
     final userProfile =  mailboxDashBoardController.userProfile.value;
     if (arguments.presentationEmail != null && userProfile != null) {
+      final userEmailAddress = EmailAddress(null, userProfile.email);
       final recipients = arguments.presentationEmail!.generateRecipientsEmailAddressForComposer(
-          arguments.emailActionType,
-          arguments.mailboxRole);
+        arguments.emailActionType,
+        arguments.mailboxRole);
 
-      listToEmailAddress = List.from(recipients.value1);
-      listCcEmailAddress = List.from(recipients.value2);
-      listBccEmailAddress = List.from(recipients.value3);
+      final isSender = arguments.presentationEmail!.from.asList().every((element) => element.email == userEmailAddress.email);
+
+      if (isSender) {
+        listToEmailAddress = List.from(recipients.value1);
+        listCcEmailAddress = List.from(recipients.value2);
+        listBccEmailAddress = List.from(recipients.value3);
+      } else {
+        listToEmailAddress = List.from(recipients.value1.toSet().filterEmailAddress(userEmailAddress));
+        listCcEmailAddress = List.from(recipients.value2.toSet().filterEmailAddress(userEmailAddress));
+        listBccEmailAddress = List.from(recipients.value3.toSet().filterEmailAddress(userEmailAddress));
+      }
 
       if (listToEmailAddress.isNotEmpty || listCcEmailAddress.isNotEmpty || listBccEmailAddress.isNotEmpty) {
         isInitialRecipient.value = true;

--- a/model/lib/extensions/list_email_address_extension.dart
+++ b/model/lib/extensions/list_email_address_extension.dart
@@ -26,4 +26,10 @@ extension ListEmailAddressExtension on Set<EmailAddress>? {
   }
 
   int numberEmailAddress() => this != null ? this!.length : 0;
+
+  List<EmailAddress> filterEmailAddress(EmailAddress emailAddressNotExist) {
+    return this != null
+      ? this!.where((emailAddress) => emailAddress.email != emailAddressNotExist.email).toList()
+      : List.empty();
+  }
 }

--- a/model/lib/extensions/presentation_email_extension.dart
+++ b/model/lib/extensions/presentation_email_extension.dart
@@ -112,7 +112,7 @@ extension PresentationEmailExtension on PresentationEmail {
         if (mailboxRole == PresentationMailbox.roleSent) {
           return Tuple3(to.asList(), [], []);
         } else {
-          final replyToAddress = replyTo.asList().isNotEmpty ? replyTo.asList() : from.asList();
+          final replyToAddress = replyTo.asList().isNotEmpty ? to.asList() + replyTo.asList() : from.asList();
           return Tuple3(replyToAddress, [], []);
         }
       case EmailActionType.replyAll:


### PR DESCRIPTION
- Issue: #1759 

- Resolved:

`
GIVEN I am the sender
AND the only recipient
WHEN I click on reply
THEN the 'to' field is fielded with my user address
`

https://user-images.githubusercontent.com/99852347/231968492-75465cc2-5f26-4ddc-a321-e7f59529c4cf.mov

`
GIVEN I am the sender
AND there are other recipients
WHEN I click on reply
THEN the 'to' field is fielded with my user address
`
https://user-images.githubusercontent.com/99852347/232328091-6c912ca0-40b2-4d4c-935a-9c60cce31d8f.mov

`
WHEN I am the only recipient
THEN Reply to all is not shown
`

https://user-images.githubusercontent.com/99852347/231968632-3e9d8017-9576-4aea-9158-9870a7702e5d.mov

`
GIVEN I am the sender
AND there are other recipients
WHEN I click on reply to all
THEN the 'to' field is populated with all email addresses, including mine
`

https://user-images.githubusercontent.com/99852347/231968875-5d3b07cf-dbb5-4458-b217-601778aa01bd.mov


`
GIVEN somebody else is the sender
AND there are other recipients
WHEN I click on reply to all
THEN the 'to' field is populated with other addresses (other recipients + sender), not mine
`

https://user-images.githubusercontent.com/99852347/231968268-f7296fd0-dfb9-4d8e-8e62-c3b77a7e80b3.mov


`
GIVEN somebody else is the sender
AND there are other recipients
WHEN I click on reply
THEN the 'to' field is populated with the sender address
`

https://user-images.githubusercontent.com/99852347/231968310-d95a7a51-40e1-42ac-8d87-f3a823ab19c9.mov



