### PR TITLE
TF-3543 E2E composer read receipt

### DIFF
--- a/integration_test/robots/composer_robot.dart
+++ b/integration_test/robots/composer_robot.dart
@@ -8,6 +8,7 @@ import 'package:model/email/prefix_email_address.dart';
 import 'package:model/extensions/session_extension.dart';
 import 'package:model/upload/file_info.dart';
 import 'package:rich_text_composer/rich_text_composer.dart';
+import 'package:tmail_ui_user/features/base/widget/popup_item_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
 import 'package:tmail_ui_user/features/composer/presentation/view/mobile/mobile_editor_view.dart';
@@ -125,5 +126,11 @@ class ComposerRobot extends CoreRobot {
       fileSize: await file.length(),
       fileName: file.path.split('/').last,
     )));
+  }
+
+  Future<void> toggleReadReceipt() async {
+    await $(PopupItemWidget)
+      .which<PopupItemWidget>((widget) => widget.iconAction == ImagePaths().icReadReceipt)
+      .tap();
   }
 }

--- a/integration_test/scenarios/composer/send_email_with_read_receipt_enabled_scenario.dart
+++ b/integration_test/scenarios/composer/send_email_with_read_receipt_enabled_scenario.dart
@@ -1,0 +1,78 @@
+import 'package:core/core.dart';
+import 'package:duration/duration.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/email/prefix_email_address.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../robots/composer_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class SendEmailWithReadReceiptEnabledScenario extends BaseTestScenario {
+  const SendEmailWithReadReceiptEnabledScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const additionalRecipient = String.fromEnvironment('ADDITIONAL_MAIL_RECIPIENT');
+    const email = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const subject = 'Test read receipt subject';
+    const content = 'Test content';
+
+    final threadRobot = ThreadRobot($);
+    final composerRobot = ComposerRobot($);
+    final imagePaths = ImagePaths();
+    final appLocalizations = AppLocalizations();
+
+    await threadRobot.openComposer();
+    await _expectComposerViewVisible();
+
+    await composerRobot.grantContactPermission();
+
+    await composerRobot.addRecipientIntoField(
+      prefixEmailAddress: PrefixEmailAddress.to,
+      email: email,
+    );
+    await composerRobot.addRecipientIntoField(
+      prefixEmailAddress: PrefixEmailAddress.to,
+      email: additionalRecipient,
+    );
+    await composerRobot.addSubject(subject);
+    await composerRobot.addContent(content);
+    await composerRobot.tapMoreOptionOnAppBar();
+    await composerRobot.toggleReadReceipt();
+    await _expectReadReceiptToggleSuccessfullyToast(appLocalizations);
+
+    await composerRobot.sendEmail(imagePaths);
+
+    await _expectSendEmailSuccessToast(appLocalizations);
+
+    await $.pumpAndSettle(duration: seconds(5));
+    await threadRobot.openEmailWithSubject(subject);
+    await _expectReadReceiptRequestDialog(appLocalizations);
+  }
+
+  Future<void> _expectReadReceiptRequestDialog(
+    AppLocalizations appLocalizations
+  ) async {
+    await expectViewVisible(
+      $(appLocalizations.titleReadReceiptRequestNotificationMessage)
+    );
+  }
+
+  Future<void> _expectReadReceiptToggleSuccessfullyToast(
+    AppLocalizations appLocalizations
+  ) async {
+    await expectViewVisible(
+      $(appLocalizations.requestReadReceiptHasBeenEnabled)
+    );
+  }
+  
+  Future<void> _expectComposerViewVisible() => expectViewVisible($(ComposerView));
+
+  Future<void> _expectSendEmailSuccessToast(AppLocalizations appLocalizations) async {
+    await expectViewVisible(
+      $(find.text(appLocalizations.message_has_been_sent_successfully)),
+    );
+  }
+}

--- a/integration_test/tests/compose/send_email_with_read_receipt_enabled_test.dart
+++ b/integration_test/tests/compose/send_email_with_read_receipt_enabled_test.dart
@@ -1,0 +1,11 @@
+import '../../base/test_base.dart';
+import '../../scenarios/composer/send_email_with_read_receipt_enabled_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see read receipt dialog '
+      'when user toggle read receipt '
+      'and open read receipt email',
+    scenarioBuilder: ($) => SendEmailWithReadReceiptEnabledScenario($),
+  );
+}


### PR DESCRIPTION
## Issue
- #3543 

## Test result
```console
✅ Should see read receipt dialog (integration_test/tests/compose/composer_read_receipt_test.dart) (24s)

Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: .../tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 44s
```

## Test video

[integration-test-composer-read-receipt.webm](https://github.com/user-attachments/assets/864b5d95-ce5a-442e-8dca-8f185577ea95)
