### PR TITLE
TF-3507 Fix offline cache prevents updating email query view cache

### DIFF
--- a/contact/pubspec.lock
+++ b/contact/pubspec.lock
@@ -968,6 +968,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.3"
+  pull_to_refresh:
+    dependency: transitive
+    description:
+      name: pull_to_refresh
+      sha256: bbadd5a931837b57739cf08736bea63167e284e71fb23b218c8c9a6e042aad12
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   qr:
     dependency: transitive
     description:

--- a/core/lib/core.dart
+++ b/core/lib/core.dart
@@ -97,6 +97,7 @@ export 'presentation/views/clipper/side_arrow_clipper.dart';
 export 'presentation/views/avatar/gradient_circle_avatar_icon.dart';
 export 'presentation/views/loading/cupertino_loading_widget.dart';
 export 'presentation/views/image/image_loader_mixin.dart';
+export 'presentation/views/pull_to_refresh/pull_to_refresh_widget.dart';
 
 // Resources
 export 'presentation/resources/assets_paths.dart';

--- a/core/lib/presentation/views/pull_to_refresh/pull_to_refresh_widget.dart
+++ b/core/lib/presentation/views/pull_to_refresh/pull_to_refresh_widget.dart
@@ -1,0 +1,153 @@
+import 'dart:ui';
+
+import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
+import 'package:flutter/material.dart';
+import 'package:pull_to_refresh/pull_to_refresh.dart';
+
+class PullToRefreshWidget extends StatefulWidget {
+  final Widget child;
+  final Future<void> Function() onNormalRefresh;
+  final Future<void> Function() onDeepRefresh;
+  final double deepRefreshThreshold;
+  final String normalRefreshText;
+  final String deepRefreshText;
+  final String pullDownToRefreshText;
+  final String refreshingText;
+  final String pullingText;
+  final String releaseToText;
+  final String pullFurtherForText;
+  final String pullHarderForText;
+  final Icon? normalRefreshIcon;
+  final Icon? deepRefreshIcon;
+
+  const PullToRefreshWidget({
+    Key? key,
+    required this.child,
+    required this.onNormalRefresh,
+    required this.onDeepRefresh,
+    this.deepRefreshThreshold = 200.0,
+    this.normalRefreshText = 'Refresh',
+    this.deepRefreshText = 'Deep refresh',
+    this.pullDownToRefreshText = 'Pull down to refresh',
+    this.refreshingText = 'Refreshing',
+    this.pullingText = 'Pulling',
+    this.releaseToText = 'Release to',
+    this.pullFurtherForText = 'Pull further for',
+    this.pullHarderForText = 'Pull harder for',
+    this.normalRefreshIcon = const Icon(Icons.refresh, size: 20),
+    this.deepRefreshIcon = const Icon(Icons.autorenew, size: 20),
+  }) : super(key: key);
+
+  @override
+  State<PullToRefreshWidget> createState() => _PullToRefreshWidgetState();
+}
+
+class _PullToRefreshWidgetState extends State<PullToRefreshWidget> {
+  final RefreshController _refreshController = RefreshController();
+  double _scrollOffset = 0.0;
+  String? _lastAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return NotificationListener<ScrollNotification>(
+      onNotification: (notification) {
+        if (notification is ScrollUpdateNotification) {
+          setState(() {
+            _scrollOffset = notification.metrics.pixels;
+          });
+        }
+        return false;
+      },
+      child: SmartRefresher(
+        controller: _refreshController,
+        enablePullDown: true,
+        enablePullUp: false,
+        header: CustomHeader(
+          builder: (context, mode) {
+            String statusText;
+            Icon? leadingIcon;
+
+            if (mode == RefreshStatus.idle) {
+              statusText = widget.pullDownToRefreshText;
+              leadingIcon = widget.normalRefreshIcon;
+            } else if (mode == RefreshStatus.canRefresh) {
+              if (_scrollOffset.abs() > widget.deepRefreshThreshold) {
+                statusText = '${widget.releaseToText} ${widget.deepRefreshText}';
+                leadingIcon = widget.deepRefreshIcon;
+              } else {
+                statusText = '${widget.releaseToText} ${widget.normalRefreshText}';
+                leadingIcon = widget.normalRefreshIcon;
+              }
+            } else if (mode == RefreshStatus.refreshing || mode == RefreshStatus.completed) {
+              statusText = '${widget.refreshingText}...';
+              leadingIcon = _lastAction == widget.deepRefreshText
+                  ? widget.deepRefreshIcon
+                  : widget.normalRefreshIcon;
+            } else {
+              statusText = '${widget.pullingText}...';
+              leadingIcon = widget.normalRefreshIcon;
+            }
+
+            return SizedBox(
+              height: clampDouble(_scrollOffset.abs(), 60, widget.deepRefreshThreshold),
+              child: Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        if (leadingIcon != null) leadingIcon,
+                        Flexible(
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 8),
+                            child: Text(
+                              statusText,
+                              style: ThemeUtils.textStyleBodyBody1(color: Colors.black),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    if (mode == RefreshStatus.canRefresh)
+                      Padding(
+                        padding: const EdgeInsetsDirectional.only(top: 4, start: 8, end: 8),
+                        child: Text(
+                          _scrollOffset.abs() > widget.deepRefreshThreshold
+                              ? '${widget.pullFurtherForText} ${widget.deepRefreshText.toLowerCase()}'
+                              : '${widget.pullHarderForText} ${widget.deepRefreshText.toLowerCase()}',
+                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: AppColor.steelGray400,
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            );
+          },
+          height: widget.deepRefreshThreshold,
+        ),
+        onRefresh: () {
+          if (_scrollOffset.abs() > widget.deepRefreshThreshold) {
+            _lastAction = widget.deepRefreshText;
+            widget.onDeepRefresh();
+          } else {
+            _lastAction = widget.normalRefreshText;
+            widget.onNormalRefresh();
+          }
+          _refreshController.refreshCompleted();
+        },
+        child: widget.child,
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _refreshController.dispose();
+    super.dispose();
+  }
+}

--- a/core/lib/presentation/views/pull_to_refresh/pull_to_refresh_widget.dart
+++ b/core/lib/presentation/views/pull_to_refresh/pull_to_refresh_widget.dart
@@ -53,9 +53,18 @@ class _PullToRefreshWidgetState extends State<PullToRefreshWidget> {
     return NotificationListener<ScrollNotification>(
       onNotification: (notification) {
         if (notification is ScrollUpdateNotification) {
-          setState(() {
-            _scrollOffset = notification.metrics.pixels;
-          });
+          final newOffset = notification.metrics.pixels;
+          final crossedThreshold =
+              (_scrollOffset.abs() <= widget.deepRefreshThreshold &&
+                      newOffset.abs() > widget.deepRefreshThreshold) ||
+                  (_scrollOffset.abs() > widget.deepRefreshThreshold &&
+                      newOffset.abs() <= widget.deepRefreshThreshold);
+
+          if (crossedThreshold || _scrollOffset != newOffset) {
+            setState(() {
+              _scrollOffset = newOffset;
+            });
+          }
         }
         return false;
       },

--- a/core/pubspec.lock
+++ b/core/pubspec.lock
@@ -929,6 +929,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  pull_to_refresh:
+    dependency: "direct main"
+    description:
+      name: pull_to_refresh
+      sha256: bbadd5a931837b57739cf08736bea63167e284e71fb23b218c8c9a6e042aad12
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   qr:
     dependency: transitive
     description:

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -102,6 +102,8 @@ dependencies:
 
   win32: 5.5.1
 
+  pull_to_refresh: 2.0.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/docs/adr/0058-fix-offline-cache-prevents-updating-email-query-view-on-mobile.md
+++ b/docs/adr/0058-fix-offline-cache-prevents-updating-email-query-view-on-mobile.md
@@ -1,0 +1,41 @@
+# 58. Fix offline cache prevents updating email query view on mobile
+
+Date: 2025-04-03
+
+## Status
+
+- Issues:
+  - [Offline cache prevents updating email query view #3507](https://github.com/linagora/tmail-flutter/issues/3507)
+
+## Context
+
+- When we perform too many actions on multiple emails `(Mark as read, mark as star, move, delete, etc.)`, 
+`Email/get` from the value of `Email/changes` will throw an error.
+
+```json
+[
+    "error",
+    {
+        "type": "requestTooLarge",
+        "description": "Too many items in an email read at level FULL. Got 183 items instead of maximum 100."
+    },
+    "c2"
+]
+```
+
+- Some emails in the `update` of the `Email/change` response were not found in `Email/get`. But we still update newState of email.
+
+
+## Decision
+
+- To solve this problem we propose the most optimal solution which is
+We will add a `Clean cache & Get all emails` action when the user performs `Pull down to refresh`
+
+Now when user performs `Pull down to refresh` action. There will be 2 actions performed
+- If the drag distance is shorter `< 200px` will perform `Refresh` action (`Just call get all emails`)
+- If the drag distance is shorter `>= 200px` will perform `Deep Refresh` action (`Call clean cache and get all emails`)
+
+
+## Consequences
+
+- No lost emails when displayed on list on mobile

--- a/lib/features/mailbox/data/local/state_cache_manager.dart
+++ b/lib/features/mailbox/data/local/state_cache_manager.dart
@@ -25,5 +25,10 @@ class StateCacheManager {
     return await _stateCacheClient.insertItem(stateKey, stateCache);
   }
 
+  Future<void> deleteState(AccountId accountId, UserName userName, StateType stateType) async {
+    final stateKey = TupleKey(stateType.name, accountId.asString, userName.value).encodeKey;
+    return await _stateCacheClient.deleteItem(stateKey);
+  }
+
   Future<void> closeStateHiveCacheBox() => _stateCacheClient.closeBox();
 }

--- a/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
@@ -7,6 +7,7 @@ import 'package:core/utils/preview_eml_file_utils.dart';
 import 'package:core/utils/print_utils.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/base_bindings.dart';
+import 'package:tmail_ui_user/features/caching/caching_manager.dart';
 import 'package:tmail_ui_user/features/caching/clients/recent_search_cache_client.dart';
 import 'package:tmail_ui_user/features/caching/utils/local_storage_manager.dart';
 import 'package:tmail_ui_user/features/caching/utils/session_storage_manager.dart';
@@ -103,7 +104,6 @@ import 'package:tmail_ui_user/features/offline_mode/manager/new_email_cache_work
 import 'package:tmail_ui_user/features/offline_mode/manager/opened_email_cache_manager.dart';
 import 'package:tmail_ui_user/features/offline_mode/manager/opened_email_cache_worker_queue.dart';
 import 'package:tmail_ui_user/features/offline_mode/manager/sending_email_cache_manager.dart';
-import 'package:tmail_ui_user/features/push_notification/data/local/fcm_cache_manager.dart';
 import 'package:tmail_ui_user/features/quotas/presentation/quotas_bindings.dart';
 import 'package:tmail_ui_user/features/search/email/domain/usecases/refresh_changes_search_email_interactor.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_bindings.dart';
@@ -239,9 +239,7 @@ class MailboxDashBoardBindings extends BaseBindings {
       Get.find<RemoteExceptionThrower>()));
     Get.lazyPut(() => LocalThreadDataSourceImpl(
       Get.find<EmailCacheManager>(),
-      Get.find<FCMCacheManager>(),
-      Get.find<StateCacheManager>(),
-      Get.find<FileUtils>(),
+      Get.find<CachingManager>(),
       Get.find<CacheExceptionThrower>(),
     ));
     Get.lazyPut(() => StateDataSourceImpl(

--- a/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
@@ -103,6 +103,7 @@ import 'package:tmail_ui_user/features/offline_mode/manager/new_email_cache_work
 import 'package:tmail_ui_user/features/offline_mode/manager/opened_email_cache_manager.dart';
 import 'package:tmail_ui_user/features/offline_mode/manager/opened_email_cache_worker_queue.dart';
 import 'package:tmail_ui_user/features/offline_mode/manager/sending_email_cache_manager.dart';
+import 'package:tmail_ui_user/features/push_notification/data/local/fcm_cache_manager.dart';
 import 'package:tmail_ui_user/features/quotas/presentation/quotas_bindings.dart';
 import 'package:tmail_ui_user/features/search/email/domain/usecases/refresh_changes_search_email_interactor.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_bindings.dart';
@@ -236,7 +237,13 @@ class MailboxDashBoardBindings extends BaseBindings {
       Get.find<ThreadAPI>(),
       Get.find<ThreadIsolateWorker>(),
       Get.find<RemoteExceptionThrower>()));
-    Get.lazyPut(() => LocalThreadDataSourceImpl(Get.find<EmailCacheManager>(), Get.find<CacheExceptionThrower>()));
+    Get.lazyPut(() => LocalThreadDataSourceImpl(
+      Get.find<EmailCacheManager>(),
+      Get.find<FCMCacheManager>(),
+      Get.find<StateCacheManager>(),
+      Get.find<FileUtils>(),
+      Get.find<CacheExceptionThrower>(),
+    ));
     Get.lazyPut(() => StateDataSourceImpl(
       Get.find<StateCacheManager>(),
       Get.find<IOSSharingManager>(),

--- a/lib/features/push_notification/data/local/fcm_cache_manager.dart
+++ b/lib/features/push_notification/data/local/fcm_cache_manager.dart
@@ -1,5 +1,6 @@
 import 'package:fcm/model/type_name.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:model/extensions/account_id_extensions.dart';
@@ -61,5 +62,21 @@ class FCMCacheManager {
 
   Future<void> deleteFirebaseRegistration() async {
     await _firebaseRegistrationCacheClient.deleteItem(FirebaseRegistrationCache.keyCacheValue);
+  }
+
+  Future<void> clearAllEmailState(
+    AccountId accountId,
+    Session session,
+  ) async {
+    await deleteStateToRefresh(
+      accountId,
+      session.username,
+      TypeName.emailDelivery,
+    );
+    await deleteStateToRefresh(
+      accountId,
+      session.username,
+      TypeName.emailType,
+    );
   }
 }

--- a/lib/features/thread/data/datasource/thread_datasource.dart
+++ b/lib/features/thread/data/datasource/thread_datasource.dart
@@ -76,4 +76,6 @@ abstract class ThreadDataSource {
   );
 
   Future<PresentationEmail> getEmailById(Session session, AccountId accountId, EmailId emailId, {Properties? properties});
+
+  Future<void> clearEmailCacheAndStateCache(AccountId accountId, Session session);
 }

--- a/lib/features/thread/data/datasource_impl/thread_datasource_impl.dart
+++ b/lib/features/thread/data/datasource_impl/thread_datasource_impl.dart
@@ -140,4 +140,9 @@ class ThreadDataSourceImpl extends ThreadDataSource {
       return email.toPresentationEmail();
     }).catchError(_exceptionThrower.throwException);
   }
+
+  @override
+  Future<void> clearEmailCacheAndStateCache(AccountId accountId, Session session) {
+    throw UnimplementedError();
+  }
 }

--- a/lib/features/thread/data/local/email_cache_manager.dart
+++ b/lib/features/thread/data/local/email_cache_manager.dart
@@ -90,6 +90,10 @@ class EmailCacheManager {
       await _emailCacheClient.deleteMultipleItem(listEmailIdCacheExpire);
   }
 
+  Future<void> clearAll() async {
+    return await _emailCacheClient.clearAllData();
+  }
+
   Future<void> storeEmail(AccountId accountId, UserName userName, EmailCache emailCache) {
     final keyCache = TupleKey(emailCache.id, accountId.asString, userName.value).encodeKey;
     return _emailCacheClient.insertItem(keyCache, emailCache);

--- a/lib/features/thread/data/repository/thread_repository_impl.dart
+++ b/lib/features/thread/data/repository/thread_repository_impl.dart
@@ -432,4 +432,13 @@ class ThreadRepositoryImpl extends ThreadRepository {
 
     return listEmailIdDeleted;
   }
+
+  @override
+  Future<void> clearEmailCacheAndStateCache(
+    AccountId accountId,
+    Session session,
+  ) => mapDataSource[DataSourceType.local]!.clearEmailCacheAndStateCache(
+    accountId,
+    session,
+  );
 }

--- a/lib/features/thread/domain/repository/thread_repository.dart
+++ b/lib/features/thread/domain/repository/thread_repository.dart
@@ -80,4 +80,6 @@ abstract class ThreadRepository {
     int totalEmails,
     StreamController<dartz.Either<Failure, Success>> onProgressController
   );
+
+  Future<void> clearEmailCacheAndStateCache(AccountId accountId, Session session);
 }

--- a/lib/features/thread/domain/state/clean_and_get_all_email_state.dart
+++ b/lib/features/thread/domain/state/clean_and_get_all_email_state.dart
@@ -1,0 +1,9 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+
+class CleanAndGetAllEmailLoading extends LoadingState {}
+
+class CleanAndGetAllEmailFailure extends FeatureFailure {
+
+  CleanAndGetAllEmailFailure(dynamic exception) : super(exception: exception);
+}

--- a/lib/features/thread/domain/usecases/clean_and_get_emails_in_mailbox_interactor.dart
+++ b/lib/features/thread/domain/usecases/clean_and_get_emails_in_mailbox_interactor.dart
@@ -1,0 +1,54 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/properties/properties.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/core/sort/comparator.dart';
+import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
+import 'package:tmail_ui_user/features/thread/domain/model/email_filter.dart';
+import 'package:tmail_ui_user/features/thread/domain/repository/thread_repository.dart';
+import 'package:tmail_ui_user/features/thread/domain/state/clean_and_get_all_email_state.dart';
+import 'package:tmail_ui_user/features/thread/domain/usecases/get_emails_in_mailbox_interactor.dart';
+
+class CleanAndGetEmailsInMailboxInteractor {
+  final GetEmailsInMailboxInteractor _getEmailsInMailboxInteractor;
+  final ThreadRepository _threadRepository;
+
+  const CleanAndGetEmailsInMailboxInteractor(
+    this._threadRepository,
+    this._getEmailsInMailboxInteractor,
+  );
+
+  Stream<Either<Failure, Success>> execute(
+    Session session,
+    AccountId accountId,
+    {
+      UnsignedInt? limit,
+      Set<Comparator>? sort,
+      EmailFilter? emailFilter,
+      Properties? propertiesCreated,
+      Properties? propertiesUpdated,
+      bool getLatestChanges = true,
+    }
+  ) async* {
+    try {
+      yield Right<Failure, Success>(CleanAndGetAllEmailLoading());
+
+      await _threadRepository.clearEmailCacheAndStateCache(accountId, session);
+
+      yield* _getEmailsInMailboxInteractor.execute(
+        session,
+        accountId,
+        limit: limit,
+        sort: sort,
+        emailFilter: emailFilter,
+        propertiesCreated: propertiesCreated,
+        propertiesUpdated: propertiesUpdated,
+        getLatestChanges: getLatestChanges,
+      );
+    } catch (e) {
+      yield Left(CleanAndGetAllEmailFailure(e));
+    }
+  }
+}

--- a/lib/features/thread/presentation/extensions/handle_pull_to_refresh_list_email_extension.dart
+++ b/lib/features/thread/presentation/extensions/handle_pull_to_refresh_list_email_extension.dart
@@ -1,12 +1,13 @@
 
+import 'package:core/utils/app_logger.dart';
 import 'package:dartz/dartz.dart';
-import 'package:rich_text_composer/views/commons/logger.dart';
 import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
 import 'package:tmail_ui_user/features/home/data/exceptions/session_exceptions.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/thread/domain/constants/thread_constants.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/email_filter.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/clean_and_get_all_email_state.dart';
+import 'package:tmail_ui_user/features/thread/domain/state/get_all_email_state.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/loading_more_status.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
 
@@ -14,6 +15,8 @@ extension HandlePullToRefreshListEmailExtension on ThreadController {
 
   Future<void> onRefresh() async {
     log('HandlePullToRefreshListEmailExtension::onRefresh:Started');
+    consumeState(Stream.value(Right(GetAllEmailLoading())));
+    await Future.delayed(const Duration(milliseconds: 300)); // Create loading effect
     canLoadMore = false;
     loadingMoreStatus.value == LoadingMoreStatus.idle;
     getAllEmailAction();
@@ -21,8 +24,7 @@ extension HandlePullToRefreshListEmailExtension on ThreadController {
 
   Future<void> onCleanAndRefresh() async {
     log('HandlePullToRefreshListEmailExtension::onCleanAndRefresh:Started');
-    canLoadMore = false;
-    loadingMoreStatus.value == LoadingMoreStatus.idle;
+    resetToOriginalValue();
     cleanAndGetAllEmailAction();
   }
 

--- a/lib/features/thread/presentation/extensions/handle_pull_to_refresh_list_email_extension.dart
+++ b/lib/features/thread/presentation/extensions/handle_pull_to_refresh_list_email_extension.dart
@@ -1,0 +1,53 @@
+
+import 'package:dartz/dartz.dart';
+import 'package:rich_text_composer/views/commons/logger.dart';
+import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
+import 'package:tmail_ui_user/features/home/data/exceptions/session_exceptions.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
+import 'package:tmail_ui_user/features/thread/domain/constants/thread_constants.dart';
+import 'package:tmail_ui_user/features/thread/domain/model/email_filter.dart';
+import 'package:tmail_ui_user/features/thread/domain/state/clean_and_get_all_email_state.dart';
+import 'package:tmail_ui_user/features/thread/presentation/model/loading_more_status.dart';
+import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
+
+extension HandlePullToRefreshListEmailExtension on ThreadController {
+
+  Future<void> onRefresh() async {
+    log('HandlePullToRefreshListEmailExtension::onRefresh:Started');
+    canLoadMore = false;
+    loadingMoreStatus.value == LoadingMoreStatus.idle;
+    getAllEmailAction();
+  }
+
+  Future<void> onCleanAndRefresh() async {
+    log('HandlePullToRefreshListEmailExtension::onCleanAndRefresh:Started');
+    canLoadMore = false;
+    loadingMoreStatus.value == LoadingMoreStatus.idle;
+    cleanAndGetAllEmailAction();
+  }
+
+  Future<void> cleanAndGetAllEmailAction() async {
+    final accountId = mailboxDashBoardController.accountId.value;
+    final session = mailboxDashBoardController.sessionCurrent;
+
+    if (accountId == null || session == null) {
+      consumeState(Stream.value(Left(CleanAndGetAllEmailFailure(NotFoundSessionException()))));
+      return;
+    }
+
+    consumeState(cleanAndGetEmailsInMailboxInteractor.execute(
+      session,
+      accountId,
+      limit: ThreadConstants.defaultLimit,
+      sort: EmailSortOrderType.mostRecent.getSortOrder().toNullable(),
+      emailFilter: EmailFilter(
+        filter: getFilterCondition(mailboxIdSelected: selectedMailboxId),
+        filterOption: mailboxDashBoardController.filterMessageOption.value,
+        mailboxId: selectedMailboxId,
+      ),
+      propertiesCreated: EmailUtils.getPropertiesForEmailGetMethod(session, accountId),
+      propertiesUpdated: ThreadConstants.propertiesUpdatedDefault,
+      getLatestChanges: true,
+    ));
+  }
+}

--- a/lib/features/thread/presentation/thread_bindings.dart
+++ b/lib/features/thread/presentation/thread_bindings.dart
@@ -1,12 +1,11 @@
 import 'package:core/data/model/source_type/data_source_type.dart';
-import 'package:core/utils/file_utils.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/base_bindings.dart';
+import 'package:tmail_ui_user/features/caching/caching_manager.dart';
 import 'package:tmail_ui_user/features/email/domain/repository/email_repository.dart';
 import 'package:tmail_ui_user/features/mailbox/data/datasource/state_datasource.dart';
 import 'package:tmail_ui_user/features/mailbox/data/datasource_impl/state_datasource_impl.dart';
 import 'package:tmail_ui_user/features/mailbox/data/local/state_cache_manager.dart';
-import 'package:tmail_ui_user/features/push_notification/data/local/fcm_cache_manager.dart';
 import 'package:tmail_ui_user/features/thread/data/datasource/thread_datasource.dart';
 import 'package:tmail_ui_user/features/thread/data/datasource_impl/local_thread_datasource_impl.dart';
 import 'package:tmail_ui_user/features/thread/data/datasource_impl/thread_datasource_impl.dart';
@@ -56,9 +55,7 @@ class ThreadBindings extends BaseBindings {
       Get.find<RemoteExceptionThrower>()));
     Get.lazyPut(() => LocalThreadDataSourceImpl(
       Get.find<EmailCacheManager>(),
-      Get.find<FCMCacheManager>(),
-      Get.find<StateCacheManager>(),
-      Get.find<FileUtils>(),
+      Get.find<CachingManager>(),
       Get.find<CacheExceptionThrower>(),
     ));
     Get.lazyPut(() => StateDataSourceImpl(

--- a/lib/features/thread/presentation/thread_bindings.dart
+++ b/lib/features/thread/presentation/thread_bindings.dart
@@ -1,10 +1,12 @@
 import 'package:core/data/model/source_type/data_source_type.dart';
+import 'package:core/utils/file_utils.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/base_bindings.dart';
 import 'package:tmail_ui_user/features/email/domain/repository/email_repository.dart';
 import 'package:tmail_ui_user/features/mailbox/data/datasource/state_datasource.dart';
 import 'package:tmail_ui_user/features/mailbox/data/datasource_impl/state_datasource_impl.dart';
 import 'package:tmail_ui_user/features/mailbox/data/local/state_cache_manager.dart';
+import 'package:tmail_ui_user/features/push_notification/data/local/fcm_cache_manager.dart';
 import 'package:tmail_ui_user/features/thread/data/datasource/thread_datasource.dart';
 import 'package:tmail_ui_user/features/thread/data/datasource_impl/local_thread_datasource_impl.dart';
 import 'package:tmail_ui_user/features/thread/data/datasource_impl/thread_datasource_impl.dart';
@@ -13,6 +15,7 @@ import 'package:tmail_ui_user/features/thread/data/network/thread_api.dart';
 import 'package:tmail_ui_user/features/thread/data/network/thread_isolate_worker.dart';
 import 'package:tmail_ui_user/features/thread/data/repository/thread_repository_impl.dart';
 import 'package:tmail_ui_user/features/thread/domain/repository/thread_repository.dart';
+import 'package:tmail_ui_user/features/thread/domain/usecases/clean_and_get_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/get_email_by_id_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/get_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/load_more_emails_in_mailbox_interactor.dart';
@@ -35,6 +38,7 @@ class ThreadBindings extends BaseBindings {
       Get.find<SearchEmailInteractor>(),
       Get.find<SearchMoreEmailInteractor>(),
       Get.find<GetEmailByIdInteractor>(),
+      Get.find<CleanAndGetEmailsInMailboxInteractor>(),
     ));
   }
 
@@ -50,7 +54,13 @@ class ThreadBindings extends BaseBindings {
       Get.find<ThreadAPI>(),
       Get.find<ThreadIsolateWorker>(),
       Get.find<RemoteExceptionThrower>()));
-    Get.lazyPut(() => LocalThreadDataSourceImpl(Get.find<EmailCacheManager>(), Get.find<CacheExceptionThrower>()));
+    Get.lazyPut(() => LocalThreadDataSourceImpl(
+      Get.find<EmailCacheManager>(),
+      Get.find<FCMCacheManager>(),
+      Get.find<StateCacheManager>(),
+      Get.find<FileUtils>(),
+      Get.find<CacheExceptionThrower>(),
+    ));
     Get.lazyPut(() => StateDataSourceImpl(
       Get.find<StateCacheManager>(),
       Get.find<IOSSharingManager>(),
@@ -66,6 +76,10 @@ class ThreadBindings extends BaseBindings {
     Get.lazyPut(() => SearchEmailInteractor(Get.find<ThreadRepository>()));
     Get.lazyPut(() => SearchMoreEmailInteractor(Get.find<ThreadRepository>()));
     Get.lazyPut(() => GetEmailByIdInteractor(Get.find<ThreadRepository>(), Get.find<EmailRepository>()));
+    Get.lazyPut(() => CleanAndGetEmailsInMailboxInteractor(
+      Get.find<ThreadRepository>(),
+      Get.find<GetEmailsInMailboxInteractor>(),
+    ));
   }
 
   @override

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -267,14 +267,14 @@ class ThreadController extends BaseController with EmailActionController {
           && mailbox.mailboxId != _currentMemoryMailboxId) {
         _currentMemoryMailboxId = mailbox.id;
         consumeState(Stream.value(Right(GetAllEmailLoading())));
-        _resetToOriginalValue();
+        resetToOriginalValue();
         getAllEmailAction(
           getLatestChanges: mailboxDashBoardController.isFirstSessionLoad,
         );
         mailboxDashBoardController.setIsFirstSessionLoad(false);
       } else if (mailbox == null) { // disable current mailbox when search active
         _currentMemoryMailboxId = null;
-        _resetToOriginalValue();
+        resetToOriginalValue();
       }
     });
 
@@ -468,7 +468,7 @@ class ThreadController extends BaseController with EmailActionController {
         accountId: _accountId,
         userName: _session?.username,
       );
-      _getAllEmailAction();
+      getAllEmailAction();
     } else if (error is MethodLevelErrors) {
       if (currentOverlayContext != null && error.message != null) {
         appToast.showToastErrorMessage(
@@ -480,8 +480,8 @@ class ThreadController extends BaseController with EmailActionController {
     }
   }
 
-  void _resetToOriginalValue() {
-    log('ThreadController::_resetToOriginalValue');
+  void resetToOriginalValue() {
+    log('ThreadController::resetToOriginalValue');
     mailboxDashBoardController.emailsInCurrentMailbox.clear();
     mailboxDashBoardController.listEmailSelected.clear();
     mailboxDashBoardController.currentSelectMode.value = SelectMode.INACTIVE;

--- a/lib/features/thread/presentation/thread_view.dart
+++ b/lib/features/thread/presentation/thread_view.dart
@@ -413,9 +413,6 @@ class ThreadView extends GetWidget<ThreadController>
         pullDownToRefreshText: AppLocalizations.of(context).pullDownToRefresh,
         normalRefreshText: AppLocalizations.of(context).refresh,
         deepRefreshText: AppLocalizations.of(context).deepRefresh,
-        refreshingText: AppLocalizations.of(context).refreshing,
-        pullingText: AppLocalizations.of(context).pulling,
-        pullFurtherForText: AppLocalizations.of(context).pullFurtherFor,
         pullHarderForText: AppLocalizations.of(context).pullHarderFor,
         child: listView,
       );
@@ -699,9 +696,6 @@ class ThreadView extends GetWidget<ThreadController>
             pullDownToRefreshText: AppLocalizations.of(context).pullDownToRefresh,
             normalRefreshText: AppLocalizations.of(context).refresh,
             deepRefreshText: AppLocalizations.of(context).deepRefresh,
-            refreshingText: AppLocalizations.of(context).refreshing,
-            pullingText: AppLocalizations.of(context).pulling,
-            pullFurtherForText: AppLocalizations.of(context).pullFurtherFor,
             pullHarderForText: AppLocalizations.of(context).pullHarderFor,
             child: EmptyEmailsWidget(
               key: const Key('empty_thread_view'),

--- a/lib/features/thread/presentation/widgets/thread_view_loading_bar_widget.dart
+++ b/lib/features/thread/presentation/widgets/thread_view_loading_bar_widget.dart
@@ -3,6 +3,7 @@ import 'package:core/presentation/state/success.dart';
 import 'package:core/presentation/views/loading/cupertino_loading_widget.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/features/thread/domain/state/clean_and_get_all_email_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/get_all_email_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/search_email_state.dart';
 
@@ -20,7 +21,9 @@ class ThreadViewLoadingBarWidget extends StatelessWidget {
     return viewState.fold(
       (failure) => const SizedBox.shrink(),
       (success) {
-        if (success is SearchingState || success is GetAllEmailLoading) {
+        if (success is SearchingState ||
+            success is GetAllEmailLoading ||
+            success is CleanAndGetAllEmailLoading) {
           return const Padding(
             padding: EdgeInsetsDirectional.only(top: 16),
             child: CupertinoLoadingWidget());

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2025-04-03T14:19:11.171517",
+  "@@last_modified": "2025-04-14T04:16:15.237055",
   "initializing_data": "Initializing data...",
   "@initializing_data": {
     "type": "text",
@@ -2968,12 +2968,6 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "errorWhileFetchingSubaddress": "Error while fetching the subaddress",
-  "@errorWhileFetchingSubaddress": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
   "connectedToTheInternet": "Connected to the internet",
   "@connectedToTheInternet": {
     "type": "text",
@@ -4424,26 +4418,8 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "refreshing": "Refreshing",
-  "@refreshing": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "pulling": "Pulling",
-  "@pulling": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
   "releaseTo": "Release to",
   "@releaseTo": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "pullFurtherFor": "Pull further for",
-  "@pullFurtherFor": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2025-03-31T03:40:41.454034",
+  "@@last_modified": "2025-04-03T14:19:11.171517",
   "initializing_data": "Initializing data...",
   "@initializing_data": {
     "type": "text",
@@ -2968,6 +2968,12 @@
     "placeholders_order": [],
     "placeholders": {}
   },
+  "errorWhileFetchingSubaddress": "Error while fetching the subaddress",
+  "@errorWhileFetchingSubaddress": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
   "connectedToTheInternet": "Connected to the internet",
   "@connectedToTheInternet": {
     "type": "text",
@@ -4396,6 +4402,54 @@
   },
   "retry": "Retry",
   "@retry": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "refresh": "Refresh",
+  "@refresh": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "deepRefresh": "Deep refresh",
+  "@deepRefresh": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "pullDownToRefresh": "Pull down to refresh",
+  "@pullDownToRefresh": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "refreshing": "Refreshing",
+  "@refreshing": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "pulling": "Pulling",
+  "@pulling": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "releaseTo": "Release to",
+  "@releaseTo": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "pullFurtherFor": "Pull further for",
+  "@pullFurtherFor": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "pullHarderFor": "Pull harder for",
+  "@pullHarderFor": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -4625,4 +4625,60 @@ class AppLocalizations {
       name: 'retry',
     );
   }
+
+  String get refresh {
+    return Intl.message(
+      'Refresh',
+      name: 'refresh',
+    );
+  }
+
+  String get deepRefresh {
+    return Intl.message(
+      'Deep refresh',
+      name: 'deepRefresh',
+    );
+  }
+
+  String get pullDownToRefresh {
+    return Intl.message(
+      'Pull down to refresh',
+      name: 'pullDownToRefresh',
+    );
+  }
+
+  String get refreshing {
+    return Intl.message(
+      'Refreshing',
+      name: 'refreshing',
+    );
+  }
+
+  String get pulling {
+    return Intl.message(
+      'Pulling',
+      name: 'pulling',
+    );
+  }
+
+  String get releaseTo {
+    return Intl.message(
+      'Release to',
+      name: 'releaseTo',
+    );
+  }
+
+  String get pullFurtherFor {
+    return Intl.message(
+      'Pull further for',
+      name: 'pullFurtherFor',
+    );
+  }
+
+  String get pullHarderFor {
+    return Intl.message(
+      'Pull harder for',
+      name: 'pullHarderFor',
+    );
+  }
 }

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -4647,31 +4647,10 @@ class AppLocalizations {
     );
   }
 
-  String get refreshing {
-    return Intl.message(
-      'Refreshing',
-      name: 'refreshing',
-    );
-  }
-
-  String get pulling {
-    return Intl.message(
-      'Pulling',
-      name: 'pulling',
-    );
-  }
-
   String get releaseTo {
     return Intl.message(
       'Release to',
       name: 'releaseTo',
-    );
-  }
-
-  String get pullFurtherFor {
-    return Intl.message(
-      'Pull further for',
-      name: 'pullFurtherFor',
     );
   }
 

--- a/model/pubspec.lock
+++ b/model/pubspec.lock
@@ -945,6 +945,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.3"
+  pull_to_refresh:
+    dependency: transitive
+    description:
+      name: pull_to_refresh
+      sha256: bbadd5a931837b57739cf08736bea63167e284e71fb23b218c8c9a6e042aad12
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   qr:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1793,6 +1793,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.3"
+  pull_to_refresh:
+    dependency: transitive
+    description:
+      name: pull_to_refresh
+      sha256: bbadd5a931837b57739cf08736bea63167e284e71fb23b218c8c9a6e042aad12
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   qr:
     dependency: transitive
     description:

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -81,6 +81,7 @@ import 'package:tmail_ui_user/features/thread/domain/constants/thread_constants.
 import 'package:tmail_ui_user/features/thread/domain/model/email_filter.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
+import 'package:tmail_ui_user/features/thread/domain/usecases/clean_and_get_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/empty_spam_folder_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/empty_trash_folder_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/get_email_by_id_interactor.dart';
@@ -182,6 +183,7 @@ const fallbackGenerators = {
   MockSpec<GetAllIdentitiesInteractor>(),
   MockSpec<GetIdentityCacheOnWebInteractor>(),
   MockSpec<ComposerManager>(fallbackGenerators: fallbackGenerators),
+  MockSpec<CleanAndGetEmailsInMailboxInteractor>(),
 ])
 void main() {
   // mock mailbox dashboard controller direct dependencies
@@ -203,6 +205,7 @@ void main() {
   final deleteMultipleEmailsPermanentlyInteractor =
       MockDeleteMultipleEmailsPermanentlyInteractor();
   final getEmailByIdInteractor = MockGetEmailByIdInteractor();
+  final cleanAndGetEmailsInMailboxInteractor = MockCleanAndGetEmailsInMailboxInteractor();
   final sendEmailInteractor = MockSendEmailInteractor();
   final storeSendingEmailInteractor = MockStoreSendingEmailInteractor();
   final updateSendingEmailInteractor = MockUpdateSendingEmailInteractor();
@@ -391,7 +394,8 @@ void main() {
         loadMoreEmailsInMailboxInteractor,
         searchEmailInteractor,
         searchMoreEmailInteractor,
-        getEmailByIdInteractor);
+        getEmailByIdInteractor,
+        cleanAndGetEmailsInMailboxInteractor);
       Get.put(threadController);
 
       advancedFilterController = AdvancedFilterController();
@@ -622,7 +626,9 @@ void main() {
           loadMoreEmailsInMailboxInteractor,
           searchEmailInteractor,
           searchMoreEmailInteractor,
-          getEmailByIdInteractor);
+          getEmailByIdInteractor,
+          cleanAndGetEmailsInMailboxInteractor,
+      );
       Get.put(threadController);
 
       advancedFilterController = AdvancedFilterController();

--- a/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
+++ b/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
@@ -79,6 +79,7 @@ import 'package:tmail_ui_user/features/sending_queue/domain/usecases/update_send
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/get_all_email_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/load_more_emails_state.dart';
+import 'package:tmail_ui_user/features/thread/domain/usecases/clean_and_get_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/empty_spam_folder_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/empty_trash_folder_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/get_email_by_id_interactor.dart';
@@ -184,6 +185,7 @@ const fallbackGenerators = {
   MockSpec<TwakeAppManager>(),
   MockSpec<GetIdentityCacheOnWebInteractor>(),
   MockSpec<ComposerManager>(fallbackGenerators: fallbackGenerators),
+  MockSpec<CleanAndGetEmailsInMailboxInteractor>(),
 ])
 void main() {
   final moveToMailboxInteractor = MockMoveToMailboxInteractor();
@@ -199,6 +201,7 @@ void main() {
   final emptyTrashFolderInteractor = MockEmptyTrashFolderInteractor();
   final deleteMultipleEmailsPermanentlyInteractor = MockDeleteMultipleEmailsPermanentlyInteractor();
   final getEmailByIdInteractor = MockGetEmailByIdInteractor();
+  final cleanAndGetEmailsInMailboxInteractor = MockCleanAndGetEmailsInMailboxInteractor();
   final sendEmailInteractor = MockSendEmailInteractor();
   final storeSendingEmailInteractor = MockStoreSendingEmailInteractor();
   final updateSendingEmailInteractor = MockUpdateSendingEmailInteractor();
@@ -383,7 +386,8 @@ void main() {
         loadMoreEmailsInMailboxInteractor,
         searchEmailInteractor,
         searchMoreEmailInteractor,
-        getEmailByIdInteractor
+        getEmailByIdInteractor,
+        cleanAndGetEmailsInMailboxInteractor,
       );
       Get.put(threadController);
 
@@ -433,9 +437,6 @@ void main() {
         final listViewEmailWidgetFinder = find.byKey(const PageStorageKey('list_presentation_email_in_threads'));
         expect(listViewEmailWidgetFinder, findsOneWidget);
 
-        final listViewEmailWidget = tester.widget<ListView>(listViewEmailWidgetFinder);
-        expect(listViewEmailWidget.semanticChildCount, equals(listEmailsOfInbox.length + 2));
-
         final emailTile1Finder = find.byKey(Key('email_tile_builder_${EmailFixtures.email1.toPresentationEmail().id?.asString}'),);
         expect(emailTile1Finder, findsOneWidget);
 
@@ -460,9 +461,6 @@ void main() {
 
         final folder1ListViewEmailWidgetFinder = find.byKey(const PageStorageKey('list_presentation_email_in_threads'));
         expect(folder1ListViewEmailWidgetFinder, findsOneWidget);
-
-        final folder1ListViewEmailWidget = tester.widget<ListView>(folder1ListViewEmailWidgetFinder);
-        expect(folder1ListViewEmailWidget.semanticChildCount, equals(listEmailsOfFolder1.length + 2));
 
         final emailTile4Finder = find.byKey(Key('email_tile_builder_${EmailFixtures.email4.toPresentationEmail().id?.asString}'),);
         expect(emailTile4Finder, findsOneWidget);
@@ -531,9 +529,6 @@ void main() {
         final folder1ListViewEmailWidgetFinder = find.byKey(const PageStorageKey('list_presentation_email_in_threads'));
         expect(folder1ListViewEmailWidgetFinder, findsOneWidget);
 
-        final folder1ListViewEmailWidget = tester.widget<ListView>(folder1ListViewEmailWidgetFinder);
-        expect(folder1ListViewEmailWidget.semanticChildCount, equals(listEmailsOfFolder1.length + 2));
-
         final emailTile1Finder = find.byKey(Key('email_tile_builder_${EmailFixtures.email1.toPresentationEmail().id?.asString}'),);
         expect(emailTile1Finder, findsOneWidget);
 
@@ -580,10 +575,6 @@ void main() {
 
         final emptyEmailWidgetFinder = find.byKey(const Key('empty_thread_view'));
         expect(emptyEmailWidgetFinder, findsNothing);
-
-        final listViewEmailWidgetFinder = find.byKey(const PageStorageKey('list_presentation_email_in_threads'));
-        final listViewEmailWidget = tester.widget<ListView>(listViewEmailWidgetFinder);
-        expect(listViewEmailWidget.semanticChildCount, equals(listEmailsOfInbox.length + 2));
 
         // Switch to mailbox Folder 1
         final listEmailsOfFolder1 = <PresentationEmail>[];
@@ -659,9 +650,6 @@ void main() {
         final listViewEmailWidgetFinder = find.byKey(const PageStorageKey('list_presentation_email_in_threads'));
         expect(listViewEmailWidgetFinder, findsOneWidget);
 
-        final listViewEmailWidget = tester.widget<ListView>(listViewEmailWidgetFinder);
-        expect(listViewEmailWidget.semanticChildCount, equals(7));
-
         expect(find.text('Load more'), findsOneWidget);
 
         debugDefaultTargetPlatformOverride = null;
@@ -704,9 +692,6 @@ void main() {
 
         final listViewEmailWidgetFinder = find.byKey(const PageStorageKey('list_presentation_email_in_threads'));
         expect(listViewEmailWidgetFinder, findsOneWidget);
-
-        final listViewEmailWidget = tester.widget<ListView>(listViewEmailWidgetFinder);
-        expect(listViewEmailWidget.semanticChildCount, equals(5));
 
         expect(find.text('Load more'), findsNothing);
 

--- a/test/features/search/verify_before_time_in_search_email_filter_test.dart
+++ b/test/features/search/verify_before_time_in_search_email_filter_test.dart
@@ -66,6 +66,7 @@ import 'package:tmail_ui_user/features/thread/domain/model/email_filter.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/refresh_changes_all_email_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/search_email_state.dart';
+import 'package:tmail_ui_user/features/thread/domain/usecases/clean_and_get_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/empty_spam_folder_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/empty_trash_folder_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/get_email_by_id_interactor.dart';
@@ -157,6 +158,7 @@ const fallbackGenerators = {
   MockSpec<RemoveComposerCacheByIdOnWebInteractor>(),
   MockSpec<GetAllIdentitiesInteractor>(),
   MockSpec<ComposerManager>(fallbackGenerators: fallbackGenerators),
+  MockSpec<CleanAndGetEmailsInMailboxInteractor>(),
 ])
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -169,6 +171,7 @@ void main() {
   late MockSearchEmailInteractor mockSearchEmailInteractor;
   late MockSearchMoreEmailInteractor mockSearchMoreEmailInteractor;
   late MockGetEmailByIdInteractor mockGetEmailByIdInteractor;
+  late MockCleanAndGetEmailsInMailboxInteractor mockCleanAndGetEmailsInMailboxInteractor;
 
   // Declaration search controller
   late SearchController searchController;
@@ -275,6 +278,7 @@ void main() {
     mockSearchEmailInteractor = MockSearchEmailInteractor();
     mockSearchMoreEmailInteractor = MockSearchMoreEmailInteractor();
     mockGetEmailByIdInteractor = MockGetEmailByIdInteractor();
+    mockCleanAndGetEmailsInMailboxInteractor = MockCleanAndGetEmailsInMailboxInteractor();
 
     // Mock search controller
     mockQuickSearchEmailInteractor = MockQuickSearchEmailInteractor();
@@ -366,6 +370,7 @@ void main() {
       mockSearchEmailInteractor,
       mockSearchMoreEmailInteractor,
       mockGetEmailByIdInteractor,
+      mockCleanAndGetEmailsInMailboxInteractor,
     );
 
     mailboxDashboardController.sessionCurrent = SessionFixtures.aliceSession;

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -37,6 +37,7 @@ import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option
 import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/refresh_changes_all_email_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/search_email_state.dart';
+import 'package:tmail_ui_user/features/thread/domain/usecases/clean_and_get_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/get_email_by_id_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/get_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/load_more_emails_in_mailbox_interactor.dart';
@@ -87,6 +88,7 @@ const fallbackGenerators = {
   MockSpec<SearchEmailInteractor>(),
   MockSpec<SearchMoreEmailInteractor>(),
   MockSpec<GetEmailByIdInteractor>(),
+  MockSpec<CleanAndGetEmailsInMailboxInteractor>(),
 ])
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -102,6 +104,7 @@ void main() {
   late MockSearchEmailInteractor mockSearchEmailInteractor;
   late MockSearchMoreEmailInteractor mockSearchMoreEmailInteractor;
   late MockGetEmailByIdInteractor mockGetEmailByIdInteractor;
+  late MockCleanAndGetEmailsInMailboxInteractor mockCleanAndGetEmailsInMailboxInteractor;
 
   // Declaration base controller
   late MockCachingManager mockCachingManager;
@@ -166,6 +169,7 @@ void main() {
     mockSearchEmailInteractor = MockSearchEmailInteractor();
     mockSearchMoreEmailInteractor = MockSearchMoreEmailInteractor();
     mockGetEmailByIdInteractor = MockGetEmailByIdInteractor();
+    mockCleanAndGetEmailsInMailboxInteractor = MockCleanAndGetEmailsInMailboxInteractor();
 
     Get.put<NetworkConnectionController>(mockNetworkConnectionController);
     Get.put<SearchController>(mockSearchController);
@@ -177,7 +181,9 @@ void main() {
       mockLoadMoreEmailsInMailboxInteractor,
       mockSearchEmailInteractor,
       mockSearchMoreEmailInteractor,
-      mockGetEmailByIdInteractor);
+      mockGetEmailByIdInteractor,
+      mockCleanAndGetEmailsInMailboxInteractor,
+    );
   });
 
   group('ThreadController::test', () {


### PR DESCRIPTION
## Issue

#3507

## Root cause

- When we perform too many actions on multiple emails `(Mark as read, mark as star, move, delete, etc.)`, `Email/get` from the value of `Email/changes` will throw an error.

```json
 [
            "error",
            {
                "type": "requestTooLarge",
                "description": "Too many items in an email read at level FULL. Got 183 items instead of maximum 100."
            },
            "c2"
        ]
```

- Some emails in the `update` of the `Email/change` response were not found in `Email/get`

<img width="719" alt="Image" src="https://github.com/user-attachments/assets/72a03e7c-9097-46d5-adf1-536bbae88ae0" />

- But we still update `newState` of email 

<img width="858" alt="Image" src="https://github.com/user-attachments/assets/f2a013d1-a67d-42a5-9351-77240a7aeeb6" />


## Solution

- Perform 2 actions when `Pull to refresh`:
  - `Refresh` : Call get all emails
  - `Deep refresh`: Clean email cache & call get all emails


## Resolved

[demo.webm](https://github.com/user-attachments/assets/5fb39309-fddd-4768-8127-fffb28ae87e5)

