### PR TITLE
[HOT-FIX] Fix large gap appears between setting items in Setting View on Web responsive

### DIFF
--- a/lib/features/manage_account/presentation/menu/settings/settings_first_level_view.dart
+++ b/lib/features/manage_account/presentation/menu/settings/settings_first_level_view.dart
@@ -142,7 +142,7 @@ class SettingsFirstLevelView extends GetWidget<SettingsController> {
           () => controller.selectSettings(AccountMenuItem.languageAndRegion)
         ),
         Obx(() {
-          if (PlatformInfo.isMobile && controller.manageAccountDashboardController.isFcmCapabilitySupported) {
+          if (controller.manageAccountDashboardController.isFcmCapabilitySupported && PlatformInfo.isMobile) {
             return Column(children: [
               Divider(
                   color: AppColor.colorDividerHorizontal,


### PR DESCRIPTION
## Issue

- Large gap appears between setting items in Setting View on Web responsive



https://github.com/user-attachments/assets/d6079811-0763-4627-b90c-5744de570578

## Side effect 

- https://github.com/linagora/tmail-flutter/pull/3428/commits/638271939df59df920578da41e2caa0370a566cb#diff-918e30671cd7628bb2f062f6559bc0a80f97ce69b93f739aabd66be52e96f965

## Root cause

The `PlatformInfo.isMobile` condition in the `If` in the `Obx(() {})` function is not an observable variable `obs`. So `Obx` throws an exception when it does not find any `obs` variable in it.

## Solution 

Check the condition `controller.manageAccountDashboardController.isFcmCapabilitySupported` first


## Resolved

- Web:


https://github.com/user-attachments/assets/3d15f2a2-d38e-4bed-9765-c46bc122cff7


- Mobile:


[demo-mobile.webm](https://github.com/user-attachments/assets/0e896982-402f-4a48-9d01-1826e3986475)



