### PR TITLE
TF 2827 Fix clicking reply before content is loaded

### DIFF
--- a/lib/features/email/domain/model/email_print.dart
+++ b/lib/features/email/domain/model/email_print.dart
@@ -1,12 +1,6 @@
 import 'package:equatable/equatable.dart';
-import 'package:flutter/material.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:model/email/attachment.dart';
-import 'package:model/extensions/list_email_address_extension.dart';
-import 'package:model/extensions/presentation_email_extension.dart';
-import 'package:tmail_ui_user/features/email/presentation/action/email_ui_action.dart';
-import 'package:tmail_ui_user/features/email/presentation/model/email_loaded.dart';
-import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 class EmailPrint with EquatableMixin {
   final String appName;
@@ -44,30 +38,6 @@ class EmailPrint with EquatableMixin {
     this.bccAddress,
     this.replyToAddress,
   });
-
-  factory EmailPrint.generate({
-    required PrintEmailAction printEmailAction,
-    required EmailLoaded emailLoaded
-  }) {
-    return EmailPrint(
-      appName: AppLocalizations.of(printEmailAction.context).app_name,
-      userName: printEmailAction.userEmail,
-      emailInformation: printEmailAction.email.toEmail(),
-      attachments: emailLoaded.attachments,
-      emailContent: emailLoaded.htmlContent,
-      locale: Localizations.localeOf(printEmailAction.context).toLanguageTag(),
-      fromPrefix: AppLocalizations.of(printEmailAction.context).from_email_address_prefix,
-      toPrefix: AppLocalizations.of(printEmailAction.context).to_email_address_prefix,
-      ccPrefix: AppLocalizations.of(printEmailAction.context).cc_email_address_prefix,
-      bccPrefix: AppLocalizations.of(printEmailAction.context).bcc_email_address_prefix,
-      replyToPrefix: AppLocalizations.of(printEmailAction.context).replyToEmailAddressPrefix,
-      titleAttachment: AppLocalizations.of(printEmailAction.context).attachments.toLowerCase(),
-      toAddress: printEmailAction.email.to?.listEmailAddressToString(isFullEmailAddress: true),
-      ccAddress: printEmailAction.email.cc?.listEmailAddressToString(isFullEmailAddress: true),
-      bccAddress: printEmailAction.email.bcc?.listEmailAddressToString(isFullEmailAddress: true),
-      replyToAddress: printEmailAction.email.replyTo?.listEmailAddressToString(isFullEmailAddress: true),
-    );
-  }
 
   @override
   List<Object?> get props => [

--- a/lib/features/email/presentation/action/email_ui_action.dart
+++ b/lib/features/email/presentation/action/email_ui_action.dart
@@ -1,7 +1,5 @@
 
-import 'package:flutter/cupertino.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
-import 'package:model/email/presentation_email.dart';
 import 'package:tmail_ui_user/features/base/action/ui_action.dart';
 
 class EmailUIAction extends UIAction {
@@ -25,22 +23,6 @@ class RefreshChangeEmailAction extends EmailUIAction {
 class CloseEmailDetailedViewToRedirectToTheInboxAction extends EmailUIAction {}
 
 class CloseEmailDetailedViewAction extends EmailUIAction {}
-
-class PrintEmailAction extends EmailUIAction {
-
-  final BuildContext context;
-  final String userEmail;
-  final PresentationEmail email;
-
-  PrintEmailAction({
-    required this.context,
-    required this.userEmail,
-    required this.email
-  });
-
-  @override
-  List<Object?> get props => [context, userEmail, email];
-}
 
 class HideEmailContentViewAction extends EmailUIAction {}
 

--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -369,7 +369,7 @@ class EmailView extends GetWidget<SingleEmailController> {
                 ),
               Obx(() => CalendarEventDetailWidget(
                 calendarEvent: calendarEvent,
-                emailContent: controller.currentEmailLoaded?.htmlContent ?? '',
+                emailContent: controller.currentEmailLoaded.value?.htmlContent ?? '',
                 isDraggableAppActive: controller.mailboxDashBoardController.isAttachmentDraggableAppActive,
                 onOpenComposerAction: controller.openNewComposerAction,
                 onOpenNewTabAction: controller.openNewTabAction,

--- a/lib/features/email/presentation/widgets/email_view_app_bar_widget.dart
+++ b/lib/features/email/presentation/widgets/email_view_app_bar_widget.dart
@@ -8,6 +8,7 @@ import 'package:model/email/email_action_type.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:model/extensions/presentation_mailbox_extension.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/email/presentation/controller/single_email_controller.dart';
 import 'package:tmail_ui_user/features/email/presentation/styles/email_view_app_bar_widget_styles.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/email_view_back_button.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
@@ -18,6 +19,7 @@ typedef OnMoreActionClick = void Function(PresentationEmail, RelativeRect?);
 class EmailViewAppBarWidget extends StatelessWidget {
   final _imagePaths = Get.find<ImagePaths>();
   final _responsiveUtils = Get.find<ResponsiveUtils>();
+  final _singleEmailController = Get.find<SingleEmailController>();
 
   final PresentationEmail presentationEmail;
   final List<Widget>? optionsWidget;
@@ -99,11 +101,14 @@ class EmailViewAppBarWidget extends StatelessWidget {
                     presentationEmail.hasStarred ? EmailActionType.unMarkAsStarred : EmailActionType.markAsStarred
                   )
                 ),
-                if (PlatformInfo.isWeb && PlatformInfo.isCanvasKit)
-                  ...[
-                    const SizedBox(width: EmailViewAppBarWidgetStyles.space),
-                    TMailButtonWidget.fromIcon(
+                Obx(() {
+                  if (_singleEmailController.currentEmailLoaded.value != null
+                    && PlatformInfo.isWeb
+                    && PlatformInfo.isCanvasKit
+                  ) {
+                    return TMailButtonWidget.fromIcon(
                       icon: _imagePaths.icPrinter,
+                      margin: const EdgeInsetsDirectional.only(start: EmailViewAppBarWidgetStyles.space),
                       iconSize: EmailViewAppBarWidgetStyles.deleteButtonIconSize,
                       backgroundColor: Colors.transparent,
                       padding: EmailViewAppBarWidgetStyles.buttonPadding,
@@ -112,8 +117,11 @@ class EmailViewAppBarWidget extends StatelessWidget {
                         presentationEmail,
                         EmailActionType.printAll
                       )
-                    ),
-                  ],
+                    );
+                  } else {
+                    return const SizedBox.shrink();
+                  }
+                }),
                 const SizedBox(width: EmailViewAppBarWidgetStyles.space),
                 TMailButtonWidget.fromIcon(
                   icon: _imagePaths.icDeleteComposer,

--- a/lib/features/email/presentation/widgets/email_view_bottom_bar_widget.dart
+++ b/lib/features/email/presentation/widgets/email_view_bottom_bar_widget.dart
@@ -6,6 +6,7 @@ import 'package:get/get.dart';
 import 'package:model/email/email_action_type.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:model/extensions/presentation_email_extension.dart';
+import 'package:tmail_ui_user/features/email/presentation/controller/single_email_controller.dart';
 import 'package:tmail_ui_user/features/email/presentation/styles/email_view_bottom_bar_widget_styles.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
@@ -15,6 +16,7 @@ class EmailViewBottomBarWidget extends StatelessWidget {
 
   final _imagePaths = Get.find<ImagePaths>();
   final _responsiveUtils = Get.find<ResponsiveUtils>();
+  final _singleEmailController = Get.find<SingleEmailController>();
 
   final PresentationEmail presentationEmail;
   final OnEmailActionCallback emailActionCallback;
@@ -45,55 +47,73 @@ class EmailViewBottomBarWidget extends StatelessWidget {
       child: IntrinsicHeight(
         child: Row(
           children: [
-            if (presentationEmail.numberOfAllEmailAddress() > 1)
-              Expanded(
-                child: TMailButtonWidget(
-                  key: const Key('reply_all_emails_button'),
-                  text: AppLocalizations.of(context).reply_all,
-                  icon: _imagePaths.icReplyAll,
-                  borderRadius: EmailViewBottomBarWidgetStyles.buttonRadius,
-                  iconSize: EmailViewBottomBarWidgetStyles.buttonIconSize,
-                  textAlign: TextAlign.center,
-                  flexibleText: true,
-                  padding: EmailViewBottomBarWidgetStyles.buttonPadding,
-                  backgroundColor: EmailViewBottomBarWidgetStyles.buttonBackgroundColor,
-                  textStyle: EmailViewBottomBarWidgetStyles.getButtonTextStyle(context, _responsiveUtils),
-                  verticalDirection: _responsiveUtils.isPortraitMobile(context),
-                  onTapActionCallback: () => emailActionCallback.call(EmailActionType.replyAll, presentationEmail),
-                ),
-              ),
-            Expanded(
-              child: TMailButtonWidget(
-                key: const Key('reply_email_button'),
-                text: AppLocalizations.of(context).reply,
-                icon: _imagePaths.icReply,
-                borderRadius: EmailViewBottomBarWidgetStyles.buttonRadius,
-                iconSize: EmailViewBottomBarWidgetStyles.buttonIconSize,
-                textAlign: TextAlign.center,
-                flexibleText: true,
-                padding: EmailViewBottomBarWidgetStyles.buttonPadding,
-                backgroundColor: EmailViewBottomBarWidgetStyles.buttonBackgroundColor,
-                textStyle: EmailViewBottomBarWidgetStyles.getButtonTextStyle(context, _responsiveUtils),
-                verticalDirection: _responsiveUtils.isPortraitMobile(context),
-                onTapActionCallback: () => emailActionCallback.call(EmailActionType.reply, presentationEmail),
-              ),
-            ),
-            Expanded(
-              child: TMailButtonWidget(
-                key: const Key('forward_email_button'),
-                text: AppLocalizations.of(context).forward,
-                icon: _imagePaths.icForward,
-                borderRadius: EmailViewBottomBarWidgetStyles.buttonRadius,
-                iconSize: EmailViewBottomBarWidgetStyles.buttonIconSize,
-                textAlign: TextAlign.center,
-                flexibleText: true,
-                padding: EmailViewBottomBarWidgetStyles.buttonPadding,
-                backgroundColor: EmailViewBottomBarWidgetStyles.buttonBackgroundColor,
-                textStyle: EmailViewBottomBarWidgetStyles.getButtonTextStyle(context, _responsiveUtils),
-                verticalDirection: _responsiveUtils.isPortraitMobile(context),
-                onTapActionCallback: () => emailActionCallback.call(EmailActionType.forward, presentationEmail),
-              ),
-            ),
+            Obx(() {
+              if (_singleEmailController.currentEmailLoaded.value != null
+                  && presentationEmail.numberOfAllEmailAddress() > 1) {
+                return Expanded(
+                  child: TMailButtonWidget(
+                    key: const Key('reply_all_emails_button'),
+                    text: AppLocalizations.of(context).reply_all,
+                    icon: _imagePaths.icReplyAll,
+                    borderRadius: EmailViewBottomBarWidgetStyles.buttonRadius,
+                    iconSize: EmailViewBottomBarWidgetStyles.buttonIconSize,
+                    textAlign: TextAlign.center,
+                    flexibleText: true,
+                    padding: EmailViewBottomBarWidgetStyles.buttonPadding,
+                    backgroundColor: EmailViewBottomBarWidgetStyles.buttonBackgroundColor,
+                    textStyle: EmailViewBottomBarWidgetStyles.getButtonTextStyle(context, _responsiveUtils),
+                    verticalDirection: _responsiveUtils.isPortraitMobile(context),
+                    onTapActionCallback: () => emailActionCallback.call(EmailActionType.replyAll, presentationEmail),
+                  ),
+                );
+              } else {
+                return const SizedBox.shrink();
+              }
+            }),
+            Obx(() {
+              if (_singleEmailController.currentEmailLoaded.value != null) {
+                return Expanded(
+                  child: TMailButtonWidget(
+                    key: const Key('reply_email_button'),
+                    text: AppLocalizations.of(context).reply,
+                    icon: _imagePaths.icReply,
+                    borderRadius: EmailViewBottomBarWidgetStyles.buttonRadius,
+                    iconSize: EmailViewBottomBarWidgetStyles.buttonIconSize,
+                    textAlign: TextAlign.center,
+                    flexibleText: true,
+                    padding: EmailViewBottomBarWidgetStyles.buttonPadding,
+                    backgroundColor: EmailViewBottomBarWidgetStyles.buttonBackgroundColor,
+                    textStyle: EmailViewBottomBarWidgetStyles.getButtonTextStyle(context, _responsiveUtils),
+                    verticalDirection: _responsiveUtils.isPortraitMobile(context),
+                    onTapActionCallback: () => emailActionCallback.call(EmailActionType.reply, presentationEmail),
+                  ),
+                );
+              } else {
+                return const SizedBox.shrink();
+              }
+            }),
+            Obx(() {
+              if (_singleEmailController.currentEmailLoaded.value != null) {
+                return Expanded(
+                  child: TMailButtonWidget(
+                    key: const Key('forward_email_button'),
+                    text: AppLocalizations.of(context).forward,
+                    icon: _imagePaths.icForward,
+                    borderRadius: EmailViewBottomBarWidgetStyles.buttonRadius,
+                    iconSize: EmailViewBottomBarWidgetStyles.buttonIconSize,
+                    textAlign: TextAlign.center,
+                    flexibleText: true,
+                    padding: EmailViewBottomBarWidgetStyles.buttonPadding,
+                    backgroundColor: EmailViewBottomBarWidgetStyles.buttonBackgroundColor,
+                    textStyle: EmailViewBottomBarWidgetStyles.getButtonTextStyle(context, _responsiveUtils),
+                    verticalDirection: _responsiveUtils.isPortraitMobile(context),
+                    onTapActionCallback: () => emailActionCallback.call(EmailActionType.forward, presentationEmail),
+                  ),
+                );
+              } else {
+                return const SizedBox.shrink();
+              }
+            }),
             Expanded(
               child: TMailButtonWidget(
                 key: const Key('compose_new_email_button'),


### PR DESCRIPTION
## Issue

#2827 

## Solution

- Only display the `Reply`, `Reply all`, `Forward`, `Print` actions when the email content has been loaded successfully.

## Resolved


https://github.com/linagora/tmail-flutter/assets/80730648/3f37d187-0980-43d3-afc5-dec79e58485b

