### PR TITLE
TF-3583 E2E Mailbox create and hide sub folder

### DIFF
--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -1,7 +1,13 @@
 
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:core/presentation/views/text/text_field_builder.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/label_mailbox_item_widget.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/mailbox_item_widget.dart';
+import 'package:tmail_ui_user/features/mailbox_creator/presentation/mailbox_creator_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../base/core_robot.dart';
 
@@ -16,6 +22,52 @@ class MailboxMenuRobot extends CoreRobot {
     await $(MailboxItemWidget)
       .$(LabelMailboxItemWidget)
       .$(find.text(name))
+      .tap();
+  }
+
+  Future<void> longPressMailboxWithName(String name) async {
+    await $(name).longPress();
+    await $.pumpAndSettle();
+  }
+
+  Future<void> tapCreateNewSubFolder() async {
+    await $(AppLocalizations().newSubfolder).tap();
+  }
+
+  Future<void> enterNewSubFolderName(String name) async {
+    await $(MailboxCreatorView)
+      .$(TextFieldBuilder)
+      .enterText(name);
+  }
+
+  Future<void> confirmCreateNewSubFolder() async {
+    await $(MailboxCreatorView)
+      .$(AppLocalizations().done)
+      .tap();
+  }
+
+  Future<void> expandMailboxWithName(String name) async {
+    await $(MailboxItemWidget)
+      .which<MailboxItemWidget>((widget) {
+        return widget.mailboxNode.item.name?.name.toLowerCase() ==
+          name.toLowerCase();
+      })
+      .$(TMailButtonWidget)
+      .which<TMailButtonWidget>((widget) {
+        return widget.icon == ImagePaths().icArrowRight;
+      })
+      .tap();
+  }
+
+  Future<void> tapHideMailbox() async {
+    await $(AppLocalizations().hideFolder).tap();
+  }
+
+  Future<void> closeMenu() async {
+    await $(IconButton)
+      .which<IconButton>((widget) {
+        return widget.tooltip == AppLocalizations().close;
+      })
       .tap();
   }
 }

--- a/integration_test/scenarios/mailbox/create_and_hide_sub_folder_scenario.dart
+++ b/integration_test/scenarios/mailbox/create_and_hide_sub_folder_scenario.dart
@@ -1,0 +1,59 @@
+import 'package:tmail_ui_user/features/mailbox/presentation/widgets/mailbox_item_widget.dart';
+import 'package:tmail_ui_user/features/thread/presentation/widgets/app_bar/default_mobile_app_bar_thread_widget.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class CreateAndHideSubFolderScenario extends BaseTestScenario {
+  const CreateAndHideSubFolderScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const subFolderName = 'hidden sub folder';
+
+    final threadRobot = ThreadRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.longPressMailboxWithName(
+      appLocalizations.inboxMailboxDisplayName,
+    );
+    await mailboxMenuRobot.tapCreateNewSubFolder();
+    await mailboxMenuRobot.enterNewSubFolderName(subFolderName);
+    await mailboxMenuRobot.confirmCreateNewSubFolder();
+    await _expectMailboxWithNameVisible(subFolderName);
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.expandMailboxWithName(
+      appLocalizations.inboxMailboxDisplayName
+    );
+    await mailboxMenuRobot.longPressMailboxWithName(subFolderName);
+    await mailboxMenuRobot.tapHideMailbox();
+    await _expectMailboxWithNameHaveNoChildren(
+      appLocalizations.inboxMailboxDisplayName
+    );
+    await mailboxMenuRobot.closeMenu();
+    await _expectMailboxWithNameVisible(
+      appLocalizations.inboxMailboxDisplayName
+    );
+  }
+
+  Future<void> _expectMailboxWithNameVisible(String name) async {
+    await expectViewVisible(
+      $(DefaultMobileAppBarThreadWidget).$(name)
+    );
+  }
+
+  Future<void> _expectMailboxWithNameHaveNoChildren(String name) async {
+    await expectViewVisible(
+      $(MailboxItemWidget)
+        .which<MailboxItemWidget>((widget) {
+          return widget.mailboxNode.item.name?.name.toLowerCase() ==
+            name.toLowerCase() && !widget.mailboxNode.hasChildren();
+        })
+    );
+  }
+}

--- a/integration_test/tests/mailbox/create_and_hide_sub_folder_test.dart
+++ b/integration_test/tests/mailbox/create_and_hide_sub_folder_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/mailbox/create_and_hide_sub_folder_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should create and hide sub folder successfully',
+    scenarioBuilder: ($) => CreateAndHideSubFolderScenario($),
+  );
+}


### PR DESCRIPTION
## Issue
- #3583 

## Test result
```console
✅ Should create and hide sub folder successfully (integration_test/tests/mailbox/

Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: …/tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 84s
```

## Test video

[subfolder-create-and-hide.webm](https://github.com/user-attachments/assets/d4c9d03f-9bfd-4aca-856b-507fc419210b)
