### PR TITLE
TF-2830 Fix add recipient is buggy in forwards

### DIFF
--- a/lib/features/manage_account/domain/exceptions/forward_exception.dart
+++ b/lib/features/manage_account/domain/exceptions/forward_exception.dart
@@ -1,3 +1,5 @@
-class NotFoundForwardException implements Exception {
-  NotFoundForwardException();
-}
+class NotFoundForwardException implements Exception {}
+
+class RecipientListIsEmptyException implements Exception {}
+
+class RecipientListWithInvalidEmailsException implements Exception {}

--- a/lib/features/manage_account/presentation/forward/forward_controller.dart
+++ b/lib/features/manage_account/presentation/forward/forward_controller.dart
@@ -15,6 +15,7 @@ import 'package:tmail_ui_user/features/base/base_controller.dart';
 import 'package:tmail_ui_user/features/base/state/banner_state.dart';
 import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
 import 'package:tmail_ui_user/features/home/domain/extensions/session_extensions.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/exceptions/forward_exception.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/add_recipients_in_forwarding_request.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/delete_recipient_in_forwarding_request.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/edit_local_copy_in_forwarding_request.dart';
@@ -319,12 +320,12 @@ class ForwardController extends BaseController {
     );
   }
 
-  void handleExceptionCallback(BuildContext context, bool isListEmailEmpty) {
-    if (isListEmailEmpty) {
+  void handleExceptionCallback(BuildContext context, Exception exception) {
+    if (exception is RecipientListIsEmptyException) {
       appToast.showToastErrorMessage(
         context,
         AppLocalizations.of(context).emptyListEmailForward);
-    } else {
+    } else if (exception is RecipientListWithInvalidEmailsException) {
       appToast.showToastErrorMessage(
         context,
         AppLocalizations.of(context).incorrectEmailFormat);

--- a/lib/features/manage_account/presentation/forward/forward_view.dart
+++ b/lib/features/manage_account/presentation/forward/forward_view.dart
@@ -133,8 +133,8 @@ class ForwardView extends GetWidget<ForwardController> with AppLoaderMixin {
       onAddContactCallback: (listRecipientsSelected) {
         controller.addRecipientAction(context, listRecipientsSelected);
       },
-      onExceptionCallback: (isListEmailEmpty) {
-        controller.handleExceptionCallback(context, isListEmailEmpty);
+      onExceptionCallback: (exception) {
+        controller.handleExceptionCallback(context, exception);
       },
     );
   }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -3858,7 +3858,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "emailReadReceipts": "Accusés de réception",
+  "emailReadReceipts": "Accusés de lecture",
   "@emailReadReceipts": {
     "type": "text",
     "placeholders_order": [],


### PR DESCRIPTION
## Issue

#2830 

## Resolved

- [x] people click on `+ Add recipients`, account should be add directly
- [x] still have the read toast in some case (adding demo)
- [x] Replace `reception` to `lecture` for French language 

## Demo

- Forward:

https://github.com/linagora/tmail-flutter/assets/80730648/ab330185-98a6-46bd-89ce-edaffa1a8252

- Read recipient:


https://github.com/linagora/tmail-flutter/assets/80730648/b0f747f3-1bde-4dbf-a7ed-79606642e2e3

