### PR TITLE
TF-2831 Custom message for forwards

### DIFF
--- a/env.file
+++ b/env.file
@@ -5,3 +5,4 @@ OIDC_SCOPES=openid,profile,email,offline_access
 APP_GRID_AVAILABLE=supported
 FCM_AVAILABLE=supported
 IOS_FCM=supported
+FORWARD_WARNING_MESSAGE=

--- a/lib/features/manage_account/presentation/forward/widgets/autocomplete_contact_text_field_with_tags.dart
+++ b/lib/features/manage_account/presentation/forward/widgets/autocomplete_contact_text_field_with_tags.dart
@@ -21,6 +21,7 @@ import 'package:tmail_ui_user/features/contact/presentation/widgets/contact_sugg
 import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/menu/settings_utils.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/utils/app_config.dart';
 import 'package:tmail_ui_user/main/utils/app_utils.dart';
 
 typedef OnSuggestionContactCallbackAction = Future<List<EmailAddress>> Function(String query);
@@ -365,7 +366,7 @@ class _AutocompleteContactTextFieldWithTagsState extends State<AutocompleteConta
       context,
       AppLocalizations.of(context).doYouWantToProceed,
       AppLocalizations.of(context).yes,
-      title: AppLocalizations.of(context).messageWarningDialogForForwardsToOtherDomains,
+      title: AppConfig.getForwardWarningMessage(context),
       cancelTitle: AppLocalizations.of(context).no,
       alignCenter: true,
       onConfirmAction: confirmAction,

--- a/lib/features/manage_account/presentation/forward/widgets/forward_warning_banner.dart
+++ b/lib/features/manage_account/presentation/forward/widgets/forward_warning_banner.dart
@@ -3,7 +3,7 @@ import 'package:core/presentation/resources/image_paths.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
-import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/utils/app_config.dart';
 
 class ForwardWarningBanner extends StatelessWidget {
 
@@ -29,7 +29,7 @@ class ForwardWarningBanner extends StatelessWidget {
         const SizedBox(width: 12),
         Expanded(
           child: Text(
-            AppLocalizations.of(context).messageWarningDialogForForwardsToOtherDomains,
+            AppConfig.getForwardWarningMessage(context),
             style: Theme.of(context).textTheme.labelSmall?.copyWith(
               fontSize: 15,
               color: Colors.black

--- a/lib/main/utils/app_config.dart
+++ b/lib/main/utils/app_config.dart
@@ -1,8 +1,10 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:tmail_ui_user/features/login/data/network/config/oidc_constant.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 class AppConfig {
   static const int limitCharToStartSearch = 3;
@@ -46,5 +48,17 @@ class AppConfig {
     } catch (e) {
       return OIDCConstant.oidcScope;
     }
+  }
+
+  static String getForwardWarningMessage(BuildContext context) {
+    final forwardWarningMessage = dotenv.get(
+        'FORWARD_WARNING_MESSAGE',
+        fallback: AppLocalizations.of(context).messageWarningDialogForForwardsToOtherDomains);
+
+    if (forwardWarningMessage.trim().isEmpty) {
+      return AppLocalizations.of(context).messageWarningDialogForForwardsToOtherDomains;
+    }
+
+    return forwardWarningMessage;
   }
 }


### PR DESCRIPTION
## Issue

#2831

## Resolved

- `FORWARD_WARNING_MESSAGE` added `env.file`

<img width="1438" alt="Screenshot 2024-05-02 at 09 08 26" src="https://github.com/linagora/tmail-flutter/assets/80730648/b93db0df-3299-46af-bc94-d8e19a37ee51">


- No  `FORWARD_WARNING_MESSAGE`


<img width="1438" alt="Screenshot 2024-05-02 at 09 29 06" src="https://github.com/linagora/tmail-flutter/assets/80730648/2a2fda7a-e782-42dd-89bf-658a3747cfed">

