### PR TITLE
TF-2517 Fix rename a folder with special characters, it does not show error message.

### DIFF
--- a/lib/features/base/base_mailbox_controller.dart
+++ b/lib/features/base/base_mailbox_controller.dart
@@ -38,6 +38,7 @@ import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_tree.d
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_tree_builder.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/model/verification/duplicate_name_validator.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/model/verification/empty_name_validator.dart';
+import 'package:tmail_ui_user/features/mailbox_creator/domain/model/verification/special_character_validator.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/state/verify_name_view_state.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/usecases/verify_name_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/presentation/extensions/validator_failure_extension.dart';
@@ -291,6 +292,7 @@ abstract class BaseMailboxController extends BaseController {
     return verifyNameInteractor.execute(newName, [
       EmptyNameValidator(),
       DuplicateNameValidator(listMailboxName),
+      SpecialCharacterValidator()
     ]).fold((failure) {
       if (failure is VerifyNameFailure) {
         return failure.getMessage(context, actions: mailboxActions);

--- a/lib/features/destination_picker/presentation/destination_picker_controller.dart
+++ b/lib/features/destination_picker/presentation/destination_picker_controller.dart
@@ -30,6 +30,7 @@ import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_node.d
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_tree_builder.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/model/verification/duplicate_name_validator.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/model/verification/empty_name_validator.dart';
+import 'package:tmail_ui_user/features/mailbox_creator/domain/model/verification/special_character_validator.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/state/verify_name_view_state.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/usecases/verify_name_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/presentation/extensions/validator_failure_extension.dart';
@@ -205,6 +206,7 @@ class DestinationPickerController extends BaseMailboxController {
       [
         EmptyNameValidator(),
         DuplicateNameValidator(listMailboxNameAsStringExist),
+        SpecialCharacterValidator()
       ]
     ).fold(
       (failure) {

--- a/lib/features/mailbox_creator/domain/extensions/mailbox_name_special_character_validator_extension.dart
+++ b/lib/features/mailbox_creator/domain/extensions/mailbox_name_special_character_validator_extension.dart
@@ -1,0 +1,15 @@
+
+extension MailboxNameSpecialCharacterValidatorExtension on String {
+  bool get isValid {
+    if (startsWith('#')) {
+      return false;
+    }
+
+    final forbiddenChars = RegExp(r'[%*\r\n]');
+    if (forbiddenChars.hasMatch(this)) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/lib/features/mailbox_creator/domain/extensions/name_validator_string_extension.dart
+++ b/lib/features/mailbox_creator/domain/extensions/name_validator_string_extension.dart
@@ -1,6 +1,0 @@
-
-extension NameValidatorStringExtension on String {
-  bool hasSpecialCharactersInName() {
-    return  RegExp(r'(?=.*?[#?!@$%^&*)(=+}{:;?/|\\><.,`~])').hasMatch(this);
-  }
-}

--- a/lib/features/mailbox_creator/domain/model/verification/special_character_validator.dart
+++ b/lib/features/mailbox_creator/domain/model/verification/special_character_validator.dart
@@ -1,8 +1,8 @@
-
-import 'package:core/core.dart';
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
 import 'package:dartz/dartz.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/exceptions/verify_name_exception.dart';
-import 'package:tmail_ui_user/features/mailbox_creator/domain/extensions/name_validator_string_extension.dart';
+import 'package:tmail_ui_user/features/mailbox_creator/domain/extensions/mailbox_name_special_character_validator_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/model/verification/new_name_request.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/model/verification/validator.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/state/verify_name_view_state.dart';
@@ -11,7 +11,7 @@ class SpecialCharacterValidator extends Validator<NewNameRequest> {
 
   @override
   Either<Failure, Success> validate(NewNameRequest value) {
-    if (value.value != null && value.value!.hasSpecialCharactersInName()) {
+    if (value.value != null && !value.value!.isValid) {
       return Left<Failure, Success>(VerifyNameFailure(const SpecialCharacterException()));
     } else {
       return Right<Failure, Success>(VerifyNameViewState());

--- a/lib/features/mailbox_creator/presentation/mailbox_creator_controller.dart
+++ b/lib/features/mailbox_creator/presentation/mailbox_creator_controller.dart
@@ -13,6 +13,7 @@ import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_node.d
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_tree.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/model/verification/duplicate_name_validator.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/model/verification/empty_name_validator.dart';
+import 'package:tmail_ui_user/features/mailbox_creator/domain/model/verification/special_character_validator.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/state/verify_name_view_state.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/usecases/verify_name_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/presentation/extensions/validator_failure_extension.dart';
@@ -122,6 +123,7 @@ class MailboxCreatorController extends BaseController {
           if (canCheckNameString)
             EmptyNameValidator(),
           DuplicateNameValidator(listMailboxNameAsStringExist),
+          SpecialCharacterValidator()
         ]
     ).fold(
       (failure) {

--- a/test/features/mailbox/presentation/utils/mailbox_name_special_character_validator_test.dart
+++ b/test/features/mailbox/presentation/utils/mailbox_name_special_character_validator_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/mailbox_creator/domain/extensions/mailbox_name_special_character_validator_extension.dart';
+
+void main() {
+  group('isValid::test', () {
+
+    test('should return true for a valid string', () {
+      expect('hello'.isValid, isTrue);
+    });
+
+    test('should return false for a string starting with #', () {
+      expect('#hello'.isValid, isFalse);
+    });
+
+    test('should return false for a string containing %', () {
+      expect('hello%world'.isValid, isFalse);
+    });
+
+    test('should return false for a string containing *', () {
+      expect('hello*world'.isValid, isFalse);
+    });
+
+    test('should return false for a string containing \\n', () {
+      expect('hello\nworld'.isValid, isFalse);
+    });
+
+    test('should return false for a string containing \\r', () {
+      expect('hello\rworld'.isValid, isFalse);
+    });
+
+    test('should return true for an empty string', () {
+      expect(''.isValid, isTrue);
+    });
+
+    test('should return true for a string with no forbidden characters and not starting with #', () {
+      expect('validString123'.isValid, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Issue 

#2517 

## Mailbox special characters validation

- Does not contain one of the forbidden characters `%*\r\n` or start with `#`

## Resolved


https://github.com/user-attachments/assets/17852f72-6a88-411d-990e-9998f97ade50

