### PR TITLE
TF-3791 Fix email in sending queue lost body

### DIFF
--- a/lib/features/composer/presentation/extensions/setup_email_important_flag_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_important_flag_extension.dart
@@ -14,6 +14,9 @@ extension SetupEmailImportantFlagExtension on ComposerController {
       case EmailActionType.reopenComposerBrowser:
         isMarkAsImportant.value = arguments.isMarkAsImportant ?? false;
         break;
+      case EmailActionType.editSendingEmail:
+        isMarkAsImportant.value = arguments.sendingEmail?.presentationEmail.isMarkAsImportant ?? false;
+        break;
       default:
         break;
     }

--- a/lib/features/composer/presentation/extensions/setup_email_request_read_receipt_flag_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_request_read_receipt_flag_extension.dart
@@ -1,5 +1,6 @@
 
 import 'package:model/email/email_action_type.dart';
+import 'package:model/extensions/email_extension.dart';
 import 'package:server_settings/server_settings/tmail_server_settings_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/composer_arguments.dart';
@@ -11,6 +12,8 @@ extension SetupEmailRequestReadReceiptFlagExtension on ComposerController {
   void setupEmailRequestReadReceiptFlag(ComposerArguments arguments) {
     if (currentEmailActionType == EmailActionType.reopenComposerBrowser) {
       hasRequestReadReceipt.value = arguments.hasRequestReadReceipt ?? false;
+    } else if (currentEmailActionType == EmailActionType.editSendingEmail) {
+      hasRequestReadReceipt.value = arguments.sendingEmail?.email.hasRequestReadReceipt ?? false;
     } else if (currentEmailActionType != EmailActionType.editDraft &&
         currentEmailActionType != EmailActionType.editAsNewEmail) {
 

--- a/model/lib/extensions/email_extension.dart
+++ b/model/lib/extensions/email_extension.dart
@@ -117,6 +117,8 @@ extension EmailExtension on Email {
       mailboxIds: mailboxIds,
       selectMode: selectMode,
       emailHeader: headers?.toList(),
+      bodyValues: bodyValues,
+      htmlBody: htmlBody,
       headerCalendarEvent: headerCalendarEvent,
       xPriorityHeader: xPriorityHeader,
       importanceHeader: importanceHeader,
@@ -193,7 +195,10 @@ extension EmailExtension on Email {
       EmailId? emailId,
     }
   ) {
-    return toPresentationEmail(selectMode: selectMode, emailId: emailId);
+    return toPresentationEmail(
+      selectMode: selectMode,
+      emailId: emailId,
+    );
   }
 
   Email updateEmailHeaderMdn(

--- a/model/lib/extensions/email_extension.dart
+++ b/model/lib/extensions/email_extension.dart
@@ -35,7 +35,8 @@ extension EmailExtension on Email {
 
   String get listUnsubscribe => headers.listUnsubscribe;
 
-  bool get hasRequestReadReceipt => headers.readReceiptHasBeenRequested;
+  bool get hasRequestReadReceipt => headers.readReceiptHasBeenRequested ||
+      headerMdn?.containsKey(IndividualHeaderIdentifier.headerMdn) == true;
 
   bool get hasListUnsubscribe => listUnsubscribe.isNotEmpty;
 


### PR DESCRIPTION
## Issue

#3791 

## Root cause

- Missing `bodyValues`, `htmlValues` properties when convert Email to PresentationEmail

## Resolved

- Lost body

[demo-miss-content.webm](https://github.com/user-attachments/assets/b59b12bc-7384-46ba-8e21-6ff68df5e364)

- Lost Mark as important, Request read receipt:

[demo-lost-important-mdn.webm](https://github.com/user-attachments/assets/27cc8f13-d223-4581-8f45-d7b488e0fd95)

