### PR TITLE
[HOT] Fix drag n drop image in Safari, image be placed under signature

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1269,10 +1269,10 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "27272e278bcd94d48522ce1944f8650c9366e51a"
+      resolved-ref: cc1822bc62f4d372018d0778f436a04547a0ab27
       url: "https://github.com/linagora/html-editor-enhanced.git"
     source: git
-    version: "3.1.9"
+    version: "3.2.0"
   html_unescape:
     dependency: transitive
     description:


### PR DESCRIPTION
## Issue

https://github.com/linagora/tmail-flutter/issues/3891#issuecomment-3100918452

## Reproduce


https://github.com/user-attachments/assets/b34c821f-c4d4-49e1-8673-ca6be80a159a


## Root cause 


On Safari, if the editor `(.note-editable)` has never been focused, `window.getSelection()` returns no valid range `(rangeCount === 0)`. As a result, `pasteHTML` doesn't know where to insert the content → the image is inserted at the end

## Dependency

- Need merged: https://github.com/linagora/html-editor-enhanced/pull/57 
 


## Resolved


https://github.com/user-attachments/assets/dee6c34d-73e4-4efd-a3c8-93b985ee8713

