### PR TITLE
Fix 3D links not work on mobile

### DIFF
--- a/core/lib/presentation/utils/html_transformer/dom/sanitize_hyper_link_tag_in_html_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/sanitize_hyper_link_tag_in_html_transformers.dart
@@ -18,6 +18,7 @@ class SanitizeHyperLinkTagInHtmlTransformer extends DomTransformer {
   }) async {
     final elements = document.querySelectorAll('a');
     await Future.wait(elements.map((element) async {
+      _sanitizeUrlResource(element);
       if (useTooltip) {
         _addToolTipWhenHoverLink(element);
       }
@@ -26,7 +27,7 @@ class SanitizeHyperLinkTagInHtmlTransformer extends DomTransformer {
     }));
   }
 
-  void _addToolTipWhenHoverLink(Element element) {
+  void _sanitizeUrlResource(Element element) {
     final url = element.attributes['href'] ?? '';
 
     final urlSanitized = _sanitizeUrl.process(url);
@@ -35,7 +36,10 @@ class SanitizeHyperLinkTagInHtmlTransformer extends DomTransformer {
     }
 
     element.attributes['href'] = urlSanitized;
+  }
 
+  void _addToolTipWhenHoverLink(Element element) {
+    final url = element.attributes['href'] ?? '';
     final text = element.text;
     final children = element.children;
     if (children.isEmpty && text.isNotEmpty) {


### PR DESCRIPTION
## Issue

This PR #2917 solved 3D links on web, but still not working on mobile.

[reproduce.webm](https://github.com/user-attachments/assets/e9b499c9-700b-408e-8eb0-c5c200c479f2)


## Root cause

- Because the value `useTooltip=true` is only true on the web. So `sanitizeUrl` only handle for web

## Solution

- Separate `sanitizeUrl` handling to apply to both mobile and web.
- Clear email cache avoid emails content being loaded from storage.

## Resolved

[demo.webm](https://github.com/user-attachments/assets/c0fd4438-9043-4bf2-aae5-07e43c270eec)



