### PR TITLE
TF-1753 Fix [EmailSuggestion] Email at cc is removed once user select email at bcc suggestion list

### DIFF
--- a/docs/adr/0025-fix-can-not-select-suggestion-email-by-mouse-clicking-on-web.md
+++ b/docs/adr/0025-fix-can-not-select-suggestion-email-by-mouse-clicking-on-web.md
@@ -1,0 +1,24 @@
+# 25. Fix can't select suggestion email by mouse clicking on web
+
+Date: 2023-04-24
+
+## Status
+
+- Issue: [#1576](https://github.com/linagora/tmail-flutter/issues/1576)
+- Issue: [#1753](https://github.com/linagora/tmail-flutter/issues/1753)
+
+## Context
+
+Tap events are not being simulated to overlay on the `Web/Desktop` but work fine on mobile devices. This worked fine until the previous release stable `3.3`
+
+## Root cause
+
+Because the thing that the overlay is attached to is a `TextField`, so in order to keep from unfocused the text field when tapping outside of it, you need to tell the overlay widget that it's part of the TextField for purposes of the `Tap outside` behavior
+
+## Decision
+
+- Try wrapping a `TextFieldTapRegion` around the `Material` in the overlay. So that when the tap arrives, it's considered `inside` of the text field.
+
+## Consequences
+
+- Widget on overlay work fine.

--- a/lib/features/composer/presentation/widgets/email_address_input_builder.dart
+++ b/lib/features/composer/presentation/widgets/email_address_input_builder.dart
@@ -15,6 +15,7 @@ import 'package:super_tag_editor/widgets/rich_text_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/prefix_email_address_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/suggestion_email_address.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/utils/app_constants.dart';
 
 typedef OnSuggestionEmailAddress = Future<List<EmailAddress>> Function(String word);
 typedef OnUpdateListEmailAddressAction = void Function(PrefixEmailAddress, List<EmailAddress>);
@@ -437,7 +438,7 @@ class EmailAddressInputBuilder {
     }
 
     final tmailSuggestion = List<SuggestionEmailAddress>.empty(growable: true);
-    if (processedQuery.isNotEmpty && _onSuggestionEmailAddress != null) {
+    if (processedQuery.length >= AppConstants.limitCharToStartSearch && _onSuggestionEmailAddress != null) {
       tmailSuggestion.addAll(
         (await _onSuggestionEmailAddress!(processedQuery))
           .map((emailAddress) => _toSuggestionEmailAddress(emailAddress, listEmailAddress)));

--- a/lib/main/utils/app_constants.dart
+++ b/lib/main/utils/app_constants.dart
@@ -1,0 +1,4 @@
+
+class AppConstants {
+  static const int limitCharToStartSearch = 3;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -361,11 +361,11 @@ packages:
     source: hosted
     version: "2.0.0"
   enough_html_editor:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       path: "."
-      ref: "fix/escaped-html-signature"
-      resolved-ref: ff1a6f33cab442cd59d3d8548f51313ca0274a27
+      ref: email_supported
+      resolved-ref: ed465d707389bbb959ce2898b899fabb9e9608ed
       url: "https://github.com/linagora/enough_html_editor.git"
     source: git
     version: "0.0.5"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1473,10 +1473,10 @@ packages:
     dependency: "direct main"
     description:
       name: super_tag_editor
-      sha256: "0888ef22d5a1485baeb628892de449e03af4b6f901ac7f7c9ddd2f44f6199e22"
+      sha256: f992eab1bad3595148f1a62f98fd981fac814d53682b8414311eca470dbfa768
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.1"
+    version: "0.1.2"
   syncfusion_flutter_core:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -194,7 +194,7 @@ dependencies:
   # flutter_localizations depends on intl 0.17.0
   intl: 0.17.0
 
-  super_tag_editor: 0.1.1
+  super_tag_editor: 0.1.2
 
   external_app_launcher: 3.1.0
 
@@ -226,6 +226,7 @@ dependency_overrides:
     git:
       url: https://github.com/linagora/enough_html_editor.git
       ref: fix/escaped-html-signature
+
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -222,12 +222,6 @@ dependency_overrides:
 
   pointer_interceptor: 0.9.1
 
-  enough_html_editor:
-    git:
-      url: https://github.com/linagora/enough_html_editor.git
-      ref: fix/escaped-html-signature
-
-
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 


### PR DESCRIPTION
### Issue

#1753 

### Root cause

Because the thing that the overlay is attached to is a `TextField`, so in order to keep from unfocused the text field when tapping outside of it, you need to tell the overlay widget that it's part of the TextField for purposes of the `Tap outside` behavior

### Dependent

- Need merged: https://github.com/dab246/super_tag_editor/pull/19

### Resolved


https://user-images.githubusercontent.com/80730648/233897128-5e3277d7-ce6b-429c-a6f9-c042dc04449b.mov



