### PR TITLE
TF-3691 Support html escaping in search snippets

### DIFF
--- a/contact/pubspec.lock
+++ b/contact/pubspec.lock
@@ -592,6 +592,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.15.3"
+  html_unescape:
+    dependency: transitive
+    description:
+      name: html_unescape
+      sha256: "15362d7a18f19d7b742ef8dcb811f5fd2a2df98db9f80ea393c075189e0b61e3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   http:
     dependency: transitive
     description:

--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:math';
 
+import 'package:html_unescape/html_unescape.dart';
+
 import 'js_interop_stub.dart' if (dart.library.html) 'dart:js_interop';
 import 'dart:typed_data';
 
@@ -13,6 +15,7 @@ import 'package:universal_html/html.dart' as html;
 
 class HtmlUtils {
   static final random = Random();
+  static final htmlUnescape = HtmlUnescape();
 
   static const lineHeight100Percent = (
     script: '''
@@ -529,5 +532,21 @@ class HtmlUtils {
     } catch (e) {
       logError('AppUtils::setWindowBrowserTitle:Exception = $e');
     }
+  }
+
+  static String unescapeHtml(String input) {
+    try {
+      return htmlUnescape.convert(input);
+    } catch (e) {
+      logError('HtmlUtils::unescapeHtml:Exception = $e');
+      return input;
+    }
+  }
+
+  static String removeWhitespace(String input) {
+    return input
+        .replaceAll('\r', '')
+        .replaceAll('\n', '')
+        .replaceAll('\t', '');
   }
 }

--- a/core/pubspec.lock
+++ b/core/pubspec.lock
@@ -585,6 +585,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.15.3"
+  html_unescape:
+    dependency: "direct main"
+    description:
+      name: html_unescape
+      sha256: "15362d7a18f19d7b742ef8dcb811f5fd2a2df98db9f80ea393c075189e0b61e3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   http:
     dependency: "direct main"
     description:

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -104,6 +104,8 @@ dependencies:
 
   pull_to_refresh: 2.0.0
 
+  html_unescape: 2.0.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/core/test/utils/html_utils_test.dart
+++ b/core/test/utils/html_utils_test.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/utils/html_transformer/dom/image_transformers.dart';
+import 'package:core/utils/html/html_utils.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -29,6 +30,114 @@ void main() {
       const style = 'background-image: invalid-url(\'example.com/image.jpg\');';
       final result = imageTransformer.findImageUrlFromStyleTag(style);
       expect(result, null);
+    });
+  });
+
+  group('HtmlUtils.unescapeHtml', () {
+    test('should return original string when no HTML entities present', () {
+      const input = 'This is a normal string';
+      expect(HtmlUtils.unescapeHtml(input), equals(input));
+    });
+
+    test('should unescape basic HTML entities', () {
+      const input = '&lt;div&gt;Hello &amp; Welcome&lt;/div&gt;';
+      const expected = '<div>Hello & Welcome</div>';
+      expect(HtmlUtils.unescapeHtml(input), equals(expected));
+    });
+
+    test('should unescape numeric decimal HTML entities', () {
+      const input = '&#65;&#66;&#67;';
+      const expected = 'ABC';
+      expect(HtmlUtils.unescapeHtml(input), equals(expected));
+    });
+
+    test('should unescape numeric hexadecimal HTML entities', () {
+      const input = '&#x41;&#x42;&#x43;';
+      const expected = 'ABC';
+      expect(HtmlUtils.unescapeHtml(input), equals(expected));
+    });
+
+    test('should unescape special character entities', () {
+      const input = '&quot;Hello&apos; &copy; &reg; &trade;';
+      const expected = '"Hello\' © ® ™';
+      expect(HtmlUtils.unescapeHtml(input), equals(expected));
+    });
+
+    test('should handle empty string', () {
+      const input = '';
+      expect(HtmlUtils.unescapeHtml(input), isEmpty);
+    });
+
+    test('should handle string with only HTML entity', () {
+      const input = '&amp;';
+      const expected = '&';
+      expect(HtmlUtils.unescapeHtml(input), equals(expected));
+    });
+
+    test('should leave invalid HTML entities unchanged', () {
+      const input = 'This & is not an entity &invalid; &123';
+      const expected = 'This & is not an entity &invalid; &123';
+      expect(HtmlUtils.unescapeHtml(input), equals(expected));
+    });
+
+    test('should handle Unicode characters', () {
+      const input = '&lt;こんにちは&gt;'; // <こんにちは>
+      const expected = '<こんにちは>';
+      expect(HtmlUtils.unescapeHtml(input), equals(expected));
+    });
+
+    test('should handle complex mixed entities', () {
+      const input = '&lt;script&gt;alert(&quot;Hello&quot;);&lt;/script&gt;&amp;&#64;&#x40;';
+      const expected = '<script>alert("Hello");</script>&@@';
+      expect(HtmlUtils.unescapeHtml(input), equals(expected));
+    });
+  });
+
+  group('HtmlUtils.removeWhitespace', () {
+    test('should remove carriage returns (\\r)', () {
+      expect(HtmlUtils.removeWhitespace('Hello\rWorld'), equals('HelloWorld'));
+      expect(HtmlUtils.removeWhitespace('\r\r\r'), equals(''));
+      expect(HtmlUtils.removeWhitespace('a\rb\rc'), equals('abc'));
+    });
+
+    test('should remove newlines (\\n)', () {
+      expect(HtmlUtils.removeWhitespace('Hello\nWorld'), equals('HelloWorld'));
+      expect(HtmlUtils.removeWhitespace('\n\n\n'), equals(''));
+      expect(HtmlUtils.removeWhitespace('a\nb\nc'), equals('abc'));
+    });
+
+    test('should remove tabs (\\t)', () {
+      expect(HtmlUtils.removeWhitespace('Hello\tWorld'), equals('HelloWorld'));
+      expect(HtmlUtils.removeWhitespace('\t\t\t'), equals(''));
+      expect(HtmlUtils.removeWhitespace('a\tb\tc'), equals('abc'));
+    });
+
+    test('should remove all whitespace characters when combined', () {
+      expect(HtmlUtils.removeWhitespace('Hello\r\n\tWorld'), equals('HelloWorld'));
+      expect(HtmlUtils.removeWhitespace('a\rb\nc\td'), equals('abcd'));
+      expect(HtmlUtils.removeWhitespace('\r\n\t\r\n\t'), equals(''));
+    });
+
+    test('should return empty string for empty input', () {
+      expect(HtmlUtils.removeWhitespace(''), equals(''));
+    });
+
+    test('should leave string unchanged when no whitespace present', () {
+      expect(HtmlUtils.removeWhitespace('HelloWorld'), equals('HelloWorld'));
+      expect(HtmlUtils.removeWhitespace('12345'), equals('12345'));
+      expect(HtmlUtils.removeWhitespace('!@#\$%^'), equals('!@#\$%^'));
+    });
+
+    test('should preserve spaces if not configured to remove them', () {
+      expect(HtmlUtils.removeWhitespace('Hello World'), equals('Hello World'));
+      expect(HtmlUtils.removeWhitespace('a b c'), equals('a b c'));
+    });
+
+    test('should handle mixed content with various whitespace', () {
+      expect(
+        HtmlUtils.removeWhitespace('Text\rwith\nnew\tlines\r\nand\ttabs'),
+        equals('Textwithnewlinesandtabs'),
+      );
     });
   });
 }

--- a/integration_test/scenarios/search/search_snippets_with_html_escape_scenario.dart
+++ b/integration_test/scenarios/search/search_snippets_with_html_escape_scenario.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/search_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class SearchSnippetsWithHtmlEscapeScenario extends BaseTestScenario {
+  SearchSnippetsWithHtmlEscapeScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const email = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const subject = '<Search snippets html escape>';
+
+    final threadRobot = ThreadRobot($);
+    final searchRobot = SearchRobot($);
+
+    await provisionEmail(
+      [ProvisioningEmail(toEmail: email, subject: subject, content: subject)],
+      requestReadReceipt: false,
+    );
+    await $.pumpAndSettle();
+
+    await threadRobot.tapOnSearchField();
+    await searchRobot.enterKeyword(subject);
+    await searchRobot.tapOnShowAllResultsText();
+    await $.pumpAndSettle();
+
+    await _expectEmailWithSubjectUnescapedVisible(subject);
+  }
+
+  Future<void> _expectEmailWithSubjectUnescapedVisible(String subject) async {
+    await expectViewVisible($(find.text(subject)));
+  }
+}

--- a/integration_test/tests/search/search_snippets_with_html_escape_test.dart
+++ b/integration_test/tests/search/search_snippets_with_html_escape_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/search/search_snippets_with_html_escape_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see email with subject escaped when search email successfully',
+    scenarioBuilder: ($) => SearchSnippetsWithHtmlEscapeScenario($),
+  );
+}

--- a/model/lib/extensions/presentation_email_extension.dart
+++ b/model/lib/extensions/presentation_email_extension.dart
@@ -4,6 +4,7 @@ import 'package:core/data/constants/constant.dart';
 import 'package:core/domain/extensions/datetime_extension.dart';
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/utils/app_logger.dart';
+import 'package:core/utils/html/html_utils.dart';
 import 'package:http_parser/http_parser.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
@@ -185,10 +186,11 @@ extension PresentationEmailExtension on PresentationEmail {
     );
   }
 
-  String? _sanitizeSearchSnippet(String? searchSnippet) => searchSnippet
-    ?.replaceAll('\r', '')
-    .replaceAll('\n', '')
-    .replaceAll('\t', '');
+  String? _sanitizeSearchSnippet(String? searchSnippet) {
+    if (searchSnippet == null) return null;
+    return HtmlUtils.unescapeHtml(HtmlUtils.removeWhitespace(searchSnippet));
+  }
+
   String? get sanitizedSearchSnippetSubject => _sanitizeSearchSnippet(searchSnippetSubject);
   String? get sanitizedSearchSnippetPreview => _sanitizeSearchSnippet(searchSnippetPreview);
 }

--- a/model/pubspec.lock
+++ b/model/pubspec.lock
@@ -592,6 +592,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.15.3"
+  html_unescape:
+    dependency: transitive
+    description:
+      name: html_unescape
+      sha256: "15362d7a18f19d7b742ef8dcb811f5fd2a2df98db9f80ea393c075189e0b61e3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   http:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1241,6 +1241,14 @@ packages:
       url: "https://github.com/linagora/html-editor-enhanced.git"
     source: git
     version: "3.1.6"
+  html_unescape:
+    dependency: transitive
+    description:
+      name: html_unescape
+      sha256: "15362d7a18f19d7b742ef8dcb811f5fd2a2df98db9f80ea393c075189e0b61e3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   http:
     dependency: transitive
     description:


### PR DESCRIPTION
## Issue

#3691

## Root cause

Currently we use `Text.rich` to display `search snippets`. But `Text.rich` in Flutter does not automatically `unescape` HTML entities like `&lt;`, `&#x2F;`, `&amp;`,... Because `Text.rich` only displays plain text strings (`TextSpan`)

## Solution 

Perform `unescape html` on `subject` and `preview` returned from search snippet

## Resolved

- Demo:

**Before**

<img width="1043" alt="before" src="https://github.com/user-attachments/assets/86493ac0-177c-4c7c-9bde-68f98f26e2d2" />


**After**

<img width="1043" alt="after" src="https://github.com/user-attachments/assets/1e7538f8-8a59-4c0d-9f82-576e16b727fc" />


- E2E test

```console
🧪 Should see email with subject escaped when search email successfully
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. tap widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  10. enterText widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  11. waitUntilVisible widgets with text containing f3d5-2001-ee0-4161-9501-a18f-edf9-4c6c-6a7f.ngrok-free.app.
        ✅  12. tap widgets with text "Next".
✅ Should see email with subject escaped when search email successfully (integration_test/tests/search/search_snippets_with_html_escape_test.dart) (17s)

Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: …/tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 38s

```

[demo-e2e.webm](https://github.com/user-attachments/assets/6c28b1f2-30dc-4add-b1e9-16a3daeee29e)

