### PR TITLE
TF-1845 Fix the searching result is not correct with the condition `Doesn't have` and `Has the words`

### DIFF
--- a/lib/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart
+++ b/lib/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart
@@ -108,8 +108,8 @@ class SearchEmailFilter with EquatableMixin {
             from.map((e) => EmailFilterCondition(from: e)).toSet()),
       if (notKeyword.isNotEmpty)
         LogicFilterOperator(
-            Operator.AND,
-            notKeyword.map((e) => EmailFilterCondition(notKeyword: e)).toSet()),
+          Operator.NOT,
+          notKeyword.map((e) => EmailFilterCondition(text: e)).toSet()),
       if (moreFilterCondition != null && moreFilterCondition.hasCondition)
         moreFilterCondition
     };


### PR DESCRIPTION
## Issue

#1845 

## Resolved


https://github.com/linagora/tmail-flutter/assets/80730648/a56871db-9676-4fbd-8536-5c1b61e1aa04

