### PR TITLE
TF-2925 The message list not showed correctly when change mailbox very quick 

### DIFF
--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -553,7 +553,7 @@ class MailboxController extends BaseMailboxController with MailboxActionHandlerM
     BuildContext context,
     PresentationMailbox presentationMailboxSelected
   ) {
-    log('MailboxController::_handleOpenMailbox():MailboxName: ${presentationMailboxSelected.name}');
+    log('MailboxController::_handleOpenMailbox():MAILBOX_ID = ${presentationMailboxSelected.id.asString} | MAILBOX_NAME: ${presentationMailboxSelected.name?.name}');
     KeyboardUtils.hideKeyboard(context);
     mailboxDashBoardController.clearSelectedEmail();
     if (presentationMailboxSelected.id != mailboxDashBoardController.selectedMailbox.value?.id) {

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -586,13 +586,8 @@ class MailboxDashBoardController extends ReloadableController {
   }
 
   void setSelectedMailbox(PresentationMailbox? newPresentationMailbox) {
-    final previousMailbox = selectedMailbox.value;
-    if (previousMailbox == newPresentationMailbox) {
-      selectedMailbox.value = newPresentationMailbox;
-      selectedMailbox.refresh();
-    } else {
-      selectedMailbox.value = newPresentationMailbox;
-    }
+    log('MailboxDashBoardController::setSelectedMailbox: SELECTED_MAILBOX_ID = ${newPresentationMailbox?.id.asString} |  SELECTED_MAILBOX_NAME = ${newPresentationMailbox?.name?.name} | ');
+    selectedMailbox.value = newPresentationMailbox;
   }
 
   void setSelectedEmail(PresentationEmail? newPresentationEmail) {

--- a/lib/features/thread/domain/state/get_all_email_state.dart
+++ b/lib/features/thread/domain/state/get_all_email_state.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/email/presentation_email.dart';
 
 class RefreshAllEmailLoading extends LoadingState {}
@@ -10,11 +11,20 @@ class GetAllEmailLoading extends LoadingState {}
 class GetAllEmailSuccess extends UIState {
   final List<PresentationEmail> emailList;
   final State? currentEmailState;
+  final MailboxId? currentMailboxId;
 
-  GetAllEmailSuccess({required this.emailList, this.currentEmailState});
+  GetAllEmailSuccess({
+    required this.emailList,
+    this.currentEmailState,
+    this.currentMailboxId,
+  });
 
   @override
-  List<Object?> get props => [emailList, currentEmailState];
+  List<Object?> get props => [
+    emailList,
+    currentEmailState,
+    currentMailboxId,
+  ];
 }
 
 class GetAllEmailFailure extends FeatureFailure {

--- a/lib/features/thread/domain/state/refresh_changes_all_email_state.dart
+++ b/lib/features/thread/domain/state/refresh_changes_all_email_state.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/email/presentation_email.dart';
 
 class RefreshChangesAllEmailLoading extends LoadingState {}
@@ -8,11 +9,20 @@ class RefreshChangesAllEmailLoading extends LoadingState {}
 class RefreshChangesAllEmailSuccess extends UIState {
   final List<PresentationEmail> emailList;
   final State? currentEmailState;
+  final MailboxId? currentMailboxId;
 
-  RefreshChangesAllEmailSuccess({required this.emailList, this.currentEmailState});
+  RefreshChangesAllEmailSuccess({
+    required this.emailList,
+    this.currentEmailState,
+    this.currentMailboxId
+  });
 
   @override
-  List<Object?> get props => [emailList, currentEmailState];
+  List<Object?> get props => [
+    emailList,
+    currentEmailState,
+    currentMailboxId
+  ];
 }
 
 class RefreshChangesAllEmailFailure extends FeatureFailure {

--- a/lib/features/thread/domain/usecases/get_emails_in_mailbox_interactor.dart
+++ b/lib/features/thread/domain/usecases/get_emails_in_mailbox_interactor.dart
@@ -5,6 +5,7 @@ import 'package:jmap_dart_client/jmap/core/properties/properties.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/sort/comparator.dart';
 import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/email_filter.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/email_response.dart';
 import 'package:tmail_ui_user/features/thread/domain/repository/thread_repository.dart';
@@ -39,18 +40,25 @@ class GetEmailsInMailboxInteractor {
           emailFilter: emailFilter,
           propertiesCreated: propertiesCreated,
           propertiesUpdated: propertiesUpdated)
-        .map(_toGetEmailState);
+        .map((emailResponse) => _toGetEmailState(
+          emailResponse: emailResponse,
+          currentMailboxId: emailFilter?.mailboxId
+        ));
     } catch (e) {
       yield Left(GetAllEmailFailure(e));
     }
   }
 
-  Either<Failure, Success> _toGetEmailState(EmailsResponse emailResponse) {
+  Either<Failure, Success> _toGetEmailState({
+    required EmailsResponse emailResponse,
+    MailboxId? currentMailboxId,
+  }) {
     final presentationEmailList = emailResponse.emailList
       ?.map((email) => email.toPresentationEmail()).toList() ?? List.empty();
 
     return Right<Failure, Success>(GetAllEmailSuccess(
       emailList: presentationEmailList,
-      currentEmailState: emailResponse.state));
+      currentEmailState: emailResponse.state,
+      currentMailboxId: currentMailboxId));
   }
 }

--- a/lib/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor.dart
+++ b/lib/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor.dart
@@ -4,6 +4,7 @@ import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/properties/properties.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/sort/comparator.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/email_filter.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/email_response.dart';
 import 'package:tmail_ui_user/features/thread/domain/repository/thread_repository.dart';
@@ -39,18 +40,25 @@ class RefreshChangesEmailsInMailboxInteractor {
           propertiesCreated: propertiesCreated,
           propertiesUpdated: propertiesUpdated,
           emailFilter: emailFilter)
-        .map(_toGetEmailState);
+        .map((emailResponse) => _toGetEmailState(
+          emailResponse: emailResponse,
+          currentMailboxId: emailFilter?.mailboxId
+        ));
     } catch (e) {
       yield Left(RefreshChangesAllEmailFailure(e));
     }
   }
 
-  Either<Failure, Success> _toGetEmailState(EmailsResponse emailResponse) {
+  Either<Failure, Success> _toGetEmailState({
+    required EmailsResponse emailResponse,
+    MailboxId? currentMailboxId
+  }) {
     final presentationEmailList = emailResponse.emailList
       ?.map((email) => email.toPresentationEmail()).toList() ?? List.empty();
 
     return Right<Failure, Success>(RefreshChangesAllEmailSuccess(
       emailList: presentationEmailList,
-      currentEmailState: emailResponse.state));
+      currentEmailState: emailResponse.state,
+      currentMailboxId: currentMailboxId));
   }
 }

--- a/test/features/thread/domain/usecases/get_emails_in_mailbox_interactor_test.dart
+++ b/test/features/thread/domain/usecases/get_emails_in_mailbox_interactor_test.dart
@@ -87,7 +87,8 @@ void main() {
             EmailFixtures.email1.toPresentationEmail(),
             EmailFixtures.email2.toPresentationEmail()
           }.toList(),
-          currentEmailState: jmap.State('s1'))
+          currentEmailState: jmap.State('s1'),
+          currentMailboxId: MailboxFixtures.inboxMailbox.id)
         ),
         Right(GetAllEmailSuccess(
           emailList: {
@@ -97,7 +98,8 @@ void main() {
             EmailFixtures.email4.toPresentationEmail(),
             EmailFixtures.email5.toPresentationEmail(),
           }.toList(),
-          currentEmailState: jmap.State('s1'))
+          currentEmailState: jmap.State('s1'),
+          currentMailboxId: MailboxFixtures.inboxMailbox.id)
         )
       }));
     });

--- a/test/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor_test.dart
+++ b/test/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor_test.dart
@@ -80,7 +80,8 @@ void main() {
             EmailFixtures.email4.toPresentationEmail(),
             EmailFixtures.email5.toPresentationEmail(),
           }.toList(),
-          currentEmailState: jmap.State('s1'))
+          currentEmailState: jmap.State('s1'),
+          currentMailboxId: MailboxFixtures.inboxMailbox.id)
         )
       }));
     });


### PR DESCRIPTION
## Issue

#2925 

## Root cause

- Because `RefreshChangeEmail` executes before `GetAllEmail` but returns the following result. So the email list will not be updated correctly.

## Resolved

[demo.webm](https://github.com/user-attachments/assets/6455ebbf-27ce-4427-ae92-f207ac370ce0)

