### PR TITLE
Fix TMail load fonts from `https://fonts.gstatic.com`

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -94,7 +94,9 @@
           }
           _flutter.loader.load({
             onEntrypointLoaded: async function(engineInitializer) {
-              const appRunner = await engineInitializer.initializeEngine();
+              const appRunner = await engineInitializer.initializeEngine({
+                fontFallbackBaseUrl: ''
+              });
               await setTimeout( async function () {
                 await appRunner.runApp();
               }, 2000);
@@ -104,7 +106,9 @@
     } else {
       _flutter.loader.load({
         onEntrypointLoaded: async function(engineInitializer) {
-          const appRunner = await engineInitializer.initializeEngine();
+          const appRunner = await engineInitializer.initializeEngine({
+            fontFallbackBaseUrl: ''
+          });
           await setTimeout( async function () {
             await appRunner.runApp();
           }, 2000);


### PR DESCRIPTION
## Issue

[TMail load fonts from https://fonts.gstatic.com](https://www.notion.so/linagora/TMail-Load-fonts-from-https-fonts-gstatic-com-21862718bad1806ebcb2d8b26d6e9bee?source=copy_link)

Twake Mail load font from other domains:

```
https://fonts.gstatic.com/s/roboto/v20/KFOmCnqEu92Fr1Me5WZLCzYlKw.ttf
https://fonts.gstatic.com/s/notosanssymbols/v43/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3gfQ8gavVFRkzrbQ.ttf
```

<img width="1104" alt="Screenshot 2025-07-02 at 11 33 52" src="https://github.com/user-attachments/assets/808d9822-a71a-46cf-97b6-4f55c208dfd3" />

## Root cause 

In our project, we do not declare any objects related to loading fonts from 

```
https://fonts.gstatic.com/s/roboto/v20/KFOmCnqEu92Fr1Me5WZLCzYlKw.ttf
https://fonts.gstatic.com/s/notosanssymbols/v43/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3gfQ8gavVFRkzrbQ.ttf
```

These are the default fonts of Flutter 


![Screenshot 2025-07-02 at 11 40 12](https://github.com/user-attachments/assets/9b56dc1f-68f0-4eae-96e6-da885e04c2a3)

## Workaround

Flutter web allows you to set a custom font fallback base URL via `initializeEngine()`. But the `Roboto` font will still be called.

```html
_flutter.loader.load({  onEntrypointLoaded: function(engineInitializer) {
    engineInitializer.initializeEngine({
      // Load local fallback fonts if needed.
      fontFallbackBaseUrl: ''
    }).then(function(appRunner) {
      appRunner.runApp();
    });
  }
});
```

## Resolved


https://github.com/user-attachments/assets/2e43d4af-935b-4c26-8230-19e4d8639869

## Related


This issue is also raised on Flutter's GitHub, and there is currently no fix for it

- https://github.com/flutter/flutter/issues/163823
- https://github.com/flutter/flutter/issues/163554