### PR TITLE
TF-1806 Fix impossible to disable used fonts in email composer

### DIFF
--- a/lib/features/composer/presentation/composer_view_web.dart
+++ b/lib/features/composer/presentation/composer_view_web.dart
@@ -818,7 +818,6 @@ class ComposerView extends GetWidget<ComposerController>
           blockQuotedContent: initContent,
           htmlToolbarOptions: const HtmlToolbarOptions(
             toolbarType: ToolbarType.hide,
-            toolbarPosition: ToolbarPosition.custom,
             defaultToolbarButtons: []
           ),
           otherOptions: const OtherOptions(height: 550),


### PR DESCRIPTION
### Issue

#1806 

### Root cause

- Due the `onChangeSelection` function is not called every time the editor changes the style. `onChangeSelection` is called only when `ToolbarWidgetState != null`

### Resolved


https://user-images.githubusercontent.com/80730648/236453232-c7679c46-771c-401b-a48a-6d3ef1a1f50a.mov

