### PR TITLE
Fix default browser warning dialog is auto shown when get 401 error

### DIFF
--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -191,6 +191,7 @@ abstract class BaseController extends GetxController
   }
 
   Future<void> _executeBeforeReconnectAndLogOut() async {
+    twakeAppManager.setExecutingBeforeReconnect(true);
     await executeBeforeReconnect();
     clearDataAndGoToLoginPage();
   }

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -330,6 +330,7 @@ class MailboxDashBoardController extends ReloadableController
   void onReady() {
     if (PlatformInfo.isWeb) {
       listSearchFilterScrollController = ScrollController();
+      twakeAppManager.setExecutingBeforeReconnect(false);
     }
     if (PlatformInfo.isIOS) {
       _registerPendingCurrentEmailIdInNotification();
@@ -497,7 +498,10 @@ class MailboxDashBoardController extends ReloadableController
 
   @override
   Future<void> onBeforeUnloadBrowserListener(html.Event event) async {
-    if (event is html.BeforeUnloadEvent && twakeAppManager.hasComposer) {
+    log('MailboxDashBoardController::onBeforeUnloadBrowserListener:event = ${event.runtimeType} | hasComposer = ${twakeAppManager.hasComposer} | isExecutingBeforeReconnect = ${twakeAppManager.isExecutingBeforeReconnect}');
+    if (event is html.BeforeUnloadEvent &&
+        twakeAppManager.hasComposer &&
+        !twakeAppManager.isExecutingBeforeReconnect) {
       event.preventDefault();
     }
   }

--- a/lib/main/utils/twake_app_manager.dart
+++ b/lib/main/utils/twake_app_manager.dart
@@ -1,8 +1,13 @@
 
 class TwakeAppManager {
   bool _hasComposer = false;
+  bool _isExecutingBeforeReconnect = false;
 
   void setHasComposer(bool value) => _hasComposer = value;
 
   bool get hasComposer => _hasComposer;
+
+  void setExecutingBeforeReconnect(bool value) => _isExecutingBeforeReconnect = value;
+
+  bool get isExecutingBeforeReconnect => _isExecutingBeforeReconnect;
 }


### PR DESCRIPTION
## Issue


https://github.com/user-attachments/assets/acba6b99-9b64-4d38-b566-0f8f5c9d8c13

## Root cause

In Flutter web, `html.window.onBeforeUnload` is triggered right before the user leaves the page, such as when:

- Closing the tab or browser.

- Refreshing the page.

- Navigating to a different URL.

So when we receive error 401, we return to the logic screen, at this time the navigation router will change.

## Solution

Use a variable to check `_isExecutingBeforeReconnect`, when is the system's automatic reconnect action and when is the user's page reload action.

## Resolved


https://github.com/user-attachments/assets/2adb9f4b-39b3-4e73-acb3-966edb03581b

