### PR TITLE
TF-2537 Fix user got crash when trying attach pdf file

### DIFF
--- a/core/lib/utils/platform_info.dart
+++ b/core/lib/utils/platform_info.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:core/utils/app_logger.dart';
+import 'package:core/utils/web_renderer/canvas_kit.dart';
 import 'package:flutter/foundation.dart';
 
 abstract class PlatformInfo {
@@ -13,7 +14,7 @@ abstract class PlatformInfo {
   static bool get isAndroid => !kIsWeb && Platform.isAndroid;
   static bool get isMobile => isAndroid || isIOS;
   static bool get isDesktop => isLinux || isWindows || isMacOS;
-  static bool get isWebMobile => kIsWeb && (defaultTargetPlatform == TargetPlatform.iOS || defaultTargetPlatform == TargetPlatform.android);
+  static bool get isCanvasKit => isRendererCanvasKit;
 
   static String get platformNameOS {
     var platformName = '';

--- a/core/lib/utils/web_renderer/canvas_kit.dart
+++ b/core/lib/utils/web_renderer/canvas_kit.dart
@@ -1,0 +1,1 @@
+export 'canvas_kit_stub.dart' if (dart.library.html) 'canvas_kit_web.dart';

--- a/core/lib/utils/web_renderer/canvas_kit_stub.dart
+++ b/core/lib/utils/web_renderer/canvas_kit_stub.dart
@@ -1,0 +1,4 @@
+/// Whether the CanvasKit renderer is being used on web.
+///
+/// Always returns `false` on non-web.
+bool get isRendererCanvasKit => false;

--- a/core/lib/utils/web_renderer/canvas_kit_web.dart
+++ b/core/lib/utils/web_renderer/canvas_kit_web.dart
@@ -1,0 +1,6 @@
+import 'dart:js' as js;
+
+/// Whether the CanvasKit renderer is being used on web.
+///
+/// Always returns `false` on non-web.
+bool get isRendererCanvasKit => js.context['flutterCanvasKit'] != null;

--- a/lib/features/composer/presentation/widgets/attachment_item_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/attachment_item_composer_widget.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:extended_text/extended_text.dart';
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
@@ -58,18 +59,25 @@ class AttachmentItemComposerWidget extends StatelessWidget with AppLoaderMixin {
                     ),
                     const SizedBox(width: AttachmentItemComposerWidgetStyle.space),
                     Expanded(
-                      child: ExtendedText(
-                        fileState.fileName,
-                        maxLines: 1,
-                        overflowWidget: const TextOverflowWidget(
-                          position: TextOverflowPosition.middle,
-                          child: Text(
-                            '...',
-                            style: AttachmentItemComposerWidgetStyle.dotsLabelTextStyle,
-                          ),
-                        ),
-                        style: AttachmentItemComposerWidgetStyle.labelTextStyle,
-                      ),
+                      child: PlatformInfo.isCanvasKit
+                        ? ExtendedText(
+                            fileState.fileName,
+                            maxLines: 1,
+                            overflowWidget: const TextOverflowWidget(
+                              position: TextOverflowPosition.middle,
+                              child: Text(
+                                '...',
+                                style: AttachmentItemComposerWidgetStyle.dotsLabelTextStyle,
+                              ),
+                            ),
+                            style: AttachmentItemComposerWidgetStyle.labelTextStyle,
+                          )
+                        : Text(
+                            fileState.fileName,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: AttachmentItemComposerWidgetStyle.labelTextStyle,
+                          )
                     ),
                     const SizedBox(width: AttachmentItemComposerWidgetStyle.space),
                     Text(

--- a/lib/features/composer/presentation/widgets/recipient_tag_item_widget.dart
+++ b/lib/features/composer/presentation/widgets/recipient_tag_item_widget.dart
@@ -57,7 +57,7 @@ class RecipientTagItemWidget extends StatelessWidget {
             Flexible(
               child: Padding(
                 padding: EdgeInsetsDirectional.only(
-                  top: PlatformInfo.isWebMobile ? 0 : 8
+                  top: !PlatformInfo.isCanvasKit ? 0 : 8
                 ),
                 child: InkWell(
                   onTap: () => isCollapsed
@@ -158,10 +158,10 @@ class RecipientTagItemWidget extends StatelessWidget {
   }
 
   EdgeInsetsGeometry? get _counterMargin {
-    if (PlatformInfo.isWebMobile) {
-      return RecipientTagItemWidgetStyle.webMobileCounterMargin;
-    } else if (PlatformInfo.isWeb) {
-      return RecipientTagItemWidgetStyle.webCounterMargin;
+    if (PlatformInfo.isWeb) {
+      return PlatformInfo.isCanvasKit
+        ? RecipientTagItemWidgetStyle.webCounterMargin
+        : RecipientTagItemWidgetStyle.webMobileCounterMargin;
     } else {
       return RecipientTagItemWidgetStyle.counterMargin;
     }

--- a/lib/features/email/presentation/widgets/attachment_item_widget.dart
+++ b/lib/features/email/presentation/widgets/attachment_item_widget.dart
@@ -53,18 +53,25 @@ class AttachmentItemWidget extends StatelessWidget {
               ),
               const SizedBox(width: AttachmentItemWidgetStyle.space),
               Expanded(
-                child: ExtendedText(
-                  (attachment.name ?? ''),
-                  maxLines: 1,
-                  overflowWidget: const TextOverflowWidget(
-                    position: TextOverflowPosition.middle,
-                    child: Text(
-                      "...",
-                      style: AttachmentItemWidgetStyle.dotsLabelTextStyle,
-                    ),
-                  ),
-                  style: AttachmentItemWidgetStyle.labelTextStyle,
-                ),
+                child: PlatformInfo.isCanvasKit
+                  ? ExtendedText(
+                      (attachment.name ?? ''),
+                      maxLines: 1,
+                      overflowWidget: const TextOverflowWidget(
+                        position: TextOverflowPosition.middle,
+                        child: Text(
+                          "...",
+                          style: AttachmentItemWidgetStyle.dotsLabelTextStyle,
+                        ),
+                      ),
+                      style: AttachmentItemWidgetStyle.labelTextStyle,
+                    )
+                  : Text(
+                      (attachment.name ?? ''),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: AttachmentItemWidgetStyle.labelTextStyle,
+                    )
               ),
               const SizedBox(width: AttachmentItemWidgetStyle.space),
               Text(

--- a/lib/features/email/presentation/widgets/attachment_list/attachment_list_item_widget.dart
+++ b/lib/features/email/presentation/widgets/attachment_list/attachment_list_item_widget.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/style_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:extended_text/extended_text.dart';
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
@@ -46,18 +47,26 @@ class AttachmentListItemWidget extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    ExtendedText(
-                      (attachment.name ?? ''),
-                      maxLines: 1,
-                      overflowWidget: const TextOverflowWidget(
-                        position: TextOverflowPosition.middle,
-                        child: Text(
-                          "...",
-                          style: AttachmentListItemWidgetStyle.dotsLabelTextStyle,
+                    if (PlatformInfo.isCanvasKit)
+                      ExtendedText(
+                        (attachment.name ?? ''),
+                        maxLines: 1,
+                        overflowWidget: const TextOverflowWidget(
+                          position: TextOverflowPosition.middle,
+                          child: Text(
+                            "...",
+                            style: AttachmentListItemWidgetStyle.dotsLabelTextStyle,
+                          ),
                         ),
+                        style: AttachmentListItemWidgetStyle.labelTextStyle,
+                      )
+                    else
+                     Text(
+                        (attachment.name ?? ''),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: AttachmentListItemWidgetStyle.labelTextStyle,
                       ),
-                      style: AttachmentListItemWidgetStyle.labelTextStyle,
-                    ),
                     const SizedBox(height: AttachmentListItemWidgetStyle.fileTitleBottomSpace),
                     Text(
                       filesize(attachment.size?.value),

--- a/lib/features/email/presentation/widgets/feedback_draggable_attachment_item_widget.dart
+++ b/lib/features/email/presentation/widgets/feedback_draggable_attachment_item_widget.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:extended_text/extended_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -43,20 +44,27 @@ class FeedbackDraggableAttachmentItemWidget extends StatelessWidget {
           ),
           const SizedBox(width: FeedbackDraggableAttachmentItemWidgetStyle.space),
           Flexible(
-            child: DefaultTextStyle(
-              style: FeedbackDraggableAttachmentItemWidgetStyle.labelTextStyle,
-              child: ExtendedText(
-                attachment.name ?? '',
-                maxLines: 1,
-                overflowWidget: const TextOverflowWidget(
-                  position: TextOverflowPosition.middle,
-                  child: Text(
-                    '...',
-                    style: FeedbackDraggableAttachmentItemWidgetStyle.dotsLabelTextStyle,
+            child: PlatformInfo.isCanvasKit
+              ? DefaultTextStyle(
+                  style: FeedbackDraggableAttachmentItemWidgetStyle.labelTextStyle,
+                  child: ExtendedText(
+                    attachment.name ?? '',
+                    maxLines: 1,
+                    overflowWidget: const TextOverflowWidget(
+                      position: TextOverflowPosition.middle,
+                      child: Text(
+                        '...',
+                        style: FeedbackDraggableAttachmentItemWidgetStyle.dotsLabelTextStyle,
+                      ),
+                    ),
                   ),
+                )
+              : Text(
+                  attachment.name ?? '',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: FeedbackDraggableAttachmentItemWidgetStyle.labelTextStyle,
                 ),
-              ),
-            ),
           )
         ],
       ),


### PR DESCRIPTION
## Issue

#2537 

## Root cause

- Dependence `ExtendedText` widget use `BlendMode.clear` but flutter web does not support `BlendMode.clear` or `BlendMode.dst` when using `html renderer`


![Screenshot 2024-02-20 at 09 23 46](https://github.com/linagora/tmail-flutter/assets/80730648/c34f62ac-8d52-4e25-a716-c271e4a1051d)

## Solution

- Only use `ExtendedText` widget when `web_renderer` is `canvaskit`

## Demo



https://github.com/linagora/tmail-flutter/assets/80730648/d774d255-13f9-4525-a77a-aaa6f0d7722e

