### PR TITLE
TF-2610 Fix missing attachments when mail sent from iphone

### DIFF
--- a/docs/adr/0038-logic-for-displaying-attachment-types-in-emails.md
+++ b/docs/adr/0038-logic-for-displaying-attachment-types-in-emails.md
@@ -1,0 +1,31 @@
+# 38. Logic for displaying `attachment` types in emails
+
+Date: 2024-02-20
+
+## Status
+
+Accepted
+
+## Context
+
+- The logic for displaying `attachments` while reading emails is complex
+- Avoid unwanted loss of `attachments` with each new version release
+
+## Decision
+
+Brief the logic flows to make it easier to track changes during `attachment` display in emails:
+
+1. External attachments: Displayed as files outside the email content
+
+- Display is only allowed when one of the following conditions is met:
+  - `cid is NULL` AND `not in htmlBody` AND `does not satisfy this condition mimeType = 'application/rtf' && disposition = 'inline'`
+  - `disposition != 'inline'` AND `not in htmlBody` AND `does not satisfy this condition mimeType='application/rtf' && disposition = 'inline'`
+
+2. Inline attachments: Displayed within the email body
+
+- Display is only allowed when the following conditions are met:
+  - `cid is not NULL` AND `disposition = 'inline'`
+
+## Consequences
+
+- Any changes to attachment display while reading emails should be updated in this ADR.

--- a/model/lib/email/attachment.dart
+++ b/model/lib/email/attachment.dart
@@ -37,10 +37,6 @@ class Attachment with EquatableMixin {
 
   bool isDispositionInlined() => disposition == ContentDisposition.inline;
 
-  bool isDispositionAttachment() => disposition == ContentDisposition.attachment;
-
-  bool isDispositionAttachmentNoCID() => isDispositionAttachment() && noCid();
-
   bool isApplicationRTFInlined() => type?.mimeType == applicationRTFType && isDispositionInlined();
 
   String getDownloadUrl(String baseDownloadUrl, AccountId accountId) {

--- a/model/lib/extensions/attachment_extension.dart
+++ b/model/lib/extensions/attachment_extension.dart
@@ -29,7 +29,7 @@ extension AttachmentExtension on Attachment {
   }
 
   bool isOutsideAttachment(List<Attachment> htmlBodyAttachments) {
-    return (isDispositionAttachmentNoCID() || !isDispositionInlined()) &&
+    return (noCid() || !isDispositionInlined()) &&
       !isApplicationRTFInlined() &&
       !htmlBodyAttachments.include(this);
   }

--- a/model/test/attachment_test.dart
+++ b/model/test/attachment_test.dart
@@ -118,12 +118,12 @@ void main() {
       'GIVE attachmentG has disposition = `inline`\n'
       'AND htmlBodyAttachments is empty\n'
       'WHEN perform call `attachmentG.isOutsideAttachment()`\n'
-      'SHOULD return false',
+      'SHOULD return true',
     () {
       List<Attachment> htmlBodyAttachments = [];
       bool result = attachmentG.isOutsideAttachment(htmlBodyAttachments);
 
-      expect(result, isFalse);
+      expect(result, isTrue);
     });
 
     test(


### PR DESCRIPTION
## Issue

#2610

## Root cause

- The attachment display logic is incorrect. In this case, we don't display when `disposition = inline` and `cid is null`

<img width="313" alt="Screenshot 2024-02-20 at 15 52 54" src="https://github.com/linagora/tmail-flutter/assets/80730648/c1697065-2e9a-4a43-bd77-53697862fb3a">

## Solution

- Change attachment display logic.
- Write `adr` for attachments display logic
