### PR TITLE
Fix cannot send email after close attachment reminder dialog

### DIFF
--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -931,7 +931,7 @@ class ComposerController extends BaseController
         onCancelAction: () {
           _sendButtonState = ButtonState.enabled;
         }
-      );
+      ).whenComplete(() => _sendButtonState = ButtonState.enabled);
       return;
     }
 
@@ -1094,7 +1094,7 @@ class ComposerController extends BaseController
           _closeComposerAction(closeOverlays: true);
         }
       },
-    );
+    ).whenComplete(() => _sendButtonState = ButtonState.enabled);
   }
 
   void _checkContactPermission() async {

--- a/lib/features/composer/presentation/extensions/attachment_detection_extension.dart
+++ b/lib/features/composer/presentation/extensions/attachment_detection_extension.dart
@@ -28,7 +28,7 @@ extension AttachmentDetectionExtension on ComposerController {
     }
   }
 
-  void showAttachmentReminderModal({
+  Future<void> showAttachmentReminderModal({
     required BuildContext context,
     required List<String> keywords,
     required VoidCallback onConfirmAction,
@@ -37,7 +37,7 @@ extension AttachmentDetectionExtension on ComposerController {
     final appLocalizations = AppLocalizations.of(context);
     String formattedKeywords = keywords.map((k) => '"$k"').join(', ');
     log('$runtimeType::showAttachmentReminderModal:formattedKeywords = $formattedKeywords');
-    MessageDialogActionManager().showConfirmDialogAction(
+    return MessageDialogActionManager().showConfirmDialogAction(
       key: const Key('attachment_reminder_modal'),
       context,
       title: appLocalizations.attachmentReminderModalTitle,


### PR DESCRIPTION
## Issue

https://github.com/linagora/tmail-flutter/issues/4022#issuecomment-3305357661

## Root cause

Do not update the status of the send button after closing the attachment reminder dialog

## Resolved



https://github.com/user-attachments/assets/3a7f1ae2-fb36-43a3-a95f-6b42ca789eba




