### PR TITLE
Fix white overlay hides bottom action in create identity view on iOS

### DIFF
--- a/lib/main/pages/app_pages.dart
+++ b/lib/main/pages/app_pages.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:core/core.dart';
 import 'package:get/get.dart';
 import 'package:get/get_navigation/src/routes/get_route.dart';
@@ -136,7 +134,6 @@ class AppPages {
           binding: SearchMailboxBindings()),
         GetPage(
           name: AppRoutes.identityCreator,
-          opaque: Platform.isAndroid ? true : false,
           page: () => DeferredWidget(
             identity_creator.loadLibrary,
             () => identity_creator.IdentityCreatorView()


### PR DESCRIPTION
## Issue

When opening the Create Identity screen on iOS and the keyboard appears, a white overlay covers the bottom part of the view (including the action buttons). This issue does not occur on Android.

## Reproduce


https://github.com/user-attachments/assets/663317ca-f984-4d53-a056-d6e55807450b



## Root cause

In the GetPage configuration for the Identity Creator route, the property `opaque: false` was set on iOS. When opaque = false, the route becomes translucent, meaning it does not fully cover the screen and therefore does not receive keyboard inset events on iOS. As a result, the Scaffold does not resize when the keyboard opens, causing the white overlay to appear.


## Resolved

- iOS


https://github.com/user-attachments/assets/ce8b5b2d-98e3-4429-b555-f54d2dc787d2


- Android:

<img width="1080" height="2400" alt="Screenshot_20251015_163654" src="https://github.com/user-attachments/assets/19bf4acc-fe49-46e9-be38-b3e0d03f381f" />

