### PR TITLE
Fix display empty state when no favorites are available

### DIFF
--- a/integration_test/scenarios/mailbox/display_empty_view_for_favorite_folder_scenario.dart
+++ b/integration_test/scenarios/mailbox/display_empty_view_for_favorite_folder_scenario.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/widgets/label_mailbox_item_widget.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/widgets/mailbox_item_widget.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class DisplayEmptyViewForFavoriteFolderScenario extends BaseTestScenario {
+  const DisplayEmptyViewForFavoriteFolderScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    final threadRobot = ThreadRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await threadRobot.openMailbox();
+    await _expectFolderVisible(appLocalizations.favoriteMailboxDisplayName);
+
+    await mailboxMenuRobot.openFolderByName(
+      appLocalizations.favoriteMailboxDisplayName,
+    );
+    await $.pumpAndTrySettle();
+    await _expectEmptyViewVisible();
+  }
+
+  Future<void> _expectFolderVisible(String folderName) {
+    return expectViewVisible($(MailboxItemWidget)
+        .$(LabelMailboxItemWidget)
+        .$(find.text(folderName)));
+  }
+
+  Future<void> _expectEmptyViewVisible() =>
+      expectViewVisible($(#empty_thread_view));
+}

--- a/integration_test/tests/mailbox/display_empty_view_for_favorite_folder_test.dart
+++ b/integration_test/tests/mailbox/display_empty_view_for_favorite_folder_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/mailbox/display_empty_view_for_favorite_folder_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should display empty view when no mail favorites',
+    scenarioBuilder: ($) => DisplayEmptyViewForFavoriteFolderScenario($),
+  );
+}

--- a/lib/features/thread/presentation/thread_view.dart
+++ b/lib/features/thread/presentation/thread_view.dart
@@ -744,7 +744,8 @@ class ThreadView extends GetWidget<ThreadController>
         }
 
         if (success is GetAllEmailSuccess
-            && success.currentMailboxId != controller.selectedMailboxId) {
+            && success.currentMailboxId != controller.selectedMailboxId &&
+            controller.selectedMailbox?.isFavorite != true) {
           return const SizedBox.shrink();
         } else {
           return PullToRefreshWidget(
@@ -759,6 +760,7 @@ class ThreadView extends GetWidget<ThreadController>
               isNetworkConnectionAvailable: controller.networkConnectionController.isNetworkConnectionAvailable(),
               isSearchActive: controller.isSearchActive,
               isFilterMessageActive: controller.mailboxDashBoardController.filterMessageOption.value != FilterMessageOption.all,
+              isFavoriteFolder: controller.selectedMailbox?.isFavorite == true,
             ),
           );
         }

--- a/lib/features/thread/presentation/widgets/empty_emails_widget.dart
+++ b/lib/features/thread/presentation/widgets/empty_emails_widget.dart
@@ -13,6 +13,7 @@ class EmptyEmailsWidget extends StatelessWidget {
   final bool isSearchActive;
   final bool isFilterMessageActive;
   final bool isNetworkConnectionAvailable;
+  final bool isFavoriteFolder;
 
   final _responsiveUtils = Get.find<ResponsiveUtils>();
   final _imagePaths = Get.find<ImagePaths>();
@@ -22,6 +23,7 @@ class EmptyEmailsWidget extends StatelessWidget {
     this.isSearchActive = false,
     this.isFilterMessageActive = false,
     this.isNetworkConnectionAvailable = true,
+    this.isFavoriteFolder = false,
   }) : super(key: key);
 
   @override
@@ -43,7 +45,7 @@ class EmptyEmailsWidget extends StatelessWidget {
             padding: EmptyEmailsWidgetStyles.labelPadding,
             child: Text(
               key: const Key('empty_email_message'),
-              _getMessageEmptyEmail(context),
+              _getMessageEmptyEmail(AppLocalizations.of(context)),
               style: ThemeUtils.textStyleInter600(),
               textAlign: TextAlign.center,
             ),
@@ -51,7 +53,7 @@ class EmptyEmailsWidget extends StatelessWidget {
           if (_showEmailSubMessage)
             Text(
               key: const Key('empty_email_sub_message'),
-              AppLocalizations.of(context).startToComposeEmails,
+              _getSubMessageEmptyEmail(AppLocalizations.of(context)),
               style: ThemeUtils.textStyleInter400.copyWith(
                 letterSpacing: -0.15,
                 fontSize: 16,
@@ -76,21 +78,33 @@ class EmptyEmailsWidget extends StatelessWidget {
     );
   }
 
-  bool get _showEmailSubMessage => isNetworkConnectionAvailable &&
-      !isFilterMessageActive &&
-      !isSearchActive;
+  bool get _showEmailSubMessage =>
+      (isNetworkConnectionAvailable &&
+          !isFilterMessageActive &&
+          !isSearchActive) ||
+      (isFavoriteFolder && !isFilterMessageActive);
 
-  String _getMessageEmptyEmail(BuildContext context) {
+  String _getMessageEmptyEmail(AppLocalizations appLocalizations) {
     if (!isNetworkConnectionAvailable) {
-      return AppLocalizations.of(context).no_internet_connection_try_again_later;
+      return appLocalizations.no_internet_connection_try_again_later;
     }
     
     if (isSearchActive) {
-      return AppLocalizations.of(context).no_emails_matching_your_search;
+      return appLocalizations.no_emails_matching_your_search;
     } else if (isFilterMessageActive) {
-      return AppLocalizations.of(context).noEmailMatchYourCurrentFilter;
+      return appLocalizations.noEmailMatchYourCurrentFilter;
+    } else if (isFavoriteFolder) {
+      return appLocalizations.youDoNotHaveAnyFavoritesEmails;
     } else {
-      return AppLocalizations.of(context).youDoNotHaveAnyEmailInYourCurrentFolder;
+      return appLocalizations.youDoNotHaveAnyEmailInYourCurrentFolder;
+    }
+  }
+
+  String _getSubMessageEmptyEmail(AppLocalizations appLocalizations) {
+    if (isFavoriteFolder) {
+      return appLocalizations.startToAddFavoritesEmails;
+    } else {
+      return appLocalizations.startToComposeEmails;
     }
   }
 }

--- a/lib/features/thread/presentation/widgets/empty_emails_widget.dart
+++ b/lib/features/thread/presentation/widgets/empty_emails_widget.dart
@@ -78,11 +78,14 @@ class EmptyEmailsWidget extends StatelessWidget {
     );
   }
 
-  bool get _showEmailSubMessage =>
-      (isNetworkConnectionAvailable &&
-          !isFilterMessageActive &&
-          !isSearchActive) ||
-      (isFavoriteFolder && !isFilterMessageActive);
+  bool get _showEmailSubMessage {
+    if (isFilterMessageActive) return false;
+
+    final showNetwork = isNetworkConnectionAvailable && !isSearchActive;
+    final showFavorite = isFavoriteFolder;
+
+    return showNetwork || showFavorite;
+  }
 
   String _getMessageEmptyEmail(AppLocalizations appLocalizations) {
     if (!isNetworkConnectionAvailable) {

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -2597,13 +2597,13 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "noEmailInYourCurrentFolder": "We're sorry, there are no emails in your current folder",
+  "noEmailInYourCurrentFolder": "There are no emails in your current folder",
   "@noEmailInYourCurrentFolder": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "noEmailMatchYourCurrentFilter": "We're sorry, there are no emails that match your current filter.",
+  "noEmailMatchYourCurrentFilter": "There are no emails that match your current filter.",
   "@noEmailMatchYourCurrentFilter": {
     "type": "text",
     "placeholders_order": [],

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2025-11-18T16:44:44.341535",
+  "@@last_modified": "2025-11-20T14:48:58.635692",
   "initializing_data": "Initializing data...",
   "@initializing_data": {
     "type": "text",

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2025-11-12T23:59:36.025917",
+  "@@last_modified": "2025-11-18T16:44:44.341535",
   "initializing_data": "Initializing data...",
   "@initializing_data": {
     "type": "text",
@@ -5114,6 +5114,18 @@
   },
   "manageYourTwakeAccount": "Manage your Twake account",
   "@manageYourTwakeAccount": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "youDoNotHaveAnyFavoritesEmails": "You don’t have any favorites emails.",
+  "@youDoNotHaveAnyFavoritesEmails": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "startToAddFavoritesEmails": "Start to add favorites emails",
+  "@startToAddFavoritesEmails": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -5422,4 +5422,18 @@ class AppLocalizations {
       name: 'manageYourTwakeAccount',
     );
   }
+
+  String get youDoNotHaveAnyFavoritesEmails {
+    return Intl.message(
+      'You don’t have any favorites emails.',
+      name: 'youDoNotHaveAnyFavoritesEmails',
+    );
+  }
+
+  String get startToAddFavoritesEmails {
+    return Intl.message(
+      'Start to add favorites emails',
+      name: 'startToAddFavoritesEmails',
+    );
+  }
 }

--- a/test/features/thread/presentation/widgets/empty_email_widget_test.dart
+++ b/test/features/thread/presentation/widgets/empty_email_widget_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/empty_emails_widget.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations_delegate.dart';
 import 'package:tmail_ui_user/main/localizations/localization_service.dart';
 
@@ -83,7 +84,8 @@ void main() {
       final emptyEmailMessageWidget = tester.widget<Text>(emptyEmailMessageWidgetFinder);
       expect(
         emptyEmailMessageWidget.data,
-        'We\'re sorry, there are no emails that match your current filter.');
+        AppLocalizations().noEmailMatchYourCurrentFilter,
+      );
     });
 
     testWidgets(


### PR DESCRIPTION
## Issue

https://github.com/linagora/tmail-flutter/issues/4154#issuecomment-3546437404

## Resolved

- Demo:


https://github.com/user-attachments/assets/ce97073f-263f-42d4-b91d-a52311afb070

- E2E test

[Screen_recording_20251120_123737.webm](https://github.com/user-attachments/assets/64b1bf48-0295-4307-9e68-8afa89519f6c)


```console
🧪 Should display empty view when no mail favorites
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
✅ Should display empty view when no mail favorites (integration_test/tests/mailbox/display_empty_view_for_favorite_folder_test.dart) (13s)


Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: file:///Users/datvu/WorkingSpace/tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 91s
```
