### PR TITLE
TF-2469 Fix email set into root mailbox's SENT instead of team mailbox's SENT

### DIFF
--- a/docs/adr/0057-team-mailboxes-matching.md
+++ b/docs/adr/0057-team-mailboxes-matching.md
@@ -1,0 +1,25 @@
+# 57. Team Mailboxes Matching
+
+Date: 2025-02-18
+
+## Status
+
+Accepted
+
+## Context
+
+- Team mailboxes were not considered when sending emails
+- Sent emails were saved to default sent mailbox, although selected identity's email was based on team mailbox email
+
+## Decision
+
+- Instead of hard coding default sent mailbox, sent emails will be saved to mailbox based on
+  - identity's email
+  - mailbox's name (hard coded English)
+- Only when there's no matching mailbox, default sent mailbox will be used
+- Same logic is applied to drafts mailbox and outbox mailbox
+
+## Consequences
+
+- Team mailboxes will be considered when sending emails
+- Potentially, if team mailboxes existed but the name is not in English, sent emails will be saved to default sent mailbox

--- a/docs/adr/0057-team-mailboxes-matching.md
+++ b/docs/adr/0057-team-mailboxes-matching.md
@@ -10,6 +10,7 @@ Accepted
 
 - Team mailboxes were not considered when sending emails
 - Sent emails were saved to default sent mailbox, although selected identity's email was based on team mailbox email
+- User does not have permission to edit mailboxes of team mailboxes
 
 ## Decision
 

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -55,6 +55,7 @@ import 'package:tmail_ui_user/features/composer/domain/usecases/save_composer_ca
 import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_web_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/email_action_type_extension.dart';
+import 'package:tmail_ui_user/features/composer/presentation/extensions/get_sent_mailbox_id_for_composer_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/list_identities_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/list_shared_media_file_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/mixin/drag_drog_file_mixin.dart';
@@ -481,7 +482,7 @@ class ComposerController extends BaseController
       attachments: uploadController.attachmentsUploaded,
       inlineAttachments: uploadController.mapInlineAttachments,
       outboxMailboxId: mailboxDashBoardController.outboxMailbox?.mailboxId,
-      sentMailboxId: mailboxDashBoardController.mapDefaultMailboxIdByRole[PresentationMailbox.roleSent],
+      sentMailboxId: getSentMailboxIdForComposer(),
       draftsMailboxId: mailboxDashBoardController.mapDefaultMailboxIdByRole[PresentationMailbox.roleDrafts],
       draftsEmailId: getDraftEmailId(),
       answerForwardEmailId: composerArguments.value!.presentationEmail?.id,
@@ -1052,7 +1053,7 @@ class ComposerController extends BaseController
           attachments: uploadController.attachmentsUploaded,
           inlineAttachments: uploadController.mapInlineAttachments,
           outboxMailboxId: mailboxDashBoardController.outboxMailbox?.mailboxId,
-          sentMailboxId: mailboxDashBoardController.mapDefaultMailboxIdByRole[PresentationMailbox.roleSent],
+          sentMailboxId: getSentMailboxIdForComposer(),
           draftsEmailId: getDraftEmailId(),
           answerForwardEmailId: composerArguments.value!.presentationEmail?.id,
           unsubscribeEmailId: composerArguments.value!.previousEmailId,
@@ -2354,7 +2355,7 @@ class ComposerController extends BaseController
           identity: identitySelected.value,
           attachments: uploadController.attachmentsUploaded,
           inlineAttachments: uploadController.mapInlineAttachments,
-          sentMailboxId: mailboxDashBoardController.mapDefaultMailboxIdByRole[PresentationMailbox.roleSent],
+          sentMailboxId: getSentMailboxIdForComposer(),
           draftsMailboxId: mailboxDashBoardController.mapDefaultMailboxIdByRole[PresentationMailbox.roleDrafts],
           draftsEmailId: draftEmailId,
           answerForwardEmailId: composerArguments.value!.presentationEmail?.id,

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -55,6 +55,7 @@ import 'package:tmail_ui_user/features/composer/domain/usecases/save_composer_ca
 import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_web_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/email_action_type_extension.dart';
+import 'package:tmail_ui_user/features/composer/presentation/extensions/get_draft_mailbox_id_for_composer_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/get_sent_mailbox_id_for_composer_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/list_identities_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/list_shared_media_file_extension.dart';
@@ -483,7 +484,7 @@ class ComposerController extends BaseController
       inlineAttachments: uploadController.mapInlineAttachments,
       outboxMailboxId: mailboxDashBoardController.outboxMailbox?.mailboxId,
       sentMailboxId: getSentMailboxIdForComposer(),
-      draftsMailboxId: mailboxDashBoardController.mapDefaultMailboxIdByRole[PresentationMailbox.roleDrafts],
+      draftsMailboxId: getDraftMailboxIdForComposer(),
       draftsEmailId: getDraftEmailId(),
       answerForwardEmailId: composerArguments.value!.presentationEmail?.id,
       unsubscribeEmailId: composerArguments.value!.previousEmailId,
@@ -1296,7 +1297,7 @@ class ComposerController extends BaseController
     if (composerArguments.value == null ||
         mailboxDashBoardController.sessionCurrent == null ||
         mailboxDashBoardController.accountId.value == null ||
-        mailboxDashBoardController.mapDefaultMailboxIdByRole[PresentationMailbox.roleDrafts] == null
+        getDraftMailboxIdForComposer() == null
     ) {
       log('ComposerController::handleClickSaveAsDraftsButton: SESSION or ACCOUNT_ID or ARGUMENTS is NULL');
       _saveToDraftButtonState = ButtonState.enabled;
@@ -2283,7 +2284,7 @@ class ComposerController extends BaseController
     if (composerArguments.value == null ||
         mailboxDashBoardController.sessionCurrent == null ||
         mailboxDashBoardController.accountId.value == null ||
-        mailboxDashBoardController.mapDefaultMailboxIdByRole[PresentationMailbox.roleDrafts] == null
+        getDraftMailboxIdForComposer() == null
     ) {
       log('ComposerController::_handleSaveMessageToDraft: SESSION or ACCOUNT_ID or ARGUMENTS is NULL');
       _closeComposerButtonState = ButtonState.enabled;
@@ -2356,7 +2357,7 @@ class ComposerController extends BaseController
           attachments: uploadController.attachmentsUploaded,
           inlineAttachments: uploadController.mapInlineAttachments,
           sentMailboxId: getSentMailboxIdForComposer(),
-          draftsMailboxId: mailboxDashBoardController.mapDefaultMailboxIdByRole[PresentationMailbox.roleDrafts],
+          draftsMailboxId: getDraftMailboxIdForComposer(),
           draftsEmailId: draftEmailId,
           answerForwardEmailId: composerArguments.value!.presentationEmail?.id,
           unsubscribeEmailId: composerArguments.value!.previousEmailId,

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -56,6 +56,7 @@ import 'package:tmail_ui_user/features/composer/presentation/controller/rich_tex
 import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_web_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/email_action_type_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/get_draft_mailbox_id_for_composer_extension.dart';
+import 'package:tmail_ui_user/features/composer/presentation/extensions/get_outbox_mailbox_id_for_composer_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/get_sent_mailbox_id_for_composer_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/list_identities_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/list_shared_media_file_extension.dart';
@@ -482,7 +483,7 @@ class ComposerController extends BaseController
       identity: identitySelected.value,
       attachments: uploadController.attachmentsUploaded,
       inlineAttachments: uploadController.mapInlineAttachments,
-      outboxMailboxId: mailboxDashBoardController.outboxMailbox?.mailboxId,
+      outboxMailboxId: getOutboxMailboxIdForComposer(),
       sentMailboxId: getSentMailboxIdForComposer(),
       draftsMailboxId: getDraftMailboxIdForComposer(),
       draftsEmailId: getDraftEmailId(),
@@ -1053,7 +1054,7 @@ class ComposerController extends BaseController
           identity: identitySelected.value,
           attachments: uploadController.attachmentsUploaded,
           inlineAttachments: uploadController.mapInlineAttachments,
-          outboxMailboxId: mailboxDashBoardController.outboxMailbox?.mailboxId,
+          outboxMailboxId: getOutboxMailboxIdForComposer(),
           sentMailboxId: getSentMailboxIdForComposer(),
           draftsEmailId: getDraftEmailId(),
           answerForwardEmailId: composerArguments.value!.presentationEmail?.id,

--- a/lib/features/composer/presentation/extensions/get_draft_mailbox_id_for_composer_extension.dart
+++ b/lib/features/composer/presentation/extensions/get_draft_mailbox_id_for_composer_extension.dart
@@ -1,0 +1,22 @@
+import 'package:collection/collection.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/extensions/presentation_mailbox_extension.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
+
+extension GetDraftMailboxIdForComposerExtension on ComposerController {
+  MailboxId? getDraftMailboxIdForComposer() {
+    final defaultDraftsMailbox = mailboxDashBoardController.mapDefaultMailboxIdByRole[
+      PresentationMailbox.roleDrafts
+    ];
+    final lowercaseDraftsRole = PresentationMailbox.roleDrafts.value.toLowerCase();
+
+    return mailboxDashBoardController.mapMailboxById.entries
+      .firstWhereOrNull((entry) {
+        final mailbox = entry.value;
+        return mailbox.emailTeamMailBoxes == identitySelected.value?.email &&
+          mailbox.name?.name.toLowerCase() == lowercaseDraftsRole;
+      })
+      ?.key ?? defaultDraftsMailbox;
+  }
+}

--- a/lib/features/composer/presentation/extensions/get_outbox_mailbox_id_for_composer_extension.dart
+++ b/lib/features/composer/presentation/extensions/get_outbox_mailbox_id_for_composer_extension.dart
@@ -1,0 +1,22 @@
+import 'package:collection/collection.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/extensions/presentation_mailbox_extension.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
+
+extension GetOutboxMailboxIdForComposerExtension on ComposerController {
+  MailboxId? getOutboxMailboxIdForComposer() {
+    final defaultOutboxMailbox = mailboxDashBoardController.mapDefaultMailboxIdByRole[
+      PresentationMailbox.roleOutbox
+    ];
+    final lowercaseOutboxRole = PresentationMailbox.roleOutbox.value.toLowerCase();
+
+    return mailboxDashBoardController.mapMailboxById.entries
+      .firstWhereOrNull((entry) {
+        final mailbox = entry.value;
+        return mailbox.emailTeamMailBoxes == identitySelected.value?.email &&
+          mailbox.name?.name.toLowerCase() == lowercaseOutboxRole;
+      })
+      ?.key ?? defaultOutboxMailbox;
+  }
+}

--- a/lib/features/composer/presentation/extensions/get_sent_mailbox_id_for_composer_extension.dart
+++ b/lib/features/composer/presentation/extensions/get_sent_mailbox_id_for_composer_extension.dart
@@ -14,7 +14,7 @@ extension GetSentMailboxIdForComposerExtension on ComposerController {
       .firstWhereOrNull((entry) {
         final mailbox = entry.value;
         return mailbox.emailTeamMailBoxes == identitySelected.value?.email &&
-               mailbox.name?.name.toLowerCase() == lowercaseSentRole;
+          mailbox.name?.name.toLowerCase() == lowercaseSentRole;
       })
       ?.key ?? defaultSentMailbox;
   }

--- a/lib/features/composer/presentation/extensions/get_sent_mailbox_id_for_composer_extension.dart
+++ b/lib/features/composer/presentation/extensions/get_sent_mailbox_id_for_composer_extension.dart
@@ -1,0 +1,21 @@
+import 'package:collection/collection.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/model.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
+
+extension GetSentMailboxIdForComposerExtension on ComposerController {
+  MailboxId? getSentMailboxIdForComposer() {
+    final defaultSentMailbox = mailboxDashBoardController.mapDefaultMailboxIdByRole[
+      PresentationMailbox.roleSent
+    ];
+    final lowercaseSentRole = PresentationMailbox.roleSent.value.toLowerCase();
+
+    return mailboxDashBoardController.mapMailboxById.entries
+      .firstWhereOrNull((entry) {
+        final mailbox = entry.value;
+        return mailbox.emailTeamMailBoxes == identitySelected.value?.email &&
+               mailbox.name?.name.toLowerCase() == lowercaseSentRole;
+      })
+      ?.key ?? defaultSentMailbox;
+  }
+}

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -127,6 +127,9 @@ class MockMailboxDashBoardController extends Mock implements MailboxDashBoardCon
 
   @override
   int get minInputLengthAutocomplete => AppConfig.defaultMinInputLengthAutocomplete;
+
+  @override
+  Map<MailboxId, PresentationMailbox> get mapMailboxById => {};
 }
 
 @GenerateNiceMocks([


### PR DESCRIPTION
## Issue
- #2469 

## Root cause
- Always direct email to default "Sent" mailbox

## Solution
- Compare selected identity email with available mailboxes, get the mailbox which email is the same and the name is "Sent". If none exists, fall back to default "Sent" mailbox

## Demo

https://github.com/user-attachments/assets/fc26cf06-7f0b-4c07-8c8a-c46325b8fa4d

