### PR TITLE
[Hotfix] Email list auto reload again when perform some actions email (Mark as read/star,..)

### DIFF
--- a/lib/features/email/presentation/action/email_ui_action.dart
+++ b/lib/features/email/presentation/action/email_ui_action.dart
@@ -1,5 +1,6 @@
 
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
+import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:tmail_ui_user/features/base/action/ui_action.dart';
 
 class EmailUIAction extends UIAction {
@@ -9,6 +10,15 @@ class EmailUIAction extends UIAction {
 
   @override
   List<Object?> get props => [];
+}
+
+class GetAllEmailAction extends EmailUIAction {
+  final PresentationMailbox? selectedMailbox;
+
+  GetAllEmailAction(this.selectedMailbox);
+
+  @override
+  List<Object?> get props => [selectedMailbox];
 }
 
 class RefreshChangeEmailAction extends EmailUIAction {

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -588,6 +588,9 @@ class MailboxDashBoardController extends ReloadableController with UserSettingPo
 
   void setSelectedMailbox(PresentationMailbox? newPresentationMailbox) {
     log('MailboxDashBoardController::setSelectedMailbox: SELECTED_MAILBOX_ID = ${newPresentationMailbox?.id.asString} |  SELECTED_MAILBOX_NAME = ${newPresentationMailbox?.name?.name} | ');
+    if (selectedMailbox.value?.id != newPresentationMailbox?.id) {
+      dispatchEmailUIAction(GetAllEmailAction(newPresentationMailbox));
+    }
     selectedMailbox.value = newPresentationMailbox;
   }
 


### PR DESCRIPTION
## Issue

- Email list auto reload again when perform some actions email (Mark as read/star,..)


https://github.com/user-attachments/assets/8aabd7ac-0c9d-4b59-b5b5-0d70d7056c16



## Root cause

- Because every time we perform an action with email, we will refresh the mailbox list. On the other hand, we always reset the value for the currently selected mailbox, which leads to it always calling the `getAllEmail` function.

<img width="560" alt="Screenshot 2024-08-05 at 19 13 52" src="https://github.com/user-attachments/assets/05d1ced5-7958-481c-9206-90ae86bdf1fd">


## Solution

We will check if the current mailbox is selected then only update that mailbox but not call the function to get the email list again. Switch the `SelectedMailbox` listener to `EmailUIAction` to perform the call to `getAllEmail`


## Resolved


https://github.com/user-attachments/assets/1884dc29-0ce2-41ae-85d1-6247e021dde4




