### PR TITLE
TF-3332 Prevent refresh when switching mailbox

### DIFF
--- a/lib/features/thread/data/repository/thread_repository_impl.dart
+++ b/lib/features/thread/data/repository/thread_repository_impl.dart
@@ -45,6 +45,7 @@ class ThreadRepositoryImpl extends ThreadRepository {
       EmailFilter? emailFilter,
       Properties? propertiesCreated,
       Properties? propertiesUpdated,
+      bool getLatestChanges = true,
     }
   ) async* {
     log('ThreadRepositoryImpl::getAllEmail(): filter = ${emailFilter?.mailboxId}');
@@ -92,7 +93,7 @@ class ThreadRepositoryImpl extends ThreadRepository {
       await _updateEmailCache(accountId, session.username, newCreated: networkEmailResponse.emailList);
     }
 
-    if (localEmailResponse.hasState()) {
+    if (localEmailResponse.hasState() && getLatestChanges) {
       log('ThreadRepositoryImpl::getAllEmail(): filter = ${emailFilter?.mailboxId} local has state: ${localEmailResponse.state}');
       await _synchronizeCacheWithChanges(
         session,

--- a/lib/features/thread/domain/repository/thread_repository.dart
+++ b/lib/features/thread/domain/repository/thread_repository.dart
@@ -25,6 +25,7 @@ abstract class ThreadRepository {
       EmailFilter? emailFilter,
       Properties? propertiesCreated,
       Properties? propertiesUpdated,
+      bool getLatestChanges = true,
     }
   );
 

--- a/lib/features/thread/domain/usecases/get_emails_in_mailbox_interactor.dart
+++ b/lib/features/thread/domain/usecases/get_emails_in_mailbox_interactor.dart
@@ -26,6 +26,7 @@ class GetEmailsInMailboxInteractor {
       EmailFilter? emailFilter,
       Properties? propertiesCreated,
       Properties? propertiesUpdated,
+      bool getLatestChanges = true,
     }
   ) async* {
     try {
@@ -39,7 +40,8 @@ class GetEmailsInMailboxInteractor {
           sort: sort,
           emailFilter: emailFilter,
           propertiesCreated: propertiesCreated,
-          propertiesUpdated: propertiesUpdated)
+          propertiesUpdated: propertiesUpdated,
+          getLatestChanges: getLatestChanges)
         .map((emailResponse) => _toGetEmailState(
           emailResponse: emailResponse,
           currentMailboxId: emailFilter?.mailboxId

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -262,7 +262,7 @@ class ThreadController extends BaseController with EmailActionController {
         _currentMemoryMailboxId = mailbox.id;
         consumeState(Stream.value(Right(GetAllEmailLoading())));
         _resetToOriginalValue();
-        _getAllEmailAction();
+        _getAllEmailAction(getLatestChanges: false);
       } else if (mailbox == null) { // disable current mailbox when search active
         _currentMemoryMailboxId = null;
         _resetToOriginalValue();
@@ -506,7 +506,7 @@ class ThreadController extends BaseController with EmailActionController {
     }
   }
 
-  void _getAllEmailAction() {
+  void _getAllEmailAction({bool getLatestChanges = true}) {
     log('ThreadController::_getAllEmailAction:');
     if (_session != null &&_accountId != null) {
       consumeState(_getEmailsInMailboxInteractor.execute(
@@ -521,6 +521,7 @@ class ThreadController extends BaseController with EmailActionController {
         ),
         propertiesCreated: EmailUtils.getPropertiesForEmailGetMethod(_session!, _accountId!),
         propertiesUpdated: ThreadConstants.propertiesUpdatedDefault,
+        getLatestChanges: getLatestChanges,
       ));
     } else {
       consumeState(Stream.value(Left(GetAllEmailFailure(NotFoundSessionException()))));

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -414,6 +414,7 @@ void main() {
         limit: anyNamed('limit'),
         sort: anyNamed('sort'),
         emailFilter: anyNamed('emailFilter'),
+        getLatestChanges: anyNamed('getLatestChanges'),
         propertiesCreated: anyNamed('propertiesCreated'),
         propertiesUpdated: anyNamed('propertiesUpdated')));
       expect(searchController.sortOrderFiltered, EmailSortOrderType.mostRecent);
@@ -426,6 +427,7 @@ void main() {
           filter: EmailFilterCondition(inMailbox: testMailboxId),
           filterOption: FilterMessageOption.all,
           mailboxId: testMailboxId),
+        getLatestChanges: false,
         propertiesCreated: ThreadConstants.propertiesDefault,
         propertiesUpdated: ThreadConstants.propertiesUpdatedDefault));
     });
@@ -471,6 +473,7 @@ void main() {
         limit: anyNamed('limit'),
         sort: anyNamed('sort'),
         emailFilter: anyNamed('emailFilter'),
+        getLatestChanges: anyNamed('getLatestChanges'),
         propertiesCreated: anyNamed('propertiesCreated'),
         propertiesUpdated: anyNamed('propertiesUpdated')));
       expect(searchController.sortOrderFiltered, EmailSortOrderType.mostRecent);
@@ -483,6 +486,7 @@ void main() {
           filter: EmailFilterCondition(inMailbox: testMailboxId),
           filterOption: FilterMessageOption.all,
           mailboxId: testMailboxId),
+        getLatestChanges: false,
         propertiesCreated: ThreadConstants.propertiesDefault,
         propertiesUpdated: ThreadConstants.propertiesUpdatedDefault
       )).called(1);

--- a/test/features/thread/data/repository/thread_repository_impl_test.dart
+++ b/test/features/thread/data/repository/thread_repository_impl_test.dart
@@ -1,0 +1,129 @@
+import 'package:core/data/model/source_type/data_source_type.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/mailbox/data/datasource/state_datasource.dart';
+import 'package:tmail_ui_user/features/thread/data/datasource/thread_datasource.dart';
+import 'package:tmail_ui_user/features/thread/data/model/email_change_response.dart';
+import 'package:tmail_ui_user/features/thread/data/repository/thread_repository_impl.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import '../../../../fixtures/session_fixtures.dart';
+import 'thread_repository_impl_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<ThreadDataSource>(),
+  MockSpec<StateDataSource>(),
+])
+void main() {
+  final threadDataSource = MockThreadDataSource();
+  final stateDataSource = MockStateDataSource();
+  final threadRepository = ThreadRepositoryImpl(
+    {
+      DataSourceType.network: threadDataSource,
+      DataSourceType.local: threadDataSource,
+    },
+    stateDataSource,
+  );
+
+  group('thread repository impl test:', () {
+    test(
+      'should not call threadDatasource.getChanges '
+      'when getAllEmail is called '
+      'and getLatestChanges is false',
+    () async {
+      // arrange
+      when(threadDataSource.getAllEmailCache(
+        any,
+        any,
+        filterOption: anyNamed('filterOption'),
+        inMailboxId: anyNamed('inMailboxId'),
+        limit: anyNamed('limit'),
+        sort: anyNamed('sort'),
+      )).thenAnswer(
+        (_) => Future.value(List.generate(30, (index) => Email(id: EmailId(Id('$index'))))),
+      );
+      when(stateDataSource.getState(
+        any,
+        any,
+        any,
+      )).thenAnswer((_) => Future.value(State('some-state')));
+      when(threadDataSource.getChanges(
+        any,
+        any,
+        any,
+        propertiesCreated: anyNamed('propertiesCreated'),
+        propertiesUpdated: anyNamed('propertiesUpdated'),
+      )).thenAnswer(
+        (_) => Future.value(EmailChangeResponse(hasMoreChanges: false)),
+      );
+      
+      // act
+      await threadRepository.getAllEmail(
+        SessionFixtures.aliceSession,
+        AccountFixtures.aliceAccountId,
+        getLatestChanges: false,
+      ).last;
+      
+      // assert
+      verifyNever(threadDataSource.getChanges(
+        any,
+        any,
+        any,
+        propertiesCreated: anyNamed('propertiesCreated'),
+        propertiesUpdated: anyNamed('propertiesUpdated'),
+      ));
+    });
+
+    test(
+      'should call threadDatasource.getChanges '
+      'when getAllEmail is called '
+      'and getLatestChanges is true',
+    () async {
+      // arrange
+      when(threadDataSource.getAllEmailCache(
+        any,
+        any,
+        filterOption: anyNamed('filterOption'),
+        inMailboxId: anyNamed('inMailboxId'),
+        limit: anyNamed('limit'),
+        sort: anyNamed('sort'),
+      )).thenAnswer(
+        (_) => Future.value(List.generate(30, (index) => Email(id: EmailId(Id('$index'))))),
+      );
+      when(stateDataSource.getState(
+        any,
+        any,
+        any,
+      )).thenAnswer((_) => Future.value(State('some-state')));
+      when(threadDataSource.getChanges(
+        any,
+        any,
+        any,
+        propertiesCreated: anyNamed('propertiesCreated'),
+        propertiesUpdated: anyNamed('propertiesUpdated'),
+      )).thenAnswer(
+        (_) => Future.value(EmailChangeResponse(hasMoreChanges: false)),
+      );
+      
+      // act
+      await threadRepository.getAllEmail(
+        SessionFixtures.aliceSession,
+        AccountFixtures.aliceAccountId,
+        getLatestChanges: true,
+      ).last;
+      
+      // assert
+      verify(threadDataSource.getChanges(
+        any,
+        any,
+        any,
+        propertiesCreated: anyNamed('propertiesCreated'),
+        propertiesUpdated: anyNamed('propertiesUpdated'),
+      ));
+    });
+  });
+}

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -43,6 +43,7 @@ import 'package:tmail_ui_user/features/thread/domain/usecases/refresh_changes_em
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_more_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/search_state.dart';
+import 'package:tmail_ui_user/features/thread/presentation/model/search_status.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
@@ -416,6 +417,56 @@ void main() {
         )).called(1);
         expect(mockMailboxDashBoardController.emailsInCurrentMailbox.isEmpty, isTrue);
         expect(mockMailboxDashBoardController.emailsInCurrentMailbox.length, equals(0));
+      });
+    });
+
+    group('_registerObxStreamListener test:', () {
+      test(
+        'should call _getEmailsInMailboxInteractor.execute with getLatestChanges is false '
+        'when mailboxDashBoardController.selectedMailbox updated',
+      () async {
+        // arrange
+        final mailboxBefore = PresentationMailbox(MailboxId(Id('mailbox-before-id')));
+        final mailboxAfter = PresentationMailbox(MailboxId(Id('mailbox-after-id')));
+        final selectedMailbox = Rxn(mailboxBefore);
+        when(mockMailboxDashBoardController.sessionCurrent).thenReturn(SessionFixtures.aliceSession);
+        when(mockMailboxDashBoardController.accountId).thenReturn(Rxn(AccountFixtures.aliceAccountId));
+        when(mockMailboxDashBoardController.selectedMailbox).thenReturn(selectedMailbox);
+        when(mockMailboxDashBoardController.searchController).thenReturn(mockSearchController);
+        when(mockMailboxDashBoardController.dashBoardAction).thenReturn(Rxn());
+        when(mockMailboxDashBoardController.emailUIAction).thenReturn(Rxn());
+        when(mockMailboxDashBoardController.viewState).thenReturn(Rx(Right(UIState.idle)));
+        when(mockMailboxDashBoardController.emailsInCurrentMailbox).thenReturn(RxList());
+        when(mockMailboxDashBoardController.listEmailSelected).thenReturn(RxList());
+        when(mockMailboxDashBoardController.currentSelectMode).thenReturn(Rx(SelectMode.INACTIVE));
+        when(mockMailboxDashBoardController.filterMessageOption).thenReturn(Rx(FilterMessageOption.all));
+        when(mockSearchController.searchState).thenReturn(SearchState(SearchStatus.INACTIVE).obs);
+        
+        // act
+        threadController.onInit();
+        mockMailboxDashBoardController.selectedMailbox.value = mailboxAfter;
+        await untilCalled(mockGetEmailsInMailboxInteractor.execute(
+          any,
+          any,
+          limit: anyNamed('limit'),
+          sort: anyNamed('sort'),
+          emailFilter: anyNamed('emailFilter'),
+          propertiesCreated: anyNamed('propertiesCreated'),
+          propertiesUpdated: anyNamed('propertiesUpdated'),
+          getLatestChanges: anyNamed('getLatestChanges'),
+        ));
+        
+        // assert
+        verify(mockGetEmailsInMailboxInteractor.execute(
+          any,
+          any,
+          limit: anyNamed('limit'),
+          sort: anyNamed('sort'),
+          emailFilter: anyNamed('emailFilter'),
+          propertiesCreated: anyNamed('propertiesCreated'),
+          propertiesUpdated: anyNamed('propertiesUpdated'),
+          getLatestChanges: false,
+        ));
       });
     });
   });

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -453,7 +453,7 @@ void main() {
           emailFilter: anyNamed('emailFilter'),
           propertiesCreated: anyNamed('propertiesCreated'),
           propertiesUpdated: anyNamed('propertiesUpdated'),
-          getLatestChanges: anyNamed('getLatestChanges'),
+          getLatestChanges: false,
         ));
         
         // assert


### PR DESCRIPTION
## Issue
- #3332 

## Should not call refresh when switching mailbox
### Demo condition
- https://github.com/linagora/tmail-flutter/pull/3357

### Web

https://github.com/user-attachments/assets/efcfd350-c05e-4490-a2eb-4cfe57e38389

### Mobile

https://github.com/user-attachments/assets/f301af91-a056-40a3-aee5-22089affb5e1

## Should fetch latest changes when open app
### Web

https://github.com/user-attachments/assets/86fefeed-fc97-40cd-97d8-23fb60a1c36c

### Mobile

https://github.com/user-attachments/assets/5c75360a-315f-45a1-8f92-83f308960dbf

