### PR TITLE
[HOT-FIX] Upgrade gradle version to support class file major version 61 in Java (Java 17)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,21 +2,20 @@ buildscript {
     ext.kotlin_version = '1.6.10'
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 
     dependencies {
         classpath 'com.google.gms:google-services:4.3.10'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:7.1.3'
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip


### PR DESCRIPTION
### Issue

<img width="835" alt="Screenshot 2023-05-24 at 08 57 34" src="https://github.com/linagora/tmail-flutter/assets/80730648/a83985b9-1673-48ac-af1b-e3bd934eaa48">

### Root cause

- We have compiled the class with Java 17(major version 17) and we are trying to run class file under lower java version (version 16 or below)

### Resolved

- Upgrade gradle version
