### PR TITLE
TF-3820 Fix IOS signature is not shown after switching between identities if having a quote text

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -500,10 +500,10 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: e5a98bf86c8264e213d126bc8fec1d666b2fbc6b
+      resolved-ref: "0a2684235bccbb701b55559b75502984dd9091d3"
       url: "https://github.com/linagora/enough_html_editor.git"
     source: git
-    version: "0.1.4"
+    version: "0.1.5"
   enough_platform_widgets:
     dependency: transitive
     description:


### PR DESCRIPTION
## Issue

#3820 

## Root cause

The statement causing the error: `nodeEditor.insertBefore(signatureContainer, quotedMessage);`. `quotedMessage` is not a direct child of `nodeEditor`, will throw `NotFoundError`

## Dependency

Need merged:

- https://github.com/linagora/enough_html_editor/pull/38


## Resolved

- Compose email:

https://github.com/user-attachments/assets/7bd1f8d5-0926-4189-995d-6d54849d7cca

- Reply email:


https://github.com/user-attachments/assets/fd8e9511-5eb1-49d3-91ed-31797f019649


