### PR TITLE
TF-2326 Allow display count of total emails for draft folder

### DIFF
--- a/model/lib/extensions/presentation_mailbox_extension.dart
+++ b/model/lib/extensions/presentation_mailbox_extension.dart
@@ -51,7 +51,7 @@ extension PresentationMailboxExtension on PresentationMailbox {
 
   bool get allowedToDisplayCountOfUnreadEmails => !(isTrash || isSpam || isDrafts || isTemplates || isSent) && countUnreadEmails > 0;
 
-  bool get allowedToDisplayCountOfTotalEmails => (isTrash || isSpam) && countTotalEmails > 0;
+  bool get allowedToDisplayCountOfTotalEmails => (isTrash || isSpam || isDrafts) && countTotalEmails > 0;
 
   bool get allowedHasEmptyAction => (isTrash || isSpam) && countTotalEmails > 0;
 


### PR DESCRIPTION
## Issue
#2326 

## Resolved
- Web:

https://github.com/linagora/tmail-flutter/assets/80142234/3d949f71-02d2-452f-a2c2-cca713c02500


- Android:

https://github.com/linagora/tmail-flutter/assets/80142234/8c660220-56a1-4433-951a-4772b814dc99

