### PR TITLE
[HOT] Fix missing signature when open composer on mobile web responsive

### DIFF
--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -631,7 +631,9 @@ class ComposerController extends BaseController
     await setupListIdentities(arguments);
     await setupEmailContent(arguments);
 
-    if (screenDisplayMode.value.isNotContentVisible()) {
+    if (screenDisplayMode.value.isNotContentVisible() &&
+        currentContext != null &&
+        responsiveUtils.isWebDesktop(currentContext!)) {
       await setupSelectedIdentityWithoutApplySignature();
     }
   }


### PR DESCRIPTION
## Issue

Missing signature when open composer on `mobile web responsive`

## Reproduce

https://github.com/user-attachments/assets/c7e29191-e576-439e-8c7b-8607921528dc


## Root cause 

Signature is applied before email content is loaded

## Resolved 

- Web:



https://github.com/user-attachments/assets/cb563b9e-e7db-4fb5-9360-347fe0508826



- Mobile:


[demo-mobile.webm](https://github.com/user-attachments/assets/0b35a745-79d0-4a50-a81c-6dc0c1284071)

