### PR TITLE
TF-3685 Fix `From` field is displayed incorrectly in drafts on mobile

### DIFF
--- a/integration_test/models/provisioning_identity.dart
+++ b/integration_test/models/provisioning_identity.dart
@@ -1,0 +1,11 @@
+import 'package:jmap_dart_client/jmap/identities/identity.dart';
+
+class ProvisioningIdentity {
+  final Identity identity;
+  final bool isDefault;
+
+  ProvisioningIdentity({
+    required this.identity,
+    this.isDefault = false,
+  });
+}

--- a/integration_test/robots/composer_robot.dart
+++ b/integration_test/robots/composer_robot.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:model/email/prefix_email_address.dart';
 import 'package:rich_text_composer/rich_text_composer.dart';
@@ -7,6 +8,7 @@ import 'package:tmail_ui_user/features/composer/presentation/composer_controller
 import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
 import 'package:tmail_ui_user/features/composer/presentation/view/mobile/mobile_editor_view.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/mobile/app_bar_composer_widget.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/mobile/from_composer_mobile_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/recipient_composer_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/recipient_suggestion_item_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/subject_composer_widget.dart';
@@ -96,5 +98,17 @@ class ComposerRobot extends CoreRobot {
 
   Future<void> tapReadReceiptPopupItemOnMenu() async {
     await $(#read_receipt_popup_item).tap();
+  }
+
+  Future<void> tapSaveAsDraftPopupItemOnMenu() async {
+    await $(#save_as_draft_popup_item).tap();
+  }
+
+  Future<void> tapRecipientExpandButton() async {
+    await $(#prefix_to_recipient_expand_button).tap();
+  }
+
+  Future<void> tapFromFieldPopupMenu() async {
+    await $(FromComposerMobileWidget).$(InkWell).tap();
   }
 }

--- a/integration_test/robots/identities_list_menu_robot.dart
+++ b/integration_test/robots/identities_list_menu_robot.dart
@@ -1,0 +1,12 @@
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../base/core_robot.dart';
+
+class IdentitiesListMenuRobot extends CoreRobot {
+  IdentitiesListMenuRobot(super.$);
+
+  Future<void> selectIdentityByName(String name) async {
+    await $(find.text(name)).tap();
+  }
+}

--- a/integration_test/scenarios/composer/change_identity_in_draft_email_scenario.dart
+++ b/integration_test/scenarios/composer/change_identity_in_draft_email_scenario.dart
@@ -1,0 +1,108 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
+import 'package:jmap_dart_client/jmap/identities/identity.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/mobile/from_composer_mobile_widget.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_identity.dart';
+import '../../robots/composer_robot.dart';
+import '../../robots/identities_list_menu_robot.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class ChangeIdentityInDraftEmailScenario extends BaseTestScenario {
+  const ChangeIdentityInDraftEmailScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const email = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const subject = 'Change identity in draft email';
+
+    final threadRobot = ThreadRobot($);
+    final composerRobot = ComposerRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+    final identitiesListMenuRobot = IdentitiesListMenuRobot($);
+    final imagePaths = ImagePaths();
+    final appLocalizations = AppLocalizations();
+
+    final identity1 = Identity(
+      name: 'Identity 1',
+      email: email,
+      htmlSignature: Signature('Signature 1'),
+      sortOrder: UnsignedInt(0),
+    );
+    final identity2 = Identity(
+      name: 'Identity 2',
+      email: email,
+      htmlSignature: Signature('Signature 2'),
+      sortOrder: UnsignedInt(100),
+    );
+    await provisionIdentities([
+      ProvisioningIdentity(identity: identity1, isDefault: true),
+      ProvisioningIdentity(identity: identity2),
+    ]);
+    await $.pumpAndSettle();
+
+    await threadRobot.openComposer();
+    await $.pumpAndSettle();
+    await _expectComposerViewVisible();
+
+    await composerRobot.grantContactPermission();
+
+    await composerRobot.addSubject(subject);
+    await composerRobot.addContent(subject);
+
+    await composerRobot.tapRecipientExpandButton();
+    await $.pumpAndSettle();
+    await _expectIdentityVisible(identity1);
+
+    await composerRobot.tapFromFieldPopupMenu();
+    await identitiesListMenuRobot.selectIdentityByName(identity2.name!);
+    await $.pumpAndSettle();
+    await _expectIdentityVisible(identity2);
+
+    await composerRobot.tapMoreOptionOnAppBar();
+    await _expectSaveAsDraftOptionPopupMenuVisible();
+
+    await composerRobot.tapSaveAsDraftPopupItemOnMenu();
+    await _expectSaveAsDraftEmailSuccessToast(appLocalizations);
+
+    await composerRobot.tapCloseComposer(imagePaths);
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot
+        .openFolderByName(appLocalizations.draftsMailboxDisplayName);
+
+    await threadRobot.openEmailWithSubject(subject);
+    await _expectComposerViewVisible();
+
+    await composerRobot.grantContactPermission();
+
+    await composerRobot.tapRecipientExpandButton();
+    await $.pumpAndSettle();
+    await _expectIdentityVisible(identity2);
+  }
+
+  Future<void> _expectComposerViewVisible() =>
+      expectViewVisible($(ComposerView));
+
+  Future<void> _expectSaveAsDraftOptionPopupMenuVisible() =>
+      expectViewVisible($(#save_as_draft_popup_item));
+
+  Future<void> _expectSaveAsDraftEmailSuccessToast(
+    AppLocalizations appLocalizations,
+  ) =>
+      expectViewVisible($(appLocalizations.drafts_saved));
+
+  Future<void> _expectIdentityVisible(Identity identity) async {
+    expect(
+      $(FromComposerMobileWidget).which<FromComposerMobileWidget>(
+        (widget) => widget.selectedIdentity?.name == identity.name
+      ).visible,
+      isTrue,
+    );
+  }
+}

--- a/integration_test/tests/compose/change_identity_in_draft_email_test.dart
+++ b/integration_test/tests/compose/change_identity_in_draft_email_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/composer/change_identity_in_draft_email_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see new identity in From field when select new identity and save as draft successfully',
+    scenarioBuilder: ($) => ChangeIdentityInDraftEmailScenario($),
+  );
+}

--- a/lib/features/base/upgradeable/upgrade_hive_database_steps_v15.dart
+++ b/lib/features/base/upgradeable/upgrade_hive_database_steps_v15.dart
@@ -1,0 +1,17 @@
+
+import 'package:tmail_ui_user/features/base/upgradeable/upgrade_database_steps.dart';
+import 'package:tmail_ui_user/features/caching/caching_manager.dart';
+
+class UpgradeHiveDatabaseStepsV15 extends UpgradeDatabaseSteps {
+
+  final CachingManager _cachingManager;
+
+  UpgradeHiveDatabaseStepsV15(this._cachingManager);
+
+  @override
+  Future<void> onUpgrade(int oldVersion, int newVersion) async {
+    if (oldVersion > 0 && oldVersion < newVersion && newVersion == 15) {
+      await _cachingManager.clearDetailedEmailCache();
+    }
+  }
+}

--- a/lib/features/caching/config/cache_version.dart
+++ b/lib/features/caching/config/cache_version.dart
@@ -1,4 +1,4 @@
 
 class CacheVersion {
-  static const int hiveDBVersion = 14;
+  static const int hiveDBVersion = 15;
 }

--- a/lib/features/composer/presentation/composer_view.dart
+++ b/lib/features/composer/presentation/composer_view.dart
@@ -114,7 +114,7 @@ class ComposerView extends GetWidget<ComposerController> {
                         children: [
                           Obx(() {
                             if (controller.fromRecipientState.value == PrefixRecipientState.enabled) {
-                              return  FromComposerMobileWidget(
+                              return FromComposerMobileWidget(
                                 selectedIdentity: controller.identitySelected.value,
                                 imagePaths: controller.imagePaths,
                                 responsiveUtils: controller.responsiveUtils,
@@ -551,6 +551,7 @@ class ComposerView extends GetWidget<ComposerController> {
       PopupMenuItem(
         padding: EdgeInsets.zero,
         child: PopupItemWidget(
+          key: const Key('save_as_draft_popup_item'),
           iconAction: controller.imagePaths.icSaveToDraft,
           nameAction: AppLocalizations.of(context).saveAsDraft,
           colorIcon: ComposerStyle.popupItemIconColor,

--- a/lib/features/composer/presentation/extensions/setup_email_content_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_content_extension.dart
@@ -1,5 +1,4 @@
 
-import 'package:core/presentation/state/success.dart';
 import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:dartz/dartz.dart';
@@ -96,7 +95,7 @@ extension SetupEmailContentExtension on ComposerController {
           emailContentsViewState.value = Left(uiState);
           consumeState(Stream.value(Left(uiState)));
         } else {
-          emailContentsViewState.value = Right(UIState.idle);
+          emailContentsViewState.value = Right(LoadEmailContentCompleted());
         }
         break;
       case EmailActionType.editSendingEmail:
@@ -161,7 +160,7 @@ extension SetupEmailContentExtension on ComposerController {
             emailContentsViewState.value = Left(GetEmailContentFailure(uiState.exception));
             consumeState(Stream.value(Left(GetEmailContentFailure(uiState.exception))));
           } else {
-            emailContentsViewState.value = Right(UIState.idle);
+            emailContentsViewState.value = Right(LoadEmailContentCompleted());
           }
         }
         break;
@@ -207,7 +206,7 @@ extension SetupEmailContentExtension on ComposerController {
             emailContentsViewState.value = Left(GetEmailContentFailure(uiState.exception));
             consumeState(Stream.value(Left(GetEmailContentFailure(uiState.exception))));
           } else {
-            emailContentsViewState.value = Right(UIState.idle);
+            emailContentsViewState.value = Right(LoadEmailContentCompleted());
           }
         }
         break;
@@ -219,7 +218,7 @@ extension SetupEmailContentExtension on ComposerController {
         emailContentsViewState.value = Right(successState);
         break;
       default:
-        emailContentsViewState.value = Right(UIState.idle);
+        emailContentsViewState.value = Right(LoadEmailContentCompleted());
         break;
     }
   }

--- a/lib/features/composer/presentation/extensions/setup_email_content_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_content_extension.dart
@@ -86,6 +86,9 @@ extension SetupEmailContentExtension on ComposerController {
             setupEmailRequestReadReceiptFlagForEditDraft(
               uiState.emailCurrent.hasRequestReadReceipt,
             );
+            setupSelectedIdentityForEditDraft(
+              uiState.emailCurrent.identityIdFromHeader,
+            );
           }
 
           emailContentsViewState.value = Right(uiState);

--- a/lib/features/email/domain/extensions/detailed_email_extension.dart
+++ b/lib/features/email/domain/extensions/detailed_email_extension.dart
@@ -21,6 +21,7 @@ extension DetailedEmailExtension on DetailedEmail {
       references: references?.ids.toList(),
       inlineImages: inlineImages?.toHiveCache(),
       sMimeStatusHeader: sMimeStatusHeader?.toMapString(),
+      identityHeader: identityHeader?.toMapString(),
     );
   }
 
@@ -40,7 +41,8 @@ extension DetailedEmailExtension on DetailedEmail {
       messageId: messageId,
       references: references,
       inlineImages: inlineImages,
-      sMimeStatusHeader: sMimeStatusHeader
+      sMimeStatusHeader: sMimeStatusHeader,
+      identityHeader: identityHeader,
     );
   }
 }

--- a/lib/features/email/domain/extensions/detailed_email_hive_cache_extension.dart
+++ b/lib/features/email/domain/extensions/detailed_email_hive_cache_extension.dart
@@ -29,6 +29,12 @@ extension DetailedEmailHiveCacheExtension on DetailedEmailHiveCache {
       sMimeStatusHeader: sMimeStatusHeader != null
         ? Map.fromIterables(sMimeStatusHeader!.keys.map((value) => IndividualHeaderIdentifier(value)), sMimeStatusHeader!.values)
         : null,
+      identityHeader: identityHeader != null
+          ? Map.fromIterables(
+              identityHeader!.keys.map((value) => IndividualHeaderIdentifier(value)),
+              identityHeader!.values,
+            )
+          : null,
     );
  }
 }

--- a/lib/features/email/domain/extensions/email_extension.dart
+++ b/lib/features/email/domain/extensions/email_extension.dart
@@ -17,6 +17,7 @@ extension EmailExtension on Email {
       references: references,
       inlineImages: allAttachments.listAttachmentsDisplayedInContent,
       sMimeStatusHeader: sMimeStatusHeader,
+      identityHeader: identityHeader,
     );
   }
 }

--- a/lib/features/email/domain/model/detailed_email.dart
+++ b/lib/features/email/domain/model/detailed_email.dart
@@ -17,6 +17,7 @@ class DetailedEmail with EquatableMixin {
   final MessageIdsHeaderValue? references;
   final List<Attachment>? inlineImages;
   final Map<IndividualHeaderIdentifier, String?>? sMimeStatusHeader;
+  final Map<IndividualHeaderIdentifier, String?>? identityHeader;
 
   DetailedEmail({
     required this.emailId,
@@ -30,6 +31,7 @@ class DetailedEmail with EquatableMixin {
     this.references,
     this.inlineImages,
     this.sMimeStatusHeader,
+    this.identityHeader,
   });
 
   @override
@@ -45,5 +47,6 @@ class DetailedEmail with EquatableMixin {
     references,
     inlineImages,
     sMimeStatusHeader,
+    identityHeader,
   ];
 }

--- a/lib/features/email/domain/state/get_email_content_state.dart
+++ b/lib/features/email/domain/state/get_email_content_state.dart
@@ -49,6 +49,8 @@ class GetEmailContentFromCacheSuccess extends UIState {
   ];
 }
 
+class LoadEmailContentCompleted extends UIState {}
+
 class GetEmailContentFailure extends FeatureFailure {
 
   GetEmailContentFailure(dynamic exception, {super.onRetry})

--- a/lib/features/email/domain/usecases/get_email_content_interactor.dart
+++ b/lib/features/email/domain/usecases/get_email_content_interactor.dart
@@ -182,6 +182,7 @@ class GetEmailContentInteractor {
         emailCurrent: emailCache.copyWith(
           headers: detailedEmail.headers,
           sMimeStatusHeader: detailedEmail.sMimeStatusHeader,
+          identityHeader: detailedEmail.identityHeader,
         )
       ));
     } catch (e) {

--- a/lib/features/offline_mode/model/detailed_email_hive_cache.dart
+++ b/lib/features/offline_mode/model/detailed_email_hive_cache.dart
@@ -41,6 +41,9 @@ class DetailedEmailHiveCache extends HiveObject with EquatableMixin {
   @HiveField(9)
   Map<String, String?>? sMimeStatusHeader;
 
+  @HiveField(10)
+  Map<String, String?>? identityHeader;
+
   DetailedEmailHiveCache({
     required this.emailId,
     required this.timeSaved,
@@ -52,6 +55,7 @@ class DetailedEmailHiveCache extends HiveObject with EquatableMixin {
     this.references,
     this.inlineImages,
     this.sMimeStatusHeader,
+    this.identityHeader,
   });
 
   @override
@@ -66,5 +70,6 @@ class DetailedEmailHiveCache extends HiveObject with EquatableMixin {
     references,
     inlineImages,
     sMimeStatusHeader,
+    identityHeader,
   ];
 }

--- a/lib/features/thread/domain/constants/thread_constants.dart
+++ b/lib/features/thread/domain/constants/thread_constants.dart
@@ -64,6 +64,7 @@ class ThreadConstants {
     EmailProperty.attachments,
     EmailProperty.headers,
     IndividualHeaderIdentifier.sMimeStatusHeader.value,
+    IndividualHeaderIdentifier.identityHeader.value,
   });
 
   static final propertiesCalendarEvent = Properties({


### PR DESCRIPTION
## Issue

#3685

## Root cause

Emails reopened from the Draft folder are loaded from cache, so the identity is not stored in the cache and cannot be retrieved.

## Solution

Save identity id in email cache header

## Resolved

- Demo: 


[Screen_recording_20250423_114842.webm](https://github.com/user-attachments/assets/4bce2167-63a3-45f9-b9a4-92630b6f1c24)


- E2E test:

```console
🧪 Should see new identity in From field when select new identity and save as draft successfully
        : 
        : > Task :app:connectedDebugAndroidTest
        : Starting 1 tests on Pixel_6_Pro_API_33(AVD) - 13
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. tap widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  10. enterText widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  11. waitUntilVisible widgets with text containing 5411-222-252-23-73.ngrok-free.app.
        ✅  12. tap widgets with text "Next".
        ⏳  13. waitUntilVisible widgets with key [<'credential_input_form'>] descending from widgets with type "LoginVie
        ✅  13. waitUntilVisible widgets with key [<'credential_input_form'>] descending from widgets with type "LoginView".
        ✅  14. enterText widgets with type "TextField" descending from widgets with key [<'login_username_input'>].
        ✅  15. waitUntilVisible widgets with text "bob@example.com".
        ✅  16. tap widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
        ✅  17. enterText widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
        ✅  18. tap widgets with key [<'loginSubmitForm'>].
        ✅  19. isPermissionDialogVisible (native)
        ✅  20. waitUntilVisible widgets with type "ThreadView".
        ✅  21. tap widgets with type "InkWell" descending from widgets with type "ComposeFloatingButton".
        ✅  22. waitUntilVisible widgets with type "ComposerView".
        ✅  23. isPermissionDialogVisible (native)
        ✅  24. grantPermissionWhenInUse (native)
        ✅  25. tap widgets with type "SubjectComposerWidget".
        ✅  26. enterText widgets with type "SubjectComposerWidget".
        ⏳  27. tap widgets with type "InAppWebView" descending from widgets with type "HtmlEditor" descending from widgets with type "MobileEditorView" descending from widgets with widget matching predicate descending from widgets with type
        ✅  27. tap widgets with type "InAppWebView" descending from widgets with type "HtmlEditor" descending from widgets with type "MobileEditorView" descending from widgets with widget matching predicate descending from widgets with type "ComposerView" inclusive.
        ✅  28. tap widgets with key [<'prefix_to_recipient_expand_button'>].
        ✅  29. tap widgets with type "InkWell" descending from widgets with type "FromComposerMobileWidget".
        ✅  30. tap widgets with text "Identity 2".
        ✅  31. tap widgets with key [<'composer_more_button'>].
        ✅  32. waitUntilVisible widgets with key [<'save_as_draft_popup_item'>].
        ✅  33. tap widgets with key [<'save_as_draft_popup_item'>].
        ✅  34. waitUntilVisible widgets with text "Draft saved".
        ⏳  35. tap widgets with widget matching predicate descending from widgets with type "TMailButtonWidget" descendi
✅ Should see new identity in From field when select new identity and save as draft successfully (integration_test/tests/compose/change_identity_in_draft_email_test.dart) (33s)

Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: …/tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 53s

```

[demo.webm](https://github.com/user-attachments/assets/eed2b0ed-97af-4620-be99-f29898f45b23)

