### PR TITLE
TF-3444 Fix could not expand folder tree in folder visibility on iOS

### DIFF
--- a/lib/features/manage_account/presentation/manage_account_dashboard_view.dart
+++ b/lib/features/manage_account/presentation/manage_account_dashboard_view.dart
@@ -99,7 +99,11 @@ class ManageAccountDashBoardView extends GetWidget<ManageAccountDashBoardControl
                 ],
               ))
             ]),
-            mobile: SettingsView(closeAction: () => controller.backToMailboxDashBoard(context: context))
+            mobile: SafeArea(
+              child: SettingsView(
+                closeAction: () =>
+                  controller.backToMailboxDashBoard(context: context)),
+            )
         ),
       ),
     );

--- a/lib/features/manage_account/presentation/menu/settings/settings_view.dart
+++ b/lib/features/manage_account/presentation/menu/settings/settings_view.dart
@@ -33,75 +33,53 @@ class SettingsView extends GetWidget<SettingsController> {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      color: Colors.white,
-      child: SafeArea(
-        top: controller.manageAccountDashboardController.isVacationCapabilitySupported,
-        bottom: controller.manageAccountDashboardController.isVacationCapabilitySupported,
-        left: controller.manageAccountDashboardController.isVacationCapabilitySupported &&
-          controller.responsiveUtils.isPortraitMobile(context),
-        right: controller.manageAccountDashboardController.isVacationCapabilitySupported &&
-          controller.responsiveUtils.isPortraitMobile(context),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            SafeArea(
-              bottom: false,
-              child: SizedBox.fromSize(
-                size: const Size.fromHeight(52),
-                child: Padding(
-                  padding: SettingsUtils.getPaddingAppBar(context, controller.responsiveUtils),
-                  child: _buildAppbar(context))),
-            ),
-            const Divider(color: AppColor.colorDividerComposer, height: 1),
-            Obx(() {
-              if (controller.manageAccountDashboardController.vacationResponse.value?.vacationResponderIsValid == true) {
-                return SafeArea(
-                  top: false,
-                  bottom: false,
-                  child: VacationNotificationMessageWidget(
-                    margin: const EdgeInsetsDirectional.only(start: 12, end: 12, top: 8),
-                    fromAccountDashBoard: true,
-                    vacationResponse: controller.manageAccountDashboardController.vacationResponse.value!,
-                    actionGotoVacationSetting: !controller.manageAccountDashboardController.inVacationSettings()
-                      ? () => controller.manageAccountDashboardController.selectAccountMenuItem(AccountMenuItem.vacation)
-                      : null,
-                    actionEndNow: controller.manageAccountDashboardController.disableVacationResponder
-                  ),
-                );
-              } else if ((controller.manageAccountDashboardController.vacationResponse.value?.vacationResponderIsWaiting == true
-                  || controller.manageAccountDashboardController.vacationResponse.value?.vacationResponderIsStopped == true)
-                  && controller.manageAccountDashboardController.inVacationSettings()) {
-                return SafeArea(
-                  top: false,
-                  bottom: false,
-                  child: VacationNotificationMessageWidget(
-                    margin: const EdgeInsetsDirectional.only(start: 12, end: 12, top: 8),
-                    fromAccountDashBoard: true,
-                    vacationResponse: controller.manageAccountDashboardController.vacationResponse.value!,
-                    padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 16),
-                    leadingIcon: const Padding(
-                      padding: EdgeInsetsDirectional.only(end: 12),
-                      child: Icon(Icons.timer, size: 20),
-                    )
-                  ),
-                );
-              } else {
-                return const SizedBox.shrink();
-              }
-            }),
-            Obx(() {
-              if (controller.manageAccountDashboardController.forwardWarningBannerState.value == BannerState.enabled &&
-                  controller.manageAccountDashboardController.accountMenuItemSelected.value == AccountMenuItem.forward) {
-                return ForwardWarningBanner();
-              } else {
-                return const SizedBox.shrink();
-              }
-            }),
-            Expanded(child: _bodySettingsScreen())
-          ]
-        ),
-      ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox.fromSize(
+          size: const Size.fromHeight(52),
+          child: Padding(
+            padding: SettingsUtils.getPaddingAppBar(context, controller.responsiveUtils),
+            child: _buildAppbar(context))),
+        const Divider(color: AppColor.colorDividerComposer, height: 1),
+        Obx(() {
+          if (controller.manageAccountDashboardController.vacationResponse.value?.vacationResponderIsValid == true) {
+            return VacationNotificationMessageWidget(
+              margin: const EdgeInsetsDirectional.only(start: 12, end: 12, top: 8),
+              fromAccountDashBoard: true,
+              vacationResponse: controller.manageAccountDashboardController.vacationResponse.value!,
+              actionGotoVacationSetting: !controller.manageAccountDashboardController.inVacationSettings()
+                ? () => controller.manageAccountDashboardController.selectAccountMenuItem(AccountMenuItem.vacation)
+                : null,
+              actionEndNow: controller.manageAccountDashboardController.disableVacationResponder
+            );
+          } else if ((controller.manageAccountDashboardController.vacationResponse.value?.vacationResponderIsWaiting == true
+              || controller.manageAccountDashboardController.vacationResponse.value?.vacationResponderIsStopped == true)
+              && controller.manageAccountDashboardController.inVacationSettings()) {
+            return VacationNotificationMessageWidget(
+              margin: const EdgeInsetsDirectional.only(start: 12, end: 12, top: 8),
+              fromAccountDashBoard: true,
+              vacationResponse: controller.manageAccountDashboardController.vacationResponse.value!,
+              padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 16),
+              leadingIcon: const Padding(
+                padding: EdgeInsetsDirectional.only(end: 12),
+                child: Icon(Icons.timer, size: 20),
+              )
+            );
+          } else {
+            return const SizedBox.shrink();
+          }
+        }),
+        Obx(() {
+          if (controller.manageAccountDashboardController.forwardWarningBannerState.value == BannerState.enabled &&
+              controller.manageAccountDashboardController.accountMenuItemSelected.value == AccountMenuItem.forward) {
+            return ForwardWarningBanner();
+          } else {
+            return const SizedBox.shrink();
+          }
+        }),
+        Expanded(child: _bodySettingsScreen())
+      ]
     );
   }
 
@@ -200,9 +178,7 @@ class SettingsView extends GetWidget<SettingsController> {
     return Obx(() {
       switch (controller.manageAccountDashboardController.settingsPageLevel.value) {
         case SettingsPageLevel.universal:
-          return const SafeArea(
-            top: false,
-            child: SettingsFirstLevelView());
+          return const SettingsFirstLevelView();
         case SettingsPageLevel.level1:
           return _viewDisplayedOfAccountMenuItem();
       }
@@ -213,34 +189,24 @@ class SettingsView extends GetWidget<SettingsController> {
     return Obx(() {
       switch(controller.manageAccountDashboardController.accountMenuItemSelected.value) {
         case AccountMenuItem.profiles:
-          return SafeArea(
-            top: false,
-            child: ProfilesView());
+          return ProfilesView();
         case AccountMenuItem.languageAndRegion:
-          return const SafeArea(
-            top: false,
-            child: LanguageAndRegionView());
+          return const LanguageAndRegionView();
         case AccountMenuItem.emailRules:
           if (controller.manageAccountDashboardController.isRuleFilterCapabilitySupported) {
-            return SafeArea(
-              top: false,
-              child: EmailRulesView());
+            return EmailRulesView();
           } else {
             return const SizedBox.shrink();
           }
         case AccountMenuItem.alwaysReadReceipt:
           if (controller.manageAccountDashboardController.isServerSettingsCapabilitySupported) {
-            return const SafeArea(
-              top: false,
-              child: AlwaysReadReceiptView());
+            return const AlwaysReadReceiptView();
           } else {
             return const SizedBox.shrink();
           }
         case AccountMenuItem.forward:
           if (controller.manageAccountDashboardController.isForwardCapabilitySupported) {
-            return SafeArea(
-              top: false,
-              child: ForwardView());
+            return ForwardView();
           } else {
             return const SizedBox.shrink();
           }
@@ -251,13 +217,9 @@ class SettingsView extends GetWidget<SettingsController> {
             return const SizedBox.shrink();
           }
         case AccountMenuItem.mailboxVisibility:
-          return SafeArea(
-            top: false,
-            child: MailboxVisibilityView());
+          return MailboxVisibilityView();
         case AccountMenuItem.notification:
-          return const SafeArea(
-            top: false,
-            child: NotificationView());
+          return const NotificationView();
         default:
           return const SizedBox.shrink();
       }


### PR DESCRIPTION
## Issue

#3444 

## Reproduce


https://github.com/user-attachments/assets/53ffa285-65fa-4210-8cc3-1d91eed73b39



## Root cause

Due to using multiple nested `SafeAreas`, a single `SafeArea` class is creating unwanted extra space above the top of the list. The height is about `50dp` so only the `Inbox` item is not clickable.

## Solution

Use only one `SafeArea` that wraps the outermost part of the view

## Resolved

- iOS:

https://github.com/user-attachments/assets/e9cf4620-daf4-47aa-9393-7d09a40075af



- Android:

[demo-android.webm](https://github.com/user-attachments/assets/a7713274-ee57-47cc-a884-770af3694e99)


- Web:



https://github.com/user-attachments/assets/0d3a2b7f-7a1d-4caf-977a-62303393f3d7




