### PR TITLE
Fix show `Your storage is almost full` message in Storage section

### DIFF
--- a/lib/features/manage_account/presentation/storage/storage_controller.dart
+++ b/lib/features/manage_account/presentation/storage/storage_controller.dart
@@ -16,6 +16,22 @@ class StorageController extends BaseController with SaaSPremiumMixin {
     return isPremiumAvailable(accountId: accountId, session: session);
   }
 
+  bool validateUserHasIsAlreadyHighestSubscription() {
+    final accountId = dashBoardController.accountId.value;
+    final session = dashBoardController.sessionCurrent;
+
+    if (accountId == null || session == null) {
+      return false;
+    }
+
+    return isAlreadyHighestSubscription(accountId: accountId, session: session);
+  }
+
+  bool get isUpgradeStorageIsDisabled {
+    return !validatePremiumIsAvailable() ||
+        validateUserHasIsAlreadyHighestSubscription();
+  }
+
   void onUpgradeStorage() {
     dashBoardController.paywallController?.navigateToPaywall();
   }

--- a/lib/features/manage_account/presentation/storage/storage_view.dart
+++ b/lib/features/manage_account/presentation/storage/storage_view.dart
@@ -68,6 +68,10 @@ class StorageView extends GetWidget<StorageController> with AppLoaderMixin {
                     .value;
 
                 if (octetsQuota != null && octetsQuota.storageAvailable) {
+                  final isPremiumAvailable = PlatformInfo.isWeb &&
+                      !controller.isUpgradeStorageIsDisabled;
+                  final isQuotaExceeds90Percent = octetsQuota.allowedDisplayToQuotaBanner;
+
                   return SingleChildScrollView(
                     child: Padding(
                       padding: _getPadding(
@@ -83,16 +87,15 @@ class StorageView extends GetWidget<StorageController> with AppLoaderMixin {
                             quota: octetsQuota,
                             isMobile: isMobile,
                           ),
-                          UpgradeStorageWidget(
-                            imagePaths: controller.imagePaths,
-                            isMobile: isMobile,
-                            isPremiumAvailable: PlatformInfo.isWeb &&
-                                !controller.isUpgradeStorageIsDisabled,
-                            isQuotaExceeds90Percent:
-                              octetsQuota.allowedDisplayToQuotaBanner,
-                            onUpgradeStorageAction:
-                                controller.onUpgradeStorage,
-                          ),
+                          if (isPremiumAvailable || isQuotaExceeds90Percent)
+                            UpgradeStorageWidget(
+                              imagePaths: controller.imagePaths,
+                              isMobile: isMobile,
+                              isPremiumAvailable: isPremiumAvailable,
+                              isQuotaExceeds90Percent: isQuotaExceeds90Percent,
+                              onUpgradeStorageAction:
+                                  controller.onUpgradeStorage,
+                            ),
                         ],
                       ),
                     ),

--- a/lib/features/manage_account/presentation/storage/storage_view.dart
+++ b/lib/features/manage_account/presentation/storage/storage_view.dart
@@ -83,19 +83,16 @@ class StorageView extends GetWidget<StorageController> with AppLoaderMixin {
                             quota: octetsQuota,
                             isMobile: isMobile,
                           ),
-                          Obx(() {
-                            if (controller.validatePremiumIsAvailable() &&
-                                PlatformInfo.isWeb) {
-                              return UpgradeStorageWidget(
-                                imagePaths: controller.imagePaths,
-                                isMobile: isMobile,
-                                onUpgradeStorageAction:
-                                  controller.onUpgradeStorage,
-                              );
-                            } else {
-                              return const SizedBox.shrink();
-                            }
-                          })
+                          UpgradeStorageWidget(
+                            imagePaths: controller.imagePaths,
+                            isMobile: isMobile,
+                            isPremiumAvailable: PlatformInfo.isWeb &&
+                                !controller.isUpgradeStorageIsDisabled,
+                            isQuotaExceeds90Percent:
+                              octetsQuota.allowedDisplayToQuotaBanner,
+                            onUpgradeStorageAction:
+                                controller.onUpgradeStorage,
+                          ),
                         ],
                       ),
                     ),

--- a/lib/features/manage_account/presentation/storage/widgets/upgrade_storage_widget.dart
+++ b/lib/features/manage_account/presentation/storage/widgets/upgrade_storage_widget.dart
@@ -9,6 +9,8 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 class UpgradeStorageWidget extends StatelessWidget {
   final ImagePaths imagePaths;
   final bool isMobile;
+  final bool isPremiumAvailable;
+  final bool isQuotaExceeds90Percent;
   final VoidCallback onUpgradeStorageAction;
 
   const UpgradeStorageWidget({
@@ -16,6 +18,8 @@ class UpgradeStorageWidget extends StatelessWidget {
     required this.imagePaths,
     required this.onUpgradeStorageAction,
     this.isMobile = false,
+    this.isPremiumAvailable = false,
+    this.isQuotaExceeds90Percent = false,
   });
 
   @override
@@ -27,40 +31,44 @@ class UpgradeStorageWidget extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              SvgPicture.asset(
-                imagePaths.icWarning,
-                width: 16,
-                height: 16,
-                fit: BoxFit.fill,
-              ),
-              const SizedBox(width: 7),
-              Expanded(
-                child: Text(
-                  appLocalizations.storageIsAlmostFullMessage,
-                  style: ThemeUtils.textStyleInter600().copyWith(
-                    color: AppColor.m3Neutral40,
-                    fontSize: 12,
-                    height: 16 / 12,
-                    letterSpacing: 0.4,
+          if (isQuotaExceeds90Percent)
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SvgPicture.asset(
+                  imagePaths.icWarning,
+                  width: 16,
+                  height: 16,
+                  fit: BoxFit.fill,
+                ),
+                const SizedBox(width: 7),
+                Expanded(
+                  child: Text(
+                    appLocalizations.storageIsAlmostFullMessage,
+                    style: ThemeUtils.textStyleInter600().copyWith(
+                      color: AppColor.m3Neutral40,
+                      fontSize: 12,
+                      height: 16 / 12,
+                      letterSpacing: 0.4,
+                    ),
                   ),
                 ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 16),
-          Container(
-            constraints: const BoxConstraints(minWidth: 179),
-            height: 48,
-            child: ConfirmDialogButton(
-              label: appLocalizations.upgradeStorage,
-              backgroundColor: AppColor.primaryMain,
-              textColor: Colors.white,
-              onTapAction: onUpgradeStorageAction,
+              ],
             ),
-          ),
+          if (isPremiumAvailable)
+            Container(
+              constraints: const BoxConstraints(minWidth: 179),
+              margin: isQuotaExceeds90Percent
+                  ? const EdgeInsetsDirectional.only(start: 16)
+                  : null,
+              height: 48,
+              child: ConfirmDialogButton(
+                label: appLocalizations.upgradeStorage,
+                backgroundColor: AppColor.primaryMain,
+                textColor: Colors.white,
+                onTapAction: onUpgradeStorageAction,
+              ),
+            ),
         ],
       ),
     );

--- a/lib/features/manage_account/presentation/storage/widgets/upgrade_storage_widget.dart
+++ b/lib/features/manage_account/presentation/storage/widgets/upgrade_storage_widget.dart
@@ -25,51 +25,71 @@ class UpgradeStorageWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final appLocalizations = AppLocalizations.of(context);
-    return SizedBox(
-      width: isMobile ? double.infinity : 439,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (isQuotaExceeds90Percent)
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                SvgPicture.asset(
-                  imagePaths.icWarning,
-                  width: 16,
-                  height: 16,
-                  fit: BoxFit.fill,
-                ),
-                const SizedBox(width: 7),
-                Expanded(
-                  child: Text(
-                    appLocalizations.storageIsAlmostFullMessage,
-                    style: ThemeUtils.textStyleInter600().copyWith(
-                      color: AppColor.m3Neutral40,
-                      fontSize: 12,
-                      height: 16 / 12,
-                      letterSpacing: 0.4,
-                    ),
-                  ),
-                ),
-              ],
+
+    final widgets = [
+      if (isQuotaExceeds90Percent) _buildWarning(context, appLocalizations),
+      if (isPremiumAvailable) _buildUpgradeButton(appLocalizations),
+    ];
+
+    if (widgets.isEmpty) return const SizedBox.shrink();
+
+    final body = widgets.length == 1
+        ? widgets.first
+        : Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: widgets,
+          );
+
+    return isQuotaExceeds90Percent
+        ? SizedBox(
+            width: isMobile ? double.infinity : 439,
+            child: body,
+          )
+        : body;
+  }
+
+  Widget _buildWarning(
+    BuildContext context,
+    AppLocalizations appLocalizations,
+  ) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SvgPicture.asset(
+          imagePaths.icWarning,
+          width: 16,
+          height: 16,
+          fit: BoxFit.fill,
+        ),
+        const SizedBox(width: 7),
+        Expanded(
+          child: Text(
+            appLocalizations.storageIsAlmostFullMessage,
+            style: ThemeUtils.textStyleInter600().copyWith(
+              color: AppColor.m3Neutral40,
+              fontSize: 12,
+              height: 16 / 12,
+              letterSpacing: 0.4,
             ),
-          if (isPremiumAvailable)
-            Container(
-              constraints: const BoxConstraints(minWidth: 179),
-              margin: isQuotaExceeds90Percent
-                  ? const EdgeInsetsDirectional.only(start: 16)
-                  : null,
-              height: 48,
-              child: ConfirmDialogButton(
-                label: appLocalizations.upgradeStorage,
-                backgroundColor: AppColor.primaryMain,
-                textColor: Colors.white,
-                onTapAction: onUpgradeStorageAction,
-              ),
-            ),
-        ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildUpgradeButton(AppLocalizations appLocalizations) {
+    return Container(
+      margin: isQuotaExceeds90Percent
+          ? const EdgeInsetsDirectional.only(top: 16)
+          : null,
+      height: 48,
+      constraints: const BoxConstraints(minWidth: 179),
+      child: ConfirmDialogButton(
+        label: appLocalizations.upgradeStorage,
+        backgroundColor: AppColor.primaryMain,
+        textColor: Colors.white,
+        onTapAction: onUpgradeStorageAction,
       ),
     );
   }


### PR DESCRIPTION
## Issue

Fix show `Your storage is almost full` message in Storage section

<img width="1680" height="941" alt="Capture d’écran 2025-11-18 à 10 34 26" src="https://github.com/user-attachments/assets/37ad984c-7b1c-48f3-8701-0a0c65436515" />

## Resolved

- With quota >= 90%


https://github.com/user-attachments/assets/f9eaa829-a603-4bb8-badf-dc2e8e41e445



- With quota < 90%

https://github.com/user-attachments/assets/a46ef9f9-16b8-4086-ad7f-391385b75bc4


