### PR TITLE
HOTFIX Thread Detail show actions when setting enabled

### DIFF
--- a/lib/features/thread_detail/presentation/thread_detail_view.dart
+++ b/lib/features/thread_detail/presentation/thread_detail_view.dart
@@ -39,8 +39,7 @@ class ThreadDetailView extends GetWidget<ThreadDetailController> {
             closeThreadDetailAction: controller.closeThreadDetailAction,
             isThreadDetailEnabled: controller.isThreadDetailEnabled,
             mailboxContain: _getMailboxContain(),
-            threadActionReady: controller.emailsInThreadDetailInfo.isNotEmpty &&
-                controller.emailIdsPresentation.length > 1,
+            threadActionReady: controller.emailsInThreadDetailInfo.isNotEmpty,
             threadDetailIsStarred: controller.threadDetailIsStarred,
             threadDetailCanPermanentlyDelete: controller.threadDetailCanPermanentlyDelete,
             onThreadActionClick: controller.onThreadDetailActionClick,


### PR DESCRIPTION
## Issue
Now, icon are not displayed when I desactivate thread mode (👍) but when I activate thread mode, if I open an single email (not related to others emails), I haven’t icon. I would like : always have icon on thread mode, never when thread mode is unactivated.

## Demo

https://github.com/user-attachments/assets/5dae872f-4e76-4050-8487-63810fdb7feb

