### PR TITLE
Small improvements

### DIFF
--- a/lib/features/login/data/network/oidc_http_client.dart
+++ b/lib/features/login/data/network/oidc_http_client.dart
@@ -1,9 +1,11 @@
 
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:core/data/model/query/query_parameter.dart';
 import 'package:core/data/network/dio_client.dart';
 import 'package:core/utils/app_logger.dart';
+import 'package:get/get_connect/http/src/exceptions/exceptions.dart';
 import 'package:model/oidc/oidc_configuration.dart';
 import 'package:model/oidc/request/oidc_request.dart';
 import 'package:model/oidc/response/oidc_discovery_response.dart';
@@ -39,7 +41,13 @@ class OIDCHttpClient {
         return OIDCResponse.fromJson(jsonDecode(result));
       }
     } on DioError catch (exception) {
-      if (exception.response?.statusCode == 404) {
+      if (exception.error is HandshakeException) {
+        throw exception.error!;
+      } else if (exception.error is SocketException) {
+        throw exception.error!;
+      } else if (exception.response?.statusCode == 401) {
+        throw UnauthorizedException();
+      } else if (exception.response?.statusCode == 404) {
         throw CanNotFoundOIDCLinks();
       }
       throw CanRetryOIDCException();

--- a/lib/features/mailbox/presentation/mixin/mailbox_widget_mixin.dart
+++ b/lib/features/mailbox/presentation/mixin/mailbox_widget_mixin.dart
@@ -13,6 +13,7 @@ import 'package:tmail_ui_user/features/mailbox/presentation/mailbox_controller.d
 import 'package:tmail_ui_user/features/mailbox/presentation/model/context_item_mailbox_action.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_actions.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_categories.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/utils/mailbox_utils.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/mailbox_bottom_sheet_action_tile_builder.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/app_dashboard/app_list_dashboard_item.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
@@ -27,7 +28,8 @@ mixin MailboxWidgetMixin {
 
   List<MailboxActions> _listActionForDefaultMailbox(
     PresentationMailbox mailbox,
-    bool spamReportEnabled
+    bool spamReportEnabled,
+    bool deletedMessageVaultSupported
   ) {
 
     return [
@@ -38,7 +40,8 @@ mixin MailboxWidgetMixin {
       if (mailbox.isTrash)
         ...[
           MailboxActions.emptyTrash,
-          MailboxActions.recoverDeletedMessages
+          if (deletedMessageVaultSupported)
+            MailboxActions.recoverDeletedMessages,
         ]
       else if (mailbox.isSpam)
         ...[
@@ -84,10 +87,11 @@ mixin MailboxWidgetMixin {
 
   List<MailboxActions> _listActionForAllMailboxType(
     PresentationMailbox mailbox,
-    bool spamReportEnabled
+    bool spamReportEnabled,
+    bool deletedMessageVaultSupported
   ) {
     if (mailbox.isDefault) {
-      return _listActionForDefaultMailbox(mailbox, spamReportEnabled);
+      return _listActionForDefaultMailbox(mailbox, spamReportEnabled, deletedMessageVaultSupported);
     } else if (mailbox.isPersonal) {
       return _listActionForPersonalMailbox(mailbox);
     } else {
@@ -101,9 +105,14 @@ mixin MailboxWidgetMixin {
     PresentationMailbox mailbox,
     MailboxController controller
   ) {
+    final bool deletedMessageVaultSupported = MailboxUtils.isDeletedMessageVaultSupported(
+        controller.mailboxDashBoardController.sessionCurrent,
+        controller.mailboxDashBoardController.accountId.value);
+
     final contextMenuActions = listContextMenuItemAction(
       mailbox,
-      controller.mailboxDashBoardController.enableSpamReport
+      controller.mailboxDashBoardController.enableSpamReport,
+      deletedMessageVaultSupported
     );
 
     if (contextMenuActions.isEmpty) {
@@ -174,9 +183,10 @@ mixin MailboxWidgetMixin {
 
   List<ContextMenuItemMailboxAction> listContextMenuItemAction(
     PresentationMailbox mailbox,
-    bool spamReportEnabled
+    bool spamReportEnabled,
+    bool deletedMessageVaultSupported
   ) {
-    final mailboxActionsSupported = _listActionForAllMailboxType(mailbox, spamReportEnabled);
+    final mailboxActionsSupported = _listActionForAllMailboxType(mailbox, spamReportEnabled, deletedMessageVaultSupported);
 
     final listContextMenuItemAction = mailboxActionsSupported
       .map((action) => ContextMenuItemMailboxAction(action, action.getContextMenuItemState(mailbox)))
@@ -193,9 +203,14 @@ mixin MailboxWidgetMixin {
     PresentationMailbox mailbox,
     MailboxController controller
   ) {
+    final bool deletedMessageVaultSupported = MailboxUtils.isDeletedMessageVaultSupported(
+        controller.mailboxDashBoardController.sessionCurrent,
+        controller.mailboxDashBoardController.accountId.value);
+
     final contextMenuActions = listContextMenuItemAction(
       mailbox,
-      controller.mailboxDashBoardController.enableSpamReport
+      controller.mailboxDashBoardController.enableSpamReport,
+      deletedMessageVaultSupported
     );
 
     if (contextMenuActions.isEmpty) {

--- a/lib/features/mailbox/presentation/utils/mailbox_utils.dart
+++ b/lib/features/mailbox/presentation/utils/mailbox_utils.dart
@@ -1,11 +1,15 @@
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:dartz/dartz.dart';
+import 'package:email_recovery/email_recovery/capability_deleted_messages_vault.dart';
 import 'package:flutter/material.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/extensions/list_mailbox_node_extension.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_tree.dart';
+import 'package:tmail_ui_user/main/error/capability_validator.dart';
 
 class MailboxUtils {
 
@@ -49,5 +53,12 @@ class MailboxUtils {
         return const EdgeInsets.symmetric(horizontal: 32, vertical: 16);
       }
     }
+  }
+
+  static bool isDeletedMessageVaultSupported(Session? session, AccountId? accountId) {
+    if (session == null || accountId == null) {
+      return false;
+    }
+    return capabilityDeletedMessagesVault.isSupported(session, accountId);
   }
 }

--- a/lib/features/manage_account/presentation/manage_account_dashboard_controller.dart
+++ b/lib/features/manage_account/presentation/manage_account_dashboard_controller.dart
@@ -2,6 +2,7 @@
 import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:core/core.dart';
 import 'package:dartz/dartz.dart';
+import 'package:fcm/model/firebase_capability.dart';
 import 'package:flutter/material.dart';
 import 'package:forward/forward/capability_forward.dart';
 import 'package:get/get.dart';
@@ -224,6 +225,14 @@ class ManageAccountDashBoardController extends ReloadableController with UserSet
   bool get isVacationCapabilitySupported {
     if (accountId.value != null && sessionCurrent != null) {
       return [CapabilityIdentifier.jmapVacationResponse].isSupported(sessionCurrent!, accountId.value!);
+    } else {
+      return false;
+    }
+  }
+
+  bool get isFcmCapabilitySupported {
+    if (accountId.value != null && sessionCurrent != null) {
+      return [FirebaseCapability.fcmIdentifier].isSupported(sessionCurrent!, accountId.value!);
     } else {
       return false;
     }

--- a/lib/features/manage_account/presentation/menu/settings/settings_first_level_view.dart
+++ b/lib/features/manage_account/presentation/menu/settings/settings_first_level_view.dart
@@ -139,20 +139,26 @@ class SettingsFirstLevelView extends GetWidget<SettingsController> {
           AccountMenuItem.languageAndRegion.getIcon(controller.imagePaths),
           () => controller.selectSettings(AccountMenuItem.languageAndRegion)
         ),
-        if (PlatformInfo.isMobile) ...[
-          Divider(
-            color: AppColor.colorDividerHorizontal,
-            height: 1,
-            indent: SettingsUtils.getHorizontalPadding(context, controller.responsiveUtils),
-            endIndent: SettingsUtils.getHorizontalPadding(context, controller.responsiveUtils)
-          ),
-          SettingFirstLevelTileBuilder(
-            AppLocalizations.of(context).notification,
-            controller.imagePaths.icNotification,
-            () => controller.selectSettings(AccountMenuItem.notification),
-            subtitle: AppLocalizations.of(context).allowsTwakeMailToNotifyYouWhenANewMessageArrivesOnYourPhone,
-          )
-        ],
+        Obx(() {
+          if (PlatformInfo.isMobile && controller.manageAccountDashboardController.isFcmCapabilitySupported) {
+            return Column(children: [
+              Divider(
+                  color: AppColor.colorDividerHorizontal,
+                  height: 1,
+                  indent: SettingsUtils.getHorizontalPadding(context, controller.responsiveUtils),
+                  endIndent: SettingsUtils.getHorizontalPadding(context, controller.responsiveUtils)
+              ),
+              SettingFirstLevelTileBuilder(
+                AppLocalizations.of(context).notification,
+                controller.imagePaths.icNotification,
+                    () => controller.selectSettings(AccountMenuItem.notification),
+                subtitle: AppLocalizations.of(context).allowsTwakeMailToNotifyYouWhenANewMessageArrivesOnYourPhone,
+              )
+            ]);
+          } else {
+            return const SizedBox.shrink();
+          }
+        }),
         Obx(() {
           final accountId = controller
             .manageAccountDashboardController

--- a/lib/features/search/mailbox/presentation/search_mailbox_view.dart
+++ b/lib/features/search/mailbox/presentation/search_mailbox_view.dart
@@ -15,6 +15,7 @@ import 'package:tmail_ui_user/features/mailbox/domain/state/search_mailbox_state
 import 'package:tmail_ui_user/features/mailbox/presentation/mixin/mailbox_widget_mixin.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/context_item_mailbox_action.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_actions.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/utils/mailbox_utils.dart';
 import 'package:tmail_ui_user/features/search/mailbox/presentation/search_mailbox_controller.dart';
 import 'package:tmail_ui_user/features/search/mailbox/presentation/utils/search_mailbox_utils.dart';
 import 'package:tmail_ui_user/features/search/mailbox/presentation/widgets/mailbox_searched_item_builder.dart';
@@ -196,9 +197,14 @@ class SearchMailboxView extends GetWidget<SearchMailboxController>
   }
 
   List<FocusedMenuItem> _listPopupMenuItemAction(BuildContext context, PresentationMailbox mailbox) {
+    final bool deletedMessageVaultSupported = MailboxUtils.isDeletedMessageVaultSupported(
+        controller.dashboardController.sessionCurrent,
+        controller.dashboardController.accountId.value);
+
     final contextMenuActions = listContextMenuItemAction(
       mailbox,
       controller.dashboardController.enableSpamReport,
+      deletedMessageVaultSupported
     );
     return contextMenuActions
       .map((action) => _mailboxFocusedMenuItem(context, action, mailbox))
@@ -252,9 +258,14 @@ class SearchMailboxView extends GetWidget<SearchMailboxController>
     PresentationMailbox mailbox,
     {RelativeRect? position}
   ) {
+    final bool deletedMessageVaultSupported = MailboxUtils.isDeletedMessageVaultSupported(
+        controller.dashboardController.sessionCurrent,
+        controller.dashboardController.accountId.value);
+
     final contextMenuActions = listContextMenuItemAction(
       mailbox,
       controller.dashboardController.enableSpamReport,
+      deletedMessageVaultSupported
     );
 
     if (contextMenuActions.isEmpty) {

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -130,6 +130,16 @@
       "errorMessage": {}
     }
   },
+  "handshakeException": "Handshake error in client: {errorMessage}",
+  "@handshakeException": {
+    "type": "text",
+    "placeholders_order": [
+      "errorMessage"
+    ],
+    "placeholders": {
+      "errorMessage": {}
+    }
+  },
   "search_folder": "Search folder",
   "@search_folder": {
     "type": "text",

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -120,6 +120,16 @@
     "placeholders_order": [],
     "placeholders": {}
   },
+  "unexpectedError": "Unexpected error: {errorMessage}",
+  "@unexpectedError": {
+    "type": "text",
+    "placeholders_order": [
+      "errorMessage"
+    ],
+    "placeholders": {
+      "errorMessage": {}
+    }
+  },
   "search_folder": "Search folder",
   "@search_folder": {
     "type": "text",

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -120,6 +120,13 @@ class AppLocalizations {
         args: [errorMessage]);
   }
 
+  String handshakeException(String errorMessage) {
+    return Intl.message(
+      'Handshake error in client: $errorMessage',
+      name: 'handshakeException',
+      args: [errorMessage]);
+  }
+
   String get search_folder {
     return Intl.message(
       'Search folder',

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -114,6 +114,12 @@ class AppLocalizations {
         name: 'unknownError');
   }
 
+  String unexpectedError(String errorMessage) {
+    return Intl.message('Unexpected error: $errorMessage',
+        name: 'unexpectedError',
+        args: [errorMessage]);
+  }
+
   String get search_folder {
     return Intl.message(
       'Search folder',

--- a/lib/main/utils/toast_manager.dart
+++ b/lib/main/utils/toast_manager.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:core/domain/exceptions/web_session_exception.dart';
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/utils/app_toast.dart';
@@ -49,6 +51,8 @@ class ToastManager {
       return AppLocalizations.of(context).notFoundSession;
     } else if (exception is NoNetworkError) {
       return AppLocalizations.of(context).youAreOffline;
+    } else if (exception is HandshakeException) {
+      return AppLocalizations.of(context).handshakeException(exception.osError?.message ?? '');
     } else {
       try {
         return AppLocalizations.of(context).unexpectedError(exception.message);

--- a/lib/main/utils/toast_manager.dart
+++ b/lib/main/utils/toast_manager.dart
@@ -50,7 +50,11 @@ class ToastManager {
     } else if (exception is NoNetworkError) {
       return AppLocalizations.of(context).youAreOffline;
     } else {
-      return null;
+      try {
+        return AppLocalizations.of(context).unexpectedError(exception.message);
+      } catch(_) {
+        return AppLocalizations.of(context).unexpectedError(exception.toString());
+      }
     }
   }
 


### PR DESCRIPTION
i suggest here two small improvements for tmail-frontend:

1. on the login page, sometimes i was getting a frustrating `unknown error occurred, please try again`. upon inspecting the logs, the error was actually known and had a helpful descriptive message. i think it would be better to display that message rather than leaving it in the logs ? i corrected that in one line.
2. even when working with a server that does not support the `recover deleted messages` feature (eg, the capability `deletedMessagesVault` `com:linagora:params:jmap:messages:vault`), the option still appears in the `trash` mailbox actions. i corrected the bug by adding a little `if` statement.