### PR TITLE
TF-3674 Fix logic reply incorrectly

### DIFF
--- a/docs/adr/0053-patrol-integration-test.md
+++ b/docs/adr/0053-patrol-integration-test.md
@@ -1,4 +1,4 @@
-# 52. Patrol integration test
+# 53. Patrol integration test
 
 Date: 2024-04-10
 

--- a/docs/adr/0054-standardize-html-sanitizing.md
+++ b/docs/adr/0054-standardize-html-sanitizing.md
@@ -1,4 +1,4 @@
-# 53. Standardize HTML sanitizing
+# 54. Standardize HTML sanitizing
 
 Date: 2024-10-24
 

--- a/docs/adr/0055-web-socket-data-synchronization.md
+++ b/docs/adr/0055-web-socket-data-synchronization.md
@@ -1,4 +1,4 @@
-# 53. Web socket data synchronization
+# 55. Web socket data synchronization
 
 Date: 2024-11-10
 

--- a/docs/adr/0056-update-flutter-service-worker-initialization.md
+++ b/docs/adr/0056-update-flutter-service-worker-initialization.md
@@ -1,4 +1,4 @@
-# 54. Update Flutter Service Worker Initialization
+# 56. Update Flutter Service Worker Initialization
 
 Date: 2024-11-15
 

--- a/docs/adr/0057-ios-fcm-routing.md
+++ b/docs/adr/0057-ios-fcm-routing.md
@@ -1,4 +1,4 @@
-# 55. iOS FCM routing
+# 57. iOS FCM routing
 
 Date: 2024-12-05
 

--- a/docs/adr/0058-remove-flutter-service-worker.md
+++ b/docs/adr/0058-remove-flutter-service-worker.md
@@ -1,4 +1,4 @@
-# 55. Remove Flutter Service Worker
+# 58. Remove Flutter Service Worker
 
 Date: 2024-11-26
 

--- a/docs/adr/0059-web-socket-ping-strategy.md
+++ b/docs/adr/0059-web-socket-ping-strategy.md
@@ -1,4 +1,4 @@
-# 56. Web Socket Ping Strategy
+# 59. Web Socket Ping Strategy
 
 Date: 2024-12-16
 

--- a/docs/adr/0060-team-mailboxes-matching.md
+++ b/docs/adr/0060-team-mailboxes-matching.md
@@ -1,4 +1,4 @@
-# 57. Team Mailboxes Matching
+# 60. Team Mailboxes Matching
 
 Date: 2025-02-18
 

--- a/docs/adr/0061-fix-ios-email-view-gone-blank-with-large-html-content.md
+++ b/docs/adr/0061-fix-ios-email-view-gone-blank-with-large-html-content.md
@@ -1,4 +1,4 @@
-# 58. Fix iOS email view gone blank with large HTML content
+# 61. Fix iOS email view gone blank with large HTML content
 
 Date: 2024-04-05
 

--- a/docs/adr/0062-fix-offline-cache-prevents-updating-email-query-view-on-mobile.md
+++ b/docs/adr/0062-fix-offline-cache-prevents-updating-email-query-view-on-mobile.md
@@ -1,4 +1,4 @@
-# 58. Fix offline cache prevents updating email query view on mobile
+# 62. Fix offline cache prevents updating email query view on mobile
 
 Date: 2025-04-03
 

--- a/docs/adr/0063-hide-session-expires-dialog-to-avoid-confusing-users..md
+++ b/docs/adr/0063-hide-session-expires-dialog-to-avoid-confusing-users..md
@@ -1,4 +1,4 @@
-# 58. Hide session expires dialog to avoid confusing users
+# 63. Hide session expires dialog to avoid confusing users
 
 Date: 2025-04-14
 

--- a/docs/adr/0064-reply-to-own-sent-email.md
+++ b/docs/adr/0064-reply-to-own-sent-email.md
@@ -1,4 +1,4 @@
-# 59. Reply to own sent email
+# 64. Reply to own sent email
 
 Date: 2025-04-15
 

--- a/docs/adr/0065-logic-for-reply-email.md
+++ b/docs/adr/0065-logic-for-reply-email.md
@@ -1,0 +1,98 @@
+# 65. Logic for reply email
+
+Date: 2025-04-21
+
+## Status
+
+Accepted
+
+## Context
+
+- The email reply logic is quite complex so to avoid mistakes and regression of errors later.
+
+## Decision
+
+Brief the logic flow to easily follow changes during email reply process:
+
+**1. Reply:**
+
+- If the user is the `sender`
+
+```console
+To = email.to
+Cc, Bcc, ReplyTo = Empty
+```
+
+- Otherwise, If the email has a `List-Post` header then:
+
+```console
+To = email.from.withoutUser
+Cc, Bcc, ReplyTo = Empty
+```
+
+- Otherwise, If the email without a `List-Post` header, `email.replyTo` is not empty then:
+
+ ```console
+To = email.replyTo.withoutUser
+Cc, Bcc, ReplyTo = Empty
+```
+
+- Otherwise:
+
+```console
+To = email.from.withoutUser
+Cc, Bcc, ReplyTo = Empty
+```
+
+**2. Reply To List:**
+
+- If the email has a `List-Post` header then:
+
+```console
+To = email.List-Post.withoutUser
+Cc, Bcc, ReplyTo = Empty
+```
+
+- Otherwise: There is no `Reply To List` feature
+
+3. Reply all
+
+- If the user is the sender
+
+```console
+To = email.to.withoutUser
+Cc = email.cc.withoutUser
+Bcc = email.bcc.withoutUser
+ReplyTo = email.replyTo.withoutUser
+```
+
+- Otherwise, If the email has a `List-Post` header then:
+
+```console
+To = (email.replyTo + email.from + email.to).withoutUser
+Cc = email.cc.withoutUser
+Bcc = email.bcc.withoutUser
+ReplyTo = Empty
+```
+
+- Otherwise, If the email without a `List-Post` header, `email.replyTo` is not empty then:
+
+```console
+To = (email.replyTo + email.to).withoutUser
+Cc = email.cc.withoutUser
+Bcc = email.bcc.withoutUser
+ReplyTo = Empty
+```
+
+- Otherwise
+
+```console
+To = (email.from + email.to).withoutUser
+Cc = email.cc.withoutUser
+Bcc = email.bcc.withoutUser
+ReplyTo = Empty
+```
+
+## Consequences
+
+- Any changes to reply email should be updated in this ADR.

--- a/integration_test/robots/email_robot.dart
+++ b/integration_test/robots/email_robot.dart
@@ -21,6 +21,14 @@ class EmailRobot extends CoreRobot {
     await $(#reply_email_button).tap();
   }
 
+  Future<void> onTapReplyToListEmail() async {
+    await $(#reply_to_list_email_button).tap();
+  }
+
+  Future<void> onTapReplyAllEmail() async {
+    await $(#reply_all_emails_button).tap();
+  }
+
   Future<void> onTapBackButton() async {
     await $(find.byType(EmailViewBackButton)).first.tap();
   }

--- a/integration_test/scenarios/email_detailed/reply_all_email_scenario.dart
+++ b/integration_test/scenarios/email_detailed/reply_all_email_scenario.dart
@@ -1,0 +1,112 @@
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/email/prefix_email_address.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/recipient_composer_widget.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/subject_composer_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/email_view.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/search_email_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../robots/composer_robot.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/search_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class ReplyAllEmailScenario extends BaseTestScenario {
+
+  const ReplyAllEmailScenario(super.$);
+
+  static const String queryString = 'Reply all email';
+
+  @override
+  Future<void> runTestLogic() async {
+    final threadRobot = ThreadRobot($);
+    final searchRobot = SearchRobot($);
+    final emailRobot = EmailRobot($);
+    final composerRobot = ComposerRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await threadRobot.openSearchView();
+    await _expectSearchViewVisible();
+
+    await searchRobot.enterQueryString(queryString);
+    await searchRobot.tapOnShowAllResultsText();
+    await _expectSearchResultEmailListVisible();
+
+    await searchRobot.openEmailWithSubject(queryString);
+    await _expectEmailViewVisible();
+    await _expectReplyAllEmailButtonVisible();
+
+    await emailRobot.onTapReplyAllEmail();
+    await _expectComposerViewVisible();
+
+    await composerRobot.grantContactPermission();
+
+    await _expectComposerSubjectDisplayedCorrectly(appLocalizations);
+    await _expectToFieldContainListEmailAddressCorrectly();
+    await _expectCcFieldContainListEmailAddressCorrectly();
+    await _expectBccFieldContainListEmailAddressCorrectly();
+  }
+
+  Future<void> _expectSearchViewVisible() async {
+    await expectViewVisible($(SearchEmailView));
+  }
+
+  Future<void> _expectSearchResultEmailListVisible() async {
+    await expectViewVisible($(#search_email_list_notification_listener));
+    await $.pump(const Duration(seconds: 3));
+  }
+
+  Future<void> _expectEmailViewVisible() async {
+    await expectViewVisible($(EmailView));
+  }
+
+  Future<void> _expectReplyAllEmailButtonVisible() async {
+    await expectViewVisible($(#reply_all_emails_button));
+  }
+
+  Future<void> _expectComposerViewVisible() async {
+    await expectViewVisible($(ComposerView));
+  }
+
+  Future<void> _expectComposerSubjectDisplayedCorrectly(AppLocalizations appLocalizations) async {
+    expect(
+      $(SubjectComposerWidget).which<SubjectComposerWidget>((widget) =>
+        widget.textController.text == '${appLocalizations.prefix_reply_email} $queryString'
+      ).visible,
+      isTrue,
+    );
+  }
+
+  Future<void> _expectToFieldContainListEmailAddressCorrectly() async {
+    expect(
+      $(RecipientComposerWidget).which<RecipientComposerWidget>((widget) =>
+        widget.prefix == PrefixEmailAddress.to &&
+        isMatchingEmailList(widget.listEmailAddress, {'emma-reply-to@example.com', 'emma@example.com'})
+      ).visible,
+      isTrue,
+    );
+  }
+
+  Future<void> _expectCcFieldContainListEmailAddressCorrectly() async {
+    expect(
+      $(RecipientComposerWidget).which<RecipientComposerWidget>((widget) =>
+        widget.prefix == PrefixEmailAddress.cc &&
+        isMatchingEmailList(widget.listEmailAddress, {'alice@example.com'})
+      ).visible,
+      isTrue,
+    );
+  }
+
+  Future<void> _expectBccFieldContainListEmailAddressCorrectly() async {
+    expect(
+      $(RecipientComposerWidget).which<RecipientComposerWidget>((widget) =>
+        widget.prefix == PrefixEmailAddress.bcc &&
+        isMatchingEmailList(widget.listEmailAddress, {'brian@example.com'})
+      ).visible,
+      isTrue,
+    );
+  }
+}

--- a/integration_test/scenarios/email_detailed/reply_email_with_reply_to_scenario.dart
+++ b/integration_test/scenarios/email_detailed/reply_email_with_reply_to_scenario.dart
@@ -1,0 +1,90 @@
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/email/prefix_email_address.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/recipient_composer_widget.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/subject_composer_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/email_view.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/search_email_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../robots/composer_robot.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/search_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class ReplyEmailWithReplyToScenario extends BaseTestScenario {
+
+  const ReplyEmailWithReplyToScenario(super.$);
+
+  static const String queryString = 'Reply email with Reply-To';
+
+  @override
+  Future<void> runTestLogic() async {
+    final threadRobot = ThreadRobot($);
+    final searchRobot = SearchRobot($);
+    final emailRobot = EmailRobot($);
+    final composerRobot = ComposerRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await threadRobot.openSearchView();
+    await _expectSearchViewVisible();
+
+    await searchRobot.enterQueryString(queryString);
+    await searchRobot.tapOnShowAllResultsText();
+    await _expectSearchResultEmailListVisible();
+
+    await searchRobot.openEmailWithSubject(queryString);
+    await _expectEmailViewVisible();
+    await _expectReplyEmailButtonVisible();
+
+    await emailRobot.onTapReplyEmail();
+    await _expectComposerViewVisible();
+
+    await composerRobot.grantContactPermission();
+
+    await _expectComposerSubjectDisplayedCorrectly(appLocalizations);
+    await _expectToFieldContainReplyToAndFromEmailAddress();
+  }
+
+  Future<void> _expectSearchViewVisible() async {
+    await expectViewVisible($(SearchEmailView));
+  }
+
+  Future<void> _expectSearchResultEmailListVisible() async {
+    await expectViewVisible($(#search_email_list_notification_listener));
+    await $.pump(const Duration(seconds: 3));
+  }
+
+  Future<void> _expectEmailViewVisible() async {
+    await expectViewVisible($(EmailView));
+  }
+
+  Future<void> _expectReplyEmailButtonVisible() async {
+    await expectViewVisible($(#reply_email_button));
+  }
+
+  Future<void> _expectComposerViewVisible() async {
+    await expectViewVisible($(ComposerView));
+  }
+
+  Future<void> _expectComposerSubjectDisplayedCorrectly(AppLocalizations appLocalizations) async {
+    expect(
+      $(SubjectComposerWidget).which<SubjectComposerWidget>((widget) =>
+        widget.textController.text == '${appLocalizations.prefix_reply_email} $queryString'
+      ).visible,
+      isTrue,
+    );
+  }
+
+  Future<void> _expectToFieldContainReplyToAndFromEmailAddress() async {
+    expect(
+      $(RecipientComposerWidget).which<RecipientComposerWidget>((widget) =>
+        widget.prefix == PrefixEmailAddress.to &&
+        isMatchingEmailList(widget.listEmailAddress, {'emma@example.com'})
+      ).visible,
+      isTrue,
+    );
+  }
+}

--- a/integration_test/scenarios/email_detailed/reply_email_without_reply_to_scenario.dart
+++ b/integration_test/scenarios/email_detailed/reply_email_without_reply_to_scenario.dart
@@ -1,0 +1,90 @@
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/email/prefix_email_address.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/recipient_composer_widget.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/subject_composer_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/email_view.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/search_email_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../robots/composer_robot.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/search_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class ReplyEmailWithoutReplyToScenario extends BaseTestScenario {
+
+  const ReplyEmailWithoutReplyToScenario(super.$);
+
+  static const String queryString = 'Reply email without Reply-To';
+
+  @override
+  Future<void> runTestLogic() async {
+    final threadRobot = ThreadRobot($);
+    final searchRobot = SearchRobot($);
+    final emailRobot = EmailRobot($);
+    final composerRobot = ComposerRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await threadRobot.openSearchView();
+    await _expectSearchViewVisible();
+
+    await searchRobot.enterQueryString(queryString);
+    await searchRobot.tapOnShowAllResultsText();
+    await _expectSearchResultEmailListVisible();
+
+    await searchRobot.openEmailWithSubject(queryString);
+    await _expectEmailViewVisible();
+    await _expectReplyEmailButtonVisible();
+
+    await emailRobot.onTapReplyEmail();
+    await _expectComposerViewVisible();
+
+    await composerRobot.grantContactPermission();
+
+    await _expectComposerSubjectDisplayedCorrectly(appLocalizations);
+    await _expectToFieldContainFromEmailAddress();
+  }
+
+  Future<void> _expectSearchViewVisible() async {
+    await expectViewVisible($(SearchEmailView));
+  }
+
+  Future<void> _expectSearchResultEmailListVisible() async {
+    await expectViewVisible($(#search_email_list_notification_listener));
+    await $.pump(const Duration(seconds: 3));
+  }
+
+  Future<void> _expectEmailViewVisible() async {
+    await expectViewVisible($(EmailView));
+  }
+
+  Future<void> _expectReplyEmailButtonVisible() async {
+    await expectViewVisible($(#reply_email_button));
+  }
+
+  Future<void> _expectComposerViewVisible() async {
+    await expectViewVisible($(ComposerView));
+  }
+
+  Future<void> _expectComposerSubjectDisplayedCorrectly(AppLocalizations appLocalizations) async {
+    expect(
+      $(SubjectComposerWidget).which<SubjectComposerWidget>((widget) =>
+        widget.textController.text == '${appLocalizations.prefix_reply_email} $queryString'
+      ).visible,
+      isTrue,
+    );
+  }
+
+  Future<void> _expectToFieldContainFromEmailAddress() async {
+    expect(
+      $(RecipientComposerWidget).which<RecipientComposerWidget>((widget) =>
+        widget.prefix == PrefixEmailAddress.to &&
+        isMatchingEmailList(widget.listEmailAddress, {'emma@example.com'})
+      ).visible,
+      isTrue,
+    );
+  }
+}

--- a/integration_test/scenarios/email_detailed/reply_to_list_email_scenario.dart
+++ b/integration_test/scenarios/email_detailed/reply_to_list_email_scenario.dart
@@ -1,0 +1,90 @@
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/email/prefix_email_address.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/recipient_composer_widget.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/subject_composer_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/email_view.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/search_email_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../robots/composer_robot.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/search_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class ReplyToListEmailScenario extends BaseTestScenario {
+
+  const ReplyToListEmailScenario(super.$);
+
+  static const String queryString = 'Reply to list email';
+
+  @override
+  Future<void> runTestLogic() async {
+    final threadRobot = ThreadRobot($);
+    final searchRobot = SearchRobot($);
+    final emailRobot = EmailRobot($);
+    final composerRobot = ComposerRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await threadRobot.openSearchView();
+    await _expectSearchViewVisible();
+
+    await searchRobot.enterQueryString(queryString);
+    await searchRobot.tapOnShowAllResultsText();
+    await _expectSearchResultEmailListVisible();
+
+    await searchRobot.openEmailWithSubject(queryString);
+    await _expectEmailViewVisible();
+    await _expectReplyToListEmailButtonVisible();
+
+    await emailRobot.onTapReplyToListEmail();
+    await _expectComposerViewVisible();
+
+    await composerRobot.grantContactPermission();
+
+    await _expectComposerSubjectDisplayedCorrectly(appLocalizations);
+    await _expectToFieldContainListPostEmailAddress();
+  }
+
+  Future<void> _expectSearchViewVisible() async {
+    await expectViewVisible($(SearchEmailView));
+  }
+
+  Future<void> _expectSearchResultEmailListVisible() async {
+    await expectViewVisible($(#search_email_list_notification_listener));
+    await $.pump(const Duration(seconds: 3));
+  }
+
+  Future<void> _expectEmailViewVisible() async {
+    await expectViewVisible($(EmailView));
+  }
+
+  Future<void> _expectReplyToListEmailButtonVisible() async {
+    await expectViewVisible($(#reply_to_list_email_button));
+  }
+
+  Future<void> _expectComposerViewVisible() async {
+    await expectViewVisible($(ComposerView));
+  }
+
+  Future<void> _expectComposerSubjectDisplayedCorrectly(AppLocalizations appLocalizations) async {
+    expect(
+      $(SubjectComposerWidget).which<SubjectComposerWidget>((widget) =>
+        widget.textController.text == '${appLocalizations.prefix_reply_email} $queryString'
+      ).visible,
+      isTrue,
+    );
+  }
+
+  Future<void> _expectToFieldContainListPostEmailAddress() async {
+    expect(
+      $(RecipientComposerWidget).which<RecipientComposerWidget>((widget) =>
+        widget.prefix == PrefixEmailAddress.to &&
+        isMatchingEmailList(widget.listEmailAddress, {'emma-reply-to-list@example.com'})
+      ).visible,
+      isTrue,
+    );
+  }
+}

--- a/integration_test/tests/email_detailed/reply_all_email_test.dart
+++ b/integration_test/tests/email_detailed/reply_all_email_test.dart
@@ -1,0 +1,11 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/reply_all_email_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description:
+      'SHOULD see the Subject contain the prefix `Re:`\n'
+      'AND the To, Cc, Bcc field should display correctly',
+    scenarioBuilder: ($) => ReplyAllEmailScenario($),
+  );
+}

--- a/integration_test/tests/email_detailed/reply_email_with_reply_to_test.dart
+++ b/integration_test/tests/email_detailed/reply_email_with_reply_to_test.dart
@@ -1,0 +1,11 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/reply_email_with_reply_to_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description:
+      'SHOULD see the Subject contain the prefix `Re:`\n'
+      'AND the To field should contain the email\'s `Reply-To` address.',
+    scenarioBuilder: ($) => ReplyEmailWithReplyToScenario($),
+  );
+}

--- a/integration_test/tests/email_detailed/reply_email_without_reply_to_test.dart
+++ b/integration_test/tests/email_detailed/reply_email_without_reply_to_test.dart
@@ -1,0 +1,11 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/reply_email_without_reply_to_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description:
+      'SHOULD see the Subject contain the prefix `Re:`\n'
+      'AND the To field should contain the email\'s `From` address.',
+    scenarioBuilder: ($) => ReplyEmailWithoutReplyToScenario($),
+  );
+}

--- a/integration_test/tests/email_detailed/reply_to_list_email_test.dart
+++ b/integration_test/tests/email_detailed/reply_to_list_email_test.dart
@@ -1,0 +1,11 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/reply_to_list_email_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description:
+      'SHOULD see the Subject contain the prefix `Re:`\n'
+      'AND the To field should contain the email\'s `List-Post` address.',
+    scenarioBuilder: ($) => ReplyToListEmailScenario($),
+  );
+}

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -682,10 +682,10 @@ class ComposerController extends BaseController
       listPost: listPost,
     );
 
-    listToEmailAddress = List.from(recipients.value1);
-    listCcEmailAddress = List.from(recipients.value2);
-    listBccEmailAddress = List.from(recipients.value3);
-    listReplyToEmailAddress = List.from(recipients.value4);
+    listToEmailAddress = List.from(recipients.to);
+    listCcEmailAddress = List.from(recipients.cc);
+    listBccEmailAddress = List.from(recipients.bcc);
+    listReplyToEmailAddress = List.from(recipients.replyTo);
 
     if (listToEmailAddress.isNotEmpty || listCcEmailAddress.isNotEmpty || listBccEmailAddress.isNotEmpty || listReplyToEmailAddress.isNotEmpty) {
       isInitialRecipient.value = true;

--- a/provisioning/integration_test/eml/reply_email/reply-all.eml
+++ b/provisioning/integration_test/eml/reply_email/reply-all.eml
@@ -1,16 +1,19 @@
-Return-Path: <david@example.com>
+Return-Path: <emma@example.com>
 MIME-Version: 1.0
 References: <Mime4j.4c.b3b452d18f0d0ef9.192d67aaafc@example.com>
-Subject: David send Bob
-From: david@example.com
-To: "bob@example.com" <bob@example.com>
-Reply-To: david@example.com
-Date: Fri, 1 Nov 2024 07:13:50 +0000
+Subject: Reply all email
+From: emma@example.com
+To: "bob" <bob@example.com>
+Cc: "alice" <alice@example.com>
+Bcc: "brian" <brian@example.com>
+Reply-To: emma-reply-to@example.com
+Date: Tue, 17 Dec 2024 16:31:00 +0000
 Message-ID: <Mime4j.4e.728b2b72b23cc182.192d67ae03c@example.com>
 User-Agent: Twake-Mail/0.13.2 Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15;
  rv:131.0) Gecko/20100101 Firefox/131.0
 Content-Type: multipart/alternative;
  boundary="-=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=-"
+List-Post: <mailto:emma-reply-to-list@example.com>
 
 ---=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=-
 Content-Type: text/plain; charset=UTF-8
@@ -18,7 +21,7 @@ Content-Transfer-Encoding: quoted-printable
 Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT
 Content-Language: en-US
 
-Hello Bob.
+Reply all email
 
 Invite you in to a meeting: Event OPEN TECH TALK: INNOVATION FOR THE TWAKE WORKPLACE
 

--- a/provisioning/integration_test/eml/reply_email/reply-to-list.eml
+++ b/provisioning/integration_test/eml/reply_email/reply-to-list.eml
@@ -1,16 +1,18 @@
-Return-Path: <david@example.com>
+Return-Path: <emma@example.com>
 MIME-Version: 1.0
 References: <Mime4j.4c.b3b452d18f0d0ef9.192d67aaafc@example.com>
-Subject: David send Bob
-From: david@example.com
-To: "bob@example.com" <bob@example.com>
-Reply-To: david@example.com
-Date: Fri, 1 Nov 2024 07:13:50 +0000
+Subject: Reply to list email
+From: emma@example.com
+To: "bob" <bob@example.com>
+Cc: "alice" <alice@example.com>
+Bcc: "brian" <brian@example.com>
+Date: Tue, 17 Dec 2024 16:31:00 +0000
 Message-ID: <Mime4j.4e.728b2b72b23cc182.192d67ae03c@example.com>
 User-Agent: Twake-Mail/0.13.2 Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15;
  rv:131.0) Gecko/20100101 Firefox/131.0
 Content-Type: multipart/alternative;
  boundary="-=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=-"
+List-Post: <mailto:emma-reply-to-list@example.com>
 
 ---=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=-
 Content-Type: text/plain; charset=UTF-8
@@ -18,7 +20,7 @@ Content-Transfer-Encoding: quoted-printable
 Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT
 Content-Language: en-US
 
-Hello Bob.
+Reply to list email
 
 Invite you in to a meeting: Event OPEN TECH TALK: INNOVATION FOR THE TWAKE WORKPLACE
 

--- a/provisioning/integration_test/eml/reply_email/with-reply-to.eml
+++ b/provisioning/integration_test/eml/reply_email/with-reply-to.eml
@@ -1,16 +1,19 @@
-Return-Path: <david@example.com>
+Return-Path: <emma@example.com>
 MIME-Version: 1.0
 References: <Mime4j.4c.b3b452d18f0d0ef9.192d67aaafc@example.com>
-Subject: David send Bob
-From: david@example.com
-To: "bob@example.com" <bob@example.com>
-Reply-To: david@example.com
-Date: Fri, 1 Nov 2024 07:13:50 +0000
+Subject: Reply email with Reply-To
+From: emma@example.com
+To: "bob" <bob@example.com>
+Cc: "alice" <alice@example.com>
+Bcc: "brian" <brian@example.com>
+Reply-To: emma-reply-to@example.com
+Date: Tue, 17 Dec 2024 16:31:00 +0000
 Message-ID: <Mime4j.4e.728b2b72b23cc182.192d67ae03c@example.com>
 User-Agent: Twake-Mail/0.13.2 Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15;
  rv:131.0) Gecko/20100101 Firefox/131.0
 Content-Type: multipart/alternative;
  boundary="-=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=-"
+List-Post: <mailto:emma-reply-to-list@example.com>
 
 ---=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=-
 Content-Type: text/plain; charset=UTF-8
@@ -18,7 +21,7 @@ Content-Transfer-Encoding: quoted-printable
 Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT
 Content-Language: en-US
 
-Hello Bob.
+Reply email with Reply-To
 
 Invite you in to a meeting: Event OPEN TECH TALK: INNOVATION FOR THE TWAKE WORKPLACE
 

--- a/provisioning/integration_test/eml/reply_email/without-reply-to.eml
+++ b/provisioning/integration_test/eml/reply_email/without-reply-to.eml
@@ -1,11 +1,12 @@
-Return-Path: <david@example.com>
+Return-Path: <emma@example.com>
 MIME-Version: 1.0
 References: <Mime4j.4c.b3b452d18f0d0ef9.192d67aaafc@example.com>
-Subject: David send Bob
-From: david@example.com
-To: "bob@example.com" <bob@example.com>
-Reply-To: david@example.com
-Date: Fri, 1 Nov 2024 07:13:50 +0000
+Subject: Reply email without Reply-To
+From: emma@example.com
+To: "bob" <bob@example.com>
+Cc: "alice" <alice@example.com>
+Bcc: "brian" <brian@example.com>
+Date: Tue, 17 Dec 2024 16:31:00 +0000
 Message-ID: <Mime4j.4e.728b2b72b23cc182.192d67ae03c@example.com>
 User-Agent: Twake-Mail/0.13.2 Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15;
  rv:131.0) Gecko/20100101 Firefox/131.0
@@ -18,7 +19,7 @@ Content-Transfer-Encoding: quoted-printable
 Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT
 Content-Language: en-US
 
-Hello Bob.
+Reply email without Reply-To
 
 Invite you in to a meeting: Event OPEN TECH TALK: INNOVATION FOR THE TWAKE WORKPLACE
 

--- a/provisioning/integration_test/eml/search_email_with_sort_order/0.eml
+++ b/provisioning/integration_test/eml/search_email_with_sort_order/0.eml
@@ -30,11 +30,4 @@ Our 3rd Open Tech Talk in 2024!
 
 We are waiting for you!
 
----=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=-
-Content-Type: text/html; charset=UTF-8
-Content-Transfer-Encoding: quoted-printable
-Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT
-Content-Language: en-US
-
-
 ---=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=---

--- a/provisioning/integration_test/eml/search_email_with_sort_order/1.eml
+++ b/provisioning/integration_test/eml/search_email_with_sort_order/1.eml
@@ -30,11 +30,4 @@ Our 3rd Open Tech Talk in 2024!
 
 We are waiting for you!
 
----=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=-
-Content-Type: text/html; charset=UTF-8
-Content-Transfer-Encoding: quoted-printable
-Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT
-Content-Language: en-US
-
-
 ---=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=---

--- a/provisioning/integration_test/eml/search_email_with_sort_order/2.eml
+++ b/provisioning/integration_test/eml/search_email_with_sort_order/2.eml
@@ -30,11 +30,4 @@ Our 3rd Open Tech Talk in 2024!
 
 We are waiting for you!
 
----=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=-
-Content-Type: text/html; charset=UTF-8
-Content-Transfer-Encoding: quoted-printable
-Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT
-Content-Language: en-US
-
-
 ---=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=---

--- a/provisioning/integration_test/eml/search_email_with_sort_order/4.eml
+++ b/provisioning/integration_test/eml/search_email_with_sort_order/4.eml
@@ -30,11 +30,4 @@ Our 3rd Open Tech Talk in 2024!
 
 We are waiting for you!
 
----=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=-
-Content-Type: text/html; charset=UTF-8
-Content-Transfer-Encoding: quoted-printable
-Accept-Language: fr-FR, en-US, vi-VN, ru-RU, ar-TN, it-IT
-Content-Language: en-US
-
-
 ---=Part.4f.450e1cfbcd355387.192d67ae03d.c367d8042fea24dd=---

--- a/provisioning/integration_test/provisioning.sh
+++ b/provisioning/integration_test/provisioning.sh
@@ -2,7 +2,7 @@
 
 # Define users and folders
 users=("alice" "bob" "brian" "charlotte" "david" "emma")
-bobFolders=("Search Emails" "Forward Emails" "Disposition" "MailBase64" "Calendar")
+bobFolders=("Search Emails" "Forward Emails" "Disposition" "MailBase64" "Calendar" "Reply Emails")
 
 # Add users
 for user in "${users[@]}"; do
@@ -67,3 +67,12 @@ james-cli ImportEml \#private "bob@example.com" "MailBase64" "/root/conf/integra
 # Import email into 'Calendar' folder for user Bob
 echo "Importing calendar eml into 'Calendar' folder for user bob"
 james-cli ImportEml \#private "bob@example.com" "Calendar" "/root/conf/integration_test/eml/calendar/calendar_counter.eml"
+
+# For test reply email
+# Import emails into 'Reply Emails' folder for user Bob
+replyEmailsEML=("reply-all.eml" "reply-to-list.eml" "with-reply-to.eml" "without-reply-to.eml")
+
+for eml in "${replyEmailsEML[@]}"; do
+  echo "Importing $eml into 'Reply Emails' folder for user bob"
+  james-cli ImportEml \#private "bob@example.com" "Reply Emails" "/root/conf/integration_test/eml/reply_email/$eml"
+done

--- a/test/model/lib/extensions/presentation_email_extension_test.dart
+++ b/test/model/lib/extensions/presentation_email_extension_test.dart
@@ -45,10 +45,10 @@ void main() {
           userName: userAEmailAddress.emailAddress,
         );
 
-        expect(result.value1, containsAll(expectedResult.value1));
-        expect(result.value2, containsAll(expectedResult.value2));
-        expect(result.value3, containsAll(expectedResult.value3));
-        expect(result.value4, containsAll(expectedResult.value4));
+        expect(result.to, equals(expectedResult.value1));
+        expect(result.cc, equals(expectedResult.value2));
+        expect(result.bcc, equals(expectedResult.value3));
+        expect(result.replyTo, equals(expectedResult.value4));
       });
 
       test(
@@ -75,10 +75,10 @@ void main() {
           userName: userAEmailAddress.emailAddress,
         );
 
-        expect(result.value1, containsAll(expectedResult.value1));
-        expect(result.value2, containsAll(expectedResult.value2));
-        expect(result.value3, containsAll(expectedResult.value3));
-        expect(result.value4, containsAll(expectedResult.value4));
+        expect(result.to, equals(expectedResult.value1));
+        expect(result.cc, equals(expectedResult.value2));
+        expect(result.bcc, equals(expectedResult.value3));
+        expect(result.replyTo, equals(expectedResult.value4));
       });
     });
 
@@ -113,10 +113,10 @@ void main() {
           listPost: listPost,
         );
 
-        expect(result.value1, containsAll(expectedResult.value1));
-        expect(result.value2, containsAll(expectedResult.value2));
-        expect(result.value3, containsAll(expectedResult.value3));
-        expect(result.value4, containsAll(expectedResult.value4));
+        expect(result.to, equals(expectedResult.value1));
+        expect(result.cc, equals(expectedResult.value2));
+        expect(result.bcc, equals(expectedResult.value3));
+        expect(result.replyTo, equals(expectedResult.value4));
       });
 
       test(
@@ -145,10 +145,10 @@ void main() {
           userName: userAEmailAddress.emailAddress,
         );
 
-        expect(result.value1, containsAll(expectedResult.value1));
-        expect(result.value2, containsAll(expectedResult.value2));
-        expect(result.value3, containsAll(expectedResult.value3));
-        expect(result.value4, containsAll(expectedResult.value4));
+        expect(result.to, equals(expectedResult.value1));
+        expect(result.cc, equals(expectedResult.value2));
+        expect(result.bcc, equals(expectedResult.value3));
+        expect(result.replyTo, equals(expectedResult.value4));
       });
     });
 
@@ -175,10 +175,10 @@ void main() {
           listPost: listPost,
         );
 
-        expect(result.value1, equals([userBEmailAddress, userAEmailAddress]));
-        expect(result.value2, isEmpty);
-        expect(result.value3, isEmpty);
-        expect(result.value4, isEmpty);
+        expect(result.to, equals([userBEmailAddress, userAEmailAddress]));
+        expect(result.cc, isEmpty);
+        expect(result.bcc, isEmpty);
+        expect(result.replyTo, isEmpty);
       });
 
       test(
@@ -208,10 +208,10 @@ void main() {
           listPost: listPost,
         );
 
-        expect(result.value1, containsAll(expectedResult.value1));
-        expect(result.value2, containsAll(expectedResult.value2));
-        expect(result.value3, containsAll(expectedResult.value3));
-        expect(result.value4, containsAll(expectedResult.value4));
+        expect(result.to, equals(expectedResult.value1));
+        expect(result.cc, equals(expectedResult.value2));
+        expect(result.bcc, equals(expectedResult.value3));
+        expect(result.replyTo, equals(expectedResult.value4));
       });
 
       test(
@@ -240,10 +240,10 @@ void main() {
           userName: userAEmailAddress.emailAddress,
         );
 
-        expect(result.value1, containsAll(expectedResult.value1));
-        expect(result.value2, containsAll(expectedResult.value2));
-        expect(result.value3, containsAll(expectedResult.value3));
-        expect(result.value4, containsAll(expectedResult.value4));
+        expect(result.to, equals(expectedResult.value1));
+        expect(result.cc, equals(expectedResult.value2));
+        expect(result.bcc, equals(expectedResult.value3));
+        expect(result.replyTo, equals(expectedResult.value4));
       });
     });
 
@@ -252,6 +252,7 @@ void main() {
       'AND send an email to user A and user E, cc to user C, bcc to user D',
     () {
       test(
+        'Email without the List-Post header'
         'THEN user A click reply, generateRecipientsEmailAddressForComposer\n'
         'SHOULD return only replyToEmailAddress email to reply' ,
       () {
@@ -275,18 +276,51 @@ void main() {
           isSender: false,
         );
 
-        expect(result.value1, containsAll(expectedResult.value1));
-        expect(result.value2, containsAll(expectedResult.value2));
-        expect(result.value3, containsAll(expectedResult.value3));
-        expect(result.value4, containsAll(expectedResult.value4));
+        expect(result.to, equals(expectedResult.value1));
+        expect(result.cc, equals(expectedResult.value2));
+        expect(result.bcc, equals(expectedResult.value3));
+        expect(result.replyTo, equals(expectedResult.value4));
       });
 
       test(
+        'Email has the List-Post header'
+        'THEN user A click reply, generateRecipientsEmailAddressForComposer\n'
+        'SHOULD return only user B email to reply' ,
+      () {
+        final expectedResult = Tuple4(
+          [userBEmailAddress],
+          <EmailAddress>[],
+          <EmailAddress>[],
+          <EmailAddress>[],
+        );
+
+        final emailToReply = PresentationEmail(
+          from: {userBEmailAddress},
+          replyTo: {replyToEmailAddress},
+          to: {userAEmailAddress, userEEmailAddress},
+          cc: {userCEmailAddress},
+          bcc: {userDEmailAddress}
+        );
+
+        final result = emailToReply.generateRecipientsEmailAddressForComposer(
+          emailActionType: EmailActionType.reply,
+          isSender: false,
+          listPost: listPost,
+        );
+
+        expect(result.to, equals(expectedResult.value1));
+        expect(result.cc, equals(expectedResult.value2));
+        expect(result.bcc, equals(expectedResult.value3));
+        expect(result.replyTo, equals(expectedResult.value4));
+      });
+
+      test(
+        'Email without the List-Post header'
         'THEN user A clicks reply all, generateRecipientsEmailAddressForComposer\n'
         'SHOULD return replyToEmailAddress + user A email + user E email to reply, user C email address to cc, user D email address to bcc',
       () {
         final expectedResult = Tuple4(
-          [userAEmailAddress, userEEmailAddress, replyToEmailAddress],
+          [replyToEmailAddress, userAEmailAddress, userEEmailAddress],
           <EmailAddress>[userCEmailAddress],
           <EmailAddress>[userDEmailAddress],
           <EmailAddress>[],
@@ -305,10 +339,42 @@ void main() {
           isSender: false,
         );
 
-        expect(result.value1, containsAll(expectedResult.value1));
-        expect(result.value2, containsAll(expectedResult.value2));
-        expect(result.value3, containsAll(expectedResult.value3));
-        expect(result.value4, containsAll(expectedResult.value4));
+        expect(result.to, equals(expectedResult.value1));
+        expect(result.cc, equals(expectedResult.value2));
+        expect(result.bcc, equals(expectedResult.value3));
+        expect(result.replyTo, equals(expectedResult.value4));
+      });
+
+      test(
+        'Email has the List-Post header'
+        'THEN user A clicks reply all, generateRecipientsEmailAddressForComposer\n'
+        'SHOULD return replyToEmailAddress + user B email + user A email + user E email to reply, user C email address to cc, user D email address to bcc',
+      () {
+        final expectedResult = Tuple4(
+          [replyToEmailAddress, userBEmailAddress, userAEmailAddress, userEEmailAddress],
+          <EmailAddress>[userCEmailAddress],
+          <EmailAddress>[userDEmailAddress],
+          <EmailAddress>[],
+        );
+
+        final emailToReply = PresentationEmail(
+          from: {userBEmailAddress},
+          replyTo: {replyToEmailAddress},
+          to: {userAEmailAddress, userEEmailAddress},
+          cc: {userCEmailAddress},
+          bcc: {userDEmailAddress}
+        );
+
+        final result = emailToReply.generateRecipientsEmailAddressForComposer(
+          emailActionType: EmailActionType.replyAll,
+          isSender: false,
+          listPost: listPost,
+        );
+
+        expect(result.to, equals(expectedResult.value1));
+        expect(result.cc, equals(expectedResult.value2));
+        expect(result.bcc, equals(expectedResult.value3));
+        expect(result.replyTo, equals(expectedResult.value4));
       });
     });
 
@@ -339,10 +405,10 @@ void main() {
           isSender: false,
         );
 
-        expect(result.value1, containsAll(expectedResult.value1));
-        expect(result.value2, containsAll(expectedResult.value2));
-        expect(result.value3, containsAll(expectedResult.value3));
-        expect(result.value4, containsAll(expectedResult.value4));
+        expect(result.to, equals(expectedResult.value1));
+        expect(result.cc, equals(expectedResult.value2));
+        expect(result.bcc, equals(expectedResult.value3));
+        expect(result.replyTo, equals(expectedResult.value4));
       });
 
       test(
@@ -350,7 +416,7 @@ void main() {
         'SHOULD return user A email + user E email + user B email to reply, user C email to cc, user D email to bcc',
       () {
         final expectedResult = Tuple4(
-          [userAEmailAddress, userEEmailAddress, userBEmailAddress],
+          [userBEmailAddress, userAEmailAddress, userEEmailAddress],
           <EmailAddress>[userCEmailAddress],
           <EmailAddress>[userDEmailAddress],
           <EmailAddress>[],
@@ -368,10 +434,10 @@ void main() {
           isSender: false,
         );
 
-        expect(result.value1, containsAll(expectedResult.value1));
-        expect(result.value2, containsAll(expectedResult.value2));
-        expect(result.value3, containsAll(expectedResult.value3));
-        expect(result.value4, containsAll(expectedResult.value4));
+        expect(result.to, equals(expectedResult.value1));
+        expect(result.cc, equals(expectedResult.value2));
+        expect(result.bcc, equals(expectedResult.value3));
+        expect(result.replyTo, equals(expectedResult.value4));
       });
 
       test(
@@ -394,10 +460,10 @@ void main() {
           listPost: listPost,
         );
 
-        expect(result.value1, containsAll(expectedResult.value1));
-        expect(result.value2, containsAll(expectedResult.value2));
-        expect(result.value3, containsAll(expectedResult.value3));
-        expect(result.value4, containsAll(expectedResult.value4));
+        expect(result.to, equals(expectedResult.value1));
+        expect(result.cc, equals(expectedResult.value2));
+        expect(result.bcc, equals(expectedResult.value3));
+        expect(result.replyTo, equals(expectedResult.value4));
       });
     });
 
@@ -429,10 +495,10 @@ void main() {
           isSender: false,
         );
 
-        expect(result.value1, containsAll(expectedResult.value1));
-        expect(result.value2, containsAll(expectedResult.value2));
-        expect(result.value3, containsAll(expectedResult.value3));
-        expect(result.value4, containsAll(expectedResult.value4));
+        expect(result.to, equals(expectedResult.value1));
+        expect(result.cc, equals(expectedResult.value2));
+        expect(result.bcc, equals(expectedResult.value3));
+        expect(result.replyTo, equals(expectedResult.value4));
       });
     });
   });


### PR DESCRIPTION
## Issue

#3674 

## Resolved

- Demo

https://github.com/user-attachments/assets/d75ba3c6-49ac-4ec6-a0a7-aa01a52fe853

- E2E:


```console
🧪 SHOULD see the Subject contain the prefix `Re:`
AND the To, Cc, Bcc field should display correctly
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. tap widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  10. enterText widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  11. waitUntilVisible widgets with text containing 5e65-222-252-23-73.ngrok-free.app.
        ✅  12. tap widgets with text "Next".
        ✅  13. waitUntilVisible widgets with key [<'credential_input_form'>] descending from widgets with type "LoginView".
        ✅  14. enterText widgets with type "TextField" descending from widgets with key [<'login_username_input'>].
        ✅  15. waitUntilVisible widgets with text "bob@example.com".
        ✅  16. tap widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
✅ SHOULD see the Subject contain the prefix `Re:`
AND the To, Cc, Bcc field should display correctly (integration_test/tests/email_detailed/reply_all_email_test.dart) (26s)
🧪 SHOULD see the Subject contain the prefix `Re:`
AND the To field should contain the email's `Reply-To` address.
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. tap widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  10. enterText widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  11. waitUntilVisible widgets with text containing 5e65-222-252-23-73.ngrok-free.app.
        ✅  12. tap widgets with text "Next".
        ✅  13. waitUntilVisible widgets with key [<'credential_input_form'>] descending from widgets with type "LoginView".
        ✅  14. enterText widgets with type "TextField" descending from widgets with key [<'login_username_input'>].
        ✅  15. waitUntilVisible widgets with text "bob@example.com".
        ✅  16. tap widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
✅ SHOULD see the Subject contain the prefix `Re:`
AND the To field should contain the email's `Reply-To` address. (integration_test/tests/email_detailed/reply_email_with_reply_to_test.dart) (27s)
🧪 SHOULD see the Subject contain the prefix `Re:`
AND the To field should contain the email's `From` address.
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. tap widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  10. enterText widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  11. waitUntilVisible widgets with text containing 5e65-222-252-23-73.ngrok-free.app.
        ✅  12. tap widgets with text "Next".
        ✅  13. waitUntilVisible widgets with key [<'credential_input_form'>] descending from widgets with type "LoginView".
        ✅  14. enterText widgets with type "TextField" descending from widgets with key [<'login_username_input'>].
        ✅  15. waitUntilVisible widgets with text "bob@example.com".
        ✅  16. tap widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
✅ SHOULD see the Subject contain the prefix `Re:`
AND the To field should contain the email's `From` address. (integration_test/tests/email_detailed/reply_email_without_reply_to_test.dart) (27s)
🧪 SHOULD see the Subject contain the prefix `Re:`
AND the To field should contain the email's `List-Post` address.
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. tap widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  10. enterText widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  11. waitUntilVisible widgets with text containing 5e65-222-252-23-73.ngrok-free.app.
        ✅  12. tap widgets with text "Next".
        ✅  13. waitUntilVisible widgets with key [<'credential_input_form'>] descending from widgets with type "LoginView".
        ✅  14. enterText widgets with type "TextField" descending from widgets with key [<'login_username_input'>].
        ✅  15. waitUntilVisible widgets with text "bob@example.com".
        ✅  16. tap widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
✅ SHOULD see the Subject contain the prefix `Re:`
AND the To field should contain the email's `List-Post` address. (integration_test/tests/email_detailed/reply_to_list_email_test.dart) (26s)

```

https://github.com/user-attachments/assets/b92bbec4-0e91-49b8-a5ce-6a01bb95c7ce


