### PR TITLE
TF-3683 Fix message `Draft saved` just is shown at the first saving

### DIFF
--- a/integration_test/scenarios/composer/update_draft_email_with_message_success_toast_scenario.dart
+++ b/integration_test/scenarios/composer/update_draft_email_with_message_success_toast_scenario.dart
@@ -1,0 +1,73 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/email/prefix_email_address.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../robots/composer_robot.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class UpdateDraftEmailWithMessageSuccessToastScenario extends BaseTestScenario {
+
+  const UpdateDraftEmailWithMessageSuccessToastScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const email = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const subject = 'Update draft email with message toast';
+    const updatedSubject = 'New update draft email with message toast';
+
+    final threadRobot = ThreadRobot($);
+    final composerRobot = ComposerRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+    final appLocalizations = AppLocalizations();
+    final imagePaths = ImagePaths();
+
+    await threadRobot.openComposer();
+    await _expectComposerViewVisible();
+
+    await composerRobot.grantContactPermission();
+    await composerRobot.addRecipientIntoField(
+      prefixEmailAddress: PrefixEmailAddress.to,
+      email: email,
+    );
+    await composerRobot.addSubject(subject);
+    await composerRobot.addContent(subject);
+
+    await composerRobot.tapCloseComposer(imagePaths);
+    await $.pumpAndSettle();
+    await _expectSaveDraftConfirmDialogVisible();
+
+    await composerRobot.tapSaveButtonOnSaveDraftConfirmDialog(appLocalizations);
+    await _expectSaveDraftEmailSuccessToast(appLocalizations);
+    await $.pumpAndSettle();
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openFolderByName(
+      appLocalizations.draftsMailboxDisplayName,
+    );
+    await threadRobot.openEmailWithSubject(subject);
+    await _expectComposerViewVisible();
+
+    await composerRobot.grantContactPermission();
+    await composerRobot.addSubject(updatedSubject);
+    await composerRobot.tapCloseComposer(imagePaths);
+    await $.pumpAndSettle();
+    await _expectSaveDraftConfirmDialogVisible();
+
+    await composerRobot.tapSaveButtonOnSaveDraftConfirmDialog(appLocalizations);
+    await _expectSaveDraftEmailSuccessToast(appLocalizations);
+  }
+  
+  Future<void> _expectComposerViewVisible() => expectViewVisible($(ComposerView));
+
+  Future<void> _expectSaveDraftEmailSuccessToast(AppLocalizations appLocalizations) async {
+    await expectViewVisible($(find.text(appLocalizations.drafts_saved)));
+  }
+
+  Future<void> _expectSaveDraftConfirmDialogVisible() async {
+    await expectViewVisible($(#confirm_dialog_action));
+  }
+}

--- a/integration_test/tests/compose/update_draft_email_with_messsage_success_toast_test.dart
+++ b/integration_test/tests/compose/update_draft_email_with_messsage_success_toast_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/composer/update_draft_email_with_message_success_toast_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see message success toast when edit draft email and save draft successfully',
+    scenarioBuilder: ($) => UpdateDraftEmailWithMessageSuccessToastScenario($),
+  );
+}

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -102,6 +102,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/spam_report_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/delete_emails_in_mailbox_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_preferences_setting_extension.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_save_email_as_draft_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/open_and_close_composer_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/reopen_composer_cache_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/set_error_extension.dart';
@@ -378,6 +379,8 @@ class MailboxDashBoardController extends ReloadableController
       _handleSendEmailSuccess(success);
     } else if (success is SaveEmailAsDraftsSuccess) {
       _saveEmailAsDraftsSuccess(success);
+    } else if (success is UpdateEmailDraftsSuccess) {
+      handleUpdateEmailAsDraftsSuccess();
     } else if (success is MoveToMailboxSuccess) {
       _moveToMailboxSuccess(success);
     } else if (success is DeleteEmailPermanentlySuccess) {

--- a/lib/features/mailbox_dashboard/presentation/extensions/handle_save_email_as_draft_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/handle_save_email_as_draft_extension.dart
@@ -1,0 +1,22 @@
+
+import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+
+extension HandleSaveEmailAsDraftExtension on MailboxDashBoardController {
+
+  void handleUpdateEmailAsDraftsSuccess() {
+    if (currentContext == null || currentOverlayContext == null) return;
+
+    appToast.showToastMessage(
+      currentOverlayContext!,
+      AppLocalizations.of(currentContext!).drafts_saved,
+      leadingSVGIcon: imagePaths.icMailboxDrafts,
+      leadingSVGIconColor: Colors.white,
+      backgroundColor: AppColor.toastSuccessBackgroundColor,
+      textColor: Colors.white,
+    );
+  }
+}


### PR DESCRIPTION
## Issue

#3683 

## Root cause

Unhandled for action update draft email with state `UpdateEmailDraftsSuccess `

## Resolved

- Demo:


https://github.com/user-attachments/assets/70fc422f-c0c1-450d-8453-9fa044f4e019

- E2E test:

```console
🧪 Should see message success toast when edit draft email and save draft successfully
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. tap widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  10. enterText widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  11. waitUntilVisible widgets with text containing 14d8-222-252-23-73.ngrok-free.app.
        ✅  12. tap widgets with text "Next".
        ✅  13. waitUntilVisible widgets with key [<'credential_input_form'>] descending from widgets with type "LoginView".
        ✅  14. enterText widgets with type "TextField" descending from widgets with key [<'login_username_input'>].
        ✅  15. waitUntilVisible widgets with text "bob@example.com".
        ✅  16. tap widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
        ✅  17. enterText widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
        ✅  18. tap widgets with key [<'loginSubmitForm'>].
        ✅  19. isPermissionDialogVisible (native)
        ✅  20. waitUntilVisible widgets with type "ThreadView".
        ✅  21. tap widgets with type "InkWell" descending from widgets with type "ComposeFloatingButton".
        ✅  22. waitUntilVisible widgets with type "ComposerView".
        ✅  23. isPermissionDialogVisible (native)
        ✅  24. grantPermissionWhenInUse (native)
        ✅  25. enterText widgets with widget matching predicate descending from widgets with type "RecipientComposerWidget" inclusive.
        ✅  26. tap widgets with widget matching predicate descending from widgets with type "RecipientSuggestionItemWidget" inclusive.
        ✅  27. tap widgets with type "SubjectComposerWidget".
        ✅  28. enterText widgets with type "SubjectComposerWidget".
        ⏳  29. tap widgets with type "InAppWebView" descending from widgets with type "HtmlEditor" descending from widgets with type "MobileEditorView" descending from
        ✅  29. tap widgets with type "InAppWebView" descending from widgets with type "HtmlEditor" descending from widgets with type "MobileEditorView" descending from widgets with widget matching predicate descending from widgets with type "ComposerView" inclusive.
        ⏳  30. tap widgets with widget matching predicate descending from widgets with type "TMailButtonWidget" descending from widgets with type "AppBarComposerWidget
        ✅  30. tap widgets with widget matching predicate descending from widgets with type "TMailButtonWidget" descending from widgets with type "AppBarComposerWidget" inclusive.
✅ Should see message success toast when edit draft email and save draft successfully (integration_test/tests/compose/update_draft_email_with_messsage_success_toast_test.dart) (36s)


Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: .../tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 58s


```

[demo-e2e.webm](https://github.com/user-attachments/assets/c852090a-cee0-4056-a9c5-c91f4a0d89f4)

