### PR TITLE
TF-3296 Fix [SEARCH] Can't apply the "Starred" filter in search

### DIFF
--- a/lib/features/mailbox_dashboard/presentation/controller/search_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/search_controller.dart
@@ -150,10 +150,15 @@ class SearchController extends BaseController with DateRangePickerMixin {
       }
     }
 
+    final listHasKeyword = listFilterOnSuggestionForm.contains(QuickSearchFilter.starred)
+      ? {KeyWordIdentifier.emailFlagged.value}
+      : null;
+
     updateFilterEmail(
       emailReceiveTimeTypeOption: Some(receiveTime),
       hasAttachmentOption: Some(hasAttachment),
-      fromOption: Some(listFromAddress)
+      fromOption: Some(listFromAddress),
+      hasKeywordOption: optionOf(listHasKeyword),
     );
 
     clearFilterSuggestion();


### PR DESCRIPTION
## Issue

#3296 

## Root cause

- The keyword `starred` was not added to the filter when performing a search.

## Resolved


https://github.com/user-attachments/assets/6a3d40c6-3bec-405f-a690-0ba46afdcff7

