### PR TITLE
TF-2092 Add `dash-dash-space` to signature delimiter

### DIFF
--- a/core/lib/presentation/extensions/html_extension.dart
+++ b/core/lib/presentation/extensions/html_extension.dart
@@ -2,7 +2,7 @@
 extension HtmlExtension on String {
 
   static const String editorStartTags = '<br><div><br></div>';
-  static const String signaturePrefix = '-- ';
+  static const String signaturePrefix = '--&nbsp;';
 
   String addBlockTag(String tag, {String? attribute}) =>
       attribute != null


### PR DESCRIPTION
## Issue

#2092 

# Resolved



https://github.com/linagora/tmail-flutter/assets/80730648/322b4511-d86e-4af7-831b-e9bdc0292c05

