### PR TITLE
TF-2089 Pull to refresh mailbox view not working

### DIFF
--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -205,10 +205,6 @@ class MailboxController extends BaseMailboxController with MailboxActionHandlerM
     });
   }
 
-  void handleScrollEnable() {
-    isMailboxListScrollable.value = mailboxListScrollController.hasClients && mailboxListScrollController.position.maxScrollExtent > 0;
-  }
-
   void _registerObxStreamListener() {
     ever(mailboxDashBoardController.accountId, (accountId) {
       if (accountId != null && mailboxDashBoardController.sessionCurrent != null) {
@@ -299,7 +295,7 @@ class MailboxController extends BaseMailboxController with MailboxActionHandlerM
     }
   }
 
-  void refreshAllMailbox() {
+  Future<void> refreshAllMailbox() async {
     final session = mailboxDashBoardController.sessionCurrent;
     final accountId = mailboxDashBoardController.accountId.value;
     if (session != null && accountId != null) {

--- a/lib/features/mailbox/presentation/mailbox_view.dart
+++ b/lib/features/mailbox/presentation/mailbox_view.dart
@@ -45,7 +45,7 @@ class MailboxView extends BaseMailboxView {
                               color: Colors.white,
                               child: RefreshIndicator(
                                 color: AppColor.primaryColor,
-                                onRefresh: () async => controller.refreshAllMailbox(),
+                                onRefresh: controller.refreshAllMailbox,
                                 child: SafeArea(
                                   top: false,
                                   right: false,
@@ -154,124 +154,118 @@ class MailboxView extends BaseMailboxView {
   }
 
   Widget _buildListMailbox(BuildContext context) {
-    return NotificationListener(
-      onNotification: (_) {
-        controller.handleScrollEnable();
-        return true;
-      },
-      child: SingleChildScrollView(
-        controller: controller.mailboxListScrollController,
-        key: const PageStorageKey('mailbox_list'),
-        physics: const ClampingScrollPhysics(),
-        padding: const EdgeInsets.only(bottom: 16),
-        child: Column(children: [
-          Obx(() {
-            if (controller.isSelectionEnabled() && responsiveUtils.isLandscapeMobile(context)) {
-              return const SizedBox.shrink();
-            }
-            return buildUserInformation(context);
-          }),
-          buildLoadingView(),
-          AppConfig.appGridDashboardAvailable
-            ? buildAppGridDashboard(context, responsiveUtils, imagePaths, controller)
-            : const SizedBox.shrink(),
-          const SizedBox(height: 8),
-          Obx(() {
-            if (controller.defaultMailboxIsNotEmpty) {
-              return _buildMailboxCategory(
-                context,
-                MailboxCategories.exchange,
-                controller.defaultRootNode
-              );
-            } else {
-              return const SizedBox.shrink();
-            }
-          }),
-          Obx(() {
-            if (controller.mailboxDashBoardController.listSendingEmails.isNotEmpty &&
-                PlatformInfo.isMobile &&
-                !controller.isSelectionEnabled()) {
-              return SendingQueueMailboxWidget(
-                listSendingEmails: controller.mailboxDashBoardController.listSendingEmails,
-                onOpenSendingQueueAction: () => controller.openSendingQueueViewAction(context),
-                isSelected: controller.mailboxDashBoardController.dashboardRoute.value == DashboardRoutes.sendingQueue,
-              );
-            } else {
-              return const SizedBox.shrink();
-            }
-          }),
-          const SizedBox(height: 8),
-          const Divider(color: AppColor.colorDividerMailbox, height: 1),
-          const SizedBox(height: 12),
-          Container(
-            margin: EdgeInsetsDirectional.only(
-              start: responsiveUtils.isLandscapeMobile(context) ? 0 : 8,
-              end: 16),
-            padding: const EdgeInsetsDirectional.only(start: 8),
-            child: Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    AppLocalizations.of(context).folders,
-                    style: const TextStyle(
-                      fontSize: 20,
-                      color: Colors.black,
-                      fontWeight: FontWeight.bold
-                    )
-                  ),
+    return SingleChildScrollView(
+      controller: controller.mailboxListScrollController,
+      key: const PageStorageKey('mailbox_list'),
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Column(children: [
+        Obx(() {
+          if (controller.isSelectionEnabled() && responsiveUtils.isLandscapeMobile(context)) {
+            return const SizedBox.shrink();
+          }
+          return buildUserInformation(context);
+        }),
+        buildLoadingView(),
+        AppConfig.appGridDashboardAvailable
+          ? buildAppGridDashboard(context, responsiveUtils, imagePaths, controller)
+          : const SizedBox.shrink(),
+        const SizedBox(height: 8),
+        Obx(() {
+          if (controller.defaultMailboxIsNotEmpty) {
+            return _buildMailboxCategory(
+              context,
+              MailboxCategories.exchange,
+              controller.defaultRootNode
+            );
+          } else {
+            return const SizedBox.shrink();
+          }
+        }),
+        Obx(() {
+          if (controller.mailboxDashBoardController.listSendingEmails.isNotEmpty &&
+              PlatformInfo.isMobile &&
+              !controller.isSelectionEnabled()) {
+            return SendingQueueMailboxWidget(
+              listSendingEmails: controller.mailboxDashBoardController.listSendingEmails,
+              onOpenSendingQueueAction: () => controller.openSendingQueueViewAction(context),
+              isSelected: controller.mailboxDashBoardController.dashboardRoute.value == DashboardRoutes.sendingQueue,
+            );
+          } else {
+            return const SizedBox.shrink();
+          }
+        }),
+        const SizedBox(height: 8),
+        const Divider(color: AppColor.colorDividerMailbox, height: 1),
+        const SizedBox(height: 12),
+        Container(
+          margin: EdgeInsetsDirectional.only(
+            start: responsiveUtils.isLandscapeMobile(context) ? 0 : 8,
+            end: 16),
+          padding: const EdgeInsetsDirectional.only(start: 8),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  AppLocalizations.of(context).mailBoxes,
+                  style: const TextStyle(
+                    fontSize: 20,
+                    color: Colors.black,
+                    fontWeight: FontWeight.bold
+                  )
                 ),
-                Row(children: [
-                  buildIconWeb(
-                    minSize: 40,
-                    iconPadding: EdgeInsets.zero,
-                    icon: SvgPicture.asset(
-                      imagePaths.icSearchBar,
-                      colorFilter: AppColor.colorTextButton.asFilter(),
-                      fit: BoxFit.fill
-                    ),
-                    tooltip: AppLocalizations.of(context).searchForMailboxes,
-                    onTap: () => controller.openSearchViewAction(context)
+              ),
+              Row(children: [
+                buildIconWeb(
+                  minSize: 40,
+                  iconPadding: EdgeInsets.zero,
+                  icon: SvgPicture.asset(
+                    imagePaths.icSearchBar,
+                    colorFilter: AppColor.colorTextButton.asFilter(),
+                    fit: BoxFit.fill
                   ),
-                  buildIconWeb(
-                    minSize: 40,
-                    iconSize: 20,
-                    iconPadding: EdgeInsets.zero,
-                    splashRadius: 15,
-                    icon: SvgPicture.asset(
-                      imagePaths.icAddNewFolder,
-                      colorFilter: AppColor.colorTextButton.asFilter(),
-                      fit: BoxFit.fill),
-                    tooltip: AppLocalizations.of(context).new_mailbox,
-                  onTap: () => controller.goToCreateNewMailboxView(context)),
-                ]),
+                  tooltip: AppLocalizations.of(context).searchForMailboxes,
+                  onTap: () => controller.openSearchViewAction(context)
+                ),
+                buildIconWeb(
+                  minSize: 40,
+                  iconSize: 20,
+                  iconPadding: EdgeInsets.zero,
+                  splashRadius: 15,
+                  icon: SvgPicture.asset(
+                    imagePaths.icAddNewFolder,
+                    colorFilter: AppColor.colorTextButton.asFilter(),
+                    fit: BoxFit.fill),
+                  tooltip: AppLocalizations.of(context).new_mailbox,
+                onTap: () => controller.goToCreateNewMailboxView(context)),
               ]),
-            ),
-          const SizedBox(height: 8),
-          Obx(() {
-            if (controller.personalMailboxIsNotEmpty) {
-              return _buildMailboxCategory(
-                context,
-                MailboxCategories.personalFolders,
-                controller.personalRootNode
-              );
-            } else {
-              return const SizedBox.shrink();
-            }
-          }),
-          const SizedBox(height: 8),
-          Obx(() {
-            if (controller.teamMailboxesIsNotEmpty) {
-              return _buildMailboxCategory(
-                context,
-                MailboxCategories.teamMailboxes,
-                controller.teamMailboxesRootNode
-              );
-            } else {
-              return const SizedBox.shrink();
-            }
-          }),
-        ])
-      ),
+            ]),
+          ),
+        const SizedBox(height: 8),
+        Obx(() {
+          if (controller.personalMailboxIsNotEmpty) {
+            return _buildMailboxCategory(
+              context,
+              MailboxCategories.personalFolders,
+              controller.personalRootNode
+            );
+          } else {
+            return const SizedBox.shrink();
+          }
+        }),
+        const SizedBox(height: 8),
+        Obx(() {
+          if (controller.teamMailboxesIsNotEmpty) {
+            return _buildMailboxCategory(
+              context,
+              MailboxCategories.teamMailboxes,
+              controller.teamMailboxesRootNode
+            );
+          } else {
+            return const SizedBox.shrink();
+          }
+        }),
+      ])
     );
   }
 

--- a/lib/features/mailbox/presentation/mailbox_view_web.dart
+++ b/lib/features/mailbox/presentation/mailbox_view_web.dart
@@ -1,4 +1,5 @@
 import 'package:core/core.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
@@ -40,11 +41,7 @@ class MailboxView extends BaseMailboxView {
                 color: responsiveUtils.isDesktop(context)
                   ? AppColor.colorBgDesktop
                   : Colors.white,
-                child: RefreshIndicator(
-                  color: AppColor.primaryColor,
-                  onRefresh: () async => controller.refreshAllMailbox(),
-                  child: _buildListMailbox(context)
-                ),
+                child: _buildListMailbox(context),
               ),
             )),
             const QuotasView(),
@@ -83,101 +80,115 @@ class MailboxView extends BaseMailboxView {
   Widget _buildListMailbox(BuildContext context) {
     return Stack(
       children: [
-        SingleChildScrollView(
-          controller: controller.mailboxListScrollController,
-          key: const PageStorageKey('mailbox_list'),
-          physics: const ClampingScrollPhysics(),
-          padding: EdgeInsetsDirectional.only(end: responsiveUtils.isDesktop(context) ? 16 : 0),
-          child: Column(children: [
-            if (!responsiveUtils.isDesktop(context))
-              buildUserInformation(context),
-            buildLoadingView(),
-            AppConfig.appGridDashboardAvailable && responsiveUtils.isWebNotDesktop(context)
-              ? buildAppGridDashboard(context, responsiveUtils, imagePaths, controller)
-              : const SizedBox.shrink(),
-            const SizedBox(height: 8),
-            Obx(() {
-              if (controller.defaultMailboxIsNotEmpty) {
-                return _buildMailboxCategory(
-                  context,
-                  MailboxCategories.exchange,
-                  controller.defaultRootNode
-                );
-              } else {
-                return const SizedBox.shrink();
-              }
-            }),
-            const SizedBox(height: 8),
-            const Divider(color: AppColor.colorDividerMailbox, height: 1),
-            const SizedBox(height: 13),
-            Padding(
-              padding: EdgeInsetsDirectional.only(
-                start: responsiveUtils.isDesktop(context) ? 0 : 12,
-                bottom: 8
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Expanded(child: Text(
-                    AppLocalizations.of(context).folders,
-                    style: const TextStyle(
-                      fontSize: 17,
-                      color: Colors.black,
-                      fontWeight: FontWeight.bold
-                    )
-                  )),
-                  Padding(
-                    padding: EdgeInsetsDirectional.only(end: responsiveUtils.isDesktop(context) ? 0 : 12),
-                    child: Row(
-                      children: [
-                        buildIconWeb(
-                          minSize: 40,
-                          iconPadding: EdgeInsets.zero,
-                          icon: SvgPicture.asset(
-                            imagePaths.icSearchBar,
-                            colorFilter: AppColor.colorTextButton.asFilter(),
-                            fit: BoxFit.fill
-                          ),
-                          onTap: () => controller.openSearchViewAction(context)
-                        ),
-                        buildIconWeb(
-                            minSize: 40,
-                            iconSize: 20,
-                            iconPadding: EdgeInsets.zero,
-                            splashRadius: 15,
-                            icon: SvgPicture.asset(
-                              imagePaths.icAddNewFolder,
-                              colorFilter: AppColor.colorTextButton.asFilter(),
-                              fit: BoxFit.fill),
-                            tooltip: AppLocalizations.of(context).new_mailbox,
-                            onTap: () => controller.goToCreateNewMailboxView(context)),
-                      ],
+        ScrollConfiguration(
+          behavior: ScrollConfiguration.of(context).copyWith(
+            physics: const BouncingScrollPhysics(),
+            dragDevices: {
+              PointerDeviceKind.touch,
+              PointerDeviceKind.mouse,
+              PointerDeviceKind.trackpad
+            },
+          ),
+          child: RefreshIndicator(
+            color: AppColor.primaryColor,
+            onRefresh: controller.refreshAllMailbox,
+            child: SingleChildScrollView(
+              controller: controller.mailboxListScrollController,
+              key: const PageStorageKey('mailbox_list'),
+              physics: const AlwaysScrollableScrollPhysics(),
+              padding: EdgeInsetsDirectional.only(end: responsiveUtils.isDesktop(context) ? 16 : 0),
+              child: Column(children: [
+                if (!responsiveUtils.isDesktop(context))
+                  buildUserInformation(context),
+                buildLoadingView(),
+                AppConfig.appGridDashboardAvailable && responsiveUtils.isWebNotDesktop(context)
+                  ? buildAppGridDashboard(context, responsiveUtils, imagePaths, controller)
+                  : const SizedBox.shrink(),
+                const SizedBox(height: 8),
+                Obx(() {
+                  if (controller.defaultMailboxIsNotEmpty) {
+                    return _buildMailboxCategory(
+                      context,
+                      MailboxCategories.exchange,
+                      controller.defaultRootNode
+                    );
+                  } else {
+                    return const SizedBox.shrink();
+                  }
+                }),
+                const SizedBox(height: 8),
+                const Divider(color: AppColor.colorDividerMailbox, height: 1),
+                const SizedBox(height: 13),
+                Padding(
+                  padding: EdgeInsetsDirectional.only(
+                    start: responsiveUtils.isDesktop(context) ? 0 : 12,
+                    bottom: 8
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Expanded(child: Text(
+                        AppLocalizations.of(context).folders,
+                        style: const TextStyle(
+                          fontSize: 17,
+                          color: Colors.black,
+                          fontWeight: FontWeight.bold
+                        )
                       )),
-                ]),
+                      Padding(
+                        padding: EdgeInsetsDirectional.only(end: responsiveUtils.isDesktop(context) ? 0 : 12),
+                        child: Row(
+                          children: [
+                            buildIconWeb(
+                              minSize: 40,
+                              iconPadding: EdgeInsets.zero,
+                              icon: SvgPicture.asset(
+                                imagePaths.icSearchBar,
+                                colorFilter: AppColor.colorTextButton.asFilter(),
+                                fit: BoxFit.fill
+                              ),
+                              onTap: () => controller.openSearchViewAction(context)
+                            ),
+                            buildIconWeb(
+                                minSize: 40,
+                                iconSize: 20,
+                                iconPadding: EdgeInsets.zero,
+                                splashRadius: 15,
+                                icon: SvgPicture.asset(
+                                  imagePaths.icAddNewFolder,
+                                  colorFilter: AppColor.colorTextButton.asFilter(),
+                                  fit: BoxFit.fill),
+                                tooltip: AppLocalizations.of(context).new_mailbox,
+                                onTap: () => controller.goToCreateNewMailboxView(context)),
+                          ],
+                          )),
+                    ]),
+                ),
+                Obx(() {
+                  if (controller.personalMailboxIsNotEmpty) {
+                    return _buildMailboxCategory(
+                      context,
+                      MailboxCategories.personalFolders,
+                      controller.personalRootNode
+                    );
+                  } else {
+                    return const SizedBox.shrink();
+                  }
+                }),
+                Obx(() {
+                  if (controller.teamMailboxesIsNotEmpty) {
+                    return _buildMailboxCategory(
+                      context,
+                      MailboxCategories.teamMailboxes,
+                      controller.teamMailboxesRootNode
+                    );
+                  } else {
+                    return const SizedBox.shrink();
+                  }
+                })
+              ])
             ),
-            Obx(() {
-              if (controller.personalMailboxIsNotEmpty) {
-                return _buildMailboxCategory(
-                  context,
-                  MailboxCategories.personalFolders,
-                  controller.personalRootNode
-                );
-              } else {
-                return const SizedBox.shrink();
-              }
-            }),
-            Obx(() {
-              if (controller.teamMailboxesIsNotEmpty) {
-                return _buildMailboxCategory(
-                  context,
-                  MailboxCategories.teamMailboxes,
-                  controller.teamMailboxesRootNode
-                );
-              } else {
-                return const SizedBox.shrink();
-              }
-            })
-          ])
+          ),
         ),
         Obx(() => controller.mailboxDashBoardController.isDraggingMailbox && controller.activeScrollTop
             ? Align(


### PR DESCRIPTION
## Issue

#2089 

## Root cause

- Because we override SingleScrollView's scroll event, RefreshIndicator can't listen and control its scroll.

## Resolved

- Mobile


https://github.com/linagora/tmail-flutter/assets/80730648/58fc19e1-682c-4573-bc0e-5e6d9ecf6760



- Web


https://github.com/linagora/tmail-flutter/assets/80730648/b3eb79c6-6986-48e3-ae6b-35f1ee953e8b

