### PR TITLE
[WIP] Pin attachment list to bottom of Email View

### DIFF
--- a/integration_test/robots/email_robot.dart
+++ b/integration_test/robots/email_robot.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/attachment_item_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/attachments_pin/email_attachments_pin_header_widget.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/email_view_back_button.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/information_sender_and_receiver_builder.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
@@ -16,7 +17,7 @@ class EmailRobot extends CoreRobot {
   }
 
   Future<void> tapDownloadAllButton() async {
-    await $(AppLocalizations().archiveAndDownload).tap();
+    await $(AppLocalizations().downloadAll).tap();
     await $.pumpAndSettle();
   }
 
@@ -78,6 +79,10 @@ class EmailRobot extends CoreRobot {
 
   Future<void> longPressSenderEmailAddress(String email) async {
     await $(InformationSenderAndReceiverBuilder).$(email).longPress();
+  }
+
+  Future<void> tapAttachmentPin() async {
+    await $(EmailAttachmentsPinHeaderWidget).$(InkWell).tap();
   }
 
   Future<void> onTapAttachmentItem() async {

--- a/integration_test/scenarios/email_detailed/export_attachment_scenario.dart
+++ b/integration_test/scenarios/email_detailed/export_attachment_scenario.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tmail_ui_user/features/email/presentation/email_view.dart';
-import 'package:tmail_ui_user/features/email/presentation/widgets/attachment_item_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/attachments_pin/email_attachments_pin_widget.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../../base/base_test_scenario.dart';
@@ -37,8 +37,9 @@ class ExportAttachmentScenario extends BaseTestScenario {
 
     await threadRobot.openEmailWithSubject(subject);
     await $.pumpAndSettle();
-    _expectAttachmentVisible();
+    _expectAttachmentPinVisible();
 
+    await emailRobot.tapAttachmentPin();
     await emailRobot.onTapAttachmentItem();
     await $.pumpAndSettle();
 
@@ -47,8 +48,8 @@ class ExportAttachmentScenario extends BaseTestScenario {
     _expectExportDialogLoadingInvisible(appLocalizations);
   }
 
-  void _expectAttachmentVisible() {
-    expect($(AttachmentItemWidget), findsOneWidget);
+  void _expectAttachmentPinVisible() {
+    expect($(EmailAttachmentsPinWidget), findsOneWidget);
   }
 
   void _expectEmailViewVisible() {

--- a/lib/features/email/data/datasource/email_datasource.dart
+++ b/lib/features/email/data/datasource/email_datasource.dart
@@ -235,4 +235,6 @@ abstract class EmailDataSource {
   );
 
   Future<String> generateEntireMessageAsDocument(ViewEntireMessageRequest entireMessageRequest);
+
+  Future<bool> isPinAttachmentEnabled();
 }

--- a/lib/features/email/data/datasource_impl/email_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_datasource_impl.dart
@@ -611,4 +611,9 @@ class EmailDataSourceImpl extends EmailDataSource {
   Future<String> generateEntireMessageAsDocument(ViewEntireMessageRequest entireMessageRequest) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<bool> isPinAttachmentEnabled() {
+    throw UnimplementedError();
+  }
 }

--- a/lib/features/email/data/datasource_impl/email_hive_cache_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_hive_cache_datasource_impl.dart
@@ -612,4 +612,9 @@ class EmailHiveCacheDataSourceImpl extends EmailDataSource {
   Future<String> generateEntireMessageAsDocument(ViewEntireMessageRequest entireMessageRequest) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<bool> isPinAttachmentEnabled() {
+    throw UnimplementedError();
+  }
 }

--- a/lib/features/email/data/datasource_impl/email_local_storage_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_local_storage_datasource_impl.dart
@@ -43,6 +43,7 @@ import 'package:tmail_ui_user/features/email/domain/model/view_entire_message_re
 import 'package:tmail_ui_user/features/email/presentation/extensions/attachment_extension.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/eml_previewer.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/model/create_new_mailbox_request.dart';
+import 'package:tmail_ui_user/features/manage_account/data/local/preferences_setting_manager.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/model/sending_email.dart';
 import 'package:tmail_ui_user/main/exceptions/exception_thrower.dart';
 
@@ -53,6 +54,8 @@ class EmailLocalStorageDataSourceImpl extends EmailDataSource {
   final ExceptionThrower _exceptionThrower;
   final ImagePaths _imagePaths = Get.find<ImagePaths>();
   final FileUtils _fileUtils = Get.find<FileUtils>();
+  final PreferencesSettingManager _settingManager =
+      Get.find<PreferencesSettingManager>();
 
   EmailLocalStorageDataSourceImpl(
     this._localStorageManager,
@@ -377,4 +380,10 @@ class EmailLocalStorageDataSourceImpl extends EmailDataSource {
   }) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<bool> isPinAttachmentEnabled() => Future.sync(() async {
+    final config = await _settingManager.getPinAttachmentsConfig();
+    return config.isEnabled;
+  }).catchError(_exceptionThrower.throwException);
 }

--- a/lib/features/email/data/datasource_impl/email_session_storage_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_session_storage_datasource_impl.dart
@@ -293,4 +293,9 @@ class EmailSessionStorageDatasourceImpl extends EmailDataSource {
   }) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<bool> isPinAttachmentEnabled() {
+    throw UnimplementedError();
+  }
 }

--- a/lib/features/email/data/repository/email_repository_impl.dart
+++ b/lib/features/email/data/repository/email_repository_impl.dart
@@ -617,4 +617,9 @@ class EmailRepositoryImpl extends EmailRepository {
   Future<String> generateEntireMessageAsDocument(ViewEntireMessageRequest entireMessageRequest) {
     return emailDataSource[DataSourceType.local]!.generateEntireMessageAsDocument(entireMessageRequest);
   }
+
+  @override
+  Future<bool> isPinAttachmentEnabled() {
+    return emailDataSource[DataSourceType.local]!.isPinAttachmentEnabled();
+  }
 }

--- a/lib/features/email/domain/repository/email_repository.dart
+++ b/lib/features/email/domain/repository/email_repository.dart
@@ -233,4 +233,6 @@ abstract class EmailRepository {
   );
 
   Future<String> generateEntireMessageAsDocument(ViewEntireMessageRequest entireMessageRequest);
+
+  Future<bool> isPinAttachmentEnabled();
 }

--- a/lib/features/email/domain/state/get_pin_attachment_status_state.dart
+++ b/lib/features/email/domain/state/get_pin_attachment_status_state.dart
@@ -1,0 +1,17 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+
+class GettingPinAttachmentStatus extends LoadingState {}
+
+class GetPinAttachmentStatusSuccess extends UIState {
+  final bool isEnabled;
+
+  GetPinAttachmentStatusSuccess(this.isEnabled);
+
+  @override
+  List<Object?> get props => [isEnabled];
+}
+
+class GetPinAttachmentStatusFailure extends FeatureFailure {
+  GetPinAttachmentStatusFailure(dynamic exception) : super(exception: exception,);
+}

--- a/lib/features/email/domain/usecases/get_pin_attachment_status_interactor.dart
+++ b/lib/features/email/domain/usecases/get_pin_attachment_status_interactor.dart
@@ -1,0 +1,21 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:tmail_ui_user/features/email/domain/repository/email_repository.dart';
+import 'package:tmail_ui_user/features/email/domain/state/get_pin_attachment_status_state.dart';
+
+class GetPinAttachmentStatusInteractor {
+  final EmailRepository _emailRepository;
+
+  const GetPinAttachmentStatusInteractor(this._emailRepository);
+
+  Stream<Either<Failure, Success>> execute() async* {
+    try {
+      yield Right<Failure, Success>(GettingPinAttachmentStatus());
+      final isEnabled = await _emailRepository.isPinAttachmentEnabled();
+      yield Right<Failure, Success>(GetPinAttachmentStatusSuccess(isEnabled));
+    } catch (e) {
+      yield Left<Failure, Success>(GetPinAttachmentStatusFailure(e));
+    }
+  }
+}

--- a/lib/features/email/presentation/action/email_ui_action.dart
+++ b/lib/features/email/presentation/action/email_ui_action.dart
@@ -1,10 +1,12 @@
 
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:model/email/attachment.dart';
 import 'package:model/email/email_action_type.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:tmail_ui_user/features/base/action/ui_action.dart';
 import 'package:tmail_ui_user/features/thread/data/model/email_change_response.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 class EmailUIAction extends UIAction {
   static final idle = EmailUIAction();
@@ -87,4 +89,41 @@ class CollapseEmailInThreadDetailAction extends EmailUIAction {
 
   @override
   List<Object?> get props => [emailId];
+}
+
+class DownloadEmailAttachmentInThreadDetailAction extends EmailUIAction {
+  final Attachment attachment;
+  final EmailId emailIdOpened;
+
+  DownloadEmailAttachmentInThreadDetailAction(
+    this.attachment,
+    this.emailIdOpened,
+  );
+
+  @override
+  List<Object?> get props => [attachment, emailIdOpened];
+}
+
+class ViewEmailAttachmentInThreadDetailAction extends EmailUIAction {
+  final AppLocalizations appLocalizations;
+  final Attachment attachment;
+  final EmailId emailIdOpened;
+
+  ViewEmailAttachmentInThreadDetailAction(
+    this.appLocalizations,
+    this.attachment,
+    this.emailIdOpened,
+  );
+
+  @override
+  List<Object?> get props => [appLocalizations, attachment, emailIdOpened];
+}
+
+class DownloadAllEmailAttachmentInThreadDetailAction extends EmailUIAction {
+  final EmailId emailIdOpened;
+
+  DownloadAllEmailAttachmentInThreadDetailAction(this.emailIdOpened);
+
+  @override
+  List<Object?> get props => [emailIdOpened];
 }

--- a/lib/features/email/presentation/bindings/email_bindings.dart
+++ b/lib/features/email/presentation/bindings/email_bindings.dart
@@ -24,6 +24,7 @@ import 'package:tmail_ui_user/features/email/domain/usecases/export_all_attachme
 import 'package:tmail_ui_user/features/email/domain/usecases/export_attachment_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_email_content_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_entire_message_as_document_interactor.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/get_pin_attachment_status_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_stored_email_state_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_email_read_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_star_email_interactor.dart';
@@ -190,6 +191,9 @@ class EmailBindings extends BaseBindings {
         Get.find<EmailRepository>(),
       ));
     }
+    Get.lazyPut(
+      () => GetPinAttachmentStatusInteractor(Get.find<EmailRepository>()),
+    );
   }
 
   @override

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -189,7 +189,6 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
   final isEmailContentClipped = RxBool(false);
   final attendanceStatus = Rxn<AttendanceStatus>();
   final htmlContentViewKey = GlobalKey<HtmlContentViewState>();
-  final isAttachmentsPinEnabled = RxBool(true);
 
   final ScrollController emailScrollController = ScrollController();
 
@@ -223,6 +222,8 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
   String get ownEmailAddress => mailboxDashBoardController.ownEmailAddress.value;
 
   GlobalObjectKey? get htmlViewKey => _threadDetailController?.expandedEmailHtmlViewKey;
+
+  ThreadDetailController? get threadDetailController => _threadDetailController;
 
   SingleEmailController(
     this._getEmailContentInteractor,

--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -160,7 +160,7 @@ class EmailView extends GetWidget<SingleEmailController> {
                 ),
                 Obx(() {
                   if (controller.attachments.isEmpty ||
-                      controller.isAttachmentsPinEnabled.isFalse) {
+                      controller.threadDetailController?.isAttachmentsPinEnabled.value != true) {
                     return const SizedBox.shrink();
                   }
 
@@ -471,7 +471,7 @@ class EmailView extends GetWidget<SingleEmailController> {
           ),
         Obx(() {
           if (controller.attachments.isNotEmpty &&
-              controller.isAttachmentsPinEnabled.isFalse) {
+              controller.threadDetailController?.isAttachmentsPinEnabled.value != true) {
             return EmailAttachmentsWidget(
               responsiveUtils: controller.responsiveUtils,
               attachments: controller.attachments,

--- a/lib/features/email/presentation/widgets/attachment_item_widget.dart
+++ b/lib/features/email/presentation/widgets/attachment_item_widget.dart
@@ -13,6 +13,7 @@ import 'package:model/email/attachment.dart';
 import 'package:tmail_ui_user/features/email/presentation/controller/single_email_controller.dart';
 import 'package:tmail_ui_user/features/email/presentation/extensions/attachment_extension.dart';
 import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
 typedef OnDownloadAttachmentFileAction = void Function(Attachment attachment);
 typedef OnViewAttachmentFileAction = void Function(Attachment attachment);
@@ -41,12 +42,16 @@ class AttachmentItemWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Obx(() {
-      final controller = Get.find<SingleEmailController>(tag: singleEmailControllerTag);
-      final attachmentsViewState = controller.attachmentsViewState;
+      final controller = getBinding<SingleEmailController>(
+        tag: singleEmailControllerTag,
+      );
+      final attachmentsViewState = controller?.attachmentsViewState;
       bool isLoading = false;
-      if (attachment.blobId != null) {
+      if (attachment.blobId != null &&
+          attachmentsViewState?.isNotEmpty == true) {
         isLoading = !EmailUtils.checkingIfAttachmentActionIsEnabled(
-            attachmentsViewState[attachment.blobId!]);
+          attachmentsViewState?[attachment.blobId!],
+        );
       }
 
       const loadingIndicator = SizedBox(

--- a/lib/features/email/presentation/widgets/attachment_list/attachment_list_item_widget.dart
+++ b/lib/features/email/presentation/widgets/attachment_list/attachment_list_item_widget.dart
@@ -13,6 +13,7 @@ import 'package:tmail_ui_user/features/email/presentation/extensions/attachment_
 import 'package:tmail_ui_user/features/email/presentation/styles/attachment/attachment_list_item_widget_styles.dart';
 import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/attachment_item_widget.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
 class AttachmentListItemWidget extends StatelessWidget {
 
@@ -35,12 +36,15 @@ class AttachmentListItemWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Obx(
       () {
-        final controller = Get.find<SingleEmailController>(tag: singleEmailControllerTag);
-        final attachmentsViewState = controller.attachmentsViewState;
+        final controller = getBinding<SingleEmailController>(
+          tag: singleEmailControllerTag,
+        );
+        final attachmentsViewState = controller?.attachmentsViewState;
         bool isLoading = false;
-        if (attachment.blobId != null) {
+        if (attachment.blobId != null &&
+            attachmentsViewState?.isNotEmpty == true) {
           isLoading = !EmailUtils.checkingIfAttachmentActionIsEnabled(
-            attachmentsViewState[attachment.blobId!]);
+            attachmentsViewState?[attachment.blobId!]);
         }
 
         return Material(

--- a/lib/features/email/presentation/widgets/attachments_pin/email_attachments_pin_body_widget.dart
+++ b/lib/features/email/presentation/widgets/attachments_pin/email_attachments_pin_body_widget.dart
@@ -1,0 +1,74 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/utils/platform_info.dart';
+import 'package:flutter/material.dart';
+import 'package:model/email/attachment.dart';
+import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/attachment_item_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/draggable_attachment_item_widget.dart';
+
+class EmailAttachmentsPinBodyWidget extends StatelessWidget {
+  final List<Attachment> attachments;
+  final ImagePaths imagePaths;
+  final ResponsiveUtils responsiveUtils;
+  final String? singleEmailControllerTag;
+  final OnDragAttachmentStarted? onDragStarted;
+  final OnDragAttachmentEnd? onDragEnd;
+  final OnDownloadAttachmentFileAction? downloadAttachmentAction;
+  final OnViewAttachmentFileAction? viewAttachmentAction;
+
+  const EmailAttachmentsPinBodyWidget({
+    super.key,
+    required this.attachments,
+    required this.imagePaths,
+    required this.responsiveUtils,
+    this.singleEmailControllerTag,
+    this.onDragStarted,
+    this.onDragEnd,
+    this.downloadAttachmentAction,
+    this.viewAttachmentAction,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsetsDirectional.symmetric(
+        vertical: 8,
+        horizontal: 16,
+      ),
+      constraints: const BoxConstraints(maxHeight: 150),
+      child: SingleChildScrollView(
+        child: Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: attachments.map((attachment) {
+            if (PlatformInfo.isWeb && responsiveUtils.isDesktop(context)) {
+              return DraggableAttachmentItemWidget(
+                attachment: attachment,
+                imagePaths: imagePaths,
+                width: EmailUtils.desktopItemMaxWidth,
+                onDragStarted: onDragStarted,
+                onDragEnd: onDragEnd,
+                downloadAttachmentAction: downloadAttachmentAction,
+                viewAttachmentAction: viewAttachmentAction,
+                singleEmailControllerTag: singleEmailControllerTag,
+              );
+            } else {
+              return AttachmentItemWidget(
+                attachment: attachment,
+                imagePaths: imagePaths,
+                width: responsiveUtils.isMobile(context)
+                  ? double.infinity
+                  : EmailUtils.desktopItemMaxWidth,
+                downloadAttachmentAction: downloadAttachmentAction,
+                viewAttachmentAction: viewAttachmentAction,
+                singleEmailControllerTag: singleEmailControllerTag,
+              );
+            }
+          }).toList(),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/email/presentation/widgets/attachments_pin/email_attachments_pin_header_widget.dart
+++ b/lib/features/email/presentation/widgets/attachments_pin/email_attachments_pin_header_widget.dart
@@ -1,0 +1,122 @@
+import 'package:core/presentation/action/action_callback_define.dart';
+import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/theme_utils.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:filesize/filesize.dart';
+import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+typedef OnToggleExpandAttachmentPinAction = Function(bool isCollapsed);
+
+class EmailAttachmentsPinHeaderWidget extends StatelessWidget {
+  final int countAttachments;
+  final num totalSizeAttachments;
+  final bool isCollapsed;
+  final bool isMobile;
+  final ImagePaths imagePaths;
+  final OnToggleExpandAttachmentPinAction onToggleExpandAction;
+  final OnTapActionCallback? onDownloadAllAttachmentsAction;
+
+  const EmailAttachmentsPinHeaderWidget({
+    super.key,
+    required this.countAttachments,
+    required this.totalSizeAttachments,
+    required this.isCollapsed,
+    required this.imagePaths,
+    required this.isMobile,
+    required this.onToggleExpandAction,
+    this.onDownloadAllAttachmentsAction,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: _toggleExpand,
+      child: Container(
+        padding: const EdgeInsetsDirectional.all(8),
+        decoration: isCollapsed
+            ? null
+            : const BoxDecoration(
+                border: Border(
+                  bottom: BorderSide(
+                    color: AppColor.colorLineComposer,
+                    width: 1,
+                  ),
+                ),
+              ),
+        child: Row(
+          children: [
+            TMailButtonWidget.fromIcon(
+              icon: isCollapsed
+                  ? imagePaths.icArrowRight
+                  : imagePaths.icArrowBottom,
+              iconSize: 20,
+              iconColor: AppColor.steelGrayA540,
+              backgroundColor: Colors.white,
+              padding: EdgeInsets.zero,
+              onTapActionCallback: _toggleExpand,
+            ),
+            const SizedBox(width: 4),
+            Expanded(
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Flexible(
+                    child: Text(
+                      '$countAttachments ${AppLocalizations.of(context).attachments}',
+                      style: ThemeUtils.textStyleInter500().copyWith(
+                        fontSize: 13,
+                        height: 16 / 13,
+                        color: AppColor.steelGrayA540,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Container(
+                    decoration: const BoxDecoration(
+                      color: AppColor.primaryColor,
+                      borderRadius: BorderRadius.all(Radius.circular(12)),
+                    ),
+                    padding: const EdgeInsetsDirectional.symmetric(
+                      horizontal: 5,
+                      vertical: 2,
+                    ),
+                    child: Text(
+                      filesize(totalSizeAttachments),
+                      style: ThemeUtils.textStyleInter500().copyWith(
+                        fontSize: 12,
+                        height: 14 / 12,
+                        color: Colors.white,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 4),
+            if (onDownloadAllAttachmentsAction != null)
+              TMailButtonWidget(
+                icon: imagePaths.icDownloadAll,
+                text: isMobile
+                    ? AppLocalizations.of(context).downloadAll
+                    : AppLocalizations.of(context).archiveAndDownload,
+                iconSize: 20,
+                iconColor: AppColor.steelGrayA540,
+                iconAlignment: TextDirection.rtl,
+                backgroundColor: Colors.transparent,
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                onTapActionCallback: onDownloadAllAttachmentsAction,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _toggleExpand() => onToggleExpandAction(!isCollapsed);
+}

--- a/lib/features/email/presentation/widgets/attachments_pin/email_attachments_pin_widget.dart
+++ b/lib/features/email/presentation/widgets/attachments_pin/email_attachments_pin_widget.dart
@@ -1,0 +1,96 @@
+import 'package:core/presentation/action/action_callback_define.dart';
+import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:model/email/attachment.dart';
+import 'package:model/extensions/list_attachment_extension.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/attachment_item_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/attachments_pin/email_attachments_pin_body_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/attachments_pin/email_attachments_pin_header_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/draggable_attachment_item_widget.dart';
+
+class EmailAttachmentsPinWidget extends StatefulWidget {
+  final List<Attachment> attachments;
+  final String? singleEmailControllerTag;
+  final OnDragAttachmentStarted? onDragStarted;
+  final OnDragAttachmentEnd? onDragEnd;
+  final OnDownloadAttachmentFileAction? onDownloadAttachmentFileAction;
+  final OnViewAttachmentFileAction? onViewAttachmentFileAction;
+  final OnTapActionCallback? onDownloadAllAttachmentsAction;
+
+  const EmailAttachmentsPinWidget({
+    super.key,
+    required this.attachments,
+    this.singleEmailControllerTag,
+    this.onDragStarted,
+    this.onDragEnd,
+    this.onDownloadAttachmentFileAction,
+    this.onViewAttachmentFileAction,
+    this.onDownloadAllAttachmentsAction,
+  });
+
+  @override
+  State<EmailAttachmentsPinWidget> createState() =>
+      _EmailAttachmentsPinWidgetState();
+}
+
+class _EmailAttachmentsPinWidgetState extends State<EmailAttachmentsPinWidget> {
+  final _imagePaths = Get.find<ImagePaths>();
+  final _responsiveUtils = Get.find<ResponsiveUtils>();
+
+  bool _isCollapsed = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        boxShadow: [
+          BoxShadow(
+            color: AppColor.colorShadowBgContentEmail,
+            blurRadius: 24,
+          ),
+          BoxShadow(
+            color: AppColor.colorShadowBgContentEmail,
+            blurRadius: 2,
+          ),
+        ],
+      ),
+      width: double.infinity,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          EmailAttachmentsPinHeaderWidget(
+            countAttachments: widget.attachments.length,
+            totalSizeAttachments: widget.attachments.totalSize,
+            isCollapsed: _isCollapsed,
+            imagePaths: _imagePaths,
+            isMobile: _responsiveUtils.isMobile(context),
+            onToggleExpandAction: _toggleExpand,
+            onDownloadAllAttachmentsAction:
+              widget.onDownloadAllAttachmentsAction,
+          ),
+          if (!_isCollapsed)
+            EmailAttachmentsPinBodyWidget(
+              attachments: widget.attachments,
+              imagePaths: _imagePaths,
+              responsiveUtils: _responsiveUtils,
+              singleEmailControllerTag: widget.singleEmailControllerTag,
+              onDragStarted: widget.onDragStarted,
+              onDragEnd: widget.onDragEnd,
+              downloadAttachmentAction: widget.onDownloadAttachmentFileAction,
+              viewAttachmentAction: widget.onViewAttachmentFileAction,
+            ),
+        ],
+      ),
+    );
+  }
+
+  void _toggleExpand(bool newIsCollapsed) {
+    if (mounted) {
+      setState(() => _isCollapsed = newIsCollapsed);
+    }
+  }
+}

--- a/lib/features/email/presentation/widgets/email_attachments_widget.dart
+++ b/lib/features/email/presentation/widgets/email_attachments_widget.dart
@@ -5,6 +5,7 @@ import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/utils/app_logger.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
 import 'package:model/email/attachment.dart';
@@ -236,7 +237,8 @@ class EmailAttachmentsWidget extends StatelessWidget {
                     crossAxisAlignment: WrapCrossAlignment.center,
                     children: [
                       ...displayedAttachments.map((attachment) {
-                        if (responsiveUtils.isDesktop(context)) {
+                        if (PlatformInfo.isWeb &&
+                            responsiveUtils.isDesktop(context)) {
                           return DraggableAttachmentItemWidget(
                             attachment: attachment,
                             imagePaths: imagePaths,

--- a/lib/features/manage_account/data/datasource_impl/manage_account_datasource_impl.dart
+++ b/lib/features/manage_account/data/datasource_impl/manage_account_datasource_impl.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:tmail_ui_user/features/manage_account/data/datasource/manage_account_datasource.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/preferences_setting_manager.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/pin_attachments_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/spam_report_config.dart';
@@ -38,6 +39,10 @@ class ManageAccountDataSourceImpl extends ManageAccountDataSource {
       } else if (preferencesConfig is SpamReportConfig) {
         await _preferencesSettingManager.updateSpamReport(
           isEnabled: preferencesConfig.isEnabled,
+        );
+      } else if (preferencesConfig is PinAttachmentsConfig) {
+        await _preferencesSettingManager.updatePinAttachments(
+          preferencesConfig.isEnabled,
         );
       } else {
         await _preferencesSettingManager.savePreferences(

--- a/lib/features/manage_account/data/local/preferences_setting_manager.dart
+++ b/lib/features/manage_account/data/local/preferences_setting_manager.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/default_preferences_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/empty_preferences_config.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/pin_attachments_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/spam_report_config.dart';
@@ -14,6 +15,8 @@ class PreferencesSettingManager {
       '${_preferencesSettingKey}_THREAD';
   static const String _preferencesSettingSpamReportKey =
       '${_preferencesSettingKey}_SPAM_REPORT';
+  static const String _preferencesSettingPinAttachmentsKey =
+      '${_preferencesSettingKey}_PIN_ATTACHMENTS';
 
   const PreferencesSettingManager(this._sharedPreferences);
 
@@ -36,6 +39,8 @@ class PreferencesSettingManager {
             return ThreadDetailConfig.fromJson(jsonDecoded);
           case _preferencesSettingSpamReportKey:
             return SpamReportConfig.fromJson(jsonDecoded);
+          case _preferencesSettingPinAttachmentsKey:
+            return PinAttachmentsConfig.fromJson(jsonDecoded);
           default:
             return DefaultPreferencesConfig.fromJson(jsonDecoded);
         }
@@ -59,6 +64,11 @@ class PreferencesSettingManager {
     } else if (config is SpamReportConfig) {
       await _sharedPreferences.setString(
         _preferencesSettingSpamReportKey,
+        jsonEncode(config.toJson()),
+      );
+    } else if (config is PinAttachmentsConfig) {
+      await _sharedPreferences.setString(
+        _preferencesSettingPinAttachmentsKey,
         jsonEncode(config.toJson()),
       );
     } else {
@@ -109,5 +119,23 @@ class PreferencesSettingManager {
     return jsonString == null
         ? ThreadDetailConfig.initial()
         : ThreadDetailConfig.fromJson(jsonDecode(jsonString));
+  }
+
+  Future<PinAttachmentsConfig> getPinAttachmentsConfig() async {
+    await _sharedPreferences.reload();
+
+    final jsonString = _sharedPreferences.getString(
+      _preferencesSettingPinAttachmentsKey,
+    );
+
+    return jsonString == null
+        ? PinAttachmentsConfig.initial()
+        : PinAttachmentsConfig.fromJson(jsonDecode(jsonString));
+  }
+
+  Future<void> updatePinAttachments(bool isEnabled) async {
+    final currentConfig = await getPinAttachmentsConfig();
+    final updatedConfig = currentConfig.copyWith(isEnabled: isEnabled);
+    await savePreferences(updatedConfig);
   }
 }

--- a/lib/features/manage_account/domain/model/preferences/pin_attachments_config.dart
+++ b/lib/features/manage_account/domain/model/preferences/pin_attachments_config.dart
@@ -1,0 +1,30 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_config.dart';
+
+part 'pin_attachments_config.g.dart';
+
+@JsonSerializable()
+class PinAttachmentsConfig extends PreferencesConfig {
+  final bool isEnabled;
+
+  PinAttachmentsConfig({this.isEnabled = true});
+
+  factory PinAttachmentsConfig.initial() => PinAttachmentsConfig();
+
+  factory PinAttachmentsConfig.fromJson(Map<String, dynamic> json) =>
+      _$PinAttachmentsConfigFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$PinAttachmentsConfigToJson(this);
+
+  @override
+  List<Object> get props => [isEnabled];
+}
+
+extension PinAttachmentsConfigExtension on PinAttachmentsConfig {
+  PinAttachmentsConfig copyWith({bool? isEnabled}) {
+    return PinAttachmentsConfig(
+      isEnabled: isEnabled ?? this.isEnabled,
+    );
+  }
+}

--- a/lib/features/manage_account/domain/model/preferences/preferences_setting.dart
+++ b/lib/features/manage_account/domain/model/preferences/preferences_setting.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/pin_attachments_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/spam_report_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/thread_detail_config.dart';
@@ -13,6 +14,7 @@ class PreferencesSetting with EquatableMixin {
     return PreferencesSetting([
       ThreadDetailConfig.initial(),
       SpamReportConfig.initial(),
+      PinAttachmentsConfig.initial(),
     ]);
   }
 
@@ -33,6 +35,16 @@ class PreferencesSetting with EquatableMixin {
       return spamConfig as SpamReportConfig;
     } else {
       return SpamReportConfig.initial();
+    }
+  }
+
+  PinAttachmentsConfig get pinAttachmentsConfig {
+    final pinAttachmentConfig =
+        configs.firstWhereOrNull((config) => config is PinAttachmentsConfig);
+    if (pinAttachmentConfig != null) {
+      return pinAttachmentConfig as PinAttachmentsConfig;
+    } else {
+      return PinAttachmentsConfig.initial();
     }
   }
 

--- a/lib/features/manage_account/domain/model/preferences/spam_report_config.dart
+++ b/lib/features/manage_account/domain/model/preferences/spam_report_config.dart
@@ -14,12 +14,7 @@ class SpamReportConfig extends PreferencesConfig {
     this.lastTimeDismissedMilliseconds = 0,
   });
 
-  factory SpamReportConfig.initial() {
-    return SpamReportConfig(
-      isEnabled: true,
-      lastTimeDismissedMilliseconds: 0,
-    );
-  }
+  factory SpamReportConfig.initial() => SpamReportConfig();
 
   factory SpamReportConfig.fromJson(Map<String, dynamic> json) =>
       _$SpamReportConfigFromJson(json);

--- a/lib/features/manage_account/domain/model/preferences/thread_detail_config.dart
+++ b/lib/features/manage_account/domain/model/preferences/thread_detail_config.dart
@@ -9,11 +9,7 @@ class ThreadDetailConfig extends PreferencesConfig {
 
   ThreadDetailConfig({this.isEnabled = false});
 
-  factory ThreadDetailConfig.initial() {
-    return ThreadDetailConfig(
-      isEnabled: false,
-    );
-  }
+  factory ThreadDetailConfig.initial() => ThreadDetailConfig();
 
   factory ThreadDetailConfig.fromJson(Map<String, dynamic> json) =>
       _$ThreadDetailConfigFromJson(json);

--- a/lib/features/manage_account/presentation/model/preferences_option_type.dart
+++ b/lib/features/manage_account/presentation/model/preferences_option_type.dart
@@ -8,7 +8,8 @@ enum PreferencesOptionType {
   readReceipt(isLocal: false),
   senderPriority(isLocal: false),
   thread(isLocal: true),
-  spamReport(isLocal: true);
+  spamReport(isLocal: true),
+  pinAttachment(isLocal: true);
 
   final bool isLocal;
 
@@ -24,6 +25,8 @@ enum PreferencesOptionType {
         return appLocalizations.thread;
       case PreferencesOptionType.spamReport:
         return appLocalizations.spamReports;
+      case PreferencesOptionType.pinAttachment:
+        return appLocalizations.pinAttachments;
     }
   }
 
@@ -37,6 +40,8 @@ enum PreferencesOptionType {
         return appLocalizations.threadSettingExplanation;
       case PreferencesOptionType.spamReport:
         return appLocalizations.spamReportsSettingExplanation;
+      case PreferencesOptionType.pinAttachment:
+        return appLocalizations.pinAttachmentsSettingExplanation;
     }
   }
 
@@ -50,6 +55,8 @@ enum PreferencesOptionType {
         return appLocalizations.threadToggleDescription;
       case PreferencesOptionType.spamReport:
         return appLocalizations.spamReportToggleDescription;
+      case PreferencesOptionType.pinAttachment:
+        return appLocalizations.pinAttachmentsToggleDescription;
     }
   }
 
@@ -66,6 +73,8 @@ enum PreferencesOptionType {
         return preferencesSetting.threadConfig.isEnabled;
       case PreferencesOptionType.spamReport:
         return preferencesSetting.spamReportConfig.isEnabled;
+      case PreferencesOptionType.pinAttachment:
+        return preferencesSetting.pinAttachmentsConfig.isEnabled;
     }
   }
 }

--- a/lib/features/manage_account/presentation/preferences/preferences_controller.dart
+++ b/lib/features/manage_account/presentation/preferences/preferences_controller.dart
@@ -7,6 +7,7 @@ import 'package:server_settings/server_settings/tmail_server_settings.dart';
 import 'package:tmail_ui_user/features/base/base_controller.dart';
 import 'package:tmail_ui_user/features/home/data/exceptions/session_exceptions.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/loader_status.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/pin_attachments_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/spam_report_config.dart';
@@ -149,6 +150,9 @@ class PreferencesController extends BaseController {
         break;
       case PreferencesOptionType.spamReport:
         config = SpamReportConfig(isEnabled: !isEnabled);
+        break;
+      case PreferencesOptionType.pinAttachment:
+        config = PinAttachmentsConfig(isEnabled: !isEnabled);
         break;
       default:
         break;

--- a/lib/features/thread_detail/presentation/extension/handle_download_attachment_extension.dart
+++ b/lib/features/thread_detail/presentation/extension/handle_download_attachment_extension.dart
@@ -1,0 +1,48 @@
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:model/email/attachment.dart';
+import 'package:rich_text_composer/views/commons/logger.dart';
+import 'package:tmail_ui_user/features/email/presentation/action/email_ui_action.dart';
+import 'package:tmail_ui_user/features/home/domain/extensions/session_extensions.dart';
+import 'package:tmail_ui_user/features/thread_detail/presentation/thread_detail_controller.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+extension HandleDownloadAttachmentExtension on ThreadDetailController {
+  bool isDownloadAllEnabled(int countAttachments) {
+    return session?.isDownloadAllSupported(accountId) == true &&
+        countAttachments > 1;
+  }
+
+  void handleDownloadAttachment(Attachment attachment, EmailId emailIdOpened) {
+    log('$runtimeType::handleDownloadAttachment: Attachment name is ${attachment.name},  Email id opened is $emailIdOpened');
+    mailboxDashBoardController
+      ..dispatchEmailUIAction(DownloadEmailAttachmentInThreadDetailAction(
+          attachment,
+          emailIdOpened,
+        ))
+      ..dispatchEmailUIAction(EmailUIAction());
+  }
+
+  void handleViewAttachment(
+    AppLocalizations appLocalizations,
+    Attachment attachment,
+    EmailId emailIdOpened,
+  ) {
+    log('$runtimeType::handleViewAttachment: Attachment name is ${attachment.name},  Email id opened is $emailIdOpened');
+    mailboxDashBoardController
+      ..dispatchEmailUIAction(ViewEmailAttachmentInThreadDetailAction(
+          appLocalizations,
+          attachment,
+          emailIdOpened,
+        ))
+      ..dispatchEmailUIAction(EmailUIAction());
+  }
+
+  void handleDownloadAllAttachmentsAction(EmailId emailIdOpened) {
+    log('$runtimeType::handleDownloadAllAttachmentsAction: Email id opened is $emailIdOpened');
+    mailboxDashBoardController
+      ..dispatchEmailUIAction(DownloadAllEmailAttachmentInThreadDetailAction(
+          emailIdOpened
+        ))
+      ..dispatchEmailUIAction(EmailUIAction());
+  }
+}

--- a/lib/features/thread_detail/presentation/extension/setup_pin_attachment_status_extension.dart
+++ b/lib/features/thread_detail/presentation/extension/setup_pin_attachment_status_extension.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/loader_status.dart';
+import 'package:tmail_ui_user/features/thread_detail/presentation/thread_detail_controller.dart';
+
+extension SetupPinAttachmentStatusExtension on ThreadDetailController {
+  void getPinAttachmentsStatus() {
+    consumeState(getPinAttachmentStatusInteractor.execute());
+  }
+
+  void updatePinAttachmentsStatus(bool isEnabled) {
+    isAttachmentsPinEnabled.value = isEnabled;
+  }
+
+  void triggerAppState() {
+    appLifecycleListener ??= AppLifecycleListener(
+      onResume: () {
+        if (pinAttachmentsLoaderStatus == LoaderStatus.loading) {
+          return;
+        }
+        getPinAttachmentsStatus();
+      },
+    );
+  }
+
+  void updatePinAttachmentsLoaderStatus(LoaderStatus loaderStatus) {
+    pinAttachmentsLoaderStatus = loaderStatus;
+  }
+}

--- a/lib/features/thread_detail/presentation/thread_detail_bindings.dart
+++ b/lib/features/thread_detail/presentation/thread_detail_bindings.dart
@@ -4,6 +4,7 @@ import 'package:jmap_dart_client/http/http_client.dart';
 import 'package:tmail_ui_user/features/base/base_bindings.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/download_attachment_for_web_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_email_content_interactor.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/get_pin_attachment_status_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_email_read_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_star_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/print_email_interactor.dart';
@@ -47,6 +48,7 @@ class ThreadDetailBindings extends BaseBindings {
       Get.find<DownloadAttachmentForWebInteractor>(),
       Get.find<MarkAsStarMultipleEmailInteractor>(),
       Get.find<MarkAsMultipleEmailReadInteractor>(),
+      Get.find<GetPinAttachmentStatusInteractor>(),
     ));
   }
 

--- a/lib/features/thread_detail/presentation/thread_detail_controller.dart
+++ b/lib/features/thread_detail/presentation/thread_detail_controller.dart
@@ -87,6 +87,7 @@ class ThreadDetailController extends BaseController {
   final currentExpandedEmailId = Rxn<EmailId>();
   final currentEmailLoaded = Rxn<EmailLoaded>();
   final emailsInThreadDetailInfo = RxList<EmailInThreadDetailInfo>();
+  final isAttachmentsPinEnabled = RxBool(true);
 
   late final EmailActionReactor emailActionReactor;
   final additionalProperties = Properties({

--- a/lib/features/thread_detail/presentation/thread_detail_view.dart
+++ b/lib/features/thread_detail/presentation/thread_detail_view.dart
@@ -9,12 +9,14 @@ import 'package:get/get.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:tmail_ui_user/features/email/presentation/action/email_ui_action.dart';
 import 'package:tmail_ui_user/features/email/presentation/styles/email_view_app_bar_widget_styles.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/attachments_pin/email_attachments_pin_widget.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/email_view_bottom_bar_widget.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/extensions/vacation_response_extension.dart';
 import 'package:tmail_ui_user/features/thread_detail/domain/state/get_thread_by_id_state.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/extension/close_thread_detail_action.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/extension/get_thread_detail_action_status.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/extension/get_thread_details_email_views.dart';
+import 'package:tmail_ui_user/features/thread_detail/presentation/extension/handle_download_attachment_extension.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/extension/on_thread_detail_action_click.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/extension/on_thread_page_changed.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/thread_detail_controller.dart';
@@ -152,6 +154,58 @@ class ThreadDetailView extends GetWidget<ThreadDetailController> {
           }
 
           return nonPageViewThread;
+        }),
+        Obx(() {
+          final expandedEmailId = controller.currentExpandedEmailId.value;
+          if (expandedEmailId == null) {
+            return const SizedBox.shrink();
+          }
+          final expandedPresentationEmail = controller.emailIdsPresentation[expandedEmailId];
+          if (expandedPresentationEmail == null) {
+            return const SizedBox.shrink();
+          }
+
+          final currentEmailLoaded = controller.currentEmailLoaded.value;
+          if (currentEmailLoaded == null) {
+            return const SizedBox.shrink();
+          }
+
+          if (currentEmailLoaded.attachments.isEmpty ||
+              controller.isAttachmentsPinEnabled.isFalse) {
+            return const SizedBox.shrink();
+          }
+          final dashboardController =
+              controller.mailboxDashBoardController;
+
+          final isDownloadAllEnabled = controller.isDownloadAllEnabled(
+            currentEmailLoaded.attachments.length,
+          );
+
+          final emailIdOpened = expandedPresentationEmail.id!;
+
+          return EmailAttachmentsPinWidget(
+            attachments: currentEmailLoaded.attachments,
+            singleEmailControllerTag: tag,
+            onDragStarted: dashboardController.enableAttachmentDraggableApp,
+            onDragEnd: (_) =>
+                dashboardController.disableAttachmentDraggableApp(),
+            onDownloadAttachmentFileAction: (attachment) =>
+                controller.handleDownloadAttachment(
+                  attachment,
+                  emailIdOpened,
+                ),
+            onViewAttachmentFileAction: (attachment) =>
+                controller.handleViewAttachment(
+                  AppLocalizations.of(context),
+                  attachment,
+                  emailIdOpened,
+                ),
+            onDownloadAllAttachmentsAction: isDownloadAllEnabled
+                ? () => controller.handleDownloadAllAttachmentsAction(
+                    emailIdOpened,
+                  )
+                : null,
+          );
         }),
         Obx(() {
           final expandedEmailId = controller.currentExpandedEmailId.value;

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2025-09-11T12:24:54.969188",
+  "@@last_modified": "2025-09-17T13:26:24.972125",
   "initializing_data": "Initializing data...",
   "@initializing_data": {
     "type": "text",
@@ -4842,7 +4842,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "attachmentReminderModalMessage": "You wrote {keyword} in your message but did not add any attachments. Do you still want to send ?",
+  "attachmentReminderModalMessage": "You wrote {keyword} in your message but did not add any attachments. Do you still want to send?",
   "@attachmentReminderModalMessage": {
     "type": "text",
     "placeholders_order": [
@@ -4866,6 +4866,24 @@
   },
   "spamReportToggleDescription": "Enable spam report",
   "@spamReportToggleDescription": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "pinAttachments": "Pin attachments",
+  "@pinAttachments": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "pinAttachmentsSettingExplanation": "Show pinned attachment list at the bottom of the Email View",
+  "@pinAttachmentsSettingExplanation": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "pinAttachmentsToggleDescription": "Enable pin attachments",
+  "@pinAttachmentsToggleDescription": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -5145,4 +5145,25 @@ class AppLocalizations {
       name: 'spamReportToggleDescription',
     );
   }
+
+  String get pinAttachments {
+    return Intl.message(
+      'Pin attachments',
+      name: 'pinAttachments',
+    );
+  }
+
+  String get pinAttachmentsSettingExplanation {
+    return Intl.message(
+      'Show pinned attachment list at the bottom of the Email View',
+      name: 'pinAttachmentsSettingExplanation',
+    );
+  }
+
+  String get pinAttachmentsToggleDescription {
+    return Intl.message(
+      'Enable pin attachments',
+      name: 'pinAttachmentsToggleDescription',
+    );
+  }
 }


### PR DESCRIPTION
## Issue

With the current design, the attachment list is pushed to the bottom of the email content. For long emails, users have to spend time scrolling all the way down before they can see the attachments.

## Solution

- We will `pin the attachments` at the bottom of the Email View so that users can always see them.
- Users will be able to `expand/collapse` this pinned attachment section to view all attachments or hide them.
- The pinned attachment thread will only be displayed for `emails that are expanded`.
- The maximum height of the pinned widget when expanded is `150dp`.
- Add an option in `Settings` to enable or disable pinned attachments.

## Resolved



- Web: 


https://github.com/user-attachments/assets/99f77b93-f502-41be-93db-ecf86f11b39b



- Mobile:

[Screen_recording_20250916_153912.webm](https://github.com/user-attachments/assets/6bda490b-cb4c-4f71-92c7-ca1288834510)

- Setup in Setting


https://github.com/user-attachments/assets/faab6c46-3b38-4610-bcaf-56fe14e3ef78



- E2E console:

```console

🧪 Should see save dialog when download all attachments successfully
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
✅ Should see save dialog when download all attachments successfully 

Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: ../tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 50s

🧪 Should auto preview attachment when export attachment successfully
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. enterText widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
✅ Should auto preview attachment when export attachment successfully 

Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: ../tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 41s

```