### PR TITLE
[PART 2] Migrate `dev-features` to `dev`

### DIFF
--- a/core/lib/presentation/utils/html_transformer/transform_configuration.dart
+++ b/core/lib/presentation/utils/html_transformer/transform_configuration.dart
@@ -43,7 +43,6 @@ class TransformConfiguration {
     if (PlatformInfo.isWeb)
       const RemoveTooltipLinkTransformer(),
     const SignatureTransformer(),
-    const RemoveLazyLoadingForBackgroundImageTransformer(),
     const RemoveCollapsedSignatureButtonTransformer(),
   ]);
 

--- a/core/lib/presentation/utils/responsive_utils.dart
+++ b/core/lib/presentation/utils/responsive_utils.dart
@@ -19,15 +19,15 @@ class ResponsiveUtils {
   static const double desktopVerticalMargin = 120.0;
   static const double desktopHorizontalMargin = 200.0;
 
-  bool isScreenWithShortestSide(BuildContext context) => context.mediaQueryShortestSide < minTabletWidth;
+  bool isScreenWithShortestSide(BuildContext context) => getSizeScreenShortestSide(context) < minTabletWidth;
 
-  double getSizeScreenWidth(BuildContext context) => context.width;
+  double getSizeScreenWidth(BuildContext context) => MediaQuery.sizeOf(context).width;
 
-  double getSizeScreenHeight(BuildContext context) => context.height;
+  double getSizeScreenHeight(BuildContext context) => MediaQuery.sizeOf(context).height;
 
-  double getSizeScreenShortestSide(BuildContext context) => context.mediaQueryShortestSide;
+  double getSizeScreenShortestSide(BuildContext context) => MediaQuery.sizeOf(context).shortestSide;
 
-  double getDeviceWidth(BuildContext context) => context.width;
+  double getDeviceWidth(BuildContext context) => MediaQuery.sizeOf(context).width;
 
   bool isMobile(BuildContext context) => getDeviceWidth(context) < minTabletWidth;
 
@@ -46,21 +46,21 @@ class ResponsiveUtils {
   bool isLandscapeMobile(BuildContext context) => isScreenWithShortestSide(context) && isLandscape(context);
 
   bool isLandscapeTablet(BuildContext context) {
-    return context.mediaQueryShortestSide >= minTabletWidth &&
-        context.mediaQueryShortestSide < minDesktopWidth &&
+    return getSizeScreenShortestSide(context) >= minTabletWidth &&
+        getSizeScreenShortestSide(context) < minDesktopWidth &&
         isLandscape(context);
   }
 
   bool isPortraitMobile(BuildContext context) => isScreenWithShortestSide(context) && isPortrait(context);
 
   bool isPortraitTablet(BuildContext context) {
-    return context.mediaQueryShortestSide >= minTabletWidth &&
-        context.mediaQueryShortestSide < minDesktopWidth &&
+    return getSizeScreenShortestSide(context) >= minTabletWidth &&
+        getSizeScreenShortestSide(context) < minDesktopWidth &&
         isPortrait(context);
   }
 
   bool isHeightShortest(BuildContext context) {
-    return MediaQuery.of(context).size.shortestSide < heightShortest;
+    return getSizeScreenShortestSide(context) < heightShortest;
   }
 
   double getMaxWidthToast(BuildContext context) {

--- a/core/lib/presentation/views/dialog/confirmation_dialog_builder.dart
+++ b/core/lib/presentation/views/dialog/confirmation_dialog_builder.dart
@@ -34,6 +34,8 @@ class ConfirmDialogBuilder {
   Color? _backgroundColor;
   bool showAsBottomSheet;
   List<TextSpan>? listTextSpan;
+  int? titleActionButtonMaxLines;
+  bool isArrangeActionButtonsVertical;
 
   OnConfirmButtonAction? _onConfirmButtonAction;
   OnCancelButtonAction? _onCancelButtonAction;
@@ -45,6 +47,8 @@ class ConfirmDialogBuilder {
       this.showAsBottomSheet = false,
       this.listTextSpan,
       this.maxWith = double.infinity,
+      this.titleActionButtonMaxLines,
+      this.isArrangeActionButtonsVertical = false,
     }
   );
 
@@ -223,7 +227,32 @@ class ConfirmDialogBuilder {
                   ),
                 ),
               ),
-            Padding(
+            if (isArrangeActionButtonsVertical)
+              ...[
+                if (_cancelText.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsetsDirectional.only(top: 8, start: 16, end: 16),
+                    child: _buildButton(
+                      name: _cancelText,
+                      bgColor: _colorCancelButton,
+                      radius: _radiusButton,
+                      textStyle: _styleTextCancelButton,
+                      action: _onCancelButtonAction),
+                  ),
+                if (_confirmText.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsetsDirectional.only(top: 8, start: 16, end: 16),
+                    child: _buildButton(
+                      name: _confirmText,
+                      bgColor: _colorConfirmButton,
+                      radius: _radiusButton,
+                      textStyle: _styleTextConfirmButton,
+                      action: _onConfirmButtonAction),
+                  ),
+                const SizedBox(height: 16),
+              ]
+            else
+              Padding(
                 padding: _paddingButton ?? const EdgeInsetsDirectional.only(bottom: 16, start: 16, end: 16),
                 child: Row(
                     children: [
@@ -254,27 +283,33 @@ class ConfirmDialogBuilder {
     TextStyle? textStyle,
     Color? bgColor,
     double? radius,
-    Function? action
+    Function()? action
   }) {
     return SizedBox(
       width: double.infinity,
+      height: titleActionButtonMaxLines == 1 ? 45 : null,
       child: ElevatedButton(
-        onPressed: () => action?.call(),
-        style: ButtonStyle(
-            foregroundColor: MaterialStateProperty.resolveWith<Color>(
-                  (Set<MaterialState> states) => bgColor ?? AppColor.colorTextButton),
-            backgroundColor: MaterialStateProperty.resolveWith<Color>(
-                  (Set<MaterialState> states) => bgColor ?? AppColor.colorTextButton),
-            shape: MaterialStateProperty.all(RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(radius ?? 8),
-              side: BorderSide(width: 0, color: bgColor ?? AppColor.colorTextButton),
-            )),
-            padding: MaterialStateProperty.resolveWith<EdgeInsets>((Set<MaterialState> states) => const EdgeInsets.all(8)),
-            elevation: MaterialStateProperty.resolveWith<double>((Set<MaterialState> states) => 0)),
-        child: Text(name ?? '',
-            textAlign: TextAlign.center,
-            style: textStyle ?? const TextStyle(fontSize: 17, fontWeight: FontWeight.w500, color: Colors.white)),
-      )
+        onPressed: action,
+        style: ElevatedButton.styleFrom(
+          foregroundColor: bgColor ?? AppColor.colorTextButton,
+          backgroundColor: bgColor ?? AppColor.colorTextButton,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(radius ?? 8),
+            side: BorderSide(width: 0, color: bgColor ?? AppColor.colorTextButton),
+          ),
+          padding: const EdgeInsets.all(8),
+          elevation: 0
+        ),
+        child: Text(
+          name ?? '',
+          textAlign: TextAlign.center,
+          maxLines: titleActionButtonMaxLines,
+          style: textStyle ?? const TextStyle(
+            fontSize: 17,
+            fontWeight: FontWeight.w500,
+            color: Colors.white
+          )),
+      ),
     );
   }
 }

--- a/core/lib/presentation/views/dialog/confirmation_dialog_builder.dart
+++ b/core/lib/presentation/views/dialog/confirmation_dialog_builder.dart
@@ -29,7 +29,6 @@ class ConfirmDialogBuilder {
   EdgeInsetsGeometry? _marginIcon;
   EdgeInsets? _margin;
   double? _widthDialog;
-  double? _heightDialog;
   double maxWith;
   Alignment? _alignment;
   Color? _backgroundColor;
@@ -117,10 +116,6 @@ class ConfirmDialogBuilder {
     _widthDialog = value;
   }
 
-  void heightDialog(double? value) {
-    _heightDialog = value;
-  }
-
   void alignment(Alignment? alignment) {
     _alignment = alignment;
   }
@@ -168,7 +163,6 @@ class ConfirmDialogBuilder {
   Widget _bodyContent() {
     return Container(
         width: _widthDialog ?? 400,
-        height: _heightDialog,
         constraints: BoxConstraints(maxWidth: maxWith),
         decoration: const BoxDecoration(
           color: Colors.white,

--- a/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
+++ b/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
@@ -65,12 +65,12 @@ class _HtmlContentViewState extends State<HtmlContentViewer> {
     super.initState();
     if (PlatformInfo.isAndroid) {
       _gestureRecognizers = {
-        Factory<LongPressGestureRecognizer>(() => LongPressGestureRecognizer(duration: _longPressGestureDuration)),
+        Factory<LongPressGestureRecognizer>(() => LongPressGestureRecognizer()),
         Factory<ScaleGestureRecognizer>(() => ScaleGestureRecognizer()),
       };
     } else {
       _gestureRecognizers = {
-        Factory<LongPressGestureRecognizer>(() => LongPressGestureRecognizer(duration: _longPressGestureDuration)),
+        Factory<LongPressGestureRecognizer>(() => LongPressGestureRecognizer(duration: _longPressGestureDurationIOS)),
       };
     }
     if (PlatformInfo.isAndroid) {
@@ -211,7 +211,7 @@ class _HtmlContentViewState extends State<HtmlContentViewer> {
 
       if (!isScrollActivated && PlatformInfo.isIOS) {
         newGestureRecognizers = {
-          Factory<LongPressGestureRecognizer>(() => LongPressGestureRecognizer(duration: _longPressGestureDuration)),
+          Factory<LongPressGestureRecognizer>(() => LongPressGestureRecognizer(duration: _longPressGestureDurationIOS)),
           Factory<HorizontalDragGestureRecognizer>(() => HorizontalDragGestureRecognizer())
         };
       }
@@ -272,7 +272,7 @@ class _HtmlContentViewState extends State<HtmlContentViewer> {
     return NavigationActionPolicy.CANCEL;
   }
 
-  Duration? get _longPressGestureDuration => const Duration(milliseconds: 100);
+  Duration? get _longPressGestureDurationIOS => const Duration(milliseconds: 100);
 
   @override
   void dispose() {

--- a/lib/features/base/mixin/message_dialog_action_mixin.dart
+++ b/lib/features/base/mixin/message_dialog_action_mixin.dart
@@ -34,6 +34,8 @@ mixin MessageDialogActionMixin {
         Color? cancelButtonColor,
         EdgeInsetsGeometry? marginIcon,
         PopInvokedCallback? onPopInvoked,
+        bool isArrangeActionButtonsVertical = false,
+        int? titleActionButtonMaxLines,
       }
   ) async {
     final responsiveUtils = Get.find<ResponsiveUtils>();
@@ -41,7 +43,12 @@ mixin MessageDialogActionMixin {
 
     if (alignCenter) {
       final childWidget = PointerInterceptor(
-        child: (ConfirmDialogBuilder(imagePaths, listTextSpan: listTextSpan)
+        child: (ConfirmDialogBuilder(
+            imagePaths,
+            listTextSpan: listTextSpan,
+            titleActionButtonMaxLines: titleActionButtonMaxLines,
+            isArrangeActionButtonsVertical: isArrangeActionButtonsVertical
+          )
           ..key(const Key('confirm_dialog_action'))
           ..title(title ?? '')
           ..content(message)
@@ -92,7 +99,9 @@ mixin MessageDialogActionMixin {
               imagePaths,
               showAsBottomSheet: true,
               listTextSpan: listTextSpan,
-              maxWith: responsiveUtils.getSizeScreenShortestSide(context) - 16
+              maxWith: responsiveUtils.getSizeScreenShortestSide(context) - 16,
+              titleActionButtonMaxLines: titleActionButtonMaxLines,
+              isArrangeActionButtonsVertical: isArrangeActionButtonsVertical
             )
             ..key(const Key('confirm_dialog_action'))
             ..title(title ?? '')
@@ -168,7 +177,12 @@ mixin MessageDialogActionMixin {
         }
       } else {
         final childWidget = PointerInterceptor(
-          child: (ConfirmDialogBuilder(imagePaths, listTextSpan: listTextSpan)
+          child: (ConfirmDialogBuilder(
+              imagePaths,
+              listTextSpan: listTextSpan,
+              titleActionButtonMaxLines: titleActionButtonMaxLines,
+              isArrangeActionButtonsVertical: isArrangeActionButtonsVertical
+            )
             ..key(const Key('confirm_dialog_action'))
             ..title(title ?? '')
             ..content(message)

--- a/lib/features/base/mixin/message_dialog_action_mixin.dart
+++ b/lib/features/base/mixin/message_dialog_action_mixin.dart
@@ -22,6 +22,7 @@ mixin MessageDialogActionMixin {
         bool showAsBottomSheet = false,
         bool alignCenter = false,
         bool outsideDismissible = true,
+        bool autoPerformPopBack = true,
         List<TextSpan>? listTextSpan,
         Widget? icon,
         TextStyle? titleStyle,
@@ -59,13 +60,17 @@ mixin MessageDialogActionMixin {
             ..styleTextCancelButton(cancelStyle ?? const TextStyle(fontSize: 17, fontWeight: FontWeight.w500, color: AppColor.colorTextButton))
             ..styleTextConfirmButton(actionStyle ?? const TextStyle(fontSize: 17, fontWeight: FontWeight.w500, color: Colors.white))
             ..onConfirmButtonAction(actionName, () {
-                popBack();
+                if (autoPerformPopBack) {
+                  popBack();
+                }
                 onConfirmAction?.call();
             })
             ..onCancelButtonAction(
                 hasCancelButton ? cancelTitle ?? AppLocalizations.of(context).cancel : '',
                 () {
-                  popBack();
+                  if (autoPerformPopBack) {
+                    popBack();
+                  }
                   onCancelAction?.call();
                 }
             )
@@ -106,13 +111,17 @@ mixin MessageDialogActionMixin {
                 ..styleTextCancelButton(cancelStyle ?? const TextStyle(fontSize: 17, fontWeight: FontWeight.w500, color: AppColor.colorTextButton))
                 ..styleTextConfirmButton(actionStyle ?? const TextStyle(fontSize: 17, fontWeight: FontWeight.w500, color: Colors.white))
                 ..onConfirmButtonAction(actionName, () {
-                    popBack();
+                    if (autoPerformPopBack) {
+                      popBack();
+                    }
                     onConfirmAction?.call();
                 })
                 ..onCancelButtonAction(
                     hasCancelButton ? cancelTitle ?? AppLocalizations.of(context).cancel : '',
                     () {
-                      popBack();
+                      if (autoPerformPopBack) {
+                        popBack();
+                      }
                       onCancelAction?.call();
                     }
                 )
@@ -136,12 +145,16 @@ mixin MessageDialogActionMixin {
             ..onCancelAction(
                 cancelTitle ?? AppLocalizations.of(context).cancel,
                 () {
-                  popBack();
+                  if (autoPerformPopBack) {
+                    popBack();
+                  }
                   onCancelAction?.call();
                 }
             )
             ..onConfirmAction(actionName, () {
-                popBack();
+                if (autoPerformPopBack) {
+                  popBack();
+                }
                 onConfirmAction?.call();
             })).show();
         }
@@ -167,13 +180,17 @@ mixin MessageDialogActionMixin {
               ..styleTextCancelButton(cancelStyle ?? const TextStyle(fontSize: 17, fontWeight: FontWeight.w500, color: AppColor.colorTextButton))
               ..styleTextConfirmButton(actionStyle ?? const TextStyle(fontSize: 17, fontWeight: FontWeight.w500, color: Colors.white))
               ..onConfirmButtonAction(actionName, () {
-                popBack();
+                if (autoPerformPopBack) {
+                  popBack();
+                }
                 onConfirmAction?.call();
               })
               ..onCancelButtonAction(
                   hasCancelButton ? cancelTitle ?? AppLocalizations.of(context).cancel : '',
                   () {
-                    popBack();
+                    if (autoPerformPopBack) {
+                      popBack();
+                    }
                     onCancelAction?.call();
                   }
               )

--- a/lib/features/composer/presentation/composer_bindings.dart
+++ b/lib/features/composer/presentation/composer_bindings.dart
@@ -214,9 +214,12 @@ class ComposerBindings extends BaseBindings {
 
   @override
   void bindingsController() {
-    Get.lazyPut(() => RichTextMobileTabletController());
+    if (PlatformInfo.isWeb) {
+      Get.lazyPut(() => RichTextWebController());
+    } else {
+      Get.lazyPut(() => RichTextMobileTabletController());
+    }
     Get.lazyPut(() => UploadController(Get.find<UploadAttachmentInteractor>()));
-    Get.lazyPut(() => RichTextWebController());
     Get.lazyPut(() => ComposerController(
       Get.find<LocalFilePickerInteractor>(),
       Get.find<LocalImagePickerInteractor>(),
@@ -225,7 +228,6 @@ class ComposerBindings extends BaseBindings {
       Get.find<UploadController>(),
       Get.find<RemoveComposerCacheOnWebInteractor>(),
       Get.find<SaveComposerCacheOnWebInteractor>(),
-      Get.find<RichTextWebController>(),
       Get.find<DownloadImageAsBase64Interactor>(),
       Get.find<TransformHtmlEmailContentInteractor>(),
       Get.find<GetAlwaysReadReceiptSettingInteractor>(),
@@ -235,9 +237,12 @@ class ComposerBindings extends BaseBindings {
   }
 
   void dispose() {
+    if (PlatformInfo.isWeb) {
+      Get.delete<RichTextWebController>();
+    } else {
+      Get.delete<RichTextMobileTabletController>();
+    }
     Get.delete<UploadController>();
-    Get.delete<RichTextWebController>();
-    Get.delete<RichTextMobileTabletController>();
     Get.delete<ComposerController>();
   }
 }

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1563,6 +1563,10 @@ class ComposerController extends BaseController with DragDropFileMixin {
     if (newIdentity.signatureAsString.isNotEmpty == true) {
       await _applySignature(newIdentity.signatureAsString.asSignatureHtml());
     }
+
+    if (PlatformInfo.isMobile) {
+      await htmlEditorApi?.onDocumentChanged();
+    }
   }
 
   void _applyBccEmailAddressFromIdentity(Set<EmailAddress> listEmailAddress) {

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -829,7 +829,9 @@ class ComposerController extends BaseController with DragDropFileMixin {
       return;
     }
 
-    popBack();
+    if (Get.isDialogOpen == true) {
+      popBack();
+    }
 
     final emailContent = await _getContentInEditor();
     final cancelToken = CancelToken();
@@ -2031,7 +2033,6 @@ class ComposerController extends BaseController with DragDropFileMixin {
     } else if ((resultState is SaveEmailAsDraftsFailure && resultState.exception is SavingEmailToDraftsCanceledException) ||
         (resultState is UpdateEmailDraftsFailure && resultState.exception is SavingEmailToDraftsCanceledException)) {
       _closeComposerButtonState = ButtonState.enabled;
-      _closeComposerAction();
     } else if ((resultState is SaveEmailAsDraftsFailure ||
         resultState is UpdateEmailDraftsFailure ||
         resultState is GenerateEmailFailure) &&

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1340,11 +1340,6 @@ class ComposerController extends BaseController with DragDropFileMixin {
       _autoFocusFieldWhenLauncher);
   }
 
-  void deleteComposer() {
-    FocusManager.instance.primaryFocus?.unfocus();
-    mailboxDashBoardController.closeComposerOverlay();
-  }
-
   void addEmailAddressType(PrefixEmailAddress prefixEmailAddress) {
     switch(prefixEmailAddress) {
       case PrefixEmailAddress.from:

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1923,6 +1923,8 @@ class ComposerController extends BaseController with DragDropFileMixin {
       alignCenter: true,
       outsideDismissible: false,
       autoPerformPopBack: false,
+      titleActionButtonMaxLines: 1,
+      isArrangeActionButtonsVertical: true,
       usePopScope: true,
       onConfirmAction: () => _handleSaveMessageToDraft(context),
       onCancelAction: () {

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1923,6 +1923,7 @@ class ComposerController extends BaseController with DragDropFileMixin {
       alignCenter: true,
       outsideDismissible: false,
       autoPerformPopBack: false,
+      usePopScope: true,
       onConfirmAction: () => _handleSaveMessageToDraft(context),
       onCancelAction: () {
         _closeComposerButtonState = ButtonState.enabled;
@@ -1932,6 +1933,14 @@ class ComposerController extends BaseController with DragDropFileMixin {
         _closeComposerButtonState = ButtonState.enabled;
         popBack();
         _autoFocusFieldWhenLauncher();
+      },
+      onPopInvoked: (didPop) {
+        log('ComposerController::_showConfirmDialogSaveMessage: didPop = $didPop');
+        if (!didPop) {
+          _closeComposerButtonState = ButtonState.enabled;
+          popBack();
+          _autoFocusFieldWhenLauncher();
+        }
       },
       marginIcon: EdgeInsets.zero,
       icon: SvgPicture.asset(

--- a/lib/features/composer/presentation/composer_view.dart
+++ b/lib/features/composer/presentation/composer_view.dart
@@ -217,7 +217,7 @@ class ComposerView extends GetWidget<ComposerController> {
                               onLoadCompletedEditorAction: controller.onLoadCompletedMobileEditorAction,
                             ),
                           )),
-                          SizedBox(height: MediaQuery.viewInsetsOf(context).bottom),
+                          SizedBox(height: MediaQuery.viewInsetsOf(context).bottom + 64),
                         ],
                       ),
                     ),
@@ -369,6 +369,7 @@ class ComposerView extends GetWidget<ComposerController> {
                           onLoadCompletedEditorAction: controller.onLoadCompletedMobileEditorAction,
                         ),
                       )),
+                      SizedBox(height: MediaQuery.viewInsetsOf(context).bottom + 64),
                     ],
                   ),
                 )

--- a/lib/features/composer/presentation/composer_view.dart
+++ b/lib/features/composer/presentation/composer_view.dart
@@ -36,7 +36,7 @@ class ComposerView extends GetWidget<ComposerController> {
     return ResponsiveWidget(
       responsiveUtils: controller.responsiveUtils,
       mobile: MobileContainerView(
-        keyboardRichTextController: controller.keyboardRichTextController,
+        keyboardRichTextController: controller.richTextMobileTabletController!.richTextController,
         onCloseViewAction: () => controller.handleClickCloseComposer(context),
         onClearFocusAction: () => controller.clearFocus(context),
         onAttachFileAction: () => controller.isNetworkConnectionAvailable
@@ -228,7 +228,7 @@ class ComposerView extends GetWidget<ComposerController> {
         ),
       ),
       tablet: TabletContainerView(
-        keyboardRichTextController: controller.keyboardRichTextController,
+        keyboardRichTextController: controller.richTextMobileTabletController!.richTextController,
         onCloseViewAction: () => controller.handleClickCloseComposer(context),
         onClearFocusAction: () => controller.clearFocus(context),
         onAttachFileAction: () => controller.isNetworkConnectionAvailable

--- a/lib/features/composer/presentation/composer_view_web.dart
+++ b/lib/features/composer/presentation/composer_view_web.dart
@@ -43,9 +43,9 @@ class ComposerView extends GetWidget<ComposerController> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Obx(() => MobileResponsiveAppBarComposerWidget(
-                  isCodeViewEnabled: controller.richTextWebController.codeViewEnabled,
-                  isFormattingOptionsEnabled: controller.richTextWebController.isFormattingOptionsEnabled,
-                  openRichToolbarAction: controller.richTextWebController.toggleFormattingOptions,
+                  isCodeViewEnabled: controller.richTextWebController!.codeViewEnabled,
+                  isFormattingOptionsEnabled: controller.richTextWebController!.isFormattingOptionsEnabled,
+                  openRichToolbarAction: controller.richTextWebController!.toggleFormattingOptions,
                   isSendButtonEnabled: controller.isEnableEmailSendButton.value,
                   onCloseViewAction: () => controller.handleClickCloseComposer(context),
                   attachFileAction: () => controller.openFilePickerByType(context, FileType.any),
@@ -177,7 +177,7 @@ class ComposerView extends GetWidget<ComposerController> {
                                 child: Padding(
                                   padding: ComposerStyle.mobileEditorPadding,
                                   child: Obx(() => WebEditorView(
-                                    editorController: controller.richTextWebController.editorController,
+                                    editorController: controller.richTextWebController!.editorController,
                                     arguments: controller.composerArguments.value,
                                     contentViewState: controller.emailContentsViewState.value,
                                     currentWebContent: controller.textEditorWeb,
@@ -186,8 +186,8 @@ class ComposerView extends GetWidget<ComposerController> {
                                     onFocus: controller.handleOnFocusHtmlEditorWeb,
                                     onUnFocus: controller.handleOnUnFocusHtmlEditorWeb,
                                     onMouseDown: controller.handleOnMouseDownHtmlEditorWeb,
-                                    onEditorSettings: controller.richTextWebController.onEditorSettingsChange,
-                                    onEditorTextSizeChanged: controller.richTextWebController.onEditorTextSizeChanged,
+                                    onEditorSettings: controller.richTextWebController!.onEditorSettingsChange,
+                                    onEditorTextSizeChanged: controller.richTextWebController!.onEditorTextSizeChanged,
                                     width: constraints.maxWidth,
                                     height: constraints.maxHeight,
                                     onDragEnter: controller.handleOnDragEnterHtmlEditorWeb,
@@ -207,9 +207,9 @@ class ComposerView extends GetWidget<ComposerController> {
                                 }
                               }),
                               Obx(() {
-                                if (controller.richTextWebController.isFormattingOptionsEnabled) {
+                                if (controller.richTextWebController!.isFormattingOptionsEnabled) {
                                   return ToolbarRichTextWebBuilder(
-                                    richTextWebController: controller.richTextWebController,
+                                    richTextWebController: controller.richTextWebController!,
                                     padding: ComposerStyle.richToolbarPadding,
                                     decoration: const BoxDecoration(
                                       color: ComposerStyle.richToolbarColor,
@@ -418,7 +418,7 @@ class ComposerView extends GetWidget<ComposerController> {
                                         padding: ComposerStyle.desktopEditorPadding,
                                         child: Obx(() {
                                           return WebEditorView(
-                                            editorController: controller.richTextWebController.editorController,
+                                            editorController: controller.richTextWebController!.editorController,
                                             arguments: controller.composerArguments.value,
                                             contentViewState: controller.emailContentsViewState.value,
                                             currentWebContent: controller.textEditorWeb,
@@ -427,8 +427,8 @@ class ComposerView extends GetWidget<ComposerController> {
                                             onFocus: controller.handleOnFocusHtmlEditorWeb,
                                             onUnFocus: controller.handleOnUnFocusHtmlEditorWeb,
                                             onMouseDown: controller.handleOnMouseDownHtmlEditorWeb,
-                                            onEditorSettings: controller.richTextWebController.onEditorSettingsChange,
-                                            onEditorTextSizeChanged: controller.richTextWebController.onEditorTextSizeChanged,
+                                            onEditorSettings: controller.richTextWebController?.onEditorSettingsChange,
+                                            onEditorTextSizeChanged: controller.richTextWebController?.onEditorTextSizeChanged,
                                             width: constraints.maxWidth,
                                             height: constraints.maxHeight,
                                             onDragEnter: controller.handleOnDragEnterHtmlEditorWeb,
@@ -449,9 +449,9 @@ class ComposerView extends GetWidget<ComposerController> {
                                       }
                                     }),
                                     Obx(() {
-                                      if (controller.richTextWebController.isFormattingOptionsEnabled) {
+                                      if (controller.richTextWebController!.isFormattingOptionsEnabled) {
                                         return ToolbarRichTextWebBuilder(
-                                          richTextWebController: controller.richTextWebController,
+                                          richTextWebController: controller.richTextWebController!,
                                           padding: ComposerStyle.richToolbarPadding,
                                           decoration: const BoxDecoration(
                                             color: ComposerStyle.richToolbarColor,
@@ -467,12 +467,12 @@ class ComposerView extends GetWidget<ComposerController> {
                               ),
                             ),
                             Obx(() => BottomBarComposerWidget(
-                              isCodeViewEnabled: controller.richTextWebController.codeViewEnabled,
-                              isFormattingOptionsEnabled: controller.richTextWebController.isFormattingOptionsEnabled,
-                              openRichToolbarAction: controller.richTextWebController.toggleFormattingOptions,
+                              isCodeViewEnabled: controller.richTextWebController!.codeViewEnabled,
+                              isFormattingOptionsEnabled: controller.richTextWebController!.isFormattingOptionsEnabled,
+                              openRichToolbarAction: controller.richTextWebController!.toggleFormattingOptions,
                               attachFileAction: () => controller.openFilePickerByType(context, FileType.any),
                               insertImageAction: () => controller.insertImage(context, constraints.maxWidth),
-                              showCodeViewAction: controller.richTextWebController.toggleCodeView,
+                              showCodeViewAction: controller.richTextWebController!.toggleCodeView,
                               deleteComposerAction: () => controller.handleClickDeleteComposer(context),
                               saveToDraftAction: () => controller.handleClickSaveAsDraftsButton(context),
                               sendMessageAction: () => controller.handleClickSendButton(context),
@@ -680,7 +680,7 @@ class ComposerView extends GetWidget<ComposerController> {
                                 child: Padding(
                                   padding: ComposerStyle.tabletEditorPadding,
                                   child: Obx(() => WebEditorView(
-                                    editorController: controller.richTextWebController.editorController,
+                                    editorController: controller.richTextWebController!.editorController,
                                     arguments: controller.composerArguments.value,
                                     contentViewState: controller.emailContentsViewState.value,
                                     currentWebContent: controller.textEditorWeb,
@@ -689,8 +689,8 @@ class ComposerView extends GetWidget<ComposerController> {
                                     onFocus: controller.handleOnFocusHtmlEditorWeb,
                                     onUnFocus: controller.handleOnUnFocusHtmlEditorWeb,
                                     onMouseDown: controller.handleOnMouseDownHtmlEditorWeb,
-                                    onEditorSettings: controller.richTextWebController.onEditorSettingsChange,
-                                    onEditorTextSizeChanged: controller.richTextWebController.onEditorTextSizeChanged,
+                                    onEditorSettings: controller.richTextWebController!.onEditorSettingsChange,
+                                    onEditorTextSizeChanged: controller.richTextWebController!.onEditorTextSizeChanged,
                                     width: constraints.maxWidth,
                                     height: constraints.maxHeight,
                                     onDragEnter: controller.handleOnDragEnterHtmlEditorWeb,
@@ -710,9 +710,9 @@ class ComposerView extends GetWidget<ComposerController> {
                                 }
                               }),
                               Obx(() {
-                                if (controller.richTextWebController.isFormattingOptionsEnabled) {
+                                if (controller.richTextWebController!.isFormattingOptionsEnabled) {
                                   return ToolbarRichTextWebBuilder(
-                                    richTextWebController: controller.richTextWebController,
+                                    richTextWebController: controller.richTextWebController!,
                                     padding: ComposerStyle.richToolbarPadding,
                                     decoration: const BoxDecoration(
                                       color: ComposerStyle.richToolbarColor,
@@ -777,12 +777,12 @@ class ComposerView extends GetWidget<ComposerController> {
                 ),
               ),
               Obx(() => BottomBarComposerWidget(
-                isCodeViewEnabled: controller.richTextWebController.codeViewEnabled,
-                isFormattingOptionsEnabled: controller.richTextWebController.isFormattingOptionsEnabled,
-                openRichToolbarAction: controller.richTextWebController.toggleFormattingOptions,
+                isCodeViewEnabled: controller.richTextWebController!.codeViewEnabled,
+                isFormattingOptionsEnabled: controller.richTextWebController!.isFormattingOptionsEnabled,
+                openRichToolbarAction: controller.richTextWebController!.toggleFormattingOptions,
                 attachFileAction: () => controller.openFilePickerByType(context, FileType.any),
                 insertImageAction: () => controller.insertImage(context, constraints.maxWidth),
-                showCodeViewAction: controller.richTextWebController.toggleCodeView,
+                showCodeViewAction: controller.richTextWebController!.toggleCodeView,
                 deleteComposerAction: () => controller.handleClickDeleteComposer(context),
                 saveToDraftAction: () => controller.handleClickSaveAsDraftsButton(context),
                 sendMessageAction: () => controller.handleClickSendButton(context),
@@ -833,10 +833,10 @@ class ComposerView extends GetWidget<ComposerController> {
           colorIcon: ComposerStyle.popupItemIconColor,
           padding: ComposerStyle.popupItemPadding,
           selectedIcon: controller.imagePaths.icFilterSelected,
-          isSelected: controller.richTextWebController.codeViewEnabled,
+          isSelected: controller.richTextWebController?.codeViewEnabled,
           onCallbackAction: () {
             popBack();
-            controller.richTextWebController.toggleCodeView();
+            controller.richTextWebController?.toggleCodeView();
           }
         )
       ),

--- a/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
+++ b/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
@@ -11,6 +11,8 @@ import 'package:tmail_ui_user/features/composer/presentation/model/inline_image.
 class RichTextMobileTabletController extends BaseRichTextController {
   HtmlEditorApi? htmlEditorApi;
 
+  final RichTextController richTextController = RichTextController();
+
   void insertImage(InlineImage inlineImage) async {
     if (inlineImage.fileInfo.isShared == true) {
       await htmlEditorApi?.moveCursorAtLastNode();
@@ -40,5 +42,12 @@ class RichTextMobileTabletController extends BaseRichTextController {
     } catch (e) {
       logError('RichTextMobileTabletController::insertImageData:Exception: $e');
     }
+  }
+
+  @override
+  void onClose() {
+    richTextController.dispose();
+    htmlEditorApi = null;
+    super.onClose();
   }
 }

--- a/lib/features/composer/presentation/styles/mobile/mobile_container_view_style.dart
+++ b/lib/features/composer/presentation/styles/mobile/mobile_container_view_style.dart
@@ -8,6 +8,4 @@ class MobileContainerViewStyle {
   static final Color keyboardToolbarBackgroundColor = PlatformInfo.isIOS
     ? AppColor.colorBackgroundKeyboard
     : AppColor.colorBackgroundKeyboardAndroid;
-
-  static const EdgeInsets keyboardToolbarPadding = EdgeInsets.only(bottom: 64);
 }

--- a/lib/features/composer/presentation/styles/mobile/tablet_container_view_style.dart
+++ b/lib/features/composer/presentation/styles/mobile/tablet_container_view_style.dart
@@ -14,8 +14,6 @@ class TabletContainerViewStyle {
     ? AppColor.colorBackgroundKeyboard
     : AppColor.colorBackgroundKeyboardAndroid;
 
-  static const EdgeInsets keyboardToolbarPadding = EdgeInsets.only(bottom: 64);
-
   static EdgeInsetsGeometry getMargin(
     BuildContext context,
     ResponsiveUtils responsiveUtils

--- a/lib/features/composer/presentation/view/mobile/mobile_container_view.dart
+++ b/lib/features/composer/presentation/view/mobile/mobile_container_view.dart
@@ -1,7 +1,6 @@
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:get/get.dart';
 import 'package:rich_text_composer/rich_text_composer.dart' as rich_composer;
 import 'package:rich_text_composer/views/widgets/rich_text_keyboard_toolbar.dart';

--- a/lib/features/composer/presentation/view/mobile/mobile_container_view.dart
+++ b/lib/features/composer/presentation/view/mobile/mobile_container_view.dart
@@ -49,7 +49,6 @@ class MobileContainerView extends StatelessWidget {
           backgroundColor: backgroundColor ?? MobileContainerViewStyle.outSideBackgroundColor,
           resizeToAvoidBottomInset: false,
           body: LayoutBuilder(builder: (context, constraints) {
-            return KeyboardVisibilityBuilder(builder: (context, isKeyboardVisible) {
               return rich_composer.KeyboardRichText(
                 richTextController: keyboardRichTextController,
                 keyBroadToolbar: RichTextKeyboardToolBar(
@@ -66,12 +65,9 @@ class MobileContainerView extends StatelessWidget {
                   titleFormatBottomSheet: AppLocalizations.of(context).titleFormat,
                   titleBack: AppLocalizations.of(context).format,
                 ),
-                paddingChild: isKeyboardVisible
-                  ? MobileContainerViewStyle.keyboardToolbarPadding
-                  : EdgeInsets.zero,
+                paddingChild: EdgeInsets.zero,
                 child: childBuilder(context, constraints),
               );
-            });
           })
         ),
       )

--- a/lib/features/composer/presentation/view/mobile/tablet_container_view.dart
+++ b/lib/features/composer/presentation/view/mobile/tablet_container_view.dart
@@ -1,7 +1,6 @@
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:get/get.dart';
 import 'package:rich_text_composer/rich_text_composer.dart';
 import 'package:rich_text_composer/views/widgets/rich_text_keyboard_toolbar.dart';

--- a/lib/features/composer/presentation/view/mobile/tablet_container_view.dart
+++ b/lib/features/composer/presentation/view/mobile/tablet_container_view.dart
@@ -45,7 +45,6 @@ class TabletContainerView extends StatelessWidget {
         child: Scaffold(
           backgroundColor: TabletContainerViewStyle.outSideBackgroundColor,
           body: LayoutBuilder(builder: (context, constraints) {
-            return KeyboardVisibilityBuilder(builder: (context, isKeyboardVisible) {
               return KeyboardRichText(
                 richTextController: keyboardRichTextController,
                 keyBroadToolbar: RichTextKeyboardToolBar(
@@ -62,9 +61,7 @@ class TabletContainerView extends StatelessWidget {
                   titleFormatBottomSheet: AppLocalizations.of(context).titleFormat,
                   titleBack: AppLocalizations.of(context).format,
                 ),
-                paddingChild: isKeyboardVisible
-                  ? TabletContainerViewStyle.keyboardToolbarPadding
-                  : EdgeInsets.zero,
+                paddingChild: EdgeInsets.zero,
                 child: Center(
                   child: Card(
                     elevation: TabletContainerViewStyle.elevation,
@@ -81,7 +78,6 @@ class TabletContainerView extends StatelessWidget {
                   ),
                 ),
               );
-            });
           })
         ),
       )

--- a/lib/features/composer/presentation/widgets/recipient_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/recipient_composer_widget.dart
@@ -149,14 +149,7 @@ class _RecipientComposerWidgetState extends State<RecipientComposerWidget> {
             child: FocusScope(
               child: Focus(
                 onFocusChange: (focus) => widget.onFocusEmailAddressChangeAction?.call(widget.prefix, focus),
-                onKey: (focusNode, event) {
-                  if (event is RawKeyDownEvent && event.logicalKey == LogicalKeyboardKey.tab) {
-                    widget.nextFocusNode?.requestFocus();
-                    widget.onFocusNextAddressAction?.call();
-                    return KeyEventResult.handled;
-                  }
-                  return KeyEventResult.ignored;
-                },
+                onKey: PlatformInfo.isWeb ? _recipientInputOnKeyListener : null,
                 child: StatefulBuilder(
                   builder: (context, stateSetter) {
                     if (PlatformInfo.isWeb || widget.isTestingForWeb) {
@@ -387,6 +380,15 @@ class _RecipientComposerWidgetState extends State<RecipientComposerWidget> {
         ]
       ),
     );
+  }
+
+  KeyEventResult _recipientInputOnKeyListener(FocusNode node, RawKeyEvent event) {
+    if (event is RawKeyDownEvent && event.logicalKey == LogicalKeyboardKey.tab) {
+      widget.nextFocusNode?.requestFocus();
+      widget.onFocusNextAddressAction?.call();
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
   }
 
   bool get _isCollapse => _currentListEmailAddress.length > 1 && widget.expandMode == ExpandMode.COLLAPSE;

--- a/lib/features/email/presentation/action/email_ui_action.dart
+++ b/lib/features/email/presentation/action/email_ui_action.dart
@@ -41,3 +41,7 @@ class PrintEmailAction extends EmailUIAction {
   @override
   List<Object?> get props => [context, userEmail, email];
 }
+
+class HideEmailContentViewAction extends EmailUIAction {}
+
+class ShowEmailContentViewAction extends EmailUIAction {}

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -128,6 +128,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
   final emailLoadedViewState = Rx<Either<Failure, Success>>(Right(UIState.idle));
   final emailUnsubscribe = Rxn<EmailUnsubscribe>();
   final attachmentsViewState = RxMap<Id, Either<Failure, Success>>();
+  final isEmailContentHidden = RxBool(false);
 
   EmailId? _currentEmailId;
   Identity? _identitySelected;
@@ -266,6 +267,12 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
         mailboxDashBoardController.clearEmailUIAction();
       } else if (action is CloseEmailDetailedViewAction) {
         closeEmailView(context: currentContext);
+        mailboxDashBoardController.clearEmailUIAction();
+      } else if (action is HideEmailContentViewAction) {
+        isEmailContentHidden.value = true;
+        mailboxDashBoardController.clearEmailUIAction();
+      } else if (action is ShowEmailContentViewAction) {
+        isEmailContentHidden.value = false;
         mailboxDashBoardController.clearEmailUIAction();
       }
     });

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -305,8 +305,10 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
       markAsEmailRead(selectedEmail, ReadActions.markAsRead, MarkReadAction.tap);
     }
 
-    if (_identitySelected == null) {
+    if (mailboxDashBoardController.listIdentities.isEmpty) {
       _getAllIdentities();
+    } else {
+      _initializeSelectedIdentity(mailboxDashBoardController.listIdentities);
     }
   }
 
@@ -393,17 +395,20 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
 
   void _getAllIdentitiesSuccess(GetAllIdentitiesSuccess success) {
     if (success.identities?.isNotEmpty == true) {
-      if (currentEmail != null) {
-        final currentMailbox = getMailboxContain(currentEmail!);
-        log('SingleEmailController::_getAllIdentitiesSuccess():currentMailbox: $currentMailbox');
-        if (_isBelongToTeamMailboxes(currentMailbox)) {
-          _setUpDefaultIdentityForTeamMailbox(success.identities!, currentMailbox!);
-        } else {
-          _setUpDefaultIdentity(success.identities!);
-        }
+      _initializeSelectedIdentity(success.identities!);
+    }
+  }
+
+  void _initializeSelectedIdentity(List<Identity> identities) {
+    if (currentEmail != null) {
+      final currentMailbox = getMailboxContain(currentEmail!);
+      if (_isBelongToTeamMailboxes(currentMailbox)) {
+        _setUpDefaultIdentityForTeamMailbox(identities, currentMailbox!);
       } else {
-        _setUpDefaultIdentity(success.identities!);
+        _setUpDefaultIdentity(identities);
       }
+    } else {
+      _setUpDefaultIdentity(identities);
     }
   }
 
@@ -597,6 +602,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
     eventActions.clear();
     emailUnsubscribe.value = null;
     _printEmailAction = null;
+    _identitySelected = null;
     if (isEmailClosing) {
       emailLoadedViewState.value = Right(UIState.idle);
       viewState.value = Right(UIState.idle);

--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -392,6 +392,30 @@ class EmailView extends GetWidget<SingleEmailController> {
                     }),
                   ),
                 );
+              } else if (PlatformInfo.isIOS
+                  && !controller.responsiveUtils.isScreenWithShortestSide(context)) {
+                return Obx(() {
+                  if (controller.isEmailContentHidden.isTrue) {
+                    return const SizedBox.shrink();
+                  } else {
+                    return Padding(
+                      padding: const EdgeInsetsDirectional.symmetric(
+                        vertical: EmailViewStyles.mobileContentVerticalMargin,
+                        horizontal: EmailViewStyles.mobileContentHorizontalMargin
+                      ),
+                      child: LayoutBuilder(builder: (context, constraints) {
+                        return HtmlContentViewer(
+                          contentHtml: allEmailContents,
+                          initialWidth: constraints.maxWidth,
+                          direction: AppUtils.getCurrentDirection(context),
+                          onMailtoDelegateAction: controller.openMailToLink,
+                          onScrollHorizontalEnd: controller.toggleScrollPhysicsPagerView,
+                          onLoadWidthHtmlViewer: controller.emailSupervisorController.updateScrollPhysicPageView,
+                        );
+                      })
+                    );
+                  }
+                });
               } else {
                 return Padding(
                   padding: const EdgeInsetsDirectional.symmetric(

--- a/lib/features/identity_creator/presentation/identity_creator_view.dart
+++ b/lib/features/identity_creator/presentation/identity_creator_view.dart
@@ -147,14 +147,14 @@ class IdentityCreatorView extends GetWidget<IdentityCreatorController>
             ? AppColor.colorBackgroundKeyboard
             : AppColor.colorBackgroundKeyboardAndroid,
           isLandScapeMode: controller.responsiveUtils.isLandscapeMobile(context),
-          richTextController: controller.keyboardRichTextController,
+          richTextController: controller.richTextMobileTabletController!.richTextController,
           titleQuickStyleBottomSheet: AppLocalizations.of(context).titleQuickStyles,
           titleBackgroundBottomSheet: AppLocalizations.of(context).titleBackground,
           titleForegroundBottomSheet: AppLocalizations.of(context).titleForeground,
           titleFormatBottomSheet: AppLocalizations.of(context).titleFormat,
           insertImage: () => controller.pickImage(context),
         ),
-        richTextController: controller.keyboardRichTextController,
+        richTextController: controller.richTextMobileTabletController!.richTextController,
         paddingChild: EdgeInsets.zero,
         child: responsiveWidget
       );
@@ -311,7 +311,7 @@ class IdentityCreatorView extends GetWidget<IdentityCreatorController>
       children: [
         if (PlatformInfo.isWeb)
           ToolbarRichTextWebBuilder(
-            richTextWebController: controller.richTextWebController,
+            richTextWebController: controller.richTextWebController!,
             padding: const EdgeInsets.only(bottom: 12),
             extendedOption: [
               Padding(
@@ -344,7 +344,7 @@ class IdentityCreatorView extends GetWidget<IdentityCreatorController>
   Widget _buildHtmlEditorWeb(BuildContext context, String initContent) {
     return html_editor_browser.HtmlEditor(
       key: const Key('identity_create_editor_web'),
-      controller: controller.richTextWebController.editorController,
+      controller: controller.richTextWebController!.editorController,
       htmlEditorOptions: html_editor_browser.HtmlEditorOptions(
         shouldEnsureVisible: true,
         hint: '',
@@ -361,16 +361,16 @@ class IdentityCreatorView extends GetWidget<IdentityCreatorController>
         onBeforeCommand: controller.updateContentHtmlEditor,
         onChangeContent: controller.updateContentHtmlEditor,
         onInit: () {
-          controller.richTextWebController.editorController.setFullScreen();
+          controller.richTextWebController?.editorController.setFullScreen();
           controller.updateContentHtmlEditor(initContent);
         }, onFocus: () {
           FocusManager.instance.primaryFocus?.unfocus();
           Future.delayed(const Duration(milliseconds: 500), () {
-            controller.richTextWebController.editorController.setFocus();
+            controller.richTextWebController?.editorController.setFocus();
           });
-          controller.richTextWebController.closeAllMenuPopup();
+          controller.richTextWebController?.closeAllMenuPopup();
         },
-        onChangeSelection: controller.richTextWebController.onEditorSettingsChange,
+        onChangeSelection: controller.richTextWebController?.onEditorSettingsChange,
         onChangeCodeview: controller.updateContentHtmlEditor
       ),
     );

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -1276,8 +1276,6 @@ class MailboxDashBoardController extends ReloadableController {
         result is SaveEmailAsDraftsSuccess ||
         result is UpdateEmailDraftsSuccess) {
       consumeState(Stream.value(Right<Failure, Success>(result)));
-    } else if (validateSendingEmailFailedWhenNetworkIsLostOnMobile(result)) {
-      _storeSendingEmailInCaseOfSendingFailureInMobile(result);
     }
 
     await _removeComposerCacheOnWeb();
@@ -1449,8 +1447,6 @@ class MailboxDashBoardController extends ReloadableController {
       } else if (validateSendingEmailFailedWhenNetworkIsLostOnMobile(result)) {
         _storeSendingEmailInCaseOfSendingFailureInMobile(result);
       }
-
-      await _removeComposerCacheOnWeb();
     }
   }
 

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -2523,6 +2523,8 @@ class MailboxDashBoardController extends ReloadableController {
     log('MailboxDashBoardController::_handleGetAllIdentitiesSuccess: IDENTITIES_SIZE = ${_identities?.length}');
   }
 
+  List<Identity> get listIdentities => _identities ?? [];
+
   @override
   void onClose() {
     _emailReceiveManager.closeEmailReceiveManagerStream();

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -38,6 +38,7 @@ import 'package:tmail_ui_user/features/composer/domain/state/update_email_drafts
 import 'package:tmail_ui_user/features/composer/domain/usecases/get_autocomplete_interactor.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/send_email_interactor.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_bindings.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/email_action_type_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/list_identities_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/compose_action_mode.dart';
@@ -1411,7 +1412,31 @@ class MailboxDashBoardController extends ReloadableController {
     } else {
       BackButtonInterceptor.removeByName(AppRoutes.dashboard);
 
-      final result = await push(AppRoutes.composer, arguments: argumentsWithIdentity);
+      bool isTabletPlatform = currentContext != null
+        && !responsiveUtils.isScreenWithShortestSide(currentContext!);
+      dynamic result;
+
+      if (isTabletPlatform) {
+        if (PlatformInfo.isIOS) {
+          dispatchEmailUIAction(HideEmailContentViewAction());
+        }
+
+        result = await Get.to(
+          () => const ComposerView(),
+          binding: ComposerBindings(),
+          opaque: false,
+          arguments: argumentsWithIdentity);
+
+        if (PlatformInfo.isIOS) {
+          await Future.delayed(
+            const Duration(milliseconds: 200),
+            () => dispatchEmailUIAction(ShowEmailContentViewAction()));
+        }
+      } else {
+        result = await push(
+          AppRoutes.composer,
+          arguments: argumentsWithIdentity);
+      }
 
       BackButtonInterceptor.add(_onBackButtonInterceptor, name: AppRoutes.dashboard);
 

--- a/lib/features/manage_account/presentation/profiles/identities/widgets/delete_identity_dialog_builder.dart
+++ b/lib/features/manage_account/presentation/profiles/identities/widgets/delete_identity_dialog_builder.dart
@@ -26,9 +26,8 @@ class DeleteIdentityDialogBuilder extends StatelessWidget {
       responsiveUtils: responsiveUtils, 
       mobile: (_buildDeleteDialog(context)
           ..alignment(Alignment.bottomCenter)
-          ..outsideDialogPadding(const EdgeInsets.only(left: 0, right: 0, bottom: PlatformInfo.isWeb ? 42 : 16))
-          ..widthDialog(MediaQuery.of(context).size.width - 16)
-          ..heightDialog(280))
+          ..outsideDialogPadding(const EdgeInsets.only(bottom: PlatformInfo.isWeb ? 42 : 16))
+          ..widthDialog(MediaQuery.of(context).size.width - 16))
         .build(),
       landscapeMobile: _buildDeleteDialog(context).build(),
       tablet: _buildDeleteDialog(context).build(),

--- a/lib/main/pages/app_pages.dart
+++ b/lib/main/pages/app_pages.dart
@@ -85,7 +85,6 @@ class AppPages {
       ...[
         GetPage(
             name: AppRoutes.composer,
-            opaque: false,
             page: () => DeferredWidget(
                 composer.loadLibrary,
                 () => composer.ComposerView()),

--- a/lib/main/routes/route_navigation.dart
+++ b/lib/main/routes/route_navigation.dart
@@ -18,8 +18,8 @@ Future<dynamic> pushAndPopAll(String routeName, {dynamic arguments}) async {
   return Get.offAllNamed(routeName, arguments: arguments);
 }
 
-void popBack({dynamic result}) {
-  Get.back(result: result);
+void popBack({dynamic result, bool closeOverlays = false}) {
+  Get.back(closeOverlays: closeOverlays, result: result);
 }
 
 bool canBack(BuildContext context) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -413,7 +413,7 @@ packages:
     description:
       path: "."
       ref: "bugfix/fix-lost-part-of-content-with-long-text"
-      resolved-ref: "273f3817c1f93a5fbdebbc09580a303338237f21"
+      resolved-ref: cb615723b8d086024e91ab72fb3777e775751708
       url: "https://github.com/linagora/enough_html_editor.git"
     source: git
     version: "0.0.5"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -409,11 +409,11 @@ packages:
     source: path
     version: "1.0.0+1"
   enough_html_editor:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       path: "."
-      ref: cnb_supported
-      resolved-ref: "69996e32a708a62b8a613f2524c5635f5c556617"
+      ref: "bugfix/fix-lost-part-of-content-with-long-text"
+      resolved-ref: "273f3817c1f93a5fbdebbc09580a303338237f21"
       url: "https://github.com/linagora/enough_html_editor.git"
     source: git
     version: "0.0.5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -266,6 +266,11 @@ dependency_overrides:
       url: https://github.com/linagora/flutter_file_picker
       ref: email_supported_5.3.1
 
+  enough_html_editor:
+    git:
+      url: https://github.com/linagora/enough_html_editor.git
+      ref: bugfix/fix-lost-part-of-content-with-long-text
+
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 


### PR DESCRIPTION
## Issues

- [x]  Part of the content is lost when replying or forwarding emails
- [x] The editor background appears gray when the waning dialog appears
- [x] Overflow height delete identity dialog on mobile
- [x] Avoid fetching again identity lists in SingleEmailController

## Dependent

- Need merged:
    - https://github.com/linagora/enough_html_editor/pull/32

## Resolved

- Part of the content is lost when replying or forwarding emails

https://github.com/linagora/tmail-flutter/assets/80730648/1d0c7518-7183-40bc-b43c-bbba2c758ea0

- The editor background appears gray when the waning dialog appears

https://github.com/linagora/tmail-flutter/assets/80730648/d8d50fe0-981e-420b-a81d-a3a0762727e8



## Related

- https://github.com/linagora/tmail-flutter/pull/2807
