### PR TITLE
Bump version to v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [0.15.0] - 2025-03-19
+### Added
+- #1192 Support multiple composer
+- #3450 Preview of other simple attachments (`image/*`, `text/plain`, `text/markdown`, `application/json`)
+- Translation zh_Hans, ga, de
+
+### Fixed
+- #3410 Reduce color noise
+- #3511 Android email view system back action
+- #3502 Composer image loading icon
+- #3533 Migrate android gradle plugins
+- #3548 Handle exceeded quota
+- Disable charset detector on iOS as workaround to fix build ios fail
+
 ## [0.14.15] - 2025-03-10
 ### Added
 - #3349 Sender can set priority in composer

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.14.15
+version: 0.15.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## [0.15.0] - 2025-03-19
### Added
- #1192 Support multiple composer
- #3450 Preview of other simple attachments (`image/*`, `text/plain`, `text/markdown`, `application/json`)
- Translation zh_Hans, ga, de

### Fixed
- #3410 Reduce color noise
- #3511 Android email view system back action
- #3502 Composer image loading icon
- #3533 Migrate android gradle plugins
- #3548 Handle exceeded quota
- Disable charset detector on iOS as workaround to fix build ios fail