### PR TITLE
TF-3835 Fix problems with selecting Italic in fonts on Android

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -500,10 +500,10 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: "0a2684235bccbb701b55559b75502984dd9091d3"
+      resolved-ref: "235dc4ec3e07940510173d34ddeaafcdde36fbe2"
       url: "https://github.com/linagora/enough_html_editor.git"
     source: git
-    version: "0.1.5"
+    version: "0.1.6"
   enough_platform_widgets:
     dependency: transitive
     description:
@@ -1863,10 +1863,10 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "4a4ee913fbdec0f98cc1755f31df54fb402d0957"
+      resolved-ref: fad6dc0102d07589c1cc6af97f1d8092749d1185
       url: "https://github.com/linagora/rich-text-composer.git"
     source: git
-    version: "0.1.0"
+    version: "0.1.1"
   rule_filter:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## Issue

#3835 

## Root cause 

Because `document.onselectionchange` is only fired when the selection changes, not when the content or formatting of the selection changes. When `document.execCommand('italic')` applies the formatting but does not change the selection, so `onselectionchange` is not called again.

## Solution

Use `MutationObserver` to listen for DOM changes.

## Dependency

- Need merged: https://github.com/linagora/rich-text-composer/pull/30  


## Resolved

- Android:

[demo-android.webm](https://github.com/user-attachments/assets/f26cbba0-77ad-46d5-9b23-a4d855282ef9)

- iOS:


https://github.com/user-attachments/assets/8ff5fb36-d103-4610-a712-62cb745f10ed


