### PR TITLE
HOTFIX Realtime update while searching on mobile

### DIFF
--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -636,7 +636,7 @@ class ThreadController extends BaseController with EmailActionController {
 
   Future<void> _handleWebSocketMessage(WebSocketMessage message) async {
     try {
-      if (searchController.isSearchEmailRunning) {
+      if (searchController.isSearchEmailRunning && PlatformInfo.isWeb) {
         await _refreshChangeSearchEmail();
       } else {
         await _refreshChangeListEmail();


### PR DESCRIPTION
## Issue
- While searching email on mobile, if there are new emails come via web socket, and user press back from search email view to thread view, the email list is de-synced.

## Resolved

https://github.com/user-attachments/assets/23ab37cc-95f2-4d6d-9dcb-2ed9b0149607

