### PR TITLE
TF-4139 Fix attachment reminder mistakenly shown when replying to an email

### DIFF
--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -685,14 +685,31 @@ class HtmlUtils {
       });
     </script>''';
 
-  static String extractPlainText(String html) {
+  static String extractPlainText(
+    String html, {
+    bool removeQuotes = true,
+    bool removeStyle = true,
+    bool removeScript = true,
+  }) {
     var cleaned = html;
-    // Delete the blockquote and the content inside
-    final blockquoteRegex = RegExp(
-      r'<blockquote[\s\S]*?</blockquote>',
-      caseSensitive: false,
-    );
-    cleaned = html.replaceAll(blockquoteRegex, '');
+
+    if (cleaned.isEmpty) return '';
+
+    // Parse DOM
+    final doc = parser.parse(cleaned);
+
+    // Remove unwanted nodes by CSS selector
+    if (removeQuotes) {
+      doc.querySelectorAll('blockquote').forEach((e) => e.remove());
+    }
+    if (removeStyle) {
+      doc.querySelectorAll('style').forEach((e) => e.remove());
+    }
+    if (removeScript) {
+      doc.querySelectorAll('script').forEach((e) => e.remove());
+    }
+
+    cleaned = doc.outerHtml;
 
     // Decode HTML entities up to 5 times (&amp; → &, &nbsp; → space, &lt;div&gt; → <div>, ...)
     int iterations = 0;


### PR DESCRIPTION
## Issue

#4139 

## Root cause

The original implementation used a simple regex `(<blockquote[\\s\\S]*?</blockquote>)` to remove blockquotes, which only deleted the first-level blockquote and failed to handle nested or malformed quotes. As a result, text inside deeper blockquote levels (like disclaimers) remained in the extracted plain text.

## Solution

Use an `HTML DOM` parser to traverse and remove all `<blockquote>` nodes recursively, ensuring all quoted content is properly stripped regardless of nesting depth or malformed structure.

## Resolved



https://github.com/user-attachments/assets/6449e2de-a1bd-48ed-9c88-de7e20f5c95c



