### PR TITLE
TF-2087 Fix status bar missing in dark theme mode

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -91,5 +91,9 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIUserInterfaceStyle</key>
+    <string>Light</string>
+    <key>UIViewControllerBasedStatusBarAppearance</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Issue

#2087 

## Resolved

- iOS


https://github.com/linagora/tmail-flutter/assets/80730648/d7040f9c-e8d8-45c3-87f3-a781d585f2fb



- Android


[android.webm](https://github.com/linagora/tmail-flutter/assets/80730648/54972d69-906f-48ea-9744-87b8890a552e)


