### PR TITLE
TF-1534 Fix cannot selection text on ios

### DIFF
--- a/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
+++ b/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
@@ -65,12 +65,12 @@ class _HtmlContentViewState extends State<HtmlContentViewer> {
     super.initState();
     if (PlatformInfo.isAndroid) {
       _gestureRecognizers = {
-        Factory<LongPressGestureRecognizer>(() => LongPressGestureRecognizer()),
+        Factory<LongPressGestureRecognizer>(() => LongPressGestureRecognizer(duration: _longPressGestureDuration)),
         Factory<ScaleGestureRecognizer>(() => ScaleGestureRecognizer()),
       };
     } else {
       _gestureRecognizers = {
-        Factory<LongPressGestureRecognizer>(() => LongPressGestureRecognizer()),
+        Factory<LongPressGestureRecognizer>(() => LongPressGestureRecognizer(duration: _longPressGestureDuration)),
       };
     }
     if (PlatformInfo.isAndroid) {
@@ -153,9 +153,9 @@ class _HtmlContentViewState extends State<HtmlContentViewer> {
   }
 
   void _onLoadStop(InAppWebViewController controller, WebUri? webUri) async {
-    log('_HtmlContentViewState::_onLoadStop:');
     await _getActualSizeHtmlViewer();
     _loadingBarNotifier.value = false;
+    log('_HtmlContentViewState::_onLoadStop: GestureRecognizers = $_gestureRecognizers');
   }
 
   void _onContentSizeChanged(
@@ -211,7 +211,7 @@ class _HtmlContentViewState extends State<HtmlContentViewer> {
 
       if (!isScrollActivated && PlatformInfo.isIOS) {
         newGestureRecognizers = {
-          Factory<LongPressGestureRecognizer>(() => LongPressGestureRecognizer()),
+          Factory<LongPressGestureRecognizer>(() => LongPressGestureRecognizer(duration: _longPressGestureDuration)),
           Factory<HorizontalDragGestureRecognizer>(() => HorizontalDragGestureRecognizer())
         };
       }
@@ -271,6 +271,8 @@ class _HtmlContentViewState extends State<HtmlContentViewer> {
 
     return NavigationActionPolicy.CANCEL;
   }
+
+  Duration? get _longPressGestureDuration => const Duration(milliseconds: 100);
 
   @override
   void dispose() {


### PR DESCRIPTION
## Issue

#1534 

## Root cause

- Due to conflict between `LongPress` and `Scroll` gesture responses

## Solution

- Reduced `LongPressGestureRecognizer` response time

## Resolved

- iOS


https://github.com/linagora/tmail-flutter/assets/80730648/acdc8e52-be04-43eb-8c51-601fbe4d7883



- Android


https://github.com/linagora/tmail-flutter/assets/80730648/ff585688-8081-4dc1-b583-8f682e1c8a9d


