### PR TITLE
TF-2510 Fix failure handle empty CIDs

### DIFF
--- a/lib/features/email/presentation/extensions/attachment_extension.dart
+++ b/lib/features/email/presentation/extensions/attachment_extension.dart
@@ -1,11 +1,14 @@
 
-import 'package:core/core.dart';
+import 'package:core/domain/extensions/media_type_extension.dart';
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/utils/app_logger.dart';
+import 'package:http_parser/http_parser.dart';
 import 'package:model/email/attachment.dart';
 
 extension AttachmentExtension on Attachment {
 
-  String getIcon(ImagePaths imagePaths) {
-    final mediaType = type;
+  String getIcon(ImagePaths imagePaths, {MediaType? fileMediaType}) {
+    final mediaType = type ?? fileMediaType;
     log('AttachmentExtension::getIcon(): mediaType: $mediaType');
     if (isDisplayedPDFIcon) {
       return imagePaths.icFilePdf;

--- a/lib/features/email/presentation/extensions/attachment_extension.dart
+++ b/lib/features/email/presentation/extensions/attachment_extension.dart
@@ -7,6 +7,10 @@ extension AttachmentExtension on Attachment {
   String getIcon(ImagePaths imagePaths) {
     final mediaType = type;
     log('AttachmentExtension::getIcon(): mediaType: $mediaType');
+    if (isDisplayedPDFIcon) {
+      return imagePaths.icFilePdf;
+    }
+
     if (mediaType == null) {
       return imagePaths.icFileEPup;
     }
@@ -25,4 +29,7 @@ extension AttachmentExtension on Attachment {
     }
     return imagePaths.icFileEPup;
   }
+
+  bool get isDisplayedPDFIcon => type?.mimeType == 'application/pdf' ||
+    (type?.mimeType == 'application/octet-stream' && name?.endsWith('.pdf') == true);
 }

--- a/lib/features/email/presentation/styles/attachment/attachment_item_widget_style.dart
+++ b/lib/features/email/presentation/styles/attachment/attachment_item_widget_style.dart
@@ -4,29 +4,27 @@ import 'package:flutter/material.dart';
 
 class AttachmentItemWidgetStyle {
   static const double radius = 8;
-  static const double mobileWidth = 224;
-  static const double width = 260;
+  static const double maxWidthMobile = 260;
+  static const double maxWidthTablet = 240;
+  static const double maxWidthTabletLarge = 200;
   static const double height = 36;
   static const double iconSize = 20;
   static const double space = 8;
-  static const double downloadIconSize = 20;
-  static const double attachmentNameMaxWidth = 130;
+  static const double downloadIconSize = 22;
 
-  static const EdgeInsetsGeometry padding = EdgeInsetsDirectional.only(end: 0);
-  static const EdgeInsetsGeometry contentPadding = EdgeInsetsDirectional.all(8);
+  static const EdgeInsetsGeometry contentPadding = EdgeInsetsDirectional.symmetric(horizontal: 8, vertical: 5);
 
   static const Color borderColor = AppColor.attachmentFileBorderColor;
-  static const Color downloadIconColor = AppColor.primaryColor;
 
   static const TextStyle labelTextStyle = TextStyle(
     fontSize: 14,
     color: AppColor.attachmentFileNameColor,
-    fontWeight: FontWeight.normal
+    fontWeight: FontWeight.w500
   );
   static const TextStyle dotsLabelTextStyle = TextStyle(
     fontSize: 12,
     color: AppColor.attachmentFileNameColor,
-    fontWeight: FontWeight.normal
+    fontWeight: FontWeight.w500
   );
   static const TextStyle sizeLabelTextStyle = TextStyle(
     fontSize: 12,

--- a/lib/features/email/presentation/styles/attachment/attachment_list_item_widget_styles.dart
+++ b/lib/features/email/presentation/styles/attachment/attachment_list_item_widget_styles.dart
@@ -3,27 +3,22 @@ import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:flutter/material.dart';
 
 class AttachmentListItemWidgetStyle {
-  static const double height = 60;
   static const double iconSize = 44;
   static const double space = 8;
   static const double downloadIconSize = 24;
   static const double fileTitleBottomSpace = 4;
 
-  static const EdgeInsetsGeometry contentPadding = EdgeInsetsDirectional.all(8);
-  static const EdgeInsetsGeometry fileTitlePadding = EdgeInsetsDirectional.all(4);
-  static const EdgeInsetsGeometry downloadIconPadding = EdgeInsets.only(right: 13.0);
-
-  static const Color downloadIconColor = AppColor.primaryColor;
+  static const EdgeInsetsGeometry contentPadding = EdgeInsetsDirectional.all(12);
 
   static const TextStyle labelTextStyle = TextStyle(
     fontSize: 14,
     color: AppColor.attachmentFileNameColor,
-    fontWeight: FontWeight.normal
+    fontWeight: FontWeight.w500
   );
   static const TextStyle dotsLabelTextStyle = TextStyle(
     fontSize: 12,
     color: AppColor.attachmentFileNameColor,
-    fontWeight: FontWeight.normal
+    fontWeight: FontWeight.w500
   );
   static const TextStyle sizeLabelTextStyle = TextStyle(
     fontSize: 12,

--- a/lib/features/email/presentation/styles/attachment/attachment_list_styles.dart
+++ b/lib/features/email/presentation/styles/attachment/attachment_list_styles.dart
@@ -5,7 +5,6 @@ class AttachmentListStyles {
   static const double headerBorderWidth = 1.0;
   static const double titleSpace = 8.0;
   static const double scrollbarThickness = 8.0;
-  static const double separatorHeight = 1.0;
   static const double buttonsSpaceBetween = 12.0;
   static const double dialogBottomSpace = 20.0;
   static const double buttonBorderWidth = 1.0;
@@ -28,8 +27,6 @@ class AttachmentListStyles {
   );
   static const EdgeInsetsGeometry listAreaPadding = EdgeInsets.all(12.0);
   static const EdgeInsetsGeometry listAreaPaddingMobile = EdgeInsets.symmetric(vertical: 12);
-  static const EdgeInsetsGeometry listItemPadding = EdgeInsets.only(right: 8.0);
-  static const EdgeInsetsGeometry separatorPadding = EdgeInsets.only(right: 8.0);
   static const EdgeInsetsGeometry buttonsPadding = EdgeInsets.symmetric(
     horizontal: 24.0,
     vertical: 12.0

--- a/lib/features/email/presentation/styles/email_attachments_styles.dart
+++ b/lib/features/email/presentation/styles/email_attachments_styles.dart
@@ -10,20 +10,18 @@ class EmailAttachmentsStyles {
   static const double buttonTextSize = 13;
   static const double buttonMoreAttachmentsTextSize = 14;
   static const double buttonBorderRadius = 8;
-  static const double listSpace = 12;
-  static const double listHeight = 36;
-  static const double mobileListHeight = 100;
-  static const double moreAttachmentsButtonPadding = 8;
+  static const double listSpace = 8;
 
   static const Color headerTextColor = AppColor.colorTitleHeaderAttachment;
   static const Color headerIconColor = AppColor.colorAttachmentIcon;
   static const Color buttonTextColor = AppColor.primaryColor;
-  static const Color ButtonMoreAttachmentsTextColor = AppColor.colorLabelMoreAttachmentsButton;
+  static const Color buttonMoreAttachmentsTextColor = AppColor.colorLabelMoreAttachmentsButton;
 
   static const FontWeight headerFontWeight = FontWeight.w400;
   static const FontWeight buttonFontWeight = FontWeight.w400;
   static const FontWeight buttonMoreAttachmentsFontWeight = FontWeight.w500;
 
-  static const EdgeInsetsGeometry padding = EdgeInsetsDirectional.symmetric(vertical: 12, horizontal: 16);
+  static const EdgeInsetsGeometry padding = EdgeInsetsDirectional.only(start: 16, end: 16, bottom: 12);
   static const EdgeInsetsGeometry buttonPadding = EdgeInsets.symmetric(vertical: 8, horizontal: 12);
+  static const EdgeInsetsGeometry moreButtonMargin = EdgeInsetsDirectional.only(bottom: 2, start: 8);
 }

--- a/lib/features/email/presentation/widgets/attachment_item_widget.dart
+++ b/lib/features/email/presentation/widgets/attachment_item_widget.dart
@@ -1,7 +1,7 @@
-
-import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
-import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:extended_text/extended_text.dart';
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
@@ -19,6 +19,7 @@ class AttachmentItemWidget extends StatelessWidget {
   final OnDownloadAttachmentFileActionClick? downloadAttachmentAction;
 
   final _imagePaths = Get.find<ImagePaths>();
+  final _responsiveUtils = Get.find<ResponsiveUtils>();
 
   AttachmentItemWidget({
     Key? key,
@@ -41,73 +42,63 @@ class AttachmentItemWidget extends StatelessWidget {
             borderRadius: const BorderRadius.all(Radius.circular(AttachmentItemWidgetStyle.radius)),
             border: Border.all(color: AttachmentItemWidgetStyle.borderColor),
           ),
-          width: AttachmentItemWidgetStyle.width,
-          height: AttachmentItemWidgetStyle.height,
-          child: Stack(
+          width: _getMaxWidthItem(context),
+          child: Row(
             children: [
-              Positioned.fill(
-                child: Row(
-                  children: [
-                    SvgPicture.asset(
-                      attachment.getIcon(_imagePaths),
-                      width: AttachmentItemWidgetStyle.iconSize,
-                      height: AttachmentItemWidgetStyle.iconSize,
-                      fit: BoxFit.fill
+              SvgPicture.asset(
+                attachment.getIcon(_imagePaths),
+                width: AttachmentItemWidgetStyle.iconSize,
+                height: AttachmentItemWidgetStyle.iconSize,
+                fit: BoxFit.fill
+              ),
+              const SizedBox(width: AttachmentItemWidgetStyle.space),
+              Expanded(
+                child: ExtendedText(
+                  (attachment.name ?? ''),
+                  maxLines: 1,
+                  overflowWidget: const TextOverflowWidget(
+                    position: TextOverflowPosition.middle,
+                    child: Text(
+                      "...",
+                      style: AttachmentItemWidgetStyle.dotsLabelTextStyle,
                     ),
-                    const SizedBox(width: AttachmentItemWidgetStyle.space),
-                    Expanded(child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        SizedBox(
-                          width: AttachmentItemWidgetStyle.attachmentNameMaxWidth,
-                          child: ExtendedText(
-                            (attachment.name ?? ''),
-                            maxLines: 1,
-                            overflow: CommonTextStyle.defaultTextOverFlow,
-                            softWrap: CommonTextStyle.defaultSoftWrap,
-                            overflowWidget: TextOverflowWidget(
-                              position: Directionality.maybeOf(context) == TextDirection.rtl
-                                ? TextOverflowPosition.start
-                                : TextOverflowPosition.end,
-                              child: const Text(
-                                "...",
-                                style: AttachmentItemWidgetStyle.dotsLabelTextStyle,
-                              ),
-                            ),
-                            style: AttachmentItemWidgetStyle.labelTextStyle,
-                          ),
-                        ),
-                        Text(
-                          filesize(attachment.size?.value),
-                          maxLines: 1,
-                          overflow: CommonTextStyle.defaultTextOverFlow,
-                          softWrap: CommonTextStyle.defaultSoftWrap,
-                          style: AttachmentItemWidgetStyle.sizeLabelTextStyle,
-                        )
-                      ]
-                    )),
-                    Material(
-                      color: Colors.transparent,
-                      child: InkWell(
-                        customBorder: const CircleBorder(),
-                        child: SvgPicture.asset(
-                          _imagePaths.icDownloadAttachment,
-                          width: AttachmentItemWidgetStyle.downloadIconSize,
-                          height: AttachmentItemWidgetStyle.downloadIconSize,
-                          colorFilter: AttachmentItemWidgetStyle.downloadIconColor.asFilter(),
-                          fit: BoxFit.fill
-                        ),
-                        onTap: () => downloadAttachmentAction?.call(attachment)
-                      ),
-                    ),
-                  ]
+                  ),
+                  style: AttachmentItemWidgetStyle.labelTextStyle,
                 ),
-              ),          
+              ),
+              const SizedBox(width: AttachmentItemWidgetStyle.space),
+              Text(
+                filesize(attachment.size?.value),
+                maxLines: 1,
+                style: AttachmentItemWidgetStyle.sizeLabelTextStyle,
+              ),
+              TMailButtonWidget.fromIcon(
+                icon: _imagePaths.icDownloadAttachment,
+                backgroundColor: Colors.transparent,
+                padding: const EdgeInsets.all(5),
+                iconSize: AttachmentItemWidgetStyle.downloadIconSize,
+                onTapActionCallback: () => downloadAttachmentAction?.call(attachment)
+              )
             ]
           )
         ),
       ),
     );
+  }
+
+  double _getMaxWidthItem(BuildContext context) {
+    if (PlatformInfo.isMobile) {
+      return _responsiveUtils.isMobile(context)
+        ? AttachmentItemWidgetStyle.maxWidthMobile
+        : AttachmentItemWidgetStyle.maxWidthTablet;
+    } else {
+      if (_responsiveUtils.isTabletLarge(context)) {
+        return AttachmentItemWidgetStyle.maxWidthTabletLarge;
+      } else if (_responsiveUtils.isTablet(context)) {
+        return AttachmentItemWidgetStyle.maxWidthTablet;
+      } else {
+        return AttachmentItemWidgetStyle.maxWidthMobile;
+      }
+    }
   }
 }

--- a/lib/features/email/presentation/widgets/attachment_list/attachment_list_bottom_sheet_body_builder.dart
+++ b/lib/features/email/presentation/widgets/attachment_list/attachment_list_bottom_sheet_body_builder.dart
@@ -1,6 +1,6 @@
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:model/email/attachment.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:tmail_ui_user/features/email/presentation/styles/attachment/attachment_list_styles.dart';
@@ -64,14 +64,13 @@ class AttachmentListBottomSheetBodyBuilder extends StatelessWidget {
                   ),
                   centerTitle: true,
                   actions: [
-                    GestureDetector(
-                      child: Padding(
-                        padding: AttachmentListStyles.closeButtonPadding,
-                        child: SvgPicture.asset(imagePaths.icCircleClose),
-                      ),
-                      onTapDown: (_) {
-                        onCloseButtonAction?.call();
-                      },
+                    TMailButtonWidget.fromIcon(
+                      icon: imagePaths.icCircleClose,
+                      backgroundColor: Colors.transparent,
+                      iconSize: 28,
+                      margin: const EdgeInsetsDirectional.only(end: 12),
+                      padding: const EdgeInsets.all(5),
+                      onTapActionCallback: onCloseButtonAction,
                     )
                   ],
                 ),
@@ -80,44 +79,34 @@ class AttachmentListBottomSheetBodyBuilder extends StatelessWidget {
                   child: Column(
                     children: [
                       Expanded(
-                        child: Padding(
-                          padding: AttachmentListStyles.listAreaPaddingMobile,
-                          child: RawScrollbar(
-                            trackColor: AttachmentListStyles.scrollbarTrackColor,
-                            thumbColor: AttachmentListStyles.scrollbarThumbColor,
-                            radius: AttachmentListStyles.scrollbarThumbRadius,
-                            trackRadius: AttachmentListStyles.scrollbarTrackRadius,
-                            thickness: AttachmentListStyles.scrollbarThickness,
-                            thumbVisibility: true,
-                            trackVisibility: true,
-                            controller: scrollController,
-                            trackBorderColor: AttachmentListStyles.scrollbarTrackBorderColor,
-                            child: Padding(
-                              padding: AttachmentListStyles.listItemPadding,
-                              child: ScrollConfiguration(
-                                behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
-                                child: ListView.separated(
-                                  controller: scrollController,
-                                  shrinkWrap: true,
-                                  physics: const ScrollPhysics(),
-                                  itemCount: attachments.length,
-                                  itemBuilder: (context, index) {
-                                    return AttachmentListItemWidget(
-                                      attachment: attachments[index],
-                                      downloadAttachmentAction: onDownloadAttachmentFileAction,
-                                    );
-                                  },
-                                  separatorBuilder: (context, index) {
-                                    return const Padding(
-                                      padding: AttachmentListStyles.separatorPadding,
-                                      child: Divider(
-                                        height: AttachmentListStyles.separatorHeight,
-                                        color: AttachmentListStyles.separatorColor,
-                                      ),
-                                    );
-                                  },
-                                ),
-                              ),
+                        child: RawScrollbar(
+                          trackColor: AttachmentListStyles.scrollbarTrackColor,
+                          thumbColor: AttachmentListStyles.scrollbarThumbColor,
+                          radius: AttachmentListStyles.scrollbarThumbRadius,
+                          trackRadius: AttachmentListStyles.scrollbarTrackRadius,
+                          thickness: AttachmentListStyles.scrollbarThickness,
+                          thumbVisibility: true,
+                          trackVisibility: true,
+                          controller: scrollController,
+                          trackBorderColor: AttachmentListStyles.scrollbarTrackBorderColor,
+                          child: ScrollConfiguration(
+                            behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
+                            child: ListView.separated(
+                              controller: scrollController,
+                              shrinkWrap: true,
+                              physics: const ScrollPhysics(),
+                              itemCount: attachments.length,
+                              itemBuilder: (context, index) {
+                                return AttachmentListItemWidget(
+                                  attachment: attachments[index],
+                                  downloadAttachmentAction: onDownloadAttachmentFileAction,
+                                );
+                              },
+                              separatorBuilder: (context, index) {
+                                return const Divider(
+                                  color: AttachmentListStyles.separatorColor,
+                                );
+                              },
                             ),
                           ),
                         ),

--- a/lib/features/email/presentation/widgets/attachment_list/attachment_list_dialog_body_builder.dart
+++ b/lib/features/email/presentation/widgets/attachment_list/attachment_list_dialog_body_builder.dart
@@ -1,7 +1,6 @@
 import 'package:core/presentation/resources/image_paths.dart';
-import 'package:core/presentation/views/button/icon_button_web.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:model/email/attachment.dart';
 import 'package:tmail_ui_user/features/email/presentation/styles/attachment/attachment_list_styles.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/attachment_list/attachment_list_action_button_builder.dart';
@@ -47,68 +46,75 @@ class AttachmentListDialogBodyBuilder extends StatelessWidget {
               padding: AttachmentListStyles.headerPadding,
               decoration: AttachmentListStyles.headerDecoration,
               child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  const Spacer(),
-                  Text(
-                      AppLocalizations.of(context).attachmentList,
-                      style: AttachmentListStyles.titleTextStyle
+                  const SizedBox(width: 50),
+                  Expanded(
+                    child: Center(
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Flexible(
+                            child: Text(
+                              AppLocalizations.of(context).attachmentList,
+                              style: AttachmentListStyles.titleTextStyle,
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                          const SizedBox(width: AttachmentListStyles.titleSpace),
+                          Flexible(
+                            child: Text(
+                              '${attachments.length} ${AppLocalizations.of(context).files}',
+                              style: AttachmentListStyles.subTitleTextStyle,
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          )
+                        ],
+                      ),
+                    )
                   ),
-                  const SizedBox(width: AttachmentListStyles.titleSpace),
-                  Text(
-                      '${attachments.length} ${AppLocalizations.of(context).files}',
-                      style: AttachmentListStyles.subTitleTextStyle
+                  const SizedBox(width: 8),
+                  TMailButtonWidget.fromIcon(
+                    icon: imagePaths.icCircleClose,
+                    onTapActionCallback: onCloseButtonAction,
+                    iconSize: 28,
+                    backgroundColor: Colors.transparent,
+                    padding: const EdgeInsets.all(5),
                   ),
-                  if (onCloseButtonAction != null)
-                    const Spacer(),
-                  buildIconWeb(
-                    icon: SvgPicture.asset(imagePaths.icCircleClose),
-                    onTap: () {
-                      onCloseButtonAction!.call();
-                    },
-                  ),
+                  const SizedBox(width: 8)
                 ],
               )
           ),
           Expanded(
-            child: Padding(
-              padding: AttachmentListStyles.listAreaPadding,
-              child: RawScrollbar(
-                trackColor: AttachmentListStyles.scrollbarTrackColor,
-                thumbColor: AttachmentListStyles.scrollbarThumbColor,
-                radius: AttachmentListStyles.scrollbarThumbRadius,
-                trackRadius: AttachmentListStyles.scrollbarTrackRadius,
-                thickness: AttachmentListStyles.scrollbarThickness,
-                thumbVisibility: true,
-                trackVisibility: true,
-                controller: scrollController,
-                trackBorderColor: AttachmentListStyles.scrollbarTrackBorderColor,
-                child: Padding(
-                  padding: AttachmentListStyles.listItemPadding,
-                  child: ScrollConfiguration(
-                    behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
-                    child: ListView.separated(
-                      controller: scrollController,
-                      shrinkWrap: true,
-                      physics: const ScrollPhysics(),
-                      itemCount: attachments.length,
-                      itemBuilder: (context, index) {
-                        return AttachmentListItemWidget(
-                          attachment: attachments[index],
-                          downloadAttachmentAction: onDownloadAttachmentFileAction,
-                        );
-                      },
-                      separatorBuilder: (context, index) {
-                        return const Padding(
-                          padding: AttachmentListStyles.separatorPadding,
-                          child: Divider(
-                            height: AttachmentListStyles.separatorHeight,
-                            color: AttachmentListStyles.separatorColor,
-                          ),
-                        );
-                      },
-                    ),
-                  ),
+            child: RawScrollbar(
+              trackColor: AttachmentListStyles.scrollbarTrackColor,
+              thumbColor: AttachmentListStyles.scrollbarThumbColor,
+              radius: AttachmentListStyles.scrollbarThumbRadius,
+              trackRadius: AttachmentListStyles.scrollbarTrackRadius,
+              thickness: AttachmentListStyles.scrollbarThickness,
+              thumbVisibility: true,
+              trackVisibility: true,
+              controller: scrollController,
+              trackBorderColor: AttachmentListStyles.scrollbarTrackBorderColor,
+              child: ScrollConfiguration(
+                behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
+                child: ListView.separated(
+                  controller: scrollController,
+                  shrinkWrap: true,
+                  physics: const ScrollPhysics(),
+                  itemCount: attachments.length,
+                  itemBuilder: (context, index) {
+                    return AttachmentListItemWidget(
+                      attachment: attachments[index],
+                      downloadAttachmentAction: onDownloadAttachmentFileAction,
+                    );
+                  },
+                  separatorBuilder: (context, index) {
+                    return const Divider(
+                      color: AttachmentListStyles.separatorColor,
+                    );
+                  },
                 ),
               ),
             ),

--- a/lib/features/email/presentation/widgets/attachment_list/attachment_list_item_widget.dart
+++ b/lib/features/email/presentation/widgets/attachment_list/attachment_list_item_widget.dart
@@ -1,7 +1,6 @@
-
-import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:extended_text/extended_text.dart';
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
@@ -29,84 +28,55 @@ class AttachmentListItemWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Material(
-      color: Colors.transparent,
+      type: MaterialType.transparency,
       child: InkWell(
         onTap: () => downloadAttachmentAction?.call(attachment),
-        child: Container(
+        child: Padding(
           padding: AttachmentListItemWidgetStyle.contentPadding,
-          height: AttachmentListItemWidgetStyle.height,
-          child: Stack(
+          child: Row(
             children: [
-              Positioned.fill(
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
+              SvgPicture.asset(
+                attachment.getIcon(_imagePaths),
+                width: AttachmentListItemWidgetStyle.iconSize,
+                height: AttachmentListItemWidgetStyle.iconSize,
+                fit: BoxFit.fill
+              ),
+              const SizedBox(width: AttachmentListItemWidgetStyle.space),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    SvgPicture.asset(
-                      attachment.getIcon(_imagePaths),
-                      width: AttachmentListItemWidgetStyle.iconSize,
-                      height: AttachmentListItemWidgetStyle.iconSize,
-                      fit: BoxFit.fill
-                    ),
-                    const SizedBox(width: AttachmentListItemWidgetStyle.space),
-                    Expanded(
-                      child: Padding(
-                        padding: AttachmentListItemWidgetStyle.fileTitlePadding,
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            ExtendedText(
-                              (attachment.name ?? ''),
-                              maxLines: 1,
-                              overflow: CommonTextStyle.defaultTextOverFlow,
-                              softWrap: CommonTextStyle.defaultSoftWrap,
-                              overflowWidget: TextOverflowWidget(
-                                position: Directionality.maybeOf(context) == TextDirection.rtl
-                                  ? TextOverflowPosition.start
-                                  : TextOverflowPosition.end,
-                                child: const Text(
-                                  "...",
-                                  style: AttachmentListItemWidgetStyle.dotsLabelTextStyle,
-                                ),
-                              ),
-                              style: AttachmentListItemWidgetStyle.labelTextStyle,
-                            ),
-                            const SizedBox(height: AttachmentListItemWidgetStyle.fileTitleBottomSpace),
-                            Text(
-                              filesize(attachment.size?.value),
-                              maxLines: 1,
-                              overflow: CommonTextStyle.defaultTextOverFlow,
-                              softWrap: CommonTextStyle.defaultSoftWrap,
-                              style: AttachmentListItemWidgetStyle.sizeLabelTextStyle,
-                            )
-                          ]
+                    ExtendedText(
+                      (attachment.name ?? ''),
+                      maxLines: 1,
+                      overflowWidget: const TextOverflowWidget(
+                        position: TextOverflowPosition.middle,
+                        child: Text(
+                          "...",
+                          style: AttachmentListItemWidgetStyle.dotsLabelTextStyle,
                         ),
-                      )
+                      ),
+                      style: AttachmentListItemWidgetStyle.labelTextStyle,
+                    ),
+                    const SizedBox(height: AttachmentListItemWidgetStyle.fileTitleBottomSpace),
+                    Text(
+                      filesize(attachment.size?.value),
+                      maxLines: 1,
+                      overflow: CommonTextStyle.defaultTextOverFlow,
+                      softWrap: CommonTextStyle.defaultSoftWrap,
+                      style: AttachmentListItemWidgetStyle.sizeLabelTextStyle,
                     )
                   ]
-                ),
+                )
               ),
-              Align(
-                alignment: AlignmentDirectional.centerEnd,
-                child: Padding(
-                  padding: AttachmentListItemWidgetStyle.downloadIconPadding,
-                  child: Material(
-                    color: Colors.transparent,
-                    child: InkWell(
-                      customBorder: const CircleBorder(),
-                      child: SvgPicture.asset(
-                        _imagePaths.icDownloadAttachment,
-                        width: AttachmentListItemWidgetStyle.downloadIconSize,
-                        height: AttachmentListItemWidgetStyle.downloadIconSize,
-                        colorFilter: AttachmentListItemWidgetStyle.downloadIconColor.asFilter(),
-                        fit: BoxFit.fill
-                      ),
-                      onTap: () => downloadAttachmentAction?.call(attachment)
-                    ),
-                  ),
-                ),
-              ),
+              const SizedBox(width: AttachmentListItemWidgetStyle.space),
+              TMailButtonWidget.fromIcon(
+                icon: _imagePaths.icDownloadAttachment,
+                backgroundColor: Colors.transparent,
+                onTapActionCallback: () => downloadAttachmentAction?.call(attachment)
+              )
             ]
-          )
+          ),
         ),
       ),
     );

--- a/lib/features/email/presentation/widgets/email_address_dialog_builder.dart
+++ b/lib/features/email/presentation/widgets/email_address_dialog_builder.dart
@@ -1,7 +1,6 @@
 
 import 'package:core/core.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
 import 'package:model/model.dart';
@@ -51,15 +50,15 @@ class EmailAddressDialogBuilder extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             Align(
-                alignment: Alignment.centerRight,
-                child: IconButton(
-                    padding: const EdgeInsets.only(top: 16, right: 16),
-                    onPressed: () => onCloseDialogAction?.call(),
-                    icon: SvgPicture.asset(
-                        imagePaths.icCircleClose,
-                        width: 24,
-                        height: 24,
-                        fit: BoxFit.fill))),
+              alignment: Alignment.centerRight,
+              child: TMailButtonWidget.fromIcon(
+                onTapActionCallback: onCloseDialogAction,
+                icon: imagePaths.icCircleClose,
+                backgroundColor: Colors.transparent,
+                margin: const EdgeInsetsDirectional.only(top: 8, end: 8),
+                iconSize: 24,
+              )
+            ),
             Padding(padding: const EdgeInsets.symmetric(horizontal: 16),
               child: Center(child: (AvatarBuilder()
                   ..text(_emailAddress.asString().firstLetterToUpperCase)

--- a/lib/features/email/presentation/widgets/email_attachments_widget.dart
+++ b/lib/features/email/presentation/widgets/email_attachments_widget.dart
@@ -37,16 +37,8 @@ class EmailAttachmentsWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    int getItemCount() {
-      if (attachments.length <= 2) {
-        return attachments.length;
-      }
-      if (attachments.length == 3) {
-        return responsiveUtils.isDesktop(context) ? attachments.length : 2;
-      } 
-      return responsiveUtils.isDesktop(context) ? 4 : 2;
-    }
-    int hideItemsCount = attachments.length - getItemCount();
+    final attachmentDisplayed = _getAttachmentDisplayed(context);
+    int hideItemsCount = attachments.length - attachmentDisplayed.length;
     return Padding(
       padding: EmailAttachmentsStyles.padding,
       child: Column(
@@ -99,63 +91,78 @@ class EmailAttachmentsWidget extends StatelessWidget {
             ],
           ),
           const SizedBox(height: EmailAttachmentsStyles.marginHeader),
-          SizedBox(
-            height: responsiveUtils.isMobile(context) ? EmailAttachmentsStyles.mobileListHeight : EmailAttachmentsStyles.listHeight,
-            child: Row(
-              children: [
-                Flexible(
-                  child: ListView.separated(
-                    shrinkWrap: true,
-                    scrollDirection: responsiveUtils.isMobile(context) ? Axis.vertical : Axis.horizontal,
-                    itemCount: getItemCount(),
-                    itemBuilder: (context, index) {
-                      if (PlatformInfo.isWeb) {
-                        return DraggableAttachmentItemWidget(
-                          attachment: attachments[index],
+          Row(
+            crossAxisAlignment: responsiveUtils.isMobile(context)
+              ? CrossAxisAlignment.end
+              : CrossAxisAlignment.center,
+            children: [
+              Flexible(
+                child: Wrap(
+                  spacing: EmailAttachmentsStyles.listSpace,
+                  runSpacing: EmailAttachmentsStyles.listSpace,
+                  children: attachmentDisplayed.map((attachment) {
+                    if (PlatformInfo.isWeb) {
+                      return DraggableAttachmentItemWidget(
+                          attachment: attachment,
                           onDragStarted: onDragStarted,
                           onDragEnd: onDragEnd,
                           downloadAttachmentAction: downloadAttachmentAction
-                        );
-                      } else {
-                        return AttachmentItemWidget(
-                          attachment: attachments[index],
+                      );
+                    } else {
+                      return AttachmentItemWidget(
+                          attachment: attachment,
                           downloadAttachmentAction: downloadAttachmentAction
-                        );
-                      }
-                    },
-                    separatorBuilder: (context, index) {
-                      if (responsiveUtils.isMobile(context)) {
-                        return const SizedBox(height: EmailAttachmentsStyles.listSpace);
-                      } else {
-                        return const SizedBox(width: EmailAttachmentsStyles.listSpace);
-                      }
-                    },
-                  ),
+                      );
+                    }
+                  }).toList(),
                 ),
-                if (hideItemsCount != 0)
-                  Container(
-                    padding: EdgeInsets.only(bottom: responsiveUtils.isMobile(context) ? EmailAttachmentsStyles.moreAttachmentsButtonPadding : 0),
-                    alignment: responsiveUtils.isMobile(context)
-                      ? Alignment.bottomRight
-                      : Alignment.centerRight,
-                    child: TMailButtonWidget(
-                      text: AppLocalizations.of(context).moreAttachments(hideItemsCount),
-                      backgroundColor: Colors.transparent,
-                      borderRadius: EmailAttachmentsStyles.buttonBorderRadius,
-                      padding: EmailAttachmentsStyles.buttonPadding,
-                      textStyle: const TextStyle(
-                        fontSize: EmailAttachmentsStyles.buttonMoreAttachmentsTextSize,
-                        color: EmailAttachmentsStyles.ButtonMoreAttachmentsTextColor,
-                        fontWeight: EmailAttachmentsStyles.buttonMoreAttachmentsFontWeight,
-                      ),
-                      onTapActionCallback: onTapShowAllAttachmentFile,
-                    ),
+              ),
+              if (hideItemsCount > 0)
+                TMailButtonWidget(
+                  text: AppLocalizations.of(context).moreAttachments(hideItemsCount),
+                  backgroundColor: Colors.transparent,
+                  borderRadius: EmailAttachmentsStyles.buttonBorderRadius,
+                  padding: EmailAttachmentsStyles.buttonPadding,
+                  margin: EmailAttachmentsStyles.moreButtonMargin,
+                  textStyle: const TextStyle(
+                    fontSize: EmailAttachmentsStyles.buttonMoreAttachmentsTextSize,
+                    color: EmailAttachmentsStyles.buttonMoreAttachmentsTextColor,
+                    fontWeight: EmailAttachmentsStyles.buttonMoreAttachmentsFontWeight,
                   ),
-              ]
-            )
+                  onTapActionCallback: onTapShowAllAttachmentFile,
+                ),
+            ]
           ),
         ],
       ),
     );
+  }
+
+  List<Attachment> _getAttachmentDisplayed(BuildContext context) {
+    if (attachments.length <= 2) {
+      return attachments;
+    }
+
+    if (attachments.length == 3) {
+      if (PlatformInfo.isWeb) {
+        return responsiveUtils.isDesktop(context)
+          ? attachments
+          : attachments.sublist(0, 2);
+      } else {
+        return responsiveUtils.isMobile(context)
+          ? attachments
+          : attachments.sublist(0, 2);
+      }
+    }
+
+    if (PlatformInfo.isWeb) {
+      return responsiveUtils.isDesktop(context) || responsiveUtils.isMobile(context)
+        ? attachments.sublist(0, 4)
+        : attachments.sublist(0, 2);
+    } else {
+      return responsiveUtils.isMobile(context)
+        ? attachments.sublist(0, 4)
+        : attachments.sublist(0, 2);
+    }
   }
 }

--- a/lib/features/email/presentation/widgets/information_sender_and_receiver_builder.dart
+++ b/lib/features/email/presentation/widgets/information_sender_and_receiver_builder.dart
@@ -37,7 +37,7 @@ class InformationSenderAndReceiverBuilder extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       color: Colors.white,
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      padding: const EdgeInsetsDirectional.only(start: 16, end: 16, top: 16),
       child: Row(
         crossAxisAlignment: emailSelected.numberOfAllEmailAddress() > 0
           ? CrossAxisAlignment.start

--- a/lib/features/upload/presentation/model/upload_file_state.dart
+++ b/lib/features/upload/presentation/model/upload_file_state.dart
@@ -1,12 +1,11 @@
 
-import 'package:core/domain/extensions/media_type_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
-import 'package:core/utils/app_logger.dart';
 import 'package:dio/dio.dart';
 import 'package:equatable/equatable.dart';
 import 'package:http_parser/http_parser.dart';
 import 'package:model/email/attachment.dart';
 import 'package:model/upload/file_info.dart';
+import 'package:tmail_ui_user/features/email/presentation/extensions/attachment_extension.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
 import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_status.dart';
 
@@ -77,24 +76,7 @@ class UploadFileState with EquatableMixin {
     if (mediaType == null && file != null) {
       mediaType = MediaType.parse(file!.mimeType);
     }
-    log('AttachmentExtension::getIcon(): mediaType: $mediaType');
-    if (mediaType == null) {
-      return imagePaths.icFileEPup;
-    }
-    if (mediaType.isDocFile()) {
-      return imagePaths.icFileDocx;
-    } else if (mediaType.isExcelFile()) {
-      return imagePaths.icFileXlsx;
-    } else if (mediaType.isPowerPointFile()) {
-      return imagePaths.icFilePptx;
-    } else if (mediaType.isPdfFile()) {
-      return imagePaths.icFilePdf;
-    } else if (mediaType.isZipFile()) {
-      return imagePaths.icFileZip;
-    } else if (mediaType.isImageFile()) {
-      return imagePaths.icFilePng;
-    }
-    return imagePaths.icFileEPup;
+    return attachment?.getIcon(imagePaths, fileMediaType: mediaType) ?? imagePaths.icFileEPup;
   }
 
   @override

--- a/model/lib/email/attachment.dart
+++ b/model/lib/email/attachment.dart
@@ -11,6 +11,7 @@ class Attachment with EquatableMixin {
 
   static const String eventICSSubtype = 'ics';
   static const String eventCalendarSubtype = 'calendar';
+  static const String applicationRTFType = 'application/rtf';
 
   final PartId? partId;
   final Id? blobId;
@@ -34,7 +35,13 @@ class Attachment with EquatableMixin {
 
   bool hasCid() => cid != null && cid?.isNotEmpty == true;
 
-  bool isInlined() => disposition == ContentDisposition.inline;
+  bool isDispositionInlined() => disposition == ContentDisposition.inline;
+
+  bool isDispositionAttachment() => disposition == ContentDisposition.attachment;
+
+  bool isDispositionAttachmentNoCID() => isDispositionAttachment() && noCid();
+
+  bool isApplicationRTFInlined() => type?.mimeType == applicationRTFType && isDispositionInlined();
 
   String getDownloadUrl(String baseDownloadUrl, AccountId accountId) {
     final downloadUriTemplate = UriTemplate(baseDownloadUrl);

--- a/model/lib/extensions/attachment_extension.dart
+++ b/model/lib/extensions/attachment_extension.dart
@@ -27,4 +27,10 @@ extension AttachmentExtension on Attachment {
         disposition: disposition ?? this.disposition
     );
   }
+
+  bool isOutsideAttachment(List<Attachment> htmlBodyAttachments) {
+    return (isDispositionAttachmentNoCID() || !isDispositionInlined()) &&
+      !isApplicationRTFInlined() &&
+      !htmlBodyAttachments.include(this);
+  }
 }

--- a/model/lib/extensions/list_attachment_extension.dart
+++ b/model/lib/extensions/list_attachment_extension.dart
@@ -2,6 +2,7 @@
 import 'package:collection/collection.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:model/email/attachment.dart';
+import 'package:model/extensions/attachment_extension.dart';
 
 extension ListAttachmentExtension on List<Attachment> {
 
@@ -14,21 +15,18 @@ extension ListAttachmentExtension on List<Attachment> {
     return 0;
   }
 
-  List<Attachment> getListAttachmentsDisplayedOutside(List<Attachment>? htmlBodyAttachments) {
-    return where((attachment) => _validateOutsideAttachment(attachment, htmlBodyAttachments)).toList();
+  List<Attachment> getListAttachmentsDisplayedOutside(List<Attachment> htmlBodyAttachments) {
+    return where((attachment) => attachment.isOutsideAttachment(htmlBodyAttachments)).toList();
   }
 
-  bool _validateOutsideAttachment(Attachment attachment, List<Attachment>? htmlBodyAttachments) {
-    final result = (attachment.noCid() || !attachment.isInlined()) && (htmlBodyAttachments == null || !htmlBodyAttachments._include(attachment));
-    return result;
-  }
-
-  bool _include(Attachment newAttachment) {
+  bool include(Attachment newAttachment) {
     final matchedAttachment = firstWhereOrNull((attachment) => attachment.blobId == newAttachment.blobId);
     return matchedAttachment != null;
   }
 
-  List<Attachment> get listAttachmentsDisplayedInContent => where((attachment) => attachment.hasCid()).toList();
+  List<Attachment> get listAttachmentsDisplayedInContent =>
+    where((attachment) => attachment.hasCid() && attachment.isDispositionInlined())
+    .toList();
 
   Map<String, String> toMapCidImageDownloadUrl({
     required AccountId accountId,

--- a/model/test/attachment_test.dart
+++ b/model/test/attachment_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http_parser/http_parser.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:model/model.dart';
+
+void main() {
+  final attachmentA = Attachment(
+    disposition: ContentDisposition.attachment,
+  );
+
+  final attachmentB = Attachment(
+    disposition: ContentDisposition.attachment,
+  );
+
+  final attachmentC = Attachment(
+    disposition: ContentDisposition.attachment,
+    cid: 'attachmentC',
+  );
+
+  final attachmentD = Attachment(
+    disposition: ContentDisposition.attachment,
+    type: MediaType.parse('image/pdf'),
+  );
+
+  final attachmentE = Attachment(
+    disposition: ContentDisposition.attachment,
+    type: MediaType.parse('application/rtf'),
+  );
+
+  final attachmentF = Attachment(
+    disposition: ContentDisposition.inline,
+    type: MediaType.parse('application/rtf'),
+  );
+
+  final attachmentG = Attachment(
+    disposition: ContentDisposition.inline,
+  );
+
+  final attachmentH = Attachment();
+
+  final attachmentI = Attachment(blobId: Id('attachmentI'));
+
+  group('isOutsideAttachment method test', () {
+    test(
+      'GIVE attachmentA has disposition = `attachment` and cid is null\n'
+      'AND htmlBodyAttachments is empty\n'
+      'WHEN perform call `attachmentA.isOutsideAttachment()`\n'
+      'SHOULD return true',
+    () {
+      List<Attachment> htmlBodyAttachments = [];
+      bool result = attachmentA.isOutsideAttachment(htmlBodyAttachments);
+
+      expect(result, isTrue);
+    });
+
+    test(
+      'GIVE attachmentB has disposition = `attachment`\n'
+      'AND htmlBodyAttachments is empty\n'
+      'WHEN perform call `attachmentB.isOutsideAttachment()`\n'
+      'SHOULD return true',
+    () {
+      List<Attachment> htmlBodyAttachments = [];
+      bool result = attachmentB.isOutsideAttachment(htmlBodyAttachments);
+
+      expect(result, isTrue);
+    });
+
+    test(
+      'GIVE attachmentC has disposition = `attachment` and cid = `attachmentC`\n'
+      'AND htmlBodyAttachments is empty\n'
+      'WHEN perform call `attachmentB.isOutsideAttachment()`\n'
+      'SHOULD return true',
+    () {
+      List<Attachment> htmlBodyAttachments = [];
+      bool result = attachmentC.isOutsideAttachment(htmlBodyAttachments);
+
+      expect(result, isTrue);
+    });
+
+    test(
+      'GIVE attachmentD has disposition = `attachment` and mediaType = `image/pdf`\n'
+      'AND htmlBodyAttachments is empty\n'
+      'WHEN perform call `attachmentD.isOutsideAttachment()`\n'
+      'SHOULD return true',
+    () {
+      List<Attachment> htmlBodyAttachments = [];
+      bool result = attachmentD.isOutsideAttachment(htmlBodyAttachments);
+
+      expect(result, isTrue);
+    });
+
+    test(
+      'GIVE attachmentE has disposition = `attachment` and mediaType = `application/rtf`\n'
+      'AND htmlBodyAttachments is empty\n'
+      'WHEN perform call `attachmentE.isOutsideAttachment()`\n'
+      'SHOULD return true',
+    () {
+      List<Attachment> htmlBodyAttachments = [];
+      bool result = attachmentE.isOutsideAttachment(htmlBodyAttachments);
+
+      expect(result, isTrue);
+    });
+
+
+    test(
+      'GIVE attachmentF has disposition = `inline` and mediaType = `application/rtf`\n'
+      'AND htmlBodyAttachments is empty\n'
+      'WHEN perform call `attachmentF.isOutsideAttachment()`\n'
+      'SHOULD return true',
+    () {
+      List<Attachment> htmlBodyAttachments = [];
+      bool result = attachmentF.isOutsideAttachment(htmlBodyAttachments);
+
+      expect(result, isFalse);
+    });
+
+    test(
+      'GIVE attachmentG has disposition = `inline`\n'
+      'AND htmlBodyAttachments is empty\n'
+      'WHEN perform call `attachmentG.isOutsideAttachment()`\n'
+      'SHOULD return false',
+    () {
+      List<Attachment> htmlBodyAttachments = [];
+      bool result = attachmentG.isOutsideAttachment(htmlBodyAttachments);
+
+      expect(result, isFalse);
+    });
+
+    test(
+      'GIVE attachmentH has disposition is null\n'
+      'AND htmlBodyAttachments is empty\n'
+      'WHEN perform call `attachmentH.isOutsideAttachment()`\n'
+      'SHOULD return true',
+    () {
+      List<Attachment> htmlBodyAttachments = [];
+      bool result = attachmentH.isOutsideAttachment(htmlBodyAttachments);
+
+      expect(result, isTrue);
+    });
+
+    test(
+      'GIVE attachmentI has blobId = `attachmentI`\n'
+      'AND htmlBodyAttachments has `attachmentI`\n'
+      'WHEN perform call `attachmentI.isOutsideAttachment()`\n'
+      'SHOULD return false',
+    () {
+      List<Attachment> htmlBodyAttachments = [attachmentI];
+      bool result = attachmentI.isOutsideAttachment(htmlBodyAttachments);
+
+      expect(result, isFalse);
+    });
+  });
+}

--- a/test/features/model/attachment_extension_test.dart
+++ b/test/features/model/attachment_extension_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http_parser/http_parser.dart';
+import 'package:model/model.dart';
+import 'package:tmail_ui_user/features/email/presentation/extensions/attachment_extension.dart';
+
+void main() {
+  final attachmentA = Attachment(
+    type: MediaType.parse('application/pdf')
+  );
+
+  final attachmentB = Attachment(
+    name: 'attachmentB.pdf',
+    type: MediaType.parse('application/octet-stream')
+  );
+
+  final attachmentC = Attachment(
+    name: 'attachmentC.docx',
+    type: MediaType.parse('application/octet-stream')
+  );
+
+  final attachmentD = Attachment(
+    name: 'attachmentD.png',
+    type: MediaType.parse('image/png')
+  );
+
+  final attachmentE = Attachment(
+    name: 'attachmentE.pdf',
+    type: MediaType.parse('text/html')
+  );
+
+  group('isDisplayedPDFIcon method test', () {
+    test(
+      'GIVE attachmentA has mimeType = `application/pdf`\n'
+      'WHEN perform call `attachmentA.isDisplayedPDFIcon()`\n'
+      'SHOULD return true',
+    () {
+      bool result = attachmentA.isDisplayedPDFIcon;
+
+      expect(result, isTrue);
+    });
+
+    test(
+      'GIVE attachmentB has mimeType = `application/octet-stream`\n'
+      'AND name = `attachmentB.pdf`\n'
+      'WHEN perform call `attachmentB.isDisplayedPDFIcon()`\n'
+      'SHOULD return true',
+    () {
+      bool result = attachmentB.isDisplayedPDFIcon;
+
+      expect(result, isTrue);
+    });
+
+    test(
+      'GIVE attachmentC has mimeType = `application/octet-stream`\n'
+      'AND name = `attachmentC.docx`\n'
+      'WHEN perform call `attachmentC.isDisplayedPDFIcon()`\n'
+      'SHOULD return false',
+    () {
+      bool result = attachmentC.isDisplayedPDFIcon;
+
+      expect(result, isFalse);
+    });
+
+    test(
+      'GIVE attachmentD has mimeType = `image/png`\n'
+      'AND name = `attachmentD.png`\n'
+      'WHEN perform call `attachmentD.isDisplayedPDFIcon()`\n'
+      'SHOULD return false',
+    () {
+      bool result = attachmentD.isDisplayedPDFIcon;
+
+      expect(result, isFalse);
+    });
+
+    test(
+      'GIVE attachmentE has mimeType = `text/html`\n'
+      'AND name = `attachmentE.pdf`\n'
+      'WHEN perform call `attachmentE.isDisplayedPDFIcon()`\n'
+      'SHOULD return false',
+    () {
+      bool result = attachmentE.isDisplayedPDFIcon;
+
+      expect(result, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Issue

#2510 

## Done

 - [x] Remove `application/rtf` inlined in attachment list
 - [x] Show PDF icon `if (mimetype == pdf || (mimetype == application/octet-stream && file.extension == pdf)`

## Demo

https://github.com/linagora/tmail-flutter/assets/80730648/a8be6ad5-b81d-4acf-89e5-afde7a91ef7f


