### PR TITLE
[AI Scribe] Add "replace" and improve "insert" action

### DIFF
--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -111,6 +111,16 @@ class HtmlUtils {
       });''',
     name: 'onSelectionChange');
 
+  static const collapseSelectionToEnd = (
+    script: '''
+      (() => {
+        const selection = window.getSelection();
+        if (selection) {
+          selection.collapseToEnd()
+        }
+      })();''',
+    name: 'collapseSelectionToEnd');
+
   static recalculateEditorHeight({double? maxHeight}) => (
     script: '''
       const editable = document.querySelector('.note-editable');

--- a/lib/features/composer/presentation/mixin/ai_scribe_in_composer_mixin.dart
+++ b/lib/features/composer/presentation/mixin/ai_scribe_in_composer_mixin.dart
@@ -81,7 +81,8 @@ mixin AIScribeInComposerMixin {
       context: context,
       imagePaths: imagePaths,
       content: fullText,
-      onInsertText: insertTextInEditor,
+      onInsertText: onInsertTextCallback,
+      onReplaceText: fullText.isEmpty ? null : onReplaceTextCallback,
       interactor: generateAITextInteractor,
       buttonPosition: buttonPosition,
     );
@@ -97,7 +98,8 @@ mixin AIScribeInComposerMixin {
       context: context,
       imagePaths: imagePaths,
       content: selection,
-      onInsertText: insertTextInEditor,
+      onInsertText: onInsertTextCallback,
+      onReplaceText: onReplaceTextCallback,
       interactor: generateAITextInteractor,
       buttonPosition: buttonPosition,
     );

--- a/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
@@ -186,6 +186,10 @@ class _WebEditorState extends State<WebEditorWidget> with TextSelectionMixin {
             script: HtmlUtils.registerSelectionChangeListener.script,
           ),
           WebScript(
+            name: HtmlUtils.collapseSelectionToEnd.name,
+            script: HtmlUtils.collapseSelectionToEnd.script,
+          ),
+          WebScript(
             name: HtmlUtils.recalculateEditorHeight(maxHeight: maxHeight).name,
             script: HtmlUtils.recalculateEditorHeight(maxHeight: maxHeight).script,
           ),

--- a/scribe/lib/scribe/ai/l10n/intl_en.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_en.arb
@@ -113,5 +113,11 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
+  },
+  "replaceButton": "Replace",
+  "@replaceButton": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
 }

--- a/scribe/lib/scribe/ai/l10n/intl_fr.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_fr.arb
@@ -113,5 +113,11 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
+  },
+  "replaceButton": "Remplacer",
+  "@replaceButton": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
 }

--- a/scribe/lib/scribe/ai/l10n/intl_messages.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_messages.arb
@@ -113,5 +113,11 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
+  },
+  "replaceButton": "Replace",
+  "@replaceButton": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
 }

--- a/scribe/lib/scribe/ai/l10n/intl_ru.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_ru.arb
@@ -113,5 +113,11 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
+  },
+  "replaceButton": "заменить",
+  "@replaceButton": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
 }

--- a/scribe/lib/scribe/ai/l10n/intl_vi.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_vi.arb
@@ -113,5 +113,11 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
+  },
+  "replaceButton": "Thay thế",
+  "@replaceButton": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
 }

--- a/scribe/lib/scribe/ai/localizations/scribe_localizations.dart
+++ b/scribe/lib/scribe/ai/localizations/scribe_localizations.dart
@@ -121,6 +121,11 @@ class ScribeLocalizations {
     return Intl.message('Insert',
         name: 'insertButton');
   }
+
+  String get replaceButton {
+    return Intl.message('Replace',
+        name: 'replaceButton');
+  }
 }
 
 class _ScribeLocalizationsDelegate extends LocalizationsDelegate<ScribeLocalizations> {

--- a/scribe/lib/scribe/ai/presentation/widgets/ai_scribe.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/ai_scribe.dart
@@ -18,6 +18,7 @@ Future<void> showAIScribeDialog({
   required ImagePaths imagePaths,
   required String content,
   required AIScribeResultCallback onInsertText,
+  AIScribeResultCallback? onReplaceText,
   required GenerateAITextInteractor interactor,
   List<AIScribeMenuCategory>? availableCategories,
   Offset? buttonPosition,
@@ -124,6 +125,10 @@ Future<void> showAIScribeDialog({
           onInsertText(result);
           Navigator.of(context).pop();
         },
+        onReplace: onReplaceText != null ? (result) {
+          onReplaceText(result);
+          Navigator.of(context).pop();
+        } : null,
         imagePaths: imagePaths,
       );
 

--- a/scribe/lib/scribe/ai/presentation/widgets/ai_scribe_suggestion.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/ai_scribe_suggestion.dart
@@ -13,6 +13,7 @@ class AIScribeSuggestion extends StatefulWidget {
   final Future<String> suggestionFuture;
   final VoidCallback onClose;
   final OnInsertTextCallback onInsert;
+  final OnInsertTextCallback? onReplace;
   final ImagePaths imagePaths;
 
   const AIScribeSuggestion({
@@ -21,6 +22,7 @@ class AIScribeSuggestion extends StatefulWidget {
     required this.suggestionFuture,
     required this.onClose,
     required this.onInsert,
+    this.onReplace,
     required this.imagePaths,
   });
 
@@ -184,13 +186,27 @@ class _AIScribeSuggestionModalState extends State<AIScribeSuggestion> {
               Clipboard.setData(ClipboardData(text: suggestion));
             },
           ),
-          TMailButtonWidget(
-            text: ScribeLocalizations.of(context)!.insertButton,
-            textStyle: AIScribeButtonStyles.mainActionButtonText,
-            padding: AIScribeButtonStyles.mainActionButtonPadding,
-            backgroundColor: AIScribeButtonStyles.mainActionButtonBackgroundColor,
-            onTapActionCallback: () => widget.onInsert(suggestion),
-          )
+          Row(
+            children: [
+              if (widget.onReplace != null) ...[
+                TMailButtonWidget(
+                  text: ScribeLocalizations.of(context)!.replaceButton,
+                  textStyle: AIScribeButtonStyles.mainActionButtonText,
+                  padding: AIScribeButtonStyles.mainActionButtonPadding,
+                  backgroundColor: Colors.transparent,
+                  onTapActionCallback: () => widget.onReplace!(suggestion),
+                ),
+                const SizedBox(width: AIScribeSizes.fieldSpacing),
+              ],
+              TMailButtonWidget(
+                text: ScribeLocalizations.of(context)!.insertButton,
+                textStyle: AIScribeButtonStyles.mainActionButtonText,
+                padding: AIScribeButtonStyles.mainActionButtonPadding,
+                backgroundColor: AIScribeButtonStyles.mainActionButtonBackgroundColor,
+                onTapActionCallback: () => widget.onInsert(suggestion),
+              ),
+            ],
+          ),
         ],
       ),
     );


### PR DESCRIPTION
In some case, we want to be able with the result of the LLM to:
- insert it in the composer at the cursor position
- replace the relevant content in the composer : replace the current selection or replace the full content

Here I add a "replace" optional button and correctly manage "replace" and "insert" action in all cases.

## Screenshot

<img width="784" height="303" alt="Screenshot 2025-12-11 at 15 46 29" src="https://github.com/user-attachments/assets/57a5b350-fd88-44a3-ad3d-a2e4b4fb8be7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AI Scribe dialog now includes a Replace button option alongside Insert for direct text replacement
  * Improved editor selection and text insertion handling for more precise cursor positioning
  * Added multi-language support for Replace action (English, French, Russian, Vietnamese)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->