### PR TITLE
TF-2326 Allow display count of total emails for draft folder

### DIFF
--- a/model/lib/extensions/presentation_mailbox_extension.dart
+++ b/model/lib/extensions/presentation_mailbox_extension.dart
@@ -51,7 +51,7 @@ extension PresentationMailboxExtension on PresentationMailbox {
 
   bool get allowedToDisplayCountOfUnreadEmails => !(isTrash || isSpam || isDrafts || isTemplates || isSent) && countUnreadEmails > 0;
 
-  bool get allowedToDisplayCountOfTotalEmails => (isTrash || isSpam) && countTotalEmails > 0;
+  bool get allowedToDisplayCountOfTotalEmails => (isTrash || isSpam || isDrafts) && countTotalEmails > 0;
 
   bool get allowedHasEmptyAction => (isTrash || isSpam) && countTotalEmails > 0;
 


### PR DESCRIPTION
(cherry picked from commit 3bb7c65c942c17f2b5a0a2efe2923f26c5ceebd2)

## Resolved

https://github.com/linagora/tmail-flutter/assets/80142234/e781b61e-6de2-4ad6-9c3a-5242084611b8

