### PR TITLE
Use `junk` role for `Spam/Junk` folder

### DIFF
--- a/contact/pubspec.lock
+++ b/contact/pubspec.lock
@@ -564,7 +564,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: "21d15bc1a6a75e048ee1e3cd751dd0815492ce20"
+      resolved-ref: "1e7d1e2aaaca2a079b997aa2188e8e7039e2ad72"
       url: "https://github.com/linagora/jmap-dart-client.git"
     source: git
     version: "0.0.1"

--- a/fcm/pubspec.lock
+++ b/fcm/pubspec.lock
@@ -296,7 +296,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: "21d15bc1a6a75e048ee1e3cd751dd0815492ce20"
+      resolved-ref: "1e7d1e2aaaca2a079b997aa2188e8e7039e2ad72"
       url: "https://github.com/linagora/jmap-dart-client.git"
     source: git
     version: "0.0.1"

--- a/forward/pubspec.lock
+++ b/forward/pubspec.lock
@@ -296,7 +296,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: "21d15bc1a6a75e048ee1e3cd751dd0815492ce20"
+      resolved-ref: "1e7d1e2aaaca2a079b997aa2188e8e7039e2ad72"
       url: "https://github.com/linagora/jmap-dart-client.git"
     source: git
     version: "0.0.1"

--- a/model/lib/mailbox/presentation_mailbox.dart
+++ b/model/lib/mailbox/presentation_mailbox.dart
@@ -14,7 +14,7 @@ class PresentationMailbox with EquatableMixin {
   static const String templatesRole= 'templates';
   static const String outboxRole = 'outbox';
   static const String draftsRole = 'drafts';
-  static const String spamRole = 'spam';
+  static const String spamRole = 'junk';
   static const String archiveRole = 'archive';
   static const String recoveredRole = 'restored messages';
 

--- a/model/pubspec.lock
+++ b/model/pubspec.lock
@@ -556,7 +556,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: "21d15bc1a6a75e048ee1e3cd751dd0815492ce20"
+      resolved-ref: "1e7d1e2aaaca2a079b997aa2188e8e7039e2ad72"
       url: "https://github.com/linagora/jmap-dart-client.git"
     source: git
     version: "0.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1132,7 +1132,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: "21d15bc1a6a75e048ee1e3cd751dd0815492ce20"
+      resolved-ref: "1e7d1e2aaaca2a079b997aa2188e8e7039e2ad72"
       url: "https://github.com/linagora/jmap-dart-client.git"
     source: git
     version: "0.0.1"

--- a/rule_filter/pubspec.lock
+++ b/rule_filter/pubspec.lock
@@ -296,7 +296,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: "21d15bc1a6a75e048ee1e3cd751dd0815492ce20"
+      resolved-ref: "1e7d1e2aaaca2a079b997aa2188e8e7039e2ad72"
       url: "https://github.com/linagora/jmap-dart-client.git"
     source: git
     version: "0.0.1"

--- a/server_settings/.gitignore
+++ b/server_settings/.gitignore
@@ -23,7 +23,6 @@ migrate_working_dir/
 
 # Flutter/Dart/Pub related
 # Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
-/pubspec.lock
 **/doc/api/
 .dart_tool/
 build/

--- a/server_settings/pubspec.lock
+++ b/server_settings/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "64e12b0521812d1684b1917bc80945625391cb9bdd4312536b1d69dcb6133ed8"
+      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   build_runner:
     dependency: "direct dev"
     description:
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "69acb7007eb2a31dc901512bfe0f7b767168be34cb734835d54c070bfa74c1b2"
+      sha256: fedde275e0a6b798c3296963c5cd224e3e1b55d0e478d5b7e65e6b540f363a0e
       url: "https://pub.dev"
     source: hosted
-    version: "8.8.0"
+    version: "8.9.1"
   characters:
     dependency: transitive
     description:
@@ -133,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: b2151ce26a06171005b379ecff6e08d34c470180ffe16b8e14b6d52be292b55f
+      sha256: f692079e25e7869c14132d39f223f8eec9830eb76131925143b2129c4bb01b37
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.10.0"
   collection:
     dependency: transitive
     description:
@@ -222,14 +222,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_lints:
-    dependency: "direct dev"
-    description:
-      name: flutter_lints
-      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -324,14 +316,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.6.1"
-  lints:
-    dependency: transitive
-    description:
-      name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.1"
   logging:
     dependency: transitive
     description:
@@ -368,10 +352,10 @@ packages:
     dependency: transitive
     description:
       name: mime
-      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      sha256: "2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   mockito:
     dependency: "direct dev"
     description:
@@ -453,10 +437,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: fc0da689e5302edb6177fdd964efcb7f58912f43c28c2047a808f5bfff643d16
+      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   source_helper:
     dependency: transitive
     description:
@@ -578,5 +562,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
+  dart: ">=3.2.0 <4.0.0"
   flutter: ">=3.0.0"


### PR DESCRIPTION
This is the role that should be used according to the JMAP specification. Closes #2894

In order not to break compatibility with current JAMES implementation (that uses incorrect `spam` role), this should be merged when `jmap-dart-client` [PR 89](https://github.com/linagora/jmap-dart-client/pull/89) has been merged.