### PR TITLE
Handle keyboard shortcut FocusNode causing memory leak

### DIFF
--- a/lib/features/thread_detail/presentation/extension/close_thread_detail_action.dart
+++ b/lib/features/thread_detail/presentation/extension/close_thread_detail_action.dart
@@ -1,5 +1,6 @@
 import 'package:tmail_ui_user/features/email/presentation/action/email_ui_action.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
+import 'package:tmail_ui_user/features/thread_detail/presentation/extension/handle_mail_shortcut_actions_extension.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/thread_detail_controller.dart';
 
 extension CloseThreadDetailAction on ThreadDetailController {
@@ -14,6 +15,8 @@ extension CloseThreadDetailAction on ThreadDetailController {
     Future.delayed(Duration.zero, () {
       mailboxDashBoardController.dispatchEmailUIAction(EmailUIAction());
     });
+
+    onKeyboardShortcutDispose();
 
     reset();
   }

--- a/lib/features/thread_detail/presentation/extension/handle_mail_shortcut_actions_extension.dart
+++ b/lib/features/thread_detail/presentation/extension/handle_mail_shortcut_actions_extension.dart
@@ -34,7 +34,6 @@ extension HandleMailShortcutActionsExtension on ThreadDetailController {
 
   void onKeyboardShortcutInit() {
     if (PlatformInfo.isWeb) {
-      onKeyboardShortcutDispose();
       keyboardShortcutFocusNode = FocusNode();
       shortcutActionEventController =
           StreamController<MailViewShortcutActionViewEvent>();

--- a/lib/features/thread_detail/presentation/extension/handle_mail_shortcut_actions_extension.dart
+++ b/lib/features/thread_detail/presentation/extension/handle_mail_shortcut_actions_extension.dart
@@ -34,6 +34,7 @@ extension HandleMailShortcutActionsExtension on ThreadDetailController {
 
   void onKeyboardShortcutInit() {
     if (PlatformInfo.isWeb) {
+      onKeyboardShortcutDispose();
       keyboardShortcutFocusNode = FocusNode();
       shortcutActionEventController =
           StreamController<MailViewShortcutActionViewEvent>();

--- a/lib/features/thread_detail/presentation/extension/handle_mail_shortcut_actions_extension.dart
+++ b/lib/features/thread_detail/presentation/extension/handle_mail_shortcut_actions_extension.dart
@@ -56,6 +56,7 @@ extension HandleMailShortcutActionsExtension on ThreadDetailController {
   void onKeyboardShortcutDispose() {
     if (PlatformInfo.isWeb) {
       keyboardShortcutFocusNode?.dispose();
+      keyboardShortcutFocusNode = null;
       shortcutActionEventSubscription?.cancel();
       shortcutActionEventController?.close();
     }

--- a/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
+++ b/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
@@ -10,6 +10,7 @@ import 'package:tmail_ui_user/features/thread_detail/domain/state/get_emails_by_
 import 'package:tmail_ui_user/features/thread_detail/domain/state/get_thread_by_id_state.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/action/thread_detail_ui_action.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/extension/close_thread_detail_action.dart';
+import 'package:tmail_ui_user/features/thread_detail/presentation/extension/handle_mail_shortcut_actions_extension.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/thread_detail_controller.dart';
 
 extension ThreadDetailOnSelectedEmailUpdated on ThreadDetailController {
@@ -23,6 +24,7 @@ extension ThreadDetailOnSelectedEmailUpdated on ThreadDetailController {
     }
 
     emailIdsPresentation.clear();
+    onKeyboardShortcutInit();
     scrollController ??= ScrollController();
 
     if (currentExpandedEmailId.value == null) {

--- a/lib/features/thread_detail/presentation/thread_detail_controller.dart
+++ b/lib/features/thread_detail/presentation/thread_detail_controller.dart
@@ -212,8 +212,6 @@ class ThreadDetailController extends BaseController {
         );
       }
     });
-
-    onKeyboardShortcutInit();
   }
 
   bool _validateLoadThread(ThreadId? threadId) {


### PR DESCRIPTION
## Issue
- https://github.com/linagora/tmail-flutter/issues/4154#issuecomment-3546521359

## Root cause
`keyboardShortcutFocusNode` init when `ThreadDetailController` init, and dispose when `ThreadDetailController` dispose. However, `ThreadDetailController` lives as long as the app lives, so `keyboardShortcutFocusNode` is never disposed, dragging any of its dependencies.

## Approach
- `keyboardShortcutFocusNode` init when `ThreadDetailController` start processing new selected email
- `keyboardShortcutFocusNode` dispose when `ThreadDetailController` is closed, as selected email is null.

## Before
<img width="1221" height="704" alt="Screenshot 2025-11-18 at 5 20 07 PM" src="https://github.com/user-attachments/assets/e1be3c8d-a169-4441-8e36-9c6b91f75933" />

## After
<img width="1221" height="704" alt="Screenshot 2025-11-18 at 5 18 06 PM" src="https://github.com/user-attachments/assets/84402c00-3b7e-48ce-beee-5efd0747c4b5" />
