### PR TITLE
TF-3740 Fix duplicated signatures when changing the From field with inline image in body

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -493,10 +493,10 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: "6c08edd506019917a878dcd26fcc29018b8d48e5"
+      resolved-ref: e5a98bf86c8264e213d126bc8fec1d666b2fbc6b
       url: "https://github.com/linagora/enough_html_editor.git"
     source: git
-    version: "0.1.3"
+    version: "0.1.4"
   enough_platform_widgets:
     dependency: transitive
     description:


### PR DESCRIPTION
## Issue

#3740

## Root cause 

Because inserting the image and then entering the text accidentally placed the `signature` tag inside the `div` tag. Therefore, when removing and inserting the signature, the DOM Selector statement `document.querySelector('#editor > .tmail-signature');` did not find any direct child elements of `#editor` with the class `.tmail-signature`.

## Solution

Use the Selector `document.querySelector('#editor .tmail-signature');` to find any children within `#editor` with the class `tmail-signature`, regardless of nesting level.

## Dependency

- Need merged: https://github.com/linagora/enough_html_editor/pull/37

## Resolved


https://github.com/user-attachments/assets/5098cc89-0261-4755-b1e8-c1a020a17135


