### PR TITLE
TF-2345 Fix attachments are not displayed when cid is present

### DIFF
--- a/model/lib/email/attachment.dart
+++ b/model/lib/email/attachment.dart
@@ -34,6 +34,8 @@ class Attachment with EquatableMixin {
 
   bool hasCid() => cid != null && cid?.isNotEmpty == true;
 
+  bool isInlined() => disposition == ContentDisposition.inline;
+
   String getDownloadUrl(String baseDownloadUrl, AccountId accountId) {
     final downloadUriTemplate = UriTemplate(baseDownloadUrl);
     final downloadUri = downloadUriTemplate.expand({

--- a/model/lib/extensions/list_attachment_extension.dart
+++ b/model/lib/extensions/list_attachment_extension.dart
@@ -13,7 +13,7 @@ extension ListAttachmentExtension on List<Attachment> {
     return 0;
   }
 
-  List<Attachment> get listAttachmentsDisplayedOutSide => where((attachment) => attachment.noCid()).toList();
+  List<Attachment> get listAttachmentsDisplayedOutSide => where((attachment) => attachment.noCid() || !attachment.isInlined()).toList();
 
   List<Attachment> get listAttachmentsDisplayedInContent => where((attachment) => attachment.hasCid()).toList();
 


### PR DESCRIPTION
## Issue

#2345 

## Resolved


https://github.com/linagora/tmail-flutter/assets/80730648/ede5f68c-cc02-4332-a60e-03f72d18fb88

