### PR TITLE
Hot fix cannot send email on Cyrus server when the first open app

### DIFF
--- a/lib/features/composer/presentation/extensions/get_outbox_mailbox_id_for_composer_extension.dart
+++ b/lib/features/composer/presentation/extensions/get_outbox_mailbox_id_for_composer_extension.dart
@@ -6,9 +6,7 @@ import 'package:tmail_ui_user/features/composer/presentation/composer_controller
 
 extension GetOutboxMailboxIdForComposerExtension on ComposerController {
   MailboxId? getOutboxMailboxIdForComposer() {
-    final defaultOutboxMailbox = mailboxDashBoardController.mapDefaultMailboxIdByRole[
-      PresentationMailbox.roleOutbox
-    ];
+    final defaultOutboxMailboxId = mailboxDashBoardController.outboxMailbox?.mailboxId;
     final lowercaseOutboxRole = PresentationMailbox.roleOutbox.value.toLowerCase();
 
     return mailboxDashBoardController.mapMailboxById.entries
@@ -17,6 +15,6 @@ extension GetOutboxMailboxIdForComposerExtension on ComposerController {
         return mailbox.emailTeamMailBoxes == identitySelected.value?.email &&
           mailbox.name?.name.toLowerCase() == lowercaseOutboxRole;
       })
-      ?.key ?? defaultOutboxMailbox;
+      ?.key ?? defaultOutboxMailboxId;
   }
 }

--- a/lib/features/email/data/network/email_api.dart
+++ b/lib/features/email/data/network/email_api.dart
@@ -174,7 +174,8 @@ class EmailAPI with HandleSetErrorMixin {
     final emailSubmissionId = EmailSubmissionId(ReferenceId(ReferencePrefix.defaultPrefix, submissionCreateId));
     Map<EmailSubmissionId, PatchObject> mapEmailSubmissionUpdated = {
       emailSubmissionId: PatchObject({
-        emailRequest.sentMailboxId!.generatePath() : true,
+        if (emailRequest.sentMailboxId != null)
+          emailRequest.sentMailboxId!.generatePath() : true,
         outboxMailboxId!.generatePath() : null,
         KeyWordIdentifier.emailSeen.generatePath(): true,
         KeyWordIdentifier.emailDraft.generatePath(): null

--- a/lib/features/mailbox/data/datasource/mailbox_datasource.dart
+++ b/lib/features/mailbox/data/datasource/mailbox_datasource.dart
@@ -52,7 +52,7 @@ abstract class MailboxDataSource {
 
   Future<bool> handleMailboxRightRequest(Session session, AccountId accountId, MailboxRightRequest request);
 
-  Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> createDefaultMailbox(Session session, AccountId accountId, List<Role> listRole);
+  Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> createDefaultMailbox(Session session, AccountId accountId, Map<Id, Role> mapRoles);
 
   Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> setRoleDefaultMailbox(Session session, AccountId accountId, List<Mailbox> listMailbox);
 

--- a/lib/features/mailbox/data/datasource/mailbox_datasource.dart
+++ b/lib/features/mailbox/data/datasource/mailbox_datasource.dart
@@ -52,9 +52,9 @@ abstract class MailboxDataSource {
 
   Future<bool> handleMailboxRightRequest(Session session, AccountId accountId, MailboxRightRequest request);
 
-  Future<List<Mailbox>> createDefaultMailbox(Session session, AccountId accountId, List<Role> listRole);
+  Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> createDefaultMailbox(Session session, AccountId accountId, List<Role> listRole);
 
-  Future<void> setRoleDefaultMailbox(Session session, AccountId accountId, List<Mailbox> listMailbox);
+  Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> setRoleDefaultMailbox(Session session, AccountId accountId, List<Mailbox> listMailbox);
 
   Future<GetMailboxByRoleResponse> getMailboxByRole(Session session, AccountId accountId, Role role);
 

--- a/lib/features/mailbox/data/datasource_impl/mailbox_cache_datasource_impl.dart
+++ b/lib/features/mailbox/data/datasource_impl/mailbox_cache_datasource_impl.dart
@@ -141,7 +141,7 @@ class MailboxCacheDataSourceImpl extends MailboxDataSource {
   }
 
   @override
-  Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> createDefaultMailbox(Session session, AccountId accountId, List<Role> listRole) {
+  Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> createDefaultMailbox(Session session, AccountId accountId, Map<Id, Role> mapRoles) {
     throw UnimplementedError();
   }
 

--- a/lib/features/mailbox/data/datasource_impl/mailbox_cache_datasource_impl.dart
+++ b/lib/features/mailbox/data/datasource_impl/mailbox_cache_datasource_impl.dart
@@ -141,12 +141,12 @@ class MailboxCacheDataSourceImpl extends MailboxDataSource {
   }
 
   @override
-  Future<List<Mailbox>> createDefaultMailbox(Session session, AccountId accountId, List<Role> listRole) {
+  Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> createDefaultMailbox(Session session, AccountId accountId, List<Role> listRole) {
     throw UnimplementedError();
   }
 
   @override
-  Future<List<MailboxId>> setRoleDefaultMailbox(Session session, AccountId accountId, List<Mailbox> listMailbox) {
+  Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> setRoleDefaultMailbox(Session session, AccountId accountId, List<Mailbox> listMailbox) {
     throw UnimplementedError();
   }
   

--- a/lib/features/mailbox/data/datasource_impl/mailbox_datasource_impl.dart
+++ b/lib/features/mailbox/data/datasource_impl/mailbox_datasource_impl.dart
@@ -130,9 +130,9 @@ class MailboxDataSourceImpl extends MailboxDataSource {
   }
 
   @override
-  Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> createDefaultMailbox(Session session, AccountId accountId, List<Role> listRole) {
+  Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> createDefaultMailbox(Session session, AccountId accountId, Map<Id, Role> mapRoles) {
     return Future.sync(() async {
-      return await mailboxAPI.createDefaultMailbox(session, accountId, listRole);
+      return await mailboxAPI.createDefaultMailbox(session, accountId, mapRoles);
     }).catchError(_exceptionThrower.throwException);
   }
 

--- a/lib/features/mailbox/data/datasource_impl/mailbox_datasource_impl.dart
+++ b/lib/features/mailbox/data/datasource_impl/mailbox_datasource_impl.dart
@@ -130,14 +130,14 @@ class MailboxDataSourceImpl extends MailboxDataSource {
   }
 
   @override
-  Future<List<Mailbox>> createDefaultMailbox(Session session, AccountId accountId, List<Role> listRole) {
+  Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> createDefaultMailbox(Session session, AccountId accountId, List<Role> listRole) {
     return Future.sync(() async {
       return await mailboxAPI.createDefaultMailbox(session, accountId, listRole);
     }).catchError(_exceptionThrower.throwException);
   }
 
   @override
-  Future<void> setRoleDefaultMailbox(Session session, AccountId accountId, List<Mailbox> listMailbox) {
+  Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> setRoleDefaultMailbox(Session session, AccountId accountId, List<Mailbox> listMailbox) {
     return Future.sync(() async {
       return await mailboxAPI.setRoleDefaultMailbox(session, accountId, listMailbox);
     }).catchError(_exceptionThrower.throwException);

--- a/lib/features/mailbox/data/network/mailbox_api.dart
+++ b/lib/features/mailbox/data/network/mailbox_api.dart
@@ -456,13 +456,8 @@ class MailboxAPI with HandleSetErrorMixin {
   Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> createDefaultMailbox(
     Session session,
     AccountId accountId,
-    List<Role> listRole
+    Map<Id, Role> mapRoles,
   ) async {
-    final mapRoles = {
-      for (var role in listRole)
-        Id(_uuid.v1()) : role
-    };
-
     final mapCreate = {
       for (var id in mapRoles.keys)
         id : Mailbox(name: MailboxName(mapRoles[id]!.mailboxName), isSubscribed: IsSubscribed(true))

--- a/lib/features/mailbox/data/repository/mailbox_repository_impl.dart
+++ b/lib/features/mailbox/data/repository/mailbox_repository_impl.dart
@@ -292,8 +292,8 @@ class MailboxRepositoryImpl extends MailboxRepository {
   }
 
   @override
-  Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> createDefaultMailbox(Session session, AccountId accountId, List<Role> listRole) {
-    return mapDataSource[DataSourceType.network]!.createDefaultMailbox(session, accountId, listRole);
+  Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> createDefaultMailbox(Session session, AccountId accountId, Map<Id, Role> mapRoles) {
+    return mapDataSource[DataSourceType.network]!.createDefaultMailbox(session, accountId, mapRoles);
   }
 
   @override

--- a/lib/features/mailbox/data/repository/mailbox_repository_impl.dart
+++ b/lib/features/mailbox/data/repository/mailbox_repository_impl.dart
@@ -292,12 +292,12 @@ class MailboxRepositoryImpl extends MailboxRepository {
   }
 
   @override
-  Future<List<Mailbox>> createDefaultMailbox(Session session, AccountId accountId, List<Role> listRole) {
+  Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> createDefaultMailbox(Session session, AccountId accountId, List<Role> listRole) {
     return mapDataSource[DataSourceType.network]!.createDefaultMailbox(session, accountId, listRole);
   }
 
   @override
-  Future<void> setRoleDefaultMailbox(Session session, AccountId accountId, List<Mailbox> listMailbox) {
+  Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> setRoleDefaultMailbox(Session session, AccountId accountId, List<Mailbox> listMailbox) {
     return mapDataSource[DataSourceType.network]!.setRoleDefaultMailbox(session, accountId, listMailbox);
   }
   

--- a/lib/features/mailbox/domain/exceptions/set_mailbox_method_exception.dart
+++ b/lib/features/mailbox/domain/exceptions/set_mailbox_method_exception.dart
@@ -1,14 +1,3 @@
-
-import 'package:jmap_dart_client/jmap/core/error/set_error.dart';
-import 'package:jmap_dart_client/jmap/core/id.dart';
-
-class SetMailboxMethodException implements Exception {
-
-  final Map<Id, SetError> mapErrors;
-
-  SetMailboxMethodException(this.mapErrors);
-}
-
 class NotFoundMailboxCreatedException implements Exception {}
 
 class NotFoundMailboxUpdatedRoleException implements Exception {}

--- a/lib/features/mailbox/domain/repository/mailbox_repository.dart
+++ b/lib/features/mailbox/domain/repository/mailbox_repository.dart
@@ -49,9 +49,9 @@ abstract class MailboxRepository {
 
   Future<bool> handleMailboxRightRequest(Session session, AccountId accountId, MailboxRightRequest request);
 
-  Future<List<Mailbox>> createDefaultMailbox(Session session, AccountId accountId, List<Role> listRole);
+  Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> createDefaultMailbox(Session session, AccountId accountId, List<Role> listRole);
 
-  Future<void> setRoleDefaultMailbox(Session session, AccountId accountId, List<Mailbox> listMailbox);
+  Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> setRoleDefaultMailbox(Session session, AccountId accountId, List<Mailbox> listMailbox);
 
   Future<GetMailboxByRoleResponse> getMailboxByRole(Session session, AccountId accountId, Role role, {UnsignedInt? limit});
 }

--- a/lib/features/mailbox/domain/repository/mailbox_repository.dart
+++ b/lib/features/mailbox/domain/repository/mailbox_repository.dart
@@ -49,7 +49,7 @@ abstract class MailboxRepository {
 
   Future<bool> handleMailboxRightRequest(Session session, AccountId accountId, MailboxRightRequest request);
 
-  Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> createDefaultMailbox(Session session, AccountId accountId, List<Role> listRole);
+  Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> createDefaultMailbox(Session session, AccountId accountId, Map<Id, Role> mapRoles);
 
   Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> setRoleDefaultMailbox(Session session, AccountId accountId, List<Mailbox> listMailbox);
 

--- a/lib/features/mailbox/domain/state/create_default_mailbox_state.dart
+++ b/lib/features/mailbox/domain/state/create_default_mailbox_state.dart
@@ -1,25 +1,20 @@
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
-import 'package:tmail_ui_user/features/base/state/ui_action_state.dart';
-import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 
 class CreateDefaultMailboxLoading extends LoadingState {}
 
-class CreateDefaultMailboxAllSuccess extends UIActionState {
-  CreateDefaultMailboxAllSuccess({
-    jmap.State? currentEmailState,
-    jmap.State? currentMailboxState,
-  }) : super(currentEmailState, currentMailboxState);
+class CreateDefaultMailboxAllSuccess extends UIState {
+
+  final List<Mailbox> listMailbox;
+
+  CreateDefaultMailboxAllSuccess(this.listMailbox);
 
   @override
-  List<Object?> get props => [...super.props];
+  List<Object?> get props => [listMailbox];
 }
 
 class CreateDefaultMailboxFailure extends FeatureFailure {
-  final jmap.State? currentMailboxState;
 
-  CreateDefaultMailboxFailure(this.currentMailboxState, dynamic exception) : super(exception: exception);
-
-  @override
-  List<Object?> get props => [currentMailboxState, exception];
+  CreateDefaultMailboxFailure(dynamic exception) : super(exception: exception);
 }

--- a/lib/features/mailbox/domain/usecases/create_new_default_mailbox_interactor.dart
+++ b/lib/features/mailbox/domain/usecases/create_new_default_mailbox_interactor.dart
@@ -4,8 +4,8 @@ import 'package:core/utils/app_logger.dart';
 import 'package:dartz/dartz.dart' as dartz;
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
-import 'package:jmap_dart_client/jmap/core/state.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/exceptions/set_mailbox_method_exception.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/repository/mailbox_repository.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/state/create_default_mailbox_state.dart';
 
@@ -19,32 +19,48 @@ class CreateDefaultMailboxInteractor {
     AccountId accountId,
     List<Role> listRole
   ) async* {
-    final currentMailboxState = await _getCurrentMailboxState(session, accountId);
     try {
       yield dartz.Right<Failure, Success>(CreateDefaultMailboxLoading());
-      final listMailboxCreated = await _mailboxRepository.createDefaultMailbox(
+      final mailboxesRecord = await _mailboxRepository.createDefaultMailbox(
         session,
         accountId,
         listRole
       );
-      await _mailboxRepository.setRoleDefaultMailbox(
+
+      final listMailboxCreated = mailboxesRecord.$1;
+      log('CreateDefaultMailboxInteractor::execute:listMailboxCreated = $listMailboxCreated');
+      if (listMailboxCreated.isEmpty) {
+        yield dartz.Left<Failure, Success>(CreateDefaultMailboxFailure(NotFoundMailboxCreatedException()));
+        return;
+      }
+
+      final listMailboxUpdated = await _updateRoleToListMailbox(
         session,
         accountId,
-        listMailboxCreated
+        listMailboxCreated,
       );
-      yield dartz.Right<Failure, Success>(CreateDefaultMailboxAllSuccess(currentMailboxState: currentMailboxState));
+
+      yield dartz.Right<Failure, Success>(CreateDefaultMailboxAllSuccess(listMailboxUpdated));
     } catch (e) {
-      yield dartz.Left<Failure, Success>(CreateDefaultMailboxFailure(currentMailboxState, e));
+      yield dartz.Left<Failure, Success>(CreateDefaultMailboxFailure(e));
     }
   }
 
-  Future<State?> _getCurrentMailboxState(Session session, AccountId accountId) async {
+  Future<List<Mailbox>> _updateRoleToListMailbox(
+    Session session,
+    AccountId accountId,
+    List<Mailbox> mailboxes,
+  ) async {
     try {
-      final currentMailboxState = await _mailboxRepository.getMailboxState(session, accountId);
-      log('CreateDefaultMailboxInteractor::_getCurrentMailboxState:currentMailboxState: $currentMailboxState');
-      return currentMailboxState;
+      final mailboxUpdatedRecord = await _mailboxRepository.setRoleDefaultMailbox(
+        session,
+        accountId,
+        mailboxes,
+      );
+      return mailboxUpdatedRecord.$1;
     } catch (e) {
-      return null;
+      logError('CreateDefaultMailboxInteractor::_updateRoleToListMailbox:Exception = $e');
+      return mailboxes;
     }
   }
 }

--- a/lib/features/mailbox/domain/usecases/create_new_default_mailbox_interactor.dart
+++ b/lib/features/mailbox/domain/usecases/create_new_default_mailbox_interactor.dart
@@ -3,6 +3,7 @@ import 'package:core/presentation/state/success.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:dartz/dartz.dart' as dartz;
 import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/exceptions/set_mailbox_method_exception.dart';
@@ -17,14 +18,14 @@ class CreateDefaultMailboxInteractor {
   Stream<dartz.Either<Failure, Success>> execute(
     Session session,
     AccountId accountId,
-    List<Role> listRole
+    Map<Id, Role> mapRoles,
   ) async* {
     try {
       yield dartz.Right<Failure, Success>(CreateDefaultMailboxLoading());
       final mailboxesRecord = await _mailboxRepository.createDefaultMailbox(
         session,
         accountId,
-        listRole
+        mapRoles,
       );
 
       final listMailboxCreated = mailboxesRecord.$1;

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -10,6 +10,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/error/method/error_method_response.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
@@ -650,12 +651,17 @@ class MailboxController extends BaseMailboxController
     final listRoleMissing = MailboxConstants.defaultMailboxRoles
       .whereNot((role) => mapDefaultMailboxRole.containsKey(role) || findNodeByNameOnFirstLevel(role.value) != null)
       .toList();
-    log('MailboxController::_handleCreateDefaultFolderIfMissing():listRoleMissing: $listRoleMissing');
-    if (listRoleMissing.isNotEmpty && accountId != null && session != null) {
+
+    final mapRoles = {
+      for (var role in listRoleMissing)
+        Id(uuid.v1()) : role
+    };
+    log('MailboxController::_handleCreateDefaultFolderIfMissing():mapRoles: $mapRoles');
+    if (mapRoles.isNotEmpty && accountId != null && session != null) {
       consumeState(_createDefaultMailboxInteractor.execute(
         session!,
         accountId!,
-        listRoleMissing
+        mapRoles,
       ));
     }
   }

--- a/model/lib/extensions/mailbox_extension.dart
+++ b/model/lib/extensions/mailbox_extension.dart
@@ -56,6 +56,24 @@ extension MailboxExtension on Mailbox {
     );
   }
 
+  Mailbox toMailboxWithoutRole() {
+    return Mailbox(
+      id: id,
+      name: name,
+      parentId: parentId,
+      role: null,
+      sortOrder: sortOrder,
+      totalEmails: totalEmails,
+      unreadEmails: unreadEmails,
+      totalThreads: totalThreads,
+      unreadThreads: unreadThreads,
+      myRights: myRights,
+      isSubscribed: isSubscribed,
+      namespace: namespace,
+      rights: rights,
+    );
+  }
+
   Mailbox toMailbox(MailboxName mailboxName, {MailboxId? parentId, Role? mailboxRole}) {
     return Mailbox(
         id: id,

--- a/test/features/mailbox/data/mailbox_api_test.dart
+++ b/test/features/mailbox/data/mailbox_api_test.dart
@@ -1,0 +1,393 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/http/http_client.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/extensions/account_id_extensions.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/mailbox/data/network/mailbox_api.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/extensions/role_extension.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../fixtures/account_fixtures.dart';
+import '../../../fixtures/session_fixtures.dart';
+
+import 'mailbox_api_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<HttpClient>(),
+  MockSpec<Uuid>()
+])
+void main() {
+  group('MailboxAPI::', () {
+    late HttpClient httpClient;
+    late Uuid uuid;
+    late MailboxAPI mailboxAPI;
+
+    final accountId = AccountFixtures.aliceAccountId;
+    final session = SessionFixtures.aliceSession;
+
+    final mapRoles = <Id, Role>{
+      Id('sent-create-id'): PresentationMailbox.roleSent,
+      Id('outbox-create-id'): PresentationMailbox.roleOutbox,
+    };
+
+    setUp(() {
+      httpClient = MockHttpClient();
+      uuid = MockUuid();
+
+      mailboxAPI = MailboxAPI(httpClient, uuid);
+    });
+
+    group('createDefaultMailbox::', () {
+      test('Should return full mailbox with input is a list roles when create mailbox success', () async {
+        final mapResponseData = {
+          "methodResponses": [
+            [
+              "Mailbox/set",
+              {
+                "oldState": "105",
+                "newState": "107",
+                "created": {
+                  "sent-create-id": {
+                    "id": "sent-id",
+                    "myRights": {
+                      "mayReadItems": true,
+                      "mayAddItems": true,
+                      "mayRemoveItems": true,
+                      "mayCreateChild": true,
+                      "mayDelete": true,
+                      "maySubmit": true,
+                      "maySetSeen": true,
+                      "maySetKeywords": true,
+                      "mayAdmin": true,
+                      "mayRename": true
+                    },
+                    "totalEmails": 0,
+                    "unreadEmails": 0,
+                    "totalThreads": 0,
+                    "unreadThreads": 0,
+                    "isSeenShared": false,
+                    "sortOrder": 10,
+                    "showAsLabel": true
+                  },
+                  "outbox-create-id": {
+                    "id": "outbox-id",
+                    "myRights": {
+                      "mayReadItems": true,
+                      "mayAddItems": true,
+                      "mayRemoveItems": true,
+                      "mayCreateChild": true,
+                      "mayDelete": true,
+                      "maySubmit": true,
+                      "maySetSeen": true,
+                      "maySetKeywords": true,
+                      "mayAdmin": true,
+                      "mayRename": true
+                    },
+                    "totalEmails": 0,
+                    "unreadEmails": 0,
+                    "totalThreads": 0,
+                    "unreadThreads": 0,
+                    "isSeenShared": false,
+                    "sortOrder": 10,
+                    "showAsLabel": true
+                  }
+                },
+                "updated": null,
+                "destroyed": null,
+                "notCreated": null,
+                "notUpdated": null,
+                "notDestroyed": null,
+                "accountId": accountId.asString,
+              },
+              "c0"
+            ]
+          ],
+          "sessionState": "0"
+        };
+
+        when(httpClient.post(
+          '',
+          data: anyNamed('data'),
+          cancelToken: anyNamed('cancelToken'),
+        )).thenAnswer((_) async => mapResponseData);
+
+        final mailboxRecords = await mailboxAPI.createDefaultMailbox(
+          session,
+          accountId,
+          mapRoles,
+        );
+
+        final listMailbox = mailboxRecords.$1;
+        final mapErrors = mailboxRecords.$2;
+
+        verify(httpClient.post(
+          '',
+          data: anyNamed('data'),
+          cancelToken: anyNamed('cancelToken'),
+        ));
+        expect(listMailbox.length, mapRoles.length);
+        expect(mapErrors.isEmpty, isTrue);
+        expect(
+          listMailbox.any((mailbox) => mailbox.name!.name == PresentationMailbox.roleSent.mailboxName),
+          isTrue,
+        );
+        expect(
+          listMailbox.any((mailbox) => mailbox.name!.name == PresentationMailbox.roleOutbox.mailboxName),
+          isTrue,
+        );
+      });
+
+      test('Should return some mailbox list with input is a list roles when create mailbox fail', () async {
+        final mapResponseData = {
+          "methodResponses": [
+            [
+              "Mailbox/set",
+              {
+                "oldState": "105",
+                "newState": "107",
+                "created": {
+                  "sent-create-id": {
+                    "id": "sent-id",
+                    "myRights": {
+                      "mayReadItems": true,
+                      "mayAddItems": true,
+                      "mayRemoveItems": true,
+                      "mayCreateChild": true,
+                      "mayDelete": true,
+                      "maySubmit": true,
+                      "maySetSeen": true,
+                      "maySetKeywords": true,
+                      "mayAdmin": true,
+                      "mayRename": true
+                    },
+                    "totalEmails": 0,
+                    "unreadEmails": 0,
+                    "totalThreads": 0,
+                    "unreadThreads": 0,
+                    "isSeenShared": false,
+                    "sortOrder": 10,
+                    "showAsLabel": true
+                  }
+                },
+                "updated": null,
+                "destroyed": null,
+                "notCreated": {
+                  "outbox-create-id": {
+                    "type": "invalidProperties",
+                    "properties": [
+                      "role"
+                    ]
+                  }
+                },
+                "notUpdated": null,
+                "notDestroyed": null,
+                "accountId": accountId.asString,
+              },
+              "c0"
+            ]
+          ],
+          "sessionState": "0"
+        };
+
+        when(httpClient.post(
+          '',
+          data: anyNamed('data'),
+          cancelToken: anyNamed('cancelToken'),
+        )).thenAnswer((_) async => mapResponseData);
+
+        final mailboxRecords = await mailboxAPI.createDefaultMailbox(
+          session,
+          accountId,
+          mapRoles,
+        );
+
+        final listMailbox = mailboxRecords.$1;
+        final mapErrors = mailboxRecords.$2;
+
+        verify(httpClient.post(
+          '',
+          data: anyNamed('data'),
+          cancelToken: anyNamed('cancelToken'),
+        ));
+
+        expect(listMailbox.length, lessThan(mapRoles.length));
+        expect(mapErrors.isNotEmpty, isTrue);
+        expect(
+          listMailbox.any((mailbox) => mailbox.name?.name == PresentationMailbox.roleSent.mailboxName),
+          isTrue,
+        );
+        expect(
+          listMailbox.every((mailbox) => mailbox.name?.name != PresentationMailbox.roleOutbox.mailboxName),
+          isTrue,
+        );
+      });
+
+      test('Should throw exception when http client throw exception', () async {
+        when(httpClient.post(
+          '',
+          data: anyNamed('data'),
+          cancelToken: anyNamed('cancelToken'),
+        )).thenThrow(Exception());
+
+        expect(
+          () => mailboxAPI.createDefaultMailbox(session, accountId, mapRoles),
+          throwsA(isA<Exception>()),
+        );
+      });
+    });
+
+    group('setRoleDefaultMailbox::', () {
+      final listMailbox = <Mailbox>[
+        Mailbox(
+          id: MailboxId(Id('sent-id')),
+          name: MailboxName(PresentationMailbox.roleSent.mailboxName),
+          role: PresentationMailbox.roleSent,
+          isSubscribed: IsSubscribed(true),
+        ) ,
+        Mailbox(
+          id: MailboxId(Id('outbox-id')),
+          name: MailboxName(PresentationMailbox.roleOutbox.mailboxName),
+          role: PresentationMailbox.roleOutbox,
+          isSubscribed: IsSubscribed(true),
+        )
+      ];
+
+      test('Should return full mailbox with role when update role mailbox success', () async {
+        final mapResponseData = {
+          "methodResponses": [
+            [
+              "Mailbox/set",
+              {
+                "oldState": "105",
+                "newState": "107",
+                "created": null,
+                "updated": {
+                  'sent-id': null,
+                  'outbox-id': null
+                },
+                "destroyed": null,
+                "notCreated": null,
+                "notUpdated": null,
+                "notDestroyed": null,
+                "accountId": accountId.asString,
+              },
+              "c0"
+            ]
+          ],
+          "sessionState": "0"
+        };
+
+        when(httpClient.post(
+          '',
+          data: anyNamed('data'),
+          cancelToken: anyNamed('cancelToken'),
+        )).thenAnswer((_) async => mapResponseData);
+
+        final mailboxRecords = await mailboxAPI.setRoleDefaultMailbox(
+          session,
+          accountId,
+          listMailbox,
+        );
+
+        final newListMailbox = mailboxRecords.$1;
+        final mapErrors = mailboxRecords.$2;
+
+        verify(httpClient.post(
+          '',
+          data: anyNamed('data'),
+          cancelToken: anyNamed('cancelToken'),
+        ));
+        expect(newListMailbox.length, listMailbox.length);
+        expect(mapErrors.isEmpty, isTrue);
+        expect(
+          newListMailbox.any((mailbox) => mailbox.role == PresentationMailbox.roleSent),
+          isTrue,
+        );
+        expect(
+          newListMailbox.any((mailbox) => mailbox.role == PresentationMailbox.roleOutbox),
+          isTrue,
+        );
+      });
+
+      test('Should return some mailbox with role when update role mailbox fail', () async {
+        final mapResponseData = {
+          "methodResponses": [
+            [
+              "Mailbox/set",
+              {
+                "oldState": "105",
+                "newState": "107",
+                "created": null,
+                "updated": {
+                  'sent-id': null
+                },
+                "destroyed": null,
+                "notCreated": null,
+                "notUpdated": {
+                  "outbox-id": {
+                    "type": "invalidProperties",
+                    "properties": [
+                      "role"
+                    ]
+                  }
+                },
+                "notDestroyed": null,
+                "accountId": accountId.asString,
+              },
+              "c0"
+            ]
+          ],
+          "sessionState": "0"
+        };
+
+        when(httpClient.post(
+          '',
+          data: anyNamed('data'),
+          cancelToken: anyNamed('cancelToken'),
+        )).thenAnswer((_) async => mapResponseData);
+
+        final mailboxRecords = await mailboxAPI.setRoleDefaultMailbox(
+          session,
+          accountId,
+          listMailbox,
+        );
+
+        final newListMailbox = mailboxRecords.$1;
+        final mapErrors = mailboxRecords.$2;
+
+        verify(httpClient.post(
+          '',
+          data: anyNamed('data'),
+          cancelToken: anyNamed('cancelToken'),
+        ));
+
+        expect(newListMailbox.length,listMailbox.length);
+        expect(mapErrors.isNotEmpty, isTrue);
+        expect(
+          newListMailbox.any((mailbox) => mailbox.role == PresentationMailbox.roleSent),
+          isTrue,
+        );
+        expect(
+          newListMailbox.every((mailbox) => mailbox.role != PresentationMailbox.roleOutbox),
+          isTrue,
+        );
+      });
+
+      test('Should throw exception when http client throw exception', () async {
+        when(httpClient.post(
+          '',
+          data: anyNamed('data'),
+          cancelToken: anyNamed('cancelToken'),
+        )).thenThrow(Exception());
+
+        expect(
+          () => mailboxAPI.setRoleDefaultMailbox(session, accountId, listMailbox),
+          throwsA(isA<Exception>()),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Issue

- Cannot send email on Cyrus server when the first open app: https://github.com/linagora/tmail-flutter/issues/3498#issuecomment-2670684260

## Root cause

Default mailboxes (`Outbox, Sent,..`) are automatically created when they do not exist and are not synchronized to memory in time.

## Resolved



https://github.com/user-attachments/assets/7c7cbb38-8e47-47d2-8e14-a1a66f0f4a2c


