### PR TITLE
Hot fix gray screen when reload setting view

### DIFF
--- a/lib/features/manage_account/presentation/menu/manage_account_menu_controller.dart
+++ b/lib/features/manage_account/presentation/menu/manage_account_menu_controller.dart
@@ -4,7 +4,6 @@ import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/mixin/contact_support_mixin.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/manage_account_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
@@ -12,7 +11,6 @@ import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 class ManageAccountMenuController extends GetxController with ContactSupportMixin {
 
   final dashBoardController = Get.find<ManageAccountDashBoardController>();
-  final mailboxDashBoardController = Get.find<MailboxDashBoardController>();
   final responsiveUtils = Get.find<ResponsiveUtils>();
   final imagePaths = Get.find<ImagePaths>();
 


### PR DESCRIPTION
## Issue

When I do a page reload at the Setting screen, a gray overlay appears on the screen and doesn't go away.


https://github.com/user-attachments/assets/e3ff3658-d7f7-45f0-8231-efb4de7bafd7

## Root cause

- Because `Get.find<MailboxDashBoardController>();` is null in ManageAccountMenuController and it's not use any where.


## Side effect



From https://github.com/linagora/tmail-flutter/pull/3452/files#diff-bf070e8df0d2bb83d6cdd5ed8f5fa9043a199f60caae971e6c77c0e2909c2377

## Resolved



https://github.com/user-attachments/assets/28b2eb81-de17-420e-9eba-e8d82f2c4137


