### PR TITLE
Hot fix cursor pointer indicator in composer is wrong color on Android >= 31

### DIFF
--- a/android/app/src/main/res/values-night-v31/styles.xml
+++ b/android/app/src/main/res/values-night-v31/styles.xml
@@ -8,6 +8,7 @@
         <item name="android:windowSplashScreenBackground">#ffffff</item>
         <item name="android:windowSplashScreenBrandingImage">@drawable/android12branding</item>
         <item name="android:windowSplashScreenAnimatedIcon">@drawable/android12splash</item>
+        <item name="android:colorControlActivated">@color/colorPrimary</item>
     </style>
     <!-- Theme applied to the Android Window as soon as the process has started.
          This theme determines the color of the Android Window while your
@@ -17,5 +18,6 @@
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
     <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
+        <item name="android:colorControlActivated">@color/colorPrimary</item>
     </style>
 </resources>

--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -6,7 +6,7 @@
              Flutter draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
         <item name="android:windowFullscreen">false</item>
-        <item name="android:colorControlActivated" tools:targetApi="lollipop">@color/colorPrimary</item>
+        <item name="android:colorControlActivated" >@color/colorPrimary</item>
         <item name="android:forceDarkAllowed" tools:targetApi="q">false</item>
         <item name="android:windowSplashScreenBackground" tools:targetApi="s">@drawable/launch_background</item>
         <item name="android:windowSplashScreenBrandingImage" tools:targetApi="s">@drawable/branding</item>
@@ -19,7 +19,7 @@
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
     <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
-        <item name="android:colorControlActivated" tools:targetApi="lollipop">@color/colorPrimary</item>
+        <item name="android:colorControlActivated" >@color/colorPrimary</item>
         <item name="android:forceDarkAllowed" tools:targetApi="q">false</item>
         <item name="android:windowSplashScreenBackground" tools:targetApi="s">@drawable/launch_background</item>
         <item name="android:windowSplashScreenBrandingImage" tools:targetApi="s">@drawable/branding</item>

--- a/android/app/src/main/res/values-v31/styles.xml
+++ b/android/app/src/main/res/values-v31/styles.xml
@@ -8,6 +8,7 @@
         <item name="android:windowSplashScreenBackground">#ffffff</item>
         <item name="android:windowSplashScreenBrandingImage">@drawable/android12branding</item>
         <item name="android:windowSplashScreenAnimatedIcon">@drawable/android12splash</item>
+        <item name="android:colorControlActivated">@color/colorPrimary</item>
     </style>
     <!-- Theme applied to the Android Window as soon as the process has started.
          This theme determines the color of the Android Window while your
@@ -19,5 +20,6 @@
         <item name="android:windowBackground">?android:colorBackground</item>
         <item name="android:windowSplashScreenBackground">#ffffff</item>
         <item name="android:windowSplashScreenAnimatedIcon">@drawable/android12splash</item>
+        <item name="android:colorControlActivated">@color/colorPrimary</item>
     </style>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -5,10 +5,10 @@
         <!-- Show a splash screen on the activity. Automatically removed when
              Flutter draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
-        <item name="android:colorControlActivated" tools:targetApi="lollipop">@color/colorPrimary</item>
-        <item name="android:forceDarkAllowed">false</item>
+        <item name="android:colorControlActivated">@color/colorPrimary</item>
+        <item name="android:forceDarkAllowed" tools:targetApi="q">false</item>
         <item name="android:windowFullscreen">false</item>
-        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+        <item name="android:windowLayoutInDisplayCutoutMode" tools:targetApi="o_mr1">shortEdges</item>
     </style>
     <!-- Theme applied to the Android Window as soon as the process has started.
          This theme determines the color of the Android Window while your
@@ -18,7 +18,7 @@
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
     <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
-        <item name="android:colorControlActivated" tools:targetApi="lollipop">@color/colorPrimary</item>
+        <item name="android:colorControlActivated" >@color/colorPrimary</item>
         <item name="android:forceDarkAllowed" tools:targetApi="q">false</item>
         <item name="android:windowSplashScreenBackground" tools:targetApi="s">@drawable/launch_background</item>
         <item name="android:windowSplashScreenBrandingImage" tools:targetApi="s">@drawable/branding</item>


### PR DESCRIPTION
## Issue

Cursor pointer indicator in composer is wrong color on Android >= 31


![android-31](https://github.com/user-attachments/assets/d0a1a5e5-8cdb-451b-9e9f-0fb99f490fa4)

## Root cause

Missing value `colorControlActivated` in android resource values folder. Side effect from https://github.com/linagora/tmail-flutter/pull/3788

## Resolved

- Android 31:

![fix-android-31](https://github.com/user-attachments/assets/dd26e81f-706f-4209-8e67-9f8701a4ae36)

- Android 33:

![android-33](https://github.com/user-attachments/assets/79dfa829-ab1a-4e93-8079-d903dd999264)

