### PR TITLE
[CI] Fix prevent "No space left on device" by cleaning up and using release build

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -5,6 +5,9 @@ on:
 
 name: Deploy PR on Github Pages
 
+env:
+  FLUTTER_VERSION: 3.27.4
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
@@ -17,33 +20,61 @@ jobs:
       url: ${{ steps.configure.outputs.URL }}
 
     steps:
+      # 🧹 Free up space before building
+      - name: Free up disk space before build
+        run: |
+          echo "=== Disk space before cleanup ==="
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo apt-get clean
+          sudo apt-get autoclean
+          echo "=== Disk space after cleanup ==="
+          df -h
+
+      # 🔄 Checkout code
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup flutter
+      # 🧰 Setup Flutter
+      - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.27.4"
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: "stable"
           cache: true
           cache-key: deps-${{ hashFiles('**/pubspec.lock') }} # optional, change this to force refresh cache
           cache-path: ${{ runner.tool_cache }}/flutter # optional, change this to specify the cache path
 
+      # 🧹 Clean Flutter cache before building
+      - name: Flutter clean
+        run: flutter clean
+
+      # 📦 Run prebuild (if any)
       - name: Run prebuild
         run: ./scripts/prebuild.sh
 
+      # ⚙️ Configure environment for PR
       - name: Configure environments
         id: configure
         env:
           FOLDER: ${{ github.event.pull_request.number }}
         run: ./scripts/configure-web-environment.sh
 
-      - name: Build
+      # 🧱 Build Flutter Web (release)
+      - name: Build Web (Release)
         env:
           FOLDER: ${{ github.event.pull_request.number }}
-        run: ./scripts/build-web.sh
+        run: |
+          echo "=== Disk usage before build ==="
+          df -h
+          ./scripts/build-web.sh
+          echo "=== Disk usage after build ==="
+          df -h
 
-      - name: Deploy to Github Pages
+      # 🚀 Deploy to GitHub Pages
+      - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -51,6 +82,16 @@ jobs:
           keep_files: true
           publish_dir: "build/web"
 
+      # 🧹 Clean up after build to save space
+      - name: Cleanup after deploy
+        if: always()
+        run: |
+          rm -rf build/
+          rm -rf .dart_tool/
+          echo "=== Disk usage after cleanup ==="
+          df -h
+
+      # 💬 Create or update comments on PR
       - name: Find deployment comment
         uses: peter-evans/find-comment@v3
         id: fc

--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
 
 set -eux
-flutter build web --profile --verbose --base-href "/${GITHUB_REPOSITORY##*/}/$FOLDER/"
+
+# Build web in release mode (lightweight, optimized)
+flutter build web --release --base-href "/${GITHUB_REPOSITORY##*/}/$FOLDER/"


### PR DESCRIPTION
## Issue

The GitHub Actions workflow failed during the Flutter web build step with the following error:
```console
System.IO.IOException: No space left on device
```
This caused the CI job to stop before completing the build and deployment process.

## Root cause

The failure occurred because the GitHub Actions runner (with a storage limit of ~14 GB) ran out of available disk space.
The workflow was building the Flutter web app in --profile mode with the --verbose flag, which:
- Generated large build artifacts containing profiling and debugging data.
- Produced very large logs, consuming additional disk space. In addition, the workflow lacked cleanup steps to:
- Remove unused SDKs (e.g. Android, .NET, Haskell).
- Clear previous build caches and temporary directories (build/, .dart_tool/).
As a result, the runner’s limited disk capacity was quickly exhausted during the build process.

## Solution

To fix the issue and optimize the CI pipeline:

- Switched build mode from --profile to --release to produce smaller, optimized artifacts.
- Removed the --verbose flag to prevent excessive log output.
- Added cleanup steps to free disk space before and after the build:

    - Delete unused SDKs (dotnet, android, ghc).
    - Run flutter clean before building.
    - Remove build/ and .dart_tool/ directories after deployment.

- Monitored disk usage with df -h before and after build steps for debugging.

These changes ensure the runner has enough space to complete the Flutter web build and deploy successfully.

