### PR TITLE
TF-3584 Fix PDF Previewer on old Safari 16

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2100,10 +2100,10 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "79918fce64cfe7b7dd3d4b4555f4494e3fbb5639"
+      resolved-ref: dea73316291d9d3871da14a4f2b13130865dbbd8
       url: "https://github.com/linagora/twake-previewer-flutter.git"
     source: git
-    version: "0.0.14"
+    version: "0.0.15"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## Issue
- #3584 

## Root cause
- Current pdfjs version (4.5.136), dependency of current Pdfrx dependency of twake_previewer_flutter remove its support for `Promise.withResolvers` method

## Solution
- Use the old pdfjs version (3.4.120) before merging new previewer.

## Demo

https://github.com/user-attachments/assets/b0742c89-4157-4c95-90cc-19d8d4d37c78

