### PR TITLE
Cherry pick add `attachment image` button to app bar composer (#2532)

### DIFF
--- a/lib/features/composer/presentation/composer_view.dart
+++ b/lib/features/composer/presentation/composer_view.dart
@@ -19,10 +19,10 @@ import 'package:tmail_ui_user/features/composer/presentation/widgets/mobile/app_
 import 'package:tmail_ui_user/features/composer/presentation/widgets/mobile/from_composer_mobile_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/mobile/landscape_app_bar_composer_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/mobile/mobile_attachment_composer_widget.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/mobile/tablet_app_bar_composer_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/mobile/tablet_bottom_bar_composer_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/recipient_composer_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/subject_composer_widget.dart';
-import 'package:tmail_ui_user/features/composer/presentation/widgets/web/desktop_app_bar_composer_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/web/from_composer_drop_down_widget.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
@@ -69,6 +69,12 @@ class ComposerView extends GetWidget<ComposerController> {
                         radius: ComposerStyle.popupMenuRadius
                       );
                     },
+                    isNetworkConnectionAvailable: controller.isNetworkConnectionAvailable,
+                    attachFileAction: () => controller.openPickAttachmentMenu(
+                      context,
+                      _pickAttachmentsActionTiles(context)
+                    ),
+                    insertImageAction: () => controller.insertImage(context, constraints.maxWidth),
                   ))
                 else
                   Obx(() => AppBarComposerWidget(
@@ -83,6 +89,12 @@ class ComposerView extends GetWidget<ComposerController> {
                         radius: ComposerStyle.popupMenuRadius
                       );
                     },
+                    isNetworkConnectionAvailable: controller.isNetworkConnectionAvailable,
+                    attachFileAction: () => controller.openPickAttachmentMenu(
+                      context,
+                      _pickAttachmentsActionTiles(context)
+                    ),
+                    insertImageAction: () => controller.insertImage(context, constraints.maxWidth),
                   )),
                 Expanded(
                   child: SafeArea(
@@ -244,10 +256,16 @@ class ComposerView extends GetWidget<ComposerController> {
           color: ComposerStyle.mobileBackgroundColor,
           child: Column(
             children: [
-              Obx(() => DesktopAppBarComposerWidget(
+              Obx(() => TabletAppBarComposerWidget(
                 emailSubject: controller.subjectEmail.value ?? '',
                 onCloseViewAction: () => controller.handleClickCloseComposer(context),
                 constraints: constraints,
+                isNetworkConnectionAvailable: controller.isNetworkConnectionAvailable,
+                attachFileAction: () => controller.openPickAttachmentMenu(
+                  context,
+                  _pickAttachmentsActionTiles(context)
+                ),
+                insertImageAction: () => controller.insertImage(context, constraints.maxWidth),
               )),
               Expanded(
                 child: SingleChildScrollView(

--- a/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
+++ b/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
@@ -12,11 +12,13 @@ class RichTextMobileTabletController extends BaseRichTextController {
   HtmlEditorApi? htmlEditorApi;
 
   void insertImage(InlineImage inlineImage) async {
-    if (inlineImage.fileInfo.isShared == true) {
-      await htmlEditorApi?.moveCursorAtLastNode();
+    bool isEditorFocused = await htmlEditorApi?.hasFocus() ?? false;
+    log('RichTextMobileTabletController::insertImage: isEditorFocused = $isEditorFocused');
+    if (!isEditorFocused) {
+      await htmlEditorApi?.requestFocusLastChild();
     }
     if (inlineImage.base64Uri?.isNotEmpty == true) {
-      await htmlEditorApi?.insertHtml(inlineImage.base64Uri!);
+      await htmlEditorApi?.insertHtml('${inlineImage.base64Uri ?? ''}<br/><br/>');
     }
   }
 

--- a/lib/features/composer/presentation/widgets/mobile/app_bar_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/app_bar_composer_widget.dart
@@ -9,8 +9,11 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 class AppBarComposerWidget extends StatelessWidget {
 
   final bool isSendButtonEnabled;
+  final bool isNetworkConnectionAvailable;
   final VoidCallback onCloseViewAction;
   final VoidCallback sendMessageAction;
+  final VoidCallback attachFileAction;
+  final VoidCallback insertImageAction;
   final OnOpenContextMenuAction openContextMenuAction;
 
   final _imagePaths = Get.find<ImagePaths>();
@@ -21,6 +24,9 @@ class AppBarComposerWidget extends StatelessWidget {
     required this.onCloseViewAction,
     required this.sendMessageAction,
     required this.openContextMenuAction,
+    required this.attachFileAction,
+    required this.insertImageAction,
+    this.isNetworkConnectionAvailable = false,
   });
 
   @override
@@ -41,6 +47,27 @@ class AppBarComposerWidget extends StatelessWidget {
             onTapActionCallback: onCloseViewAction
           ),
           const Spacer(),
+          if (isNetworkConnectionAvailable)
+            ...[
+              TMailButtonWidget.fromIcon(
+                icon: _imagePaths.icAttachFile,
+                iconColor: MobileAppBarComposerWidgetStyle.iconColor,
+                backgroundColor: Colors.transparent,
+                iconSize: MobileAppBarComposerWidgetStyle.iconSize,
+                tooltipMessage: AppLocalizations.of(context).attach_file,
+                onTapActionCallback: attachFileAction,
+              ),
+              const SizedBox(width: 8),
+              TMailButtonWidget.fromIcon(
+                icon: _imagePaths.icInsertImage,
+                iconColor: MobileAppBarComposerWidgetStyle.iconColor,
+                backgroundColor: Colors.transparent,
+                iconSize: MobileAppBarComposerWidgetStyle.iconSize,
+                tooltipMessage: AppLocalizations.of(context).insertImage,
+                onTapActionCallback: insertImageAction,
+              ),
+              const SizedBox(width: 8),
+            ],
           TMailButtonWidget.fromIcon(
             icon: isSendButtonEnabled
               ? _imagePaths.icSendMobile

--- a/lib/features/composer/presentation/widgets/mobile/landscape_app_bar_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/landscape_app_bar_composer_widget.dart
@@ -9,8 +9,11 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 class LandscapeAppBarComposerWidget extends StatelessWidget {
 
   final bool isSendButtonEnabled;
+  final bool isNetworkConnectionAvailable;
   final VoidCallback onCloseViewAction;
   final VoidCallback sendMessageAction;
+  final VoidCallback attachFileAction;
+  final VoidCallback insertImageAction;
   final OnOpenContextMenuAction openContextMenuAction;
 
   final _imagePaths = Get.find<ImagePaths>();
@@ -21,6 +24,9 @@ class LandscapeAppBarComposerWidget extends StatelessWidget {
     required this.onCloseViewAction,
     required this.sendMessageAction,
     required this.openContextMenuAction,
+    required this.attachFileAction,
+    required this.insertImageAction,
+    this.isNetworkConnectionAvailable = false,
   });
 
   @override
@@ -44,6 +50,27 @@ class LandscapeAppBarComposerWidget extends StatelessWidget {
               onTapActionCallback: onCloseViewAction
             ),
             const Spacer(),
+            if (isNetworkConnectionAvailable)
+              ...[
+                TMailButtonWidget.fromIcon(
+                  icon: _imagePaths.icAttachFile,
+                  iconColor: MobileAppBarComposerWidgetStyle.iconColor,
+                  backgroundColor: Colors.transparent,
+                  iconSize: MobileAppBarComposerWidgetStyle.iconSize,
+                  tooltipMessage: AppLocalizations.of(context).attach_file,
+                  onTapActionCallback: attachFileAction,
+                ),
+                const SizedBox(width: 8),
+                TMailButtonWidget.fromIcon(
+                  icon: _imagePaths.icInsertImage,
+                  iconColor: MobileAppBarComposerWidgetStyle.iconColor,
+                  backgroundColor: Colors.transparent,
+                  iconSize: MobileAppBarComposerWidgetStyle.iconSize,
+                  tooltipMessage: AppLocalizations.of(context).insertImage,
+                  onTapActionCallback: insertImageAction,
+                ),
+                const SizedBox(width: 8),
+              ],
             TMailButtonWidget.fromIcon(
               icon: isSendButtonEnabled
                 ? _imagePaths.icSendMobile

--- a/lib/features/composer/presentation/widgets/mobile/tablet_app_bar_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/tablet_app_bar_composer_widget.dart
@@ -1,0 +1,90 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/composer/presentation/model/screen_display_mode.dart';
+import 'package:tmail_ui_user/features/composer/presentation/styles/app_bar_composer_widget_style.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/title_composer_widget.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+class TabletAppBarComposerWidget extends StatelessWidget {
+
+  final String emailSubject;
+  final VoidCallback onCloseViewAction;
+  final ScreenDisplayMode? displayMode;
+  final BoxConstraints? constraints;
+  final VoidCallback attachFileAction;
+  final VoidCallback insertImageAction;
+  final bool isNetworkConnectionAvailable;
+
+  final _imagePaths = Get.find<ImagePaths>();
+
+  TabletAppBarComposerWidget({
+    super.key,
+    required this.emailSubject,
+    required this.onCloseViewAction,
+    required this.attachFileAction,
+    required this.insertImageAction,
+    this.displayMode,
+    this.constraints,
+    this.isNetworkConnectionAvailable = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: AppBarComposerWidgetStyle.height,
+      padding: AppBarComposerWidgetStyle.padding,
+      color: AppBarComposerWidgetStyle.backgroundColor,
+      child: Stack(
+        children: [
+          Center(
+            child: Container(
+              constraints: constraints != null
+                ? BoxConstraints(maxWidth: constraints!.maxWidth / 2)
+                : null,
+              child: TitleComposerWidget(emailSubject: emailSubject),
+            ),
+          ),
+          Align(
+            alignment: AlignmentDirectional.centerEnd,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (isNetworkConnectionAvailable)
+                  ...[
+                    TMailButtonWidget.fromIcon(
+                      icon: _imagePaths.icAttachFile,
+                      iconColor: AppBarComposerWidgetStyle.iconColor,
+                      backgroundColor: Colors.transparent,
+                      iconSize: AppBarComposerWidgetStyle.iconSize,
+                      tooltipMessage: AppLocalizations.of(context).attach_file,
+                      onTapActionCallback: attachFileAction,
+                    ),
+                    const SizedBox(width: AppBarComposerWidgetStyle.space),
+                    TMailButtonWidget.fromIcon(
+                      icon: _imagePaths.icInsertImage,
+                      iconColor: AppBarComposerWidgetStyle.iconColor,
+                      backgroundColor: Colors.transparent,
+                      iconSize: AppBarComposerWidgetStyle.iconSize,
+                      tooltipMessage: AppLocalizations.of(context).insertImage,
+                      onTapActionCallback: insertImageAction,
+                    ),
+                    const SizedBox(width: AppBarComposerWidgetStyle.space),
+                  ],
+                TMailButtonWidget.fromIcon(
+                  icon: _imagePaths.icCancel,
+                  backgroundColor: Colors.transparent,
+                  tooltipMessage: AppLocalizations.of(context).saveAndClose,
+                  iconSize: AppBarComposerWidgetStyle.iconSize,
+                  iconColor: AppBarComposerWidgetStyle.iconColor,
+                  onTapActionCallback: onCloseViewAction
+                ),
+              ],
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -415,7 +415,6 @@ class MailboxDashBoardController extends ReloadableController {
     _emailAddressStreamSubscription =
       _emailReceiveManager.pendingEmailAddressInfo.stream.listen((emailAddress) {
         if (emailAddress?.email?.isNotEmpty == true) {
-          _emailReceiveManager.clearPendingEmailAddress();
           goToComposer(ComposerArguments.fromEmailAddress(emailAddress!));
         }
       });
@@ -425,7 +424,6 @@ class MailboxDashBoardController extends ReloadableController {
     _emailContentStreamSubscription =
       _emailReceiveManager.pendingEmailContentInfo.stream.listen((emailContent) {
         if (emailContent?.content.isNotEmpty == true) {
-          _emailReceiveManager.clearPendingEmailContent();
           goToComposer(ComposerArguments.fromContentShared([emailContent!].asHtmlString));
         }
       });
@@ -435,7 +433,6 @@ class MailboxDashBoardController extends ReloadableController {
     _fileReceiveManagerStreamSubscription =
       _emailReceiveManager.pendingFileInfo.stream.listen((listFile) {
         if (listFile.isNotEmpty) {
-          _emailReceiveManager.clearPendingFileInfo();
           goToComposer(ComposerArguments.fromFileShared(listFile));
         }
       });

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -159,9 +159,6 @@ class UploadController extends BaseController {
             cid: uuid.v1()
           );
 
-          final uploadFileState = _uploadingStateInlineFiles.getUploadFileStateById(success.uploadId);
-          log('UploadController::_handleProgressUploadInlineImageStateStream:uploadId: ${uploadFileState?.uploadTaskId} | fromFileShared: ${uploadFileState?.file?.isShared}');
-
           _uploadingStateInlineFiles.updateElementByUploadTaskId(
             success.uploadId,
             (currentState) {

--- a/lib/main/utils/email_receive_manager.dart
+++ b/lib/main/utils/email_receive_manager.dart
@@ -29,16 +29,16 @@ class EmailReceiveManager {
   }
 
   void setPendingEmailAddress(EmailAddress emailAddress) async {
-    clearPendingEmailAddress();
+    _clearPendingEmailAddress();
     _pendingEmailAddressInfo.add(emailAddress);
   }
 
   void setPendingEmailContent(EmailContent emailContent) async {
-    clearPendingEmailAddress();
+    _clearPendingEmailContent();
     _pendingEmailContentInfo.add(emailContent);
   }
 
-  void clearPendingEmailContent() {
+  void _clearPendingEmailContent() {
     if (_pendingEmailContentInfo.isClosed) {
       _pendingEmailContentInfo = BehaviorSubject.seeded(null);
     } else {
@@ -46,7 +46,7 @@ class EmailReceiveManager {
     }
   }
 
-  void clearPendingEmailAddress() {
+  void _clearPendingEmailAddress() {
     if(_pendingEmailAddressInfo.isClosed) {
       _pendingEmailAddressInfo = BehaviorSubject.seeded(null);
     } else {
@@ -56,22 +56,20 @@ class EmailReceiveManager {
 
   void closeEmailReceiveManagerStream() {
     _pendingEmailAddressInfo.close();
+    _pendingEmailContentInfo.close();
+    _pendingFileInfo.close();
   }
 
   void setPendingFileInfo(List<SharedMediaFile> list) async {
-    clearPendingFileInfo();
+    _clearPendingFileInfo();
     _pendingFileInfo.add(list);
   }
 
-  void clearPendingFileInfo() {
+  void _clearPendingFileInfo() {
     if(_pendingFileInfo.isClosed) {
       _pendingFileInfo = BehaviorSubject.seeded(List.empty(growable: true));
     } else {
       _pendingFileInfo.add(List.empty(growable: true));
     }
-  }
-
-  void closeFileSharingStream() {
-    _pendingFileInfo.close();
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -409,11 +409,11 @@ packages:
     source: path
     version: "1.0.0+1"
   enough_html_editor:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       path: "."
-      ref: cnb_supported
-      resolved-ref: "669cfd989498cf398c88a6618eebb089967b9e28"
+      ref: cherry-pick-add-attachment-app-bar
+      resolved-ref: c17bdd8fae6bd9dc8614906ca1f068f2a06fca80
       url: "https://github.com/linagora/enough_html_editor.git"
     source: git
     version: "0.0.5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -261,6 +261,11 @@ dependency_overrides:
 
   firebase_core_platform_interface: 4.6.0
 
+  enough_html_editor:
+    git:
+      url: https://github.com/linagora/enough_html_editor.git
+      ref: cherry-pick-add-attachment-app-bar
+
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 


### PR DESCRIPTION
## Issue 

#2532 

## Dependent

- Need merged: https://github.com/linagora/enough_html_editor/pull/30

## Demo

https://github.com/linagora/tmail-flutter/assets/80730648/3ab8d90f-63a2-4913-bd1b-3b1177ebcb0a


