### PR TITLE
Bump version to v0.14.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.14.8] - 2025-01-09
+### Fiexed
+- #3396 Fetch latest change when open the app 
+- #3385 Fix loading forever after delete all email in one folder
+- #3323 Handle reconnect websocket in somecases: laptop in sleep, network change
+- #3413 Add Reply to list button
+- #3399 Fix focus in composer in mobile browser
+
 ## [0.14.7] - 2025-01-05
 ### Fixed
 - Delegate cache control from Flutter to browser

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.14.7
+version: 0.14.8
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## [0.14.8] - 2025-01-09
### Fiexed
- #3396 Fetch latest change when open the app 
- #3385 Fix loading forever after delete all email in one folder
- #3323 Handle reconnect websocket in somecases: laptop in sleep, network change
- #3413 Add Reply to list button
- #3399 Fix focus in composer in mobile browser
