### PR TITLE
[bugfix] TF-2394 Add `mostRecent` as default value of sortOrder

### DIFF
--- a/lib/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart
+++ b/lib/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart
@@ -28,7 +28,9 @@ class SearchEmailFilter with EquatableMixin {
   final Set<Comparator>? sortOrder;
   final int? position;
 
-  factory SearchEmailFilter.initial() => SearchEmailFilter();
+  factory SearchEmailFilter.initial() => SearchEmailFilter(
+    sortOrder: EmailSortOrderType.mostRecent.getSortOrder().toNullable()
+  );
 
   SearchEmailFilter({
     Set<String>? from,


### PR DESCRIPTION
## Issue
---
#2394 

## Resolved
---

https://github.com/linagora/tmail-flutter/assets/80142234/eac84ff1-6496-4d2a-994e-2f2a14690021

