### PR TITLE
[HOT-FIX] operator not supported in dart

### DIFF
--- a/lib/features/base/reloadable/reloadable_controller.dart
+++ b/lib/features/base/reloadable/reloadable_controller.dart
@@ -128,7 +128,7 @@ abstract class ReloadableController extends BaseController {
   }
 
   void _handleGetSessionFailure(GetSessionFailure failure) {
-    if (failure.exception !is BadCredentialsException) {
+    if (failure.exception is! BadCredentialsException) {
       toastManager.showMessageFailure(failure);
     }
     clearDataAndGoToLoginPage();

--- a/test/main/utils/type_operator_test.dart
+++ b/test/main/utils/type_operator_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/main/exceptions/remote_exception.dart';
+
+bool isNotBadCredentialsExceptionUseIsNotOperator(dynamic exception) {
+  return exception is! BadCredentialsException;
+}
+
+bool isBadCredentialsExceptionUseIsOperator(dynamic exception) {
+  return exception is BadCredentialsException;
+}
+
+bool isBadCredentialsExceptionUseNotIsOperator(dynamic exception) {
+  return exception !is BadCredentialsException;
+}
+
+void main() {
+  group('is! operator unit test', () {
+    test('should return true when exception is not a BadCredentialsException', () {
+      // Arrange
+      const connectionError = ConnectionError();
+
+      // Act
+      final result = isNotBadCredentialsExceptionUseIsNotOperator(connectionError);
+
+      // Assert
+      expect(result, true);
+    });
+
+    test('should return false when exception is a BadCredentialsException', () {
+      // Arrange
+      const badCredentialsException = BadCredentialsException();
+
+      // Act
+      final result = isNotBadCredentialsExceptionUseIsNotOperator(badCredentialsException);
+
+      // Assert
+      expect(result, false);
+    });
+  });
+
+  group('is operator unit test', () {
+    test('should return true when exception is a BadCredentialsException', () {
+      // Arrange
+      const badCredentialsException = BadCredentialsException();
+
+      // Act
+      final result = isBadCredentialsExceptionUseIsOperator(badCredentialsException);
+
+      // Assert
+      expect(result, true);
+    });
+
+    test('should return false when exception is not a BadCredentialsException', () {
+      // Arrange
+      const connectionError = ConnectionError();
+
+      // Act
+      final result = isBadCredentialsExceptionUseIsOperator(connectionError);
+
+      // Assert
+      expect(result, false);
+    });
+  });
+
+  group('!is operator unit test', () {
+    test('should return true when exception is a BadCredentialsException', () {
+      // Arrange
+      const badCredentialsException = BadCredentialsException();
+
+      // Act
+      final result = isBadCredentialsExceptionUseNotIsOperator(badCredentialsException);
+
+      // Assert
+      expect(result, true);
+    });
+
+    test('should return false when exception is not a BadCredentialsException', () {
+      // Arrange
+      const connectionError = ConnectionError();
+
+      // Act
+      final result = isBadCredentialsExceptionUseNotIsOperator(connectionError);
+
+      // Assert
+      expect(result, false);
+    });
+  });
+}


### PR DESCRIPTION
## Issue

- https://github.com/linagora/tmail-flutter/pull/3139

## Root cause

- In Dart, there is no operator `!is`. Construction `!is` will perform a non-null assertion on the left operand (!) and then execute the is operator. So the code almost never behaves as expected.

## Documents 

- https://dart.dev/language/operators#type-test-operators