### PR TITLE
TF-1869: Open email cache from notification

### DIFF
--- a/lib/features/caching/clients/detailed_email_hive_cache_client.dart
+++ b/lib/features/caching/clients/detailed_email_hive_cache_client.dart
@@ -6,5 +6,5 @@ import 'package:tmail_ui_user/features/offline_mode/model/detailed_email_hive_ca
 class DetailedEmailHiveCacheClient extends HiveCacheClient<DetailedEmailHiveCache> {
 
   @override
-  String get tableName => CachingConstants.detailedEmailCacheBoxName;
+  String get tableName => CachingConstants.incomingEmailedCacheBoxName;
 }

--- a/lib/features/caching/config/hive_cache_client.dart
+++ b/lib/features/caching/config/hive_cache_client.dart
@@ -57,8 +57,11 @@ abstract class HiveCacheClient<T> {
     });
   }
 
-  Future<T?> getItem(String key) {
+  Future<T?> getItem(String key, {bool needToReopen = false}) {
     return Future.sync(() async {
+      if (needToReopen) {
+        await closeBox();
+      }
       final boxItem = encryption
           ? await openBoxEncryption()
           : await openBox();
@@ -68,8 +71,11 @@ abstract class HiveCacheClient<T> {
     });
   }
 
-  Future<List<T>> getAll() {
+  Future<List<T>> getAll({bool needToReopen = false}) {
     return Future.sync(() async {
+      if (needToReopen) {
+        await closeBox();
+      }
       final boxItem = encryption
           ? await openBoxEncryption()
           : await openBox();
@@ -79,8 +85,11 @@ abstract class HiveCacheClient<T> {
     });
   }
 
-  Future<List<T>> getListByTupleKey(String accountId, String userName) {
+  Future<List<T>> getListByTupleKey(String accountId, String userName, {bool needToReopen = false}) {
     return Future.sync(() async {
+      if (needToReopen) {
+        await closeBox();
+      }
       final boxItem = encryption ? await openBoxEncryption() : await openBox();
       return boxItem.toMap()
         .where((key, value) => _matchedKey(key, accountId, userName))
@@ -173,5 +182,12 @@ abstract class HiveCacheClient<T> {
     }).catchError((error) {
       throw error;
     });
+  }
+
+  Future<void> closeBox() async {
+    if (Hive.isBoxOpen(tableName)) {
+      await Hive.box<T>(tableName).close();
+    }
+    return Future.value();
   }
 }

--- a/lib/features/caching/utils/caching_constants.dart
+++ b/lib/features/caching/utils/caching_constants.dart
@@ -21,7 +21,7 @@ class CachingConstants {
   static const String fcmCacheBoxName = 'fcm_cache_box';
   static const String detailedEmailCacheBoxName = 'detailed_email_cache_box';
   static const String newEmailContentFolderName = 'new_email';
-  static const String openedEmailContentFolderNamee = 'opened_email';
+  static const String openedEmailContentFolderName = 'opened_email';
   static const String openedEmailCacheBoxName = 'opened_email_cache_box';
 
   static const int maxNumberNewEmailsForOffline = 10;

--- a/lib/features/caching/utils/caching_constants.dart
+++ b/lib/features/caching/utils/caching_constants.dart
@@ -19,8 +19,8 @@ class CachingConstants {
   static const int DETAILED_EMAIL_HIVE_CACHE_ID = 17;
 
   static const String fcmCacheBoxName = 'fcm_cache_box';
-  static const String detailedEmailCacheBoxName = 'detailed_email_cache_box';
-  static const String newEmailContentFolderName = 'new_email';
+  static const String incomingEmailedCacheBoxName = 'incoming_emailed_cache_box';
+  static const String incomingEmailedContentFolderName = 'incoming_emailed';
   static const String openedEmailContentFolderName = 'opened_email';
   static const String openedEmailCacheBoxName = 'opened_email_cache_box';
 

--- a/lib/features/email/data/datasource/email_datasource.dart
+++ b/lib/features/email/data/datasource/email_datasource.dart
@@ -80,7 +80,11 @@ abstract class EmailDataSource {
 
   Future<void> storeEmail(Session session, AccountId accountId, Email email);
 
+  Future<Email?> getEmailFromCache(Session session, AccountId accountId, EmailId emailId);
+
   Future<void> storeOpenedEmail(Session session, AccountId accountId, DetailedEmail detailedEmail);
 
   Future<DetailedEmail?> getOpenedEmail(Session session, AccountId accountId, EmailId emailId);
+
+  Future<DetailedEmail?> getDetailedEmail(Session session, AccountId accountId, EmailId emailId);
 }

--- a/lib/features/email/data/datasource/email_datasource.dart
+++ b/lib/features/email/data/datasource/email_datasource.dart
@@ -80,11 +80,11 @@ abstract class EmailDataSource {
 
   Future<void> storeEmail(Session session, AccountId accountId, Email email);
 
-  Future<Email?> getEmailFromCache(Session session, AccountId accountId, EmailId emailId);
+  Future<Email?> getEmailStored(Session session, AccountId accountId, EmailId emailId);
 
   Future<void> storeOpenedEmail(Session session, AccountId accountId, DetailedEmail detailedEmail);
 
   Future<DetailedEmail?> getOpenedEmail(Session session, AccountId accountId, EmailId emailId);
 
-  Future<DetailedEmail?> getDetailedEmail(Session session, AccountId accountId, EmailId emailId);
+  Future<DetailedEmail?> getIncomingEmailedStored(Session session, AccountId accountId, EmailId emailId);
 }

--- a/lib/features/email/data/datasource_impl/email_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_datasource_impl.dart
@@ -178,12 +178,12 @@ class EmailDataSourceImpl extends EmailDataSource {
   }
 
   @override
-  Future<DetailedEmail?> getDetailedEmail(Session session, AccountId accountId, EmailId emailId) {
+  Future<DetailedEmail?> getIncomingEmailedStored(Session session, AccountId accountId, EmailId emailId) {
     throw UnimplementedError();
   }
 
   @override
-  Future<Email?> getEmailFromCache(Session session, AccountId accountId, EmailId emailId) {
+  Future<Email?> getEmailStored(Session session, AccountId accountId, EmailId emailId) {
     throw UnimplementedError();
   }
 }

--- a/lib/features/email/data/datasource_impl/email_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_datasource_impl.dart
@@ -176,4 +176,14 @@ class EmailDataSourceImpl extends EmailDataSource {
   Future<DetailedEmail> getOpenedEmail(Session session, AccountId accountId, EmailId emailId) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<DetailedEmail?> getDetailedEmail(Session session, AccountId accountId, EmailId emailId) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Email?> getEmailFromCache(Session session, AccountId accountId, EmailId emailId) {
+    throw UnimplementedError();
+  }
 }

--- a/lib/features/email/data/datasource_impl/email_hive_cache_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_hive_cache_datasource_impl.dart
@@ -211,18 +211,19 @@ class EmailHiveCacheDataSourceImpl extends EmailDataSource {
   }
 
   @override
-  Future<DetailedEmail?> getDetailedEmail(Session session, AccountId accountId, EmailId emailId) {
+  Future<DetailedEmail?> getIncomingEmailedStored(Session session, AccountId accountId, EmailId emailId) {
     return Future.sync(() async {
       final detailedEmailHiveCache = await _detailedEmailCacheManager.getDetailEmailExistedInCache(accountId, session.username, emailId);
 
       if (detailedEmailHiveCache == null) {
         return null;
       }
+
       log('EmailHiveCacheDataSourceImpl::getDetailedEmail():folderPath: ${detailedEmailHiveCache.emailContentPath}');
 
       final emailContent = await _fileUtils.getContentFromFile(
         nameFile: emailId.asString,
-        folderPath: CachingConstants.newEmailContentFolderName
+        folderPath: CachingConstants.incomingEmailedContentFolderName
       );
 
       return detailedEmailHiveCache.toDetailedEmailWithContent(emailContent);
@@ -230,9 +231,8 @@ class EmailHiveCacheDataSourceImpl extends EmailDataSource {
   }
 
   @override
-  Future<Email?> getEmailFromCache(Session session, AccountId accountId, EmailId emailId) {
+  Future<Email?> getEmailStored(Session session, AccountId accountId, EmailId emailId) {
     return Future.sync(() async {
-      log('EmailHiveCacheDataSourceImpl::getEmailFromCache():emailId: ${emailId.asString}');
       final email = await _emailCacheManager.getEmailFromCache(accountId, session.username, emailId);
       log('EmailHiveCacheDataSourceImpl::getEmailFromCache():emailId: $email');
       return email?.toEmail();

--- a/lib/features/email/data/repository/email_repository_impl.dart
+++ b/lib/features/email/data/repository/email_repository_impl.dart
@@ -206,17 +206,17 @@ class EmailRepositoryImpl extends EmailRepository {
 
   @override
   Future<DetailedEmail?> getOpenedEmail(Session session, AccountId accountId, EmailId emailId) async {
-    final detailedEmail = await emailDataSource[DataSourceType.hiveCache]!.getDetailedEmail(session, accountId, emailId);
+    final getIncomingEmailedStored = await emailDataSource[DataSourceType.hiveCache]!.getIncomingEmailedStored(session, accountId, emailId);
     final openedEmail = await emailDataSource[DataSourceType.hiveCache]!.getOpenedEmail(session, accountId, emailId);
-    if (detailedEmail != null) {
-      return detailedEmail;
+    if (getIncomingEmailedStored != null) {
+      return getIncomingEmailedStored;
     } else {
       return openedEmail;
     }
   }
 
   @override
-  Future<Email?> getEmailFromCache(Session session, AccountId accountId, EmailId emailId) {
-    return emailDataSource[DataSourceType.hiveCache]!.getEmailFromCache(session, accountId, emailId);
+  Future<Email?> getEmailStored(Session session, AccountId accountId, EmailId emailId) {
+    return emailDataSource[DataSourceType.hiveCache]!.getEmailStored(session, accountId, emailId);
   }
 }

--- a/lib/features/email/data/repository/email_repository_impl.dart
+++ b/lib/features/email/data/repository/email_repository_impl.dart
@@ -205,7 +205,18 @@ class EmailRepositoryImpl extends EmailRepository {
   }
 
   @override
-  Future<DetailedEmail?> getOpenedEmail(Session session, AccountId accountId, EmailId emailId) {
-    return emailDataSource[DataSourceType.hiveCache]!.getOpenedEmail(session, accountId, emailId);
+  Future<DetailedEmail?> getOpenedEmail(Session session, AccountId accountId, EmailId emailId) async {
+    final detailedEmail = await emailDataSource[DataSourceType.hiveCache]!.getDetailedEmail(session, accountId, emailId);
+    final openedEmail = await emailDataSource[DataSourceType.hiveCache]!.getOpenedEmail(session, accountId, emailId);
+    if (detailedEmail != null) {
+      return detailedEmail;
+    } else {
+      return openedEmail;
+    }
+  }
+
+  @override
+  Future<Email?> getEmailFromCache(Session session, AccountId accountId, EmailId emailId) {
+    return emailDataSource[DataSourceType.hiveCache]!.getEmailFromCache(session, accountId, emailId);
   }
 }

--- a/lib/features/email/domain/extensions/detailed_email_extension.dart
+++ b/lib/features/email/domain/extensions/detailed_email_extension.dart
@@ -17,7 +17,7 @@ extension DetailedEmailExtension on DetailedEmail {
     );
   }
 
-  String get newEmailFolderPath => CachingConstants.newEmailContentFolderName;
+  String get newEmailFolderPath => CachingConstants.incomingEmailedContentFolderName;
 
   String get openedEmailFolderPath => CachingConstants.openedEmailContentFolderName;
 

--- a/lib/features/email/domain/extensions/detailed_email_extension.dart
+++ b/lib/features/email/domain/extensions/detailed_email_extension.dart
@@ -19,7 +19,7 @@ extension DetailedEmailExtension on DetailedEmail {
 
   String get newEmailFolderPath => CachingConstants.newEmailContentFolderName;
 
-  String get openedEmailFolderPath => CachingConstants.openedEmailContentFolderNamee;
+  String get openedEmailFolderPath => CachingConstants.openedEmailContentFolderName;
 
   DetailedEmail fromEmailContentPath(String path) {
     return DetailedEmail(

--- a/lib/features/email/domain/repository/email_repository.dart
+++ b/lib/features/email/domain/repository/email_repository.dart
@@ -94,6 +94,8 @@ abstract class EmailRepository {
 
   Future<void> storeEmailToCache(Session session, AccountId accountId, Email email);
 
+  Future<Email?> getEmailFromCache(Session session, AccountId accountId, EmailId emailId);
+
   Future<void> storeOpenedEmail(Session session, AccountId accountId, DetailedEmail detailedEmail);
 
   Future<DetailedEmail?> getOpenedEmail(Session session, AccountId accountId, EmailId emailId);

--- a/lib/features/email/domain/repository/email_repository.dart
+++ b/lib/features/email/domain/repository/email_repository.dart
@@ -94,7 +94,7 @@ abstract class EmailRepository {
 
   Future<void> storeEmailToCache(Session session, AccountId accountId, Email email);
 
-  Future<Email?> getEmailFromCache(Session session, AccountId accountId, EmailId emailId);
+  Future<Email?> getEmailStored(Session session, AccountId accountId, EmailId emailId);
 
   Future<void> storeOpenedEmail(Session session, AccountId accountId, DetailedEmail detailedEmail);
 

--- a/lib/features/email/domain/usecases/get_email_content_interactor.dart
+++ b/lib/features/email/domain/usecases/get_email_content_interactor.dart
@@ -92,10 +92,10 @@ class GetEmailContentInteractor {
         bool draftsEmail = false
       }
   ) async* {
-    log('GetEmailContentInteractor::_getOpenedEmailCache():');
     try {
       final detailedEmail = await emailRepository.getOpenedEmail(session, accountId, emailId);
       if (detailedEmail != null) {
+        log('GetEmailContentInteractor::_tryToGetOpenedEmailCache(): $detailedEmail');
         yield Right<Failure, Success>(GetEmailContentFromCacheSuccess(
           detailedEmail.htmlEmailContent ?? "",
           detailedEmail.attachments ?? [],

--- a/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
@@ -303,7 +303,8 @@ class MailboxDashBoardBindings extends BaseBindings {
     Get.lazyPut(() => GetAppDashboardConfigurationInteractor(
         Get.find<AppConfigLoader>()));
     Get.lazyPut(() => GetEmailByIdInteractor(
-      Get.find<ThreadRepository>()));
+      Get.find<ThreadRepository>(),
+      Get.find<EmailRepository>()));
     Get.lazyPut(() => UpdateAuthenticationAccountInteractor(Get.find<AccountRepository>()));
     Get.lazyPut(() => StoreSpamReportInteractor(
       Get.find<SpamReportRepository>()));

--- a/lib/features/offline_mode/manager/detailed_email_cache_manager.dart
+++ b/lib/features/offline_mode/manager/detailed_email_cache_manager.dart
@@ -77,7 +77,7 @@ class DetailedEmailCacheManager {
     EmailId emailId
   ) async {
     final keyCache = TupleKey(emailId.asString, accountId.asString, userName.value).encodeKey;
-    final detailedEmailCache = await _cacheClient.getItem(keyCache);
+    final detailedEmailCache = await _cacheClient.getItem(keyCache, needToReopen: true);
     log('DetailedEmailCacheManager::getDetailEmailExistedInCache():Email: $detailedEmailCache');
     return detailedEmailCache;
   }

--- a/lib/features/offline_mode/manager/detailed_email_cache_manager.dart
+++ b/lib/features/offline_mode/manager/detailed_email_cache_manager.dart
@@ -3,7 +3,8 @@ import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/file_utils.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
-import 'package:model/extensions/account_id_extensions.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:model/model.dart';
 import 'package:tmail_ui_user/features/caching/clients/detailed_email_hive_cache_client.dart';
 import 'package:tmail_ui_user/features/caching/utils/cache_utils.dart';
 import 'package:tmail_ui_user/features/caching/utils/caching_constants.dart';
@@ -68,5 +69,16 @@ class DetailedEmailCacheManager {
 
   Future<void> _deleteFileExisted(String pathFile) async {
     await _fileUtils.deleteFile(pathFile);
+  }
+
+  Future<DetailedEmailHiveCache?> getDetailEmailExistedInCache(
+    AccountId accountId,
+    UserName userName,
+    EmailId emailId
+  ) async {
+    final keyCache = TupleKey(emailId.asString, accountId.asString, userName.value).encodeKey;
+    final detailedEmailCache = await _cacheClient.getItem(keyCache);
+    log('DetailedEmailCacheManager::getDetailEmailExistedInCache():Email: $detailedEmailCache');
+    return detailedEmailCache;
   }
 }

--- a/lib/features/offline_mode/manager/opened_email_cache_manager.dart
+++ b/lib/features/offline_mode/manager/opened_email_cache_manager.dart
@@ -93,8 +93,8 @@ class OpenedEmailCacheManager {
     EmailId emailId
   ) async {
     final keyCache = TupleKey(emailId.asString, accountId.asString, userName.value).encodeKey;
-    final detailedEmailCache = await _cacheClient.getItem(keyCache);
-    log('OpenedEmailCacheManager::_getDetailedEmailCache():_getDetailedEmailCache: $detailedEmailCache');
+    final detailedEmailCache = await _cacheClient.getItem(keyCache,needToReopen: true);
+    log('OpenedEmailCacheManager::getOpenedEmailExistedInCache(): $detailedEmailCache');
     return detailedEmailCache;
   }
 

--- a/lib/features/offline_mode/manager/opened_email_cache_manager.dart
+++ b/lib/features/offline_mode/manager/opened_email_cache_manager.dart
@@ -73,7 +73,7 @@ class OpenedEmailCacheManager {
     EmailId emailId
   ) async {
     final emailContentPathExists = await _isFileExisted(emailId);
-    final detailedEmailCacheExists = await getDetailEmailExistedInCache(accountId, userName, emailId);
+    final detailedEmailCacheExists = await getOpenedEmailExistedInCache(accountId, userName, emailId);
 
     return emailContentPathExists == true && detailedEmailCacheExists != null;
   }
@@ -81,13 +81,13 @@ class OpenedEmailCacheManager {
   Future<bool?> _isFileExisted(EmailId emailId) async {
     final fileSaved = await _fileUtils.isFileExisted(
       nameFile: emailId.asString,
-      folderPath: CachingConstants.openedEmailContentFolderNamee,
+      folderPath: CachingConstants.openedEmailContentFolderName,
     );
     log('OpenedEmailCacheManager::_getDetailedEmailCache():_getEmailContentPath: $fileSaved');
     return fileSaved;
   }
 
-  Future<DetailedEmailHiveCache?> getDetailEmailExistedInCache(
+  Future<DetailedEmailHiveCache?> getOpenedEmailExistedInCache(
     AccountId accountId,
     UserName userName,
     EmailId emailId

--- a/lib/features/thread/data/local/email_cache_manager.dart
+++ b/lib/features/thread/data/local/email_cache_manager.dart
@@ -99,6 +99,6 @@ class EmailCacheManager {
 
   Future<EmailCache?> getEmailFromCache(AccountId accountId, UserName userName, EmailId emailId) {
     final keyCache = TupleKey(emailId.asString, accountId.asString, userName.value).encodeKey;
-    return _emailCacheClient.getItem(keyCache);
+    return _emailCacheClient.getItem(keyCache, needToReopen: true);
   }
 }

--- a/lib/features/thread/data/local/email_cache_manager.dart
+++ b/lib/features/thread/data/local/email_cache_manager.dart
@@ -96,4 +96,9 @@ class EmailCacheManager {
     final keyCache = TupleKey(emailCache.id, accountId.asString, userName.value).encodeKey;
     return _emailCacheClient.insertItem(keyCache, emailCache);
   }
+
+  Future<EmailCache?> getEmailFromCache(AccountId accountId, UserName userName, EmailId emailId) {
+    final keyCache = TupleKey(emailId.asString, accountId.asString, userName.value).encodeKey;
+    return _emailCacheClient.getItem(keyCache);
+  }
 }

--- a/lib/features/thread/domain/usecases/get_email_by_id_interactor.dart
+++ b/lib/features/thread/domain/usecases/get_email_by_id_interactor.dart
@@ -66,7 +66,7 @@ class GetEmailByIdInteractor {
   ) async* {
     try {
 
-      final email = await _emailRepository.getEmailFromCache(session, accountId, emailId);
+      final email = await _emailRepository.getEmailStored(session, accountId, emailId);
 
       if (email != null) {
         yield Right<Failure, Success>(GetEmailByIdSuccess(email.toPresentationEmail()));

--- a/lib/features/thread/domain/usecases/get_email_by_id_interactor.dart
+++ b/lib/features/thread/domain/usecases/get_email_by_id_interactor.dart
@@ -1,17 +1,23 @@
+import 'dart:io';
+
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
+import 'package:core/utils/build_utils.dart';
 import 'package:dartz/dartz.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/properties/properties.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:model/extensions/email_extension.dart';
+import 'package:tmail_ui_user/features/email/domain/repository/email_repository.dart';
 import 'package:tmail_ui_user/features/thread/domain/repository/thread_repository.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/get_email_by_id_state.dart';
 
 class GetEmailByIdInteractor {
   final ThreadRepository _threadRepository;
+  final EmailRepository _emailRepository;
 
-  GetEmailByIdInteractor(this._threadRepository);
+  GetEmailByIdInteractor(this._threadRepository, this._emailRepository);
 
   Stream<Either<Failure, Success>> execute(
     Session session,
@@ -23,10 +29,56 @@ class GetEmailByIdInteractor {
   ) async* {
     try {
       yield Right<Failure, Success>(GetEmailByIdLoading());
+      if (!BuildUtils.isWeb) {
+        yield* _tryToGetEmailFromCache(session, accountId, emailId, properties: properties);
+      } else {
+        yield* _getEmailByIdFromServer(session, accountId, emailId, properties: properties);
+      }
+    } catch (e) {
+      yield Left<Failure, Success>(GetEmailByIdFailure(e));
+    }
+  }
+
+  Stream<Either<Failure, Success>> _getEmailByIdFromServer(
+    Session session,
+    AccountId accountId,
+    EmailId emailId,
+    {
+      Properties? properties,
+    }
+  ) async* {
+    try {
       final email = await _threadRepository.getEmailById(session, accountId, emailId, properties: properties);
       yield Right<Failure, Success>(GetEmailByIdSuccess(email));
     } catch (e) {
       yield Left<Failure, Success>(GetEmailByIdFailure(e));
+    }
+
+  }
+
+  Stream<Either<Failure, Success>> _tryToGetEmailFromCache(
+    Session session,
+    AccountId accountId,
+    EmailId emailId,
+    {
+      Properties? properties,
+    }
+  ) async* {
+    try {
+
+      final email = await _emailRepository.getEmailFromCache(session, accountId, emailId);
+
+      if (email != null) {
+        yield Right<Failure, Success>(GetEmailByIdSuccess(email.toPresentationEmail()));
+      } else {
+        yield* _getEmailByIdFromServer(session, accountId, emailId, properties: properties);
+      }
+    } catch (e) {
+      if (e is PathNotFoundException) {
+        yield* _getEmailByIdFromServer(session, accountId, emailId, properties: properties);
+      } else {
+        yield Left<Failure, Success>(GetEmailByIdFailure(e));
+      }
     }
   }
 }

--- a/lib/features/thread/presentation/thread_bindings.dart
+++ b/lib/features/thread/presentation/thread_bindings.dart
@@ -2,6 +2,7 @@ import 'package:core/data/model/source_type/data_source_type.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/base_bindings.dart';
 import 'package:tmail_ui_user/features/caching/clients/state_cache_client.dart';
+import 'package:tmail_ui_user/features/email/domain/repository/email_repository.dart';
 import 'package:tmail_ui_user/features/mailbox/data/datasource/state_datasource.dart';
 import 'package:tmail_ui_user/features/mailbox/data/datasource_impl/state_datasource_impl.dart';
 import 'package:tmail_ui_user/features/thread/data/datasource/thread_datasource.dart';
@@ -59,7 +60,7 @@ class ThreadBindings extends BaseBindings {
     Get.lazyPut(() => LoadMoreEmailsInMailboxInteractor(Get.find<ThreadRepository>()));
     Get.lazyPut(() => SearchEmailInteractor(Get.find<ThreadRepository>()));
     Get.lazyPut(() => SearchMoreEmailInteractor(Get.find<ThreadRepository>()));
-    Get.lazyPut(() => GetEmailByIdInteractor(Get.find<ThreadRepository>()));
+    Get.lazyPut(() => GetEmailByIdInteractor(Get.find<ThreadRepository>(), Get.find<EmailRepository>()));
   }
 
   @override


### PR DESCRIPTION
- Issue: #1869 

- Resolved:

**- OFFLINE MODE** 

1.  Received new noti and save to local DB

https://github.com/linagora/tmail-flutter/assets/99852347/d1f2434d-cef7-46c2-9718-5796a0ee42af

2. Check local DB has been save

https://github.com/linagora/tmail-flutter/assets/99852347/1fe45d4b-ffcb-451b-8aca-8c8702f44c81

3. Open noti and double check for duplicate email

https://github.com/linagora/tmail-flutter/assets/99852347/7788e2be-c115-4620-90ab-5d3feddac2ad

4. When reconnecting network and opening email again 

In this case: Only open email in folder `new_email` has been saved when received noti. Not save to `opened_email`

https://github.com/linagora/tmail-flutter/assets/99852347/36d2b775-7826-446a-b7ab-1277e23cf706

**- ONLINE MODE** 
1. Received new noti and save to local DB, Check local DB has been save
https://github.com/linagora/tmail-flutter/assets/99852347/18308a97-710f-490d-bd00-5f6caa62c790

2. Open noti and double check for duplicate email

https://github.com/linagora/tmail-flutter/assets/99852347/102b85e3-21bf-46c2-93a8-6f5ceb1f4bf1

