### PR TITLE
TF-3585 Fix request read receipt popup is not shown on mobile

### DIFF
--- a/core/lib/presentation/views/dialog/confirm_dialog_button.dart
+++ b/core/lib/presentation/views/dialog/confirm_dialog_button.dart
@@ -40,7 +40,7 @@ class ConfirmDialogButton extends StatelessWidget {
           ),
           alignment: Alignment.center,
           padding: maxLines == 1
-            ? null
+            ? const EdgeInsets.symmetric(horizontal: 8)
             : padding ?? const EdgeInsets.symmetric(horizontal: 8, vertical: 12),
           child: Text(
             label,

--- a/integration_test/robots/composer_robot.dart
+++ b/integration_test/robots/composer_robot.dart
@@ -93,4 +93,8 @@ class ComposerRobot extends CoreRobot {
   Future<void> tapMarkAsImportantPopupItemOnMenu() async {
     await $(#mark_as_important_popup_item).tap();
   }
+
+  Future<void> tapReadReceiptPopupItemOnMenu() async {
+    await $(#read_receipt_popup_item).tap();
+  }
 }

--- a/integration_test/scenarios/send_email_with_read_receipt_enabled_scenario.dart
+++ b/integration_test/scenarios/send_email_with_read_receipt_enabled_scenario.dart
@@ -1,0 +1,91 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:duration/duration.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/email/prefix_email_address.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../base/base_test_scenario.dart';
+import '../robots/composer_robot.dart';
+import '../robots/email_robot.dart';
+import '../robots/thread_robot.dart';
+
+class SendEmailWithReadReceiptEnabledScenario extends BaseTestScenario {
+  const SendEmailWithReadReceiptEnabledScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const emailSubject = 'Email with read receipt enabled';
+
+    final threadRobot = ThreadRobot($);
+    final composerRobot = ComposerRobot($);
+    final emailRobot = EmailRobot($);
+    final imagePaths = ImagePaths();
+    final appLocalizations = AppLocalizations();
+
+    await threadRobot.openComposer();
+    await _expectComposerViewVisible();
+
+    await composerRobot.grantContactPermission();
+
+    await composerRobot.addRecipientIntoField(
+      prefixEmailAddress: PrefixEmailAddress.to,
+      email: emailUser,
+    );
+
+    await composerRobot.addSubject(emailSubject);
+    await composerRobot.addContent(emailSubject);
+
+    await composerRobot.tapMoreOptionOnAppBar();
+    await $.pump(const Duration(seconds: 2));
+    await _expectMoreOptionPopupMenuVisible();
+
+    await composerRobot.tapReadReceiptPopupItemOnMenu();
+    await $.pump(const Duration(seconds: 2));
+    await _expectToastDisplayWithMessageReadReceiptEnabled(appLocalizations);
+
+    await composerRobot.sendEmail(imagePaths);
+    await $.pumpAndSettle(duration: seconds(5));
+    await _expectEmailWithReadReceiptVisible(emailSubject);
+
+    await threadRobot.openEmailWithSubject(emailSubject);
+    await _expectReadReceiptRequestDialog(appLocalizations);
+
+    await $.native.pressBack();
+    await emailRobot.onTapBackButton();
+
+    await $.pumpAndSettle(duration: seconds(5));
+
+    // Try opening it again when the email is cached
+    await threadRobot.openEmailWithSubject(emailSubject);
+    await _expectReadReceiptRequestDialog(appLocalizations);
+  }
+
+  Future<void> _expectComposerViewVisible() => expectViewVisible($(ComposerView));
+
+  Future<void> _expectMoreOptionPopupMenuVisible() async {
+    await expectViewVisible($(#read_receipt_popup_item));
+  }
+
+  Future<void> _expectToastDisplayWithMessageReadReceiptEnabled(
+    AppLocalizations appLocalizations,
+  ) async {
+    await expectViewVisible(
+      $(find.text(appLocalizations.requestReadReceiptHasBeenEnabled)),
+    );
+  }
+
+  Future<void> _expectReadReceiptRequestDialog(
+    AppLocalizations appLocalizations
+  ) async {
+    await expectViewVisible(
+      $(appLocalizations.titleReadReceiptRequestNotificationMessage)
+    );
+  }
+
+  Future<void> _expectEmailWithReadReceiptVisible(String subject) async {
+    await expectViewVisible($(EmailTileBuilder).$(find.text(subject)));
+  }
+}

--- a/integration_test/tests/compose/send_email_with_read_receipt_enabled_test.dart
+++ b/integration_test/tests/compose/send_email_with_read_receipt_enabled_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/send_email_with_read_receipt_enabled_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see read receipt dialog when user toggle read receipt and open read receipt email',
+    scenarioBuilder: ($) => SendEmailWithReadReceiptEnabledScenario($),
+  );
+}

--- a/lib/features/base/mixin/message_dialog_action_mixin.dart
+++ b/lib/features/base/mixin/message_dialog_action_mixin.dart
@@ -46,6 +46,7 @@ mixin MessageDialogActionMixin {
         bool isArrangeActionButtonsVertical = false,
         int? titleActionButtonMaxLines,
         bool useIconAsBasicLogo = false,
+        EdgeInsetsGeometry? dialogMargin,
       }
   ) async {
     final responsiveUtils = Get.find<ResponsiveUtils>();
@@ -111,6 +112,7 @@ mixin MessageDialogActionMixin {
             textContent: message,
             title: title ?? '',
             iconWidget: icon,
+            margin: dialogMargin,
             widthDialog: responsiveUtils.getSizeScreenWidth(context),
             confirmBackgroundButtonColor: actionButtonColor,
             cancelBackgroundButtonColor: cancelButtonColor,

--- a/lib/features/composer/presentation/composer_view.dart
+++ b/lib/features/composer/presentation/composer_view.dart
@@ -517,6 +517,7 @@ class ComposerView extends GetWidget<ComposerController> {
       PopupMenuItem(
         padding: EdgeInsets.zero,
         child: PopupItemWidget(
+          key: const Key('read_receipt_popup_item'),
           iconAction: controller.imagePaths.icReadReceipt,
           nameAction: AppLocalizations.of(context).requestReadReceipt,
           styleName: ComposerStyle.popupItemTextStyle,

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -735,6 +735,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
         AppLocalizations.of(currentContext!).yes,
         onConfirmAction: () => _handleSendReceiptToSenderAction(currentContext!),
         showAsBottomSheet: true,
+        dialogMargin: MediaQuery.paddingOf(currentContext!).add(const EdgeInsets.only(bottom: 12)),
         title: AppLocalizations.of(currentContext!).titleReadReceiptRequestNotificationMessage,
         cancelTitle: AppLocalizations.of(currentContext!).no,
         icon: SvgPicture.asset(imagePaths.icReadReceiptMessage, fit: BoxFit.fill),

--- a/model/lib/extensions/email_extension.dart
+++ b/model/lib/extensions/email_extension.dart
@@ -54,7 +54,7 @@ extension EmailExtension on Email {
     final mailboxCurrent = findMailboxContain(mapMailbox);
     return !hasMdnSent &&
         headers.readReceiptHasBeenRequested &&
-        mailboxCurrent?.isSent == false;
+        mailboxCurrent?.isSent != true;
   }
 
   String getReceivedAt({required String newLocale, String? pattern}) {

--- a/model/test/extensions/email_extension_test.dart
+++ b/model/test/extensions/email_extension_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email_header.dart';
+import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/email/email_property.dart';
+import 'package:model/extensions/email_extension.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+
+void main() {
+  group('EmailExtension::hasReadReceipt:', () {
+    late Email email;
+    late Map<MailboxId, PresentationMailbox> mailboxMap;
+
+    setUp(() {
+      mailboxMap = {};
+    });
+
+    test('Should return true when the email contains a Disposition-Notification-To header, has no \$mdnsent keyword, and is not in the sent mailbox', () {
+      email = Email(
+        headers: {
+          EmailHeader(
+            EmailProperty.headerMdnKey,
+            'user@example.com',
+          ),
+        },
+        keywords: {},
+        mailboxIds: {
+          MailboxId(Id('inbox')): true
+        }
+      );
+      mailboxMap[MailboxId(Id('inbox'))] = PresentationMailbox(
+        MailboxId(Id('inbox')),
+        role: PresentationMailbox.roleInbox,
+      );
+
+      expect(email.hasReadReceipt(mailboxMap), isTrue);
+    });
+
+    test('Should return false when the email contains the \$mdnsent keyword', () {
+      email = Email(
+        headers: {
+          EmailHeader(
+            EmailProperty.headerMdnKey,
+            'user@example.com',
+          ),
+        },
+        keywords: {
+          KeyWordIdentifier.mdnSent: true,
+        },
+        mailboxIds: {
+          MailboxId(Id('inbox')): true
+        }
+      );
+      mailboxMap[MailboxId(Id('inbox'))] = PresentationMailbox(
+        MailboxId(Id('inbox')),
+        role: PresentationMailbox.roleInbox,
+      );
+
+      expect(email.hasReadReceipt(mailboxMap), isFalse);
+    });
+
+    test('Should return false when the email does not contain a Disposition-Notification-To header', () {
+      email = Email(
+        headers: {},
+        keywords: {},
+        mailboxIds: {
+          MailboxId(Id('inbox')): true
+        }
+      );
+      mailboxMap[MailboxId(Id('inbox'))] = PresentationMailbox(
+        MailboxId(Id('inbox')),
+        role: PresentationMailbox.roleInbox,
+      );
+
+      expect(email.hasReadReceipt(mailboxMap), isFalse);
+    });
+
+    test('Should return false when the email is in the sent mailbox', () {
+      email = Email(
+        headers: {
+          EmailHeader(
+            EmailProperty.headerMdnKey,
+            'user@example.com',
+          ),
+        },
+        keywords: {},
+        mailboxIds: {
+          MailboxId(Id('sent')): true
+        }
+      );
+      mailboxMap[MailboxId(Id('sent'))] = PresentationMailbox(
+        MailboxId(Id('sent')),
+        role: PresentationMailbox.roleSent,
+      );
+
+      expect(email.hasReadReceipt(mailboxMap), isFalse);
+    });
+
+    test('Should return true when mailboxCurrent is null, the email contains a Disposition-Notification-To header, and has no \$mdnsent keyword', () {
+      email = Email(
+        headers: {
+          EmailHeader(
+            EmailProperty.headerMdnKey,
+            'user@example.com',
+          ),
+        },
+        keywords: {},
+        mailboxIds: {},
+      );
+      mailboxMap = {};
+
+      expect(email.hasReadReceipt(mailboxMap), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Issue

#3585 

## Root cause

When sending emails on a web browser, the mobile will save the email to the cache when a new email from a notification arrives. Therefore, when opening these emails, the data will be retrieved from the cache. Based on the `hasReadReceipt` function in `EmailExtension`, the current `mailboxCurrent` condition, therefore, the `mailboxCurrent?.isSent == false` is currently incorrect. This leads to the `hasReadReceipt` function always returning `false`.

<img width="596" alt="Screenshot 2025-03-24 at 11 30 59" src="https://github.com/user-attachments/assets/15407118-9830-4d24-86d0-a52eeee89df1" />


## Solution 

- Update the condition to be correct: `mailboxCurrent?.isSent != true`
- Sync caches from local

## Resolved

- Demo:

https://github.com/user-attachments/assets/cecf118e-7cdc-4448-adc8-a5d6fb07ec58


- Integration test:

```console
🧪 Should see read receipt dialog when user toggle read receipt and open read receipt email
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. tap widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  10. enterText widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  11. waitUntilVisible widgets with text containing baf1-2001-ee0-4161-e12b-d1b5-d602-b805-28ea.ngrok-free.app.
        ✅  12. tap widgets with text "Next".
        ✅  13. waitUntilVisible widgets with key [<'credential_input_form'>] descending from widgets with type "LoginView".
        ✅  14. enterText widgets with type "TextField" descending from widgets with key [<'login_username_input'>].
        ✅  15. waitUntilVisible widgets with text "bob@example.com".
        ✅  16. tap widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
        ✅  17. enterText widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
        ✅  18. tap widgets with key [<'loginSubmitForm'>].
        ✅  19. isPermissionDialogVisible (native)
        ✅  20. waitUntilVisible widgets with type "ThreadView".
        ✅  21. tap widgets with type "InkWell" descending from widgets with type "ComposeFloatingButton".
        ✅  22. waitUntilVisible widgets with type "ComposerView".
        ✅  23. isPermissionDialogVisible (native)
        ✅  24. grantPermissionWhenInUse (native)
        ✅  25. enterText widgets with widget matching predicate descending from widgets with type "RecipientComposerWidget" inclusive.
        ✅  26. tap widgets with widget matching predicate descending from widgets with type "RecipientSuggestionItemWidget" inclusive.
        ✅  27. tap widgets with type "SubjectComposerWidget".
✅ Should see read receipt dialog when user toggle read receipt and open read receipt email (integration_test/tests/compose/send_email_with_read_receipt_enabled_test.dart) (47s)

Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: ../tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 71s

```

[e2e.webm](https://github.com/user-attachments/assets/1779d33e-5f48-42bf-a062-53b492b37b32)
