### PR TITLE
Fix cannot next previous email on web

### DIFF
--- a/lib/features/thread_detail/presentation/extension/thread_detail_next_previous_actions.dart
+++ b/lib/features/thread_detail/presentation/extension/thread_detail_next_previous_actions.dart
@@ -55,7 +55,9 @@ extension ThreadDetailNextPreviousActions on ThreadDetailManager {
 
   void _navigateToEmail(int emailIndex) {
     final email = currentDisplayedEmails[emailIndex];
-    _preparePageWithIndex(emailIndex);
+    if (PlatformInfo.isMobile) {
+      _preparePageWithIndex(emailIndex);
+    }
     _goToPageWithEmail(email);
   }
 
@@ -64,7 +66,9 @@ extension ThreadDetailNextPreviousActions on ThreadDetailManager {
     final email = currentDisplayedEmails.firstWhereOrNull(
       (presentationEmail) => presentationEmail.threadId == threadId,
     );
-    _preparePageWithIndex(threadIndex);
+    if (PlatformInfo.isMobile) {
+      _preparePageWithIndex(threadIndex);
+    }
     _goToPageWithEmail(email);
   }
 


### PR DESCRIPTION
## Issue

https://github.com/linagora/tmail-flutter/issues/4022#issuecomment-3305433124

## Root cause

ScrollController of PageController not attached to any scroll views. Because PageController only use for mobile

## Side effect

From PR: https://github.com/linagora/tmail-flutter/pull/3990 

## Resolved



https://github.com/user-attachments/assets/c635d580-8a5b-4f93-9689-3b86a20ef70d

