### PR TITLE
TF-3659 Fix cannot remove forwards

### DIFF
--- a/lib/features/base/mixin/message_dialog_action_mixin.dart
+++ b/lib/features/base/mixin/message_dialog_action_mixin.dart
@@ -206,9 +206,8 @@ mixin MessageDialogActionMixin {
             onCancelButtonAction: () {
               if (autoPerformPopBack) {
                 popBack();
-              } else {
-                onCancelAction?.call();
               }
+              onCancelAction?.call();
             },
             onCloseButtonAction: onCloseButtonAction ?? popBack,
           ),


### PR DESCRIPTION
## Issue

#3659

## Reproduced

https://github.com/user-attachments/assets/df692935-a9e5-4549-8deb-4ebd99cb62a3

## Root cause

- Side effects from commit: https://github.com/linagora/tmail-flutter/pull/3414/commits/fec267dcbf8982c4ea98b2e24a524da7a14ed3d9#diff-962af98b988bd676daa119520af50b0646b0db6457032ba108275c00fad16838L222-R204

<img width="1064" alt="Image" src="https://github.com/user-attachments/assets/5ab28fd9-4729-41fe-9390-fd7a0215b8e6" />


- It only happens for the `showConfirmDialogAction` function of `MessageDialogActionMixin` when the conditions are satisfied:
```
+ showAsBottomSheet = true
+ alignCenter = false
+ hasCancelButton = true
+ autoPerformPopBack = true
+ responsiveUtils.isMobile(context) = false
+ action is negative button
```

So only the `remove forwards` action is affected.

## Resolved

https://github.com/user-attachments/assets/1855fb19-a081-4668-88be-879d8ee4a889 