### PR TITLE
TF-3670 Fix forwarding an email removes the attachments

### DIFF
--- a/integration_test/scenarios/email_detailed/forwarding_email_lost_attachments_scenario.dart
+++ b/integration_test/scenarios/email_detailed/forwarding_email_lost_attachments_scenario.dart
@@ -1,0 +1,75 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/email/prefix_email_address.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/email_attachments_widget.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/composer_robot.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class ForwardingEmailLostAttachmentsScenario extends BaseTestScenario {
+
+  const ForwardingEmailLostAttachmentsScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const subject = 'Forwarding email lost attachments';
+    final List<String> attachmentContents = ['file1', 'file2'];
+    const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
+
+    final threadRobot = ThreadRobot($);
+    final emailRobot = EmailRobot($);
+    final composerRobot = ComposerRobot($);
+    final imagePaths = ImagePaths();
+
+    // Prepare attachment files
+    final attachmentFiles = await Future.wait(
+      attachmentContents.map(
+        (attachmentContent) => preparingTxtFile(attachmentContent),
+      ),
+    );
+
+    // Provisioning email
+    await provisionEmail(
+      [
+        ProvisioningEmail(
+          toEmail: emailUser,
+          subject: subject,
+          content: subject,
+          attachmentPaths: attachmentFiles.map((file) => file.path).toList(),
+        ),
+      ],
+      requestReadReceipt: false,
+    );
+    await $.pumpAndSettle();
+
+    await threadRobot.openEmailWithSubject(subject);
+    await $.pumpAndSettle();
+    await _expectForwardEmailButtonVisible();
+    await _expectAttachmentListVisible();
+
+    await emailRobot.onTapForwardEmail();
+    await _expectComposerViewVisible();
+
+    await composerRobot.grantContactPermission();
+    await composerRobot.addRecipientIntoField(
+      prefixEmailAddress: PrefixEmailAddress.to,
+      email: emailUser,
+    );
+    await composerRobot.sendEmail(imagePaths);
+    await $.pumpAndSettle(duration: const Duration(seconds: 3));
+
+    await _expectAttachmentListVisible();
+  }
+
+  Future<void> _expectForwardEmailButtonVisible() async {
+    await expectViewVisible($(#forward_email_button));
+  }
+
+  Future<void> _expectComposerViewVisible() => expectViewVisible($(ComposerView));
+
+  Future<void> _expectAttachmentListVisible() => expectViewVisible($(EmailAttachmentsWidget));
+}

--- a/integration_test/tests/email_detailed/forwarding_email_lost_attachments_test.dart
+++ b/integration_test/tests/email_detailed/forwarding_email_lost_attachments_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/forwarding_email_lost_attachments_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see attachment list in email view after forward email successfully',
+    scenarioBuilder: ($) => ForwardingEmailLostAttachmentsScenario($),
+  );
+}

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -1782,7 +1782,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
           ComposerArguments.forwardEmail(
             presentationEmail: presentationEmail,
             content: currentEmailLoaded.value?.htmlContent ?? '',
-            attachments: attachments,
+            attachments: List.from(attachments),
             inlineImages: currentEmailLoaded.value?.inlineImages ?? [],
             messageId: currentEmailLoaded.value?.emailCurrent?.messageId,
             references: currentEmailLoaded.value?.emailCurrent?.references,
@@ -2598,7 +2598,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
     final viewEntireMessageRequest = ViewEntireMessageRequest(
       userName: userName ?? UserName(''),
       presentationEmail: presentationEmail,
-      attachments: attachments,
+      attachments: List.from(attachments),
       emailContent: emailContent,
       locale: Localizations.localeOf(context),
       appLocalizations: appLocalizations,


### PR DESCRIPTION
## Issue

#3670

## Root cause

Because when forwarding email we pass `reference of RxList attachments` list to composer. So when composer is disposed, attachments list will be disposed, leading to it being empty. Moreover, synchronizing the `forward` icon status update for the forwarded email will cause the email to be re-rendered, leading to the attachment list being re-rendered based on the current attachments value.

## Solution

Create a `new list from RxList attachments` when forwarding email

## Resolved

- Demo:

https://github.com/user-attachments/assets/5e683153-0ca5-494d-8017-ec4bfc979007

- E2E:

```console

🧪 Should see attachment list in email view after forward email successfully
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. tap widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  10. enterText widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  11. waitUntilVisible widgets with text containing 2475-2001-ee0-4161-9501-cc0c-8b87-80dc-3265.ngrok-free.app.
        ✅  12. tap widgets with text "Next".
        ✅  13. waitUntilVisible widgets with key [<'credential_input_form'>] descending from widgets with type "LoginView".
        ✅  14. enterText widgets with type "TextField" descending from widgets with key [<'login_username_input'>].
        ✅  15. waitUntilVisible widgets with text "bob@example.com".
✅ Should see attachment list in email view after forward email successfully (integration_test/tests/email_detailed/forwarding_email_lost_attachments_test.dart) (32s)

Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: …/tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 53s

```

https://github.com/user-attachments/assets/a109e282-4808-4884-b92a-b3693559de09

