### PR TITLE
[HOT-FIX] Cannot display mailbox name when edit rule filter

### DIFF
--- a/lib/features/rules_filter_creator/presentation/rules_filter_creator_controller.dart
+++ b/lib/features/rules_filter_creator/presentation/rules_filter_creator_controller.dart
@@ -271,7 +271,7 @@ class RulesFilterCreatorController extends BaseMailboxController {
       final spamMailboxId = findMailboxNodeByRole(PresentationMailbox.roleJunk)?.item.id
         ?? findMailboxNodeByRole(PresentationMailbox.roleSpam)?.item.id;
       for (var mailboxId in mailboxIdsOfRule) {
-        if (mailboxId == spamMailboxId) {
+        if (mailboxId != spamMailboxId) {
           final mailboxNode = findMailboxNodeById(mailboxId);
           if (mailboxNode != null) {
             mailboxSelected.value = mailboxNode.item;


### PR DESCRIPTION
## Issue

Cannot display mailbox name when edit rule filter

![signal-2024-08-22-094520_002](https://github.com/user-attachments/assets/ee02775d-1c63-4364-938b-2a233f8caeb0)

## Root cause

- Side effect from PR #3049

## Resolved


https://github.com/user-attachments/assets/343d1715-29b4-4002-935a-d60636681938

