### PR TITLE
TF-4084 Fix cannot read or scroll emails when opening them in Twake Mail on Android chrome mobile browser

### DIFF
--- a/core/lib/utils/platform_info.dart
+++ b/core/lib/utils/platform_info.dart
@@ -1,6 +1,7 @@
 import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/web_renderer/canvas_kit.dart';
 import 'package:flutter/foundation.dart';
+import 'package:universal_html/html.dart' as universal_html;
 
 abstract class PlatformInfo {
   @visibleForTesting
@@ -44,4 +45,25 @@ abstract class PlatformInfo {
     log('PlatformInfo::platformNameOS(): $platformName');
     return platformName;
   }
+
+  static String get userAgent =>
+      isWeb ? universal_html.window.navigator.userAgent.toLowerCase() : '';
+
+  /// Web browser on a mobile phone
+  static bool get isWebMobile =>
+      isWeb && (userAgent.contains('iphone') ||
+          (userAgent.contains('android') && userAgent.contains('mobile')));
+
+  /// Web browser on a tablet device
+  static bool get isWebTablet =>
+      isWeb && (userAgent.contains('ipad') ||
+          (userAgent.contains('android') && !userAgent.contains('mobile')));
+
+  /// Web browser on a desktop (PC/Mac)
+  static bool get isWebDesktop =>
+      isWeb && !isWebMobile && !isWebTablet;
+
+  /// Touch devices
+  static bool get isWebTouchDevice =>
+      isWeb && (isWebMobile || isWebTablet);
 }


### PR DESCRIPTION
## Issue

#4084 

## Root cause

On `mobile browsers`, scrolling is performed via `touch gestures` rather than `mouse wheel` events.
Since browsers do not emit wheel events during touch-based scrolling, Flutter does not receive scroll input, and the `ScrollController` is not updated automatically.

## Solution

Capture touch events inside the iframe by `touchstart`,  `touchmove` and `touchend`

## Resolved

- Mobile:


https://github.com/user-attachments/assets/f211ccad-a3a9-4b8d-8e35-727924823313


- Tablet:




https://github.com/user-attachments/assets/84aae274-03d7-4cad-bf88-00fb59dd3171



