### PR TITLE
Fix re-login app when token expires in OIDC

### DIFF
--- a/env.file
+++ b/env.file
@@ -1,7 +1,7 @@
 SERVER_URL=http://localhost/
 DOMAIN_REDIRECT_URL=http://localhost:3000
 WEB_OIDC_CLIENT_ID=teammail-web
-OIDC_SCOPES=openid,profile,email
+OIDC_SCOPES=openid,profile,email,offline_access
 APP_GRID_AVAILABLE=supported
 FCM_AVAILABLE=supported
 IOS_FCM=supported


### PR DESCRIPTION
### Root cause

- `DioError` has `response` as null.

<img width="919" alt="Screenshot 2023-07-14 at 18 35 23" src="https://github.com/linagora/tmail-flutter/assets/80730648/b868904f-3bf9-4699-ba35-2eede6b28900">


<img width="1059" alt="Screenshot 2023-07-17 at 12 03 26" src="https://github.com/linagora/tmail-flutter/assets/80730648/772c663b-3921-41b5-bd5f-a8ce4106e125">


- Request header

```
POST /oidc/jmap HTTP/1.1
Accept-Encoding: gzip, deflate
Accept-Language: vi,en-US;q=0.9,en;q=0.8
Connection: keep-alive
Content-Length: 625
DNT: 1
Host: apisix.example.com:9080
Origin: http://test.sso.example.com:8080
Referer: http://test.sso.example.com:8080/
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36
accept: application/json;jmapVersion=rfc-8621
authorization: Bearer token
content-type: application/json
```

- Response header

```
HTTP/1.1 401 Unauthorized
Date: Mon, 17 Jul 2023 04:57:39 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 653
Connection: keep-alive
WWW-Authenticate: Bearer realm="apisix", error="invalid_token", error_description="jwt signature verification failed: 'exp' claim expired at Mon, 17 Jul 2023 04:54:27 GMT"
Server: APISIX/3.2.0
```