### PR TITLE
TF-3885 Fix language defaults

### DIFF
--- a/lib/features/composer/presentation/extensions/create_email_request_extension.dart
+++ b/lib/features/composer/presentation/extensions/create_email_request_extension.dart
@@ -158,7 +158,7 @@ extension CreateEmailRequestExtension on CreateEmailRequest {
             IndividualHeaderIdentifier.acceptLanguageHeader: LocalizationService.supportedLocalesToLanguageTags()
           },
           contentLanguageHeader: {
-            IndividualHeaderIdentifier.contentLanguageHeader: LocalizationService.getLocaleFromLanguage().toLanguageTag()
+            IndividualHeaderIdentifier.contentLanguageHeader: LocalizationService.getInitialLocale().toLanguageTag()
           },
         )
       },

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -2133,7 +2133,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
         {_displayingEventBlobId!},
         emailId,
         session!.getLanguageForCalendarEvent(
-          LocalizationService.getLocaleFromLanguage(),
+          LocalizationService.getInitialLocale(),
           accountId!,
         ),
       ));
@@ -2154,7 +2154,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
         {_displayingEventBlobId!},
         emailId,
         session!.getLanguageForCalendarEvent(
-          LocalizationService.getLocaleFromLanguage(),
+          LocalizationService.getInitialLocale(),
           accountId!,
         ),
       ));
@@ -2175,7 +2175,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
         {_displayingEventBlobId!},
         emailId,
         session!.getLanguageForCalendarEvent(
-          LocalizationService.getLocaleFromLanguage(),
+          LocalizationService.getInitialLocale(),
           accountId!,
         ),
       ));

--- a/lib/features/manage_account/presentation/language_and_region/language_and_region_controller.dart
+++ b/lib/features/manage_account/presentation/language_and_region/language_and_region_controller.dart
@@ -38,9 +38,10 @@ class LanguageAndRegionController extends BaseController {
 
   @override
   void handleSuccessViewState(Success success) {
-    super.handleSuccessViewState(success);
     if (success is SaveLanguageSuccess) {
-      LocalizationService.changeLocale(success.localeStored.languageCode);
+      LocalizationService.changeLocale(success.localeStored);
+    } else {
+      super.handleSuccessViewState(success);
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -87,7 +87,7 @@ class _TMailAppState extends State<TMailApp> {
         }
         return supportedLocales.first;
       },
-      locale: LocalizationService.getLocaleFromLanguage(),
+      locale: LocalizationService.getInitialLocale(),
       fallbackLocale: LocalizationService.fallbackLocale,
       translations: LocalizationService(),
       onGenerateTitle: (context) {

--- a/lib/main/localizations/localization_service.dart
+++ b/lib/main/localizations/localization_service.dart
@@ -1,12 +1,11 @@
-
-import 'dart:ui';
-
 import 'package:core/utils/app_logger.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
 import 'package:tmail_ui_user/main/localizations/language_code_constants.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+
+typedef OnServerLanguageApplied = Function(Locale locale);
 
 class LocalizationService extends Translations {
 
@@ -33,30 +32,27 @@ class LocalizationService extends Translations {
     Locale(LanguageCodeConstants.german, 'DE')
   ];
 
-  static void changeLocale(String langCode) {
-    log('LocalizationService::changeLocale():langCode: $langCode');
-    final newLocale = getLocaleFromLanguage(langCode: langCode);
-    log('LocalizationService::changeLocale():newLocale: $newLocale');
+  static void changeLocale(Locale newLocale) {
+    log('LocalizationService::changeLocale(): New locale is $newLocale');
     Get.updateLocale(newLocale);
   }
 
-  static Locale getLocaleFromLanguage({String? langCode}) {
+  static Locale getInitialLocale() {
     try {
-      final languageCacheManager = getBinding<LanguageCacheManager>();
-      log('LocalizationService::_getLocaleFromLanguage:languageCacheManager: $languageCacheManager');
-      final localeStored = languageCacheManager?.getStoredLanguage();
-      log('LocalizationService::_getLocaleFromLanguage():localeStored: $localeStored');
-      final localeSelected = supportedLocales.firstWhereOrNull(
-        (locale) => locale.languageCode == langCode,
-      );
-      return localeSelected ?? localeStored ?? Get.deviceLocale ?? defaultLocale;
+      final cachedLocale = _getCachedLocale();
+      if (cachedLocale != null) return cachedLocale;
+
+      final deviceLocale = _getDeviceLocale();
+      if (_isSupportedLocale(deviceLocale)) return deviceLocale;
+
+      return defaultLocale;
     } catch (e) {
-      logError('LocalizationService::getLocaleFromLanguage: Exception: $e');
-      return Get.deviceLocale ?? defaultLocale;
+      logError('LocalizationService::getInitialLocale:Exception is $e');
+      return defaultLocale;
     }
   }
 
-  static Locale? getCachedLocale() {
+  static Locale? _getCachedLocale() {
     try {
       final languageCacheManager = getBinding<LanguageCacheManager>();
       return languageCacheManager?.getStoredLanguage();
@@ -66,6 +62,9 @@ class LocalizationService extends Translations {
     }
   }
 
+  static Locale _getDeviceLocale() =>
+      WidgetsBinding.instance.platformDispatcher.locale;
+
   static String supportedLocalesToLanguageTags() {
     final listLanguageTags = supportedLocales.map((locale) => locale.toLanguageTag()).join(', ');
     log('LocalizationService::supportedLocalesToLanguageTags:listLanguageTags: $listLanguageTags');
@@ -74,47 +73,79 @@ class LocalizationService extends Translations {
 
   static void initializeAppLanguage({
     String? serverLanguage,
-    void Function(Locale locale)? onServerLanguageApplied,
+    OnServerLanguageApplied? onServerLanguageApplied,
   }) {
-    final currentLocale = Get.locale;
+    log('LocalizationService::initializeAppLanguage:Server language: $serverLanguage');
     try {
-      final serverLocale = supportedLocales
-        .firstWhereOrNull((locale) => locale.languageCode == serverLanguage);
-      final cachedLocale = getCachedLocale();
-      
       // From server
-      if (serverLocale != null && supportedLocales.contains(serverLocale)) {
-        changeLocale(serverLocale.languageCode);
-        onServerLanguageApplied?.call(serverLocale);
+      if (serverLanguage != null &&
+          _useServerLocale(
+            languageCode: serverLanguage,
+            onServerLanguageApplied: onServerLanguageApplied,
+          )) {
         return;
       }
-      
-      // From cache
-      if (cachedLocale != null && supportedLocales.contains(cachedLocale)) {
-        changeLocale(cachedLocale.languageCode);
-        return;
-      } 
-      
-      // From device
-      final deviceLocale = WidgetsBinding.instance.platformDispatcher.locale;
-      if (supportedLocales.contains(deviceLocale)) {
-        changeLocale(deviceLocale.languageCode);
-        return;
-      } 
-      
-      // Default
-      if (currentLocale == null || !supportedLocales.contains(currentLocale)) {
-        changeLocale(defaultLocale.languageCode);
-        return;
-      }
+
+      if (_useCachedLocale()) return;
+
+      if (_useDeviceLocale()) return;
+
+      _useDefaultLocale();
     } catch (e) {
       logError('LocalizationService::initializeAppLanguage: Exception: $e');
-      // Default
-      if (currentLocale == null || !supportedLocales.contains(currentLocale)) {
-        changeLocale(defaultLocale.languageCode);
-        return;
-      }
+      _useDefaultLocale();
     }
+  }
+
+  static void _useDefaultLocale() {
+    final currentLocale = Get.locale;
+    if (currentLocale == null || !_isSupportedLocale(currentLocale)) {
+      changeLocale(defaultLocale);
+    }
+  }
+
+  static bool _useDeviceLocale() {
+    final deviceLocale = _getDeviceLocale();
+    log('LocalizationService::_useDeviceLocale: Device locale is $deviceLocale');
+    if (_isSupportedLocale(deviceLocale)) {
+      changeLocale(deviceLocale);
+      return true;
+    }
+    return false;
+  }
+
+  static bool _useCachedLocale() {
+    final cachedLocale = _getCachedLocale();
+    log('LocalizationService::_useCachedLocale: Cached locale is $cachedLocale');
+    if (cachedLocale != null && _isSupportedLocale(cachedLocale)) {
+      changeLocale(cachedLocale);
+      return true;
+    }
+    return false;
+  }
+
+  static bool _useServerLocale({
+    required String languageCode,
+    required OnServerLanguageApplied? onServerLanguageApplied,
+  }) {
+    final serverLocale = _findSupportedLocale(languageCode);
+    log('LocalizationService::_useServerLocale: Server locale is $serverLocale');
+    if (serverLocale != null && _isSupportedLocale(serverLocale)) {
+      changeLocale(serverLocale);
+      onServerLanguageApplied?.call(serverLocale);
+      return true;
+    }
+    return false;
+  }
+
+  static bool _isSupportedLocale(Locale locale) {
+    return supportedLocales
+        .any((supported) => supported.languageCode == locale.languageCode);
+  }
+
+  static Locale? _findSupportedLocale(String languageCode) {
+    return supportedLocales.firstWhereOrNull(
+        (supported) => supported.languageCode == languageCode);
   }
 
   @override


### PR DESCRIPTION
## Issue

#3885

## Reproduce


https://github.com/user-attachments/assets/6520c2e4-4fc3-4121-800d-0c06b18dfc4c



## Root cause

Since device local returns a Locale without `countryCode` so the test condition `supportedLocales.contains(deviceLocale)` returns `false` resulting in the default locale `en` being used

https://github.com/linagora/tmail-flutter/blob/78cb93ef1cbbd47959f1207e35d7b145efc05f6c/lib/main/localizations/localization_service.dart#L97-L102

## Resolved

- When server & cached locale is NULL


https://github.com/user-attachments/assets/5ea48f15-c0d3-4329-bd40-6a2b126b2f92

- When server & cached locale is not NULL


https://github.com/user-attachments/assets/667fa9ed-e421-4be2-9c6e-beb4e697a93a



