### PR TITLE
TF-2591 Fix text overlap after pasting rich text

### DIFF
--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -16,6 +16,22 @@ class HtmlUtils {
         });''',
     name: 'lineHeight100Percent');
 
+  static const registerDropListener = (
+    script: '''
+      document.querySelector(".note-editable").addEventListener(
+        "drop",
+        (event) => window.parent.postMessage(
+          JSON.stringify({"name": "registerDropListener"})))''',
+    name: 'registerDropListener');
+
+  static const unregisterDropListener = (
+    script: '''
+      console.log("unregisterDropListener");
+      const editor = document.querySelector(".note-editable");
+      const newEditor = editor.cloneNode(true);
+      editor.parentNode.replaceChild(newEditor, editor);''',
+    name: 'unregisterDropListener');
+
   static String customCssStyleHtmlEditor({TextDirection direction = TextDirection.ltr}) {
     if (PlatformInfo.isWeb) {
       return '''

--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -7,6 +7,15 @@ import 'package:flutter/material.dart';
 import 'package:universal_html/html.dart' as html;
 
 class HtmlUtils {
+  static const lineHeight100Percent = (
+    script: '''
+      document.querySelectorAll("*")
+        .forEach((element) => {
+          if (element.style.lineHeight !== "normal")
+            element.style.lineHeight = "100%";
+        });''',
+    name: 'lineHeight100Percent');
+
   static String customCssStyleHtmlEditor({TextDirection direction = TextDirection.ltr}) {
     if (PlatformInfo.isWeb) {
       return '''

--- a/docs/adr/0041-fix-text-overlap-on-pasting-or-dropping-rich-text.md
+++ b/docs/adr/0041-fix-text-overlap-on-pasting-or-dropping-rich-text.md
@@ -1,0 +1,21 @@
+# 41. Fix text overlap on pasting or dropping rich text
+
+Date: 2024-03-07
+
+## Status
+
+Accepted
+
+## Context
+
+- When copy-pasting or drag-dropping rich text from LibreOffice to email composer, text is overlapped on the same line
+
+## Decision
+
+1. Have a js script to change the `line-height` style of all elements that has their `line-height` modified to 100%
+2. HtmlEditor has onPaste callback, trigger the `line-height` script here
+3. Add listener to `drop` event using js and also trigger `line-height` script here
+
+## Consequences
+
+- Even if the content available that's not pasted or dropped will get reformatted. Currently our composer doesn't support changing text line height, so the impact will not affect avaiable content yet.

--- a/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
@@ -1,4 +1,5 @@
 
+import 'package:collection/collection.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/html/html_utils.dart';
 import 'package:flutter/material.dart';
@@ -113,6 +114,12 @@ class _WebEditorState extends State<WebEditorWidget> {
             initialText: widget.content,
             customBodyCssStyle: HtmlUtils.customCssStyleHtmlEditor(direction: widget.direction),
             spellCheck: true,
+            webInitialScripts: UnmodifiableListView([
+              WebScript(
+                name: HtmlUtils.lineHeight100Percent.name,
+                script: HtmlUtils.lineHeight100Percent.script,
+              )
+            ])
           ),
           htmlToolbarOptions: const HtmlToolbarOptions(
             toolbarType: ToolbarType.hide,
@@ -135,6 +142,9 @@ class _WebEditorState extends State<WebEditorWidget> {
             onImageUpload: widget.onImageUploadSuccessAction,
             onImageUploadError: widget.onImageUploadFailureAction,
             onTextFontSizeChanged: widget.onEditorTextSizeChanged,
+            onPaste: () => _editorController.evaluateJavascriptWeb(
+              HtmlUtils.lineHeight100Percent.name
+            ),
           ),
         );
       }


### PR DESCRIPTION
### Issue
#2591 
### Solution
Run a JS script to update text-height for all elements to 100% on content pasted & drag-dropped to the editor
### Demo
- On paste

https://github.com/linagora/tmail-flutter/assets/160106668/e10fc7eb-9d52-4e56-9327-51ae593d5c66

- On drop

https://github.com/linagora/tmail-flutter/assets/160106668/4d91c4df-45c8-4c0b-aba0-c7702ccf5483


