### PR TITLE
TF-1778,1779 System not display signature in email after sent on mobile

### DIFF
--- a/core/lib/presentation/extensions/string_extension.dart
+++ b/core/lib/presentation/extensions/string_extension.dart
@@ -1,4 +1,5 @@
 import 'package:core/utils/app_logger.dart';
+import 'package:flutter/material.dart';
 
 extension StringExtension on String {
 
@@ -37,5 +38,12 @@ extension StringExtension on String {
       logError('StringExtension::firstLetterToUpperCase(): $e');
       return '';
     }
+  }
+
+  String get withUnicodeCharacter {
+    return characters
+      .replaceAll(Characters(' '), Characters('\u{00A0}'))
+      .replaceAll(Characters('-'), Characters('\u{2011}'))
+      .toString();
   }
 }

--- a/docs/adr/0020-fix-tmail-ui-broken-after-create-identity-successfully-by-html-style.md
+++ b/docs/adr/0020-fix-tmail-ui-broken-after-create-identity-successfully-by-html-style.md
@@ -1,6 +1,6 @@
 # 20. Fix Team Mail UI is broken after user create identity successfully by html (#1688)
 
-Date: 20223-04-03
+Date: 2023-04-03
 
 ## Status
 

--- a/docs/adr/0023-fix-system-not-display-signature-in-email-which-has-been-sent.md
+++ b/docs/adr/0023-fix-system-not-display-signature-in-email-which-has-been-sent.md
@@ -1,0 +1,19 @@
+# 23. Fix system not display signature in email which has been sent
+
+Date: 2023-04-21
+
+## Status
+
+- Issue: [#1778](https://github.com/linagora/tmail-flutter/issues/1778)
+
+## Context
+
+- Root cause: Due to a syntax error in javascript. In string contains the characters `'` and `"`
+
+## Decision
+
+- Use `template literals` to escape a string in JavaScript. Follow on [enough_html_editor#20](https://github.com/linagora/enough_html_editor/pull/20)
+
+## Consequences
+
+- Escape a string in JavaScript avoid signature display error when sending email on mobile.

--- a/docs/adr/0024-fix-logic-of-replacing-dot-in-long-email-address.md
+++ b/docs/adr/0024-fix-logic-of-replacing-dot-in-long-email-address.md
@@ -1,0 +1,20 @@
+# 24. Fix logic of replacing dot in long email address
+
+Date: 2023-04-21
+
+## Status
+
+- Issue: [#1779](https://github.com/linagora/tmail-flutter/issues/1779)
+
+## Context
+
+- Root cause: When we use the `overflow=TextOverflow.ellipsis` property for the `Text` widget for long texts, it will result in incorrect string breaks. Since string contains some characters that are supposed to be word breaks in the string. The characters `space` and `-`
+
+## Decision
+
+- Convert those special characters to unicode. 
+- Flutter is working on fixing that bug and is expected to be updated in version `3.10`. Follow on [flutter#18761](https://github.com/flutter/flutter/issues/18761)
+
+## Consequences
+
+- Text overflow with ellipsis worked correctly

--- a/lib/features/composer/presentation/composer_view.dart
+++ b/lib/features/composer/presentation/composer_view.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/extensions/capitalize_extension.dart';
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/extensions/html_extension.dart';
+import 'package:core/presentation/extensions/string_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/views/button/icon_button_web.dart';
@@ -352,7 +353,7 @@ class ComposerView extends GetWidget<ComposerController>
               left: AppUtils.isDirectionRTL(context) ? 8 : 12
             ),
             child: Text(
-              controller.identitySelected.value?.email ?? '',
+              (controller.identitySelected.value?.email ?? '').withUnicodeCharacter,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
               style: const TextStyle(fontSize: 17, fontWeight: FontWeight.normal, color: AppColor.colorEmailAddressPrefix),

--- a/lib/features/mailbox/presentation/widgets/mailbox_folder_tile_builder.dart
+++ b/lib/features/mailbox/presentation/widgets/mailbox_folder_tile_builder.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/extensions/string_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/utils/style_utils.dart';
@@ -299,7 +300,7 @@ class MailBoxFolderTileBuilder {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          _mailboxNode.item.name?.name ?? '',
+          (_mailboxNode.item.name?.name ?? '').withUnicodeCharacter,
           maxLines: 1,
           softWrap: CommonTextStyle.defaultSoftWrap,
           overflow: CommonTextStyle.defaultTextOverFlow,
@@ -310,7 +311,7 @@ class MailBoxFolderTileBuilder {
         ),
         if(_mailboxNode.item.isTeamMailboxes)
           Text(
-            _mailboxNode.item.emailTeamMailBoxes ?? '',
+            (_mailboxNode.item.emailTeamMailBoxes ?? '').withUnicodeCharacter,
             maxLines: 1,
             softWrap: CommonTextStyle.defaultSoftWrap,
             overflow: CommonTextStyle.defaultTextOverFlow,

--- a/lib/features/mailbox/presentation/widgets/user_information_widget_builder.dart
+++ b/lib/features/mailbox/presentation/widgets/user_information_widget_builder.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/extensions/string_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/style_utils.dart';
 import 'package:core/presentation/views/image/avatar_builder.dart';
@@ -59,7 +60,7 @@ class UserInformationWidgetBuilder extends StatelessWidget {
                   top: 10
                 ),
                 child: Text(
-                    _userProfile != null ? '${_userProfile?.email}' : '',
+                    _userProfile != null ? '${_userProfile?.email}'.withUnicodeCharacter : '',
                     maxLines: 1,
                     overflow: CommonTextStyle.defaultTextOverFlow,
                     softWrap: CommonTextStyle.defaultSoftWrap,

--- a/lib/features/manage_account/presentation/profiles/identities/widgets/identity_list_tile_builder.dart
+++ b/lib/features/manage_account/presentation/profiles/identities/widgets/identity_list_tile_builder.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/extensions/string_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/style_utils.dart';
 import 'package:core/presentation/views/button/icon_button_web.dart';
@@ -65,7 +66,7 @@ class IdentityListTileBuilder extends StatelessWidget {
                       Padding(
                         padding: const EdgeInsets.only(bottom: 6),
                         child: Text(
-                          identity.name ?? '',
+                          (identity.name ?? '').withUnicodeCharacter,
                           overflow: CommonTextStyle.defaultTextOverFlow,
                           softWrap: CommonTextStyle.defaultSoftWrap,
                           style: const TextStyle(
@@ -122,7 +123,7 @@ class IdentityListTileBuilder extends StatelessWidget {
             child: SvgPicture.asset(imagePath, width: 15, height: 15))),
         const SizedBox(width: 4),
         Expanded(child: Text(
-          text ?? '',
+          (text ?? '').withUnicodeCharacter,
           style: const TextStyle(
             color: AppColor.colorEmailAddressFull,
             fontWeight: FontWeight.normal,
@@ -150,7 +151,8 @@ class IdentityListTileBuilder extends StatelessWidget {
               decoration: TextDecoration.underline,
               color: AppColor.colorTextButton))),
         const SizedBox(width: 4),
-        Expanded(child: Text(text ?? '',
+        Expanded(child: Text(
+          (text ?? '').withUnicodeCharacter,
           style: const TextStyle(
             color: AppColor.colorEmailAddressFull,
             fontWeight: FontWeight.normal,

--- a/lib/features/search/mailbox/presentation/widgets/mailbox_searched_item_builder.dart
+++ b/lib/features/search/mailbox/presentation/widgets/mailbox_searched_item_builder.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/extensions/string_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/utils/style_utils.dart';
@@ -204,7 +205,7 @@ class _MailboxSearchedItemBuilderState extends State<MailboxSearchedItemBuilder>
 
   Widget _buildTitleItem() {
     return Text(
-      widget._presentationMailbox.name?.name ?? '',
+      (widget._presentationMailbox.name?.name ?? '').withUnicodeCharacter,
       maxLines: 1,
       overflow: CommonTextStyle.defaultTextOverFlow,
       softWrap: CommonTextStyle.defaultSoftWrap,
@@ -218,7 +219,7 @@ class _MailboxSearchedItemBuilderState extends State<MailboxSearchedItemBuilder>
   Widget _buildSubtitleItem() {
     if (widget._presentationMailbox.mailboxPath?.isNotEmpty == true) {
       return Text(
-        widget._presentationMailbox.mailboxPath ?? '',
+        (widget._presentationMailbox.mailboxPath ?? '').withUnicodeCharacter,
         maxLines: 1,
         overflow: CommonTextStyle.defaultTextOverFlow,
         softWrap: CommonTextStyle.defaultSoftWrap,
@@ -230,7 +231,7 @@ class _MailboxSearchedItemBuilderState extends State<MailboxSearchedItemBuilder>
       );
     } else if (widget._presentationMailbox.isTeamMailboxes) {
       return Text(
-        widget._presentationMailbox.emailTeamMailBoxes ?? '',
+        (widget._presentationMailbox.emailTeamMailBoxes ?? '').withUnicodeCharacter,
         maxLines: 1,
         softWrap: CommonTextStyle.defaultSoftWrap,
         overflow: CommonTextStyle.defaultTextOverFlow,

--- a/lib/features/thread/presentation/mixin/base_email_item_tile.dart
+++ b/lib/features/thread/presentation/mixin/base_email_item_tile.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/extensions/string_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/utils/style_utils.dart';
@@ -39,7 +40,7 @@ mixin BaseEmailItemTile {
               borderRadius: BorderRadius.circular(10),
               color: AppColor.backgroundCounterMailboxColor),
           child: Text(
-            email.mailboxName,
+            email.mailboxName.withUnicodeCharacter,
             maxLines: 1,
             softWrap: CommonTextStyle.defaultSoftWrap,
             overflow: CommonTextStyle.defaultTextOverFlow,
@@ -84,7 +85,7 @@ mixin BaseEmailItemTile {
   ) {
     if (isSearchEnabled(isSearchEmailRunning, query)) {
       return RichTextBuilder(
-          informationSender(email, mailbox),
+          informationSender(email, mailbox).withUnicodeCharacter,
           query?.value ?? '',
           TextStyle(
               fontSize: 15,
@@ -98,7 +99,7 @@ mixin BaseEmailItemTile {
       ).build();
     } else {
       return Text(
-          informationSender(email, mailbox),
+          informationSender(email, mailbox).withUnicodeCharacter,
           softWrap: CommonTextStyle.defaultSoftWrap,
           overflow: CommonTextStyle.defaultTextOverFlow,
           maxLines: 1,
@@ -118,7 +119,7 @@ mixin BaseEmailItemTile {
   ) {
     if (isSearchEnabled(isSearchEmailRunning, query)) {
       return RichTextBuilder(
-          email.getEmailTitle(),
+          email.getEmailTitle().withUnicodeCharacter,
           query?.value ?? '',
           TextStyle(
               fontSize: 13,
@@ -132,7 +133,7 @@ mixin BaseEmailItemTile {
       ).build();
     } else {
       return Text(
-          email.getEmailTitle(),
+          email.getEmailTitle().withUnicodeCharacter,
           softWrap: CommonTextStyle.defaultSoftWrap,
           overflow: CommonTextStyle.defaultTextOverFlow,
           maxLines: 1,
@@ -151,7 +152,7 @@ mixin BaseEmailItemTile {
   ) {
     if (isSearchEnabled(isSearchEmailRunning, query)) {
       return RichTextBuilder(
-          email.getPartialContent(),
+          email.getPartialContent().withUnicodeCharacter,
           query?.value ?? '',
           const TextStyle(
               fontSize: 13,
@@ -164,7 +165,7 @@ mixin BaseEmailItemTile {
       ).build();
     } else {
       return Text(
-          email.getPartialContent(),
+          email.getPartialContent().withUnicodeCharacter,
           maxLines: 1,
           softWrap: CommonTextStyle.defaultSoftWrap,
           overflow: CommonTextStyle.defaultTextOverFlow,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -361,11 +361,11 @@ packages:
     source: hosted
     version: "2.0.0"
   enough_html_editor:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       path: "."
-      ref: email_supported
-      resolved-ref: "4bbf049d7ec62d09030e4033760cd945439ba24d"
+      ref: "fix/escaped-html-signature"
+      resolved-ref: ff1a6f33cab442cd59d3d8548f51313ca0274a27
       url: "https://github.com/linagora/enough_html_editor.git"
     source: git
     version: "0.0.5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -222,6 +222,11 @@ dependency_overrides:
 
   pointer_interceptor: 0.9.1
 
+  enough_html_editor:
+    git:
+      url: https://github.com/linagora/enough_html_editor.git
+      ref: fix/escaped-html-signature
+
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 


### PR DESCRIPTION
### Issue

#1778 , #1779 

### Root cause

- `#1778`: Due to a syntax error in javascript. In `string` contains the characters `'` and `"`
- `#1779`:  When we use the `overflow=TextOverflow.ellipsis` property for the `Text` widget for long texts, it will result in incorrect string breaks. Since string contains some characters that are supposed to be word breaks in the string. The characters ` ` and `-`

### Dependent

- Need merged https://github.com/linagora/enough_html_editor/pull/20

### Resolved


https://user-images.githubusercontent.com/80730648/233637320-83e20587-ec2c-4104-9408-3dfaa75d81ec.mov

