### PR TITLE
[HOT-FIX] Disable charset detector on iOS as workaround to fix build iOS fail on CI

### DIFF
--- a/contact/pubspec.lock
+++ b/contact/pubspec.lock
@@ -344,27 +344,20 @@ packages:
   flutter_charset_detector:
     dependency: transitive
     description:
-      name: flutter_charset_detector
-      sha256: "5d4796d43dac2f37e14149b0f0c676fa08e8eb1ada8e99342a838d971d2fb9b1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.0"
+      path: flutter_charset_detector
+      ref: main
+      resolved-ref: "36c3ffeea65f7b362c1e47e608802f0ca941f4d4"
+      url: "https://github.com/dab246/flutter_charset_detector.git"
+    source: git
+    version: "5.0.0"
   flutter_charset_detector_android:
     dependency: transitive
     description:
       name: flutter_charset_detector_android
-      sha256: bee057133d5f134fe211523a27200dd22c782b93777f43359a571bd2c77da2cc
+      sha256: "443145e8fc8515b3b32aee375691e40dd59197a86a2ae153166bc88c8200d83b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
-  flutter_charset_detector_darwin:
-    dependency: transitive
-    description:
-      name: flutter_charset_detector_darwin
-      sha256: daac20390275efb92fbb14350fe11286c5e29c7b80d6b0867f52d760f0d69763
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
+    version: "3.0.0"
   flutter_charset_detector_platform_interface:
     dependency: transitive
     description:
@@ -377,10 +370,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_charset_detector_web
-      sha256: d8495115abada771c75f9395aae3e5809ffd506e8fc8f62b403ae11fc29e1d2b
+      sha256: e3ac65f94b12f4887937b21a19365d7927db816840cb93274e3861241cb0e9f2
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "2.0.0"
   flutter_image_compress:
     dependency: transitive
     description:

--- a/core/lib/utils/file_utils.dart
+++ b/core/lib/utils/file_utils.dart
@@ -141,6 +141,7 @@ class FileUtils {
 
   Future<String> getCharsetFromBytes(Uint8List bytes) async {
     try {
+      if (PlatformInfo.isIOS || PlatformInfo.isMacOS) return DEFAULT_CHARSET;
       final decodedResult = await CharsetDetector.autoDecode(bytes);
       log('FileUtils::getCharsetFromBytes: FILE_CHARSET = ${decodedResult.charset}');
       return decodedResult.charset;

--- a/core/pubspec.lock
+++ b/core/pubspec.lock
@@ -337,43 +337,36 @@ packages:
   flutter_charset_detector:
     dependency: "direct main"
     description:
-      name: flutter_charset_detector
-      sha256: "5d4796d43dac2f37e14149b0f0c676fa08e8eb1ada8e99342a838d971d2fb9b1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.0"
+      path: flutter_charset_detector
+      ref: main
+      resolved-ref: "36c3ffeea65f7b362c1e47e608802f0ca941f4d4"
+      url: "https://github.com/dab246/flutter_charset_detector.git"
+    source: git
+    version: "5.0.0"
   flutter_charset_detector_android:
     dependency: transitive
     description:
       name: flutter_charset_detector_android
-      sha256: "43d0c0063242d036b873ade737ebae38716af5cd8b2a4df1754adfd186d58e2c"
+      sha256: "443145e8fc8515b3b32aee375691e40dd59197a86a2ae153166bc88c8200d83b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
-  flutter_charset_detector_darwin:
-    dependency: transitive
-    description:
-      name: flutter_charset_detector_darwin
-      sha256: d17c1847366a0501449d95d18a43417585841afe10200ceefb4422e6b7fccefb
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
+    version: "3.0.0"
   flutter_charset_detector_platform_interface:
     dependency: transitive
     description:
       name: flutter_charset_detector_platform_interface
-      sha256: fcb61de27285031164c945aca4b42e4d36f9a9e359212f21ab652275c9c723ec
+      sha256: "1c09ed7b314a5a9dde76057b98b7d35458ba881eed03d5e5b6f7f74b4869d18c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   flutter_charset_detector_web:
     dependency: transitive
     description:
       name: flutter_charset_detector_web
-      sha256: d8495115abada771c75f9395aae3e5809ffd506e8fc8f62b403ae11fc29e1d2b
+      sha256: e3ac65f94b12f4887937b21a19365d7927db816840cb93274e3861241cb0e9f2
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "2.0.0"
   flutter_image_compress:
     dependency: "direct main"
     description:

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -89,7 +89,14 @@ dependencies:
 
   fk_user_agent: 2.1.0
 
-  flutter_charset_detector: 3.0.0
+  # flutter_charset_detector: 3.0.0
+  # TODO: Disable charset detector on IOS/MACOS to wait for migration status to complete.
+  # https://gitlab.freedesktop.org/uchardet/uchardet.git
+  flutter_charset_detector:
+    git:
+      url: https://github.com/dab246/flutter_charset_detector.git
+      ref: main
+      path: flutter_charset_detector
 
   debounce_throttle: 2.0.0
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -93,10 +93,6 @@ PODS:
   - flutter_appauth (0.0.1):
     - AppAuth (= 1.7.4)
     - Flutter
-  - flutter_charset_detector_darwin (0.0.1):
-    - Flutter
-    - FlutterMacOS
-    - UniversalDetector2 (= 2.0.1)
   - flutter_downloader (0.0.1):
     - Flutter
   - flutter_file_dialog (0.0.1):
@@ -201,7 +197,6 @@ PODS:
     - Flutter
     - FlutterMacOS
   - SwiftyGif (5.4.4)
-  - UniversalDetector2 (2.0.1)
   - url_launcher_ios (0.0.1):
     - Flutter
   - workmanager (0.0.1):
@@ -221,7 +216,6 @@ DEPENDENCIES:
   - fk_user_agent (from `.symlinks/plugins/fk_user_agent/ios`)
   - Flutter (from `Flutter`)
   - flutter_appauth (from `.symlinks/plugins/flutter_appauth/ios`)
-  - flutter_charset_detector_darwin (from `.symlinks/plugins/flutter_charset_detector_darwin/darwin`)
   - flutter_downloader (from `.symlinks/plugins/flutter_downloader/ios`)
   - flutter_file_dialog (from `.symlinks/plugins/flutter_file_dialog/ios`)
   - flutter_image_compress_common (from `.symlinks/plugins/flutter_image_compress_common/ios`)
@@ -267,7 +261,6 @@ SPEC REPOS:
     - SDWebImage
     - SDWebImageWebPCoder
     - SwiftyGif
-    - UniversalDetector2
 
 EXTERNAL SOURCES:
   app_links:
@@ -296,8 +289,6 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_appauth:
     :path: ".symlinks/plugins/flutter_appauth/ios"
-  flutter_charset_detector_darwin:
-    :path: ".symlinks/plugins/flutter_charset_detector_darwin/darwin"
   flutter_downloader:
     :path: ".symlinks/plugins/flutter_downloader/ios"
   flutter_file_dialog:
@@ -366,7 +357,6 @@ SPEC CHECKSUMS:
   fk_user_agent: 1f47ec39291e8372b1d692b50084b0d54103c545
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_appauth: 1ce438877bc111c5d8f42da47729909290624886
-  flutter_charset_detector_darwin: fb3692d6d72cb6afcce7b0dd1a9516be6e78556e
   flutter_downloader: b7301ae057deadd4b1650dc7c05375f10ff12c39
   flutter_file_dialog: 4c014a45b105709a27391e266c277d7e588e9299
   flutter_image_compress_common: ec1d45c362c9d30a3f6a0426c297f47c52007e3e
@@ -398,7 +388,6 @@ SPEC CHECKSUMS:
   share_plus: c3fef564749587fc939ef86ffb283ceac0baf9f5
   shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
   SwiftyGif: 93a1cc87bf3a51916001cf8f3d63835fb64c819f
-  UniversalDetector2: 7c9ffd935cf050eeb19edf7e90f6febe3743a1af
   url_launcher_ios: 68d46cc9766d0c41dbdc884310529557e3cd7a86
   workmanager: 0afdcf5628bbde6924c21af7836fed07b42e30e6
 

--- a/model/pubspec.lock
+++ b/model/pubspec.lock
@@ -344,27 +344,20 @@ packages:
   flutter_charset_detector:
     dependency: transitive
     description:
-      name: flutter_charset_detector
-      sha256: "5d4796d43dac2f37e14149b0f0c676fa08e8eb1ada8e99342a838d971d2fb9b1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.0"
+      path: flutter_charset_detector
+      ref: main
+      resolved-ref: "36c3ffeea65f7b362c1e47e608802f0ca941f4d4"
+      url: "https://github.com/dab246/flutter_charset_detector.git"
+    source: git
+    version: "5.0.0"
   flutter_charset_detector_android:
     dependency: transitive
     description:
       name: flutter_charset_detector_android
-      sha256: bee057133d5f134fe211523a27200dd22c782b93777f43359a571bd2c77da2cc
+      sha256: "443145e8fc8515b3b32aee375691e40dd59197a86a2ae153166bc88c8200d83b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
-  flutter_charset_detector_darwin:
-    dependency: transitive
-    description:
-      name: flutter_charset_detector_darwin
-      sha256: daac20390275efb92fbb14350fe11286c5e29c7b80d6b0867f52d760f0d69763
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
+    version: "3.0.0"
   flutter_charset_detector_platform_interface:
     dependency: transitive
     description:
@@ -377,10 +370,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_charset_detector_web
-      sha256: d8495115abada771c75f9395aae3e5809ffd506e8fc8f62b403ae11fc29e1d2b
+      sha256: e3ac65f94b12f4887937b21a19365d7927db816840cb93274e3861241cb0e9f2
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "2.0.0"
   flutter_image_compress:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -714,43 +714,36 @@ packages:
   flutter_charset_detector:
     dependency: transitive
     description:
-      name: flutter_charset_detector
-      sha256: "5d4796d43dac2f37e14149b0f0c676fa08e8eb1ada8e99342a838d971d2fb9b1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.0"
+      path: flutter_charset_detector
+      ref: main
+      resolved-ref: "36c3ffeea65f7b362c1e47e608802f0ca941f4d4"
+      url: "https://github.com/dab246/flutter_charset_detector.git"
+    source: git
+    version: "5.0.0"
   flutter_charset_detector_android:
     dependency: transitive
     description:
       name: flutter_charset_detector_android
-      sha256: "43d0c0063242d036b873ade737ebae38716af5cd8b2a4df1754adfd186d58e2c"
+      sha256: "443145e8fc8515b3b32aee375691e40dd59197a86a2ae153166bc88c8200d83b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
-  flutter_charset_detector_darwin:
-    dependency: transitive
-    description:
-      name: flutter_charset_detector_darwin
-      sha256: d17c1847366a0501449d95d18a43417585841afe10200ceefb4422e6b7fccefb
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
+    version: "3.0.0"
   flutter_charset_detector_platform_interface:
     dependency: transitive
     description:
       name: flutter_charset_detector_platform_interface
-      sha256: fcb61de27285031164c945aca4b42e4d36f9a9e359212f21ab652275c9c723ec
+      sha256: "1c09ed7b314a5a9dde76057b98b7d35458ba881eed03d5e5b6f7f74b4869d18c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   flutter_charset_detector_web:
     dependency: transitive
     description:
       name: flutter_charset_detector_web
-      sha256: d8495115abada771c75f9395aae3e5809ffd506e8fc8f62b403ae11fc29e1d2b
+      sha256: e3ac65f94b12f4887937b21a19365d7927db816840cb93274e3861241cb0e9f2
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "2.0.0"
   flutter_colorpicker:
     dependency: transitive
     description:


### PR DESCRIPTION
## Issue

<img width="944" alt="Screenshot 2025-03-18 at 11 50 07" src="https://github.com/user-attachments/assets/58b8fa1a-f7b3-47f7-95e0-68e7b2b93c06" />

## Root cause

- Currently the native library of flutter_charset_detector on iOS is in the process of moving to GitLab [uchardet.git](https://gitlab.freedesktop.org/uchardet/uchardet.git) and plans to stop service from 16/03/2025 to 22/03/2025 so we cannot access it. They also announced the completion time of this on the page.

<img width="1247" alt="Screenshot 2025-03-18 at 11 59 34" src="https://github.com/user-attachments/assets/537a7792-6543-4277-a6fc-1a28cf23acfa" />

## Workaround

- Disable charset detector on iOS (set default is `utf-8`)
- Still work fine on Android & Web

## Resolved

- CI status:

<img width="1106" alt="Screenshot 2025-03-18 at 13 56 01" src="https://github.com/user-attachments/assets/49116857-7cdd-4cc5-94d1-1a1a7f9c0f72" />


- Web:

https://github.com/user-attachments/assets/29650602-422e-4a22-98fa-4c4fec265608

- Android:

[Screen_recording_20250318_134644.webm](https://github.com/user-attachments/assets/4b7dda74-3764-4e84-8e8b-192cc267ca1a)

- iOS:



https://github.com/user-attachments/assets/95916627-eb4a-44c9-9eb1-eb4253d5f960


