### PR TITLE
Fix email content is broken when perform previous/next email then back to app

### DIFF
--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -372,7 +372,9 @@ class EmailView extends GetWidget<SingleEmailController> {
                             horizontal: EmailViewStyles.mobileContentHorizontalMargin,
                           ),
                           child: HtmlContentViewer(
-                            key: controller.htmlContentViewKey,
+                            key: PlatformInfo.isIntegrationTesting
+                                ? controller.htmlContentViewKey
+                                : null,
                             contentHtml: allEmailContents,
                             initialWidth: bodyConstraints.maxWidth,
                             direction: AppUtils.getCurrentDirection(context),
@@ -411,7 +413,9 @@ class EmailView extends GetWidget<SingleEmailController> {
                     horizontal: EmailViewStyles.mobileContentHorizontalMargin
                   ),
                   child: HtmlContentViewer(
-                    key: controller.htmlContentViewKey,
+                    key: PlatformInfo.isIntegrationTesting
+                        ? controller.htmlContentViewKey
+                        : null,
                     contentHtml: allEmailContents,
                     initialWidth: bodyConstraints.maxWidth,
                     direction: AppUtils.getCurrentDirection(context),

--- a/lib/features/thread_detail/presentation/extension/get_thread_details_email_views.dart
+++ b/lib/features/thread_detail/presentation/extension/get_thread_details_email_views.dart
@@ -69,7 +69,6 @@ extension GetThreadDetailEmailViews on ThreadDetailController {
         return Padding(
           padding: const EdgeInsetsDirectional.only(bottom: 16),
           child: EmailView(
-            key: GlobalObjectKey('${presentationEmail.id?.id.value ?? ''}firstInThread'),
             isInsideThreadDetailView: true,
             emailId: presentationEmail.id,
             isFirstEmailInThreadDetail: true,
@@ -85,7 +84,6 @@ extension GetThreadDetailEmailViews on ThreadDetailController {
       return Padding(
         padding: const EdgeInsetsDirectional.only(bottom: 16),
         child: EmailView(
-          key: GlobalObjectKey(presentationEmail.id?.id.value ?? ''),
           isInsideThreadDetailView: true,
           emailId: presentationEmail.id,
           onToggleThreadDetailCollapseExpand: () {

--- a/lib/features/thread_detail/presentation/thread_detail_view.dart
+++ b/lib/features/thread_detail/presentation/thread_detail_view.dart
@@ -136,9 +136,6 @@ class ThreadDetailView extends GetWidget<ThreadDetailController> {
                         ? manager.availableThreadIds.length
                         : manager.currentDisplayedEmails.length,
                     itemBuilder: (context, index) {
-                      if (index != currentIndex) {
-                        return const SizedBox.shrink();
-                      }
                       return SingleChildScrollView(child: threadBody);
                     },
                     onPageChanged: controller.onThreadPageChanged,


### PR DESCRIPTION
## Issue

Email content is broken when perform previous/next email, click hyper link then back to app

## Root cause

Page index change causes widget to render empty

## Resolved


https://github.com/user-attachments/assets/09c0a883-a990-40c1-8440-d317333c7387


