### PR TITLE
TF-3570 E2E Perform actions with emails in EmailView

### DIFF
--- a/integration_test/robots/destination_picker_robot.dart
+++ b/integration_test/robots/destination_picker_robot.dart
@@ -1,0 +1,17 @@
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/widgets/label_mailbox_item_widget.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/widgets/mailbox_item_widget.dart';
+
+import '../base/core_robot.dart';
+
+class DestinationPickerRobot extends CoreRobot {
+  DestinationPickerRobot(super.$);
+
+  Future<void> selectFolderByName(String name) async {
+    await $(MailboxItemWidget)
+      .$(LabelMailboxItemWidget)
+      .$(find.text(name))
+      .tap();
+  }
+}

--- a/integration_test/robots/email_robot.dart
+++ b/integration_test/robots/email_robot.dart
@@ -32,4 +32,8 @@ class EmailRobot extends CoreRobot {
   Future<void> tapMarkAsUnreadOptionInContextMenu() async {
     await $(#markAsUnread_action).tap();
   }
+
+  Future<void> tapEmailDetailedStarButton() async {
+    await $(#email_detailed_star_button).tap();
+  }
 }

--- a/integration_test/robots/email_robot.dart
+++ b/integration_test/robots/email_robot.dart
@@ -48,4 +48,8 @@ class EmailRobot extends CoreRobot {
   Future<void> tapMarkAsSpamOptionInContextMenu() async {
     await $(#moveToSpam_action).tap();
   }
+
+  Future<void> tapArchiveMessageOptionInContextMenu() async {
+    await $(#archiveMessage_action).tap();
+  }
 }

--- a/integration_test/robots/email_robot.dart
+++ b/integration_test/robots/email_robot.dart
@@ -36,4 +36,8 @@ class EmailRobot extends CoreRobot {
   Future<void> tapEmailDetailedStarButton() async {
     await $(#email_detailed_star_button).tap();
   }
+
+  Future<void> tapEmailDetailedMoveEmailButton() async {
+    await $(#email_detailed_move_email_button).tap();
+  }
 }

--- a/integration_test/robots/email_robot.dart
+++ b/integration_test/robots/email_robot.dart
@@ -44,4 +44,8 @@ class EmailRobot extends CoreRobot {
   Future<void> tapEmailDetailedDeleteEmailButton() async {
     await $(#email_detailed_delete_email_button).tap();
   }
+
+  Future<void> tapMarkAsSpamOptionInContextMenu() async {
+    await $(#moveToSpam_action).tap();
+  }
 }

--- a/integration_test/robots/email_robot.dart
+++ b/integration_test/robots/email_robot.dart
@@ -24,4 +24,12 @@ class EmailRobot extends CoreRobot {
   Future<void> onTapBackButton() async {
     await $(find.byType(EmailViewBackButton)).first.tap();
   }
+
+  Future<void> tapEmailDetailedMoreButton() async {
+    await $(#email_detailed_more_button).tap();
+  }
+
+  Future<void> tapMarkAsUnreadOptionInContextMenu() async {
+    await $(#markAsUnread_action).tap();
+  }
 }

--- a/integration_test/robots/email_robot.dart
+++ b/integration_test/robots/email_robot.dart
@@ -40,4 +40,8 @@ class EmailRobot extends CoreRobot {
   Future<void> tapEmailDetailedMoveEmailButton() async {
     await $(#email_detailed_move_email_button).tap();
   }
+
+  Future<void> tapEmailDetailedDeleteEmailButton() async {
+    await $(#email_detailed_delete_email_button).tap();
+  }
 }

--- a/integration_test/scenarios/email_detailed/archive_email_scenario.dart
+++ b/integration_test/scenarios/email_detailed/archive_email_scenario.dart
@@ -1,0 +1,61 @@
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class ArchiveEmailScenario extends BaseTestScenario {
+
+  const ArchiveEmailScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const subject = 'Archive email';
+    const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    final threadRobot = ThreadRobot($);
+    final emailRobot = EmailRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await provisionEmail(
+      [
+        ProvisioningEmail(
+          toEmail: emailUser,
+          subject: subject,
+          content: subject,
+        ),
+      ],
+      requestReadReceipt: false,
+    );
+    await $.pumpAndSettle();
+
+    await threadRobot.openEmailWithSubject(subject);
+    await $.pumpAndSettle();
+    _expectEmailDetailedMoreButtonVisible();
+
+    await emailRobot.tapEmailDetailedMoreButton();
+    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+
+    await emailRobot.tapArchiveMessageOptionInContextMenu();
+    await $.pumpAndSettle(duration: const Duration(seconds: 3));
+
+    await emailRobot.onTapBackButton();
+    await $.pumpAndSettle();
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openFolderByName(appLocalizations.archiveMailboxDisplayName);
+    await _expectEmailWithSubjectInArchiveFolderVisible(subject);
+  }
+
+  void _expectEmailDetailedMoreButtonVisible() {
+    expect($(#email_detailed_more_button), findsOneWidget);
+  }
+
+  Future<void> _expectEmailWithSubjectInArchiveFolderVisible(String subject) async {
+    await expectViewVisible($(subject));
+  }
+}

--- a/integration_test/scenarios/email_detailed/delete_email_scenario.dart
+++ b/integration_test/scenarios/email_detailed/delete_email_scenario.dart
@@ -1,0 +1,57 @@
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/email/presentation/email_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class DeleteEmailScenario extends BaseTestScenario {
+
+  const DeleteEmailScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const subject = 'Delete email';
+    const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    final threadRobot = ThreadRobot($);
+    final emailRobot = EmailRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await provisionEmail(
+      [
+        ProvisioningEmail(
+          toEmail: emailUser,
+          subject: subject,
+          content: subject,
+        ),
+      ],
+      requestReadReceipt: false,
+    );
+    await $.pumpAndSettle();
+
+    await threadRobot.openEmailWithSubject(subject);
+    await $.pumpAndSettle();
+
+    await emailRobot.tapEmailDetailedDeleteEmailButton();
+    await $.pumpAndSettle(duration: const Duration(seconds: 3));
+
+    _expectEmailViewInvisible();
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openFolderByName(appLocalizations.trashMailboxDisplayName);
+    await _expectEmailWithSubjectInDestinationFolderVisible(subject);
+  }
+
+  void _expectEmailViewInvisible() {
+    expect($(EmailView).visible, isFalse);
+  }
+
+  Future<void> _expectEmailWithSubjectInDestinationFolderVisible(String subject) async {
+    await expectViewVisible($(subject));
+  }
+}

--- a/integration_test/scenarios/email_detailed/mark_as_spam_email_scenario.dart
+++ b/integration_test/scenarios/email_detailed/mark_as_spam_email_scenario.dart
@@ -9,13 +9,13 @@ import '../../robots/email_robot.dart';
 import '../../robots/mailbox_menu_robot.dart';
 import '../../robots/thread_robot.dart';
 
-class DeleteEmailScenario extends BaseTestScenario {
+class MarkAsSpamEmailScenario extends BaseTestScenario {
 
-  const DeleteEmailScenario(super.$);
+  const MarkAsSpamEmailScenario(super.$);
 
   @override
   Future<void> runTestLogic() async {
-    const subject = 'Delete email';
+    const subject = 'Mark as spam email';
     const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
     final threadRobot = ThreadRobot($);
     final emailRobot = EmailRobot($);
@@ -36,22 +36,29 @@ class DeleteEmailScenario extends BaseTestScenario {
 
     await threadRobot.openEmailWithSubject(subject);
     await $.pumpAndSettle();
+    _expectEmailDetailedMoreButtonVisible();
 
-    await emailRobot.tapEmailDetailedDeleteEmailButton();
+    await emailRobot.tapEmailDetailedMoreButton();
+    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+
+    await emailRobot.tapMarkAsSpamOptionInContextMenu();
     await $.pumpAndSettle(duration: const Duration(seconds: 3));
-
     _expectEmailViewInvisible();
 
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.openFolderByName(appLocalizations.trashMailboxDisplayName);
-    await _expectEmailWithSubjectInTrashFolderVisible(subject);
+    await mailboxMenuRobot.openFolderByName(appLocalizations.spamMailboxDisplayName);
+    await _expectEmailWithSubjectInSpamFolderVisible(subject);
+  }
+
+  void _expectEmailDetailedMoreButtonVisible() {
+    expect($(#email_detailed_more_button), findsOneWidget);
   }
 
   void _expectEmailViewInvisible() {
     expect($(EmailView).visible, isFalse);
   }
 
-  Future<void> _expectEmailWithSubjectInTrashFolderVisible(String subject) async {
+  Future<void> _expectEmailWithSubjectInSpamFolderVisible(String subject) async {
     await expectViewVisible($(subject));
   }
 }

--- a/integration_test/scenarios/email_detailed/mark_as_star_email_scenario.dart
+++ b/integration_test/scenarios/email_detailed/mark_as_star_email_scenario.dart
@@ -1,0 +1,65 @@
+
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class MarkAsStarEmailScenario extends BaseTestScenario {
+
+  const MarkAsStarEmailScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const subject = 'Mark as star/unStar email';
+    const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    final threadRobot = ThreadRobot($);
+    final emailRobot = EmailRobot($);
+    final imagePaths = ImagePaths();
+
+    await provisionEmail(
+      [
+        ProvisioningEmail(
+          toEmail: emailUser,
+          subject: subject,
+          content: subject,
+        ),
+      ],
+      requestReadReceipt: false,
+    );
+    await $.pumpAndSettle();
+
+    await threadRobot.openEmailWithSubject(subject);
+    await $.pumpAndSettle();
+    _expectEmailDetailedStarButtonVisible();
+
+    await emailRobot.tapEmailDetailedStarButton();
+    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+    await _expectDisplayedStarIcon(imagePaths);
+
+    await emailRobot.tapEmailDetailedStarButton();
+    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+    await _expectDisplayedUnStarIcon(imagePaths);
+  }
+
+  void _expectEmailDetailedStarButtonVisible() {
+    expect($(#email_detailed_star_button), findsOneWidget);
+  }
+
+  Future<void> _expectDisplayedStarIcon(ImagePaths imagePaths) async {
+    await expectViewVisible(
+      $(#email_detailed_star_button).which<TMailButtonWidget>(
+          (widget) => widget.icon == imagePaths.icStar),
+    );
+  }
+
+  Future<void> _expectDisplayedUnStarIcon(ImagePaths imagePaths) async {
+    await expectViewVisible(
+      $(#email_detailed_star_button).which<TMailButtonWidget>(
+          (widget) => widget.icon == imagePaths.icUnStar),
+    );
+  }
+}

--- a/integration_test/scenarios/email_detailed/mark_as_unread_email_scenario.dart
+++ b/integration_test/scenarios/email_detailed/mark_as_unread_email_scenario.dart
@@ -1,0 +1,66 @@
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/email/presentation/email_view.dart';
+import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class MarkAsUnreadEmailScenario extends BaseTestScenario {
+
+  const MarkAsUnreadEmailScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const subject = 'Mark as unread email';
+    const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    final threadRobot = ThreadRobot($);
+    final emailRobot = EmailRobot($);
+
+    await provisionEmail(
+      [
+        ProvisioningEmail(
+          toEmail: emailUser,
+          subject: subject,
+          content: subject,
+        ),
+      ],
+      requestReadReceipt: false,
+    );
+    await $.pumpAndSettle();
+
+    await threadRobot.openEmailWithSubject(subject);
+    await $.pumpAndSettle();
+    _expectEmailDetailedMoreButtonVisible();
+
+    await emailRobot.tapEmailDetailedMoreButton();
+    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+
+    await emailRobot.tapMarkAsUnreadOptionInContextMenu();
+    await $.pumpAndSettle(duration: const Duration(seconds: 3));
+
+    _expectEmailViewInvisible();
+    await _expectDisplayedEmailHasUnreadIcon(subject);
+  }
+
+  void _expectEmailDetailedMoreButtonVisible() {
+    expect($(#email_detailed_more_button), findsOneWidget);
+  }
+
+  void _expectEmailViewInvisible() {
+    expect($(EmailView).visible, isFalse);
+  }
+
+  Future<void> _expectDisplayedEmailHasUnreadIcon(String subject) async {
+    await expectViewVisible(
+      $(EmailTileBuilder)
+          .which<EmailTileBuilder>(
+              (widget) => widget.presentationEmail.subject == subject
+              && !widget.presentationEmail.hasRead
+      ),
+    );
+    await expectViewVisible($(#unread_status_icon));
+  }
+}

--- a/integration_test/scenarios/email_detailed/move_email_to_folder_scenario.dart
+++ b/integration_test/scenarios/email_detailed/move_email_to_folder_scenario.dart
@@ -1,0 +1,60 @@
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/destination_picker_robot.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class MoveEmailToFolderScenario extends BaseTestScenario {
+
+  const MoveEmailToFolderScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const subject = 'Move email to folder';
+    const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    final threadRobot = ThreadRobot($);
+    final emailRobot = EmailRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+    final destinationPickerRobot = DestinationPickerRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await provisionEmail(
+      [
+        ProvisioningEmail(
+          toEmail: emailUser,
+          subject: subject,
+          content: subject,
+        ),
+      ],
+      requestReadReceipt: false,
+    );
+    await $.pumpAndSettle();
+
+    await threadRobot.openEmailWithSubject(subject);
+    await $.pumpAndSettle();
+
+    await emailRobot.tapEmailDetailedMoveEmailButton();
+    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+
+    await destinationPickerRobot.selectFolderByName(appLocalizations.templatesMailboxDisplayName);
+    await $.pumpAndSettle(duration: const Duration(seconds: 3));
+    _expectEmailWithSubjectInCurrentFolderInvisible(subject);
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openFolderByName(appLocalizations.templatesMailboxDisplayName);
+    await _expectEmailWithSubjectInDestinationFolderVisible(subject);
+  }
+
+  void _expectEmailWithSubjectInCurrentFolderInvisible(String subject) {
+    expect($(subject), findsNothing);
+  }
+
+  Future<void> _expectEmailWithSubjectInDestinationFolderVisible(String subject) async {
+    await expectViewVisible($(subject));
+  }
+}

--- a/integration_test/tests/email_detailed/archive_email_when_open_detailed_email_test.dart
+++ b/integration_test/tests/email_detailed/archive_email_when_open_detailed_email_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/archive_email_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see email in Archive folder when open detailed email and archive email successfully',
+    scenarioBuilder: ($) => ArchiveEmailScenario($),
+  );
+}

--- a/integration_test/tests/email_detailed/delete_email_when_open_detailed_email_test.dart
+++ b/integration_test/tests/email_detailed/delete_email_when_open_detailed_email_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/delete_email_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see email in Trash folder when open detailed email and delete email successfully',
+    scenarioBuilder: ($) => DeleteEmailScenario($),
+  );
+}

--- a/integration_test/tests/email_detailed/mark_as_spam_email_when_open_detailed_email_test.dart
+++ b/integration_test/tests/email_detailed/mark_as_spam_email_when_open_detailed_email_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/mark_as_spam_email_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see email in Spam folder when open detailed email and mark as spam email successfully',
+    scenarioBuilder: ($) => MarkAsSpamEmailScenario($),
+  );
+}

--- a/integration_test/tests/email_detailed/mark_as_star_email_when_open_detailed_email_test.dart
+++ b/integration_test/tests/email_detailed/mark_as_star_email_when_open_detailed_email_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/mark_as_star_email_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see star and unStar icon when open detailed email and mark as star and unStar email successfully',
+    scenarioBuilder: ($) => MarkAsStarEmailScenario($),
+  );
+}

--- a/integration_test/tests/email_detailed/mark_as_unread_email_when_open_detailed_email_test.dart
+++ b/integration_test/tests/email_detailed/mark_as_unread_email_when_open_detailed_email_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/mark_as_unread_email_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see email item has unread icon when open detailed email and select mark as unread email successfully',
+    scenarioBuilder: ($) => MarkAsUnreadEmailScenario($),
+  );
+}

--- a/integration_test/tests/email_detailed/move_email_to_folder_when_open_detailed_email_test.dart
+++ b/integration_test/tests/email_detailed/move_email_to_folder_when_open_detailed_email_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/move_email_to_folder_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see email in destination folder when open detailed email and move email to destination folder successfully',
+    scenarioBuilder: ($) => MoveEmailToFolderScenario($),
+  );
+}

--- a/lib/features/email/presentation/widgets/email_view_app_bar_widget.dart
+++ b/lib/features/email/presentation/widgets/email_view_app_bar_widget.dart
@@ -119,6 +119,7 @@ class EmailViewAppBarWidget extends StatelessWidget {
                     ),
                   )),
                 TMailButtonWidget.fromIcon(
+                  key: const Key('email_detailed_delete_email_button'),
                   icon: _imagePaths.icDeleteComposer,
                   iconSize: EmailViewAppBarWidgetStyles.deleteButtonIconSize,
                   iconColor: EmailViewAppBarWidgetStyles.iconColor,

--- a/lib/features/email/presentation/widgets/email_view_app_bar_widget.dart
+++ b/lib/features/email/presentation/widgets/email_view_app_bar_widget.dart
@@ -85,6 +85,7 @@ class EmailViewAppBarWidget extends StatelessWidget {
                   onTapActionCallback: () => onEmailActionClick?.call(presentationEmail, EmailActionType.moveToMailbox)
                 ),
                 TMailButtonWidget.fromIcon(
+                  key: const Key('email_detailed_star_button'),
                   icon: presentationEmail.hasStarred
                     ? _imagePaths.icStar
                     : _imagePaths.icUnStar,

--- a/lib/features/email/presentation/widgets/email_view_app_bar_widget.dart
+++ b/lib/features/email/presentation/widgets/email_view_app_bar_widget.dart
@@ -133,6 +133,7 @@ class EmailViewAppBarWidget extends StatelessWidget {
                   }
                 ),
                 TMailButtonWidget.fromIcon(
+                  key: const Key('email_detailed_more_button'),
                   icon: _imagePaths.icMoreVertical,
                   iconSize: EmailViewAppBarWidgetStyles.buttonIconSize,
                   iconColor: EmailViewAppBarWidgetStyles.iconColor,

--- a/lib/features/email/presentation/widgets/email_view_app_bar_widget.dart
+++ b/lib/features/email/presentation/widgets/email_view_app_bar_widget.dart
@@ -77,6 +77,7 @@ class EmailViewAppBarWidget extends StatelessWidget {
             children: [
                 if (optionsWidget != null) ... optionsWidget!,
                 TMailButtonWidget.fromIcon(
+                  key: const Key('email_detailed_move_email_button'),
                   icon: _imagePaths.icMoveEmail,
                   iconSize: EmailViewAppBarWidgetStyles.buttonIconSize,
                   iconColor: EmailViewAppBarWidgetStyles.iconColor,

--- a/lib/features/thread/presentation/mixin/base_email_item_tile.dart
+++ b/lib/features/thread/presentation/mixin/base_email_item_tile.dart
@@ -208,6 +208,7 @@ mixin BaseEmailItemTile {
 
   Widget buildIconUnreadStatus() {
     return SvgPicture.asset(
+      key: const Key('unread_status_icon'),
       imagePaths.icUnreadStatus,
       width: 9,
       height: 9,

--- a/lib/features/thread/presentation/widgets/email_tile_builder.dart
+++ b/lib/features/thread/presentation/widgets/email_tile_builder.dart
@@ -1,6 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:model/email/email_action_type.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
@@ -73,11 +72,8 @@ class EmailTileBuilder extends StatelessWidget with BaseEmailItemTile {
             if (!presentationEmail.hasRead)
               Padding(
                   padding: const EdgeInsetsDirectional.only(end: 5),
-                  child: SvgPicture.asset(
-                      imagePaths.icUnreadStatus,
-                      width: 9,
-                      height: 9,
-                      fit: BoxFit.fill)),
+                  child: buildIconUnreadStatus(),
+              ),
             Expanded(child: buildInformationSender(
               context,
               presentationEmail,


### PR DESCRIPTION
## Issue

#3570

## Resolved

- Console log:

```console
🧪 Should see email in Archive folder when open detailed email and archive email successfully
        : 
        : > Task :app:connectedDebugAndroidTest
        : Starting 6 tests on Pixel_4_API_31(AVD) - 12
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. tap widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  10. enterText widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
✅ Should see email in Archive folder when open detailed email and archive email successfully (integration_test/tests/email_detailed/archive_email_when_open_detailed_email_test.dart) (26s)
🧪 Should see email in Trash folder when open detailed email and delete email successfully
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
✅ Should see email in Trash folder when open detailed email and delete email successfully (integration_test/tests/email_detailed/delete_email_when_open_detailed_email_test.dart) (22s)
🧪 Should see email in Spam folder when open detailed email and mark as spam email successfully
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. tap widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
✅ Should see email in Spam folder when open detailed email and mark as spam email successfully (integration_test/tests/email_detailed/mark_as_spam_email_when_open_detailed_email_test.dart) (24s)
🧪 Should see star and unStar icon when open detailed email and mark as star and unStar email successfully
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
✅ Should see star and unStar icon when open detailed email and mark as star and unStar email successfully (integration_test/tests/email_detailed/mark_as_star_email_when_open_detailed_email_test.dart) (22s)
🧪 Should see email item has unread icon when open detailed email and select mark as unread email successfully
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
✅ Should see email item has unread icon when open detailed email and select mark as unread email successfully (integration_test/tests/email_detailed/mark_as_unread_email_when_open_detailed_email_test.dart) (23s)
🧪 Should see email in destination folder when open detailed email and move email to destination folder successfully
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. tap widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
✅ Should see email in destination folder when open detailed email and move email to destination folder successfully (integration_test/tests/email_detailed/move_email_to_folder_when_open_detailed_email_test.dart) (25s)

Test summary:
📝 Total: 6
✅ Successful: 6
❌ Failed: 0
⏩ Skipped: 0
📊 Report: ../tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 180s

```

- Demo:

https://github.com/user-attachments/assets/a7e3aa8e-e92b-4bfd-a646-2e34b16662a2


