### PR TITLE
Fix click twice on the signature collapse button to view signature when composer has Cc or Bcc

### DIFF
--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1908,14 +1908,14 @@ class ComposerController extends BaseController
     if (mailboxDashBoardController.isPopupMenuOpened.isTrue) {
       popBack();
     }
+    if (PlatformInfo.isWeb) {
+      _hideCcBccReplyToRecipients();
+    }
   }
 
   void handleOnMouseDownHtmlEditorWeb() {
     _collapseAllRecipient();
     autoCreateEmailTag();
-    if (PlatformInfo.isWeb) {
-      _hideCcBccReplyToRecipients();
-    }
   }
 
   FocusNode? getNextFocusOfToEmailAddress() {


### PR DESCRIPTION
## Issue

https://github.com/linagora/tmail-flutter/issues/4022#issuecomment-3305876552

## Root cause 

We hide `Cc, Bcc` in the` onMouseDown` event of the editor, causing the editor to lose focus, resulting in the signature toggle not receiving the click event.

## Resolved



https://github.com/user-attachments/assets/59759d83-99e7-419f-b43f-f180ed2b3afd


