### PR TITLE
TF-4117 Fix recipient modal blocking interaction in Mail composer

### DIFF
--- a/lib/features/composer/presentation/composer_view_web.dart
+++ b/lib/features/composer/presentation/composer_view_web.dart
@@ -32,6 +32,7 @@ import 'package:tmail_ui_user/features/composer/presentation/widgets/web/from_co
 import 'package:tmail_ui_user/features/composer/presentation/widgets/web/local_file_drop_zone_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/web/mobile_responsive_app_bar_composer_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/web/toolbar_rich_text_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/utils/email_action_reactor/email_action_reactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/verify_display_overlay_view_on_iframe_extension.dart';
 import 'package:tmail_ui_user/main/routes/dialog_router.dart';
 
@@ -49,6 +50,7 @@ class ComposerView extends GetWidget<ComposerController> {
     final iframeOverlay = Obx(() {
       bool isOverlayEnabled = controller.mailboxDashBoardController.isDisplayedOverlayViewOnIFrame ||
           MessageDialogActionManager().isDialogOpened ||
+          EmailActionReactor.isDialogOpened ||
           ColorDialogPicker().isOpened.isTrue ||
           DialogRouter.isRuleFilterDialogOpened.isTrue ||
           DialogRouter.isDialogOpened;


### PR DESCRIPTION
## Issue

#4117

## Reproduce


https://github.com/user-attachments/assets/2607c9fe-1fef-4f72-94bd-62804d31928e



## Root cause 

The Dialog is rendered above an `HtmlElementView` that is not wrapped inside an iframe, causing the view to capture focus and block user interaction with the modal.

## Resolved


https://github.com/user-attachments/assets/4abf660d-9fc6-46e9-bb55-ce8d0b4373e1

