### PR TITLE
TF-3372 Fix [MU] Emptying trash: Many unnecessary `Email/query + Email/get` requests

### DIFF
--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -499,9 +499,7 @@ class ThreadController extends BaseController with EmailActionController {
     }
     canLoadMore = newListEmail.length >= ThreadConstants.maxCountEmails;
 
-    if (mailboxDashBoardController.emailsInCurrentMailbox.isEmpty) {
-      refreshAllEmail();
-    } else if (PlatformInfo.isWeb) {
+    if (PlatformInfo.isWeb) {
       _validateBrowserHeight();
     }
   }


### PR DESCRIPTION
## Issue

#3372 

## Root cause

- Because we call `refreshAllEmail` again when `getChangeEmail` succeeds and the current list is empty.

## Resolved

[demo-empty-trash-from-user-action.mov](https://drive.google.com/file/d/18UAxh3EtyXJ-Y-RfT-0_3yNPsFMkrGaC/view?usp=sharing)


[demo-empty-trash-from-other-client-change.mov](https://drive.google.com/file/d/1qVUPZYL6Qd_J1TBrK4pg6cvaggRYjKHd/view?usp=sharing)

