### PR TITLE
TF-3819 Fix IOS modified signature is not kept in Draft folder

### DIFF
--- a/core/lib/presentation/utils/html_transformer/transform_configuration.dart
+++ b/core/lib/presentation/utils/html_transformer/transform_configuration.dart
@@ -54,7 +54,8 @@ class TransformConfiguration {
   factory TransformConfiguration.forEditDraftsEmail() => TransformConfiguration.create(
     customDomTransformers: [
       ...TransformConfiguration.forDraftsEmail().domTransformers,
-      const HideDraftSignatureTransformer()
+      if (PlatformInfo.isWeb)
+        const HideDraftSignatureTransformer()
     ]
   );
 

--- a/lib/features/composer/presentation/extensions/setup_selected_identity_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_selected_identity_extension.dart
@@ -9,8 +9,8 @@ extension SetupSelectedIdentityExtension on ComposerController {
 
   Future<void> setupSelectedIdentity() async {
     if (identitySelected.value != null) {
-      if (PlatformInfo.isMobile && currentEmailActionType == EmailActionType.editDraft) {
-        await selectIdentity(identitySelected.value);
+      if (PlatformInfo.isMobile &&
+          currentEmailActionType == EmailActionType.editDraft) {
         onCompleteSetupComposer();
       }
       return;


### PR DESCRIPTION
## Issue

#3819 

## Root cause

 On mobile, we always apply the signature content from the saved identity ID when opening a draft

## Resolved


https://github.com/user-attachments/assets/8aba6dde-fc72-40ba-a42e-e320b9123031

