### PR TITLE
TF-2129 Fix cannot attach file on mobile

### DIFF
--- a/core/lib/utils/app_logger.dart
+++ b/core/lib/utils/app_logger.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:core/utils/platform_info.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -11,24 +12,34 @@ void log(String? value, {Level level = Level.info}) {
   String logsStr = value ?? '';
   logHistory.value = '$logsStr\n${logHistory.value}';
 
-  switch (level) {
-    case Level.wtf:
-      logsStr = '\x1B[31m!!!CRITICAL!!! $logsStr\x1B[0m';
-      break;
-    case Level.error:
-      logsStr = '\x1B[31m$logsStr\x1B[0m';
-      break;
-    case Level.warning:
-      logsStr = '\x1B[33m$logsStr\x1B[0m';
-      break;
-    case Level.info:
-      logsStr = '\x1B[32m$logsStr\x1B[0m';
-      break;
-    case Level.debug:
-      logsStr = '\x1B[34m$logsStr\x1B[0m';
-      break;
-    case Level.verbose:
-      break;
+  if (PlatformInfo.isWeb) {
+    switch (level) {
+      case Level.wtf:
+        logsStr = '\x1B[31m!!!CRITICAL!!! $logsStr\x1B[0m';
+        break;
+      case Level.error:
+        logsStr = '\x1B[31m$logsStr\x1B[0m';
+        break;
+      case Level.warning:
+        logsStr = '\x1B[33m$logsStr\x1B[0m';
+        break;
+      case Level.info:
+        logsStr = '\x1B[32m$logsStr\x1B[0m';
+        break;
+      case Level.debug:
+        logsStr = '\x1B[34m$logsStr\x1B[0m';
+        break;
+      case Level.verbose:
+        break;
+    }
+  } else {
+    switch (level) {
+      case Level.error:
+        logsStr = '[ERROR] $logsStr';
+        break;
+      default:
+        break;
+    }
   }
   // ignore: avoid_print
   print('[TeamMail] $logsStr');

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -91,7 +91,7 @@ class ComposerController extends BaseController {
   final _uuid = Get.find<Uuid>();
   final _dynamicUrlInterceptors = Get.find<DynamicUrlInterceptors>();
 
-  final expandModeAttachments = ExpandMode.COLLAPSE.obs;
+  final expandModeAttachments = ExpandMode.EXPAND.obs;
   final composerArguments = Rxn<ComposerArguments>();
   final isEnableEmailSendButton = false.obs;
   final isInitialRecipient = false.obs;

--- a/lib/features/upload/data/model/upload_file_arguments.dart
+++ b/lib/features/upload/data/model/upload_file_arguments.dart
@@ -1,25 +1,28 @@
 
 import 'package:core/data/network/dio_client.dart';
-import 'package:dio/dio.dart';
 import 'package:equatable/equatable.dart';
-import 'package:model/upload/file_info.dart';
+import 'package:tmail_ui_user/features/upload/domain/model/mobile_file_upload.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
 
 class UploadFileArguments with EquatableMixin {
 
   final DioClient dioClient;
   final UploadTaskId uploadId;
-  final FileInfo fileInfo;
+  final MobileFileUpload mobileFileUpload;
   final Uri uploadUri;
-  final CancelToken? cancelToken;
 
   UploadFileArguments(
     this.dioClient,
     this.uploadId,
-    this.fileInfo,
-    this.uploadUri,
-    {this.cancelToken});
+    this.mobileFileUpload,
+    this.uploadUri
+  );
 
   @override
-  List<Object?> get props => [uploadId, fileInfo, uploadUri];
+  List<Object?> get props => [
+    dioClient,
+    uploadId,
+    mobileFileUpload,
+    uploadUri
+  ];
 }

--- a/lib/features/upload/data/network/file_uploader.dart
+++ b/lib/features/upload/data/network/file_uploader.dart
@@ -15,6 +15,7 @@ import 'package:model/upload/file_info.dart';
 import 'package:model/upload/upload_response.dart';
 import 'package:tmail_ui_user/features/upload/data/model/upload_file_arguments.dart';
 import 'package:tmail_ui_user/features/upload/domain/exceptions/upload_exception.dart';
+import 'package:tmail_ui_user/features/upload/domain/extensions/file_info_extension.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
 import 'package:tmail_ui_user/features/upload/domain/state/attachment_upload_state.dart';
 import 'package:worker_manager/worker_manager.dart' as worker;
@@ -41,13 +42,13 @@ class FileUploader {
           uploadUri,
           cancelToken: cancelToken);
     } else {
+      final mobileFileUpload = fileInfo.toMobileFileUpload();
       return await _isolateExecutor.execute(
         arg1: UploadFileArguments(
           _dioClient,
           uploadId,
-          fileInfo,
-          uploadUri,
-          cancelToken: cancelToken
+          mobileFileUpload,
+          uploadUri
         ),
         fun1: _handleUploadAttachmentAction,
         notification: (value) {
@@ -66,34 +67,31 @@ class FileUploader {
       UploadFileArguments argsUpload,
       worker.TypeSendPort sendPort
   ) async {
-    final dioClient = argsUpload.dioClient;
-    final fileInfo = argsUpload.fileInfo;
-    final uploadUri = argsUpload.uploadUri;
-    final cancelToken = argsUpload.cancelToken;
+    final headerParam = argsUpload.dioClient.getHeaders();
+    headerParam[HttpHeaders.contentTypeHeader] = argsUpload.mobileFileUpload.mimeType;
+    headerParam[HttpHeaders.contentLengthHeader] = argsUpload.mobileFileUpload.fileSize;
+    final data = File(argsUpload.mobileFileUpload.filePath).openRead();
 
-    final resultJson = await _invokeRequestToServer(
-      dioClient,
-      uploadUri,
-      fileInfo,
-      cancelToken: cancelToken,
+    final resultJson = await argsUpload.dioClient.post(
+      Uri.decodeFull(argsUpload.uploadUri.toString()),
+      options: Options(headers: headerParam),
+      data: data,
       onSendProgress: (count, total) {
         log('FileUploader::_handleUploadAttachmentAction():onSendProgress: [${argsUpload.uploadId.id}] = $count');
         sendPort.send(
           UploadingAttachmentUploadState(
             argsUpload.uploadId,
             count,
-            fileInfo.fileSize
+            argsUpload.mobileFileUpload.fileSize
           )
         );
       }
     );
     log('FileUploader::_handleUploadAttachmentAction():resultJson: $resultJson');
-    if (cancelToken?.isCancelled == true) {
-      log('FileUploader::_handleUploadAttachmentAction(): upload is cancelled');
-      return null;
-    }
-
-    return _parsingResponse(resultJson: resultJson, fileName: fileInfo.fileName);
+    return _parsingResponse(
+      resultJson: resultJson,
+      fileName: argsUpload.mobileFileUpload.fileName
+    );
   }
 
   Future<Attachment?> _handleUploadAttachmentActionOnWeb(
@@ -103,10 +101,15 @@ class FileUploader {
     Uri uploadUri,
     {CancelToken? cancelToken}
   ) async {
-    final resultJson = await _invokeRequestToServer(
-      _dioClient,
-      uploadUri,
-      fileInfo,
+    final headerParam = _dioClient.getHeaders();
+    headerParam[HttpHeaders.contentTypeHeader] = fileInfo.mimeType;
+    headerParam[HttpHeaders.contentLengthHeader] = fileInfo.fileSize;
+    final data = fileInfo.readStream;
+
+    final resultJson = await _dioClient.post(
+      Uri.decodeFull(uploadUri.toString()),
+      options: Options(headers: headerParam),
+      data: data,
       cancelToken: cancelToken,
       onSendProgress: (count, total) {
         log('FileUploader::_handleUploadAttachmentActionOnWeb():onSendProgress: [${uploadId.id}] = $count');
@@ -119,42 +122,8 @@ class FileUploader {
         );
       }
     );
-
     log('FileUploader::_handleUploadAttachmentActionOnWeb():resultJson: $resultJson');
-
-    if (cancelToken?.isCancelled == true) {
-      log('FileUploader::_handleUploadAttachmentActionOnWeb(): upload is cancelled');
-      return null;
-    }
-
     return _parsingResponse(resultJson: resultJson, fileName: fileInfo.fileName);
-  }
-
-  static Future<dynamic> _invokeRequestToServer(
-    DioClient dioClient,
-    Uri uploadUri,
-    FileInfo fileInfo, {
-    CancelToken? cancelToken,
-    ProgressCallback? onSendProgress
-  }) {
-    final headerParam = dioClient.getHeaders();
-    headerParam[HttpHeaders.contentTypeHeader] = fileInfo.mimeType;
-    headerParam[HttpHeaders.contentLengthHeader] = fileInfo.fileSize;
-
-    final data = fileInfo.readStream ?? File(fileInfo.filePath).openRead();
-
-    if (cancelToken?.isCancelled == true) {
-      log('FileUploader::_invokeRequestToServer(): upload is cancelled');
-      return Future.value();
-    }
-
-    return dioClient.post(
-      Uri.decodeFull(uploadUri.toString()),
-      options: Options(headers: headerParam),
-      data: data,
-      cancelToken: cancelToken,
-      onSendProgress: onSendProgress
-    );
   }
 
   static Attachment? _parsingResponse({dynamic resultJson, required String fileName}) {

--- a/lib/features/upload/domain/extensions/file_info_extension.dart
+++ b/lib/features/upload/domain/extensions/file_info_extension.dart
@@ -1,0 +1,7 @@
+
+import 'package:model/upload/file_info.dart';
+import 'package:tmail_ui_user/features/upload/domain/model/mobile_file_upload.dart';
+
+extension FileInfoExtension on FileInfo {
+  MobileFileUpload toMobileFileUpload() => MobileFileUpload(fileName, filePath, fileSize, mimeType);
+}

--- a/lib/features/upload/domain/model/mobile_file_upload.dart
+++ b/lib/features/upload/domain/model/mobile_file_upload.dart
@@ -1,0 +1,24 @@
+
+import 'package:equatable/equatable.dart';
+
+class MobileFileUpload with EquatableMixin {
+  final String fileName;
+  final String filePath;
+  final int fileSize;
+  final String mimeType;
+
+  MobileFileUpload(
+    this.fileName,
+    this.filePath,
+    this.fileSize,
+    this.mimeType
+  );
+
+  @override
+  List<Object?> get props => [
+    fileName,
+    filePath,
+    fileSize,
+    mimeType,
+  ];
+}


### PR DESCRIPTION
## Issue

#2129 

## Root cause

- Impact from upgrading version flutter `3.10.6` and dart `3.0.0`. Dart SDK have tightened the rules for which objects can be sent across isolates (see https://api.dart.dev/stable/3.0.0/dart-isolate/SendPort/send.html and https://github.com/dart-lang/sdk/commit/67683c39)

## Resolved



https://github.com/linagora/tmail-flutter/assets/80730648/b836a564-b032-4a01-9cbb-b1b4716bcebb



