### PR TITLE
TF-1743: Hide Hide Horizontal scroll bar in Email detail view

### DIFF
--- a/core/lib/presentation/utils/html_transformer/html_template.dart
+++ b/core/lib/presentation/utils/html_transformer/html_template.dart
@@ -53,7 +53,7 @@ String generateHtml(String content, {
     </style>
     ${javaScripts ?? ''}
     </head>
-    <body>
+    <body style = "overflow-x: hidden">
     <div class="tmail-content">$content</div>
     </body>
     </html> 

--- a/docs/adr/0026-fix-horizontal-scroll-bar-in-email-detail-view.md
+++ b/docs/adr/0026-fix-horizontal-scroll-bar-in-email-detail-view.md
@@ -1,0 +1,24 @@
+# 25. Hide Horizontal scroll bar in Email detail view
+
+Date: 2023-04-24
+
+## Status
+
+- Issue: [#1743](https://github.com/linagora/tmail-flutter/issues/1743)
+
+## Context
+
+In email view always show horizontal scroll bar in Email detail view and don't wrap text instead
+
+## Root cause
+
+The horizontal scrollbar appears when the content inside the body element is wider than the width of the viewport. By default, the overflow property is set to "visible", which means that the content can overflow the element's boundaries.
+
+## Decision
+
+When you set `overflow-x: hidden`; on the body element, it prevents the content from overflowing the element's boundaries in the horizontal direction, 
+effectively disabling the horizontal scrollbar. However, if you don't set this property and the content is wider than the viewport, 
+the scrollbar will appear to allow the user to scroll horizontally to see the content that is outside the viewport.
+## Consequences
+
+- Hide Horizontal scroll bar in Email detail view


### PR DESCRIPTION
- Issue: #1743 

- Root cause: 
The horizontal scrollbar appears when the content inside the body element is wider than the width of the viewport. By default, the overflow property is set to "visible", which means that the content can overflow the element's boundaries.

- Resolved:

`Mac OS`

https://user-images.githubusercontent.com/99852347/234059455-a4a71800-2423-4ab3-8928-03dc8cfe988b.mov

`Ubuntu (Firefox, chromium)`


https://user-images.githubusercontent.com/99852347/234156703-8c3b23b6-17a8-4ed9-bd07-55424047e6f5.mov

