### PR TITLE
TF-2564 Fix impossible clean all spam mailbox when more 1000 emails

### DIFF
--- a/lib/features/thread/data/datasource/thread_datasource.dart
+++ b/lib/features/thread/data/datasource/thread_datasource.dart
@@ -55,7 +55,6 @@ abstract class ThreadDataSource {
     Session session,
     AccountId accountId,
     MailboxId mailboxId,
-    Future<void> Function(List<EmailId>? newDestroyed) updateDestroyedEmailCache,
   );
 
   Future<PresentationEmail> getEmailById(Session session, AccountId accountId, EmailId emailId, {Properties? properties});

--- a/lib/features/thread/data/datasource_impl/local_thread_datasource_impl.dart
+++ b/lib/features/thread/data/datasource_impl/local_thread_datasource_impl.dart
@@ -96,7 +96,6 @@ class LocalThreadDataSourceImpl extends ThreadDataSource {
     Session session,
     AccountId accountId,
     MailboxId mailboxId,
-    Future<void> Function(List<EmailId>? newDestroyed) updateDestroyedEmailCache
   ) {
     throw UnimplementedError();
   }

--- a/lib/features/thread/data/datasource_impl/thread_datasource_impl.dart
+++ b/lib/features/thread/data/datasource_impl/thread_datasource_impl.dart
@@ -90,15 +90,13 @@ class ThreadDataSourceImpl extends ThreadDataSource {
   Future<List<EmailId>> emptyMailboxFolder(
     Session session,
     AccountId accountId,
-    MailboxId mailboxId,
-    Future<void> Function(List<EmailId>? newDestroyed) updateDestroyedEmailCache
+    MailboxId mailboxId
   ) {
     return Future.sync(() async {
       return await _threadIsolateWorker.emptyMailboxFolder(
         session,
         accountId,
-        mailboxId,
-        updateDestroyedEmailCache,
+        mailboxId
       );
     }).catchError(_exceptionThrower.throwException);
   }

--- a/lib/features/thread/data/local/email_cache_manager.dart
+++ b/lib/features/thread/data/local/email_cache_manager.dart
@@ -65,20 +65,20 @@ class EmailCacheManager {
     List<Email>? created,
     List<EmailId>? destroyed
   }) async {
-    final emailCacheExist = await _emailCacheClient.isExistTable();
-    if (emailCacheExist) {
-      final updatedCacheEmails = updated?.toMapCache(accountId, userName) ?? {};
-      final createdCacheEmails = created?.toMapCache(accountId, userName) ?? {};
-      final destroyedCacheEmails = destroyed?.toCacheKeyList(accountId, userName) ?? [];
-
-      await Future.wait([
-        _emailCacheClient.updateMultipleItem(updatedCacheEmails),
-        _emailCacheClient.insertMultipleItem(createdCacheEmails),
-        _emailCacheClient.deleteMultipleItem(destroyedCacheEmails)
-      ]);
-    } else {
-      final createdCacheEmails = created?.toMapCache(accountId, userName) ?? {};
+    if (created?.isNotEmpty == true) {
+      final createdCacheEmails = created!.toMapCache(accountId, userName);
       await _emailCacheClient.insertMultipleItem(createdCacheEmails);
+    }
+
+    if (updated?.isNotEmpty == true) {
+      final updatedCacheEmails = updated!.toMapCache(accountId, userName);
+      await _emailCacheClient.updateMultipleItem(updatedCacheEmails);
+    }
+
+    final emailCacheExist = await _emailCacheClient.isExistTable();
+    if (destroyed?.isNotEmpty == true && emailCacheExist) {
+      final destroyedCacheEmails = destroyed!.toCacheKeyList(accountId, userName);
+      await _emailCacheClient.deleteMultipleItem(destroyedCacheEmails);
     }
   }
 

--- a/lib/features/thread/data/repository/thread_repository_impl.dart
+++ b/lib/features/thread/data/repository/thread_repository_impl.dart
@@ -309,14 +309,17 @@ class ThreadRepositoryImpl extends ThreadRepository {
 
   @override
   Future<List<EmailId>> emptyTrashFolder(Session session, AccountId accountId, MailboxId trashMailboxId) async {
-    return mapDataSource[DataSourceType.network]!.emptyMailboxFolder(
+    final listEmailIdDeleted = await mapDataSource[DataSourceType.network]!.emptyMailboxFolder(
       session,
       accountId,
-      trashMailboxId,
-      (listEmailIdDeleted) async {
-        await _updateEmailCache(accountId, session.username, newDestroyed: listEmailIdDeleted);
-      },
-    );
+      trashMailboxId);
+
+    await _updateEmailCache(
+      accountId,
+      session.username,
+      newDestroyed: listEmailIdDeleted);
+
+    return listEmailIdDeleted;
   }
 
   Future<void> _synchronizeCacheWithChanges(
@@ -388,18 +391,17 @@ class ThreadRepositoryImpl extends ThreadRepository {
   }
 
   @override
-  Future<List<EmailId>> emptySpamFolder(Session session, AccountId accountId, MailboxId spamMailboxId) {
-    return mapDataSource[DataSourceType.network]!.emptyMailboxFolder(
+  Future<List<EmailId>> emptySpamFolder(Session session, AccountId accountId, MailboxId spamMailboxId) async {
+    final listEmailIdDeleted = await mapDataSource[DataSourceType.network]!.emptyMailboxFolder(
       session,
       accountId,
-      spamMailboxId,
-      (listEmailIdDeleted) async {
-        await _updateEmailCache(
-          accountId,
-          session.username,
-          newDestroyed: listEmailIdDeleted
-        );
-      },
-    );
+      spamMailboxId);
+
+    await _updateEmailCache(
+      accountId,
+      session.username,
+      newDestroyed: listEmailIdDeleted);
+
+    return listEmailIdDeleted;
   }
 }


### PR DESCRIPTION
## Issue

#2564 

## Analysis

- Context: On Mobile, use `Isolate` to delete emails in the mailbox. After each deletion of an email list, we call `sendPort.send()` to transmit the deleted email list to `main`:
    - If `sendPort.send()` submitted successfully → Update cache
    - If `sendPort.send()` faulty  → Cache not updated. This is the issue.

## Solution

We wait for the email delete request to `JMAP` to complete before updating the cache.

