### PR TITLE
TF-3623 Fix `Cancel`, `Create`, `Save as default` are displayed 2 times in the dialog `Create new identity`

### DIFF
--- a/lib/features/identity_creator/presentation/identity_creator_controller.dart
+++ b/lib/features/identity_creator/presentation/identity_creator_controller.dart
@@ -833,9 +833,14 @@ class IdentityCreatorController extends BaseController with DragDropFileMixin im
     return compressedFilePath;
   }
 
-  bool isMobile(BuildContext context) =>
-    responsiveUtils.isPortraitMobile(context) ||
-    responsiveUtils.isLandscapeMobile(context);
+  bool isMobile(BuildContext context) {
+    if (PlatformInfo.isMobile) {
+      return responsiveUtils.isPortraitMobile(context) ||
+          responsiveUtils.isLandscapeMobile(context);
+    } else {
+      return responsiveUtils.isMobile(context);
+    }
+  }
 
   double _getMaxWidthInlineImage(BuildContext context) {
     if (isMobile(context)) {


### PR DESCRIPTION
## Issue

#3623 

## Root cause

The `controller.isMobile(context)` check fails to correctly identify mobile layout when the screen height is less than its width, causing the bottom actions to not display as expected.

## Solution 

Ensure the platform is correctly detected to render the appropriate layout or UI elements

## Resolved


https://github.com/user-attachments/assets/44cc807c-9d80-447f-a3e3-76408e56d288


