### PR TITLE
Tf-2460 Fix realtime updates for web are broken

### DIFF
--- a/lib/features/push_notification/presentation/model/broadcast_message_event_data.dart
+++ b/lib/features/push_notification/presentation/model/broadcast_message_event_data.dart
@@ -1,0 +1,21 @@
+
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'broadcast_message_event_data.g.dart';
+
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
+class BroadcastMessageEventData with EquatableMixin {
+
+  final String? messageId;
+  final Map<String, dynamic>? data;
+
+  BroadcastMessageEventData(this.messageId, this.data);
+
+  factory BroadcastMessageEventData.fromJson(Map<String, dynamic> json) => _$BroadcastMessageEventDataFromJson(json);
+
+  Map<String, dynamic> toJson() => _$BroadcastMessageEventDataToJson(this);
+
+  @override
+  List<Object?> get props => [messageId, data];
+}

--- a/lib/features/push_notification/presentation/services/fcm_receiver.dart
+++ b/lib/features/push_notification/presentation/services/fcm_receiver.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/controller/fcm_message_controller.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/services/fcm_service.dart';
 import 'package:tmail_ui_user/main/utils/app_config.dart';
+import 'package:universal_html/html.dart' as html;
 
 @pragma('vm:entry-point')
 Future<void> handleFirebaseBackgroundMessage(RemoteMessage message) async {
@@ -29,6 +30,9 @@ class FcmReceiver {
 
     _onForegroundMessage();
     _onBackgroundMessage();
+    if (PlatformInfo.isWeb) {
+      _onMessageBroadcastChannel();
+    }
 
     if (PlatformInfo.isIOS) {
       notificationInteractionChannel.setMethodCallHandler((call) async {
@@ -47,6 +51,11 @@ class FcmReceiver {
 
   void _onBackgroundMessage() {
     FirebaseMessaging.onBackgroundMessage(handleFirebaseBackgroundMessage);
+  }
+
+  void _onMessageBroadcastChannel() {
+    final broadcast = html.BroadcastChannel('background-message');
+    broadcast.onMessage.listen(FcmService.instance.handleMessageEventBroadcastChannel);
   }
 
   Future<String?> _getInitialToken() async {

--- a/lib/features/push_notification/presentation/services/fcm_service.dart
+++ b/lib/features/push_notification/presentation/services/fcm_service.dart
@@ -1,13 +1,16 @@
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:core/utils/app_logger.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:tmail_ui_user/features/push_notification/presentation/model/broadcast_message_event_data.dart';
 import 'package:tmail_ui_user/main/routes/app_routes.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:tmail_ui_user/main/routes/route_utils.dart';
+import 'package:universal_html/html.dart' as html;
 
 class FcmService {
 
@@ -32,6 +35,19 @@ class FcmService {
     log('FcmService::handleFirebaseBackgroundMessage():data: ${newRemoteMessage.data}');
     if (newRemoteMessage.data.isNotEmpty) {
       backgroundMessageStreamController?.add(newRemoteMessage.data);
+    }
+  }
+
+  void handleMessageEventBroadcastChannel(html.MessageEvent messageEvent) {
+    log('FcmService::handleMessageEventBroadcastChannel():TYPE: ${messageEvent.data.runtimeType} | DATA: ${messageEvent.data}');
+    try {
+      final jsonEventData = jsonDecode(jsonEncode(messageEvent.data)) as Map<String, dynamic>;
+      final eventData = BroadcastMessageEventData.fromJson(jsonEventData);
+      if (eventData.data?.isNotEmpty == true) {
+        foregroundMessageStreamController?.add(eventData.data!);
+      }
+    } catch (e) {
+      logError('FcmService::handleMessageEventBroadcastChannel: Exception = $e');
     }
   }
 

--- a/web/firebase-messaging-sw.js
+++ b/web/firebase-messaging-sw.js
@@ -12,3 +12,9 @@ firebase.initializeApp({
 });
 // Retrieve an instance of Firebase Messaging so that it can handle background messages.
 const messaging = firebase.messaging();
+
+const broadcast = new BroadcastChannel('background-message');
+
+messaging.onBackgroundMessage((message) => {
+    broadcast.postMessage(message);
+});


### PR DESCRIPTION
## Issue

#2460 

## Root cause

- The `onBackgroundMessage` does not get called when the tab is still active but covered by other OS windows. See more at [here](https://firebase.flutter.dev/docs/messaging/usage/#background-messages)

![Screenshot 2024-03-22 at 16 53 43](https://github.com/linagora/tmail-flutter/assets/80730648/27d83ca7-e846-4384-a4a3-f90977343f26)

## Solution

- Use the [BroadcastChannel](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel) API to communication between different documents (in different windows, tabs, frames or iframes) of the same origin

## Demo

https://github.com/linagora/tmail-flutter/assets/80730648/03702cdd-63d3-4103-a469-cdc44040d8dd




