### PR TITLE
TF-4051 Fix text and images are truncated on mobile in received emails

### DIFF
--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -150,6 +150,16 @@ class HtmlUtils {
         table {
           white-space: normal !important;
         }
+              
+        @media only screen and (max-width: 600px) {
+          table {
+            width: 100% !important;
+          }
+          
+          a {
+            width: -webkit-fill-available !important;
+          }
+        }
         
         ${styleCSS ?? ''}
       </style>


### PR DESCRIPTION
## Issue

#4051 

## Root cause 

The email content contains html tags (specifically `table`, `a` ) with a specific width set, so when the screen width is smaller than the width of the tag, it will be scrolled according to the set width.

## Resolved

- Android:

[android.webm](https://github.com/user-attachments/assets/a11a04ce-14c0-435d-a064-c995f010bb05)

- iOS:

https://github.com/user-attachments/assets/fc4835d0-4a92-4a13-a774-b937acc79afb


- Web:


https://github.com/user-attachments/assets/0cd14e55-aa5a-4ae1-a72e-7f7995e230f5

