### PR TITLE
Fix Storage still visible in settings when quota is empty

### DIFF
--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -1946,6 +1946,7 @@ class MailboxDashBoardController extends ReloadableController
       arguments: ManageAccountArguments(
         sessionCurrent,
         previousUri: RouteUtils.baseUri,
+        quota: octetsQuota.value,
       ),
     );
 
@@ -2020,7 +2021,8 @@ class MailboxDashBoardController extends ReloadableController
       arguments: ManageAccountArguments(
         sessionCurrent,
         menuSettingCurrent: AccountMenuItem.vacation,
-        previousUri: RouteUtils.baseUri
+        previousUri: RouteUtils.baseUri,
+        quota: octetsQuota.value,
       )
     );
 

--- a/lib/features/manage_account/presentation/extensions/validate_storage_menu_visible_extension.dart
+++ b/lib/features/manage_account/presentation/extensions/validate_storage_menu_visible_extension.dart
@@ -1,0 +1,47 @@
+import 'package:dartz/dartz.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:tmail_ui_user/features/home/data/exceptions/session_exceptions.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/extensions/validate_setting_capability_supported_extension.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/manage_account_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/quotas/domain/exceptions/quotas_exception.dart';
+import 'package:tmail_ui_user/features/quotas/domain/extensions/list_quotas_extensions.dart';
+import 'package:tmail_ui_user/features/quotas/domain/state/get_quotas_state.dart';
+import 'package:tmail_ui_user/features/quotas/domain/use_case/get_quotas_interactor.dart';
+import 'package:tmail_ui_user/features/quotas/presentation/quotas_interactor_bindings.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+
+extension ValidateStorageMenuVisibleExtension
+    on ManageAccountDashBoardController {
+  void injectQuotaBindings() {
+    if (isStorageCapabilitySupported) {
+      QuotasInteractorBindings().dependencies();
+    }
+  }
+
+  void getQuotas(AccountId? accountId) {
+    if (accountId == null) {
+      consumeState(
+        Stream.value(Left(GetQuotasFailure(NotFoundAccountIdException))),
+      );
+      return;
+    }
+
+    getQuotasInteractor = getBinding<GetQuotasInteractor>();
+    if (getQuotasInteractor == null || !isStorageCapabilitySupported) {
+      consumeState(
+        Stream.value(Left(GetQuotasFailure(QuotasNotSupportedException))),
+      );
+      return;
+    }
+
+    consumeState(getQuotasInteractor!.execute(accountId));
+  }
+
+  void handleGetQuotasSuccess(GetQuotasSuccess success) {
+    octetsQuota.value = success.quotas.octetsQuota;
+  }
+
+  void handleGetQuotasFailure() {
+    octetsQuota.value = null;
+  }
+}

--- a/lib/features/manage_account/presentation/menu/manage_account_menu_controller.dart
+++ b/lib/features/manage_account/presentation/menu/manage_account_menu_controller.dart
@@ -1,10 +1,8 @@
-
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/mixin/contact_support_mixin.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/extensions/validate_setting_capability_supported_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/manage_account_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
@@ -21,12 +19,23 @@ class ManageAccountMenuController extends GetxController with ContactSupportMixi
     AccountMenuItem.languageAndRegion,
   ]);
 
+  late Worker _quotaRxWorker;
+
   void _registerObxStreamListener() {
     ever(dashBoardController.accountId, (accountId) {
       if (accountId != null) {
         _createListAccountMenu();
       }
     });
+
+    _quotaRxWorker = ever(
+      dashBoardController.octetsQuota,
+      (octetsQuota) {
+        if (octetsQuota != null) {
+          _addStorageToMenuList();
+        }
+      },
+    );
   }
 
   @override
@@ -49,8 +58,6 @@ class ManageAccountMenuController extends GetxController with ContactSupportMixi
       AccountMenuItem.mailboxVisibility,
       if (dashBoardController.isLanguageSettingDisplayed)
         AccountMenuItem.languageAndRegion,
-      if (dashBoardController.isStorageCapabilitySupported)
-        AccountMenuItem.storage,
     ];
     listAccountMenuItem.value = newListMenuSetting;
 
@@ -69,5 +76,21 @@ class ManageAccountMenuController extends GetxController with ContactSupportMixi
 
   void backToMailboxDashBoard(BuildContext context) {
     dashBoardController.backToMailboxDashBoard(context: context);
+  }
+
+  void _addStorageToMenuList() {
+    listAccountMenuItem.add(AccountMenuItem.storage);
+
+    if (dashBoardController.selectedMenu != null) {
+      dashBoardController.selectAccountMenuItem(
+        dashBoardController.selectedMenu!,
+      );
+    }
+  }
+
+  @override
+  void onClose() {
+    _quotaRxWorker.dispose();
+    super.onClose();
   }
 }

--- a/lib/features/manage_account/presentation/menu/settings/settings_first_level_view.dart
+++ b/lib/features/manage_account/presentation/menu/settings/settings_first_level_view.dart
@@ -7,7 +7,6 @@ import 'package:tmail_ui_user/features/home/domain/extensions/session_extensions
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/user_information_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/profile_setting/profile_setting_action_type.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/extensions/handle_profile_setting_action_type_click_extension.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/extensions/validate_setting_capability_supported_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/menu/settings/settings_controller.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/menu/settings_utils.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/menu/widgets/setting_first_level_tile_builder.dart';
@@ -171,7 +170,7 @@ class SettingsFirstLevelView extends GetWidget<SettingsController> {
           ]);
         }),
         Obx(() {
-          if (controller.manageAccountDashboardController.isStorageCapabilitySupported) {
+          if (controller.manageAccountDashboardController.octetsQuota.value != null) {
             return Column(children: [
               Divider(
                 color: AppColor.colorDividerHorizontal,

--- a/lib/features/manage_account/presentation/model/manage_account_arguments.dart
+++ b/lib/features/manage_account/presentation/model/manage_account_arguments.dart
@@ -1,6 +1,6 @@
-
 import 'package:equatable/equatable.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/quotas/quota.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
 
 class ManageAccountArguments with EquatableMixin {
@@ -8,12 +8,14 @@ class ManageAccountArguments with EquatableMixin {
   final Session? session;
   final AccountMenuItem? menuSettingCurrent;
   final Uri? previousUri;
+  final Quota? quota;
 
   ManageAccountArguments(
     this.session,
     {
       this.menuSettingCurrent,
       this.previousUri,
+      this.quota,
     }
   );
 
@@ -22,5 +24,6 @@ class ManageAccountArguments with EquatableMixin {
     session,
     menuSettingCurrent,
     previousUri,
+    quota,
   ];
 }

--- a/lib/features/manage_account/presentation/storage/storage_bindings.dart
+++ b/lib/features/manage_account/presentation/storage/storage_bindings.dart
@@ -1,12 +1,9 @@
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/storage/storage_controller.dart';
-import 'package:tmail_ui_user/features/quotas/domain/use_case/get_quotas_interactor.dart';
-import 'package:tmail_ui_user/features/quotas/presentation/quotas_interactor_bindings.dart';
 
 class StorageBindings extends Bindings {
   @override
   void dependencies() {
-    QuotasInteractorBindings().dependencies();
-    Get.lazyPut(() => StorageController(Get.find<GetQuotasInteractor>()));
+    Get.lazyPut(() => StorageController());
   }
 }

--- a/lib/features/manage_account/presentation/storage/storage_controller.dart
+++ b/lib/features/manage_account/presentation/storage/storage_controller.dart
@@ -1,49 +1,11 @@
-import 'package:core/presentation/state/failure.dart';
-import 'package:core/presentation/state/success.dart';
-import 'package:dartz/dartz.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
-import 'package:jmap_dart_client/jmap/account_id.dart';
-import 'package:jmap_dart_client/jmap/quotas/quota.dart';
 import 'package:tmail_ui_user/features/base/base_controller.dart';
-import 'package:tmail_ui_user/features/home/data/exceptions/session_exceptions.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/manage_account_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/paywall/presentation/saas_premium_mixin.dart';
-import 'package:tmail_ui_user/features/quotas/domain/extensions/list_quotas_extensions.dart';
-import 'package:tmail_ui_user/features/quotas/domain/state/get_quotas_state.dart';
-import 'package:tmail_ui_user/features/quotas/domain/use_case/get_quotas_interactor.dart';
 
 class StorageController extends BaseController with SaaSPremiumMixin {
   final dashBoardController = Get.find<ManageAccountDashBoardController>();
-
-  final GetQuotasInteractor _getQuotasInteractor;
-
-  final octetsQuota = Rxn<Quota>();
-
-  StorageController(this._getQuotasInteractor);
-
-  @override
-  void onReady() {
-    final accountId = dashBoardController.accountId.value;
-    if (accountId != null) {
-      _getQuotasAction(accountId);
-    } else {
-      consumeState(
-        Stream.value(
-          Left(GetQuotasFailure(NotFoundAccountIdException())),
-        ),
-      );
-    }
-    super.onReady();
-  }
-
-  void _getQuotasAction(AccountId accountId) {
-    consumeState(_getQuotasInteractor.execute(accountId));
-  }
-
-  void _handleGetQuotasSuccess(GetQuotasSuccess success) {
-    octetsQuota.value = success.quotas.octetsQuota;
-  }
 
   bool validatePremiumIsAvailable() {
     final accountId = dashBoardController.accountId.value;
@@ -57,26 +19,5 @@ class StorageController extends BaseController with SaaSPremiumMixin {
 
   void onUpgradeStorage(BuildContext context) {
     dashBoardController.paywallController?.navigateToPaywall(context);
-  }
-
-  bool get isLoading => viewState.value
-      .fold((failure) => false, (success) => success is GetQuotasLoading);
-
-  @override
-  void handleSuccessViewState(Success success) {
-    if (success is GetQuotasSuccess) {
-      _handleGetQuotasSuccess(success);
-    } else {
-      super.handleSuccessViewState(success);
-    }
-  }
-
-  @override
-  void handleFailureViewState(Failure failure) {
-    if (failure is GetQuotasFailure) {
-      octetsQuota.value = null;
-    } else {
-      super.handleFailureViewState(failure);
-    }
   }
 }

--- a/lib/features/manage_account/presentation/storage/storage_view.dart
+++ b/lib/features/manage_account/presentation/storage/storage_view.dart
@@ -3,7 +3,6 @@ import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/mixin/app_loader_mixin.dart';
-import 'package:tmail_ui_user/features/base/widget/circle_loading_widget.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/base/setting_detail_view_builder.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/menu/settings_utils.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
@@ -61,23 +60,13 @@ class StorageView extends GetWidget<StorageController> with AppLoaderMixin {
                 isCenter: true,
                 textAlign: TextAlign.center,
               ),
-            Obx(() {
-              if (!controller.isLoading) {
-                return const SizedBox.shrink();
-              }
-              return Center(
-                child: Padding(
-                  padding: SettingsUtils.getSettingProgressBarPadding(
-                    context,
-                    controller.responsiveUtils,
-                  ),
-                  child: const CircleLoadingWidget(),
-                ),
-              );
-            }),
             Expanded(
               child: Obx(() {
-                final octetsQuota = controller.octetsQuota.value;
+                final octetsQuota = controller
+                    .dashBoardController
+                    .octetsQuota
+                    .value;
+
                 if (octetsQuota != null && octetsQuota.storageAvailable) {
                   return SingleChildScrollView(
                     child: Padding(

--- a/lib/features/quotas/domain/exceptions/quotas_exception.dart
+++ b/lib/features/quotas/domain/exceptions/quotas_exception.dart
@@ -1,3 +1,3 @@
-class NotFoundQuotasException implements Exception {
-  NotFoundQuotasException();
-}
+class NotFoundQuotasException implements Exception {}
+
+class QuotasNotSupportedException implements Exception {}


### PR DESCRIPTION
## Issue

In the settings menu, the Storage section is still displayed even when the user's quota information is empty or unavailable. This creates confusion since no data is shown inside that section.

https://github.com/linagora/tmail-flutter/issues/4112#issuecomment-3420419586

## Reproduce


https://github.com/user-attachments/assets/b650e593-6aad-4ab6-9b3d-68fb10e43d46

## Resolved

- Without Quota

https://github.com/user-attachments/assets/3c364229-5909-4e2e-b55c-af4f575e1a29

- With Quota


https://github.com/user-attachments/assets/dd05d8b4-718d-42a1-b167-5a0d7e6e8de9


