### PR TITLE
TF-3348 Move access token from persistent to memory

### DIFF
--- a/docs/adr/0075-move-access-token-to-session-storage-on-web.md
+++ b/docs/adr/0075-move-access-token-to-session-storage-on-web.md
@@ -1,0 +1,21 @@
+# 75. Move Access Token from Persistent Storage to Session Storage on Web
+
+Date: 2026-04-06
+
+## Status
+
+Accepted
+
+## Context
+
+Issue [#3348](https://github.com/linagora/tmail-flutter/issues/3348): closing and reopening the browser kept the user logged in because the OIDC access token was persisted to disk. Closing the browser should require re-authentication; refreshing or opening a new tab within the same session should not.
+
+## Decision
+
+On web, store the access token in `sessionStorage` (cleared when the browser closes) instead of persistent storage. Metadata needed for token refresh (tokenId, refreshToken) remains on disk. Native platforms are unaffected.
+
+## Consequences
+
+- Closing the browser clears the access token; re-login is required (or silent refresh if the refresh token is still valid).
+- Page refresh and new tabs within the same session work without re-authentication.
+- The access token never touches disk on web, reducing the persistent attack surface.

--- a/lib/features/caching/interaction/cache_manager_interaction.dart
+++ b/lib/features/caching/interaction/cache_manager_interaction.dart
@@ -1,4 +1,6 @@
 
 abstract class CacheManagerInteraction {
+  const CacheManagerInteraction();
+
   Future<void> migrateHiveToIsolatedHive();
 }

--- a/lib/features/login/data/extensions/token_oidc_extension.dart
+++ b/lib/features/login/data/extensions/token_oidc_extension.dart
@@ -5,4 +5,8 @@ extension TokenOidcExtension on TokenOIDC {
   TokenOidcCache toTokenOidcCache() {
     return TokenOidcCache(token, tokenId.uuid, refreshToken, expiredTime: expiredTime);
   }
+
+  TokenOidcCache toTokenOidcCacheWithoutToken() {
+    return TokenOidcCache('', tokenId.uuid, refreshToken, expiredTime: expiredTime);
+  }
 }

--- a/lib/features/login/data/local/token_oidc_cache_manager.dart
+++ b/lib/features/login/data/local/token_oidc_cache_manager.dart
@@ -9,7 +9,7 @@ import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_ex
 class TokenOidcCacheManager extends CacheManagerInteraction {
   final TokenOidcCacheClient _tokenOidcCacheClient;
 
-  TokenOidcCacheManager(this._tokenOidcCacheClient);
+  const TokenOidcCacheManager(this._tokenOidcCacheClient);
 
   Future<TokenOIDC> getTokenOidc(String tokenIdHash) async {
     log('TokenOidcCacheManager::getTokenOidc(): tokenIdHash: $tokenIdHash');

--- a/lib/features/login/data/local/web_token_oidc_cache_manager.dart
+++ b/lib/features/login/data/local/web_token_oidc_cache_manager.dart
@@ -1,0 +1,58 @@
+import 'package:core/utils/app_logger.dart';
+import 'package:model/oidc/token_oidc.dart';
+import 'package:tmail_ui_user/features/caching/clients/token_oidc_cache_client.dart';
+import 'package:tmail_ui_user/features/login/data/extensions/token_oidc_cache_extension.dart';
+import 'package:tmail_ui_user/features/login/data/extensions/token_oidc_extension.dart';
+import 'package:tmail_ui_user/features/login/data/local/token_oidc_cache_manager.dart';
+import 'package:tmail_ui_user/features/login/data/model/token_oidc_cache.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_exception.dart';
+import 'package:universal_html/html.dart';
+
+class WebTokenOidcCacheManager extends TokenOidcCacheManager {
+  const WebTokenOidcCacheManager(this._tokenOidcCacheClient)
+    : super(_tokenOidcCacheClient);
+
+  final TokenOidcCacheClient _tokenOidcCacheClient;
+
+  static const _sessionStorageTokenKey = 'twake_mail_token_session_storage';
+
+  @override
+  Future<TokenOIDC> getTokenOidc(String tokenIdHash) async {
+    log('WebTokenOidcCacheManager::getTokenOidc(): tokenIdHash: $tokenIdHash');
+    final tokenHiveCache = await _tokenOidcCacheClient.getItem(tokenIdHash);
+    final tokenSessionStorageCache = window.sessionStorage[_sessionStorageTokenKey];
+    log('WebTokenOidcCacheManager::getTokenOidc(): tokenHiveCache: $tokenHiveCache');
+    log('WebTokenOidcCacheManager::getTokenOidc(): tokenSessionStorageCache: $tokenSessionStorageCache');
+    if (tokenHiveCache == null) {
+      throw NotFoundStoredTokenException();
+    } else {
+      return TokenOidcCache(
+        tokenSessionStorageCache ?? 'dummy_token',
+        tokenHiveCache.tokenId,
+        tokenHiveCache.refreshToken,
+        expiredTime: tokenSessionStorageCache != null
+          ? tokenHiveCache.expiredTime
+          : DateTime.now().subtract(const Duration(hours: 1)),
+      ).toTokenOidc();
+    }
+  }
+
+  @override
+  Future<void> persistOneTokenOidc(TokenOIDC tokenOIDC) async {
+    log('TokenOidcCacheManager::persistOneTokenOidc(): $tokenOIDC');
+    await _tokenOidcCacheClient.clearAllData();
+    log('TokenOidcCacheManager::persistOneTokenOidc(): key: ${tokenOIDC.tokenId.uuid}');
+    log('TokenOidcCacheManager::persistOneTokenOidc(): key\'s hash: ${tokenOIDC.tokenIdHash}');
+    log('TokenOidcCacheManager::persistOneTokenOidc(): token: ${tokenOIDC.token}');
+    final tokenHiveCache = tokenOIDC.toTokenOidcCacheWithoutToken();
+    await _tokenOidcCacheClient.insertItem(tokenOIDC.tokenIdHash, tokenHiveCache);
+    window.sessionStorage[_sessionStorageTokenKey] = tokenOIDC.token;
+    log('TokenOidcCacheManager::persistOneTokenOidc(): done');
+  }
+
+  @override
+  Future<void> deleteTokenOidc() async {
+    await _tokenOidcCacheClient.clearAllData();
+    window.sessionStorage.remove(_sessionStorageTokenKey);
+  }
+}

--- a/lib/features/login/data/local/web_token_oidc_cache_manager.dart
+++ b/lib/features/login/data/local/web_token_oidc_cache_manager.dart
@@ -26,10 +26,12 @@ class WebTokenOidcCacheManager extends TokenOidcCacheManager {
       throw NotFoundStoredTokenException();
     } else {
       return TokenOidcCache(
-        tokenSessionStorageCache,
+        tokenSessionStorageCache ?? 'dummy_token',
         tokenHiveCache.tokenId,
         tokenHiveCache.refreshToken,
-        expiredTime: tokenHiveCache.expiredTime,
+        expiredTime: tokenSessionStorageCache != null
+          ? tokenHiveCache.expiredTime
+          : DateTime.now().subtract(const Duration(hours: 1)),
       ).toTokenOidc();
     }
   }

--- a/lib/features/login/data/local/web_token_oidc_cache_manager.dart
+++ b/lib/features/login/data/local/web_token_oidc_cache_manager.dart
@@ -22,7 +22,7 @@ class WebTokenOidcCacheManager extends TokenOidcCacheManager {
     final tokenHiveCache = await _tokenOidcCacheClient.getItem(tokenIdHash);
     final tokenSessionStorageCache = window.sessionStorage[_sessionStorageTokenKey];
     log('WebTokenOidcCacheManager::getTokenOidc(): tokenSessionStorageCache: ${tokenSessionStorageCache != null ? "[present]" : "[missing]"}');
-    if (tokenHiveCache == null || tokenSessionStorageCache == null) {
+    if (tokenHiveCache == null) {
       throw NotFoundStoredTokenException();
     } else {
       return TokenOidcCache(

--- a/lib/features/login/data/local/web_token_oidc_cache_manager.dart
+++ b/lib/features/login/data/local/web_token_oidc_cache_manager.dart
@@ -22,7 +22,7 @@ class WebTokenOidcCacheManager extends TokenOidcCacheManager {
     final tokenHiveCache = await _tokenOidcCacheClient.getItem(tokenIdHash);
     final tokenSessionStorageCache = window.sessionStorage[_sessionStorageTokenKey];
     log('WebTokenOidcCacheManager::getTokenOidc(): tokenHiveCache: $tokenHiveCache');
-    log('WebTokenOidcCacheManager::getTokenOidc(): tokenSessionStorageCache: $tokenSessionStorageCache');
+    log('WebTokenOidcCacheManager::getTokenOidc(): tokenSessionStorageCache: ${tokenSessionStorageCache != null ? "[present]" : "[missing]"}');
     if (tokenHiveCache == null) {
       throw NotFoundStoredTokenException();
     } else {
@@ -39,11 +39,11 @@ class WebTokenOidcCacheManager extends TokenOidcCacheManager {
 
   @override
   Future<void> persistOneTokenOidc(TokenOIDC tokenOIDC) async {
-    log('TokenOidcCacheManager::persistOneTokenOidc(): $tokenOIDC');
+    log('TokenOidcCacheManager::persistOneTokenOidc(): tokenIdHash=${tokenOIDC.tokenIdHash}');
     await _tokenOidcCacheClient.clearAllData();
     log('TokenOidcCacheManager::persistOneTokenOidc(): key: ${tokenOIDC.tokenId.uuid}');
     log('TokenOidcCacheManager::persistOneTokenOidc(): key\'s hash: ${tokenOIDC.tokenIdHash}');
-    log('TokenOidcCacheManager::persistOneTokenOidc(): token: ${tokenOIDC.token}');
+    log('TokenOidcCacheManager::persistOneTokenOidc(): token: [redacted]');
     final tokenHiveCache = tokenOIDC.toTokenOidcCacheWithoutToken();
     await _tokenOidcCacheClient.insertItem(tokenOIDC.tokenIdHash, tokenHiveCache);
     window.sessionStorage[_sessionStorageTokenKey] = tokenOIDC.token;
@@ -51,7 +51,7 @@ class WebTokenOidcCacheManager extends TokenOidcCacheManager {
   }
 
   @override
-  Future<void> deleteTokenOidc() async {
+  Future<void> clear() async {
     await _tokenOidcCacheClient.clearAllData();
     window.sessionStorage.remove(_sessionStorageTokenKey);
   }

--- a/lib/features/login/data/local/web_token_oidc_cache_manager.dart
+++ b/lib/features/login/data/local/web_token_oidc_cache_manager.dart
@@ -21,18 +21,15 @@ class WebTokenOidcCacheManager extends TokenOidcCacheManager {
     log('WebTokenOidcCacheManager::getTokenOidc(): tokenIdHash: $tokenIdHash');
     final tokenHiveCache = await _tokenOidcCacheClient.getItem(tokenIdHash);
     final tokenSessionStorageCache = window.sessionStorage[_sessionStorageTokenKey];
-    log('WebTokenOidcCacheManager::getTokenOidc(): tokenHiveCache: $tokenHiveCache');
     log('WebTokenOidcCacheManager::getTokenOidc(): tokenSessionStorageCache: ${tokenSessionStorageCache != null ? "[present]" : "[missing]"}');
-    if (tokenHiveCache == null) {
+    if (tokenHiveCache == null || tokenSessionStorageCache == null) {
       throw NotFoundStoredTokenException();
     } else {
       return TokenOidcCache(
-        tokenSessionStorageCache ?? 'dummy_token',
+        tokenSessionStorageCache,
         tokenHiveCache.tokenId,
         tokenHiveCache.refreshToken,
-        expiredTime: tokenSessionStorageCache != null
-          ? tokenHiveCache.expiredTime
-          : DateTime.now().subtract(const Duration(hours: 1)),
+        expiredTime: tokenHiveCache.expiredTime,
       ).toTokenOidc();
     }
   }
@@ -41,9 +38,7 @@ class WebTokenOidcCacheManager extends TokenOidcCacheManager {
   Future<void> persistOneTokenOidc(TokenOIDC tokenOIDC) async {
     log('TokenOidcCacheManager::persistOneTokenOidc(): tokenIdHash=${tokenOIDC.tokenIdHash}');
     await _tokenOidcCacheClient.clearAllData();
-    log('TokenOidcCacheManager::persistOneTokenOidc(): key: ${tokenOIDC.tokenId.uuid}');
-    log('TokenOidcCacheManager::persistOneTokenOidc(): key\'s hash: ${tokenOIDC.tokenIdHash}');
-    log('TokenOidcCacheManager::persistOneTokenOidc(): token: [redacted]');
+    log('TokenOidcCacheManager::persistOneTokenOidc(): key: ${tokenOIDC.tokenId.uuid} - key\'s hash: ${tokenOIDC.tokenIdHash} - token: [redacted]');
     final tokenHiveCache = tokenOIDC.toTokenOidcCacheWithoutToken();
     await _tokenOidcCacheClient.insertItem(tokenOIDC.tokenIdHash, tokenHiveCache);
     window.sessionStorage[_sessionStorageTokenKey] = tokenOIDC.token;

--- a/lib/main/bindings/local/local_bindings.dart
+++ b/lib/main/bindings/local/local_bindings.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/utils/file_utils.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:get/get.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -31,6 +32,7 @@ import 'package:tmail_ui_user/features/login/data/local/authentication_info_cach
 import 'package:tmail_ui_user/features/login/data/local/encryption_key_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/local/oidc_configuration_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/local/token_oidc_cache_manager.dart';
+import 'package:tmail_ui_user/features/login/data/local/web_token_oidc_cache_manager.dart';
 import 'package:tmail_ui_user/features/mailbox/data/local/mailbox_cache_manager.dart';
 import 'package:tmail_ui_user/features/mailbox/data/local/state_cache_manager.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/local/local_sort_order_manager.dart';
@@ -66,7 +68,11 @@ class LocalBindings extends Bindings {
     Get.put(RecentSearchCacheClient());
     Get.put(RecentSearchCacheManager(Get.find<RecentSearchCacheClient>()));
     Get.put(TokenOidcCacheClient());
-    Get.put(TokenOidcCacheManager(Get.find<TokenOidcCacheClient>()));
+    if (PlatformInfo.isWeb) {
+      Get.put<TokenOidcCacheManager>(WebTokenOidcCacheManager(Get.find<TokenOidcCacheClient>()));
+    } else {
+      Get.put(TokenOidcCacheManager(Get.find<TokenOidcCacheClient>()));
+    }
     Get.put(AccountCacheClient());
     Get.put(AccountCacheManager(Get.find<AccountCacheClient>()));
     Get.put(EncryptionKeyCacheClient());

--- a/lib/main/bindings/local/local_isolate_bindings.dart
+++ b/lib/main/bindings/local/local_isolate_bindings.dart
@@ -1,4 +1,5 @@
 
+import 'package:core/utils/platform_info.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/caching/clients/account_cache_client.dart';
 import 'package:tmail_ui_user/features/caching/clients/encryption_key_cache_client.dart';
@@ -6,6 +7,7 @@ import 'package:tmail_ui_user/features/caching/clients/token_oidc_cache_client.d
 import 'package:tmail_ui_user/features/login/data/local/account_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/local/encryption_key_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/local/token_oidc_cache_manager.dart';
+import 'package:tmail_ui_user/features/login/data/local/web_token_oidc_cache_manager.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
 
 class LocalIsolateBindings extends Bindings {
@@ -17,10 +19,17 @@ class LocalIsolateBindings extends Bindings {
 
   void _bindingCaching() {
     Get.put(TokenOidcCacheClient(), tag: BindingTag.isolateTag);
-    Get.put(TokenOidcCacheManager(
-      Get.find<TokenOidcCacheClient>(tag: BindingTag.isolateTag)),
-      tag: BindingTag.isolateTag
-    );
+    if (PlatformInfo.isWeb) {
+      Get.put<TokenOidcCacheManager>(WebTokenOidcCacheManager(
+        Get.find<TokenOidcCacheClient>(tag: BindingTag.isolateTag)),
+        tag: BindingTag.isolateTag
+      );
+    } else {
+      Get.put(TokenOidcCacheManager(
+        Get.find<TokenOidcCacheClient>(tag: BindingTag.isolateTag)),
+        tag: BindingTag.isolateTag
+      );
+    }
     Get.put(AccountCacheClient(), tag: BindingTag.isolateTag);
     Get.put(AccountCacheManager(
       Get.find<AccountCacheClient>(tag: BindingTag.isolateTag)),

--- a/test/main/bindings/local/local_bindings_test.dart
+++ b/test/main/bindings/local/local_bindings_test.dart
@@ -1,0 +1,60 @@
+import 'package:core/utils/file_utils.dart';
+import 'package:core/utils/platform_info.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/instance_manager.dart';
+import 'package:mockito/annotations.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tmail_ui_user/features/login/data/local/token_oidc_cache_manager.dart';
+import 'package:tmail_ui_user/features/login/data/local/web_token_oidc_cache_manager.dart';
+import 'package:tmail_ui_user/main/bindings/local/local_bindings.dart';
+
+import 'local_bindings_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<FlutterSecureStorage>(),
+  MockSpec<SharedPreferences>(),
+  MockSpec<FileUtils>(),
+])
+void main() {
+  late LocalBindings localBindings;
+
+  setUp(() {
+    localBindings = LocalBindings();
+    Get.put<FlutterSecureStorage>(MockFlutterSecureStorage());
+    Get.put<SharedPreferences>(MockSharedPreferences());
+    Get.put<FileUtils>(MockFileUtils());
+  });
+
+  group('local bindings test:', () {
+    test(
+      'should inject WebTokenOidcCacheManager '
+      'when platform is web',
+    () {
+      // arrange
+      PlatformInfo.isTestingForWeb = true;
+      localBindings.dependencies();
+      
+      // act
+      final cacheManager = Get.find<TokenOidcCacheManager>();
+      
+      // assert
+      expect(cacheManager, isInstanceOf<WebTokenOidcCacheManager>());
+      PlatformInfo.isTestingForWeb = false;
+    });
+
+    test(
+      'should inject TokenOidcCacheManager '
+      'when platform is not web (default)',
+    () {
+      // arrange
+      localBindings.dependencies();
+      
+      // act
+      final cacheManager = Get.find<TokenOidcCacheManager>();
+      
+      // assert
+      expect(cacheManager, isInstanceOf<TokenOidcCacheManager>());
+    });
+  });
+}

--- a/test/main/bindings/local/local_bindings_test.dart
+++ b/test/main/bindings/local/local_bindings_test.dart
@@ -26,6 +26,11 @@ void main() {
     Get.put<FileUtils>(MockFileUtils());
   });
 
+  tearDown(() async {
+    PlatformInfo.isTestingForWeb = false;
+    await Get.deleteAll();
+  });
+
   group('local bindings test:', () {
     test(
       'should inject WebTokenOidcCacheManager '
@@ -54,7 +59,8 @@ void main() {
       final cacheManager = Get.find<TokenOidcCacheManager>();
       
       // assert
-      expect(cacheManager, isInstanceOf<TokenOidcCacheManager>());
+      expect(cacheManager, isA<TokenOidcCacheManager>());
+      expect(cacheManager, isNot(isA<WebTokenOidcCacheManager>()));
     });
   });
 }


### PR DESCRIPTION
## Issue
- #3348 

## Demo
### Should not refresh token if token is still valid and browser is refresh

https://github.com/user-attachments/assets/11126ba4-6f39-4022-9b5b-b1d8054716b1

### Should not force user to login and refresh token if refresh token is still valid and new tab is open

https://github.com/user-attachments/assets/ec729e0c-45d4-4716-b1fc-476296bc6007



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web sessions: access tokens are stored in browser sessionStorage (cleared on browser close) while refresh metadata remains persisted.
  * Platform-aware runtime selection of a web-specific token manager.
  * Added a utility to create token cache entries without including the raw access token.

* **Refactor**
  * Constructors updated to allow compile-time instantiation.

* **Tests**
  * Added tests verifying platform-aware dependency wiring selects the correct token manager.

* **Documentation**
  * Added ADR documenting web session-storage behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->