### PR TITLE
Fix patrol test on Firebase Test Lab

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -100,5 +100,5 @@ dependencies {
     implementation 'androidx.work:work-runtime-ktx:2.7.0'
     implementation 'com.android.support:multidex:1.0.3'
     implementation 'androidx.window:window:1.0.0'
-    androidTestUtil "androidx.test:orchestrator:1.5.0"
+    androidTestUtil "androidx.test:orchestrator:1.5.1"
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1525,10 +1525,10 @@ packages:
     dependency: "direct dev"
     description:
       name: patrol
-      sha256: ef07b0022f6eabee77655a3cde2364ff57cf22c29018d524476e972a5476724f
+      sha256: "6ac5e239384282da389a6b78d68aa86d8760ad8d5481d665937c4eb586c0b3dc"
       url: "https://pub.dev"
     source: hosted
-    version: "3.11.1"
+    version: "3.11.0"
   patrol_finders:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -281,7 +281,7 @@ dev_dependencies:
 
   http_mock_adapter: 0.4.2
 
-  patrol: 3.11.1
+  patrol: 3.11.0
 
   plugin_platform_interface: 2.1.8
 


### PR DESCRIPTION
## Root cause
- Current `Patrol` version is `3.11.1`, fixing the issue of white space in test name for androidx test orchestrator 1.5.0 ([Patrol changelogs](https://pub.dev/packages/patrol/changelog))
- Androidx test orchestrator released version 1.5.1, which is to fix the same issue
- With `Patrol: 3.11.1`, our test cases now crash with https://github.com/leancodepl/patrol/issues/1725

## Solution
Revert `Patrol` back 1 patch to `3.11.0`, reverting the change `Patrol` tried to fix with Androidx test orchestrator 1.5.0

## Before
Currently we have 6 test cases, but only 2 is ran. The test crashed so the other 4 is discarded.

![Screenshot 2024-12-09 at 11 03 46](https://github.com/user-attachments/assets/66f9a282-fde9-4aec-93c5-c5de1a136b3c)

## After
All 6 test cases is ran.

![Screenshot 2024-12-09 at 11 03 58](https://github.com/user-attachments/assets/0ea8d300-c36d-4e58-839c-ae0af7027041)
