### PR TITLE
TF-1974 RefreshToken with OIDC on `jmap.linagora.com/oidc`

### DIFF
--- a/lib/features/email/domain/usecases/download_attachments_interactor.dart
+++ b/lib/features/email/domain/usecases/download_attachments_interactor.dart
@@ -72,7 +72,8 @@ class DownloadAttachmentsInteractor {
       }
     } catch (exception) {
       log('DownloadAttachmentsInteractor::execute(): $exception');
-      if (exception is DownloadAttachmentHasTokenExpiredException) {
+      if (exception is DownloadAttachmentHasTokenExpiredException &&
+          exception.refreshToken.isNotEmpty) {
         yield* _retryDownloadAttachments(
             accountId,
             baseDownloadUrl,

--- a/lib/features/login/data/network/config/authorization_interceptors.dart
+++ b/lib/features/login/data/network/config/authorization_interceptors.dart
@@ -79,6 +79,7 @@ class AuthorizationInterceptors extends InterceptorsWrapper {
     log('AuthorizationInterceptors::onError(): $err');
     if (_isTokenExpired() &&
         err.response?.statusCode == 401 &&
+        _isRefreshTokenNotEmpty() &&
         _isAuthenticationOidcValid()) {
       try {
         final newToken = await _authenticationClient.refreshingTokensOIDC(
@@ -138,6 +139,8 @@ class AuthorizationInterceptors extends InterceptorsWrapper {
     }
     return false;
   }
+
+  bool _isRefreshTokenNotEmpty() => _token != null && _token!.refreshToken.isNotEmpty;
 
   String _getAuthorizationAsBasicHeader(String? authorization) => 'Basic $authorization';
 


### PR DESCRIPTION
### Issue

#1974 

### Root cause

- I have hard-coded for `RefreshToken` as null. Before calling `appAuth.token()` and getting the same error as store.

<img width="1440" alt="Screenshot 2023-07-04 at 00 46 59" src="https://github.com/linagora/tmail-flutter/assets/80730648/4d1f7548-157a-4950-92ad-6eb00abfb6ab">

- After that investigation, we concluded that `refreshToken` was empty leading to the application crash.  Details in the native library [openid](https://github.com/openid/AppAuth-Android/blob/d73ced59d07a4b93d9039ab3d193942fc7197959/library/java/net/openid/appauth/TokenRequest.java#L399)

<img width="735" alt="Screenshot 2023-07-04 at 00 51 45" src="https://github.com/linagora/tmail-flutter/assets/80730648/b6f9bc1f-a134-4d9f-b45a-4a504680e23a">

- It only happens on Android devices

### Solution

- Check for non-empty `refreshToken` before being used.

### Related 

- Same issue raised on `Flutter AppAuth` library [Issues#396](https://github.com/MaikuB/flutter_appauth/issues/396)