### PR TITLE
TF-4014 Fix copy and paste images is broken after going full screen

### DIFF
--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -2338,7 +2338,7 @@ class ComposerController extends BaseController
     required BuildContext context,
     required double maxWidth
   }) {
-    if (responsiveUtils.isMobile(context)) {
+    if (context.mounted && responsiveUtils.isMobile(context)) {
       maxWithEditor = maxWidth - 40;
     } else {
       maxWithEditor = maxWidth - 70;
@@ -2368,6 +2368,8 @@ class ComposerController extends BaseController
     required UploadError uploadError
   }) {
     logError('ComposerController::handleOnPasteImageFailureAction: $uploadError');
+    if (!context.mounted) return;
+
     appToast.showToastErrorMessage(
       context,
       AppLocalizations.of(context).thisImageCannotBePastedIntoTheEditor);

--- a/lib/features/composer/presentation/composer_view_web.dart
+++ b/lib/features/composer/presentation/composer_view_web.dart
@@ -237,7 +237,7 @@ class ComposerView extends GetWidget<ComposerController> {
                 ),
                 Expanded(
                   child: LayoutBuilder(
-                    builder: (context, constraintsEditor) {
+                    builder: (_, constraintsEditor) {
                       return Stack(
                         children: [
                           Column(
@@ -361,7 +361,7 @@ class ComposerView extends GetWidget<ComposerController> {
         }
       ),
       desktop: Obx(() => DesktopResponsiveContainerView(
-        childBuilder: (context, constraints) {
+        childBuilder: (_, constraints) {
           return GestureDetector(
             onTap: () => controller.clickOutsideComposer(context),
             child: Column(children: [
@@ -517,7 +517,7 @@ class ComposerView extends GetWidget<ComposerController> {
               ),
               Expanded(
                 child: LayoutBuilder(
-                  builder: (context, constraintsEditor) {
+                  builder: (_, constraintsEditor) {
                     return Stack(
                       children: [
                         Column(
@@ -686,7 +686,7 @@ class ComposerView extends GetWidget<ComposerController> {
         onChangeDisplayModeAction: controller.displayScreenTypeComposerAction,
       )),
       tablet: TabletResponsiveContainerView(
-        childBuilder: (context, constraints) {
+        childBuilder: (_, constraints) {
           return GestureDetector(
             onTap: () => controller.clickOutsideComposer(context),
             child: Column(children: [
@@ -840,7 +840,7 @@ class ComposerView extends GetWidget<ComposerController> {
               ),
               Expanded(
                 child: LayoutBuilder(
-                  builder: (context, constraintsBody) {
+                  builder: (_, constraintsBody) {
                     return Stack(
                       children: [
                         Column(

--- a/lib/features/composer/presentation/view/web/desktop_responsive_container_view.dart
+++ b/lib/features/composer/presentation/view/web/desktop_responsive_container_view.dart
@@ -56,7 +56,7 @@ class DesktopResponsiveContainerView extends StatelessWidget {
           height: composerManager.composerIdsQueue.length > 1
             ? DesktopResponsiveContainerViewStyle.normalScreenMaxHeight
             : responsiveUtils.getSizeScreenHeight(context) * 0.85,
-          child: LayoutBuilder(builder: (context, constraints) =>
+          child: LayoutBuilder(builder: (_, constraints) =>
             PointerInterceptor(
               child: childBuilder.call(context, constraints),
             )
@@ -80,7 +80,7 @@ class DesktopResponsiveContainerView extends StatelessWidget {
               color: DesktopResponsiveContainerViewStyle.backgroundColor,
               width: maxWidth,
               height: maxHeight,
-              child: LayoutBuilder(builder: (context, constraints) =>
+              child: LayoutBuilder(builder: (_, constraints) =>
                 PointerInterceptor(
                   child: childBuilder.call(context, constraints)
                 )

--- a/lib/features/composer/presentation/view/web/mobile_responsive_container_view.dart
+++ b/lib/features/composer/presentation/view/web/mobile_responsive_container_view.dart
@@ -15,7 +15,7 @@ class MobileResponsiveContainerView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: MobileResponsiveContainerViewStyle.outSideBackgroundColor,
-      body: LayoutBuilder(builder: (context, constraints) =>
+      body: LayoutBuilder(builder: (_, constraints) =>
         PointerInterceptor(
           child: childBuilder.call(context, constraints)
         )

--- a/lib/features/composer/presentation/view/web/tablet_responsive_container_view.dart
+++ b/lib/features/composer/presentation/view/web/tablet_responsive_container_view.dart
@@ -30,7 +30,7 @@ class TabletResponsiveContainerView extends StatelessWidget {
           child: Container(
             color: TabletResponsiveContainerViewStyle.backgroundColor,
             width: TabletResponsiveContainerViewStyle.getWidth(context, _responsiveUtils),
-            child: LayoutBuilder(builder: (context, constraints) =>
+            child: LayoutBuilder(builder: (_, constraints) =>
               PointerInterceptor(
                 child: childBuilder.call(context, constraints)
               )


### PR DESCRIPTION
## Issue

#4014

## Root Cause

The application was using the `BuildContext` from a `LayoutBuilder` to perform actions. When the composer view was rebuilt due to display changes, the LayoutBuilder’s context became invalid (`DEFUNCT`). Any subsequent attempt to access this context (e.g., via `MediaQuery.sizeOf(context)`) resulted in an exception being thrown.

## Resolved

https://github.com/user-attachments/assets/d4798297-308c-4870-883d-3c6a92d10f36



