### PR TITLE
TF-3964 Text is not well displayed when preview

### DIFF
--- a/core/test/utils/normalize_line_height_in_style_transformer_test.dart
+++ b/core/test/utils/normalize_line_height_in_style_transformer_test.dart
@@ -1,0 +1,108 @@
+import 'package:core/presentation/utils/html_transformer/dom/normalize_line_height_in_style_transformer.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:html/parser.dart' show parse;
+import 'package:html/dom.dart';
+import 'package:core/data/network/dio_client.dart';
+import 'package:mockito/annotations.dart';
+
+import 'normalize_line_height_in_style_transformer_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<DioClient>()])
+void main() {
+  group('NormalizeLineHeightInStyleTransformer', () {
+    const transformer = NormalizeLineHeightInStyleTransformer();
+    final dioClient = MockDioClient();
+
+    Future<Document> run(String html) async {
+      final doc = parse(html);
+      await transformer.process(document: doc, dioClient: dioClient);
+      return doc;
+    }
+
+    test('Should removes line-height:1px', () async {
+      final doc = await run('<p style="color:red; line-height:1px;">Hello</p>');
+      expect(doc.querySelector('p')!.attributes['style'], 'color:red;');
+    });
+
+    test('Should removes line-height:100%', () async {
+      final doc = await run(
+        '<p style="line-height:100%; font-size:14px;">Hi</p>',
+      );
+      expect(doc.querySelector('p')!.attributes['style'], 'font-size:14px;');
+    });
+
+    test('Should keeps other line-height values', () async {
+      final doc = await run(
+        '<p style="line-height:150%; font-weight:bold;">Hi</p>',
+      );
+      expect(
+        doc.querySelector('p')!.attributes['style'],
+        'line-height:150%; font-weight:bold;',
+      );
+    });
+
+    test('Should removes style attribute if only line-height existed',
+        () async {
+      final doc = await run('<div style="line-height:1px;"></div>');
+      expect(
+        doc.querySelector('div')!.attributes.containsKey('style'),
+        isFalse,
+      );
+    });
+
+    test('Should handles missing style gracefully', () async {
+      final doc = await run('<span>No style here</span>');
+      expect(
+        doc.querySelector('span')!.attributes.containsKey('style'),
+        isFalse,
+      );
+    });
+
+    test('Should removes multiple unwanted line-heights', () async {
+      final doc = await run(
+        '<p style="line-height:1px; color:blue; line-height:100%; font-size:12px;"></p>',
+      );
+      expect(
+        doc.querySelector('p')!.attributes['style'],
+        'color:blue; font-size:12px;',
+      );
+    });
+
+    test('Should removes line-height even with irregular spacing', () async {
+      final doc = await run(
+        '<p style="line-height :   1px ; color: green;"></p>',
+      );
+      expect(doc.querySelector('p')!.attributes['style'], 'color: green;');
+    });
+
+    test('Should keep line-height:auto', () async {
+      final doc = await run(
+        '<p style="line-height:auto; font-size:16px;"></p>',
+      );
+      expect(
+        doc.querySelector('p')!.attributes['style'],
+        'line-height:auto; font-size:16px;',
+      );
+    });
+
+    test('Should not touch unrelated CSS properties', () async {
+      final doc = await run(
+        '<p style="margin:0; padding:5px;"></p>',
+      );
+      expect(
+        doc.querySelector('p')!.attributes['style'],
+        'margin:0; padding:5px;',
+      );
+    });
+
+    test('Should trim trailing semicolon after removal', () async {
+      final doc = await run(
+        '<p style="line-height:1px;"></p>',
+      );
+      expect(
+        doc.querySelector('p')!.attributes.containsKey('style'),
+        isFalse,
+      );
+    });
+  });
+}

--- a/lib/features/base/upgradeable/upgrade_hive_database_steps_v20.dart
+++ b/lib/features/base/upgradeable/upgrade_hive_database_steps_v20.dart
@@ -1,0 +1,20 @@
+
+import 'package:core/utils/platform_info.dart';
+import 'package:tmail_ui_user/features/base/upgradeable/upgrade_database_steps.dart';
+import 'package:tmail_ui_user/features/caching/caching_manager.dart';
+
+class UpgradeHiveDatabaseStepsV20 extends UpgradeDatabaseSteps {
+
+  final CachingManager _cachingManager;
+
+  UpgradeHiveDatabaseStepsV20(this._cachingManager);
+
+  @override
+  Future<void> onUpgrade(int oldVersion, int newVersion) async {
+    if (oldVersion > 0 &&
+        oldVersion < newVersion &&
+        newVersion == 20 && PlatformInfo.isMobile) {
+      await _cachingManager.clearDetailedEmailCache();
+    }
+  }
+}

--- a/lib/features/caching/config/cache_version.dart
+++ b/lib/features/caching/config/cache_version.dart
@@ -1,4 +1,4 @@
 
 class CacheVersion {
-  static const int hiveDBVersion = 19;
+  static const int hiveDBVersion = 20;
 }

--- a/lib/features/caching/config/hive_cache_config.dart
+++ b/lib/features/caching/config/hive_cache_config.dart
@@ -16,6 +16,7 @@ import 'package:tmail_ui_user/features/base/upgradeable/upgrade_hive_database_st
 import 'package:tmail_ui_user/features/base/upgradeable/upgrade_hive_database_steps_v17.dart';
 import 'package:tmail_ui_user/features/base/upgradeable/upgrade_hive_database_steps_v18.dart';
 import 'package:tmail_ui_user/features/base/upgradeable/upgrade_hive_database_steps_v19.dart';
+import 'package:tmail_ui_user/features/base/upgradeable/upgrade_hive_database_steps_v20.dart';
 import 'package:tmail_ui_user/features/base/upgradeable/upgrade_hive_database_steps_v7.dart';
 import 'package:tmail_ui_user/features/caching/caching_manager.dart';
 import 'package:tmail_ui_user/features/caching/config/cache_version.dart';
@@ -95,6 +96,7 @@ class HiveCacheConfig {
     await UpgradeHiveDatabaseStepsV17(cachingManager).onUpgrade(oldVersion, newVersion);
     await UpgradeHiveDatabaseStepsV18(cachingManager).onUpgrade(oldVersion, newVersion);
     await UpgradeHiveDatabaseStepsV19(cachingManager).onUpgrade(oldVersion, newVersion);
+    await UpgradeHiveDatabaseStepsV20(cachingManager).onUpgrade(oldVersion, newVersion);
 
     if (oldVersion != newVersion) {
       await cachingManager.storeCacheVersion(newVersion);


### PR DESCRIPTION
## Issue

#3964 

## Root cause

 There are too many `line-height=100%` attributes in the email body tags. It does not match the `font-size` leading to rendering errors.

## Solution

Remove `line-height=100%` attributes

## Resolved


- Mobile:

<img width="302" height="310" alt="Screenshot 2025-08-21 at 17 52 46" src="https://github.com/user-attachments/assets/54d9bcb0-174f-49aa-b2a8-36d4ca6bd1bd" />


- Web:

<img width="478" height="155" alt="Screenshot 2025-08-21 at 17 49 49" src="https://github.com/user-attachments/assets/9eb2b21f-dcf5-48dc-851c-80e39d2abd32" />



