### PR TITLE
[HOT] Fix email tag not removed when dragging between `From` and `To` in advanced search

### DIFF
--- a/lib/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart
@@ -554,11 +554,23 @@ class AdvancedFilterController extends BaseController {
     switch(draggableEmailAddress.prefix) {
       case PrefixEmailAddress.to:
         listToEmailAddress.remove(draggableEmailAddress.emailAddress);
+        _updateMemorySearchFilter(
+          toOption: option(
+            listToEmailAddress.isNotEmpty,
+            listToEmailAddress.asSetAddress(),
+          ),
+        );
         toAddressExpandMode.value = ExpandMode.EXPAND;
         toAddressExpandMode.refresh();
         break;
       case PrefixEmailAddress.from:
         listFromEmailAddress.remove(draggableEmailAddress.emailAddress);
+        _updateMemorySearchFilter(
+          fromOption: option(
+            listFromEmailAddress.isNotEmpty,
+            listFromEmailAddress.asSetAddress(),
+          ),
+        );
         fromAddressExpandMode.value = ExpandMode.EXPAND;
         fromAddressExpandMode.refresh();
         break;


### PR DESCRIPTION
## Issue

In the advanced search, when a user drags and drops an email address tag from the `From` field to the `To` field (or vice versa), the tag appears correctly in the target field. However, after closing and reopening the advanced search, the tag reappears in the original field, resulting in the tag being shown in both fields.

## Steps to Reproduce

1. Open the advanced search.
2. Add an email address to the From field.
3. Drag the tag to the To field.
4. Close the advanced search.
5. Reopen the advanced search.
6. Observe that the tag is now shown in both the From and To fields.


https://github.com/user-attachments/assets/7de4dbd8-d41f-4d7e-a072-18de885d4d4d


## Root cause

The search filter list in memory is not updated after drag-and-drop.

## Resolved


https://github.com/user-attachments/assets/0386b916-23d1-4fd6-b4a3-d10bb89e07ff


