### PR TITLE
TF-1974 Fix refresh token OIDC failed

### DIFF
--- a/lib/features/login/data/network/config/oidc_constant.dart
+++ b/lib/features/login/data/network/config/oidc_constant.dart
@@ -3,7 +3,7 @@ import 'package:tmail_ui_user/main/utils/app_config.dart';
 
 class OIDCConstant {
   static String get mobileOidcClientId => 'teammail-mobile';
-  static List<String> get oidcScope => ['openid', 'email'];
+  static List<String> get oidcScope => ['openid', 'profile', 'email', 'offline_access'];
   static const keyAuthorityOidc = 'KEY_AUTHORITY_OIDC';
   static const authResponseKey = "auth_info";
 


### PR DESCRIPTION
## Issue

#1974 

## Root cause

- We get this error when we call refreshToken: `PlatformException(token_failed, Concurrent operations detected: token, token, null, null)` . As implied by the error, this would mean your application is making concurrent calls to the plugin where it's not waiting for an operation to finish before starting another one.

## Solution

- Use `QueuedInterceptorsWrapper`.  If there are multiple concurrent requests, the request is added to a queue before
entering the interceptor. Only one request at a time enters the interceptor, and after that request is processed by the interceptor, the next request will enter the interceptor.

## Resolved

- Work fine  on device Android