### PR TITLE
TF-2532 Add `attachment/inlineImage` to app bar composer Mobile/Tablet

### DIFF
--- a/lib/features/composer/domain/state/download_image_as_base64_state.dart
+++ b/lib/features/composer/domain/state/download_image_as_base64_state.dart
@@ -10,15 +10,11 @@ class DownloadImageAsBase64Success extends UIState {
   final String base64Uri;
   final String cid;
   final FileInfo fileInfo;
-  final bool fromFileShared;
 
   DownloadImageAsBase64Success(
     this.base64Uri,
     this.cid,
     this.fileInfo,
-    {
-      this.fromFileShared = false
-    }
   );
 
   @override
@@ -26,7 +22,6 @@ class DownloadImageAsBase64Success extends UIState {
     base64Uri,
     cid,
     fileInfo,
-    fromFileShared,
   ];
 }
 

--- a/lib/features/composer/domain/usecases/download_image_as_base64_interactor.dart
+++ b/lib/features/composer/domain/usecases/download_image_as_base64_interactor.dart
@@ -16,7 +16,6 @@ class DownloadImageAsBase64Interactor {
     {
       double? maxWidth,
       bool? compress,
-      bool fromFileShared = false,
     }
   ) async* {
     try {
@@ -33,7 +32,6 @@ class DownloadImageAsBase64Interactor {
           result!,
           cid,
           fileInfo,
-          fromFileShared: fromFileShared
         ));
       } else {
         yield Left<Failure, Success>(DownloadImageAsBase64Failure(null));

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -283,7 +283,6 @@ class ComposerController extends BaseController {
             cid: success.cid,
             base64Uri: success.base64Uri
           ),
-          fromFileShare: success.fromFileShared
         );
       }
       maxWithEditor = null;
@@ -1863,7 +1862,6 @@ class ComposerController extends BaseController {
         uploadState.attachment.cid!,
         uploadState.fileInfo,
         maxWidth: maxWithEditor,
-        fromFileShared: uploadState.fromFileShared,
       ));
     }
   }

--- a/lib/features/composer/presentation/composer_view.dart
+++ b/lib/features/composer/presentation/composer_view.dart
@@ -19,10 +19,10 @@ import 'package:tmail_ui_user/features/composer/presentation/widgets/mobile/app_
 import 'package:tmail_ui_user/features/composer/presentation/widgets/mobile/from_composer_mobile_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/mobile/landscape_app_bar_composer_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/mobile/mobile_attachment_composer_widget.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/mobile/tablet_app_bar_composer_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/mobile/tablet_bottom_bar_composer_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/recipient_composer_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/subject_composer_widget.dart';
-import 'package:tmail_ui_user/features/composer/presentation/widgets/web/desktop_app_bar_composer_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/web/from_composer_drop_down_widget.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
@@ -49,7 +49,7 @@ class ComposerView extends GetWidget<ComposerController> {
           ? controller.insertImage(context, constraints.maxWidth)
           : null,
         backgroundColor: MobileAppBarComposerWidgetStyle.backgroundColor,
-        childBuilder: (context) => Container(
+        childBuilder: (context, constraints) => Container(
           color: ComposerStyle.mobileBackgroundColor,
           child: Column(
             children: [
@@ -66,6 +66,12 @@ class ComposerView extends GetWidget<ComposerController> {
                       radius: ComposerStyle.popupMenuRadius
                     );
                   },
+                  isNetworkConnectionAvailable: controller.isNetworkConnectionAvailable,
+                  attachFileAction: () => controller.openPickAttachmentMenu(
+                    context,
+                    _pickAttachmentsActionTiles(context)
+                  ),
+                  insertImageAction: () => controller.insertImage(context, constraints.maxWidth),
                 ))
               else
                 Obx(() => AppBarComposerWidget(
@@ -80,6 +86,12 @@ class ComposerView extends GetWidget<ComposerController> {
                       radius: ComposerStyle.popupMenuRadius
                     );
                   },
+                  isNetworkConnectionAvailable: controller.isNetworkConnectionAvailable,
+                  attachFileAction: () => controller.openPickAttachmentMenu(
+                    context,
+                    _pickAttachmentsActionTiles(context)
+                  ),
+                  insertImageAction: () => controller.insertImage(context, constraints.maxWidth),
                 )),
               Expanded(
                 child: SafeArea(
@@ -233,10 +245,16 @@ class ComposerView extends GetWidget<ComposerController> {
           color: ComposerStyle.mobileBackgroundColor,
           child: Column(
             children: [
-              Obx(() => DesktopAppBarComposerWidget(
+              Obx(() => TabletAppBarComposerWidget(
                 emailSubject: controller.subjectEmail.value ?? '',
                 onCloseViewAction: () => controller.saveToDraftAndClose(context),
                 constraints: constraints,
+                isNetworkConnectionAvailable: controller.isNetworkConnectionAvailable,
+                attachFileAction: () => controller.openPickAttachmentMenu(
+                  context,
+                  _pickAttachmentsActionTiles(context)
+                ),
+                insertImageAction: () => controller.insertImage(context, constraints.maxWidth),
               )),
               Expanded(
                 child: SingleChildScrollView(

--- a/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
+++ b/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
@@ -12,21 +12,16 @@ import 'package:tmail_ui_user/features/composer/presentation/model/inline_image.
 class RichTextMobileTabletController extends BaseRichTextController {
   HtmlEditorApi? htmlEditorApi;
 
-  void insertImage(
-    InlineImage image,
-    {
-      double? maxWithEditor,
-      bool fromFileShare = false
-    }
-  ) async {
-    log('RichTextMobileTabletController::insertImage(): $image | maxWithEditor: $maxWithEditor | $fromFileShare');
-    if (image.source == ImageSource.network) {
-      htmlEditorApi?.insertImageLink(image.link!);
+  void insertImage(InlineImage inlineImage) async {
+    if (inlineImage.source == ImageSource.network) {
+      htmlEditorApi?.insertImageLink(inlineImage.link!);
     } else {
-      if (fromFileShare) {
-        await htmlEditorApi?.moveCursorAtLastNode();
+      bool isEditorFocused = await htmlEditorApi?.hasFocus() ?? false;
+      log('RichTextMobileTabletController::insertImage: isEditorFocused = $isEditorFocused');
+      if (!isEditorFocused) {
+        await htmlEditorApi?.requestFocusLastChild();
       }
-      await htmlEditorApi?.insertHtml(image.base64Uri ?? '');
+      await htmlEditorApi?.insertHtml('${inlineImage.base64Uri ?? ''}<br/><br/>');
     }
   }
 

--- a/lib/features/composer/presentation/view/mobile/mobile_container_view.dart
+++ b/lib/features/composer/presentation/view/mobile/mobile_container_view.dart
@@ -10,7 +10,7 @@ typedef OnInsertImageAction = Function(BoxConstraints constraints);
 
 class MobileContainerView extends StatelessWidget {
 
-  final Widget Function(BuildContext context) childBuilder;
+  final Widget Function(BuildContext context, BoxConstraints constraints) childBuilder;
   final rich_composer.RichTextController keyboardRichTextController;
   final VoidCallback onCloseViewAction;
   final VoidCallback? onAttachFileAction;
@@ -61,7 +61,7 @@ class MobileContainerView extends StatelessWidget {
                   formatLabel: AppLocalizations.of(context).titleFormat,
                   titleBack: AppLocalizations.of(context).format,
                 ),
-                child: childBuilder(context),
+                child: childBuilder(context, constraints),
               );
             }),
           )

--- a/lib/features/composer/presentation/widgets/mobile/app_bar_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/app_bar_composer_widget.dart
@@ -9,8 +9,11 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 class AppBarComposerWidget extends StatelessWidget {
 
   final bool isSendButtonEnabled;
+  final bool isNetworkConnectionAvailable;
   final VoidCallback onCloseViewAction;
   final VoidCallback sendMessageAction;
+  final VoidCallback attachFileAction;
+  final VoidCallback insertImageAction;
   final OnOpenContextMenuAction openContextMenuAction;
 
   final _imagePaths = Get.find<ImagePaths>();
@@ -21,6 +24,9 @@ class AppBarComposerWidget extends StatelessWidget {
     required this.onCloseViewAction,
     required this.sendMessageAction,
     required this.openContextMenuAction,
+    required this.attachFileAction,
+    required this.insertImageAction,
+    this.isNetworkConnectionAvailable = false,
   });
 
   @override
@@ -41,6 +47,27 @@ class AppBarComposerWidget extends StatelessWidget {
             onTapActionCallback: onCloseViewAction
           ),
           const Spacer(),
+          if (isNetworkConnectionAvailable)
+            ...[
+              TMailButtonWidget.fromIcon(
+                icon: _imagePaths.icAttachFile,
+                iconColor: MobileAppBarComposerWidgetStyle.iconColor,
+                backgroundColor: Colors.transparent,
+                iconSize: MobileAppBarComposerWidgetStyle.iconSize,
+                tooltipMessage: AppLocalizations.of(context).attach_file,
+                onTapActionCallback: attachFileAction,
+              ),
+              const SizedBox(width: 8),
+              TMailButtonWidget.fromIcon(
+                icon: _imagePaths.icInsertImage,
+                iconColor: MobileAppBarComposerWidgetStyle.iconColor,
+                backgroundColor: Colors.transparent,
+                iconSize: MobileAppBarComposerWidgetStyle.iconSize,
+                tooltipMessage: AppLocalizations.of(context).insertImage,
+                onTapActionCallback: insertImageAction,
+              ),
+              const SizedBox(width: 8),
+            ],
           TMailButtonWidget.fromIcon(
             icon: isSendButtonEnabled
               ? _imagePaths.icSendMobile

--- a/lib/features/composer/presentation/widgets/mobile/landscape_app_bar_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/landscape_app_bar_composer_widget.dart
@@ -9,8 +9,11 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 class LandscapeAppBarComposerWidget extends StatelessWidget {
 
   final bool isSendButtonEnabled;
+  final bool isNetworkConnectionAvailable;
   final VoidCallback onCloseViewAction;
   final VoidCallback sendMessageAction;
+  final VoidCallback attachFileAction;
+  final VoidCallback insertImageAction;
   final OnOpenContextMenuAction openContextMenuAction;
 
   final _imagePaths = Get.find<ImagePaths>();
@@ -21,6 +24,9 @@ class LandscapeAppBarComposerWidget extends StatelessWidget {
     required this.onCloseViewAction,
     required this.sendMessageAction,
     required this.openContextMenuAction,
+    required this.attachFileAction,
+    required this.insertImageAction,
+    this.isNetworkConnectionAvailable = false,
   });
 
   @override
@@ -44,6 +50,27 @@ class LandscapeAppBarComposerWidget extends StatelessWidget {
               onTapActionCallback: onCloseViewAction
             ),
             const Spacer(),
+            if (isNetworkConnectionAvailable)
+              ...[
+                TMailButtonWidget.fromIcon(
+                  icon: _imagePaths.icAttachFile,
+                  iconColor: MobileAppBarComposerWidgetStyle.iconColor,
+                  backgroundColor: Colors.transparent,
+                  iconSize: MobileAppBarComposerWidgetStyle.iconSize,
+                  tooltipMessage: AppLocalizations.of(context).attach_file,
+                  onTapActionCallback: attachFileAction,
+                ),
+                const SizedBox(width: 8),
+                TMailButtonWidget.fromIcon(
+                  icon: _imagePaths.icInsertImage,
+                  iconColor: MobileAppBarComposerWidgetStyle.iconColor,
+                  backgroundColor: Colors.transparent,
+                  iconSize: MobileAppBarComposerWidgetStyle.iconSize,
+                  tooltipMessage: AppLocalizations.of(context).insertImage,
+                  onTapActionCallback: insertImageAction,
+                ),
+                const SizedBox(width: 8),
+              ],
             TMailButtonWidget.fromIcon(
               icon: isSendButtonEnabled
                 ? _imagePaths.icSendMobile

--- a/lib/features/composer/presentation/widgets/mobile/tablet_app_bar_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/tablet_app_bar_composer_widget.dart
@@ -1,0 +1,90 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/composer/presentation/model/screen_display_mode.dart';
+import 'package:tmail_ui_user/features/composer/presentation/styles/app_bar_composer_widget_style.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/title_composer_widget.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+class TabletAppBarComposerWidget extends StatelessWidget {
+
+  final String emailSubject;
+  final VoidCallback onCloseViewAction;
+  final ScreenDisplayMode? displayMode;
+  final BoxConstraints? constraints;
+  final VoidCallback attachFileAction;
+  final VoidCallback insertImageAction;
+  final bool isNetworkConnectionAvailable;
+
+  final _imagePaths = Get.find<ImagePaths>();
+
+  TabletAppBarComposerWidget({
+    super.key,
+    required this.emailSubject,
+    required this.onCloseViewAction,
+    required this.attachFileAction,
+    required this.insertImageAction,
+    this.displayMode,
+    this.constraints,
+    this.isNetworkConnectionAvailable = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: AppBarComposerWidgetStyle.height,
+      padding: AppBarComposerWidgetStyle.padding,
+      color: AppBarComposerWidgetStyle.backgroundColor,
+      child: Stack(
+        children: [
+          Center(
+            child: Container(
+              constraints: constraints != null
+                ? BoxConstraints(maxWidth: constraints!.maxWidth / 2)
+                : null,
+              child: TitleComposerWidget(emailSubject: emailSubject),
+            ),
+          ),
+          Align(
+            alignment: AlignmentDirectional.centerEnd,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (isNetworkConnectionAvailable)
+                  ...[
+                    TMailButtonWidget.fromIcon(
+                      icon: _imagePaths.icAttachFile,
+                      iconColor: AppBarComposerWidgetStyle.iconColor,
+                      backgroundColor: Colors.transparent,
+                      iconSize: AppBarComposerWidgetStyle.iconSize,
+                      tooltipMessage: AppLocalizations.of(context).attach_file,
+                      onTapActionCallback: attachFileAction,
+                    ),
+                    const SizedBox(width: AppBarComposerWidgetStyle.space),
+                    TMailButtonWidget.fromIcon(
+                      icon: _imagePaths.icInsertImage,
+                      iconColor: AppBarComposerWidgetStyle.iconColor,
+                      backgroundColor: Colors.transparent,
+                      iconSize: AppBarComposerWidgetStyle.iconSize,
+                      tooltipMessage: AppLocalizations.of(context).insertImage,
+                      onTapActionCallback: insertImageAction,
+                    ),
+                    const SizedBox(width: AppBarComposerWidgetStyle.space),
+                  ],
+                TMailButtonWidget.fromIcon(
+                  icon: _imagePaths.icCancel,
+                  backgroundColor: Colors.transparent,
+                  tooltipMessage: AppLocalizations.of(context).saveAndClose,
+                  iconSize: AppBarComposerWidgetStyle.iconSize,
+                  iconColor: AppBarComposerWidgetStyle.iconColor,
+                  onTapActionCallback: onCloseViewAction
+                ),
+              ],
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -406,7 +406,6 @@ class MailboxDashBoardController extends ReloadableController {
     _emailAddressStreamSubscription =
       _emailReceiveManager.pendingEmailAddressInfo.stream.listen((emailAddress) {
         if (emailAddress?.email?.isNotEmpty == true) {
-          _emailReceiveManager.clearPendingEmailAddress();
           goToComposer(ComposerArguments.fromEmailAddress(emailAddress!));
         }
       });
@@ -416,7 +415,6 @@ class MailboxDashBoardController extends ReloadableController {
     _emailContentStreamSubscription =
       _emailReceiveManager.pendingEmailContentInfo.stream.listen((emailContent) {
         if (emailContent?.content.isNotEmpty == true) {
-          _emailReceiveManager.clearPendingEmailContent();
           goToComposer(ComposerArguments.fromContentShared([emailContent!].asHtmlString));
         }
       });
@@ -426,7 +424,6 @@ class MailboxDashBoardController extends ReloadableController {
     _fileReceiveManagerStreamSubscription =
       _emailReceiveManager.pendingFileInfo.stream.listen((listFile) {
         if (listFile.isNotEmpty) {
-          _emailReceiveManager.clearPendingFileInfo();
           goToComposer(ComposerArguments.fromFileShared(listFile));
         }
       });

--- a/lib/features/upload/domain/state/attachment_upload_state.dart
+++ b/lib/features/upload/domain/state/attachment_upload_state.dart
@@ -31,15 +31,11 @@ class SuccessAttachmentUploadState extends Success {
   final UploadTaskId uploadId;
   final Attachment attachment;
   final FileInfo fileInfo;
-  final bool fromFileShared;
 
   SuccessAttachmentUploadState(
     this.uploadId,
     this.attachment,
-    this.fileInfo,
-    {
-      this.fromFileShared = false
-    }
+    this.fileInfo
   );
 
   @override
@@ -47,7 +43,6 @@ class SuccessAttachmentUploadState extends Success {
     uploadId,
     attachment,
     fileInfo,
-    fromFileShared,
   ];
 }
 

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -155,9 +155,6 @@ class UploadController extends BaseController {
             cid: uuid.v1()
           );
 
-          final uploadFileState = _uploadingStateInlineFiles.getUploadFileStateById(success.uploadId);
-          log('UploadController::_handleProgressUploadInlineImageStateStream:uploadId: ${uploadFileState?.uploadTaskId} | fromFileShared: ${uploadFileState?.fromFileShared}');
-
           _uploadingStateInlineFiles.updateElementByUploadTaskId(
             success.uploadId,
             (currentState) {
@@ -173,7 +170,6 @@ class UploadController extends BaseController {
             success.uploadId,
             inlineAttachment,
             success.fileInfo,
-            fromFileShared: uploadFileState?.fromFileShared ?? false
           );
           _handleUploadInlineAttachmentsSuccess(newUploadSuccess);
         }
@@ -378,7 +374,7 @@ class UploadController extends BaseController {
     super.handleSuccessViewState(success);
     if (success is UploadAttachmentSuccess) {
       if (success.isInline) {
-        _uploadingStateInlineFiles.add(success.uploadAttachment.toUploadFileState(fromFileShared: success.fromFileShared));
+        _uploadingStateInlineFiles.add(success.uploadAttachment.toUploadFileState());
         await _progressUploadInlineImageStateStreamGroup.add(success.uploadAttachment.progressState);
       } else {
         _uploadingStateFiles.add(success.uploadAttachment.toUploadFileState());

--- a/lib/features/upload/presentation/extensions/upload_attachment_extension.dart
+++ b/lib/features/upload/presentation/extensions/upload_attachment_extension.dart
@@ -4,12 +4,11 @@ import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_sta
 
 extension UploadAttachmentExtension on UploadAttachment {
 
-  UploadFileState toUploadFileState({bool fromFileShared = false}) {
+  UploadFileState toUploadFileState() {
     return UploadFileState(
       uploadTaskId,
       file: fileInfo,
       cancelToken: cancelToken,
-      fromFileShared: fromFileShared,
     );
   }
 }

--- a/lib/features/upload/presentation/model/upload_file_state.dart
+++ b/lib/features/upload/presentation/model/upload_file_state.dart
@@ -18,7 +18,6 @@ class UploadFileState with EquatableMixin {
   final int uploadingProgress;
   final Attachment? attachment;
   final CancelToken? cancelToken;
-  final bool fromFileShared;
 
   UploadFileState(
     this.uploadTaskId,
@@ -28,7 +27,6 @@ class UploadFileState with EquatableMixin {
       this.uploadingProgress = 0,
       this.attachment,
       this.cancelToken,
-      this.fromFileShared = false,
     }
   );
 
@@ -39,7 +37,6 @@ class UploadFileState with EquatableMixin {
     int? uploadingProgress,
     Attachment? attachment,
     CancelToken? cancelToken,
-    bool? fromFileShared,
   }) {
     return UploadFileState(
       uploadTaskId ?? this.uploadTaskId,
@@ -48,7 +45,6 @@ class UploadFileState with EquatableMixin {
       uploadingProgress: uploadingProgress ?? this.uploadingProgress,
       attachment: attachment ?? this.attachment,
       cancelToken: cancelToken ?? this.cancelToken,
-      fromFileShared: fromFileShared ?? this.fromFileShared
     );
   }
 
@@ -105,6 +101,5 @@ class UploadFileState with EquatableMixin {
     uploadingProgress,
     attachment,
     cancelToken,
-    fromFileShared,
   ];
 }

--- a/lib/main/utils/email_receive_manager.dart
+++ b/lib/main/utils/email_receive_manager.dart
@@ -29,16 +29,16 @@ class EmailReceiveManager {
   }
 
   void setPendingEmailAddress(EmailAddress emailAddress) async {
-    clearPendingEmailAddress();
+    _clearPendingEmailAddress();
     _pendingEmailAddressInfo.add(emailAddress);
   }
 
   void setPendingEmailContent(EmailContent emailContent) async {
-    clearPendingEmailAddress();
+    _clearPendingEmailContent();
     _pendingEmailContentInfo.add(emailContent);
   }
 
-  void clearPendingEmailContent() {
+  void _clearPendingEmailContent() {
     if (_pendingEmailContentInfo.isClosed) {
       _pendingEmailContentInfo = BehaviorSubject.seeded(null);
     } else {
@@ -46,7 +46,7 @@ class EmailReceiveManager {
     }
   }
 
-  void clearPendingEmailAddress() {
+  void _clearPendingEmailAddress() {
     if(_pendingEmailAddressInfo.isClosed) {
       _pendingEmailAddressInfo = BehaviorSubject.seeded(null);
     } else {
@@ -56,22 +56,20 @@ class EmailReceiveManager {
 
   void closeEmailReceiveManagerStream() {
     _pendingEmailAddressInfo.close();
+    _pendingEmailContentInfo.close();
+    _pendingFileInfo.close();
   }
 
   void setPendingFileInfo(List<SharedMediaFile> list) async {
-    clearPendingFileInfo();
+    _clearPendingFileInfo();
     _pendingFileInfo.add(list);
   }
 
-  void clearPendingFileInfo() {
+  void _clearPendingFileInfo() {
     if(_pendingFileInfo.isClosed) {
       _pendingFileInfo = BehaviorSubject.seeded(List.empty(growable: true));
     } else {
       _pendingFileInfo.add(List.empty(growable: true));
     }
-  }
-
-  void closeFileSharingStream() {
-    _pendingFileInfo.close();
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -404,8 +404,8 @@ packages:
     dependency: transitive
     description:
       path: "."
-      ref: "bugfix/build-failed-on-android"
-      resolved-ref: "33991d46432a22a79b5d3593262033ae49da77f6"
+      ref: email_supported
+      resolved-ref: "562ef89121d2ea8b12340cdf0998104b3fc25857"
       url: "https://github.com/linagora/enough_html_editor.git"
     source: git
     version: "0.0.5"
@@ -1540,7 +1540,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: "9c0eb7e3627af6ba6860e986ec6ac1f6f170c71d"
+      resolved-ref: "91809cfa3095b71f3cce04e8f29f38c238d2e770"
       url: "https://github.com/linagora/rich-text-composer.git"
     source: git
     version: "0.0.2"


### PR DESCRIPTION
## Issue

#2532 

## Dependent

- Need merged: 
    - https://github.com/linagora/enough_html_editor/pull/27
    - https://github.com/linagora/rich-text-composer/pull/26

## Demo

- Android


https://github.com/linagora/tmail-flutter/assets/80730648/340b1372-5144-4d31-933e-81c2768a058a



- iPhone

https://github.com/linagora/tmail-flutter/assets/80730648/a700568e-fcd6-402f-9246-76cc2b1d660b



- iPad


https://github.com/linagora/tmail-flutter/assets/80730648/5e650aac-4bda-4bc3-b6af-8eef3d4aceb3

