### PR TITLE
TF-2774 Fix big image dimension in signature

### DIFF
--- a/core/lib/data/network/download/download_client.dart
+++ b/core/lib/data/network/download/download_client.dart
@@ -107,7 +107,7 @@ class DownloadClient {
     if (fileName.contains('.')) {
       fileName = fileName.split('.').first;
     }
-    final base64Uri = '<img src="${HtmlUtils.convertBase64ToImageResourceData(base64Data: base64Data, mimeType: mimeType)}" alt="$fileName" id="cid:$cid" style="max-width: 100%" />';
+    final base64Uri = '<img src="${HtmlUtils.convertBase64ToImageResourceData(base64Data: base64Data, mimeType: mimeType)}" alt="$fileName" id="cid:$cid" style="max-width: 100%;" />';
     return base64Uri;
   }
 }

--- a/core/lib/presentation/utils/html_transformer/dom/image_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/image_transformers.dart
@@ -24,6 +24,9 @@ class ImageTransformer extends DomTransformer {
     await Future.wait(imageElements.map((imageElement) async {
       var exStyle = imageElement.attributes['style'];
       if (exStyle != null) {
+        if (!exStyle.trim().endsWith(';')) {
+          exStyle = '$exStyle;';
+        }
         if (!exStyle.contains('display')) {
           exStyle = '$exStyle display:inline;';
         }

--- a/lib/features/composer/presentation/controller/rich_text_web_controller.dart
+++ b/lib/features/composer/presentation/controller/rich_text_web_controller.dart
@@ -289,7 +289,7 @@ class RichTextWebController extends BaseRichTextController {
     if (platformFile.bytes != null) {
       final base64Data = base64Encode(platformFile.bytes!);
       editorController.insertHtml(
-        '<img src="${HtmlUtils.convertBase64ToImageResourceData(base64Data: base64Data, mimeType: 'image/${platformFile.extension}')}" data-filename="${platformFile.name}" alt="Image in my signature" style="max-width: 100%"/>'
+        '<img src="${HtmlUtils.convertBase64ToImageResourceData(base64Data: base64Data, mimeType: 'image/${platformFile.extension}')}" data-filename="${platformFile.name}" alt="Image in my signature" style="max-width: 100%;"/>'
       );
     } else {
       logError("RichTextWebController::insertImageAsBase64: bytes is null");


### PR DESCRIPTION
## Issue 

#2774 

## Root cause

- Missing `;` character to separate values in `style` attribute of `img` tag results in `max-width=100%` value not working as expected.

## Solution 

- Add `;` character after after each value

## Demo


https://github.com/linagora/tmail-flutter/assets/80730648/12aed6ef-31c5-42a8-9043-4f21f7582abd

