### PR TITLE
TF-1862: Fix show widget of draggable when click right on email part ii

### DIFF
--- a/lib/features/thread/presentation/thread_view.dart
+++ b/lib/features/thread/presentation/thread_view.dart
@@ -361,6 +361,7 @@ class ThreadView extends GetWidget<ThreadController>
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
       onSecondaryTapDown: (_) {},
+      onTapDown: (_) {},
       child: Draggable<List<PresentationEmail>>(
         data: controller.listEmailDrag,
         feedback: _buildFeedBackWidget(context),
@@ -447,6 +448,7 @@ class ThreadView extends GetWidget<ThreadController>
     return SizedBox(
       height: 60,
       child: Material(
+        clipBehavior: Clip.hardEdge,
         borderRadius: BorderRadius.circular(10),
         color: AppColor.colorTextButton,
         child: Padding(


### PR DESCRIPTION
- Issue : 

```
GIVEN I am in email list view
WHEN I right click on an item multiple times
THEN the right clicks menu open
AND the move dialog is shown

WHEN I left click to close menu
THEN the move dialog is still here
```

https://github.com/linagora/tmail-flutter/assets/99852347/56f25735-a015-4bb3-973f-b9b3b5541fc7

- Resolved:

https://github.com/linagora/tmail-flutter/assets/99852347/813de239-83d4-4654-810a-855d2e9d1467

