### PR TITLE
TF-3647 Disable email view zoom

### DIFF
--- a/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
+++ b/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
@@ -77,6 +77,7 @@ class _HtmlContentViewState extends State<HtmlContentViewer> {
   final _webViewSetting = InAppWebViewSettings(
     transparentBackground: true,
     verticalScrollBarEnabled: false,
+    supportZoom: false,
   );
 
   @override


### PR DESCRIPTION
## Issue
- #3647 

## Reason
- Flutter zoom on web view is buggy (https://github.com/pichillilorenzo/flutter_inappwebview/issues/2458, https://github.com/flutter/flutter/issues/138815)
- Even when zoomed, user cannot pan to view the content that is outside the view, as swipe action is reserved to change email.
