### PR TITLE
TF-3611 E2E Trash & spam empty and recover

### DIFF
--- a/backend-docker/deletedMessageVault.properties
+++ b/backend-docker/deletedMessageVault.properties
@@ -1,0 +1,8 @@
+# ============================================= Deleted Messages Vault Configuration ==================================
+
+enabled=true
+restoreLocation=Restored-Messages
+
+# Retention period for your deleted messages into the vault, after which they expire and can be potentially cleaned up
+# Optional, default 1y
+# retentionPeriod=1y

--- a/backend-docker/docker-compose.yaml
+++ b/backend-docker/docker-compose.yaml
@@ -10,6 +10,8 @@ services:
       - ./mailetcontainer.xml:/root/conf/mailetcontainer.xml
       - ./imapserver.xml:/root/conf/imapserver.xml
       - ./jmap.properties:/root/conf/jmap.properties
+      - ./deletedMessageVault.properties:/root/conf/deletedMessageVault.properties
+      - ./listeners.xml:/root/conf/listeners.xml
       - ./linagora-ecosystem.properties:/root/conf/linagora-ecosystem.properties
       - ./openpaas.properties:/root/conf/openpaas.properties
       - ../provisioning/integration_test/provisioning.sh:/root/conf/integration_test/provisioning.sh

--- a/backend-docker/listeners.xml
+++ b/backend-docker/listeners.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<listeners>
+  <preDeletionHook>
+    <class>org.apache.james.vault.DeletedMessageVaultHook</class>
+  </preDeletionHook>
+</listeners>

--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -125,4 +125,16 @@ class MailboxMenuRobot extends CoreRobot {
     getBinding<QuotasController>()?.reloadQuota();
     await $.pumpAndSettle(duration: const Duration(seconds: 2));
   }
+
+  Future<void> tapRecoverDeletedMessages() async {
+    await $(AppLocalizations().recoverDeletedMessages).tap();
+  }
+
+  Future<void> tapConfirmRecoverDeletedMessages() async {
+    if (await $.native.isPermissionDialogVisible(timeout: const Duration(seconds: 2))) {
+      await $.native.grantPermissionWhenInUse();
+    }
+    await $(AppLocalizations().restore).tap();
+    await $.pumpAndSettle();
+  }
 }

--- a/integration_test/robots/thread_robot.dart
+++ b/integration_test/robots/thread_robot.dart
@@ -103,4 +103,8 @@ class ThreadRobot extends CoreRobot {
     await $(AppLocalizations().delete).tap();
     await $.pumpAndSettle(duration: const Duration(seconds: 2));
   }
+
+  Future<void> tapEmptySpamAfterLongPress() async {
+    await $(AppLocalizations().deleteAllSpamEmails).tap();
+  }
 }

--- a/integration_test/robots/thread_robot.dart
+++ b/integration_test/robots/thread_robot.dart
@@ -82,4 +82,8 @@ class ThreadRobot extends CoreRobot {
     await $(name).tap();
     await $.pumpAndSettle();
   }
+
+  Future<void> confirmEmptyTrash() async {
+    await $(AppLocalizations().delete_all).tap();
+  }
 }

--- a/integration_test/robots/thread_robot.dart
+++ b/integration_test/robots/thread_robot.dart
@@ -94,4 +94,13 @@ class ThreadRobot extends CoreRobot {
   Future<void> confirmEmptySpam() async {
     await $(AppLocalizations().delete_all).tap();
   }
+
+  Future<void> tapEmptyTrashAfterLongPress() async {
+    await $(AppLocalizations().emptyTrash).tap();
+  }
+
+  Future<void> tapConfirmEmptyTrashAfterLongPress() async {
+    await $(AppLocalizations().delete).tap();
+    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+  }
 }

--- a/integration_test/robots/thread_robot.dart
+++ b/integration_test/robots/thread_robot.dart
@@ -86,4 +86,12 @@ class ThreadRobot extends CoreRobot {
   Future<void> confirmEmptyTrash() async {
     await $(AppLocalizations().delete_all).tap();
   }
+
+  Future<void> tapEmptySpamBanner() async {
+    await $(' ${AppLocalizations().deleteAllSpamEmailsNow}').tap();
+  }
+
+  Future<void> confirmEmptySpam() async {
+    await $(AppLocalizations().delete_all).tap();
+  }
 }

--- a/integration_test/scenarios/mailbox/empty_and_recover_spam_scenario.dart
+++ b/integration_test/scenarios/mailbox/empty_and_recover_spam_scenario.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/base/widget/clean_messages_banner.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class EmptyAndRecoverSpamScenario extends BaseTestScenario {
+  const EmptyAndRecoverSpamScenario(super.$);
+  
+  @override
+  Future<void> runTestLogic() async {
+    const toEmail = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const subject = 'spam and recover';
+
+    final threadRobot = ThreadRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await provisionEmail(
+      [ProvisioningEmail(
+        toEmail: toEmail,
+        subject: subject,
+        content: '',
+      )],
+      folderLocationRole: PresentationMailbox.roleJunk,
+    );
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openFolderByName(
+      appLocalizations.spamMailboxDisplayName,
+    );
+    await threadRobot.tapEmptySpamBanner();
+    await threadRobot.confirmEmptySpam();
+    await _expectSpamBannerInvisible();
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.longPressMailboxWithName(
+      appLocalizations.trashMailboxDisplayName,
+    );
+    await mailboxMenuRobot.tapRecoverDeletedMessages();
+    await mailboxMenuRobot.tapConfirmRecoverDeletedMessages();
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openFolderByName(
+      appLocalizations.recoveredMailboxDisplayName,
+    );
+    await _expectEmailWithSubjectVisible(subject);
+  }
+  
+  Future<void> _expectSpamBannerInvisible() async {
+    await $(#clean_message_banner_not_visible).waitUntilExists();
+    expect($(CleanMessagesBanner).visible, false);
+  }
+
+  Future<void> _expectEmailWithSubjectVisible(String subject) async {
+    await expectViewVisible($(subject));
+  }
+} 

--- a/integration_test/scenarios/mailbox/empty_and_recover_trash_scenario.dart
+++ b/integration_test/scenarios/mailbox/empty_and_recover_trash_scenario.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/base/widget/clean_messages_banner.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class EmptyAndRecoverTrashScenario extends BaseTestScenario {
+  const EmptyAndRecoverTrashScenario(super.$);
+  
+  @override
+  Future<void> runTestLogic() async {
+    const toEmail = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const subject = 'trash and recover';
+
+    final threadRobot = ThreadRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await provisionEmail(
+      [ProvisioningEmail(
+        toEmail: toEmail,
+        subject: subject,
+        content: '',
+      )],
+      folderLocationRole: PresentationMailbox.roleTrash,
+    );
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openFolderByName(
+      appLocalizations.trashMailboxDisplayName,
+    );
+    await threadRobot.tapEmptyTrashBanner();
+    await threadRobot.confirmEmptyTrash();
+    await _expectTrashBannerInvisible();
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.longPressMailboxWithName(
+      appLocalizations.trashMailboxDisplayName,
+    );
+    await mailboxMenuRobot.tapRecoverDeletedMessages();
+    await mailboxMenuRobot.tapConfirmRecoverDeletedMessages();
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openFolderByName(
+      appLocalizations.recoveredMailboxDisplayName,
+    );
+    await _expectEmailWithSubjectVisible(subject);
+  }
+  
+  Future<void> _expectTrashBannerInvisible() async {
+    await $(#clean_message_banner_not_visible).waitUntilExists();
+    expect($(CleanMessagesBanner).visible, false);
+  }
+
+  Future<void> _expectEmailWithSubjectVisible(String subject) async {
+    await expectViewVisible($(subject));
+  }
+}

--- a/integration_test/scenarios/mailbox/long_press_empty_and_recover_spam_scenario.dart
+++ b/integration_test/scenarios/mailbox/long_press_empty_and_recover_spam_scenario.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/extensions/presentation_mailbox_extension.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/base/widget/clean_messages_banner.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/widgets/trailing_mailbox_item_widget.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class LongPressEmptyAndRecoverSpamScenario extends BaseTestScenario {
+  const LongPressEmptyAndRecoverSpamScenario(super.$);
+  
+  @override
+  Future<void> runTestLogic() async {
+    const toEmail = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const subject = 'long press spam';
+
+    final threadRobot = ThreadRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await provisionEmail(
+      [ProvisioningEmail(
+        toEmail: toEmail,
+        subject: subject,
+        content: '',
+      )],
+      folderLocationRole: PresentationMailbox.roleJunk,
+    );
+    await $.pumpAndTrySettle(duration: const Duration(seconds: 2));
+    await threadRobot.openMailbox();
+    await $.pumpAndTrySettle();
+    _expectSpamUnreadCountVisible(
+      appLocalizations.spamMailboxDisplayName,
+    );
+    await mailboxMenuRobot.longPressMailboxWithName(
+      appLocalizations.spamMailboxDisplayName,
+    );
+    await threadRobot.tapEmptySpamAfterLongPress();
+    await threadRobot.confirmEmptySpam();
+    await $.pumpAndTrySettle(duration: const Duration(seconds: 2));
+    _expectSpamUnreadCountInvisible(
+      appLocalizations.spamMailboxDisplayName,
+    );
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openFolderByName(
+      appLocalizations.spamMailboxDisplayName,
+    );
+    await _expectSpamBannerInvisible();
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.longPressMailboxWithName(
+      appLocalizations.trashMailboxDisplayName,
+    );
+    await mailboxMenuRobot.tapRecoverDeletedMessages();
+    await mailboxMenuRobot.tapConfirmRecoverDeletedMessages();
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openFolderByName(
+      appLocalizations.recoveredMailboxDisplayName,
+    );
+    await _expectEmailWithSubjectVisible(subject);
+  }
+  
+  Future<void> _expectSpamBannerInvisible() async {
+    await $(#clean_message_banner_not_visible).waitUntilExists();
+    expect($(CleanMessagesBanner).visible, false);
+  }
+
+  Future<void> _expectEmailWithSubjectVisible(String subject) async {
+    await expectViewVisible($(subject));
+  }
+
+  void _expectSpamUnreadCountVisible(String name) {
+    expect(
+      $(TrailingMailboxItemWidget).which<TrailingMailboxItemWidget>((widget) {
+        final mailbox = widget.mailboxNode.item;
+        return mailbox.name?.name.toLowerCase() == name.toLowerCase() &&
+            mailbox.countTotalEmailsAsString.isNotEmpty;
+      }),
+      findsOneWidget,
+    );
+  }
+
+  void _expectSpamUnreadCountInvisible(String name) {
+    expect(
+      $(TrailingMailboxItemWidget).which<TrailingMailboxItemWidget>((widget) {
+        final mailbox = widget.mailboxNode.item;
+        return mailbox.name?.name.toLowerCase() == name.toLowerCase() &&
+            mailbox.countTotalEmailsAsString.isNotEmpty;
+      }),
+      findsNothing,
+    );
+  }
+} 

--- a/integration_test/scenarios/mailbox/long_press_empty_and_recover_trash_scenario.dart
+++ b/integration_test/scenarios/mailbox/long_press_empty_and_recover_trash_scenario.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/extensions/presentation_mailbox_extension.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/base/widget/clean_messages_banner.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/widgets/trailing_mailbox_item_widget.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class LongPressEmptyAndRecoverTrashScenario extends BaseTestScenario {
+  const LongPressEmptyAndRecoverTrashScenario(super.$);
+  
+  @override
+  Future<void> runTestLogic() async {
+    const toEmail = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const subject = 'long press trash';
+
+    final threadRobot = ThreadRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await provisionEmail(
+      [ProvisioningEmail(
+        toEmail: toEmail,
+        subject: subject,
+        content: '',
+      )],
+      folderLocationRole: PresentationMailbox.roleTrash,
+    );
+    await $.pumpAndTrySettle(duration: const Duration(seconds: 2));
+    await threadRobot.openMailbox();
+    await $.pumpAndTrySettle();
+    _expectTrashUnreadCountVisible(
+      appLocalizations.trashMailboxDisplayName,
+    );
+    await mailboxMenuRobot.longPressMailboxWithName(
+      appLocalizations.trashMailboxDisplayName,
+    );
+    await threadRobot.tapEmptyTrashAfterLongPress();
+    await threadRobot.tapConfirmEmptyTrashAfterLongPress();
+    _expectTrashUnreadCountInvisible(
+      appLocalizations.trashMailboxDisplayName,
+    );
+    await mailboxMenuRobot.openFolderByName(
+      appLocalizations.trashMailboxDisplayName,
+    );
+    await _expectTrashBannerInvisible();
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.longPressMailboxWithName(
+      appLocalizations.trashMailboxDisplayName,
+    );
+    await mailboxMenuRobot.tapRecoverDeletedMessages();
+    await mailboxMenuRobot.tapConfirmRecoverDeletedMessages();
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openFolderByName(
+      appLocalizations.recoveredMailboxDisplayName,
+    );
+    await _expectEmailWithSubjectVisible(subject);
+  }
+  
+  Future<void> _expectTrashBannerInvisible() async {
+    await $(#clean_message_banner_not_visible).waitUntilExists();
+    expect($(CleanMessagesBanner).visible, false);
+  }
+
+  Future<void> _expectEmailWithSubjectVisible(String subject) async {
+    await expectViewVisible($(subject));
+  }
+
+  void _expectTrashUnreadCountVisible(String name) {
+    expect(
+      $(TrailingMailboxItemWidget).which<TrailingMailboxItemWidget>((widget) {
+        final mailbox = widget.mailboxNode.item;
+        return mailbox.name?.name.toLowerCase() == name.toLowerCase() &&
+            mailbox.countTotalEmailsAsString.isNotEmpty;
+      }),
+      findsOneWidget,
+    );
+  }
+
+  void _expectTrashUnreadCountInvisible(String name) {
+    expect(
+      $(TrailingMailboxItemWidget).which<TrailingMailboxItemWidget>((widget) {
+        final mailbox = widget.mailboxNode.item;
+        return mailbox.name?.name.toLowerCase() == name.toLowerCase() &&
+            mailbox.countTotalEmailsAsString.isNotEmpty;
+      }),
+      findsNothing,
+    );
+  }
+}

--- a/integration_test/tests/mailbox/empty_and_recover_spam_test.dart
+++ b/integration_test/tests/mailbox/empty_and_recover_spam_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/mailbox/empty_and_recover_spam_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should empty and recover spam successfully',
+    scenarioBuilder: ($) => EmptyAndRecoverSpamScenario($),
+  );
+} 

--- a/integration_test/tests/mailbox/empty_and_recover_trash_test.dart
+++ b/integration_test/tests/mailbox/empty_and_recover_trash_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/mailbox/empty_and_recover_trash_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should empty and recover trash successfully',
+    scenarioBuilder: ($) => EmptyAndRecoverTrashScenario($),
+  );
+}

--- a/integration_test/tests/mailbox/long_press_empty_and_recover_spam_test.dart
+++ b/integration_test/tests/mailbox/long_press_empty_and_recover_spam_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/mailbox/long_press_empty_and_recover_spam_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should empty and recover spam by long press mailbox successfully',
+    scenarioBuilder: ($) => LongPressEmptyAndRecoverSpamScenario($),
+  );
+}

--- a/integration_test/tests/mailbox/long_press_empty_and_recover_trash_test.dart
+++ b/integration_test/tests/mailbox/long_press_empty_and_recover_trash_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/mailbox/long_press_empty_and_recover_trash_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should empty and recover trash by long press mailbox successfully',
+    scenarioBuilder: ($) => LongPressEmptyAndRecoverTrashScenario($),
+  );
+}

--- a/lib/features/thread/presentation/thread_view.dart
+++ b/lib/features/thread/presentation/thread_view.dart
@@ -237,7 +237,9 @@ class ThreadView extends GetWidget<ThreadController>
                             ),
                           );
                         } else {
-                          return const SizedBox.shrink();
+                          return const SizedBox.shrink(
+                            key: Key('clean_message_banner_not_visible'),
+                          );
                         }
                       }),
                       if (!controller.responsiveUtils.isDesktop(context))


### PR DESCRIPTION
## Issue
- #3611 

## Test result
```console
✅ Should empty and recover trash successfully (integration_test/tests/mailbox/empty_and_recover_trash_test.dart) (30s)
✅ Should empty and recover trash by long press mailbox successfully (integration_test/tests/mailbox/long_press_empty_and_recover_trash_test.dart) (29s)
✅ Should empty and recover spam successfully (integration_test/tests/mailbox/empty_and_recover_spam_test.dart) (28s)
✅ Should empty and recover spam by long press mailbox successfully (integration_test/tests/mailbox/long_press_empty_and_recover_spam_test.dart) (28s)

Test summary:
📝 Total: 4
✅ Successful: 4
❌ Failed: 0
⏩ Skipped: 0
📊 Report: .../tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 145s
```
## Test video

[too big, please run locally]