### PR TITLE
[HOT] Fix cannot display name after press Enter key to select autocomplete in composer

### DIFF
--- a/lib/features/composer/presentation/widgets/recipient_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/recipient_composer_widget.dart
@@ -524,10 +524,12 @@ class _RecipientComposerWidgetState extends State<RecipientComposerWidget> {
   void _handleSelectOptionAction(
     SuggestionEmailAddress suggestionEmailAddress,
     StateSetter stateSetter
-  ) => _onEmailAddressReceived(
-    suggestionEmailAddress.emailAddress.emailAddress,
-    stateSetter,
-  );
+  ) {
+    if (!_isDuplicatedRecipient(suggestionEmailAddress.emailAddress.emailAddress)) {
+      stateSetter(() => _currentListEmailAddress.add(suggestionEmailAddress.emailAddress));
+      _updateListEmailAddressAction();
+    }
+  }
 
   void _handleSubmitTagAction(
     String value,


### PR DESCRIPTION
## Issue

```
As user, I open composer and enter the name in the To field,
Then the list of suggestions appears, 
And I use the down arrow key on the keyboard to find the contact with the display name.
Then, I press Enter to select, the contact has been tagged but has no display name
```


https://github.com/user-attachments/assets/7e0c4a73-6934-495e-a566-628996117bdf


## Root cause

The logic handling when pressing `Enter` and selecting a contact in the suggestion list is incorrect. We only take the `emailAddress` address in the contact to create a new email address via the `_generateEmailAddressFromString` function. Therefore, the `displayName` is lost.


## Solution

Keep the `EmailAddress` from suggestion list to use

## Resolved


https://github.com/user-attachments/assets/df1e04b4-fc0e-4f5f-8a0c-ec40514d2729



