### PR TITLE
TF-3622 Fix deformed inlined image

### DIFF
--- a/core/lib/data/network/download/download_client.dart
+++ b/core/lib/data/network/download/download_client.dart
@@ -119,7 +119,7 @@ class DownloadClient {
       fileName = fileName.split('.').first;
     }
     mimeType = HtmlUtils.validateHtmlImageResourceMimeType(mimeType);
-    final base64Uri = '<img src="${HtmlUtils.convertBase64ToImageResourceData(base64Data: base64Data, mimeType: mimeType)}" alt="$fileName" style="max-width: $maxWidth;" data-mimetype="$mimeType" id="cid:$cid" />';
+    final base64Uri = '<img src="${HtmlUtils.convertBase64ToImageResourceData(base64Data: base64Data, mimeType: mimeType)}" alt="$fileName" style="max-width:$maxWidth;" data-mimetype="$mimeType" id="cid:$cid" />';
     return base64Uri;
   }
 }

--- a/core/lib/presentation/utils/html_transformer/dom/image_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/image_transformers.dart
@@ -27,24 +27,11 @@ class ImageTransformer extends DomTransformer {
       if (imageElements.isEmpty) return;
 
       await Future.wait(imageElements.map((imageElement) async {
-        var exStyle = imageElement.attributes['style'];
-        if (exStyle != null) {
-          if (!exStyle.trim().endsWith(';')) {
-            exStyle = '$exStyle;';
-          }
-          if (!exStyle.contains('display')) {
-            exStyle = '$exStyle display:inline;';
-          }
-          if (!exStyle.contains('max-width')) {
-            exStyle = '$exStyle max-width:100%;';
-          }
-          imageElement.attributes['style'] = exStyle;
-        } else {
-          imageElement.attributes['style'] = 'display:inline;max-width:100%;';
-        }
         final src = imageElement.attributes['src'];
 
         if (src == null) return;
+
+        final id = imageElement.attributes['id'] ?? '';
         final mimeType = imageElement.attributes['data-mimetype'];
         if (src.startsWith('cid:') && mapUrlDownloadCID != null) {
           final imageBase64 = await _convertCidToBase64Image(
@@ -54,7 +41,10 @@ class ImageTransformer extends DomTransformer {
             mimeType: mimeType,
           );
           imageElement.attributes['src'] = imageBase64 ?? src;
-          imageElement.attributes['id'] ??= src;
+
+          if (!id.startsWith('cid:')) {
+            imageElement.attributes['id'] = src;
+          }
         } else if (src.startsWith('https://') || src.startsWith('http://')) {
           if (!imageElement.attributes.containsKey('loading')) {
             imageElement.attributes['loading'] = 'lazy';

--- a/core/lib/presentation/views/html_viewer/html_content_viewer_on_web_widget.dart
+++ b/core/lib/presentation/views/html_viewer/html_content_viewer_on_web_widget.dart
@@ -267,7 +267,10 @@ class _HtmlContentViewerOnWebState extends State<HtmlContentViewerOnWeb> {
       minHeight: minHeight,
       minWidth: _minWidth,
       styleCSS: HtmlTemplate.tooltipLinkCss,
-      javaScripts: webViewActionScripts + scriptsDisableZoom + HtmlInteraction.scriptsHandleLazyLoadingBackgroundImage,
+      javaScripts: webViewActionScripts
+          + scriptsDisableZoom
+          + HtmlInteraction.scriptsHandleLazyLoadingBackgroundImage
+          + HtmlInteraction.generateNormalizeImageScript(widget.widthContent),
       direction: widget.direction,
       contentPadding: widget.contentPadding,
       useDefaultFont: widget.useDefaultFont,

--- a/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
+++ b/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
@@ -68,7 +68,7 @@ class _HtmlContentViewState extends State<HtmlContentViewer> {
   late InAppWebViewController _webViewController;
   late double _actualHeight;
   late Set<Factory<OneSequenceGestureRecognizer>> _gestureRecognizers;
-  late String _customScripts;
+  late StringBuffer _customScriptsBuilder;
 
   final _loadingBarNotifier = ValueNotifier(true);
 
@@ -92,10 +92,13 @@ class _HtmlContentViewState extends State<HtmlContentViewer> {
         Factory<LongPressGestureRecognizer>(() => LongPressGestureRecognizer(duration: _longPressGestureDurationIOS)),
       };
     }
+    _customScriptsBuilder = StringBuffer();
+    _customScriptsBuilder.write(HtmlInteraction.scriptsHandleLazyLoadingBackgroundImage);
+    if (widget.initialWidth != null) {
+      _customScriptsBuilder.write(HtmlInteraction.generateNormalizeImageScript(widget.initialWidth!));
+    }
     if (PlatformInfo.isAndroid) {
-      _customScripts = HtmlInteraction.scriptsHandleLazyLoadingBackgroundImage + HtmlInteraction.scriptsHandleContentSizeChanged;
-    } else {
-      _customScripts = HtmlInteraction.scriptsHandleLazyLoadingBackgroundImage;
+      _customScriptsBuilder.write(HtmlInteraction.scriptsHandleContentSizeChanged);
     }
     _initialData();
   }
@@ -115,7 +118,7 @@ class _HtmlContentViewState extends State<HtmlContentViewer> {
     _htmlData = HtmlUtils.generateHtmlDocument(
       content: widget.contentHtml,
       direction: widget.direction,
-      javaScripts: _customScripts,
+      javaScripts: _customScriptsBuilder.toString(),
       contentPadding: widget.contentPadding,
       useDefaultFont: widget.useDefaultFont,
     );

--- a/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
+++ b/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
@@ -60,10 +60,10 @@ class HtmlContentViewer extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  State<StatefulWidget> createState() => _HtmlContentViewState();
+  State<StatefulWidget> createState() => HtmlContentViewState();
 }
 
-class _HtmlContentViewState extends State<HtmlContentViewer> {
+class HtmlContentViewState extends State<HtmlContentViewer> {
 
   late InAppWebViewController _webViewController;
   late double _actualHeight;
@@ -78,6 +78,9 @@ class _HtmlContentViewState extends State<HtmlContentViewer> {
     transparentBackground: true,
     verticalScrollBarEnabled: false,
   );
+
+  @visibleForTesting
+  InAppWebViewController get webViewController => _webViewController;
 
   @override
   void initState() {

--- a/core/lib/utils/html/html_interaction.dart
+++ b/core/lib/utils/html/html_interaction.dart
@@ -158,22 +158,9 @@ class HtmlInteraction {
         function normalizeStyleAttribute(attrs) {
           // Normalize style attribute to ensure proper responsive behavior
           let style = attrs['style'];
-          const widthStr = attrs['width'];
           
           if (!style) {
-            if (!widthStr) {
-              attrs['style'] = 'max-width: 100%;height: auto;display: inline;';
-            } else {
-              if (!style.includes('height')) {
-                style += 'height: auto;';
-              }
-        
-              if (!style.includes('display')) {
-                style += 'display: inline;';
-              }
-        
-              attrs['style'] = style;
-            }
+            attrs['style'] = 'max-width:100%;height:auto;display:inline;';
             return;
           }
     
@@ -199,15 +186,15 @@ class HtmlInteraction {
     
           // Add responsive defaults if missing
           if (!style.includes('max-width')) {
-            style += 'max-width: 100%;';
+            style += 'max-width:100%;';
           }
     
           if (!style.includes('height')) {
-            style += 'height: auto;';
+            style += 'height:auto;';
           }
     
           if (!style.includes('display')) {
-            style += 'display: inline;';
+            style += 'display:inline;';
           }
     
           attrs['style'] = style;

--- a/core/lib/utils/html/html_interaction.dart
+++ b/core/lib/utils/html/html_interaction.dart
@@ -99,4 +99,144 @@ class HtmlInteraction {
       };
     </script>
   ''';
+
+  static String generateNormalizeImageScript(double displayWidth) {
+    return '''
+      <script type="text/javascript">
+        const displayWidth = $displayWidth;
+    
+        const sizeUnits = ['px', 'in', 'cm', 'mm', 'pt', 'pc'];
+    
+        function convertToPx(value, unit) {
+          switch (unit.toLowerCase()) {
+            case 'px': return value;
+            case 'in': return value * 96;
+            case 'cm': return value * 37.8;
+            case 'mm': return value * 3.78;
+            case 'pt': return value * (96 / 72);
+            case 'pc': return value * (96 / 6);
+            default: return value;
+          }
+        }
+    
+        function removeWidthHeightFromStyle(style) {
+          style = style.replace(/width\\s*:\\s*[\\d.]+[a-zA-Z%]+\\s*;?/gi, '');
+          style = style.replace(/height\\s*:\\s*[\\d.]+[a-zA-Z%]+\\s*;?/gi, '');
+          style = style.trim();
+          if (style.length && !style.endsWith(';')) {
+            style += ';';
+          }
+          return style;
+        }
+    
+        function extractWidthHeightFromStyle(style) {
+          const result = {};
+          const widthMatch = style.match(/width\\s*:\\s*([\\d.]+)([a-zA-Z%]+)\\s*;?/);
+          const heightMatch = style.match(/height\\s*:\\s*([\\d.]+)([a-zA-Z%]+)\\s*;?/);
+    
+          if (widthMatch) {
+            const value = parseFloat(widthMatch[1]);
+            const unit = widthMatch[2];
+            if (!isNaN(value) && unit) {
+              result['width'] = { value, unit };
+            }
+          }
+    
+          if (heightMatch) {
+            const value = parseFloat(heightMatch[1]);
+            const unit = heightMatch[2];
+            if (!isNaN(value) && unit) {
+              result['height'] = { value, unit };
+            }
+          }
+    
+          return result;
+        }
+    
+        function normalizeStyleAttribute(attrs) {
+          let style = attrs['style'];
+          if (!style) {
+            attrs['style'] = 'display:inline;max-width:100%;';
+            return;
+          }
+    
+          style = style.trim();
+          const dimensions = extractWidthHeightFromStyle(style);
+          const hasWidth = dimensions.hasOwnProperty('width');
+    
+          if (hasWidth) {
+            const widthData = dimensions['width'];
+            const widthPx = convertToPx(widthData.value, widthData.unit);
+    
+            if (displayWidth !== undefined &&
+                widthPx > displayWidth &&
+                sizeUnits.includes(widthData.unit)) {
+              style = removeWidthHeightFromStyle(style).trim();
+            }
+          }
+    
+          if (style.length && !style.endsWith(';')) {
+            style += ';';
+          }
+    
+          if (!style.includes('max-width')) {
+            style += 'max-width:100%;height:auto;';
+          }
+    
+          if (!style.includes('display')) {
+            style += 'display:inline;';
+          }
+    
+          attrs['style'] = style;
+        }
+    
+        function normalizeWidthHeightAttribute(attrs) {
+          const widthStr = attrs['width'];
+          const heightStr = attrs['height'];
+    
+          if (!widthStr || displayWidth === undefined) return;
+    
+          const widthValue = parseFloat(widthStr);
+          if (isNaN(widthValue) || widthValue <= displayWidth) return;
+    
+          delete attrs['width'];
+          delete attrs['height'];
+        }
+    
+        function normalizeImageSize(attrs) {
+          normalizeStyleAttribute(attrs);
+          normalizeWidthHeightAttribute(attrs);
+        }
+    
+        function applyImageNormalization() {
+          document.querySelectorAll('img').forEach(img => {
+            const attrs = {
+              style: img.getAttribute('style'),
+              width: img.getAttribute('width'),
+              height: img.getAttribute('height')
+            };
+    
+            normalizeImageSize(attrs);
+    
+            if (attrs.style != null) img.setAttribute('style', attrs.style);
+            if ('width' in attrs) img.setAttribute('width', attrs.width);
+            else img.removeAttribute('width');
+    
+            if ('height' in attrs) img.setAttribute('height', attrs.height);
+            else img.removeAttribute('height');
+          });
+        }
+        
+        function safeApplyImageNormalization() {
+          try {
+            applyImageNormalization();
+          } catch (e) {
+            console.error('Image normalization failed:', e);
+          }
+        }
+        
+        window.onload = safeApplyImageNormalization;
+      </script>
+    ''';
+  }
 }

--- a/core/lib/utils/platform_info.dart
+++ b/core/lib/utils/platform_info.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 abstract class PlatformInfo {
   @visibleForTesting
   static bool isTestingForWeb = false;
+  static bool isIntegrationTesting = false;
 
   static bool get isWeb => kIsWeb || isTestingForWeb;
   static bool get isLinux => !isWeb && defaultTargetPlatform == TargetPlatform.linux;

--- a/integration_test/scenarios/email_detailed/deformed_inlined_image_scenario.dart
+++ b/integration_test/scenarios/email_detailed/deformed_inlined_image_scenario.dart
@@ -1,0 +1,158 @@
+import 'package:core/presentation/views/html_viewer/html_content_viewer_widget.dart';
+import 'package:core/utils/app_logger.dart';
+import 'package:core/utils/platform_info.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/email/presentation/controller/single_email_controller.dart';
+import 'package:tmail_ui_user/features/email/presentation/email_view.dart';
+import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/thread_robot.dart';
+
+class DeformedInlinedImageScenario extends BaseTestScenario {
+  const DeformedInlinedImageScenario(super.$);
+
+  static const String subject = 'Deformed inlined image';
+  static const String content = '''
+    <img 
+      src="https://example.com/image.jpg"
+      alt="inline-image-no-style"/>
+    <br>
+    <img 
+      src="https://example.com/image.jpg"
+      style="width: 2000px; height: 200px;" 
+      alt="inline-image-oversize-with-style"/>
+    <br>
+    <img 
+      src="https://example.com/image.jpg"
+      width="2000" 
+      height="200"
+      alt="inline-image-oversize-with-width-attribute"/>
+    <br>
+    <img 
+      src="https://example.com/image.jpg"
+      style="width: 2000px; height: 200px;" 
+      width="2000"
+      height="200"
+      alt="inline-image-oversize-with-style-and-width-attribute"/>
+    <br>
+    <img 
+      src="https://example.com/image.jpg"
+      width="100" 
+      height="100"
+      alt="inline-image-normal-size-with-width-attribute"/>
+    <br>
+    <img 
+      src="https://example.com/image.jpg"
+      style="width: 100px; height: 100px;" 
+      width="100"
+      height="100"
+      alt="inline-image-normal-size-with-style-and-width-attribute"/>
+  ''';
+
+  @override
+  Future<void> runTestLogic() async {
+    PlatformInfo.isIntegrationTesting = true;
+
+    const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    final provisioningEmail = ProvisioningEmail(
+      toEmail: emailUser,
+      subject: subject,
+      content: content,
+    );
+
+    await provisionEmail([provisioningEmail], requestReadReceipt: false);
+    await $.pumpAndSettle(duration: const Duration(seconds: 3));
+    await _expectDisplayedEmailWithSubject();
+
+    final threadRobot = ThreadRobot($);
+    await threadRobot.openEmailWithSubject(subject);
+    await $.pumpAndSettle(duration: const Duration(seconds: 3));
+    await _expectEmailViewDisplaysNormalizedInlineImages();
+
+    PlatformInfo.isIntegrationTesting = false;
+  }
+
+  Future<void> _expectDisplayedEmailWithSubject() async {
+    await expectViewVisible(
+      $(EmailTileBuilder).which<EmailTileBuilder>(
+        (widget) => widget.presentationEmail.subject == subject
+      ),
+    );
+  }
+
+  Future<void> _expectEmailViewDisplaysNormalizedInlineImages() async {
+    HtmlContentViewer? htmlContentViewer;
+    await $(HtmlContentViewer)
+      .which<HtmlContentViewer>((view) {
+        htmlContentViewer = view;
+        return true;
+      })
+      .first
+      .tap();
+    expect(htmlContentViewer, isNotNull);
+    log('DeformedInlinedImageScenario::_expectEmailViewDisplaysNormalizedInlineImages:initialWidth = ${htmlContentViewer?.initialWidth}');
+    expect(htmlContentViewer?.contentHtml.isNotEmpty, isTrue);
+
+    SingleEmailController? emailController;
+    await $(EmailView)
+      .which<EmailView>((view) {
+        emailController = view.controller;
+        return true;
+      })
+      .first
+      .tap();
+    expect(emailController, isNotNull);
+
+    final webViewController = emailController
+      ?.htmlContentViewKey
+      ?.currentState
+      ?.webViewController;
+    expect(webViewController, isNotNull);
+
+    final result = await webViewController?.evaluateJavascript(
+      source: '''
+        (function() {
+          const images = document.querySelectorAll('img');
+          return Array.from(images).map(img => ({
+            src: img.getAttribute('src'),
+            width: img.getAttribute('width'),
+            height: img.getAttribute('height'),
+            style: img.getAttribute('style'),
+            alt: img.getAttribute('alt'),
+            outerHTML: img.outerHTML
+          }));
+        })();
+      '''
+    );
+
+    final imageList = List<Map<String, dynamic>>.from(result);
+
+    expect(imageList.length, 6);
+
+    for (var img in imageList) {
+      final imgWidth= img['width'];
+      final imgHeight = img['height'];
+      final imgStyle = img['style'];
+      final imgAlt = img['alt'];
+      final imgOuterHTML = img['outerHTML'];
+      log("DeformedInlinedImageScenario::_expectEmailViewDisplaysNormalizedInlineImages:Image $imgOuterHTML");
+
+      if (imgAlt == 'inline-image-normal-size-with-width-attribute') {
+        expect(imgStyle, isNull);
+        expect(imgWidth, equals('100'));
+        expect(imgHeight, equals('100'));
+      } else if (imgAlt == 'inline-image-normal-size-with-style-and-width-attribute') {
+        expect(imgStyle.contains('max-width: 100%;'), isFalse);
+        expect(imgStyle.contains('width: 100px; height: 100px;'), isTrue);
+        expect(imgWidth, equals('100'));
+        expect(imgHeight, equals('100'));
+      } else {
+        expect(imgStyle, equals('max-width: 100%;height: auto;display: inline;'));
+        expect(imgWidth, isNull);
+        expect(imgHeight, isNull);
+      }
+    }
+  }
+}

--- a/integration_test/scenarios/email_detailed/deformed_inlined_image_scenario.dart
+++ b/integration_test/scenarios/email_detailed/deformed_inlined_image_scenario.dart
@@ -21,7 +21,7 @@ class DeformedInlinedImageScenario extends BaseTestScenario {
     <br>
     <img 
       src="https://example.com/image.jpg"
-      style="width: 2000px; height: 200px;" 
+      style="width: 2000px;height: 200px;" 
       alt="inline-image-oversize-with-style"/>
     <br>
     <img 
@@ -32,7 +32,7 @@ class DeformedInlinedImageScenario extends BaseTestScenario {
     <br>
     <img 
       src="https://example.com/image.jpg"
-      style="width: 2000px; height: 200px;" 
+      style="width: 2000px;height: 200px;" 
       width="2000"
       height="200"
       alt="inline-image-oversize-with-style-and-width-attribute"/>
@@ -45,7 +45,7 @@ class DeformedInlinedImageScenario extends BaseTestScenario {
     <br>
     <img 
       src="https://example.com/image.jpg"
-      style="width: 100px; height: 100px;" 
+      style="width: 100px;height: 100px;" 
       width="100"
       height="100"
       alt="inline-image-normal-size-with-style-and-width-attribute"/>
@@ -105,13 +105,10 @@ class DeformedInlinedImageScenario extends BaseTestScenario {
       .tap();
     expect(emailController, isNotNull);
 
-    final webViewController = emailController
-      ?.htmlContentViewKey
-      ?.currentState
-      ?.webViewController;
-    expect(webViewController, isNotNull);
+    final htmlContentViewKey = emailController?.htmlContentViewKey;
+    expect(htmlContentViewKey, isNotNull);
 
-    final result = await webViewController?.evaluateJavascript(
+    final result = await htmlContentViewKey!.currentState!.webViewController.evaluateJavascript(
       source: '''
         (function() {
           const images = document.querySelectorAll('img');
@@ -144,8 +141,7 @@ class DeformedInlinedImageScenario extends BaseTestScenario {
         expect(imgWidth, equals('100'));
         expect(imgHeight, equals('100'));
       } else if (imgAlt == 'inline-image-normal-size-with-style-and-width-attribute') {
-        expect(imgStyle.contains('max-width: 100%;'), isFalse);
-        expect(imgStyle.contains('width: 100px; height: 100px;'), isTrue);
+        expect(imgStyle.contains('width: 100px;height: 100px;'), isTrue);
         expect(imgWidth, equals('100'));
         expect(imgHeight, equals('100'));
       } else {

--- a/integration_test/scenarios/email_detailed/deformed_inlined_image_scenario.dart
+++ b/integration_test/scenarios/email_detailed/deformed_inlined_image_scenario.dart
@@ -21,8 +21,18 @@ class DeformedInlinedImageScenario extends BaseTestScenario {
     <br>
     <img 
       src="https://example.com/image.jpg"
+      style="width: 2000px; height: 200px;" 
+      alt="inline-image-oversize-with-style-have-full-whitespaces"/>
+    <br>
+    <img 
+      src="https://example.com/image.jpg"
       style="width: 2000px;height: 200px;" 
-      alt="inline-image-oversize-with-style"/>
+      alt="inline-image-oversize-with-style-have-whitespaces"/>
+    <br>
+    <img 
+      src="https://example.com/image.jpg"
+      style="width:2000px;height:200px;" 
+      alt="inline-image-oversize-with-style-no-whitespaces"/>
     <br>
     <img 
       src="https://example.com/image.jpg"
@@ -32,10 +42,24 @@ class DeformedInlinedImageScenario extends BaseTestScenario {
     <br>
     <img 
       src="https://example.com/image.jpg"
+      style="width: 2000px; height: 200px;" 
+      width="2000"
+      height="200"
+      alt="inline-image-oversize-with-style-and-width-attribute-have-full-whitespaces"/>
+    <br>
+    <img 
+      src="https://example.com/image.jpg"
       style="width: 2000px;height: 200px;" 
       width="2000"
       height="200"
-      alt="inline-image-oversize-with-style-and-width-attribute"/>
+      alt="inline-image-oversize-with-style-and-width-attribute-have-whitespaces"/>
+    <br>
+    <img 
+      src="https://example.com/image.jpg"
+      style="width:2000px;height:200px;" 
+      width="2000"
+      height="200"
+      alt="inline-image-oversize-with-style-and-width-attribute-no-whitespaces"/>
     <br>
     <img 
       src="https://example.com/image.jpg"
@@ -45,10 +69,24 @@ class DeformedInlinedImageScenario extends BaseTestScenario {
     <br>
     <img 
       src="https://example.com/image.jpg"
+      style="width: 100px; height: 100px;" 
+      width="100"
+      height="100"
+      alt="inline-image-normal-size-with-style-and-width-attribute-have-full-whitespaces"/>
+    <br>
+    <img 
+      src="https://example.com/image.jpg"
       style="width: 100px;height: 100px;" 
       width="100"
       height="100"
-      alt="inline-image-normal-size-with-style-and-width-attribute"/>
+      alt="inline-image-normal-size-with-style-and-width-attribute-have-whitespaces"/>
+    <br>
+    <img 
+      src="https://example.com/image.jpg"
+      style="width:100px;height:100px;" 
+      width="100"
+      height="100"
+      alt="inline-image-normal-size-with-style-and-width-attribute-no-whitespaces"/>
   ''';
 
   @override
@@ -126,28 +164,33 @@ class DeformedInlinedImageScenario extends BaseTestScenario {
 
     final imageList = List<Map<String, dynamic>>.from(result);
 
-    expect(imageList.length, 6);
+    expect(imageList.length, 12);
 
     for (var img in imageList) {
       final imgWidth= img['width'];
       final imgHeight = img['height'];
       final imgStyle = img['style'];
-      final imgAlt = img['alt'];
+      final imgAlt = img['alt'] as String;
       final imgOuterHTML = img['outerHTML'];
       log("DeformedInlinedImageScenario::_expectEmailViewDisplaysNormalizedInlineImages:Image $imgOuterHTML");
+      expect(imgStyle.contains('max-width:100%'), isTrue);
+      expect(imgStyle.contains('display:inline'), isTrue);
+      expect(imgStyle.contains('height:'), isTrue);
 
-      if (imgAlt == 'inline-image-normal-size-with-width-attribute') {
-        expect(imgStyle, isNull);
-        expect(imgWidth, equals('100'));
-        expect(imgHeight, equals('100'));
-      } else if (imgAlt == 'inline-image-normal-size-with-style-and-width-attribute') {
-        expect(imgStyle.contains('width: 100px;height: 100px;'), isTrue);
-        expect(imgWidth, equals('100'));
-        expect(imgHeight, equals('100'));
-      } else {
-        expect(imgStyle, equals('max-width: 100%;height: auto;display: inline;'));
+      if (imgAlt.startsWith('inline-image-normal-size')) {
+        expect(imgWidth, isNotNull);
+        expect(imgHeight, isNotNull);
+      } else if (imgAlt.startsWith('inline-image-oversize')) {
         expect(imgWidth, isNull);
         expect(imgHeight, isNull);
+      }
+
+      if (imgAlt.startsWith('inline-image-normal-size-with-style-and-width-attribute')) {
+        expect(imgStyle.contains('width:'), isTrue);
+        expect(imgStyle.contains('100px'), isTrue);
+      } else if (imgAlt.startsWith('inline-image-oversize-with-style-and-width-attribute')) {
+        expect(imgStyle.contains('style="width:2000px'), isFalse);
+        expect(imgStyle.contains('style="width: 2000px'), isFalse);
       }
     }
   }

--- a/integration_test/tests/email_detailed/deformed_inlined_image_test.dart
+++ b/integration_test/tests/email_detailed/deformed_inlined_image_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/deformed_inlined_image_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see normalized inline image when open email with content contain inline image',
+    scenarioBuilder: ($) => DeformedInlinedImageScenario($),
+  );
+}

--- a/lib/features/composer/presentation/controller/rich_text_web_controller.dart
+++ b/lib/features/composer/presentation/controller/rich_text_web_controller.dart
@@ -284,7 +284,7 @@ class RichTextWebController extends BaseRichTextController {
       final base64Data = base64Encode(platformFile.bytes!);
       final mimeType = HtmlUtils.validateHtmlImageResourceMimeType('image/${platformFile.extension}');
       editorController.insertHtml(
-        '<img src="${HtmlUtils.convertBase64ToImageResourceData(base64Data: base64Data, mimeType: mimeType)}" data-filename="${platformFile.name}" alt="Image in my signature" style="max-width: ${maxWidth != null ? '${maxWidth}px' : '100%'};" data-mimetype="$mimeType"/>'
+        '<img src="${HtmlUtils.convertBase64ToImageResourceData(base64Data: base64Data, mimeType: mimeType)}" data-filename="${platformFile.name}" alt="Image in my signature" style="max-width:${maxWidth != null ? '${maxWidth}px' : '100%'};" data-mimetype="$mimeType"/>'
       );
     } else {
       logError("RichTextWebController::insertImageAsBase64: bytes is null");

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -195,8 +195,8 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
   final currentEmailLoaded = Rxn<EmailLoaded>();
   final isEmailContentClipped = RxBool(false);
   final attendanceStatus = Rxn<AttendanceStatus>();
+  final htmlContentViewKey = GlobalKey<HtmlContentViewState>();
 
-  GlobalKey<HtmlContentViewState>? htmlContentViewKey;
   EmailId? _currentEmailId;
   Identity? _identitySelected;
   ButtonState? _printEmailButtonState;
@@ -244,9 +244,6 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
   void onInit() {
     _registerObxStreamListener();
     _listenDownloadAttachmentProgressState();
-    if (PlatformInfo.isIntegrationTesting) {
-      htmlContentViewKey = GlobalKey<HtmlContentViewState>();
-    }
     super.onInit();
   }
 
@@ -254,9 +251,6 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
   void onClose() {
     _downloadProgressStateController.close();
     _attachmentListScrollController.dispose();
-    if (PlatformInfo.isIntegrationTesting) {
-      htmlContentViewKey = null;
-    }
     super.onClose();
   }
 

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -196,6 +196,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
   final isEmailContentClipped = RxBool(false);
   final attendanceStatus = Rxn<AttendanceStatus>();
 
+  GlobalKey<HtmlContentViewState>? htmlContentViewKey;
   EmailId? _currentEmailId;
   Identity? _identitySelected;
   ButtonState? _printEmailButtonState;
@@ -243,6 +244,9 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
   void onInit() {
     _registerObxStreamListener();
     _listenDownloadAttachmentProgressState();
+    if (PlatformInfo.isIntegrationTesting) {
+      htmlContentViewKey = GlobalKey<HtmlContentViewState>();
+    }
     super.onInit();
   }
 
@@ -250,6 +254,9 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
   void onClose() {
     _downloadProgressStateController.close();
     _attachmentListScrollController.dispose();
+    if (PlatformInfo.isIntegrationTesting) {
+      htmlContentViewKey = null;
+    }
     super.onClose();
   }
 

--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -447,7 +447,9 @@ class EmailView extends GetWidget<SingleEmailController> {
                           ),
                           child: LayoutBuilder(builder: (context, constraints) {
                             return HtmlContentViewer(
-                              key: controller.htmlContentViewKey,
+                              key: PlatformInfo.isIntegrationTesting
+                                ? controller.htmlContentViewKey
+                                : null,
                               contentHtml: allEmailContents,
                               initialWidth: constraints.maxWidth,
                               direction: AppUtils.getCurrentDirection(context),
@@ -487,7 +489,9 @@ class EmailView extends GetWidget<SingleEmailController> {
                   ),
                   child: LayoutBuilder(builder: (context, constraints) {
                     return HtmlContentViewer(
-                      key: controller.htmlContentViewKey,
+                      key: PlatformInfo.isIntegrationTesting
+                        ? controller.htmlContentViewKey
+                        : null,
                       contentHtml: allEmailContents,
                       initialWidth: constraints.maxWidth,
                       direction: AppUtils.getCurrentDirection(context),

--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -447,6 +447,7 @@ class EmailView extends GetWidget<SingleEmailController> {
                           ),
                           child: LayoutBuilder(builder: (context, constraints) {
                             return HtmlContentViewer(
+                              key: controller.htmlContentViewKey,
                               contentHtml: allEmailContents,
                               initialWidth: constraints.maxWidth,
                               direction: AppUtils.getCurrentDirection(context),
@@ -486,6 +487,7 @@ class EmailView extends GetWidget<SingleEmailController> {
                   ),
                   child: LayoutBuilder(builder: (context, constraints) {
                     return HtmlContentViewer(
+                      key: controller.htmlContentViewKey,
                       contentHtml: allEmailContents,
                       initialWidth: constraints.maxWidth,
                       direction: AppUtils.getCurrentDirection(context),

--- a/lib/features/public_asset/presentation/public_asset_controller.dart
+++ b/lib/features/public_asset/presentation/public_asset_controller.dart
@@ -186,7 +186,7 @@ class PublicAssetController extends BaseController {
     newlyPickedPublicAssetIds.add(publicAsset.id!);
     final imageTag = '<img '
       'src="${publicAsset.publicURI!}" '
-      'style="max-width: 100%;" '
+      'style="max-width:100%;" '
       'public-asset-id="${publicAsset.id!.value}">';
     if (PlatformInfo.isWeb) {
       Get


### PR DESCRIPTION
## Issue

#3622

## Root cause

Some `img` elements have a width attribute that is larger than the current display width. In the previous handling flow, we always added the `max-width=100%` property to the style to ensure that the image fits the display width. However, this caused the images to become deformed.

## Solution 

Normalize the images each time email content is loaded for display by checking their dimensions. If an image's width exceeds the allowed display width, we remove its default width and height attributes; otherwise, we leave them unchanged.

## Resolved

- Web:



https://github.com/user-attachments/assets/0917e9ab-1059-44bd-b6d2-d690c9838ee9


- Mobile:

[demo.webm](https://github.com/user-attachments/assets/70e38463-b37a-44ca-a9b1-8b54737834ef)

- Integration test:


[Screen_recording_20250411_140028.webm](https://github.com/user-attachments/assets/ffa624d6-e2d7-416b-854c-5ecf525021bd)

- E22 on CI


![Screenshot 2025-04-14 at 10 56 38](https://github.com/user-attachments/assets/a2579bc4-af6f-43fe-bc27-af8792580db2)


