### PR TITLE
TF-3601 Fix iOS email view gone blank with large html content

### DIFF
--- a/core/lib/presentation/constants/constants_ui.dart
+++ b/core/lib/presentation/constants/constants_ui.dart
@@ -1,3 +1,7 @@
 class ConstantsUI {
-  static const fontApp = 'Inter';
+  static const String fontApp = 'Inter';
+  static const double htmlContentMaxHeight = 22000.0;
+  static const double composerHtmlContentMaxHeight = 20000.0;
+  static const double htmlContentMinHeight = 150;
+  static const double htmlContentOffsetHeight = 30.0;
 }

--- a/core/lib/presentation/views/html_viewer/ios_html_content_viewer_widget.dart
+++ b/core/lib/presentation/views/html_viewer/ios_html_content_viewer_widget.dart
@@ -1,0 +1,102 @@
+import 'dart:async';
+
+import 'package:core/data/constants/constant.dart';
+import 'package:core/presentation/views/html_viewer/html_content_viewer_widget.dart';
+import 'package:core/utils/html/html_interaction.dart';
+import 'package:core/utils/html/html_utils.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:url_launcher/url_launcher.dart' as launcher;
+import 'package:url_launcher/url_launcher_string.dart';
+
+class IosHtmlContentViewerWidget extends StatefulWidget {
+
+  final String contentHtml;
+  final TextDirection? direction;
+  final bool useDefaultFont;
+  final OnMailtoDelegateAction? onMailtoDelegateAction;
+  final OnPreviewEMLDelegateAction? onPreviewEMLDelegateAction;
+  final OnDownloadAttachmentDelegateAction? onDownloadAttachmentDelegateAction;
+
+  const IosHtmlContentViewerWidget({
+    Key? key,
+    required this.contentHtml,
+    this.direction,
+    this.useDefaultFont = false,
+    this.onMailtoDelegateAction,
+    this.onPreviewEMLDelegateAction,
+    this.onDownloadAttachmentDelegateAction,
+  }) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => _IosHtmlContentViewerWidgetState();
+}
+
+class _IosHtmlContentViewerWidgetState extends State<IosHtmlContentViewerWidget> {
+
+  @override
+  Widget build(BuildContext context) {
+    return InAppWebView(
+      initialSettings: InAppWebViewSettings(transparentBackground: true),
+      onWebViewCreated: _onWebViewCreated,
+      shouldOverrideUrlLoading: _shouldOverrideUrlLoading,
+      gestureRecognizers: {
+        Factory<LongPressGestureRecognizer>(() => LongPressGestureRecognizer()),
+      },
+    );
+  }
+
+  Future<void> _onWebViewCreated(InAppWebViewController controller) async {
+    await controller.loadData(data: HtmlUtils.generateHtmlDocument(
+      content: widget.contentHtml,
+      direction: widget.direction,
+      javaScripts: HtmlInteraction.scriptsHandleLazyLoadingBackgroundImage,
+      useDefaultFont: widget.useDefaultFont,
+    ));
+  }
+
+  Future<NavigationActionPolicy?> _shouldOverrideUrlLoading(
+    InAppWebViewController controller,
+    NavigationAction navigationAction
+  ) async {
+    final url = navigationAction.request.url?.toString();
+
+    if (url == null) {
+      return NavigationActionPolicy.CANCEL;
+    }
+
+    if (navigationAction.isForMainFrame && url == 'about:blank') {
+      return NavigationActionPolicy.ALLOW;
+    }
+
+    final requestUri = Uri.parse(url);
+    if (widget.onMailtoDelegateAction != null &&
+        requestUri.isScheme(Constant.mailtoScheme)) {
+      await widget.onMailtoDelegateAction?.call(requestUri);
+      return NavigationActionPolicy.CANCEL;
+    }
+
+    if (widget.onPreviewEMLDelegateAction != null &&
+        requestUri.isScheme(Constant.emlPreviewerScheme)) {
+      await widget.onPreviewEMLDelegateAction?.call(requestUri);
+      return NavigationActionPolicy.CANCEL;
+    }
+
+    if (widget.onDownloadAttachmentDelegateAction != null &&
+        requestUri.isScheme(Constant.attachmentScheme)) {
+      await widget.onDownloadAttachmentDelegateAction?.call(requestUri);
+      return NavigationActionPolicy.CANCEL;
+    }
+
+    if (await launcher.canLaunchUrl(Uri.parse(url))) {
+      await launcher.launchUrl(
+        Uri.parse(url),
+        mode: LaunchMode.externalApplication
+      );
+    }
+
+    return NavigationActionPolicy.CANCEL;
+  }
+}

--- a/docs/adr/0058-fix-ios-email-view-gone-blank-with-large-html-content.md
+++ b/docs/adr/0058-fix-ios-email-view-gone-blank-with-large-html-content.md
@@ -1,0 +1,27 @@
+# 58. Fix iOS email view gone blank with large HTML content
+
+Date: 2024-04-05
+
+## Status
+
+- Issues: 
+  - [iOS Email view gone blank with large HTML content #3601](https://github.com/linagora/tmail-flutter/issues/3601)
+
+## Context
+
+- On iOS, when using an `InAppWebView` inside a `SingleChildScrollView`, the height of the `SingleChildScrollView` depends on the `InAppWebView`. 
+Continuously updating the height of the `InAppWebView` up to a certain limit can cause the `SingleChildScrollView` to fail to render, 
+resulting in the content of the `InAppWebView` not being displayed.
+
+## Decision
+
+- Workaround:
+
+Set the maximum display height for content on iOS to `22,000` (not an absolute limit, but verified across various emails and found to be the most reasonable value).
+If the email content exceeds this height, a `View entire message` button will be displayed at the bottom of the email.
+When users click this button, they will be able to view the full email content, similar to previewing an EML file.
+
+
+## Consequences
+
+- All emails display fine on iOS

--- a/lib/features/composer/presentation/composer_bindings.dart
+++ b/lib/features/composer/presentation/composer_bindings.dart
@@ -136,6 +136,7 @@ class ComposerBindings extends BaseBindings {
     ), tag: composerId);
     Get.lazyPut(() => EmailLocalStorageDataSourceImpl(
       Get.find<LocalStorageManager>(),
+      Get.find<PreviewEmlFileUtils>(),
       Get.find<CacheExceptionThrower>(),
     ), tag: composerId);
     Get.lazyPut(() => EmailSessionStorageDatasourceImpl(

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -138,6 +138,7 @@ class ComposerController extends BaseController
   final listFromIdentities = RxList<Identity>();
   final isEmailChanged = Rx<bool>(false);
   final isMarkAsImportant = Rx<bool>(false);
+  final isContentHeightExceeded = Rx<bool>(false);
 
   final LocalFilePickerInteractor _localFilePickerInteractor;
   final LocalImagePickerInteractor _localImagePickerInteractor;

--- a/lib/features/composer/presentation/composer_view.dart
+++ b/lib/features/composer/presentation/composer_view.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/views/context_menu/simple_context_menu_action_builder.dart';
 import 'package:core/presentation/views/responsive/responsive_widget.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -8,6 +9,7 @@ import 'package:get/get.dart';
 import 'package:model/email/prefix_email_address.dart';
 import 'package:tmail_ui_user/features/base/widget/popup_item_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
+import 'package:tmail_ui_user/features/composer/presentation/extensions/handle_content_height_exceeded_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/mark_as_important_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/prefix_recipient_state.dart';
 import 'package:tmail_ui_user/features/composer/presentation/styles/composer_style.dart';
@@ -25,6 +27,7 @@ import 'package:tmail_ui_user/features/composer/presentation/widgets/mobile/tabl
 import 'package:tmail_ui_user/features/composer/presentation/widgets/recipient_composer_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/subject_composer_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/web/from_composer_drop_down_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/view_entire_message_with_message_clipped_widget.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
@@ -107,6 +110,7 @@ class ComposerView extends GetWidget<ComposerController> {
                       controller: controller.scrollController,
                       physics: const ClampingScrollPhysics(),
                       child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Obx(() {
                             if (controller.fromRecipientState.value == PrefixRecipientState.enabled) {
@@ -260,8 +264,20 @@ class ComposerView extends GetWidget<ComposerController> {
                               contentViewState: controller.emailContentsViewState.value,
                               onCreatedEditorAction: controller.onCreatedMobileEditorAction,
                               onLoadCompletedEditorAction: controller.onLoadCompletedMobileEditorAction,
+                              onEditorContentHeightChanged: controller.onEditorContentHeightChangedOnIOS,
                             ),
                           )),
+                          Obx(() {
+                            if (controller.isContentHeightExceeded.isTrue && PlatformInfo.isIOS) {
+                              return ViewEntireMessageWithMessageClippedWidget(
+                                buttonActionName: AppLocalizations.of(context).viewEntireMessage.toUpperCase(),
+                                onViewEntireMessageAction: () => controller.viewEntireContent(context),
+                                topPadding: 12,
+                              );
+                            } else {
+                              return const SizedBox.shrink();
+                            }
+                          }),
                           SizedBox(height: MediaQuery.viewInsetsOf(context).bottom + 64),
                         ],
                       ),
@@ -296,6 +312,7 @@ class ComposerView extends GetWidget<ComposerController> {
                   controller: controller.scrollController,
                   physics: const ClampingScrollPhysics(),
                   child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Obx(() => Column(
                         children: [
@@ -433,8 +450,20 @@ class ComposerView extends GetWidget<ComposerController> {
                           contentViewState: controller.emailContentsViewState.value,
                           onCreatedEditorAction: controller.onCreatedMobileEditorAction,
                           onLoadCompletedEditorAction: controller.onLoadCompletedMobileEditorAction,
+                          onEditorContentHeightChanged: controller.onEditorContentHeightChangedOnIOS,
                         ),
                       )),
+                      Obx(() {
+                        if (controller.isContentHeightExceeded.isTrue && PlatformInfo.isIOS) {
+                          return ViewEntireMessageWithMessageClippedWidget(
+                            buttonActionName: AppLocalizations.of(context).viewEntireMessage.toUpperCase(),
+                            onViewEntireMessageAction: () => controller.viewEntireContent(context),
+                            topPadding: 12,
+                          );
+                        } else {
+                          return const SizedBox.shrink();
+                        }
+                      }),
                       SizedBox(height: MediaQuery.viewInsetsOf(context).bottom + 64),
                     ],
                   ),

--- a/lib/features/composer/presentation/extensions/handle_content_height_exceeded_extension.dart
+++ b/lib/features/composer/presentation/extensions/handle_content_height_exceeded_extension.dart
@@ -1,0 +1,31 @@
+
+import 'package:core/presentation/constants/constants_ui.dart';
+import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/utils/app_logger.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
+import 'package:tmail_ui_user/features/composer/presentation/view/mobile/editor_fullscreen_dialog_view.dart';
+
+extension HandleContentHeightExceededExtension on ComposerController {
+
+  void onEditorContentHeightChangedOnIOS(double height) {
+    log('HandleContentHeightExceededExtension::onEditorContentHeightChangedOnIOS:height: $height');
+    isContentHeightExceeded.value = height == ConstantsUI.composerHtmlContentMaxHeight;
+  }
+
+  Future<void> viewEntireContent(BuildContext context) async {
+    clearFocus(context);
+
+    final currentContent = await getContentInEditor();
+    log('HandleContentHeightExceededExtension::showComposerFullscreen:currentContent = $currentContent');
+    Get.dialog(
+      EditorFullscreenDialogView(
+        content: currentContent,
+        imagePaths: imagePaths,
+        subject: subjectEmail.value,
+      ),
+      barrierColor: AppColor.colorDefaultCupertinoActionSheet,
+    );
+  }
+}

--- a/lib/features/composer/presentation/view/mobile/editor_fullscreen_dialog_view.dart
+++ b/lib/features/composer/presentation/view/mobile/editor_fullscreen_dialog_view.dart
@@ -1,0 +1,82 @@
+
+import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:core/presentation/views/html_viewer/ios_html_content_viewer_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+import 'package:tmail_ui_user/main/utils/app_utils.dart';
+
+class EditorFullscreenDialogView extends StatelessWidget {
+  final String content;
+  final ImagePaths imagePaths;
+  final String? subject;
+
+  const EditorFullscreenDialogView({
+    super.key,
+    required this.imagePaths,
+    required this.content,
+    this.subject,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.only(
+          topRight: Radius.circular(16),
+          topLeft: Radius.circular(16),
+        ),
+      ),
+      insetPadding: EdgeInsets.zero,
+      alignment: Alignment.center,
+      backgroundColor: Colors.white,
+      child: Container(
+        decoration: const BoxDecoration(
+          borderRadius: BorderRadius.only(
+            topRight: Radius.circular(16),
+            topLeft: Radius.circular(16),
+          ),
+        ),
+        width: double.infinity,
+        height: double.infinity,
+        clipBehavior: Clip.antiAlias,
+        child: Column(
+          children: [
+            SizedBox(
+              height: 52,
+              child: Row(
+                children: [
+                  const SizedBox(width: 40),
+                  Expanded(child: Text(
+                    subject ?? AppLocalizations.of(context).compose_email,
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      color: Colors.black,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  )),
+                  TMailButtonWidget.fromIcon(
+                    icon: imagePaths.icComposerClose,
+                    backgroundColor: Colors.transparent,
+                    margin: const EdgeInsetsDirectional.only(end: 12),
+                    onTapActionCallback: popBack,
+                  )
+                ],
+              ),
+            ),
+            const Divider(color: AppColor.colorDivider, height: 1),
+            Expanded(
+              child: IosHtmlContentViewerWidget(
+                contentHtml: content,
+                useDefaultFont: true,
+                direction: AppUtils.getCurrentDirection(context),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/composer/presentation/view/mobile/mobile_editor_view.dart
+++ b/lib/features/composer/presentation/view/mobile/mobile_editor_view.dart
@@ -18,6 +18,7 @@ class MobileEditorView extends StatelessWidget with EditorViewMixin {
   final Either<Failure, Success>? contentViewState;
   final OnCreatedEditorAction onCreatedEditorAction;
   final OnLoadCompletedEditorAction onLoadCompletedEditorAction;
+  final OnEditorContentHeightChanged? onEditorContentHeightChanged;
 
   const MobileEditorView({
     super.key,
@@ -25,6 +26,7 @@ class MobileEditorView extends StatelessWidget with EditorViewMixin {
     required this.onLoadCompletedEditorAction,
     this.arguments,
     this.contentViewState,
+    this.onEditorContentHeightChanged,
   });
 
   @override
@@ -41,7 +43,8 @@ class MobileEditorView extends StatelessWidget with EditorViewMixin {
           content: HtmlExtension.editorStartTags,
           direction: AppUtils.getCurrentDirection(context),
           onCreatedEditorAction: onCreatedEditorAction,
-          onLoadCompletedEditorAction: onLoadCompletedEditorAction
+          onLoadCompletedEditorAction: onLoadCompletedEditorAction,
+          onEditorContentHeightChanged: onEditorContentHeightChanged,
         );
       case EmailActionType.editDraft:
       case EmailActionType.editSendingEmail:
@@ -58,7 +61,8 @@ class MobileEditorView extends StatelessWidget with EditorViewMixin {
             content: HtmlExtension.editorStartTags,
             direction: AppUtils.getCurrentDirection(context),
             onCreatedEditorAction: onCreatedEditorAction,
-            onLoadCompletedEditorAction: onLoadCompletedEditorAction
+            onLoadCompletedEditorAction: onLoadCompletedEditorAction,
+            onEditorContentHeightChanged: onEditorContentHeightChanged,
           ),
           (success) {
             if (success is GetEmailContentLoading) {
@@ -77,7 +81,8 @@ class MobileEditorView extends StatelessWidget with EditorViewMixin {
                 content: newContent,
                 direction: AppUtils.getCurrentDirection(context),
                 onCreatedEditorAction: onCreatedEditorAction,
-                onLoadCompletedEditorAction: onLoadCompletedEditorAction
+                onLoadCompletedEditorAction: onLoadCompletedEditorAction,
+                onEditorContentHeightChanged: onEditorContentHeightChanged,
               );
             }
           }
@@ -102,7 +107,8 @@ class MobileEditorView extends StatelessWidget with EditorViewMixin {
               content: emailContentQuoted,
               direction: AppUtils.getCurrentDirection(context),
               onCreatedEditorAction: onCreatedEditorAction,
-              onLoadCompletedEditorAction: onLoadCompletedEditorAction
+              onLoadCompletedEditorAction: onLoadCompletedEditorAction,
+              onEditorContentHeightChanged: onEditorContentHeightChanged,
             );
           },
           (success) {
@@ -122,7 +128,8 @@ class MobileEditorView extends StatelessWidget with EditorViewMixin {
                 content: emailContentQuoted,
                 direction: AppUtils.getCurrentDirection(context),
                 onCreatedEditorAction: onCreatedEditorAction,
-                onLoadCompletedEditorAction: onLoadCompletedEditorAction
+                onLoadCompletedEditorAction: onLoadCompletedEditorAction,
+                onEditorContentHeightChanged: onEditorContentHeightChanged,
               );
             }
           }
@@ -132,7 +139,8 @@ class MobileEditorView extends StatelessWidget with EditorViewMixin {
           content: HtmlExtension.editorStartTags,
           direction: AppUtils.getCurrentDirection(context),
           onCreatedEditorAction: onCreatedEditorAction,
-          onLoadCompletedEditorAction: onLoadCompletedEditorAction
+          onLoadCompletedEditorAction: onLoadCompletedEditorAction,
+          onEditorContentHeightChanged: onEditorContentHeightChanged,
         );
     }
   }

--- a/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
@@ -1,10 +1,13 @@
 
+import 'package:core/presentation/constants/constants_ui.dart';
 import 'package:core/utils/html/html_utils.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 import 'package:rich_text_composer/rich_text_composer.dart';
 
 typedef OnCreatedEditorAction = Function(BuildContext context, HtmlEditorApi editorApi, String content);
 typedef OnLoadCompletedEditorAction = Function(HtmlEditorApi editorApi, WebUri? url);
+typedef OnEditorContentHeightChanged = Function(double height);
 
 class MobileEditorWidget extends StatelessWidget {
 
@@ -12,6 +15,7 @@ class MobileEditorWidget extends StatelessWidget {
   final TextDirection direction;
   final OnCreatedEditorAction onCreatedEditorAction;
   final OnLoadCompletedEditorAction onLoadCompletedEditorAction;
+  final OnEditorContentHeightChanged? onEditorContentHeightChanged;
 
   const MobileEditorWidget({
     super.key,
@@ -19,6 +23,7 @@ class MobileEditorWidget extends StatelessWidget {
     required this.direction,
     required this.onCreatedEditorAction,
     required this.onLoadCompletedEditorAction,
+    this.onEditorContentHeightChanged,
   });
 
   @override
@@ -26,6 +31,7 @@ class MobileEditorWidget extends StatelessWidget {
     return HtmlEditor(
       key: const Key('mobile_editor'),
       minHeight: 550,
+      maxHeight: PlatformInfo.isIOS ? ConstantsUI.composerHtmlContentMaxHeight : null,
       addDefaultSelectionMenuItems: false,
       initialContent: content,
       customStyleCss: HtmlUtils.customCssStyleHtmlEditor(
@@ -34,6 +40,7 @@ class MobileEditorWidget extends StatelessWidget {
       ),
       onCreated: (editorApi) => onCreatedEditorAction.call(context, editorApi, content),
       onCompleted: onLoadCompletedEditorAction,
+      onContentHeightChanged: PlatformInfo.isIOS ? onEditorContentHeightChanged : null,
     );
   }
 }

--- a/lib/features/email/data/datasource/email_datasource.dart
+++ b/lib/features/email/data/datasource/email_datasource.dart
@@ -26,6 +26,7 @@ import 'package:tmail_ui_user/features/email/domain/model/event_action.dart';
 import 'package:tmail_ui_user/features/email/domain/model/move_to_mailbox_request.dart';
 import 'package:tmail_ui_user/features/email/domain/model/preview_email_eml_request.dart';
 import 'package:tmail_ui_user/features/email/domain/model/restore_deleted_message_request.dart';
+import 'package:tmail_ui_user/features/email/domain/model/view_entire_message_request.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/eml_previewer.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/model/create_new_mailbox_request.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/model/sending_email.dart';
@@ -221,4 +222,6 @@ abstract class EmailDataSource {
     AccountRequest accountRequest,
     {CancelToken? cancelToken}
   );
+
+  Future<String> generateEntireMessageAsDocument(ViewEntireMessageRequest entireMessageRequest);
 }

--- a/lib/features/email/data/datasource_impl/email_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_datasource_impl.dart
@@ -36,6 +36,7 @@ import 'package:tmail_ui_user/features/email/domain/model/event_action.dart';
 import 'package:tmail_ui_user/features/email/domain/model/move_to_mailbox_request.dart';
 import 'package:tmail_ui_user/features/email/domain/model/preview_email_eml_request.dart';
 import 'package:tmail_ui_user/features/email/domain/model/restore_deleted_message_request.dart';
+import 'package:tmail_ui_user/features/email/domain/model/view_entire_message_request.dart';
 import 'package:tmail_ui_user/features/email/presentation/extensions/attachment_extension.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/eml_previewer.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/model/create_new_mailbox_request.dart';
@@ -582,4 +583,9 @@ class EmailDataSourceImpl extends EmailDataSource {
       cancelToken: cancelToken,
     );
   }).catchError(_exceptionThrower.throwException);
+
+  @override
+  Future<String> generateEntireMessageAsDocument(ViewEntireMessageRequest entireMessageRequest) {
+    throw UnimplementedError();
+  }
 }

--- a/lib/features/email/data/datasource_impl/email_hive_cache_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_hive_cache_datasource_impl.dart
@@ -36,6 +36,7 @@ import 'package:tmail_ui_user/features/email/domain/model/event_action.dart';
 import 'package:tmail_ui_user/features/email/domain/model/move_to_mailbox_request.dart';
 import 'package:tmail_ui_user/features/email/domain/model/preview_email_eml_request.dart';
 import 'package:tmail_ui_user/features/email/domain/model/restore_deleted_message_request.dart';
+import 'package:tmail_ui_user/features/email/domain/model/view_entire_message_request.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/eml_previewer.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/model/create_new_mailbox_request.dart';
 import 'package:tmail_ui_user/features/offline_mode/extensions/list_sending_email_hive_cache_extension.dart';
@@ -580,6 +581,11 @@ class EmailHiveCacheDataSourceImpl extends EmailDataSource {
   
   @override
   Future<DownloadedResponse> exportAllAttachments(AccountId accountId, EmailId emailId, String baseDownloadAllUrl, String outputFileName, AccountRequest accountRequest, {CancelToken? cancelToken}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<String> generateEntireMessageAsDocument(ViewEntireMessageRequest entireMessageRequest) {
     throw UnimplementedError();
   }
 }

--- a/lib/features/email/data/datasource_impl/email_session_storage_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_session_storage_datasource_impl.dart
@@ -30,6 +30,7 @@ import 'package:tmail_ui_user/features/email/domain/model/event_action.dart';
 import 'package:tmail_ui_user/features/email/domain/model/move_to_mailbox_request.dart';
 import 'package:tmail_ui_user/features/email/domain/model/preview_email_eml_request.dart';
 import 'package:tmail_ui_user/features/email/domain/model/restore_deleted_message_request.dart';
+import 'package:tmail_ui_user/features/email/domain/model/view_entire_message_request.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/eml_previewer.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/model/create_new_mailbox_request.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/model/sending_email.dart';
@@ -269,6 +270,11 @@ class EmailSessionStorageDatasourceImpl extends EmailDataSource {
   
   @override
   Future<DownloadedResponse> exportAllAttachments(AccountId accountId, EmailId emailId, String baseDownloadAllUrl, String outputFileName, AccountRequest accountRequest, {CancelToken? cancelToken}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<String> generateEntireMessageAsDocument(ViewEntireMessageRequest entireMessageRequest) {
     throw UnimplementedError();
   }
 }

--- a/lib/features/email/data/repository/email_repository_impl.dart
+++ b/lib/features/email/data/repository/email_repository_impl.dart
@@ -34,6 +34,7 @@ import 'package:tmail_ui_user/features/email/domain/model/event_action.dart';
 import 'package:tmail_ui_user/features/email/domain/model/move_to_mailbox_request.dart';
 import 'package:tmail_ui_user/features/email/domain/model/preview_email_eml_request.dart';
 import 'package:tmail_ui_user/features/email/domain/model/restore_deleted_message_request.dart';
+import 'package:tmail_ui_user/features/email/domain/model/view_entire_message_request.dart';
 import 'package:tmail_ui_user/features/email/domain/repository/email_repository.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/eml_previewer.dart';
 import 'package:tmail_ui_user/features/mailbox/data/datasource/state_datasource.dart';
@@ -567,4 +568,9 @@ class EmailRepositoryImpl extends EmailRepository {
     outputFileName,
     accountRequest,
   );
+
+  @override
+  Future<String> generateEntireMessageAsDocument(ViewEntireMessageRequest entireMessageRequest) {
+    return emailDataSource[DataSourceType.local]!.generateEntireMessageAsDocument(entireMessageRequest);
+  }
 }

--- a/lib/features/email/domain/model/view_entire_message_request.dart
+++ b/lib/features/email/domain/model/view_entire_message_request.dart
@@ -1,0 +1,34 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:model/email/attachment.dart';
+import 'package:model/email/presentation_email.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+class ViewEntireMessageRequest with EquatableMixin {
+  final UserName userName;
+  final PresentationEmail presentationEmail;
+  final List<Attachment> attachments;
+  final String emailContent;
+  final Locale locale;
+  final AppLocalizations appLocalizations;
+
+  ViewEntireMessageRequest({
+    required this.userName,
+    required this.presentationEmail,
+    required this.attachments,
+    required this.emailContent,
+    required this.locale,
+    required this.appLocalizations,
+  });
+
+  @override
+  List<Object?> get props => [
+    userName,
+    presentationEmail,
+    attachments,
+    emailContent,
+    locale,
+    appLocalizations,
+  ];
+}

--- a/lib/features/email/domain/repository/email_repository.dart
+++ b/lib/features/email/domain/repository/email_repository.dart
@@ -29,6 +29,7 @@ import 'package:tmail_ui_user/features/email/domain/model/event_action.dart';
 import 'package:tmail_ui_user/features/email/domain/model/move_to_mailbox_request.dart';
 import 'package:tmail_ui_user/features/email/domain/model/preview_email_eml_request.dart';
 import 'package:tmail_ui_user/features/email/domain/model/restore_deleted_message_request.dart';
+import 'package:tmail_ui_user/features/email/domain/model/view_entire_message_request.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/eml_previewer.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/model/create_new_mailbox_request.dart';
 
@@ -219,4 +220,6 @@ abstract class EmailRepository {
     AccountRequest accountRequest,
     {CancelToken? cancelToken}
   );
+
+  Future<String> generateEntireMessageAsDocument(ViewEntireMessageRequest entireMessageRequest);
 }

--- a/lib/features/email/domain/state/get_entire_message_as_document_state.dart
+++ b/lib/features/email/domain/state/get_entire_message_as_document_state.dart
@@ -1,0 +1,18 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+
+class GettingEntireMessageAsDocument extends LoadingState {}
+
+class GetEntireMessageAsDocumentSuccess extends UIState {
+  final String messageDocument;
+
+  GetEntireMessageAsDocumentSuccess(this.messageDocument);
+
+  @override
+  List<Object?> get props => [messageDocument];
+}
+
+class GetEntireMessageAsDocumentFailure extends FeatureFailure {
+
+  GetEntireMessageAsDocumentFailure({dynamic exception}) : super(exception: exception);
+}

--- a/lib/features/email/domain/usecases/get_entire_message_as_document_interactor.dart
+++ b/lib/features/email/domain/usecases/get_entire_message_as_document_interactor.dart
@@ -1,0 +1,22 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:tmail_ui_user/features/email/domain/model/view_entire_message_request.dart';
+import 'package:tmail_ui_user/features/email/domain/repository/email_repository.dart';
+import 'package:tmail_ui_user/features/email/domain/state/get_entire_message_as_document_state.dart';
+
+class GetEntireMessageAsDocumentInteractor {
+  final EmailRepository _emailRepository;
+
+  GetEntireMessageAsDocumentInteractor(this._emailRepository);
+
+  Stream<Either<Failure, Success>> execute(ViewEntireMessageRequest messageRequest) async* {
+    try {
+      yield Right(GettingEntireMessageAsDocument());
+      final messageDocument = await _emailRepository.generateEntireMessageAsDocument(messageRequest);
+      yield Right(GetEntireMessageAsDocumentSuccess(messageDocument));
+    } catch (e) {
+      yield Left(GetEntireMessageAsDocumentFailure(exception: e));
+    }
+  }
+}

--- a/lib/features/email/presentation/bindings/email_bindings.dart
+++ b/lib/features/email/presentation/bindings/email_bindings.dart
@@ -22,6 +22,7 @@ import 'package:tmail_ui_user/features/email/domain/usecases/download_attachment
 import 'package:tmail_ui_user/features/email/domain/usecases/export_all_attachments_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/export_attachment_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_email_content_interactor.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/get_entire_message_as_document_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_stored_email_state_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_email_read_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_star_email_interactor.dart';
@@ -134,6 +135,7 @@ class EmailBindings extends BaseBindings {
       Get.find<CacheExceptionThrower>()));
     Get.lazyPut(() => EmailLocalStorageDataSourceImpl(
       Get.find<LocalStorageManager>(),
+      Get.find<PreviewEmlFileUtils>(),
       Get.find<CacheExceptionThrower>()));
     Get.lazyPut(() => EmailSessionStorageDatasourceImpl(
       Get.find<SessionStorageManager>(),
@@ -182,6 +184,11 @@ class EmailBindings extends BaseBindings {
       Get.find<AccountRepository>(),
       Get.find<AuthenticationOIDCRepository>(),
       Get.find<CredentialRepository>()));
+    if (PlatformInfo.isIOS) {
+      Get.lazyPut(() => GetEntireMessageAsDocumentInteractor(
+        Get.find<EmailRepository>(),
+      ));
+    }
   }
 
   @override

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -2428,9 +2428,17 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
         return;
       }
 
-      showModalSheetToPreviewEMLAttachment(
-        currentContext!,
-        success.emlPreviewer);
+      if (PlatformInfo.isAndroid) {
+        showModalSheetToPreviewEMLAttachment(
+          currentContext!,
+          success.emlPreviewer,
+        );
+      } if (PlatformInfo.isIOS) {
+        showDialogToPreviewEMLAttachment(
+          currentContext!,
+          success.emlPreviewer,
+        );
+      }
     }
   }
 
@@ -2454,6 +2462,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
           initialChildSize: 1.0,
           builder: (context, ___) => EmailPreviewerDialogView(
             emlPreviewer: emlPreviewer,
+            imagePaths: imagePaths,
             onMailtoDelegateAction: openMailToLink,
             onPreviewEMLDelegateAction: (uri) => _openEMLPreviewer(context, uri),
             onDownloadAttachmentDelegateAction: (uri) =>
@@ -2461,6 +2470,20 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
           ),
         );
       },
+    );
+  }
+
+  void showDialogToPreviewEMLAttachment(BuildContext context, EMLPreviewer emlPreviewer) {
+    Get.dialog(
+      EmailPreviewerDialogView(
+        emlPreviewer: emlPreviewer,
+        imagePaths: imagePaths,
+        onMailtoDelegateAction: openMailToLink,
+        onPreviewEMLDelegateAction: (uri) => _openEMLPreviewer(context, uri),
+        onDownloadAttachmentDelegateAction: (uri) =>
+            _downloadAttachmentInEMLPreview(context, uri),
+      ),
+      barrierColor: AppColor.colorDefaultCupertinoActionSheet,
     );
   }
 

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -190,6 +190,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
   final attachmentsViewState = RxMap<Id, Either<Failure, Success>>();
   final isEmailContentHidden = RxBool(false);
   final currentEmailLoaded = Rxn<EmailLoaded>();
+  final isEmailContentClipped = RxBool(false);
 
   EmailId? _currentEmailId;
   Identity? _identitySelected;
@@ -750,6 +751,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
     blobCalendarEvent.value = null;
     emailUnsubscribe.value = null;
     _identitySelected = null;
+    isEmailContentClipped.value = false;
     if (isEmailClosing) {
       emailLoadedViewState.value = Right(UIState.idle);
       viewState.value = Right(UIState.idle);
@@ -2519,5 +2521,10 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
     } catch (e) {
       return '';
     }
+  }
+
+  void onHtmlContentClippedAction(bool isClipped) {
+    log('SingleEmailController::onHtmlContentClippedAction:isClipped = $isClipped');
+    isEmailContentClipped.value = isClipped;
   }
 }

--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -482,7 +482,12 @@ class EmailView extends GetWidget<SingleEmailController> {
                                     bottom: 24,
                                   ),
                                   backgroundColor: Colors.transparent,
-                                  onTapActionCallback: () {},
+                                  onTapActionCallback: () =>
+                                    controller.onViewEntireMessage(
+                                      context: context,
+                                      emailContent: allEmailContents,
+                                      presentationEmail: presentationEmail,
+                                    ),
                                 ),
                               ],
                             );

--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/constants/constants_ui.dart';
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/presentation/views/html_viewer/html_content_viewer_on_web_widget.dart';
@@ -32,6 +33,7 @@ import 'package:tmail_ui_user/features/email/presentation/widgets/email_view_emp
 import 'package:tmail_ui_user/features/email/presentation/widgets/email_view_loading_bar_widget.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/information_sender_and_receiver_builder.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/mail_unsubscribed_banner.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/view_entire_message_with_message_clipped_widget.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/extensions/vacation_response_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/vacation/widgets/vacation_notification_message_widget.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
@@ -390,7 +392,7 @@ class EmailView extends GetWidget<SingleEmailController> {
         else if (presentationEmail.id == controller.currentEmail?.id)
           Obx(() {
             if (controller.emailContents.value != null) {
-              String allEmailContents = controller.emailContents.value ?? '';
+              final allEmailContents = controller.emailContents.value ?? '';
 
               if (PlatformInfo.isWeb) {
                 return Expanded(
@@ -449,6 +451,7 @@ class EmailView extends GetWidget<SingleEmailController> {
                               direction: AppUtils.getCurrentDirection(context),
                               contentPadding: 0,
                               useDefaultFont: true,
+                              maxHtmlContentHeight: ConstantsUI.htmlContentMaxHeight,
                               onMailtoDelegateAction: controller.openMailToLink,
                               onScrollHorizontalEnd: controller.toggleScrollPhysicsPagerView,
                               onLoadWidthHtmlViewer: controller.emailSupervisorController.updateScrollPhysicPageView,
@@ -458,38 +461,13 @@ class EmailView extends GetWidget<SingleEmailController> {
                         ),
                         Obx(() {
                           if (controller.isEmailContentClipped.isTrue) {
-                            return Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Padding(
-                                  padding: const EdgeInsets.symmetric(horizontal: 16),
-                                  child: Text(
-                                    AppLocalizations.of(context).messageClipped,
-                                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                      color: AppColor.steelGray400,
-                                    ),
-                                  ),
-                                ),
-                                TMailButtonWidget.fromText(
-                                  text: AppLocalizations.of(context).viewEntireMessage.toUpperCase(),
-                                  textStyle: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                                    color: AppColor.primaryColor,
-                                    fontSize: 14,
-                                  ),
-                                  margin: const EdgeInsetsDirectional.only(
-                                    start: 8,
-                                    end: 8,
-                                    bottom: 24,
-                                  ),
-                                  backgroundColor: Colors.transparent,
-                                  onTapActionCallback: () =>
-                                    controller.onViewEntireMessage(
-                                      context: context,
-                                      emailContent: allEmailContents,
-                                      presentationEmail: presentationEmail,
-                                    ),
-                                ),
-                              ],
+                            return ViewEntireMessageWithMessageClippedWidget(
+                              buttonActionName: AppLocalizations.of(context).viewEntireMessage.toUpperCase(),
+                              onViewEntireMessageAction: () => controller.onViewEntireMessage(
+                                context: context,
+                                emailContent: allEmailContents,
+                                presentationEmail: presentationEmail,
+                              ),
                             );
                           } else {
                             return const SizedBox.shrink();
@@ -515,7 +493,6 @@ class EmailView extends GetWidget<SingleEmailController> {
                       onMailtoDelegateAction: controller.openMailToLink,
                       onScrollHorizontalEnd: controller.toggleScrollPhysicsPagerView,
                       onLoadWidthHtmlViewer: controller.emailSupervisorController.updateScrollPhysicPageView,
-                      onHtmlContentClippedAction: controller.onHtmlContentClippedAction,
                     );
                   })
                 );

--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -390,7 +390,7 @@ class EmailView extends GetWidget<SingleEmailController> {
         else if (presentationEmail.id == controller.currentEmail?.id)
           Obx(() {
             if (controller.emailContents.value != null) {
-              final allEmailContents = controller.emailContents.value ?? '';
+              String allEmailContents = controller.emailContents.value ?? '';
 
               if (PlatformInfo.isWeb) {
                 return Expanded(
@@ -429,29 +429,68 @@ class EmailView extends GetWidget<SingleEmailController> {
                     }),
                   ),
                 );
-              } else if (PlatformInfo.isIOS
-                  && !controller.responsiveUtils.isScreenWithShortestSide(context)) {
+              } else if (PlatformInfo.isIOS) {
                 return Obx(() {
-                  if (controller.isEmailContentHidden.isTrue) {
+                  if (controller.isEmailContentHidden.isTrue && !controller.responsiveUtils.isScreenWithShortestSide(context)) {
                     return const SizedBox.shrink();
                   } else {
-                    return Padding(
-                      padding: const EdgeInsetsDirectional.symmetric(
-                        vertical: EmailViewStyles.mobileContentVerticalMargin,
-                        horizontal: EmailViewStyles.mobileContentHorizontalMargin
-                      ),
-                      child: LayoutBuilder(builder: (context, constraints) {
-                        return HtmlContentViewer(
-                          contentHtml: allEmailContents,
-                          initialWidth: constraints.maxWidth,
-                          direction: AppUtils.getCurrentDirection(context),
-                          contentPadding: 0,
-                          useDefaultFont: true,
-                          onMailtoDelegateAction: controller.openMailToLink,
-                          onScrollHorizontalEnd: controller.toggleScrollPhysicsPagerView,
-                          onLoadWidthHtmlViewer: controller.emailSupervisorController.updateScrollPhysicPageView,
-                        );
-                      })
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Padding(
+                          padding: const EdgeInsetsDirectional.symmetric(
+                            vertical: EmailViewStyles.mobileContentVerticalMargin,
+                            horizontal: EmailViewStyles.mobileContentHorizontalMargin,
+                          ),
+                          child: LayoutBuilder(builder: (context, constraints) {
+                            return HtmlContentViewer(
+                              contentHtml: allEmailContents,
+                              initialWidth: constraints.maxWidth,
+                              direction: AppUtils.getCurrentDirection(context),
+                              contentPadding: 0,
+                              useDefaultFont: true,
+                              onMailtoDelegateAction: controller.openMailToLink,
+                              onScrollHorizontalEnd: controller.toggleScrollPhysicsPagerView,
+                              onLoadWidthHtmlViewer: controller.emailSupervisorController.updateScrollPhysicPageView,
+                              onHtmlContentClippedAction: controller.onHtmlContentClippedAction,
+                            );
+                          }),
+                        ),
+                        Obx(() {
+                          if (controller.isEmailContentClipped.isTrue) {
+                            return Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Padding(
+                                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                                  child: Text(
+                                    AppLocalizations.of(context).messageClipped,
+                                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                      color: AppColor.steelGray400,
+                                    ),
+                                  ),
+                                ),
+                                TMailButtonWidget.fromText(
+                                  text: AppLocalizations.of(context).viewEntireMessage.toUpperCase(),
+                                  textStyle: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                                    color: AppColor.primaryColor,
+                                    fontSize: 14,
+                                  ),
+                                  margin: const EdgeInsetsDirectional.only(
+                                    start: 8,
+                                    end: 8,
+                                    bottom: 24,
+                                  ),
+                                  backgroundColor: Colors.transparent,
+                                  onTapActionCallback: () {},
+                                ),
+                              ],
+                            );
+                          } else {
+                            return const SizedBox.shrink();
+                          }
+                        }),
+                      ],
                     );
                   }
                 });
@@ -471,6 +510,7 @@ class EmailView extends GetWidget<SingleEmailController> {
                       onMailtoDelegateAction: controller.openMailToLink,
                       onScrollHorizontalEnd: controller.toggleScrollPhysicsPagerView,
                       onLoadWidthHtmlViewer: controller.emailSupervisorController.updateScrollPhysicPageView,
+                      onHtmlContentClippedAction: controller.onHtmlContentClippedAction,
                     );
                   })
                 );

--- a/lib/features/email/presentation/widgets/calendar_event/event_body_content_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/event_body_content_widget.dart
@@ -1,4 +1,5 @@
 
+import 'package:core/presentation/constants/constants_ui.dart';
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/views/html_viewer/html_content_viewer_on_web_widget.dart';
@@ -72,6 +73,9 @@ class EventBodyContentWidget extends StatelessWidget {
               return HtmlContentViewer(
                 contentHtml: content,
                 initialWidth: constraints.maxWidth,
+                maxHtmlContentHeight: PlatformInfo.isIOS
+                  ? ConstantsUI.htmlContentMaxHeight
+                  : null,
                 direction: AppUtils.getCurrentDirection(context),
                 onMailtoDelegateAction: onMailtoDelegateAction
               );

--- a/lib/features/email/presentation/widgets/view_entire_message_with_message_clipped_widget.dart
+++ b/lib/features/email/presentation/widgets/view_entire_message_with_message_clipped_widget.dart
@@ -1,0 +1,54 @@
+
+
+import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+class ViewEntireMessageWithMessageClippedWidget extends StatelessWidget {
+
+  final String buttonActionName;
+  final VoidCallback onViewEntireMessageAction;
+  final double? topPadding;
+
+  const ViewEntireMessageWithMessageClippedWidget({
+    super.key,
+    required this.buttonActionName,
+    required this.onViewEntireMessageAction,
+    this.topPadding,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (topPadding != null)
+          SizedBox(height: topPadding),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Text(
+            AppLocalizations.of(context).messageClipped,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: AppColor.steelGray400,
+            ),
+          ),
+        ),
+        TMailButtonWidget.fromText(
+          text: buttonActionName,
+          textStyle: Theme.of(context).textTheme.bodyLarge?.copyWith(
+            color: AppColor.primaryColor,
+            fontSize: 14,
+          ),
+          margin: const EdgeInsetsDirectional.only(
+            start: 8,
+            end: 8,
+            bottom: 24,
+          ),
+          backgroundColor: Colors.transparent,
+          onTapActionCallback: onViewEntireMessageAction,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/email_previewer/email_previewer_bindings.dart
+++ b/lib/features/email_previewer/email_previewer_bindings.dart
@@ -3,6 +3,7 @@ import 'package:core/data/model/source_type/data_source_type.dart';
 import 'package:core/data/network/download/download_manager.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/utils/file_utils.dart';
+import 'package:core/utils/preview_eml_file_utils.dart';
 import 'package:core/utils/print_utils.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/base_bindings.dart';
@@ -97,6 +98,7 @@ class EmailPreviewerBindings extends BaseBindings {
         Get.find<CacheExceptionThrower>()));
     Get.lazyPut(() => EmailLocalStorageDataSourceImpl(
         Get.find<LocalStorageManager>(),
+        Get.find<PreviewEmlFileUtils>(),
         Get.find<CacheExceptionThrower>()));
     Get.lazyPut(() => EmailSessionStorageDatasourceImpl(
         Get.find<SessionStorageManager>(),

--- a/lib/features/email_previewer/email_previewer_dialog_view.dart
+++ b/lib/features/email_previewer/email_previewer_dialog_view.dart
@@ -1,13 +1,20 @@
 
+import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/presentation/views/html_viewer/html_content_viewer_widget.dart';
+import 'package:core/presentation/views/html_viewer/ios_html_content_viewer_widget.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/eml_previewer.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:tmail_ui_user/main/utils/app_utils.dart';
 
 class EmailPreviewerDialogView extends StatelessWidget {
 
   final EMLPreviewer emlPreviewer;
+  final ImagePaths imagePaths;
   final OnMailtoDelegateAction onMailtoDelegateAction;
   final OnPreviewEMLDelegateAction onPreviewEMLDelegateAction;
   final OnDownloadAttachmentDelegateAction onDownloadAttachmentDelegateAction;
@@ -15,6 +22,7 @@ class EmailPreviewerDialogView extends StatelessWidget {
   const EmailPreviewerDialogView({
     super.key,
     required this.emlPreviewer,
+    required this.imagePaths,
     required this.onMailtoDelegateAction,
     required this.onPreviewEMLDelegateAction,
     required this.onDownloadAttachmentDelegateAction,
@@ -22,18 +30,73 @@ class EmailPreviewerDialogView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.white,
-      body: SingleChildScrollView(
-        child: HtmlContentViewer(
-          contentHtml: emlPreviewer.content,
-          initialWidth: context.width,
-          direction: AppUtils.getCurrentDirection(context),
-          onMailtoDelegateAction: onMailtoDelegateAction,
-          onPreviewEMLDelegateAction: onPreviewEMLDelegateAction,
-          onDownloadAttachmentDelegateAction: onDownloadAttachmentDelegateAction,
+    if (PlatformInfo.isIOS) {
+      return Dialog(
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.only(
+            topRight: Radius.circular(16),
+            topLeft: Radius.circular(16),
+          ),
         ),
-      ),
-    );
+        insetPadding: EdgeInsets.zero,
+        alignment: Alignment.center,
+        backgroundColor: Colors.white,
+        child: Container(
+          decoration: const BoxDecoration(
+            borderRadius: BorderRadius.only(
+              topRight: Radius.circular(16),
+              topLeft: Radius.circular(16),
+            ),
+          ),
+          width: double.infinity,
+          height: double.infinity,
+          clipBehavior: Clip.antiAlias,
+          child: Column(
+            children: [
+              SizedBox(
+                height: 52,
+                child: Row(
+                  children: [
+                    const Spacer(),
+                    TMailButtonWidget.fromIcon(
+                      icon: imagePaths.icComposerClose,
+                      backgroundColor: Colors.transparent,
+                      margin: const EdgeInsetsDirectional.only(end: 12),
+                      onTapActionCallback: popBack,
+                    )
+                  ],
+                ),
+              ),
+              const Divider(color: AppColor.colorDivider, height: 1),
+              Expanded(
+                child: IosHtmlContentViewerWidget(
+                  contentHtml: emlPreviewer.content,
+                  useDefaultFont: true,
+                  direction: AppUtils.getCurrentDirection(context),
+                  onMailtoDelegateAction: onMailtoDelegateAction,
+                  onPreviewEMLDelegateAction: onPreviewEMLDelegateAction,
+                  onDownloadAttachmentDelegateAction: onDownloadAttachmentDelegateAction,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    } else {
+      return Scaffold(
+        backgroundColor: Colors.white,
+        body: SingleChildScrollView(
+          child: HtmlContentViewer(
+            contentHtml: emlPreviewer.content,
+            initialWidth: context.width,
+            useDefaultFont: true,
+            direction: AppUtils.getCurrentDirection(context),
+            onMailtoDelegateAction: onMailtoDelegateAction,
+            onPreviewEMLDelegateAction: onPreviewEMLDelegateAction,
+            onDownloadAttachmentDelegateAction: onDownloadAttachmentDelegateAction,
+          ),
+        ),
+      );
+    }
   }
 }

--- a/lib/features/identity_creator/presentation/identity_creator_controller.dart
+++ b/lib/features/identity_creator/presentation/identity_creator_controller.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
+import 'package:core/presentation/constants/constants_ui.dart';
 import 'package:core/presentation/extensions/list_nullable_extensions.dart';
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
@@ -116,7 +117,6 @@ class IdentityCreatorController extends BaseController with DragDropFileMixin im
   PublicAssetController? publicAssetController;
 
   final GlobalKey htmlKey = GlobalKey();
-  final htmlEditorMinHeight = 150;
   bool isLoadSignatureCompleted = false;
   bool _userScrolled = false;
 
@@ -658,7 +658,7 @@ class IdentityCreatorController extends BaseController with DragDropFileMixin im
     await Future.delayed(const Duration(milliseconds: 500), () {
       final offset = scrollController.position.pixels +
         defaultKeyboardToolbarHeight +
-        htmlEditorMinHeight;
+        ConstantsUI.htmlContentMinHeight;
       scrollController.animateTo(
         offset,
         duration: const Duration(milliseconds: 1),

--- a/lib/features/identity_creator/presentation/identity_creator_view.dart
+++ b/lib/features/identity_creator/presentation/identity_creator_view.dart
@@ -1,5 +1,6 @@
 import 'dart:math' as math;
 
+import 'package:core/presentation/constants/constants_ui.dart';
 import 'package:core/presentation/extensions/capitalize_extension.dart';
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/style_utils.dart';
@@ -555,7 +556,8 @@ class IdentityCreatorView extends GetWidget<IdentityCreatorController>
   Widget _buildHtmlEditor(BuildContext context, {String? initialContent}) {
     return HtmlEditor(
       key: controller.htmlKey,
-      minHeight: controller.htmlEditorMinHeight,
+      minHeight: ConstantsUI.htmlContentMinHeight.toInt(),
+      maxHeight: PlatformInfo.isIOS ? ConstantsUI.composerHtmlContentMaxHeight : null,
       addDefaultSelectionMenuItems: false,
       initialContent: initialContent ?? '',
       customStyleCss: HtmlUtils.customCssStyleHtmlEditor(direction: AppUtils.getCurrentDirection(context)),

--- a/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
@@ -3,6 +3,7 @@ import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/html_transformer/html_transform.dart';
 import 'package:core/utils/config/app_config_loader.dart';
 import 'package:core/utils/file_utils.dart';
+import 'package:core/utils/preview_eml_file_utils.dart';
 import 'package:core/utils/print_utils.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/base_bindings.dart';
@@ -276,6 +277,7 @@ class MailboxDashBoardBindings extends BaseBindings {
       Get.find<CacheExceptionThrower>()));
     Get.lazyPut(() => EmailLocalStorageDataSourceImpl(
       Get.find<LocalStorageManager>(),
+      Get.find<PreviewEmlFileUtils>(),
       Get.find<CacheExceptionThrower>()));
     Get.lazyPut(() => EmailSessionStorageDatasourceImpl(
       Get.find<SessionStorageManager>(),

--- a/lib/features/manage_account/presentation/vacation/vacation_controller.dart
+++ b/lib/features/manage_account/presentation/vacation/vacation_controller.dart
@@ -33,7 +33,6 @@ class VacationController extends BaseController {
   final subjectTextController = TextEditingController();
   final subjectTextFocusNode = FocusNode();
   final richTextControllerForMobile = RichTextController();
-  final htmlEditorMinHeight = 150;
 
   final GlobalKey htmlKey = GlobalKey();
 
@@ -338,7 +337,7 @@ class VacationController extends BaseController {
     await Scrollable.ensureVisible(htmlKey.currentContext!);
     await Future.delayed(const Duration(milliseconds: 500), () {
       scrollController.animateTo(
-        scrollController.position.pixels + defaultKeyboardToolbarHeight + htmlEditorMinHeight,
+        scrollController.position.pixels + defaultKeyboardToolbarHeight + ConstantsUI.htmlContentMinHeight,
         duration: const Duration(milliseconds: 1),
         curve: Curves.linear,
       );

--- a/lib/features/manage_account/presentation/vacation/vacation_view.dart
+++ b/lib/features/manage_account/presentation/vacation/vacation_view.dart
@@ -1,4 +1,5 @@
 
+import 'package:core/presentation/constants/constants_ui.dart';
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/keyboard_utils.dart';
 import 'package:core/presentation/views/button/icon_button_web.dart';
@@ -503,7 +504,8 @@ class VacationView extends GetWidget<VacationController> with RichTextButtonMixi
     } else {
       return HtmlEditor(
           key: controller.htmlKey,
-          minHeight: controller.htmlEditorMinHeight,
+          minHeight: ConstantsUI.htmlContentMinHeight.toInt(),
+          maxHeight: PlatformInfo.isIOS ? ConstantsUI.composerHtmlContentMaxHeight : null,
           addDefaultSelectionMenuItems: false,
           initialContent: controller.vacationMessageHtmlText ?? '',
           customStyleCss: HtmlUtils.customCssStyleHtmlEditor(direction: AppUtils.getCurrentDirection(context)),

--- a/lib/features/offline_mode/bindings/sending_email_interactor_bindings.dart
+++ b/lib/features/offline_mode/bindings/sending_email_interactor_bindings.dart
@@ -1,6 +1,7 @@
 import 'package:core/data/model/source_type/data_source_type.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/utils/file_utils.dart';
+import 'package:core/utils/preview_eml_file_utils.dart';
 import 'package:core/utils/print_utils.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/interactors_bindings.dart';
@@ -95,6 +96,7 @@ class SendEmailInteractorBindings extends InteractorsBindings {
       Get.find<CacheExceptionThrower>()));
     Get.lazyPut(() => EmailLocalStorageDataSourceImpl(
       Get.find<LocalStorageManager>(),
+      Get.find<PreviewEmlFileUtils>(),
       Get.find<CacheExceptionThrower>()));
     Get.lazyPut(() => EmailSessionStorageDatasourceImpl(
       Get.find<SessionStorageManager>(),

--- a/lib/features/push_notification/presentation/bindings/fcm_interactor_bindings.dart
+++ b/lib/features/push_notification/presentation/bindings/fcm_interactor_bindings.dart
@@ -1,6 +1,7 @@
 import 'package:core/data/model/source_type/data_source_type.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/utils/file_utils.dart';
+import 'package:core/utils/preview_eml_file_utils.dart';
 import 'package:core/utils/print_utils.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/interactors_bindings.dart';
@@ -133,6 +134,7 @@ class FcmInteractorBindings extends InteractorsBindings {
       Get.find<CacheExceptionThrower>()));
     Get.lazyPut(() => EmailLocalStorageDataSourceImpl(
       Get.find<LocalStorageManager>(),
+      Get.find<PreviewEmlFileUtils>(),
       Get.find<CacheExceptionThrower>()));
     Get.lazyPut(() => EmailSessionStorageDatasourceImpl(
       Get.find<SessionStorageManager>(),

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2025-02-20T19:41:05.121752",
+  "@@last_modified": "2025-03-31T03:40:41.454034",
   "initializing_data": "Initializing data...",
   "@initializing_data": {
     "type": "text",
@@ -2962,6 +2962,12 @@
     "placeholders_order": [],
     "placeholders": {}
   },
+  "errorWhileFetchingSubaddress": "Error while fetching the subaddress",
+  "@errorWhileFetchingSubaddress": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
   "connectedToTheInternet": "Connected to the internet",
   "@connectedToTheInternet": {
     "type": "text",
@@ -4238,12 +4244,6 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "messageWarningDialogWhenExpiredOIDCTokenAndReconnection": "Your session expired. We need to take you back to the login page in order to refresh it. You might want to save the email you are currently editing before we do so.",
-  "@messageWarningDialogWhenExpiredOIDCTokenAndReconnection": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
   "replyToList": "Reply to list",
   "@replyToList": {
     "type": "text",
@@ -4372,6 +4372,18 @@
   },
   "exitFullscreen": "Exit fullscreen",
   "@exitFullscreen": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "messageClipped": "[Message clipped]",
+  "@messageClipped": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "viewEntireMessage": "View entire message",
+  "@viewEntireMessage": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -4597,4 +4597,18 @@ class AppLocalizations {
       name: 'exitFullscreen',
     );
   }
+
+  String get messageClipped {
+    return Intl.message(
+      '[Message clipped]',
+      name: 'messageClipped',
+    );
+  }
+
+  String get viewEntireMessage {
+    return Intl.message(
+      'View entire message',
+      name: 'viewEntireMessage',
+    );
+  }
 }

--- a/model/lib/extensions/presentation_email_extension.dart
+++ b/model/lib/extensions/presentation_email_extension.dart
@@ -58,6 +58,16 @@ extension PresentationEmailExtension on PresentationEmail {
     return '';
   }
 
+  String getSentAt(String newLocale, {String? pattern}) {
+    if (sentAt != null) {
+      return sentAt!.formatDateToLocal(
+        pattern: pattern ?? sentAt!.value.toLocal().toPattern(),
+        locale: newLocale,
+      );
+    }
+    return '';
+  }
+
   Set<EmailAddress> get listEmailAddressSender => from.asSet()..addAll(replyTo.asSet());
 
   PresentationEmail toggleSelect() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -493,10 +493,10 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: "590b825e406edd50556074eee32ab896afb99933"
+      resolved-ref: b95d69a865f17575924868159bca43ef47b67fcd
       url: "https://github.com/linagora/enough_html_editor.git"
     source: git
-    version: "0.1.1"
+    version: "0.1.2"
   enough_platform_widgets:
     dependency: transitive
     description:


### PR DESCRIPTION
## Issue

#3601 

## Root cause

On iOS, when using an `InAppWebView` inside a `SingleChildScrollView`, the height of the `SingleChildScrollView` depends on the `InAppWebView`. Continuously updating the height of the `InAppWebView` up to a certain limit can cause the `SingleChildScrollView` to fail to render, resulting in the content of the `InAppWebView` not being displayed.

## Workaround

Set the maximum display height for content on iOS to `22,000` (not an absolute limit, but verified across various emails and found to be the most reasonable value). If the email content exceeds this height, a `View entire message` button will be displayed at the bottom of the email. When users click this button, they will be able to view the full email content, similar to previewing an EML file.

## Dependency

Need merged: https://github.com/linagora/enough_html_editor/pull/35

## Resolved

- EmailView:


https://github.com/user-attachments/assets/c72dc3ee-1e6c-4965-876e-20d844799a69


- ComposerView:


https://github.com/user-attachments/assets/85a6b3ef-5234-430c-981e-d2d3aed746f5


