### PR TITLE
TF-3684 Fix signature is located in a wrong place if you move an inline image right-left

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1245,10 +1245,10 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "3279b9d164723ca349ca3d030abc27efbadd0d34"
+      resolved-ref: d23d675f8e3f7d8909abb9707aa2700437673d01
       url: "https://github.com/linagora/html-editor-enhanced.git"
     source: git
-    version: "3.1.7"
+    version: "3.1.8"
   html_unescape:
     dependency: transitive
     description:


### PR DESCRIPTION
## Issue

#3684 

## Root cause

- According to [MDN's document](https://developer.mozilla.org/en-US/docs/Web/CSS/float), the `float` attribute changes the order of elements in html. So images set to `float: right` will float to the right and content behind it can `float` up to the edge of the image.
- Only the `Web` is affected because the new web has the feature to change `float` for images

## Solution

Set `clear: both` CSS style for Signature to remove the effect of `float`. See more at [MDN-Web/CSS/clear](https://developer.mozilla.org/en-US/docs/Web/CSS/clear)

## Dependency

Need merged: 

 - https://github.com/linagora/html-editor-enhanced/pull/53 

## Resolved


https://github.com/user-attachments/assets/58e94683-fafd-4264-995b-504988783160


