### PR TITLE
TF-4016 Fix email not rendered

### DIFF
--- a/core/lib/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart
@@ -27,6 +27,7 @@ class StandardizeHtmlSanitizingTransformers extends TextTransformer {
     'nav',
     'main',
     'footer',
+    'supress_time_adjustment',
   ];
 
   const StandardizeHtmlSanitizingTransformers();

--- a/core/test/utils/standardize_html_sanitizing_transformers_test.dart
+++ b/core/test/utils/standardize_html_sanitizing_transformers_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'dart:convert';
 
 void main() {
-  group('StandardizeHtmlSanitizingTransformers::test', () {
+  group('StandardizeHtmlSanitizingTransformers.process', () {
     const transformer = StandardizeHtmlSanitizingTransformers();
     const htmlEscape = HtmlEscape();
     const listHTMLTags = [
@@ -19,6 +19,7 @@ void main() {
       'style',
       'section',
       'google-sheets-html-origin',
+      'supress_time_adjustment',
     ];
     const listOnEventAttributes = [
       'mousedown',
@@ -187,6 +188,16 @@ void main() {
       final result = transformer.process(inputHtml, htmlEscape);
 
       expect(result, equals('<footer></footer>'));
+    });
+
+    test(
+      'SHOULD persist supress_time_adjustment tag and remove href attribute of A tag '
+      'WHEN href is invalid',
+    () {
+      const inputHtml = '<supress_time_adjustment href="javascript:alert(1)"></supress_time_adjustment>';
+      final result = transformer.process(inputHtml, htmlEscape);
+
+      expect(result, equals('<supress_time_adjustment></supress_time_adjustment>'));
     });
   });
 }

--- a/lib/features/base/upgradeable/upgrade_hive_database_steps_v21.dart
+++ b/lib/features/base/upgradeable/upgrade_hive_database_steps_v21.dart
@@ -1,0 +1,19 @@
+import 'package:core/utils/platform_info.dart';
+import 'package:tmail_ui_user/features/base/upgradeable/upgrade_database_steps.dart';
+import 'package:tmail_ui_user/features/caching/caching_manager.dart';
+
+class UpgradeHiveDatabaseStepsV21 extends UpgradeDatabaseSteps {
+  final CachingManager _cachingManager;
+
+  UpgradeHiveDatabaseStepsV21(this._cachingManager);
+
+  @override
+  Future<void> onUpgrade(int oldVersion, int newVersion) async {
+    if (oldVersion > 0 &&
+        oldVersion < newVersion &&
+        newVersion == 21 &&
+        PlatformInfo.isMobile) {
+      await _cachingManager.clearDetailedEmailCache();
+    }
+  }
+}

--- a/lib/features/caching/config/cache_version.dart
+++ b/lib/features/caching/config/cache_version.dart
@@ -1,4 +1,4 @@
 
 class CacheVersion {
-  static const int hiveDBVersion = 20;
+  static const int hiveDBVersion = 21;
 }

--- a/lib/features/caching/config/hive_cache_config.dart
+++ b/lib/features/caching/config/hive_cache_config.dart
@@ -17,6 +17,7 @@ import 'package:tmail_ui_user/features/base/upgradeable/upgrade_hive_database_st
 import 'package:tmail_ui_user/features/base/upgradeable/upgrade_hive_database_steps_v18.dart';
 import 'package:tmail_ui_user/features/base/upgradeable/upgrade_hive_database_steps_v19.dart';
 import 'package:tmail_ui_user/features/base/upgradeable/upgrade_hive_database_steps_v20.dart';
+import 'package:tmail_ui_user/features/base/upgradeable/upgrade_hive_database_steps_v21.dart';
 import 'package:tmail_ui_user/features/base/upgradeable/upgrade_hive_database_steps_v7.dart';
 import 'package:tmail_ui_user/features/caching/caching_manager.dart';
 import 'package:tmail_ui_user/features/caching/config/cache_version.dart';
@@ -97,6 +98,7 @@ class HiveCacheConfig {
     await UpgradeHiveDatabaseStepsV18(cachingManager).onUpgrade(oldVersion, newVersion);
     await UpgradeHiveDatabaseStepsV19(cachingManager).onUpgrade(oldVersion, newVersion);
     await UpgradeHiveDatabaseStepsV20(cachingManager).onUpgrade(oldVersion, newVersion);
+    await UpgradeHiveDatabaseStepsV21(cachingManager).onUpgrade(oldVersion, newVersion);
 
     if (oldVersion != newVersion) {
       await cachingManager.storeCacheVersion(newVersion);


### PR DESCRIPTION
## Issue

#4016 

## Root cause

Because the email content contains a `supress_time_adjustment` tag wrapping all other tags, it gets removed during HTML sanitization.

## Resolved

- Web:

https://github.com/user-attachments/assets/4a9f430a-dd1a-495e-85d9-b49274878594

- Mobile:


[Screen_recording_20250915_094856.webm](https://github.com/user-attachments/assets/58e75033-e693-4998-ba49-1224ea0b39f6)
