### PR TITLE
TF-4099 Mobile adding an attachment causes composer UI issues

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -45,6 +45,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:largeHeap="true"
             android:launchMode="singleTask"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -36,7 +36,8 @@
    <application
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:largeHeap="true">
 
        <meta-data
            android:name="com.google.firebase.messaging.default_notification_icon"
@@ -45,7 +46,6 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:largeHeap="true"
             android:launchMode="singleTask"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -10,7 +10,6 @@ import 'package:dio/dio.dart';
 import 'package:dropdown_button2/dropdown_button2.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:filesize/filesize.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
@@ -612,6 +611,9 @@ class ComposerController extends BaseController
 
   void onCreatedMobileEditorAction(BuildContext context, HtmlEditorApi editorApi, String? content) {
     richTextMobileTabletController?.htmlEditorApi = editorApi;
+    richTextMobileTabletController?.onInitWebViewLifecycleManager(
+      editorApi.webViewController,
+    );
     richTextMobileTabletController?.richTextController.onCreateHTMLEditor(
       editorApi,
       onEnterKeyDown: _onEnterKeyDown,
@@ -1157,14 +1159,18 @@ class ComposerController extends BaseController
       .build();
   }
 
-  void openFilePickerByType(BuildContext context, FileType fileType) async {
-    if (!kIsWeb) {
+  void openFilePickerByType(BuildContext context, FileType fileType) {
+    if (PlatformInfo.isMobile) {
       popBack();
+      richTextMobileTabletController?.webViewLifecycleManager?.pause();
     }
     consumeState(_localFilePickerInteractor.execute(fileType: fileType));
   }
 
   void _handlePickFileFailure(LocalFilePickerFailure failure) {
+    if (PlatformInfo.isMobile) {
+      richTextMobileTabletController?.webViewLifecycleManager?.resume();
+    }
     if (currentOverlayContext != null && currentContext != null && failure.exception is! PickFileCanceledException) {
       appToast.showToastErrorMessage(
         currentOverlayContext!,
@@ -1173,6 +1179,9 @@ class ComposerController extends BaseController
   }
 
   void _handlePickImageFailure(LocalImagePickerFailure failure) {
+    if (PlatformInfo.isMobile) {
+      richTextMobileTabletController?.webViewLifecycleManager?.resume();
+    }
     if (currentOverlayContext != null && currentContext != null && failure.exception is! PickFileCanceledException) {
       appToast.showToastErrorMessage(
         currentOverlayContext!,
@@ -1181,6 +1190,9 @@ class ComposerController extends BaseController
   }
 
   void _handlePickFileSuccess(LocalFilePickerSuccess success) {
+    if (PlatformInfo.isMobile) {
+      richTextMobileTabletController?.webViewLifecycleManager?.resume();
+    }
     uploadController.validateTotalSizeAttachmentsBeforeUpload(
       totalSizePreparedFiles: success.pickedFiles.totalSize,
       onValidationSuccess: () => uploadAttachmentsAction(pickedFiles: success.pickedFiles)
@@ -1188,6 +1200,9 @@ class ComposerController extends BaseController
   }
 
   void _handlePickImageSuccess(LocalImagePickerSuccess success) {
+    if (PlatformInfo.isMobile) {
+      richTextMobileTabletController?.webViewLifecycleManager?.resume();
+    }
     uploadController.validateTotalSizeInlineAttachmentsBeforeUpload(
       totalSizePreparedFiles: success.fileInfo.fileSize,
       onValidationSuccess: () => uploadAttachmentsAction(pickedFiles: [success.fileInfo.withInline()])
@@ -1680,6 +1695,9 @@ class ComposerController extends BaseController
       maxWithEditor = maxWith - 70;
     }
 
+    if (PlatformInfo.isMobile) {
+      richTextMobileTabletController?.webViewLifecycleManager?.pause();
+    }
     consumeState(_localImagePickerInteractor.execute());
   }
 

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -235,6 +235,7 @@ class ComposerController extends BaseController
 
   List<Attachment> initialAttachments = <Attachment>[];
   String? _textEditorWeb;
+  String? _savedEditorContentBeforePicker;
   double? maxWithEditor;
   EmailId? emailIdEditing;
   bool isAttachmentCollapsed = false;
@@ -1159,17 +1160,38 @@ class ComposerController extends BaseController
       .build();
   }
 
-  void openFilePickerByType(BuildContext context, FileType fileType) {
+  Future<void> _saveEditorContentBeforePicker() async {
+    _savedEditorContentBeforePicker = await getContentInEditor();
+  }
+
+  Future<void> _restoreEditorContentIfBlank() async {
+    final saved = _savedEditorContentBeforePicker;
+    _savedEditorContentBeforePicker = null;
+    if (saved == null || saved.isEmpty) return;
+    try {
+      final current = await getContentInEditor();
+      if (current.isEmpty) {
+        await htmlEditorApi?.setText(saved);
+        log('ComposerController::_restoreEditorContentIfBlank: restored editor content after WebView renderer recovery');
+      }
+    } catch (e) {
+      logWarning('ComposerController::_restoreEditorContentIfBlank:Exception = $e');
+    }
+  }
+
+  Future<void> openFilePickerByType(BuildContext context, FileType fileType) async {
     if (PlatformInfo.isMobile) {
       popBack();
-      richTextMobileTabletController?.webViewLifecycleManager?.pause();
+      await _saveEditorContentBeforePicker();
+      await richTextMobileTabletController?.webViewLifecycleManager?.pause();
     }
     consumeState(_localFilePickerInteractor.execute(fileType: fileType));
   }
 
-  void _handlePickFileFailure(LocalFilePickerFailure failure) {
+  Future<void> _handlePickFileFailure(LocalFilePickerFailure failure) async {
     if (PlatformInfo.isMobile) {
-      richTextMobileTabletController?.webViewLifecycleManager?.resume();
+      await richTextMobileTabletController?.webViewLifecycleManager?.resume();
+      await _restoreEditorContentIfBlank();
     }
     if (currentOverlayContext != null && currentContext != null && failure.exception is! PickFileCanceledException) {
       appToast.showToastErrorMessage(
@@ -1178,9 +1200,10 @@ class ComposerController extends BaseController
     }
   }
 
-  void _handlePickImageFailure(LocalImagePickerFailure failure) {
+  Future<void> _handlePickImageFailure(LocalImagePickerFailure failure) async {
     if (PlatformInfo.isMobile) {
-      richTextMobileTabletController?.webViewLifecycleManager?.resume();
+      await richTextMobileTabletController?.webViewLifecycleManager?.resume();
+      await _restoreEditorContentIfBlank();
     }
     if (currentOverlayContext != null && currentContext != null && failure.exception is! PickFileCanceledException) {
       appToast.showToastErrorMessage(
@@ -1189,9 +1212,10 @@ class ComposerController extends BaseController
     }
   }
 
-  void _handlePickFileSuccess(LocalFilePickerSuccess success) {
+  Future<void> _handlePickFileSuccess(LocalFilePickerSuccess success) async {
     if (PlatformInfo.isMobile) {
-      richTextMobileTabletController?.webViewLifecycleManager?.resume();
+      await richTextMobileTabletController?.webViewLifecycleManager?.resume();
+      await _restoreEditorContentIfBlank();
     }
     uploadController.validateTotalSizeAttachmentsBeforeUpload(
       totalSizePreparedFiles: success.pickedFiles.totalSize,
@@ -1199,9 +1223,10 @@ class ComposerController extends BaseController
     );
   }
 
-  void _handlePickImageSuccess(LocalImagePickerSuccess success) {
+  Future<void> _handlePickImageSuccess(LocalImagePickerSuccess success) async {
     if (PlatformInfo.isMobile) {
-      richTextMobileTabletController?.webViewLifecycleManager?.resume();
+      await richTextMobileTabletController?.webViewLifecycleManager?.resume();
+      await _restoreEditorContentIfBlank();
     }
     uploadController.validateTotalSizeInlineAttachmentsBeforeUpload(
       totalSizePreparedFiles: success.fileInfo.fileSize,
@@ -1686,7 +1711,7 @@ class ComposerController extends BaseController
     }
   }
 
-  void insertImage(BuildContext context, double maxWith) {
+  Future<void> insertImage(BuildContext context, double maxWith) async {
     clearFocus();
 
     if (responsiveUtils.isMobile(context)) {
@@ -1696,7 +1721,8 @@ class ComposerController extends BaseController
     }
 
     if (PlatformInfo.isMobile) {
-      richTextMobileTabletController?.webViewLifecycleManager?.pause();
+      await _saveEditorContentBeforePicker();
+      await richTextMobileTabletController?.webViewLifecycleManager?.pause();
     }
     consumeState(_localImagePickerInteractor.execute());
   }

--- a/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
+++ b/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-
 import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/html/html_utils.dart';
 import 'package:core/utils/platform_info.dart';
@@ -8,12 +7,14 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get/get.dart';
 import 'package:rich_text_composer/rich_text_composer.dart';
+import 'package:tmail_ui_user/features/composer/presentation/controller/web_view_lifecycle_manager.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/header_style_type.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/inline_image.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 class RichTextMobileTabletController extends GetxController {
   HtmlEditorApi? htmlEditorApi;
+  WebViewLifecycleManager? webViewLifecycleManager;
 
   final RichTextController richTextController = RichTextController();
 
@@ -87,6 +88,10 @@ class RichTextMobileTabletController extends GetxController {
     }
   }
 
+  void onInitWebViewLifecycleManager(InAppWebViewController? controller) {
+    webViewLifecycleManager = WebViewLifecycleManager(controller);
+  }
+
   @override
   void onClose() {
     richTextController.dispose();
@@ -99,6 +104,7 @@ class RichTextMobileTabletController extends GetxController {
     } else {
       htmlEditorApi?.webViewController.dispose();
     }
+    webViewLifecycleManager = null;
     htmlEditorApi = null;
     super.onClose();
   }

--- a/lib/features/composer/presentation/controller/web_view_lifecycle_manager.dart
+++ b/lib/features/composer/presentation/controller/web_view_lifecycle_manager.dart
@@ -1,0 +1,28 @@
+import 'package:core/utils/app_logger.dart';
+import 'package:rich_text_composer/rich_text_composer.dart';
+
+class WebViewLifecycleManager {
+  final InAppWebViewController? controller;
+
+  WebViewLifecycleManager(this.controller);
+
+  Future<void> pause() async {
+    if (controller == null) return;
+    try {
+      await controller!.pauseTimers();
+      await controller!.pause();
+    } catch (e) {
+      logError('$runtimeType::pause:[WebViewLifecycleManager] pause error: $e');
+    }
+  }
+
+  Future<void> resume() async {
+    if (controller == null) return;
+    try {
+      await controller!.resume();
+      await controller!.resumeTimers();
+    } catch (e) {
+      logError('$runtimeType::resume:[WebViewLifecycleManager] resume error: $e');
+    }
+  }
+}

--- a/lib/features/upload/domain/usecases/local_file_picker_interactor.dart
+++ b/lib/features/upload/domain/usecases/local_file_picker_interactor.dart
@@ -1,6 +1,9 @@
 
+import 'dart:io';
+
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
+import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:dartz/dartz.dart';
 import 'package:file_picker/file_picker.dart';
@@ -14,6 +17,7 @@ class LocalFilePickerInteractor {
 
   Stream<Either<Failure, Success>> execute({FileType fileType = FileType.any}) async* {
     try {
+      log('$runtimeType::execute:Memory info: ${(ProcessInfo.currentRss / (1024 * 1024)).toStringAsFixed(2)} MB');
       yield Right<Failure, Success>(LocalFilePickerLoading());
 
       final filesResult = await FilePicker.platform.pickFiles(

--- a/lib/features/upload/domain/usecases/local_file_picker_interactor.dart
+++ b/lib/features/upload/domain/usecases/local_file_picker_interactor.dart
@@ -1,9 +1,6 @@
 
-import 'dart:io';
-
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
-import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:dartz/dartz.dart';
 import 'package:file_picker/file_picker.dart';
@@ -17,7 +14,6 @@ class LocalFilePickerInteractor {
 
   Stream<Either<Failure, Success>> execute({FileType fileType = FileType.any}) async* {
     try {
-      log('$runtimeType::execute:Memory info: ${(ProcessInfo.currentRss / (1024 * 1024)).toStringAsFixed(2)} MB');
       yield Right<Failure, Success>(LocalFilePickerLoading());
 
       final filesResult = await FilePicker.platform.pickFiles(


### PR DESCRIPTION
## Issue

#4099

## Root cause

- Log analysis:

```console
[ERROR:android_webview/browser/aw_browser_terminator.cc:165]
Renderer process (14064) crash detected (code -1).
[ERROR:android_webview/browser/aw_browser_terminator.cc:113]
Render process (14064) kill (OOM or update) wasn't handled by all associated webviews, killing application.

```

This is a typical crash of Android WebView renderer being `OOM (Out Of Memory)` or being force-killed due to `low-memory` policy.

Special:

```console
Process com.linagora.android.teammail (pid 12911) has died: svc +1 LAST
skip restart com.linagora.android.teammail because this device is a lowmemory device!

```

Confirmed MIUI (system_server) killed the process to reclaim memory, as the device recognized it as a “lowmemory device”.

- Conclude:

`flutter_inappwebview` creates its own sandbox renderer (Chromium engine) -> consumes a lot of RAM.

When file_picker turns on `Intent.ACTION_OPEN_DOCUMENT`, Android temporarily switches foreground to another app → causing MIUI or Android low-memory killer to think your app is in the background → kill WebView renderer.

Then WebView cannot recover because Chromium sandbox is dead → Flutter is terminated.


## Workaround

- Reduce WebView memory footprint
- Enable `android:largeHeap="true"` in AndroidManifest => Allow process to keep more RAM, limit OOM kill when DocumentsUI is open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced editor state preservation when accessing file and image pickers on mobile devices.

* **Bug Fixes**
  * Fixed editor content loss during file/image picker interactions on mobile.

* **Chores**
  * Optimized memory allocation to support larger operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->