### PR TITLE
TF-2121 Fix drag and drop text outside the composer inside the composer

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -913,8 +913,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: email_supported
-      resolved-ref: "21ab3006789f622a5df09024741aac2f24d5e7f4"
+      ref: "bugfix/replace-all-line-break-to-br-tag-in-drop-text"
+      resolved-ref: "417501a2dd832c466aabc0914b5de13f3fec00bc"
       url: "https://github.com/linagora/html-editor-enhanced.git"
     source: git
     version: "2.5.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   html_editor_enhanced:
     git:
       url: https://github.com/linagora/html-editor-enhanced.git
-      ref: email_supported
+      ref: bugfix/replace-all-line-break-to-br-tag-in-drop-text
 
   jmap_dart_client:
     git:


### PR DESCRIPTION
## Issue

#2121 

## Root cause

- Because the `drag and drop` handling function of the `summernote` library is incorrect.
- Fixed here: https://github.com/linagora/html-editor-enhanced/pull/22

## Dependent

- Need merged: https://github.com/linagora/html-editor-enhanced/pull/22

## Resolved


https://github.com/linagora/tmail-flutter/assets/80730648/0a0b30fa-5891-4514-a9fb-ba838c17e2c9


