### PR TITLE
TF-4145 Changing the way to get the `URL`

### DIFF
--- a/core/lib/core.dart
+++ b/core/lib/core.dart
@@ -59,6 +59,7 @@ export 'utils/application_manager.dart';
 export 'utils/preview_eml_file_utils.dart';
 export 'utils/logger/log_tracking.dart';
 export 'utils/html/html_utils.dart';
+export 'utils/web_link_generator.dart';
 
 // Views
 export 'presentation/views/text/slogan_builder.dart';

--- a/core/lib/utils/web_link_generator.dart
+++ b/core/lib/utils/web_link_generator.dart
@@ -1,0 +1,86 @@
+import 'package:core/core.dart';
+
+/// Utility class for generating web links in flat subdomain format.
+class WebLinkGenerator {
+  const WebLinkGenerator();
+
+  /// Ensures that a path starts with `/`.
+  String ensureFirstSlash(String? path) {
+    if (path == null || path.isEmpty) return '/';
+    return path.startsWith('/') ? path : '/$path';
+  }
+
+  /// Validates if a given FQDN looks valid (has at least 2 parts and non-empty).
+  bool isValidFqdn(String fqdn) {
+    if (fqdn.trim().isEmpty || !fqdn.contains('.')) return false;
+    final parts = fqdn.split('.').where((p) => p.trim().isNotEmpty).toList();
+    return parts.length >= 2;
+  }
+
+  /// Generates a web link based on a workplace FQDN and app slug.
+  ///
+  /// Throws [ArgumentError] when input is invalid.
+  String generateWebLink({
+    required String workplaceFqdn,
+    required String slug,
+    String? pathname,
+    String? hash,
+    List<List<String>>? searchParams,
+  }) {
+    if (!isValidFqdn(workplaceFqdn)) {
+      throw ArgumentError('Invalid workplace FQDN: $workplaceFqdn');
+    }
+
+    final hostParts = workplaceFqdn
+        .split('.')
+        .where((p) => p.trim().isNotEmpty)
+        .toList();
+
+    hostParts[0] = '${hostParts[0]}-$slug';
+    final newHost = hostParts.join('.');
+
+    final safePath = ensureFirstSlash(pathname);
+    final safeHash = (hash == null || hash.isEmpty) ? null : ensureFirstSlash(hash);
+
+    final queryParams = <String, String>{};
+    for (final param in searchParams ?? const []) {
+      if (param.length == 2) queryParams[param[0]] = param[1];
+    }
+
+    final uri = Uri(
+      scheme: 'https',
+      host: newHost,
+      path: safePath,
+      queryParameters: queryParams.isEmpty ? null : queryParams,
+      fragment: safeHash,
+    );
+
+    return uri.toString();
+  }
+
+  /// A safe version of [generateWebLink] that **never throws**.
+  ///
+  /// Returns `''` (empty string) when an error occurs.
+  String safeGenerateWebLink({
+    required String workplaceFqdn,
+    required String slug,
+    String? pathname,
+    String? hash,
+    List<List<String>>? searchParams,
+  }) {
+    try {
+      if (slug.trim().isEmpty) return '';
+
+      return generateWebLink(
+        workplaceFqdn: workplaceFqdn,
+        slug: slug,
+        pathname: pathname,
+        hash: hash,
+        searchParams: searchParams,
+      );
+    } catch (e) {
+      logError('[WebLinkGenerator] Error: $e');
+      return '';
+    }
+  }
+}

--- a/core/lib/utils/web_link_generator.dart
+++ b/core/lib/utils/web_link_generator.dart
@@ -1,4 +1,5 @@
-import 'package:core/core.dart';
+
+import 'package:core/utils/app_logger.dart';
 
 /// Utility class for generating web links in flat subdomain format.
 class WebLinkGenerator {

--- a/core/test/utils/web_link_generator_test.dart
+++ b/core/test/utils/web_link_generator_test.dart
@@ -1,0 +1,136 @@
+import 'package:core/utils/web_link_generator.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('WebLinkGenerator (with workplaceFqdn)', () {
+    const generator = WebLinkGenerator();
+
+    test('should generate correct link for flat subdomain', () {
+      final result = generator.generateWebLink(
+        workplaceFqdn: 'alice.example.app',
+        searchParams: [
+          ['sharecode', 'sharingIsCaring'],
+          ['username', 'alice'],
+        ],
+        pathname: 'public',
+        hash: '/n/4',
+        slug: 'notes',
+      );
+
+      expect(
+        result,
+        'https://alice-notes.example.app/public?sharecode=sharingIsCaring&username=alice#/n/4',
+      );
+    });
+
+    test('should prepend slash to path and hash if missing', () {
+      final result = generator.generateWebLink(
+        workplaceFqdn: 'bob.example.tools',
+        pathname: 'files',
+        hash: 'folder/123',
+        slug: 'drive',
+      );
+
+      expect(result, 'https://bob-drive.example.tools/files#/folder/123');
+    });
+
+    test('should work with no search params', () {
+      final result = generator.generateWebLink(
+        workplaceFqdn: 'charlie.domain.com',
+        slug: 'settings',
+      );
+
+      expect(result, 'https://charlie-settings.domain.com/');
+    });
+
+    test('should throw when workplaceFqdn is empty', () {
+      expect(
+        () => generator.generateWebLink(
+          workplaceFqdn: '',
+          slug: 'notes',
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('should throw when workplaceFqdn only contains TLD', () {
+      expect(
+        () => generator.generateWebLink(
+          workplaceFqdn: 'com',
+          slug: 'notes',
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('should throw when workplaceFqdn has no dot', () {
+      expect(
+        () => generator.generateWebLink(
+          workplaceFqdn: 'localhost',
+          slug: 'notes',
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('should handle malformed FQDN gracefully (multiple dots)', () {
+      final result = generator.generateWebLink(
+        workplaceFqdn: '....example..app',
+        slug: 'notes',
+      );
+
+      expect(result.startsWith('https://'), isTrue);
+      expect(result.contains('-notes'), isTrue);
+    });
+
+    test('should ignore malformed searchParams', () {
+      final result = generator.generateWebLink(
+        workplaceFqdn: 'dave.example.app',
+        slug: 'drive',
+        searchParams: [
+          ['username'],
+          ['key', 'value'],
+        ],
+      );
+
+      expect(result, 'https://dave-drive.example.app/?key=value');
+    });
+
+    test('should not add fragment when hash is empty string', () {
+      final result = generator.generateWebLink(
+        workplaceFqdn: 'eve.example.app',
+        slug: 'settings',
+        hash: '',
+      );
+
+      expect(result, 'https://eve-settings.example.app/');
+    });
+
+    test('safeGenerateWebLink should return empty string on invalid FQDN', () {
+      final result = generator.safeGenerateWebLink(
+        workplaceFqdn: '',
+        slug: 'notes',
+      );
+
+      expect(result, '');
+    });
+
+    test('safeGenerateWebLink should return empty string on missing slug', () {
+      final result = generator.safeGenerateWebLink(
+        workplaceFqdn: 'alice.example.app',
+        slug: '',
+      );
+
+      expect(result, '');
+    });
+
+    test('safeGenerateWebLink should still return valid URL when input ok', () {
+      final result = generator.safeGenerateWebLink(
+        workplaceFqdn: 'bob.example.app',
+        slug: 'drive',
+      );
+
+      expect(result, 'https://bob-drive.example.app/');
+    });
+  });
+}

--- a/core/test/utils/web_link_generator_test.dart
+++ b/core/test/utils/web_link_generator_test.dart
@@ -41,7 +41,7 @@ void main() {
       expect(result, 'https://charlie-settings.domain.com/');
     });
 
-    test('✅ should throw when workplaceFqdn is empty', () {
+    test('should throw when workplaceFqdn is empty', () {
       expect(
         () => WebLinkGenerator.generateWebLink(
           workplaceFqdn: '',
@@ -131,6 +131,108 @@ void main() {
       expect(result, 'https://bob.example.app/');
     });
 
+
+    test('generateWebLink should include path and no hash when hash is null', () {
+      final result = WebLinkGenerator.generateWebLink(
+        workplaceFqdn: 'alice.example.app',
+        slug: 'notes',
+        pathname: 'welcome',
+        hash: null,
+      );
+
+      expect(result, 'https://alice-notes.example.app/welcome');
+      expect(result.contains('#'), isFalse);
+    });
+
+    test('generateWebLink should include path and no hash when hash is empty', () {
+      final result = WebLinkGenerator.generateWebLink(
+        workplaceFqdn: 'bob.example.app',
+        slug: 'drive',
+        pathname: 'folder/123',
+        hash: '',
+      );
+
+      expect(result, 'https://bob-drive.example.app/folder/123');
+      expect(result.contains('#'), isFalse);
+    });
+
+    test('generateWebLink should return root path when pathname is null', () {
+      final result = WebLinkGenerator.generateWebLink(
+        workplaceFqdn: 'charlie.example.app',
+        slug: 'settings',
+        pathname: null,
+      );
+
+      expect(result, 'https://charlie-settings.example.app/');
+      expect(result.contains('#'), isFalse);
+    });
+
+    test('generateWebLink should include path and no hash when slug is null and only pathname is provided', () {
+      final result = WebLinkGenerator.generateWebLink(
+        workplaceFqdn: 'alice.example.app',
+        slug: null,
+        pathname: 'welcome',
+      );
+
+      expect(result, 'https://alice.example.app/welcome');
+      expect(result.contains('#'), isFalse);
+    });
+
+    test('generateWebLink should include path and no hash when slug is empty and only pathname is provided', () {
+      final result = WebLinkGenerator.generateWebLink(
+        workplaceFqdn: 'bob.example.app',
+        slug: '',
+        pathname: 'dashboard',
+      );
+
+      expect(result, 'https://bob.example.app/dashboard');
+      expect(result.contains('#'), isFalse);
+    });
+
+    test('generateWebLink should handle multi-segment pathname with leading slash when slug is null', () {
+      final result = WebLinkGenerator.generateWebLink(
+        workplaceFqdn: 'alice.example.app',
+        slug: null,
+        pathname: '/name1/name2',
+      );
+
+      expect(result, 'https://alice.example.app/name1/name2');
+      expect(result.contains('#'), isFalse);
+    });
+
+    test('generateWebLink should handle multi-segment pathname without leading slash when slug is null', () {
+      final result = WebLinkGenerator.generateWebLink(
+        workplaceFqdn: 'bob.example.app',
+        slug: null,
+        pathname: 'name1/name2',
+      );
+
+      expect(result, 'https://bob.example.app/name1/name2');
+      expect(result.contains('#'), isFalse);
+    });
+
+    test('generateWebLink should handle deep multi-segment pathname with leading slash when slug is empty', () {
+      final result = WebLinkGenerator.generateWebLink(
+        workplaceFqdn: 'charlie.example.app',
+        slug: '',
+        pathname: '/a/b/c/d',
+      );
+
+      expect(result, 'https://charlie.example.app/a/b/c/d');
+      expect(result.contains('#'), isFalse);
+    });
+
+    test('generateWebLink should handle deep multi-segment pathname without leading slash when slug is empty', () {
+      final result = WebLinkGenerator.generateWebLink(
+        workplaceFqdn: 'dave.example.app',
+        slug: '',
+        pathname: 'a/b/c/d',
+      );
+
+      expect(result, 'https://dave.example.app/a/b/c/d');
+      expect(result.contains('#'), isFalse);
+    });
+
     test('safeGenerateWebLink should return empty string on invalid FQDN', () {
       final result = WebLinkGenerator.safeGenerateWebLink(
         workplaceFqdn: '',
@@ -166,5 +268,85 @@ void main() {
 
       expect(result, 'https://example.com/');
     });
+
+    test('safeGenerateWebLink should include path and no hash when hash is null', () {
+      final result = WebLinkGenerator.safeGenerateWebLink(
+        workplaceFqdn: 'dave.example.app',
+        slug: 'profile',
+        pathname: 'user/info',
+        hash: null,
+      );
+
+      expect(result, 'https://dave-profile.example.app/user/info');
+      expect(result.contains('#'), isFalse);
+    });
+
+    test('safeGenerateWebLink should include path and no hash when hash is empty', () {
+      final result = WebLinkGenerator.safeGenerateWebLink(
+        workplaceFqdn: 'eve.example.app',
+        slug: 'docs',
+        pathname: 'help',
+        hash: '',
+      );
+
+      expect(result, 'https://eve-docs.example.app/help');
+      expect(result.contains('#'), isFalse);
+    });
+
+    test('safeGenerateWebLink should return root path when pathname is null', () {
+      final result = WebLinkGenerator.safeGenerateWebLink(
+        workplaceFqdn: 'frank.example.app',
+        slug: 'notes',
+        pathname: null,
+      );
+
+      expect(result, 'https://frank-notes.example.app/');
+      expect(result.contains('#'), isFalse);
+    });
+
+    test('safeGenerateWebLink should handle no slug and only pathname (slug = null)', () {
+      final result = WebLinkGenerator.safeGenerateWebLink(
+        workplaceFqdn: 'charlie.example.app',
+        slug: null,
+        pathname: 'home',
+      );
+
+      expect(result, 'https://charlie.example.app/home');
+      expect(result.contains('#'), isFalse);
+    });
+
+    test('safeGenerateWebLink should handle no slug and only pathname (slug = empty string)', () {
+      final result = WebLinkGenerator.safeGenerateWebLink(
+        workplaceFqdn: 'dave.example.app',
+        slug: '',
+        pathname: 'portal',
+      );
+
+      expect(result, 'https://dave.example.app/portal');
+      expect(result.contains('#'), isFalse);
+    });
+
+    test('safeGenerateWebLink should handle multi-segment pathname with leading slash and no slug', () {
+      final result = WebLinkGenerator.safeGenerateWebLink(
+        workplaceFqdn: 'eve.example.app',
+        slug: null,
+        pathname: '/x/y/z',
+      );
+
+      expect(result, 'https://eve.example.app/x/y/z');
+      expect(result.contains('#'), isFalse);
+    });
+
+    test('safeGenerateWebLink should handle multi-segment pathname without leading slash and no slug', () {
+      final result = WebLinkGenerator.safeGenerateWebLink(
+        workplaceFqdn: 'frank.example.app',
+        slug: null,
+        pathname: 'x/y/z',
+      );
+
+      expect(result, 'https://frank.example.app/x/y/z');
+      expect(result.contains('#'), isFalse);
+    });
+
   });
 }

--- a/core/test/utils/web_link_generator_test.dart
+++ b/core/test/utils/web_link_generator_test.dart
@@ -2,11 +2,9 @@ import 'package:core/utils/web_link_generator.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('WebLinkGenerator (with workplaceFqdn)', () {
-    const generator = WebLinkGenerator();
-
+  group('WebLinkGenerator', () {
     test('should generate correct link for flat subdomain', () {
-      final result = generator.generateWebLink(
+      final result = WebLinkGenerator.generateWebLink(
         workplaceFqdn: 'alice.example.app',
         searchParams: [
           ['sharecode', 'sharingIsCaring'],
@@ -24,7 +22,7 @@ void main() {
     });
 
     test('should prepend slash to path and hash if missing', () {
-      final result = generator.generateWebLink(
+      final result = WebLinkGenerator.generateWebLink(
         workplaceFqdn: 'bob.example.tools',
         pathname: 'files',
         hash: 'folder/123',
@@ -35,7 +33,7 @@ void main() {
     });
 
     test('should work with no search params', () {
-      final result = generator.generateWebLink(
+      final result = WebLinkGenerator.generateWebLink(
         workplaceFqdn: 'charlie.domain.com',
         slug: 'settings',
       );
@@ -43,9 +41,9 @@ void main() {
       expect(result, 'https://charlie-settings.domain.com/');
     });
 
-    test('should throw when workplaceFqdn is empty', () {
+    test('✅ should throw when workplaceFqdn is empty', () {
       expect(
-        () => generator.generateWebLink(
+        () => WebLinkGenerator.generateWebLink(
           workplaceFqdn: '',
           slug: 'notes',
         ),
@@ -55,7 +53,7 @@ void main() {
 
     test('should throw when workplaceFqdn only contains TLD', () {
       expect(
-        () => generator.generateWebLink(
+        () => WebLinkGenerator.generateWebLink(
           workplaceFqdn: 'com',
           slug: 'notes',
         ),
@@ -65,7 +63,7 @@ void main() {
 
     test('should throw when workplaceFqdn has no dot', () {
       expect(
-        () => generator.generateWebLink(
+        () => WebLinkGenerator.generateWebLink(
           workplaceFqdn: 'localhost',
           slug: 'notes',
         ),
@@ -74,7 +72,7 @@ void main() {
     });
 
     test('should handle malformed FQDN gracefully (multiple dots)', () {
-      final result = generator.generateWebLink(
+      final result = WebLinkGenerator.generateWebLink(
         workplaceFqdn: '....example..app',
         slug: 'notes',
       );
@@ -84,7 +82,7 @@ void main() {
     });
 
     test('should ignore malformed searchParams', () {
-      final result = generator.generateWebLink(
+      final result = WebLinkGenerator.generateWebLink(
         workplaceFqdn: 'dave.example.app',
         slug: 'drive',
         searchParams: [
@@ -97,7 +95,7 @@ void main() {
     });
 
     test('should not add fragment when hash is empty string', () {
-      final result = generator.generateWebLink(
+      final result = WebLinkGenerator.generateWebLink(
         workplaceFqdn: 'eve.example.app',
         slug: 'settings',
         hash: '',
@@ -106,8 +104,35 @@ void main() {
       expect(result, 'https://eve-settings.example.app/');
     });
 
+    test('should keep original host when slug is null', () {
+      final result = WebLinkGenerator.generateWebLink(
+        workplaceFqdn: 'alice.example.app',
+        slug: null,
+      );
+
+      expect(result, 'https://alice.example.app/');
+    });
+
+    test('should keep original host when slug is empty', () {
+      final result = WebLinkGenerator.generateWebLink(
+        workplaceFqdn: 'alice.example.app',
+        slug: '',
+      );
+
+      expect(result, 'https://alice.example.app/');
+    });
+
+    test('should keep original host when slug is only whitespace', () {
+      final result = WebLinkGenerator.generateWebLink(
+        workplaceFqdn: 'bob.example.app',
+        slug: '   ',
+      );
+
+      expect(result, 'https://bob.example.app/');
+    });
+
     test('safeGenerateWebLink should return empty string on invalid FQDN', () {
-      final result = generator.safeGenerateWebLink(
+      final result = WebLinkGenerator.safeGenerateWebLink(
         workplaceFqdn: '',
         slug: 'notes',
       );
@@ -115,22 +140,31 @@ void main() {
       expect(result, '');
     });
 
-    test('safeGenerateWebLink should return empty string on missing slug', () {
-      final result = generator.safeGenerateWebLink(
+    test('safeGenerateWebLink should return valid URL on missing slug', () {
+      final result = WebLinkGenerator.safeGenerateWebLink(
         workplaceFqdn: 'alice.example.app',
         slug: '',
       );
 
-      expect(result, '');
+      expect(result, 'https://alice.example.app/');
     });
 
     test('safeGenerateWebLink should still return valid URL when input ok', () {
-      final result = generator.safeGenerateWebLink(
+      final result = WebLinkGenerator.safeGenerateWebLink(
         workplaceFqdn: 'bob.example.app',
         slug: 'drive',
       );
 
       expect(result, 'https://bob-drive.example.app/');
+    });
+
+    test('safeGenerateWebLink should handle slug = null gracefully', () {
+      final result = WebLinkGenerator.safeGenerateWebLink(
+        workplaceFqdn: 'example.com',
+        slug: null,
+      );
+
+      expect(result, 'https://example.com/');
     });
   });
 }

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1049,7 +1049,7 @@ class ComposerController extends BaseController
         popBack();
 
         if (needIncreaseMySpace) {
-          mailboxDashBoardController.paywallController?.navigateToPaywall(context);
+          mailboxDashBoardController.paywallController?.navigateToPaywall();
         } else {
           _autoFocusFieldWhenLauncher();
         }
@@ -1332,7 +1332,7 @@ class ComposerController extends BaseController
             popBack();
 
             if (needIncreaseMySpace) {
-              mailboxDashBoardController.paywallController?.navigateToPaywall(context);
+              mailboxDashBoardController.paywallController?.navigateToPaywall();
             } else {
               _autoFocusFieldWhenLauncher();
             }
@@ -2279,7 +2279,7 @@ class ComposerController extends BaseController
           popBack();
 
           if (needIncreaseMySpace) {
-            mailboxDashBoardController.paywallController?.navigateToPaywall(context);
+            mailboxDashBoardController.paywallController?.navigateToPaywall();
           } else {
             _autoFocusFieldWhenLauncher();
           }

--- a/lib/features/login/data/datasource/authentication_oidc_datasource.dart
+++ b/lib/features/login/data/datasource/authentication_oidc_datasource.dart
@@ -46,4 +46,6 @@ abstract class AuthenticationOIDCDataSource {
   Future<String> getAuthenticationInfo();
 
   Future<void> removeAuthDestinationUrl();
+
+  Future<OidcUserInfo> fetchUserInfo(String userInfoEndpoint);
 }

--- a/lib/features/login/data/datasource_impl/authentication_oidc_datasource_impl.dart
+++ b/lib/features/login/data/datasource_impl/authentication_oidc_datasource_impl.dart
@@ -2,6 +2,7 @@ import 'package:model/oidc/oidc_configuration.dart';
 import 'package:model/oidc/request/oidc_request.dart';
 import 'package:model/oidc/response/oidc_discovery_response.dart';
 import 'package:model/oidc/response/oidc_response.dart';
+import 'package:model/oidc/response/oidc_user_info.dart';
 import 'package:model/oidc/token_id.dart';
 import 'package:model/oidc/token_oidc.dart';
 import 'package:tmail_ui_user/features/caching/utils/session_storage_manager.dart';
@@ -173,5 +174,15 @@ class AuthenticationOIDCDataSourceImpl extends AuthenticationOIDCDataSource {
         LoginConstants.AUTH_DESTINATION_KEY,
       );
     }).catchError(_cacheExceptionThrower.throwException);
+  }
+
+  @override
+  Future<OidcUserInfo> fetchUserInfo(String userInfoEndpoint) {
+    return Future.sync(() async {
+      return await _oidcHttpClient.fetchUserInfo(userInfoEndpoint);
+    }).catchError((error, stackTrace) async {
+      await _exceptionThrower.throwException(error, stackTrace);
+      throw error;
+    });
   }
 }

--- a/lib/features/login/data/network/oidc_error.dart
+++ b/lib/features/login/data/network/oidc_error.dart
@@ -5,3 +5,5 @@ class CanNotFoundOIDCLinks implements Exception {}
 class CanNotFindToken implements Exception {}
 
 class CanRetryOIDCException implements Exception {}
+
+class NotFoundUserInfoEndpointException implements Exception {}

--- a/lib/features/login/data/network/oidc_http_client.dart
+++ b/lib/features/login/data/network/oidc_http_client.dart
@@ -10,6 +10,7 @@ import 'package:model/oidc/oidc_configuration.dart';
 import 'package:model/oidc/request/oidc_request.dart';
 import 'package:model/oidc/response/oidc_discovery_response.dart';
 import 'package:model/oidc/response/oidc_response.dart';
+import 'package:model/oidc/response/oidc_user_info.dart';
 import 'package:tmail_ui_user/features/login/data/extensions/service_path_extension.dart';
 import 'package:tmail_ui_user/features/login/data/network/config/oidc_constant.dart';
 import 'package:tmail_ui_user/features/login/data/network/endpoint.dart';
@@ -82,6 +83,16 @@ class OIDCHttpClient {
       return OIDCDiscoveryResponse.fromJson(result);
     } else {
       return OIDCDiscoveryResponse.fromJson(jsonDecode(result));
+    }
+  }
+
+  Future<OidcUserInfo> fetchUserInfo(String userInfoEndpoint) async {
+    final result = await _dioClient.get(userInfoEndpoint);
+
+    if (result is Map<String, dynamic>) {
+      return OidcUserInfo.fromJson(result);
+    } else {
+      return OidcUserInfo.fromJson(jsonDecode(result));
     }
   }
 }

--- a/lib/features/login/data/repository/authentication_oidc_repository_impl.dart
+++ b/lib/features/login/data/repository/authentication_oidc_repository_impl.dart
@@ -2,6 +2,7 @@ import 'package:model/oidc/oidc_configuration.dart';
 import 'package:model/oidc/request/oidc_request.dart';
 import 'package:model/oidc/response/oidc_discovery_response.dart';
 import 'package:model/oidc/response/oidc_response.dart';
+import 'package:model/oidc/response/oidc_user_info.dart';
 import 'package:model/oidc/token_id.dart';
 import 'package:model/oidc/token_oidc.dart';
 import 'package:tmail_ui_user/features/login/data/datasource/authentication_oidc_datasource.dart';
@@ -109,5 +110,10 @@ class AuthenticationOIDCRepositoryImpl extends AuthenticationOIDCRepository {
   @override
   Future<void> removeAuthDestinationUrl() {
     return _oidcDataSource.removeAuthDestinationUrl();
+  }
+
+  @override
+  Future<OidcUserInfo> fetchUserInfo(String userInfoEndpoint) {
+    return _oidcDataSource.fetchUserInfo(userInfoEndpoint);
   }
 }

--- a/lib/features/login/domain/repository/authentication_oidc_repository.dart
+++ b/lib/features/login/domain/repository/authentication_oidc_repository.dart
@@ -46,4 +46,6 @@ abstract class AuthenticationOIDCRepository {
   Future<String> getAuthenticationInfo();
 
   Future<void> removeAuthDestinationUrl();
+
+  Future<OidcUserInfo> fetchUserInfo(String userInfoEndpoint);
 }

--- a/lib/features/login/domain/state/get_oidc_user_info_state.dart
+++ b/lib/features/login/domain/state/get_oidc_user_info_state.dart
@@ -1,0 +1,18 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:model/oidc/response/oidc_user_info.dart';
+
+class GettingOidcUserInfo extends LoadingState {}
+
+class GetOidcUserInfoSuccess extends UIState {
+  final OidcUserInfo oidcUserInfo;
+
+  GetOidcUserInfoSuccess(this.oidcUserInfo);
+
+  @override
+  List<Object> get props => [oidcUserInfo];
+}
+
+class GetOidcUserInfoFailure extends FeatureFailure {
+  GetOidcUserInfoFailure(dynamic exception) : super(exception: exception);
+}

--- a/lib/features/login/domain/usecases/get_oidc_user_info_interactor.dart
+++ b/lib/features/login/domain/usecases/get_oidc_user_info_interactor.dart
@@ -1,0 +1,37 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:model/oidc/oidc_configuration.dart';
+import 'package:tmail_ui_user/features/login/data/network/oidc_error.dart';
+import 'package:tmail_ui_user/features/login/domain/repository/authentication_oidc_repository.dart';
+import 'package:tmail_ui_user/features/login/domain/state/get_oidc_user_info_state.dart';
+
+class GetOidcUserInfoInteractor {
+  final AuthenticationOIDCRepository _authenticationOIDCRepository;
+
+  GetOidcUserInfoInteractor(this._authenticationOIDCRepository);
+
+  Stream<Either<Failure, Success>> execute(OIDCConfiguration config) async* {
+    try {
+      yield Right<Failure, Success>(GettingOidcUserInfo());
+
+      final oidcDiscoveryResponse =
+          await _authenticationOIDCRepository.discoverOIDC(config);
+
+      final userInfoEndpoint = oidcDiscoveryResponse.userInfoEndpoint;
+
+      if (userInfoEndpoint != null) {
+        final oidcUserInfo =
+            await _authenticationOIDCRepository.fetchUserInfo(userInfoEndpoint);
+
+        yield Right<Failure, Success>(GetOidcUserInfoSuccess(oidcUserInfo));
+      } else {
+        yield Left<Failure, Success>(
+          GetOidcUserInfoFailure(NotFoundUserInfoEndpointException()),
+        );
+      }
+    } catch (e) {
+      yield Left<Failure, Success>(GetOidcUserInfoFailure(e));
+    }
+  }
+}

--- a/lib/features/mailbox/presentation/mailbox_view_web.dart
+++ b/lib/features/mailbox/presentation/mailbox_view_web.dart
@@ -62,7 +62,7 @@ class MailboxView extends BaseMailboxView {
                   onTapAction: () => controller
                       .mailboxDashBoardController
                       .paywallController
-                      ?.navigateToPaywall(context),
+                      ?.navigateToPaywall(),
                 );
               } else {
                 return const SizedBox.shrink();

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -872,12 +872,11 @@ class MailboxDashBoardController extends ReloadableController
     if (PlatformInfo.isMobile) {
       getAllSendingEmails();
       _storeSessionAction(session);
-    } else {
-      paywallController = PaywallController(
-        ownEmailAddress: ownEmailAddress.value,
-      );
-      paywallController?.loadPaywallUrl();
     }
+
+    paywallController = PaywallController(
+      ownEmailAddress: ownEmailAddress.value,
+    );
   }
 
   void _handleMailtoURL(MailtoArguments arguments) {

--- a/lib/features/manage_account/presentation/extensions/validate_storage_menu_visible_extension.dart
+++ b/lib/features/manage_account/presentation/extensions/validate_storage_menu_visible_extension.dart
@@ -1,7 +1,6 @@
 import 'package:dartz/dartz.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:tmail_ui_user/features/home/data/exceptions/session_exceptions.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/extensions/validate_setting_capability_supported_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/manage_account_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/quotas/domain/exceptions/quotas_exception.dart';
 import 'package:tmail_ui_user/features/quotas/domain/extensions/list_quotas_extensions.dart';
@@ -13,9 +12,7 @@ import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 extension ValidateStorageMenuVisibleExtension
     on ManageAccountDashBoardController {
   void injectQuotaBindings() {
-    if (isStorageCapabilitySupported) {
-      QuotasInteractorBindings().dependencies();
-    }
+    QuotasInteractorBindings().dependencies();
   }
 
   void getQuotas(AccountId? accountId) {
@@ -27,7 +24,7 @@ extension ValidateStorageMenuVisibleExtension
     }
 
     getQuotasInteractor = getBinding<GetQuotasInteractor>();
-    if (getQuotasInteractor == null || !isStorageCapabilitySupported) {
+    if (getQuotasInteractor == null) {
       consumeState(
         Stream.value(Left(GetQuotasFailure(QuotasNotSupportedException))),
       );

--- a/lib/features/manage_account/presentation/manage_account_dashboard_controller.dart
+++ b/lib/features/manage_account/presentation/manage_account_dashboard_controller.dart
@@ -30,6 +30,7 @@ import 'package:tmail_ui_user/features/manage_account/presentation/email_rules/b
 import 'package:tmail_ui_user/features/manage_account/presentation/extensions/export_trace_log_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/extensions/handle_vacation_response_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/extensions/vacation_response_extension.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/extensions/validate_setting_capability_supported_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/extensions/validate_storage_menu_visible_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/forward/bindings/forward_bindings.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/identities/identity_bindings.dart';
@@ -154,11 +155,10 @@ class ManageAccountDashBoardController extends ReloadableController
     paywallController = PaywallController(
       ownEmailAddress: ownEmailAddress.value,
     );
-    paywallController?.loadPaywallUrl();
 
     if (quota != null) {
       octetsQuota.value = quota;
-    } else {
+    } else if (isStorageCapabilitySupported) {
       getQuotas(accountId.value);
     }
   }
@@ -194,7 +194,9 @@ class ManageAccountDashBoardController extends ReloadableController
     injectVacationBindings(session, accountId);
     injectForwardBindings(session, accountId);
     injectRuleFilterBindings(session, accountId);
-    injectQuotaBindings();
+    if (isStorageCapabilitySupported) {
+      injectQuotaBindings();
+    }
   }
 
   @override

--- a/lib/features/manage_account/presentation/manage_account_dashboard_view.dart
+++ b/lib/features/manage_account/presentation/manage_account_dashboard_view.dart
@@ -25,6 +25,7 @@ import 'package:tmail_ui_user/features/manage_account/presentation/preferences/p
 import 'package:tmail_ui_user/features/manage_account/presentation/storage/storage_view.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/vacation/vacation_view.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/vacation/widgets/vacation_notification_message_widget.dart';
+import 'package:tmail_ui_user/features/quotas/domain/extensions/quota_extensions.dart';
 
 class ManageAccountDashBoardView extends GetWidget<ManageAccountDashBoardController> {
 
@@ -171,7 +172,9 @@ class ManageAccountDashBoardView extends GetWidget<ManageAccountDashBoardControl
         case AccountMenuItem.mailboxVisibility:
           return MailboxVisibilityView();
         case AccountMenuItem.storage:
-          if (controller.isStorageCapabilitySupported) {
+          if (controller.octetsQuota.value != null &&
+              controller.octetsQuota.value?.storageAvailable == true &&
+              controller.isStorageCapabilitySupported) {
             return const StorageView();
           } else {
             return const SizedBox.shrink();

--- a/lib/features/manage_account/presentation/menu/manage_account_menu_controller.dart
+++ b/lib/features/manage_account/presentation/menu/manage_account_menu_controller.dart
@@ -6,6 +6,7 @@ import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/mixin/contact_support_mixin.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/manage_account_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
+import 'package:tmail_ui_user/features/quotas/domain/extensions/quota_extensions.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
 class ManageAccountMenuController extends GetxController with ContactSupportMixin {
@@ -33,7 +34,7 @@ class ManageAccountMenuController extends GetxController with ContactSupportMixi
     _quotaRxWorker = ever(
       dashBoardController.octetsQuota,
       (octetsQuota) {
-        if (octetsQuota != null) {
+        if (octetsQuota != null && octetsQuota.storageAvailable) {
           _addStorageToMenuList();
         }
       },

--- a/lib/features/manage_account/presentation/menu/settings/settings_first_level_view.dart
+++ b/lib/features/manage_account/presentation/menu/settings/settings_first_level_view.dart
@@ -9,6 +9,7 @@ import 'package:tmail_ui_user/features/manage_account/presentation/menu/settings
 import 'package:tmail_ui_user/features/manage_account/presentation/menu/settings_utils.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/menu/widgets/setting_first_level_tile_builder.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
+import 'package:tmail_ui_user/features/quotas/domain/extensions/quota_extensions.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/app_routes.dart';
 
@@ -140,14 +141,27 @@ class SettingsFirstLevelView extends GetWidget<SettingsController> {
             ),
           ]);
         }),
+        if (PlatformInfo.isWeb)
+          ...[
+            divider,
+            _buildSettingItem(
+              context: context,
+              menuItem: AccountMenuItem.keyboardShortcuts,
+              appLocalizations: appLocalizations,
+            ),
+          ],
         Obx(() {
-          if (controller.manageAccountDashboardController.octetsQuota.value != null) {
+          final octetsQuota = controller
+              .manageAccountDashboardController
+              .octetsQuota
+              .value;
+
+          if (octetsQuota != null && octetsQuota.storageAvailable) {
             return Column(children: [
               divider,
               _buildSettingItem(
-                key: const ValueKey('setting_storage'),
                 context: context,
-                menuItem: AccountMenuItem.keyboardShortcuts,
+                menuItem: AccountMenuItem.storage,
                 appLocalizations: appLocalizations,
               ),
             ]);

--- a/lib/features/manage_account/presentation/menu/settings/settings_view.dart
+++ b/lib/features/manage_account/presentation/menu/settings/settings_view.dart
@@ -18,6 +18,7 @@ import 'package:tmail_ui_user/features/manage_account/presentation/preferences/p
 import 'package:tmail_ui_user/features/manage_account/presentation/storage/storage_view.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/vacation/vacation_view.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/vacation/widgets/vacation_notification_message_widget.dart';
+import 'package:tmail_ui_user/features/quotas/domain/extensions/quota_extensions.dart';
 
 class SettingsView extends GetWidget<SettingsController> {
   const SettingsView({Key? key}) : super(key: key);
@@ -141,7 +142,9 @@ class SettingsView extends GetWidget<SettingsController> {
         case AccountMenuItem.notification:
           return const NotificationView();
         case AccountMenuItem.storage:
-          if (controller.manageAccountDashboardController.isStorageCapabilitySupported) {
+          if (controller.manageAccountDashboardController.octetsQuota.value != null &&
+              controller.manageAccountDashboardController.octetsQuota.value?.storageAvailable == true &&
+              controller.manageAccountDashboardController.isStorageCapabilitySupported) {
             return const StorageView();
           } else {
             return const SizedBox.shrink();

--- a/lib/features/manage_account/presentation/storage/storage_controller.dart
+++ b/lib/features/manage_account/presentation/storage/storage_controller.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/base_controller.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/manage_account_dashboard_controller.dart';
@@ -17,7 +16,7 @@ class StorageController extends BaseController with SaaSPremiumMixin {
     return isPremiumAvailable(accountId: accountId, session: session);
   }
 
-  void onUpgradeStorage(BuildContext context) {
-    dashBoardController.paywallController?.navigateToPaywall(context);
+  void onUpgradeStorage() {
+    dashBoardController.paywallController?.navigateToPaywall();
   }
 }

--- a/lib/features/manage_account/presentation/storage/storage_view.dart
+++ b/lib/features/manage_account/presentation/storage/storage_view.dart
@@ -89,8 +89,8 @@ class StorageView extends GetWidget<StorageController> with AppLoaderMixin {
                               return UpgradeStorageWidget(
                                 imagePaths: controller.imagePaths,
                                 isMobile: isMobile,
-                                onUpgradeStorageAction: () =>
-                                    controller.onUpgradeStorage(context),
+                                onUpgradeStorageAction:
+                                  controller.onUpgradeStorage,
                               );
                             } else {
                               return const SizedBox.shrink();

--- a/lib/features/paywall/domain/model/paywall_url_pattern.dart
+++ b/lib/features/paywall/domain/model/paywall_url_pattern.dart
@@ -13,7 +13,7 @@ class PaywallUrlPattern with EquatableMixin {
     final mailAddress = _getMailAddress(ownerEmail: ownerEmail);
     return PaywallUtils.buildPaywallUrlFromTemplate(
       template: pattern,
-      localPart: mailAddress?.localPart,
+      localPart: mailAddress?.localPart.replaceAll('.', ''),
       domainName: domainName ?? mailAddress?.domain.domainName,
     );
   }

--- a/lib/features/quotas/presentation/quotas_controller.dart
+++ b/lib/features/quotas/presentation/quotas_controller.dart
@@ -2,7 +2,6 @@ import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:dartz/dartz.dart';
-import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/capability/capability_identifier.dart';
@@ -104,8 +103,8 @@ class QuotasController extends BaseController {
       mailboxDashBoardController.validateUserHasIsAlreadyHighestSubscription();
   }
 
-  void handleManageMyStorage(BuildContext context) {
-    mailboxDashBoardController.paywallController?.navigateToPaywall(context);
+  void handleManageMyStorage() {
+    mailboxDashBoardController.paywallController?.navigateToPaywall();
   }
 
   void closeBanner() {

--- a/lib/features/quotas/presentation/widget/quotas_banner_widget.dart
+++ b/lib/features/quotas/presentation/widget/quotas_banner_widget.dart
@@ -80,8 +80,8 @@ class QuotasBannerWidget extends StatelessWidget {
                                   backgroundColor: QuotasBannerStyles.backgroundColor,
                                   textStyle: QuotasBannerStyles.manageStorageButtonTextStyle,
                                   padding: EdgeInsets.zero,
-                                  onTapActionCallback: () =>
-                                    _quotasController.handleManageMyStorage(context),
+                                  onTapActionCallback:
+                                    _quotasController.handleManageMyStorage,
                                 ),
                               ],
                             ),

--- a/lib/main/bindings/credential/credential_bindings.dart
+++ b/lib/main/bindings/credential/credential_bindings.dart
@@ -31,6 +31,7 @@ import 'package:tmail_ui_user/features/login/domain/usecases/get_authenticated_a
 import 'package:tmail_ui_user/features/login/domain/usecases/get_authentication_info_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_credential_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_oidc_configuration_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/get_oidc_user_info_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_stored_oidc_configuration_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_stored_token_oidc_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_token_oidc_interactor.dart';
@@ -91,6 +92,9 @@ class CredentialBindings extends InteractorsBindings {
       Get.find<AuthenticationOIDCRepository>(),
     ));
     Get.put(RemoveAuthDestinationUrlInteractor(
+      Get.find<AuthenticationOIDCRepository>(),
+    ));
+    Get.put(GetOidcUserInfoInteractor(
       Get.find<AuthenticationOIDCRepository>(),
     ));
   }

--- a/lib/main/utils/app_utils.dart
+++ b/lib/main/utils/app_utils.dart
@@ -33,6 +33,7 @@ class AppUtils {
   }
 
   static void launchLink(String url, {bool isNewTab = true}) {
+    log('AppUtils::launchLink: url = $url');
     if (PlatformInfo.isWeb && HtmlUtils.isSafariBelow17()) {
       html.window.open(url, isNewTab ? '_blank' : '_self');
     } else {

--- a/lib/main/utils/twake_app_manager.dart
+++ b/lib/main/utils/twake_app_manager.dart
@@ -1,7 +1,10 @@
 
+import 'package:model/oidc/response/oidc_user_info.dart';
+
 class TwakeAppManager {
   bool _hasComposer = false;
   bool _isExecutingBeforeReconnect = false;
+  OidcUserInfo? _oidcUserInfo;
 
   void setHasComposer(bool value) => _hasComposer = value;
 
@@ -10,4 +13,10 @@ class TwakeAppManager {
   void setExecutingBeforeReconnect(bool value) => _isExecutingBeforeReconnect = value;
 
   bool get isExecutingBeforeReconnect => _isExecutingBeforeReconnect;
+
+  void setOidcUserInfo(OidcUserInfo value) => _oidcUserInfo = value;
+
+  void clearOidcUserInfo() => _oidcUserInfo = null;
+
+  OidcUserInfo? get oidcUserInfo => _oidcUserInfo;
 }

--- a/model/lib/model.dart
+++ b/model/lib/model.dart
@@ -78,6 +78,7 @@ export 'oidc/request/oidc_request.dart';
 export 'oidc/response/oidc_discovery_response.dart';
 export 'oidc/response/oidc_link_dto.dart';
 export 'oidc/response/oidc_response.dart';
+export 'oidc/response/oidc_user_info.dart';
 export 'oidc/token_id.dart';
 export 'oidc/token_oidc.dart';
 // Upload

--- a/model/lib/oidc/response/oidc_discovery_response.dart
+++ b/model/lib/oidc/response/oidc_discovery_response.dart
@@ -5,7 +5,6 @@ part 'oidc_discovery_response.g.dart';
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
 class OIDCDiscoveryResponse with EquatableMixin {
-
   @JsonKey(name: 'authorization_endpoint')
   final String? authorizationEndpoint;
 
@@ -15,12 +14,26 @@ class OIDCDiscoveryResponse with EquatableMixin {
   @JsonKey(name: 'end_session_endpoint')
   final String? endSessionEndpoint;
 
-  OIDCDiscoveryResponse(this.authorizationEndpoint, this.tokenEndpoint, this.endSessionEndpoint);
+  @JsonKey(name: 'userinfo_endpoint')
+  final String? userInfoEndpoint;
 
-  factory OIDCDiscoveryResponse.fromJson(Map<String, dynamic> json) => _$OIDCDiscoveryResponseFromJson(json);
+  OIDCDiscoveryResponse(
+    this.authorizationEndpoint,
+    this.tokenEndpoint,
+    this.endSessionEndpoint,
+    this.userInfoEndpoint,
+  );
+
+  factory OIDCDiscoveryResponse.fromJson(Map<String, dynamic> json) =>
+      _$OIDCDiscoveryResponseFromJson(json);
 
   Map<String, dynamic> toJson() => _$OIDCDiscoveryResponseToJson(this);
 
   @override
-  List<Object?> get props => [authorizationEndpoint, tokenEndpoint, endSessionEndpoint];
+  List<Object?> get props => [
+        authorizationEndpoint,
+        tokenEndpoint,
+        endSessionEndpoint,
+        userInfoEndpoint,
+      ];
 }

--- a/model/lib/oidc/response/oidc_user_info.dart
+++ b/model/lib/oidc/response/oidc_user_info.dart
@@ -1,0 +1,48 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'oidc_user_info.g.dart';
+
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
+class OidcUserInfo with EquatableMixin {
+  @JsonKey(name: 'sid')
+  final String? id;
+
+  final String? email;
+
+  final String? sub;
+
+  final String? name;
+
+  @JsonKey(name: 'given_name')
+  final String? givenName;
+
+  @JsonKey(name: 'family_name')
+  final String? familyName;
+
+  const OidcUserInfo({
+    this.id,
+    this.sub,
+    this.name,
+    this.givenName,
+    this.familyName,
+    this.email,
+  });
+
+  /// Factory for creating object from JSON
+  factory OidcUserInfo.fromJson(Map<String, dynamic> json) =>
+      _$OidcUserInfoFromJson(json);
+
+  /// Convert object to JSON map
+  Map<String, dynamic> toJson() => _$OidcUserInfoToJson(this);
+
+  @override
+  List<Object?> get props => [
+        id,
+        sub,
+        name,
+        givenName,
+        familyName,
+        email,
+      ];
+}

--- a/model/lib/oidc/response/oidc_user_info.dart
+++ b/model/lib/oidc/response/oidc_user_info.dart
@@ -14,19 +14,26 @@ class OidcUserInfo with EquatableMixin {
 
   final String? name;
 
+  @JsonKey(name: 'preferred_username')
+  final String? preferredUsername;
+
   @JsonKey(name: 'given_name')
   final String? givenName;
 
   @JsonKey(name: 'family_name')
   final String? familyName;
 
+  final String? workplaceFqdn;
+
   const OidcUserInfo({
     this.id,
     this.sub,
     this.name,
+    this.preferredUsername,
     this.givenName,
     this.familyName,
     this.email,
+    this.workplaceFqdn,
   });
 
   /// Factory for creating object from JSON
@@ -41,8 +48,10 @@ class OidcUserInfo with EquatableMixin {
         id,
         sub,
         name,
+        preferredUsername,
         givenName,
         familyName,
         email,
+        workplaceFqdn,
       ];
 }

--- a/test/features/home/presentation/home_controller_test.dart
+++ b/test/features/home/presentation/home_controller_test.dart
@@ -25,6 +25,7 @@ import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oi
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_authenticated_account_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_oidc_configuration_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/get_oidc_user_info_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/remove_auth_destination_url_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/update_account_cache_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
@@ -58,6 +59,7 @@ import 'home_controller_test.mocks.dart';
   MockSpec<GetSessionInteractor>(),
   MockSpec<GetAuthenticatedAccountInteractor>(),
   MockSpec<UpdateAccountCacheInteractor>(),
+  MockSpec<GetOidcUserInfoInteractor>(),
   MockSpec<CachingManager>(),
   MockSpec<LanguageCacheManager>(),
   MockSpec<ApplicationManager>(),
@@ -80,6 +82,7 @@ void main() {
   late MockGetSessionInteractor mockGetSessionInteractor;
   late MockGetAuthenticatedAccountInteractor mockGetAuthenticatedAccountInteractor;
   late MockUpdateAccountCacheInteractor mockUpdateAccountCacheInteractor;
+  late MockGetOidcUserInfoInteractor mockGetOidcUserInfoInteractor;
 
   late MockCachingManager mockCachingManager;
   late MockLanguageCacheManager mockLanguageCacheManager;
@@ -109,6 +112,7 @@ void main() {
     mockGetSessionInteractor = MockGetSessionInteractor();
     mockGetAuthenticatedAccountInteractor = MockGetAuthenticatedAccountInteractor();
     mockUpdateAccountCacheInteractor = MockUpdateAccountCacheInteractor();
+    mockGetOidcUserInfoInteractor = MockGetOidcUserInfoInteractor();
 
     //mock base controller
     mockCachingManager = MockCachingManager();
@@ -129,6 +133,7 @@ void main() {
     Get.put<GetSessionInteractor>(mockGetSessionInteractor);
     Get.put<GetAuthenticatedAccountInteractor>(mockGetAuthenticatedAccountInteractor);
     Get.put<UpdateAccountCacheInteractor>(mockUpdateAccountCacheInteractor);
+    Get.put<GetOidcUserInfoInteractor>(mockGetOidcUserInfoInteractor);
 
     Get.put<CachingManager>(mockCachingManager);
     Get.put<LanguageCacheManager>(mockLanguageCacheManager);

--- a/test/features/login/presentation/login_controller_test.dart
+++ b/test/features/login/presentation/login_controller_test.dart
@@ -30,6 +30,7 @@ import 'package:tmail_ui_user/features/login/domain/usecases/get_all_recent_logi
 import 'package:tmail_ui_user/features/login/domain/usecases/get_authenticated_account_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_authentication_info_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_oidc_configuration_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/get_oidc_user_info_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_stored_oidc_configuration_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_token_oidc_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/remove_auth_destination_url_interactor.dart';
@@ -78,6 +79,7 @@ import 'login_controller_test.mocks.dart';
   MockSpec<GetSessionInteractor>(),
   MockSpec<GetAuthenticatedAccountInteractor>(),
   MockSpec<UpdateAccountCacheInteractor>(),
+  MockSpec<GetOidcUserInfoInteractor>(),
   MockSpec<CachingManager>(),
   MockSpec<LanguageCacheManager>(),
   MockSpec<ApplicationManager>(),
@@ -103,6 +105,7 @@ void main() {
   late MockGetSessionInteractor mockGetSessionInteractor;
   late MockGetAuthenticatedAccountInteractor mockGetAuthenticatedAccountInteractor;
   late MockUpdateAccountCacheInteractor mockUpdateAccountCacheInteractor;
+  late MockGetOidcUserInfoInteractor mockGetOidcUserInfoInteractor;
   late CachingManager mockCachingManager;
   late LanguageCacheManager mockLanguageCacheManager;
   late MockAuthorizationInterceptors mockAuthorizationInterceptors;
@@ -141,6 +144,7 @@ void main() {
     mockGetSessionInteractor = MockGetSessionInteractor();
     mockGetAuthenticatedAccountInteractor = MockGetAuthenticatedAccountInteractor();
     mockUpdateAccountCacheInteractor = MockUpdateAccountCacheInteractor();
+    mockGetOidcUserInfoInteractor = MockGetOidcUserInfoInteractor();
 
     //mock base controller
     mockCachingManager = MockCachingManager();
@@ -161,6 +165,7 @@ void main() {
     Get.put<GetSessionInteractor>(mockGetSessionInteractor);
     Get.put<GetAuthenticatedAccountInteractor>(mockGetAuthenticatedAccountInteractor);
     Get.put<UpdateAccountCacheInteractor>(mockUpdateAccountCacheInteractor);
+    Get.put<GetOidcUserInfoInteractor>(mockGetOidcUserInfoInteractor);
     Get.put<CachingManager>(mockCachingManager);
     Get.put<LanguageCacheManager>(mockLanguageCacheManager);
     Get.put<AuthorizationInterceptors>(mockAuthorizationInterceptors);

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -38,6 +38,7 @@ import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oi
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_authenticated_account_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_authentication_info_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/get_oidc_user_info_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_stored_oidc_configuration_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_token_oidc_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/update_account_cache_interactor.dart';
@@ -158,6 +159,7 @@ const fallbackGenerators = {
   MockSpec<GetSessionInteractor>(),
   MockSpec<GetAuthenticatedAccountInteractor>(),
   MockSpec<UpdateAccountCacheInteractor>(),
+  MockSpec<GetOidcUserInfoInteractor>(),
   MockSpec<CreateNewMailboxInteractor>(),
   MockSpec<DeleteMultipleMailboxInteractor>(),
   MockSpec<RenameMailboxInteractor>(),
@@ -272,6 +274,7 @@ void main() {
   final getSessionInteractor = MockGetSessionInteractor();
   final getAuthenticatedAccountInteractor = MockGetAuthenticatedAccountInteractor();
   final updateAccountCacheInteractor = MockUpdateAccountCacheInteractor();
+  final getOidcUserInfoInteractor = MockGetOidcUserInfoInteractor();
 
   // mock mailbox controller direct dependencies
   final createNewMailboxInteractor = MockCreateNewMailboxInteractor();
@@ -345,6 +348,7 @@ void main() {
     Get.put<GetSessionInteractor>(getSessionInteractor);
     Get.put<GetAuthenticatedAccountInteractor>(getAuthenticatedAccountInteractor);
     Get.put<UpdateAccountCacheInteractor>(updateAccountCacheInteractor);
+    Get.put<GetOidcUserInfoInteractor>(getOidcUserInfoInteractor);
     Get.put<GetAllIdentitiesInteractor>(getAllIdentitiesInteractor);
     Get.put<ClearMailboxInteractor>(clearMailboxInteractor);
     Get.put<RemoveAllComposerCacheOnWebInteractor>(removeAllComposerCacheOnWebInteractor);

--- a/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
+++ b/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
@@ -37,6 +37,7 @@ import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oi
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_authenticated_account_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_authentication_info_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/get_oidc_user_info_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_stored_oidc_configuration_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_token_oidc_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/update_account_cache_interactor.dart';
@@ -159,6 +160,7 @@ const fallbackGenerators = {
   MockSpec<GetSessionInteractor>(),
   MockSpec<GetAuthenticatedAccountInteractor>(),
   MockSpec<UpdateAccountCacheInteractor>(),
+  MockSpec<GetOidcUserInfoInteractor>(),
   MockSpec<CreateNewMailboxInteractor>(),
   MockSpec<DeleteMultipleMailboxInteractor>(),
   MockSpec<RenameMailboxInteractor>(),
@@ -259,6 +261,7 @@ void main() {
   final getSessionInteractor = MockGetSessionInteractor();
   final getAuthenticatedAccountInteractor = MockGetAuthenticatedAccountInteractor();
   final updateAccountCacheInteractor = MockUpdateAccountCacheInteractor();
+  final getOidcUserInfoInteractor = MockGetOidcUserInfoInteractor();
 
   final createNewMailboxInteractor = MockCreateNewMailboxInteractor();
   final deleteMultipleMailboxInteractor = MockDeleteMultipleMailboxInteractor();
@@ -341,6 +344,7 @@ void main() {
       Get.put<GetSessionInteractor>(getSessionInteractor);
       Get.put<GetAuthenticatedAccountInteractor>(getAuthenticatedAccountInteractor);
       Get.put<UpdateAccountCacheInteractor>(updateAccountCacheInteractor);
+      Get.put<GetOidcUserInfoInteractor>(getOidcUserInfoInteractor);
       Get.put<GetAllIdentitiesInteractor>(getAllIdentitiesInteractor);
       Get.put<ClearMailboxInteractor>(clearMailboxInteractor);
       Get.put<RemoveAllComposerCacheOnWebInteractor>(removeAllComposerCacheOnWebInteractor);

--- a/test/features/manage_account/presentation/profiles/identities/identities_controller_test.dart
+++ b/test/features/manage_account/presentation/profiles/identities/identities_controller_test.dart
@@ -19,6 +19,7 @@ import 'package:tmail_ui_user/features/login/data/network/interceptors/authoriza
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oidc_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_authenticated_account_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/get_oidc_user_info_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/update_account_cache_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/state/get_all_identities_state.dart';
@@ -72,6 +73,7 @@ const fallbackGenerators = {
   MockSpec<GetSessionInteractor>(),
   MockSpec<GetAuthenticatedAccountInteractor>(),
   MockSpec<UpdateAccountCacheInteractor>(),
+  MockSpec<GetOidcUserInfoInteractor>(),
 
   // Identities controller mockspecs
   MockSpec<GetAllIdentitiesInteractor>(),
@@ -157,6 +159,7 @@ void main() {
     Get.put<GetSessionInteractor>(MockGetSessionInteractor());
     Get.put<GetAuthenticatedAccountInteractor>(MockGetAuthenticatedAccountInteractor());
     Get.put<UpdateAccountCacheInteractor>(MockUpdateAccountCacheInteractor());
+    Get.put<GetOidcUserInfoInteractor>(MockGetOidcUserInfoInteractor());
 
     // mock identities controller
     mockGetAllIdentitiesInteractor = MockGetAllIdentitiesInteractor();

--- a/test/features/search/verify_before_time_in_search_email_filter_test.dart
+++ b/test/features/search/verify_before_time_in_search_email_filter_test.dart
@@ -38,6 +38,7 @@ import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oi
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_authenticated_account_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_authentication_info_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/get_oidc_user_info_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_stored_oidc_configuration_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/get_token_oidc_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/update_account_cache_interactor.dart';
@@ -133,6 +134,7 @@ const fallbackGenerators = {
   MockSpec<GetSessionInteractor>(),
   MockSpec<GetAuthenticatedAccountInteractor>(),
   MockSpec<UpdateAccountCacheInteractor>(),
+  MockSpec<GetOidcUserInfoInteractor>(),
   MockSpec<EmailReceiveManager>(),
   MockSpec<DownloadController>(fallbackGenerators: fallbackGenerators),
   MockSpec<AppGridDashboardController>(fallbackGenerators: fallbackGenerators),
@@ -198,6 +200,7 @@ void main() {
   final MockGetSessionInteractor getSessionInteractor = MockGetSessionInteractor();
   final MockGetAuthenticatedAccountInteractor getAuthenticatedAccountInteractor = MockGetAuthenticatedAccountInteractor();
   final MockUpdateAccountCacheInteractor updateAccountCacheInteractor = MockUpdateAccountCacheInteractor();
+  final MockGetOidcUserInfoInteractor getOidcUserInfoInteractor = MockGetOidcUserInfoInteractor();
   final MockRemoveEmailDraftsInteractor removeEmailDraftsInteractor = MockRemoveEmailDraftsInteractor();
   final MockEmailReceiveManager emailReceiveManager = MockEmailReceiveManager();
   final MockDownloadController downloadController = MockDownloadController();
@@ -353,6 +356,7 @@ void main() {
     Get.put<GetSessionInteractor>(getSessionInteractor);
     Get.put<GetAuthenticatedAccountInteractor>(getAuthenticatedAccountInteractor);
     Get.put<UpdateAccountCacheInteractor>(updateAccountCacheInteractor);
+    Get.put<GetOidcUserInfoInteractor>(getOidcUserInfoInteractor);
     Get.put<ComposerManager>(composerManager);
     Get.put<GetAuthenticationInfoInteractor>(getAuthenticationInfoInteractor);
     Get.put<GetStoredOidcConfigurationInteractor>(getStoredOidcConfigurationInteractor);


### PR DESCRIPTION
## Issue

#4145 

## Summary

Refactor the logic to generate the `Paywall `URL using the user's `workplaceFqdn` instead of relying solely on static domain resolution.

## Context

Previously, the Paywall URL was built using a default fallback pattern (`pattern.getQualifiedUrl`), which combined the user's email and a root domain from `RouteUtils.getRootDomain()`. This approach worked, but did not respect the user’s actual workspace domain (`FQDN`).

To fix this, the system now leverages the `workplaceFqdn` obtained from the authenticated OIDC user info (`oidcUserInfo.workplaceFqdn`) to dynamically generate the `Paywall` URL for the correct tenant.

## Implementation Details

1. Using `WebLinkGenerator.safeGenerateWebLink`

- The `workplaceFqdn` value (`e.g. alice.example.app`) is passed to` WebLinkGenerator` to construct the Paywall URL.
- The method automatically handles malformed or missing values and guarantees a valid `https://` link.
- Example

```
WebLinkGenerator.safeGenerateWebLink(workplaceFqdn: 'alice.example.app');
// → https://alice.example.app/
```

2. Improved fallback behavior

If `workplaceFqdn` is unavailable or invalid, the code now gracefully falls back to:

```dart
pattern.getQualifiedUrl(
  ownerEmail: ownEmailAddress,
  domainName: RouteUtils.getRootDomain(),
);
```
This ensures that even in the worst case, the Paywall link remains functional.