### PR TITLE
HOTFIX Integration test Forward attachments email

### DIFF
--- a/integration_test/scenarios/email_detailed/forwarding_email_lost_attachments_scenario.dart
+++ b/integration_test/scenarios/email_detailed/forwarding_email_lost_attachments_scenario.dart
@@ -17,7 +17,7 @@ class ForwardingEmailLostAttachmentsScenario extends BaseTestScenario {
   @override
   Future<void> runTestLogic() async {
     const subject = 'Forwarding email lost attachments';
-    final List<String> attachmentContents = ['file1', 'file2'];
+    final List<String> attachmentContents = ['file1', 'file2', 'file3'];
     const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
 
     final threadRobot = ThreadRobot($);
@@ -55,9 +55,6 @@ class ForwardingEmailLostAttachmentsScenario extends BaseTestScenario {
     await _expectComposerViewVisible();
 
     await composerRobot.grantContactPermission();
-
-    await composerRobot.expandRecipientsFields();
-    await $.pumpAndSettle();
 
     await composerRobot.addRecipientIntoField(
       prefixEmailAddress: PrefixEmailAddress.to,


### PR DESCRIPTION
### Before
```console
❌ Should see attachment list in email view after forward email successfully (integration_test/tests/email_detailed/forwarding_email_lost_attachments_test.dart) (48s)
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞═════════════════
The following WaitUntilVisibleTimeoutException was thrown running
a test:
TimeoutException after 0:00:30.000000: Finder "Found 1 widget
with type "EmailAttachmentsWidget": [
  EmailAttachmentsWidget(dependencies: [MediaQuery,
_LocalizationsScope-[GlobalKey#b44c2]]),
]" did not find any visible (i.e. hit-testable) widgets

When the exception was thrown, this was the stack:
#0      PatrolTester.waitUntilVisible.<anonymous closure>.<anonymous closure> (package:patrol_finders/src/custom_finders/patrol_tester.dart:575:15)
<asynchronous suspension>
#1      PatrolTester.wrapWithPatrolLog (package:patrol_finders/src/custom_finders/patrol_tester.dart:168:22)
<asynchronous suspension>
#2      TestAsyncUtils.guard.<anonymous closure> (package:flutter_test/src/test_async_utils.dart:130:27)
<asynchronous suspension>
#3      BaseScenario.expectViewVisible (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/base/base_scenario.dart:16:5)
<asynchronous suspension>
#4      ForwardingEmailLostAttachmentsScenario.runTestLogic (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/scenarios/email_detailed/forwarding_email_lost_attachments_scenario.dart:52:5)
<asynchronous suspension>
#5      BaseTestScenario.execute (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/base/base_test_scenario.dart:14:5)
<asynchronous suspension>
#6      TestBase.runPatrolTest.<anonymous closure> (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/base/test_base.dart:31:9)
<asynchronous suspension>
#7      patrolTest.<anonymous closure> (package:patrol/src/common.dart:149:7)
<asynchronous suspension>
#8      testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:193:15)
<asynchronous suspension>
#9      PatrolBinding._wrapTestBodyWithExceptionGatherer (package:patrol/src/binding.dart:250:5)
<asynchronous suspension>
#10     TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:1064:5)
<asynchronous suspension>
#11     TestWidgetsFlutterBinding._createTestCompletionHandler.<anonymous closure> (package:flutter_test/src/binding.dart:814:12)
<asynchronous suspension>

The test description was:
  Should see attachment list in email view after forward email
  successfully
═════════════════════════════════════════════════════════════════


Test summary:
📝 Total: 1
✅ Successful: 0
❌ Failed: 1
  - Should see attachment list in email view after forward email successfully (integration_test/tests/email_detailed/forwarding_email_lost_attachments_test.dart)
⏩ Skipped: 0
📊 Report: file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 117s
```
### After
```console
✅ Should see attachment list in email view after forward email successfully (integration_test/tests/email_detailed/forwarding_email_lost_attachments_test.dart) (26s)

Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 104s
```