### PR TITLE
TF-3847 Fix blank user avatar on Stalwart server

### DIFF
--- a/lib/features/composer/presentation/extensions/composer_print_draft_extension.dart
+++ b/lib/features/composer/presentation/extensions/composer_print_draft_extension.dart
@@ -85,7 +85,7 @@ extension ComposerPrintDraftExtension on ComposerController {
       child: PrintDraftDialogView(
         emailPrint: DraftEmailPrint(
           appName: appLocalizations.app_name,
-          userName: mailboxDashBoardController.getOwnEmailAddress(),
+          userName: mailboxDashBoardController.ownEmailAddress.value,
           attachments: uploadController.allAttachmentsUploaded,
           emailContent: emailContent,
           fromPrefix: appLocalizations.from_email_address_prefix,

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -220,7 +220,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
 
   Session? get session => mailboxDashBoardController.sessionCurrent;
 
-  String get ownEmailAddress => mailboxDashBoardController.getOwnEmailAddress();
+  String get ownEmailAddress => mailboxDashBoardController.ownEmailAddress.value;
 
   SingleEmailController(
     this._getEmailContentInteractor,
@@ -2052,7 +2052,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
       _printEmailInteractor.execute(
         EmailPrint(
           appName: appLocalizations.app_name,
-          userName: mailboxDashBoardController.getOwnEmailAddress(),
+          userName: mailboxDashBoardController.ownEmailAddress.value,
           attachments: currentEmailLoaded.value!.attachments,
           emailContent: currentEmailLoaded.value!.htmlContent,
           fromPrefix: appLocalizations.from_email_address_prefix,
@@ -2555,7 +2555,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
 
     listEmailAddressAttendees.addAll(listEmailAddress);
 
-    final currentUserEmail = mailboxDashBoardController.getOwnEmailAddress();
+    final currentUserEmail = mailboxDashBoardController.ownEmailAddress.value;
     final listEmailAddressMailTo = listEmailAddressAttendees.removeInvalidEmails(currentUserEmail);
     log('SingleEmailController::handleMailToAttendees: listEmailAddressMailTo = $listEmailAddressMailTo');
     mailboxDashBoardController.openComposer(

--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -375,7 +375,8 @@ class EmailView extends GetWidget<SingleEmailController> {
                 attendanceStatus: controller.attendanceStatus.value,
                 ownEmailAddress: controller
                     .mailboxDashBoardController
-                    .getOwnEmailAddress(),
+                    .ownEmailAddress
+                    .value,
                 onMailtoAttendeesAction: controller.handleMailToAttendees,
                 openEmailAddressDetailAction: controller.openEmailAddressDialog,
                 isFree: controller.isCalendarEventFree,

--- a/lib/features/mailbox/presentation/base_mailbox_view.dart
+++ b/lib/features/mailbox/presentation/base_mailbox_view.dart
@@ -34,9 +34,7 @@ abstract class BaseMailboxView extends GetWidget<MailboxController>
       final dashboardController = controller.mailboxDashBoardController;
       final accountId = dashboardController.accountId.value;
       final session = dashboardController.sessionCurrent;
-      final username = accountId != null
-          ? dashboardController.getOwnEmailAddress()
-          : '';
+      final username = dashboardController.ownEmailAddress.value;
 
       final linagoraApps = dashboardController
           .appGridDashboardController

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -1229,7 +1229,7 @@ class MailboxController extends BaseMailboxController
       case MailboxActions.copySubaddress:
         try{
           final subaddress = getSubAddress(
-            mailboxDashBoardController.getOwnEmailAddress(),
+            mailboxDashBoardController.ownEmailAddress.value,
             findNodePathWithSeparator(mailbox.id, '.')!,
           );
           copySubAddressAction(context, subaddress);
@@ -1247,7 +1247,7 @@ class MailboxController extends BaseMailboxController
       case MailboxActions.allowSubaddressing:
         try{
           final subAddress = getSubAddress(
-            mailboxDashBoardController.getOwnEmailAddress(),
+            mailboxDashBoardController.ownEmailAddress.value,
             findNodePathWithSeparator(mailbox.id, '.')!,
           );
           openConfirmationDialogSubAddressingAction(

--- a/lib/features/mailbox/presentation/widgets/user_information_widget.dart
+++ b/lib/features/mailbox/presentation/widgets/user_information_widget.dart
@@ -11,7 +11,7 @@ typedef OnSubtitleClick = void Function();
 
 class UserInformationWidget extends StatelessWidget {
 
-  final String userName;
+  final String ownEmailAddress;
   final String? subtitle;
   final EdgeInsetsGeometry? titlePadding;
   final OnSubtitleClick? onSubtitleClick;
@@ -20,7 +20,7 @@ class UserInformationWidget extends StatelessWidget {
 
   const UserInformationWidget({
     Key? key,
-    required this.userName,
+    required this.ownEmailAddress,
     this.subtitle,
     this.titlePadding,
     this.onSubtitleClick,
@@ -35,7 +35,7 @@ class UserInformationWidget extends StatelessWidget {
       decoration: BoxDecoration(border: border),
       child: Row(children: [
         UserAvatarBuilder(
-          username: userName.firstLetterToUpperCase,
+          username: ownEmailAddress.firstLetterToUpperCase,
           size: 51,
           textStyle: ThemeUtils.textStyleInter500().copyWith(
             fontSize: 25.5,
@@ -49,7 +49,7 @@ class UserInformationWidget extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             SelectableText(
-              userName,
+              ownEmailAddress,
               maxLines: 1,
               style: ThemeUtils.defaultTextStyleInterFont.copyWith(
                 fontSize: 17,

--- a/lib/features/mailbox_dashboard/presentation/extensions/update_own_email_address_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/update_own_email_address_extension.dart
@@ -1,0 +1,24 @@
+
+import 'package:core/utils/app_logger.dart';
+import 'package:jmap_dart_client/jmap/identities/identity.dart';
+import 'package:model/extensions/session_extension.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+
+extension UpdateOwnEmailAddressExtension on MailboxDashBoardController {
+
+  void synchronizeOwnEmailAddress(String emailAddress) {
+    log('UpdateOwnEmailAddressExtension::synchronizeOwnEmailAddress:OwnEmailAddress = ${ownEmailAddress.value}, NewEmailAddress = $emailAddress');
+    if (ownEmailAddress.value.isNotEmpty || emailAddress.isEmpty) return;
+    ownEmailAddress.value = emailAddress;
+  }
+
+  void updateOwnEmailAddressFromIdentities(List<Identity> listIdentities) {
+    final identityEmailAddress = listIdentities.firstOrNull?.email ?? '';
+
+    if (identityEmailAddress.isNotEmpty) {
+      synchronizeOwnEmailAddress(identityEmailAddress);
+    } else {
+      synchronizeOwnEmailAddress(sessionCurrent?.getUserDisplayName() ?? '');
+    }
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart
+++ b/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart
@@ -78,30 +78,34 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
 
                         return Obx(() {
                           final accountId = controller.accountId.value;
-
-                        return NavigationBarWidget(
-                          imagePaths: controller.imagePaths,
-                          accountId: accountId,
-                          ownEmailAddress: controller.getOwnEmailAddress(),
-                          contactSupportCapability: accountId != null
+                          final ownEmailAddress = controller.ownEmailAddress.value;
+                          final contactSupportCapability = accountId != null
                             ? controller.sessionCurrent?.getContactSupportCapability(accountId)
-                            : null,
-                          searchForm: SearchInputFormWidget(),
-                          appGridController: controller.appGridDashboardController,
-                          settingActionTypes: ProfileSettingActionType.values,
-                          onTapApplicationLogoAction: controller.redirectToInboxAction,
-                          onTapContactSupportAction: (contactSupport) =>
-                              controller.onGetHelpOrReportBug(contactSupport),
-                          onProfileSettingActionTypeClick: (actionType) =>
-                            controller.handleProfileSettingActionTypeClick(
+                            : null;
+
+                          return NavigationBarWidget(
+                            imagePaths: controller.imagePaths,
+                            accountId: accountId,
+                            ownEmailAddress: ownEmailAddress,
+                            contactSupportCapability: contactSupportCapability,
+                            searchForm: SearchInputFormWidget(),
+                            appGridController:
+                                controller.appGridDashboardController,
+                            settingActionTypes: ProfileSettingActionType.values,
+                            onTapApplicationLogoAction:
+                                controller.redirectToInboxAction,
+                            onTapContactSupportAction: (contactSupport) =>
+                                controller.onGetHelpOrReportBug(contactSupport),
+                            onProfileSettingActionTypeClick: (actionType) =>
+                                controller.handleProfileSettingActionTypeClick(
                               context: context,
                               actionType: actionType,
                             ),
                           );
                         });
-                      }
+                      },
                     ),
-                    Expanded(child: Row(children: [
+                  Expanded(child: Row(children: [
                       Column(children: [
                         ComposeButtonWidget(
                           imagePaths: controller.imagePaths,
@@ -144,13 +148,8 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
                                   ),
                                   const Spacer(),
                                   Obx(() {
-                                    final accountId = controller.accountId.value;
-                                    final ownEmailAddress = accountId == null
-                                      ? ''
-                                      : controller.getOwnEmailAddress();
-
                                     return ProfileSettingIcon(
-                                      ownEmailAddress: ownEmailAddress,
+                                      ownEmailAddress: controller.ownEmailAddress.value,
                                       settingActionTypes: ProfileSettingActionType.values,
                                       onProfileSettingActionTypeClick: (actionType) =>
                                         controller.handleProfileSettingActionTypeClick(

--- a/lib/features/manage_account/presentation/extensions/update_own_email_address_extension.dart
+++ b/lib/features/manage_account/presentation/extensions/update_own_email_address_extension.dart
@@ -1,0 +1,24 @@
+
+import 'package:core/utils/app_logger.dart';
+import 'package:jmap_dart_client/jmap/identities/identity.dart';
+import 'package:model/extensions/session_extension.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/manage_account_dashboard_controller.dart';
+
+extension UpdateOwnEmailAddressExtension on ManageAccountDashBoardController {
+
+  void synchronizeOwnEmailAddress(String emailAddress) {
+    log('UpdateOwnEmailAddressExtension::synchronizeOwnEmailAddress:OwnEmailAddress = ${ownEmailAddress.value}, NewEmailAddress = $emailAddress');
+    if (ownEmailAddress.value.isNotEmpty || emailAddress.isEmpty) return;
+    ownEmailAddress.value = emailAddress;
+  }
+
+  void updateOwnEmailAddressFromIdentities(List<Identity> listIdentities) {
+    final identityEmailAddress = listIdentities.firstOrNull?.email ?? '';
+
+    if (identityEmailAddress.isNotEmpty) {
+      synchronizeOwnEmailAddress(identityEmailAddress);
+    } else {
+      synchronizeOwnEmailAddress(sessionCurrent?.getUserDisplayName() ?? '');
+    }
+  }
+}

--- a/lib/features/manage_account/presentation/manage_account_dashboard_controller.dart
+++ b/lib/features/manage_account/presentation/manage_account_dashboard_controller.dart
@@ -24,6 +24,7 @@ import 'package:tmail_ui_user/features/manage_account/domain/usecases/update_vac
 import 'package:tmail_ui_user/features/manage_account/presentation/action/dashboard_setting_action.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/email_rules/bindings/email_rules_bindings.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/extensions/export_trace_log_extension.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/extensions/update_own_email_address_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/extensions/vacation_response_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/forward/bindings/forward_bindings.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/language_and_region/language_and_region_bindings.dart';
@@ -53,6 +54,7 @@ class ManageAccountDashBoardController extends ReloadableController {
   final settingsPageLevel = SettingsPageLevel.universal.obs;
   final vacationResponse = Rxn<VacationResponse>();
   final dashboardSettingAction = Rxn<UIAction>();
+  final ownEmailAddress = Rx<String>('');
 
   Session? sessionCurrent;
   bool? isVacationDateDialogDisplayed;
@@ -103,6 +105,7 @@ class ManageAccountDashBoardController extends ReloadableController {
     log('ManageAccountDashBoardController::handleReloaded:');
     sessionCurrent = session;
     accountId.value = session.accountId;
+    synchronizeOwnEmailAddress(session.getOwnEmailAddressOrEmpty());
     _bindingInteractorForMenuItemView(sessionCurrent, accountId.value);
     _getVacationResponse();
     _getParametersRouter();
@@ -112,7 +115,8 @@ class ManageAccountDashBoardController extends ReloadableController {
     final arguments = Get.arguments;
     if (arguments is ManageAccountArguments) {
       sessionCurrent = arguments.session;
-      accountId.value = arguments.session?.personalAccount.accountId;
+      accountId.value = arguments.session?.accountId;
+      synchronizeOwnEmailAddress(arguments.session?.getOwnEmailAddressOrEmpty() ?? '');
       previousUri = arguments.previousUri;
       _bindingInteractorForMenuItemView(sessionCurrent, accountId.value);
       _getVacationResponse();
@@ -398,9 +402,6 @@ class ManageAccountDashBoardController extends ReloadableController {
       session: sessionCurrent!,
       accountId: accountId.value!);
   }
-
-  String getOwnEmailAddress() =>
-      sessionCurrent?.getOwnEmailAddressOrEmpty() ?? '';
 
   @override
   void onClose() {

--- a/lib/features/manage_account/presentation/manage_account_dashboard_view.dart
+++ b/lib/features/manage_account/presentation/manage_account_dashboard_view.dart
@@ -47,7 +47,7 @@ class ManageAccountDashBoardView extends GetWidget<ManageAccountDashBoardControl
                   return Obx(() => NavigationBarWidget(
                       imagePaths: controller.imagePaths,
                       accountId: controller.accountId.value,
-                      ownEmailAddress: controller.getOwnEmailAddress(),
+                      ownEmailAddress: controller.ownEmailAddress.value,
                       onTapApplicationLogoAction: () =>
                           controller.backToMailboxDashBoard(context: context),
                   settingActionTypes: const [ProfileSettingActionType.signOut],

--- a/lib/features/manage_account/presentation/menu/settings/settings_first_level_view.dart
+++ b/lib/features/manage_account/presentation/menu/settings/settings_first_level_view.dart
@@ -20,11 +20,16 @@ class SettingsFirstLevelView extends GetWidget<SettingsController> {
       key: const Key('setting_menu'),
       child: Column(children: [
         Obx(() => UserInformationWidget(
-          userName: controller.manageAccountDashboardController.accountId.value != null
-            ? controller.manageAccountDashboardController.getOwnEmailAddress()
-            : '',
-          padding: SettingsUtils.getPaddingInFirstLevel(context, controller.responsiveUtils),
-          titlePadding: const EdgeInsetsDirectional.only(start: 16))),
+          ownEmailAddress: controller
+            .manageAccountDashboardController
+            .ownEmailAddress
+            .value,
+          padding: SettingsUtils.getPaddingInFirstLevel(
+            context,
+            controller.responsiveUtils,
+          ),
+          titlePadding: const EdgeInsetsDirectional.only(start: 16),
+        )),
         Divider(
           color: AppColor.colorDividerHorizontal,
           height: 1,

--- a/lib/features/search/mailbox/presentation/search_mailbox_controller.dart
+++ b/lib/features/search/mailbox/presentation/search_mailbox_controller.dart
@@ -357,7 +357,7 @@ class SearchMailboxController extends BaseMailboxController with MailboxActionHa
       case MailboxActions.copySubaddress:
         try {
           final subAddress = getSubAddress(
-            dashboardController.getOwnEmailAddress(),
+            dashboardController.ownEmailAddress.value,
             findNodePathWithSeparator(mailbox.id, '.')!,
           );
           copySubAddressAction(context, subAddress);
@@ -371,7 +371,7 @@ class SearchMailboxController extends BaseMailboxController with MailboxActionHa
       case MailboxActions.allowSubaddressing:
         try{
           final subAddress = getSubAddress(
-            dashboardController.getOwnEmailAddress(),
+            dashboardController.ownEmailAddress.value,
             findNodePathWithSeparator(mailbox.id, '.')!,
           );
           openConfirmationDialogSubAddressingAction(

--- a/model/lib/extensions/session_extension.dart
+++ b/model/lib/extensions/session_extension.dart
@@ -72,6 +72,20 @@ extension SessionExtension on Session {
     }
   }
 
+  String getUserDisplayName() {
+    try {
+      final accountDisplayName = personalAccount.name.value;
+      if (accountDisplayName.isNotEmpty) {
+        return accountDisplayName;
+      } else {
+        return username.value;
+      }
+    } catch (e) {
+      logError('SessionExtension::getUserDisplayName:Exception: $e');
+      return '';
+    }
+  }
+
   String getOwnEmailAddressOrEmpty() {
     try {
       return getOwnEmailAddress();

--- a/test/features/manage_account/presentation/profiles/identities/identities_controller_test.dart
+++ b/test/features/manage_account/presentation/profiles/identities/identities_controller_test.dart
@@ -243,6 +243,7 @@ void main() {
         .thenAnswer((_) => Stream.value(Right(GetAllIdentitiesSuccess(
           [identity1, identity2, identity3, identity4],
           null))));
+      when(mockManageAccountDashBoardController.ownEmailAddress).thenReturn(Rx(''));
       when(mockManageAccountDashBoardController.accountId).thenReturn(Rxn());
       when(mockManageAccountDashBoardController.sessionCurrent).thenReturn(SessionFixtures.aliceSession);
         


### PR DESCRIPTION
## Issue

#3847 

## Root cause

We use the owner email address retrieved from the session info via some fields like (`username`, `name`, `sendTo`), to display the name for the user avatar. But the `Stalwart` server does not return any email address in the session (https://github.com/linagora/tmail-flutter/issues/3717#issuecomment-3036701594)

## Solution

Order of getting owner email address:

`Session -> Identity -> User display name of session`

## Resolved

- Session with email address:


https://github.com/user-attachments/assets/13026052-f3e8-495f-9986-ab659777be0b


- Session/Identity without email address:



https://github.com/user-attachments/assets/2c6382ab-3907-40c1-bfe0-c945ce68ccd8

