### PR TITLE
TF-3318 Fix black pixel when clicking on attachment with long name

### DIFF
--- a/lib/features/composer/presentation/widgets/attachment_item_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/attachment_item_composer_widget.dart
@@ -77,6 +77,7 @@ class AttachmentItemComposerWidget extends StatelessWidget with AppLoaderMixin {
                             maxLines: 1,
                             overflowWidget: const TextOverflowWidget(
                               position: TextOverflowPosition.middle,
+                              clearType: TextOverflowClearType.clipRect,
                               child: Text(
                                 '...',
                                 style: AttachmentItemComposerWidgetStyle.dotsLabelTextStyle,

--- a/lib/features/email/presentation/widgets/attachment_item_widget.dart
+++ b/lib/features/email/presentation/widgets/attachment_item_widget.dart
@@ -78,6 +78,7 @@ class AttachmentItemWidget extends StatelessWidget {
                           maxLines: 1,
                           overflowWidget: const TextOverflowWidget(
                             position: TextOverflowPosition.middle,
+                            clearType: TextOverflowClearType.clipRect,
                             child: Text(
                               "...",
                               style: AttachmentItemWidgetStyle.dotsLabelTextStyle,

--- a/lib/features/email/presentation/widgets/attachment_list/attachment_list_item_widget.dart
+++ b/lib/features/email/presentation/widgets/attachment_list/attachment_list_item_widget.dart
@@ -70,6 +70,7 @@ class AttachmentListItemWidget extends StatelessWidget {
                             maxLines: 1,
                             overflowWidget: const TextOverflowWidget(
                               position: TextOverflowPosition.middle,
+                              clearType: TextOverflowClearType.clipRect,
                               child: Text(
                                 "...",
                                 style: AttachmentListItemWidgetStyle.dotsLabelTextStyle,

--- a/lib/features/email/presentation/widgets/feedback_draggable_attachment_item_widget.dart
+++ b/lib/features/email/presentation/widgets/feedback_draggable_attachment_item_widget.dart
@@ -52,6 +52,7 @@ class FeedbackDraggableAttachmentItemWidget extends StatelessWidget {
                     maxLines: 1,
                     overflowWidget: const TextOverflowWidget(
                       position: TextOverflowPosition.middle,
+                      clearType: TextOverflowClearType.clipRect,
                       child: Text(
                         '...',
                         style: FeedbackDraggableAttachmentItemWidgetStyle.dotsLabelTextStyle,


### PR DESCRIPTION
## Issue
- #3318 

## Related
- https://github.com/flutter/flutter/issues/24466
- https://github.com/flutter/flutter/issues/112696#issuecomment-1826300932

## Demo

https://github.com/user-attachments/assets/8e8418d8-43da-4a61-99e9-39e62bea8d9e

