### PR TITLE
TF-3734 Fix cannot open email as new tab on safari `v16.6`

### DIFF
--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -554,4 +554,25 @@ class HtmlUtils {
         .replaceAll('\n', '')
         .replaceAll('\t', '');
   }
+
+
+  /// Returns true if the browser is Safari and its major version is less than 17.
+  static bool isSafariBelow17() {
+    try {
+      final userAgent = html.window.navigator.userAgent;
+      log('HtmlUtils::isOldSafari:UserAgent = $userAgent');
+      final isSafari = userAgent.contains('Safari') && !userAgent.contains('Chrome');
+      if (!isSafari) return false;
+
+      final match = RegExp(r'Version/(\d+)\.').firstMatch(userAgent);
+      if (match == null) return false;
+
+      final version = int.tryParse(match.group(1)!);
+      log('HtmlUtils::isOldSafari:Version = $version');
+      return version != null && version < 17;
+    } catch (e) {
+      logError('HtmlUtils::isOldSafari:Exception = $e');
+      return false;
+    }
+  }
 }

--- a/lib/main/utils/app_utils.dart
+++ b/lib/main/utils/app_utils.dart
@@ -1,4 +1,5 @@
-import 'package:core/utils/app_logger.dart';
+import 'package:core/core.dart';
+import 'package:core/utils/html/html_utils.dart';
 import 'package:date_format/date_format.dart' as date_format;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -9,6 +10,7 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/localizations/language_code_constants.dart';
 import 'package:tmail_ui_user/main/utils/app_config.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:tmail_ui_user/main/universal_import/html_stub.dart' as html;
 
 class AppUtils {
   const AppUtils._();
@@ -31,12 +33,16 @@ class AppUtils {
     );
   }
 
-  static Future<bool> launchLink(String url, {bool isNewTab = true}) async {
-    return await launchUrl(
-      Uri.parse(url),
-      webOnlyWindowName: isNewTab ? '_blank' : '_self',
-      mode: LaunchMode.externalApplication
-    );
+  static void launchLink(String url, {bool isNewTab = true}) {
+    if (PlatformInfo.isWeb && HtmlUtils.isSafariBelow17()) {
+      html.window.open(url, isNewTab ? '_blank' : '_self');
+    } else {
+      launchUrl(
+        Uri.parse(url),
+        webOnlyWindowName: isNewTab ? '_blank' : '_self',
+        mode: LaunchMode.externalApplication,
+      );
+    }
   }
 
   static bool isDirectionRTL(BuildContext context) {


### PR DESCRIPTION
## Issue

#3734 

## Root cause

In the `launchUrl` function of the `url_launcher` package, use `window.open(url, target, 'noopener,noreferrer')`. But due to the strict security restrictions of Safari `16.6`, adding a third parameter to the `window.open` function, such as `noopener,noreferrer` will cause Safari to limit access between windows, and in some cases, it thinks it is malicious behavior or not part of the user gesture, it will block opening a new tab.

## Solution

On Safari with `version < 17`, use `html.window.open(url, '_blank');` directly without the 3rd parameter.

## Resolved

- Safari `v16.6`:


https://github.com/user-attachments/assets/44cefcff-c6e6-4b4a-bb8b-8cc8e144e807



- Safari `v18.1.1`:



https://github.com/user-attachments/assets/ce6889fc-e1d2-458b-bb4a-c755f09deee7


- Chrome:


https://github.com/user-attachments/assets/d3d748be-4ae4-4a3f-bcfc-bdb605de46e5




- Firefox:


https://github.com/user-attachments/assets/b11bd870-464f-40e3-9beb-b94db67e38a9



- Edge:


https://github.com/user-attachments/assets/0c8ebe2a-7ab9-44d3-aca4-243e1abd0826



- Mobile:

[demo-mobile.webm](https://github.com/user-attachments/assets/42e91e7d-81ca-4ad7-8116-c1fdb9faa53f)



## Bug Related

- https://developer.apple.com/forums/thread/739902
- https://discussions.apple.com/thread/253020466