### PR TITLE
Force browsers to re-validate cache before reuse

### DIFF
--- a/server/nginx.conf
+++ b/server/nginx.conf
@@ -22,7 +22,7 @@ http {
     #tcp_nopush     on;
 
     keepalive_timeout  65;
-    expires 86400;
+    add_header Cache-Control "no-cache";
     etag on;
 
     include /etc/nginx/conf.d/*.conf;


### PR DESCRIPTION
resolved https://github.com/linagora/tmail-flutter/issues/1507

Upon new release, NGINX would return 200 OK with new static files. 
Otherwise, NGINX would return 304 Not Modified with an empty response, and the browser continues to reuse cached static files.

![demo revalidate static files](https://github.com/linagora/tmail-flutter/assets/55171818/6a786fcb-ebf4-4780-8597-3d393ef00caa)

rf: https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests#cache_update