### PR TITLE
TF-1931 Fix user cannot do infinity scroll when he turn off network and reconnect again

### DIFF
--- a/lib/features/thread/presentation/model/loading_more_status.dart
+++ b/lib/features/thread/presentation/model/loading_more_status.dart
@@ -1,0 +1,8 @@
+
+enum LoadingMoreStatus {
+  idle,
+  running,
+  completed;
+
+  bool get isRunning => this == LoadingMoreStatus.running;
+}

--- a/lib/features/thread/presentation/thread_view.dart
+++ b/lib/features/thread/presentation/thread_view.dart
@@ -302,9 +302,10 @@ class ThreadView extends GetWidget<ThreadController>
     return NotificationListener<ScrollNotification>(
       onNotification: (ScrollNotification scrollInfo) {
         if (scrollInfo is ScrollEndNotification
-            && !controller.isLoadingMore
+            && !controller.loadingMoreStatus.isRunning
             && scrollInfo.metrics.pixels == scrollInfo.metrics.maxScrollExtent
         ) {
+          log('ThreadView::_buildListEmailBody(): CALL LOAD MORE');
           if (controller.isSearchActive() || controller.searchController.advancedSearchIsActivated.isTrue) {
             controller.searchMoreEmails();
           } else {


### PR DESCRIPTION
### Issue

#1931 

### Root cause

- `isLoadMore` is not reset to `false` when network connection is re-enabled

### Solution

- Create `LoadingMoreStatus` to manage loading status more

```dart
enum LoadingMoreStatus {
  idle,
  running,
  completed;
}
```
- Reset value of `loadingMoreStatus = idle` when it process is a error

### Resolved


https://github.com/linagora/tmail-flutter/assets/80730648/80614212-01d2-421a-9a01-dfb4565190aa

