### PR TITLE
TF-3735 Add clearer warning dialog when sending message with Reply-To but no recipients

### DIFF
--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -753,8 +753,7 @@ class ComposerController extends BaseController
   void updateStatusEmailSendButton() {
     if (listToEmailAddress.isNotEmpty
         || listCcEmailAddress.isNotEmpty
-        || listBccEmailAddress.isNotEmpty
-        || listReplyToEmailAddress.isNotEmpty) {
+        || listBccEmailAddress.isNotEmpty) {
       isEnableEmailSendButton.value = true;
     } else {
       isEnableEmailSendButton.value = false;


### PR DESCRIPTION
## Issue

#3735


## Resolved

- Web:


https://github.com/user-attachments/assets/ade699df-3606-45fe-ba59-ecf6e8f69866

- Mobile:

https://github.com/user-attachments/assets/866ff092-67af-4f64-ad40-2e96ec11819d
