### PR TITLE
TF-3173 [SEARCH] Fix `Sort by` is not set to default value when performing `Clear filter` in advanced search

### DIFF
--- a/lib/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart
@@ -83,6 +83,7 @@ class AdvancedFilterController extends BaseController {
     _resetAllToOriginalValue();
     _clearAllTextFieldInput();
     searchController.searchInputController.clear();
+    searchController.clearSortOrder();
     searchController.deactivateAdvancedSearch();
     searchController.isAdvancedSearchViewOpen.value = false;
     _mailboxDashBoardController.searchEmail(context);

--- a/lib/features/mailbox_dashboard/presentation/controller/search_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/search_controller.dart
@@ -286,7 +286,7 @@ class SearchController extends BaseController with DateRangePickerMixin {
     searchFocus.unfocus();
   }
   
-  void _clearSortOrder() {
+  void clearSortOrder() {
     sortOrderFiltered.value = EmailSortOrderType.mostRecent;
   }
 
@@ -295,7 +295,7 @@ class SearchController extends BaseController with DateRangePickerMixin {
     deactivateSimpleSearch();
     hideSimpleSearchFormView();
 
-    _clearSortOrder();
+    clearSortOrder();
     clearSearchFilter();
     deactivateAdvancedSearch();
     hideAdvancedSearchFormView();


### PR DESCRIPTION
## Issue

#3173

## Resolved


https://github.com/user-attachments/assets/b375679e-9fc1-421d-899d-537ff9192f4b

