### PR TITLE
TF-3323 Fix web socket still not reconnect when network disconnected

### DIFF
--- a/lib/features/network_connection/presentation/network_connection_controller.dart
+++ b/lib/features/network_connection/presentation/network_connection_controller.dart
@@ -46,6 +46,8 @@ class NetworkConnectionController extends GetxController {
     super.onClose();
   }
 
+  Connectivity get connectivity => _connectivity;
+
   void _getCurrentNetworkConnectionState() async {
     final listConnectionResult = await Future.wait([
       _connectivity.checkConnectivity(),

--- a/lib/features/network_connection/presentation/web_network_connection_controller.dart
+++ b/lib/features/network_connection/presentation/web_network_connection_controller.dart
@@ -43,6 +43,8 @@ class NetworkConnectionController extends GetxController {
     super.onClose();
   }
 
+  Connectivity get connectivity => _connectivity;
+
   void _getCurrentNetworkConnectionState() async {
     final connectionResult = await _connectivity.checkConnectivity();
     log('NetworkConnectionController::_getCurrentNetworkConnectionState():connectionResult: $connectionResult');


### PR DESCRIPTION
## Issue

#3323 

https://github.com/user-attachments/assets/2c888ab8-64c5-4f4d-9f25-ec501bfeb3b7




## Root cause

- Because when we disconnect the network, the web socket does not receive any data to maintain the connection.
- If we enable `WS_ECHO_PING=true` then the web socket connection is still maintained continuously. But when we disable it, the web socket data is not maintained and synchronized to the client side.

## Solution

- To solve this problem, we will listen for changes in network connectivity and changes in the state of the application (`previously deployed`). Whenever we lose network connectivity, we close the clean up web socket and reopen the connection when the network is available.

## Resolved

https://github.com/user-attachments/assets/8e7c2c7f-0dde-4b46-a544-edf2ff59b0a2



