### PR TITLE
TF-4004 Apply new UI for delete rule email dialog as a confirm modal

### DIFF
--- a/lib/features/manage_account/presentation/email_rules/email_rules_controller.dart
+++ b/lib/features/manage_account/presentation/email_rules/email_rules_controller.dart
@@ -175,6 +175,7 @@ class EmailRulesController extends BaseController {
       title: AppLocalizations.of(context).deleteEmailRule,
       AppLocalizations.of(context).messageConfirmationDialogDeleteEmailRule(emailRule.name),
       AppLocalizations.of(context).delete,
+      alignCenter: true,
       cancelTitle: AppLocalizations.of(context).cancel,
       onConfirmAction: () => _handleDeleteEmailRuleAction(emailRule),
       onCloseButtonAction: popBack,


### PR DESCRIPTION
## Issue

#4004 

The delete rule email dialog interface is not consistent with the new design.

<img width="352" height="774" alt="Capture d’écran 2025-10-23 à 09 50 16" src="https://github.com/user-attachments/assets/7a659e54-1b9c-4458-a46e-33a5f9c22913" />


## Resolved

[Screen_recording_20251029_163304.webm](https://github.com/user-attachments/assets/38b92e51-4f65-47f1-bbb3-52959e57cc77)
