### PR TITLE
TF-3113 Fix cannot empty spam on mobile

### DIFF
--- a/lib/features/thread/data/network/thread_isolate_worker.dart
+++ b/lib/features/thread/data/network/thread_isolate_worker.dart
@@ -66,12 +66,13 @@ class ThreadIsolateWorker {
     EmptyMailboxFolderArguments args,
     TypeSendPort sendPort
   ) async {
-    final rootIsolateToken = args.isolateToken;
-    BackgroundIsolateBinaryMessenger.ensureInitialized(rootIsolateToken);
-    await HiveCacheConfig.instance.setUp();
-
-    List<EmailId> emailListCompleted = List.empty(growable: true);
     try {
+      final rootIsolateToken = args.isolateToken;
+      BackgroundIsolateBinaryMessenger.ensureInitialized(rootIsolateToken);
+      await HiveCacheConfig.instance.setUp();
+
+      List<EmailId> emailListCompleted = List.empty(growable: true);
+
       var hasEmails = true;
       Email? lastEmail;
 
@@ -104,11 +105,12 @@ class ThreadIsolateWorker {
           hasEmails = false;
         }
       }
+      log('ThreadIsolateWorker::_emptyMailboxFolderAction(): TOTAL_REMOVE: ${emailListCompleted.length}');
+      return emailListCompleted;
     } catch (e) {
-      log('ThreadIsolateWorker::_emptyMailboxFolderAction(): ERROR: $e');
+      logError('ThreadIsolateWorker::_emptyMailboxFolderAction(): ERROR: $e');
+      rethrow;
     }
-    log('ThreadIsolateWorker::_emptyMailboxFolderAction(): TOTAL_REMOVE: ${emailListCompleted.length}');
-    return emailListCompleted;
   }
 
   Future<List<EmailId>> _emptyMailboxFolderOnWeb(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/utils/app_logger.dart';
+import 'package:core/utils/build_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:get/get.dart';
@@ -22,7 +23,7 @@ void main() async {
     await Future.wait([
        MainBindings().dependencies(),
        HiveCacheConfig.instance.setUp(),
-       Executor().warmUp(),
+       Executor().warmUp(log: BuildUtils.isDebugMode),
        AppUtils.loadEnvFile()
     ]);
     await HiveCacheConfig.instance.initializeEncryptionKey();

--- a/lib/main/bindings/network/network_isolate_binding.dart
+++ b/lib/main/bindings/network/network_isolate_binding.dart
@@ -42,8 +42,8 @@ class NetworkIsolateBindings extends Bindings {
       tag: BindingTag.isolateTag);
     Get.put(const FlutterAppAuth(), tag: BindingTag.isolateTag);
     Get.put(AppAuthWebPlugin(), tag: BindingTag.isolateTag);
-    Get.put(AuthenticationClientBase(
-      tag: BindingTag.isolateTag),
+    Get.put(
+      AuthenticationClientBase(tag: BindingTag.isolateTag),
       tag: BindingTag.isolateTag);
   }
 

--- a/lib/main/bindings/network/network_isolate_binding.dart
+++ b/lib/main/bindings/network/network_isolate_binding.dart
@@ -1,17 +1,22 @@
 import 'package:core/core.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:dio/dio.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_appauth/flutter_appauth.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/http/http_client.dart';
 import 'package:tmail_ui_user/features/email/data/network/email_api.dart';
 import 'package:tmail_ui_user/features/login/data/local/account_cache_manager.dart';
+import 'package:tmail_ui_user/features/login/data/local/authentication_info_cache_manager.dart';
+import 'package:tmail_ui_user/features/login/data/local/oidc_configuration_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/local/token_oidc_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/network/authentication_client/authentication_client_base.dart';
 import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
+import 'package:tmail_ui_user/features/login/data/network/oidc_http_client.dart';
 import 'package:tmail_ui_user/features/login/data/utils/library_platform/app_auth_plugin/app_auth_plugin.dart';
+import 'package:tmail_ui_user/features/mailbox/data/local/mailbox_cache_manager.dart';
+import 'package:tmail_ui_user/features/mailbox/data/local/state_cache_manager.dart';
 import 'package:tmail_ui_user/features/mailbox/data/network/mailbox_isolate_worker.dart';
+import 'package:tmail_ui_user/features/push_notification/data/keychain/keychain_sharing_manager.dart';
 import 'package:tmail_ui_user/features/thread/data/network/thread_api.dart';
 import 'package:tmail_ui_user/features/thread/data/network/thread_isolate_worker.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
@@ -24,41 +29,57 @@ class NetworkIsolateBindings extends Bindings {
   @override
   void dependencies() {
     _bindingDio();
+    _bindingSharing();
+    _bindingInterceptors();
     _bindingApi();
     _bindingIsolateWorker();
   }
 
   void _bindingDio() {
-    final dio = Get.put(Dio(Get.find<BaseOptions>()), tag: BindingTag.isolateTag);
-    Get.put(DioClient(dio), tag: BindingTag.isolateTag);
+    Get.put(Dio(Get.find<BaseOptions>()), tag: BindingTag.isolateTag);
+    Get.put(DioClient(
+      Get.find<Dio>(tag: BindingTag.isolateTag)),
+      tag: BindingTag.isolateTag);
     Get.put(const FlutterAppAuth(), tag: BindingTag.isolateTag);
     Get.put(AppAuthWebPlugin(), tag: BindingTag.isolateTag);
-    Get.put(AuthenticationClientBase(tag: BindingTag.isolateTag), tag: BindingTag.isolateTag);
-    _bindingInterceptors(dio);
+    Get.put(AuthenticationClientBase(
+      tag: BindingTag.isolateTag),
+      tag: BindingTag.isolateTag);
   }
 
-  void _bindingInterceptors(Dio dio) {
+  void _bindingInterceptors() {
     Get.put(AuthorizationInterceptors(
-      dio,
+      Get.find<Dio>(tag: BindingTag.isolateTag),
       Get.find<AuthenticationClientBase>(tag: BindingTag.isolateTag),
       Get.find<TokenOidcCacheManager>(tag: BindingTag.isolateTag),
       Get.find<AccountCacheManager>(tag: BindingTag.isolateTag),
-      Get.find<IOSSharingManager>(),
+      Get.find<IOSSharingManager>(tag: BindingTag.isolateTag),
     ), tag: BindingTag.isolateTag);
-    dio.interceptors.add(Get.find<DynamicUrlInterceptors>());
-    dio.interceptors.add(Get.find<AuthorizationInterceptors>(tag: BindingTag.isolateTag));
-    if (kDebugMode) {
-      dio.interceptors.add(LogInterceptor(requestBody: true));
+    Get.find<Dio>(tag: BindingTag.isolateTag).interceptors
+      .add(Get.find<DynamicUrlInterceptors>());
+    Get.find<Dio>(tag: BindingTag.isolateTag).interceptors
+      .add(Get.find<AuthorizationInterceptors>(tag: BindingTag.isolateTag));
+    if (BuildUtils.isDebugMode) {
+      Get.find<Dio>(tag: BindingTag.isolateTag).interceptors
+        .add(LogInterceptor(requestBody: true));
     }
   }
 
   void _bindingApi() {
-    final httpClient = Get.put(HttpClient(Get.find<Dio>(tag: BindingTag.isolateTag)), tag: BindingTag.isolateTag);
-    Get.put(DownloadClient(Get.find<DioClient>(tag: BindingTag.isolateTag), Get.find<CompressFileUtils>()), tag: BindingTag.isolateTag);
-    Get.put(DownloadManager(Get.find<DownloadClient>(tag: BindingTag.isolateTag), Get.find<DeviceInfoPlugin>()), tag: BindingTag.isolateTag);
-    Get.put(ThreadAPI(httpClient), tag: BindingTag.isolateTag);
+    Get.put(HttpClient(
+      Get.find<Dio>(tag: BindingTag.isolateTag)),
+      tag: BindingTag.isolateTag);
+    Get.put(DownloadClient(
+      Get.find<DioClient>(tag: BindingTag.isolateTag),
+      Get.find<CompressFileUtils>()), tag: BindingTag.isolateTag);
+    Get.put(DownloadManager(
+      Get.find<DownloadClient>(tag: BindingTag.isolateTag),
+      Get.find<DeviceInfoPlugin>()), tag: BindingTag.isolateTag);
+    Get.put(ThreadAPI(
+      Get.find<HttpClient>(tag: BindingTag.isolateTag)),
+      tag: BindingTag.isolateTag);
     Get.put(EmailAPI(
-      httpClient,
+      Get.find<HttpClient>(tag: BindingTag.isolateTag),
       Get.find<DownloadManager>(tag: BindingTag.isolateTag),
       Get.find<DioClient>(tag: BindingTag.isolateTag),
       Get.find<Uuid>()
@@ -77,5 +98,20 @@ class NetworkIsolateBindings extends Bindings {
       Get.find<EmailAPI>(tag: BindingTag.isolateTag),
       Get.find<Executor>(),
     ));
+  }
+
+  void _bindingSharing() {
+    Get.put(OIDCHttpClient(
+      Get.find<DioClient>(tag: BindingTag.isolateTag)),
+      tag: BindingTag.isolateTag);
+    Get.put(IOSSharingManager(
+      Get.find<KeychainSharingManager>(),
+      Get.find<StateCacheManager>(),
+      Get.find<TokenOidcCacheManager>(),
+      Get.find<AuthenticationInfoCacheManager>(),
+      Get.find<OidcConfigurationCacheManager>(),
+      Get.find<OIDCHttpClient>(tag: BindingTag.isolateTag),
+      Get.find<MailboxCacheManager>(),
+    ), tag: BindingTag.isolateTag);
   }
 }


### PR DESCRIPTION
## Issue

#3113 

## Reproduced

[reproduced.webm](https://github.com/user-attachments/assets/41525a2b-c933-4bcb-9b5b-6a2d16f81e9d)

## Root cause

- [SendPort.send()](https://api.flutter.dev/flutter/dart-isolate/SendPort/send.html) of isolate flutter only supports some objects
- Network connection objects cannot be shared between isolates.

<img width="930" alt="Screenshot 2024-09-04 at 10 41 49" src="https://github.com/user-attachments/assets/70aa5cd4-6949-4efc-8455-2d472305db6f">

## Resolved

[demo-spam.webm](https://github.com/user-attachments/assets/c82868e1-95ea-4c62-b7e9-70cb8e71c685)




