### PR TITLE
TF-3430 Fix reply button is not synced

### DIFF
--- a/lib/features/email/data/datasource/email_datasource.dart
+++ b/lib/features/email/data/datasource/email_datasource.dart
@@ -175,4 +175,14 @@ abstract class EmailDataSource {
     AccountId accountId,
     EmailId emailId,
     EventActionType eventActionType);
+
+  Future<void> markAsAnswered(
+    Session session,
+    AccountId accountId,
+    List<EmailId> emailIds);
+
+  Future<void> markAsForwarded(
+    Session session,
+    AccountId accountId,
+    List<EmailId> emailIds);
 }

--- a/lib/features/email/data/datasource_impl/email_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_datasource_impl.dart
@@ -368,4 +368,14 @@ class EmailDataSourceImpl extends EmailDataSource {
         eventActionType);
     }).catchError(_exceptionThrower.throwException);
   }
+
+  @override
+  Future<void> markAsAnswered(Session session, AccountId accountId, List<EmailId> emailIds) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> markAsForwarded(Session session, AccountId accountId, List<EmailId> emailIds) {
+    throw UnimplementedError();
+  }
 }

--- a/lib/features/email/data/datasource_impl/email_hive_cache_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_hive_cache_datasource_impl.dart
@@ -476,4 +476,54 @@ class EmailHiveCacheDataSourceImpl extends EmailDataSource {
   Future<Email> storeEventAttendanceStatus(Session session, AccountId accountId, EmailId emailId, EventActionType eventActionType) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<void> markAsAnswered(Session session, AccountId accountId, List<EmailId> emailIds) async {
+    final cacheEmails = await _emailCacheManager.getMultipleStoredEmails(
+      accountId,
+      session.username,
+      emailIds,
+    );
+
+    final storedEmails = cacheEmails
+      .map((emailCache) => emailCache.toEmail())
+      .toList();
+
+    for (var email in storedEmails) {
+      email.keywords?[KeyWordIdentifier.emailAnswered] = true;
+    }
+
+    await _emailCacheManager.storeMultipleEmails(
+      accountId,
+      session.username,
+      storedEmails.map((email) => email.toEmailCache()).toList(),
+    );
+
+    return Future.value();
+  }
+
+  @override
+  Future<void> markAsForwarded(Session session, AccountId accountId, List<EmailId> emailIds) async {
+    final cacheEmails = await _emailCacheManager.getMultipleStoredEmails(
+      accountId,
+      session.username,
+      emailIds,
+    );
+
+    final storedEmails = cacheEmails
+      .map((emailCache) => emailCache.toEmail())
+      .toList();
+
+    for (var email in storedEmails) {
+      email.keywords?[KeyWordIdentifier.emailForwarded] = true;
+    }
+
+    await _emailCacheManager.storeMultipleEmails(
+      accountId,
+      session.username,
+      storedEmails.map((email) => email.toEmailCache()).toList(),
+    );
+
+    return Future.value();
+  }
 }

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -2722,6 +2722,14 @@ class MailboxDashBoardController extends ReloadableController
         success.emailRequest.previousEmailId != null) {
       unsubscribeMail(success.emailRequest.previousEmailId!);
     }
+
+    if (success.emailRequest.isEmailAnswered) {
+      updateEmailAnswered(success.emailRequest.emailIdAnsweredOrForwarded!);
+    }
+
+    if (success.emailRequest.isEmailForwarded) {
+      updateEmailForwarded(success.emailRequest.emailIdAnsweredOrForwarded!);
+    }
   }
 
   Future<List<EmailAddress>> getContactSuggestion(String query) async {

--- a/lib/features/mailbox_dashboard/presentation/extensions/update_current_emails_flags_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/update_current_emails_flags_extension.dart
@@ -3,6 +3,7 @@ import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
 import 'package:model/email/mark_star_action.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:model/email/read_actions.dart';
+import 'package:model/extensions/presentation_email_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
 
@@ -11,12 +12,19 @@ extension UpdateCurrentEmailsFlagsExtension on MailboxDashBoardController {
     List<EmailId> emailIds, {
     ReadActions? readAction,
     MarkStarAction? markStarAction,
+    bool markAsAnswered = false,
+    bool markAsForwarded = false,
   }) {
-    if (readAction == null && markStarAction == null) return;
+    if (readAction == null &&
+        markStarAction == null &&
+        !markAsAnswered &&
+        !markAsForwarded) return;
 
     final currentEmails = dashboardRoute.value == DashboardRoutes.searchEmail
       ? listResultSearch
       : emailsInCurrentMailbox;
+
+    if (currentEmails.isEmpty) return;
 
     for (var email in currentEmails) {
       if (!emailIds.contains(email.id)) continue;
@@ -42,6 +50,14 @@ extension UpdateCurrentEmailsFlagsExtension on MailboxDashBoardController {
         default:
           break;
       }
+
+      if (markAsAnswered) {
+        _updateKeyword(email, KeyWordIdentifier.emailAnswered, true);
+      }
+
+      if (markAsForwarded) {
+        _updateKeyword(email, KeyWordIdentifier.emailForwarded, true);
+      }
     }
 
     currentEmails.refresh();
@@ -57,5 +73,29 @@ extension UpdateCurrentEmailsFlagsExtension on MailboxDashBoardController {
     } else {
       presentationEmail.keywords?.remove(keyword);
     }
+  }
+
+  void updateEmailAnswered(EmailId emailId) {
+    if (selectedEmail.value != null) {
+      final newEmail = selectedEmail.value!.updateKeywords({
+        KeyWordIdentifier.emailAnswered: true,
+      });
+      setSelectedEmail(newEmail);
+    }
+
+    if (emailsInCurrentMailbox.isNotEmpty) {
+      updateEmailFlagByEmailIds([emailId], markAsAnswered: true);
+    }
+  }
+
+  void updateEmailForwarded(EmailId emailId) {
+    if (selectedEmail.value != null) {
+      final newEmail = selectedEmail.value!.updateKeywords({
+        KeyWordIdentifier.emailForwarded: true,
+      });
+      setSelectedEmail(newEmail);
+    }
+
+    updateEmailFlagByEmailIds([emailId], markAsForwarded: true);
   }
 }


### PR DESCRIPTION
## Issue

#3430


## Root cause

- This error may occur because the data from `web socket` has not been returned yet, so the data has not been synchronized to the latest. 
- We have checked it again and it still works well, the data synchronization from `web socket` after performing `Forward` or `Answer` email is accurate and fast. 
- BUT to improve this synchronization, we will synchronize the data right on `Memory` and `Cache` before waiting for `Web socket` to return the data.

## Solution

- We will synchronize the data right on `Memory` and `Cache` before waiting for `Web socket` to return the data.


## Resolved

https://github.com/user-attachments/assets/5c425121-1321-4a57-aa5b-ef47fa357288


