### PR TITLE
Bump version to v0.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.15.3] - 2025-04-22
+### Fixed
+- #3670 Forwarding email make attachment bar disappear
+- #3661 Fix memory leak for file picker
+- #3674 Refactor reply email base on thunderbird logic
+- Handle session in case of using isolate for Mark as Read, Empty Trash, Empty Spam
+
 ## [0.15.2] - 2025-04-15
 ### Added
 - #3578 Blue bar: free and busy status

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.15.2
+version: 0.15.3
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## [0.15.3] - 2025-04-22
### Fixed
- #3670 Forwarding email make attachment bar disappear
- #3661 Fix memory leak for file picker
- #3674 Refactor reply email base on thunderbird logic
- Handle session in case of using isolate for Mark as Read, Empty Trash, Empty Spam