### PR TITLE
TF-2930 Fix inline attachment lost in draft email

### DIFF
--- a/core/lib/presentation/utils/html_transformer/transform_configuration.dart
+++ b/core/lib/presentation/utils/html_transformer/transform_configuration.dart
@@ -46,7 +46,7 @@ class TransformConfiguration {
     const RemoveCollapsedSignatureButtonTransformer(),
   ]);
 
-  factory TransformConfiguration.forDraftsEmail() => TransformConfiguration.empty();
+  factory TransformConfiguration.forDraftsEmail() => TransformConfiguration.fromDomTransformers([const ImageTransformer()]);
 
   factory TransformConfiguration.forPreviewEmailOnWeb() => TransformConfiguration.create(
     customDomTransformers: [

--- a/lib/features/composer/domain/usecases/save_composer_cache_on_web_interactor.dart
+++ b/lib/features/composer/domain/usecases/save_composer_cache_on_web_interactor.dart
@@ -5,7 +5,7 @@ import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:tmail_ui_user/features/composer/domain/repository/composer_repository.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/create_email_request.dart';
-import 'package:tmail_ui_user/features/composer/presentation/model/screen_display_mode.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/save_composer_cache_state.dart';
 
@@ -22,18 +22,18 @@ class SaveComposerCacheOnWebInteractor {
     CreateEmailRequest createEmailRequest,
     AccountId accountId,
     UserName userName,
-    {required ScreenDisplayMode displayMode}
   ) async {
     try {
       final emailCreated = await _composerRepository.generateEmail(createEmailRequest);
-      final identity = createEmailRequest.identity;
       await _composerCacheRepository.saveComposerCacheOnWeb(
-        emailCreated,
         accountId: accountId,
         userName: userName,
-        displayMode: displayMode,
-        identity: identity,
-        readReceipentEnabled: createEmailRequest.isRequestReadReceipt);
+        composerCache: ComposerCache(
+          email: emailCreated,
+          identity: createEmailRequest.identity,
+          hasRequestReadReceipt: createEmailRequest.hasRequestReadReceipt,
+          displayMode: createEmailRequest.displayMode
+        ));
       return Right(SaveComposerCacheSuccess());
     } catch (exception) {
       return Left(SaveComposerCacheFailure(exception));

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -219,7 +219,6 @@ class ComposerController extends BaseController with DragDropFileMixin implement
     createFocusNodeInput();
     scrollControllerEmailAddress.addListener(_scrollControllerEmailAddressListener);
     _listenStreamEvent();
-    _getAlwaysReadReceiptSetting();
     _beforeReconnectManager.addListener(onBeforeReconnect);
   }
 
@@ -427,8 +426,7 @@ class ComposerController extends BaseController with DragDropFileMixin implement
     await _saveComposerCacheOnWebInteractor.execute(
       createEmailRequest,
       mailboxDashBoardController.accountId.value!,
-      mailboxDashBoardController.sessionCurrent!.username,
-      displayMode: screenDisplayMode.value);
+      mailboxDashBoardController.sessionCurrent!.username);
   }
 
   Future<CreateEmailRequest?> _generateCreateEmailRequest() async {
@@ -452,7 +450,7 @@ class ComposerController extends BaseController with DragDropFileMixin implement
       toRecipients: listToEmailAddress.toSet(),
       ccRecipients: listCcEmailAddress.toSet(),
       bccRecipients: listBccEmailAddress.toSet(),
-      isRequestReadReceipt: hasRequestReadReceipt.value,
+      hasRequestReadReceipt: hasRequestReadReceipt.value,
       identity: identitySelected.value,
       attachments: uploadController.attachmentsUploaded,
       inlineAttachments: uploadController.mapInlineAttachments,
@@ -464,7 +462,8 @@ class ComposerController extends BaseController with DragDropFileMixin implement
       unsubscribeEmailId: composerArguments.value!.previousEmailId,
       messageId: composerArguments.value!.messageId,
       references: composerArguments.value!.references,
-      emailSendingQueue: composerArguments.value!.sendingEmail
+      emailSendingQueue: composerArguments.value!.sendingEmail,
+      displayMode: screenDisplayMode.value
     );
   }
 
@@ -668,8 +667,6 @@ class ComposerController extends BaseController with DragDropFileMixin implement
             accountId: accountId,
             downloadUrl: downloadUrl
           );
-
-          hasRequestReadReceipt.value = arguments.readRecepientEnabled ?? false;
           break;
         case EmailActionType.composeFromUnsubscribeMailtoLink:
           if (arguments.subject != null) {
@@ -686,6 +683,13 @@ class ComposerController extends BaseController with DragDropFileMixin implement
           break;
         default:
           break;
+      }
+
+      if (composerArguments.value?.emailActionType == EmailActionType.reopenComposerBrowser) {
+        log('ComposerController::_initEmail: hasRequestReadReceipt = ${arguments.hasRequestReadReceipt}');
+        hasRequestReadReceipt.value = arguments.hasRequestReadReceipt ?? false;
+      } else {
+        _getAlwaysReadReceiptSetting();
       }
     }
   }
@@ -985,7 +989,7 @@ class ComposerController extends BaseController with DragDropFileMixin implement
           toRecipients: listToEmailAddress.toSet(),
           ccRecipients: listCcEmailAddress.toSet(),
           bccRecipients: listBccEmailAddress.toSet(),
-          isRequestReadReceipt: hasRequestReadReceipt.value,
+          hasRequestReadReceipt: hasRequestReadReceipt.value,
           identity: identitySelected.value,
           attachments: uploadController.attachmentsUploaded,
           inlineAttachments: uploadController.mapInlineAttachments,
@@ -998,7 +1002,8 @@ class ComposerController extends BaseController with DragDropFileMixin implement
           unsubscribeEmailId: composerArguments.value!.previousEmailId,
           messageId: composerArguments.value!.messageId,
           references: composerArguments.value!.references,
-          emailSendingQueue: composerArguments.value!.sendingEmail
+          emailSendingQueue: composerArguments.value!.sendingEmail,
+          displayMode: screenDisplayMode.value
         ),
         createNewAndSendEmailInteractor: _createNewAndSendEmailInteractor,
         onCancelSendingEmailAction: _handleCancelSendingMessage,
@@ -2104,6 +2109,7 @@ class ComposerController extends BaseController with DragDropFileMixin implement
   }
 
   void _getAlwaysReadReceiptSetting() {
+    log('ComposerController::_getAlwaysReadReceiptSetting:');
     final accountId = mailboxDashBoardController.accountId.value;
     if (accountId != null) {
       consumeState(_getAlwaysReadReceiptSettingInteractor.execute(accountId));
@@ -2220,7 +2226,7 @@ class ComposerController extends BaseController with DragDropFileMixin implement
           toRecipients: listToEmailAddress.toSet(),
           ccRecipients: listCcEmailAddress.toSet(),
           bccRecipients: listBccEmailAddress.toSet(),
-          isRequestReadReceipt: hasRequestReadReceipt.value,
+          hasRequestReadReceipt: hasRequestReadReceipt.value,
           identity: identitySelected.value,
           attachments: uploadController.attachmentsUploaded,
           inlineAttachments: uploadController.mapInlineAttachments,
@@ -2231,7 +2237,8 @@ class ComposerController extends BaseController with DragDropFileMixin implement
           unsubscribeEmailId: composerArguments.value!.previousEmailId,
           messageId: composerArguments.value!.messageId,
           references: composerArguments.value!.references,
-          emailSendingQueue: composerArguments.value!.sendingEmail
+          emailSendingQueue: composerArguments.value!.sendingEmail,
+          displayMode: screenDisplayMode.value
         ),
         createNewAndSaveEmailToDraftsInteractor: _createNewAndSaveEmailToDraftsInteractor,
         onCancelSavingEmailToDraftsAction: _handleCancelSavingMessageToDrafts,

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -625,6 +625,10 @@ class ComposerController extends BaseController with DragDropFileMixin implement
             presentationEmail: arguments.presentationEmail!,
             actionType: arguments.emailActionType
           );
+          _initAttachmentsAndInlineImages(
+            attachments: arguments.attachments,
+            inlineImages: arguments.inlineImages);
+
           _transformHtmlEmailContent(arguments.emailContents);
           break;
         case EmailActionType.forward:

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -326,9 +326,7 @@ class ComposerController extends BaseController with DragDropFileMixin implement
 
   void _updateEditorContent(RestoreEmailInlineImagesSuccess success) {
     richTextWebController?.editorController.setText(success.emailContent);
-    consumeState(Stream.value(Right(GetEmailContentSuccess(
-      htmlEmailContent: success.emailContent,
-      attachments: []))));
+    consumeState(Stream.value(Right(GetEmailContentSuccess(htmlEmailContent: success.emailContent))));
   }
 
   @override
@@ -582,6 +580,12 @@ class ComposerController extends BaseController with DragDropFileMixin implement
             presentationEmail: arguments.sendingEmail!.presentationEmail,
             actionType: EmailActionType.editSendingEmail
           );
+          final allAttachments = arguments.sendingEmail!.email.allAttachments;
+          _initAttachmentsAndInlineImages(
+            attachments: allAttachments.getListAttachmentsDisplayedOutside(
+              arguments.sendingEmail!.email.htmlBodyAttachments),
+            inlineImages: allAttachments.listAttachmentsDisplayedInContent);
+
           _getEmailContentFromSendingEmail(arguments.sendingEmail!);
           _emailIdEditing = arguments.sendingEmail!.presentationEmail.id!;
           break;
@@ -628,7 +632,9 @@ class ComposerController extends BaseController with DragDropFileMixin implement
             presentationEmail: arguments.presentationEmail!,
             actionType: arguments.emailActionType
           );
-          _initAttachments(arguments.attachments ?? []);
+          _initAttachmentsAndInlineImages(
+            attachments: arguments.attachments,
+            inlineImages: arguments.inlineImages);
           _transformHtmlEmailContent(arguments.emailContents);
           break;
         case EmailActionType.reopenComposerBrowser:
@@ -644,9 +650,9 @@ class ComposerController extends BaseController with DragDropFileMixin implement
             presentationEmail: arguments.presentationEmail!,
             actionType: EmailActionType.reopenComposerBrowser
           );
-          _initAttachments(
-            arguments.attachments ?? [],
-            inlineAttachments: arguments.inlineImages);
+          _initAttachmentsAndInlineImages(
+            attachments: arguments.attachments,
+            inlineImages: arguments.inlineImages);
 
           final accountId = mailboxDashBoardController.accountId.value;
           final downloadUrl = mailboxDashBoardController.sessionCurrent
@@ -690,13 +696,16 @@ class ComposerController extends BaseController with DragDropFileMixin implement
     subjectEmailInputController.text = newSubject;
   }
 
-  void _initAttachments(List<Attachment> attachments, {List<Attachment>? inlineAttachments}) {
-    if (attachments.isNotEmpty) {
-      initialAttachments = attachments;
+  void _initAttachmentsAndInlineImages({
+    List<Attachment>? attachments,
+    List<Attachment>? inlineImages
+  }) {
+    if (attachments?.isNotEmpty == true) {
+      initialAttachments = attachments!;
       uploadController.initializeUploadAttachments(attachments);
     }
-    if (inlineAttachments != null) {
-      uploadController.initializeUploadInlineAttachments(inlineAttachments);
+    if (inlineImages?.isNotEmpty == true) {
+      uploadController.initializeUploadInlineAttachments(inlineImages!);
     }
   }
 
@@ -1323,7 +1332,6 @@ class ComposerController extends BaseController with DragDropFileMixin implement
     consumeState(Stream.value(
       Right(GetEmailContentSuccess(
         htmlEmailContent: sendingEmail.presentationEmail.emailContentList.asHtmlString,
-        attachments: sendingEmail.email.allAttachments,
         emailCurrent: sendingEmail.email
       ))
     ));
@@ -1346,32 +1354,17 @@ class ComposerController extends BaseController with DragDropFileMixin implement
   }
 
   void _getEmailContentFromContentShared(String content) {
-    consumeState(Stream.value(
-      Right(GetEmailContentSuccess(
-        htmlEmailContent: content,
-        attachments: [],
-      ))
-    ));
+    consumeState(Stream.value(Right(GetEmailContentSuccess(htmlEmailContent: content))));
   }
 
   void _getEmailContentFromMailtoUri(String content) {
     log('ComposerController::_getEmailContentFromMailtoUri:content: $content');
-    consumeState(Stream.value(
-      Right(GetEmailContentSuccess(
-        htmlEmailContent: content,
-        attachments: [],
-      ))
-    ));
+    consumeState(Stream.value(Right(GetEmailContentSuccess(htmlEmailContent: content))));
   }
 
   void _getEmailContentFromUnsubscribeMailtoLink(String content) {
     log('ComposerController::_getEmailContentFromUnsubscribeMailtoLink:content: $content');
-    consumeState(Stream.value(
-      Right(GetEmailContentSuccess(
-        htmlEmailContent: content,
-        attachments: [],
-      ))
-    ));
+    consumeState(Stream.value(Right(GetEmailContentSuccess(htmlEmailContent: content))));
   }
 
   void _getEmailContentFromEmailId({required EmailId emailId, bool isDraftEmail = false}) {
@@ -1389,12 +1382,16 @@ class ComposerController extends BaseController with DragDropFileMixin implement
   }
 
   void _getEmailContentOffLineSuccess(GetEmailContentFromCacheSuccess success) {
-    _initAttachments(success.attachments);
+    _initAttachmentsAndInlineImages(
+      attachments: success.attachments,
+      inlineImages: success.inlineImages);
     emailContentsViewState.value = Right(success);
   }
 
   void _getEmailContentSuccess(GetEmailContentSuccess success) {
-    _initAttachments(success.attachments);
+    _initAttachmentsAndInlineImages(
+      attachments: success.attachments,
+      inlineImages: success.inlineImages);
     emailContentsViewState.value = Right(success);
   }
 

--- a/lib/features/composer/presentation/extensions/create_email_request_extension.dart
+++ b/lib/features/composer/presentation/extensions/create_email_request_extension.dart
@@ -142,7 +142,7 @@ extension CreateEmailRequestExtension on CreateEmailRequest {
       attachments: newEmailAttachments.isNotEmpty
         ? newEmailAttachments
         : null,
-      headerMdn: isRequestReadReceipt
+      headerMdn: hasRequestReadReceipt
         ? { IndividualHeaderIdentifier.headerMdn: createMdnEmailAddress() }
         : null,
     );

--- a/lib/features/composer/presentation/model/create_email_request.dart
+++ b/lib/features/composer/presentation/model/create_email_request.dart
@@ -8,6 +8,7 @@ import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/email/attachment.dart';
 import 'package:model/email/email_action_type.dart';
+import 'package:tmail_ui_user/features/composer/presentation/model/screen_display_mode.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/model/sending_email.dart';
 
 class CreateEmailRequest with EquatableMixin {
@@ -17,7 +18,7 @@ class CreateEmailRequest with EquatableMixin {
   final EmailActionType emailActionType;
   final String subject;
   final String emailContent;
-  final bool isRequestReadReceipt;
+  final bool hasRequestReadReceipt;
   final Set<EmailAddress> fromSender;
   final Set<EmailAddress> toRecipients;
   final Set<EmailAddress> ccRecipients;
@@ -34,6 +35,7 @@ class CreateEmailRequest with EquatableMixin {
   final MessageIdsHeaderValue? messageId;
   final MessageIdsHeaderValue? references;
   final SendingEmail? emailSendingQueue;
+  final ScreenDisplayMode displayMode;
 
   CreateEmailRequest({
     required this.session,
@@ -45,7 +47,7 @@ class CreateEmailRequest with EquatableMixin {
     required this.toRecipients,
     required this.ccRecipients,
     required this.bccRecipients,
-    this.isRequestReadReceipt = true,
+    this.hasRequestReadReceipt = true,
     this.identity,
     this.attachments,
     this.inlineAttachments,
@@ -57,7 +59,8 @@ class CreateEmailRequest with EquatableMixin {
     this.unsubscribeEmailId,
     this.messageId,
     this.references,
-    this.emailSendingQueue
+    this.emailSendingQueue,
+    this.displayMode = ScreenDisplayMode.normal
   });
 
   @override
@@ -72,7 +75,7 @@ class CreateEmailRequest with EquatableMixin {
     ccRecipients,
     bccRecipients,
     identity,
-    isRequestReadReceipt,
+    hasRequestReadReceipt,
     attachments,
     inlineAttachments,
     outboxMailboxId,
@@ -83,6 +86,7 @@ class CreateEmailRequest with EquatableMixin {
     unsubscribeEmailId,
     references,
     references,
-    emailSendingQueue
+    emailSendingQueue,
+    displayMode,
   ];
 }

--- a/lib/features/composer/presentation/view/web/web_editor_view.dart
+++ b/lib/features/composer/presentation/view/web/web_editor_view.dart
@@ -7,6 +7,7 @@ import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
 import 'package:html_editor_enhanced/html_editor.dart';
 import 'package:model/email/email_action_type.dart';
+import 'package:tmail_ui_user/features/composer/domain/state/restore_email_inline_images_state.dart';
 import 'package:tmail_ui_user/features/composer/presentation/view/editor_view_mixin.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/web/web_editor_widget.dart';
 import 'package:tmail_ui_user/features/email/domain/state/get_email_content_state.dart';
@@ -102,7 +103,7 @@ class WebEditorView extends StatelessWidget with EditorViewMixin {
             onDragEnter: onDragEnter,
           ),
           (success) {
-            if (success is GetEmailContentLoading) {
+            if (success is GetEmailContentLoading || success is RestoringEmailInlineImages) {
               return const CupertinoLoadingWidget(padding: EdgeInsets.all(16.0));
             } else {
               var newContent = success is GetEmailContentSuccess

--- a/lib/features/composer/presentation/widgets/insert_image_loading_bar_widget.dart
+++ b/lib/features/composer/presentation/widgets/insert_image_loading_bar_widget.dart
@@ -4,7 +4,6 @@ import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/base/widget/circle_loading_widget.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/download_image_as_base64_state.dart';
-import 'package:tmail_ui_user/features/composer/domain/state/restore_email_inline_images_state.dart';
 import 'package:tmail_ui_user/features/upload/domain/state/attachment_upload_state.dart';
 
 class InsertImageLoadingBarWidget extends StatelessWidget {
@@ -38,9 +37,7 @@ class InsertImageLoadingBarWidget extends StatelessWidget {
     return viewState.fold(
       (failure) => const SizedBox.shrink(),
       (success) {
-        if (success is DownloadingImageAsBase64 ||
-            success is RestoringEmailInlineImages
-        ) {
+        if (success is DownloadingImageAsBase64) {
           return CircleLoadingWidget(padding: padding);
         } else {
           return const SizedBox.shrink();

--- a/lib/features/email/domain/extensions/detailed_email_extension.dart
+++ b/lib/features/email/domain/extensions/detailed_email_extension.dart
@@ -18,6 +18,7 @@ extension DetailedEmailExtension on DetailedEmail {
       emailContentPath: emailContentPath,
       messageId: messageId?.ids.toList(),
       references: references?.ids.toList(),
+      inlineImages: inlineImages?.toHiveCache(),
     );
   }
 
@@ -36,6 +37,7 @@ extension DetailedEmailExtension on DetailedEmail {
       emailContentPath: path,
       messageId: messageId,
       references: references,
+      inlineImages: inlineImages,
     );
   }
 }

--- a/lib/features/email/domain/extensions/detailed_email_hive_cache_extension.dart
+++ b/lib/features/email/domain/extensions/detailed_email_hive_cache_extension.dart
@@ -22,7 +22,8 @@ extension DetailedEmailHiveCacheExtension on DetailedEmailHiveCache {
         : null,
       references: references != null
         ? MessageIdsHeaderValue(references!.toSet())
-        : null
+        : null,
+      inlineImages: inlineImages?.toAttachment(),
     );
  }
 }

--- a/lib/features/email/domain/extensions/email_extension.dart
+++ b/lib/features/email/domain/extensions/email_extension.dart
@@ -14,7 +14,8 @@ extension EmailExtension on Email {
       keywords: keywords,
       htmlEmailContent: htmlEmailContent,
       messageId: messageId,
-      references: references
+      references: references,
+      inlineImages: allAttachments.listAttachmentsDisplayedInContent,
     );
   }
 }

--- a/lib/features/email/domain/model/detailed_email.dart
+++ b/lib/features/email/domain/model/detailed_email.dart
@@ -14,6 +14,7 @@ class DetailedEmail with EquatableMixin {
   final DateTime createdTime;
   final MessageIdsHeaderValue? messageId;
   final MessageIdsHeaderValue? references;
+  final List<Attachment>? inlineImages;
 
   DetailedEmail({
     required this.emailId,
@@ -25,6 +26,7 @@ class DetailedEmail with EquatableMixin {
     this.emailContentPath,
     this.messageId,
     this.references,
+    this.inlineImages,
   });
 
   @override
@@ -38,5 +40,6 @@ class DetailedEmail with EquatableMixin {
     emailContentPath,
     messageId,
     references,
+    inlineImages,
   ];
 }

--- a/lib/features/email/domain/state/get_email_content_state.dart
+++ b/lib/features/email/domain/state/get_email_content_state.dart
@@ -7,12 +7,14 @@ class GetEmailContentLoading extends LoadingState {}
 
 class GetEmailContentSuccess extends UIState {
   final String htmlEmailContent;
-  final List<Attachment> attachments;
+  final List<Attachment>? attachments;
+  final List<Attachment>? inlineImages;
   final Email? emailCurrent;
 
   GetEmailContentSuccess({
     required this.htmlEmailContent,
-    required this.attachments,
+    this.attachments,
+    this.inlineImages,
     this.emailCurrent
   });
 
@@ -20,18 +22,21 @@ class GetEmailContentSuccess extends UIState {
   List<Object?> get props => [
     htmlEmailContent,
     attachments,
+    inlineImages,
     emailCurrent
   ];
 }
 
 class GetEmailContentFromCacheSuccess extends UIState {
   final String htmlEmailContent;
-  final List<Attachment> attachments;
+  final List<Attachment>? attachments;
+  final List<Attachment>? inlineImages;
   final Email? emailCurrent;
 
   GetEmailContentFromCacheSuccess({
     required this.htmlEmailContent,
-    required this.attachments,
+    this.attachments,
+    this.inlineImages,
     this.emailCurrent
   });
 
@@ -39,6 +44,7 @@ class GetEmailContentFromCacheSuccess extends UIState {
   List<Object?> get props => [
     htmlEmailContent,
     attachments,
+    inlineImages,
     emailCurrent,
   ];
 }

--- a/lib/features/email/domain/usecases/get_email_content_interactor.dart
+++ b/lib/features/email/domain/usecases/get_email_content_interactor.dart
@@ -47,9 +47,11 @@ class GetEmailContentInteractor {
   ) async* {
     try {
       final email = await emailRepository.getEmailContent(session, accountId, emailId);
+      final listAttachments = email.allAttachments.getListAttachmentsDisplayedOutside(email.htmlBodyAttachments);
+      final listInlineImages = email.allAttachments.listAttachmentsDisplayedInContent;
 
       if (email.emailContentList.isNotEmpty) {
-        final mapCidImageDownloadUrl = email.attachmentsWithCid.toMapCidImageDownloadUrl(
+        final mapCidImageDownloadUrl = listInlineImages.toMapCidImageDownloadUrl(
           accountId: accountId,
           downloadUrl: baseDownloadUrl
         );
@@ -61,13 +63,15 @@ class GetEmailContentInteractor {
 
         yield Right<Failure, Success>(GetEmailContentSuccess(
           htmlEmailContent: newEmailContents.asHtmlString,
-          attachments: email.allAttachments.getListAttachmentsDisplayedOutside(email.htmlBodyAttachments),
+          attachments: listAttachments,
+          inlineImages: listInlineImages,
           emailCurrent: email
         ));
       } else {
         yield Right<Failure, Success>(GetEmailContentSuccess(
           htmlEmailContent: '',
-          attachments: email.allAttachments.getListAttachmentsDisplayedOutside(email.htmlBodyAttachments),
+          attachments: listAttachments,
+          inlineImages: listInlineImages,
           emailCurrent: email
         ));
       }
@@ -90,6 +94,7 @@ class GetEmailContentInteractor {
       yield Right<Failure, Success>(GetEmailContentFromCacheSuccess(
         htmlEmailContent: detailedEmail.htmlEmailContent ?? '',
         attachments: detailedEmail.attachments ?? [],
+        inlineImages: detailedEmail.inlineImages ?? [],
         emailCurrent: Email(
           id: emailId,
           headers: detailedEmail.headers,
@@ -121,6 +126,7 @@ class GetEmailContentInteractor {
       yield Right<Failure, Success>(GetEmailContentFromCacheSuccess(
         htmlEmailContent: detailedEmail.htmlEmailContent ?? '',
         attachments: detailedEmail.attachments ?? [],
+        inlineImages: detailedEmail.inlineImages ?? [],
         emailCurrent: Email(
           id: emailId,
           headers: detailedEmail.headers,

--- a/lib/features/email/domain/usecases/get_list_detailed_email_by_id_interator.dart
+++ b/lib/features/email/domain/usecases/get_list_detailed_email_by_id_interator.dart
@@ -57,7 +57,7 @@ class GetListDetailedEmailByIdInteractor {
 
     final listEmailContent = email.emailContentList;
     if (listEmailContent.isNotEmpty) {
-      final mapCidImageDownloadUrl = email.attachmentsWithCid.toMapCidImageDownloadUrl(
+      final mapCidImageDownloadUrl = email.allAttachments.listAttachmentsDisplayedInContent.toMapCidImageDownloadUrl(
         accountId: accountId,
         downloadUrl: baseDownloadUrl
       );

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -469,6 +469,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
         GetEmailContentSuccess(
           htmlEmailContent: emailLoaded.htmlContent,
           attachments: emailLoaded.attachments,
+          inlineImages: emailLoaded.inlineImages,
           emailCurrent: emailLoaded.emailCurrent
         )
       )));
@@ -501,22 +502,23 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
 
     currentEmailLoaded.value = EmailLoaded(
       htmlContent: success.htmlEmailContent,
-      attachments: List.of(success.attachments),
+      attachments: List.of(success.attachments ?? []),
+      inlineImages: List.of(success.inlineImages ?? []),
       emailCurrent: success.emailCurrent,
     );
     emailSupervisorController.pushEmailQueue(currentEmailLoaded.value!);
 
     if (success.emailCurrent?.id == currentEmail?.id) {
-      attachments.value = success.attachments;
+      attachments.value = success.attachments ?? [];
       attachmentsViewState.value = {
         for (var attachment in attachments.where((item) => item.blobId != null))
           attachment.blobId!: Right(IdleDownloadAttachmentForWeb())
       };
 
-      if (_canParseCalendarEvent(blobIds: success.attachments.calendarEventBlobIds)) {
+      if (_canParseCalendarEvent(blobIds: success.attachments?.calendarEventBlobIds ?? {})) {
         _parseCalendarEventAction(
           accountId: mailboxDashBoardController.accountId.value!,
-          blobIds: success.attachments.calendarEventBlobIds,
+          blobIds: success.attachments?.calendarEventBlobIds ?? {},
           emailContents: success.htmlEmailContent
         );
       } else {
@@ -545,22 +547,23 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
 
     currentEmailLoaded.value = EmailLoaded(
       htmlContent: success.htmlEmailContent,
-      attachments: List.of(success.attachments),
+      attachments: List.of(success.attachments ?? []),
+      inlineImages: List.of(success.inlineImages ?? []),
       emailCurrent: success.emailCurrent,
     );
     emailSupervisorController.pushEmailQueue(currentEmailLoaded.value!);
 
     if (success.emailCurrent?.id == currentEmail?.id) {
-      attachments.value = success.attachments;
+      attachments.value = success.attachments ?? [];
       attachmentsViewState.value = {
         for (var attachment in attachments.where((item) => item.blobId != null))
           attachment.blobId!: Right(IdleDownloadAttachmentForWeb())
       };
 
-      if (_canParseCalendarEvent(blobIds: success.attachments.calendarEventBlobIds)) {
+      if (_canParseCalendarEvent(blobIds: success.attachments?.calendarEventBlobIds ?? {})) {
         _parseCalendarEventAction(
           accountId: mailboxDashBoardController.accountId.value!,
-          blobIds: success.attachments.calendarEventBlobIds,
+          blobIds: success.attachments?.calendarEventBlobIds ?? {},
           emailContents: success.htmlEmailContent
         );
       } else {
@@ -1343,6 +1346,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
           ComposerArguments.replyEmail(
             presentationEmail: presentationEmail,
             content: currentEmailLoaded.value?.htmlContent ?? '',
+            inlineImages: currentEmailLoaded.value?.inlineImages ?? [],
             mailboxRole: presentationEmail.mailboxContain?.role,
             messageId: currentEmailLoaded.value?.emailCurrent?.messageId,
             references: currentEmailLoaded.value?.emailCurrent?.references,
@@ -1354,6 +1358,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
           ComposerArguments.replyAllEmail(
             presentationEmail: presentationEmail,
             content: currentEmailLoaded.value?.htmlContent ?? '',
+            inlineImages: currentEmailLoaded.value?.inlineImages ?? [],
             mailboxRole: presentationEmail.mailboxContain?.role,
             messageId: currentEmailLoaded.value?.emailCurrent?.messageId,
             references: currentEmailLoaded.value?.emailCurrent?.references,
@@ -1366,6 +1371,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
             presentationEmail: presentationEmail,
             content: currentEmailLoaded.value?.htmlContent ?? '',
             attachments: attachments,
+            inlineImages: currentEmailLoaded.value?.inlineImages ?? [],
             messageId: currentEmailLoaded.value?.emailCurrent?.messageId,
             references: currentEmailLoaded.value?.emailCurrent?.references,
           )

--- a/lib/features/email/presentation/model/composer_arguments.dart
+++ b/lib/features/email/presentation/model/composer_arguments.dart
@@ -28,7 +28,7 @@ class ComposerArguments extends RouterArguments {
   final List<Identity>? identities;
   final Identity? selectedIdentity;
   final List<Attachment>? inlineImages;
-  final bool? readRecepientEnabled;
+  final bool? hasRequestReadReceipt;
   final ScreenDisplayMode displayMode;
 
   ComposerArguments({
@@ -48,7 +48,7 @@ class ComposerArguments extends RouterArguments {
     this.identities,
     this.selectedIdentity,
     this.inlineImages,
-    this.readRecepientEnabled,
+    this.hasRequestReadReceipt,
     this.displayMode = ScreenDisplayMode.normal
   });
 
@@ -98,7 +98,7 @@ class ComposerArguments extends RouterArguments {
       attachments: composerCache.email?.allAttachments.getListAttachmentsDisplayedOutside(composerCache.email?.htmlBodyAttachments ?? []),
       selectedIdentity: composerCache.identity,
       inlineImages: composerCache.email?.allAttachments.listAttachmentsDisplayedInContent,
-      readRecepientEnabled: composerCache.readReceipentEnabled,
+      hasRequestReadReceipt: composerCache.hasRequestReadReceipt,
       displayMode: composerCache.displayMode,
     );
 
@@ -187,7 +187,12 @@ class ComposerArguments extends RouterArguments {
     body,
     messageId,
     references,
+    previousEmailId,
     identities,
+    selectedIdentity,
+    inlineImages,
+    hasRequestReadReceipt,
+    displayMode,
   ];
 
   ComposerArguments copyWith({
@@ -207,7 +212,7 @@ class ComposerArguments extends RouterArguments {
     List<Identity>? identities,
     Identity? selectedIdentity,
     List<Attachment>? inlineImages,
-    bool? readRecepientEnabled,
+    bool? hasRequestReadReceipt,
     ScreenDisplayMode? displayMode,
   }) {
     return ComposerArguments(
@@ -227,7 +232,7 @@ class ComposerArguments extends RouterArguments {
       identities: identities ?? this.identities,
       selectedIdentity: selectedIdentity ?? this.selectedIdentity,
       inlineImages: inlineImages ?? this.inlineImages,
-      readRecepientEnabled: readRecepientEnabled ?? this.readRecepientEnabled,
+      hasRequestReadReceipt: hasRequestReadReceipt ?? this.hasRequestReadReceipt,
       displayMode: displayMode ?? this.displayMode,
     );
   }

--- a/lib/features/email/presentation/model/composer_arguments.dart
+++ b/lib/features/email/presentation/model/composer_arguments.dart
@@ -95,11 +95,9 @@ class ComposerArguments extends RouterArguments {
       emailActionType: EmailActionType.reopenComposerBrowser,
       presentationEmail: composerCache.email?.toPresentationEmail(),
       emailContents: composerCache.email?.emailContentList.asHtmlString,
-      attachments: composerCache.email?.allAttachments
-        .where((attachment) => attachment.disposition != ContentDisposition.inline)
-        .toList(),
+      attachments: composerCache.email?.allAttachments.getListAttachmentsDisplayedOutside(composerCache.email?.htmlBodyAttachments ?? []),
       selectedIdentity: composerCache.identity,
-      inlineImages: composerCache.email?.attachmentsWithCid,
+      inlineImages: composerCache.email?.allAttachments.listAttachmentsDisplayedInContent,
       readRecepientEnabled: composerCache.readReceipentEnabled,
       displayMode: composerCache.displayMode,
     );
@@ -107,6 +105,7 @@ class ComposerArguments extends RouterArguments {
   factory ComposerArguments.replyEmail({
     required PresentationEmail presentationEmail,
     required String content,
+    required List<Attachment> inlineImages,
     Role? mailboxRole,
     MessageIdsHeaderValue? messageId,
     MessageIdsHeaderValue? references,
@@ -114,6 +113,7 @@ class ComposerArguments extends RouterArguments {
     emailActionType: EmailActionType.reply,
     presentationEmail: presentationEmail,
     emailContents: content,
+    inlineImages: inlineImages,
     mailboxRole: mailboxRole,
     messageId: messageId,
     references: references,
@@ -122,6 +122,7 @@ class ComposerArguments extends RouterArguments {
   factory ComposerArguments.replyAllEmail({
     required PresentationEmail presentationEmail,
     required String content,
+    required List<Attachment> inlineImages,
     Role? mailboxRole,
     MessageIdsHeaderValue? messageId,
     MessageIdsHeaderValue? references,
@@ -129,6 +130,7 @@ class ComposerArguments extends RouterArguments {
     emailActionType: EmailActionType.replyAll,
     presentationEmail: presentationEmail,
     emailContents: content,
+    inlineImages: inlineImages,
     mailboxRole: mailboxRole,
     messageId: messageId,
     references: references,
@@ -138,6 +140,7 @@ class ComposerArguments extends RouterArguments {
     required PresentationEmail presentationEmail,
     required String content,
     required List<Attachment> attachments,
+    required List<Attachment> inlineImages,
     MessageIdsHeaderValue? messageId,
     MessageIdsHeaderValue? references,
   }) => ComposerArguments(
@@ -145,6 +148,7 @@ class ComposerArguments extends RouterArguments {
     presentationEmail: presentationEmail,
     emailContents: content,
     attachments: attachments,
+    inlineImages: inlineImages,
     mailboxRole: presentationEmail.mailboxContain?.role,
     messageId: messageId,
     references: references,

--- a/lib/features/email/presentation/model/email_loaded.dart
+++ b/lib/features/email/presentation/model/email_loaded.dart
@@ -5,11 +5,13 @@ import 'package:model/email/attachment.dart';
 class EmailLoaded with EquatableMixin {
   final String htmlContent;
   final List<Attachment> attachments;
+  final List<Attachment> inlineImages;
   final Email? emailCurrent;
 
   EmailLoaded({
     required this.htmlContent,
     required this.attachments,
+    required this.inlineImages,
     this.emailCurrent,
   });
 
@@ -17,6 +19,7 @@ class EmailLoaded with EquatableMixin {
   List<Object?> get props => [
     htmlContent,
     attachments,
+    inlineImages,
     emailCurrent
   ];
 }

--- a/lib/features/mailbox_dashboard/data/datasource/session_storage_composer_datasource.dart
+++ b/lib/features/mailbox_dashboard/data/datasource/session_storage_composer_datasource.dart
@@ -1,22 +1,14 @@
 import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
-import 'package:jmap_dart_client/jmap/identities/identity.dart';
-import 'package:jmap_dart_client/jmap/mail/email/email.dart';
-import 'package:tmail_ui_user/features/composer/presentation/model/screen_display_mode.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
 
 abstract class SessionStorageComposerDatasource {
-  Future<void> saveComposerCacheOnWeb(
-    Email email,
-    {
-      required AccountId accountId,
-      required UserName userName,
-      required ScreenDisplayMode displayMode,
-      Identity? identity,
-      bool? readReceipentEnabled,
-    }
-  );
+  Future<void> saveComposerCacheOnWeb({
+    required AccountId accountId,
+    required UserName userName,
+    required ComposerCache composerCache,
+  });
 
   Future<ComposerCache> getComposerCacheOnWeb(
     AccountId accountId,

--- a/lib/features/mailbox_dashboard/data/datasource_impl/session_storage_composer_datasoure_impl.dart
+++ b/lib/features/mailbox_dashboard/data/datasource_impl/session_storage_composer_datasoure_impl.dart
@@ -1,13 +1,12 @@
 import 'dart:convert';
 import 'package:collection/collection.dart';
-import 'package:core/core.dart';
+import 'package:core/domain/exceptions/web_session_exception.dart';
+import 'package:core/presentation/utils/html_transformer/html_transform.dart';
+import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
-import 'package:jmap_dart_client/jmap/identities/identity.dart';
-import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:model/model.dart';
 import 'package:tmail_ui_user/features/caching/utils/cache_utils.dart';
-import 'package:tmail_ui_user/features/composer/presentation/model/screen_display_mode.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/session_storage_composer_datasource.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
 import 'package:tmail_ui_user/main/exceptions/exception_thrower.dart';
@@ -50,30 +49,18 @@ class SessionStorageComposerDatasourceImpl
   }
 
   @override
-  Future<void> saveComposerCacheOnWeb(
-    Email email,
-    {
-      required AccountId accountId,
-      required UserName userName,
-      required ScreenDisplayMode displayMode,
-      Identity? identity,
-      bool? readReceipentEnabled
-    }
-  ) async {
+  Future<void> saveComposerCacheOnWeb({
+    required AccountId accountId,
+    required UserName userName,
+    required ComposerCache composerCache,
+  }) async {
     return Future.sync(() {
       final composerCacheKey = TupleKey(
         EmailActionType.reopenComposerBrowser.name,
         accountId.asString,
         userName.value).toString();
       Map<String, String> entries = {
-        composerCacheKey: jsonEncode(
-          ComposerCache(
-            displayMode: displayMode,
-            email: email,
-            identity: identity,
-            readReceipentEnabled: readReceipentEnabled,
-          ).toJson()
-        )
+        composerCacheKey: jsonEncode(composerCache.toJson())
       };
       html.window.sessionStorage.addAll(entries);
     }).catchError(_exceptionThrower.throwException);

--- a/lib/features/mailbox_dashboard/data/model/composer_cache.dart
+++ b/lib/features/mailbox_dashboard/data/model/composer_cache.dart
@@ -1,44 +1,35 @@
 import 'package:equatable/equatable.dart';
 import 'package:jmap_dart_client/jmap/identities/identity.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:json_annotation/json_annotation.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/screen_display_mode.dart';
 
+part 'composer_cache.g.dart';
+
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class ComposerCache with EquatableMixin {
 
   final Email? email;
   final Identity? identity;
-  final bool? readReceipentEnabled;
+  final bool? hasRequestReadReceipt;
   final ScreenDisplayMode displayMode;
 
   ComposerCache({
-    required this.displayMode,
     this.email,
     this.identity,
-    this.readReceipentEnabled,
+    this.hasRequestReadReceipt,
+    this.displayMode = ScreenDisplayMode.normal
   });
+
+  factory ComposerCache.fromJson(Map<String, dynamic> json) => _$ComposerCacheFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ComposerCacheToJson(this);
 
   @override
   List<Object?> get props => [
     email,
     identity,
-    readReceipentEnabled
+    hasRequestReadReceipt,
+    displayMode
   ];
-
-  Map<String, dynamic> toJson() {
-    return <String, dynamic>{
-      'email': email?.toJson(),
-      'identity': identity?.toJson(),
-      'readReceipentEnabled': readReceipentEnabled,
-      'displayMode': displayMode.toJson()
-    };
-  }
-
-  factory ComposerCache.fromJson(Map<String, dynamic> map) {
-    return ComposerCache(
-      displayMode: ScreenDisplayMode.fromJson(map['displayMode'] ?? ''),
-      email: map['email'] != null ? Email.fromJson(map['email']) : null,
-      identity: map['identity'] != null ? Identity.fromJson(map['identity']) : null,
-      readReceipentEnabled: map['readReceipentEnabled'] as bool?
-    );
-  }
 }

--- a/lib/features/mailbox_dashboard/data/repository/composer_cache_repository_impl.dart
+++ b/lib/features/mailbox_dashboard/data/repository/composer_cache_repository_impl.dart
@@ -1,9 +1,6 @@
 import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
-import 'package:jmap_dart_client/jmap/identities/identity.dart';
-import 'package:jmap_dart_client/jmap/mail/email/email.dart';
-import 'package:tmail_ui_user/features/composer/presentation/model/screen_display_mode.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/session_storage_composer_datasource.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
@@ -28,23 +25,15 @@ class ComposerCacheRepositoryImpl extends ComposerCacheRepository {
   }
 
   @override
-  Future<void> saveComposerCacheOnWeb(
-    Email email,
-    {
-      required AccountId accountId,
-      required UserName userName,
-      required ScreenDisplayMode displayMode,
-      Identity? identity,
-      bool? readReceipentEnabled
-    }
-  ) {
+  Future<void> saveComposerCacheOnWeb({
+    required AccountId accountId,
+    required UserName userName,
+    required ComposerCache composerCache,
+  }) {
     return composerCacheDataSource.saveComposerCacheOnWeb(
-      email,
       accountId: accountId,
       userName: userName,
-      displayMode: displayMode,
-      identity: identity,
-      readReceipentEnabled: readReceipentEnabled);
+      composerCache: composerCache);
   }
 
   @override

--- a/lib/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart
+++ b/lib/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart
@@ -1,22 +1,14 @@
 import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
-import 'package:jmap_dart_client/jmap/identities/identity.dart';
-import 'package:jmap_dart_client/jmap/mail/email/email.dart';
-import 'package:tmail_ui_user/features/composer/presentation/model/screen_display_mode.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
 
 abstract class ComposerCacheRepository {
-  Future<void> saveComposerCacheOnWeb(
-    Email email,
-    {
-      required AccountId accountId,
-      required UserName userName,
-      required ScreenDisplayMode displayMode,
-      Identity? identity,
-      bool? readReceipentEnabled
-    }
-  );
+  Future<void> saveComposerCacheOnWeb({
+    required AccountId accountId,
+    required UserName userName,
+    required ComposerCache composerCache,
+  });
 
   Future<ComposerCache> getComposerCacheOnWeb(
     AccountId accountId,

--- a/lib/features/offline_mode/model/detailed_email_hive_cache.dart
+++ b/lib/features/offline_mode/model/detailed_email_hive_cache.dart
@@ -35,6 +35,9 @@ class DetailedEmailHiveCache extends HiveObject with EquatableMixin {
   @HiveField(7)
   final List<String>? references;
 
+  @HiveField(8)
+  final List<AttachmentHiveCache>? inlineImages;
+
   DetailedEmailHiveCache({
     required this.emailId,
     required this.timeSaved,
@@ -44,6 +47,7 @@ class DetailedEmailHiveCache extends HiveObject with EquatableMixin {
     this.keywords,
     this.messageId,
     this.references,
+    this.inlineImages,
   });
 
   @override
@@ -56,5 +60,6 @@ class DetailedEmailHiveCache extends HiveObject with EquatableMixin {
     keywords,
     messageId,
     references,
+    inlineImages,
   ];
 }

--- a/model/lib/extensions/email_extension.dart
+++ b/model/lib/extensions/email_extension.dart
@@ -151,8 +151,6 @@ extension EmailExtension on Email {
 
   List<Attachment> get allAttachments => attachments?.map((item) => item.toAttachment()).toList() ?? [];
 
-  List<Attachment> get attachmentsWithCid => allAttachments.where((attachment) => attachment.hasCid()).toList();
-
   PresentationMailbox? findMailboxContain(Map<MailboxId, PresentationMailbox> mapMailbox) {
     final newMailboxIds = mailboxIds;
     newMailboxIds?.removeWhere((key, value) => !value);

--- a/model/lib/extensions/list_attachment_extension.dart
+++ b/model/lib/extensions/list_attachment_extension.dart
@@ -33,7 +33,7 @@ extension ListAttachmentExtension on List<Attachment> {
     required String downloadUrl
   }) {
     final mapUrlDownloadCID = {
-      for (var attachment in listAttachmentsDisplayedInContent)
+      for (var attachment in this)
         attachment.cid! : attachment.getDownloadUrl(downloadUrl, accountId)
     };
     return mapUrlDownloadCID;


### PR DESCRIPTION
## Issue

#2930 

## Root cause

- Because unconverted `img` tag with source is `cid` to `base64`

## Resolved


https://github.com/user-attachments/assets/c8259f0d-70e5-455d-aba9-9a9afec1445a

