### PR TITLE
TF-3323 Handle corner cases of web socket disconnected 

### DIFF
--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -379,6 +379,7 @@ abstract class BaseController extends GetxController
 
   void injectWebSocket(Session? session, AccountId? accountId) {
     try {
+      log('$runtimeType::injectWebSocket:');
       requireCapability(
         session!,
         accountId!,


### PR DESCRIPTION
## Issue

#3323

## Root cause

- In case the user loses network connection or closes the device and reopens it after a while. The websocket connection fails, the number of reconnection attempts `_retryRemained = 0` but still cannot connect to the server.

## Solution

- Use `AppLifecycleListener` to listen for changes in the application state. We will perform a WebSocket connection check every time the application appears and the user can interact ('onResume'). If the WebSocket connection is lost, we reconnect.

## Demo

