### PR TITLE
TF-3253 Fix body content is lost

### DIFF
--- a/core/lib/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart
@@ -19,6 +19,7 @@ class StandardizeHtmlSanitizingTransformers extends TextTransformer {
     'center',
     'style',
     'body',
+    'section',
   ];
 
   const StandardizeHtmlSanitizingTransformers();

--- a/core/test/utils/standardize_html_sanitizing_transformers_test.dart
+++ b/core/test/utils/standardize_html_sanitizing_transformers_test.dart
@@ -89,7 +89,7 @@ void main() {
       ];
 
       const listHTMLTags = [
-        'div', 'span', 'p', 'a', 'u', 'i', 'table'
+        'div', 'span', 'p', 'a', 'u', 'i', 'table', 'section'
       ];
 
       for (var tag in listHTMLTags) {


### PR DESCRIPTION
## Issue

#3253 

## Root cause

- The `section` tag of the html content is removed when sanitizing the html

## Solution

- Add the `section` tag to the list of tags allowed to appear in html

## Resolved


https://github.com/user-attachments/assets/a4b6bd07-81ed-4cc2-82a2-2b6a9ed8c821

