### PR TITLE
[HOT-FIX] Fix built release but nginx route `404 not found` on web

### DIFF
--- a/server/nginx.conf
+++ b/server/nginx.conf
@@ -25,7 +25,7 @@ http {
     add_header Cache-Control "no-cache";
     etag on;
 
-    include /etc/nginx/conf.d/*.conf;
+    # include /etc/nginx/conf.d/*.conf;
 
     server {
       listen 80;


### PR DESCRIPTION
## Issue

<img width="1435" alt="Screenshot 2023-09-19 at 11 27 31" src="https://github.com/linagora/tmail-flutter/assets/80730648/97789dd3-d4fa-417e-b6c7-4ecfdad274b8">


## Root cause

- Impact from configuring the URL strategy on the web use `PathUrlStrategy` not work on `release` mode
- Due to the line `include /etc/nginx/conf.d/*.conf;`. The `default.conf` is loaded and your server config is ignored.

## Solution

- Comment the following line: 
```
# include /etc/nginx/conf.d/*.conf;
```

## Resolved


https://github.com/linagora/tmail-flutter/assets/80730648/92afced7-4381-489b-8143-a98ed22c7ad9


