### PR TITLE
TF-3614 E2E mailbox search, quota & team mailbox

### DIFF
--- a/integration_test/integration_test/exceptions/mailbox/null_quota_exception.dart
+++ b/integration_test/integration_test/exceptions/mailbox/null_quota_exception.dart
@@ -1,0 +1,1 @@
+class NullQuotaException implements Exception {}

--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -6,12 +6,15 @@ import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/label_mailbox_item_widget.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/mailbox_item_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/presentation/mailbox_creator_view.dart';
+import 'package:tmail_ui_user/features/quotas/presentation/quotas_controller.dart';
 import 'package:tmail_ui_user/features/search/mailbox/presentation/search_mailbox_view.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
 import '../base/core_robot.dart';
 import '../exceptions/mailbox/null_inbox_unread_count_exception.dart';
+import '../integration_test/exceptions/mailbox/null_quota_exception.dart';
 
 class MailboxMenuRobot extends CoreRobot {
   MailboxMenuRobot(super.$);
@@ -108,5 +111,18 @@ class MailboxMenuRobot extends CoreRobot {
 
   Future<void> confirmSignOut() async {
     await $(AppLocalizations().yesLogout).tap();
+  }
+
+  int getUsedQuota() {
+    final usedQuota =
+        getBinding<QuotasController>()?.octetsQuota.value?.used?.value.toInt();
+    if (usedQuota == null) throw NullQuotaException();
+
+    return usedQuota;
+  }
+
+  Future<void> refreshQuota() async {
+    getBinding<QuotasController>()?.reloadQuota();
+    await $.pumpAndSettle(duration: const Duration(seconds: 2));
   }
 }

--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -21,10 +21,9 @@ class MailboxMenuRobot extends CoreRobot {
   }
 
   Future<void> openFolderByName(String name) async {
-    await $(MailboxItemWidget)
-      .$(LabelMailboxItemWidget)
-      .$(find.text(name))
-      .tap();
+    final mailboxItem = $(MailboxItemWidget).$(LabelMailboxItemWidget).$(name);
+    await $.scrollUntilVisible(finder: mailboxItem);
+    await mailboxItem.tap();
   }
 
   Future<void> openSetting() async {

--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -1,4 +1,3 @@
-
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/presentation/views/text/text_field_builder.dart';
@@ -7,6 +6,7 @@ import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/label_mailbox_item_widget.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/mailbox_item_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/presentation/mailbox_creator_view.dart';
+import 'package:tmail_ui_user/features/search/mailbox/presentation/search_mailbox_view.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 
@@ -63,6 +63,19 @@ class MailboxMenuRobot extends CoreRobot {
         return widget.icon == ImagePaths().icArrowRight;
       })
       .tap();
+  }
+
+  Future<void> openMailboxSearch() async {
+    await $(TMailButtonWidget)
+      .which<TMailButtonWidget>((widget) {
+        return widget.icon == ImagePaths().icSearchBar;
+      })
+      .tap();
+  }
+
+  Future<void> searchMailbox(String query) async {
+    await $(SearchMailboxView).$(TextFieldBuilder).enterText(query);
+    await $.pumpAndSettle();
   }
 
   Future<void> tapHideMailbox() async {

--- a/integration_test/scenarios/mailbox/quota_count_scenario.dart
+++ b/integration_test/scenarios/mailbox/quota_count_scenario.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class QuotaCountScenario extends BaseTestScenario {
+  const QuotaCountScenario(super.$);
+  
+  @override
+  Future<void> runTestLogic() async {
+    const email = String.fromEnvironment('BASIC_AUTH_EMAIL');
+
+    final threadRobot = ThreadRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+
+    await threadRobot.openMailbox();
+    final beforeUsedQuota = mailboxMenuRobot.getUsedQuota();
+
+    final file = await preparingTxtFile('some content');
+    await provisionEmail([ProvisioningEmail(
+      toEmail: email,
+      subject: 'test increase quota',
+      content: '',
+      attachmentPaths: [file.path],
+    )]);
+    await mailboxMenuRobot.refreshQuota();
+    final afterUsedQuota = mailboxMenuRobot.getUsedQuota();
+
+    _expectQuotaIncreased(beforeUsedQuota, afterUsedQuota);
+  }
+
+  void _expectQuotaIncreased(int before, int after) {
+    expect(after, greaterThan(before));
+  }
+}

--- a/integration_test/scenarios/mailbox/search_mailbox_inbox_scenario.dart
+++ b/integration_test/scenarios/mailbox/search_mailbox_inbox_scenario.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/mailbox_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class SearchMailboxInboxScenario extends BaseTestScenario {
+  const SearchMailboxInboxScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    final threadRobot = ThreadRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await threadRobot.openMailbox();
+    await _expectMailboxViewVisible();
+
+    await _expectMailboxWithNameVisible(appLocalizations.inboxMailboxDisplayName);
+    await mailboxMenuRobot.openMailboxSearch();
+    await mailboxMenuRobot.searchMailbox(appLocalizations.inboxMailboxDisplayName);
+    await _expectMailboxWithNameVisible(appLocalizations.inboxMailboxDisplayName);
+  }
+
+  Future<void> _expectMailboxViewVisible() async {
+    await expectViewVisible($(MailboxView));
+  }
+
+  Future<void> _expectMailboxWithNameVisible(String name) async {
+    await expectViewVisible($(name));
+  }
+} 

--- a/integration_test/scenarios/mailbox/team_mailbox_receive_email_scenario.dart
+++ b/integration_test/scenarios/mailbox/team_mailbox_receive_email_scenario.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/email/prefix_email_address.dart';
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/mailbox_view.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../robots/composer_robot.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class TeamMailboxReceiveEmailScenario extends BaseTestScenario {
+  const TeamMailboxReceiveEmailScenario(super.$);
+  
+  @override
+  Future<void> runTestLogic() async {
+    const teamMailboxName = 'bob-guests';
+    const teamMailboxEmail = '$teamMailboxName@example.com';
+    const subject = 'email to team mailbox';
+
+    final threadRobot = ThreadRobot($);
+    final composerRobot = ComposerRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+    final imagePaths = ImagePaths();
+    final appLocalizations = AppLocalizations();
+
+    await threadRobot.openMailbox();
+    await _expectMailboxViewVisible();
+    await _expectTeamMailboxVisible(teamMailboxName);
+
+    await mailboxMenuRobot.closeMenu();
+    await threadRobot.openComposer();
+    await _expectComposerViewVisible();
+    await composerRobot.grantContactPermission();
+    await composerRobot.addRecipientIntoField(
+      prefixEmailAddress: PrefixEmailAddress.to,
+      email: teamMailboxEmail,
+    );
+    await composerRobot.addSubject(subject);
+    await composerRobot.sendEmail(imagePaths);
+    await _expectSendEmailSuccessToast(appLocalizations);
+    await $.pump(const Duration(seconds: 2));
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.expandMailboxWithName(teamMailboxName);
+    await mailboxMenuRobot.openFolderByName(appLocalizations.inboxMailboxDisplayName.toUpperCase());
+    await _expectEmailWithSubjectVisible(subject);
+  }
+
+  Future<void> _expectMailboxViewVisible() async {
+    await expectViewVisible($(MailboxView));
+  }
+
+  Future<void> _expectTeamMailboxVisible(String name) async {
+    await $.scrollUntilVisible(finder: $(name));
+    await expectViewVisible($(name));
+  }
+
+  Future<void> _expectComposerViewVisible() async {
+    await expectViewVisible($(ComposerView));
+  }
+
+  Future<void> _expectSendEmailSuccessToast(AppLocalizations appLocalizations) async {
+    await expectViewVisible(
+      $(find.text(appLocalizations.message_has_been_sent_successfully)),
+    );
+  }
+
+  Future<void> _expectEmailWithSubjectVisible(String subject) async {
+    await expectViewVisible($(subject));
+  }
+}

--- a/integration_test/tests/mailbox/quota_count_test.dart
+++ b/integration_test/tests/mailbox/quota_count_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/mailbox/quota_count_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see quota increase when send email successfully',
+    scenarioBuilder: ($) => QuotaCountScenario($),
+  );
+}

--- a/integration_test/tests/mailbox/search_mailbox_inbox_test.dart
+++ b/integration_test/tests/mailbox/search_mailbox_inbox_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/mailbox/search_mailbox_inbox_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see expected mailbox when searching mailboxes',
+    scenarioBuilder: ($) => SearchMailboxInboxScenario($),
+  );
+} 

--- a/integration_test/tests/mailbox/team_mailbox_receive_email_test.dart
+++ b/integration_test/tests/mailbox/team_mailbox_receive_email_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/mailbox/team_mailbox_receive_email_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see email in team mailbox INBOX after sending to team mailbox address',
+    scenarioBuilder: ($) => TeamMailboxReceiveEmailScenario($),
+  );
+} 

--- a/provisioning/integration_test/provisioning.sh
+++ b/provisioning/integration_test/provisioning.sh
@@ -85,3 +85,8 @@ for eml in "${replyEmailsEML[@]}"; do
   echo "Importing $eml into 'Reply Emails' folder for user bob"
   james-cli ImportEml \#private "bob@example.com" "Reply Emails" "/root/conf/integration_test/eml/reply_email/$eml"
 done
+
+# For test team mailbox
+curl -XPUT http://172.18.0.2:8000/domains/example.com/team-mailboxes/bob-guests
+curl -XPUT http://172.18.0.2:8000/domains/example.com/team-mailboxes/bob-guests/members/bob@example.com?role=member
+curl -XPUT http://172.18.0.2:8000/domains/example.com/team-mailboxes/bob-guests/members/alice@example.com?role=member

--- a/provisioning/integration_test/provisioning.sh
+++ b/provisioning/integration_test/provisioning.sh
@@ -90,3 +90,6 @@ done
 curl -XPUT http://172.18.0.2:8000/domains/example.com/team-mailboxes/bob-guests
 curl -XPUT http://172.18.0.2:8000/domains/example.com/team-mailboxes/bob-guests/members/bob@example.com?role=member
 curl -XPUT http://172.18.0.2:8000/domains/example.com/team-mailboxes/bob-guests/members/alice@example.com?role=member
+
+# For test quota
+curl -X PUT http://172.18.0.2:8000/quota/users/bob@example.com -d '{"count":200,"size":50000000}' -H "Content-Type: application/json" # 200 emails, 50MB


### PR DESCRIPTION
## Issue
- #3614

## Test result
```console
✅ Should see quota increase when send email successfully (integration_test/tests/mailbox/quota_count_test.dart) (16s)
✅ Should see expected mailbox when searching mailboxes (integration_test/tests/mailbox/search_mailbox_inbox_test.dart) (15s)
✅ Should see email in team mailbox INBOX after sending to team mailbox address (integration_test/tests/mailbox/team_mailbox_receive_email_test.dart) (22s)

Test summary:
📝 Total: 3
✅ Successful: 3
❌ Failed: 0
⏩ Skipped: 0
📊 Report: .../tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 80s
```
## Test video

[search-quota-team-mailbox.webm](https://github.com/user-attachments/assets/edaf47f2-410b-432a-8544-06edbb44fe9b)
