### PR TITLE
[Part-IV] TF-2812 Calendar event accept Integrate UI

### DIFF
--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -145,7 +145,9 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
 
   EmailLoaded? get currentEmailLoaded => _currentEmailLoaded;
 
-  bool get calendarEventProcessing => viewState.value is CalendarEventReplying;
+  bool get calendarEventProcessing => viewState.value.fold(
+    (failure) => false,
+    (success) => success is CalendarEventReplying);
 
   CalendarEvent? get calendarEvent => blobCalendarEvent.value?.calendarEventList.firstOrNull;
   Id? get _displayingEventBlobId => blobCalendarEvent.value?.blobId;
@@ -1684,8 +1686,8 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
    );
   }
 
-  void onCalendarEventReplyAction(EventAction eventAction) {
-    switch (eventAction.actionType) {
+  void onCalendarEventReplyAction(EventActionType eventActionType) {
+    switch (eventActionType) {
       case EventActionType.yes:
         _acceptCalendarEventAction();
         break;

--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -375,6 +375,8 @@ class EmailView extends GetWidget<SingleEmailController> {
                 calendarEvent: calendarEvent,
                 onOpenComposerAction: controller.openNewComposerAction,
                 onOpenNewTabAction: controller.openNewTabAction,
+                onCalendarEventReplyActionClick: controller.onCalendarEventReplyAction,
+                calendarEventReplying: controller.calendarEventProcessing,
               ),
               if (calendarEvent.getTitleEventAction(context, emailAddressSender ?? []).isNotEmpty)
                 CalendarEventActionBannerWidget(
@@ -388,6 +390,8 @@ class EmailView extends GetWidget<SingleEmailController> {
                 onOpenComposerAction: controller.openNewComposerAction,
                 onOpenNewTabAction: controller.openNewTabAction,
                 onMailtoDelegateAction: controller.openMailToLink,
+                onCalendarEventReplyActionClick: controller.onCalendarEventReplyAction,
+                calendarEventReplying: controller.calendarEventProcessing,
               ),
             ],
           )

--- a/lib/features/email/presentation/styles/calendar_event_action_button_widget_styles.dart
+++ b/lib/features/email/presentation/styles/calendar_event_action_button_widget_styles.dart
@@ -10,6 +10,7 @@ class CalendarEventActionButtonWidgetStyles {
   static const double minWidth = 80;
 
   static const Color backgroundColor = Colors.transparent;
+  static Color loadingBackgroundColor = Colors.grey.shade300;
   static const Color textColor = AppColor.primaryColor;
 
   static const FontWeight fontWeight = FontWeight.w500;

--- a/lib/features/email/presentation/widgets/calendar_event/calendar_event_action_button_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/calendar_event_action_button_widget.dart
@@ -4,14 +4,19 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/email/domain/model/event_action.dart';
 import 'package:tmail_ui_user/features/email/presentation/styles/calendar_event_action_button_widget_styles.dart';
-import 'package:tmail_ui_user/main/utils/app_utils.dart';
+
+typedef OnCalendarEventReplyActionClick = void Function(EventActionType eventActionType);
 
 class CalendarEventActionButtonWidget extends StatelessWidget {
 
   final EdgeInsetsGeometry? margin;
+  final OnCalendarEventReplyActionClick onCalendarEventReplyActionClick;
+  final bool calendarEventReplying;
 
   const CalendarEventActionButtonWidget({
     super.key,
+    required this.onCalendarEventReplyActionClick,
+    required this.calendarEventReplying,
     this.margin,
   });
 
@@ -30,7 +35,9 @@ class CalendarEventActionButtonWidget extends StatelessWidget {
         children: EventActionType.values
           .map((action) => TMailButtonWidget(
             text: action.getLabelButton(context),
-            backgroundColor: CalendarEventActionButtonWidgetStyles.backgroundColor,
+            backgroundColor: calendarEventReplying
+              ? CalendarEventActionButtonWidgetStyles.loadingBackgroundColor
+              : CalendarEventActionButtonWidgetStyles.backgroundColor,
             borderRadius: CalendarEventActionButtonWidgetStyles.borderRadius,
             padding: CalendarEventActionButtonWidgetStyles.buttonPadding,
             textStyle: const TextStyle(
@@ -45,8 +52,9 @@ class CalendarEventActionButtonWidget extends StatelessWidget {
               width: CalendarEventActionButtonWidgetStyles.borderWidth,
               color: CalendarEventActionButtonWidgetStyles.textColor
             ),
-            // TODO: Handle in part 4
-            onTapActionCallback: () => AppUtils.launchLink(''),
+            onTapActionCallback: calendarEventReplying
+              ? null
+              : () => onCalendarEventReplyActionClick(action),
           ))
           .toList(),
       ),

--- a/lib/features/email/presentation/widgets/calendar_event/calendar_event_detail_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/calendar_event_detail_widget.dart
@@ -21,11 +21,15 @@ class CalendarEventDetailWidget extends StatelessWidget {
   final OnOpenComposerAction? onOpenComposerAction;
   final bool? isDraggableAppActive;
   final OnMailtoDelegateAction? onMailtoDelegateAction;
+  final OnCalendarEventReplyActionClick onCalendarEventReplyActionClick;
+  final bool calendarEventReplying;
 
   const CalendarEventDetailWidget({
     super.key,
     required this.calendarEvent,
     required this.emailContent,
+    required this.onCalendarEventReplyActionClick,
+    required this.calendarEventReplying,
     this.isDraggableAppActive,
     this.onOpenNewTabAction,
     this.onOpenComposerAction,
@@ -89,7 +93,9 @@ class CalendarEventDetailWidget extends StatelessWidget {
                 organizer: calendarEvent.organizer!,
               ),
             ),
-          const CalendarEventActionButtonWidget(),
+          CalendarEventActionButtonWidget(
+            onCalendarEventReplyActionClick: onCalendarEventReplyActionClick,
+            calendarEventReplying: calendarEventReplying),
         ],
       ),
     );

--- a/lib/features/email/presentation/widgets/calendar_event/calendar_event_information_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/calendar_event_information_widget.dart
@@ -21,10 +21,14 @@ class CalendarEventInformationWidget extends StatelessWidget {
   final CalendarEvent calendarEvent;
   final OnOpenNewTabAction? onOpenNewTabAction;
   final OnOpenComposerAction? onOpenComposerAction;
+  final OnCalendarEventReplyActionClick onCalendarEventReplyActionClick;
+  final bool calendarEventReplying;
 
   const CalendarEventInformationWidget({
     super.key,
     required this.calendarEvent,
+    required this.onCalendarEventReplyActionClick,
+    required this.calendarEventReplying,
     this.onOpenNewTabAction,
     this.onOpenComposerAction,
   });
@@ -110,8 +114,10 @@ class CalendarEventInformationWidget extends StatelessWidget {
                           organizer: calendarEvent.organizer!,
                         ),
                       ),
-                    const CalendarEventActionButtonWidget(
+                    CalendarEventActionButtonWidget(
                       margin: EdgeInsetsDirectional.zero,
+                      onCalendarEventReplyActionClick: onCalendarEventReplyActionClick,
+                      calendarEventReplying: calendarEventReplying,
                     ),
                   ],
                 ),
@@ -178,8 +184,10 @@ class CalendarEventInformationWidget extends StatelessWidget {
                           organizer: calendarEvent.organizer!,
                         ),
                       ),
-                    const CalendarEventActionButtonWidget(
+                    CalendarEventActionButtonWidget(
                       margin: EdgeInsetsDirectional.zero,
+                      onCalendarEventReplyActionClick: onCalendarEventReplyActionClick,
+                      calendarEventReplying: calendarEventReplying,
                     ),
                   ],
                 ),

--- a/test/features/email/presentation/controller/single_email_controller_test.dart
+++ b/test/features/email/presentation/controller/single_email_controller_test.dart
@@ -286,8 +286,7 @@ void main() {
                 calendarEventList: [calendarEvent])]));
 
         // act
-        singleEmailController.onCalendarEventReplyAction(
-          EventAction(EventActionType.yes, ''));
+        singleEmailController.onCalendarEventReplyAction(EventActionType.yes);
         await untilCalled(acceptCalendarEventInteractor.execute(any, any));
 
         // assert


### PR DESCRIPTION
### Issue
- #2812 

### TODO
- [x] Test when backend is ready
- [x] Add demo after testing

### Testing setup in preprod
- Take an `ics` from prod's email, change `organizer` to an email from preprod, let's call email A, in the form of `abc@upn.integration-open-paas.org`, also update an attendee to the testing email, let's call email B, with the same form as the organizer
- Sign in to email B, compose an email, send to self, with the attachment is the ics above
- Due to faking of calendar event, the email content will not be qualify for the 3 buttons `yes`, `maybe` and `no` to appear. A fake parse has to be created. Head to `lib/features/email/data/local/html_analyzer.dart`, replace all code inside `getListEventAction` to:
 ```dart
return [
  EventAction(EventActionType.yes, ''),
  EventAction(EventActionType.maybe, ''),
  EventAction(EventActionType.no, ''),
];
```
- Make the loading duration longer by heading to `lib/features/email/domain/usecases/calendar_event_accept_interactor.dart`, add `await Future.delayed(const Duration(seconds: 2));` to line `19`

### Demo

https://github.com/linagora/tmail-flutter/assets/160106668/ca805515-ce4a-4bd0-846e-d4a39643098c

