### PR TITLE
Apply new style for profile avatar setting

### DIFF
--- a/lib/features/base/widget/user_avatar_builder.dart
+++ b/lib/features/base/widget/user_avatar_builder.dart
@@ -6,6 +6,7 @@ class UserAvatarBuilder extends StatelessWidget {
   final String username;
   final double? size;
   final EdgeInsetsGeometry? padding;
+  final TextStyle? textStyle;
   final VoidCallback? onTapAction;
 
   const UserAvatarBuilder({
@@ -13,6 +14,7 @@ class UserAvatarBuilder extends StatelessWidget {
     required this.username,
     this.size,
     this.padding,
+    this.textStyle,
     this.onTapAction,
   }) : super(key: key);
 
@@ -21,7 +23,7 @@ class UserAvatarBuilder extends StatelessWidget {
     final avatarBuilder = AvatarBuilder()
       ..text(username.firstLetterToUpperCase)
       ..size(size ?? 32)
-      ..addTextStyle(Theme.of(context).textTheme.titleMedium?.copyWith(
+      ..addTextStyle(textStyle ?? Theme.of(context).textTheme.titleMedium?.copyWith(
             color: Colors.white,
           ))
       ..avatarColor(username.gradientColors);

--- a/lib/features/mailbox/presentation/widgets/user_information_widget.dart
+++ b/lib/features/mailbox/presentation/widgets/user_information_widget.dart
@@ -1,10 +1,9 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
-import 'package:core/presentation/extensions/string_extension.dart';
-import 'package:core/presentation/views/image/avatar_builder.dart';
-import 'package:core/utils/platform_info.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/base/widget/material_text_button.dart';
+import 'package:tmail_ui_user/features/base/widget/user_avatar_builder.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 typedef OnSubtitleClick = void Function();
@@ -34,15 +33,16 @@ class UserInformationWidget extends StatelessWidget {
       padding: padding ?? const EdgeInsetsDirectional.only(start: 16, end: 4, top: 16, bottom: 16),
       decoration: BoxDecoration(border: border),
       child: Row(children: [
-        (AvatarBuilder()
-            ..text(userName.firstCharacterToUpperCase)
-            ..backgroundColor(Colors.white)
-            ..textColor(Colors.black)
-            ..addBoxShadows([const BoxShadow(
-                color: AppColor.colorShadowBgContentEmail,
-                spreadRadius: 1, blurRadius: 1, offset: Offset(0, 0.5))])
-            ..size(PlatformInfo.isWeb ? 48 : 56))
-          .build(),
+        UserAvatarBuilder(
+          username: userName,
+          size: 51,
+          textStyle: ThemeUtils.textStyleInter500().copyWith(
+            fontSize: 25.5,
+            height: 38.3 / 25.5,
+            letterSpacing: 0.24,
+            color: Colors.white,
+          ),
+        ),
         const SizedBox(width: 16),
         Expanded(child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
## Issue

https://www.notion.so/linagora/Profile-identities-section-in-settings-UXUI-22262718bad180808615e52d238828d2?source=copy_link


<img width="316" height="533" alt="Screenshot 2025-07-11 at 10 50 16" src="https://github.com/user-attachments/assets/583a160d-9738-4634-8e46-b6d9b3462692" />

## Resolved


<img width="1440" height="3120" alt="demo" src="https://github.com/user-attachments/assets/56fc289d-bd11-4c08-a907-9bfe9c07048c" />