### PR TITLE
[HOT-FIX] Email content disappears after marking as star/unstar when thread is disabled on mobile

### DIFF
--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2025-10-14T15:18:48.964794",
+  "@@last_modified": "2025-10-17T09:52:08.303266",
   "initializing_data": "Initializing data...",
   "@initializing_data": {
     "type": "text",
@@ -4925,5 +4925,17 @@
     "placeholders": {
       "count": {}
     }
+  },
+  "mailHasBeenStarred": "Mail has been starred",
+  "@mailHasBeenStarred": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "mailHasBeenUnstarred": "Mail has been unstarred",
+  "@mailHasBeenUnstarred": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
 }

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -5198,4 +5198,18 @@ class AppLocalizations {
       args: [count],
     );
   }
+
+  String get mailHasBeenStarred {
+    return Intl.message(
+      'Mail has been starred',
+      name: 'mailHasBeenStarred',
+    );
+  }
+
+  String get mailHasBeenUnstarred {
+    return Intl.message(
+      'Mail has been unstarred',
+      name: 'mailHasBeenUnstarred',
+    );
+  }
 }

--- a/lib/main/utils/toast_manager.dart
+++ b/lib/main/utils/toast_manager.dart
@@ -12,11 +12,13 @@ import 'package:jmap_dart_client/jmap/core/error/method/error_method_response.da
 import 'package:jmap_dart_client/jmap/core/error/method/exception/error_method_response_exception.dart';
 import 'package:jmap_dart_client/jmap/core/error/set_error.dart';
 import 'package:model/email/email_action_type.dart';
+import 'package:model/email/mark_star_action.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:tmail_ui_user/features/composer/domain/exceptions/set_method_exception.dart';
 import 'package:tmail_ui_user/features/email/domain/exceptions/calendar_event_exceptions.dart';
 import 'package:tmail_ui_user/features/email/domain/model/move_action.dart';
 import 'package:tmail_ui_user/features/email/domain/state/calendar_event_reply_state.dart';
+import 'package:tmail_ui_user/features/email/domain/state/mark_as_email_star_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/parse_email_by_blob_id_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/preview_email_from_eml_file_state.dart';
 import 'package:tmail_ui_user/features/home/data/exceptions/session_exceptions.dart';
@@ -244,6 +246,10 @@ class ToastManager {
       } else {
         message = appLocalizations.you_are_changed_your_identity_successfully;
       }
+    } else if (success is MarkAsStarEmailSuccess) {
+      message = success.markStarAction == MarkStarAction.markStar
+          ? appLocalizations.mailHasBeenStarred
+          : appLocalizations.mailHasBeenUnstarred;
     }
     log('ToastManager::showMessageSuccess: Message: $message');
     if (message?.trim().isNotEmpty == true) {

--- a/model/lib/extensions/presentation_email_extension.dart
+++ b/model/lib/extensions/presentation_email_extension.dart
@@ -202,4 +202,9 @@ extension PresentationEmailExtension on PresentationEmail {
 
   MailboxId? get firstMailboxIdAvailable =>
       mailboxIds?.entries.firstWhereOrNull((element) => element.value)?.key;
+
+  void resyncKeywords(Map<KeyWordIdentifier, bool> newKeywords) {
+    keywords?.addAll(newKeywords);
+    keywords?.removeWhere((key, value) => !value);
+  }
 }


### PR DESCRIPTION
## Issue

Email content disappears after marking as `star/unstar` when thread is disabled


## Reproduce

Steps to reproduce:

```
Go to Settings → Disable thread mode.

Open any email from the mail list.

Open the context menu (three dots) of the email.

Click “Mark as star” or “Unstar”.
```

[Screen_recording_20251017_100626.webm](https://github.com/user-attachments/assets/0d1073f6-79d1-48f1-8fe3-01658312e9b6)


## Root cause

When the user performs the mark as star/unstar action, the state of the currently opened (selected) email is not updated properly. As a result, after the email list is refreshed, the selected email is no longer referenced or found, causing the email content to disappear from the view.

## Resolved

[Screen_recording_20251017_095856.webm](https://github.com/user-attachments/assets/c99fc12c-64f3-43cf-be12-80875ab6a6f8)

