### PR TITLE
TF-3703 Fix have to scroll left right to read some parts of email

### DIFF
--- a/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
+++ b/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
@@ -46,7 +46,7 @@ class HtmlContentViewer extends StatefulWidget {
     this.initialWidth,
     this.direction,
     this.minHtmlContentHeight = ConstantsUI.htmlContentMinHeight,
-    this.offsetHtmlContentHeight = ConstantsUI.htmlContentMinHeight,
+    this.offsetHtmlContentHeight = ConstantsUI.htmlContentOffsetHeight,
     this.keepWidthWhileLoading = false,
     this.contentPadding,
     this.useDefaultFont = false,

--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -169,6 +169,11 @@ class HtmlUtils {
             scrollbar-width: none;  /* Firefox */
           }
         ''' : ''}
+        
+        pre {
+          white-space: pre-wrap;
+        }
+        
         ${styleCSS ?? ''}
       </style>
       </head>


### PR DESCRIPTION
## Issue

#3703 

## Root cause

Content is in the `pre` tag of html, do not set line break when container size is exceeded.

## Solution

Add the `white-space: pre-wrap;` property to allow content to wrap automatically when it exceeds the container size

## Resolved

-  Mobile:

https://github.com/user-attachments/assets/9e01fde5-625e-40a8-838b-ac0f0ec24d30



- Web:


https://github.com/user-attachments/assets/e9fd044d-b2b1-4ac8-985f-b8363a007c75



