### PR TITLE
TF-3665 Fix autocomplete position

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2026,11 +2026,10 @@ packages:
   super_tag_editor:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "bugfix/suggestion-list-shown-on-top"
-      resolved-ref: "44a5ba35951915b3e2aec0e64a61eb1a1dd9eb93"
-      url: "https://github.com/dab246/super_tag_editor.git"
-    source: git
+      name: super_tag_editor
+      sha256: "291b4b5ef5c44d1d06dc0337f66b71f7afd77b8c98d0ad0f4f8baca6a6f3cbc4"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.3.2"
   syncfusion_flutter_core:
     dependency: transitive

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2026,11 +2026,12 @@ packages:
   super_tag_editor:
     dependency: "direct main"
     description:
-      name: super_tag_editor
-      sha256: d49a4100253de1d46d2c9b20cd7f215129f105028f6ad8a7fba388a4e3b4df9d
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.1"
+      path: "."
+      ref: "bugfix/suggestion-list-shown-on-top"
+      resolved-ref: "44a5ba35951915b3e2aec0e64a61eb1a1dd9eb93"
+      url: "https://github.com/dab246/super_tag_editor.git"
+    source: git
+    version: "0.3.2"
   syncfusion_flutter_core:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -107,7 +107,10 @@ dependencies:
       ref: master
 
   ### Dependencies from pub.dev ###
-  super_tag_editor: 0.3.1
+  super_tag_editor:
+    git:
+      url: https://github.com/dab246/super_tag_editor.git
+      ref: bugfix/suggestion-list-shown-on-top
 
   cupertino_icons: 1.0.6
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -107,10 +107,7 @@ dependencies:
       ref: master
 
   ### Dependencies from pub.dev ###
-  super_tag_editor:
-    git:
-      url: https://github.com/dab246/super_tag_editor.git
-      ref: bugfix/suggestion-list-shown-on-top
+  super_tag_editor: 0.3.2
 
   cupertino_icons: 1.0.6
 


### PR DESCRIPTION
## Issue

#3665 

## Reproduced


https://github.com/user-attachments/assets/60a5a147-5b65-438d-ace0-a9d410c0e256


## Dependency

Need merged: https://github.com/dab246/super_tag_editor/pull/50

## Root cause

Due to incorrect suggestion display logic, previously we displayed the suggestion position based on the size of the empty space above and below the input field. If `TopSpaces > BottomSpaces` then display above and vice versa.

## Solution 

Based on the height of the suggestion list to display the position

## Resolved



https://github.com/user-attachments/assets/c5e849ff-84a1-4be2-8aac-b79503a2c58a

