### PR TITLE
TF-3554 E2E email view reply forward email

### DIFF
--- a/integration_test/mixin/scenario_utils_mixin.dart
+++ b/integration_test/mixin/scenario_utils_mixin.dart
@@ -198,4 +198,14 @@ mixin ScenarioUtilsMixin {
       },
     );
   }
+
+  bool isMatchingEmailList(List<EmailAddress> emailList, Set<String> allowedEmails) {
+    if (emailList.length != allowedEmails.length) {
+      return false;
+    }
+
+    final Set<String> emails = emailList.map((e) => e.email).whereType<String>().toSet();
+
+    return emails.length == allowedEmails.length && emails.containsAll(allowedEmails);
+  }
 }

--- a/integration_test/robots/email_robot.dart
+++ b/integration_test/robots/email_robot.dart
@@ -21,6 +21,14 @@ class EmailRobot extends CoreRobot {
     await $(#reply_email_button).tap();
   }
 
+  Future<void> onTapReplyToListEmail() async {
+    await $(#reply_to_list_email_button).tap();
+  }
+
+  Future<void> onTapReplyAllEmail() async {
+    await $(#reply_all_emails_button).tap();
+  }
+
   Future<void> onTapBackButton() async {
     await $(find.byType(EmailViewBackButton)).first.tap();
   }

--- a/integration_test/scenarios/email_detailed/reply_all_email_scenario.dart
+++ b/integration_test/scenarios/email_detailed/reply_all_email_scenario.dart
@@ -1,0 +1,112 @@
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/email/prefix_email_address.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/recipient_composer_widget.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/subject_composer_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/email_view.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/search_email_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../robots/composer_robot.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/search_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class ReplyAllEmailScenario extends BaseTestScenario {
+
+  const ReplyAllEmailScenario(super.$);
+
+  static const String queryString = 'Reply all email';
+
+  @override
+  Future<void> runTestLogic() async {
+    final threadRobot = ThreadRobot($);
+    final searchRobot = SearchRobot($);
+    final emailRobot = EmailRobot($);
+    final composerRobot = ComposerRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await threadRobot.openSearchView();
+    await _expectSearchViewVisible();
+
+    await searchRobot.enterQueryString(queryString);
+    await searchRobot.tapOnShowAllResultsText();
+    await _expectSearchResultEmailListVisible();
+
+    await searchRobot.openEmailWithSubject(queryString);
+    await _expectEmailViewVisible();
+    await _expectReplyAllEmailButtonVisible();
+
+    await emailRobot.onTapReplyAllEmail();
+    await _expectComposerViewVisible();
+
+    await composerRobot.grantContactPermission();
+
+    await _expectComposerSubjectDisplayedCorrectly(appLocalizations);
+    await _expectToFieldContainListEmailAddressCorrectly();
+    await _expectCcFieldContainListEmailAddressCorrectly();
+    await _expectBccFieldContainListEmailAddressCorrectly();
+  }
+
+  Future<void> _expectSearchViewVisible() async {
+    await expectViewVisible($(SearchEmailView));
+  }
+
+  Future<void> _expectSearchResultEmailListVisible() async {
+    await expectViewVisible($(#search_email_list_notification_listener));
+    await $.pump(const Duration(seconds: 3));
+  }
+
+  Future<void> _expectEmailViewVisible() async {
+    await expectViewVisible($(EmailView));
+  }
+
+  Future<void> _expectReplyAllEmailButtonVisible() async {
+    await expectViewVisible($(#reply_all_emails_button));
+  }
+
+  Future<void> _expectComposerViewVisible() async {
+    await expectViewVisible($(ComposerView));
+  }
+
+  Future<void> _expectComposerSubjectDisplayedCorrectly(AppLocalizations appLocalizations) async {
+    expect(
+      $(SubjectComposerWidget).which<SubjectComposerWidget>((widget) =>
+        widget.textController.text == '${appLocalizations.prefix_reply_email} $queryString'
+      ).visible,
+      isTrue,
+    );
+  }
+
+  Future<void> _expectToFieldContainListEmailAddressCorrectly() async {
+    expect(
+      $(RecipientComposerWidget).which<RecipientComposerWidget>((widget) =>
+        widget.prefix == PrefixEmailAddress.to &&
+        isMatchingEmailList(widget.listEmailAddress, {'emma@example.com'})
+      ).visible,
+      isTrue,
+    );
+  }
+
+  Future<void> _expectCcFieldContainListEmailAddressCorrectly() async {
+    expect(
+      $(RecipientComposerWidget).which<RecipientComposerWidget>((widget) =>
+        widget.prefix == PrefixEmailAddress.cc &&
+        isMatchingEmailList(widget.listEmailAddress, {'alice@example.com'})
+      ).visible,
+      isTrue,
+    );
+  }
+
+  Future<void> _expectBccFieldContainListEmailAddressCorrectly() async {
+    expect(
+      $(RecipientComposerWidget).which<RecipientComposerWidget>((widget) =>
+        widget.prefix == PrefixEmailAddress.bcc &&
+        isMatchingEmailList(widget.listEmailAddress, {'brian@example.com'})
+      ).visible,
+      isTrue,
+    );
+  }
+}

--- a/integration_test/scenarios/email_detailed/reply_email_with_reply_to_scenario.dart
+++ b/integration_test/scenarios/email_detailed/reply_email_with_reply_to_scenario.dart
@@ -1,0 +1,90 @@
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/email/prefix_email_address.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/recipient_composer_widget.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/subject_composer_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/email_view.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/search_email_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../robots/composer_robot.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/search_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class ReplyEmailWithReplyToScenario extends BaseTestScenario {
+
+  const ReplyEmailWithReplyToScenario(super.$);
+
+  static const String queryString = 'Reply email with Reply-To';
+
+  @override
+  Future<void> runTestLogic() async {
+    final threadRobot = ThreadRobot($);
+    final searchRobot = SearchRobot($);
+    final emailRobot = EmailRobot($);
+    final composerRobot = ComposerRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await threadRobot.openSearchView();
+    await _expectSearchViewVisible();
+
+    await searchRobot.enterQueryString(queryString);
+    await searchRobot.tapOnShowAllResultsText();
+    await _expectSearchResultEmailListVisible();
+
+    await searchRobot.openEmailWithSubject(queryString);
+    await _expectEmailViewVisible();
+    await _expectReplyEmailButtonVisible();
+
+    await emailRobot.onTapReplyEmail();
+    await _expectComposerViewVisible();
+
+    await composerRobot.grantContactPermission();
+
+    await _expectComposerSubjectDisplayedCorrectly(appLocalizations);
+    await _expectToFieldContainReplyToEmailAddress();
+  }
+
+  Future<void> _expectSearchViewVisible() async {
+    await expectViewVisible($(SearchEmailView));
+  }
+
+  Future<void> _expectSearchResultEmailListVisible() async {
+    await expectViewVisible($(#search_email_list_notification_listener));
+    await $.pump(const Duration(seconds: 3));
+  }
+
+  Future<void> _expectEmailViewVisible() async {
+    await expectViewVisible($(EmailView));
+  }
+
+  Future<void> _expectReplyEmailButtonVisible() async {
+    await expectViewVisible($(#reply_email_button));
+  }
+
+  Future<void> _expectComposerViewVisible() async {
+    await expectViewVisible($(ComposerView));
+  }
+
+  Future<void> _expectComposerSubjectDisplayedCorrectly(AppLocalizations appLocalizations) async {
+    expect(
+      $(SubjectComposerWidget).which<SubjectComposerWidget>((widget) =>
+        widget.textController.text == '${appLocalizations.prefix_reply_email} $queryString'
+      ).visible,
+      isTrue,
+    );
+  }
+
+  Future<void> _expectToFieldContainReplyToEmailAddress() async {
+    expect(
+      $(RecipientComposerWidget).which<RecipientComposerWidget>((widget) =>
+        widget.prefix == PrefixEmailAddress.to &&
+        isMatchingEmailList(widget.listEmailAddress, {'emma-reply-to@example.com'})
+      ).visible,
+      isTrue,
+    );
+  }
+}

--- a/integration_test/scenarios/email_detailed/reply_email_without_reply_to_scenario.dart
+++ b/integration_test/scenarios/email_detailed/reply_email_without_reply_to_scenario.dart
@@ -1,0 +1,90 @@
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/email/prefix_email_address.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/recipient_composer_widget.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/subject_composer_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/email_view.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/search_email_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../robots/composer_robot.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/search_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class ReplyEmailWithoutReplyToScenario extends BaseTestScenario {
+
+  const ReplyEmailWithoutReplyToScenario(super.$);
+
+  static const String queryString = 'Reply email without Reply-To';
+
+  @override
+  Future<void> runTestLogic() async {
+    final threadRobot = ThreadRobot($);
+    final searchRobot = SearchRobot($);
+    final emailRobot = EmailRobot($);
+    final composerRobot = ComposerRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await threadRobot.openSearchView();
+    await _expectSearchViewVisible();
+
+    await searchRobot.enterQueryString(queryString);
+    await searchRobot.tapOnShowAllResultsText();
+    await _expectSearchResultEmailListVisible();
+
+    await searchRobot.openEmailWithSubject(queryString);
+    await _expectEmailViewVisible();
+    await _expectReplyEmailButtonVisible();
+
+    await emailRobot.onTapReplyEmail();
+    await _expectComposerViewVisible();
+
+    await composerRobot.grantContactPermission();
+
+    await _expectComposerSubjectDisplayedCorrectly(appLocalizations);
+    await _expectToFieldContainFromEmailAddress();
+  }
+
+  Future<void> _expectSearchViewVisible() async {
+    await expectViewVisible($(SearchEmailView));
+  }
+
+  Future<void> _expectSearchResultEmailListVisible() async {
+    await expectViewVisible($(#search_email_list_notification_listener));
+    await $.pump(const Duration(seconds: 3));
+  }
+
+  Future<void> _expectEmailViewVisible() async {
+    await expectViewVisible($(EmailView));
+  }
+
+  Future<void> _expectReplyEmailButtonVisible() async {
+    await expectViewVisible($(#reply_email_button));
+  }
+
+  Future<void> _expectComposerViewVisible() async {
+    await expectViewVisible($(ComposerView));
+  }
+
+  Future<void> _expectComposerSubjectDisplayedCorrectly(AppLocalizations appLocalizations) async {
+    expect(
+      $(SubjectComposerWidget).which<SubjectComposerWidget>((widget) =>
+        widget.textController.text == '${appLocalizations.prefix_reply_email} $queryString'
+      ).visible,
+      isTrue,
+    );
+  }
+
+  Future<void> _expectToFieldContainFromEmailAddress() async {
+    expect(
+      $(RecipientComposerWidget).which<RecipientComposerWidget>((widget) =>
+        widget.prefix == PrefixEmailAddress.to &&
+        isMatchingEmailList(widget.listEmailAddress, {'emma@example.com'})
+      ).visible,
+      isTrue,
+    );
+  }
+}

--- a/integration_test/scenarios/email_detailed/reply_to_list_email_scenario.dart
+++ b/integration_test/scenarios/email_detailed/reply_to_list_email_scenario.dart
@@ -1,0 +1,90 @@
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/email/prefix_email_address.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/recipient_composer_widget.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/subject_composer_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/email_view.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/search_email_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../robots/composer_robot.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/search_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class ReplyToListEmailScenario extends BaseTestScenario {
+
+  const ReplyToListEmailScenario(super.$);
+
+  static const String queryString = 'Reply to list email';
+
+  @override
+  Future<void> runTestLogic() async {
+    final threadRobot = ThreadRobot($);
+    final searchRobot = SearchRobot($);
+    final emailRobot = EmailRobot($);
+    final composerRobot = ComposerRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await threadRobot.openSearchView();
+    await _expectSearchViewVisible();
+
+    await searchRobot.enterQueryString(queryString);
+    await searchRobot.tapOnShowAllResultsText();
+    await _expectSearchResultEmailListVisible();
+
+    await searchRobot.openEmailWithSubject(queryString);
+    await _expectEmailViewVisible();
+    await _expectReplyToListEmailButtonVisible();
+
+    await emailRobot.onTapReplyToListEmail();
+    await _expectComposerViewVisible();
+
+    await composerRobot.grantContactPermission();
+
+    await _expectComposerSubjectDisplayedCorrectly(appLocalizations);
+    await _expectToFieldContainListPostEmailAddress();
+  }
+
+  Future<void> _expectSearchViewVisible() async {
+    await expectViewVisible($(SearchEmailView));
+  }
+
+  Future<void> _expectSearchResultEmailListVisible() async {
+    await expectViewVisible($(#search_email_list_notification_listener));
+    await $.pump(const Duration(seconds: 3));
+  }
+
+  Future<void> _expectEmailViewVisible() async {
+    await expectViewVisible($(EmailView));
+  }
+
+  Future<void> _expectReplyToListEmailButtonVisible() async {
+    await expectViewVisible($(#reply_to_list_email_button));
+  }
+
+  Future<void> _expectComposerViewVisible() async {
+    await expectViewVisible($(ComposerView));
+  }
+
+  Future<void> _expectComposerSubjectDisplayedCorrectly(AppLocalizations appLocalizations) async {
+    expect(
+      $(SubjectComposerWidget).which<SubjectComposerWidget>((widget) =>
+        widget.textController.text == '${appLocalizations.prefix_reply_email} $queryString'
+      ).visible,
+      isTrue,
+    );
+  }
+
+  Future<void> _expectToFieldContainListPostEmailAddress() async {
+    expect(
+      $(RecipientComposerWidget).which<RecipientComposerWidget>((widget) =>
+        widget.prefix == PrefixEmailAddress.to &&
+        isMatchingEmailList(widget.listEmailAddress, {'emma-reply-to-list@example.com'})
+      ).visible,
+      isTrue,
+    );
+  }
+}

--- a/integration_test/scenarios/forward_email_scenario.dart
+++ b/integration_test/scenarios/forward_email_scenario.dart
@@ -15,6 +15,8 @@ import '../robots/thread_robot.dart';
 
 class ForwardEmailScenario extends BaseTestScenario {
 
+  static const String queryString = 'Fwd: Forward email to Bob';
+
   const ForwardEmailScenario(super.$);
 
   @override
@@ -24,12 +26,11 @@ class ForwardEmailScenario extends BaseTestScenario {
     await _expectSearchViewVisible();
 
     final searchRobot = SearchRobot($);
-    await searchRobot.enterQueryString('Forward email');
-    await _expectSuggestionSearchListViewVisible();
+    await searchRobot.enterQueryString(queryString);
     await searchRobot.tapOnShowAllResultsText();
     await _expectSearchResultEmailListVisible();
 
-    await searchRobot.openEmailWithSubject('Fwd: Forward email');
+    await searchRobot.openEmailWithSubject(queryString);
     await _expectEmailViewVisible();
     await _expectForwardEmailButtonVisible();
 
@@ -48,10 +49,6 @@ class ForwardEmailScenario extends BaseTestScenario {
     await expectViewVisible($(SearchEmailView));
   }
 
-  Future<void> _expectSuggestionSearchListViewVisible() async {
-    await expectViewVisible($(#suggestion_search_list_view));
-  }
-
   Future<void> _expectSearchResultEmailListVisible() async {
     await expectViewVisible($(#search_email_list_notification_listener));
     await $.pump(const Duration(seconds: 3));
@@ -63,7 +60,6 @@ class ForwardEmailScenario extends BaseTestScenario {
 
   Future<void> _expectForwardEmailButtonVisible() async {
     await expectViewVisible($(#forward_email_button));
-    await $.pump(const Duration(seconds: 3));
   }
 
   Future<void> _expectComposerViewVisible() async {

--- a/integration_test/tests/email_detailed/reply_all_email_test.dart
+++ b/integration_test/tests/email_detailed/reply_all_email_test.dart
@@ -1,0 +1,11 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/reply_all_email_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description:
+      'SHOULD see the Subject contain the prefix `Re:`\n'
+      'AND the To, Cc, Bcc field should display correctly',
+    scenarioBuilder: ($) => ReplyAllEmailScenario($),
+  );
+}

--- a/integration_test/tests/email_detailed/reply_email_with_reply_to_test.dart
+++ b/integration_test/tests/email_detailed/reply_email_with_reply_to_test.dart
@@ -1,0 +1,11 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/reply_email_with_reply_to_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description:
+      'SHOULD see the Subject contain the prefix `Re:`\n'
+      'AND the To field should contain the email\'s `Reply-To` address.',
+    scenarioBuilder: ($) => ReplyEmailWithReplyToScenario($),
+  );
+}

--- a/integration_test/tests/email_detailed/reply_email_without_reply_to_test.dart
+++ b/integration_test/tests/email_detailed/reply_email_without_reply_to_test.dart
@@ -1,0 +1,11 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/reply_email_without_reply_to_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description:
+      'SHOULD see the Subject contain the prefix `Re:`\n'
+      'AND the To field should contain the email\'s `From` address.',
+    scenarioBuilder: ($) => ReplyEmailWithoutReplyToScenario($),
+  );
+}

--- a/integration_test/tests/email_detailed/reply_to_list_email_test.dart
+++ b/integration_test/tests/email_detailed/reply_to_list_email_test.dart
@@ -1,0 +1,11 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/reply_to_list_email_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description:
+      'SHOULD see the Subject contain the prefix `Re:`\n'
+      'AND the To field should contain the email\'s `List-Post` address.',
+    scenarioBuilder: ($) => ReplyToListEmailScenario($),
+  );
+}

--- a/provisioning/integration_test/eml/forward_email/0.eml
+++ b/provisioning/integration_test/eml/forward_email/0.eml
@@ -20,7 +20,7 @@ Content-Transfer-Encoding: quoted-printable
 Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT
 Content-Language: en-US
 
-Forward email to Bob
+Fwd: Forward email to Bob
 
 Invite you in to a meeting: Event OPEN TECH TALK: INNOVATION FOR THE TWAKE WORKPLACE
 
@@ -31,12 +31,5 @@ Our 3rd Open Tech Talk in 2024!
  ► Topic: "Websocket: Real-time Update
 
 We are waiting for you!
-
----=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=-
-Content-Type: text/html; charset=UTF-8
-Content-Transfer-Encoding: quoted-printable
-Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT
-Content-Language: en-US
-
 
 ---=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=---

--- a/provisioning/integration_test/eml/reply_email/reply-all.eml
+++ b/provisioning/integration_test/eml/reply_email/reply-all.eml
@@ -1,16 +1,18 @@
-Return-Path: <david@example.com>
+Return-Path: <emma@example.com>
 MIME-Version: 1.0
 References: <Mime4j.4c.b3b452d18f0d0ef9.192d67aaafc@example.com>
-Subject: David send Bob
-From: david@example.com
-To: "bob@example.com" <bob@example.com>
-Reply-To: david@example.com
-Date: Fri, 1 Nov 2024 07:13:50 +0000
+Subject: Reply all email
+From: emma@example.com
+To: "bob" <bob@example.com>
+Cc: "alice" <alice@example.com>
+Bcc: "brian" <brian@example.com>
+Date: Tue, 17 Dec 2024 16:31:00 +0000
 Message-ID: <Mime4j.4e.728b2b72b23cc182.192d67ae03c@example.com>
 User-Agent: Twake-Mail/0.13.2 Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15;
  rv:131.0) Gecko/20100101 Firefox/131.0
 Content-Type: multipart/alternative;
  boundary="-=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=-"
+List-Post: <mailto:emma-reply-to-list@example.com>
 
 ---=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=-
 Content-Type: text/plain; charset=UTF-8
@@ -18,7 +20,7 @@ Content-Transfer-Encoding: quoted-printable
 Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT
 Content-Language: en-US
 
-Hello Bob.
+Reply all email
 
 Invite you in to a meeting: Event OPEN TECH TALK: INNOVATION FOR THE TWAKE WORKPLACE
 

--- a/provisioning/integration_test/eml/reply_email/reply-to-list.eml
+++ b/provisioning/integration_test/eml/reply_email/reply-to-list.eml
@@ -1,16 +1,18 @@
-Return-Path: <david@example.com>
+Return-Path: <emma@example.com>
 MIME-Version: 1.0
 References: <Mime4j.4c.b3b452d18f0d0ef9.192d67aaafc@example.com>
-Subject: David send Bob
-From: david@example.com
-To: "bob@example.com" <bob@example.com>
-Reply-To: david@example.com
-Date: Fri, 1 Nov 2024 07:13:50 +0000
+Subject: Reply to list email
+From: emma@example.com
+To: "bob" <bob@example.com>
+Cc: "alice" <alice@example.com>
+Bcc: "brian" <brian@example.com>
+Date: Tue, 17 Dec 2024 16:31:00 +0000
 Message-ID: <Mime4j.4e.728b2b72b23cc182.192d67ae03c@example.com>
 User-Agent: Twake-Mail/0.13.2 Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15;
  rv:131.0) Gecko/20100101 Firefox/131.0
 Content-Type: multipart/alternative;
  boundary="-=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=-"
+List-Post: <mailto:emma-reply-to-list@example.com>
 
 ---=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=-
 Content-Type: text/plain; charset=UTF-8
@@ -18,7 +20,7 @@ Content-Transfer-Encoding: quoted-printable
 Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT
 Content-Language: en-US
 
-Hello Bob.
+Reply to list email
 
 Invite you in to a meeting: Event OPEN TECH TALK: INNOVATION FOR THE TWAKE WORKPLACE
 

--- a/provisioning/integration_test/eml/reply_email/with-reply-to.eml
+++ b/provisioning/integration_test/eml/reply_email/with-reply-to.eml
@@ -1,11 +1,13 @@
-Return-Path: <david@example.com>
+Return-Path: <emma@example.com>
 MIME-Version: 1.0
 References: <Mime4j.4c.b3b452d18f0d0ef9.192d67aaafc@example.com>
-Subject: David send Bob
-From: david@example.com
-To: "bob@example.com" <bob@example.com>
-Reply-To: david@example.com
-Date: Fri, 1 Nov 2024 07:13:50 +0000
+Subject: Reply email with Reply-To
+From: emma@example.com
+To: "bob" <bob@example.com>
+Cc: "alice" <alice@example.com>
+Bcc: "brian" <brian@example.com>
+Reply-To: emma-reply-to@example.com
+Date: Tue, 17 Dec 2024 16:31:00 +0000
 Message-ID: <Mime4j.4e.728b2b72b23cc182.192d67ae03c@example.com>
 User-Agent: Twake-Mail/0.13.2 Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15;
  rv:131.0) Gecko/20100101 Firefox/131.0
@@ -18,7 +20,7 @@ Content-Transfer-Encoding: quoted-printable
 Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT
 Content-Language: en-US
 
-Hello Bob.
+Reply email with Reply-To
 
 Invite you in to a meeting: Event OPEN TECH TALK: INNOVATION FOR THE TWAKE WORKPLACE
 

--- a/provisioning/integration_test/eml/reply_email/without-reply-to.eml
+++ b/provisioning/integration_test/eml/reply_email/without-reply-to.eml
@@ -1,11 +1,12 @@
-Return-Path: <david@example.com>
+Return-Path: <emma@example.com>
 MIME-Version: 1.0
 References: <Mime4j.4c.b3b452d18f0d0ef9.192d67aaafc@example.com>
-Subject: David send Bob
-From: david@example.com
-To: "bob@example.com" <bob@example.com>
-Reply-To: david@example.com
-Date: Fri, 1 Nov 2024 07:13:50 +0000
+Subject: Reply email without Reply-To
+From: emma@example.com
+To: "bob" <bob@example.com>
+Cc: "alice" <alice@example.com>
+Bcc: "brian" <brian@example.com>
+Date: Tue, 17 Dec 2024 16:31:00 +0000
 Message-ID: <Mime4j.4e.728b2b72b23cc182.192d67ae03c@example.com>
 User-Agent: Twake-Mail/0.13.2 Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15;
  rv:131.0) Gecko/20100101 Firefox/131.0
@@ -18,7 +19,7 @@ Content-Transfer-Encoding: quoted-printable
 Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT
 Content-Language: en-US
 
-Hello Bob.
+Reply email without Reply-To
 
 Invite you in to a meeting: Event OPEN TECH TALK: INNOVATION FOR THE TWAKE WORKPLACE
 

--- a/provisioning/integration_test/eml/search_email_with_sort_order/0.eml
+++ b/provisioning/integration_test/eml/search_email_with_sort_order/0.eml
@@ -30,11 +30,4 @@ Our 3rd Open Tech Talk in 2024!
 
 We are waiting for you!
 
----=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=-
-Content-Type: text/html; charset=UTF-8
-Content-Transfer-Encoding: quoted-printable
-Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT
-Content-Language: en-US
-
-
 ---=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=---

--- a/provisioning/integration_test/eml/search_email_with_sort_order/1.eml
+++ b/provisioning/integration_test/eml/search_email_with_sort_order/1.eml
@@ -30,11 +30,4 @@ Our 3rd Open Tech Talk in 2024!
 
 We are waiting for you!
 
----=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=-
-Content-Type: text/html; charset=UTF-8
-Content-Transfer-Encoding: quoted-printable
-Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT
-Content-Language: en-US
-
-
 ---=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=---

--- a/provisioning/integration_test/eml/search_email_with_sort_order/2.eml
+++ b/provisioning/integration_test/eml/search_email_with_sort_order/2.eml
@@ -30,11 +30,4 @@ Our 3rd Open Tech Talk in 2024!
 
 We are waiting for you!
 
----=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=-
-Content-Type: text/html; charset=UTF-8
-Content-Transfer-Encoding: quoted-printable
-Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT
-Content-Language: en-US
-
-
 ---=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=---

--- a/provisioning/integration_test/eml/search_email_with_sort_order/4.eml
+++ b/provisioning/integration_test/eml/search_email_with_sort_order/4.eml
@@ -30,11 +30,4 @@ Our 3rd Open Tech Talk in 2024!
 
 We are waiting for you!
 
----=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=-
-Content-Type: text/html; charset=UTF-8
-Content-Transfer-Encoding: quoted-printable
-Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT
-Content-Language: en-US
-
-
 ---=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=---

--- a/provisioning/integration_test/provisioning.sh
+++ b/provisioning/integration_test/provisioning.sh
@@ -2,7 +2,7 @@
 
 # Define users and folders
 users=("alice" "bob" "brian" "charlotte" "david" "emma")
-bobFolders=("Search Emails" "Forward Emails" "Disposition" "MailBase64")
+bobFolders=("Search Emails" "Forward Emails" "Disposition" "MailBase64" "Reply Emails")
 
 # Add users
 for user in "${users[@]}"; do
@@ -62,3 +62,12 @@ james-cli ImportEml \#private "bob@example.com" "Disposition" "/root/conf/integr
 # Import email into 'MailBase64' folder for user Bob
 echo "Importing 0.eml into 'MailBase64' folder for user bob"
 james-cli ImportEml \#private "bob@example.com" "MailBase64" "/root/conf/integration_test/eml/reply_email_with_image_base64/0.eml"
+
+# For test reply email
+# Import emails into 'Reply Emails' folder for user Bob
+replyEmailsEML=("reply-all.eml" "reply-to-list.eml" "with-reply-to.eml" "without-reply-to.eml")
+
+for eml in "${replyEmailsEML[@]}"; do
+  echo "Importing $eml into 'Reply Emails' folder for user bob"
+  james-cli ImportEml \#private "bob@example.com" "Reply Emails" "/root/conf/integration_test/eml/reply_email/$eml"
+done


### PR DESCRIPTION
## Issue

#3554 

## Resolved

- E2E console log:

```console
🧪 SHOULD see the Subject contain the prefix `Re:`
AND the To, Cc, Bcc field should display correctly
        : 
        : > Task :app:connectedDebugAndroidTest
        : Starting 4 tests on Pixel_3a_API_31(AVD) - 12
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. tap widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  10. enterText widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  11. waitUntilVisible widgets with text containing 7da6-2001-ee0-4161-7fbc-143b-6049-441d-34b.ngrok-free.app.
        ✅  12. tap widgets with text "Next".
        ✅  13. waitUntilVisible widgets with key [<'credential_input_form'>] descending from widgets with type "LoginView".
        ✅  14. enterText widgets with type "TextField" descending from widgets with key [<'login_username_input'>].
        ✅  15. waitUntilVisible widgets with text "bob@example.com".
        ✅  16. tap widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
        ✅  17. enterText widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
✅ SHOULD see the Subject contain the prefix `Re:`
AND the To, Cc, Bcc field should display correctly (integration_test/tests/email_detailed/reply_all_email_test.dart) (27s)
🧪 SHOULD see the Subject contain the prefix `Re:`
AND the To field should contain the email's `Reply-To` address.
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. tap widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  10. enterText widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  11. waitUntilVisible widgets with text containing 7da6-2001-ee0-4161-7fbc-143b-6049-441d-34b.ngrok-free.app.
        ✅  12. tap widgets with text "Next".
        ✅  13. waitUntilVisible widgets with key [<'credential_input_form'>] descending from widgets with type "LoginView".
        ✅  14. enterText widgets with type "TextField" descending from widgets with key [<'login_username_input'>].
        ✅  15. waitUntilVisible widgets with text "bob@example.com".
        ✅  16. tap widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
        ✅  17. enterText widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
✅ SHOULD see the Subject contain the prefix `Re:`
AND the To field should contain the email's `Reply-To` address. (integration_test/tests/email_detailed/reply_email_with_reply_to_test.dart) (25s)
🧪 SHOULD see the Subject contain the prefix `Re:`
AND the To field should contain the email's `From` address.
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. tap widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  10. enterText widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  11. waitUntilVisible widgets with text containing 7da6-2001-ee0-4161-7fbc-143b-6049-441d-34b.ngrok-free.app.
        ✅  12. tap widgets with text "Next".
        ✅  13. waitUntilVisible widgets with key [<'credential_input_form'>] descending from widgets with type "LoginView".
        ✅  14. enterText widgets with type "TextField" descending from widgets with key [<'login_username_input'>].
        ✅  15. waitUntilVisible widgets with text "bob@example.com".
        ✅  16. tap widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
        ✅  17. enterText widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
✅ SHOULD see the Subject contain the prefix `Re:`
AND the To field should contain the email's `From` address. (integration_test/tests/email_detailed/reply_email_without_reply_to_test.dart) (24s)
🧪 SHOULD see the Subject contain the prefix `Re:`
AND the To field should contain the email's `List-Post` address.
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. tap widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  10. enterText widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  11. waitUntilVisible widgets with text containing 7da6-2001-ee0-4161-7fbc-143b-6049-441d-34b.ngrok-free.app.
        ✅  12. tap widgets with text "Next".
        ✅  13. waitUntilVisible widgets with key [<'credential_input_form'>] descending from widgets with type "LoginView".
        ✅  14. enterText widgets with type "TextField" descending from widgets with key [<'login_username_input'>].
        ✅  15. waitUntilVisible widgets with text "bob@example.com".
        ✅  16. tap widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
        ✅  17. enterText widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
✅ SHOULD see the Subject contain the prefix `Re:`
AND the To field should contain the email's `List-Post` address. (integration_test/tests/email_detailed/reply_to_list_email_test.dart) (24s)

Test summary:
📝 Total: 4
✅ Successful: 4
❌ Failed: 0
⏩ Skipped: 0
📊 Report: …/tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 132s

```

- Video demo:


[demo.webm](https://github.com/user-attachments/assets/25f58b37-76b8-4771-a924-48072dcc6df8)

