### PR TITLE
Fix cannot preview image with file name containing image extension (`jpg`,..) and mime type is `application/octet-stream`

### DIFF
--- a/core/lib/domain/preview/supported_preview_file_types.dart
+++ b/core/lib/domain/preview/supported_preview_file_types.dart
@@ -4,7 +4,13 @@ class SupportedPreviewFileTypes {
     'image/jpeg',
     'image/gif',
     'image/webp',
-    'image/png',];
+    'image/png',
+    'image/svg+xml',
+    'image/x-icon',
+    'image/tiff',
+    'image/heif',
+    'image/avif'
+  ];
 
   static const textMimeTypes = [
     'text/plain',

--- a/core/lib/presentation/extensions/media_type_extension.dart
+++ b/core/lib/presentation/extensions/media_type_extension.dart
@@ -1,6 +1,7 @@
 import 'package:core/data/constants/constant.dart';
 import 'package:core/domain/preview/document_uti.dart';
 import 'package:core/domain/preview/supported_preview_file_types.dart';
+import 'package:core/presentation/extensions/string_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:http_parser/http_parser.dart';
 
@@ -38,7 +39,7 @@ extension MediaTypeExtension on MediaType {
       return imagePaths.icFilePptx;
     } else if (isZipFile()) {
       return imagePaths.icFileZip;
-    } else if (isImageFile()) {
+    } else if (isImageSupportedPreview(fileName: fileName)) {
       return imagePaths.icFilePng;
     } else {
       return imagePaths.icFileEPup;
@@ -56,4 +57,11 @@ extension MediaTypeExtension on MediaType {
       mimeType == Constant.textHtmlMimeType ||
       (mimeType == Constant.octetStreamMimeType &&
           fileName?.endsWith(Constant.htmlExtension) == true);
+
+  bool isImageSupportedPreview({required String? fileName}) =>
+      isImageFile() ||
+      (mimeType == Constant.octetStreamMimeType &&
+          fileName != null &&
+          SupportedPreviewFileTypes.imageMimeTypes
+              .contains(fileName.imageMimeType));
 }

--- a/core/lib/presentation/extensions/string_extension.dart
+++ b/core/lib/presentation/extensions/string_extension.dart
@@ -40,4 +40,42 @@ extension StringExtension on String {
   }
 
   String get firstCharacterToUpperCase => isNotEmpty ? this[0].toUpperCase() : '';
+
+  String get fileExtension {
+    int dotIndex = lastIndexOf('.');
+    if (dotIndex == -1 || dotIndex == length - 1) {
+      return '';
+    }
+    return substring(dotIndex + 1);
+  }
+
+  String get imageMimeType {
+    switch (fileExtension.toLowerCase()) {
+      case 'jpg':
+      case 'jpeg':
+        return 'image/jpeg';
+      case 'png':
+        return 'image/png';
+      case 'gif':
+        return 'image/gif';
+      case 'webp':
+        return 'image/webp';
+      case 'svg':
+        return 'image/svg+xml';
+      case 'bmp':
+        return 'image/bmp';
+      case 'ico':
+        return 'image/x-icon';
+      case 'tif':
+      case 'tiff':
+        return 'image/tiff';
+      case 'heic':
+      case 'heif':
+        return 'image/heif';
+      case 'avif':
+        return 'image/avif';
+      default:
+        return 'application/octet-stream'; // Unknown type
+    }
+  }
 }

--- a/core/test/presentation/extensions/string_extension_test.dart
+++ b/core/test/presentation/extensions/string_extension_test.dart
@@ -58,4 +58,38 @@ void main() {
       expect(name.firstLetterToUpperCase, equals(''));
     });
   });
+
+  group('fileExtension', () {
+    test('should return empty string when no dot in path', () {
+      expect('filename'.fileExtension, equals(''));
+    });
+
+    test('should return empty string when dot is last character', () {
+      expect('filename.'.fileExtension, equals(''));
+    });
+
+    test('should return extension for simple filename', () {
+      expect('filename.txt'.fileExtension, equals('txt'));
+    });
+
+    test('should return extension for filename with multiple dots', () {
+      expect('file.name.with.dots.pdf'.fileExtension, equals('pdf'));
+    });
+
+    test('should return extension for path with directories', () {
+      expect('/path/to/file/image.png'.fileExtension, equals('png'));
+    });
+
+    test('should handle empty string', () {
+      expect(''.fileExtension, equals(''));
+    });
+
+    test('should handle whitespace after dot', () {
+      expect('filename. txt'.fileExtension, equals(' txt'));
+    });
+
+    test('should handle complex extensions', () {
+      expect('archive.tar.gz'.fileExtension, equals('gz'));
+    });
+  });
 }

--- a/lib/features/email/presentation/extensions/attachment_extension.dart
+++ b/lib/features/email/presentation/extensions/attachment_extension.dart
@@ -41,7 +41,7 @@ extension AttachmentExtension on Attachment {
 
   bool get isHTMLFile => type?.isHTMLFile(fileName: name) ?? false;
 
-  bool get isImage => type?.isImageFile() ?? false;
+  bool get isImage => type?.isImageSupportedPreview(fileName: name) ?? false;
 
   bool get isText => (type?.isTextFile() ?? false)
     || name?.endsWith('.txt') == true


### PR DESCRIPTION
## Issue

Cannot preview image with file name containing image extension (`jpg`,..) and mime type is `application/octet-stream`

https://github.com/user-attachments/assets/4c6a50fe-48d8-4186-96ed-4379ab0b5e4b

## Resolved

https://github.com/user-attachments/assets/ca3c7332-b636-4b93-a4b7-78c8211f473c


