### PR TITLE
TF-3846 Fix Notion email always not wrap in mobile view

### DIFF
--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -177,6 +177,10 @@ class HtmlUtils {
           white-space: pre-wrap;
         }
         
+        table {
+          white-space: normal !important;
+        }
+        
         ${styleCSS ?? ''}
       </style>
       </head>


### PR DESCRIPTION
## Issue

#3846

## Root cause

The `table` element in the email content's HTML uses `white-space: nowrap;` which prevents the text from wrapping automatically

## Solution

Use CSS style for table:

```css
table {
  white-space: normal !important;
}
```

## Resolved

- Mobile:

[demo.webm](https://github.com/user-attachments/assets/45484835-e36e-47c9-aa1a-b1749b6ce863)

- Web:



https://github.com/user-attachments/assets/f32a573f-1db9-4f84-a641-9ceedd34dba3


