### PR TITLE
[HOT-FIX] Duplicated email subject after enabling thread mode

### DIFF
--- a/lib/features/email/presentation/styles/email_subject_styles.dart
+++ b/lib/features/email/presentation/styles/email_subject_styles.dart
@@ -12,7 +12,6 @@ class EmailSubjectStyles {
     overflow: PlatformInfo.isWeb ? TextOverflow.ellipsis : null,
     color: Colors.black,
     fontSize: 24,
-    height: 1,
     letterSpacing: -0.24,
   );
 }

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -3273,6 +3273,9 @@ class MailboxDashBoardController extends ReloadableController
 
   jmap.State? get currentEmailState => _currentEmailState;
 
+  bool get isThreadDetailedViewVisible =>
+      dashboardRoute.value == DashboardRoutes.threadDetailed;
+
   void _loadAppGrid() {
     if (PlatformInfo.isWeb && AppConfig.appGridDashboardAvailable) {
       appGridDashboardController.loadAppDashboardConfiguration();

--- a/lib/features/thread_detail/presentation/action/thread_detail_ui_action.dart
+++ b/lib/features/thread_detail/presentation/action/thread_detail_ui_action.dart
@@ -25,6 +25,8 @@ class UpdatedEmailKeywordsAction extends ThreadDetailUIAction {
 
 class UpdatedThreadDetailSettingAction extends ThreadDetailUIAction {}
 
+class ResyncThreadDetailWhenSettingChangedAction extends ThreadDetailUIAction {}
+
 class EmailMovedAction extends ThreadDetailUIAction {
   EmailMovedAction({
     required this.emailId,

--- a/lib/features/thread_detail/presentation/extension/refresh_thread_detail_on_setting_changed.dart
+++ b/lib/features/thread_detail/presentation/extension/refresh_thread_detail_on_setting_changed.dart
@@ -1,10 +1,19 @@
+import 'package:core/utils/platform_info.dart';
+import 'package:tmail_ui_user/features/thread_detail/presentation/action/thread_detail_ui_action.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/thread_detail_manager.dart';
 
 extension RefreshThreadDetailOnSettingChanged on ThreadDetailManager {
   void refreshThreadDetailOnSettingChanged() {
     if (threadDetailWasEnabled != isThreadDetailEnabled) {
       threadDetailWasEnabled = isThreadDetailEnabled;
-      mailboxDashBoardController.selectedEmail.refresh();
+      if (PlatformInfo.isWeb &&
+          mailboxDashBoardController.isThreadDetailedViewVisible) {
+        mailboxDashBoardController.dispatchThreadDetailUIAction(
+          ResyncThreadDetailWhenSettingChangedAction(),
+        );
+      } else {
+        mailboxDashBoardController.selectedEmail.refresh();
+      }
     }
   }
 }

--- a/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
+++ b/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
@@ -8,7 +8,6 @@ import 'package:tmail_ui_user/features/email/presentation/action/email_ui_action
 import 'package:tmail_ui_user/features/thread/presentation/extensions/list_presentation_email_extensions.dart';
 import 'package:tmail_ui_user/features/thread_detail/domain/state/get_emails_by_ids_state.dart';
 import 'package:tmail_ui_user/features/thread_detail/domain/state/get_thread_by_id_state.dart';
-import 'package:tmail_ui_user/features/thread_detail/domain/usecases/get_thread_by_id_interactor.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/action/thread_detail_ui_action.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/extension/close_thread_detail_action.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/thread_detail_controller.dart';
@@ -16,7 +15,6 @@ import 'package:tmail_ui_user/features/thread_detail/presentation/thread_detail_
 extension ThreadDetailOnSelectedEmailUpdated on ThreadDetailController {
   void onSelectedEmailUpdated(
     PresentationEmail? selectedEmail,
-    GetThreadByIdInteractor getThreadByIdInteractor,
     BuildContext? context,
   ) {
     if (selectedEmail?.id == null) {
@@ -75,5 +73,20 @@ extension ThreadDetailOnSelectedEmailUpdated on ThreadDetailController {
       )),
       Right(PreloadEmailsByIdsSuccess([selectedEmail])),
     ]));
+  }
+
+  void resyncThreadDetailWhenSettingChanged() {
+    final selectedEmail = mailboxDashBoardController.selectedEmail.value;
+    if (selectedEmail == null) return;
+
+    emailIdsPresentation.clear();
+    scrollController ??= ScrollController();
+
+    mailboxDashBoardController.dispatchEmailUIAction(
+      DisposePreviousExpandedEmailAction(selectedEmail.id!),
+    );
+
+    loadThreadOnThreadChanged = isThreadDetailEnabled;
+    _preloadSelectedEmail(selectedEmail);
   }
 }

--- a/lib/features/thread_detail/presentation/thread_detail_controller.dart
+++ b/lib/features/thread_detail/presentation/thread_detail_controller.dart
@@ -177,7 +177,6 @@ class ThreadDetailController extends BaseController {
     ever(mailboxDashBoardController.selectedEmail, (presentationEmail) async {
       onSelectedEmailUpdated(
         presentationEmail,
-        _getEmailIdsByThreadIdInteractor,
         currentContext,
       );
     });
@@ -206,6 +205,8 @@ class ThreadDetailController extends BaseController {
         refocusMailShortcutFocus();
       } else if (action is ClearMailViewKeyboardShortcutFocusAction) {
         clearMailShortcutFocus();
+      } else if (action is ResyncThreadDetailWhenSettingChangedAction) {
+        resyncThreadDetailWhenSettingChanged();
       }
       // Reset [threadDetailUIAction] to original value
       mailboxDashBoardController.dispatchThreadDetailUIAction(

--- a/test/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated_test.dart
+++ b/test/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated_test.dart
@@ -11,7 +11,6 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/thread/presentation/extensions/list_presentation_email_extensions.dart';
 import 'package:tmail_ui_user/features/thread_detail/domain/state/get_emails_by_ids_state.dart';
 import 'package:tmail_ui_user/features/thread_detail/domain/state/get_thread_by_id_state.dart';
-import 'package:tmail_ui_user/features/thread_detail/domain/usecases/get_thread_by_id_interactor.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/thread_detail_controller.dart';
 
@@ -21,17 +20,14 @@ import 'thread_detail_on_selected_email_updated_test.mocks.dart';
 
 @GenerateNiceMocks([
   MockSpec<ThreadDetailController>(),
-  MockSpec<GetThreadByIdInteractor>(),
   MockSpec<MailboxDashBoardController>(),
 ])
 void main() {
   late MockThreadDetailController threadDetailController;
-  late MockGetThreadByIdInteractor getThreadByIdInteractor;
   late MockMailboxDashBoardController mailboxDashboardController;
 
   setUp(() {
     threadDetailController = MockThreadDetailController();
-    getThreadByIdInteractor = MockGetThreadByIdInteractor();
     mailboxDashboardController = MockMailboxDashBoardController();
     when(threadDetailController.session)
       .thenReturn(SessionFixtures.aliceSession);
@@ -51,7 +47,6 @@ void main() {
       // act
       threadDetailController.onSelectedEmailUpdated(
         null,
-        getThreadByIdInteractor,
         null,
       );
       
@@ -76,7 +71,6 @@ void main() {
       // act
       threadDetailController.onSelectedEmailUpdated(
         selectedEmail,
-        getThreadByIdInteractor,
         null,
       );
       


### PR DESCRIPTION
## Issue

Duplicated email subject after enabling thread mode

## Reproduce

Steps to reproduce

```
Open any email while thread mode is disabled.
Go to Settings → Enable thread mode.
Go back to the previously opened email view.
```

https://github.com/user-attachments/assets/ba733eb3-d546-4619-9128-0e7754f71ef2

## Root cause

The issue occurs because the EmailView uses a GlobalKey, which prevents the widget from being disposed of when switching views. As a result, when the EmailView is rebuilt, it retains the previous object state within the class instead of creating a fresh instance, causing outdated or incorrect data (such as the old email subject) to be displayed.

## Resolved


https://github.com/user-attachments/assets/3998e534-f284-4f17-8419-2abebed7e355





