### PR TITLE
TF-3564 E2E Mailbox count real time update

### DIFF
--- a/integration_test/exceptions/mailbox/null_inbox_unread_count_exception.dart
+++ b/integration_test/exceptions/mailbox/null_inbox_unread_count_exception.dart
@@ -1,0 +1,1 @@
+class NullInboxUnreadCountException implements Exception {}

--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -4,12 +4,15 @@ import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/presentation/views/text/text_field_builder.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/label_mailbox_item_widget.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/mailbox_item_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/presentation/mailbox_creator_view.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 
 import '../base/core_robot.dart';
+import '../exceptions/mailbox/null_inbox_unread_count_exception.dart';
 
 class MailboxMenuRobot extends CoreRobot {
   MailboxMenuRobot(super.$);
@@ -69,5 +72,21 @@ class MailboxMenuRobot extends CoreRobot {
         return widget.tooltip == AppLocalizations().close;
       })
       .tap();
+  }
+
+  int getCurrentInboxCount() {
+    final inboxCount = Get.find<MailboxDashBoardController>()
+      .selectedMailbox
+      .value
+      ?.unreadEmails
+      ?.value
+      .value
+      .toInt();
+
+    if (inboxCount == null) {
+      throw NullInboxUnreadCountException();
+    }
+
+    return inboxCount;
   }
 }

--- a/integration_test/scenarios/mailbox/mailbox_count_real_time_update_scenario.dart
+++ b/integration_test/scenarios/mailbox/mailbox_count_real_time_update_scenario.dart
@@ -1,0 +1,47 @@
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class MailboxCountRealTimeUpdateScenario extends BaseTestScenario {
+  const MailboxCountRealTimeUpdateScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const email = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const subject = 'mailbox unread realtime update';
+
+    final threadRobot = ThreadRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+
+    await provisionEmail([ProvisioningEmail(
+      toEmail: email,
+      subject: 'dummy email',
+      content: '',
+    )]);
+    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+
+    await threadRobot.openMailbox();
+    final currentInboxCount = mailboxMenuRobot.getCurrentInboxCount();
+    await _expectInboxWithCount(currentInboxCount);
+
+    await provisionEmail([ProvisioningEmail(
+      toEmail: email,
+      subject: subject,
+      content: '',
+    )]);
+    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+    await _expectInboxWithCount(currentInboxCount + 1);
+
+    await simulateUpdateFlagsOfEmailsWithSubjectsFromOutsideCurrentClient(
+      subjects: [subject],
+      isRead: true,
+    );
+    await $.pumpAndSettle(duration: const Duration(seconds: 5));
+    await _expectInboxWithCount(currentInboxCount);
+  }
+
+  Future<void> _expectInboxWithCount(int currentInboxCount) async {
+    await expectViewVisible($(currentInboxCount.toString()));
+  }
+}

--- a/integration_test/tests/mailbox/mailbox_count_real_time_update_test.dart
+++ b/integration_test/tests/mailbox/mailbox_count_real_time_update_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/mailbox/mailbox_count_real_time_update_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see mailbox unread count update real time',
+    scenarioBuilder: ($) => MailboxCountRealTimeUpdateScenario($),
+  );
+}


### PR DESCRIPTION
## Issue
- #3564 

## Test result
```console
✅ Should see mailbox unread count update real time (integration_test/tests/mailbox/mailbox_count_real_time_update_test.dart) (19s)

Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: .../tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 38s
```

## Test video

[mailbox-count-real-time-update.webm](https://github.com/user-attachments/assets/8368f8a3-bd4e-443c-ab96-7d05b481b700)
