### PR TITLE
TF-3424 Fix Tmail web should display `text/plain` with a fixed width font

### DIFF
--- a/core/lib/core.dart
+++ b/core/lib/core.dart
@@ -33,6 +33,7 @@ export 'presentation/utils/style_utils.dart';
 export 'presentation/utils/app_toast.dart';
 export 'presentation/utils/html_transformer/html_transform.dart';
 export 'presentation/utils/html_transformer/transform_configuration.dart';
+export 'presentation/utils/html_transformer/text/persist_preformatted_text_transformer.dart';
 export 'data/utils/device_manager.dart';
 export 'utils/app_logger.dart';
 export 'utils/benchmark.dart';

--- a/core/lib/presentation/utils/html_transformer/text/persist_preformatted_text_transformer.dart
+++ b/core/lib/presentation/utils/html_transformer/text/persist_preformatted_text_transformer.dart
@@ -1,0 +1,12 @@
+import 'dart:convert';
+
+import 'package:core/presentation/utils/html_transformer/base/text_transformer.dart';
+
+class PersistPreformattedTextTransformer extends TextTransformer {
+  const PersistPreformattedTextTransformer();
+
+  @override
+  String process(String text, HtmlEscape htmlEscape) {
+    return '<pre>$text</pre>';
+  }
+}

--- a/lib/features/email/data/local/html_analyzer.dart
+++ b/lib/features/email/data/local/html_analyzer.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:core/data/constants/constant.dart';
 import 'package:core/presentation/utils/html_transformer/html_transform.dart';
+import 'package:core/presentation/utils/html_transformer/text/persist_preformatted_text_transformer.dart';
 import 'package:core/presentation/utils/html_transformer/text/sanitize_autolink_html_transformers.dart';
 import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:core/utils/app_logger.dart';
@@ -37,7 +38,8 @@ class HtmlAnalyzer {
         final message = _htmlTransform.transformToTextPlain(
           content: emailContent.content,
           transformConfiguration: TransformConfiguration.fromTextTransformers([
-            const SanitizeAutolinkHtmlTransformers()
+            const SanitizeAutolinkHtmlTransformers(),
+            const PersistPreformattedTextTransformer(),
           ]),
         );
         return EmailContent(emailContent.type, message);


### PR DESCRIPTION
## Issue

#3424 

## Root cause

- When text content is in `text/plain` format when displayed in web view, the text format and structure are not preserved. The values ​​`space`, `blank line`, and `line break` will be ignored.

## Solution

- Use html `<pre>` tag to display `text/plain` content. Helps to preserve text formatting and pre-formatted data

## Resolved



https://github.com/user-attachments/assets/87f16b38-de4d-46d7-b261-f4080fdd2e2a



