### PR TITLE
TF-3551 E2E Mailbox scroll back to top and quick filter

### DIFF
--- a/integration_test/robots/thread_robot.dart
+++ b/integration_test/robots/thread_robot.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tmail_ui_user/features/base/widget/compose_floating_button.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_view.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';
+import 'package:tmail_ui_user/features/thread/presentation/widgets/scroll_to_top_button_widget.dart';
 
 import '../base/core_robot.dart';
 
@@ -42,5 +43,21 @@ class ThreadRobot extends CoreRobot {
   Future<void> scrollToTop() async {
     await $(ScrollToTopButtonWidget).$(InkWell).tap();
     await $.pumpAndSettle();
+  }
+
+  Future<void> openQuickFilter() async {
+    await $(#mobile_filter_message_button).tap();
+  }
+
+  Future<void> selectAttachmentFilter() async {
+    await $(#filter_email_attachments).tap();
+  }
+
+  Future<void> selectUnreadFilter() async {
+    await $(#filter_email_unread).tap();
+  }
+
+  Future<void> selectStarredFilter() async {
+    await $(#filter_email_starred).tap();
   }
 }

--- a/integration_test/robots/thread_robot.dart
+++ b/integration_test/robots/thread_robot.dart
@@ -33,4 +33,14 @@ class ThreadRobot extends CoreRobot {
   Future<void> openMailbox() async {
     await $(#mobile_mailbox_menu_button).tap();
   }
+
+  Future<void> scrollToEmailWithSubject(String subject) async {
+    await $.scrollUntilVisible(finder: $(subject), delta: 300);
+    await $.pumpAndSettle();
+  }
+
+  Future<void> scrollToTop() async {
+    await $(ScrollToTopButtonWidget).$(InkWell).tap();
+    await $.pumpAndSettle();
+  }
 }

--- a/integration_test/scenarios/mailbox/quick_filter_scenario.dart
+++ b/integration_test/scenarios/mailbox/quick_filter_scenario.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/thread_robot.dart';
+
+class QuickFilterScenario extends BaseTestScenario {
+  const QuickFilterScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const email = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    final unreadEmail = ProvisioningEmail(
+      toEmail: email,
+      subject: 'quick filter unread email',
+      content: '',
+    );
+    final readEmail = ProvisioningEmail(
+      toEmail: email,
+      subject: 'quick filter read email',
+      content: '',
+    );
+    final starredEmail = ProvisioningEmail(
+      toEmail: email,
+      subject: 'quick filter starred email',
+      content: '',
+    );
+    final file = await preparingTxtFile('some content');
+    final attachmentEmail = ProvisioningEmail(
+      toEmail: email,
+      subject: 'quick filter attachment email',
+      content: '',
+      attachmentPaths: [file.path],
+    );
+
+    final threadRobot = ThreadRobot($);
+
+    await provisionEmail([
+      unreadEmail,
+      readEmail,
+      starredEmail,
+      attachmentEmail,
+    ]);
+    await $.pumpAndSettle(); 
+
+    await simulateUpdateFlagsOfEmailsWithSubjectsFromOutsideCurrentClient(
+      subjects: ['quick filter read email'],
+      isRead: true,
+    );
+    await simulateUpdateFlagsOfEmailsWithSubjectsFromOutsideCurrentClient(
+      subjects: ['quick filter starred email'],
+      isStar: true,
+    );
+
+    await threadRobot.openQuickFilter();
+    await threadRobot.selectAttachmentFilter();
+    await _expectEmailWithAttachmentVisible();
+
+    await threadRobot.openQuickFilter();
+    await threadRobot.selectUnreadFilter();
+    await _expectUnreadEmailVisible();
+
+    await threadRobot.openQuickFilter();
+    await threadRobot.selectStarredFilter();
+    await _expectStarredEmailVisible();
+  }
+  
+  Future<void> _expectEmailWithAttachmentVisible() async {
+    await expectViewVisible($('quick filter attachment email'));
+  }
+
+  Future<void> _expectUnreadEmailVisible() async {
+    await expectViewVisible($('quick filter unread email'));
+  }
+  
+  Future<void> _expectStarredEmailVisible() async {
+    await expectViewVisible($('quick filter starred email'));
+  }
+}

--- a/integration_test/scenarios/mailbox/scroll_list_email_in_mailbox_and_back_to_top_scenario.dart
+++ b/integration_test/scenarios/mailbox/scroll_list_email_in_mailbox_and_back_to_top_scenario.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/thread/presentation/widgets/scroll_to_top_button_widget.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/thread_robot.dart';
+
+class ScrollListEmailInMailboxAndBackToTopScenario extends BaseTestScenario {
+  const ScrollListEmailInMailboxAndBackToTopScenario(super.$);
+
+  String _getSubjectWithIndex(int emailIndex) => 'scroll email subject $emailIndex';
+
+  @override
+  Future<void> runTestLogic() async {
+    const email = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const totalEmails = 15;
+    const bottomEmailSubject = 'scroll email subject bottom';
+
+    final threadRobot = ThreadRobot($);
+
+    await provisionEmail([ProvisioningEmail(
+      toEmail: email,
+      subject: bottomEmailSubject,
+      content: '',
+    )]);
+    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+    await provisionEmail(List.generate(
+      totalEmails,
+      (index) => ProvisioningEmail(
+        toEmail: email,
+        subject: _getSubjectWithIndex(index),
+        content: '$index',
+      ),
+    ));
+    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+
+    await threadRobot.scrollToEmailWithSubject(bottomEmailSubject);
+    await _expectScrollToTopButtonVisible();
+
+    await threadRobot.scrollToTop();
+    await _expectScrollToTopButtonInvisible();
+  }
+  
+  _expectScrollToTopButtonVisible() {
+    expect($(ScrollToTopButtonWidget), findsOneWidget);
+  }
+
+  Future<void> _expectScrollToTopButtonInvisible() async {
+    expect($(ScrollToTopButtonWidget).visible, false);
+  }
+}

--- a/integration_test/tests/mailbox/quick_filter_test.dart
+++ b/integration_test/tests/mailbox/quick_filter_test.dart
@@ -1,0 +1,10 @@
+import '../../base/test_base.dart';
+import '../../scenarios/mailbox/quick_filter_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see email with expected condition '
+      'when quick filter email changed',
+    scenarioBuilder: ($) => QuickFilterScenario($),
+  );
+}

--- a/integration_test/tests/mailbox/scroll_list_email_in_mailbox_and_back_to_top_test.dart
+++ b/integration_test/tests/mailbox/scroll_list_email_in_mailbox_and_back_to_top_test.dart
@@ -1,0 +1,10 @@
+import '../../base/test_base.dart';
+import '../../scenarios/mailbox/scroll_list_email_in_mailbox_and_back_to_top_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see back to top button when scroll list email in mailbox to bottom '
+      'and not see back to top button when scroll list email to top',
+    scenarioBuilder: ($) => ScrollListEmailInMailboxAndBackToTopScenario($),
+  );
+}


### PR DESCRIPTION
## Issue
- #3551 

## Test result
```console
✅ Should see email with expected condition when quick filter email changed (integration_test/tests/mailbox/quick_filter_test.dart) (17s)
✅ Should see back to top button when scroll mailbox to bottom and not see back to top button when scroll mailbox to top (integration_test/tests/mailbox/scroll_mailbox_and_back_to_top_test.dart) (18s)

Test summary:
📝 Total: 2
✅ Successful: 2
❌ Failed: 0
⏩ Skipped: 0
📊 Report: .../tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 57s
```

## Test video

[filter-and-back-to-top.webm](https://github.com/user-attachments/assets/783af608-eed3-4b0a-a81c-78f635b64e67)
