### PR TITLE
HOTFIX Update lottie ios to have privacy manifest

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -160,10 +160,10 @@ PODS:
   - libwebp/sharpyuv (1.5.0)
   - libwebp/webp (1.5.0):
     - libwebp/sharpyuv
-  - lottie-ios (4.3.4)
+  - lottie-ios (4.4.1)
   - lottie_native (0.0.1):
     - Flutter
-    - lottie-ios (~> 4.3.4)
+    - lottie-ios (~> 4.4.1)
   - Mantle (2.2.0):
     - Mantle/extobjc (= 2.2.0)
   - Mantle/extobjc (2.2.0)
@@ -386,8 +386,8 @@ SPEC CHECKSUMS:
   GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
   GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
-  lottie-ios: 3d98679b41fa6fd6aff2352b3953dbd3df8a397e
-  lottie_native: e880defad595321983cebac72516c1a10b6df719
+  lottie-ios: e047b1d2e6239b787cc5e9755b988869cf190494
+  lottie_native: c2e590a297861fc32a0188cf8dab39aa97f86d81
   Mantle: c5aa8794a29a022dfbbfc9799af95f477a69b62d
   nanopb: d4d75c12cd1316f4a64e3c6963f879ecd4b5e0d5
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1438,10 +1438,10 @@ packages:
     dependency: "direct main"
     description:
       name: lottie_native
-      sha256: e834047f8172a0fe070eac6355d3c646b241b411619a26c914f0d804909b51a1
+      sha256: eb6bec966f377b9def86fd0fc9d4413882d85e48575c9a77abb1d999b530d579
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.1"
+    version: "0.1.2"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -265,7 +265,7 @@ dependencies:
       url: https://github.com/linagora/twake-previewer-flutter.git
       ref: main
 
-  lottie_native: 0.1.1
+  lottie_native: 0.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Issue
- Apple required privacy manifest from all common used 3rd party frameworks
- Current lottie-ios version lacks privacy manifest
- https://github.com/airbnb/lottie-ios/issues/2213#issuecomment-1854431163

## Solution
Update lottie-native, in turns, lottie-ios is updated