### PR TITLE
TF-2628 Create open PDF in new browser tab feature

### DIFF
--- a/core/lib/data/constants/constant.dart
+++ b/core/lib/data/constants/constant.dart
@@ -1,4 +1,5 @@
 class Constant {
   static const acceptHeaderDefault = 'application/json';
   static const contentTypeHeaderDefault = 'application/json';
+  static const pdfMimeType = 'application/pdf';
 }

--- a/core/lib/data/network/download/download_manager.dart
+++ b/core/lib/data/network/download/download_manager.dart
@@ -104,6 +104,20 @@ class DownloadManager {
     }
   }
 
+  void openDownloadedFileWeb(Uint8List bytes, String? mimeType) {
+    try {
+      final blob = html.Blob([bytes], mimeType);
+      final url = html.Url.createObjectUrlFromBlob(blob);
+
+      html.window.open(url, '_blank');
+
+      html.Url.revokeObjectUrl(url);
+    } catch (exception) {
+      logError('DownloadManager::openDownloadedFileWeb(): ERROR: $exception');
+      rethrow;
+    }
+  }
+
   MediaType? _extractMediaTypeFromResponse(ResponseBody responseBody) {
     try {
       final contentType = responseBody.headers[Headers.contentTypeHeader];

--- a/docs/adr/0039-logic-for-opening-pdf-in-new-browser-tab.md
+++ b/docs/adr/0039-logic-for-opening-pdf-in-new-browser-tab.md
@@ -1,0 +1,31 @@
+# 39. Logic for displaying PDF in new browser tab
+
+Date: 2024-02-23
+
+## Status
+
+Accepted
+
+## Context
+
+- When user tap PDF attachment inside email web, the attachment should be automatically opened in new tab
+- The attachment button in web at the moment can be tapped on itself, and also at the download icon inside it
+- The behavior when tapping either of those places are the same
+
+## Decision
+
+Separate the business logic of both tappable places:
+
+1. When download icon is tapped
+
+- Create download anchor and click on it programmatically, triggering the download action of the browser
+- After the browser download the file, browser will handle the file by its own settings & policies
+
+2. When anywhere else inside the attachment button is tapped
+
+- If attachment is PDF, trigger window.open from html.dart with `_blank` parameter so that the file is opened in new tab
+- If attachment is not PDF, treat the action as if the download icon is tapped as case 1
+
+## Consequences
+
+- Different behaviors will be triggered depends on where user taps inside the attachment button on Twake Mail web

--- a/lib/features/email/domain/state/view_attachment_for_web_state.dart
+++ b/lib/features/email/domain/state/view_attachment_for_web_state.dart
@@ -1,0 +1,23 @@
+import 'package:tmail_ui_user/features/email/domain/state/download_attachment_for_web_state.dart';
+
+class StartViewAttachmentForWeb extends StartDownloadAttachmentForWeb {
+  StartViewAttachmentForWeb(super.taskId, super.attachment);
+}
+
+class ViewingAttachmentForWeb extends DownloadingAttachmentForWeb {
+  ViewingAttachmentForWeb(
+    super.taskId,
+    super.attachment,
+    super.progress,
+    super.downloaded,
+    super.total,
+  );
+}
+
+class ViewAttachmentForWebSuccess extends DownloadAttachmentForWebSuccess {
+  ViewAttachmentForWebSuccess(super.taskId, super.attachment, super.bytes);
+}
+
+class ViewAttachmentForWebFailure extends DownloadAttachmentForWebFailure {
+  ViewAttachmentForWebFailure({super.taskId, super.exception});
+}

--- a/lib/features/email/domain/usecases/view_attachment_for_web_interactor.dart
+++ b/lib/features/email/domain/usecases/view_attachment_for_web_interactor.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:model/download/download_task_id.dart';
+import 'package:model/email/attachment.dart';
+import 'package:tmail_ui_user/features/email/domain/state/download_attachment_for_web_state.dart';
+import 'package:tmail_ui_user/features/email/domain/state/view_attachment_for_web_state.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/download_attachment_for_web_interactor.dart';
+
+class ViewAttachmentForWebInteractor {
+  ViewAttachmentForWebInteractor(this._downloadAttachmentForWebInteractor);
+
+  final DownloadAttachmentForWebInteractor _downloadAttachmentForWebInteractor;
+
+  Stream<Either<Failure, Success>> execute(
+    DownloadTaskId taskId,
+    Attachment attachment,
+    AccountId accountId,
+    String baseDownloadUrl,
+    StreamController<Either<Failure, Success>> onReceiveController,
+  ) =>
+      _downloadAttachmentForWebInteractor
+          .execute(
+            taskId,
+            attachment,
+            accountId,
+            baseDownloadUrl,
+            onReceiveController)
+          .map(
+            (result) => result.fold(
+              (failure) {
+                if (failure is DownloadAttachmentForWebFailure) {
+                  return Left(ViewAttachmentForWebFailure(
+                    taskId: failure.taskId,
+                    exception: failure.exception,
+                  ));
+                }
+
+                return Left(failure);
+              },
+              (success) {
+                if (success is StartDownloadAttachmentForWeb) {
+                  return Right(StartViewAttachmentForWeb(
+                    success.taskId,
+                    success.attachment,
+                  ));
+                }
+
+                if (success is DownloadingAttachmentForWeb) {
+                  return Right(ViewingAttachmentForWeb(
+                    success.taskId,
+                    success.attachment,
+                    success.progress,
+                    success.downloaded,
+                    success.total,
+                  ));
+                }
+
+                if (success is DownloadAttachmentForWebSuccess) {
+                  return Right(ViewAttachmentForWebSuccess(
+                    success.taskId,
+                    success.attachment,
+                    success.bytes,
+                  ));
+                }
+
+                return Right(success);
+              },
+            ),
+          );
+}

--- a/lib/features/email/presentation/bindings/email_bindings.dart
+++ b/lib/features/email/presentation/bindings/email_bindings.dart
@@ -20,6 +20,7 @@ import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_email_read_
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_star_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/move_to_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/store_opened_email_interactor.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/view_attachment_for_web_interactor.dart';
 import 'package:tmail_ui_user/features/email/presentation/controller/email_supervisor_controller.dart';
 import 'package:tmail_ui_user/features/email/presentation/controller/single_email_controller.dart';
 import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
@@ -64,7 +65,8 @@ class EmailBindings extends BaseBindings {
       Get.find<MarkAsStarEmailInteractor>(),
       Get.find<DownloadAttachmentForWebInteractor>(),
       Get.find<GetAllIdentitiesInteractor>(),
-      Get.find<StoreOpenedEmailInteractor>()
+      Get.find<StoreOpenedEmailInteractor>(),
+      Get.find<ViewAttachmentForWebInteractor>(),
     ));
   }
 
@@ -136,6 +138,8 @@ class EmailBindings extends BaseBindings {
       Get.find<AccountRepository>(),
       Get.find<AuthenticationOIDCRepository>()));
     Get.lazyPut(() => GetStoredEmailStateInteractor(Get.find<EmailRepository>()));
+    Get.lazyPut(() => ViewAttachmentForWebInteractor(
+        Get.find<DownloadAttachmentForWebInteractor>()));
     Get.lazyPut(() => StoreOpenedEmailInteractor(Get.find<EmailRepository>()));
     IdentityInteractorsBindings().dependencies();
   }

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -1453,7 +1453,14 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
               } else {
                 exportAttachment(context, attachment);
               }
-            }
+            },
+            onViewAttachmentFileAction: (attachment) {
+              if (PlatformInfo.isWeb) {
+                viewAttachmentForWeb(attachment);
+              } else {
+                exportAttachment(context, attachment);
+              }
+            },
           )
         ),
         barrierColor: AppColor.colorDefaultCupertinoActionSheet,

--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -345,7 +345,14 @@ class EmailView extends GetWidget<SingleEmailController> {
               },
               downloadAttachmentAction: (attachment) {
                 if (PlatformInfo.isWeb) {
-                  controller.downloadAttachmentForWeb(context, attachment);
+                  controller.downloadAttachmentForWeb(attachment);
+                } else {
+                  controller.exportAttachment(context, attachment);
+                }
+              },
+              viewAttachmentAction: (attachment) {
+                if (PlatformInfo.isWeb) {
+                  controller.viewAttachmentForWeb(attachment);
                 } else {
                   controller.exportAttachment(context, attachment);
                 }

--- a/lib/features/email/presentation/widgets/attachment_item_widget.dart
+++ b/lib/features/email/presentation/widgets/attachment_item_widget.dart
@@ -12,11 +12,13 @@ import 'package:tmail_ui_user/features/email/presentation/extensions/attachment_
 import 'package:tmail_ui_user/features/email/presentation/styles/attachment/attachment_item_widget_style.dart';
 
 typedef OnDownloadAttachmentFileActionClick = void Function(Attachment attachment);
+typedef OnViewAttachmentFileActionClick = void Function(Attachment attachment);
 
 class AttachmentItemWidget extends StatelessWidget {
 
   final Attachment attachment;
   final OnDownloadAttachmentFileActionClick? downloadAttachmentAction;
+  final OnViewAttachmentFileActionClick? viewAttachmentAction;
 
   final _imagePaths = Get.find<ImagePaths>();
   final _responsiveUtils = Get.find<ResponsiveUtils>();
@@ -25,6 +27,7 @@ class AttachmentItemWidget extends StatelessWidget {
     Key? key,
     required this.attachment,
     this.downloadAttachmentAction,
+    this.viewAttachmentAction,
   }) : super(key: key);
 
   @override
@@ -32,7 +35,7 @@ class AttachmentItemWidget extends StatelessWidget {
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        onTap: () => downloadAttachmentAction?.call(attachment),
+        onTap: () => viewAttachmentAction?.call(attachment),
         customBorder: const RoundedRectangleBorder(
           borderRadius: BorderRadius.all(Radius.circular(AttachmentItemWidgetStyle.radius))
         ),

--- a/lib/features/email/presentation/widgets/attachment_list/attachment_list_dialog_body_builder.dart
+++ b/lib/features/email/presentation/widgets/attachment_list/attachment_list_dialog_body_builder.dart
@@ -17,6 +17,7 @@ class AttachmentListDialogBodyBuilder extends StatelessWidget {
   final double? heightDialog;
   final OnDownloadAllButtonAction? onDownloadAllButtonAction;
   final OnDownloadAttachmentFileAction? onDownloadAttachmentFileAction;
+  final OnViewAttachmentFileAction? onViewAttachmentFileAction;
   final OnCancelButtonAction? onCancelButtonAction;
   final OnCloseButtonAction? onCloseButtonAction;
 
@@ -30,6 +31,7 @@ class AttachmentListDialogBodyBuilder extends StatelessWidget {
     this.heightDialog,
     this.onDownloadAllButtonAction,
     this.onDownloadAttachmentFileAction,
+    this.onViewAttachmentFileAction,
     this.onCancelButtonAction,
     this.onCloseButtonAction
   });
@@ -108,6 +110,7 @@ class AttachmentListDialogBodyBuilder extends StatelessWidget {
                     return AttachmentListItemWidget(
                       attachment: attachments[index],
                       downloadAttachmentAction: onDownloadAttachmentFileAction,
+                      viewAttachmentAction: onViewAttachmentFileAction,
                     );
                   },
                   separatorBuilder: (context, index) {

--- a/lib/features/email/presentation/widgets/attachment_list/attachment_list_dialog_builder.dart
+++ b/lib/features/email/presentation/widgets/attachment_list/attachment_list_dialog_builder.dart
@@ -6,6 +6,7 @@ import 'package:tmail_ui_user/features/email/presentation/styles/attachment/atta
 import 'package:tmail_ui_user/features/email/presentation/widgets/attachment_list/attachment_list_dialog_body_builder.dart';
 
 typedef OnDownloadAttachmentFileAction = void Function(Attachment attachment);
+typedef OnViewAttachmentFileAction = void Function(Attachment attachment);
 typedef OnDownloadAllButtonAction = void Function();
 typedef OnCancelButtonAction = void Function();
 typedef OnCloseButtonAction = void Function();
@@ -22,6 +23,7 @@ class AttachmentListDialogBuilder extends StatelessWidget {
   final double? heightDialog;
   final OnDownloadAllButtonAction? onDownloadAllButtonAction;
   final OnDownloadAttachmentFileAction? onDownloadAttachmentFileAction;
+  final OnViewAttachmentFileAction? onViewAttachmentFileAction;
   final OnCancelButtonAction? onCancelButtonAction;
   final OnCloseButtonAction? onCloseButtonAction;
 
@@ -36,6 +38,7 @@ class AttachmentListDialogBuilder extends StatelessWidget {
     this.heightDialog,
     this.onDownloadAllButtonAction,
     this.onDownloadAttachmentFileAction,
+    this.onViewAttachmentFileAction,
     this.onCancelButtonAction,
     this.onCloseButtonAction,
   }) : super(key: key);
@@ -59,6 +62,7 @@ class AttachmentListDialogBuilder extends StatelessWidget {
         scrollController: scrollController,
         onDownloadAllButtonAction: onDownloadAllButtonAction,
         onDownloadAttachmentFileAction: onDownloadAttachmentFileAction,
+        onViewAttachmentFileAction: onViewAttachmentFileAction,
         onCancelButtonAction: onCancelButtonAction,
         onCloseButtonAction: onCloseButtonAction,
       ),

--- a/lib/features/email/presentation/widgets/attachment_list/attachment_list_item_widget.dart
+++ b/lib/features/email/presentation/widgets/attachment_list/attachment_list_item_widget.dart
@@ -10,6 +10,7 @@ import 'package:get/get.dart';
 import 'package:model/email/attachment.dart';
 import 'package:tmail_ui_user/features/email/presentation/extensions/attachment_extension.dart';
 import 'package:tmail_ui_user/features/email/presentation/styles/attachment/attachment_list_item_widget_styles.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/attachment_item_widget.dart';
 
 typedef OnDownloadAttachmentFileActionClick = void Function(Attachment attachment);
 
@@ -17,6 +18,7 @@ class AttachmentListItemWidget extends StatelessWidget {
 
   final Attachment attachment;
   final OnDownloadAttachmentFileActionClick? downloadAttachmentAction;
+  final OnViewAttachmentFileActionClick? viewAttachmentAction;
 
   final _imagePaths = Get.find<ImagePaths>();
 
@@ -24,6 +26,7 @@ class AttachmentListItemWidget extends StatelessWidget {
     Key? key,
     required this.attachment,
     this.downloadAttachmentAction,
+    this.viewAttachmentAction,
   }) : super(key: key);
 
   @override
@@ -31,7 +34,7 @@ class AttachmentListItemWidget extends StatelessWidget {
     return Material(
       type: MaterialType.transparency,
       child: InkWell(
-        onTap: () => downloadAttachmentAction?.call(attachment),
+        onTap: () => viewAttachmentAction?.call(attachment),
         child: Padding(
           padding: AttachmentListItemWidgetStyle.contentPadding,
           child: Row(

--- a/lib/features/email/presentation/widgets/draggable_attachment_item_widget.dart
+++ b/lib/features/email/presentation/widgets/draggable_attachment_item_widget.dart
@@ -13,6 +13,7 @@ class DraggableAttachmentItemWidget extends StatelessWidget{
   final OnDragAttachmentStarted? onDragStarted;
   final OnDragAttachmentEnd? onDragEnd;
   final OnDownloadAttachmentFileActionClick? downloadAttachmentAction;
+  final OnViewAttachmentFileActionClick? viewAttachmentAction;
 
   const DraggableAttachmentItemWidget({
     Key? key,
@@ -20,6 +21,7 @@ class DraggableAttachmentItemWidget extends StatelessWidget{
     this.onDragStarted,
     this.onDragEnd,
     this.downloadAttachmentAction,
+    this.viewAttachmentAction,
   }) : super(key: key);
 
   @override
@@ -31,7 +33,8 @@ class DraggableAttachmentItemWidget extends StatelessWidget{
       onDragEnd: onDragEnd,
       child: AttachmentItemWidget(
         attachment: attachment,
-        downloadAttachmentAction: downloadAttachmentAction
+        downloadAttachmentAction: downloadAttachmentAction,
+        viewAttachmentAction: viewAttachmentAction,
       ),
     );
   }

--- a/lib/features/email/presentation/widgets/email_attachments_widget.dart
+++ b/lib/features/email/presentation/widgets/email_attachments_widget.dart
@@ -20,6 +20,7 @@ class EmailAttachmentsWidget extends StatelessWidget {
   final OnDragAttachmentStarted? onDragStarted;
   final OnDragAttachmentEnd? onDragEnd;
   final OnDownloadAttachmentFileActionClick? downloadAttachmentAction;
+  final OnViewAttachmentFileActionClick? viewAttachmentAction;
   final ResponsiveUtils responsiveUtils;
   final ImagePaths imagePaths;
   final OnTapActionCallback? onTapShowAllAttachmentFile;
@@ -32,6 +33,7 @@ class EmailAttachmentsWidget extends StatelessWidget {
     this.onDragStarted,
     this.onDragEnd,
     this.downloadAttachmentAction,
+    this.viewAttachmentAction,
     this.onTapShowAllAttachmentFile,
   });
 
@@ -106,7 +108,8 @@ class EmailAttachmentsWidget extends StatelessWidget {
                           attachment: attachment,
                           onDragStarted: onDragStarted,
                           onDragEnd: onDragEnd,
-                          downloadAttachmentAction: downloadAttachmentAction
+                          downloadAttachmentAction: downloadAttachmentAction,
+                          viewAttachmentAction: viewAttachmentAction,
                       );
                     } else {
                       return AttachmentItemWidget(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1192,7 +1192,7 @@ packages:
     source: hosted
     version: "1.10.0"
   mime:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: mime
       sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -229,6 +229,8 @@ dependencies:
 
   flutter_secure_storage: 8.0.0
 
+  mime: 1.0.4
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/features/email/domain/usecases/view_attachment_for_web_interactor_test.dart
+++ b/test/features/email/domain/usecases/view_attachment_for_web_interactor_test.dart
@@ -1,0 +1,253 @@
+import 'dart:async';
+
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/download/download_task_id.dart';
+import 'package:model/email/attachment.dart';
+import 'package:tmail_ui_user/features/email/domain/state/download_attachment_for_web_state.dart';
+import 'package:tmail_ui_user/features/email/domain/state/view_attachment_for_web_state.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/download_attachment_for_web_interactor.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/view_attachment_for_web_interactor.dart';
+
+import 'view_attachment_for_web_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<DownloadAttachmentForWebInteractor>(),
+  MockSpec<Failure>(),
+  MockSpec<Success>(),
+])
+void main() {
+  final testDownloadAttachmentForWebInteractor =
+      MockDownloadAttachmentForWebInteractor();
+  final viewAttachmentForWebInteractor =
+      ViewAttachmentForWebInteractor(testDownloadAttachmentForWebInteractor);
+
+  final testDownloadTaskId = DownloadTaskId('123');
+  final testAttachment = Attachment();
+  final testAccountId = AccountId(Id('id'));
+  final testException = TimeoutException('321');
+  const testBaseDownloadUrl = 'base_download_url';
+  final testReceiveController = StreamController<Either<Failure, Success>>();
+  final testFailure = MockFailure();
+  final testSuccess = MockSuccess();
+  final testBytes = Uint8List(12);
+
+  group('View attachment for web interactor', () {
+    test(
+      'should yield ViewAttachmentForWebFailure '
+      'when downloadAttachmentForWebInteractor yield DownloadAttachmentForWebFailure',
+      () {
+        // arrange
+        when(testDownloadAttachmentForWebInteractor.execute(
+          testDownloadTaskId,
+          testAttachment,
+          testAccountId,
+          testBaseDownloadUrl,
+          testReceiveController,
+        )).thenAnswer(
+          (_) => Stream.value(
+            Left(
+              DownloadAttachmentForWebFailure(
+                taskId: testDownloadTaskId,
+                exception: testException,
+              ),
+            ),
+          ),
+        );
+
+        // assert
+        expect(
+          viewAttachmentForWebInteractor.execute(
+            testDownloadTaskId,
+            testAttachment,
+            testAccountId,
+            testBaseDownloadUrl,
+            testReceiveController,
+          ),
+          emitsInOrder([
+            Left(
+              ViewAttachmentForWebFailure(
+                taskId: testDownloadTaskId,
+                exception: testException,
+              ),
+            )
+          ]),
+        );
+      },
+    );
+
+    test(
+      'should yield Failure '
+      'when downloadAttachmentForWebInteractor doesn\'t yield DownloadAttachmentForWebFailure',
+      () {
+        // arrange
+        when(testDownloadAttachmentForWebInteractor.execute(
+          testDownloadTaskId,
+          testAttachment,
+          testAccountId,
+          testBaseDownloadUrl,
+          testReceiveController,
+        )).thenAnswer((_) => Stream.value(Left(testFailure)));
+
+        // assert
+        expect(
+          viewAttachmentForWebInteractor.execute(
+            testDownloadTaskId,
+            testAttachment,
+            testAccountId,
+            testBaseDownloadUrl,
+            testReceiveController,
+          ),
+          emitsInOrder([Left(testFailure)]),
+        );
+      },
+    );
+
+    test(
+      'should yield StartViewAttachmentForWeb '
+      'when downloadAttachmentForWebInteractor yield StartDownloadAttachmentForWeb',
+      () {
+        // arrange
+        when(testDownloadAttachmentForWebInteractor.execute(
+          testDownloadTaskId,
+          testAttachment,
+          testAccountId,
+          testBaseDownloadUrl,
+          testReceiveController,
+        )).thenAnswer((_) => Stream.value(
+              Right(StartDownloadAttachmentForWeb(
+                testDownloadTaskId,
+                testAttachment,
+              )),
+            ));
+
+        // assert
+        expect(
+          viewAttachmentForWebInteractor.execute(
+            testDownloadTaskId,
+            testAttachment,
+            testAccountId,
+            testBaseDownloadUrl,
+            testReceiveController,
+          ),
+          emitsInOrder([
+            Right(StartViewAttachmentForWeb(
+              testDownloadTaskId,
+              testAttachment,
+            ))
+          ]),
+        );
+      },
+    );
+
+    test(
+      'should yield ViewingAttachmentForWeb '
+      'when downloadAttachmentForWebInteractor yield DownloadingAttachmentForWeb',
+      () {
+        // arrange
+        when(testDownloadAttachmentForWebInteractor.execute(
+          testDownloadTaskId,
+          testAttachment,
+          testAccountId,
+          testBaseDownloadUrl,
+          testReceiveController,
+        )).thenAnswer(
+          (_) => Stream.fromIterable([
+            Right(DownloadingAttachmentForWeb(testDownloadTaskId, testAttachment, 0.5, 1, 2)),
+            Right(DownloadingAttachmentForWeb(testDownloadTaskId, testAttachment, 1, 1, 2)),
+            Right(DownloadingAttachmentForWeb(testDownloadTaskId, testAttachment, 1, 2, 2)),
+          ]),
+        );
+
+        // assert
+        expect(
+          viewAttachmentForWebInteractor.execute(
+            testDownloadTaskId,
+            testAttachment,
+            testAccountId,
+            testBaseDownloadUrl,
+            testReceiveController,
+          ),
+          emitsInOrder([
+            Right(ViewingAttachmentForWeb(testDownloadTaskId, testAttachment, 0.5, 1, 2)),
+            Right(ViewingAttachmentForWeb(testDownloadTaskId, testAttachment, 1, 1, 2)),
+            Right(ViewingAttachmentForWeb(testDownloadTaskId, testAttachment, 1, 2, 2)),
+          ]),
+        );
+      },
+    );
+
+    test(
+      'should yield ViewAttachmentForWebSuccess '
+      'when downloadAttachmentForWebInteractor yield DownloadAttachmentForWebSuccess',
+      () {
+        // arrange
+        when(testDownloadAttachmentForWebInteractor.execute(
+          testDownloadTaskId,
+          testAttachment,
+          testAccountId,
+          testBaseDownloadUrl,
+          testReceiveController,
+        )).thenAnswer((_) => Stream.value(
+              Right(DownloadAttachmentForWebSuccess(
+                testDownloadTaskId,
+                testAttachment,
+                testBytes,
+              )),
+            ));
+
+        // assert
+        expect(
+          viewAttachmentForWebInteractor.execute(
+            testDownloadTaskId,
+            testAttachment,
+            testAccountId,
+            testBaseDownloadUrl,
+            testReceiveController,
+          ),
+          emitsInOrder([
+            Right(ViewAttachmentForWebSuccess(
+              testDownloadTaskId,
+              testAttachment,
+              testBytes,
+            )),
+          ]),
+        );
+      },
+    );
+
+    test(
+      'should yield Success '
+      'when downloadAttachmentForWebInteractor yield state doesn\'t match any of the above',
+      () {
+        // arrange
+        when(testDownloadAttachmentForWebInteractor.execute(
+          testDownloadTaskId,
+          testAttachment,
+          testAccountId,
+          testBaseDownloadUrl,
+          testReceiveController,
+        )).thenAnswer((_) => Stream.value(Right(testSuccess)));
+
+        // assert
+        expect(
+          viewAttachmentForWebInteractor.execute(
+            testDownloadTaskId,
+            testAttachment,
+            testAccountId,
+            testBaseDownloadUrl,
+            testReceiveController,
+          ),
+          emitsInOrder([Right(testSuccess)]),
+        );
+      },
+    );
+  });
+}

--- a/test/features/email/presentation/controller/single_email_controller_test.dart
+++ b/test/features/email/presentation/controller/single_email_controller_test.dart
@@ -1,0 +1,247 @@
+import 'package:core/core.dart';
+import 'package:dartz/dartz.dart' hide State;
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:http_parser/http_parser.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/model.dart';
+import 'package:tmail_ui_user/features/caching/caching_manager.dart';
+import 'package:tmail_ui_user/features/email/domain/state/view_attachment_for_web_state.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/download_attachment_for_web_interactor.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/download_attachments_interactor.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/export_attachment_interactor.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/get_email_content_interactor.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_email_read_interactor.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_star_email_interactor.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/move_to_mailbox_interactor.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/store_opened_email_interactor.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/view_attachment_for_web_interactor.dart';
+import 'package:tmail_ui_user/features/email/presentation/controller/email_supervisor_controller.dart';
+import 'package:tmail_ui_user/features/email/presentation/controller/single_email_controller.dart';
+import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oidc_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_all_identities_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
+import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
+import 'package:uuid/uuid.dart';
+
+import 'single_email_controller_test.mocks.dart';
+
+mockControllerCallback() => InternalFinalCallback<void>(callback: () {});
+const fallbackGenerators = {
+  #onStart: mockControllerCallback,
+  #onDelete: mockControllerCallback,
+};
+
+@GenerateNiceMocks([
+  MockSpec<GetEmailContentInteractor>(),
+  MockSpec<MarkAsEmailReadInteractor>(),
+  MockSpec<DownloadAttachmentsInteractor>(),
+  MockSpec<DeviceManager>(),
+  MockSpec<ExportAttachmentInteractor>(),
+  MockSpec<MoveToMailboxInteractor>(),
+  MockSpec<MarkAsStarEmailInteractor>(),
+  MockSpec<DownloadAttachmentForWebInteractor>(),
+  MockSpec<GetAllIdentitiesInteractor>(),
+  MockSpec<StoreOpenedEmailInteractor>(),
+  MockSpec<ViewAttachmentForWebInteractor>(),
+  MockSpec<MailboxDashBoardController>(fallbackGenerators: fallbackGenerators),
+  MockSpec<EmailSupervisorController>(fallbackGenerators: fallbackGenerators),
+  MockSpec<DownloadManager>(fallbackGenerators: fallbackGenerators),
+  MockSpec<CachingManager>(fallbackGenerators: fallbackGenerators),
+  MockSpec<LanguageCacheManager>(fallbackGenerators: fallbackGenerators),
+  MockSpec<AuthorizationInterceptors>(),
+  MockSpec<DynamicUrlInterceptors>(),
+  MockSpec<DeleteCredentialInteractor>(),
+  MockSpec<LogoutOidcInteractor>(),
+  MockSpec<DeleteAuthorityOidcInteractor>(),
+  MockSpec<AppToast>(),
+  MockSpec<ImagePaths>(),
+  MockSpec<ResponsiveUtils>(),
+  MockSpec<Uuid>(),
+])
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final getEmailContentInteractor = MockGetEmailContentInteractor();
+  final markAsEmailReadInteractor = MockMarkAsEmailReadInteractor();
+  final downloadAttachmentsInteractor = MockDownloadAttachmentsInteractor();
+  final deviceManager = MockDeviceManager();
+  final exportAttachmentInteractor = MockExportAttachmentInteractor();
+  final moveToMailboxInteractor = MockMoveToMailboxInteractor();
+  final markAsStarEmailInteractor = MockMarkAsStarEmailInteractor();
+  final downloadAttachmentForWebInteractor =
+      MockDownloadAttachmentForWebInteractor();
+  final getAllIdentitiesInteractor = MockGetAllIdentitiesInteractor();
+  final storeOpenedEmailInteractor = MockStoreOpenedEmailInteractor();
+  final viewAttachmentForWebInteractor = MockViewAttachmentForWebInteractor();
+  final mailboxDashboardController = MockMailboxDashBoardController();
+  final emailSupervisorController = MockEmailSupervisorController();
+  final downloadManager = MockDownloadManager();
+  final cachingManager = MockCachingManager();
+  final languageCacheManager = MockLanguageCacheManager();
+  final authorizationInterceptors = MockAuthorizationInterceptors();
+  final dynamicUrlInterceptors = MockDynamicUrlInterceptors();
+  final deleteCredentialInteractor = MockDeleteCredentialInteractor();
+  final logoutOidcInteractor = MockLogoutOidcInteractor();
+  final deleteAuthorityOidcInteractor = MockDeleteAuthorityOidcInteractor();
+  final appToast = MockAppToast();
+  final imagePaths = MockImagePaths();
+  final responsiveUtils = MockResponsiveUtils();
+  final uuid = MockUuid();
+
+  late SingleEmailController singleEmailController = SingleEmailController(
+    getEmailContentInteractor,
+    markAsEmailReadInteractor,
+    downloadAttachmentsInteractor,
+    deviceManager,
+    exportAttachmentInteractor,
+    moveToMailboxInteractor,
+    markAsStarEmailInteractor,
+    downloadAttachmentForWebInteractor,
+    getAllIdentitiesInteractor,
+    storeOpenedEmailInteractor,
+    viewAttachmentForWebInteractor,
+  );
+
+  final testAccountId = AccountId(Id('123'));
+  final google = Uri.parse('https://www.google.com');
+  final testSession =
+      Session({}, {}, {}, UserName('data'), google, google, google, google, State('1'));
+  const testTaskId = 'taskId';
+  final testDownloadTaskId = DownloadTaskId(testTaskId);
+  final testBytes = Uint8List(123);
+
+  setUpAll(() {
+    Get.put<MailboxDashBoardController>(mailboxDashboardController);
+    Get.put<EmailSupervisorController>(emailSupervisorController);
+    Get.put<DownloadManager>(downloadManager);
+    Get.put<CachingManager>(cachingManager);
+    Get.put<LanguageCacheManager>(languageCacheManager);
+    Get.put<AuthorizationInterceptors>(authorizationInterceptors);
+    Get.put<AuthorizationInterceptors>(
+      authorizationInterceptors,
+      tag: BindingTag.isolateTag,
+    );
+    Get.put<DynamicUrlInterceptors>(dynamicUrlInterceptors);
+    Get.put<DeleteCredentialInteractor>(deleteCredentialInteractor);
+    Get.put<LogoutOidcInteractor>(logoutOidcInteractor);
+    Get.put<DeleteAuthorityOidcInteractor>(deleteAuthorityOidcInteractor);
+    Get.put<AppToast>(appToast);
+    Get.put<ImagePaths>(imagePaths);
+    Get.put<ResponsiveUtils>(responsiveUtils);
+    Get.put<Uuid>(uuid);
+
+    when(mailboxDashboardController.accountId).thenReturn(Rxn(testAccountId));
+    when(uuid.v4()).thenReturn(testTaskId);
+  });
+
+  group('single email controller', () {
+    test(
+      'should call execute on ViewAttachmentForWebInteractor '
+      'when viewAttachmentForWeb is called',
+      () {
+        // arrange
+        when(mailboxDashboardController.sessionCurrent).thenReturn(testSession);
+        final testAttachment = Attachment();
+
+        // act
+        singleEmailController.viewAttachmentForWeb(testAttachment);
+
+        // assert
+        verify(viewAttachmentForWebInteractor.execute(
+          any,
+          testAttachment,
+          testAccountId,
+          any,
+          any,
+        )).called(1);
+      },
+    );
+
+    test(
+      'should trigger mailboxDashBoardController.deleteDownloadTask & downloadManager.openDownloadedFileWeb'
+      'when attachment mime type is pdf',
+      () async {
+        // arrange
+        final testAttachment = Attachment(type: MediaType('application', 'pdf'));
+        when(mailboxDashboardController.sessionCurrent).thenReturn(testSession);
+        when(viewAttachmentForWebInteractor.execute(
+          testDownloadTaskId,
+          testAttachment,
+          testAccountId,
+          any,
+          any,
+        )).thenAnswer((_) => Stream.value(
+              right(ViewAttachmentForWebSuccess(
+                testDownloadTaskId,
+                testAttachment,
+                testBytes,
+              )),
+            ));
+
+        // act
+        singleEmailController.viewAttachmentForWeb(testAttachment);
+
+        // assert
+        await untilCalled(mailboxDashboardController.deleteDownloadTask(any));
+        verify(mailboxDashboardController.deleteDownloadTask(testDownloadTaskId))
+            .called(1);
+        await untilCalled(downloadManager.openDownloadedFileWeb(any, any));
+        verify(downloadManager.openDownloadedFileWeb(
+          testBytes,
+          Constant.pdfMimeType,
+        )).called(1);
+      },
+    );
+
+    test(
+      'should trigger mailboxDashBoardController.deleteDownloadTask & downloadManager.createAnchorElementDownloadFileWeb'
+      'when attachment mime type is not pdf',
+      () async {
+        // arrange
+        const testFileName = 'test_file.txt';
+        final testAttachment = Attachment(name: testFileName);
+        when(mailboxDashboardController.sessionCurrent).thenReturn(testSession);
+        when(viewAttachmentForWebInteractor.execute(
+          testDownloadTaskId,
+          testAttachment,
+          testAccountId,
+          any,
+          any,
+        )).thenAnswer((_) => Stream.value(
+              right(ViewAttachmentForWebSuccess(
+                testDownloadTaskId,
+                testAttachment,
+                testBytes,
+              )),
+            ));
+
+        // act
+        singleEmailController.viewAttachmentForWeb(testAttachment);
+
+        // assert
+        await untilCalled(mailboxDashboardController.deleteDownloadTask(any));
+        verify(mailboxDashboardController.deleteDownloadTask(testDownloadTaskId))
+            .called(1);
+        await untilCalled(
+          downloadManager.createAnchorElementDownloadFileWeb(any, any),
+        );
+        verify(downloadManager.createAnchorElementDownloadFileWeb(
+          testBytes,
+          testFileName,
+        )).called(1);
+      },
+    );
+  });
+}


### PR DESCRIPTION
### **Issue**

https://github.com/linagora/tmail-flutter/issues/2628
### **Resolved**

As discussed with @hoangdat , @dab246 & @hieutbui , attachment button for PDF in web version will have 2 functionalities. When user tap on download icon inside the button, openDownloadedFileWeb will be triggered, showing the PDF inside new browser tab and user can download the file here themselves. When tapping anywhere else inside the attachment button, the PDF will be downloaded automatically, and the auto opening feature will be handle by the browser itself depends on its own settings.

- Firefox

https://github.com/linagora/tmail-flutter/assets/160106668/9947e64d-b9db-4670-8d9b-ed6e2810a83d

https://github.com/linagora/tmail-flutter/assets/160106668/27166523-d924-4ca1-8e18-c53867f3f749

- Safari

https://github.com/linagora/tmail-flutter/assets/160106668/8448ef39-46a5-4c6a-a591-fc6efa65eaa8

https://github.com/linagora/tmail-flutter/assets/160106668/c7c72340-0f8d-4ed9-b25e-4c5b0a3a200d

- Chrome

https://github.com/linagora/tmail-flutter/assets/160106668/bc002736-3a56-4d9e-a90e-53fb307a1785

https://github.com/linagora/tmail-flutter/assets/160106668/046ee15e-ffca-44ae-8b58-7abd4f1f341e

