### PR TITLE
TF-4146 Should handle time for email view

### DIFF
--- a/core/lib/domain/extensions/datetime_extension.dart
+++ b/core/lib/domain/extensions/datetime_extension.dart
@@ -51,9 +51,9 @@ extension DateTimeNullableExtension on DateTime? {
 
   String toPatternForEmailView() {
     if (this?.isThisYear() == true) {
-      return 'dd MMM, HH:mm a';
+      return 'dd MMM, hh:mm a';
     } else {
-      return 'dd MMM yyyy, HH:mm a';
+      return 'dd MMM yyyy, hh:mm a';
     }
   }
 

--- a/core/test/domain/extensions/date_time_extension_test.dart
+++ b/core/test/domain/extensions/date_time_extension_test.dart
@@ -1,0 +1,85 @@
+import 'package:core/domain/extensions/datetime_extension.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+
+void main() {
+  group('DateTimeExtension → toPatternForEmailView', () {
+    test('should return pattern without year when date is in current year', () {
+      // Arrange
+      final now = DateTime.now();
+      final date = DateTime(now.year, 5, 10, 17, 30);
+
+      // Act
+      final pattern = date.toPatternForEmailView();
+      final formatted = DateFormat(pattern, 'en_US').format(date);
+
+      // Assert
+      expect(pattern, 'dd MMM, hh:mm a');
+      expect(
+        formatted.contains('${date.year}'),
+        isFalse,
+        reason: 'Should not include year when in the current year',
+      );
+    });
+
+    test('should return pattern with year when date is not in current year',
+        () {
+      // Arrange
+      final now = DateTime.now();
+      final date = DateTime(now.year - 1, 12, 25, 8, 45);
+
+      // Act
+      final pattern = date.toPatternForEmailView();
+      final formatted = DateFormat(pattern, 'en_US').format(date);
+
+      // Assert
+      expect(pattern, 'dd MMM yyyy, hh:mm a');
+      expect(
+        formatted.contains('${date.year}'),
+        isTrue,
+        reason: 'Should include year when not in current year',
+      );
+    });
+
+    test('should return pattern with year when date is null', () {
+      // Arrange
+      DateTime? date;
+
+      // Act & Assert
+      expect(
+        date.toPatternForEmailView(),
+        'dd MMM yyyy, hh:mm a',
+        reason: 'Null date should return default pattern with year',
+      );
+    });
+
+    test('should correctly display 12-hour format with AM/PM (no 24h time)',
+        () {
+      // Arrange
+      final now = DateTime.now();
+      final date = DateTime(now.year, 11, 13, 17, 0); // 17:00 = 5:00 PM
+
+      // Act
+      final pattern = date.toPatternForEmailView();
+      final formatted = DateFormat(pattern, 'en_US').format(date);
+
+      // Assert
+      expect(pattern, 'dd MMM, hh:mm a');
+      expect(
+        formatted.contains('17:'),
+        isFalse,
+        reason: 'Should not show 24-hour format like 17:00',
+      );
+      expect(
+        formatted.toLowerCase().contains('pm'),
+        isTrue,
+        reason: 'Should contain AM/PM indicator',
+      );
+      expect(
+        formatted.contains('05:'),
+        isTrue,
+        reason: 'Should display 12-hour format (05:00 PM)',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Issue

#4146 

## Reproduce


https://github.com/user-attachments/assets/0fb15c83-e308-4c0c-90c4-48fa2355a1b9



## Root cause

The `toPatternForEmailView()` method used the 24-hour format (HH) together with the AM/PM marker (a).
This combination is invalid and results in incorrect output such as "17:00 pm".


## Solution

Use the 12-hour format (hh) whenever the pattern includes the AM/PM marker:

```
return 'dd MMM, hh:mm a';
```

Additionally, add test cases to ensure the output never falls back to 24-hour time when AM/PM is present (e.g., ensure it never shows "17:xx pm").

## Resolved


https://github.com/user-attachments/assets/07cbb406-9d25-4fcf-a650-0e97b2aadff6



