### PR TITLE
[HOT] Fix incorrect `Support` folder alignment

### DIFF
--- a/lib/features/mailbox/presentation/base_mailbox_view.dart
+++ b/lib/features/mailbox/presentation/base_mailbox_view.dart
@@ -122,9 +122,15 @@ abstract class BaseMailboxView extends GetWidget<MailboxController>
               isArrangeLTR: false,
               showIcon: true,
               padding: isDesktop
-                  ? const EdgeInsetsDirectional.only(start: 10)
-                  : const EdgeInsets.symmetric(horizontal: 24),
-              height: isDesktop ? 36 : 40,
+                  ? const EdgeInsets.symmetric(
+                      horizontal: MailboxItemWidgetStyles.itemPadding,
+                    )
+                  : const EdgeInsets.symmetric(
+                      horizontal: MailboxItemWidgetStyles.mobileItemPadding * 2,
+                    ),
+              height: isDesktop
+                  ? MailboxItemWidgetStyles.height
+                  : MailboxItemWidgetStyles.mobileHeight,
               iconSpace: isDesktop
                   ? null
                   : MailboxItemWidgetStyles.mobileLabelIconSpace,
@@ -355,9 +361,16 @@ abstract class BaseMailboxView extends GetWidget<MailboxController>
                 padding: isDesktop
                     ? null
                     : const EdgeInsets.symmetric(horizontal: 12),
-                itemPadding: const EdgeInsets.symmetric(
-                  horizontal: MailboxItemWidgetStyles.mobileItemPadding,
-                ),
+                itemPadding: isDesktop
+                    ? null
+                    : const EdgeInsets.symmetric(
+                        horizontal: MailboxItemWidgetStyles.mobileItemPadding,
+                      ),
+                iconPadding: isDesktop
+                    ? null
+                    : const EdgeInsetsDirectional.only(
+                        end: MailboxItemWidgetStyles.mobileLabelIconSpace,
+                      ),
                 borderRadius: isDesktop
                   ? null
                   : MailboxItemWidgetStyles.mobileBorderRadius,

--- a/lib/features/mailbox/presentation/widgets/folder_widget.dart
+++ b/lib/features/mailbox/presentation/widgets/folder_widget.dart
@@ -12,6 +12,7 @@ class FolderWidget extends StatelessWidget {
   final String? tooltip;
   final EdgeInsetsGeometry? padding;
   final EdgeInsetsGeometry? itemPadding;
+  final EdgeInsetsGeometry? iconPadding;
   final double? borderRadius;
   final double? height;
   final TextStyle? labelTextStyle;
@@ -24,6 +25,7 @@ class FolderWidget extends StatelessWidget {
     this.tooltip,
     this.padding,
     this.itemPadding,
+    this.iconPadding,
     this.borderRadius,
     this.height,
     this.labelTextStyle,
@@ -44,9 +46,7 @@ class FolderWidget extends StatelessWidget {
       child: Row(children: [
         MailboxIconWidget(
           icon: icon,
-          padding: const EdgeInsetsDirectional.only(
-            end: MailboxItemWidgetStyles.mobileLabelIconSpace,
-          ),
+          padding: iconPadding,
           color: AppColor.iconFolder,
         ),
         Expanded(


### PR DESCRIPTION
## Issue

<img width="232" alt="error" src="https://github.com/user-attachments/assets/079d4ddc-dc41-4d81-b113-d06a85d98510" />

## Resolved

- Web:

https://github.com/user-attachments/assets/773b6674-9e8e-489d-aa3f-a57709d23b66


- Mobile:


![mobile](https://github.com/user-attachments/assets/f1d8ebfa-d0f5-46b6-a526-2b9dc3462362)
