### PR TITLE
[HOT] Fix missing `name` and `args` to `Intl.plural` in `daysAgo`

### DIFF
--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2025-07-08T10:52:37.280039",
+  "@@last_modified": "2025-07-23T15:51:45.812311",
   "initializing_data": "Initializing data...",
   "@initializing_data": {
     "type": "text",
@@ -4591,5 +4591,15 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
+  },
+  "daysAgo": "{days,plural, =0{}=1{ (1 day ago)}other{ ({days} days ago)}}",
+  "@daysAgo": {
+    "type": "text",
+    "placeholders_order": [
+      "days"
+    ],
+    "placeholders": {
+      "days": {}
+    }
   }
 }

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -4844,6 +4844,8 @@ class AppLocalizations {
       zero: '',
       one: ' (1 day ago)',
       other: ' ($days days ago)',
+      name: 'daysAgo',
+      args: [days],
     );
   }
 }


### PR DESCRIPTION
## Issue 

When run command 

`dart run intl_generator:extract_to_arb --output-dir=./lib/l10n lib/main/localizations/app_localizations.dart `

 get error message

```console
Skipping invalid Intl.message invocation
    <Intl.plural(days, zero: '', one: ' (1 day ago)', other: ' ($days days ago)')>
    reason: The 'args' argument for Intl.message must be specified for messages with parameters. Consider using rewrite_intl_messages.dart
    from lib/main/localizations/app_localizations.dart    line: 4842, column: 12
```

## Resolved



https://github.com/user-attachments/assets/a583fff7-2abf-442e-a4f6-7a8c1a8154d4


