### PR TITLE
TF-3247 [SEARCH] Fix Cc is displayed when clicking quick search results

### DIFF
--- a/lib/features/mailbox_dashboard/presentation/controller/search_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/search_controller.dart
@@ -20,6 +20,7 @@ import 'package:model/extensions/email_filter_condition_extension.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:tmail_ui_user/features/base/base_controller.dart';
 import 'package:tmail_ui_user/features/base/mixin/date_range_picker_mixin.dart';
+import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/model/recent_search.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/get_all_recent_search_latest_state.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/quick_search_email_state.dart';
@@ -30,7 +31,6 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/sear
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
-import 'package:tmail_ui_user/features/thread/domain/constants/thread_constants.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/search_state.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/search_status.dart';
@@ -97,7 +97,7 @@ class SearchController extends BaseController with DateRangePickerMixin {
         EmailComparator(EmailComparatorProperty.receivedAt)
           ..setIsAscending(false)),
       filter: _mappingToFilterOnSuggestionForm(userName: session.username, query: query),
-      properties: ThreadConstants.propertiesQuickSearch
+      properties: EmailUtils.getPropertiesForEmailGetMethod(session, accountId),
     ).then((result) => result.fold(
       (failure) => <PresentationEmail>[],
       (success) => success is QuickSearchEmailSuccess

--- a/lib/features/search/email/presentation/search_email_controller.dart
+++ b/lib/features/search/email/presentation/search_email_controller.dart
@@ -349,7 +349,7 @@ class SearchEmailController extends BaseController
           limit: UnsignedInt(5),
           sort: searchEmailFilter.value.sortOrderType.getSortOrder().toNullable(),
           filter: searchEmailFilter.value.mappingToEmailFilterCondition(),
-          properties: ThreadConstants.propertiesQuickSearch)
+          properties: EmailUtils.getPropertiesForEmailGetMethod(session, accountId))
         .then((result) => result.fold(
             (failure) => <PresentationEmail>[],
             (success) => success is QuickSearchEmailSuccess

--- a/lib/features/thread/domain/constants/thread_constants.dart
+++ b/lib/features/thread/domain/constants/thread_constants.dart
@@ -28,20 +28,6 @@ class ThreadConstants {
     EmailProperty.mailboxIds,
   });
 
-  static final propertiesQuickSearch = Properties({
-    EmailProperty.id,
-    EmailProperty.blobId,
-    EmailProperty.subject,
-    EmailProperty.from,
-    EmailProperty.to,
-    EmailProperty.keywords,
-    EmailProperty.receivedAt,
-    EmailProperty.sentAt,
-    EmailProperty.preview,
-    EmailProperty.hasAttachment,
-    EmailProperty.mailboxIds,
-  });
-
   static final propertiesGetEmailContent = Properties({
     EmailProperty.bodyValues,
     EmailProperty.htmlBody,


### PR DESCRIPTION
## Issue

#3247 

## Root cause

- Due to missing `Cc`property when passing in `Email/get` method

## Resolved


https://github.com/user-attachments/assets/3e46d7fb-eff6-4b6d-827c-7de443613979

