### PR TITLE
TF-3631 E2E log out

### DIFF
--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -88,4 +88,13 @@ class MailboxMenuRobot extends CoreRobot {
 
     return inboxCount;
   }
+
+  Future<void> tapSignOut() async {
+    await $.scrollUntilVisible(finder: $(AppLocalizations().sign_out));
+    await $(AppLocalizations().sign_out).tap();
+  }
+
+  Future<void> confirmSignOut() async {
+    await $(AppLocalizations().yesLogout).tap();
+  }
 }

--- a/integration_test/scenarios/misc/log_out_scenario.dart
+++ b/integration_test/scenarios/misc/log_out_scenario.dart
@@ -1,0 +1,26 @@
+import 'package:tmail_ui_user/features/starting_page/presentation/twake_welcome/twake_welcome_view.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class LogOutScenario extends BaseTestScenario {
+  const LogOutScenario(super.$);
+  
+  @override
+  Future<void> runTestLogic() async {
+    final threadRobot = ThreadRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openSetting();
+    await mailboxMenuRobot.tapSignOut();
+    await mailboxMenuRobot.confirmSignOut();
+
+    await _expectTwakeWelcomeViewVisible();
+  }
+  
+  Future<void> _expectTwakeWelcomeViewVisible() async {
+    await expectViewVisible($(TwakeWelcomeView));
+  }
+}

--- a/integration_test/tests/misc/log_out_test.dart
+++ b/integration_test/tests/misc/log_out_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/misc/log_out_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see Twake welcome screen when log out successfully',
+    scenarioBuilder: ($) => LogOutScenario($),
+  );
+}

--- a/lib/features/composer/presentation/controller/rich_text_web_controller.dart
+++ b/lib/features/composer/presentation/controller/rich_text_web_controller.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/html/html_utils.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:custom_pop_up_menu/custom_pop_up_menu.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
@@ -318,7 +319,9 @@ class RichTextWebController extends GetxController {
   void onClose() {
     menuParagraphController.dispose();
     menuOrderListController.dispose();
-    editorController.clear();
+    if (PlatformInfo.isWeb || editorController.editorController != null) {
+      editorController.clear();
+    }
     super.onClose();
   }
 }


### PR DESCRIPTION
## Issue
- #3631 

## Test result
```console
✅ Should see Twake welcome screen when log out successfully (integration_test/tests/misc/log_out_test.dart) (15s)

Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: .../tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 32s
```
## Test video

[log-out.webm](https://github.com/user-attachments/assets/8407f16d-d171-4f7d-9a2a-31d273631939)
