### PR TITLE
[HOT-FIX] Fix missing email subject prefix (`Re:`, `Fwd:`) when `reply` or `forward` email

### DIFF
--- a/integration_test/scenarios/send_email_with_mark_as_important_scenario.dart
+++ b/integration_test/scenarios/send_email_with_mark_as_important_scenario.dart
@@ -43,7 +43,6 @@ class SendEmailWithMarkAsImportantScenario extends BaseTestScenario {
     await _expectToastDisplayWithMessageMarkAsImportantIsEnabled(appLocalizations);
 
     await composerRobot.sendEmail(imagePaths);
-    await _expectSendEmailSuccessToast(appLocalizations);
     await $.pump(const Duration(seconds: 2));
 
     await _expectDisplayedEmailHasImportantFlagIcon();
@@ -60,14 +59,6 @@ class SendEmailWithMarkAsImportantScenario extends BaseTestScenario {
   ) async {
     await expectViewVisible(
       $(find.text(appLocalizations.markAsImportantIsEnabled)),
-    );
-  }
-
-  Future<void> _expectSendEmailSuccessToast(
-    AppLocalizations appLocalizations,
-  ) async {
-    await expectViewVisible(
-      $(find.text(appLocalizations.message_has_been_sent_successfully)),
     );
   }
 

--- a/lib/features/composer/presentation/extensions/email_action_type_extension.dart
+++ b/lib/features/composer/presentation/extensions/email_action_type_extension.dart
@@ -19,7 +19,7 @@ extension EmailActionTypeExtension on EmailActionType {
         } else {
           return context != null
             ? '${AppLocalizations.of(context).prefix_reply_email} $subject'
-            : subject;
+            : 'Re: $subject';
         }
       case EmailActionType.forward:
         if (subject.toLowerCase().startsWith('fwd:')) {
@@ -27,7 +27,7 @@ extension EmailActionTypeExtension on EmailActionType {
         } else {
           return context != null
             ? '${AppLocalizations.of(context).prefix_forward_email} $subject'
-            : subject;
+            : 'Fwd: $subject';
         }
       case EmailActionType.editDraft:
       case EmailActionType.editSendingEmail:

--- a/lib/features/composer/presentation/extensions/setup_email_subject_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_subject_extension.dart
@@ -37,8 +37,8 @@ extension SetupEmailSubjectExtension on ComposerController {
     );
 
     if (newSubject.isNotEmpty) {
-      setSubjectEmail(subject);
-      subjectEmailInputController.text = subject;
+      setSubjectEmail(newSubject);
+      subjectEmailInputController.text = newSubject;
     }
   }
 }


### PR DESCRIPTION
## Issue

```
When I reply an email
Then I don't see prefix `Re:` in subject field
```

2. Integration test failed


![Screenshot 2025-04-08 at 16 20 50](https://github.com/user-attachments/assets/3fd05808-f192-4ec8-a506-287ef7b4526f)


![Screenshot 2025-04-08 at 16 19 32](https://github.com/user-attachments/assets/c3e7ef7b-ebd8-4797-8a19-18b261a2b7fe)


![Screenshot 2025-04-08 at 16 27 31](https://github.com/user-attachments/assets/aa1e5810-c6b2-441e-8617-1ffcf7985987)

## Resolved


https://github.com/user-attachments/assets/54077ce7-deb9-49a7-bef4-f628c4a65f8c


![Screenshot 2025-04-09 at 11 31 21](https://github.com/user-attachments/assets/353fb854-78be-4c37-b6ef-8843a8b4cf41)

