### PR TITLE
handle parsing exception for `OIDCHttpClient::checkOIDCIsAvailable()`

### DIFF
--- a/lib/features/login/data/network/oidc_http_client.dart
+++ b/lib/features/login/data/network/oidc_http_client.dart
@@ -11,6 +11,7 @@ import 'package:model/oidc/response/oidc_response.dart';
 import 'package:tmail_ui_user/features/login/data/extensions/service_path_extension.dart';
 import 'package:tmail_ui_user/features/login/data/network/config/oidc_constant.dart';
 import 'package:tmail_ui_user/features/login/data/network/endpoint.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/login_exception.dart';
 import 'package:tmail_ui_user/features/login/data/network/oidc_error.dart';
 import 'package:tmail_ui_user/main/utils/app_config.dart';
 import 'package:dio/dio.dart' show DioError;
@@ -38,6 +39,9 @@ class OIDCHttpClient {
       } else {
         return OIDCResponse.fromJson(jsonDecode(result));
       }
+    } on FormatException catch (exception) {
+      log('checkOIDCIsAvailable(): error while parsing server response (JSON expected): ${exception.message}');
+      throw InvalidOIDCResponseException();
     } on DioError catch (exception) {
       if (exception.response?.statusCode == 404) {
         throw CanNotFoundOIDCLinks();

--- a/lib/features/login/domain/exceptions/login_exception.dart
+++ b/lib/features/login/domain/exceptions/login_exception.dart
@@ -5,6 +5,8 @@ class NotFoundDataResourceRecordException implements Exception {}
 
 class NotFoundUrlException implements Exception {}
 
+class InvalidOIDCResponseException implements Exception {}
+
 class NoSuitableBrowserForOIDCException implements Exception {
 
   static const noBrowserAvailableCode = 'no_browser_available';

--- a/lib/features/login/presentation/login_controller.dart
+++ b/lib/features/login/presentation/login_controller.dart
@@ -274,7 +274,7 @@ class LoginController extends ReloadableController {
   }
 
   void _handleCheckOIDCIsAvailableFailure(CheckOIDCIsAvailableFailure failure) {
-    if (failure.exception is CanNotFoundOIDCLinks) {
+    if (failure.exception is CanNotFoundOIDCLinks || failure.exception is InvalidOIDCResponseException) {
       _handleCommonOIDCFailure();
     } else {
       loginFormType.value = LoginFormType.retry;


### PR DESCRIPTION
here is a fix for a bug pointed out by [this user experience review](https://github.com/linagora/tmail-flutter/discussions/3435#discussioncomment-12008196).

- upon providing `https://api.fastmail.com/jmap/session`, the actual error is a `401 Unauthorized` and this case was handeled in [this pull request](https://github.com/linagora/tmail-flutter/pull/3428) ;
- upon providing the correct `https://api.fastmail.com`, another error occured because the server answers with HTML instead of JSON, eg, `FormatException`. the correct behaviour, which i fix with the current PR, is to ignore webfinger and fall back to the classic credential form.