### PR TITLE
TF-3558 E2E mailbox switch and pull to refresh

### DIFF
--- a/integration_test/robots/thread_robot.dart
+++ b/integration_test/robots/thread_robot.dart
@@ -67,4 +67,14 @@ class ThreadRobot extends CoreRobot {
   Future<void> selectStarredFilter() async {
     await $(#starred_filter).tap();
   }
+
+  Future<void> pullToRefreshByEmailSubject(String subject) async {
+    await $(subject).waitUntilVisible();
+    await $.tester.fling(
+      $(subject),
+      const Offset(0, 300),
+      1000,
+    );
+    await $.pumpAndSettle();
+  }
 }

--- a/integration_test/robots/thread_robot.dart
+++ b/integration_test/robots/thread_robot.dart
@@ -77,4 +77,9 @@ class ThreadRobot extends CoreRobot {
     );
     await $.pumpAndSettle();
   }
+
+  Future<void> tapOnMailboxWithName(String name) async {
+    await $(name).tap();
+    await $.pumpAndSettle();
+  }
 }

--- a/integration_test/scenarios/mailbox/pull_to_refresh_scenario.dart
+++ b/integration_test/scenarios/mailbox/pull_to_refresh_scenario.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/thread_robot.dart';
+
+class PullToRefreshScenario extends BaseTestScenario {
+  const PullToRefreshScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const toEmail = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const visibleBeforePullToRefresh = 'before pull to refresh';
+    const visibleAfterPullToRefresh = 'after pull to refresh';
+
+    final threadRobot = ThreadRobot($);
+
+    await provisionEmail(
+      [ProvisioningEmail(
+        toEmail: toEmail,
+        subject: visibleBeforePullToRefresh,
+        content: '',
+      )],
+    );
+    await $.pumpAndSettle();
+    _expectEmailWithSubjectVisible(visibleBeforePullToRefresh);
+
+    await provisionEmail(
+      [ProvisioningEmail(
+        toEmail: toEmail,
+        subject: visibleAfterPullToRefresh,
+        content: '',
+      )],
+      refreshEmailView: false,
+    );
+    await $.pumpAndSettle();
+    _expectEmailWithSubjectInvisible(visibleAfterPullToRefresh);
+
+    await threadRobot.pullToRefreshByEmailSubject(visibleBeforePullToRefresh);
+    _expectEmailWithSubjectVisible(visibleAfterPullToRefresh);
+  }
+
+  _expectEmailWithSubjectVisible(String subject) {
+    expect($(subject), findsOneWidget);
+  }
+
+  _expectEmailWithSubjectInvisible(String subject) {
+    expect($(subject), findsNothing);
+  }
+}

--- a/integration_test/scenarios/mailbox/switch_mailbox_scenario.dart
+++ b/integration_test/scenarios/mailbox/switch_mailbox_scenario.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/thread_robot.dart';
+
+class SwitchMailboxScenario extends BaseTestScenario {
+  const SwitchMailboxScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const toEmail = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const sentEmailSubject = 'sent subject';
+    const trashEmailSubject = 'trash subject';
+
+    final threadRobot = ThreadRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await provisionEmail(
+      [ProvisioningEmail(
+        toEmail: toEmail,
+        subject: sentEmailSubject,
+        content: '',
+      )],
+    );
+    await provisionEmail(
+      [ProvisioningEmail(
+        toEmail: toEmail,
+        subject: trashEmailSubject,
+        content: '',
+      )],
+      folderLocationRole: PresentationMailbox.roleTrash,
+    );
+
+    await threadRobot.openMailbox();
+    await threadRobot.tapOnMailboxWithName(appLocalizations.sentMailboxDisplayName);
+    await _expectEmailWithSubjectVisible(sentEmailSubject);
+
+    await threadRobot.openMailbox();
+    await threadRobot.tapOnMailboxWithName(appLocalizations.trashMailboxDisplayName);
+    await _expectEmailWithSubjectVisible(trashEmailSubject);
+  }
+  
+  Future<void> _expectEmailWithSubjectVisible(String subject) async {
+    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+    expect($(subject), findsOneWidget);
+  }
+}

--- a/integration_test/tests/mailbox/pull_to_refresh_test.dart
+++ b/integration_test/tests/mailbox/pull_to_refresh_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/mailbox/pull_to_refresh_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should refresh email list when pull to refresh',
+    scenarioBuilder: ($) => PullToRefreshScenario($),
+  );
+}

--- a/integration_test/tests/mailbox/switch_mailbox_test.dart
+++ b/integration_test/tests/mailbox/switch_mailbox_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/mailbox/switch_mailbox_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should switch and see emails in mailboxes',
+    scenarioBuilder: ($) => SwitchMailboxScenario($),
+  );
+}


### PR DESCRIPTION
## Issue
- #3558 

## Test result
```console
✅ Should refresh email list when pull to refresh (integration_test/tests/mailbox/pull_to_refresh_test.dart) (14s)
✅ Should switch and see emails in mailboxes (integration_test/tests/mailbox/switch_mailbox_test.dart) (16s)

Test summary:
📝 Total: 2
✅ Successful: 2
❌ Failed: 0
⏩ Skipped: 0
📊 Report: .../tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 51s
```

## Test video

[pull-to-refresh-and-switch.webm](https://github.com/user-attachments/assets/b95fef4e-24a1-41c8-8724-d9cf5096394b)
