### PR TITLE
TF-4056 Persist filter search when change quick search input text

### DIFF
--- a/core/lib/presentation/extensions/string_extension.dart
+++ b/core/lib/presentation/extensions/string_extension.dart
@@ -98,4 +98,6 @@ extension StringExtension on String {
       return 0;
     }
   }
+
+  String get trimmed => trim();
 }

--- a/integration_test/robots/search_robot.dart
+++ b/integration_test/robots/search_robot.dart
@@ -85,4 +85,14 @@ class SearchRobot extends CoreRobot {
   Future<void> tapBackButton() async {
     await $(#search_email_back_button).tap();
   }
+
+  Future<void> selectAttachmentFilter() async {
+    await $.scrollUntilVisible(
+      finder: $(#mobile_hasAttachment_search_filter_button),
+      view: $(#search_filter_list_view),
+      scrollDirection: AxisDirection.right,
+      delta: 50,
+    );
+    await $(#mobile_hasAttachment_search_filter_button).tap();
+  }
 }

--- a/integration_test/scenarios/search/persist_filter_when_change_search_input_text_scenario.dart
+++ b/integration_test/scenarios/search/persist_filter_when_change_search_input_text_scenario.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_filters/search_filter_button.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/search_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class PersistFilterWhenChangeSearchInputTextScenario
+    extends BaseTestScenario {
+  const PersistFilterWhenChangeSearchInputTextScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const email = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const subject = 'Persist search filter';
+    const queryStringFirst = 'Persist';
+    const queryStringSecond = 'Persist search';
+
+    final threadRobot = ThreadRobot($);
+    final searchRobot = SearchRobot($);
+
+    final file = await preparingTxtFile('attachment');
+    await provisionEmail(
+      [
+        ProvisioningEmail(
+          toEmail: email,
+          subject: subject,
+          content: subject,
+          attachmentPaths: [file.path],
+        ),
+      ],
+      requestReadReceipt: false,
+    );
+    await $.pumpAndSettle();
+
+    await threadRobot.tapOnSearchField();
+    await searchRobot.enterKeyword(queryStringFirst);
+    await searchRobot.tapOnShowAllResultsText();
+    await _expectEmailWithSubjectVisible(subject);
+
+    await searchRobot.selectAttachmentFilter();
+    await _expectEmailWithSubjectVisible(subject);
+    _expectAttachmentFilterSelected();
+
+    await searchRobot.enterKeyword(queryStringSecond);
+    await _expectEmailWithSubjectVisible(subject);
+    _expectAttachmentFilterSelected();
+  }
+
+  Future<void> _expectEmailWithSubjectVisible(String subject) async {
+    await expectViewVisible($(find.text(subject)));
+  }
+
+  void _expectAttachmentFilterSelected() {
+    expect(
+      $(#mobile_hasAttachment_search_filter_button)
+          .which<SearchFilterButton>((widget) => widget.isSelected)
+          .visible,
+      true,
+    );
+  }
+}

--- a/integration_test/tests/search/persist_filter_when_change_search_input_text_test.dart
+++ b/integration_test/tests/search/persist_filter_when_change_search_input_text_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/search/persist_filter_when_change_search_input_text_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see the same email when selecting filter and changing search input text',
+    scenarioBuilder: ($) => PersistFilterWhenChangeSearchInputTextScenario($),
+  );
+}

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -262,12 +262,6 @@ class MailboxController extends BaseMailboxController
       _handleNavigationRouteParameters
     );
 
-    ever(mailboxDashBoardController.dashBoardAction, (action) {
-      if (action is ClearSearchEmailAction) {
-        _switchBackToMailboxDefault();
-      }
-    });
-
     ever(mailboxDashBoardController.mailboxUIAction, (action) {
       if (action is SelectMailboxDefaultAction) {
         _switchBackToMailboxDefault();

--- a/lib/features/mailbox_dashboard/presentation/action/dashboard_action.dart
+++ b/lib/features/mailbox_dashboard/presentation/action/dashboard_action.dart
@@ -58,8 +58,6 @@ class StartSearchEmailAction extends DashBoardAction {}
 
 class EmptyTrashAction extends DashBoardAction {}
 
-class ClearSearchEmailAction extends DashBoardAction {}
-
 class ClearAllFieldOfAdvancedSearchAction extends DashBoardAction {}
 
 class OpenEmailInsideMailboxFromLocationBar extends DashBoardAction {

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -998,11 +998,6 @@ class MailboxDashBoardController extends ReloadableController
       && dashboardRoute.value == DashboardRoutes.threadDetailed;
   }
 
-  void clearSearchEmail() {
-    dispatchAction(ClearSearchEmailAction());
-    searchController.disableSimpleSearch();
-  }
-
   void _unSelectedMailbox() {
     selectedMailbox.value = null;
   }

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -968,7 +968,6 @@ class MailboxDashBoardController extends ReloadableController
   void searchEmailByQueryString(String queryString) {
     final isMailAddress = EmailUtils.isEmailAddressValid(queryString);
     log('MailboxDashBoardController::searchEmailByQueryString():QueryString = $queryString | isMailAddress = $isMailAddress');
-    clearFilterMessageOption();
     if (_searchInsideThreadDetailViewIsActive()) {
       _closeEmailDetailedView();
     }

--- a/lib/features/mailbox_dashboard/presentation/controller/search_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/search_controller.dart
@@ -231,13 +231,6 @@ class SearchController extends BaseController with DateRangePickerMixin {
     searchState.value = searchState.value.enableSearchState();
   }
 
-  void disableSimpleSearch() {
-    updateFilterEmail(textOption: Some(SearchQuery.initial()));
-    _clearAllTextInputSimpleSearch();
-    deactivateSimpleSearch();
-    hideSimpleSearchFormView();
-  }
-
   void clearTextSearch() {
     searchInputController.clear();
     searchFocus.requestFocus();

--- a/lib/features/mailbox_dashboard/presentation/controller/search_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/search_controller.dart
@@ -143,17 +143,16 @@ class SearchController extends BaseController with DateRangePickerMixin {
   void applyFilterSuggestionToSearchFilter(String currentUserEmail) {
     final receiveTime = listFilterOnSuggestionForm.contains(QuickSearchFilter.last7Days)
       ? EmailReceiveTimeType.last7Days
-      : EmailReceiveTimeType.allTime;
+      : null;
 
-    final hasAttachment = listFilterOnSuggestionForm.contains(QuickSearchFilter.hasAttachment) ? true : false;
+    final hasAttachment = listFilterOnSuggestionForm.contains(QuickSearchFilter.hasAttachment)
+        ? true
+        : null;
 
     var listFromAddress = searchEmailFilter.value.from;
-    if (currentUserEmail.isNotEmpty) {
-      if (listFilterOnSuggestionForm.contains(QuickSearchFilter.fromMe)) {
-        listFromAddress.add(currentUserEmail);
-      } else {
-        listFromAddress.remove(currentUserEmail);
-      }
+    if (currentUserEmail.isNotEmpty &&
+        listFilterOnSuggestionForm.contains(QuickSearchFilter.fromMe)) {
+      listFromAddress.add(currentUserEmail);
     }
 
     final listHasKeyword = listFilterOnSuggestionForm.contains(QuickSearchFilter.starred)
@@ -161,10 +160,10 @@ class SearchController extends BaseController with DateRangePickerMixin {
       : null;
 
     updateFilterEmail(
-      emailReceiveTimeTypeOption: Some(receiveTime),
-      hasAttachmentOption: Some(hasAttachment),
+      emailReceiveTimeTypeOption: receiveTime != null ? Some(receiveTime) : null,
+      hasAttachmentOption: hasAttachment != null ? Some(hasAttachment) : null,
       fromOption: Some(listFromAddress),
-      hasKeywordOption: optionOf(listHasKeyword),
+      hasKeywordOption: listHasKeyword != null ? Some(listHasKeyword) : null,
     );
 
     clearFilterSuggestion();

--- a/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
@@ -168,9 +168,6 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
     }
 
     if (queryString.isNotEmpty || _searchController.listFilterOnSuggestionForm.isNotEmpty) {
-      _searchController.clearSearchFilter(
-        sortOrderType: _dashBoardController.currentSortOrder,
-      );
       _searchController.applyFilterSuggestionToSearchFilter(
         _dashBoardController.ownEmailAddress.value,
       );
@@ -208,9 +205,6 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
     _searchController.searchInputController.text = recent.value;
     _searchController.searchFocus.unfocus();
     _searchController.enableSearch();
-    _searchController.clearSearchFilter(
-      sortOrderType: _dashBoardController.currentSortOrder,
-    );
     _searchController.applyFilterSuggestionToSearchFilter(
       _dashBoardController.ownEmailAddress.value,
     );

--- a/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/extensions/string_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/utils/theme_utils.dart';
@@ -160,21 +161,22 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
 
   void _invokeSearchEmailAction(String queryString) {
     log('SearchInputFormWidget::_invokeSearchEmailAction:QueryString = $queryString');
+    final trimmedQueryString = queryString.trimmed;
+
     _searchController.searchFocus.unfocus();
     _searchController.enableSearch();
 
-    if (queryString.isNotEmpty) {
-      _saveRecentSearch(queryString);
+    if (trimmedQueryString.isNotEmpty) {
+      _saveRecentSearch(trimmedQueryString);
     }
 
-    if (queryString.isNotEmpty || _searchController.listFilterOnSuggestionForm.isNotEmpty) {
+    if (_searchController.listFilterOnSuggestionForm.isNotEmpty) {
       _searchController.applyFilterSuggestionToSearchFilter(
         _dashBoardController.ownEmailAddress.value,
       );
-      _dashBoardController.searchEmailByQueryString(queryString);
-    } else {
-      _dashBoardController.clearSearchEmail();
     }
+
+    _dashBoardController.searchEmailByQueryString(trimmedQueryString);
   }
 
   void _saveRecentSearch(String queryString) {
@@ -189,7 +191,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
     _searchController.saveRecentSearch(
       accountId,
       userName,
-      RecentSearch.now(queryString),
+      RecentSearch.now(queryString.trimmed),
     );
   }
 

--- a/lib/features/search/email/presentation/search_email_controller.dart
+++ b/lib/features/search/email/presentation/search_email_controller.dart
@@ -603,9 +603,6 @@ class SearchEmailController extends BaseController
     listResultSearch.clear();
     emailReceiveTimeType.value = EmailReceiveTimeType.allTime;
     emailSortOrderType.value = mailboxDashBoardController.currentSortOrder;
-    searchEmailFilter.value = SearchEmailFilter.withSortOrder(
-      emailSortOrderType.value,
-    );
     searchIsRunning.value = false;
     final isMailAddress = EmailUtils.isEmailAddressValid(queryString);
     if (isMailAddress) {


### PR DESCRIPTION
## Issue

#4056

## Resolved

- Demo

https://github.com/user-attachments/assets/3ab15b28-791d-42a6-a328-325d5da816e6

- E2E Console:

```console
🧪 Should see the same email when selecting filter and changing search input text
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. enterText widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  10. waitUntilVisible widgets with text containing 1d37cdea321e.ngrok-free.app.
        ✅  11. tap widgets with text "Next".
        ✅  12. waitUntilVisible widgets with key [<'credential_input_form'>] descending from widgets with type "LoginView".
        ✅  13. enterText widgets with type "TextField" descending from widgets with key [<'login_username_input'>].
✅ Should see the same email when selecting filter and changing search input text (integration_test/tests/search/per

Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: file:///Users/datvu/WorkingSpace/tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 41s
```

[Screen_recording_20250925_090703.webm](https://github.com/user-attachments/assets/951f0dea-a3ce-414a-b92c-1b95ee238624)

