### PR TITLE
[HOT-FIX] Avoid adding `reply-to` when replying to emails with `List-Post` header

### DIFF
--- a/model/lib/extensions/presentation_email_extension.dart
+++ b/model/lib/extensions/presentation_email_extension.dart
@@ -70,7 +70,7 @@ extension PresentationEmailExtension on PresentationEmail {
     return '';
   }
 
-  Set<EmailAddress> get listEmailAddressSender => from.asSet()..addAll(replyTo.asSet());
+  Set<EmailAddress> get listEmailAddressSender => {...?from, ...?replyTo};
 
   PresentationEmail toggleSelect() {
     return copyWith(


### PR DESCRIPTION
## Issue

When replying to an email that contains a `List-Post` header, the composer currently adds both the `from` and `reply-to` addresses as recipients.

## Reproduce


https://github.com/user-attachments/assets/d7fef92a-2475-4a9a-b43f-90c58d3851fd

## Root cause 


The line

```console
from.asSet()..addAll(replyTo.asSet());
```

mutates the original `Set<EmailAddress>` of `from`, because `asSet()` does not create a copy — it returns the same reference. As a result, calling addAll() adds elements from `replyTo` directly into `from`, causing `PresentationEmail.from` to change unexpectedly in memory.

## Demo 




https://github.com/user-attachments/assets/2a9a5d99-9654-4ee1-b304-dfe67e7f2907



