### PR TITLE
[HOT] Fix cannot next & previous email when thread is disabled on web

### DIFF
--- a/lib/features/thread_detail/presentation/extension/get_thread_details_email_views.dart
+++ b/lib/features/thread_detail/presentation/extension/get_thread_details_email_views.dart
@@ -1,3 +1,4 @@
+import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 import 'package:model/extensions/presentation_email_extension.dart';
 import 'package:tmail_ui_user/features/email/presentation/email_view.dart';
@@ -69,6 +70,9 @@ extension GetThreadDetailEmailViews on ThreadDetailController {
         return Padding(
           padding: const EdgeInsetsDirectional.only(bottom: 16),
           child: EmailView(
+            key: PlatformInfo.isWeb
+                ? GlobalObjectKey(presentationEmail.id?.id.value ?? '')
+                : null,
             isInsideThreadDetailView: true,
             emailId: presentationEmail.id,
             isFirstEmailInThreadDetail: true,
@@ -84,6 +88,9 @@ extension GetThreadDetailEmailViews on ThreadDetailController {
       return Padding(
         padding: const EdgeInsetsDirectional.only(bottom: 16),
         child: EmailView(
+          key: PlatformInfo.isWeb
+              ? GlobalObjectKey(presentationEmail.id?.id.value ?? '')
+              : null,
           isInsideThreadDetailView: true,
           emailId: presentationEmail.id,
           onToggleThreadDetailCollapseExpand: () {


### PR DESCRIPTION
## Issue

Cannot `Next` & `Previous` email when thread is disabled on web

## Root cause

SingleEmailController is destroyed but EmailView takes the id of the previously destroyed controller

## Reproduce



https://github.com/user-attachments/assets/8394fd0e-1284-4a5c-b4f0-137d400e20d9

## Resolved


- Web:

https://github.com/user-attachments/assets/b980c3bb-60a2-444b-9804-8f0c96f8fefc

- Mobile:

[demo-android.webm](https://github.com/user-attachments/assets/b76abfa2-9587-4c8a-8cb7-c651029805c3)
