### PR TITLE
Apply new style language section setting

### DIFF
--- a/assets/images/ic_arrow_back.svg
+++ b/assets/images/ic_arrow_back.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M20 11H7.83L13.42 5.41L12 4L4 12L12 20L13.41 18.59L7.83 13H20V11Z" fill="#1C1B1F"/>
+</svg>

--- a/core/lib/presentation/extensions/color_extension.dart
+++ b/core/lib/presentation/extensions/color_extension.dart
@@ -260,12 +260,14 @@ extension AppColor on Color {
   static const gray424244 = Color(0xFF424244);
   static const redFF3347 = Color(0xFFFF3347);
   static const gray686E76 = Color(0xFF686E76);
+  static const lightGrayEBEDF0 = Color(0xFFEBEDF0);
   static const textSecondary = Color(0xFF1C1B1F);
   static const profileMenuDivider = Color(0xFF1D192B);
   static const popupMenuItemHovered = Color(0xFFF8F8F8);
   static const secondaryContrastText = Color(0xFFFFFFFF);
   static const primaryLinShare = Color(0xFF007AFF);
   static const lightGrayEAEDF2 = Color(0xFFEAEDF2);
+  static const lightIconTertiary = Color(0xFFB8C1CC);
 
   static const mapGradientColor = [
     [Color(0xFF21D4FD), Color(0xFFB721FF)],

--- a/core/lib/presentation/resources/image_paths.dart
+++ b/core/lib/presentation/resources/image_paths.dart
@@ -231,7 +231,10 @@ class ImagePaths {
   String get icDoubleArrowDown => _getImagePath('ic_double_arrow_down.svg');
   String get icRefreshQuotas => _getImagePath('ic_refresh_quotas.svg');
   String get icCreateFilter => _getImagePath('ic_create_filter.svg');
+  String get icArrowBack => _getImagePath('ic_arrow_back.svg');
+
   String get icTwakeWorkplace => _getIconPath('icon_twp.png');
+
   String get animLottieTmail => _getAnimationPath('lottie-tmail.json');
 
   String _getImagePath(String imageName) {

--- a/core/lib/presentation/utils/theme_utils.dart
+++ b/core/lib/presentation/utils/theme_utils.dart
@@ -280,6 +280,15 @@ class ThemeUtils {
     color: AppColor.textSecondary.withOpacity(0.48),
   );
 
+  static const TextStyle textStyleM3BodyLarge = TextStyle(
+    fontFamily: ConstantsUI.fontApp,
+    fontWeight: FontWeight.w500,
+    letterSpacing: 00.15,
+    fontSize: 17,
+    height: 24 / 17,
+    color: AppColor.m3SurfaceBackground,
+  );
+
   static TextStyle textStyleAppShortcut() => const TextStyle(
     fontFamily: ConstantsUI.fontApp,
     fontWeight: FontWeight.normal,

--- a/core/lib/presentation/views/button/tmail_button_widget.dart
+++ b/core/lib/presentation/views/button/tmail_button_widget.dart
@@ -44,6 +44,7 @@ class TMailButtonWidget extends StatelessWidget {
   final Color? hoverColor;
   final TextOverflow? textOverflow;
   final Alignment? alignment;
+  final bool isTextExpanded;
 
   const TMailButtonWidget({
     super.key,
@@ -81,6 +82,7 @@ class TMailButtonWidget extends StatelessWidget {
     this.hoverColor,
     this.textOverflow,
     this.alignment,
+    this.isTextExpanded = false,
   });
 
   factory TMailButtonWidget.fromIcon({
@@ -163,6 +165,7 @@ class TMailButtonWidget extends StatelessWidget {
     Color? hoverColor,
     TextOverflow? textOverflow,
     Alignment? alignment,
+    bool isTextExpanded = false,
   }) {
     return TMailButtonWidget(
       key: key,
@@ -189,48 +192,63 @@ class TMailButtonWidget extends StatelessWidget {
       hoverColor: hoverColor,
       textOverflow: textOverflow,
       alignment: alignment,
+      isTextExpanded: isTextExpanded,
     );
   }
 
   @override
   Widget build(BuildContext context) {
     Widget childWidget;
+    Widget? textWidget;
+    Widget? iconWidget;
+    Widget? trailingIconWidget;
 
+    if (text.isNotEmpty) {
+      textWidget = Text(
+        text,
+        textAlign: textAlign,
+        style: textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
+          fontSize: 12,
+          color: AppColor.colorTextButtonHeaderThread,
+        ),
+        maxLines: maxLines,
+        overflow: textOverflow ??
+            (maxLines == 1 ? CommonTextStyle.defaultTextOverFlow : null),
+        softWrap: maxLines == 1 ? CommonTextStyle.defaultSoftWrap : null,
+      );
+    }
+
+    if (icon != null) {
+      iconWidget = SvgPicture.asset(
+        icon!,
+        width: iconSize,
+        height: iconSize,
+        fit: BoxFit.fill,
+        colorFilter: iconColor?.asFilter(),
+      );
+    }
+
+    if (trailingIcon != null) {
+      trailingIconWidget = Padding(
+        padding: EdgeInsetsDirectional.only(top: iconSpace),
+        child: SvgPicture.asset(
+          trailingIcon!,
+          width: trailingIconSize,
+          height: trailingIconSize,
+          fit: BoxFit.fill,
+          colorFilter: trailingIconColor?.asFilter(),
+        ),
+      );
+    }
     if (icon != null && text.isNotEmpty) {
       if (verticalDirection) {
         childWidget = Column(
           mainAxisSize: mainAxisSize,
           children: [
-            SvgPicture.asset(
-              icon!,
-              width: iconSize,
-              height: iconSize,
-              fit: BoxFit.fill,
-              colorFilter: iconColor?.asFilter()
-            ),
+            iconWidget!,
             SizedBox(height: iconSpace),
-            Text(
-              text,
-              textAlign: textAlign,
-              style: textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
-                fontSize: 12,
-                color: AppColor.colorTextButtonHeaderThread
-              ),
-              maxLines: maxLines,
-              overflow: textOverflow ?? (maxLines == 1 ? CommonTextStyle.defaultTextOverFlow : null),
-              softWrap: maxLines == 1 ? CommonTextStyle.defaultSoftWrap : null,
-            ),
-            if (trailingIcon != null)
-              Padding(
-                padding: EdgeInsetsDirectional.only(top: iconSpace),
-                child: SvgPicture.asset(
-                  trailingIcon!,
-                  width: trailingIconSize,
-                  height: trailingIconSize,
-                  fit: BoxFit.fill,
-                  colorFilter: trailingIconColor?.asFilter()
-                ),
-              ),
+            textWidget!,
+            if (trailingIcon != null) trailingIconWidget!,
           ]
         );
       } else {
@@ -239,51 +257,15 @@ class TMailButtonWidget extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             mainAxisSize: mainAxisSize,
             children: [
-              SvgPicture.asset(
-                icon!,
-                width: iconSize,
-                height: iconSize,
-                fit: BoxFit.fill,
-                colorFilter: iconColor?.asFilter()
-              ),
+              iconWidget!,
               SizedBox(width: iconSpace),
               if (flexibleText)
-                Flexible(
-                  child: Text(
-                    text,
-                    textAlign: textAlign,
-                    style: textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
-                      fontSize: 12,
-                      color: AppColor.colorTextButtonHeaderThread
-                    ),
-                    maxLines: maxLines,
-                    overflow: textOverflow ?? (maxLines == 1 ? CommonTextStyle.defaultTextOverFlow : null),
-                    softWrap: maxLines == 1 ? CommonTextStyle.defaultSoftWrap : null,
-                  ),
-                )
+                Flexible(child: textWidget!)
+              else if (isTextExpanded)
+                Expanded(child: textWidget!)
               else
-                Text(
-                  text,
-                  textAlign: textAlign,
-                  style: textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
-                    fontSize: 12,
-                    color: AppColor.colorTextButtonHeaderThread
-                  ),
-                  maxLines: maxLines,
-                  overflow: textOverflow ?? (maxLines == 1 ? CommonTextStyle.defaultTextOverFlow : null),
-                  softWrap: maxLines == 1 ? CommonTextStyle.defaultSoftWrap : null,
-                ),
-              if (trailingIcon != null)
-                Padding(
-                  padding: EdgeInsetsDirectional.only(start: iconSpace),
-                  child: SvgPicture.asset(
-                    trailingIcon!,
-                    width: trailingIconSize,
-                    height: trailingIconSize,
-                    fit: BoxFit.fill,
-                    colorFilter: trailingIconColor?.asFilter()
-                  ),
-                ),
+                textWidget!,
+              if (trailingIcon != null) trailingIconWidget!,
             ]
           );
         } else {
@@ -292,40 +274,14 @@ class TMailButtonWidget extends StatelessWidget {
             mainAxisSize: mainAxisSize,
             children: [
               if (flexibleText)
-                Flexible(
-                  child: Text(
-                    text,
-                    textAlign: textAlign,
-                    style: textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
-                      fontSize: 12,
-                      color: AppColor.colorTextButtonHeaderThread
-                    ),
-                    maxLines: maxLines,
-                    overflow: textOverflow ?? (maxLines == 1 ? CommonTextStyle.defaultTextOverFlow : null),
-                    softWrap: maxLines == 1 ? CommonTextStyle.defaultSoftWrap : null,
-                  ),
-                )
+                Flexible(child: textWidget!)
+              else if (isTextExpanded)
+                Expanded(child: textWidget!)
               else
-                Text(
-                  text,
-                  textAlign: textAlign,
-                  style: textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
-                    fontSize: 12,
-                    color: AppColor.colorTextButtonHeaderThread
-                  ),
-                  maxLines: maxLines,
-                  overflow: textOverflow ?? (maxLines == 1 ? CommonTextStyle.defaultTextOverFlow : null),
-                  softWrap: maxLines == 1 ? CommonTextStyle.defaultSoftWrap : null,
-                ),
+                textWidget!,
               SizedBox(width: iconSpace),
               if (!isLoading)
-                SvgPicture.asset(
-                  icon!,
-                  width: iconSize,
-                  height: iconSize,
-                  fit: BoxFit.fill,
-                  colorFilter: iconColor?.asFilter()
-                )
+                iconWidget!
               else 
                 SizedBox(
                   width: iconSize,
@@ -340,25 +296,9 @@ class TMailButtonWidget extends StatelessWidget {
         }
       }
     } else if (icon != null) {
-      childWidget = SvgPicture.asset(
-        icon!,
-        width: iconSize,
-        height: iconSize,
-        fit: BoxFit.fill,
-        colorFilter: iconColor?.asFilter()
-      );
+      childWidget = iconWidget!;
     } else {
-      childWidget = Text(
-        text,
-        textAlign: textAlign,
-        style: textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
-          fontSize: 12,
-          color: AppColor.colorTextButtonHeaderThread
-        ),
-        maxLines: maxLines,
-        overflow: textOverflow ?? (maxLines == 1 ? CommonTextStyle.defaultTextOverFlow : null),
-        softWrap: maxLines == 1 ? CommonTextStyle.defaultSoftWrap : null,
-      );
+      childWidget = textWidget!;
     }
 
     return TMailContainerWidget(

--- a/core/lib/utils/logger/log_tracking.dart
+++ b/core/lib/utils/logger/log_tracking.dart
@@ -23,6 +23,7 @@ class LogTracking {
 
   final Queue<String> _messagesQueue = Queue();
   bool _isScheduled = false;
+  bool isEnabled = false;
 
   Future<void> addLog({required String message}) async {
     try {

--- a/integration_test/robots/language_robot.dart
+++ b/integration_test/robots/language_robot.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/language_and_region/extensions/locale_extension.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../base/core_robot.dart';
+
+class LanguageRobot extends CoreRobot {
+  LanguageRobot(super.$);
+
+  Future<void> openLanguageContextMenu() async {
+    await $(#language_drop_down_button).tap();
+  }
+
+  Future<void> selectLanguage(
+    Locale locale,
+    AppLocalizations appLocalizations,
+  ) async {
+    await $(find.text(
+            '${locale.getLanguageNameByCurrentLocale(appLocalizations)} - ${locale.getSourceLanguageName()}'))
+        .tap();
+  }
+}

--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -18,4 +18,8 @@ class MailboxMenuRobot extends CoreRobot {
       .$(find.text(name))
       .tap();
   }
+
+  Future<void> openSetting() async {
+    await $(#user_avatar).tap();
+  }
 }

--- a/integration_test/robots/setting_robot.dart
+++ b/integration_test/robots/setting_robot.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../base/core_robot.dart';
+
+class SettingRobot extends CoreRobot {
+  SettingRobot(super.$);
+
+  Future<void> openLanguageMenuItem() async {
+    await $(#setting_language_region).tap();
+  }
+}

--- a/integration_test/scenarios/setting/language/change_language_scenario.dart
+++ b/integration_test/scenarios/setting/language/change_language_scenario.dart
@@ -1,0 +1,64 @@
+import 'package:duration/duration.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../../base/base_test_scenario.dart';
+import '../../../robots/language_robot.dart';
+import '../../../robots/mailbox_menu_robot.dart';
+import '../../../robots/setting_robot.dart';
+import '../../../robots/thread_robot.dart';
+
+class ChangeLanguageScenario extends BaseTestScenario {
+  const ChangeLanguageScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    final threadRobot = ThreadRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+    final settingRobot = SettingRobot($);
+    final languageRobot = LanguageRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await threadRobot.openMailbox();
+    await _expectUserAvatarVisible();
+
+    await mailboxMenuRobot.openSetting();
+    await _expectSettingViewVisible(appLocalizations);
+    await $.pumpAndSettle(duration: seconds(1));
+
+    await _expectLanguageMenuItemVisible();
+    await settingRobot.openLanguageMenuItem();
+    await $.pumpAndSettle(duration: seconds(1));
+    await _expectLanguageViewWithEnglishTitleVisible();
+
+    await languageRobot.openLanguageContextMenu();
+    await _expectLanguageContextMenuVisible();
+
+    await languageRobot.selectLanguage(const Locale('vi'), appLocalizations);
+    await $.pumpAndSettle(duration: seconds(3));
+    await _expectLanguageViewWithVietnameseTitleVisible();
+  }
+
+  Future<void> _expectUserAvatarVisible() => expectViewVisible($(#user_avatar));
+
+  Future<void> _expectSettingViewVisible(AppLocalizations appLocalizations) =>
+      expectViewVisible($(find.text(appLocalizations.settings)));
+
+  Future<void> _expectLanguageMenuItemVisible() async {
+    await $(#setting_language_region).scrollTo(
+      scrollDirection: AxisDirection.down,
+    );
+    await expectViewVisible($(#setting_language_region));
+  }
+
+  Future<void> _expectLanguageViewWithEnglishTitleVisible() =>
+      expectViewVisible($(find.text('Language')));
+
+  Future<void> _expectLanguageContextMenuVisible() async {
+    await expectViewVisible($(#language_context_menu));
+  }
+
+  Future<void> _expectLanguageViewWithVietnameseTitleVisible() =>
+      expectViewVisible($(find.text('Ngôn ngữ')));
+}

--- a/integration_test/tests/setting/language/change_language_test.dart
+++ b/integration_test/tests/setting/language/change_language_test.dart
@@ -1,0 +1,9 @@
+import '../../../base/test_base.dart';
+import '../../../scenarios/setting/language/change_language_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see title in Setting change language when successfully selecting another language',
+    scenarioBuilder: ($) => ChangeLanguageScenario($),
+  );
+}

--- a/lib/features/base/widget/tmail_drop_down_widget.dart
+++ b/lib/features/base/widget/tmail_drop_down_widget.dart
@@ -1,0 +1,47 @@
+import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:flutter/material.dart';
+
+class TMailDropDownWidget extends StatelessWidget {
+
+  final String text;
+  final String dropDownIcon;
+  final VoidCallback onTap;
+  final double? width;
+  final Color? backgroundColor;
+
+  const TMailDropDownWidget({
+    super.key,
+    required this.text,
+    required this.dropDownIcon,
+    required this.onTap,
+    this.width,
+    this.backgroundColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TMailButtonWidget(
+      text: text,
+      icon: dropDownIcon,
+      iconAlignment: TextDirection.rtl,
+      width: width,
+      height: 40,
+      borderRadius: 10,
+      backgroundColor: backgroundColor ?? Colors.transparent,
+      iconSize: 20,
+      iconColor: AppColor.lightIconTertiary,
+      padding: const EdgeInsetsDirectional.only(
+        start: 12,
+        end: 8,
+        top: 8,
+        bottom: 8,
+      ),
+      textStyle: ThemeUtils.textStyleBodyBody3(color: Colors.black),
+      border: Border.all(width: 1, color: AppColor.m3Neutral90),
+      isTextExpanded: true,
+      onTapActionCallback: onTap,
+    );
+  }
+}

--- a/lib/features/mailbox/presentation/widgets/mailbox_app_bar.dart
+++ b/lib/features/mailbox/presentation/widgets/mailbox_app_bar.dart
@@ -49,6 +49,7 @@ class MailboxAppBar extends StatelessWidget {
               onTapAction: openAppGridAction!,
             ),
           UserAvatarBuilder(
+            key: const Key('user_avatar'),
             username: username.firstLetterToUpperCase,
             padding: const EdgeInsetsDirectional.only(start: 4),
             onTapAction: openSettingsAction,

--- a/lib/features/mailbox/presentation/widgets/user_information_widget.dart
+++ b/lib/features/mailbox/presentation/widgets/user_information_widget.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/extensions/string_extension.dart';
 import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/base/widget/material_text_button.dart';
@@ -34,7 +35,7 @@ class UserInformationWidget extends StatelessWidget {
       decoration: BoxDecoration(border: border),
       child: Row(children: [
         UserAvatarBuilder(
-          username: userName,
+          username: userName.firstLetterToUpperCase,
           size: 51,
           textStyle: ThemeUtils.textStyleInter500().copyWith(
             fontSize: 25.5,

--- a/lib/features/manage_account/presentation/base/setting_detail_view_builder.dart
+++ b/lib/features/manage_account/presentation/base/setting_detail_view_builder.dart
@@ -22,28 +22,40 @@ class SettingDetailViewBuilder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: SettingsUtils.getBackgroundColor(context, responsiveUtils),
-      body: GestureDetector(
-        onTap: onTapGestureDetector,
-        child: Container(
-          width: double.infinity,
-          height: double.infinity,
-          color: SettingsUtils.getContentBackgroundColor(
-            context,
-            responsiveUtils,
-            backgroundColor: backgroundColor,
-          ),
-          decoration: SettingsUtils.getBoxDecorationForContent(
-            context,
-            responsiveUtils,
-            backgroundColor: backgroundColor,
-          ),
-          margin: SettingsUtils.getMarginSettingDetailsView(context, responsiveUtils),
-          padding: padding,
-          child: child,
-        ),
+    Widget containerWidget = Container(
+      width: double.infinity,
+      height: double.infinity,
+      color: SettingsUtils.getContentBackgroundColor(
+        context,
+        responsiveUtils,
+        backgroundColor: backgroundColor,
       ),
+      decoration: SettingsUtils.getBoxDecorationForContent(
+        context,
+        responsiveUtils,
+        backgroundColor: backgroundColor,
+      ),
+      margin: SettingsUtils.getMarginSettingDetailsView(
+        context,
+        responsiveUtils,
+      ),
+      padding: padding,
+      child: child,
+    );
+
+    if (onTapGestureDetector != null) {
+      containerWidget = GestureDetector(
+        onTap: onTapGestureDetector,
+        child: containerWidget,
+      );
+    }
+
+    return Scaffold(
+      backgroundColor: SettingsUtils.getBackgroundColor(
+        context,
+        responsiveUtils,
+      ),
+      body: containerWidget,
     );
   }
 }

--- a/lib/features/manage_account/presentation/email_rules/widgets/email_rules_header_widget.dart
+++ b/lib/features/manage_account/presentation/email_rules/widgets/email_rules_header_widget.dart
@@ -35,7 +35,10 @@ class EmailRulesHeaderWidget extends StatelessWidget {
           if (responsiveUtils.isWebDesktop(context))
             const SettingHeaderWidget(menuItem: AccountMenuItem.emailRules)
           else
-            const SettingExplanationWidget(menuItem: AccountMenuItem.emailRules),
+            const SettingExplanationWidget(
+              menuItem: AccountMenuItem.emailRules,
+              padding: EdgeInsets.all(16),
+            ),
           Padding(
             padding: const EdgeInsets.all(16),
             child: _buildButtonAddNewRule(context),

--- a/lib/features/manage_account/presentation/language_and_region/extensions/locale_extension.dart
+++ b/lib/features/manage_account/presentation/language_and_region/extensions/locale_extension.dart
@@ -4,22 +4,22 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 extension LocaleExtension on Locale {
 
-  String getLanguageNameByCurrentLocale(BuildContext context) {
+  String getLanguageNameByCurrentLocale(AppLocalizations appLocalizations) {
     switch(languageCode) {
       case 'fr':
-        return AppLocalizations.of(context).languageFrench;
+        return appLocalizations.languageFrench;
       case 'en':
-        return AppLocalizations.of(context).languageEnglish;
+        return appLocalizations.languageEnglish;
       case 'vi':
-        return AppLocalizations.of(context).languageVietnamese;
+        return appLocalizations.languageVietnamese;
       case 'ru':
-        return AppLocalizations.of(context).languageRussian;
+        return appLocalizations.languageRussian;
       case 'ar':
-        return AppLocalizations.of(context).languageArabic;
+        return appLocalizations.languageArabic;
       case 'it':
-        return AppLocalizations.of(context).languageItalian;
+        return appLocalizations.languageItalian;
       case 'de':
-        return AppLocalizations.of(context).languageGerman;
+        return appLocalizations.languageGerman;
       default:
         return '';
     }

--- a/lib/features/manage_account/presentation/language_and_region/language_and_region_controller.dart
+++ b/lib/features/manage_account/presentation/language_and_region/language_and_region_controller.dart
@@ -21,7 +21,6 @@ class LanguageAndRegionController extends BaseController {
 
   final listSupportedLanguages = <Locale>[].obs;
   final languageSelected = LocalizationService.defaultLocale.obs;
-  final isLanguageMenuOverlayOpen = RxBool(false);
 
   final manageAccountDashBoardController = Get.find<ManageAccountDashBoardController>();
 
@@ -57,7 +56,6 @@ class LanguageAndRegionController extends BaseController {
   }
 
   void selectLanguage(Locale? selectedLocale) {
-    isLanguageMenuOverlayOpen.value = false;
     languageSelected.value = selectedLocale ?? LocalizationService.defaultLocale;
     _saveLanguage(languageSelected.value);
   }
@@ -76,9 +74,5 @@ class LanguageAndRegionController extends BaseController {
       accountId,
       localeCurrent,
     ));
-  }
-
-  void toggleLanguageMenuOverlay() {
-    isLanguageMenuOverlayOpen.toggle();
   }
 }

--- a/lib/features/manage_account/presentation/language_and_region/language_and_region_controller.dart
+++ b/lib/features/manage_account/presentation/language_and_region/language_and_region_controller.dart
@@ -1,8 +1,6 @@
-
-import 'dart:ui';
-
 import 'package:core/presentation/state/success.dart';
 import 'package:core/utils/app_logger.dart';
+import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:server_settings/server_settings/capability_server_settings.dart';
 import 'package:tmail_ui_user/features/base/base_controller.dart';
@@ -11,8 +9,11 @@ import 'package:tmail_ui_user/features/manage_account/domain/state/save_language
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/save_language_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/save_language_to_server_settings_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/manage_account_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/model/language/context_item_language_action.dart';
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/localizations/localization_service.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
 class LanguageAndRegionController extends BaseController {
 
@@ -74,5 +75,25 @@ class LanguageAndRegionController extends BaseController {
       accountId,
       localeCurrent,
     ));
+  }
+
+  void openLanguageContextMenu(BuildContext context) {
+    final contextMenuActions = listSupportedLanguages.map((language) {
+      return ContextItemLanguageAction(
+        language,
+        languageSelected.value,
+        AppLocalizations.of(context),
+        imagePaths,
+      );
+    }).toList();
+
+    openBottomSheetContextMenuAction(
+      context: context,
+      itemActions: contextMenuActions,
+      onContextMenuActionClick: (menuAction) {
+        popBack();
+        selectLanguage(menuAction.action);
+      },
+    );
   }
 }

--- a/lib/features/manage_account/presentation/language_and_region/language_and_region_controller.dart
+++ b/lib/features/manage_account/presentation/language_and_region/language_and_region_controller.dart
@@ -88,6 +88,7 @@ class LanguageAndRegionController extends BaseController {
     }).toList();
 
     openBottomSheetContextMenuAction(
+      key: const Key('language_context_menu'),
       context: context,
       itemActions: contextMenuActions,
       onContextMenuActionClick: (menuAction) {

--- a/lib/features/manage_account/presentation/language_and_region/language_and_region_view.dart
+++ b/lib/features/manage_account/presentation/language_and_region/language_and_region_view.dart
@@ -1,10 +1,11 @@
-import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_portal/flutter_portal.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/base/setting_detail_view_builder.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/language_and_region/language_and_region_controller.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/language_and_region/widgets/change_language_button_widget.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/menu/settings_utils.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/widgets/setting_explanation_widget.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/widgets/setting_header_widget.dart';
@@ -17,27 +18,42 @@ class LanguageAndRegionView extends GetWidget<LanguageAndRegionController> {
     return Portal(
       child: SettingDetailViewBuilder(
         responsiveUtils: controller.responsiveUtils,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            if (controller.responsiveUtils.isWebDesktop(context))
-              ...[
-                const SettingHeaderWidget(menuItem: AccountMenuItem.languageAndRegion),
-                const Divider(height: 1, color: AppColor.colorDividerHeaderSetting),
-              ]
-            else
-              const SettingExplanationWidget(menuItem: AccountMenuItem.languageAndRegion),
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsetsDirectional.only(
-                  start: 16,
-                  top: 24,
-                  end: 16,
+        child: Container(
+          color: SettingsUtils.getContentBackgroundColor(
+            context,
+            controller.responsiveUtils,
+          ),
+          decoration: SettingsUtils.getBoxDecorationForContent(
+            context,
+            controller.responsiveUtils,
+          ),
+          width: double.infinity,
+          padding: controller.responsiveUtils.isDesktop(context)
+              ? const EdgeInsets.symmetric(vertical: 30, horizontal: 22)
+              : null,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (controller.responsiveUtils.isWebDesktop(context))
+                SettingHeaderWidget(
+                  menuItem: AccountMenuItem.languageAndRegion,
+                  textStyle: ThemeUtils.textStyleInter600().copyWith(
+                    color: Colors.black.withOpacity(0.9),
+                  ),
+                  padding: EdgeInsets.zero,
+                )
+              else
+                const SettingExplanationWidget(
+                  menuItem: AccountMenuItem.languageAndRegion,
                 ),
-                child: ChangeLanguageButtonWidget(),
+              const Expanded(
+                child: Padding(
+                  padding: EdgeInsets.only(top: 39),
+                  child: ChangeLanguageButtonWidget(),
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/manage_account/presentation/language_and_region/language_and_region_view.dart
+++ b/lib/features/manage_account/presentation/language_and_region/language_and_region_view.dart
@@ -45,11 +45,20 @@ class LanguageAndRegionView extends GetWidget<LanguageAndRegionController> {
               else
                 const SettingExplanationWidget(
                   menuItem: AccountMenuItem.languageAndRegion,
+                  padding: EdgeInsetsDirectional.only(
+                    start: 16,
+                    end: 16,
+                    bottom: 16,
+                  ),
+                  isCenter: true,
                 ),
-              const Expanded(
+              Expanded(
                 child: Padding(
-                  padding: EdgeInsets.only(top: 39),
-                  child: ChangeLanguageButtonWidget(),
+                  padding: const EdgeInsets.only(top: 39),
+                  child: ChangeLanguageButtonWidget(
+                    onOpenLanguageContextMenu:
+                      controller.openLanguageContextMenu,
+                  ),
                 ),
               ),
             ],

--- a/lib/features/manage_account/presentation/language_and_region/widgets/change_language_button_widget.dart
+++ b/lib/features/manage_account/presentation/language_and_region/widgets/change_language_button_widget.dart
@@ -12,9 +12,16 @@ import 'package:tmail_ui_user/features/manage_account/presentation/language_and_
 import 'package:tmail_ui_user/features/manage_account/presentation/language_and_region/widgets/language_menu_overlay.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
+typedef OnOpenLanguageContextMenuAction = Function(BuildContext context);
+
 class ChangeLanguageButtonWidget extends StatefulWidget {
 
-  const ChangeLanguageButtonWidget({Key? key}) : super(key: key);
+  final OnOpenLanguageContextMenuAction? onOpenLanguageContextMenu;
+
+  const ChangeLanguageButtonWidget({
+    Key? key,
+    this.onOpenLanguageContextMenu,
+  }) : super(key: key);
 
   @override
   State<ChangeLanguageButtonWidget> createState() => _ChangeLanguageButtonWidgetState();
@@ -44,15 +51,19 @@ class _ChangeLanguageButtonWidgetState extends State<ChangeLanguageButtonWidget>
         ],
       );
     } else {
-      return Scaffold(
-        body: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _buildTitleLanguageWidget(context),
-            const SizedBox(height: 8),
-            _buildLanguageMenu(context, double.infinity),
-          ],
-        ),
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: _getMobileTitlePadding(context),
+            child: _buildTitleLanguageWidget(context),
+          ),
+          const SizedBox(height: 12),
+          Padding(
+            padding: _getMobileLanguageMenuPadding(context),
+            child: _buildMobileLanguageMenu(context),
+          ),
+        ],
       );
     }
   }
@@ -90,7 +101,7 @@ class _ChangeLanguageButtonWidgetState extends State<ChangeLanguageButtonWidget>
                 widthFactor: 1,
               ),
             ),
-            portalFollower: Obx(() => LanguageRegionOverlay(
+            portalFollower: LanguageRegionOverlay(
               imagePaths: _imagePaths,
               responsiveUtils: _responsiveUtils,
               listSupportedLanguages: _languageAndRegionController.listSupportedLanguages,
@@ -100,13 +111,13 @@ class _ChangeLanguageButtonWidgetState extends State<ChangeLanguageButtonWidget>
                 _toggleLanguageMenuOverlay(false);
                 _languageAndRegionController.selectLanguage(language);
               },
-            )),
+            ),
             visible: isVisible,
             child: TMailDropDownWidget(
               text: _languageAndRegionController
                 .languageSelected
                 .value
-                .getLanguageNameByCurrentLocale(context),
+                .getLanguageNameByCurrentLocale(AppLocalizations.of(context)),
               dropDownIcon: _imagePaths.icDropDown,
               backgroundColor: isVisible
                 ? AppColor.lightGrayEBEDF0.withOpacity(0.6)
@@ -119,13 +130,38 @@ class _ChangeLanguageButtonWidgetState extends State<ChangeLanguageButtonWidget>
     );
   }
 
+  Widget _buildMobileLanguageMenu(BuildContext context) {
+    return Obx(() => TMailDropDownWidget(
+      text: _languageAndRegionController
+          .languageSelected
+          .value
+          .getLanguageNameByCurrentLocale(AppLocalizations.of(context)),
+      dropDownIcon: _imagePaths.icDropDown,
+      onTap: () => widget.onOpenLanguageContextMenu?.call(context),
+    ));
+  }
+
   void _toggleLanguageMenuOverlay(bool visible) {
     _languageMenuIsVisibleNotifier.value = visible;
   }
 
-  @override
-  void dispose() {
-    _languageMenuIsVisibleNotifier.dispose();
-    super.dispose();
+  EdgeInsetsGeometry _getMobileTitlePadding(BuildContext context) {
+    if (_responsiveUtils.isPortraitMobile(context)) {
+      return const EdgeInsetsDirectional.symmetric(horizontal: 28);
+    } else if (_responsiveUtils.isLandscapeMobile(context)) {
+      return const EdgeInsetsDirectional.symmetric(horizontal: 40);
+    } else {
+      return const EdgeInsetsDirectional.symmetric(horizontal: 50);
+    }
+  }
+
+  EdgeInsetsGeometry _getMobileLanguageMenuPadding(BuildContext context) {
+    if (_responsiveUtils.isPortraitMobile(context)) {
+      return const EdgeInsetsDirectional.symmetric(horizontal: 20);
+    } else if (_responsiveUtils.isLandscapeMobile(context)) {
+      return const EdgeInsetsDirectional.symmetric(horizontal: 24);
+    } else {
+      return const EdgeInsetsDirectional.symmetric(horizontal: 44);
+    }
   }
 }

--- a/lib/features/manage_account/presentation/language_and_region/widgets/change_language_button_widget.dart
+++ b/lib/features/manage_account/presentation/language_and_region/widgets/change_language_button_widget.dart
@@ -132,6 +132,7 @@ class _ChangeLanguageButtonWidgetState extends State<ChangeLanguageButtonWidget>
 
   Widget _buildMobileLanguageMenu(BuildContext context) {
     return Obx(() => TMailDropDownWidget(
+      key: const Key('language_drop_down_button'),
       text: _languageAndRegionController
           .languageSelected
           .value

--- a/lib/features/manage_account/presentation/language_and_region/widgets/language_menu_overlay.dart
+++ b/lib/features/manage_account/presentation/language_and_region/widgets/language_menu_overlay.dart
@@ -1,22 +1,22 @@
-
-import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/language_and_region/widgets/lanuage_item_widget.dart';
 
 class LanguageRegionOverlay extends StatelessWidget {
 
+  final ImagePaths imagePaths;
+  final ResponsiveUtils responsiveUtils;
   final List<Locale> listSupportedLanguages;
   final Locale localeSelected;
   final double? maxWidth;
   final OnSelectLanguageAction onSelectLanguageAction;
 
-  final _responsiveUtils = Get.find<ResponsiveUtils>();
-
-  LanguageRegionOverlay({
+  const LanguageRegionOverlay({
     Key? key,
+    required this.imagePaths,
     required this.listSupportedLanguages,
+    required this.responsiveUtils,
     required this.localeSelected,
     required this.onSelectLanguageAction,
     this.maxWidth,
@@ -31,22 +31,27 @@ class LanguageRegionOverlay extends StatelessWidget {
       padding: const EdgeInsets.all(8),
       decoration: BoxDecoration(
         color: Colors.white,
-        borderRadius: BorderRadius.circular(12),
-        boxShadow: const [
+        borderRadius: const BorderRadius.all(Radius.circular(16)),
+        boxShadow: [
           BoxShadow(
-            color: AppColor.colorShadowBgContentEmail,
-            blurRadius: 24,
-            offset: Offset(0, 8)),
-          BoxShadow(
-            color: AppColor.colorShadowBgContentEmail,
+            color: Colors.black.withOpacity(0.3),
             blurRadius: 2,
-            offset: Offset.zero),
-          ]
+            offset: const Offset(0, 1),
+          ),
+          BoxShadow(
+            color: Colors.black.withOpacity(0.15),
+            blurRadius: 6,
+            spreadRadius: 2,
+            offset: const Offset(0, 2),
+          ),
+        ],
       ),
       child: ListView.builder(
         shrinkWrap: true,
         itemCount: listSupportedLanguages.length,
-        itemBuilder: (context, index) => LanguageItemWidget(
+        padding: const EdgeInsets.all(7),
+        itemBuilder: (_, index) => LanguageItemWidget(
+          imagePaths: imagePaths,
           localeSelected: localeSelected,
           localeCurrent: listSupportedLanguages[index],
           onSelectLanguageAction: onSelectLanguageAction
@@ -59,7 +64,7 @@ class LanguageRegionOverlay extends StatelessWidget {
     const double maxHeightTopBar = 80;
     const double maxHeightTitleLanguage = 200;
     const double paddingBottom = 16;
-    final currentHeight = _responsiveUtils.getSizeScreenHeight(context);
+    final currentHeight = responsiveUtils.getSizeScreenHeight(context);
     double maxHeightForm = currentHeight - maxHeightTopBar - maxHeightTitleLanguage - paddingBottom;
     return maxHeightForm;
   }

--- a/lib/features/manage_account/presentation/language_and_region/widgets/lanuage_item_widget.dart
+++ b/lib/features/manage_account/presentation/language_and_region/widgets/lanuage_item_widget.dart
@@ -1,22 +1,22 @@
-
+import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
-import 'package:core/presentation/utils/style_utils.dart';
 import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/language_and_region/extensions/locale_extension.dart';
 
 typedef OnSelectLanguageAction = Function(Locale? localeSelected);
 
 class LanguageItemWidget extends StatelessWidget {
 
+  final ImagePaths imagePaths;
   final Locale localeSelected;
   final Locale localeCurrent;
   final OnSelectLanguageAction onSelectLanguageAction;
 
   const LanguageItemWidget({
     super.key,
+    required this.imagePaths,
     required this.localeCurrent,
     required this.localeSelected,
     required this.onSelectLanguageAction,
@@ -24,48 +24,33 @@ class LanguageItemWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final imagePaths = Get.find<ImagePaths>();
-
     return Material(
       color: Colors.transparent,
       child: InkWell(
         onTap: () => onSelectLanguageAction.call(localeCurrent),
         borderRadius: const BorderRadius.all(Radius.circular(8)),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 16),
+        hoverColor: AppColor.lightGrayEBEDF0.withOpacity(0.6),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 17),
+          height: 51,
           child: Row(children: [
-            Expanded(child: Row(
-              children: [
-                Text(
-                  localeCurrent.getLanguageNameByCurrentLocale(context),
-                  style: ThemeUtils.defaultTextStyleInterFont.copyWith(
-                    fontSize: 17,
-                    fontWeight: FontWeight.normal,
-                    color: Colors.black
-                  ),
-                  maxLines: 1,
-                  softWrap: CommonTextStyle.defaultSoftWrap,
-                  overflow: CommonTextStyle.defaultTextOverFlow,
-                ),
-                Text(
-                  ' - ${localeCurrent.getSourceLanguageName()}',
-                  style: ThemeUtils.defaultTextStyleInterFont.copyWith(
-                    fontSize: 17,
-                    fontWeight: FontWeight.w500,
-                    color: Colors.black
-                  ),
-                  maxLines: 1,
-                  softWrap: CommonTextStyle.defaultSoftWrap,
-                  overflow: CommonTextStyle.defaultTextOverFlow,
-                )
-              ]
+            Expanded(child: Text(
+              '${localeCurrent.getLanguageNameByCurrentLocale(context)} - ${localeCurrent.getSourceLanguageName()}',
+              style: ThemeUtils.textStyleInter400.copyWith(
+                letterSpacing: -0.15,
+                fontSize: 16,
+                height: 21.01 / 16,
+                color: AppColor.gray424244.withOpacity(0.9),
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
             )),
             if (localeCurrent == localeSelected)
               SvgPicture.asset(
                 imagePaths.icChecked,
                 width: 20,
                 height: 20,
-                fit: BoxFit.fill
+                fit: BoxFit.fill,
               )
           ]),
         ),

--- a/lib/features/manage_account/presentation/language_and_region/widgets/lanuage_item_widget.dart
+++ b/lib/features/manage_account/presentation/language_and_region/widgets/lanuage_item_widget.dart
@@ -4,6 +4,7 @@ import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/language_and_region/extensions/locale_extension.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 typedef OnSelectLanguageAction = Function(Locale? localeSelected);
 
@@ -35,7 +36,7 @@ class LanguageItemWidget extends StatelessWidget {
           height: 51,
           child: Row(children: [
             Expanded(child: Text(
-              '${localeCurrent.getLanguageNameByCurrentLocale(context)} - ${localeCurrent.getSourceLanguageName()}',
+              '${localeCurrent.getLanguageNameByCurrentLocale(AppLocalizations.of(context))} - ${localeCurrent.getSourceLanguageName()}',
               style: ThemeUtils.textStyleInter400.copyWith(
                 letterSpacing: -0.15,
                 fontSize: 16,

--- a/lib/features/manage_account/presentation/manage_account_dashboard_controller.dart
+++ b/lib/features/manage_account/presentation/manage_account_dashboard_controller.dart
@@ -62,7 +62,7 @@ class ManageAccountDashBoardController extends ReloadableController {
   void onInit() {
     BackButtonInterceptor.add(_onBackButtonInterceptor, name: AppRoutes.settings);
     super.onInit();
-    if (AppConfig.isApiLoggingEnabled) {
+    if (LogTracking().isEnabled) {
       injectTraceLogDependencies();
     }
   }
@@ -405,7 +405,7 @@ class ManageAccountDashBoardController extends ReloadableController {
   @override
   void onClose() {
     BackButtonInterceptor.removeByName(AppRoutes.settings);
-    if (AppConfig.isApiLoggingEnabled) {
+    if (LogTracking().isEnabled) {
       disposeTraceLogDependencies();
     }
     super.onClose();

--- a/lib/features/manage_account/presentation/manage_account_dashboard_view.dart
+++ b/lib/features/manage_account/presentation/manage_account_dashboard_view.dart
@@ -102,11 +102,7 @@ class ManageAccountDashBoardView extends GetWidget<ManageAccountDashBoardControl
                   ],
                 ))
               ]),
-              mobile: SafeArea(
-                child: SettingsView(
-                  closeAction: () =>
-                    controller.backToMailboxDashBoard(context: context)),
-              )
+              mobile: const SafeArea(child: SettingsView())
           ),
         ),
       ),

--- a/lib/features/manage_account/presentation/menu/settings/setting_app_bar.dart
+++ b/lib/features/manage_account/presentation/menu/settings/setting_app_bar.dart
@@ -1,0 +1,45 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/menu/settings/setting_first_level_app_bar.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/menu/settings/universal_setting_app_bar.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/model/settings_page_level.dart';
+
+class SettingAppBar extends StatelessWidget {
+  final SettingsPageLevel pageLevel;
+  final AccountMenuItem accountMenuItem;
+  final ImagePaths imagePaths;
+  final ResponsiveUtils responsiveUtils;
+  final VoidCallback onBackAction;
+  final VoidCallback? onExportTraceLogAction;
+
+  const SettingAppBar({
+    super.key,
+    required this.pageLevel,
+    required this.accountMenuItem,
+    required this.imagePaths,
+    required this.responsiveUtils,
+    required this.onBackAction,
+    this.onExportTraceLogAction,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (pageLevel == SettingsPageLevel.universal) {
+      return UniversalSettingAppBar(
+        imagePaths: imagePaths,
+        responsiveUtils: responsiveUtils,
+        onBackAction: onBackAction,
+        onExportTraceLogAction: onExportTraceLogAction,
+      );
+    } else {
+      return SettingFirstLevelAppBar(
+        accountMenuItem: accountMenuItem,
+        imagePaths: imagePaths,
+        responsiveUtils: responsiveUtils,
+        onBackAction: onBackAction,
+      );
+    }
+  }
+}

--- a/lib/features/manage_account/presentation/menu/settings/setting_first_level_app_bar.dart
+++ b/lib/features/manage_account/presentation/menu/settings/setting_first_level_app_bar.dart
@@ -1,0 +1,67 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+class SettingFirstLevelAppBar extends StatelessWidget {
+  final AccountMenuItem accountMenuItem;
+  final ImagePaths imagePaths;
+  final ResponsiveUtils responsiveUtils;
+  final VoidCallback onBackAction;
+
+  const SettingFirstLevelAppBar({
+    super.key,
+    required this.accountMenuItem,
+    required this.imagePaths,
+    required this.responsiveUtils,
+    required this.onBackAction,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context);
+
+    return Container(
+      height: 64,
+      padding: _getPadding(context),
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          PositionedDirectional(
+            start: 0,
+            child: TMailButtonWidget.fromIcon(
+              icon: imagePaths.icArrowBack,
+              tooltipMessage: appLocalizations.back,
+              backgroundColor: Colors.transparent,
+              onTapActionCallback: onBackAction,
+            ),
+          ),
+          Center(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 50),
+              child: Text(
+                accountMenuItem.getName(appLocalizations),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: ThemeUtils.textStyleM3BodyLarge,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  EdgeInsetsGeometry _getPadding(BuildContext context) {
+    if (responsiveUtils.isPortraitMobile(context)) {
+      return const EdgeInsetsDirectional.symmetric(horizontal: 16);
+    } else if (responsiveUtils.isLandscapeMobile(context)) {
+      return const EdgeInsetsDirectional.symmetric(horizontal: 24);
+    } else {
+      return const EdgeInsetsDirectional.symmetric(horizontal: 32);
+    }
+  }
+}

--- a/lib/features/manage_account/presentation/menu/settings/settings_controller.dart
+++ b/lib/features/manage_account/presentation/menu/settings/settings_controller.dart
@@ -1,9 +1,12 @@
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/mixin/contact_support_mixin.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/extensions/export_trace_log_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/manage_account_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/model/settings_page_level.dart';
 
 class SettingsController extends GetxController with ContactSupportMixin {
   final manageAccountDashboardController = Get.find<ManageAccountDashBoardController>();
@@ -13,4 +16,17 @@ class SettingsController extends GetxController with ContactSupportMixin {
   void selectSettings(AccountMenuItem accountMenuItem) => manageAccountDashboardController.selectSettings(accountMenuItem);
 
   void backToUniversalSettings() => manageAccountDashboardController.backToUniversalSettings();
+
+  void onBackSettingAction(BuildContext context) {
+    if (manageAccountDashboardController.settingsPageLevel.value ==
+        SettingsPageLevel.universal) {
+      manageAccountDashboardController.backToMailboxDashBoard(context: context);
+    } else {
+      backToUniversalSettings();
+    }
+  }
+
+  void showExportTraceLogConfirmDialog(BuildContext context) {
+    manageAccountDashboardController.showExportTraceLogConfirmDialog(context);
+  }
 }

--- a/lib/features/manage_account/presentation/menu/settings/settings_first_level_view.dart
+++ b/lib/features/manage_account/presentation/menu/settings/settings_first_level_view.dart
@@ -17,6 +17,7 @@ class SettingsFirstLevelView extends GetWidget<SettingsController> {
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
+      key: const Key('setting_menu'),
       child: Column(children: [
         Obx(() => UserInformationWidget(
           userName: controller.manageAccountDashboardController.accountId.value != null
@@ -141,6 +142,7 @@ class SettingsFirstLevelView extends GetWidget<SettingsController> {
               endIndent: SettingsUtils.getHorizontalPadding(context, controller.responsiveUtils)
             ),
             SettingFirstLevelTileBuilder(
+              key: const Key('setting_language_region'),
               AccountMenuItem.languageAndRegion.getName(AppLocalizations.of(context)),
               AccountMenuItem.languageAndRegion.getIcon(controller.imagePaths),
               () => controller.selectSettings(AccountMenuItem.languageAndRegion)

--- a/lib/features/manage_account/presentation/menu/settings/settings_view.dart
+++ b/lib/features/manage_account/presentation/menu/settings/settings_view.dart
@@ -1,21 +1,13 @@
-import 'package:core/presentation/extensions/color_extension.dart';
-import 'package:core/presentation/utils/style_utils.dart';
-import 'package:core/presentation/utils/theme_utils.dart';
-import 'package:core/presentation/views/button/icon_button_web.dart';
-import 'package:core/presentation/views/button/multi_click_widget.dart';
-import 'package:core/utils/direction_utils.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/email_rules/email_rules_view.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/extensions/export_trace_log_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/extensions/vacation_response_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/forward/forward_view.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/language_and_region/language_and_region_view.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/mailbox_visibility/mailbox_visibility_view.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/menu/settings/setting_app_bar.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/menu/settings/settings_controller.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/menu/settings/settings_first_level_view.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/menu/settings_utils.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/settings_page_level.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/notification/notification_view.dart';
@@ -23,27 +15,30 @@ import 'package:tmail_ui_user/features/manage_account/presentation/preferences/p
 import 'package:tmail_ui_user/features/manage_account/presentation/profiles/profiles_view.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/vacation/vacation_view.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/vacation/widgets/vacation_notification_message_widget.dart';
-import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
-import 'package:tmail_ui_user/main/utils/app_config.dart';
-
-typedef CloseSettingsViewAction = void Function();
 
 class SettingsView extends GetWidget<SettingsController> {
-  const SettingsView({Key? key, this.closeAction}) : super(key: key);
-
-  final CloseSettingsViewAction? closeAction;
+  const SettingsView({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        SizedBox.fromSize(
-          size: const Size.fromHeight(52),
-          child: Padding(
-            padding: SettingsUtils.getPaddingAppBar(context, controller.responsiveUtils),
-            child: _buildAppbar(context))),
-        const Divider(color: AppColor.colorDividerComposer, height: 1),
+        Obx(() => SettingAppBar(
+          pageLevel: controller
+              .manageAccountDashboardController
+              .settingsPageLevel
+              .value,
+          accountMenuItem: controller
+              .manageAccountDashboardController
+              .accountMenuItemSelected
+              .value,
+          imagePaths: controller.imagePaths,
+          responsiveUtils: controller.responsiveUtils,
+          onBackAction: () => controller.onBackSettingAction(context),
+          onExportTraceLogAction: () =>
+              controller.showExportTraceLogConfirmDialog(context),
+        )),
         Obx(() {
           if (controller.manageAccountDashboardController.vacationResponse.value?.vacationResponderIsValid == true) {
             return VacationNotificationMessageWidget(
@@ -75,110 +70,6 @@ class SettingsView extends GetWidget<SettingsController> {
         Expanded(child: _bodySettingsScreen())
       ]
     );
-  }
-
-  Widget _buildAppbar(BuildContext context) {
-    return Obx(() {
-      if (controller.manageAccountDashboardController.settingsPageLevel.value == SettingsPageLevel.universal) {
-        return _buildUniversalSettingAppBar(context);
-      } else {
-        return _buildSettingLevel1AppBar(context);
-      }
-    });
-  }
-
-  Widget _buildUniversalSettingAppBar(BuildContext context) {
-    final appBarWidget = Stack(
-      alignment: Alignment.center,
-      children: [
-        Positioned(left: 0,child: _buildCloseSettingButton(context)),
-        Padding(
-          padding: const EdgeInsets.only(left: 50, right: 50),
-          child: Text(
-            AppLocalizations.of(context).settings,
-            maxLines: 1,
-            softWrap: CommonTextStyle.defaultSoftWrap,
-            overflow: CommonTextStyle.defaultTextOverFlow,
-            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
-              fontSize: 20,
-              color: AppColor.colorNameEmail,
-              fontWeight: FontWeight.w700,
-            ),
-          ),
-        ),
-      ],
-    );
-
-    if (AppConfig.isApiLoggingEnabled) {
-      return MultiClickWidget(
-        onMultiTap: () => controller
-          .manageAccountDashboardController
-          .showExportTraceLogConfirmDialog(context),
-        child: appBarWidget,
-      );
-    } else {
-      return appBarWidget;
-    }
-  }
-
-  Widget _buildSettingLevel1AppBar(BuildContext context) {
-    return Row(children: [
-      Material(
-        color: Colors.transparent,
-        child: InkWell(
-          onTap: controller.backToUniversalSettings,
-          customBorder: const RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(Radius.circular(15))),
-          child: Tooltip(
-            message: AppLocalizations.of(context).back,
-            child: Container(
-              color: Colors.transparent,
-              height: 40,
-              padding: const EdgeInsets.symmetric(horizontal: 4),
-              child: Row(mainAxisSize: MainAxisSize.min, children: [
-                SvgPicture.asset(
-                  DirectionUtils.isDirectionRTLByLanguage(context)
-                    ? controller.imagePaths.icCollapseFolder
-                    : controller.imagePaths.icBack,
-                  colorFilter: AppColor.colorTextButton.asFilter(),
-                  fit: BoxFit.fill),
-                Container(
-                  margin: const EdgeInsetsDirectional.only(start: 4),
-                  constraints: const BoxConstraints(maxWidth: 80),
-                  child: Text(
-                    AppLocalizations.of(context).settings,
-                    maxLines: 1,
-                    overflow: CommonTextStyle.defaultTextOverFlow,
-                    softWrap: CommonTextStyle.defaultSoftWrap,
-                    style: ThemeUtils.defaultTextStyleInterFont.copyWith(fontSize: 17, color: AppColor.colorTextButton)
-                  )
-                ),
-              ]),
-            ),
-          ),
-        ),
-      ),
-      Expanded(child: Text(
-        controller.manageAccountDashboardController.accountMenuItemSelected.value.getName(AppLocalizations.of(context)),
-        maxLines: 1,
-        textAlign: TextAlign.center,
-        overflow: CommonTextStyle.defaultTextOverFlow,
-        softWrap: CommonTextStyle.defaultSoftWrap,
-        style: ThemeUtils.defaultTextStyleInterFont.copyWith(
-          fontSize: 20,
-          color: Colors.black,
-          fontWeight: FontWeight.bold
-        )
-      )),
-      Container(constraints: const BoxConstraints(maxWidth: 80))
-    ]);
-  }
-
-  Widget _buildCloseSettingButton(BuildContext context) {
-    return buildIconWeb(
-      icon: SvgPicture.asset(controller.imagePaths.icClose, width: 28, height: 28, fit: BoxFit.fill),
-      tooltip: AppLocalizations.of(context).close,
-      onTap: closeAction);
   }
 
   Widget _bodySettingsScreen() {

--- a/lib/features/manage_account/presentation/menu/settings/universal_setting_app_bar.dart
+++ b/lib/features/manage_account/presentation/menu/settings/universal_setting_app_bar.dart
@@ -1,0 +1,86 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
+import 'package:core/presentation/views/button/multi_click_widget.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:core/utils/logger/log_tracking.dart';
+import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+class UniversalSettingAppBar extends StatelessWidget {
+  final ImagePaths imagePaths;
+  final ResponsiveUtils responsiveUtils;
+  final VoidCallback onBackAction;
+  final VoidCallback? onExportTraceLogAction;
+
+  const UniversalSettingAppBar({
+    super.key,
+    required this.imagePaths,
+    required this.responsiveUtils,
+    required this.onBackAction,
+    this.onExportTraceLogAction,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context);
+
+    Widget appBarWidget = Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          height: 52,
+          padding: _getPadding(context),
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              PositionedDirectional(
+                start: 24,
+                child: TMailButtonWidget.fromIcon(
+                  icon: imagePaths.icClose,
+                  iconSize: 28,
+                  padding: const EdgeInsets.all(5),
+                  tooltipMessage: appLocalizations.close,
+                  backgroundColor: Colors.transparent,
+                  onTapActionCallback: onBackAction,
+                ),
+              ),
+              Center(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 60),
+                  child: Text(
+                    appLocalizations.settings,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: ThemeUtils.textStyleInter700().copyWith(
+                      fontSize: 20,
+                      height: 24 / 20,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const Divider(color: Colors.black12),
+      ],
+    );
+
+    if (onExportTraceLogAction != null && LogTracking().isEnabled) {
+      return MultiClickWidget(
+        onMultiTap: onExportTraceLogAction!,
+        child: appBarWidget,
+      );
+    } else {
+      return appBarWidget;
+    }
+  }
+
+  EdgeInsetsGeometry _getPadding(BuildContext context) {
+    if (responsiveUtils.isPortraitMobile(context)) {
+      return EdgeInsetsDirectional.zero;
+    } else {
+      return const EdgeInsetsDirectional.symmetric(horizontal: 16);
+    }
+  }
+}

--- a/lib/features/manage_account/presentation/menu/settings_utils.dart
+++ b/lib/features/manage_account/presentation/menu/settings_utils.dart
@@ -64,7 +64,7 @@ class SettingsUtils {
   ) {
     if (responsiveUtils.isWebDesktop(context)) {
       return BoxDecoration(
-        borderRadius: const BorderRadius.all(Radius.circular(16)),
+        borderRadius: const BorderRadius.all(Radius.circular(20)),
         color: backgroundColor,
       );
     } else {

--- a/lib/features/manage_account/presentation/menu/settings_utils.dart
+++ b/lib/features/manage_account/presentation/menu/settings_utils.dart
@@ -22,16 +22,6 @@ class SettingsUtils {
     }
   }
 
-  static EdgeInsets getPaddingAppBar(BuildContext context, ResponsiveUtils responsiveUtils) {
-    if (responsiveUtils.isPortraitMobile(context)) {
-      return const EdgeInsets.symmetric(horizontal: 16);
-    } else if (responsiveUtils.isLandscapeMobile(context)) {
-      return const EdgeInsets.symmetric(horizontal: 12);
-    } else {
-      return const EdgeInsets.symmetric(horizontal: 32);
-    }
-  }
-
   static EdgeInsets getMarginViewForSettingDetails(BuildContext context, ResponsiveUtils responsiveUtils) {
     if (PlatformInfo.isWeb) {
       if (responsiveUtils.isDesktop(context)) {

--- a/lib/features/manage_account/presentation/model/language/context_item_language_action.dart
+++ b/lib/features/manage_account/presentation/model/language/context_item_language_action.dart
@@ -1,0 +1,24 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/features/base/widget/context_menu/context_menu_item_action.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/language_and_region/extensions/locale_extension.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+class ContextItemLanguageAction
+    extends ContextMenuItemActionRequiredSelectedIcon<Locale> {
+  final AppLocalizations appLocalizations;
+  final ImagePaths imagePaths;
+
+  ContextItemLanguageAction(
+    super.action,
+    super.selectedAction,
+    this.appLocalizations,
+    this.imagePaths,
+  );
+
+  @override
+  String get actionName => '${action.getLanguageNameByCurrentLocale(appLocalizations)} - ${action.getSourceLanguageName()}';
+
+  @override
+  String get selectedIcon => imagePaths.icFilterSelected;
+}

--- a/lib/features/manage_account/presentation/vacation/utils/vacation_utils.dart
+++ b/lib/features/manage_account/presentation/vacation/utils/vacation_utils.dart
@@ -3,8 +3,6 @@ import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:flutter/material.dart';
 
 class VacationUtils {
-  static const String vacationTagName = 'Vacation';
-
   static EdgeInsets getPaddingView(BuildContext context, ResponsiveUtils responsiveUtils) {
     if (responsiveUtils.isDesktop(context)) {
       return const EdgeInsets.symmetric(vertical: 24, horizontal: 20);

--- a/lib/features/manage_account/presentation/vacation/vacation_controller_bindings.dart
+++ b/lib/features/manage_account/presentation/vacation/vacation_controller_bindings.dart
@@ -1,8 +1,6 @@
 import 'package:get/get.dart';
-import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_web_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/usecases/verify_name_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/update_vacation_interactor.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/vacation/utils/vacation_utils.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/vacation/vacation_controller.dart';
 
 class VacationControllerBindings extends Bindings {
@@ -10,10 +8,6 @@ class VacationControllerBindings extends Bindings {
   @override
   void dependencies() {
     Get.lazyPut(() => VerifyNameInteractor());
-    Get.lazyPut(() => RichTextWebController(), tag: VacationUtils.vacationTagName);
-    Get.put(VacationController(
-      Get.find<UpdateVacationInteractor>(),
-      Get.find<RichTextWebController>(tag: VacationUtils.vacationTagName),
-    ));
+    Get.put(VacationController(Get.find<UpdateVacationInteractor>()));
   }
 }

--- a/lib/features/manage_account/presentation/vacation/vacation_view.dart
+++ b/lib/features/manage_account/presentation/vacation/vacation_view.dart
@@ -289,7 +289,7 @@ class VacationView extends GetWidget<VacationController> with RichTextButtonMixi
               top: false,
               right: controller.responsiveUtils.isPortraitMobile(context),
               child: KeyboardRichText(
-                richTextController: controller.richTextControllerForMobile,
+                richTextController: controller.richTextControllerForMobile!,
                 keyBroadToolbar: RichTextKeyboardToolBar(
                   rootContext: context,
                   titleBack: AppLocalizations.of(context).format,
@@ -297,7 +297,7 @@ class VacationView extends GetWidget<VacationController> with RichTextButtonMixi
                     ? AppColor.colorBackgroundKeyboard
                     : AppColor.colorBackgroundKeyboardAndroid,
                   formatLabel: AppLocalizations.of(context).format,
-                  richTextController: controller.richTextControllerForMobile,
+                  richTextController: controller.richTextControllerForMobile!,
                   quickStyleLabel: AppLocalizations.of(context).quickStyles,
                   backgroundLabel: AppLocalizations.of(context).background,
                   foregroundLabel: AppLocalizations.of(context).foreground,
@@ -323,7 +323,7 @@ class VacationView extends GetWidget<VacationController> with RichTextButtonMixi
               backgroundColor: SettingsUtils.getBackgroundColor(context, controller.responsiveUtils),
               body: SafeArea(
                 child: KeyboardRichText(
-                  richTextController: controller.richTextControllerForMobile,
+                  richTextController: controller.richTextControllerForMobile!,
                   keyBroadToolbar: RichTextKeyboardToolBar(
                     rootContext: context,
                     titleBack: AppLocalizations.of(context).format,
@@ -331,7 +331,7 @@ class VacationView extends GetWidget<VacationController> with RichTextButtonMixi
                       ? AppColor.colorBackgroundKeyboard
                       : AppColor.colorBackgroundKeyboardAndroid,
                     formatLabel: AppLocalizations.of(context).format,
-                    richTextController: controller.richTextControllerForMobile,
+                    richTextController: controller.richTextControllerForMobile!,
                     quickStyleLabel: AppLocalizations.of(context).quickStyles,
                     backgroundLabel: AppLocalizations.of(context).background,
                     foregroundLabel: AppLocalizations.of(context).foreground,
@@ -462,7 +462,7 @@ class VacationView extends GetWidget<VacationController> with RichTextButtonMixi
             child: PointerInterceptor(
               child: buildToolbarRichTextForWeb(
                 context,
-                controller.richTextControllerForWeb,
+                controller.richTextControllerForWeb!,
                 layoutType: ButtonLayoutType.scrollHorizontal
               )
             )
@@ -477,7 +477,7 @@ class VacationView extends GetWidget<VacationController> with RichTextButtonMixi
         constraints: const BoxConstraints(maxHeight: 300),
         child: html_editor_browser.HtmlEditor(
           key: const Key('vacation_message_html_text_editor_web'),
-          controller: controller.richTextControllerForWeb.editorController,
+          controller: controller.richTextControllerForWeb!.editorController,
           htmlEditorOptions: html_editor_browser.HtmlEditorOptions(
             hint: '',
             darkMode: false,
@@ -491,14 +491,14 @@ class VacationView extends GetWidget<VacationController> with RichTextButtonMixi
               defaultToolbarButtons: []),
           otherOptions: const html_editor_browser.OtherOptions(height: 150),
           callbacks: html_editor_browser.Callbacks(
-            onChangeSelection: controller.richTextControllerForWeb.onEditorSettingsChange,
+            onChangeSelection: controller.richTextControllerForWeb?.onEditorSettingsChange,
             onChangeContent: controller.updateMessageHtmlText,
             onFocus: () {
               KeyboardUtils.hideKeyboard(context);
               Future.delayed(const Duration(milliseconds: 500), () {
-                controller.richTextControllerForWeb.editorController.setFocus();
+                controller.richTextControllerForWeb?.editorController.setFocus();
               });
-              controller.richTextControllerForWeb.closeAllMenuPopup();
+              controller.richTextControllerForWeb?.closeAllMenuPopup();
             }
           ),
         ),

--- a/lib/features/manage_account/presentation/widgets/setting_explanation_widget.dart
+++ b/lib/features/manage_account/presentation/widgets/setting_explanation_widget.dart
@@ -7,21 +7,31 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 class SettingExplanationWidget extends StatelessWidget {
   final AccountMenuItem menuItem;
   final EdgeInsetsGeometry? padding;
+  final bool isCenter;
 
   const SettingExplanationWidget({
     Key? key,
     required this.menuItem,
+    this.isCenter = false,
     this.padding,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: padding ?? const EdgeInsets.all(16),
-      child: Text(
-        menuItem.getExplanation(AppLocalizations.of(context)),
-        style: ThemeUtils.textStyleBodyBody1(color: AppColor.steelGray400),
-      ),
+    Widget child = Text(
+      menuItem.getExplanation(AppLocalizations.of(context)),
+      style: ThemeUtils.textStyleM3BodyMedium1
+          .copyWith(color: AppColor.gray424244.withOpacity(0.64)),
     );
+
+    if (isCenter) {
+      child = Center(child: child);
+    }
+
+    if (padding != null) {
+      child = Padding(padding: padding!, child: child);
+    }
+
+    return child;
   }
 }

--- a/lib/features/manage_account/presentation/widgets/setting_header_widget.dart
+++ b/lib/features/manage_account/presentation/widgets/setting_header_widget.dart
@@ -7,11 +7,13 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 class SettingHeaderWidget extends StatelessWidget {
   final AccountMenuItem menuItem;
   final EdgeInsetsGeometry? padding;
+  final TextStyle? textStyle;
 
   const SettingHeaderWidget({
     Key? key,
     required this.menuItem,
     this.padding,
+    this.textStyle,
   }) : super(key: key);
 
   @override
@@ -21,16 +23,21 @@ class SettingHeaderWidget extends StatelessWidget {
     final children = [
       Text(
         menuItem.getName(appLocalizations),
-        style: ThemeUtils.textStyleInter600().copyWith(
+        style: textStyle ?? ThemeUtils.textStyleInter600().copyWith(
           color: Colors.black,
         ),
       ),
       if (menuItem.getExplanation(appLocalizations).isNotEmpty)
         Padding(
-          padding: const EdgeInsets.only(top: 8),
+          padding: const EdgeInsets.only(top: 13),
           child: Text(
             menuItem.getExplanation(appLocalizations),
-            style: ThemeUtils.textStyleBodyBody1(color: AppColor.steelGray400),
+            style: ThemeUtils.textStyleInter400.copyWith(
+              fontSize: 16,
+              height: 21.01 / 16,
+              letterSpacing: -0.15,
+              color: AppColor.gray424244.withOpacity(0.64),
+            ),
           ),
         ),
     ];

--- a/lib/features/thread/data/network/thread_api.dart
+++ b/lib/features/thread/data/network/thread_api.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:core/utils/app_logger.dart';
-import 'package:core/utils/logger/log_tracking.dart';
 import 'package:jmap_dart_client/http/http_client.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/filter/filter.dart';
@@ -31,7 +30,6 @@ import 'package:tmail_ui_user/features/thread/data/model/email_change_response.d
 import 'package:tmail_ui_user/features/thread/domain/model/email_response.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/search_emails_response.dart';
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
-import 'package:tmail_ui_user/main/utils/app_config.dart';
 
 class ThreadAPI {
 
@@ -103,12 +101,7 @@ class ThreadAPI {
       ?.notFound
       ?.toEmailIds()
       .toList();
-    log('ThreadAPI::getAllEmail:notFoundEmailIds = $notFoundEmailIds');
-    if (notFoundEmailIds?.isNotEmpty == true && AppConfig.isApiLoggingEnabled) {
-      await LogTracking().addLog(
-        message: 'ThreadAPI::getAllEmail:notFoundEmailIds = ${notFoundEmailIds!.asListString.toString()} | NewState = ${responseOfGetEmailMethod?.state.value}',
-      );
-    }
+    log('ThreadAPI::getAllEmail:notFoundEmailIds = ${notFoundEmailIds!.asListString.toString()} | NewState = ${responseOfGetEmailMethod?.state.value}');
     return EmailsResponse(
       emailList: emailList,
       notFoundEmailIds: notFoundEmailIds,
@@ -309,12 +302,7 @@ class ThreadAPI {
       log('ThreadAPI::getChanges:notFoundIdsUpdated = $notFoundIdsUpdated');
       if (notFoundIdsUpdated.isNotEmpty) {
         destroyedEmailIds.addAll(notFoundIdsUpdated);
-
-        if (AppConfig.isApiLoggingEnabled) {
-          await LogTracking().addLog(
-            message: 'ThreadAPI::getChanges:notFoundIdsUpdated = ${notFoundIdsUpdated.asListString.toString()} | SinceState = ${sinceState.value}',
-          );
-        }
+        log('ThreadAPI::getChanges:notFoundIdsUpdated = ${notFoundIdsUpdated.asListString.toString()} | SinceState = ${sinceState.value}');
       }
     }
 
@@ -329,12 +317,7 @@ class ThreadAPI {
       log('ThreadAPI::getChanges:notFoundIdsCreated = $notFoundIdsCreated');
       if (notFoundIdsCreated.isNotEmpty) {
         destroyedEmailIds.addAll(notFoundIdsCreated);
-
-        if (AppConfig.isApiLoggingEnabled) {
-          await LogTracking().addLog(
-            message: 'ThreadAPI::getChanges:notFoundIdsCreated = ${notFoundIdsCreated.asListString.toString()} | SinceState = ${sinceState.value}',
-          );
-        }
+        log('ThreadAPI::getChanges:notFoundIdsCreated = ${notFoundIdsCreated.asListString.toString()} | SinceState = ${sinceState.value}');
       }
     }
     log('ThreadAPI::getChanges:newStateChanges = $newStateChanges | newStateEmail = $newStateEmail | hasMoreChanges = $hasMoreChanges');

--- a/lib/main/utils/app_config.dart
+++ b/lib/main/utils/app_config.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:core/utils/platform_info.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -13,9 +12,6 @@ class AppConfig {
   static const int defaultMinInputLengthAutocomplete = 3;
   static const int warningAttachmentFileSizeInMegabytes = 10;
   static const int defaultLimitAutocomplete = 8;
-
-  // For testing
-  static bool isApiLoggingEnabled = PlatformInfo.isAndroid;
 
   static const String envFileName = 'env.file';
   static const String appDashboardConfigurationPath = "configurations/app_dashboard.json";


### PR DESCRIPTION
## Issue

https://www.notion.so/linagora/langues-section-Setting-22262718bad18023921df85bb4ad0858?source=copy_link

## Resolved

- Web:


https://github.com/user-attachments/assets/9cc83d3f-2b68-46c5-ae45-795701980d10


- Mobile:

[demo-mobile.webm](https://github.com/user-attachments/assets/e703c0db-395e-402f-bb8b-291d772ca741)

- E2E test:

```console
🧪 Should see title in Setting change language when successfully selecting another language
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. tap widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  10. enterText widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  11. waitUntilVisible widgets with text containing bb3c-2001-ee0-4161-c4f6-492b-632b-20da-782c.ngrok-free.app.
        ✅  12. tap widgets with text "Next".
        ⏳  13. waitUntilVisible widgets with key [<'credential_input_form'>] descending from widgets with type "LoginView
        ✅  13. waitUntilVisible widgets with key [<'credential_input_form'>] descending from widgets with type "LoginView".
        ✅  14. enterText widgets with type "TextField" descending from widgets with key [<'login_username_input'>].
✅ Should see title in Setting change language when successfully selecting another language (integration_test/tests/setting/language/change_language_test.dart) (20s)


Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: ../Projects/tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 42s

```

[e2e.webm](https://github.com/user-attachments/assets/2b949df4-2f8f-491b-9dfe-dc1a5446cbf0)
