### PR TITLE
TF-2628 Add open downloaded file in new tab feature

### DIFF
--- a/core/lib/data/constants/constant.dart
+++ b/core/lib/data/constants/constant.dart
@@ -1,4 +1,5 @@
 class Constant {
   static const acceptHeaderDefault = 'application/json';
   static const contentTypeHeaderDefault = 'application/json';
+  static const pdfMimeType = 'application/pdf';
 }

--- a/core/lib/data/network/download/download_manager.dart
+++ b/core/lib/data/network/download/download_manager.dart
@@ -115,7 +115,7 @@ class DownloadManager {
 
       html.Url.revokeObjectUrl(url);
     } catch (exception) {
-      log('DownloadManager::openDownloadedFileWeb(): ERROR: $exception');
+      logError('DownloadManager::openDownloadedFileWeb(): ERROR: $exception');
       rethrow;
     }
   }

--- a/core/lib/data/network/download/download_manager.dart
+++ b/core/lib/data/network/download/download_manager.dart
@@ -8,6 +8,7 @@ import 'package:core/domain/exceptions/download_file_exception.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:dio/dio.dart';
 import 'package:http_parser/http_parser.dart';
+import 'package:mime/mime.dart';
 import 'package:universal_html/html.dart' as html;
 
 class DownloadManager {
@@ -100,6 +101,21 @@ class DownloadManager {
       html.Url.revokeObjectUrl(url);
     } catch (exception) {
       log('DownloadManager::createAnchorElementDownloadFileWeb(): ERROR: $exception');
+      rethrow;
+    }
+  }
+
+  void openDownloadedFileWeb(Uint8List bytes, String? mimeType) {
+    try {
+      final mime = mimeType ?? lookupMimeType('', headerBytes: bytes);
+      final blob = html.Blob([bytes], mime);
+      final url = html.Url.createObjectUrlFromBlob(blob);
+
+      html.window.open(url, '_blank');
+
+      html.Url.revokeObjectUrl(url);
+    } catch (exception) {
+      log('DownloadManager::openDownloadedFileWeb(): ERROR: $exception');
       rethrow;
     }
   }

--- a/core/lib/data/network/download/download_manager.dart
+++ b/core/lib/data/network/download/download_manager.dart
@@ -8,7 +8,6 @@ import 'package:core/domain/exceptions/download_file_exception.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:dio/dio.dart';
 import 'package:http_parser/http_parser.dart';
-import 'package:mime/mime.dart';
 import 'package:universal_html/html.dart' as html;
 
 class DownloadManager {
@@ -107,8 +106,7 @@ class DownloadManager {
 
   void openDownloadedFileWeb(Uint8List bytes, String? mimeType) {
     try {
-      final mime = mimeType ?? lookupMimeType('', headerBytes: bytes);
-      final blob = html.Blob([bytes], mime);
+      final blob = html.Blob([bytes], mimeType);
       final url = html.Url.createObjectUrlFromBlob(blob);
 
       html.window.open(url, '_blank');

--- a/core/pubspec.lock
+++ b/core/pubspec.lock
@@ -400,6 +400,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  mime:
+    dependency: "direct main"
+    description:
+      name: mime
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   path:
     dependency: transitive
     description:

--- a/core/pubspec.lock
+++ b/core/pubspec.lock
@@ -400,14 +400,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
-  mime:
-    dependency: "direct main"
-    description:
-      name: mime
-      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.4"
   path:
     dependency: transitive
     description:

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -75,8 +75,6 @@ dependencies:
 
   linkify: 5.0.0
 
-  mime: 1.0.4
-
 dev_dependencies:
   flutter_test:
     sdk: flutter
@@ -124,7 +122,6 @@ flutter:
   #
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/custom-fonts/#from-packages
-
 
   # This section identifies your Flutter project as a module meant for
   # embedding in a native host app.  These identifiers should _not_ ordinarily

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -75,6 +75,8 @@ dependencies:
 
   linkify: 5.0.0
 
+  mime: 1.0.4
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -123,6 +123,7 @@ flutter:
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/custom-fonts/#from-packages
 
+
   # This section identifies your Flutter project as a module meant for
   # embedding in a native host app.  These identifiers should _not_ ordinarily
   # be changed after generation - they are used to ensure that the tooling can

--- a/docs/adr/0039-logic-for-opening-pdf-in-new-browser-tab.md
+++ b/docs/adr/0039-logic-for-opening-pdf-in-new-browser-tab.md
@@ -1,0 +1,31 @@
+# 38. Logic for displaying PDF in new browser tab
+
+Date: 2024-02-23
+
+## Status
+
+Accepted
+
+## Context
+
+- When user tap PDF attachment inside email web, the attachment should be automatically opened in new tab
+- The attachment button in web at the moment can be tapped on itself, and also at the download icon inside it
+- The behavior when tapping either of those places are the same
+
+## Decision
+
+Separate the business logic of both tappable places:
+
+1. When download icon is tapped
+
+- Create download anchor and click on it programmatically, triggering the download action of the browser
+- After the browser download the file, browser will handle the file by its own settings & policies
+
+2. When anywhere else inside the attachment button is tapped
+
+- If attachment is PDF, trigger window.open from html.dart with `_blank` parameter so that the file is opened in new tab
+- If attachment is not PDF, treat the action as if the download icon is tapped as case 1
+
+## Consequences
+
+- Different behaviors will be triggered depends on where user taps inside the attachment button on Twake Mail web

--- a/lib/features/email/domain/state/view_attachment_for_web_state.dart
+++ b/lib/features/email/domain/state/view_attachment_for_web_state.dart
@@ -1,0 +1,23 @@
+import 'package:tmail_ui_user/features/email/domain/state/download_attachment_for_web_state.dart';
+
+class StartViewAttachmentForWeb extends StartDownloadAttachmentForWeb {
+  StartViewAttachmentForWeb(super.taskId, super.attachment);
+}
+
+class ViewingAttachmentForWeb extends DownloadingAttachmentForWeb {
+  ViewingAttachmentForWeb(
+    super.taskId,
+    super.attachment,
+    super.progress,
+    super.downloaded,
+    super.total,
+  );
+}
+
+class ViewAttachmentForWebSuccess extends DownloadAttachmentForWebSuccess {
+  ViewAttachmentForWebSuccess(super.taskId, super.attachment, super.bytes);
+}
+
+class ViewAttachmentForWebFailure extends DownloadAttachmentForWebFailure {
+  ViewAttachmentForWebFailure({super.taskId, super.exception});
+}

--- a/lib/features/email/domain/usecases/view_attachment_for_web_interactor.dart
+++ b/lib/features/email/domain/usecases/view_attachment_for_web_interactor.dart
@@ -1,0 +1,58 @@
+import 'dart:async';
+
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:model/download/download_task_id.dart';
+import 'package:model/email/attachment.dart';
+import 'package:tmail_ui_user/features/email/domain/state/download_attachment_for_web_state.dart';
+import 'package:tmail_ui_user/features/email/domain/state/view_attachment_for_web_state.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/download_attachment_for_web_interactor.dart';
+
+class ViewAttachmentForWebInteractor {
+  ViewAttachmentForWebInteractor(this._downloadAttachmentForWebInteractor);
+
+  final DownloadAttachmentForWebInteractor _downloadAttachmentForWebInteractor;
+
+  Stream<Either<Failure, Success>> execute(
+    DownloadTaskId taskId,
+    Attachment attachment,
+    AccountId accountId,
+    String baseDownloadUrl,
+    StreamController<Either<Failure, Success>> onReceiveController,
+  ) =>
+      _downloadAttachmentForWebInteractor
+          .execute(taskId, attachment, accountId, baseDownloadUrl,
+              onReceiveController)
+          .map(
+            (result) => result.fold(
+              (failure) {
+                if (failure is DownloadAttachmentForWebFailure) {
+                  return left(ViewAttachmentForWebFailure(
+                      taskId: failure.taskId, exception: failure.exception));
+                }
+
+                return left(failure);
+              },
+              (r) {
+                if (r is StartDownloadAttachmentForWeb) {
+                  return right(
+                      StartViewAttachmentForWeb(r.taskId, r.attachment));
+                }
+
+                if (r is DownloadingAttachmentForWeb) {
+                  return right(ViewingAttachmentForWeb(r.taskId, r.attachment,
+                      r.progress, r.downloaded, r.total));
+                }
+
+                if (r is DownloadAttachmentForWebSuccess) {
+                  return right(ViewAttachmentForWebSuccess(
+                      r.taskId, r.attachment, r.bytes));
+                }
+
+                return right(r);
+              },
+            ),
+          );
+}

--- a/lib/features/email/presentation/bindings/email_bindings.dart
+++ b/lib/features/email/presentation/bindings/email_bindings.dart
@@ -20,6 +20,7 @@ import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_email_read_
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_star_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/move_to_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/store_opened_email_interactor.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/view_attachment_for_web_interactor.dart';
 import 'package:tmail_ui_user/features/email/presentation/controller/email_supervisor_controller.dart';
 import 'package:tmail_ui_user/features/email/presentation/controller/single_email_controller.dart';
 import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
@@ -64,7 +65,8 @@ class EmailBindings extends BaseBindings {
       Get.find<MarkAsStarEmailInteractor>(),
       Get.find<DownloadAttachmentForWebInteractor>(),
       Get.find<GetAllIdentitiesInteractor>(),
-      Get.find<StoreOpenedEmailInteractor>()
+      Get.find<StoreOpenedEmailInteractor>(),
+      Get.find<ViewAttachmentForWebInteractor>(),
     ));
   }
 
@@ -136,6 +138,8 @@ class EmailBindings extends BaseBindings {
       Get.find<AccountRepository>(),
       Get.find<AuthenticationOIDCRepository>()));
     Get.lazyPut(() => GetStoredEmailStateInteractor(Get.find<EmailRepository>()));
+    Get.lazyPut(() => ViewAttachmentForWebInteractor(
+        Get.find<DownloadAttachmentForWebInteractor>()));
     Get.lazyPut(() => StoreOpenedEmailInteractor(Get.find<EmailRepository>()));
     IdentityInteractorsBindings().dependencies();
   }

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -751,13 +751,20 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
 
     final mimeType = success.attachment.type?.mimeType ??
         lookupMimeType('', headerBytes: success.bytes);
-    if (mimeType == Constant.pdfMimeType) {
-      _downloadManager.openDownloadedFileWeb(
-          success.bytes, success.attachment.type?.mimeType);
-    } else {
+    if (mimeType != Constant.pdfMimeType) {
       _downloadManager.createAnchorElementDownloadFileWeb(
           success.bytes, success.attachment.generateFileName());
+      return;
     }
+
+    if (success.attachment.attachmentAction == AttachmentAction.download) {
+      _downloadManager.createAnchorElementDownloadFileWeb(
+          success.bytes, success.attachment.generateFileName());
+      return;
+    }
+
+    _downloadManager.openDownloadedFileWeb(
+        success.bytes, success.attachment.type?.mimeType);
   }
 
   void _downloadAttachmentForWebFailureAction(DownloadAttachmentForWebFailure failure) {

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -19,6 +19,7 @@ import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
 import 'package:jmap_dart_client/jmap/mdn/disposition.dart';
 import 'package:jmap_dart_client/jmap/mdn/mdn.dart';
+import 'package:mime/mime.dart';
 import 'package:model/model.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
@@ -748,9 +749,15 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
     log('SingleEmailController::_downloadAttachmentForWebSuccessAction():');
     mailboxDashBoardController.deleteDownloadTask(success.taskId);
 
-    _downloadManager.createAnchorElementDownloadFileWeb(
-        success.bytes,
-        success.attachment.generateFileName());
+    final mimeType = success.attachment.type?.mimeType ??
+        lookupMimeType('', headerBytes: success.bytes);
+    if (mimeType == Constant.pdfMimeType) {
+      _downloadManager.openDownloadedFileWeb(
+          success.bytes, success.attachment.type?.mimeType);
+    } else {
+      _downloadManager.createAnchorElementDownloadFileWeb(
+          success.bytes, success.attachment.generateFileName());
+    }
   }
 
   void _downloadAttachmentForWebFailureAction(DownloadAttachmentForWebFailure failure) {

--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -343,13 +343,16 @@ class EmailView extends GetWidget<SingleEmailController> {
               onDragEnd: (details) {
                 controller.mailboxDashBoardController.disableDraggableApp();
               },
-              downloadAttachmentAction: (attachment, viewOnly) {
+              downloadAttachmentAction: (attachment) {
                 if (PlatformInfo.isWeb) {
-                  controller.downloadAttachmentForWeb(
-                    context,
-                    attachment,
-                    viewOnly: viewOnly,
-                  );
+                  controller.downloadAttachmentForWeb(context, attachment);
+                } else {
+                  controller.exportAttachment(context, attachment);
+                }
+              },
+              viewAttachmentAction: (attachment) {
+                if (PlatformInfo.isWeb) {
+                  controller.viewAttachmentForWeb(context, attachment);
                 } else {
                   controller.exportAttachment(context, attachment);
                 }

--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -343,9 +343,13 @@ class EmailView extends GetWidget<SingleEmailController> {
               onDragEnd: (details) {
                 controller.mailboxDashBoardController.disableDraggableApp();
               },
-              downloadAttachmentAction: (attachment) {
+              downloadAttachmentAction: (attachment, viewOnly) {
                 if (PlatformInfo.isWeb) {
-                  controller.downloadAttachmentForWeb(context, attachment);
+                  controller.downloadAttachmentForWeb(
+                    context,
+                    attachment,
+                    viewOnly: viewOnly,
+                  );
                 } else {
                   controller.exportAttachment(context, attachment);
                 }

--- a/lib/features/email/presentation/widgets/attachment_item_widget.dart
+++ b/lib/features/email/presentation/widgets/attachment_item_widget.dart
@@ -11,7 +11,8 @@ import 'package:model/email/attachment.dart';
 import 'package:tmail_ui_user/features/email/presentation/extensions/attachment_extension.dart';
 import 'package:tmail_ui_user/features/email/presentation/styles/attachment/attachment_item_widget_style.dart';
 
-typedef OnDownloadAttachmentFileActionClick = void Function(Attachment attachment);
+typedef OnDownloadAttachmentFileActionClick = void Function(
+    Attachment attachment, bool viewOnly);
 
 class AttachmentItemWidget extends StatelessWidget {
 
@@ -32,9 +33,7 @@ class AttachmentItemWidget extends StatelessWidget {
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        onTap: () => downloadAttachmentAction?.call(attachment.copyWith(
-          attachmentAction: AttachmentAction.view,
-        )),
+        onTap: () => downloadAttachmentAction?.call(attachment, true),
         customBorder: const RoundedRectangleBorder(
           borderRadius: BorderRadius.all(Radius.circular(AttachmentItemWidgetStyle.radius))
         ),
@@ -87,9 +86,8 @@ class AttachmentItemWidget extends StatelessWidget {
                 padding: const EdgeInsets.all(5),
                 iconSize: AttachmentItemWidgetStyle.downloadIconSize,
                 onTapActionCallback: () => downloadAttachmentAction?.call(
-                  attachment.copyWith(
-                    attachmentAction: AttachmentAction.download,
-                  ),
+                  attachment,
+                  false,
                 ),
               )
             ]

--- a/lib/features/email/presentation/widgets/attachment_item_widget.dart
+++ b/lib/features/email/presentation/widgets/attachment_item_widget.dart
@@ -11,13 +11,14 @@ import 'package:model/email/attachment.dart';
 import 'package:tmail_ui_user/features/email/presentation/extensions/attachment_extension.dart';
 import 'package:tmail_ui_user/features/email/presentation/styles/attachment/attachment_item_widget_style.dart';
 
-typedef OnDownloadAttachmentFileActionClick = void Function(
-    Attachment attachment, bool viewOnly);
+typedef OnDownloadAttachmentFileActionClick = void Function(Attachment attachment);
+typedef OnViewAttachmentFileActionClick = void Function(Attachment attachment);
 
 class AttachmentItemWidget extends StatelessWidget {
 
   final Attachment attachment;
   final OnDownloadAttachmentFileActionClick? downloadAttachmentAction;
+  final OnViewAttachmentFileActionClick? viewAttachmentAction;
 
   final _imagePaths = Get.find<ImagePaths>();
   final _responsiveUtils = Get.find<ResponsiveUtils>();
@@ -26,6 +27,7 @@ class AttachmentItemWidget extends StatelessWidget {
     Key? key,
     required this.attachment,
     this.downloadAttachmentAction,
+    this.viewAttachmentAction,
   }) : super(key: key);
 
   @override
@@ -33,7 +35,7 @@ class AttachmentItemWidget extends StatelessWidget {
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        onTap: () => downloadAttachmentAction?.call(attachment, true),
+        onTap: () => viewAttachmentAction?.call(attachment),
         customBorder: const RoundedRectangleBorder(
           borderRadius: BorderRadius.all(Radius.circular(AttachmentItemWidgetStyle.radius))
         ),
@@ -85,10 +87,7 @@ class AttachmentItemWidget extends StatelessWidget {
                 backgroundColor: Colors.transparent,
                 padding: const EdgeInsets.all(5),
                 iconSize: AttachmentItemWidgetStyle.downloadIconSize,
-                onTapActionCallback: () => downloadAttachmentAction?.call(
-                  attachment,
-                  false,
-                ),
+                onTapActionCallback: () => downloadAttachmentAction?.call(attachment)
               )
             ]
           )

--- a/lib/features/email/presentation/widgets/attachment_item_widget.dart
+++ b/lib/features/email/presentation/widgets/attachment_item_widget.dart
@@ -32,7 +32,9 @@ class AttachmentItemWidget extends StatelessWidget {
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        onTap: () => downloadAttachmentAction?.call(attachment),
+        onTap: () => downloadAttachmentAction?.call(attachment.copyWith(
+          attachmentAction: AttachmentAction.view,
+        )),
         customBorder: const RoundedRectangleBorder(
           borderRadius: BorderRadius.all(Radius.circular(AttachmentItemWidgetStyle.radius))
         ),
@@ -84,7 +86,11 @@ class AttachmentItemWidget extends StatelessWidget {
                 backgroundColor: Colors.transparent,
                 padding: const EdgeInsets.all(5),
                 iconSize: AttachmentItemWidgetStyle.downloadIconSize,
-                onTapActionCallback: () => downloadAttachmentAction?.call(attachment)
+                onTapActionCallback: () => downloadAttachmentAction?.call(
+                  attachment.copyWith(
+                    attachmentAction: AttachmentAction.download,
+                  ),
+                ),
               )
             ]
           )

--- a/lib/features/email/presentation/widgets/draggable_attachment_item_widget.dart
+++ b/lib/features/email/presentation/widgets/draggable_attachment_item_widget.dart
@@ -13,6 +13,7 @@ class DraggableAttachmentItemWidget extends StatelessWidget{
   final OnDragAttachmentStarted? onDragStarted;
   final OnDragAttachmentEnd? onDragEnd;
   final OnDownloadAttachmentFileActionClick? downloadAttachmentAction;
+  final OnViewAttachmentFileActionClick? viewAttachmentAction;
 
   const DraggableAttachmentItemWidget({
     Key? key,
@@ -20,6 +21,7 @@ class DraggableAttachmentItemWidget extends StatelessWidget{
     this.onDragStarted,
     this.onDragEnd,
     this.downloadAttachmentAction,
+    this.viewAttachmentAction,
   }) : super(key: key);
 
   @override
@@ -31,7 +33,8 @@ class DraggableAttachmentItemWidget extends StatelessWidget{
       onDragEnd: onDragEnd,
       child: AttachmentItemWidget(
         attachment: attachment,
-        downloadAttachmentAction: downloadAttachmentAction
+        downloadAttachmentAction: downloadAttachmentAction,
+        viewAttachmentAction: viewAttachmentAction,
       ),
     );
   }

--- a/lib/features/email/presentation/widgets/email_attachments_widget.dart
+++ b/lib/features/email/presentation/widgets/email_attachments_widget.dart
@@ -20,6 +20,7 @@ class EmailAttachmentsWidget extends StatelessWidget {
   final OnDragAttachmentStarted? onDragStarted;
   final OnDragAttachmentEnd? onDragEnd;
   final OnDownloadAttachmentFileActionClick? downloadAttachmentAction;
+  final OnViewAttachmentFileActionClick? viewAttachmentAction;
   final ResponsiveUtils responsiveUtils;
   final ImagePaths imagePaths;
   final OnTapActionCallback? onTapShowAllAttachmentFile;
@@ -32,6 +33,7 @@ class EmailAttachmentsWidget extends StatelessWidget {
     this.onDragStarted,
     this.onDragEnd,
     this.downloadAttachmentAction,
+    this.viewAttachmentAction,
     this.onTapShowAllAttachmentFile,
   });
 
@@ -106,7 +108,8 @@ class EmailAttachmentsWidget extends StatelessWidget {
                           attachment: attachment,
                           onDragStarted: onDragStarted,
                           onDragEnd: onDragEnd,
-                          downloadAttachmentAction: downloadAttachmentAction
+                          downloadAttachmentAction: downloadAttachmentAction,
+                          viewAttachmentAction: viewAttachmentAction,
                       );
                     } else {
                       return AttachmentItemWidget(

--- a/model/lib/email/attachment.dart
+++ b/model/lib/email/attachment.dart
@@ -20,6 +20,7 @@ class Attachment with EquatableMixin {
   final MediaType? type;
   final String? cid;
   final ContentDisposition? disposition;
+  final AttachmentAction attachmentAction;
 
   Attachment({
     this.partId,
@@ -29,6 +30,7 @@ class Attachment with EquatableMixin {
     this.type,
     this.cid,
     this.disposition,
+    this.attachmentAction = AttachmentAction.download,
   });
 
   bool noCid() => cid == null || cid?.isEmpty == true;
@@ -58,8 +60,30 @@ class Attachment with EquatableMixin {
     }
   }
 
+  Attachment copyWith({
+    PartId? partId,
+    Id? blobId,
+    UnsignedInt? size,
+    String? name,
+    MediaType? type,
+    String? cid,
+    ContentDisposition? disposition,
+    AttachmentAction? attachmentAction,
+  }) {
+    return Attachment(
+        partId: partId ?? this.partId,
+        blobId: blobId ?? this.blobId,
+        size: size ?? this.size,
+        name: name ?? this.name,
+        type: type ?? this.type,
+        cid: cid ?? this.cid,
+        disposition: disposition ?? this.disposition,
+        attachmentAction: attachmentAction ?? this.attachmentAction);
+  }
+
   @override
-  List<Object?> get props => [partId, blobId, size, name, type, cid, disposition];
+  List<Object?> get props =>
+      [partId, blobId, size, name, type, cid, disposition, attachmentAction];
 }
 
 enum ContentDisposition {
@@ -96,3 +120,5 @@ extension DispositionStringExtension on String? {
     return null;
   }
 }
+
+enum AttachmentAction { download, view }

--- a/model/lib/email/attachment.dart
+++ b/model/lib/email/attachment.dart
@@ -59,8 +59,7 @@ class Attachment with EquatableMixin {
   }
 
   @override
-  List<Object?> get props =>
-      [partId, blobId, size, name, type, cid, disposition];
+  List<Object?> get props => [partId, blobId, size, name, type, cid, disposition];
 }
 
 enum ContentDisposition {

--- a/model/lib/email/attachment.dart
+++ b/model/lib/email/attachment.dart
@@ -20,7 +20,6 @@ class Attachment with EquatableMixin {
   final MediaType? type;
   final String? cid;
   final ContentDisposition? disposition;
-  final AttachmentAction attachmentAction;
 
   Attachment({
     this.partId,
@@ -30,7 +29,6 @@ class Attachment with EquatableMixin {
     this.type,
     this.cid,
     this.disposition,
-    this.attachmentAction = AttachmentAction.download,
   });
 
   bool noCid() => cid == null || cid?.isEmpty == true;
@@ -60,30 +58,9 @@ class Attachment with EquatableMixin {
     }
   }
 
-  Attachment copyWith({
-    PartId? partId,
-    Id? blobId,
-    UnsignedInt? size,
-    String? name,
-    MediaType? type,
-    String? cid,
-    ContentDisposition? disposition,
-    AttachmentAction? attachmentAction,
-  }) {
-    return Attachment(
-        partId: partId ?? this.partId,
-        blobId: blobId ?? this.blobId,
-        size: size ?? this.size,
-        name: name ?? this.name,
-        type: type ?? this.type,
-        cid: cid ?? this.cid,
-        disposition: disposition ?? this.disposition,
-        attachmentAction: attachmentAction ?? this.attachmentAction);
-  }
-
   @override
   List<Object?> get props =>
-      [partId, blobId, size, name, type, cid, disposition, attachmentAction];
+      [partId, blobId, size, name, type, cid, disposition];
 }
 
 enum ContentDisposition {
@@ -120,5 +97,3 @@ extension DispositionStringExtension on String? {
     return null;
   }
 }
-
-enum AttachmentAction { download, view }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1192,7 +1192,7 @@ packages:
     source: hosted
     version: "1.10.0"
   mime:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: mime
       sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -229,6 +229,8 @@ dependencies:
 
   flutter_secure_storage: 8.0.0
 
+  mime: 1.0.4
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
### **Issue**
#2628 
### **Resolved**

As discussed with @hoangdat , @dab246 & @hieutbui , attachment button for PDF in web version will have 2 functionalities. When user tap on download icon inside the button, `openDownloadedFileWeb` will be triggered, showing the PDF inside new browser tab and user can download the file here themselves. When tapping anywhere else inside the attachment button, the PDF will be downloaded automatically, and the auto opening feature will be handle by the browser itself depends on its own settings.

- Firefox

https://github.com/linagora/tmail-flutter/assets/160106668/3afedf5d-d3ba-44c2-9130-78b3bc074aa5

- Safari

https://github.com/linagora/tmail-flutter/assets/160106668/60350866-777b-4de4-8bdb-5304128a75e5

- Chrome

https://github.com/linagora/tmail-flutter/assets/160106668/02cbdbe0-538b-47dd-80f3-7f4362393a33
