### PR TITLE
Replace "!is" with "is!"

### DIFF
--- a/lib/features/base/reloadable/reloadable_controller.dart
+++ b/lib/features/base/reloadable/reloadable_controller.dart
@@ -89,7 +89,7 @@ abstract class ReloadableController extends BaseController {
   }
 
   void _handleGetSessionFailure(dynamic exception) {
-    if (currentContext != null && currentOverlayContext != null && exception !is BadCredentialsException) {
+    if (currentContext != null && currentOverlayContext != null && exception is! BadCredentialsException) {
       appToast.showToastErrorMessage(
         currentOverlayContext!,
         MessageToastUtils.getMessageByException(currentContext!, exception) ?? AppLocalizations.of(currentContext!).unknownError


### PR DESCRIPTION
In Dart, there is no operator `!is`. The intention was most likely to use `is!`.

In Dart, construction `!is` will perform a non-null assertion on the left operand (`!`) and then execute the `is` operator. So the code almost never behaves as expected.

At Sonar, we've implemented a rule for such issues: https://rules.sonarsource.com/dart/RSPEC-7054/

This is especially painful when you have Flutter & Kotlin in one project because Kotlin has `!is`.

Let me know if my suggestion makes sense to you.

You can also try to analyze your project on SonarCloud following this announcement: https://community.sonarsource.com/t/sonarcloud-supports-dart/124883