### PR TITLE
[HOT-FIX] Use specific version on `pub.dev` for `languagetool_textfield` dependency

### DIFF
--- a/contact/pubspec.lock
+++ b/contact/pubspec.lock
@@ -683,11 +683,10 @@ packages:
   languagetool_textfield:
     dependency: transitive
     description:
-      path: "."
-      ref: twake-supported
-      resolved-ref: f47dd9829e145acc795b4e3e62f8bc668135fcd6
-      url: "https://github.com/dab246/languagetool_textfield.git"
-    source: git
+      name: languagetool_textfield
+      sha256: "6b3d97445f1a82ff2cba39151cacebd3ef797c26aaeae0e13efcb1ffb89f1e80"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.1.0"
   leak_tracker:
     dependency: transitive

--- a/core/pubspec.lock
+++ b/core/pubspec.lock
@@ -651,11 +651,10 @@ packages:
   languagetool_textfield:
     dependency: "direct main"
     description:
-      path: "."
-      ref: twake-supported
-      resolved-ref: f47dd9829e145acc795b4e3e62f8bc668135fcd6
-      url: "https://github.com/dab246/languagetool_textfield.git"
-    source: git
+      name: languagetool_textfield
+      sha256: "6b3d97445f1a82ff2cba39151cacebd3ef797c26aaeae0e13efcb1ffb89f1e80"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.1.0"
   leak_tracker:
     dependency: transitive

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -26,14 +26,6 @@ dependencies:
   flutter:
     sdk: flutter
 
-  ### Dependencies from git ###
-  # TODO: We will change it when the PR in upstream repository will be merged
-  # https://github.com/solid-software/languagetool_textfield/pull/83
-  languagetool_textfield:
-    git:
-      url: https://github.com/dab246/languagetool_textfield.git
-      ref: twake-supported
-
   ### Dependencies from pub.dev ###
   cupertino_icons: 1.0.6
 
@@ -88,6 +80,8 @@ dependencies:
   fk_user_agent: 2.1.0
 
   flutter_charset_detector: 3.0.0
+
+  languagetool_textfield: 0.1.0
 
 dev_dependencies:
   flutter_test:

--- a/model/pubspec.lock
+++ b/model/pubspec.lock
@@ -675,11 +675,10 @@ packages:
   languagetool_textfield:
     dependency: transitive
     description:
-      path: "."
-      ref: twake-supported
-      resolved-ref: f47dd9829e145acc795b4e3e62f8bc668135fcd6
-      url: "https://github.com/dab246/languagetool_textfield.git"
-    source: git
+      name: languagetool_textfield
+      sha256: "6b3d97445f1a82ff2cba39151cacebd3ef797c26aaeae0e13efcb1ffb89f1e80"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.1.0"
   leak_tracker:
     dependency: transitive

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1267,11 +1267,10 @@ packages:
   languagetool_textfield:
     dependency: "direct main"
     description:
-      path: "."
-      ref: twake-supported
-      resolved-ref: f47dd9829e145acc795b4e3e62f8bc668135fcd6
-      url: "https://github.com/dab246/languagetool_textfield.git"
-    source: git
+      name: languagetool_textfield
+      sha256: "6b3d97445f1a82ff2cba39151cacebd3ef797c26aaeae0e13efcb1ffb89f1e80"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.1.0"
   leak_tracker:
     dependency: transitive

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -104,13 +104,6 @@ dependencies:
       url: https://github.com/linagora/flutter_pdf_render.git
       ref: main
 
-  # TODO: We will change it when the PR in upstream repository will be merged
-  # https://github.com/solid-software/languagetool_textfield/pull/83
-  languagetool_textfield:
-    git:
-      url: https://github.com/dab246/languagetool_textfield.git
-      ref: twake-supported
-
   ### Dependencies from pub.dev ###
   cupertino_icons: 1.0.6
 
@@ -247,6 +240,8 @@ dependencies:
   file_picker: 5.3.1
 
   app_settings: 5.1.1
+
+  languagetool_textfield: 0.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Issue

- PR [languagetool_textfield#83](https://github.com/solid-software/languagetool_textfield/pull/83) has been merged into the owner's main project.

<img width="919" alt="Screenshot 2024-09-19 at 12 03 27" src="https://github.com/user-attachments/assets/108128f9-d3f5-4e26-acc5-9dd9303741d0">
