### PR TITLE
TF-3707 Implement `Mailbox/clear` JMAP extension

### DIFF
--- a/backend-docker/docker-compose.yaml
+++ b/backend-docker/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   tmail-backend:
-    image: linagora/tmail-backend:memory-1.0.5
+    image: linagora/tmail-backend:memory-1.0.6-rc1
     container_name: tmail-backend
     volumes:
       - ./jwt_publickey:/root/conf/jwt_publickey

--- a/contact/pubspec.lock
+++ b/contact/pubspec.lock
@@ -669,10 +669,10 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: ad588c18cec7630bd8a85a312b7811037af93d12
+      resolved-ref: d24ee7f6fe8a4917ffb658b0d295268b9ccced38
       url: "https://github.com/linagora/jmap-dart-client.git"
     source: git
-    version: "0.3.5"
+    version: "0.3.6"
   js:
     dependency: transitive
     description:

--- a/email_recovery/pubspec.lock
+++ b/email_recovery/pubspec.lock
@@ -296,10 +296,10 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: ad588c18cec7630bd8a85a312b7811037af93d12
+      resolved-ref: d24ee7f6fe8a4917ffb658b0d295268b9ccced38
       url: "https://github.com/linagora/jmap-dart-client.git"
     source: git
-    version: "0.3.5"
+    version: "0.3.6"
   js:
     dependency: transitive
     description:

--- a/fcm/pubspec.lock
+++ b/fcm/pubspec.lock
@@ -296,10 +296,10 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: ad588c18cec7630bd8a85a312b7811037af93d12
+      resolved-ref: d24ee7f6fe8a4917ffb658b0d295268b9ccced38
       url: "https://github.com/linagora/jmap-dart-client.git"
     source: git
-    version: "0.3.5"
+    version: "0.3.6"
   js:
     dependency: transitive
     description:

--- a/forward/pubspec.lock
+++ b/forward/pubspec.lock
@@ -296,10 +296,10 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: ad588c18cec7630bd8a85a312b7811037af93d12
+      resolved-ref: d24ee7f6fe8a4917ffb658b0d295268b9ccced38
       url: "https://github.com/linagora/jmap-dart-client.git"
     source: git
-    version: "0.3.5"
+    version: "0.3.6"
   js:
     dependency: transitive
     description:

--- a/integration_test/mixin/scenario_utils_mixin.dart
+++ b/integration_test/mixin/scenario_utils_mixin.dart
@@ -10,6 +10,7 @@ import 'package:jmap_dart_client/jmap/identities/identity.dart';
 import 'package:jmap_dart_client/jmap/jmap_request.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
 import 'package:jmap_dart_client/jmap/mail/email/set/set_email_method.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/model.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/upload_attachment_state.dart';
@@ -31,6 +32,7 @@ mixin ScenarioUtilsMixin {
     List<ProvisioningEmail> provisioningEmails, {
     bool refreshEmailView = true,
     bool requestReadReceipt = true,
+    Role? folderLocationRole,
   }) async {
     ComposerBindings().dependencies();
 
@@ -56,7 +58,9 @@ mixin ScenarioUtilsMixin {
           emailContent: provisioningEmail.content,
           toRecipients: {EmailAddress(null, provisioningEmail.toEmail)},
           outboxMailboxId: mailboxDashBoardController.outboxMailbox?.mailboxId,
-          sentMailboxId: mailboxDashBoardController.mapDefaultMailboxIdByRole[PresentationMailbox.roleSent],
+          sentMailboxId: folderLocationRole != null
+            ? mailboxDashBoardController.mapDefaultMailboxIdByRole[folderLocationRole]
+            : mailboxDashBoardController.mapDefaultMailboxIdByRole[PresentationMailbox.roleSent],
           identity: identity,
           attachments: attachments,
           hasRequestReadReceipt: requestReadReceipt,

--- a/integration_test/robots/thread_robot.dart
+++ b/integration_test/robots/thread_robot.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tmail_ui_user/features/base/widget/compose_floating_button.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_view.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../base/core_robot.dart';
 
@@ -33,4 +34,10 @@ class ThreadRobot extends CoreRobot {
   Future<void> openMailbox() async {
     await $(#mobile_mailbox_menu_button).tap();
   }
+
+  Future<void> tapEmptyTrashBanner() => $(#empty_trash_banner).tap();
+
+  Future<void> tapDeleteAllButtonOnEmptyTrashConfirmDialog(
+    AppLocalizations appLocalizations,
+  ) => $(appLocalizations.delete_all).tap();
 }

--- a/integration_test/scenarios/mailbox/empty_trash_scenario.dart
+++ b/integration_test/scenarios/mailbox/empty_trash_scenario.dart
@@ -1,0 +1,79 @@
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/mailbox_view.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/widgets/label_mailbox_item_widget.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/widgets/mailbox_item_widget.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class EmptyTrashScenario extends BaseTestScenario {
+
+  const EmptyTrashScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const subject = 'Empty trash';
+
+    final threadRobot = ThreadRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await provisionEmail(
+      [
+        ProvisioningEmail(
+          toEmail: emailUser,
+          subject: subject,
+          content: subject,
+        ),
+      ],
+      folderLocationRole: PresentationMailbox.roleTrash,
+    );
+    await $.pumpAndSettle();
+
+    await threadRobot.openMailbox();
+    await _expectMailboxViewVisible();
+    await _expectFolderVisible(appLocalizations.trashMailboxDisplayName);
+
+    await mailboxMenuRobot.openFolderByName(
+      appLocalizations.trashMailboxDisplayName,
+    );
+    await $.pumpAndSettle();
+    await _expectEmptyTrashBannerVisible();
+    await _expectEmailWithSubjectVisible(subject);
+
+    await threadRobot.tapEmptyTrashBanner();
+    await _expectEmptyTrashConfirmDialogVisible(appLocalizations);
+    await threadRobot.tapDeleteAllButtonOnEmptyTrashConfirmDialog(
+      appLocalizations,
+    );
+    await $.pumpAndSettle(duration: const Duration(seconds: 3));
+    await _expectEmptyViewVisible();
+  }
+
+  Future<void> _expectMailboxViewVisible() => expectViewVisible($(MailboxView));
+
+  Future<void> _expectFolderVisible(String folderName) {
+    return expectViewVisible($(MailboxItemWidget)
+        .$(LabelMailboxItemWidget)
+        .$(find.text(folderName)));
+  }
+
+  Future<void> _expectEmptyTrashBannerVisible() =>
+      expectViewVisible($(#empty_trash_banner));
+
+  Future<void> _expectEmailWithSubjectVisible(String subject) =>
+      expectViewVisible($(subject));
+
+  Future<void> _expectEmptyTrashConfirmDialogVisible(
+    AppLocalizations appLocalizations,
+  ) => expectViewVisible($(appLocalizations.empty_trash_dialog_message));
+
+  Future<void> _expectEmptyViewVisible() =>
+      expectViewVisible($(#empty_thread_view));
+}

--- a/integration_test/tests/mailbox/empty_trash_test.dart
+++ b/integration_test/tests/mailbox/empty_trash_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/mailbox/empty_trash_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should empty view and hide empty trash banner when empty trash successfully',
+    scenarioBuilder: ($) => EmptyTrashScenario($),
+  );
+}

--- a/lib/features/mailbox/data/datasource/mailbox_datasource.dart
+++ b/lib/features/mailbox/data/datasource/mailbox_datasource.dart
@@ -9,6 +9,7 @@ import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/core/properties/properties.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart';
+import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
@@ -59,4 +60,6 @@ abstract class MailboxDataSource {
   Future<GetMailboxByRoleResponse> getMailboxByRole(Session session, AccountId accountId, Role role);
 
   Future<void> clearAllMailboxCache(AccountId accountId, UserName userName);
+
+  Future<UnsignedInt> clearMailbox(Session session, AccountId accountId, MailboxId mailboxId);
 }

--- a/lib/features/mailbox/data/datasource_impl/mailbox_cache_datasource_impl.dart
+++ b/lib/features/mailbox/data/datasource_impl/mailbox_cache_datasource_impl.dart
@@ -161,4 +161,9 @@ class MailboxCacheDataSourceImpl extends MailboxDataSource {
       return await _mailboxCacheManager.clearAll(accountId, userName);
     }).catchError(_exceptionThrower.throwException);
   }
+
+  @override
+  Future<UnsignedInt> clearMailbox(Session session, AccountId accountId, MailboxId mailboxId) {
+    throw UnimplementedError();
+  }
 }

--- a/lib/features/mailbox/data/datasource_impl/mailbox_datasource_impl.dart
+++ b/lib/features/mailbox/data/datasource_impl/mailbox_datasource_impl.dart
@@ -154,4 +154,11 @@ class MailboxDataSourceImpl extends MailboxDataSource {
   Future<void> clearAllMailboxCache(AccountId accountId, UserName userName) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<UnsignedInt> clearMailbox(Session session, AccountId accountId, MailboxId mailboxId) {
+    return Future.sync(() async {
+      return await mailboxAPI.clearMailbox(session, accountId, mailboxId);
+    }).catchError(_exceptionThrower.throwException);
+  }
 }

--- a/lib/features/mailbox/data/network/mailbox_api.dart
+++ b/lib/features/mailbox/data/network/mailbox_api.dart
@@ -20,6 +20,8 @@ import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
 import 'package:jmap_dart_client/jmap/jmap_request.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/changes/changes_mailbox_method.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/changes/changes_mailbox_response.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/clear/clear_mailbox_method.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/clear/clear_mailbox_response.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/get/get_mailbox_method.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/get/get_mailbox_response.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
@@ -605,6 +607,34 @@ class MailboxAPI with HandleSetErrorMixin {
       return GetMailboxByRoleResponse(mailbox: mailboxResponse!.list.first);
     } else {
       throw NotFoundMailboxException();
+    }
+  }
+
+  Future<UnsignedInt> clearMailbox(
+    Session session,
+    AccountId accountId,
+    MailboxId mailboxId,
+  ) async {
+    final clearMailboxMethod = ClearMailboxMethod(accountId, mailboxId);
+    final requestBuilder = JmapRequestBuilder(httpClient, ProcessingInvocation());
+    final invocation = requestBuilder.invocation(clearMailboxMethod);
+
+    final response = await (requestBuilder
+        ..usings(clearMailboxMethod.requiredCapabilities))
+      .build()
+      .execute();
+
+    final clearMailboxResponse = response.parse<ClearMailboxResponse>(
+      invocation.methodCallId,
+      ClearMailboxResponse.deserialize,
+    );
+
+    if (clearMailboxResponse?.totalDeletedMessagesCount != null) {
+      return clearMailboxResponse!.totalDeletedMessagesCount!;
+    } else if (clearMailboxResponse?.notCleared != null) {
+      throw clearMailboxResponse!.notCleared!;
+    } else {
+      throw NotFoundClearMailboxResponseException();
     }
   }
 }

--- a/lib/features/mailbox/data/repository/mailbox_repository_impl.dart
+++ b/lib/features/mailbox/data/repository/mailbox_repository_impl.dart
@@ -300,4 +300,9 @@ class MailboxRepositoryImpl extends MailboxRepository {
   Future<GetMailboxByRoleResponse> getMailboxByRole(Session session, AccountId accountId, Role role, {UnsignedInt? limit}) {
     return mapDataSource[DataSourceType.network]!.getMailboxByRole(session, accountId, role);
   }
+
+  @override
+  Future<UnsignedInt> clearMailbox(Session session, AccountId accountId, MailboxId mailboxId) {
+    return mapDataSource[DataSourceType.network]!.clearMailbox(session, accountId, mailboxId);
+  }
 }

--- a/lib/features/mailbox/domain/exceptions/mailbox_exception.dart
+++ b/lib/features/mailbox/domain/exceptions/mailbox_exception.dart
@@ -2,3 +2,5 @@
 class NotFoundInboxMailboxException implements Exception {}
 
 class NotFoundMailboxException implements Exception {}
+
+class NotFoundClearMailboxResponseException implements Exception {}

--- a/lib/features/mailbox/domain/repository/mailbox_repository.dart
+++ b/lib/features/mailbox/domain/repository/mailbox_repository.dart
@@ -54,4 +54,6 @@ abstract class MailboxRepository {
   Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> setRoleDefaultMailbox(Session session, AccountId accountId, List<Mailbox> listMailbox);
 
   Future<GetMailboxByRoleResponse> getMailboxByRole(Session session, AccountId accountId, Role role, {UnsignedInt? limit});
+
+  Future<UnsignedInt> clearMailbox(Session session, AccountId accountId, MailboxId mailboxId);
 }

--- a/lib/features/mailbox/domain/state/clear_mailbox_state.dart
+++ b/lib/features/mailbox/domain/state/clear_mailbox_state.dart
@@ -1,0 +1,19 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
+
+class ClearingMailbox extends LoadingState {}
+
+class ClearMailboxSuccess extends UIState {
+  final UnsignedInt totalDeletedMessages;
+
+  ClearMailboxSuccess(this.totalDeletedMessages);
+
+  @override
+  List<Object> get props => [totalDeletedMessages];
+}
+
+class ClearMailboxFailure extends FeatureFailure {
+
+  ClearMailboxFailure(dynamic exception) : super(exception: exception);
+}

--- a/lib/features/mailbox/domain/state/clear_mailbox_state.dart
+++ b/lib/features/mailbox/domain/state/clear_mailbox_state.dart
@@ -8,14 +8,16 @@ class ClearingMailbox extends LoadingState {}
 class ClearMailboxSuccess extends UIState {
   final UnsignedInt totalDeletedMessages;
   final MailboxId mailboxId;
+  final Role mailboxRole;
 
-  ClearMailboxSuccess(this.mailboxId, this.totalDeletedMessages);
+  ClearMailboxSuccess(this.mailboxId, this.mailboxRole, this.totalDeletedMessages);
 
   @override
-  List<Object> get props => [mailboxId, totalDeletedMessages];
+  List<Object> get props => [mailboxId, mailboxRole, totalDeletedMessages];
 }
 
 class ClearMailboxFailure extends FeatureFailure {
+  final Role mailboxRole;
 
-  ClearMailboxFailure(dynamic exception) : super(exception: exception);
+  ClearMailboxFailure(this.mailboxRole, {dynamic exception}) : super(exception: exception);
 }

--- a/lib/features/mailbox/domain/state/clear_mailbox_state.dart
+++ b/lib/features/mailbox/domain/state/clear_mailbox_state.dart
@@ -1,16 +1,18 @@
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 
 class ClearingMailbox extends LoadingState {}
 
 class ClearMailboxSuccess extends UIState {
   final UnsignedInt totalDeletedMessages;
+  final MailboxId mailboxId;
 
-  ClearMailboxSuccess(this.totalDeletedMessages);
+  ClearMailboxSuccess(this.mailboxId, this.totalDeletedMessages);
 
   @override
-  List<Object> get props => [totalDeletedMessages];
+  List<Object> get props => [mailboxId, totalDeletedMessages];
 }
 
 class ClearMailboxFailure extends FeatureFailure {

--- a/lib/features/mailbox/domain/usecases/clear_mailbox_interactor.dart
+++ b/lib/features/mailbox/domain/usecases/clear_mailbox_interactor.dart
@@ -16,6 +16,7 @@ class ClearMailboxInteractor {
     Session session,
     AccountId accountId,
     MailboxId mailboxId,
+    Role mailboxRole,
   ) async* {
     try {
       yield Right<Failure, Success>(ClearingMailbox());
@@ -24,9 +25,13 @@ class ClearMailboxInteractor {
         accountId,
         mailboxId,
       );
-      yield Right<Failure, Success>(ClearMailboxSuccess(mailboxId, totalDeletedMessages));
+      yield Right<Failure, Success>(ClearMailboxSuccess(
+        mailboxId,
+        mailboxRole,
+        totalDeletedMessages,
+      ));
     } catch (e) {
-      yield Left<Failure, Success>(ClearMailboxFailure(e));
+      yield Left<Failure, Success>(ClearMailboxFailure(mailboxRole, exception: e));
     }
   }
 }

--- a/lib/features/mailbox/domain/usecases/clear_mailbox_interactor.dart
+++ b/lib/features/mailbox/domain/usecases/clear_mailbox_interactor.dart
@@ -1,0 +1,32 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/repository/mailbox_repository.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/state/clear_mailbox_state.dart';
+
+class ClearMailboxInteractor {
+  final MailboxRepository _mailboxRepository;
+
+  ClearMailboxInteractor(this._mailboxRepository);
+
+  Stream<Either<Failure, Success>> execute(
+    Session session,
+    AccountId accountId,
+    MailboxId mailboxId,
+  ) async* {
+    try {
+      yield Right<Failure, Success>(ClearingMailbox());
+      final totalDeletedMessages = await _mailboxRepository.clearMailbox(
+        session,
+        accountId,
+        mailboxId,
+      );
+      yield Right<Failure, Success>(ClearMailboxSuccess(totalDeletedMessages));
+    } catch (e) {
+      yield Left<Failure, Success>(ClearMailboxFailure(e));
+    }
+  }
+}

--- a/lib/features/mailbox/domain/usecases/clear_mailbox_interactor.dart
+++ b/lib/features/mailbox/domain/usecases/clear_mailbox_interactor.dart
@@ -24,7 +24,7 @@ class ClearMailboxInteractor {
         accountId,
         mailboxId,
       );
-      yield Right<Failure, Success>(ClearMailboxSuccess(totalDeletedMessages));
+      yield Right<Failure, Success>(ClearMailboxSuccess(mailboxId, totalDeletedMessages));
     } catch (e) {
       yield Left<Failure, Success>(ClearMailboxFailure(e));
     }

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -46,6 +46,7 @@ import 'package:tmail_ui_user/features/mailbox/domain/model/mailbox_right_reques
 import 'package:tmail_ui_user/features/mailbox/domain/model/subscribe_mailbox_request.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/model/subscribe_multiple_mailbox_request.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/model/subscribe_request.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/state/clear_mailbox_state.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/state/create_default_mailbox_state.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/state/create_new_mailbox_state.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/state/delete_multiple_mailbox_state.dart';
@@ -396,6 +397,11 @@ class MailboxController extends BaseMailboxController
           originalMailboxIdsWithEmailIds: reactionState.originalMailboxIdsWithMoveSucceededEmailIds,
           destinationMailboxId: reactionState.destinationMailboxId,
           emailIdsWithReadStatus: reactionState.moveSucceededEmailIdsWithReadStatus,
+        );
+      } else if (reactionState is ClearMailboxSuccess) {
+        _handleDeleteEmailsFromMailbox(
+          affectedMailboxId: reactionState.mailboxId,
+          totalEmailsChanged: -reactionState.totalDeletedMessages.value.toInt(),
         );
       }
     });

--- a/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
@@ -55,6 +55,7 @@ import 'package:tmail_ui_user/features/mailbox/data/network/mailbox_api.dart';
 import 'package:tmail_ui_user/features/mailbox/data/network/mailbox_isolate_worker.dart';
 import 'package:tmail_ui_user/features/mailbox/data/repository/mailbox_repository_impl.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/repository/mailbox_repository.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/usecases/clear_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/usecases/mark_as_mailbox_read_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/mailbox_bindings.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/app_grid_datasource.dart';
@@ -200,6 +201,7 @@ class MailboxDashBoardBindings extends BaseBindings {
       Get.find<RemoveAllComposerCacheOnWebInteractor>(),
       Get.find<RemoveComposerCacheByIdOnWebInteractor>(),
       Get.find<GetAllIdentitiesInteractor>(),
+      Get.find<ClearMailboxInteractor>(),
     ));
     Get.put(AdvancedFilterController());
   }
@@ -352,6 +354,7 @@ class MailboxDashBoardBindings extends BaseBindings {
       Get.find<EmailRepository>(),
       Get.find<MailboxRepository>()
     ));
+    Get.lazyPut(() => ClearMailboxInteractor(Get.find<MailboxRepository>()));
 
     IdentityInteractorsBindings().dependencies();
     Get.lazyPut(() => GetAllIdentitiesInteractor(

--- a/lib/features/mailbox_dashboard/presentation/extensions/handle_clear_mailbox_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/handle_clear_mailbox_extension.dart
@@ -1,0 +1,36 @@
+
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/state/clear_mailbox_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+
+extension HandleClearMailboxExtension on MailboxDashBoardController {
+
+  void clearMailbox(Session session, AccountId accountId, MailboxId mailboxId) {
+    consumeState(clearMailboxInteractor.execute(
+      session,
+      accountId,
+      mailboxId,
+    ));
+  }
+
+  void clearMailboxSuccess(ClearMailboxSuccess success) {
+    viewStateMailboxActionProgress.value = Right(UIState.idle);
+
+    if (currentOverlayContext != null && currentContext != null) {
+      appToast.showToastSuccessMessage(
+        currentOverlayContext!,
+        AppLocalizations.of(currentContext!).toast_message_empty_trash_folder_success,
+      );
+    }
+
+    if (selectedMailbox.value?.id == success.mailboxId) {
+      emailsInCurrentMailbox.clear();
+    }
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/extensions/handle_clear_mailbox_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/handle_clear_mailbox_extension.dart
@@ -6,31 +6,38 @@ import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/state/clear_mailbox_state.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
-import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
-import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
 extension HandleClearMailboxExtension on MailboxDashBoardController {
 
-  void clearMailbox(Session session, AccountId accountId, MailboxId mailboxId) {
+  void clearMailbox(
+    Session session,
+    AccountId accountId,
+    MailboxId mailboxId,
+    Role mailboxRole,
+  ) {
+    viewStateMailboxActionProgress.value = Right(ClearingMailbox());
+
     consumeState(clearMailboxInteractor.execute(
       session,
       accountId,
       mailboxId,
+      mailboxRole,
     ));
   }
 
   void clearMailboxSuccess(ClearMailboxSuccess success) {
     viewStateMailboxActionProgress.value = Right(UIState.idle);
 
-    if (currentOverlayContext != null && currentContext != null) {
-      appToast.showToastSuccessMessage(
-        currentOverlayContext!,
-        AppLocalizations.of(currentContext!).toast_message_empty_trash_folder_success,
-      );
-    }
+    toastManager.showMessageSuccess(success);
 
     if (selectedMailbox.value?.id == success.mailboxId) {
       emailsInCurrentMailbox.clear();
     }
+  }
+
+  void clearMailboxFailure(ClearMailboxFailure failure) {
+    viewStateMailboxActionProgress.value = Right(UIState.idle);
+
+    toastManager.showMessageFailure(failure);
   }
 }

--- a/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart
+++ b/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart
@@ -116,7 +116,9 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
                           final presentationMailbox = controller.selectedMailbox.value;
                           if (controller.isEmptyTrashBannerEnabledOnWeb(context, presentationMailbox)) {
                             return BannerEmptyTrashWidget(
-                              onTapAction: controller.emptyTrashAction
+                              responsiveUtils: controller.responsiveUtils,
+                              imagePaths: controller.imagePaths,
+                              onTapAction: controller.emptyTrashAction,
                             );
                           } else {
                             return const SizedBox.shrink();

--- a/lib/features/mailbox_dashboard/presentation/widgets/mark_mailbox_as_read_loading_banner.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/mark_mailbox_as_read_loading_banner.dart
@@ -3,6 +3,7 @@ import 'package:core/presentation/state/success.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/base/mixin/app_loader_mixin.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/state/clear_mailbox_state.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/state/mark_as_mailbox_read_state.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/styles/mark_mailbox_as_read_loading_banner_style.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/empty_spam_folder_state.dart';
@@ -20,7 +21,7 @@ class MarkMailboxAsReadLoadingBanner extends StatelessWidget with AppLoaderMixin
     return viewState.fold(
       (failure) => const SizedBox.shrink(),
       (success) {
-        if (success is MarkAsMailboxReadLoading) {
+        if (success is MarkAsMailboxReadLoading || success is ClearingMailbox) {
           return Padding(
             padding: MarkMailboxAsReadLoadingBannerStyle.bannerMargin,
             child: horizontalLoadingWidget);

--- a/lib/features/thread/presentation/thread_view.dart
+++ b/lib/features/thread/presentation/thread_view.dart
@@ -152,9 +152,13 @@ class ThreadView extends GetWidget<ThreadController>
                         final presentationMailbox = controller.mailboxDashBoardController.selectedMailbox.value;
                         if (controller.mailboxDashBoardController.isEmptyTrashBannerEnabledOnMobile(context, presentationMailbox)) {
                           return BannerEmptyTrashWidget(
+                            key: const Key('empty_trash_banner'),
+                            responsiveUtils: controller.responsiveUtils,
+                            imagePaths: controller.imagePaths,
                             onTapAction: () => controller.deleteSelectionEmailsPermanently(
                               context,
-                              DeleteActionType.all)
+                              DeleteActionType.all,
+                            ),
                           );
                         } else {
                           return const SizedBox.shrink();

--- a/lib/features/thread/presentation/thread_view.dart
+++ b/lib/features/thread/presentation/thread_view.dart
@@ -11,6 +11,7 @@ import 'package:tmail_ui_user/features/base/mixin/popup_menu_widget_mixin.dart';
 import 'package:tmail_ui_user/features/base/widget/compose_floating_button.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/composer_arguments.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/email_action_cupertino_action_sheet_action_builder.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/state/clear_mailbox_state.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/state/mark_as_mailbox_read_state.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/open_and_close_composer_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/mixin/filter_email_popup_menu_mixin.dart';
@@ -969,7 +970,8 @@ class _MailboxActionProgressBanner extends StatelessWidget with AppLoaderMixin {
       (success) {
         if (success is MarkAsMailboxReadLoading ||
             success is EmptySpamFolderLoading ||
-            success is EmptyTrashFolderLoading) {
+            success is EmptyTrashFolderLoading ||
+            success is ClearingMailbox) {
           return Padding(
             padding: EdgeInsets.only(
               top: responsiveUtils.isDesktop(context) ? 16 : 0,

--- a/lib/features/thread/presentation/widgets/banner_empty_trash_widget.dart
+++ b/lib/features/thread/presentation/widgets/banner_empty_trash_widget.dart
@@ -3,21 +3,24 @@ import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/thread/presentation/styles/banner_empty_trash_styles.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 class BannerEmptyTrashWidget extends StatelessWidget {
 
   final VoidCallback onTapAction;
+  final ResponsiveUtils responsiveUtils;
+  final ImagePaths imagePaths;
 
-  const BannerEmptyTrashWidget({super.key, required this.onTapAction});
+  const BannerEmptyTrashWidget({
+    super.key,
+    required this.responsiveUtils,
+    required this.imagePaths,
+    required this.onTapAction,
+  });
 
   @override
   Widget build(BuildContext context) {
-    final imagePaths = Get.find<ImagePaths>();
-    final responsiveUtils = Get.find<ResponsiveUtils>();
-
     return Container(
       decoration: const ShapeDecoration(
         color: BannerEmptyTrashStyles.backgroundColor,

--- a/lib/main/error/error_method_response_exception_extension.dart
+++ b/lib/main/error/error_method_response_exception_extension.dart
@@ -1,0 +1,12 @@
+
+import 'package:jmap_dart_client/jmap/core/error/method/error_method_response.dart';
+import 'package:jmap_dart_client/jmap/core/error/method/exception/error_method_response_exception.dart';
+
+extension ErrorMethodResponseExceptionExtension on ErrorMethodResponseException {
+  String get errorMessage {
+    if (errorResponse is ErrorMethodResponse) {
+      return (errorResponse as ErrorMethodResponse).description?.trim() ?? '';
+    }
+    return '';
+  }
+}

--- a/model/pubspec.lock
+++ b/model/pubspec.lock
@@ -661,10 +661,10 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: ad588c18cec7630bd8a85a312b7811037af93d12
+      resolved-ref: d24ee7f6fe8a4917ffb658b0d295268b9ccced38
       url: "https://github.com/linagora/jmap-dart-client.git"
     source: git
-    version: "0.3.5"
+    version: "0.3.6"
   js:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1342,10 +1342,10 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: ad588c18cec7630bd8a85a312b7811037af93d12
+      resolved-ref: d24ee7f6fe8a4917ffb658b0d295268b9ccced38
       url: "https://github.com/linagora/jmap-dart-client.git"
     source: git
-    version: "0.3.5"
+    version: "0.3.6"
   js:
     dependency: transitive
     description:

--- a/rule_filter/pubspec.lock
+++ b/rule_filter/pubspec.lock
@@ -296,10 +296,10 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: ad588c18cec7630bd8a85a312b7811037af93d12
+      resolved-ref: d24ee7f6fe8a4917ffb658b0d295268b9ccced38
       url: "https://github.com/linagora/jmap-dart-client.git"
     source: git
-    version: "0.3.5"
+    version: "0.3.6"
   js:
     dependency: transitive
     description:

--- a/server_settings/pubspec.lock
+++ b/server_settings/pubspec.lock
@@ -288,10 +288,10 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: ad588c18cec7630bd8a85a312b7811037af93d12
+      resolved-ref: d24ee7f6fe8a4917ffb658b0d295268b9ccced38
       url: "https://github.com/linagora/jmap-dart-client.git"
     source: git
-    version: "0.3.5"
+    version: "0.3.6"
   js:
     dependency: transitive
     description:

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -39,6 +39,7 @@ import 'package:tmail_ui_user/features/login/domain/usecases/get_authenticated_a
 import 'package:tmail_ui_user/features/login/domain/usecases/update_account_cache_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/exceptions/empty_folder_name_exception.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/exceptions/invalid_mail_format_exception.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/usecases/clear_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/usecases/create_new_default_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/usecases/create_new_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/usecases/delete_multiple_mailbox_interactor.dart';
@@ -184,6 +185,7 @@ const fallbackGenerators = {
   MockSpec<GetIdentityCacheOnWebInteractor>(),
   MockSpec<ComposerManager>(fallbackGenerators: fallbackGenerators),
   MockSpec<CleanAndGetEmailsInMailboxInteractor>(),
+  MockSpec<ClearMailboxInteractor>(),
 ])
 void main() {
   // mock mailbox dashboard controller direct dependencies
@@ -271,6 +273,7 @@ void main() {
   final removeAllComposerCacheOnWebInteractor = MockRemoveAllComposerCacheOnWebInteractor();
   final removeComposerCacheByIdOnWebInteractor = MockRemoveComposerCacheByIdOnWebInteractor();
   final getAllIdentitiesInteractor = MockGetAllIdentitiesInteractor();
+  final clearMailboxInteractor = MockClearMailboxInteractor();
   final composerManager = MockComposerManager();
   late MailboxController mailboxController;
 
@@ -322,6 +325,7 @@ void main() {
     Get.put<GetAuthenticatedAccountInteractor>(getAuthenticatedAccountInteractor);
     Get.put<UpdateAccountCacheInteractor>(updateAccountCacheInteractor);
     Get.put<GetAllIdentitiesInteractor>(getAllIdentitiesInteractor);
+    Get.put<ClearMailboxInteractor>(clearMailboxInteractor);
     Get.put<RemoveAllComposerCacheOnWebInteractor>(removeAllComposerCacheOnWebInteractor);
     Get.put<RemoveComposerCacheByIdOnWebInteractor>(removeComposerCacheByIdOnWebInteractor);
     Get.put<ComposerManager>(composerManager);
@@ -361,6 +365,7 @@ void main() {
       removeAllComposerCacheOnWebInteractor,
       removeComposerCacheByIdOnWebInteractor,
       getAllIdentitiesInteractor,
+      clearMailboxInteractor,
     );
   });
 

--- a/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
+++ b/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
@@ -37,6 +37,7 @@ import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oi
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_authenticated_account_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/update_account_cache_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/usecases/clear_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/usecases/create_new_default_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/usecases/create_new_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/usecases/delete_multiple_mailbox_interactor.dart';
@@ -186,6 +187,7 @@ const fallbackGenerators = {
   MockSpec<GetIdentityCacheOnWebInteractor>(),
   MockSpec<ComposerManager>(fallbackGenerators: fallbackGenerators),
   MockSpec<CleanAndGetEmailsInMailboxInteractor>(),
+  MockSpec<ClearMailboxInteractor>(),
 ])
 void main() {
   final moveToMailboxInteractor = MockMoveToMailboxInteractor();
@@ -258,6 +260,7 @@ void main() {
   final removeAllComposerCacheOnWebInteractor = MockRemoveAllComposerCacheOnWebInteractor();
   final removeComposerCacheByIdOnWebInteractor = MockRemoveComposerCacheByIdOnWebInteractor();
   final getAllIdentitiesInteractor = MockGetAllIdentitiesInteractor();
+  final clearMailboxInteractor = MockClearMailboxInteractor();
   final composerManager = MockComposerManager();
 
   final getEmailsInMailboxInteractor = MockGetEmailsInMailboxInteractor();
@@ -320,6 +323,7 @@ void main() {
       Get.put<GetAuthenticatedAccountInteractor>(getAuthenticatedAccountInteractor);
       Get.put<UpdateAccountCacheInteractor>(updateAccountCacheInteractor);
       Get.put<GetAllIdentitiesInteractor>(getAllIdentitiesInteractor);
+      Get.put<ClearMailboxInteractor>(clearMailboxInteractor);
       Get.put<RemoveAllComposerCacheOnWebInteractor>(removeAllComposerCacheOnWebInteractor);
       Get.put<RemoveComposerCacheByIdOnWebInteractor>(removeComposerCacheByIdOnWebInteractor);
       Get.put<ComposerManager>(composerManager);
@@ -360,6 +364,7 @@ void main() {
         removeAllComposerCacheOnWebInteractor,
         removeComposerCacheByIdOnWebInteractor,
         getAllIdentitiesInteractor,
+        clearMailboxInteractor,
       );
       Get.put(mailboxDashboardController);
       mailboxDashboardController.onReady();

--- a/test/features/search/verify_before_time_in_search_email_filter_test.dart
+++ b/test/features/search/verify_before_time_in_search_email_filter_test.dart
@@ -38,6 +38,7 @@ import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oi
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_authenticated_account_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/update_account_cache_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/usecases/clear_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/usecases/mark_as_mailbox_read_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/get_all_recent_search_latest_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/get_composer_cache_on_web_interactor.dart';
@@ -159,6 +160,7 @@ const fallbackGenerators = {
   MockSpec<GetAllIdentitiesInteractor>(),
   MockSpec<ComposerManager>(fallbackGenerators: fallbackGenerators),
   MockSpec<CleanAndGetEmailsInMailboxInteractor>(),
+  MockSpec<ClearMailboxInteractor>(),
 ])
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -217,6 +219,7 @@ void main() {
   late MockRemoveAllComposerCacheOnWebInteractor removeAllComposerCacheOnWebInteractor;
   late MockRemoveComposerCacheByIdOnWebInteractor removeComposerCacheByIdOnWebInteractor;
   late MockGetAllIdentitiesInteractor getAllIdentitiesInteractor;
+  late MockClearMailboxInteractor clearMailboxInteractor;
 
   // Declaration base controller
   late MockCachingManager mockCachingManager;
@@ -311,6 +314,7 @@ void main() {
     removeAllComposerCacheOnWebInteractor = MockRemoveAllComposerCacheOnWebInteractor();
     removeComposerCacheByIdOnWebInteractor = MockRemoveComposerCacheByIdOnWebInteractor();
     getAllIdentitiesInteractor = MockGetAllIdentitiesInteractor();
+    clearMailboxInteractor = MockClearMailboxInteractor();
 
     searchController = SearchController(
       mockQuickSearchEmailInteractor,
@@ -357,6 +361,7 @@ void main() {
       removeAllComposerCacheOnWebInteractor,
       removeComposerCacheByIdOnWebInteractor,
       getAllIdentitiesInteractor,
+      clearMailboxInteractor,
     );
 
     when(emailReceiveManager.pendingSharedFileInfo).thenAnswer((_) => BehaviorSubject.seeded([]));


### PR DESCRIPTION
## Issue

#3707

## Dependent

Need merged:

 - https://github.com/linagora/jmap-dart-client/pull/112
 - https://github.com/linagora/jmap-dart-client/pull/113

## Resolved

- Demo:

**Web:**

https://github.com/user-attachments/assets/f8e057da-940b-483f-af33-b53fed03202f

**Mobile**

[demo-mobile.webm](https://github.com/user-attachments/assets/caed3f5f-8bd1-49fe-aac5-6d58a99b7a98)


- E2E: 

```console
🧪 Should empty view and hide empty trash banner when empty trash successfully
        : 
        : > Task :app:connectedDebugAndroidTest
        : Starting 1 tests on Pixel_6_Pro_API_33(AVD) - 13
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. tap widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  10. enterText widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  11. waitUntilVisible widgets with text containing 75f7-42-118-107-204.ngrok-free.app.
        ✅  12. tap widgets with text "Next".
        ✅  13. waitUntilVisible widgets with key [<'credential_input_form'>] descending from widgets with type "LoginView".
        ✅  14. enterText widgets with type "TextField" descending from widgets with key [<'login_username_input'>].
        ✅  15. waitUntilVisible widgets with text "bob@example.com".
✅ Should empty view and hide empty trash banner when empty trash successfully (integration_test/tests/mailbox/empty_trash_test.dart) (22s)

Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: .../tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 46s

```

[demoe2e.webm](https://github.com/user-attachments/assets/4280fca2-1f24-41e3-861c-b9491efe3c33)

