### PR TITLE
Fix cannot drag & drop attachment from email detailed view to composer on web

### DIFF
--- a/lib/features/composer/presentation/composer_view_web.dart
+++ b/lib/features/composer/presentation/composer_view_web.dart
@@ -315,6 +315,7 @@ class ComposerView extends GetWidget<ComposerController> {
                               margin: ComposerStyle.insertImageLoadingBarMargin,
                             )),
                           ),
+                          iframeOverlay,
                           Obx(() {
                             if (controller.mailboxDashBoardController.isAttachmentDraggableAppActive) {
                               return Positioned.fill(
@@ -352,7 +353,6 @@ class ComposerView extends GetWidget<ComposerController> {
                               return const SizedBox.shrink();
                             }
                           }),
-                          iframeOverlay,
                         ],
                       );
                     }
@@ -634,6 +634,7 @@ class ComposerView extends GetWidget<ComposerController> {
                             margin: ComposerStyle.insertImageLoadingBarMargin,
                           )),
                         ),
+                        iframeOverlay,
                         Obx(() {
                           if (controller.mailboxDashBoardController.isAttachmentDraggableAppActive) {
                             return Positioned.fill(
@@ -671,7 +672,6 @@ class ComposerView extends GetWidget<ComposerController> {
                             return const SizedBox.shrink();
                           }
                         }),
-                        iframeOverlay,
                       ],
                     );
                   }
@@ -955,6 +955,7 @@ class ComposerView extends GetWidget<ComposerController> {
                             margin: ComposerStyle.insertImageLoadingBarMargin,
                           )),
                         ),
+                        iframeOverlay,
                         Obx(() {
                           if (controller.mailboxDashBoardController.isAttachmentDraggableAppActive) {
                             return Positioned.fill(
@@ -992,7 +993,6 @@ class ComposerView extends GetWidget<ComposerController> {
                             return const SizedBox.shrink();
                           }
                         }),
-                        iframeOverlay,
                       ],
                     );
                   },


### PR DESCRIPTION
## Issue

Cannot drag & drop attachment from email detailed view to composer on web


https://github.com/user-attachments/assets/e4916f37-af03-4505-a58c-4877dca46fc5

## Root cause 

Because the `HtmlElementView` of `PointerInterceptor` overlays `DragTarget` making it unlistenable

## Side effect 

- From PR: https://github.com/linagora/tmail-flutter/pull/3954

## Resolved


https://github.com/user-attachments/assets/681174f8-c1c3-4d7b-89d0-83e68958a07f

