### PR TITLE
TF-2203 Unread emails which are going to spam folder will be unread

### DIFF
--- a/lib/features/email/data/network/email_api.dart
+++ b/lib/features/email/data/network/email_api.dart
@@ -41,6 +41,7 @@ import 'package:model/account/account_request.dart';
 import 'package:model/account/authentication_type.dart';
 import 'package:model/download/download_task_id.dart';
 import 'package:model/email/attachment.dart';
+import 'package:model/email/email_action_type.dart';
 import 'package:model/email/mark_star_action.dart';
 import 'package:model/email/read_actions.dart';
 import 'package:model/extensions/email_extension.dart';
@@ -55,6 +56,7 @@ import 'package:tmail_ui_user/features/base/mixin/handle_error_mixin.dart';
 import 'package:tmail_ui_user/features/composer/domain/exceptions/set_email_method_exception.dart';
 import 'package:tmail_ui_user/features/composer/domain/model/email_request.dart';
 import 'package:tmail_ui_user/features/email/domain/exceptions/email_exceptions.dart';
+import 'package:tmail_ui_user/features/email/domain/model/move_action.dart';
 import 'package:tmail_ui_user/features/email/domain/model/move_to_mailbox_request.dart';
 import 'package:tmail_ui_user/features/email/domain/state/download_attachment_for_web_state.dart';
 import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_exception.dart';
@@ -414,8 +416,13 @@ class EmailAPI with HandleSetErrorMixin {
 
       final requestBuilder = JmapRequestBuilder(_httpClient, ProcessingInvocation());
       final currentSetEmailInvocations = currentExecuteList.map((currentItem) {
+
+        final moveProperties = (moveRequest.moveAction == MoveAction.moving && moveRequest.emailActionType == EmailActionType.moveToSpam)
+            ? currentItem.value.generateMapUpdateObjectMoveToSpam(currentItem.key, moveRequest.destinationMailboxId)
+            : currentItem.value.generateMapUpdateObjectMoveToMailbox(currentItem.key, moveRequest.destinationMailboxId);
+
         return SetEmailMethod(accountId)
-          ..addUpdates(currentItem.value.generateMapUpdateObjectMoveToMailbox(currentItem.key, moveRequest.destinationMailboxId));
+          ..addUpdates(moveProperties);
       }).map(requestBuilder.invocation).toList();
 
       final capabilities = {CapabilityIdentifier.jmapCore, CapabilityIdentifier.jmapMail}

--- a/model/lib/extensions/list_email_id_extension.dart
+++ b/model/lib/extensions/list_email_id_extension.dart
@@ -30,10 +30,10 @@ extension ListEmailIdExtension on List<EmailId> {
     };
   }
 
-  Map<Id, PatchObject> generateMapUpdateObjectMarkAsSpam(MailboxId spamMailboxId) {
+  Map<Id, PatchObject> generateMapUpdateObjectMoveToSpam(MailboxId currentMailboxId, MailboxId spamMailboxId) {
     return {
       for (var emailId in this)
-        emailId.id: spamMailboxId.generateActionPath()
+        emailId.id: currentMailboxId.generateMoveToSpamActionPath(currentMailboxId, spamMailboxId)
     };
   }
 

--- a/model/lib/extensions/mailbox_id_extension.dart
+++ b/model/lib/extensions/mailbox_id_extension.dart
@@ -1,6 +1,8 @@
 import 'package:jmap_dart_client/jmap/core/patch_object.dart';
 import 'package:jmap_dart_client/jmap/core/reference_id.dart';
+import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/extensions/keyword_identifier_extension.dart';
 
 extension MailboxIdExtension on MailboxId {
   String generatePath() {
@@ -21,6 +23,14 @@ extension MailboxIdExtension on MailboxId {
   PatchObject generateActionPath() {
     return PatchObject({
       generatePath():  true,
+    });
+  }
+
+  PatchObject generateMoveToSpamActionPath(MailboxId currentMailboxId, MailboxId spamMailboxId) {
+    return PatchObject({
+      currentMailboxId.generatePath():  null,
+      spamMailboxId.generatePath(): true,
+      KeyWordIdentifier.emailSeen.generatePath(): true
     });
   }
 


### PR DESCRIPTION
Adding testing feature for marking mails which are going to spam and they will be unread so counter of unread messages will not rise, working for draging, moving to spam trough button and also marking as spam.