### PR TITLE
[HOT] Fix font error and lost text

### DIFF
--- a/core/lib/presentation/utils/app_toast.dart
+++ b/core/lib/presentation/utils/app_toast.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/toast/tmail_toast.dart';
 import 'package:core/presentation/views/toast/toast_position.dart';
 import 'package:flutter/material.dart';
@@ -106,7 +107,7 @@ class AppToast {
             },
             child: Text(
               actionName,
-              style: TextStyle(
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: 15,
                 fontWeight: FontWeight.normal,
                 color: textActionColor ?? Colors.white
@@ -132,7 +133,7 @@ class AppToast {
                     actionIcon,
                     Text(
                       actionName,
-                      style: TextStyle(
+                      style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                         fontSize: 15,
                         fontWeight: FontWeight.normal,
                         color: textActionColor ?? Colors.white
@@ -169,7 +170,7 @@ class AppToast {
       context,
       maxWidth: maxWidth ?? responsiveUtils.getMaxWidthToast(context),
       toastPosition: ToastPosition.BOTTOM,
-      textStyle: textStyle ?? TextStyle(
+      textStyle: textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
         fontSize: 15,
         fontWeight: FontWeight.normal,
         color: textColor ?? AppColor.primaryColor
@@ -222,7 +223,7 @@ class AppToast {
             },
             child: Text(
               action.actionName!,
-              style: TextStyle(
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: 15,
                 fontWeight: FontWeight.normal,
                 color: textActionColor ?? Colors.white
@@ -250,7 +251,7 @@ class AppToast {
                     action.actionIcon!,
                     Text(
                       action.actionName!,
-                      style: TextStyle(
+                      style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                         fontSize: 15,
                         fontWeight: FontWeight.normal,
                         color: textActionColor ?? Colors.white
@@ -287,7 +288,7 @@ class AppToast {
       context,
       maxWidth: maxWidth ?? responsiveUtils.getMaxWidthToast(context),
       toastPosition: ToastPosition.BOTTOM,
-      textStyle: textStyle ?? TextStyle(
+      textStyle: textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
         fontSize: 15,
         fontWeight: FontWeight.normal,
         color: textColor ?? AppColor.primaryColor

--- a/core/lib/presentation/utils/style_utils.dart
+++ b/core/lib/presentation/utils/style_utils.dart
@@ -1,14 +1,6 @@
-import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:flutter/material.dart';
 
 class CommonTextStyle {
-  static const textStyleNormal = TextStyle(
-    color: AppColor.primaryColor,
-    fontSize: 14,
-    fontStyle: FontStyle.normal,
-    fontWeight: FontWeight.normal,
-  );
-
   static const defaultTextOverFlow = TextOverflow.ellipsis;
 
   static const defaultSoftWrap = true;

--- a/core/lib/presentation/utils/theme_utils.dart
+++ b/core/lib/presentation/utils/theme_utils.dart
@@ -307,6 +307,10 @@ class ThemeUtils {
     color: AppColor.gray424244.withOpacity(0.9),
   );
 
+  static const TextStyle defaultTextStyleInterFont = TextStyle(
+    fontFamily: ConstantsUI.fontApp,
+  );
+
   static TextSelectionThemeData get _textSelectionTheme {
     return const TextSelectionThemeData(
       cursorColor: AppColor.primaryColor,
@@ -316,12 +320,16 @@ class ThemeUtils {
   }
 
   static AppBarTheme get _appBarTheme {
-    return const AppBarTheme(
+    return AppBarTheme(
       color: Colors.white,
       elevation: 0,
       systemOverlayStyle: SystemUiOverlayStyle.light,
-      iconTheme: IconThemeData(color: Colors.black),
-      titleTextStyle: TextStyle(color: Color(0XFF8B8B8B), fontSize: 18),
+      iconTheme: const IconThemeData(color: Colors.black),
+      titleTextStyle: defaultTextStyleInterFont.copyWith(
+        color: const Color(0XFF8B8B8B),
+        fontSize: 18,
+      ),
+      toolbarTextStyle: defaultTextStyleInterFont,
     );
   }
 

--- a/core/lib/presentation/views/avatar/gradient_circle_avatar_icon.dart
+++ b/core/lib/presentation/views/avatar/gradient_circle_avatar_icon.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class GradientCircleAvatarIcon extends StatelessWidget {
@@ -36,7 +37,7 @@ class GradientCircleAvatarIcon extends StatelessWidget {
         color: AppColor.avatarColor
       ),
       child: DefaultTextStyle(
-        style: textStyle ?? TextStyle(
+        style: textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
           color: Colors.white,
           fontSize: labelFontSize,
           fontWeight: FontWeight.w600

--- a/core/lib/presentation/views/bottom_popup/cupertino_action_sheet_action_builder.dart
+++ b/core/lib/presentation/views/bottom_popup/cupertino_action_sheet_action_builder.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -26,7 +27,11 @@ abstract class CupertinoActionSheetActionBuilder<T> {
   }
 
   TextStyle actionTextStyle({TextStyle? textStyle}) {
-    return textStyle ?? const TextStyle(fontSize: 17, color: AppColor.colorNameEmail);
+    return textStyle ??
+        ThemeUtils.defaultTextStyleInterFont.copyWith(
+          fontSize: 17,
+          color: AppColor.colorNameEmail,
+        );
   }
 
   Widget build();

--- a/core/lib/presentation/views/bottom_popup/cupertino_action_sheet_no_icon_builder.dart
+++ b/core/lib/presentation/views/bottom_popup/cupertino_action_sheet_no_icon_builder.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 typedef OnCupertinoActionSheetNoIconActionClick<T> = void Function(T data);
@@ -22,7 +23,11 @@ abstract class CupertinoActionSheetNoIconBuilder<T> {
   }
 
   TextStyle actionTextStyle({TextStyle? textStyle}) {
-    return textStyle ?? const TextStyle(fontSize: 17, color: Colors.black);
+    return textStyle ??
+        ThemeUtils.defaultTextStyleInterFont.copyWith(
+          fontSize: 17,
+          color: Colors.black,
+        );
   }
 
   Widget build();

--- a/core/lib/presentation/views/button/icon_button_web.dart
+++ b/core/lib/presentation/views/button/icon_button_web.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
@@ -103,7 +104,7 @@ Widget buildTextButton(String text, {
         child: Text(
             text,
             textAlign: TextAlign.center,
-            style: textStyle ?? const TextStyle(
+            style: textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: 17,
                 color: Colors.white,
                 fontWeight: FontWeight.w500)),
@@ -145,7 +146,7 @@ Widget buildButtonWrapText(String name, {
       child: Text(name,
           textAlign: TextAlign.center,
           style: textStyle ??
-              const TextStyle(
+              ThemeUtils.defaultTextStyleInterFont.copyWith(
                   fontSize: 17,
                   fontWeight: FontWeight.w500,
                   color: Colors.white)),

--- a/core/lib/presentation/views/button/tmail_button_widget.dart
+++ b/core/lib/presentation/views/button/tmail_button_widget.dart
@@ -2,6 +2,7 @@
 import 'package:core/presentation/action/action_callback_define.dart';
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/container/tmail_container_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -211,7 +212,7 @@ class TMailButtonWidget extends StatelessWidget {
             Text(
               text,
               textAlign: textAlign,
-              style: textStyle ?? const TextStyle(
+              style: textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: 12,
                 color: AppColor.colorTextButtonHeaderThread
               ),
@@ -251,7 +252,7 @@ class TMailButtonWidget extends StatelessWidget {
                   child: Text(
                     text,
                     textAlign: textAlign,
-                    style: textStyle ?? const TextStyle(
+                    style: textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
                       fontSize: 12,
                       color: AppColor.colorTextButtonHeaderThread
                     ),
@@ -264,7 +265,7 @@ class TMailButtonWidget extends StatelessWidget {
                 Text(
                   text,
                   textAlign: textAlign,
-                  style: textStyle ?? const TextStyle(
+                  style: textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
                     fontSize: 12,
                     color: AppColor.colorTextButtonHeaderThread
                   ),
@@ -295,7 +296,7 @@ class TMailButtonWidget extends StatelessWidget {
                   child: Text(
                     text,
                     textAlign: textAlign,
-                    style: textStyle ?? const TextStyle(
+                    style: textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
                       fontSize: 12,
                       color: AppColor.colorTextButtonHeaderThread
                     ),
@@ -308,7 +309,7 @@ class TMailButtonWidget extends StatelessWidget {
                 Text(
                   text,
                   textAlign: textAlign,
-                  style: textStyle ?? const TextStyle(
+                  style: textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
                     fontSize: 12,
                     color: AppColor.colorTextButtonHeaderThread
                   ),
@@ -350,7 +351,7 @@ class TMailButtonWidget extends StatelessWidget {
       childWidget = Text(
         text,
         textAlign: textAlign,
-        style: textStyle ?? const TextStyle(
+        style: textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: 12,
           color: AppColor.colorTextButtonHeaderThread
         ),

--- a/core/lib/presentation/views/context_menu/context_menu_action_builder.dart
+++ b/core/lib/presentation/views/context_menu/context_menu_action_builder.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -21,7 +22,7 @@ abstract class ContextMenuActionBuilder<T> {
   }
 
   TextStyle actionTextStyle() {
-    return const TextStyle(
+    return ThemeUtils.defaultTextStyleInterFont.copyWith(
       fontSize: 15,
       color: AppColor.nameUserColor);
   }

--- a/core/lib/presentation/views/context_menu/context_menu_header_builder.dart
+++ b/core/lib/presentation/views/context_menu/context_menu_header_builder.dart
@@ -24,7 +24,7 @@ class ContextMenuHeaderBuilder {
         transform: Matrix4.translationValues(12, 5, 0.0),
         child: Text(
           _label ?? '',
-          style: _textStyle ?? const TextStyle(fontSize: 20.0, color: AppColor.nameUserColor, fontWeight: FontWeight.w500),
+          style: _textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(fontSize: 20.0, color: AppColor.nameUserColor, fontWeight: FontWeight.w500),
         ),
       ));
   }

--- a/core/lib/presentation/views/dialog/color_picker_dialog_builder.dart
+++ b/core/lib/presentation/views/dialog/color_picker_dialog_builder.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/icon_button_web.dart';
 import 'package:flex_color_picker/flex_color_picker.dart';
 import 'package:flutter/material.dart';
@@ -45,11 +46,11 @@ class ColorPickerDialogBuilder {
           title: Text(
             title ?? '',
             textAlign: TextAlign.center,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontWeight: FontWeight.bold,
               fontSize: 20,
               color: Colors.black)),
-          titleTextStyle: const TextStyle(
+          titleTextStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
             fontWeight: FontWeight.bold,
             fontSize: 20,
             color: Colors.black),
@@ -116,7 +117,7 @@ class ColorPickerDialogBuilder {
                 textActionCancel ?? '',
                 radius: 5,
                 height: 30,
-                textStyle: const TextStyle(
+                textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     color: Colors.black,
                     fontSize: 16,
                     fontWeight: FontWeight.normal),
@@ -126,7 +127,7 @@ class ColorPickerDialogBuilder {
                 textActionResetDefault ?? '',
                 radius: 5,
                 height: 30,
-                textStyle: const TextStyle(
+                textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     color: Colors.black,
                     fontSize: 16,
                     fontWeight: FontWeight.normal),
@@ -137,7 +138,7 @@ class ColorPickerDialogBuilder {
                 textActionSetColor ?? '',
                 radius: 5,
                 height: 30,
-                textStyle: const TextStyle(
+                textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                   color: Colors.white,
                   fontSize: 16,
                   fontWeight: FontWeight.w500),

--- a/core/lib/presentation/views/dialog/downloading_file_dialog_builder.dart
+++ b/core/lib/presentation/views/dialog/downloading_file_dialog_builder.dart
@@ -38,7 +38,7 @@ class DownloadingFileDialogBuilder {
   Widget build() {
     return CupertinoAlertDialog(
       key: _key ?? const Key('DownloadingFileBuilder'),
-      title: Text(_title, style: const TextStyle(fontSize: 17.0, color: Colors.black)),
+      title: Text(_title, style: ThemeUtils.defaultTextStyleInterFont.copyWith(fontSize: 17.0, color: Colors.black)),
       content: Padding(
         padding: const EdgeInsets.only(top: 16.0, left: 16.0, right: 16.0),
         child: Center(
@@ -51,7 +51,7 @@ class DownloadingFileDialogBuilder {
               const SizedBox(height: 16),
               Text(
                 _content,
-                style: const TextStyle(fontSize: 13.0, color: Colors.black),
+                style: ThemeUtils.defaultTextStyleInterFont.copyWith(fontSize: 13.0, color: Colors.black),
                 softWrap: false,
                 maxLines: 1)
             ],
@@ -63,7 +63,7 @@ class DownloadingFileDialogBuilder {
             padding: const EdgeInsets.only(bottom: kIsWeb ? 16 : 0, top: kIsWeb ? 16 : 0),
             child: TextButton(
               onPressed: () => _onCancelDownloadActionClick?.call(),
-              child: Text(_actionText, style: const TextStyle(fontSize: 17.0, color: AppColor.appColor)),
+              child: Text(_actionText, style: ThemeUtils.defaultTextStyleInterFont.copyWith(fontSize: 17.0, color: AppColor.appColor)),
             ))
       ],
     );

--- a/core/lib/presentation/views/image/avatar_builder.dart
+++ b/core/lib/presentation/views/image/avatar_builder.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 typedef OnTapAvatarActionClick = void Function();
@@ -97,7 +98,7 @@ class AvatarBuilder {
           ),
           child: Text(
               _text ?? '',
-              style: _textStyle ?? TextStyle(fontSize: 20, color: _textColor ?? AppColor.avatarTextColor, fontWeight: FontWeight.w500)
+              style: _textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(fontSize: 20, color: _textColor ?? AppColor.avatarTextColor, fontWeight: FontWeight.w500)
           )
       ),
     );

--- a/core/lib/presentation/views/modal_sheets/edit_text_modal_sheet_builder.dart
+++ b/core/lib/presentation/views/modal_sheets/edit_text_modal_sheet_builder.dart
@@ -2,6 +2,7 @@
 import 'dart:async';
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/text/text_form_field_builder.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -123,7 +124,7 @@ class EditTextModalSheetBuilder {
                     children: <Widget>[
                       Text(
                           _title,
-                          style: const TextStyle(fontSize: 20, color: AppColor.colorNameEmail, fontWeight: FontWeight.w700),
+                          style: ThemeUtils.defaultTextStyleInterFont.copyWith(fontSize: 20, color: AppColor.colorNameEmail, fontWeight: FontWeight.w700),
                           textAlign: TextAlign.center),
                       Padding(
                           padding: const EdgeInsets.only(top: 20),
@@ -143,12 +144,12 @@ class EditTextModalSheetBuilder {
                         children: [
                           TextButton(
                             onPressed: () => _onCancelButtonPress(context),
-                            child: Text(_cancelText.toUpperCase(), style: const TextStyle(color: AppColor.colorTextButton)),
+                            child: Text(_cancelText.toUpperCase(), style: ThemeUtils.defaultTextStyleInterFont.copyWith(color: AppColor.colorTextButton)),
                           ),
                           TextButton(
                             onPressed: () => _onConfirmButtonPress(context),
                             child: Text(_confirmText.toUpperCase(),
-                                style: TextStyle(
+                                style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                                     color: (_error == null || (_error != null && _error!.isEmpty))
                                         ? AppColor.colorTextButton
                                         : AppColor.colorDisableMailboxCreateButton)),

--- a/core/lib/presentation/views/search/search_bar_view.dart
+++ b/core/lib/presentation/views/search/search_bar_view.dart
@@ -2,6 +2,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 
@@ -54,7 +55,7 @@ class SearchBarView extends StatelessWidget {
                     maxLines: 1,
                     overflow: CommonTextStyle.defaultTextOverFlow,
                     softWrap: CommonTextStyle.defaultSoftWrap,
-                    style: const TextStyle(
+                    style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                       fontSize: 17,
                       color: AppColor.colorHintSearchBar
                     )

--- a/core/lib/presentation/views/text/text_field_builder.dart
+++ b/core/lib/presentation/views/text/text_field_builder.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/semantics/text_field_semantics.dart';
 import 'package:core/utils/direction_utils.dart';
 import 'package:flutter/material.dart';
@@ -35,7 +36,7 @@ class TextFieldBuilder extends StatefulWidget {
     this.obscureText = false,
     this.autoFocus = false,
     this.readOnly = false,
-    this.textStyle = const TextStyle(color: AppColor.textFieldTextColor),
+    this.textStyle,
     this.textDirection = TextDirection.ltr,
     this.textInputAction,
     this.decoration = const InputDecoration(),
@@ -89,7 +90,9 @@ class _TextFieldBuilderState extends State<TextFieldBuilder> {
       maxLines: widget.maxLines,
       minLines: widget.minLines,
       keyboardAppearance: widget.keyboardAppearance,
-      style: widget.textStyle,
+      style: widget.textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
+        color: AppColor.textFieldTextColor,
+      ),
       obscureText: widget.obscureText,
       keyboardType: widget.keyboardType,
       autofocus: widget.autoFocus,

--- a/core/lib/presentation/views/text/text_form_field_builder.dart
+++ b/core/lib/presentation/views/text/text_form_field_builder.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/utils/direction_utils.dart';
 import 'package:flutter/material.dart';
 
@@ -33,7 +34,7 @@ class TextFormFieldBuilder extends StatefulWidget {
     this.obscureText = false,
     this.autoFocus = false,
     this.readOnly = false,
-    this.textStyle = const TextStyle(color: AppColor.textFieldTextColor),
+    this.textStyle,
     this.textDirection = TextDirection.ltr,
     this.textInputAction,
     this.decoration,
@@ -85,7 +86,9 @@ class _TextFieldFormBuilderState extends State<TextFormFieldBuilder> {
       maxLines: widget.maxLines,
       minLines: widget.minLines,
       keyboardAppearance: widget.keyboardAppearance,
-      style: widget.textStyle,
+      style: widget.textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
+        color: AppColor.textFieldTextColor,
+      ),
       obscureText: widget.obscureText,
       keyboardType: widget.keyboardType,
       autofocus: widget.autoFocus,

--- a/core/lib/presentation/views/toast/tmail_toast.dart
+++ b/core/lib/presentation/views/toast/tmail_toast.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/toast/toast_position.dart';
 import 'package:flutter/material.dart';
 
@@ -11,11 +12,7 @@ class TMailToast {
     Duration? toastDuration,
     ToastPosition? toastPosition,
     Color? backgroundColor,
-    TextStyle textStyle = const TextStyle(
-      fontSize: 15,
-      color: Colors.white,
-      fontWeight: FontWeight.normal
-    ),
+    TextStyle? textStyle,
     double toastBorderRadius = 10.0,
     Border? border,
     Widget? trailing,
@@ -93,7 +90,7 @@ class ToastView {
             ? Text(
                 text,
                 softWrap: true,
-                style: textStyle ?? const TextStyle(
+                style: textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
                   fontSize: 15,
                   color: Colors.white,
                   fontWeight: FontWeight.normal
@@ -109,7 +106,7 @@ class ToastView {
                       padding: const EdgeInsets.symmetric(horizontal: 12),
                       child: Text(
                         text,
-                        style: textStyle ?? const TextStyle(
+                        style: textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
                           fontSize: 15,
                           color: Colors.white,
                           fontWeight: FontWeight.normal
@@ -126,7 +123,7 @@ class ToastView {
                       padding: const EdgeInsets.symmetric(horizontal: 12),
                       child: Text(
                         text,
-                        style: textStyle ?? const TextStyle(
+                        style: textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
                           fontSize: 15,
                           color: Colors.white,
                           fontWeight: FontWeight.normal

--- a/core/test/presentation/views/text/rich_text_builder_test.dart
+++ b/core/test/presentation/views/text/rich_text_builder_test.dart
@@ -1,14 +1,15 @@
 import 'package:core/presentation/extensions/list_extensions.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/text/rich_text_builder.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  const normalTextStyle = TextStyle(
+  final normalTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.black,
     fontSize: 16,
   );
-  const highlightTextStyle = TextStyle(
+  final highlightTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.red,
     fontSize: 16,
   );

--- a/lib/features/base/mixin/popup_context_menu_action_mixin.dart
+++ b/lib/features/base/mixin/popup_context_menu_action_mixin.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/bottom_popup/cupertino_action_sheet_builder.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/cupertino.dart';
@@ -81,8 +82,13 @@ mixin PopupContextMenuActionMixin {
       cursor: PlatformInfo.isWeb ? WidgetStateMouseCursor.clickable : MouseCursor.defer,
       child: CupertinoActionSheetAction(
         child: Text(
-            AppLocalizations.of(context).cancel,
-            style: const TextStyle(fontWeight: FontWeight.w500, fontSize: 20, color: AppColor.colorTextButton)),
+          AppLocalizations.of(context).cancel,
+          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
+            fontWeight: FontWeight.w500,
+            fontSize: 20,
+            color: AppColor.colorTextButton,
+          ),
+        ),
         onPressed: () => popBack(),
       ),
     );

--- a/lib/features/base/mixin/popup_menu_widget_mixin.dart
+++ b/lib/features/base/mixin/popup_menu_widget_mixin.dart
@@ -30,7 +30,7 @@ mixin PopupMenuWidgetMixin {
             const SizedBox(width: 12),
             Expanded(child: Text(
               nameAction,
-              style: styleName ?? const TextStyle(
+              style: styleName ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: 17,
                 fontWeight: FontWeight.normal,
                 color: Colors.black)

--- a/lib/features/base/widget/border_button_field.dart
+++ b/lib/features/base/widget/border_button_field.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/extensions/datetime_extension.dart';
 
@@ -59,7 +60,7 @@ class BorderButtonField<T> extends StatelessWidget {
     );
     if (label != null) {
       return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-        Text(label!, style: const TextStyle(
+        Text(label!, style: ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: 14,
           fontWeight: FontWeight.normal,
           color: AppColor.colorContentEmail)),
@@ -73,12 +74,12 @@ class BorderButtonField<T> extends StatelessWidget {
 
   TextStyle? _getTextStyle(T? value) {
     if (hintText != null && value == null) {
-      return const TextStyle(
+      return ThemeUtils.defaultTextStyleInterFont.copyWith(
         fontSize: 16,
         fontWeight: FontWeight.normal,
         color: AppColor.colorHintInputCreateMailbox);
     }
-    return textStyle ?? const TextStyle(
+    return textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
         fontSize: 16,
         fontWeight: FontWeight.normal,
         color: Colors.black);

--- a/lib/features/base/widget/compose_floating_button.dart
+++ b/lib/features/base/widget/compose_floating_button.dart
@@ -2,6 +2,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/floating_button/scrolling_floating_button_animated.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -37,7 +38,7 @@ class ComposeFloatingButton extends StatelessWidget {
           child: Text(AppLocalizations.of(context).compose,
             overflow: CommonTextStyle.defaultTextOverFlow,
             softWrap: CommonTextStyle.defaultSoftWrap,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               color: Colors.white,
               fontSize: 16.0,
               fontWeight: FontWeight.w500

--- a/lib/features/base/widget/drop_down_button_widget.dart
+++ b/lib/features/base/widget/drop_down_button_widget.dart
@@ -2,6 +2,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:dropdown_button2/dropdown_button2.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -67,7 +68,7 @@ class DropDownButtonWidget<T> extends StatelessWidget {
               ? Row(children: [
                   Expanded(child: Text(
                     _getTextItemDropdown(context, item: itemSelected),
-                    style: TextStyle(fontSize: 16,
+                    style: ThemeUtils.defaultTextStyleInterFont.copyWith(fontSize: 16,
                         fontWeight: FontWeight.normal,
                         color: Colors.black.withOpacity(opacity)),
                     maxLines: 1,
@@ -85,7 +86,7 @@ class DropDownButtonWidget<T> extends StatelessWidget {
                         height: heightItem,
                         child: Row(children: [
                           Expanded(child: Text(_getTextItemDropdown(context, item: item),
-                            style: const TextStyle(
+                            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                                 fontSize: 16,
                                 fontWeight: FontWeight.normal,
                                 color: Colors.black),
@@ -121,7 +122,7 @@ class DropDownButtonWidget<T> extends StatelessWidget {
                   child: Row(children: [
                     Expanded(child: Text(
                       _getTextItemDropdown(context, item: itemSelected),
-                      style: TextStyle(fontSize: 16,
+                      style: ThemeUtils.defaultTextStyleInterFont.copyWith(fontSize: 16,
                           fontWeight: FontWeight.normal,
                           color: itemSelected != null ? Colors.black.withOpacity(opacity) : AppColor.textFieldHintColor),
                       maxLines: 1,

--- a/lib/features/base/widget/hyper_link_widget.dart
+++ b/lib/features/base/widget/hyper_link_widget.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:tmail_ui_user/features/base/styles/hyper_link_widget_styles.dart';
@@ -14,7 +15,7 @@ class HyperLinkWidget extends StatelessWidget {
     return Text.rich(
       TextSpan(
         text: urlString,
-        style: const TextStyle(
+        style: ThemeUtils.defaultTextStyleInterFont.copyWith(
           color: HyperLinkWidgetStyles.textColor,
           fontSize: HyperLinkWidgetStyles.textSize,
           decoration: TextDecoration.underline

--- a/lib/features/base/widget/material_text_button.dart
+++ b/lib/features/base/widget/material_text_button.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 typedef OnTapMaterialTextButton = Function();
@@ -48,7 +49,7 @@ class MaterialTextButton extends StatelessWidget {
             label,
             overflow: overflow,
             softWrap: softWrap,
-            style: customStyle ?? TextStyle(
+            style: customStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontSize: labelSize,
               color: labelColor ?? AppColor.colorTextButton,
               fontWeight: labelWeight ?? FontWeight.normal

--- a/lib/features/base/widget/material_text_icon_button.dart
+++ b/lib/features/base/widget/material_text_icon_button.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
@@ -47,7 +48,7 @@ class MaterialTextIconButton extends StatelessWidget {
       ),
       label: Text(
         label,
-        style: labelStyle ?? TextStyle(
+        style: labelStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: 16,
           color: labelColor ?? AppColor.colorTextButton,
           fontWeight: FontWeight.w500

--- a/lib/features/base/widget/popup_item_no_icon_widget.dart
+++ b/lib/features/base/widget/popup_item_no_icon_widget.dart
@@ -1,4 +1,5 @@
 
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
@@ -38,7 +39,7 @@ class PopupItemNoIconWidget extends StatelessWidget {
             child: Row(children: [
               Expanded(child: Text(
                 _nameAction,
-                style: const TextStyle(
+                style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                   fontSize: 17,
                   color: Colors.black,
                   fontWeight: FontWeight.normal

--- a/lib/features/base/widget/recent_item_tile_widget.dart
+++ b/lib/features/base/widget/recent_item_tile_widget.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
@@ -31,7 +32,7 @@ class RecentItemTileWidget<T> extends StatelessWidget {
           Expanded(
             child: Text(
               _getTitle(item),
-              style: const TextStyle(
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: 15,
                 fontWeight: FontWeight.normal,
                 color: Colors.black

--- a/lib/features/base/widget/text_input_decoration_builder.dart
+++ b/lib/features/base/widget/text_input_decoration_builder.dart
@@ -30,19 +30,19 @@ class TextInputDecorationBuilder extends InputDecorationBuilder {
       prefixText: prefixText,
       labelText: labelText,
       floatingLabelBehavior: FloatingLabelBehavior.never,
-      labelStyle: labelStyle ?? const TextStyle(
+      labelStyle: labelStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
           color: Colors.black,
           fontSize: 16),
       hintText: hintText,
       isDense: true,
-      hintStyle: hintStyle ?? const TextStyle(
+      hintStyle: hintStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
           color: AppColor.loginTextFieldHintColor,
           fontSize: 16),
       contentPadding: contentPadding ?? const EdgeInsets.symmetric(
           horizontal: 12,
           vertical: 12),
       errorText: errorText,
-      errorStyle: errorTextStyle ?? const TextStyle(
+      errorStyle: errorTextStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
           color: AppColor.colorInputBorderErrorVerifyName,
           fontSize: 13),
       filled: true,

--- a/lib/features/base/widget/text_input_field_builder.dart
+++ b/lib/features/base/widget/text_input_field_builder.dart
@@ -41,7 +41,7 @@ class TextInputFieldBuilder extends StatelessWidget {
       if (label != null)
         ...[
           Text(isMandatory ? '${label!}*' : label!,
-              style: const TextStyle(
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                   fontSize: 14,
                   fontWeight: FontWeight.normal,
                   color: AppColor.colorContentEmail)),
@@ -52,7 +52,7 @@ class TextInputFieldBuilder extends StatelessWidget {
         textInputAction: TextInputAction.next,
         controller: editingController,
         focusNode: focusNode,
-        textStyle: const TextStyle(color: Colors.black, fontSize: 16),
+        textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(color: Colors.black, fontSize: 16),
         keyboardType: inputType ?? TextInputType.text,
         textDirection: DirectionUtils.getDirectionByLanguage(context),
         minLines: minLines,

--- a/lib/features/base/widget/user_avatar_builder.dart
+++ b/lib/features/base/widget/user_avatar_builder.dart
@@ -7,7 +7,6 @@ class UserAvatarBuilder extends StatelessWidget {
   final double? size;
   final TextStyle? textStyle;
   final EdgeInsetsGeometry? padding;
-  final TextStyle? textStyle;
   final VoidCallback? onTapAction;
 
   const UserAvatarBuilder({
@@ -16,7 +15,6 @@ class UserAvatarBuilder extends StatelessWidget {
     this.size,
     this.textStyle,
     this.padding,
-    this.textStyle,
     this.onTapAction,
   }) : super(key: key);
 

--- a/lib/features/composer/presentation/styles/attachment_header_composer_widget_style.dart
+++ b/lib/features/composer/presentation/styles/attachment_header_composer_widget_style.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class AttachmentHeaderComposerWidgetStyle {
@@ -13,12 +14,12 @@ class AttachmentHeaderComposerWidgetStyle {
   static const EdgeInsetsGeometry sizeLabelPadding = EdgeInsetsDirectional.symmetric(horizontal: 5, vertical: 2);
   static const EdgeInsetsGeometry padding = EdgeInsetsDirectional.all(8);
 
-  static const TextStyle labelTextSize = TextStyle(
+  static TextStyle labelTextSize = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 13,
     color: AppColor.colorLabelComposer,
     fontWeight: FontWeight.w500
   );
-  static const TextStyle sizeLabelTextSize = TextStyle(
+  static TextStyle sizeLabelTextSize = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 12,
     color: Colors.white,
     fontWeight: FontWeight.w500

--- a/lib/features/composer/presentation/styles/attachment_item_composer_widget_style.dart
+++ b/lib/features/composer/presentation/styles/attachment_item_composer_widget_style.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class AttachmentItemComposerWidgetStyle {
@@ -17,19 +18,22 @@ class AttachmentItemComposerWidgetStyle {
   static const EdgeInsetsGeometry deleteIconPadding = EdgeInsetsDirectional.all(3);
   static const EdgeInsetsGeometry progressLoadingPadding = EdgeInsetsDirectional.only(top: 8);
 
-  static const TextStyle labelTextStyle = TextStyle(
+  static TextStyle labelTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 14,
     color: Colors.black,
-    fontWeight: FontWeight.w500
+    fontWeight: FontWeight.w500,
   );
-  static const TextStyle dotsLabelTextStyle = TextStyle(
+  static TextStyle dotsLabelTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 12,
     color: Colors.black,
-    fontWeight: FontWeight.w500
+    fontWeight: FontWeight.w500,
   );
-  static const TextStyle sizeLabelTextStyle = TextStyle(
+  static TextStyle sizeLabelTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 11,
     color: AppColor.colorLabelComposer,
-    fontWeight: FontWeight.w500
+    fontWeight: FontWeight.w500,
   );
 }

--- a/lib/features/composer/presentation/styles/composer_style.dart
+++ b/lib/features/composer/presentation/styles/composer_style.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 
@@ -42,7 +43,7 @@ class ComposerStyle {
   static const EdgeInsetsGeometry popupItemPadding = EdgeInsetsDirectional.symmetric(horizontal: 12);
   static const EdgeInsetsGeometry insertImageLoadingBarMargin = EdgeInsetsDirectional.only(top: 12);
 
-  static const TextStyle popupItemTextStyle = TextStyle(
+  static TextStyle popupItemTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.black,
     fontSize: 16,
     fontWeight: FontWeight.w500

--- a/lib/features/composer/presentation/styles/draggable_recipient_tag_widget_style.dart
+++ b/lib/features/composer/presentation/styles/draggable_recipient_tag_widget_style.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class DraggableRecipientTagWidgetStyle {
@@ -13,7 +14,7 @@ class DraggableRecipientTagWidgetStyle {
   static const EdgeInsetsGeometry padding = EdgeInsets.symmetric(horizontal: 6, vertical: 3);
   static const EdgeInsetsGeometry labelPadding = EdgeInsets.symmetric(horizontal: 8);
 
-  static const TextStyle labelTextStyle = TextStyle(
+  static TextStyle labelTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.white,
     fontSize: 17,
     fontWeight: FontWeight.normal

--- a/lib/features/composer/presentation/styles/mobile/from_composer_bottom_sheet_style.dart
+++ b/lib/features/composer/presentation/styles/mobile/from_composer_bottom_sheet_style.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class FromComposerBottomSheetStyle {
@@ -29,27 +30,27 @@ class FromComposerBottomSheetStyle {
     color: AppColor.colorBgSearchBar
   );
 
-  static const TextStyle appBarTitleTextStyle = TextStyle(
+  static TextStyle appBarTitleTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.black,
     fontWeight: FontWeight.w700,
     fontSize: 20.0,
   );
-  static const TextStyle searchBarTextStyle = TextStyle(
+  static TextStyle searchBarTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.black,
     fontSize: 16.0,
     fontWeight: FontWeight.w600,
   );
-  static const TextStyle searchHintTextStyle = TextStyle(
+  static TextStyle searchHintTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: AppColor.loginTextFieldHintColor,
     fontSize: 16.0,
     fontWeight: FontWeight.w400,
   );
-  static const TextStyle identityItemTitleTextStyle = TextStyle(
+  static TextStyle identityItemTitleTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.black,
     fontSize: 16.0,
     fontWeight: FontWeight.w500,
   );
-  static const TextStyle identityItemSubTitleTextStyle = TextStyle(
+  static TextStyle identityItemSubTitleTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 13,
     fontWeight: FontWeight.w400,
     color: AppColor.colorLabelQuotas

--- a/lib/features/composer/presentation/styles/mobile/from_composer_mobile_widget_style.dart
+++ b/lib/features/composer/presentation/styles/mobile/from_composer_mobile_widget_style.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class FromComposerMobileWidgetStyle {
@@ -24,18 +25,18 @@ class FromComposerMobileWidgetStyle {
     )
   );
 
-  static const TextStyle prefixTextStyle = TextStyle(
+  static TextStyle prefixTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 14,
     fontWeight: FontWeight.w400,
     color: AppColor.colorLabelComposer
   );
-  static const TextStyle buttonTitleTextStyle = TextStyle(
+  static TextStyle buttonTitleTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 16,
     fontWeight: FontWeight.w500,
     color: AppColor.colorCalendarEventUnread,
     overflow: TextOverflow.ellipsis,
   );
-  static const TextStyle buttonSubTitleTextStyle = TextStyle(
+  static TextStyle buttonSubTitleTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 16,
     fontWeight: FontWeight.w500,
     color: AppColor.colorLabelComposer,

--- a/lib/features/composer/presentation/styles/mobile/tablet_bottom_bar_composer_widget_style.dart
+++ b/lib/features/composer/presentation/styles/mobile/tablet_bottom_bar_composer_widget_style.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class TabletBottomBarComposerWidgetStyle {
@@ -18,7 +19,7 @@ class TabletBottomBarComposerWidgetStyle {
   static const EdgeInsetsGeometry padding = EdgeInsetsDirectional.symmetric(horizontal: 32, vertical: 12);
   static const EdgeInsetsGeometry iconPadding = EdgeInsetsDirectional.all(5);
   static const EdgeInsetsGeometry sendButtonPadding = EdgeInsetsDirectional.symmetric(vertical: 8, horizontal: 24);
-  static const TextStyle sendButtonTextStyle = TextStyle(
+  static TextStyle sendButtonTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontWeight: FontWeight.w500,
     fontSize: 15,
     color: Colors.white,

--- a/lib/features/composer/presentation/styles/recipient_composer_widget_style.dart
+++ b/lib/features/composer/presentation/styles/recipient_composer_widget_style.dart
@@ -31,7 +31,7 @@ class RecipientComposerWidgetStyle {
   static const EdgeInsetsGeometry recipientMargin = EdgeInsetsDirectional.only(top: 12);
   static const EdgeInsetsGeometry enableRecipientButtonMargin = EdgeInsetsDirectional.only(top: 10);
 
-  static const TextStyle prefixButtonTextStyle = TextStyle(
+  static TextStyle prefixButtonTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontFamily: ConstantsUI.fontApp,
     fontSize: 15,
     fontWeight: FontWeight.w400,

--- a/lib/features/composer/presentation/styles/recipient_suggestion_item_widget_style.dart
+++ b/lib/features/composer/presentation/styles/recipient_suggestion_item_widget_style.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class RecipientSuggestionItemWidgetStyle {
@@ -8,12 +9,12 @@ class RecipientSuggestionItemWidgetStyle {
   static const EdgeInsetsGeometry suggestionDuplicatedMargin = EdgeInsets.all(8.0);
   static const EdgeInsetsGeometry labelPadding = EdgeInsets.symmetric(horizontal: 16.0);
 
-  static const TextStyle labelTextStyle = TextStyle(
+  static TextStyle labelTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: AppColor.colorHintSearchBar,
     fontSize: 13,
     fontWeight: FontWeight.normal
   );
-  static const TextStyle labelHighlightTextStyle = TextStyle(
+  static TextStyle labelHighlightTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.black,
     fontSize: 13,
     fontWeight: FontWeight.bold

--- a/lib/features/composer/presentation/styles/recipient_tag_item_widget_style.dart
+++ b/lib/features/composer/presentation/styles/recipient_tag_item_widget_style.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class RecipientTagItemWidgetStyle {
@@ -12,7 +13,7 @@ class RecipientTagItemWidgetStyle {
   static const EdgeInsetsGeometry webMobileCounterMargin = EdgeInsetsDirectional.only(start: 8);
   static const EdgeInsetsGeometry webCounterMargin = EdgeInsetsDirectional.only(top: 8, start: 8);
 
-  static const TextStyle labelTextStyle = TextStyle(
+  static TextStyle labelTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.black,
     fontSize: 17,
     fontWeight: FontWeight.w400

--- a/lib/features/composer/presentation/styles/web/bottom_bar_composer_widget_style.dart
+++ b/lib/features/composer/presentation/styles/web/bottom_bar_composer_widget_style.dart
@@ -1,5 +1,4 @@
 
-import 'package:core/presentation/constants/constants_ui.dart';
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
@@ -26,11 +25,7 @@ class BottomBarComposerWidgetStyle {
   static const EdgeInsetsGeometry richTextIconPadding = EdgeInsetsDirectional.all(2);
   static const EdgeInsetsGeometry popupItemPadding = EdgeInsetsDirectional.symmetric(horizontal: 12);
 
-  static const TextStyle sendButtonTextStyle = TextStyle(
-    fontFamily: ConstantsUI.fontApp,
-    fontWeight: FontWeight.w500,
-    fontSize: 17,
-    height: 22 / 17,
+  static TextStyle sendButtonTextStyle = ThemeUtils.textStyleHeadingHeadingSmall().copyWith(
     color: Colors.white,
     letterSpacing: -0.41,
   );

--- a/lib/features/composer/presentation/styles/web/drop_zone_widget_style.dart
+++ b/lib/features/composer/presentation/styles/web/drop_zone_widget_style.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/composer/presentation/styles/web/bottom_bar_composer_widget_style.dart';
 
@@ -20,7 +21,7 @@ class DropZoneWidgetStyle {
     top: 8
   );
 
-  static const TextStyle labelTextStyle = TextStyle(
+  static TextStyle labelTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.black,
     fontSize: 22,
     fontWeight: FontWeight.w600

--- a/lib/features/composer/presentation/styles/web/dropdown_button_font_size_widget_style.dart
+++ b/lib/features/composer/presentation/styles/web/dropdown_button_font_size_widget_style.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class DropdownButtonFontSizeWidgetStyle {
@@ -14,7 +15,7 @@ class DropdownButtonFontSizeWidgetStyle {
   static const EdgeInsetsGeometry padding = EdgeInsets.all(4);
   static const EdgeInsetsGeometry labelPadding = EdgeInsets.symmetric(horizontal: 16);
 
-  static const TextStyle labelTextStyle = TextStyle(
+  static TextStyle labelTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 16,
     fontWeight: FontWeight.w500,
     color: AppColor.colorLabelRichText

--- a/lib/features/composer/presentation/styles/web/from_composer_drop_down_widget_style.dart
+++ b/lib/features/composer/presentation/styles/web/from_composer_drop_down_widget_style.dart
@@ -63,32 +63,32 @@ class FromComposerDropDownWidgetStyle {
     height: 72,
     overlayColor: WidgetStateProperty.resolveWith<Color>((Set<WidgetState> states) => Colors.white)
   );
-  static const TextStyle avatarTextStyle = TextStyle(
+  static TextStyle avatarTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 16,
     fontWeight: FontWeight.w600,
     color: Colors.black,
   );
-  static const TextStyle dropdownItemTitleTextStyle = TextStyle(
+  static TextStyle dropdownItemTitleTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 16,
     fontWeight: FontWeight.w500,
     color: AppColor.colorDropDownItemTitleComposer,
   );
-  static const TextStyle dropdownItemSubTitleTextStyle = TextStyle(
+  static TextStyle dropdownItemSubTitleTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 13,
     fontWeight: FontWeight.w400,
     color: AppColor.colorLabelQuotas
   );
-  static const TextStyle dropdownTitleTextStyle = TextStyle(
+  static TextStyle dropdownTitleTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 14,
     fontWeight: FontWeight.w500,
     color: AppColor.colorDropDownTitleComposer,
   );
-  static const TextStyle dropdownButtonTitleTextStyle = TextStyle(
+  static TextStyle dropdownButtonTitleTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 16,
     fontWeight: FontWeight.w500,
     color: AppColor.colorCalendarEventUnread
   );
-  static const TextStyle dropdownButtonSubTitleTextStyle = TextStyle(
+  static TextStyle dropdownButtonSubTitleTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 16,
     fontWeight: FontWeight.w500,
     color: AppColor.colorLabelComposer

--- a/lib/features/composer/presentation/styles/web/item_menu_font_size_widget_style.dart
+++ b/lib/features/composer/presentation/styles/web/item_menu_font_size_widget_style.dart
@@ -1,8 +1,9 @@
 
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class ItemMenuFontSizeWidgetStyle {
-  static const TextStyle labelTextStyle = TextStyle(
+  static TextStyle labelTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 16,
     fontWeight: FontWeight.w500,
     color: Colors.black,

--- a/lib/features/composer/presentation/widgets/attachment_item_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/attachment_item_composer_widget.dart
@@ -75,7 +75,7 @@ class AttachmentItemComposerWidget extends StatelessWidget with AppLoaderMixin {
                         ? ExtendedText(
                             fileName,
                             maxLines: 1,
-                            overflowWidget: const TextOverflowWidget(
+                            overflowWidget: TextOverflowWidget(
                               position: TextOverflowPosition.middle,
                               clearType: TextOverflowClearType.clipRect,
                               child: Text(

--- a/lib/features/composer/presentation/widgets/drop_down_menu_header_style_widget.dart
+++ b/lib/features/composer/presentation/widgets/drop_down_menu_header_style_widget.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:dropdown_button2/dropdown_button2.dart';
 import 'package:flutter/material.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
@@ -106,10 +107,11 @@ class DropDownMenuHeaderStyleWidget extends StatelessWidget {
 
   Widget _buildHeaderStyle(String name, double size, FontWeight fontWeight) {
     return Text(name,
-        style: TextStyle(
-            fontSize: size,
-            fontWeight: fontWeight,
-            color: Colors.black),
+        style: ThemeUtils.defaultTextStyleInterFont.copyWith(
+          fontSize: size,
+          fontWeight: fontWeight,
+          color: Colors.black,
+        ),
         maxLines: 1,
         softWrap: CommonTextStyle.defaultSoftWrap,
         overflow: CommonTextStyle.defaultTextOverFlow);

--- a/lib/features/contact/presentation/styles/contact_item_widget_style.dart
+++ b/lib/features/contact/presentation/styles/contact_item_widget_style.dart
@@ -1,20 +1,23 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 
 class ContactItemWidgetStyle {
-  static const TextStyle nameAddressTextStyle = TextStyle(
+  static TextStyle nameAddressTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.black,
     fontSize: 15,
-    fontWeight: FontWeight.w600
+    fontWeight: FontWeight.w600,
   );
 
-  static const TextStyle emailAddressTextStyle = TextStyle(
+  static TextStyle emailAddressTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: AppColor.colorSubtitle,
     fontSize: 13,
-    fontWeight: FontWeight.w400
+    fontWeight: FontWeight.w400,
   );
 
   static EdgeInsetsGeometry getItemPadding(

--- a/lib/features/contact/presentation/styles/contact_view_style.dart
+++ b/lib/features/contact/presentation/styles/contact_view_style.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 
@@ -8,16 +9,18 @@ class ContactViewStyle {
   static const double viewMaxHeight = 624.0;
   static const double viewMaxWidth = 558.0;
 
-  static TextStyle searchInputHintTextStyle = const TextStyle(
+  static TextStyle searchInputHintTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 15,
     fontWeight: FontWeight.w400,
-    color: AppColor.colorHintSearchBar
+    color: AppColor.colorHintSearchBar,
   );
 
-  static TextStyle searchInputTextStyle = const TextStyle(
+  static TextStyle searchInputTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 15,
     fontWeight: FontWeight.w400,
-    color: Colors.black
+    color: Colors.black,
   );
 
   static double getContactViewHeight(

--- a/lib/features/contact/presentation/widgets/app_bar_contact_widget.dart
+++ b/lib/features/contact/presentation/widgets/app_bar_contact_widget.dart
@@ -2,6 +2,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/contact/presentation/styles/app_bar_contact_widget_style.dart';
@@ -37,7 +38,7 @@ class AppBarContactWidget extends StatelessWidget {
         children: [
           Text(
             title ?? AppLocalizations.of(context).contact,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontSize: 20,
               fontWeight: FontWeight.bold,
               color: Colors.black

--- a/lib/features/contact/presentation/widgets/contact_input_tag_item.dart
+++ b/lib/features/contact/presentation/widgets/contact_input_tag_item.dart
@@ -2,6 +2,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/avatar/gradient_circle_avatar_icon.dart';
 import 'package:core/utils/direction_utils.dart';
 import 'package:core/utils/platform_info.dart';
@@ -53,10 +54,11 @@ class ContactInputTagItem extends StatelessWidget {
         maxLines: 1,
         softWrap: CommonTextStyle.defaultSoftWrap,
         overflow: CommonTextStyle.defaultTextOverFlow,
-        style: const TextStyle(
+        style: ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: 14,
           fontWeight: FontWeight.normal,
-          color: Colors.black)
+          color: Colors.black,
+        ),
       ),
       deleteIcon: deleteContactCallbackAction != null
         ? SvgPicture.asset(
@@ -66,7 +68,11 @@ class ContactInputTagItem extends StatelessWidget {
             colorFilter: AppColor.colorDeleteContactIcon.asFilter(),
             fit: BoxFit.fill)
         : null,
-      labelStyle: const TextStyle(color: Colors.black, fontSize: 14, fontWeight: FontWeight.normal),
+      labelStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+        color: Colors.black,
+        fontSize: 14,
+        fontWeight: FontWeight.normal,
+      ),
       backgroundColor: _getTagBackgroundColor(),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(20),

--- a/lib/features/contact/presentation/widgets/contact_list_action_widget.dart
+++ b/lib/features/contact/presentation/widgets/contact_list_action_widget.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/extensions/capitalize_extension.dart';
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
@@ -33,7 +34,7 @@ class ContactListActionWidget extends StatelessWidget {
               minWidth: 156,
               maxLines: 1,
               textAlign: TextAlign.center,
-              textStyle: const TextStyle(
+              textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontWeight: FontWeight.w500,
                 fontSize: 17,
                 color: AppColor.primaryColor
@@ -51,7 +52,7 @@ class ContactListActionWidget extends StatelessWidget {
               minWidth: 156,
               maxLines: 1,
               textAlign: TextAlign.center,
-              textStyle: const TextStyle(
+              textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontWeight: FontWeight.w500,
                 fontSize: 17,
                 color: Colors.white

--- a/lib/features/contact/presentation/widgets/contact_suggestion_box_item.dart
+++ b/lib/features/contact/presentation/widgets/contact_suggestion_box_item.dart
@@ -2,6 +2,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/avatar/gradient_circle_avatar_icon.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -46,7 +47,7 @@ class ContactSuggestionBoxItem extends StatelessWidget {
             maxLines: 1,
             overflow: CommonTextStyle.defaultTextOverFlow,
             softWrap: CommonTextStyle.defaultSoftWrap,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               color: Colors.black,
               fontSize: 16,
               fontWeight: FontWeight.w500)
@@ -59,7 +60,7 @@ class ContactSuggestionBoxItem extends StatelessWidget {
                 maxLines: 1,
                 overflow: CommonTextStyle.defaultTextOverFlow,
                 softWrap: CommonTextStyle.defaultSoftWrap,
-                style: const TextStyle(
+                style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                   color: AppColor.colorEmailAddressFull,
                   fontSize: 14,
                   fontWeight: FontWeight.normal)

--- a/lib/features/destination_picker/presentation/destination_picker_view.dart
+++ b/lib/features/destination_picker/presentation/destination_picker_view.dart
@@ -129,7 +129,7 @@ class DestinationPickerView extends GetWidget<DestinationPickerController>
                                           child: Text(
                                             AppLocalizations.of(context).selectParentFolder,
                                             textAlign: TextAlign.left,
-                                            style: const TextStyle(
+                                            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                                               fontSize: 13,
                                               color: AppColor.colorHintSearchBar,
                                               fontWeight: FontWeight.normal)),
@@ -220,7 +220,7 @@ class DestinationPickerView extends GetWidget<DestinationPickerController>
         controller: controller.nameInputController,
         textDirection: DirectionUtils.getDirectionByLanguage(context),
         maxLines: 1,
-        textStyle: const TextStyle(
+        textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
           color: AppColor.colorNameEmail,
           fontSize: 16,
           overflow: CommonTextStyle.defaultTextOverFlow),

--- a/lib/features/destination_picker/presentation/widgets/destination_picker_search_mailbox_item_builder.dart
+++ b/lib/features/destination_picker/presentation/widgets/destination_picker_search_mailbox_item_builder.dart
@@ -2,6 +2,7 @@ import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -97,7 +98,7 @@ class DestinationPickerSearchMailboxItemBuilder extends StatelessWidget {
       maxLines: 1,
       overflow: CommonTextStyle.defaultTextOverFlow,
       softWrap: CommonTextStyle.defaultSoftWrap,
-      style: const TextStyle(
+      style: ThemeUtils.defaultTextStyleInterFont.copyWith(
         fontSize: 15,
         color: Colors.black
       ),
@@ -111,7 +112,7 @@ class DestinationPickerSearchMailboxItemBuilder extends StatelessWidget {
         maxLines: 1,
         overflow: CommonTextStyle.defaultTextOverFlow,
         softWrap: CommonTextStyle.defaultSoftWrap,
-        style: const TextStyle(
+        style: ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: 11,
           color: AppColor.colorMailboxPath,
           fontWeight: FontWeight.normal
@@ -123,7 +124,7 @@ class DestinationPickerSearchMailboxItemBuilder extends StatelessWidget {
         maxLines: 1,
         softWrap: CommonTextStyle.defaultSoftWrap,
         overflow: CommonTextStyle.defaultTextOverFlow,
-        style: const TextStyle(
+        style: ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: 11,
           color: AppColor.colorEmailAddressFull,
           fontWeight: FontWeight.normal

--- a/lib/features/destination_picker/presentation/widgets/top_bar_destination_picker_builder.dart
+++ b/lib/features/destination_picker/presentation/widgets/top_bar_destination_picker_builder.dart
@@ -55,7 +55,7 @@ class TopBarDestinationPickerBuilder extends StatelessWidget {
                 softWrap: CommonTextStyle.defaultSoftWrap,
                 overflow: CommonTextStyle.defaultTextOverFlow,
                 textAlign: TextAlign.center,
-                style: const TextStyle(
+                style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     fontSize: 20,
                     color: Colors.black,
                     fontWeight: FontWeight.w700))),
@@ -103,7 +103,7 @@ class TopBarDestinationPickerBuilder extends StatelessWidget {
                             softWrap: CommonTextStyle.defaultSoftWrap,
                             overflow: CommonTextStyle.defaultTextOverFlow,
                             textAlign: TextAlign.center,
-                            style: const TextStyle(
+                            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                               fontSize: 15,
                               color: AppColor.colorTextButton,
                               fontWeight: FontWeight.normal))

--- a/lib/features/email/presentation/styles/attachment/attachment_item_widget_style.dart
+++ b/lib/features/email/presentation/styles/attachment/attachment_item_widget_style.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class AttachmentItemWidgetStyle {
@@ -16,20 +17,23 @@ class AttachmentItemWidgetStyle {
 
   static const Color borderColor = AppColor.attachmentFileBorderColor;
 
-  static const TextStyle labelTextStyle = TextStyle(
+  static TextStyle labelTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 14,
     color: AppColor.attachmentFileNameColor,
-    fontWeight: FontWeight.w500
+    fontWeight: FontWeight.w500,
   );
-  static const TextStyle dotsLabelTextStyle = TextStyle(
+  static TextStyle dotsLabelTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 12,
     color: AppColor.attachmentFileNameColor,
-    fontWeight: FontWeight.w500
+    fontWeight: FontWeight.w500,
   );
-  static const TextStyle sizeLabelTextStyle = TextStyle(
+  static TextStyle sizeLabelTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 12,
     color: AppColor.attachmentFileSizeColor,
-    fontWeight: FontWeight.normal
+    fontWeight: FontWeight.normal,
   );
 
   static double getMaxWidthItem({

--- a/lib/features/email/presentation/styles/attachment/attachment_list_item_widget_styles.dart
+++ b/lib/features/email/presentation/styles/attachment/attachment_list_item_widget_styles.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class AttachmentListItemWidgetStyle {
@@ -10,19 +11,22 @@ class AttachmentListItemWidgetStyle {
 
   static const EdgeInsetsGeometry contentPadding = EdgeInsetsDirectional.all(12);
 
-  static const TextStyle labelTextStyle = TextStyle(
+  static TextStyle labelTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 14,
     color: AppColor.attachmentFileNameColor,
-    fontWeight: FontWeight.w500
+    fontWeight: FontWeight.w500,
   );
-  static const TextStyle dotsLabelTextStyle = TextStyle(
+  static TextStyle dotsLabelTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 12,
     color: AppColor.attachmentFileNameColor,
-    fontWeight: FontWeight.w500
+    fontWeight: FontWeight.w500,
   );
-  static const TextStyle sizeLabelTextStyle = TextStyle(
+  static TextStyle sizeLabelTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 12,
     color: AppColor.attachmentFileSizeColor,
-    fontWeight: FontWeight.normal
+    fontWeight: FontWeight.normal,
   );
 }

--- a/lib/features/email/presentation/styles/attachment/attachment_list_styles.dart
+++ b/lib/features/email/presentation/styles/attachment/attachment_list_styles.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class AttachmentListStyles {
@@ -89,24 +90,28 @@ class AttachmentListStyles {
   static const FontWeight subTitleFontWeight = FontWeight.w400;
   static const FontWeight buttonFontWeight = FontWeight.w500;
 
-  static const TextStyle titleTextStyle = TextStyle(
+  static TextStyle titleTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: titleFontSize,
     fontWeight: titleFontWeight,
-    color: titleTextColor
+    color: titleTextColor,
   );
-  static const TextStyle subTitleTextStyle = TextStyle(
+  static TextStyle subTitleTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: subTitleFontSize,
     fontWeight: subTitleFontWeight,
-    color: subTitleTextColor
+    color: subTitleTextColor,
   );
-  static const TextStyle downloadAllButtonTextStyle = TextStyle(
+  static TextStyle downloadAllButtonTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: titleFontSize,
     fontWeight: buttonFontWeight,
-    color: downloadAllButtonTextColor
+    color: downloadAllButtonTextColor,
   );
-  static const TextStyle cancelButtonTextStyle = TextStyle(
+  static TextStyle cancelButtonTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: titleFontSize,
     fontWeight: buttonFontWeight,
-    color: cancelButtonTextColor
+    color: cancelButtonTextColor,
   );
 }

--- a/lib/features/email/presentation/styles/attachment/feedback_draggable_attachment_item_widget_style.dart
+++ b/lib/features/email/presentation/styles/attachment/feedback_draggable_attachment_item_widget_style.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class FeedbackDraggableAttachmentItemWidgetStyle {
@@ -12,15 +13,17 @@ class FeedbackDraggableAttachmentItemWidgetStyle {
 
   static const EdgeInsetsGeometry padding = EdgeInsets.symmetric(horizontal: 16, vertical: 12);
 
-  static const TextStyle labelTextStyle = TextStyle(
+  static TextStyle labelTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.black,
     fontSize: 16,
-    fontWeight: FontWeight.w500
+    fontWeight: FontWeight.w500,
   );
-  static const TextStyle dotsLabelTextStyle = TextStyle(
+  static TextStyle dotsLabelTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 12,
     color: Colors.black,
-    fontWeight: FontWeight.w500
+    fontWeight: FontWeight.w500,
   );
 
   static const List<BoxShadow> shadows = [

--- a/lib/features/email/presentation/widgets/attachment_item_widget.dart
+++ b/lib/features/email/presentation/widgets/attachment_item_widget.dart
@@ -81,7 +81,7 @@ class AttachmentItemWidget extends StatelessWidget {
                       ? ExtendedText(
                           (attachment.name ?? ''),
                           maxLines: 1,
-                          overflowWidget: const TextOverflowWidget(
+                          overflowWidget: TextOverflowWidget(
                             position: TextOverflowPosition.middle,
                             clearType: TextOverflowClearType.clipRect,
                             child: Text(

--- a/lib/features/email/presentation/widgets/attachment_list/attachment_list_item_widget.dart
+++ b/lib/features/email/presentation/widgets/attachment_list/attachment_list_item_widget.dart
@@ -68,7 +68,7 @@ class AttachmentListItemWidget extends StatelessWidget {
                           ExtendedText(
                             (attachment.name ?? ''),
                             maxLines: 1,
-                            overflowWidget: const TextOverflowWidget(
+                            overflowWidget: TextOverflowWidget(
                               position: TextOverflowPosition.middle,
                               clearType: TextOverflowClearType.clipRect,
                               child: Text(

--- a/lib/features/email/presentation/widgets/attachments_info.dart
+++ b/lib/features/email/presentation/widgets/attachments_info.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
@@ -44,7 +45,7 @@ class AttachmentsInfo extends StatelessWidget {
           numberOfAttachments,
           totalSizeInfo,
         ),
-        style: const TextStyle(
+        style: ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: EmailAttachmentsStyles.headerTextSize,
           fontWeight: EmailAttachmentsStyles.headerFontWeight,
           color: EmailAttachmentsStyles.headerTextColor
@@ -58,7 +59,7 @@ class AttachmentsInfo extends StatelessWidget {
           backgroundColor: Colors.transparent,
           borderRadius: EmailAttachmentsStyles.buttonBorderRadius,
           padding: EmailAttachmentsStyles.buttonPadding,
-          textStyle: const TextStyle(
+          textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
             fontSize: EmailAttachmentsStyles.buttonTextSize,
             color: EmailAttachmentsStyles.buttonTextColor,
             fontWeight: EmailAttachmentsStyles.buttonFontWeight
@@ -77,7 +78,7 @@ class AttachmentsInfo extends StatelessWidget {
             backgroundColor: Colors.transparent,
             borderRadius: EmailAttachmentsStyles.buttonBorderRadius,
             padding: EmailAttachmentsStyles.buttonPadding,
-            textStyle: const TextStyle(
+            textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontSize: EmailAttachmentsStyles.buttonTextSize,
               color: EmailAttachmentsStyles.buttonTextColor,
               fontWeight: EmailAttachmentsStyles.buttonFontWeight

--- a/lib/features/email/presentation/widgets/calendar_event/attendee_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/attendee_widget.dart
@@ -1,4 +1,5 @@
 
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:jmap_dart_client/jmap/mail/calendar/properties/attendee/calendar_attendee.dart';
@@ -23,7 +24,7 @@ class AttendeeWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Text.rich(
       TextSpan(
-        style: const TextStyle(
+        style: ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: AttendeeWidgetStyles.textSize,
           fontWeight: FontWeight.w500,
           color: AttendeeWidgetStyles.textColor
@@ -34,7 +35,7 @@ class AttendeeWidget extends StatelessWidget {
           if (attendee.mailto?.mailAddress.value.isNotEmpty == true)
             TextSpan(
               text: ' <${attendee.mailto!.mailAddress.value}> ',
-              style: const TextStyle(
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 color: AttendeeWidgetStyles.mailtoColor,
                 fontSize: AttendeeWidgetStyles.textSize,
                 fontWeight: FontWeight.w500

--- a/lib/features/email/presentation/widgets/calendar_event/calendar_date_icon_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/calendar_date_icon_widget.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:jmap_dart_client/jmap/mail/calendar/calendar_event.dart';
 import 'package:tmail_ui_user/features/email/presentation/extensions/calendar_event_extension.dart';
@@ -53,7 +54,7 @@ class CalendarDateIconWidget extends StatelessWidget {
             child: Text(
               calendarEvent.monthStartDateAsString,
               textAlign: TextAlign.center,
-              style: const TextStyle(
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: CalendarIconWidgetStyles.headerTextSize,
                 fontWeight: FontWeight.w400,
                 color: Colors.white
@@ -64,7 +65,7 @@ class CalendarDateIconWidget extends StatelessWidget {
             padding: const EdgeInsets.all(CalendarIconWidgetStyles.bodyContentPadding),
             child: Text(
               calendarEvent.dayStartDateAsString,
-              style: const TextStyle(
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: CalendarIconWidgetStyles.bodyDayTextSize,
                 fontWeight: FontWeight.w700,
                 color: Colors.black
@@ -79,7 +80,7 @@ class CalendarDateIconWidget extends StatelessWidget {
             padding: const EdgeInsets.all(CalendarIconWidgetStyles.bodyContentPadding),
             child: Text(
               calendarEvent.weekDayStartDateAsString,
-              style: const TextStyle(
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: CalendarIconWidgetStyles.bodyWeekDayTextSize,
                 fontWeight: FontWeight.w400,
                 color: Colors.black

--- a/lib/features/email/presentation/widgets/calendar_event/calendar_event_action_banner_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/calendar_event_action_banner_widget.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
@@ -46,7 +47,7 @@ class CalendarEventActionBannerWidget extends StatelessWidget {
             ),
           Expanded(child: Text.rich(
             TextSpan(
-              style: TextStyle(
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: CalendarEventActionBannerStyles.titleTextSize,
                 fontWeight: FontWeight.w400,
                 color: calendarEvent.getColorEventActionText(listEmailAddressSender)
@@ -58,7 +59,7 @@ class CalendarEventActionBannerWidget extends StatelessWidget {
                     imagePaths: imagePaths,
                     listEmailAddressSender: listEmailAddressSender
                   ),
-                  style: TextStyle(
+                  style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     color: calendarEvent.getColorEventActionText(listEmailAddressSender),
                     fontSize: CalendarEventActionBannerStyles.titleTextSize,
                     fontWeight: FontWeight.w700

--- a/lib/features/email/presentation/widgets/calendar_event/calendar_event_action_button_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/calendar_event_action_button_widget.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:jmap_dart_client/jmap/mail/calendar/attendance/calendar_event_attendance.dart';
@@ -43,7 +44,7 @@ class CalendarEventActionButtonWidget extends StatelessWidget {
               backgroundColor: _getButtonBackgroundColor(action),
               borderRadius: CalendarEventActionButtonWidgetStyles.borderRadius,
               padding: CalendarEventActionButtonWidgetStyles.buttonPadding,
-              textStyle: TextStyle(
+              textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontWeight: CalendarEventActionButtonWidgetStyles.fontWeight,
                 fontSize: CalendarEventActionButtonWidgetStyles.textSize,
                 color: _getButtonTextColor(action),

--- a/lib/features/email/presentation/widgets/calendar_event/calendar_event_information_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/calendar_event_information_widget.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:jmap_dart_client/jmap/mail/calendar/calendar_event.dart';
 import 'package:jmap_dart_client/jmap/mail/calendar/attendance/calendar_event_attendance.dart';
@@ -86,7 +87,7 @@ class CalendarEventInformationWidget extends StatelessWidget {
               ),
               child: Text.rich(
                 TextSpan(
-                  style: const TextStyle(
+                  style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     fontSize: CalendarEventInformationWidgetStyles
                         .invitationMessageTextSize,
                     fontWeight: FontWeight.w500,
@@ -96,7 +97,7 @@ class CalendarEventInformationWidget extends StatelessWidget {
                   children: [
                     TextSpan(
                       text: calendarEvent.organizerName,
-                      style: const TextStyle(
+                      style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                         color: CalendarEventInformationWidgetStyles
                             .invitationMessageColor,
                         fontSize: CalendarEventInformationWidgetStyles
@@ -159,7 +160,7 @@ class CalendarEventInformationWidget extends StatelessWidget {
                 AppLocalizations
                     .of(context)
                     .youAreNotInvitedToThisEventPleaseContactTheOrganizer,
-                style: const TextStyle(
+                style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                   fontSize: CalendarEventInformationWidgetStyles
                       .invitationMessageTextSize,
                   fontWeight: FontWeight.w500,

--- a/lib/features/email/presentation/widgets/calendar_event/event_attendee_detail_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/event_attendee_detail_widget.dart
@@ -1,4 +1,5 @@
 
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:flutter/material.dart';
 import 'package:jmap_dart_client/jmap/mail/calendar/properties/attendee/calendar_attendee.dart';
@@ -53,7 +54,7 @@ class _EventAttendeeDetailWidgetState extends State<EventAttendeeDetailWidget> {
           width: EventAttendeeDetailWidgetStyles.maxWidth,
           child: Text(
             AppLocalizations.of(context).who,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontSize: EventAttendeeDetailWidgetStyles.textSize,
               fontWeight: FontWeight.w500,
               color: EventAttendeeDetailWidgetStyles.labelColor

--- a/lib/features/email/presentation/widgets/calendar_event/event_link_detail_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/event_link_detail_widget.dart
@@ -1,4 +1,5 @@
 
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/base/widget/hyper_link_widget.dart';
 import 'package:tmail_ui_user/features/email/presentation/styles/event_link_detail_widget_styles.dart';
@@ -22,7 +23,7 @@ class EventLinkDetailWidget extends StatelessWidget {
           width: EventLinkDetailWidgetStyles.maxWidth,
           child: Text(
             AppLocalizations.of(context).link,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontSize: EventLinkDetailWidgetStyles.textSize,
               fontWeight: FontWeight.w500,
               color: EventLinkDetailWidgetStyles.labelColor

--- a/lib/features/email/presentation/widgets/calendar_event/event_location_information_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/event_location_information_widget.dart
@@ -1,4 +1,5 @@
 
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_linkify/flutter_linkify.dart';
@@ -28,7 +29,7 @@ class EventLocationInformationWidget extends StatelessWidget {
           width: EventLocationInformationWidgetStyles.maxWidth,
           child: Text(
             AppLocalizations.of(context).where,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontSize: EventLocationInformationWidgetStyles.textSize,
               fontWeight: FontWeight.w500,
               color: EventLocationInformationWidgetStyles.labelColor
@@ -49,7 +50,7 @@ class EventLocationInformationWidget extends StatelessWidget {
             EmailLinkifier(),
             UrlLinkifier()
           ],
-          style: const TextStyle(
+          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
             fontSize: EventLocationInformationWidgetStyles.textSize,
             fontWeight: FontWeight.w500,
             color: EventLocationInformationWidgetStyles.valueColor

--- a/lib/features/email/presentation/widgets/calendar_event/event_time_information_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/event_time_information_widget.dart
@@ -3,6 +3,7 @@ import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
@@ -32,7 +33,7 @@ class EventTimeInformationWidget extends StatelessWidget {
           width: EventTimeInformationWidgetStyles.maxWidth,
           child: Text(
             AppLocalizations.of(context).when,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontSize: EventTimeInformationWidgetStyles.textSize,
               fontWeight: FontWeight.w500,
               color: EventTimeInformationWidgetStyles.labelColor
@@ -44,7 +45,7 @@ class EventTimeInformationWidget extends StatelessWidget {
           overflow: responsiveUtils.isPortraitMobile(context) ? null : CommonTextStyle.defaultTextOverFlow,
           softWrap: responsiveUtils.isPortraitMobile(context) ? null : CommonTextStyle.defaultSoftWrap,
           maxLines: responsiveUtils.isPortraitMobile(context) ? null : 1,
-          style: const TextStyle(
+          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
             fontSize: EventTimeInformationWidgetStyles.textSize,
             fontWeight: FontWeight.w500,
             color: EventTimeInformationWidgetStyles.valueColor

--- a/lib/features/email/presentation/widgets/calendar_event/event_title_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/event_title_widget.dart
@@ -1,4 +1,5 @@
 
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/email/presentation/styles/event_title_widget_styles.dart';
 
@@ -12,7 +13,7 @@ class EventTitleWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Text(
       title,
-      style: const TextStyle(
+      style: ThemeUtils.defaultTextStyleInterFont.copyWith(
         fontWeight: FontWeight.w500,
         fontSize: EventTitleWidgetStyles.textSize,
         color: EventTitleWidgetStyles.textColor

--- a/lib/features/email/presentation/widgets/calendar_event/hide_all_attendees_button_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/hide_all_attendees_button_widget.dart
@@ -1,4 +1,5 @@
 
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:tmail_ui_user/features/base/widget/material_text_button.dart';
 import 'package:tmail_ui_user/features/email/presentation/styles/see_all_attendees_button_widget_styles.dart';
@@ -25,7 +26,7 @@ class HideAllAttendeesButtonWidget extends StatelessWidget {
           horizontal: SeeAllAttendeesButtonWidgetStyles.horizontalPadding,
           vertical: SeeAllAttendeesButtonWidgetStyles.verticalPadding
         ),
-        customStyle: const TextStyle(
+        customStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: SeeAllAttendeesButtonWidgetStyles.textSize,
           color: SeeAllAttendeesButtonWidgetStyles.textColor
         ),

--- a/lib/features/email/presentation/widgets/calendar_event/organizer_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/organizer_widget.dart
@@ -1,4 +1,5 @@
 
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:jmap_dart_client/jmap/mail/calendar/properties/calendar_organizer.dart';
@@ -22,7 +23,7 @@ class OrganizerWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Text.rich(
       TextSpan(
-        style: const TextStyle(
+        style: ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: OrganizerWidgetStyles.textSize,
           fontWeight: FontWeight.w500,
           color: OrganizerWidgetStyles.textColor
@@ -33,7 +34,7 @@ class OrganizerWidget extends StatelessWidget {
           if (organizer.mailto?.value.isNotEmpty == true)
             TextSpan(
               text: ' <${organizer.mailto!.value}> ',
-              style: const TextStyle(
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 color: OrganizerWidgetStyles.mailtoColor,
                 fontSize: OrganizerWidgetStyles.textSize,
                 fontWeight: FontWeight.w500

--- a/lib/features/email/presentation/widgets/calendar_event/see_all_attendees_button_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/see_all_attendees_button_widget.dart
@@ -1,4 +1,5 @@
 
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:tmail_ui_user/features/base/widget/material_text_button.dart';
 import 'package:tmail_ui_user/features/email/presentation/styles/see_all_attendees_button_widget_styles.dart';
@@ -25,7 +26,7 @@ class SeeAllAttendeesButtonWidget extends StatelessWidget {
           horizontal: SeeAllAttendeesButtonWidgetStyles.horizontalPadding,
           vertical: SeeAllAttendeesButtonWidgetStyles.verticalPadding
         ),
-        customStyle: const TextStyle(
+        customStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: SeeAllAttendeesButtonWidgetStyles.textSize,
           color: SeeAllAttendeesButtonWidgetStyles.textColor
         ),

--- a/lib/features/email/presentation/widgets/email_attachments_widget.dart
+++ b/lib/features/email/presentation/widgets/email_attachments_widget.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/action/action_callback_define.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:filesize/filesize.dart';
@@ -54,7 +55,7 @@ class EmailAttachmentsWidget extends StatelessWidget {
       padding: padding,
       maxWidth: EmailAttachmentsStyles.buttonMoreMaxWidth,
       margin: margin,
-      textStyle: const TextStyle(
+      textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
         fontSize: EmailAttachmentsStyles.buttonMoreAttachmentsTextSize,
         color: EmailAttachmentsStyles.buttonMoreAttachmentsTextColor,
         fontWeight: EmailAttachmentsStyles.buttonMoreAttachmentsFontWeight,
@@ -152,7 +153,7 @@ class EmailAttachmentsWidget extends StatelessWidget {
                       backgroundColor: Colors.transparent,
                       borderRadius: EmailAttachmentsStyles.buttonBorderRadius,
                       padding: EmailAttachmentsStyles.mobileButtonPadding,
-                      textStyle: const TextStyle(
+                      textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                         fontSize: EmailAttachmentsStyles.buttonTextSize,
                         color: EmailAttachmentsStyles.buttonTextColor,
                         fontWeight: EmailAttachmentsStyles.buttonFontWeight

--- a/lib/features/email/presentation/widgets/email_view_empty_widget.dart
+++ b/lib/features/email/presentation/widgets/email_view_empty_widget.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/email/presentation/styles/email_view_empty_styles.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
@@ -12,7 +13,7 @@ class EmailViewEmptyWidget extends StatelessWidget {
       child: Text(
         AppLocalizations.of(context).no_mail_selected,
         textAlign: TextAlign.center,
-        style: const TextStyle(
+        style: ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: EmailViewEmptyStyles.textSize,
           color: EmailViewEmptyStyles.textColor,
           fontWeight: EmailViewEmptyStyles.fontWeight

--- a/lib/features/email/presentation/widgets/feedback_draggable_attachment_item_widget.dart
+++ b/lib/features/email/presentation/widgets/feedback_draggable_attachment_item_widget.dart
@@ -50,7 +50,7 @@ class FeedbackDraggableAttachmentItemWidget extends StatelessWidget {
                   child: ExtendedText(
                     attachment.name ?? '',
                     maxLines: 1,
-                    overflowWidget: const TextOverflowWidget(
+                    overflowWidget: TextOverflowWidget(
                       position: TextOverflowPosition.middle,
                       clearType: TextOverflowClearType.clipRect,
                       child: Text(

--- a/lib/features/email/presentation/widgets/information_sender_and_receiver_builder.dart
+++ b/lib/features/email/presentation/widgets/information_sender_and_receiver_builder.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -82,7 +83,7 @@ class InformationSenderAndReceiverBuilder extends StatelessWidget {
                           if (!emailSelected.isSubscribed && emailUnsubscribe != null && !responsiveUtils.isPortraitMobile(context))
                             TMailButtonWidget.fromText(
                               text: AppLocalizations.of(context).unsubscribe,
-                              textStyle: const TextStyle(
+                              textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                                 fontWeight: FontWeight.normal,
                                 fontSize: 14,
                                 color: AppColor.colorTextBody,

--- a/lib/features/email/presentation/widgets/mail_unsubscribed_banner.dart
+++ b/lib/features/email/presentation/widgets/mail_unsubscribed_banner.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/email_unsubscribe.dart';
@@ -22,7 +23,7 @@ class MailUnsubscribedBanner extends StatelessWidget {
         padding: const EdgeInsetsDirectional.only(bottom: 16, start: 20, end: 20),
         child: Text(
           AppLocalizations.of(context).mailUnsubscribedMessage(presentationEmail?.firstEmailAddressInFrom ?? ''),
-          style: const TextStyle(
+          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
             fontWeight: FontWeight.normal,
             fontSize: 15,
             color: AppColor.labelColor

--- a/lib/features/email_recovery/presentation/model/email_recovery_field.dart
+++ b/lib/features/email_recovery/presentation/model/email_recovery_field.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/email_recovery/presentation/model/email_recovery_time_type.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
@@ -69,7 +70,7 @@ enum EmailRecoveryField {
   }
 
   TextStyle getTitleTextStyle() {
-    return const TextStyle(
+    return ThemeUtils.defaultTextStyleInterFont.copyWith(
       fontSize: 14,
       fontWeight: FontWeight.w400,
       color: AppColor.colorContentEmail,
@@ -89,7 +90,7 @@ enum EmailRecoveryField {
         color = AppColor.colorHintSearchBar;
         break;
     }
-    return TextStyle(
+    return ThemeUtils.defaultTextStyleInterFont.copyWith(
       fontSize: 16,
       fontWeight: FontWeight.w400,
       color: color,

--- a/lib/features/email_recovery/presentation/styles/date_selection_field/date_selection_dropdown_button_styles.dart
+++ b/lib/features/email_recovery/presentation/styles/date_selection_field/date_selection_dropdown_button_styles.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:dropdown_button2/dropdown_button2.dart';
 import 'package:flutter/material.dart';
 
@@ -26,7 +27,7 @@ class DateSelectionDropdownButtonStyles {
     color: Colors.white,
   );
 
-  static const TextStyle selectedValueTexStyle = TextStyle(
+  static TextStyle selectedValueTexStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 16,
     fontWeight: FontWeight.w400,
     color: Colors.black,

--- a/lib/features/email_recovery/presentation/styles/email_recovery_form_styles.dart
+++ b/lib/features/email_recovery/presentation/styles/email_recovery_form_styles.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class EmailRecoveryFormStyles {
@@ -11,7 +12,7 @@ class EmailRecoveryFormStyles {
     vertical: 12,
   );
 
-  static const TextStyle titleTextStyle = TextStyle(
+  static TextStyle titleTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 20,
     fontWeight: FontWeight.w700,
     color: Colors.black,

--- a/lib/features/email_recovery/presentation/styles/text_input_field/avatar_suggestion_item_widget_styles.dart
+++ b/lib/features/email_recovery/presentation/styles/text_input_field/avatar_suggestion_item_widget_styles.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class AvatarSuggestionItemWidgetStyles {
@@ -5,7 +6,7 @@ class AvatarSuggestionItemWidgetStyles {
   static const double height = 40.0;
   static const double borderWidth = 1.0;
 
-  static const TextStyle textStyle = TextStyle(
+  static TextStyle textStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.black,
     fontSize: 16,
     fontWeight: FontWeight.w400

--- a/lib/features/email_recovery/presentation/styles/text_input_field/avatar_tag_item_widget_styles.dart
+++ b/lib/features/email_recovery/presentation/styles/text_input_field/avatar_tag_item_widget_styles.dart
@@ -1,10 +1,11 @@
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class AvatarTagItemWidgetStyles {
   static const double size = 24.0;
   static const double borderWidth = 0.21;
 
-  static const TextStyle textStyle = TextStyle(
+  static TextStyle textStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.white,
     fontSize: 8.57,
     fontWeight: FontWeight.w600

--- a/lib/features/email_recovery/presentation/styles/text_input_field/suggestion_item_widget_styles.dart
+++ b/lib/features/email_recovery/presentation/styles/text_input_field/suggestion_item_widget_styles.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/composer/presentation/styles/composer_style.dart';
 
@@ -19,12 +20,12 @@ class SuggestionItemWidgetStyles {
     borderRadius: BorderRadius.all(Radius.circular(20))
   );
 
-  static const TextStyle subTitleTextOriginStyle = TextStyle(
+  static TextStyle subTitleTextOriginStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: AppColor.colorHintSearchBar,
     fontSize: 13,
     fontWeight: FontWeight.normal
   );
-  static const TextStyle subTitleWordSearchedStyle = TextStyle(
+  static TextStyle subTitleWordSearchedStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.black,
     fontSize: 13,
     fontWeight: FontWeight.bold

--- a/lib/features/email_recovery/presentation/styles/text_input_field/suggestion_tag_item_widget_styles.dart
+++ b/lib/features/email_recovery/presentation/styles/text_input_field/suggestion_tag_item_widget_styles.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class SuggestionTagItemWidgetStyles {
@@ -24,7 +25,7 @@ class SuggestionTagItemWidgetStyles {
     width: 1,
   );
 
-  static const TextStyle labelStyle = TextStyle(
+  static TextStyle labelStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.black,
     fontSize: 17,
     fontWeight: FontWeight.w400

--- a/lib/features/email_recovery/presentation/styles/text_input_field/text_input_field_widget_styles.dart
+++ b/lib/features/email_recovery/presentation/styles/text_input_field/text_input_field_widget_styles.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class TextInputFieldWidgetStyles {
@@ -42,7 +43,7 @@ class TextInputFieldWidgetStyles {
     )
   );
 
-  static const TextStyle inputtedTextStyle = TextStyle(
+  static TextStyle inputtedTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 16,
     fontWeight: FontWeight.w400,
     color: Colors.black,

--- a/lib/features/email_recovery/presentation/styles/text_input_field/text_input_suggestion_field_widget_styles.dart
+++ b/lib/features/email_recovery/presentation/styles/text_input_field/text_input_suggestion_field_widget_styles.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/composer/presentation/styles/composer_style.dart';
 
@@ -34,7 +35,7 @@ class TextInputSuggestionFieldWidgetStyles {
     borderSide: BorderSide.none,
   );
 
-  static const TextStyle inputFieldTextStyle = TextStyle(
+  static TextStyle inputFieldTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.black,
     fontSize: 16,
     fontWeight: FontWeight.w400,

--- a/lib/features/email_recovery/presentation/widgets/limits_banner.dart
+++ b/lib/features/email_recovery/presentation/widgets/limits_banner.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class LimitsBanner extends StatelessWidget {
@@ -20,7 +21,7 @@ class LimitsBanner extends StatelessWidget {
       child: Center(
         child: Text(
           bannerContent,
-          style: const TextStyle(
+          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
             fontSize: 16,
             color: Colors.black,
             fontWeight: FontWeight.bold,

--- a/lib/features/email_recovery/presentation/widgets/text_action_button_widget.dart
+++ b/lib/features/email_recovery/presentation/widgets/text_action_button_widget.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/icon_button_web.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/email_recovery/presentation/styles/text_action_button_widget_styles.dart';
@@ -25,7 +26,7 @@ class TextActionButtonWidget extends StatelessWidget {
       radius: TextActionButtonWidgetStyles.radius,
       height: TextActionButtonWidgetStyles.height,
       minWidth: minWidth,
-      textStyle: TextStyle(
+      textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
         fontSize: TextActionButtonWidgetStyles.fontSize,
         color: colorText,
         fontWeight: FontWeight.w500

--- a/lib/features/identity_creator/presentation/identity_creator_view.dart
+++ b/lib/features/identity_creator/presentation/identity_creator_view.dart
@@ -4,6 +4,7 @@ import 'package:core/presentation/constants/constants_ui.dart';
 import 'package:core/presentation/extensions/capitalize_extension.dart';
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/icon_button_web.dart';
 import 'package:core/presentation/views/responsive/responsive_widget.dart';
 import 'package:core/utils/html/html_utils.dart';
@@ -105,7 +106,7 @@ class IdentityCreatorView extends GetWidget<IdentityCreatorController>
           )),
           const SizedBox(height: 32),
           Text(AppLocalizations.of(context).signature,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontWeight: FontWeight.normal,
               fontSize: 14,
               color: AppColor.colorContentEmail,
@@ -430,7 +431,7 @@ class IdentityCreatorView extends GetWidget<IdentityCreatorController>
             textAlign: TextAlign.center,
             overflow: CommonTextStyle.defaultTextOverFlow,
             softWrap: CommonTextStyle.defaultSoftWrap,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontWeight: FontWeight.bold,
               fontSize: 20,
               color: Colors.black
@@ -621,7 +622,7 @@ class IdentityCreatorView extends GetWidget<IdentityCreatorController>
   Widget _buildCancelButton(BuildContext context, {double? width}) {
     return buildTextButton(
       AppLocalizations.of(context).cancel,
-      textStyle: const TextStyle(
+      textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
         fontWeight: FontWeight.w500,
         fontSize: 17,
         color: AppColor.colorTextButton,

--- a/lib/features/identity_creator/presentation/widgets/identity_drop_list_field_builder.dart
+++ b/lib/features/identity_creator/presentation/widgets/identity_drop_list_field_builder.dart
@@ -2,6 +2,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:dropdown_button2/dropdown_button2.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -32,7 +33,7 @@ class IdentityDropListFieldBuilder extends StatelessWidget {
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       Text(
         _label,
-        style: const TextStyle(
+        style: ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: 14,
           fontWeight: FontWeight.normal,
           color: AppColor.colorContentEmail)),
@@ -40,11 +41,15 @@ class IdentityDropListFieldBuilder extends StatelessWidget {
       DropdownButtonHideUnderline(
         child: DropdownButton2<EmailAddress>(
           isExpanded: true,
-          hint: const Row(
+          hint: Row(
             children: [
               Expanded(child: Text(
                 '',
-                style: TextStyle(fontSize: 16, fontWeight: FontWeight.normal, color: Colors.black),
+                style: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                  fontSize: 16,
+                  fontWeight: FontWeight.normal,
+                  color: Colors.black,
+                ),
                 maxLines: 1,
                 overflow: CommonTextStyle.defaultTextOverFlow,
                 softWrap: CommonTextStyle.defaultSoftWrap,
@@ -55,7 +60,7 @@ class IdentityDropListFieldBuilder extends StatelessWidget {
             value: item,
             child: Text(
               item.emailAddress,
-              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.normal, color: Colors.black),
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(fontSize: 16, fontWeight: FontWeight.normal, color: Colors.black),
               maxLines: 1,
               overflow: CommonTextStyle.defaultTextOverFlow,
               softWrap: CommonTextStyle.defaultSoftWrap,

--- a/lib/features/identity_creator/presentation/widgets/identity_field_no_editable_builder.dart
+++ b/lib/features/identity_creator/presentation/widgets/identity_field_no_editable_builder.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
 
@@ -20,7 +21,7 @@ class IdentityFieldNoEditableBuilder extends StatelessWidget {
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       Text(
         _label,
-        style: const TextStyle(
+        style: ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: 14,
           fontWeight: FontWeight.normal,
           color: AppColor.colorContentEmail)),
@@ -36,7 +37,7 @@ class IdentityFieldNoEditableBuilder extends StatelessWidget {
           color: AppColor.colorInputBackgroundCreateMailbox),
         child: Text(
           _emailAddressSelected?.email ?? '',
-          style: const TextStyle(
+          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
             fontSize: 16,
             fontWeight: FontWeight.normal,
             color: AppColor.colorInputBorderCreateMailbox),

--- a/lib/features/identity_creator/presentation/widgets/identity_input_decoration_builder.dart
+++ b/lib/features/identity_creator/presentation/widgets/identity_input_decoration_builder.dart
@@ -22,13 +22,13 @@ class IdentityInputDecorationBuilder extends InputDecorationBuilder {
       prefixText: prefixText,
       labelText: labelText,
       floatingLabelBehavior: FloatingLabelBehavior.never,
-      labelStyle: labelStyle ?? const TextStyle(color: Colors.black, fontSize: 16),
+      labelStyle: labelStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(color: Colors.black, fontSize: 16),
       hintText: hintText,
       isDense: true,
-      hintStyle: hintStyle ?? const TextStyle(color: AppColor.colorHintInputCreateMailbox, fontSize: 16),
+      hintStyle: hintStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(color: AppColor.colorHintInputCreateMailbox, fontSize: 16),
       contentPadding: contentPadding ?? const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
       errorText: errorText?.isNotEmpty == true ? errorText : null,
-      errorStyle: errorTextStyle ?? const TextStyle(color: AppColor.colorInputBorderErrorVerifyName, fontSize: 13),
+      errorStyle: errorTextStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(color: AppColor.colorInputBorderErrorVerifyName, fontSize: 13),
       filled: true,
       fillColor: errorText?.isNotEmpty == true
           ? AppColor.colorInputBackgroundErrorVerifyName

--- a/lib/features/identity_creator/presentation/widgets/identity_input_field_builder.dart
+++ b/lib/features/identity_creator/presentation/widgets/identity_input_field_builder.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/text/text_field_builder.dart';
 import 'package:core/utils/direction_utils.dart';
 import 'package:core/utils/platform_info.dart';
@@ -37,7 +38,7 @@ class IdentityInputFieldBuilder extends StatelessWidget {
       Text(
         isMandatory 
           ? '$_label ($requiredIndicator)' 
-          : _label, style: const TextStyle(
+          : _label, style: ThemeUtils.defaultTextStyleInterFont.copyWith(
             fontSize: 14,
             fontWeight: FontWeight.w500,
             color: AppColor.colorContentEmail)),
@@ -50,7 +51,7 @@ class IdentityInputFieldBuilder extends StatelessWidget {
         textDirection: DirectionUtils.getDirectionByLanguage(context),
         controller: editingController,
         focusNode: focusNode,
-        textStyle: const TextStyle(color: Colors.black, fontSize: 16),
+        textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(color: Colors.black, fontSize: 16),
         keyboardType: inputType ?? TextInputType.text,
         semanticLabel: 'Identity input field',
         decoration: (IdentityInputDecorationBuilder()

--- a/lib/features/identity_creator/presentation/widgets/identity_input_with_drop_list_field_builder.dart
+++ b/lib/features/identity_creator/presentation/widgets/identity_input_with_drop_list_field_builder.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/text/type_ahead_form_field_builder.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
@@ -36,7 +37,7 @@ class IdentityInputWithDropListFieldBuilder extends StatelessWidget {
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       Text(
         _label,
-        style: const TextStyle(
+        style: ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: 14,
           fontWeight: FontWeight.normal,
           color: AppColor.colorContentEmail)),
@@ -67,7 +68,7 @@ class IdentityInputWithDropListFieldBuilder extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
             child: Text(
               emailAddress.email ?? '',
-              style: const TextStyle(
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: 14,
                 fontWeight: FontWeight.normal,
                 color: Colors.black)));

--- a/lib/features/identity_creator/presentation/widgets/set_default_identity_checkbox_builder.dart
+++ b/lib/features/identity_creator/presentation/widgets/set_default_identity_checkbox_builder.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/semantics/checkbox_semantics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -53,7 +54,7 @@ class SetDefaultIdentityCheckboxBuilder extends StatelessWidget {
         Flexible(
           child: Text(
             AppLocalizations.of(context).setDefaultIdentity,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontWeight: FontWeight.normal,
               fontSize: 14,
               color: AppColor.colorSettingExplanation,

--- a/lib/features/login/presentation/base_login_view.dart
+++ b/lib/features/login/presentation/base_login_view.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/text/type_ahead_form_field_builder.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -30,8 +31,11 @@ abstract class BaseLoginView extends GetWidget<LoginController> {
         onPressed: () => controller.handleLoginPressed(context),
         child: Text(
           AppLocalizations.of(context).signIn,
-          style: const TextStyle(fontSize: 16, color: Colors.white)
-        )
+          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
+            fontSize: 16,
+            color: Colors.white,
+          ),
+        ),
       )
     );
   }

--- a/lib/features/login/presentation/login_view.dart
+++ b/lib/features/login/presentation/login_view.dart
@@ -87,7 +87,7 @@ class LoginView extends BaseLoginView {
                 top: controller.responsiveUtils.isHeightShortest(context) ? 64 : 0),
               child: Text(
                 AppLocalizations.of(context).login,
-                style: const TextStyle(fontSize: 32, color: AppColor.colorNameEmail, fontWeight: FontWeight.w900)
+                style: ThemeUtils.defaultTextStyleInterFont.copyWith(fontSize: 32, color: AppColor.colorNameEmail, fontWeight: FontWeight.w900)
               )
             ),
             Obx(() => LoginMessageWidget(
@@ -184,7 +184,7 @@ class LoginView extends BaseLoginView {
           )
         ),
         child: Text(AppLocalizations.of(context).next,
-          style: const TextStyle(fontSize: 16, color: Colors.white)
+          style: ThemeUtils.defaultTextStyleInterFont.copyWith(fontSize: 16, color: Colors.white)
         ),
         onPressed: () {
           if (controller.loginFormType.value == LoginFormType.retry) {

--- a/lib/features/login/presentation/login_view_web.dart
+++ b/lib/features/login/presentation/login_view_web.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/state/success.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/responsive/responsive_widget.dart';
 import 'package:core/presentation/views/text/slogan_builder.dart';
 import 'package:flutter/material.dart';
@@ -48,7 +49,7 @@ class LoginView extends BaseLoginView {
                 padding: const EdgeInsets.only(top: 67),
                 child: Text(
                     AppLocalizations.of(context).signIn,
-                    style: const TextStyle(fontSize: 32, color: AppColor.colorNameEmail, fontWeight: FontWeight.w900)
+                    style: ThemeUtils.defaultTextStyleInterFont.copyWith(fontSize: 32, color: AppColor.colorNameEmail, fontWeight: FontWeight.w900)
                 )
               ),
               Obx(() => LoginMessageWidget(
@@ -106,7 +107,11 @@ class LoginView extends BaseLoginView {
               children: [
                 Text(
                   AppLocalizations.of(context).jmapBasedMailSolution,
-                  style: const TextStyle(fontSize: 36, color: AppColor.colorNameEmail, fontWeight: FontWeight.w900)
+                  style: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                    fontSize: 36,
+                    color: AppColor.colorNameEmail,
+                    fontWeight: FontWeight.w900,
+                  ),
                 ),
                 Padding(
                   padding: const EdgeInsets.only(top: 24),
@@ -116,7 +121,11 @@ class LoginView extends BaseLoginView {
                     sizeLogo: 48.0,
                     paddingText: const EdgeInsets.only(left: 12),
                     text: AppLocalizations.of(context).jmapStandard,
-                    textStyle: const TextStyle(fontSize: 24, fontWeight: FontWeight.w400, color: AppColor.colorNameEmail)
+                    textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                      fontSize: 24,
+                      fontWeight: FontWeight.w400,
+                      color: AppColor.colorNameEmail,
+                    ),
                   )
                 ),
                 Padding(
@@ -127,7 +136,11 @@ class LoginView extends BaseLoginView {
                     sizeLogo: 48.0,
                     paddingText: const EdgeInsets.only(left: 12),
                     text: AppLocalizations.of(context).encryptedMailbox,
-                    textStyle: const TextStyle(fontSize: 24, fontWeight: FontWeight.w400, color: AppColor.colorNameEmail)
+                    textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                      fontSize: 24,
+                      fontWeight: FontWeight.w400,
+                      color: AppColor.colorNameEmail,
+                    ),
                   )
                 ),
                 Padding(
@@ -138,7 +151,11 @@ class LoginView extends BaseLoginView {
                     sizeLogo: 48.0,
                     paddingText: const EdgeInsets.only(left: 12),
                     text: AppLocalizations.of(context).manageEmailAsATeam,
-                    textStyle: const TextStyle(fontSize: 24, fontWeight: FontWeight.w400, color: AppColor.colorNameEmail)
+                    textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                      fontSize: 24,
+                      fontWeight: FontWeight.w400,
+                      color: AppColor.colorNameEmail,
+                    ),
                   )
                 ),
                 Padding(
@@ -149,7 +166,11 @@ class LoginView extends BaseLoginView {
                     sizeLogo: 48.0,
                     paddingText: const EdgeInsets.only(left: 12),
                     text: AppLocalizations.of(context).multipleIntegrations,
-                    textStyle: const TextStyle(fontSize: 24, fontWeight: FontWeight.w400, color: AppColor.colorNameEmail)
+                    textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                      fontSize: 24,
+                      fontWeight: FontWeight.w400,
+                      color: AppColor.colorNameEmail,
+                    ),
                   )
                 ),
                 Padding(
@@ -196,7 +217,7 @@ class LoginView extends BaseLoginView {
                       padding: const EdgeInsets.only(top: 67),
                       child: Text(
                         AppLocalizations.of(context).signIn,
-                        style: const TextStyle(fontSize: 32, color: AppColor.colorNameEmail, fontWeight: FontWeight.w900)
+                        style: ThemeUtils.defaultTextStyleInterFont.copyWith(fontSize: 32, color: AppColor.colorNameEmail, fontWeight: FontWeight.w900)
                       )
                     ),
                     Obx(() => LoginMessageWidget(

--- a/lib/features/login/presentation/privacy_link_widget.dart
+++ b/lib/features/login/presentation/privacy_link_widget.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
@@ -17,7 +18,7 @@ class PrivacyLinkWidget extends StatelessWidget {
       children: [
         Text(
           AppLocalizations.of(context).byContinuingYouAreAgreeingToOur,
-          style: const TextStyle(
+          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
             color: AppColor.colorTextBody,
             fontSize: 14,
             fontWeight: FontWeight.w400,
@@ -26,7 +27,7 @@ class PrivacyLinkWidget extends StatelessWidget {
         RichText(
           text: TextSpan(
             text: AppLocalizations.of(context).privacyPolicy,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               color: AppColor.loginTextFieldFocusedBorder,
               fontSize: 14),
             recognizer: TapGestureRecognizer()..onTap = () => AppUtils.launchLink(privacyUrlString)

--- a/lib/features/login/presentation/widgets/login_input_decoration_builder.dart
+++ b/lib/features/login/presentation/widgets/login_input_decoration_builder.dart
@@ -19,9 +19,9 @@ class LoginInputDecorationBuilder extends InputDecorationBuilder {
       prefixText: prefixText,
       labelText: labelText,
       floatingLabelBehavior: FloatingLabelBehavior.never,
-      labelStyle: labelStyle ?? const TextStyle(color: AppColor.textFieldLabelColor, fontSize: 16),
+      labelStyle: labelStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(color: AppColor.textFieldLabelColor, fontSize: 16),
       hintText: hintText,
-      hintStyle: hintStyle ?? const TextStyle(color: AppColor.textFieldHintColor, fontSize: 16),
+      hintStyle: hintStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(color: AppColor.textFieldHintColor, fontSize: 16),
       contentPadding: contentPadding ?? const EdgeInsetsDirectional.only(start: 25, top: 15, bottom: 15, end: 25),
       filled: true,
       fillColor: AppColor.textFieldBorderColor);

--- a/lib/features/login/presentation/widgets/login_message_widget.dart
+++ b/lib/features/login/presentation/widgets/login_message_widget.dart
@@ -3,6 +3,7 @@ import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -83,7 +84,7 @@ class LoginMessageWidget extends StatelessWidget {
             }
           ),
           textAlign: TextAlign.center,
-          style: TextStyle(
+          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
             fontSize: 15,
             fontWeight: FontWeight.w400,
             color: viewState.fold(

--- a/lib/features/login/presentation/widgets/login_text_input_builder.dart
+++ b/lib/features/login/presentation/widgets/login_text_input_builder.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/presentation/views/text/text_form_field_builder.dart';
 import 'package:flutter/material.dart';
@@ -68,7 +69,7 @@ class _LoginTextInputBuilderState extends State<LoginTextInputBuilder> {
           textInputAction: widget.textInputAction,
           autofillHints: widget.autofillHints,
           controller: _controller,
-          textStyle: const TextStyle(
+          textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
             color: AppColor.loginTextFieldHintColor,
             fontSize: 16,
             fontWeight: FontWeight.normal
@@ -83,17 +84,17 @@ class _LoginTextInputBuilderState extends State<LoginTextInputBuilder> {
                 bottom: 15,
                 end: 40
             ))
-            ..setHintStyle(const TextStyle(
+            ..setHintStyle(ThemeUtils.defaultTextStyleInterFont.copyWith(
                 color: AppColor.loginTextFieldHintColor,
                 fontSize: 16,
                 fontWeight: FontWeight.normal
             ))
-            ..setPrefixStyle(const TextStyle(
+            ..setPrefixStyle(ThemeUtils.defaultTextStyleInterFont.copyWith(
                 color: AppColor.loginTextFieldHintColor,
                 fontSize: 16,
                 fontWeight: FontWeight.normal
             ))
-            ..setErrorTextStyle(const TextStyle(
+            ..setErrorTextStyle(ThemeUtils.defaultTextStyleInterFont.copyWith(
                 color: AppColor.loginTextFieldErrorBorder,
                 fontSize: 13,
                 fontWeight: FontWeight.normal

--- a/lib/features/login/presentation/widgets/try_again_button.dart
+++ b/lib/features/login/presentation/widgets/try_again_button.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
@@ -18,7 +19,10 @@ class TryAgainButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return TMailButtonWidget.fromText(
       text: AppLocalizations.of(context).tryAgain,
-      textStyle: const TextStyle(fontSize: 16, color: Colors.white),
+      textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+        fontSize: 16,
+        color: Colors.white,
+      ),
       backgroundColor: AppColor.primaryColor,
       onTapActionCallback: onRetry,
       borderRadius: 10,

--- a/lib/features/mailbox/presentation/styles/empty_mailbox_dialog_overlay_styles.dart
+++ b/lib/features/mailbox/presentation/styles/empty_mailbox_dialog_overlay_styles.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class EmptyMailboxDialogOverlayStyles {
@@ -23,24 +24,28 @@ class EmptyMailboxDialogOverlayStyles {
   static const Color emptyButtonBackground = Colors.transparent;
   static Color get shadowColor => Colors.grey.shade500;
 
-  static const TextStyle titleTextStyle = TextStyle(
+  static TextStyle titleTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 17,
     fontWeight: FontWeight.bold,
-    color: Colors.black
+    color: Colors.black,
   );
-  static const TextStyle messageTextStyle = TextStyle(
+  static TextStyle messageTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 14,
     fontWeight: FontWeight.w400,
-    color: Colors.black
+    color: Colors.black,
   );
-  static const TextStyle buttonTextStyle = TextStyle(
+  static TextStyle buttonTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 13,
     fontWeight: FontWeight.w400,
-    color: Colors.black
+    color: Colors.black,
   );
-  static const TextStyle cleanButtonTextStyle = TextStyle(
+  static TextStyle cleanButtonTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontWeight: FontWeight.w400,
     fontSize: 13,
-    color: Colors.white
+    color: Colors.white,
   );
 }

--- a/lib/features/mailbox/presentation/widgets/bottom_bar_selection_mailbox_widget.dart
+++ b/lib/features/mailbox/presentation/widgets/bottom_bar_selection_mailbox_widget.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -51,7 +52,10 @@ class BottomBarSelectionMailboxWidget extends StatelessWidget {
               backgroundColor: Colors.transparent,
               flexibleText: true,
               tooltipMessage: action.getContextMenuTitle(AppLocalizations.of(context)),
-              textStyle: const TextStyle(fontSize: 12, color: AppColor.colorTextButton),
+              textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                fontSize: 12,
+                color: AppColor.colorTextButton,
+              ),
               onTapActionCallback: () => onMailboxActionsClick.call(action, _listSelectionMailbox),
             ));
           })

--- a/lib/features/mailbox/presentation/widgets/copy_subaddress_widget.dart
+++ b/lib/features/mailbox/presentation/widgets/copy_subaddress_widget.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 
@@ -30,7 +31,10 @@ class CopySubaddressWidget extends StatelessWidget {
             subaddress,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
-            style: const TextStyle(fontSize: 17.0, color: AppColor.colorMessageDialog),
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
+              fontSize: 17.0,
+              color: AppColor.colorMessageDialog,
+            ),
           ),
         ),
         TMailButtonWidget.fromIcon(

--- a/lib/features/mailbox/presentation/widgets/user_information_widget.dart
+++ b/lib/features/mailbox/presentation/widgets/user_information_widget.dart
@@ -50,7 +50,7 @@ class UserInformationWidget extends StatelessWidget {
             SelectableText(
               userName,
               maxLines: 1,
-              style: const TextStyle(
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: 17,
                 color: AppColor.colorNameEmail,
                 fontWeight: FontWeight.w600
@@ -66,7 +66,10 @@ class UserInformationWidget extends StatelessWidget {
                     onTap: onSubtitleClick,
                     borderRadius: 20,
                     padding: const EdgeInsetsDirectional.symmetric(horizontal: 8, vertical: 8),
-                    customStyle: const TextStyle(fontSize: 14, color: AppColor.colorTextButton),
+                    customStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                      fontSize: 14,
+                      color: AppColor.colorTextButton,
+                    ),
                   ),
                 ),
               )

--- a/lib/features/mailbox_creator/presentation/mailbox_creator_view.dart
+++ b/lib/features/mailbox_creator/presentation/mailbox_creator_view.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/text/text_field_builder.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/direction_utils.dart';
@@ -104,7 +105,7 @@ class MailboxCreatorView extends GetWidget<MailboxCreatorController> {
         controller: controller.nameInputController,
         textDirection: DirectionUtils.getDirectionByLanguage(context),
         maxLines: 1,
-        textStyle: const TextStyle(
+        textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
           color: AppColor.colorNameEmail,
           fontSize: 16,
           overflow: CommonTextStyle.defaultTextOverFlow),
@@ -124,7 +125,7 @@ class MailboxCreatorView extends GetWidget<MailboxCreatorController> {
         child: Text(
           AppLocalizations.of(context).selectParentFolder,
           textAlign: TextAlign.left,
-          style: const TextStyle(
+          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontSize: 13,
               color: AppColor.colorHintSearchBar,
               fontWeight: FontWeight.normal)),
@@ -154,7 +155,7 @@ class MailboxCreatorView extends GetWidget<MailboxCreatorController> {
                   maxLines: 1,
                   softWrap: CommonTextStyle.defaultSoftWrap,
                   overflow: CommonTextStyle.defaultTextOverFlow,
-                  style: TextStyle(
+                  style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                       fontSize: 15,
                       color: controller.selectedMailbox.value == null
                           ? AppColor.colorHintSearchBar

--- a/lib/features/mailbox_creator/presentation/widgets/app_bar_mailbox_creator_builder.dart
+++ b/lib/features/mailbox_creator/presentation/widgets/app_bar_mailbox_creator_builder.dart
@@ -50,7 +50,7 @@ class AppBarMailboxCreatorBuilder {
         child: TextButton(
             child: Text(
               AppLocalizations.of(_context).cancel,
-              style: const TextStyle(fontSize: 17, color: AppColor.colorTextButton),
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(fontSize: 17, color: AppColor.colorTextButton),
             ),
             onPressed: () => _cancelActionClick?.call()
         )
@@ -64,7 +64,7 @@ class AppBarMailboxCreatorBuilder {
         child: TextButton(
             child: Text(
               AppLocalizations.of(_context).done,
-              style: TextStyle(
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                   fontSize: 17,
                   color: isValidated
                       ? AppColor.colorTextButton
@@ -84,7 +84,7 @@ class AppBarMailboxCreatorBuilder {
         maxLines: 1,
         softWrap: CommonTextStyle.defaultSoftWrap,
         overflow: CommonTextStyle.defaultTextOverFlow,
-        style: const TextStyle(
+        style: ThemeUtils.defaultTextStyleInterFont.copyWith(
             fontSize: 20,
             color: AppColor.colorNameEmail,
             fontWeight: FontWeight.bold)));

--- a/lib/features/mailbox_creator/presentation/widgets/create_mailbox_name_input_decoration_builder.dart
+++ b/lib/features/mailbox_creator/presentation/widgets/create_mailbox_name_input_decoration_builder.dart
@@ -22,12 +22,12 @@ class CreateMailboxNameInputDecorationBuilder extends InputDecorationBuilder {
       prefixText: prefixText,
       labelText: labelText,
       floatingLabelBehavior: FloatingLabelBehavior.never,
-      labelStyle: labelStyle ?? const TextStyle(color: AppColor.colorNameEmail, fontSize: 16),
+      labelStyle: labelStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(color: AppColor.colorNameEmail, fontSize: 16),
       hintText: hintText,
-      hintStyle: hintStyle ?? const TextStyle(color: AppColor.colorHintInputCreateMailbox, fontSize: 16),
+      hintStyle: hintStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(color: AppColor.colorHintInputCreateMailbox, fontSize: 16),
       contentPadding: contentPadding ?? const EdgeInsets.all(12),
       errorText: errorText,
-      errorStyle: errorTextStyle ?? const TextStyle(color: AppColor.colorInputBorderErrorVerifyName, fontSize: 13),
+      errorStyle: errorTextStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(color: AppColor.colorInputBorderErrorVerifyName, fontSize: 13),
       filled: true,
       fillColor: errorText?.isNotEmpty == true
           ? AppColor.colorInputBackgroundErrorVerifyName

--- a/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart
+++ b/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart
@@ -424,7 +424,12 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
                 label: Text(
                   AppLocalizations.of(context).selectAllMessagesOfThisPage,
                   maxLines: 1,
-                  overflow: TextOverflow.ellipsis
+                  overflow: TextOverflow.ellipsis,
+                  style: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                    fontSize: 13,
+                    fontWeight: FontWeight.normal,
+                    color: AppColor.colorFilterMessageTitle,
+                  ),
                 ),
                 style: ElevatedButton.styleFrom(
                   backgroundColor: AppColor.colorFilterMessageButton.withOpacity(0.6),
@@ -436,7 +441,7 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
                   elevation: 0.0,
                   foregroundColor: AppColor.colorTextButtonHeaderThread,
                   maximumSize: const Size.fromWidth(250),
-                  textStyle: const TextStyle(
+                  textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     fontSize: 13,
                     fontWeight: FontWeight.normal,
                     color: AppColor.colorFilterMessageTitle
@@ -562,7 +567,7 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
                   child: TMailButtonWidget.fromText(
                     text: appLocalizations.hide,
                     backgroundColor: Colors.transparent,
-                    textStyle: const TextStyle(
+                    textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                       color: AppColor.colorCancelButton,
                     ),
                     onTapActionCallback: () {
@@ -642,7 +647,7 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
                   backgroundColor: Colors.transparent,
                   margin: const EdgeInsetsDirectional.only(start: 8),
                   borderRadius: 10,
-                  textStyle: const TextStyle(
+                  textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     color: AppColor.primaryColor,
                     fontSize: 13,
                     fontWeight: FontWeight.w500),
@@ -653,7 +658,7 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
                   backgroundColor: Colors.transparent,
                   margin: const EdgeInsetsDirectional.only(start: 8),
                   borderRadius: 10,
-                  textStyle: const TextStyle(
+                  textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     color: AppColor.primaryColor,
                     fontSize: 13,
                     fontWeight: FontWeight.w500),

--- a/lib/features/mailbox_dashboard/presentation/model/search/advanced_search_filter.dart
+++ b/lib/features/mailbox_dashboard/presentation/model/search/advanced_search_filter.dart
@@ -59,7 +59,7 @@ enum AdvancedSearchFilterField {
   }
 
   TextStyle getTitleTextStyle() {
-    return const TextStyle(
+    return ThemeUtils.defaultTextStyleInterFont.copyWith(
         fontSize: 14,
         fontWeight: FontWeight.w400,
         color: AppColor.colorContentEmail);
@@ -77,7 +77,7 @@ enum AdvancedSearchFilterField {
   }
 
   TextStyle getHintTextStyle() {
-    return const TextStyle(
+    return ThemeUtils.defaultTextStyleInterFont.copyWith(
         fontSize: 16,
         fontWeight: FontWeight.w400,
         color: AppColor.colorHintSearchBar);

--- a/lib/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart
+++ b/lib/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
 import 'package:jmap_dart_client/jmap/core/sort/comparator.dart';
@@ -99,7 +100,7 @@ enum EmailSortOrderType {
   }
 
   TextStyle getTextStyle({required bool isInDropdown}) {
-    return TextStyle(
+    return ThemeUtils.defaultTextStyleInterFont.copyWith(
       fontSize: isInDropdown ? 15 : 16,
       fontWeight: FontWeight.w400,
       color: Colors.black,

--- a/lib/features/mailbox_dashboard/presentation/styles/autocomplete_suggestion_item_style.dart
+++ b/lib/features/mailbox_dashboard/presentation/styles/autocomplete_suggestion_item_style.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class AutocompleteSuggestionItemStyle {
@@ -7,12 +8,12 @@ class AutocompleteSuggestionItemStyle {
 
   static const EdgeInsetsGeometry padding = EdgeInsets.symmetric(vertical: 10, horizontal: 12);
 
-  static const TextStyle displayNameTextStyle = TextStyle(
+  static TextStyle displayNameTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.black,
     fontSize: 16,
     fontWeight: FontWeight.normal
   );
-  static const TextStyle emailAddressNameTextStyle = TextStyle(
+  static TextStyle emailAddressNameTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: AppColor.colorHintSearchBar,
     fontSize: 13,
     fontWeight: FontWeight.normal

--- a/lib/features/mailbox_dashboard/presentation/styles/autocomplete_tag_item_style.dart
+++ b/lib/features/mailbox_dashboard/presentation/styles/autocomplete_tag_item_style.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class AutocompleteTagItemStyle {
@@ -11,7 +12,7 @@ class AutocompleteTagItemStyle {
   static const EdgeInsetsGeometry margin = EdgeInsetsDirectional.only(end: 8);
   static const EdgeInsetsGeometry padding = EdgeInsetsDirectional.only(start: 8, end: 4, top: 4, bottom: 4);
 
-  static const TextStyle labelTextStyle = TextStyle(
+  static TextStyle labelTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.black,
     fontSize: 17,
     fontWeight: FontWeight.normal

--- a/lib/features/mailbox_dashboard/presentation/styles/autocomplete_tag_item_web_style.dart
+++ b/lib/features/mailbox_dashboard/presentation/styles/autocomplete_tag_item_web_style.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class AutoCompleteTagItemWebStyle {
@@ -13,12 +14,12 @@ class AutoCompleteTagItemWebStyle {
 
   static const Color collapsedBackgroundColor = AppColor.colorEmailAddressTag;
 
-  static const TextStyle labelTextStyle = TextStyle(
+  static TextStyle labelTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.black,
     fontSize: 17,
     fontWeight: FontWeight.w400
   );
-  static const TextStyle collapsedTextStyle = TextStyle(
+  static TextStyle collapsedTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.black,
     fontSize: 17,
     fontWeight: FontWeight.w400

--- a/lib/features/mailbox_dashboard/presentation/styles/avatar_suggestion_item_style.dart
+++ b/lib/features/mailbox_dashboard/presentation/styles/avatar_suggestion_item_style.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class AvatarSuggestionItemStyle {
@@ -9,7 +10,7 @@ class AvatarSuggestionItemStyle {
   static const Color iconColor = AppColor.avatarColor;
   static const Color iconBorderColor = AppColor.colorShadowBgContentEmail;
 
-  static const TextStyle labelTextStyle = TextStyle(
+  static TextStyle labelTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.black,
     fontSize: 16,
     fontWeight: FontWeight.w600

--- a/lib/features/mailbox_dashboard/presentation/styles/avatar_tag_item_style.dart
+++ b/lib/features/mailbox_dashboard/presentation/styles/avatar_tag_item_style.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class AvatarTagItemStyle {
@@ -7,7 +8,7 @@ class AvatarTagItemStyle {
 
   static const Color iconBorderColor = AppColor.colorShadowBgContentEmail;
 
-  static const TextStyle labelTextStyle = TextStyle(
+  static TextStyle labelTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     color: Colors.white,
     fontSize: 8.57,
     fontWeight: FontWeight.w600

--- a/lib/features/mailbox_dashboard/presentation/styles/filter_message_button_style.dart
+++ b/lib/features/mailbox_dashboard/presentation/styles/filter_message_button_style.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class FilterMessageButtonStyle {
@@ -18,7 +19,7 @@ class FilterMessageButtonStyle {
   static const EdgeInsetsGeometry buttonMargin = EdgeInsetsDirectional.only(start: 16);
   static const BorderRadius borderRadius = BorderRadius.all(Radius.circular(10));
 
-  static const TextStyle titleStyle = TextStyle(
+  static TextStyle titleStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 13,
     fontWeight: FontWeight.normal,
     color: AppColor.colorFilterMessageTitle);

--- a/lib/features/mailbox_dashboard/presentation/styles/search_filter_button_style.dart
+++ b/lib/features/mailbox_dashboard/presentation/styles/search_filter_button_style.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class SearchFilterButtonStyle {
@@ -16,7 +17,7 @@ class SearchFilterButtonStyle {
   static const EdgeInsetsGeometry elementPadding = EdgeInsetsDirectional.only(start: 8);
   static const BorderRadius borderRadius = BorderRadius.all(Radius.circular(10));
 
-  static const TextStyle titleStyle = TextStyle(
+  static TextStyle titleStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 13,
     fontWeight: FontWeight.normal,
     color: AppColor.colorSearchFilterTitle);

--- a/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/date_drop_down_button.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/date_drop_down_button.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:dropdown_button2/dropdown_button2.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -115,7 +116,7 @@ class DateDropDownButton extends StatelessWidget {
           child: Row(children: [
             Expanded(child: Text(
               receiveTime.getTitle(context),
-              style: const TextStyle(
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: 16,
                 fontWeight: FontWeight.normal,
                 color: Colors.black

--- a/lib/features/mailbox_dashboard/presentation/widgets/app_dashboard/app_list_dashboard_item.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/app_dashboard/app_list_dashboard_item.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/text/slogan_builder.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/base/mixin/launcher_application_mixin.dart';
@@ -24,7 +25,11 @@ class AppListDashboardItem extends StatelessWidget with LauncherApplicationMixin
       paddingText: const EdgeInsetsDirectional.only(start: 12),
       text: app.appName,
       textAlign: TextAlign.center,
-      textStyle: const TextStyle(fontSize: 17, fontWeight: FontWeight.w500, color: AppColor.colorNameEmail),
+      textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+        fontSize: 17,
+        fontWeight: FontWeight.w500,
+        color: AppColor.colorNameEmail,
+      ),
       logo: app.getIconPath(imagePaths),
       onTapCallback: _handleOpenApp,
       padding: const EdgeInsetsDirectional.symmetric(vertical: 12, horizontal: 20),

--- a/lib/features/mailbox_dashboard/presentation/widgets/download/download_task_item_widget.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/download/download_task_item_widget.dart
@@ -3,6 +3,7 @@ import 'package:byte_converter/byte_converter.dart';
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -64,7 +65,10 @@ class DownloadTaskItemWidget extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 DefaultTextStyle(
-                  style: const TextStyle(color: Colors.white, fontSize: 14),
+                  style: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                    color: Colors.white,
+                    fontSize: 14,
+                  ),
                   child: Text(
                     taskState.attachment.generateFileName(),
                     overflow: CommonTextStyle.defaultTextOverFlow,
@@ -74,7 +78,10 @@ class DownloadTaskItemWidget extends StatelessWidget {
                 ),
                 const SizedBox(height: 4),
                 DefaultTextStyle(
-                  style: const TextStyle(color: Colors.white, fontSize: 12),
+                  style: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                    color: Colors.white,
+                    fontSize: 12,
+                  ),
                   child: Text(
                     '${ByteConverter(taskState.downloaded.toDouble()).toHumanReadable(SizeUnit.MB)}'
                       '${_getTotalSizeText()}',

--- a/lib/features/mailbox_dashboard/presentation/widgets/quick_search/contact_quick_search_item.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/quick_search/contact_quick_search_item.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
 import 'package:model/extensions/email_address_extension.dart';
@@ -31,7 +32,7 @@ class ContactQuickSearchItem extends StatelessWidget {
                   maxLines: 1,
                   softWrap: CommonTextStyle.defaultSoftWrap,
                   overflow: CommonTextStyle.defaultTextOverFlow,
-                  style: const TextStyle(
+                  style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     color: Colors.black,
                     fontSize: 16,
                     fontWeight: FontWeight.normal
@@ -43,7 +44,7 @@ class ContactQuickSearchItem extends StatelessWidget {
                     maxLines: 1,
                     softWrap: CommonTextStyle.defaultSoftWrap,
                     overflow: CommonTextStyle.defaultTextOverFlow,
-                    style: const TextStyle(
+                    style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                       color: AppColor.colorHintSearchBar,
                       fontSize: 13,
                       fontWeight: FontWeight.normal

--- a/lib/features/mailbox_dashboard/presentation/widgets/quick_search/email_quick_search_item_tile_widget.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/quick_search/email_quick_search_item_tile_widget.dart
@@ -55,12 +55,12 @@ class EmailQuickSearchItemTileWidget extends StatelessWidget {
                         child: RichTextBuilder(
                           textOrigin: _getInformationSender(),
                           wordToStyle: searchQuery?.value ?? '',
-                          styleOrigin: const TextStyle(
+                          styleOrigin: ThemeUtils.defaultTextStyleInterFont.copyWith(
                             fontSize: 15,
                             fontWeight: FontWeight.w600,
                             color: Colors.black,
                           ),
-                          styleWord: TextStyle(
+                          styleWord: ThemeUtils.defaultTextStyleInterFont.copyWith(
                             fontSize: 15,
                             fontWeight: FontWeight.w600,
                             color: Colors.black,
@@ -75,12 +75,12 @@ class EmailQuickSearchItemTileWidget extends StatelessWidget {
                           wordToStyle: searchQuery?.value ?? '',
                           preMarkedText: _presentationEmail.sanitizedSearchSnippetSubject,
                           ensureHighlightVisible: true,
-                          styleOrigin: const TextStyle(
+                          styleOrigin: ThemeUtils.defaultTextStyleInterFont.copyWith(
                             fontSize: 13,
                             color: Colors.black,
                             fontWeight: FontWeight.normal
                           ),
-                          styleWord: TextStyle(
+                          styleWord: ThemeUtils.defaultTextStyleInterFont.copyWith(
                             fontSize: 13,
                             backgroundColor: Colors.amberAccent[200],
                             color: Colors.black,
@@ -98,7 +98,7 @@ class EmailQuickSearchItemTileWidget extends StatelessWidget {
                         maxLines: 1,
                         overflow: CommonTextStyle.defaultTextOverFlow,
                         softWrap: CommonTextStyle.defaultSoftWrap,
-                        style: const TextStyle(
+                        style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                           fontSize: 13,
                           fontWeight: FontWeight.normal,
                           color: Colors.black))
@@ -109,12 +109,12 @@ class EmailQuickSearchItemTileWidget extends StatelessWidget {
                       wordToStyle: searchQuery?.value ?? '',
                       preMarkedText: _presentationEmail.sanitizedSearchSnippetPreview,
                       ensureHighlightVisible: true,
-                      styleOrigin: const TextStyle(
+                      styleOrigin: ThemeUtils.defaultTextStyleInterFont.copyWith(
                         fontSize: 13,
                         color: AppColor.colorContentEmail,
                         fontWeight: FontWeight.normal
                       ),
-                      styleWord: TextStyle(
+                      styleWord: ThemeUtils.defaultTextStyleInterFont.copyWith(
                         fontSize: 13,
                         color: AppColor.colorContentEmail,
                         backgroundColor: Colors.amberAccent[200],

--- a/lib/features/mailbox_dashboard/presentation/widgets/quick_search/recent_search_item_tile_widget.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/quick_search/recent_search_item_tile_widget.dart
@@ -28,7 +28,7 @@ class RecentSearchItemTileWidget extends StatelessWidget {
           const SizedBox(width: 8),
           Expanded(
             child: Text(recentSearch.value,
-                style: const TextStyle(
+                style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     fontSize: 15,
                     fontWeight: FontWeight.normal,
                     color: Colors.black)),

--- a/lib/features/mailbox_dashboard/presentation/widgets/recover_deleted_message_loading_banner_widget.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/recover_deleted_message_loading_banner_widget.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/styles/recover_deleted_message_loading_banner_style.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
@@ -42,7 +43,7 @@ class RecoverDeletedMessageLoadingBannerWidget extends StatelessWidget {
           children: [
             Text(
               AppLocalizations.of(context).bannerProgressingRecoveryMessage,
-              style: const TextStyle(
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: 15,
                 fontWeight: FontWeight.w400,
                 color: AppColor.primaryColor,

--- a/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
@@ -109,7 +109,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
               padding: const EdgeInsets.only(left: 12, right: 12, bottom: 8, top: 12),
               child: Text(
                 AppLocalizations.of(context).recent,
-                style: const TextStyle(
+                style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                   fontSize: 13.0,
                   color: AppColor.colorTextButtonHeaderThread,
                   fontWeight: FontWeight.w500
@@ -222,7 +222,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
         child: Row(children: [
           Text(
             AppLocalizations.of(context).showingResultsFor,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontSize: 13.0,
               color: AppColor.colorTextButtonHeaderThread,
               fontWeight: FontWeight.w500
@@ -231,7 +231,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
           const SizedBox(width: 4),
           Expanded(child: Text(
             '"$keyword"',
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontSize: 13.0,
               color: Colors.black,
               fontWeight: FontWeight.w500
@@ -262,7 +262,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
         hintStyle: ThemeUtils.textStyleBodyBody2(
           color: AppColor.steelGray400,
         ),
-        labelStyle: const TextStyle(color: Colors.black, fontSize: 16.0)
+        labelStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(color: Colors.black, fontSize: 16.0)
       ),
       leftButton: Padding(
         padding: const EdgeInsetsDirectional.symmetric(horizontal: 12),

--- a/lib/features/mailbox_dashboard/presentation/widgets/top_bar_thread_selection.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/top_bar_thread_selection.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
@@ -43,7 +44,7 @@ class TopBarThreadSelection extends StatelessWidget{
     return Row(children: [
       Text(
         AppLocalizations.of(context).count_email_selected(listEmail.length),
-        style: const TextStyle(
+        style: ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: 15,
           fontWeight: FontWeight.w400,
           color: TopBarThreadSelectionStyle.iconColor,

--- a/lib/features/manage_account/presentation/email_rules/widgets/email_rule_item_widget.dart
+++ b/lib/features/manage_account/presentation/email_rules/widgets/email_rule_item_widget.dart
@@ -29,7 +29,7 @@ class EmailRulesItemWidget extends StatelessWidget {
       color: Colors.white,
       child: Row(crossAxisAlignment: CrossAxisAlignment.center, children: [
         Text(rule.name,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: 16,
                 fontWeight: FontWeight.w400,
                 color: Colors.black)),

--- a/lib/features/manage_account/presentation/email_rules/widgets/email_rules_header_widget.dart
+++ b/lib/features/manage_account/presentation/email_rules/widgets/email_rules_header_widget.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
@@ -58,7 +59,7 @@ class EmailRulesHeaderWidget extends StatelessWidget {
             minWidth: 130,
             padding: const EdgeInsets.symmetric(vertical: 12,horizontal: 8),
             iconSize: 20,
-            textStyle: const TextStyle(
+            textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontSize: 17,
               color: Colors.white,
               fontWeight: FontWeight.w500,
@@ -78,7 +79,7 @@ class EmailRulesHeaderWidget extends StatelessWidget {
         iconColor: Colors.white,
         padding: const EdgeInsets.symmetric(vertical: 12),
         iconSize: 20,
-        textStyle: const TextStyle(
+        textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: 17,
           color: Colors.white,
           fontWeight: FontWeight.w500,

--- a/lib/features/manage_account/presentation/email_rules/widgets/list_email_rules_widget.dart
+++ b/lib/features/manage_account/presentation/email_rules/widgets/list_email_rules_widget.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -40,7 +41,7 @@ class ListEmailRulesWidget extends GetWidget<EmailRulesController> {
                   horizontal: 24,
                 ),
                 child: Text(AppLocalizations.of(context).headerNameOfRules,
-                    style: const TextStyle(
+                    style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                         fontSize: 16,
                         fontWeight: FontWeight.w500,
                         color: AppColor.colorTextButtonHeaderThread)),

--- a/lib/features/manage_account/presentation/forward/forward_view.dart
+++ b/lib/features/manage_account/presentation/forward/forward_view.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
@@ -110,7 +111,7 @@ class ForwardView extends GetWidget<ForwardController> with AppLoaderMixin {
                       AppLocalizations.of(context).keepLocalCopyForwardLabel,
                       overflow: CommonTextStyle.defaultTextOverFlow,
                       softWrap: CommonTextStyle.defaultSoftWrap,
-                      style: const TextStyle(
+                      style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                         fontSize: 16,
                         fontWeight: FontWeight.w500,
                         color: Colors.black)

--- a/lib/features/manage_account/presentation/forward/widgets/autocomplete_contact_text_field_with_tags.dart
+++ b/lib/features/manage_account/presentation/forward/widgets/autocomplete_contact_text_field_with_tags.dart
@@ -6,6 +6,7 @@ import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/keyboard_utils.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
@@ -125,14 +126,14 @@ class _AutocompleteContactTextFieldWithTagsState extends State<AutocompleteConta
         emailAddress: EmailAddress(null, value),
         isClearInput: true
       ),
-      textStyle: const TextStyle(
+      textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
         color: Colors.black,
         fontSize: 16,
         fontWeight: FontWeight.w500),
       inputDecoration: InputDecoration(
         border: InputBorder.none,
         hintText: AppLocalizations.of(context).hintInputAutocompleteContact,
-        hintStyle: const TextStyle(
+        hintStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontWeight: FontWeight.w500,
           color: AppColor.colorSettingExplanation,
           fontSize: 16

--- a/lib/features/manage_account/presentation/forward/widgets/email_forward_item_widget.dart
+++ b/lib/features/manage_account/presentation/forward/widgets/email_forward_item_widget.dart
@@ -2,6 +2,7 @@ import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/extensions/string_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/icon_button_web.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/presentation/views/image/avatar_builder.dart';
@@ -112,7 +113,7 @@ class EmailForwardItemWidget extends StatelessWidget {
                         overflow: CommonTextStyle.defaultTextOverFlow,
                         softWrap: CommonTextStyle.defaultSoftWrap,
                         maxLines: 1,
-                        style: const TextStyle(
+                        style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                           fontSize: 14,
                           fontWeight: FontWeight.normal,
                           color: AppColor.colorContentEmail
@@ -166,7 +167,7 @@ class EmailForwardItemWidget extends StatelessWidget {
       return (AvatarBuilder()
         ..text(recipientForward.emailAddress.asString().firstLetterToUpperCase)
         ..size(40)
-        ..addTextStyle(const TextStyle(
+        ..addTextStyle(ThemeUtils.defaultTextStyleInterFont.copyWith(
             fontWeight: FontWeight.w500,
             fontSize: 16,
             color: Colors.white))

--- a/lib/features/manage_account/presentation/forward/widgets/list_email_forward_widget.dart
+++ b/lib/features/manage_account/presentation/forward/widgets/list_email_forward_widget.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/icon_button_web.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -78,7 +79,7 @@ class ListEmailForwardsWidget extends GetWidget<ForwardController> {
           padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
           child: Text(
             AppLocalizations.of(context).select_all,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontSize: 15,
               fontWeight: FontWeight.normal,
               color: AppColor.colorTextButton
@@ -107,7 +108,7 @@ class ListEmailForwardsWidget extends GetWidget<ForwardController> {
             controller.isAllSelected
               ? AppLocalizations.of(context).totalEmailSelected(controller.listRecipientForwardSelected.length)
               : AppLocalizations.of(context).count_email_selected(controller.listRecipientForwardSelected.length),
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontSize: 15,
               fontWeight: FontWeight.normal,
               color: AppColor.colorTextButton
@@ -127,7 +128,7 @@ class ListEmailForwardsWidget extends GetWidget<ForwardController> {
           padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 6),
           child: Text(
             AppLocalizations.of(context).remove,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontSize: 15,
               fontWeight: FontWeight.normal,
               color: AppColor.colorDeletePermanentlyButton

--- a/lib/features/manage_account/presentation/language_and_region/widgets/change_language_button_widget.dart
+++ b/lib/features/manage_account/presentation/language_and_region/widgets/change_language_button_widget.dart
@@ -3,6 +3,7 @@ import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/responsive/responsive_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_portal/flutter_portal.dart';
@@ -54,7 +55,7 @@ class ChangeLanguageButtonWidget extends StatelessWidget {
   Widget _buildTitleLanguageWidget(BuildContext context) {
     return Text(
       AppLocalizations.of(context).language,
-      style: const TextStyle(
+      style: ThemeUtils.defaultTextStyleInterFont.copyWith(
         fontSize: 14,
         fontWeight: FontWeight.normal,
         color: AppColor.colorContentEmail
@@ -113,7 +114,7 @@ class ChangeLanguageButtonWidget extends StatelessWidget {
           child: Row(children: [
             Expanded(child: Text(
               _controller.languageSelected.value.getLanguageNameByCurrentLocale(context),
-              style: const TextStyle(
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: 16,
                 fontWeight: FontWeight.normal,
                 color: Colors.black

--- a/lib/features/manage_account/presentation/language_and_region/widgets/lanuage_item_widget.dart
+++ b/lib/features/manage_account/presentation/language_and_region/widgets/lanuage_item_widget.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
@@ -37,7 +38,7 @@ class LanguageItemWidget extends StatelessWidget {
               children: [
                 Text(
                   localeCurrent.getLanguageNameByCurrentLocale(context),
-                  style: const TextStyle(
+                  style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     fontSize: 17,
                     fontWeight: FontWeight.normal,
                     color: Colors.black
@@ -48,7 +49,7 @@ class LanguageItemWidget extends StatelessWidget {
                 ),
                 Text(
                   ' - ${localeCurrent.getSourceLanguageName()}',
-                  style: const TextStyle(
+                  style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     fontSize: 17,
                     fontWeight: FontWeight.w500,
                     color: Colors.black

--- a/lib/features/manage_account/presentation/mailbox_visibility/widgets/mailbox_visibility_folder_tile_builder.dart
+++ b/lib/features/manage_account/presentation/mailbox_visibility/widgets/mailbox_visibility_folder_tile_builder.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/utils/direction_utils.dart';
 import 'package:flutter/material.dart';
@@ -100,7 +101,7 @@ class _MailBoxVisibilityFolderTileBuilderState extends State<MailBoxVisibilityFo
           maxLines: 1,
           softWrap: CommonTextStyle.defaultSoftWrap,
           overflow: CommonTextStyle.defaultTextOverFlow,
-          style: TextStyle(
+          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
             fontSize: widget._mailboxNode.item.isTeamMailboxes ? 16 : 14,
             color: widget._mailboxNode.item.allowedToDisplay
               ? Colors.black
@@ -115,7 +116,7 @@ class _MailBoxVisibilityFolderTileBuilderState extends State<MailBoxVisibilityFo
             maxLines: 1,
             softWrap: CommonTextStyle.defaultSoftWrap,
             overflow: CommonTextStyle.defaultTextOverFlow,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontSize: 13,
               color: AppColor.colorEmailAddressFull,
               fontWeight: FontWeight.normal),
@@ -154,7 +155,7 @@ class _MailBoxVisibilityFolderTileBuilderState extends State<MailBoxVisibilityFo
             maxLines: 1,
             softWrap: CommonTextStyle.defaultSoftWrap,
             overflow: CommonTextStyle.defaultTextOverFlow,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontSize: 15,
               color: AppColor.primaryColor,
               fontWeight: FontWeight.normal

--- a/lib/features/manage_account/presentation/menu/settings/settings_view.dart
+++ b/lib/features/manage_account/presentation/menu/settings/settings_view.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/icon_button_web.dart';
 import 'package:core/presentation/views/button/multi_click_widget.dart';
 import 'package:core/utils/direction_utils.dart';
@@ -98,7 +99,7 @@ class SettingsView extends GetWidget<SettingsController> {
             maxLines: 1,
             softWrap: CommonTextStyle.defaultSoftWrap,
             overflow: CommonTextStyle.defaultTextOverFlow,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontSize: 20,
               color: AppColor.colorNameEmail,
               fontWeight: FontWeight.w700,
@@ -149,7 +150,7 @@ class SettingsView extends GetWidget<SettingsController> {
                     maxLines: 1,
                     overflow: CommonTextStyle.defaultTextOverFlow,
                     softWrap: CommonTextStyle.defaultSoftWrap,
-                    style: const TextStyle(fontSize: 17, color: AppColor.colorTextButton)
+                    style: ThemeUtils.defaultTextStyleInterFont.copyWith(fontSize: 17, color: AppColor.colorTextButton)
                   )
                 ),
               ]),
@@ -163,7 +164,7 @@ class SettingsView extends GetWidget<SettingsController> {
         textAlign: TextAlign.center,
         overflow: CommonTextStyle.defaultTextOverFlow,
         softWrap: CommonTextStyle.defaultSoftWrap,
-        style: const TextStyle(
+        style: ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: 20,
           color: Colors.black,
           fontWeight: FontWeight.bold

--- a/lib/features/manage_account/presentation/menu/widgets/setting_first_level_tile_builder.dart
+++ b/lib/features/manage_account/presentation/menu/widgets/setting_first_level_tile_builder.dart
@@ -2,6 +2,7 @@ import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/utils/direction_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
@@ -59,7 +60,7 @@ class SettingFirstLevelTileBuilder extends StatelessWidget {
                           maxLines: 1,
                           softWrap: CommonTextStyle.defaultSoftWrap,
                           overflow: CommonTextStyle.defaultTextOverFlow,
-                          style: const TextStyle(
+                          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                             fontSize: 16,
                             color: AppColor.colorNameEmail,
                             fontWeight: FontWeight.w400,
@@ -77,7 +78,7 @@ class SettingFirstLevelTileBuilder extends StatelessWidget {
                         ),
                         child: Text(
                           subtitle!,
-                          style: const TextStyle(
+                          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                             fontSize: 13,
                             color: AppColor.colorContentEmail,
                             fontWeight: FontWeight.w400)))

--- a/lib/features/manage_account/presentation/notification/notification_view.dart
+++ b/lib/features/manage_account/presentation/notification/notification_view.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
@@ -31,7 +32,7 @@ class NotificationView extends GetWidget<NotificationController> {
                   const SizedBox(height: 10),
                   Text(
                     AppLocalizations.of(context).showNotifications,
-                    style: const TextStyle(
+                    style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                       fontSize: 17,
                       height: 22 / 17,
                       fontWeight: FontWeight.w500,
@@ -39,7 +40,7 @@ class NotificationView extends GetWidget<NotificationController> {
                   const SizedBox(height: 12),
                   Text(
                     AppLocalizations.of(context).allowsTwakeMailToNotifyYouWhenANewMessageArrivesOnYourPhone,
-                    style: const TextStyle(
+                    style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                       fontSize: 15,
                       height: 20 / 15,
                       color: AppColor.colorSettingExplanation),

--- a/lib/features/manage_account/presentation/profiles/identities/widgets/identities_header_widget.dart
+++ b/lib/features/manage_account/presentation/profiles/identities/widgets/identities_header_widget.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/widget/material_text_icon_button.dart';
@@ -25,14 +26,14 @@ class IdentitiesHeaderWidget extends StatelessWidget {
       children: [
         Text(
           AppLocalizations.of(context).identities,
-          style: const TextStyle(
+          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
             fontSize: 17,
             fontWeight: FontWeight.w500,
             color: Colors.black)),
         const SizedBox(height: 4),
         Text(
           AppLocalizations.of(context).identitiesSettingExplanation,
-          style: const TextStyle(
+          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
             fontSize: 15,
             fontWeight: FontWeight.normal,
             color: AppColor.colorSettingExplanation)),

--- a/lib/features/manage_account/presentation/profiles/identities/widgets/identity_list_tile_builder.dart
+++ b/lib/features/manage_account/presentation/profiles/identities/widgets/identity_list_tile_builder.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/icon_button_web.dart';
 import 'package:core/presentation/views/text/text_overflow_builder.dart';
 import 'package:flutter/material.dart';
@@ -66,7 +67,7 @@ class IdentityListTileBuilder extends StatelessWidget {
                         padding: const EdgeInsets.only(bottom: 6),
                         child: TextOverflowBuilder(
                           (identity.name ?? ''),
-                          style: const TextStyle(
+                          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                             fontWeight: FontWeight.w500,
                             fontSize: 16,
                             color: Colors.black)),
@@ -121,7 +122,7 @@ class IdentityListTileBuilder extends StatelessWidget {
         const SizedBox(width: 4),
         Expanded(child: TextOverflowBuilder(
           (text ?? ''),
-          style: const TextStyle(
+          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
             color: AppColor.colorEmailAddressFull,
             fontWeight: FontWeight.normal,
             fontSize: 13,
@@ -140,7 +141,7 @@ class IdentityListTileBuilder extends StatelessWidget {
           alignment: Alignment.centerLeft,
           child: Text(
             character,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontSize: 15,
               fontWeight: FontWeight.normal,
               decoration: TextDecoration.underline,
@@ -148,7 +149,7 @@ class IdentityListTileBuilder extends StatelessWidget {
         const SizedBox(width: 4),
         Expanded(child: TextOverflowBuilder(
           (text ?? ''),
-          style: const TextStyle(
+          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
             color: AppColor.colorEmailAddressFull,
             fontWeight: FontWeight.normal,
             fontSize: 13,

--- a/lib/features/manage_account/presentation/vacation/vacation_view.dart
+++ b/lib/features/manage_account/presentation/vacation/vacation_view.dart
@@ -2,6 +2,7 @@
 import 'package:core/presentation/constants/constants_ui.dart';
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/keyboard_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/icon_button_web.dart';
 import 'package:core/presentation/views/responsive/responsive_widget.dart';
 import 'package:core/utils/html/html_utils.dart';
@@ -74,7 +75,7 @@ class VacationView extends GetWidget<VacationController> with RichTextButtonMixi
               Expanded(
                 child: Text(
                   AppLocalizations.of(context).vacationSettingToggleButtonAutoReply,
-                  style: const TextStyle(
+                  style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     fontSize: 16,
                     height: 20 / 16,
                     fontWeight: FontWeight.normal,
@@ -157,7 +158,7 @@ class VacationView extends GetWidget<VacationController> with RichTextButtonMixi
                   Expanded(
                     child: Text(
                       AppLocalizations.of(context).vacationStopsAt,
-                      style: const TextStyle(
+                      style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                         fontSize: 16,
                         fontWeight: FontWeight.normal,
                         color: Colors.black
@@ -357,7 +358,7 @@ class VacationView extends GetWidget<VacationController> with RichTextButtonMixi
         alignment: Alignment.centerRight,
         child: buildTextButton(
             AppLocalizations.of(context).saveChanges,
-            textStyle: const TextStyle(
+            textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 color: Colors.white,
                 fontWeight: FontWeight.normal,
                 fontSize: 16
@@ -373,7 +374,7 @@ class VacationView extends GetWidget<VacationController> with RichTextButtonMixi
           Expanded(
             child: buildTextButton(
                 AppLocalizations.of(context).cancel,
-                textStyle: const TextStyle(
+                textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     fontWeight: FontWeight.w500,
                     fontSize: 17,
                     color: AppColor.colorTextButton),
@@ -387,7 +388,7 @@ class VacationView extends GetWidget<VacationController> with RichTextButtonMixi
           Expanded(
             child: buildTextButton(
                 AppLocalizations.of(context).saveChanges,
-                textStyle: const TextStyle(
+                textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     color: Colors.white,
                     fontWeight: FontWeight.normal,
                     fontSize: 16
@@ -403,7 +404,7 @@ class VacationView extends GetWidget<VacationController> with RichTextButtonMixi
           const Spacer(),
           buildTextButton(
               AppLocalizations.of(context).cancel,
-              textStyle: const TextStyle(
+              textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                   fontWeight: FontWeight.w500,
                   fontSize: 17,
                   color: AppColor.colorTextButton),
@@ -415,7 +416,7 @@ class VacationView extends GetWidget<VacationController> with RichTextButtonMixi
           const SizedBox(width: 12),
           buildTextButton(
               AppLocalizations.of(context).saveChanges,
-              textStyle: const TextStyle(
+              textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                   color: Colors.white,
                   fontWeight: FontWeight.normal,
                   fontSize: 16
@@ -435,7 +436,7 @@ class VacationView extends GetWidget<VacationController> with RichTextButtonMixi
       children: [
         Text(
           AppLocalizations.of(context).message,
-          style: const TextStyle(
+          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
             fontSize: 14,
             fontWeight: FontWeight.normal,
             color: AppColor.colorContentEmail

--- a/lib/features/manage_account/presentation/vacation/widgets/vacation_input_decoration_builder.dart
+++ b/lib/features/manage_account/presentation/vacation/widgets/vacation_input_decoration_builder.dart
@@ -22,13 +22,13 @@ class VacationInputDecorationBuilder extends InputDecorationBuilder {
       prefixText: prefixText,
       labelText: labelText,
       floatingLabelBehavior: FloatingLabelBehavior.never,
-      labelStyle: labelStyle ?? const TextStyle(color: Colors.black, fontSize: 16),
+      labelStyle: labelStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(color: Colors.black, fontSize: 16),
       hintText: hintText,
       isDense: true,
-      hintStyle: hintStyle ?? const TextStyle(color: AppColor.colorHintInputCreateMailbox, fontSize: 16),
+      hintStyle: hintStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(color: AppColor.colorHintInputCreateMailbox, fontSize: 16),
       contentPadding: contentPadding ?? const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
       errorText: errorText,
-      errorStyle: errorTextStyle ?? const TextStyle(color: AppColor.colorInputBorderErrorVerifyName, fontSize: 13),
+      errorStyle: errorTextStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(color: AppColor.colorInputBorderErrorVerifyName, fontSize: 13),
       filled: true,
       fillColor: errorText?.isNotEmpty == true
           ? AppColor.colorInputBackgroundErrorVerifyName

--- a/lib/features/manage_account/presentation/vacation/widgets/vacation_notification_message_widget.dart
+++ b/lib/features/manage_account/presentation/vacation/widgets/vacation_notification_message_widget.dart
@@ -70,7 +70,7 @@ class VacationNotificationMessageWidget extends StatelessWidget {
           message: vacationResponse.getNotificationMessage(context),
           child: Text(
             vacationResponse.getNotificationMessage(context),
-            style: TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               color: Colors.black,
               fontSize: 16,
               fontWeight: fontWeight ?? FontWeight.normal,
@@ -83,7 +83,7 @@ class VacationNotificationMessageWidget extends StatelessWidget {
       if (actionEndNow != null)
         TMailButtonWidget.fromText(
           text: AppLocalizations.of(context).endNow,
-          textStyle: const TextStyle(
+          textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
             fontWeight: FontWeight.w500,
             fontSize: 16,
             color: AppColor.colorTextButton),
@@ -97,7 +97,7 @@ class VacationNotificationMessageWidget extends StatelessWidget {
       if (actionGotoVacationSetting != null)
         TMailButtonWidget.fromText(
           text: AppLocalizations.of(context).vacationSetting,
-          textStyle: const TextStyle(
+          textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
             fontWeight: FontWeight.w500,
             fontSize: 16,
             color: AppColor.colorTextButton),
@@ -121,7 +121,7 @@ class VacationNotificationMessageWidget extends StatelessWidget {
           message: vacationResponse.getNotificationMessage(context),
           child: Text(
             vacationResponse.getNotificationMessage(context),
-            style: TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               color: Colors.black,
               fontSize: 16,
               fontWeight: fontWeight ?? FontWeight.normal,
@@ -138,7 +138,7 @@ class VacationNotificationMessageWidget extends StatelessWidget {
               Flexible(
                 child: TMailButtonWidget.fromText(
                   text: AppLocalizations.of(context).endNow,
-                  textStyle: const TextStyle(
+                  textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     fontWeight: FontWeight.w500,
                     fontSize: 16,
                     color: AppColor.colorTextButton),
@@ -155,7 +155,7 @@ class VacationNotificationMessageWidget extends StatelessWidget {
               Flexible(
                 child: TMailButtonWidget.fromText(
                   text: AppLocalizations.of(context).vacationSetting,
-                  textStyle: const TextStyle(
+                  textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     fontWeight: FontWeight.w500,
                     fontSize: 16,
                     color: AppColor.colorTextButton),

--- a/lib/features/network_connection/presentation/network_connection_banner_widget.dart
+++ b/lib/features/network_connection/presentation/network_connection_banner_widget.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
@@ -26,7 +27,7 @@ class NetworkConnectionBannerWidget extends StatelessWidget {
           Text(
             AppLocalizations.of(context).no_internet_connection,
             textAlign: TextAlign.center,
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               color: AppColor.colorNetworkConnectionLabel,
               fontSize: 14,
               fontWeight: FontWeight.w500,

--- a/lib/features/quotas/presentation/widget/quotas_banner_widget.dart
+++ b/lib/features/quotas/presentation/widget/quotas_banner_widget.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
@@ -40,7 +41,7 @@ class QuotasBannerWidget extends StatelessWidget {
                   children: [
                     Text(
                       octetQuota.getQuotaBannerTitle(context),
-                      style: TextStyle(
+                      style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                         fontSize: QuotasBannerStyles.titleTextSize,
                         fontWeight: QuotasBannerStyles.titleFontWeight,
                         color: octetQuota.getQuotaBannerTitleColor(),
@@ -49,7 +50,7 @@ class QuotasBannerWidget extends StatelessWidget {
                     const SizedBox(height: QuotasBannerStyles.space),
                     Text(
                       octetQuota.getQuotaBannerMessage(context),
-                      style: const TextStyle(
+                      style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                         fontSize: QuotasBannerStyles.messageTextSize,
                         fontWeight: QuotasBannerStyles.messageFontWeight,
                         color: QuotasBannerStyles.messageTextColor,

--- a/lib/features/rules_filter_creator/presentation/rules_filter_creator_view.dart
+++ b/lib/features/rules_filter_creator/presentation/rules_filter_creator_view.dart
@@ -110,7 +110,7 @@ class RuleFilterCreatorView extends GetWidget<RulesFilterCreatorController> {
             alignment: Alignment.center,
             child: Obx(() => Text(
                 controller.actionType.value.getTitle(context),
-                style: const TextStyle(
+                style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     fontWeight: FontWeight.bold,
                     fontSize: 20,
                     color: Colors.black)))),
@@ -150,7 +150,7 @@ class RuleFilterCreatorView extends GetWidget<RulesFilterCreatorController> {
                           Text(
                             AppLocalizations.of(context).addCondition,
                             maxLines: 1,
-                            style: const TextStyle(
+                            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                               fontWeight: FontWeight.w500,
                               fontSize: 17,
                               color: AppColor.primaryColor
@@ -165,7 +165,7 @@ class RuleFilterCreatorView extends GetWidget<RulesFilterCreatorController> {
                     overflow: CommonTextStyle.defaultTextOverFlow,
                     softWrap: CommonTextStyle.defaultSoftWrap,
                     maxLines: 1,
-                    style: const TextStyle(
+                    style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                       fontWeight: FontWeight.w500,
                       fontSize: 16,
                       color: Colors.black)),
@@ -230,7 +230,7 @@ class RuleFilterCreatorView extends GetWidget<RulesFilterCreatorController> {
               children: [
                 buildTextButton(
                   AppLocalizations.of(context).cancel,
-                  textStyle: const TextStyle(
+                  textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     fontWeight: FontWeight.w500,
                     fontSize: 17,
                     color: AppColor.colorTextButton),
@@ -271,7 +271,7 @@ class RuleFilterCreatorView extends GetWidget<RulesFilterCreatorController> {
                 alignment: Alignment.center,
                 child: Obx(() => Text(
                     controller.actionType.value.getTitle(context),
-                    style: const TextStyle(
+                    style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                         fontWeight: FontWeight.bold,
                         fontSize: 20,
                         color: Colors.black)))),
@@ -311,7 +311,7 @@ class RuleFilterCreatorView extends GetWidget<RulesFilterCreatorController> {
                               Text(
                                 AppLocalizations.of(context).addCondition,
                                 maxLines: 1,
-                                style: const TextStyle(
+                                style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                                   fontWeight: FontWeight.w500,
                                   fontSize: 17,
                                   color: AppColor.primaryColor
@@ -326,7 +326,7 @@ class RuleFilterCreatorView extends GetWidget<RulesFilterCreatorController> {
                           overflow: CommonTextStyle.defaultTextOverFlow,
                           softWrap: CommonTextStyle.defaultSoftWrap,
                           maxLines: 1,
-                          style: const TextStyle(
+                          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                               fontWeight: FontWeight.w500,
                               fontSize: 16,
                               color: Colors.black)),
@@ -390,7 +390,7 @@ class RuleFilterCreatorView extends GetWidget<RulesFilterCreatorController> {
                   children: [
                     Expanded(child: buildTextButton(
                         AppLocalizations.of(context).cancel,
-                        textStyle: const TextStyle(
+                        textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                             fontWeight: FontWeight.w500,
                             fontSize: 17,
                             color: AppColor.colorTextButton),
@@ -431,7 +431,7 @@ class RuleFilterCreatorView extends GetWidget<RulesFilterCreatorController> {
                 alignment: Alignment.center,
                 child: Obx(() => Text(
                     controller.actionType.value.getTitle(context),
-                    style: const TextStyle(
+                    style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                         fontWeight: FontWeight.bold,
                         fontSize: 20,
                         color: Colors.black)))),
@@ -481,7 +481,7 @@ class RuleFilterCreatorView extends GetWidget<RulesFilterCreatorController> {
                               Text(
                                 AppLocalizations.of(context).addCondition,
                                 maxLines: 1,
-                                style: const TextStyle(
+                                style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                                   fontWeight: FontWeight.w500,
                                   fontSize: 17,
                                   color: AppColor.primaryColor
@@ -499,7 +499,7 @@ class RuleFilterCreatorView extends GetWidget<RulesFilterCreatorController> {
                           overflow: CommonTextStyle.defaultTextOverFlow,
                           softWrap: CommonTextStyle.defaultSoftWrap,
                           maxLines: 1,
-                          style: const TextStyle(
+                          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                               fontWeight: FontWeight.w500,
                               fontSize: 16,
                               color: Colors.black)),
@@ -568,7 +568,7 @@ class RuleFilterCreatorView extends GetWidget<RulesFilterCreatorController> {
                   children: [
                     Expanded(child: buildTextButton(
                         AppLocalizations.of(context).cancel,
-                        textStyle: const TextStyle(
+                        textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                             fontWeight: FontWeight.w500,
                             fontSize: 17,
                             color: AppColor.colorTextButton),

--- a/lib/features/rules_filter_creator/presentation/styles/rule_filter_action_styles.dart
+++ b/lib/features/rules_filter_creator/presentation/styles/rule_filter_action_styles.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class RuleFilterActionStyles {
@@ -9,13 +10,13 @@ class RuleFilterActionStyles {
   static const int maxLines = 1;
   static const double fontSize = 16.0;
   static const Color color = Colors.black;
-  static const TextStyle textStyle = TextStyle(
+  static TextStyle textStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontWeight: FontWeight.normal,
     fontSize: fontSize,
     color: color,
   );
   static const double itemDistance = 12.0;
-  static const TextStyle addActionButtonTextStyle = TextStyle(
+  static TextStyle addActionButtonTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontWeight: FontWeight.w500,
     fontSize: 17.0,
     color: AppColor.primaryColor,

--- a/lib/features/rules_filter_creator/presentation/styles/rule_filter_title_styles.dart
+++ b/lib/features/rules_filter_creator/presentation/styles/rule_filter_title_styles.dart
@@ -1,9 +1,10 @@
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class RuleFilterTitleStyles {
   static const double fontSize = 16.0;
   static const Color textColor = Colors.black;
-  static const TextStyle textStyle = TextStyle(
+  static TextStyle textStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontWeight: FontWeight.w500,
     fontSize: fontSize,
     color: textColor,

--- a/lib/features/rules_filter_creator/presentation/widgets/rule_filter_button_field.dart
+++ b/lib/features/rules_filter_creator/presentation/widgets/rule_filter_button_field.dart
@@ -2,6 +2,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
@@ -49,7 +50,7 @@ class RuleFilterButtonField<T> extends StatelessWidget {
         child: Row(children: [
           Expanded(child: Text(
             _getName(context, value),
-            style: TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: 16,
                 fontWeight: FontWeight.normal,
                 color: textColor),

--- a/lib/features/rules_filter_creator/presentation/widgets/rules_filter_input_decoration_builder.dart
+++ b/lib/features/rules_filter_creator/presentation/widgets/rules_filter_input_decoration_builder.dart
@@ -30,19 +30,19 @@ class RulesFilterInputDecorationBuilder extends InputDecorationBuilder {
       prefixText: prefixText,
       labelText: labelText,
       floatingLabelBehavior: FloatingLabelBehavior.never,
-      labelStyle: labelStyle ?? const TextStyle(
+      labelStyle: labelStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
           color: Colors.black,
           fontSize: 16),
       hintText: hintText,
       isDense: true,
-      hintStyle: hintStyle ?? const TextStyle(
+      hintStyle: hintStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
           color: AppColor.colorHintInputCreateMailbox,
           fontSize: 16),
       contentPadding: contentPadding ?? const EdgeInsets.symmetric(
           horizontal: 12,
           vertical: 12),
       errorText: errorText != '' ? errorText : null,
-      errorStyle: errorTextStyle ?? const TextStyle(
+      errorStyle: errorTextStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
           color: AppColor.colorInputBorderErrorVerifyName,
           fontSize: 13),
       filled: true,

--- a/lib/features/rules_filter_creator/presentation/widgets/rules_filter_input_field_builder.dart
+++ b/lib/features/rules_filter_creator/presentation/widgets/rules_filter_input_field_builder.dart
@@ -1,4 +1,5 @@
 
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/text/text_field_builder.dart';
 import 'package:core/utils/direction_utils.dart';
 import 'package:core/utils/platform_info.dart';
@@ -30,7 +31,10 @@ class RulesFilterInputField extends StatelessWidget {
       onTextChange: onChangeAction,
       textInputAction: TextInputAction.next,
       controller: editingController,
-      textStyle: const TextStyle(color: Colors.black, fontSize: 16),
+      textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+        color: Colors.black,
+        fontSize: 16,
+      ),
       textDirection: DirectionUtils.getDirectionByLanguage(context),
       keyboardType: TextInputType.text,
       focusNode: focusNode,

--- a/lib/features/search/email/presentation/search_email_view.dart
+++ b/lib/features/search/email/presentation/search_email_view.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/icon_button_web.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/presentation/views/text/text_field_builder.dart';
@@ -154,13 +155,19 @@ class SearchEmailView extends GetWidget<SearchEmailController>
             focusNode: controller.textInputSearchFocus,
             maxLines: 1,
             textDirection: DirectionUtils.getDirectionByLanguage(context),
-            textStyle: const TextStyle(color: Colors.black, fontSize: 16),
+            textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+              color: Colors.black,
+              fontSize: 16,
+            ),
             keyboardType: TextInputType.text,
             onTextSubmitted: (text) => controller.onTextSearchSubmitted(context, text),
             decoration: InputDecoration(
               contentPadding: const EdgeInsets.all(12),
               hintText: AppLocalizations.of(context).search_emails,
-              hintStyle: const TextStyle(color: AppColor.loginTextFieldHintColor, fontSize: 16),
+              hintStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                color: AppColor.loginTextFieldHintColor,
+                fontSize: 16,
+              ),
               border: InputBorder.none),
           )),
           Obx(() {
@@ -235,7 +242,7 @@ class SearchEmailView extends GetWidget<SearchEmailController>
               backgroundColor: Colors.transparent,
               margin: const EdgeInsetsDirectional.only(start: 8, top: 6, end: 8),
               borderRadius: 10,
-              textStyle: const TextStyle(
+              textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 color: AppColor.primaryColor,
                 fontSize: 13,
                 fontWeight: FontWeight.w500
@@ -456,7 +463,7 @@ class SearchEmailView extends GetWidget<SearchEmailController>
             children: [
               Text(
                 AppLocalizations.of(context).showingResultsFor,
-                style: const TextStyle(
+                style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                   fontSize: 13.0,
                   color: AppColor.colorTextButtonHeaderThread,
                   fontWeight: FontWeight.w500
@@ -466,7 +473,7 @@ class SearchEmailView extends GetWidget<SearchEmailController>
               Expanded(
                 child: Text(
                   '"${controller.currentSearchText.value}"',
-                  style: const TextStyle(
+                  style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     fontSize: 13.0,
                     color: Colors.black,
                     fontWeight: FontWeight.w500

--- a/lib/features/search/email/presentation/styles/search_email_view_style.dart
+++ b/lib/features/search/email/presentation/styles/search_email_view_style.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -8,10 +9,11 @@ import 'package:flutter/material.dart';
 class SearchEmailViewStyle {
   static const SizedBox searchFilterSizeBoxMargin = SizedBox(width: 8);
 
-  static const TextStyle searchRecentTitleStyle = TextStyle(
+  static TextStyle searchRecentTitleStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 13.0,
     color: AppColor.colorTextButtonHeaderThread,
-    fontWeight: FontWeight.w500
+    fontWeight: FontWeight.w500,
   );
 
   static const EdgeInsetsGeometry listSearchFilterButtonMargin = EdgeInsetsDirectional.only(top: 16);

--- a/lib/features/search/email/presentation/widgets/app_bar_selection_mode.dart
+++ b/lib/features/search/email/presentation/widgets/app_bar_selection_mode.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -49,7 +50,7 @@ class AppBarSelectionMode extends StatelessWidget {
           AppLocalizations.of(context).count_email_selected(listEmail.length),
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
-          style: const TextStyle(
+          style: ThemeUtils.defaultTextStyleInterFont.copyWith(
             fontSize: 17,
             fontWeight: FontWeight.w500,
             color: AppColor.colorTextButton

--- a/lib/features/search/email/presentation/widgets/email_receive_time_action_tile_widget.dart
+++ b/lib/features/search/email/presentation/widgets/email_receive_time_action_tile_widget.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
@@ -30,11 +31,13 @@ class EmailReceiveTimeActionTileWidget extends StatelessWidget {
               width: 320,
               child: Row(children: [
                 Expanded(child: Text(
-                    receiveTimeType.getTitle(context),
-                    style: const TextStyle(
-                        fontSize: 17,
-                        color: Colors.black,
-                        fontWeight: FontWeight.normal))),
+                  receiveTimeType.getTitle(context),
+                  style: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                    fontSize: 17,
+                    color: Colors.black,
+                    fontWeight: FontWeight.normal,
+                  ),
+                )),
                 if (receiveTimeType == receiveTimeSelected)
                   const SizedBox(width: 12),
                 if (receiveTimeType == receiveTimeSelected)

--- a/lib/features/search/mailbox/presentation/search_mailbox_view.dart
+++ b/lib/features/search/mailbox/presentation/search_mailbox_view.dart
@@ -244,7 +244,7 @@ class SearchMailboxView extends GetWidget<SearchMailboxController>
           const SizedBox(width: 12),
           Expanded(child: Text(
             contextMenuItem.action.getContextMenuTitle(AppLocalizations.of(context)),
-            style: TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontWeight: FontWeight.w500,
               fontSize: 16,
               color: contextMenuItem.action.getPopupMenuTitleColor()

--- a/lib/features/search/mailbox/presentation/widgets/mailbox_searched_item_builder.dart
+++ b/lib/features/search/mailbox/presentation/widgets/mailbox_searched_item_builder.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/presentation/views/responsive/responsive_widget.dart';
 import 'package:core/presentation/views/text/text_overflow_builder.dart';
@@ -210,7 +211,7 @@ class _MailboxSearchedItemBuilderState extends State<MailboxSearchedItemBuilder>
   Widget _buildTitleItem(BuildContext context) {
     return TextOverflowBuilder(
       widget.presentationMailbox.getDisplayName(context),
-      style: const TextStyle(
+      style: ThemeUtils.defaultTextStyleInterFont.copyWith(
         fontSize: 15,
         color: Colors.black
       ),
@@ -221,7 +222,7 @@ class _MailboxSearchedItemBuilderState extends State<MailboxSearchedItemBuilder>
     if (widget.presentationMailbox.mailboxPath?.isNotEmpty == true) {
       return TextOverflowBuilder(
         (widget.presentationMailbox.mailboxPath ?? ''),
-        style: const TextStyle(
+        style: ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: 11,
           color: AppColor.colorMailboxPath,
           fontWeight: FontWeight.normal
@@ -230,7 +231,7 @@ class _MailboxSearchedItemBuilderState extends State<MailboxSearchedItemBuilder>
     } else if (widget.presentationMailbox.isTeamMailboxes) {
       return TextOverflowBuilder(
         widget.presentationMailbox.emailTeamMailBoxes,
-        style: const TextStyle(
+        style: ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: 11,
           color: AppColor.colorEmailAddressFull,
           fontWeight: FontWeight.normal

--- a/lib/features/sending_queue/presentation/styles/app_bar_sending_queue_widget_style.dart
+++ b/lib/features/sending_queue/presentation/styles/app_bar_sending_queue_widget_style.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class AppBarSendingQueueWidgetStyle {
@@ -23,11 +24,11 @@ class AppBarSendingQueueWidgetStyle {
     }
   }
 
-  static const TextStyle countStyle = TextStyle(
+  static TextStyle countStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 17,
     color: AppColor.colorTextButton
   );
-  static const TextStyle labelStyle = TextStyle(
+  static TextStyle labelStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 21,
     color: Colors.black,
     fontWeight: FontWeight.bold

--- a/lib/features/sending_queue/presentation/styles/sending_email_tile_style.dart
+++ b/lib/features/sending_queue/presentation/styles/sending_email_tile_style.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/offline_mode/model/sending_state.dart';
 
@@ -31,17 +32,17 @@ class SendingEmailTileStyle {
     }
   }
 
-  static TextStyle getTitleTextStyle(SendingState state) => TextStyle(
+  static TextStyle getTitleTextStyle(SendingState state) => ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 15,
     color: state.getTitleSendingEmailItemColor(),
     fontWeight: FontWeight.w600
   );
-  static TextStyle getSubTitleTextStyle(SendingState state) => TextStyle(
+  static TextStyle getSubTitleTextStyle(SendingState state) => ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 13,
     color: state.getSubTitleSendingEmailItemColor(),
     fontWeight: FontWeight.normal
   );
-  static TextStyle getTimeCreatedTextStyle(SendingState state) => TextStyle(
+  static TextStyle getTimeCreatedTextStyle(SendingState state) => ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 13,
     color: state.getTitleSendingEmailItemColor(),
     fontWeight: FontWeight.normal

--- a/lib/features/sending_queue/presentation/styles/sending_state_widget_style.dart
+++ b/lib/features/sending_queue/presentation/styles/sending_state_widget_style.dart
@@ -1,4 +1,5 @@
 
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/offline_mode/model/sending_state.dart';
 
@@ -9,7 +10,7 @@ class SendingStateWidgetStyle {
 
   static const EdgeInsetsGeometry padding = EdgeInsets.symmetric(horizontal: 8, vertical: 6);
 
-  static TextStyle getTitleTextStyle(SendingState state) => TextStyle(
+  static TextStyle getTitleTextStyle(SendingState state) => ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 15,
     color: state.getTitleColor(),
     fontWeight: FontWeight.normal

--- a/lib/features/sending_queue/presentation/widgets/banner_message_sending_queue_widget.dart
+++ b/lib/features/sending_queue/presentation/widgets/banner_message_sending_queue_widget.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:tmail_ui_user/features/sending_queue/presentation/utils/sending_queue_utils.dart';
@@ -36,7 +37,7 @@ class BannerMessageSendingQueueWidget extends StatelessWidget {
             const SizedBox(width: 8),
             Expanded(child: Text(
               AppLocalizations.of(context).bannerMessageSendingQueueViewOnIOS,
-              style: const TextStyle(
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: 15,
                 color: Colors.black,
                 fontWeight: FontWeight.normal

--- a/lib/features/sending_queue/presentation/widgets/bottom_bar_sending_queue_widget.dart
+++ b/lib/features/sending_queue/presentation/widgets/bottom_bar_sending_queue_widget.dart
@@ -2,6 +2,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
@@ -47,7 +48,7 @@ class BottomBarSendingQueueWidget extends StatelessWidget {
               borderRadius: 0,
               backgroundColor: Colors.transparent,
               iconColor: SendingEmailActionType.edit.getButtonIconColor(_canEditable ? ButtonState.enabled : ButtonState.disabled),
-              textStyle: TextStyle(
+              textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: 12,
                 color: SendingEmailActionType.edit.getButtonTitleColor(_canEditable ? ButtonState.enabled : ButtonState.disabled)
               ),
@@ -70,7 +71,7 @@ class BottomBarSendingQueueWidget extends StatelessWidget {
               borderRadius: 0,
               backgroundColor: Colors.transparent,
               iconColor: SendingEmailActionType.resend.getButtonIconColor(_canResend ? ButtonState.enabled : ButtonState.disabled),
-              textStyle: TextStyle(
+              textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: 12,
                 color: SendingEmailActionType.resend.getButtonTitleColor(_canResend ? ButtonState.enabled : ButtonState.disabled)
               ),
@@ -90,7 +91,7 @@ class BottomBarSendingQueueWidget extends StatelessWidget {
               borderRadius: 0,
               backgroundColor: Colors.transparent,
               iconColor: SendingEmailActionType.delete.getButtonIconColor(ButtonState.enabled),
-              textStyle: TextStyle(
+              textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: 12,
                 color: SendingEmailActionType.delete.getButtonTitleColor(ButtonState.enabled)
               ),

--- a/lib/features/starting_page/presentation/twake_welcome/twake_welcome_view_style.dart
+++ b/lib/features/starting_page/presentation/twake_welcome/twake_welcome_view_style.dart
@@ -1,8 +1,9 @@
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 
 class TwakeWelcomeViewStyle {
-  static final TextStyle descriptionTextStyle = TextStyle(
+  static final TextStyle descriptionTextStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 14,
     fontWeight: FontWeight.w500,
     color: LinagoraSysColors.material().onSurface

--- a/lib/features/thread/domain/model/filter_message_option.dart
+++ b/lib/features/thread/domain/model/filter_message_option.dart
@@ -138,14 +138,14 @@ extension FilterMessageOptionExtension on FilterMessageOption {
   TextStyle getTextStyle() {
     switch(this) {
       case FilterMessageOption.all:
-        return const TextStyle(
+        return ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: 13,
           fontWeight: FontWeight.normal,
           color: AppColor.colorFilterMessageTitle);
       case FilterMessageOption.unread:
       case FilterMessageOption.attachments:
       case FilterMessageOption.starred:
-        return const TextStyle(
+        return ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: 13,
           fontWeight: FontWeight.normal,
           color: AppColor.primaryColor);

--- a/lib/features/thread/presentation/mixin/base_email_item_tile.dart
+++ b/lib/features/thread/presentation/mixin/base_email_item_tile.dart
@@ -44,7 +44,7 @@ mixin BaseEmailItemTile {
               color: AppColor.backgroundCounterMailboxColor),
           child: TextOverflowBuilder(
             email.mailboxContain?.getDisplayName(context) ?? '',
-            style: const TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontFamily: ConstantsUI.fontApp,
               fontSize: 10,
               color: AppColor.emailMailboxContainColor,

--- a/lib/features/thread/presentation/styles/app_bar/default_web_app_bar_thread_widget_style.dart
+++ b/lib/features/thread/presentation/styles/app_bar/default_web_app_bar_thread_widget_style.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
 
@@ -21,10 +22,11 @@ class DefaultWebAppBarThreadWidgetStyle {
   static const EdgeInsetsGeometry mailboxMenuPadding = EdgeInsets.all(5);
   static const EdgeInsetsGeometry titlePadding = EdgeInsets.symmetric(horizontal: 16);
 
-  static const TextStyle titleTextStyle = TextStyle(
+  static TextStyle titleTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 21,
     color: Colors.black,
-    fontWeight: FontWeight.bold
+    fontWeight: FontWeight.bold,
   );
 
   static Color getFilterButtonColor(FilterMessageOption option) {

--- a/lib/features/thread/presentation/styles/app_bar/mobile_app_bar_thread_widget_style.dart
+++ b/lib/features/thread/presentation/styles/app_bar/mobile_app_bar_thread_widget_style.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
 
@@ -22,15 +23,17 @@ class MobileAppBarThreadWidgetStyle {
   static const EdgeInsetsGeometry mailboxMenuPadding = EdgeInsets.all(5);
   static const EdgeInsetsGeometry titlePadding = EdgeInsets.symmetric(horizontal: 16);
 
-  static const TextStyle emailCounterTitleStyle = TextStyle(
+  static TextStyle emailCounterTitleStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 15,
     fontWeight: FontWeight.w400,
     color: AppColor.steelGrayA540,
   );
-  static const TextStyle titleTextStyle = TextStyle(
+  static TextStyle titleTextStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 21,
     color: Colors.black,
-    fontWeight: FontWeight.bold
+    fontWeight: FontWeight.bold,
   );
   static Color getFilterButtonColor(FilterMessageOption option) {
     return option == FilterMessageOption.all

--- a/lib/features/thread/presentation/styles/app_bar/selection_web_app_bar_thread_widget_style.dart
+++ b/lib/features/thread/presentation/styles/app_bar/selection_web_app_bar_thread_widget_style.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class SelectionWebAppBarThreadWidgetStyle {
@@ -18,9 +19,10 @@ class SelectionWebAppBarThreadWidgetStyle {
     }
   }
 
-  static const TextStyle emailCounterStyle = TextStyle(
+  static TextStyle emailCounterStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 15,
     fontWeight: FontWeight.w400,
-    color: AppColor.steelGrayA540
+    color: AppColor.steelGrayA540,
   );
 }

--- a/lib/features/thread/presentation/styles/app_bar/title_app_bar_thread_widget_style.dart
+++ b/lib/features/thread/presentation/styles/app_bar/title_app_bar_thread_widget_style.dart
@@ -1,17 +1,19 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 
 class TitleAppBarThreadWidgetStyle {
   static const EdgeInsetsGeometry padding = EdgeInsets.symmetric(vertical: 8, horizontal: 16);
 
-  static const TextStyle titleStyle = TextStyle(
+  static TextStyle titleStyle = ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 21,
     color: Colors.black,
-    fontWeight: FontWeight.w700
+    fontWeight: FontWeight.w700,
   );
-  static const TextStyle filterOptionStyle = TextStyle(
+  static TextStyle filterOptionStyle =
+      ThemeUtils.defaultTextStyleInterFont.copyWith(
     fontSize: 11,
-    color: AppColor.colorContentEmail
+    color: AppColor.colorContentEmail,
   );
 }

--- a/lib/features/thread/presentation/thread_view.dart
+++ b/lib/features/thread/presentation/thread_view.dart
@@ -549,7 +549,7 @@ class ThreadView extends GetWidget<ThreadController>
               !presentationEmail.hasRead
                 ? AppLocalizations.of(context).mark_as_read
                 : AppLocalizations.of(context).mark_as_unread,
-              style: const TextStyle(
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: 15,
                 color: AppColor.primaryColor,
               ),
@@ -576,7 +576,7 @@ class ThreadView extends GetWidget<ThreadController>
                 const SizedBox(width: 11),
                 Text(
                   AppLocalizations.of(context).archiveMessage,
-                  style: const TextStyle(
+                  style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     fontSize: 15,
                     color: AppColor.primaryColor,
                   ),
@@ -707,7 +707,7 @@ class ThreadView extends GetWidget<ThreadController>
                 () => Text(
                   AppLocalizations.of(context).moveConversation(controller.listEmailDrag.length),
                   overflow: TextOverflow.clip,
-                  style: const TextStyle(
+                  style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     color: Colors.white,
                     fontWeight: FontWeight.bold,
                   ),

--- a/lib/features/thread/presentation/widgets/bottom_bar_thread_selection_widget.dart
+++ b/lib/features/thread/presentation/widgets/bottom_bar_thread_selection_widget.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:model/email/email_action_type.dart';
@@ -58,7 +59,10 @@ class BottomBarThreadSelectionWidget extends StatelessWidget{
                   textAlign: TextAlign.center,
                   padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 12),
                   backgroundColor: Colors.transparent,
-                  textStyle: const TextStyle(fontSize: 12, color: AppColor.steelGrayA540),
+                  textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                    fontSize: 12,
+                    color: AppColor.steelGrayA540,
+                  ),
                   verticalDirection: _verticalDirection(context),
                   onTapActionCallback: () {
                     onPressEmailSelectionActionClick?.call(
@@ -84,7 +88,10 @@ class BottomBarThreadSelectionWidget extends StatelessWidget{
                 textAlign: TextAlign.center,
                 padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 12),
                 backgroundColor: Colors.transparent,
-                textStyle: const TextStyle(fontSize: 12, color: AppColor.steelGrayA540),
+                textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                  fontSize: 12,
+                  color: AppColor.steelGrayA540,
+                ),
                 verticalDirection: _verticalDirection(context),
                 onTapActionCallback: () {
                   onPressEmailSelectionActionClick?.call(
@@ -107,7 +114,10 @@ class BottomBarThreadSelectionWidget extends StatelessWidget{
                   flexibleText: true,
                   padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 12),
                   backgroundColor: Colors.transparent,
-                  textStyle: const TextStyle(fontSize: 12, color: AppColor.steelGrayA540),
+                  textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                    fontSize: 12,
+                    color: AppColor.steelGrayA540,
+                  ),
                   verticalDirection: _verticalDirection(context),
                   onTapActionCallback: () {
                     onPressEmailSelectionActionClick?.call(EmailActionType.moveToMailbox, _listSelectionEmail);
@@ -129,7 +139,10 @@ class BottomBarThreadSelectionWidget extends StatelessWidget{
                   textAlign: TextAlign.center,
                   padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 12),
                   backgroundColor: Colors.transparent,
-                  textStyle: const TextStyle(fontSize: 12, color: AppColor.steelGrayA540),
+                  textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                    fontSize: 12,
+                    color: AppColor.steelGrayA540,
+                  ),
                   verticalDirection: _verticalDirection(context),
                   onTapActionCallback: () {
                     if (_currentMailbox?.isSpam == true) {
@@ -152,7 +165,10 @@ class BottomBarThreadSelectionWidget extends StatelessWidget{
                 textAlign: TextAlign.center,
                 padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 12),
                 backgroundColor: Colors.transparent,
-                textStyle: const TextStyle(fontSize: 12, color: AppColor.steelGrayA540),
+                textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                  fontSize: 12,
+                  color: AppColor.steelGrayA540,
+                ),
                 verticalDirection: _verticalDirection(context),
                 onTapActionCallback: () {
                   if (canDeletePermanently) {

--- a/lib/features/thread/presentation/widgets/email_tile_web_builder.dart
+++ b/lib/features/thread/presentation/widgets/email_tile_web_builder.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/icon_button_web.dart';
 import 'package:core/presentation/views/responsive/responsive_widget.dart';
 import 'package:flutter/material.dart';
@@ -295,7 +296,7 @@ class _EmailTileBuilderState extends State<EmailTileBuilder>  with BaseEmailItem
                 buildIconAvatarText(
                   widget.presentationEmail,
                   iconSize: 32,
-                  textStyle: const TextStyle(
+                  textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
                     fontSize: 12,
                     fontWeight: FontWeight.w600,
                     color: Colors.white

--- a/lib/features/thread/presentation/widgets/search_app_bar_widget.dart
+++ b/lib/features/thread/presentation/widgets/search_app_bar_widget.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/icon_button_web.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/presentation/views/text/text_field_builder.dart';
@@ -126,7 +127,7 @@ class SearchAppBarWidget extends StatelessWidget {
       textDirection: DirectionUtils.getDirectionByLanguage(context),
       autoFocus: autoFocus ?? true,
       focusNode: searchFocusNode,
-      textStyle: inputTextStyle ?? const TextStyle(
+      textStyle: inputTextStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
         color: AppColor.colorNameEmail,
         fontSize: 17
       ),
@@ -136,11 +137,15 @@ class SearchAppBarWidget extends StatelessWidget {
         enabledBorder: InputBorder.none,
         contentPadding: EdgeInsets.zero,
         hintText: hintText,
-        hintStyle: inputHintTextStyle ?? const TextStyle(
+        hintStyle: inputHintTextStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
           color: AppColor.colorHintSearchBar,
           fontSize: 17.0
         ),
-        labelStyle: const TextStyle(color: AppColor.colorHintSearchBar, fontSize: 17.0)),
+        labelStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+          color: AppColor.colorHintSearchBar,
+          fontSize: 17.0,
+        ),
+      ),
       controller: searchInputController,
     );
   }

--- a/lib/features/thread/presentation/widgets/spam_banner/spam_report_banner_button_widget.dart
+++ b/lib/features/thread/presentation/widgets/spam_banner/spam_report_banner_button_widget.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/style_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:tmail_ui_user/features/thread/presentation/styles/spam_banner/spam_report_banner_button_styles.dart';
@@ -42,7 +43,7 @@ class SpamReportBannerButtonWidget extends StatelessWidget {
             ? Text(
                 label,
                 textAlign: TextAlign.center,
-                style: TextStyle(
+                style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                   fontSize: SpamReportBannerButtonStyles.labelTextSize,
                   color: labelColor,
                   fontWeight: FontWeight.w400
@@ -67,7 +68,7 @@ class SpamReportBannerButtonWidget extends StatelessWidget {
                     textAlign: TextAlign.center,
                     overflow: CommonTextStyle.defaultTextOverFlow,
                     softWrap: CommonTextStyle.defaultSoftWrap,
-                    style: TextStyle(
+                    style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                       fontSize: SpamReportBannerButtonStyles.labelTextSize,
                       color: labelColor,
                       fontWeight: FontWeight.w400

--- a/lib/features/thread/presentation/widgets/spam_banner/spam_report_banner_label_widget.dart
+++ b/lib/features/thread/presentation/widgets/spam_banner/spam_report_banner_label_widget.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
@@ -35,7 +36,7 @@ class SpamReportBannerLabelWidget extends StatelessWidget {
           Text(
             AppLocalizations.of(context).countNewSpamEmails(countSpamEmailsAsString),
             textAlign: TextAlign.center,
-            style: TextStyle(
+            style: ThemeUtils.defaultTextStyleInterFont.copyWith(
               fontSize: SpamReportBannerLabelStyles.labelTextSize,
               color: labelColor,
               fontWeight: FontWeight.w500
@@ -46,7 +47,7 @@ class SpamReportBannerLabelWidget extends StatelessWidget {
             child: Text(
               AppLocalizations.of(context).countNewSpamEmails(countSpamEmailsAsString),
               textAlign: TextAlign.center,
-              style: TextStyle(
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: SpamReportBannerLabelStyles.labelTextSize,
                 color: labelColor,
                 fontWeight: FontWeight.w500

--- a/lib/features/unknown_route_page/unknown_route_page_view.dart
+++ b/lib/features/unknown_route_page/unknown_route_page_view.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
@@ -41,7 +42,7 @@ class UnknownRoutePageView extends StatelessWidget {
                   Text(
                     AppLocalizations.of(context).titlePageNotFound,
                     textAlign: TextAlign.center,
-                    style: TextStyle(
+                    style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                       fontWeight: FontWeight.w500,
                       color: Colors.black,
                       fontSize: _getFontSizeTitle(context)
@@ -51,7 +52,7 @@ class UnknownRoutePageView extends StatelessWidget {
                   Text(
                     AppLocalizations.of(context).subTitlePageNotFound,
                     textAlign: TextAlign.center,
-                    style: const TextStyle(
+                    style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                       fontWeight: FontWeight.w500,
                       color: AppColor.colorSettingExplanation,
                       fontSize: 16

--- a/web/index.html
+++ b/web/index.html
@@ -94,9 +94,7 @@
           }
           _flutter.loader.load({
             onEntrypointLoaded: async function(engineInitializer) {
-              const appRunner = await engineInitializer.initializeEngine({
-                fontFallbackBaseUrl: ''
-              });
+              const appRunner = await engineInitializer.initializeEngine();
               await setTimeout( async function () {
                 await appRunner.runApp();
               }, 2000);
@@ -106,9 +104,7 @@
     } else {
       _flutter.loader.load({
         onEntrypointLoaded: async function(engineInitializer) {
-          const appRunner = await engineInitializer.initializeEngine({
-            fontFallbackBaseUrl: ''
-          });
+          const appRunner = await engineInitializer.initializeEngine();
           await setTimeout( async function () {
             await appRunner.runApp();
           }, 2000);


### PR DESCRIPTION
## Issue 

- The text `Select all messages of this page` is missing

<img width="547" alt="Screenshot 2025-07-08 at 11 21 16" src="https://github.com/user-attachments/assets/4092d17f-93f7-4a75-9001-217c33bd02be" />


- Font error when using Arabic language

<img width="1422" alt="Screenshot 2025-07-08 at 12 01 53" src="https://github.com/user-attachments/assets/066d3f3c-310a-407c-8e84-b9db287701ae" />


- Font error when text contain emoji

<img width="928" alt="Screenshot 2025-07-08 at 13 08 35" src="https://github.com/user-attachments/assets/051cd26d-567a-4727-9faa-56bed7c51751" />



## Root cause


We set `fontFallbackBaseUrl` to avoid loading fonts from `https://fonts.gstatic.com` which leads to fallback fonts not being downloaded, causing font errors in some languages ​​(like Arabic), emoji font errors, and even losing text because `fontFamily` has not been set for the style.

## Solution

- Use fontFamily for all style in Text widget
- Restore `fontFallbackBaseUrl` google by default set by Flutter

## Side effect

https://github.com/linagora/tmail-flutter/pull/3854

## Resolved

- Web:



https://github.com/user-attachments/assets/e51c9688-611e-44d8-9e16-7989091f8cb5



- Mobile:





[demo-mobile.webm](https://github.com/user-attachments/assets/ed83c759-8794-4df0-b491-837ac8c26beb)
