### PR TITLE
TF-4081 Fix mobile user was logged out again

### DIFF
--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
-import 'package:core/core.dart';
-import 'package:flutter/services.dart' as services;
+
 import 'package:contact/contact/model/capability_contact.dart';
+import 'package:core/core.dart';
 import 'package:dartz/dartz.dart';
 import 'package:fcm/model/firebase_capability.dart';
 import 'package:fcm/model/firebase_registration_id.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' as services;
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:forward/forward/capability_forward.dart';
 import 'package:get/get.dart';
@@ -57,8 +58,8 @@ import 'package:tmail_ui_user/main/exceptions/remote_exception.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/app_routes.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
-import 'package:tmail_ui_user/main/utils/app_config.dart';
 import 'package:tmail_ui_user/main/universal_import/html_stub.dart' as html;
+import 'package:tmail_ui_user/main/utils/app_config.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
 import 'package:uuid/uuid.dart';
@@ -153,7 +154,8 @@ abstract class BaseController extends GetxController
   bool validateUrgentException(dynamic exception) {
     return exception is NoNetworkError
       || exception is BadCredentialsException
-      || exception is ConnectionError;
+      || exception is ConnectionError
+      || exception is ClientAuthenticationException;
   }
 
   void handleErrorViewState(Object error, StackTrace stackTrace) {}
@@ -170,10 +172,14 @@ abstract class BaseController extends GetxController
 
   void handleUrgentExceptionOnMobile({Failure? failure, Exception? exception}) {
     logError('$runtimeType::handleUrgentExceptionOnMobile():Failure: $failure | Exception: $exception');
-    if (exception is ConnectionError) {
+    if (exception is NoNetworkError) {
+      _handleNotNetworkErrorException();
+    } else if (exception is ConnectionError) {
       _handleConnectionErrorException();
     } else if (exception is BadCredentialsException) {
       handleBadCredentialsException();
+    } else if (exception is ClientAuthenticationException) {
+      handleClientAuthenticationException(exception);
     }
   }
 
@@ -185,6 +191,8 @@ abstract class BaseController extends GetxController
       _handleConnectionErrorException();
     } else if (exception is BadCredentialsException) {
       handleBadCredentialsException();
+    } else if (exception is ClientAuthenticationException) {
+      handleClientAuthenticationException(exception);
     }
   }
 
@@ -214,7 +222,8 @@ abstract class BaseController extends GetxController
         leadingSVGIcon: imagePaths.icNotConnection,
         backgroundColor: AppColor.textFieldErrorBorderColor,
         textColor: Colors.white,
-        infinityToast: true);
+        infinityToast: PlatformInfo.isWeb,
+      );
     }
   }
 
@@ -224,6 +233,21 @@ abstract class BaseController extends GetxController
       _performSaveAndReconnection();
     } else {
       _performReconnection();
+    }
+  }
+
+  void handleClientAuthenticationException(
+    ClientAuthenticationException exception,
+  ) {
+    final message = exception.message;
+    final firstErrorCode = exception.code;
+    final secondErrorCode = exception.secondErrorCode;
+    log('$runtimeType::handleClientAuthenticationException: Message is $message, [$firstErrorCode - $secondErrorCode]');
+    if (currentOverlayContext != null && currentContext != null) {
+      appToast.showToastErrorMessage(
+        currentOverlayContext!,
+        '$message [$firstErrorCode - $secondErrorCode]',
+      );
     }
   }
 

--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -26,9 +26,11 @@ import 'package:tmail_ui_user/features/home/domain/extensions/session_extensions
 import 'package:tmail_ui_user/features/login/data/network/config/oidc_constant.dart';
 import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
 import 'package:tmail_ui_user/features/login/domain/exceptions/logout_exception.dart';
+import 'package:tmail_ui_user/features/login/domain/model/login_source.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oidc_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
 import 'package:tmail_ui_user/features/login/presentation/login_form_type.dart';
+import 'package:tmail_ui_user/features/login/presentation/model/auto_refresh_arguments.dart';
 import 'package:tmail_ui_user/features/login/presentation/model/login_arguments.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/bindings/contact_autocomplete_bindings.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/bindings/tmail_autocomplete_bindings.dart';
@@ -196,10 +198,12 @@ abstract class BaseController extends GetxController
     }
   }
 
-  Future<void> _executeBeforeReconnectAndLogOut() async {
+  Future<void> _executeBeforeReconnectAndLogOut({
+    LoginSource source = LoginSource.manual,
+  }) async {
     twakeAppManager.setExecutingBeforeReconnect(true);
     await executeBeforeReconnect();
-    clearDataAndGoToLoginPage();
+    clearDataAndGoToLoginPage(source: source);
   }
 
   void onCancelReconnectWhenSessionExpired() {}
@@ -230,9 +234,9 @@ abstract class BaseController extends GetxController
   void handleBadCredentialsException() {
     log('$runtimeType::handleBadCredentialsException:');
     if (twakeAppManager.hasComposer) {
-      _performSaveAndReconnection();
+      _performSaveAndReconnection(source: LoginSource.auto);
     } else {
-      _performReconnection();
+      _performReconnection(source: LoginSource.auto);
     }
   }
 
@@ -251,16 +255,20 @@ abstract class BaseController extends GetxController
     }
   }
 
-  void _performSaveAndReconnection() {
+  void _performSaveAndReconnection({
+    LoginSource source = LoginSource.manual,
+  }) {
     if (PlatformInfo.isWeb) {
-      _executeBeforeReconnectAndLogOut();
+      _executeBeforeReconnectAndLogOut(source: source);
     } else if (PlatformInfo.isMobile) {
-      clearDataAndGoToLoginPage();
+      clearDataAndGoToLoginPage(source: source);
     }
   }
 
-  void _performReconnection() {
-    clearDataAndGoToLoginPage();
+  void _performReconnection({
+    LoginSource source = LoginSource.manual,
+  }) {
+    clearDataAndGoToLoginPage(source: source);
   }
 
   void onDataFailureViewState(Failure failure) {
@@ -421,9 +429,24 @@ abstract class BaseController extends GetxController
     }
   }
 
-  void removeAllPageAndGoToLogin() {
+  void removeAllPageAndGoToLogin({
+    LoginSource source = LoginSource.manual,
+  }) {
     if (PlatformInfo.isMobile) {
-      pushAndPopAll(AppRoutes.twakeWelcome);
+      final jmapUrl = dynamicUrlInterceptors.jmapUrl ?? '';
+
+      final isAutoRefresh = source == LoginSource.auto &&
+          Get.currentRoute != AppRoutes.login &&
+          jmapUrl.isNotEmpty;
+
+      if (isAutoRefresh) {
+        pushAndPopAll(
+          AppRoutes.login,
+          arguments: AutoRefreshArguments(jmapUrl),
+        );
+      } else {
+        pushAndPopAll(AppRoutes.twakeWelcome);
+      }
     } else {
       navigateToLoginPage();
     }
@@ -565,10 +588,12 @@ abstract class BaseController extends GetxController
     await beforeReconnectManager?.executeBeforeReconnectListeners();
   }
 
-  Future<void> clearDataAndGoToLoginPage() async {
-    log('$runtimeType::clearDataAndGoToLoginPage:');
+  Future<void> clearDataAndGoToLoginPage({
+    LoginSource source = LoginSource.manual,
+  }) async {
+    log('$runtimeType::clearDataAndGoToLoginPage: Login source is $source');
     await clearAllData();
-    removeAllPageAndGoToLogin();
+    removeAllPageAndGoToLogin(source: source);
   }
 
   Future<void> clearAllData() async {

--- a/lib/features/caching/clients/hive_cache_version_client.dart
+++ b/lib/features/caching/clients/hive_cache_version_client.dart
@@ -17,13 +17,19 @@ class HiveCacheVersionClient extends CacheVersionClient {
     return Future.sync(() {
       final latestVersion = _sharedPreferences.getInt(versionKey);
       return latestVersion;
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<bool> storeVersion(int newVersion) {
     return Future.sync(() async {
       return await _sharedPreferences.setInt(versionKey, newVersion);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/cleanup/data/datasource_impl/cleanup_datasource_impl.dart
+++ b/lib/features/cleanup/data/datasource_impl/cleanup_datasource_impl.dart
@@ -30,27 +30,39 @@ class CleanupDataSourceImpl extends CleanupDataSource {
   Future<void> cleanEmailCache(EmailCleanupRule cleanupRule) {
     return Future.sync(() async {
       return await emailCacheManager.clean(cleanupRule);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<void> cleanRecentSearchCache(RecentSearchCleanupRule cleanupRule) {
     return Future.sync(() async {
       return await recentSearchCacheManager.clean(cleanupRule);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<void> cleanRecentLoginUrlCache(RecentLoginUrlCleanupRule cleanupRule) {
     return Future.sync(() async {
       return await recentLoginUrlCacheManager.clean(cleanupRule);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<void> cleanRecentLoginUsernameCache(RecentLoginUsernameCleanupRule cleanupRule) {
     return Future.sync(() async {
       return await recentLoginUsernameCacheManager.clean(cleanupRule);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/composer/data/datasource_impl/composer_datasource_impl.dart
+++ b/lib/features/composer/data/datasource_impl/composer_datasource_impl.dart
@@ -31,6 +31,9 @@ class ComposerDataSourceImpl extends ComposerDataSource {
         filePath: fileInfo.filePath,
         maxWidth: maxWidth,
         compress: compress);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/composer/data/datasource_impl/contact_datasource_impl.dart
+++ b/lib/features/composer/data/datasource_impl/contact_datasource_impl.dart
@@ -25,7 +25,10 @@ class ContactDataSourceImpl extends ContactDataSource {
           return <DeviceContact>[];
         }
       }
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   List<DeviceContact> _toDeviceContact(contact_service.Contact contact) {

--- a/lib/features/contact/data/datasource_impl/tmail_contact_datasource_impl.dart
+++ b/lib/features/contact/data/datasource_impl/tmail_contact_datasource_impl.dart
@@ -18,6 +18,9 @@ class TMailContactDataSourceImpl extends AutoCompleteDataSource {
     return Future.sync(() async {
       final listContacts = await _contactAPI.getAutoComplete(autoCompletePattern);
       return listContacts.map((contact) => contact.toEmailAddress()).toList();
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/email/data/datasource_impl/calendar_event_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/calendar_event_datasource_impl.dart
@@ -20,7 +20,10 @@ class CalendarEventDataSourceImpl extends CalendarEventDataSource {
   Future<List<BlobCalendarEvent>> parse(AccountId accountId, Set<Id> blobIds) {
     return Future.sync(() async {
       return await _calendarEventAPI.parse(accountId, blobIds);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
   
   @override
@@ -30,7 +33,10 @@ class CalendarEventDataSourceImpl extends CalendarEventDataSource {
     String? language) {
     return Future.sync(() async {
       return await _calendarEventAPI.acceptEventInvitation(accountId, blobIds, language);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -40,7 +46,10 @@ class CalendarEventDataSourceImpl extends CalendarEventDataSource {
     String? language) {
     return Future.sync(() async {
       return await _calendarEventAPI.maybeEventInvitation(accountId, blobIds, language);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -50,7 +59,10 @@ class CalendarEventDataSourceImpl extends CalendarEventDataSource {
     String? language) {
     return Future.sync(() async {
       return await _calendarEventAPI.rejectEventInvitation(accountId, blobIds, language);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
   
   @override
@@ -60,6 +72,9 @@ class CalendarEventDataSourceImpl extends CalendarEventDataSource {
   ) {
     return Future.sync(() async {
       return await _calendarEventAPI.acceptCounterEvent(accountId, blobIds);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/email/data/datasource_impl/email_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_datasource_impl.dart
@@ -64,7 +64,10 @@ class EmailDataSourceImpl extends EmailDataSource {
         accountId,
         emailId,
         additionalProperties: additionalProperties);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -102,7 +105,10 @@ class EmailDataSourceImpl extends EmailDataSource {
   ) {
     return Future.sync(() async {
       return await emailAPI.markAsRead(session, accountId, emailIds, readActions);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -115,7 +121,10 @@ class EmailDataSourceImpl extends EmailDataSource {
   ) {
     return Future.sync(() async {
       return await emailAPI.exportAttachment(attachment, accountId, baseDownloadUrl, accountRequest, cancelToken);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -129,7 +138,10 @@ class EmailDataSourceImpl extends EmailDataSource {
   ) {
     return Future.sync(() async {
       return await emailAPI.moveToMailbox(session, accountId, moveRequest);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -149,7 +161,10 @@ class EmailDataSourceImpl extends EmailDataSource {
         emailIds,
         markStarAction,
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -166,7 +181,10 @@ class EmailDataSourceImpl extends EmailDataSource {
         email,
         cancelToken: cancelToken
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -183,7 +201,10 @@ class EmailDataSourceImpl extends EmailDataSource {
         emailId,
         cancelToken: cancelToken
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -202,7 +223,10 @@ class EmailDataSourceImpl extends EmailDataSource {
         oldEmailId,
         cancelToken: cancelToken
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -223,7 +247,10 @@ class EmailDataSourceImpl extends EmailDataSource {
         createNewMailboxRequest: createNewMailboxRequest,
         cancelToken: cancelToken
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -242,7 +269,10 @@ class EmailDataSourceImpl extends EmailDataSource {
         oldEmailId,
         cancelToken: cancelToken
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -260,7 +290,10 @@ class EmailDataSourceImpl extends EmailDataSource {
         accountId,
         emailIds,
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -277,7 +310,10 @@ class EmailDataSourceImpl extends EmailDataSource {
         emailId,
         cancelToken: cancelToken
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -289,7 +325,10 @@ class EmailDataSourceImpl extends EmailDataSource {
   Future<Email> getDetailedEmailById(Session session, AccountId accountId, EmailId emailId) {
     return Future.sync(() async {
       return await emailAPI.getDetailedEmailById(session, accountId, emailId);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -356,21 +395,30 @@ class EmailDataSourceImpl extends EmailDataSource {
   Future<void> unsubscribeMail(Session session, AccountId accountId, EmailId emailId) {
     return Future.sync(() async {
       return await emailAPI.unsubscribeMail(session, accountId, emailId);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<EmailRecoveryAction> restoreDeletedMessage(RestoredDeletedMessageRequest restoredDeletedMessageRequest) {
     return Future.sync(() async {
       return await emailAPI.restoreDeletedMessage(restoredDeletedMessageRequest);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<EmailRecoveryAction> getRestoredDeletedMessage(EmailRecoveryActionId emailRecoveryActionId) {
     return Future.sync(() async {
       return await emailAPI.getRestoredDeletedMessage(emailRecoveryActionId);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -387,7 +435,10 @@ class EmailDataSourceImpl extends EmailDataSource {
   Future<List<Email>> parseEmailByBlobIds(AccountId accountId, Set<Id> blobIds) {
     return Future.sync(() async {
       return await emailAPI.parseEmailByBlobIds(accountId, blobIds);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -477,7 +528,10 @@ class EmailDataSourceImpl extends EmailDataSource {
       );
 
       return previewEmlHtmlDocument;
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   Future<String> _transformEmailContent(
@@ -528,7 +582,7 @@ class EmailDataSourceImpl extends EmailDataSource {
   Future<EMLPreviewer> getPreviewEMLContentInMemory(String keyStored) {
     throw UnimplementedError();
   }
-  
+
   @override
   Future<DownloadedResponse> exportAllAttachments(
     AccountId accountId,
@@ -546,7 +600,10 @@ class EmailDataSourceImpl extends EmailDataSource {
       accountRequest,
       cancelToken: cancelToken,
     );
-  }).catchError(_exceptionThrower.throwException);
+  }).catchError((error, stackTrace) async {
+    await _exceptionThrower.throwException(error, stackTrace);
+    throw error;
+  });
 
   @override
   Future<String> generateEntireMessageAsDocument(ViewEntireMessageRequest entireMessageRequest) {

--- a/lib/features/email/data/datasource_impl/email_hive_cache_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_hive_cache_datasource_impl.dart
@@ -318,7 +318,10 @@ class EmailHiveCacheDataSourceImpl extends EmailDataSource {
           return detailedEmailCache;
         });
       return _newEmailCacheWorkerQueue.addTask(task);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -346,7 +349,10 @@ class EmailHiveCacheDataSourceImpl extends EmailDataSource {
   Future<void> storeEmail(Session session, AccountId accountId, Email email) {
     return Future.sync(() async {
       return await _emailCacheManager.storeEmail(accountId, session.username, email.toEmailCache());
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -371,7 +377,10 @@ class EmailHiveCacheDataSourceImpl extends EmailDataSource {
           return detailedEmailCache;
         });
       return _openedEmailCacheWorkerQueue.addTask(task);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -386,7 +395,10 @@ class EmailHiveCacheDataSourceImpl extends EmailDataSource {
       final emailContent = listResult[1] as String;
       log('EmailHiveCacheDataSourceImpl::getStoredOpenedEmail():detailedEmailCache: ${detailedEmailCache.emailId} | emailContent: $emailContent');
       return detailedEmailCache.toDetailedEmailWithContent(emailContent);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -401,7 +413,10 @@ class EmailHiveCacheDataSourceImpl extends EmailDataSource {
       final emailContent = listResult[1] as String;
       log('EmailHiveCacheDataSourceImpl::getStoredNewEmail():detailedEmailCache: ${detailedEmailCache.emailId} | emailContent: $emailContent');
       return detailedEmailCache.toDetailedEmailWithContent(emailContent);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -409,7 +424,10 @@ class EmailHiveCacheDataSourceImpl extends EmailDataSource {
     return Future.sync(() async {
       final email = await _emailCacheManager.getStoredEmail(accountId, session.username, emailId);
       return email.toEmail();
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -417,7 +435,10 @@ class EmailHiveCacheDataSourceImpl extends EmailDataSource {
     return Future.sync(() async {
       final sendingEmailsCache = await _sendingEmailCacheManager.storeSendingEmail(accountId, userName, sendingEmail.toHiveCache());
       return sendingEmailsCache.toSendingEmail();
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -425,14 +446,20 @@ class EmailHiveCacheDataSourceImpl extends EmailDataSource {
     return Future.sync(() async {
       final sendingEmailsCache = await _sendingEmailCacheManager.getAllSendingEmailsByTupleKey(accountId, userName);
       return sendingEmailsCache.toSendingEmails();
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<void> deleteSendingEmail(AccountId accountId, UserName userName, String sendingId) {
     return Future.sync(() async {
       return await _sendingEmailCacheManager.deleteSendingEmail(accountId, userName, sendingId);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -440,7 +467,10 @@ class EmailHiveCacheDataSourceImpl extends EmailDataSource {
     return Future.sync(() async {
       final sendingEmailsCache = await _sendingEmailCacheManager.updateSendingEmail(accountId, userName, newSendingEmail.toHiveCache());
       return sendingEmailsCache.toSendingEmail();
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -448,14 +478,20 @@ class EmailHiveCacheDataSourceImpl extends EmailDataSource {
     return Future.sync(() async {
       final listSendingEmailsCache = await _sendingEmailCacheManager.updateMultipleSendingEmail(accountId, userName, newSendingEmails.toHiveCache());
       return listSendingEmailsCache.toSendingEmails();
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<void> deleteMultipleSendingEmail(AccountId accountId, UserName userName, List<String> sendingIds) {
     return Future.sync(() async {
       return await _sendingEmailCacheManager.deleteMultipleSendingEmail(accountId, userName, sendingIds);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -463,7 +499,10 @@ class EmailHiveCacheDataSourceImpl extends EmailDataSource {
     return Future.sync(() async {
       final sendingEmailCache = await _sendingEmailCacheManager.getStoredSendingEmail(accountId, userName, sendingId);
       return sendingEmailCache.toSendingEmail();
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override

--- a/lib/features/email/data/datasource_impl/email_local_storage_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_local_storage_datasource_impl.dart
@@ -172,7 +172,10 @@ class EmailLocalStorageDataSourceImpl extends EmailDataSource {
         emlPreviewer.id,
         jsonEncode(emlPreviewer.toJson()),
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -220,7 +223,10 @@ class EmailLocalStorageDataSourceImpl extends EmailDataSource {
     return Future.sync(() async {
       final data = _localStorageManager.get(keyStored);
       return EMLPreviewer.fromJson(jsonDecode(data));
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -232,7 +238,10 @@ class EmailLocalStorageDataSourceImpl extends EmailDataSource {
   Future<void> removePreviewEmailEMLContentShared(String keyStored) {
     return Future.sync(() async {
       return _localStorageManager.remove(keyStored);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -326,7 +335,10 @@ class EmailLocalStorageDataSourceImpl extends EmailDataSource {
       );
 
       return htmlDocument;
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
   
   @override

--- a/lib/features/email/data/datasource_impl/email_session_storage_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_session_storage_datasource_impl.dart
@@ -207,7 +207,10 @@ class EmailSessionStorageDatasourceImpl extends EmailDataSource {
         emlPreviewer.id,
         jsonEncode(emlPreviewer.toJson()),
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -220,7 +223,10 @@ class EmailSessionStorageDatasourceImpl extends EmailDataSource {
     return Future.sync(() {
       final data = _sessionStorageManager.get(keyStored);
       return EMLPreviewer.fromJson(jsonDecode(data));
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override

--- a/lib/features/email/data/datasource_impl/html_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/html_datasource_impl.dart
@@ -26,7 +26,10 @@ class HtmlDataSourceImpl extends HtmlDataSource {
         mapCidImageDownloadUrl,
         transformConfiguration
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -36,7 +39,10 @@ class HtmlDataSourceImpl extends HtmlDataSource {
         htmlContent,
         configuration
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -51,7 +57,10 @@ class HtmlDataSourceImpl extends HtmlDataSource {
         inlineAttachments: inlineAttachments,
         uploadUri: uploadUri,
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -60,7 +69,10 @@ class HtmlDataSourceImpl extends HtmlDataSource {
       return await _htmlAnalyzer.removeCollapsedExpandedSignatureEffect(
         emailContent: emailContent
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -69,6 +81,9 @@ class HtmlDataSourceImpl extends HtmlDataSource {
       return await _htmlAnalyzer.removeStyleLazyLoadDisplayInlineImages(
         emailContent: emailContent,
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/email/data/datasource_impl/mdn_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/mdn_datasource_impl.dart
@@ -18,6 +18,9 @@ class MdnDataSourceImpl extends MdnDataSource {
   Future<MDN?> sendReceiptToSender(AccountId accountId, SendReceiptToSenderRequest request) {
     return Future.sync(() async {
       return await _mdnAPI.sendReceiptToSender(accountId, request);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/email/data/datasource_impl/print_file_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/print_file_datasource_impl.dart
@@ -69,7 +69,10 @@ class PrintFileDataSourceImpl extends PrintFileDataSource {
         titleAttachment: emailPrint.titleAttachment,
         listAttachment: listPrintAttachment
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   Future<String> _transformHtmlEmailContent(EmailPrint emailPrint) async {

--- a/lib/features/home/data/datasource_impl/hive_session_datasource_impl.dart
+++ b/lib/features/home/data/datasource_impl/hive_session_datasource_impl.dart
@@ -21,7 +21,10 @@ class HiveSessionDataSourceImpl extends SessionDataSource {
   Future<void> storeSession(Session session) {
     return Future.sync(() async {
       return _sessionCacheManager.insertSession(session.toHiveObj());
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -29,6 +32,9 @@ class HiveSessionDataSourceImpl extends SessionDataSource {
     return Future.sync(() async {
       final sessionHiveObj = await _sessionCacheManager.getStoredSession();
       return sessionHiveObj.toSession();
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/home/data/datasource_impl/session_datasource_impl.dart
+++ b/lib/features/home/data/datasource_impl/session_datasource_impl.dart
@@ -17,7 +17,10 @@ class SessionDataSourceImpl extends SessionDataSource {
       return await _sessionAPI.getSession(
         converters: SessionExtensions.customMapCapabilitiesConverter,
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override

--- a/lib/features/identity_creator/data/datasource_impl/local_identity_creator_data_source_impl.dart
+++ b/lib/features/identity_creator/data/datasource_impl/local_identity_creator_data_source_impl.dart
@@ -31,7 +31,10 @@ class LocalIdentityCreatorDataSourceImpl implements IdentityCreatorDataSource {
         cacheKey: jsonEncode(IdentityCacheModel.fromDomain(identityCache).toJson())
       };
       window.sessionStorage.addAll(entries);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
     
   @override
@@ -48,7 +51,10 @@ class LocalIdentityCreatorDataSourceImpl implements IdentityCreatorDataSource {
       } else {
         throw NotFoundInWebSessionException();
       }
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -56,7 +62,10 @@ class LocalIdentityCreatorDataSourceImpl implements IdentityCreatorDataSource {
     return Future.sync(() {
       window.sessionStorage.removeWhere(
         (key, value) => key.startsWith(LocalIdentityCreatorDataSourceImpl.sessionStorageKeyword));
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   String _generateTupleKey(AccountId accountId, UserName userName) {

--- a/lib/features/login/data/datasource_impl/authentication_datasource_impl.dart
+++ b/lib/features/login/data/datasource_impl/authentication_datasource_impl.dart
@@ -13,6 +13,9 @@ class AuthenticationDataSourceImpl extends AuthenticationDataSource {
   Future<UserName> authenticationUser(Uri baseUrl, UserName userName, Password password) async {
     return Future.sync(() async {
       return userName;
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/login/data/datasource_impl/authentication_oidc_datasource_impl.dart
+++ b/lib/features/login/data/datasource_impl/authentication_oidc_datasource_impl.dart
@@ -38,68 +38,80 @@ class AuthenticationOIDCDataSourceImpl extends AuthenticationOIDCDataSource {
   Future<OIDCResponse> checkOIDCIsAvailable(OIDCRequest oidcRequest) {
     return Future.sync(() async {
       return await _oidcHttpClient.checkOIDCIsAvailable(oidcRequest);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<OIDCConfiguration> getOIDCConfiguration(OIDCResponse oidcResponse) {
     return Future.sync(() async {
       return await _oidcHttpClient.getOIDCConfiguration(oidcResponse);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<OIDCDiscoveryResponse> discoverOIDC(OIDCConfiguration oidcConfiguration) {
     return Future.sync(() async {
       return await _oidcHttpClient.discoverOIDC(oidcConfiguration);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
-  Future<TokenOIDC> getTokenOIDC(
-    String clientId,
-    String redirectUrl,
-    String discoveryUrl,
-    List<String> scopes, {
-    String? loginHint,
-  }) {
+  Future<TokenOIDC> getTokenOIDC(String clientId, String redirectUrl, String discoveryUrl, List<String> scopes, {String? loginHint}) {
     return Future.sync(() async {
-      return await _authenticationClient.getTokenOIDC(
-        clientId,
-        redirectUrl,
-        discoveryUrl,
-        scopes,
-        loginHint: loginHint,
-      );
-    }).catchError(_exceptionThrower.throwException);
+      return await _authenticationClient.getTokenOIDC(clientId, redirectUrl, discoveryUrl, scopes, loginHint: loginHint);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<TokenOIDC> getStoredTokenOIDC(String tokenIdHash) {
     return Future.sync(() async {
       return await _tokenOidcCacheManager.getTokenOidc(tokenIdHash);
-    }).catchError(_cacheExceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _cacheExceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<void> persistTokenOIDC(TokenOIDC tokenOidc) {
     return Future.sync(() async {
       return await _tokenOidcCacheManager.persistOneTokenOidc(tokenOidc);
-    }).catchError(_cacheExceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _cacheExceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<OIDCConfiguration> getStoredOidcConfiguration() {
     return Future.sync(() async {
       return await _oidcConfigurationCacheManager.getOidcConfiguration();
-    }).catchError(_cacheExceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _cacheExceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<void> persistOidcConfiguration(OIDCConfiguration oidcConfiguration) {
     return Future.sync(() async {
       return await _oidcConfigurationCacheManager.persistOidcConfiguration(oidcConfiguration);
-    }).catchError(_cacheExceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _cacheExceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -117,21 +129,30 @@ class AuthenticationOIDCDataSourceImpl extends AuthenticationOIDCDataSource {
         discoveryUrl,
         scopes,
         refreshToken);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<bool> logout(TokenId tokenId, OIDCConfiguration config, OIDCDiscoveryResponse oidcRescovery) {
     return Future.sync(() async {
        return await _authenticationClient.logoutOidc(tokenId, config, oidcRescovery);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<void> deleteOidcConfiguration() {
     return Future.sync(() async {
       return await _oidcConfigurationCacheManager.deleteOidcConfiguration();
-    }).catchError(_cacheExceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _cacheExceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -147,7 +168,10 @@ class AuthenticationOIDCDataSourceImpl extends AuthenticationOIDCDataSource {
         redirectUrl,
         discoveryUrl,
         scopes);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -156,14 +180,20 @@ class AuthenticationOIDCDataSourceImpl extends AuthenticationOIDCDataSource {
       return _sessionStorageManager.get(
         OIDCConstant.authResponseKey,
       );
-    }).catchError(_cacheExceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _cacheExceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<void> deleteTokenOIDC() {
     return Future.sync(() async {
       return await _tokenOidcCacheManager.deleteTokenOidc();
-    }).catchError(_cacheExceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _cacheExceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -172,6 +202,9 @@ class AuthenticationOIDCDataSourceImpl extends AuthenticationOIDCDataSource {
       return _sessionStorageManager.remove(
         LoginConstants.AUTH_DESTINATION_KEY,
       );
-    }).catchError(_cacheExceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _cacheExceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/login/data/datasource_impl/hive_account_datasource_impl.dart
+++ b/lib/features/login/data/datasource_impl/hive_account_datasource_impl.dart
@@ -21,7 +21,10 @@ class HiveAccountDatasourceImpl extends AccountDatasource {
   Future<PersonalAccount> getCurrentAccount() {
     return Future.sync(() async {
       return await _accountCacheManager.getCurrentAccount();
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -32,13 +35,19 @@ class HiveAccountDatasourceImpl extends AccountDatasource {
         await _iosSharingManager.saveKeyChainSharingSession(newCurrentAccount);
       }
       return Future.value(null);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<void> deleteCurrentAccount(String accountId) {
     return Future.sync(() async {
       return await _accountCacheManager.deleteCurrentAccount(accountId);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/login/data/datasource_impl/hive_login_datasource_impl.dart
+++ b/lib/features/login/data/datasource_impl/hive_login_datasource_impl.dart
@@ -24,7 +24,10 @@ class HiveLoginDataSourceImpl implements LoginDataSource {
       return await _recentLoginUrlCacheManager.saveLoginUrl(
         recentLoginUrl.toRecentLoginUrlCache(),
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -34,7 +37,10 @@ class HiveLoginDataSourceImpl implements LoginDataSource {
         limit: limit,
         pattern: pattern,
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -44,7 +50,10 @@ class HiveLoginDataSourceImpl implements LoginDataSource {
         limit: limit,
         pattern: pattern,
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -53,7 +62,10 @@ class HiveLoginDataSourceImpl implements LoginDataSource {
       return await _recentLoginUsernameCacheManager.saveLoginUsername(
         recentLoginUsername,
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override

--- a/lib/features/login/data/datasource_impl/login_datasource_impl.dart
+++ b/lib/features/login/data/datasource_impl/login_datasource_impl.dart
@@ -18,7 +18,10 @@ class LoginDataSourceImpl implements LoginDataSource {
   Future<String> dnsLookupToGetJmapUrl(String emailAddress) {
     return Future.sync(() async {
       return await _dnsLookupManager.lookupJmapUrl(emailAddress);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override

--- a/lib/features/login/domain/model/login_source.dart
+++ b/lib/features/login/domain/model/login_source.dart
@@ -1,0 +1,4 @@
+enum LoginSource {
+  manual,   // User manually logs in
+  auto     // Auto retry after 401
+}

--- a/lib/features/login/presentation/login_controller.dart
+++ b/lib/features/login/presentation/login_controller.dart
@@ -53,6 +53,7 @@ import 'package:tmail_ui_user/features/login/domain/usecases/try_guessing_web_fi
 import 'package:tmail_ui_user/features/login/presentation/extensions/generate_oidc_guessing_urls.dart';
 import 'package:tmail_ui_user/features/login/presentation/extensions/handle_openid_configuration.dart';
 import 'package:tmail_ui_user/features/login/presentation/login_form_type.dart';
+import 'package:tmail_ui_user/features/login/presentation/model/auto_refresh_arguments.dart';
 import 'package:tmail_ui_user/features/login/presentation/model/login_arguments.dart';
 import 'package:tmail_ui_user/features/starting_page/domain/state/sign_in_twake_workplace_state.dart';
 import 'package:tmail_ui_user/features/starting_page/domain/usecase/sign_in_twake_workplace_interactor.dart';
@@ -140,6 +141,8 @@ class LoginController extends ReloadableController {
       if (PlatformInfo.isWeb) {
         _checkOIDCIsAvailable();
       }
+    } else if (arguments is AutoRefreshArguments) {
+      _handleDNSLookupToGetJmapUrlSuccess(arguments.jmapUrl);
     } else if (PlatformInfo.isWeb) {
       _getAuthenticationInfo();
     }
@@ -194,7 +197,7 @@ class LoginController extends ReloadableController {
     } else if (success is AuthenticationUserSuccess) {
       _loginSuccessAction(success);
     } else if (success is DNSLookupToGetJmapUrlSuccess) {
-      _handleDNSLookupToGetJmapUrlSuccess(success);
+      _handleDNSLookupToGetJmapUrlSuccess(success.jmapUrl);
     } else if (success is TryGuessingWebFingerSuccess) {
       onBaseUrlChange(success.oidcResponse.subject);
       getOIDCConfiguration(success.oidcResponse);
@@ -549,8 +552,8 @@ class LoginController extends ReloadableController {
     }
   }
 
-  void _handleDNSLookupToGetJmapUrlSuccess(DNSLookupToGetJmapUrlSuccess success) {
-    onBaseUrlChange(success.jmapUrl);
+  void _handleDNSLookupToGetJmapUrlSuccess(String jmapUrl) {
+    onBaseUrlChange(jmapUrl);
     _checkOIDCIsAvailable();
   }
 

--- a/lib/features/login/presentation/model/auto_refresh_arguments.dart
+++ b/lib/features/login/presentation/model/auto_refresh_arguments.dart
@@ -1,0 +1,10 @@
+import 'package:tmail_ui_user/main/routes/router_arguments.dart';
+
+class AutoRefreshArguments extends RouterArguments {
+  final String jmapUrl;
+
+  AutoRefreshArguments(this.jmapUrl);
+
+  @override
+  List<Object?> get props => [jmapUrl];
+}

--- a/lib/features/mailbox/data/datasource_impl/mailbox_cache_datasource_impl.dart
+++ b/lib/features/mailbox/data/datasource_impl/mailbox_cache_datasource_impl.dart
@@ -50,7 +50,10 @@ class MailboxCacheDataSourceImpl extends MailboxDataSource {
   Future<void> update(AccountId accountId, UserName userName, {List<Mailbox>? updated, List<Mailbox>? created, List<MailboxId>? destroyed}) {
     return Future.sync(() async {
       return await _mailboxCacheManager.update(accountId, userName, updated: updated, created: created, destroyed: destroyed);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -58,7 +61,10 @@ class MailboxCacheDataSourceImpl extends MailboxDataSource {
     return Future.sync(() async {
       final listMailboxes = await _mailboxCacheManager.getAllMailbox(accountId, userName);
       return listMailboxes;
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -160,7 +166,10 @@ class MailboxCacheDataSourceImpl extends MailboxDataSource {
   Future<void> clearAllMailboxCache(AccountId accountId, UserName userName) {
     return Future.sync(() async {
       return await _mailboxCacheManager.deleteByKey(accountId, userName);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override

--- a/lib/features/mailbox/data/datasource_impl/mailbox_datasource_impl.dart
+++ b/lib/features/mailbox/data/datasource_impl/mailbox_datasource_impl.dart
@@ -41,14 +41,20 @@ class MailboxDataSourceImpl extends MailboxDataSource {
   Future<JmapMailboxResponse> getAllMailbox(Session session, AccountId accountId, {Properties? properties}) {
     return Future.sync(() async {
       return await mailboxAPI.getAllMailbox(session, accountId, properties: properties);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<MailboxChangeResponse> getChanges(Session session, AccountId accountId, State sinceState, {Properties? properties}) {
     return Future.sync(() async {
       return await mailboxAPI.getChanges(session, accountId, sinceState, properties: properties);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -65,28 +71,40 @@ class MailboxDataSourceImpl extends MailboxDataSource {
   Future<Mailbox?> createNewMailbox(Session session, AccountId accountId, CreateNewMailboxRequest newMailboxRequest) {
     return Future.sync(() async {
       return await mailboxAPI.createNewMailbox(session, accountId, newMailboxRequest);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<Map<Id,SetError>> deleteMultipleMailbox(Session session, AccountId accountId, List<MailboxId> mailboxIds) {
     return Future.sync(() async {
       return await mailboxAPI.deleteMultipleMailbox(session, accountId, mailboxIds);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<bool> renameMailbox(Session session, AccountId accountId, RenameMailboxRequest request) {
     return Future.sync(() async {
       return await mailboxAPI.renameMailbox(session, accountId, request);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<bool> moveMailbox(Session session, AccountId accountId, MoveMailboxRequest request) {
     return Future.sync(() async {
       return await mailboxAPI.moveMailbox(session, accountId, request);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -103,14 +121,20 @@ class MailboxDataSourceImpl extends MailboxDataSource {
           mailboxId,
           totalEmailUnread,
           onProgressController);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<bool> subscribeMailbox(Session session, AccountId accountId, SubscribeMailboxRequest request) {
     return Future.sync(() async {
       return await mailboxAPI.subscribeMailbox(session, accountId, request);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -121,35 +145,50 @@ class MailboxDataSourceImpl extends MailboxDataSource {
   ) {
     return Future.sync(() async {
       return await mailboxAPI.subscribeMultipleMailbox(session, accountId, subscribeRequest);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<bool> handleMailboxRightRequest(Session session, AccountId accountId, MailboxRightRequest request) {
     return Future.sync(() async {
       return await mailboxAPI.handleMailboxRightRequest(session, accountId, request);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> createDefaultMailbox(Session session, AccountId accountId, Map<Id, Role> mapRoles) {
     return Future.sync(() async {
       return await mailboxAPI.createDefaultMailbox(session, accountId, mapRoles);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<(List<Mailbox> mailboxes, Map<Id, SetError> mapErrors)> setRoleDefaultMailbox(Session session, AccountId accountId, List<Mailbox> listMailbox) {
     return Future.sync(() async {
       return await mailboxAPI.setRoleDefaultMailbox(session, accountId, listMailbox);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
   
   @override
   Future<GetMailboxByRoleResponse> getMailboxByRole(Session session, AccountId accountId, Role role, {UnsignedInt? limit}) {
     return Future.sync(() async {
       return await mailboxAPI.getMailboxByRole(session, accountId, role);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -161,7 +200,10 @@ class MailboxDataSourceImpl extends MailboxDataSource {
   Future<UnsignedInt> clearMailbox(Session session, AccountId accountId, MailboxId mailboxId) {
     return Future.sync(() async {
       return await mailboxAPI.clearMailbox(session, accountId, mailboxId);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override

--- a/lib/features/mailbox/data/datasource_impl/state_datasource_impl.dart
+++ b/lib/features/mailbox/data/datasource_impl/state_datasource_impl.dart
@@ -26,7 +26,10 @@ class StateDataSourceImpl extends StateDataSource {
   Future<State?> getState(AccountId accountId, UserName userName, StateType stateType) {
     return Future.sync(() async {
       return await _stateCacheManager.getState(accountId, userName, stateType);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -40,6 +43,9 @@ class StateDataSourceImpl extends StateDataSource {
         }
       }
       return Future.value(null);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/mailbox_dashboard/data/datasource_impl/app_grid_datasource_impl.dart
+++ b/lib/features/mailbox_dashboard/data/datasource_impl/app_grid_datasource_impl.dart
@@ -21,6 +21,9 @@ class AppGridDatasourceImpl extends AppGridDatasource {
   Future<LinagoraEcosystem> getLinagoraEcosystem(String baseUrl) {
     return Future.sync(() async {
       return await _linagoraEcosystemApi.getLinagoraEcosystem(baseUrl);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/mailbox_dashboard/data/datasource_impl/hive_spam_report_datasource_impl.dart
+++ b/lib/features/mailbox_dashboard/data/datasource_impl/hive_spam_report_datasource_impl.dart
@@ -36,7 +36,10 @@ class HiveSpamReportDataSourceImpl extends SpamReportDataSource {
   Future<Mailbox> getSpamMailboxCached(AccountId accountId, UserName userName) {
     return Future.sync(() async {
       return await _mailboxCacheManager.getSpamMailbox(accountId, userName);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override

--- a/lib/features/mailbox_dashboard/data/datasource_impl/local_app_grid_datasource_impl.dart
+++ b/lib/features/mailbox_dashboard/data/datasource_impl/local_app_grid_datasource_impl.dart
@@ -20,7 +20,10 @@ class LocalAppGridDatasourceImpl extends AppGridDatasource {
         path,
         AppDashboardConfigurationParser(),
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override

--- a/lib/features/mailbox_dashboard/data/datasource_impl/local_spam_report_datasource_impl.dart
+++ b/lib/features/mailbox_dashboard/data/datasource_impl/local_spam_report_datasource_impl.dart
@@ -27,7 +27,10 @@ class LocalSpamReportDataSourceImpl extends SpamReportDataSource {
       return DateTime.fromMillisecondsSinceEpoch(
         spamReportConfig.lastTimeDismissedMilliseconds,
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -39,7 +42,10 @@ class LocalSpamReportDataSourceImpl extends SpamReportDataSource {
         lastTimeDismissedMilliseconds:
             lastTimeDismissedSpamReported.millisecondsSinceEpoch,
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -48,7 +54,10 @@ class LocalSpamReportDataSourceImpl extends SpamReportDataSource {
       return await _preferencesSettingManager.updateSpamReport(
         lastTimeDismissedMilliseconds: 0,
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -69,7 +78,10 @@ class LocalSpamReportDataSourceImpl extends SpamReportDataSource {
       final spamReportConfig =
         await _preferencesSettingManager.getSpamReportConfig();
       return spamReportConfig.spamReportState;
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -78,7 +90,10 @@ class LocalSpamReportDataSourceImpl extends SpamReportDataSource {
       return await _preferencesSettingManager.updateSpamReport(
         isEnabled: spamReportState == SpamReportState.enabled,
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override

--- a/lib/features/mailbox_dashboard/data/datasource_impl/search_datasource_impl.dart
+++ b/lib/features/mailbox_dashboard/data/datasource_impl/search_datasource_impl.dart
@@ -32,7 +32,10 @@ class SearchDataSourceImpl extends SearchDataSource {
         userName,
         recentSearch,
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -51,20 +54,29 @@ class SearchDataSourceImpl extends SearchDataSource {
         limit: limit,
         pattern: pattern,
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<void> storeEmailSortOrder(EmailSortOrderType sortOrderType) {
     return Future.sync(() async {
       return await _localSortOrderManager.storeEmailSortOrderIfChanged(sortOrderType);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<EmailSortOrderType> getStoredEmailSortOrder() {
     return Future.sync(() {
       return _localSortOrderManager.getStoredEmailSortOrder();
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/mailbox_dashboard/data/datasource_impl/session_storage_composer_datasoure_impl.dart
+++ b/lib/features/mailbox_dashboard/data/datasource_impl/session_storage_composer_datasoure_impl.dart
@@ -41,7 +41,10 @@ class SessionStorageComposerDatasourceImpl
       } else {
         throw NotFoundInWebSessionException();
       }
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -61,7 +64,10 @@ class SessionStorageComposerDatasourceImpl
         composerCacheKey: jsonEncode(composerCache.toJson())
       };
       html.window.sessionStorage.addAll(entries);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
   
   @override
@@ -74,7 +80,10 @@ class SessionStorageComposerDatasourceImpl
         htmlContent: htmlContent,
         transformConfiguration: transformConfiguration,
         mapCidImageDownloadUrl: mapUrlDownloadCID);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -87,7 +96,10 @@ class SessionStorageComposerDatasourceImpl
       ).toString();
 
       html.window.sessionStorage.removeWhere((key, value) => key.startsWith(keyWithIdentity));
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -101,6 +113,9 @@ class SessionStorageComposerDatasourceImpl
       ).toString();
 
       html.window.sessionStorage.removeWhere((key, value) => key == keyWithIdentity);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/manage_account/data/datasource_impl/forwarding_data_source_impl.dart
+++ b/lib/features/manage_account/data/datasource_impl/forwarding_data_source_impl.dart
@@ -19,7 +19,10 @@ class ForwardingDataSourceImpl extends ForwardingDataSource {
   Future<TMailForward> getForward(AccountId accountId) {
     return Future.sync(() async {
       return await _forwardingAPI.getForward(accountId);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -32,7 +35,10 @@ class ForwardingDataSourceImpl extends ForwardingDataSource {
         accountId,
         deleteRequest.newTMailForward,
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -45,7 +51,10 @@ class ForwardingDataSourceImpl extends ForwardingDataSource {
         accountId,
         addRequest.newTMailForward,
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -58,6 +67,9 @@ class ForwardingDataSourceImpl extends ForwardingDataSource {
         accountId,
         editRequest.newTMailForward,
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/manage_account/data/datasource_impl/identity_data_source_impl.dart
+++ b/lib/features/manage_account/data/datasource_impl/identity_data_source_impl.dart
@@ -28,28 +28,40 @@ class IdentityDataSourceImpl extends IdentityDataSource {
   Future<IdentitiesResponse> getAllIdentities(Session session, AccountId accountId, {Properties? properties}) {
     return Future.sync(() async {
       return await _identityAPI.getAllIdentities(session, accountId, properties: properties);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<Identity> createNewIdentity(Session session, AccountId accountId, CreateNewIdentityRequest identityRequest) {
     return Future.sync(() async {
       return await _identityAPI.createNewIdentity(session, accountId, identityRequest);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<bool> deleteIdentity(Session session, AccountId accountId, IdentityId identityId) {
     return Future.sync(() async {
       return await _identityAPI.deleteIdentity(session, accountId, identityId);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<bool> editIdentity(Session session, AccountId accountId, EditIdentityRequest editIdentityRequest) {
     return Future.sync(() async {
       return await _identityAPI.editIdentity(session, accountId, editIdentityRequest);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -60,6 +72,9 @@ class IdentityDataSourceImpl extends IdentityDataSource {
         transformConfiguration: TransformConfiguration.forSignatureIdentity(),
       );
       return identitySignature.newSignature(signatureUnescape);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/manage_account/data/datasource_impl/manage_account_datasource_impl.dart
+++ b/lib/features/manage_account/data/datasource_impl/manage_account_datasource_impl.dart
@@ -25,7 +25,10 @@ class ManageAccountDataSourceImpl extends ManageAccountDataSource {
   Future<void> persistLanguage(Locale localeCurrent) {
     return Future.sync(() async {
       return await _languageCacheManager.persistLanguage(localeCurrent);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -45,13 +48,19 @@ class ManageAccountDataSourceImpl extends ManageAccountDataSource {
         );
       }
       return await _preferencesSettingManager.loadPreferences();
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<PreferencesSetting> getLocalSettings() {
     return Future.sync(() async {
       return await _preferencesSettingManager.loadPreferences();
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/manage_account/data/datasource_impl/notification_datasource_impl.dart
+++ b/lib/features/manage_account/data/datasource_impl/notification_datasource_impl.dart
@@ -22,14 +22,20 @@ class NotificationDataSourceImpl implements NotificationDataSource {
       } else {
         return await _checkAndroidNotificationPermissionEnabled(userName);
       }
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
   
   @override
   Future<void> toggleNotificationSetting() async {
     return Future.sync(() async {
       return await AppSettings.openAppSettings(type: AppSettingsType.notification);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   Future<bool> _checkIosNotificationPermissionEnabled() {

--- a/lib/features/manage_account/data/datasource_impl/rule_filter_datasource_impl.dart
+++ b/lib/features/manage_account/data/datasource_impl/rule_filter_datasource_impl.dart
@@ -22,7 +22,10 @@ class RuleFilterDataSourceImpl extends RuleFilterDataSource {
   Future<List<TMailRule>> getAllTMailRule(AccountId accountId) {
     return Future.sync(() async {
       return await _ruleFilterAPI.getListTMailRule(accountId);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -32,20 +35,29 @@ class RuleFilterDataSourceImpl extends RuleFilterDataSource {
 
     return Future.sync(() async {
       return await _ruleFilterAPI.updateListTMailRule(accountId, deleteEmailRuleRequest.currentEmailRules);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<List<TMailRule>> createNewEmailRuleFilter(AccountId accountId, CreateNewEmailRuleFilterRequest ruleFilterRequest) {
     return Future.sync(() async {
       return await _ruleFilterAPI.updateListTMailRule(accountId, ruleFilterRequest.newListTMailRules);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<List<TMailRule>> editEmailRuleFilter(AccountId accountId, EditEmailRuleFilterRequest ruleFilterRequest) {
     return Future.sync(() async {
       return await _ruleFilterAPI.updateListTMailRule(accountId, ruleFilterRequest.listTMailRulesUpdated);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/manage_account/data/datasource_impl/trace_log_datasource_impl.dart
+++ b/lib/features/manage_account/data/datasource_impl/trace_log_datasource_impl.dart
@@ -44,7 +44,10 @@ class TraceLogDataSourceImpl extends TraceLogDataSource {
         }
         throw UserCancelShareFileException();
       }
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   Future<bool> _validateStoragePermissionOnAndroid() async {

--- a/lib/features/manage_account/data/datasource_impl/vacation_data_source_impl.dart
+++ b/lib/features/manage_account/data/datasource_impl/vacation_data_source_impl.dart
@@ -15,13 +15,19 @@ class VacationDataSourceImpl extends VacationDataSource {
   Future<List<VacationResponse>> getAllVacationResponse(AccountId accountId) {
     return Future.sync(() async {
       return await _vacationAPI.getAllVacationResponse(accountId);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<List<VacationResponse>> updateVacation(AccountId accountId, VacationResponse vacationResponse) {
     return Future.sync(() async {
       return await _vacationAPI.updateVacation(accountId, vacationResponse);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/paywall/data/datasource_impl/paywall_datasource_impl.dart
+++ b/lib/features/paywall/data/datasource_impl/paywall_datasource_impl.dart
@@ -13,6 +13,9 @@ class PaywallDatasourceImpl extends PaywallDatasource {
   Future<PaywallUrlPattern> getPaywallUrl(String baseUrl) {
     return Future.sync(() async {
       return await _linagoraEcosystemApi.getPaywallUrl(baseUrl);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/public_asset/data/datasource_impl/remote_public_asset_datasource_impl.dart
+++ b/lib/features/public_asset/data/datasource_impl/remote_public_asset_datasource_impl.dart
@@ -28,7 +28,10 @@ class RemotePublicAssetDatasourceImpl implements PublicAssetDatasource {
       accountId,
       blobId: blobId,
       identityId: identityId);
-  }).catchError(_exceptionThrower.throwException);
+      }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
 
   @override
   Future<void> deletePublicAssets(
@@ -41,7 +44,10 @@ class RemotePublicAssetDatasourceImpl implements PublicAssetDatasource {
       accountId,
       publicAssetIds: publicAssetIds
     );
-  }).catchError(_exceptionThrower.throwException);
+      }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
 
   @override
   Future<List<PublicAsset>> getPublicAssetFromIds(
@@ -54,7 +60,10 @@ class RemotePublicAssetDatasourceImpl implements PublicAssetDatasource {
       accountId,
       publicAssetIds: publicAssetIds
     );
-  }).catchError(_exceptionThrower.throwException);
+      }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
 
   @override
   Future<void> updatePublicAssets(
@@ -67,7 +76,10 @@ class RemotePublicAssetDatasourceImpl implements PublicAssetDatasource {
       accountId,
       publicAssets: publicAssets
     );
-  }).catchError(_exceptionThrower.throwException);
+      }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
 
   @override
   Future<void> partialUpdatePublicAssets(
@@ -80,5 +92,8 @@ class RemotePublicAssetDatasourceImpl implements PublicAssetDatasource {
       accountId,
       mapPublicAssetIdToUpdatingIdentityIds: mapPublicAssetIdToUpdatingIdentityIds
     );
-  }).catchError(_exceptionThrower.throwException);
+      }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
 }

--- a/lib/features/push_notification/data/datasource_impl/cache_fcm_datasource_impl.dart
+++ b/lib/features/push_notification/data/datasource_impl/cache_fcm_datasource_impl.dart
@@ -24,21 +24,30 @@ class CacheFCMDatasourceImpl extends FCMDatasource {
   Future<void> storeStateToRefresh(AccountId accountId, UserName userName, TypeName typeName, jmap.State newState) {
     return Future.sync(() async {
       return await _firebaseCacheManager.storeStateToRefresh(accountId, userName, typeName, newState);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<jmap.State> getStateToRefresh(AccountId accountId, UserName userName, TypeName typeName) {
     return Future.sync(() async {
       return await _firebaseCacheManager.getStateToRefresh(accountId, userName, typeName);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<void> deleteStateToRefresh(AccountId accountId, UserName userName, TypeName typeName) {
     return Future.sync(() async {
       return await _firebaseCacheManager.deleteStateToRefresh(accountId, userName, typeName);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -55,7 +64,10 @@ class CacheFCMDatasourceImpl extends FCMDatasource {
   Future<void> storeFirebaseRegistration(FirebaseRegistration firebaseRegistration) {
    return Future.sync(() async {
       return await _firebaseCacheManager.storeFirebaseRegistration(firebaseRegistration.toFirebaseRegistrationCache());
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
   
   @override
@@ -63,7 +75,10 @@ class CacheFCMDatasourceImpl extends FCMDatasource {
     return Future.sync(() async {
       final firebaseRegistrationCache = await _firebaseCacheManager.getStoredFirebaseRegistration();
       return firebaseRegistrationCache.toFirebaseRegistration();
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -80,6 +95,9 @@ class CacheFCMDatasourceImpl extends FCMDatasource {
   Future<void> deleteFirebaseRegistrationCache() {
     return Future.sync(() async {
       return await _firebaseCacheManager.deleteFirebaseRegistration();
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/push_notification/data/datasource_impl/fcm_datasource_impl.dart
+++ b/lib/features/push_notification/data/datasource_impl/fcm_datasource_impl.dart
@@ -23,7 +23,10 @@ class FcmDatasourceImpl extends FCMDatasource {
   Future<FirebaseRegistration> getFirebaseRegistrationByDeviceId(DeviceClientId deviceId) {
     return Future.sync(() async {
       return await _fcmApi.getFirebaseRegistrationByDeviceId(deviceId);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -50,7 +53,10 @@ class FcmDatasourceImpl extends FCMDatasource {
         newFcmToken: newTokenRequest.firebaseRegistration.token,
         newTypes: newTokenRequest.firebaseRegistration.types,
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
   
   @override
@@ -67,14 +73,20 @@ class FcmDatasourceImpl extends FCMDatasource {
   Future<void> destroyFirebaseRegistration(FirebaseRegistrationId registrationId) {
     return Future.sync(() async {
       return await _fcmApi.destroyFirebaseRegistration(registrationId);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<void> updateFirebaseRegistrationToken(UpdateTokenExpiredTimeRequest expiredTimeRequest) {
     return Future.sync(() async {
       return await _fcmApi.updateFirebaseRegistrationToken(expiredTimeRequest);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override

--- a/lib/features/push_notification/data/datasource_impl/web_socket_datasource_impl.dart
+++ b/lib/features/push_notification/data/datasource_impl/web_socket_datasource_impl.dart
@@ -35,7 +35,10 @@ class WebSocketDatasourceImpl implements WebSocketDatasource {
       await webSocketChannel.ready;
 
       return webSocketChannel;
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   void _verifyWebSocketCapabilities(Session session, AccountId accountId) {

--- a/lib/features/quotas/data/datasource_impl/quotas_data_source_impl.dart
+++ b/lib/features/quotas/data/datasource_impl/quotas_data_source_impl.dart
@@ -14,6 +14,9 @@ class QuotasDataSourceImpl  extends QuotasDataSource {
   Future<List<Quota>> getQuotas(AccountId accountId) {
     return Future.sync(() async {
       return await _quotasAPI.getQuotas(accountId);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/server_settings/data/datasource_impl/remote_server_settings_data_source_impl.dart
+++ b/lib/features/server_settings/data/datasource_impl/remote_server_settings_data_source_impl.dart
@@ -17,13 +17,19 @@ class RemoteServerSettingsDataSourceImpl implements ServerSettingsDataSource {
   Future<TMailServerSettings> getServerSettings(AccountId accountId) {
     return Future.sync(() async {
       return await _serverSettingsAPI.getServerSettings(accountId);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<TMailServerSettings> updateServerSettings(Session session, AccountId accountId, TMailServerSettings serverSettings) {
     return Future.sync(() async {
       return await _serverSettingsAPI.updateServerSettings(session, accountId, serverSettings);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/starting_page/data/datasource_impl/saas_authentication_datasource_impl.dart
+++ b/lib/features/starting_page/data/datasource_impl/saas_authentication_datasource_impl.dart
@@ -18,13 +18,19 @@ class SaasAuthenticationDataSourceImpl extends SaasAuthenticationDataSource {
   Future<TokenOIDC> signInTwakeWorkplace(OIDCConfiguration oidcConfiguration) {
     return Future.sync(() async {
       return await _authenticationClient.signInTwakeWorkplace(oidcConfiguration);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
   Future<TokenOIDC> signUpTwakeWorkplace(OIDCConfiguration oidcConfiguration) {
     return Future.sync(() async {
       return await _authenticationClient.signUpTwakeWorkplace(oidcConfiguration);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/thread/data/datasource_impl/local_thread_datasource_impl.dart
+++ b/lib/features/thread/data/datasource_impl/local_thread_datasource_impl.dart
@@ -95,7 +95,10 @@ class LocalThreadDataSourceImpl extends ThreadDataSource {
         sort: sort,
         filterOption: filterOption ?? FilterMessageOption.all,
         limit: limit);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -113,7 +116,10 @@ class LocalThreadDataSourceImpl extends ThreadDataSource {
         updated: updated,
         created: created,
         destroyed: destroyed);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -139,6 +145,9 @@ class LocalThreadDataSourceImpl extends ThreadDataSource {
         accountId: accountId,
         userName: session.username,
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/thread/data/datasource_impl/thread_datasource_impl.dart
+++ b/lib/features/thread/data/datasource_impl/thread_datasource_impl.dart
@@ -57,7 +57,10 @@ class ThreadDataSourceImpl extends ThreadDataSource {
         sort: sort,
         filter: filter,
         properties: properties);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -81,7 +84,10 @@ class ThreadDataSourceImpl extends ThreadDataSource {
         sort: sort,
         filter: filter,
         properties: properties);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -101,7 +107,10 @@ class ThreadDataSourceImpl extends ThreadDataSource {
         sinceState,
         propertiesCreated: propertiesCreated,
         propertiesUpdated: propertiesUpdated);
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -130,7 +139,10 @@ class ThreadDataSourceImpl extends ThreadDataSource {
         totalEmails,
         onProgressController
       );
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -138,7 +150,10 @@ class ThreadDataSourceImpl extends ThreadDataSource {
     return Future.sync(() async {
       final email = await threadAPI.getEmailById(session, accountId, emailId, properties: properties);
       return email.toPresentationEmail();
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override

--- a/lib/features/thread_detail/data/data_source/thread_detail_local_data_source_impl.dart
+++ b/lib/features/thread_detail/data/data_source/thread_detail_local_data_source_impl.dart
@@ -30,6 +30,9 @@ class ThreadDetailLocalDataSourceImpl implements ThreadDetailDataSource {
     return Future.sync(() async {
       final threadConfig = await _preferencesSettingManager.getThreadConfig();
       return threadConfig.isEnabled;
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/thread_detail/data/data_source/thread_detail_remote_data_source_impl.dart
+++ b/lib/features/thread_detail/data/data_source/thread_detail_remote_data_source_impl.dart
@@ -22,7 +22,10 @@ class ThreadDetailRemoteDataSourceImpl implements ThreadDetailDataSource {
   ) {
     return Future.sync(() async {
       return threadDetailApi.getThreadById(threadId, accountId);
-    }).catchError(exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override
@@ -39,7 +42,10 @@ class ThreadDetailRemoteDataSourceImpl implements ThreadDetailDataSource {
         emailIds,
         properties: properties,
       );
-    }).catchError(exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 
   @override

--- a/lib/features/upload/data/datasource_impl/attachment_upload_datasource_impl.dart
+++ b/lib/features/upload/data/datasource_impl/attachment_upload_datasource_impl.dart
@@ -27,6 +27,9 @@ class AttachmentUploadDataSourceImpl extends AttachmentUploadDataSource {
         _exceptionThrower,
         cancelToken: cancelToken
       )..upload();
-    }).catchError(_exceptionThrower.throwException);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/main/exceptions/cache_exception_thrower.dart
+++ b/lib/main/exceptions/cache_exception_thrower.dart
@@ -4,7 +4,7 @@ import 'package:tmail_ui_user/main/exceptions/exception_thrower.dart';
 class CacheExceptionThrower extends ExceptionThrower {
 
   @override
-  throwException(dynamic error, dynamic stackTrace) {
+  Future<void> throwException(dynamic error, dynamic stackTrace) {
     logError('CacheExceptionThrower::throwException():error: $error | stackTrace: $stackTrace');
     throw error;
   }

--- a/lib/main/exceptions/chained_request_error.dart
+++ b/lib/main/exceptions/chained_request_error.dart
@@ -1,0 +1,15 @@
+import 'package:dio/dio.dart';
+
+class ChainedRequestError extends DioError {
+  /// Error from the first request
+  final DioError primaryError;
+
+  /// Error from the second request (retry/refresh)
+  final Object? secondaryError;
+
+  ChainedRequestError({
+    required super.requestOptions,
+    required this.primaryError,
+    this.secondaryError,
+  });
+}

--- a/lib/main/exceptions/exception_thrower.dart
+++ b/lib/main/exceptions/exception_thrower.dart
@@ -1,4 +1,4 @@
 
 abstract class ExceptionThrower {
-  throwException(dynamic error, dynamic stackTrace);
+  Future<void> throwException(dynamic error, dynamic stackTrace);
 }

--- a/lib/main/exceptions/remote_exception.dart
+++ b/lib/main/exceptions/remote_exception.dart
@@ -9,6 +9,7 @@ abstract class RemoteException with EquatableMixin implements Exception {
   static const internalServerError = 'Internal Server Error';
   static const noNetworkError = 'No network error';
   static const badCredentials = 'Bad credentials';
+  static const badResponse = 'Bad response';
   static const socketException = 'Socket exception';
 
   final Object? message;
@@ -26,6 +27,10 @@ class BadCredentialsException extends RemoteException {
 
 class UnknownError extends RemoteException {
   const UnknownError({int? code, Object? message}) : super(code: code, message: message);
+}
+
+class BadResponseException extends RemoteException {
+  const BadResponseException({String? message}) : super(message: message ?? RemoteException.badResponse);
 }
 
 class ConnectionError extends RemoteException {
@@ -62,4 +67,14 @@ class CannotCalculateChangesMethodResponseException extends MethodLevelErrors {
 
 class NoNetworkError extends RemoteException {
   const NoNetworkError() : super(message: RemoteException.noNetworkError);
+}
+
+class ClientAuthenticationException extends RemoteException {
+  final String? secondErrorCode;
+
+  const ClientAuthenticationException({
+    super.code,
+    super.message,
+    this.secondErrorCode,
+  });
 }

--- a/lib/main/exceptions/remote_exception_thrower.dart
+++ b/lib/main/exceptions/remote_exception_thrower.dart
@@ -18,7 +18,7 @@ import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 class RemoteExceptionThrower extends ExceptionThrower {
 
   @override
-  throwException(dynamic error, dynamic stackTrace) async {
+  Future<void> throwException(dynamic error, dynamic stackTrace) async {
     logError('RemoteExceptionThrower::throwException():error: $error | stackTrace: $stackTrace');
     final networkConnectionController = getBinding<NetworkConnectionController>();
     final realtimeNetworkConnectionStatus = await networkConnectionController?.hasInternetConnection();

--- a/lib/main/exceptions/send_email_exception_thrower.dart
+++ b/lib/main/exceptions/send_email_exception_thrower.dart
@@ -9,7 +9,7 @@ import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
 class SendEmailExceptionThrower extends RemoteExceptionThrower {
   @override
-  FutureOr<void> throwException(error, stackTrace) async {
+  Future<void> throwException(error, stackTrace) async {
     log('SendEmailExceptionThrower::throwException(): $error | stackTrace: $stackTrace');
     final networkConnectionController = getBinding<NetworkConnectionController>();
     final realtimeNetworkConnectionStatus = await networkConnectionController?.hasInternetConnection();

--- a/lib/main/utils/toast_manager.dart
+++ b/lib/main/utils/toast_manager.dart
@@ -150,7 +150,7 @@ class ToastManager {
     final exception = failure.exception;
     final appLocalizations = AppLocalizations.of(context);
     String? message = getMessageByException(appLocalizations, exception);
-    
+
     if (failure is GetSessionFailure) {
       message = message ??
           getMessageByException(
@@ -158,7 +158,7 @@ class ToastManager {
             exception,
             useDefaultMessage: true,
           );
-    } else if (_isEmptySpamFolderFailure(exception)) {
+    } else if (_isEmptySpamFolderFailure(failure)) {
       message = message ?? appLocalizations.emptySpamFolderFailed;
     } else if (_isEmptyTrashFolderFailure(failure)) {
       message = message ?? appLocalizations.emptyTrashFolderFailed;

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -15,6 +15,7 @@ import 'package:tmail_ui_user/features/login/data/network/authentication_client/
 import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
 import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_exception.dart';
 import 'package:tmail_ui_user/features/login/domain/extensions/oidc_configuration_extensions.dart';
+import 'package:tmail_ui_user/main/exceptions/chained_request_error.dart';
 import 'package:tmail_ui_user/main/utils/ios_sharing_manager.dart';
 
 import '../../fixtures/account_fixtures.dart';
@@ -367,8 +368,8 @@ void main() {
           dio.post('$baseUrl/1',),
           dio.post('$baseUrl/2',)
         ]),
-        throwsA(predicate<DioError>(
-          (dioError) => dioError.error is AccessTokenInvalidException))
+        throwsA(predicate<ChainedRequestError>(
+          (requestError) => requestError.secondaryError is AccessTokenInvalidException))
       );
 
       verifyZeroInteractions(authenticationClient);


### PR DESCRIPTION
## Issue

#4081 

## Analysis and Solutions

Error handling

- When encountering a network connection error (`NoNetworkError`), display the message `"No internet connection"` to the user.
- When encountering a 401 error, perform a token refresh (`refreshToken`).
    - If `refreshToken` throws an exception, display a message to the user in the format:
`"Message [CodeError1 - CodeError2]"`.
    - Otherwise, if `refreshToken` succeeds but returns an empty token, automatically log in again using the current user's information.


## Demo

-  Case: Auto re-login with user email on 401 error for mobile

[auto-refresh.webm](https://github.com/user-attachments/assets/d4a97052-eff9-4b92-b456-6e9d56f623f9)

- Case: User logs out

[logout.webm](https://github.com/user-attachments/assets/c85add03-6d2f-4ae9-8b35-ef15b6ec0f0e)
