### PR TITLE
TF-2769 Fix isolate illegal data

### DIFF
--- a/lib/features/upload/domain/model/upload_attachment.dart
+++ b/lib/features/upload/domain/model/upload_attachment.dart
@@ -64,7 +64,7 @@ class UploadAttachment with EquatableMixin {
       if (e is DioError && e.type == DioErrorType.cancel) {
         _updateEvent(Left(CancelAttachmentUploadState(uploadTaskId)));
       } else {
-        _updateEvent(Left(ErrorAttachmentUploadState(uploadId: uploadTaskId, exception: e)));
+        _updateEvent(Left(ErrorAttachmentUploadState(uploadId: uploadTaskId)));
       }
     } finally {
       await _progressStateController.close();

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -280,7 +280,7 @@ class UploadController extends BaseController {
     if (currentContext != null && currentOverlayContext != null) {
       appToast.showToastErrorMessage(
         currentOverlayContext!,
-        '${AppLocalizations.of(currentContext!).can_not_upload_this_file_as_attachments}. ${failure.exception ?? ''}',
+        AppLocalizations.of(currentContext!).can_not_upload_this_file_as_attachments,
         leadingSVGIconColor: Colors.white,
         leadingSVGIcon: imagePaths.icAttachment);
     }


### PR DESCRIPTION
### Issue
- #2769 

### Related documents
- https://api.flutter.dev/flutter/dart-isolate/SendPort/send.html
- https://github.com/machinescream/worker_manager/issues/86

### Root cause
We are using `lib/features/upload/data/network/file_uploader.dart:FileUploader:uploadAttachment:_handleUploadAttachmentAction` function to handle upload file in mobile, with the help of `Dio`, inside a separate isolate with app's main isolate. When this `Dio` throw `DioError` exception, by any reason, this exception in turns get sent from this separate isolate to the main isolate. Inside this `DioError`, the `RequestOptions:data` is sent back out of this separate isolate, with type `Stream`, exactly the type we passed into this isolate by `File(argsUpload.mobileFileUpload.filePath).openRead()`. This type is not supported by `send()` function of `Isolate` (see above document), so this isolate throw its own exception, telling us that the type we're letting that isolate call `send()` is "illegal". Also, we're showing the whole stacktrace of the error if this case happens.

**Log**
```
flutter: *** Request ***
flutter: uri: https://jmap.linagora.com/upload/8203ca9793c9c26875c5c1463ad74ec448f7bc416439afce48fc1210e9f1b77a
flutter: method: POST
flutter: responseType: ResponseType.json
flutter: followRedirects: true
flutter: persistentConnection: true
flutter: connectTimeout: null
flutter: sendTimeout: null
flutter: receiveTimeout: null
flutter: receiveDataWhenStatusError: true
flutter: extra: {upload-attachment: {platform: mobile, path: /private/var/mobile/Containers/Data/Application/84C6E2FF-DF6E-42CF-BC42-95435D8C9421/tmp/com.linagora.ios.teammail-Inbox/IMG_1632.PNG, type: image/png, size: 1050986}}

flutter: *** DioError ***:
flutter: uri: https://jmap.linagora.com/upload/8203ca9793c9c26875c5c1463ad74ec448f7bc416439afce48fc1210e9f1b77a
flutter: DioError [bad response]: The request returned an invalid status code of 502.
flutter: uri: https://jmap.linagora.com/upload/8203ca9793c9c26875c5c1463ad74ec448f7bc416439afce48fc1210e9f1b77a
flutter: statusCode: 502
flutter: headers:
flutter:  connection: keep-alive
flutter:  content-type: text/html; charset=utf-8
flutter:  date: Fri, 12 Apr 2024 08:49:28 GMT
flutter:  content-length: 229
flutter:  server: nginx
flutter:  x-apisix-upstream-status: 502
```

### Scenario
The error showing in the demos below is on purpose, to show how the error is handled. In real cases, the attachments will be uploaded as normal.

**Before**

https://github.com/linagora/tmail-flutter/assets/160106668/387c4a21-4f2e-4432-b859-198cadc3af55

**After**

https://github.com/linagora/tmail-flutter/assets/160106668/b3b7ea6a-46c3-4d09-b8e2-91a6ef8d77d4

