### PR TITLE
TF-3569 E2E Mailbox toggle read/star/spam

### DIFF
--- a/integration_test/robots/thread_robot.dart
+++ b/integration_test/robots/thread_robot.dart
@@ -127,4 +127,23 @@ class ThreadRobot extends CoreRobot {
     await $(#moveToTrash_selected_email_button).tap();
     await $.pumpAndTrySettle();
   }
+
+  Future<void> tapMarkAsReadButton() async {
+    await $(#markAsRead_selected_email_button).tap();
+    await $.pumpAndTrySettle();
+  }
+
+  Future<void> tapMarkAsStarAction() async {
+    await $(#moreAction_selected_email_button).tap();
+    await $.pumpAndTrySettle();
+    await $(#markAsStarred_action).tap();
+    await $.pumpAndTrySettle();
+  }
+
+  Future<void> tapMarkAsSpamAction() async {
+    await $(#moreAction_selected_email_button).tap();
+    await $.pumpAndTrySettle();
+    await $(#moveToSpam_action).tap();
+    await $.pumpAndTrySettle();
+  }
 }

--- a/integration_test/scenarios/mailbox/mark_single_selected_email_as_read_scenario.dart
+++ b/integration_test/scenarios/mailbox/mark_single_selected_email_as_read_scenario.dart
@@ -1,0 +1,33 @@
+import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/thread_robot.dart';
+
+class MarkSingleSelectedEmailAsReadScenario extends BaseTestScenario {
+  const MarkSingleSelectedEmailAsReadScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const email = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const readSubject = 'single selected read';
+
+    final threadRobot = ThreadRobot($);
+
+    await provisionEmail([
+      ProvisioningEmail(toEmail: email, subject: readSubject, content: ''),
+    ]);
+    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+
+    await threadRobot.longPressEmailWithSubject(readSubject);
+    await threadRobot.tapMarkAsReadButton();
+    await _expectEmailWithSubjectIsRead(readSubject);
+  }
+
+  Future<void> _expectEmailWithSubjectIsRead(String subject) async {
+    await expectViewVisible($(EmailTileBuilder).which<EmailTileBuilder>(
+      (widget) => widget.presentationEmail.subject == subject
+        && widget.presentationEmail.hasRead
+    ));
+  }
+}

--- a/integration_test/scenarios/mailbox/mark_single_selected_email_as_spam_scenario.dart
+++ b/integration_test/scenarios/mailbox/mark_single_selected_email_as_spam_scenario.dart
@@ -1,0 +1,39 @@
+import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class MarkSingleSelectedEmailAsSpamScenario extends BaseTestScenario {
+  const MarkSingleSelectedEmailAsSpamScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const email = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const spamSubject = 'single selected spam';
+
+    final threadRobot = ThreadRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+
+    await provisionEmail([
+      ProvisioningEmail(toEmail: email, subject: spamSubject, content: ''),
+    ]);
+    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+
+    await threadRobot.longPressEmailWithSubject(spamSubject);
+    await threadRobot.tapMarkAsSpamAction();
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openFolderByName(
+      AppLocalizations().spamMailboxDisplayName,
+    );
+    await _expectEmailWithSubjectExist(spamSubject);
+  }
+
+  Future<void> _expectEmailWithSubjectExist(String subject) async {
+    await expectViewVisible($(EmailTileBuilder).which<EmailTileBuilder>(
+      (widget) => widget.presentationEmail.subject == subject
+    ));
+  }
+}

--- a/integration_test/scenarios/mailbox/mark_single_selected_email_as_star_scenario.dart
+++ b/integration_test/scenarios/mailbox/mark_single_selected_email_as_star_scenario.dart
@@ -1,0 +1,33 @@
+import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/thread_robot.dart';
+
+class MarkSingleSelectedEmailAsStarScenario extends BaseTestScenario {
+  const MarkSingleSelectedEmailAsStarScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const email = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const starSubject = 'single selected star';
+
+    final threadRobot = ThreadRobot($);
+
+    await provisionEmail([
+      ProvisioningEmail(toEmail: email, subject: starSubject, content: ''),
+    ]);
+    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+
+    await threadRobot.longPressEmailWithSubject(starSubject);
+    await threadRobot.tapMarkAsStarAction();
+    await _expectEmailWithSubjectIsStarred(starSubject);
+  }
+
+  Future<void> _expectEmailWithSubjectIsStarred(String subject) async {
+    await expectViewVisible($(EmailTileBuilder).which<EmailTileBuilder>(
+      (widget) => widget.presentationEmail.subject == subject
+        && widget.presentationEmail.hasStarred
+    ));
+  }
+}

--- a/integration_test/tests/mailbox/mark_single_selected_email_as_read_test.dart
+++ b/integration_test/tests/mailbox/mark_single_selected_email_as_read_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/mailbox/mark_single_selected_email_as_read_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see selected email mark as read successfully',
+    scenarioBuilder: ($) => MarkSingleSelectedEmailAsReadScenario($),
+  );
+}

--- a/integration_test/tests/mailbox/mark_single_selected_email_as_spam_test.dart
+++ b/integration_test/tests/mailbox/mark_single_selected_email_as_spam_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/mailbox/mark_single_selected_email_as_spam_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see selected email mark as spam successfully',
+    scenarioBuilder: ($) => MarkSingleSelectedEmailAsSpamScenario($),
+  );
+}

--- a/integration_test/tests/mailbox/mark_single_selected_email_as_star_test.dart
+++ b/integration_test/tests/mailbox/mark_single_selected_email_as_star_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/mailbox/mark_single_selected_email_as_star_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see selected email mark as star successfully',
+    scenarioBuilder: ($) => MarkSingleSelectedEmailAsStarScenario($),
+  );
+}


### PR DESCRIPTION
## Issue
- #3569 

## Test result
```console
✅ Should see selected email mark as read successfully (integration_test/tests/mailbox/mark_single_selected_email_as_read_test.dart) (18s)
✅ Should see selected email mark as spam successfully (integration_test/tests/mailbox/mark_single_selected_email_as_spam_test.dart) (20s)
✅ Should see selected email mark as star successfully (integration_test/tests/mailbox/mark_single_selected_email_as_star_test.dart) (17s)

Test summary:
📝 Total: 3
✅ Successful: 3
❌ Failed: 0
⏩ Skipped: 0
📊 Report: .../tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 82s
```

## Test video

[read-star-spam-single.webm](https://github.com/user-attachments/assets/615d3086-a58d-48c3-b5ac-485915ed226b)
