### PR TITLE
TF-4136 Re-standardize the logger

### DIFF
--- a/core/lib/data/network/download/download_manager.dart
+++ b/core/lib/data/network/download/download_manager.dart
@@ -143,7 +143,7 @@ class DownloadManager {
         );
       }
     } catch (exception) {
-      logError('DownloadManager::openDownloadedFileWeb(): ERROR: $exception');
+      logWarning('DownloadManager::openDownloadedFileWeb(): ERROR: $exception');
       rethrow;
     }
   }
@@ -153,7 +153,7 @@ class DownloadManager {
       final contentType = responseBody.headers[Headers.contentTypeHeader];
       return MediaType.parse(contentType!.first);
     } catch (e) {
-      logError('DownloadManager::_extractMediaTypeFromResponse(): $e');
+      logWarning('DownloadManager::_extractMediaTypeFromResponse(): $e');
       return null;
     }
   }

--- a/core/lib/presentation/extensions/string_extension.dart
+++ b/core/lib/presentation/extensions/string_extension.dart
@@ -37,7 +37,7 @@ extension StringExtension on String {
         }
       }
     } catch (e) {
-      logError('StringExtension::firstLetterToUpperCase(): $e');
+      logWarning('StringExtension::firstLetterToUpperCase(): $e');
       return '';
     }
   }
@@ -94,7 +94,7 @@ extension StringExtension on String {
         return 0;
       }
     } catch (e) {
-      logError('StringExtension::_generateGradientColorIndex(): $e');
+      logWarning('StringExtension::_generateGradientColorIndex(): $e');
       return 0;
     }
   }

--- a/core/lib/presentation/extensions/uri_extension.dart
+++ b/core/lib/presentation/extensions/uri_extension.dart
@@ -26,7 +26,7 @@ extension URIExtension on Uri {
     try {
       return origin.isNotEmpty;
     } catch (e) {
-      logError('URIExtension::hasOrigin:Exception = $e');
+      logWarning('URIExtension::hasOrigin:Exception = $e');
       return false;
     }
   }

--- a/core/lib/presentation/utils/html_transformer/base/dom_transformer.dart
+++ b/core/lib/presentation/utils/html_transformer/base/dom_transformer.dart
@@ -41,7 +41,7 @@ abstract class DomTransformer {
         return null;
       }
     } catch (e) {
-      logError('DomTransformer::findImageUrlFromStyleTag:Exception: $e');
+      logWarning('DomTransformer::findImageUrlFromStyleTag:Exception: $e');
       return null;
     }
   }

--- a/core/lib/presentation/utils/html_transformer/dom/add_lazy_loading_for_background_image_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/add_lazy_loading_for_background_image_transformers.dart
@@ -28,7 +28,7 @@ class AddLazyLoadingForBackgroundImageTransformer extends DomTransformer {
         }
       }));
     } catch (e) {
-      logError('$runtimeType::process:Exception = $e');
+      logWarning('$runtimeType::process:Exception = $e');
     }
   }
 }

--- a/core/lib/presentation/utils/html_transformer/dom/block_code_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/block_code_transformers.dart
@@ -36,7 +36,7 @@ class BlockCodeTransformer extends DomTransformer {
         ''';
       }));
     } catch (e) {
-      logError('$runtimeType::process:Exception = $e');
+      logWarning('$runtimeType::process:Exception = $e');
     }
   }
 }

--- a/core/lib/presentation/utils/html_transformer/dom/block_quoted_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/block_quoted_transformers.dart
@@ -29,7 +29,7 @@ class BlockQuotedTransformer extends DomTransformer {
         ''';
       }));
     } catch (e) {
-      logError('$runtimeType::process:Exception = $e');
+      logWarning('$runtimeType::process:Exception = $e');
     }
   }
 }

--- a/core/lib/presentation/utils/html_transformer/dom/hide_draft_signature_transformer.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/hide_draft_signature_transformer.dart
@@ -27,7 +27,7 @@ class HideDraftSignatureTransformer extends DomTransformer {
         signature.attributes['style'] = '$currentStyle; display: none;';
       }
     } catch (e) {
-      logError('$runtimeType::process:Exception = $e');
+      logWarning('$runtimeType::process:Exception = $e');
     }
   }
 }

--- a/core/lib/presentation/utils/html_transformer/dom/image_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/image_transformers.dart
@@ -52,7 +52,7 @@ class ImageTransformer extends DomTransformer {
         }
       }));
     } catch (e) {
-      logError('$runtimeType::process:Exception = $e');
+      logWarning('$runtimeType::process:Exception = $e');
     }
   }
 

--- a/core/lib/presentation/utils/html_transformer/dom/normalize_line_height_in_style_transformer.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/normalize_line_height_in_style_transformer.dart
@@ -40,7 +40,7 @@ class NormalizeLineHeightInStyleTransformer extends DomTransformer {
         }
       }
     } catch (e) {
-      logError('$runtimeType::process: Exception = $e');
+      logWarning('$runtimeType::process: Exception = $e');
     }
   }
 }

--- a/core/lib/presentation/utils/html_transformer/dom/remove_collapsed_signature_button_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/remove_collapsed_signature_button_transformers.dart
@@ -23,7 +23,7 @@ class RemoveCollapsedSignatureButtonTransformer extends DomTransformer {
         element.remove();
       }));
     } catch (e) {
-      logError('$runtimeType::process:Exception = $e');
+      logWarning('$runtimeType::process:Exception = $e');
     }
   }
 }

--- a/core/lib/presentation/utils/html_transformer/dom/remove_lazy_loading_for_background_image_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/remove_lazy_loading_for_background_image_transformers.dart
@@ -31,7 +31,7 @@ class RemoveLazyLoadingForBackgroundImageTransformer extends DomTransformer {
         element.attributes.remove('lazy');
       }));
     } catch (e) {
-      logError('$runtimeType::process:Exception = $e');
+      logWarning('$runtimeType::process:Exception = $e');
     }
   }
 }

--- a/core/lib/presentation/utils/html_transformer/dom/remove_lazy_loading_image_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/remove_lazy_loading_image_transformers.dart
@@ -21,7 +21,7 @@ class RemoveLazyLoadingImageTransformer extends DomTransformer {
         element.attributes.remove('loading');
       }));
     } catch (e) {
-      logError('$runtimeType::process:Exception = $e');
+      logWarning('$runtimeType::process:Exception = $e');
     }
   }
 }

--- a/core/lib/presentation/utils/html_transformer/dom/remove_max_width_in_image_style_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/remove_max_width_in_image_style_transformers.dart
@@ -26,7 +26,7 @@ class RemoveMaxWidthInImageStyleTransformer extends DomTransformer {
         }
       }));
     } catch (e) {
-      logError('$runtimeType::process:Exception = $e');
+      logWarning('$runtimeType::process:Exception = $e');
     }
   }
 }

--- a/core/lib/presentation/utils/html_transformer/dom/remove_style_tag_outside_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/remove_style_tag_outside_transformers.dart
@@ -22,7 +22,7 @@ class RemoveStyleTagOutsideTransformer extends DomTransformer {
         element.remove();
       }));
     } catch (e) {
-      logError('$runtimeType::process:Exception = $e');
+      logWarning('$runtimeType::process:Exception = $e');
     }
   }
 }

--- a/core/lib/presentation/utils/html_transformer/dom/sanitize_hyper_link_tag_in_html_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/sanitize_hyper_link_tag_in_html_transformers.dart
@@ -26,7 +26,7 @@ class SanitizeHyperLinkTagInHtmlTransformer extends DomTransformer {
         _addNoReferrerForRelProperty(element);
       }));
     } catch (e) {
-      logError('$runtimeType::process:Exception = $e');
+      logWarning('$runtimeType::process:Exception = $e');
     }
   }
 

--- a/core/lib/presentation/utils/html_transformer/dom/script_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/script_transformers.dart
@@ -23,7 +23,7 @@ class RemoveScriptTransformer extends DomTransformer {
         scriptElement.remove();
       }));
     } catch (e) {
-      logError('$runtimeType::process:Exception = $e');
+      logWarning('$runtimeType::process:Exception = $e');
     }
   }
 }

--- a/core/lib/presentation/utils/html_transformer/dom/signature_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/signature_transformers.dart
@@ -23,7 +23,7 @@ class SignatureTransformer extends DomTransformer {
         element.attributes['class'] = 'tmail-signature-blocked';
       }));
     } catch (e) {
-      logError('$runtimeType::process:Exception = $e');
+      logWarning('$runtimeType::process:Exception = $e');
     }
   }
 }

--- a/core/lib/presentation/utils/html_transformer/sanitize_autolink_filter.dart
+++ b/core/lib/presentation/utils/html_transformer/sanitize_autolink_filter.dart
@@ -56,7 +56,7 @@ class SanitizeAutolinkFilter {
       log('SanitizeAutolinkFilter::process:htmlTextBuffer = $textSanitized');
       return textSanitized;
     } catch (e) {
-      logError('$runtimeType::process:Exception = $e');
+      logWarning('$runtimeType::process:Exception = $e');
       return inputText;
     }
   }

--- a/core/lib/presentation/utils/html_transformer/sanitize_url.dart
+++ b/core/lib/presentation/utils/html_transformer/sanitize_url.dart
@@ -24,7 +24,7 @@ class SanitizeUrl {
       }
       return originalUrl;
     } catch (e) {
-      logError('SanitizeUrl::process:Exception = $e');
+      logWarning('SanitizeUrl::process:Exception = $e');
       return inputText;
     }
   }

--- a/core/lib/presentation/views/html_viewer/html_content_viewer_on_web_widget.dart
+++ b/core/lib/presentation/views/html_viewer/html_content_viewer_on_web_widget.dart
@@ -166,7 +166,7 @@ class _HtmlContentViewerOnWebState extends State<HtmlContentViewerOnWeb>
         _handleHyperLinkEvent(data['url']);
       }
     } catch (e) {
-      logError('$runtimeType::_handleMessageEvent:Exception = $e');
+      logWarning('$runtimeType::_handleMessageEvent:Exception = $e');
     }
   }
 
@@ -212,7 +212,7 @@ class _HtmlContentViewerOnWebState extends State<HtmlContentViewerOnWeb>
         }
       }
     } catch (e) {
-      logError('$runtimeType::_handleIframeOnScrollChangedListener:Exception = $e');
+      logWarning('$runtimeType::_handleIframeOnScrollChangedListener:Exception = $e');
     }
   }
 
@@ -309,7 +309,7 @@ class _HtmlContentViewerOnWebState extends State<HtmlContentViewerOnWeb>
       log('$runtimeType::_handleOnIFrameKeyboardEvent:📥 Shortcut pressed: $shortcut');
       widget.onIFrameKeyboardShortcutAction?.call(shortcut);
     } catch (e) {
-      logError('$runtimeType::_handleOnIFrameKeyboardEvent: Exception = $e');
+      logWarning('$runtimeType::_handleOnIFrameKeyboardEvent: Exception = $e');
     }
   }
 
@@ -323,7 +323,7 @@ class _HtmlContentViewerOnWebState extends State<HtmlContentViewerOnWeb>
       log('$runtimeType::_handleOnIFrameClickEvent: $data');
       widget.onIFrameClickAction?.call();
     } catch (e) {
-      logError('$runtimeType::_handleOnIFrameClickEvent: Exception = $e');
+      logWarning('$runtimeType::_handleOnIFrameClickEvent: Exception = $e');
     }
   }
 
@@ -354,7 +354,7 @@ class _HtmlContentViewerOnWebState extends State<HtmlContentViewerOnWeb>
         }
       }
     } catch (e) {
-      logError('$runtimeType::_handleOnIFrameLinkHoverEvent: Exception = $e');
+      logWarning('$runtimeType::_handleOnIFrameLinkHoverEvent: Exception = $e');
     }
   }
 
@@ -363,7 +363,7 @@ class _HtmlContentViewerOnWebState extends State<HtmlContentViewerOnWeb>
       log('$runtimeType::_handleOnIFrameLinkOutEvent: $data');
       _tooltipOverlay?.hide();
     } catch (e) {
-      logError('$runtimeType::_handleOnIFrameLinkOutEvent: Exception = $e');
+      logWarning('$runtimeType::_handleOnIFrameLinkOutEvent: Exception = $e');
     }
   }
 

--- a/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
+++ b/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
@@ -411,7 +411,7 @@ class HtmlContentViewState extends State<HtmlContentViewer> with AutomaticKeepAl
       try {
         _webViewController.dispose();
       } catch (e) {
-        logError('_HtmlContentViewState:dispose:_webViewController.dispose: $e');
+        logWarning('_HtmlContentViewState:dispose:_webViewController.dispose: $e');
       }
     } else {
       _webViewController.dispose();

--- a/core/lib/presentation/views/quick_search/quick_search_suggestion_list.dart
+++ b/core/lib/presentation/views/quick_search/quick_search_suggestion_list.dart
@@ -111,7 +111,7 @@ class QuickSearchSuggestionListState<T, P, R>
     try {
       return await widget.fetchRecentActionCallback?.call(queryString);
     } catch (e) {
-      logError('SuggestionsListState::_getRecent:Exception = $e');
+      logWarning('SuggestionsListState::_getRecent:Exception = $e');
       return null;
     }
   }
@@ -120,7 +120,7 @@ class QuickSearchSuggestionListState<T, P, R>
     try {
       return await widget.contactSuggestionCallback?.call(queryString);
     } catch (e) {
-      logError('SuggestionsListState::_getListContact:Exception = $e');
+      logWarning('SuggestionsListState::_getListContact:Exception = $e');
       return null;
     }
   }
@@ -129,7 +129,7 @@ class QuickSearchSuggestionListState<T, P, R>
     try {
       return await widget.suggestionsCallback?.call(queryString);
     } catch (e) {
-      logError('SuggestionsListState::_getListSuggestion:Exception = $e');
+      logWarning('SuggestionsListState::_getListSuggestion:Exception = $e');
       return null;
     }
   }

--- a/core/lib/utils/app_logger.dart
+++ b/core/lib/utils/app_logger.dart
@@ -1,70 +1,201 @@
 import 'dart:async';
-
+import 'package:universal_html/html.dart' as html;
+import 'package:core/utils/build_utils.dart';
 import 'package:core/utils/platform_info.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-final logHistory = _Dispatcher('');
+/// ANSI escape colors (Web only)
+const ansiReset = '\x1B[0m';
+const ansiRed = '\x1B[31m';
+const ansiYellow = '\x1B[33m';
+const ansiGreen = '\x1B[32m';
+const ansiBlue = '\x1B[34m';
+const ansiBold = '\x1B[1m';
 
-void log(String? value, {Level level = Level.info}) {
-  if (!kDebugMode) return;
+const appLogName = '[TwakeMail]';
 
-  String logsStr = value ?? '';
-  logHistory.value = '$logsStr\n${logHistory.value}';
-
-  if (PlatformInfo.isWeb) {
-    switch (level) {
-      case Level.wtf:
-        logsStr = '\x1B[31m!!!CRITICAL!!! $logsStr\x1B[0m';
-        break;
-      case Level.error:
-        logsStr = '\x1B[31m$logsStr\x1B[0m';
-        break;
-      case Level.warning:
-        logsStr = '\x1B[33m$logsStr\x1B[0m';
-        break;
-      case Level.info:
-        logsStr = '\x1B[32m$logsStr\x1B[0m';
-        break;
-      case Level.debug:
-        logsStr = '\x1B[34m$logsStr\x1B[0m';
-        break;
-      case Level.verbose:
-        break;
-    }
-  } else {
-    switch (level) {
-      case Level.error:
-        logsStr = '[ERROR] $logsStr';
-        break;
-      default:
-        break;
-    }
+String _applyWebColor(Level level, String text) {
+  switch (level) {
+    case Level.wtf:
+      return '$ansiRed$ansiBold!!!CRITICAL!!! $text$ansiReset';
+    case Level.error:
+      return '$ansiRed$text$ansiReset';
+    case Level.warning:
+      return '$ansiYellow$text$ansiReset';
+    case Level.info:
+      return '$ansiGreen$text$ansiReset';
+    case Level.debug:
+      return '$ansiBlue$text$ansiReset';
+    case Level.verbose:
+      return text;
   }
+}
+
+String _applyMobileFormat(Level level, String text) {
+  switch (level) {
+    case Level.wtf:
+      return '🔥 CRITICAL: $text';
+    case Level.error:
+      return '❌ ERROR: $text';
+    case Level.warning:
+      return '⚠️ WARNING: $text';
+    case Level.info:
+      return 'ℹ️ INFO: $text';
+    case Level.debug:
+      return '🐛 DEBUG: $text';
+    case Level.verbose:
+      return '🔍 VERBOSE: $text';
+  }
+}
+
+void _internalLog(
+  String? message, {
+  required Level level,
+  Object? exception,
+  StackTrace? stackTrace,
+  Map<String, dynamic>? extras,
+  bool webConsoleEnabled = false,
+}) {
+  final rawMessage = _buildRawMessage(message, exception, extras, stackTrace);
+  final formattedMessage = _formatMessage(level, rawMessage);
+
+  if (webConsoleEnabled && PlatformInfo.isWeb) {
+    _printWebConsole(level, formattedMessage);
+  } else {
+    _debugPrint(formattedMessage);
+  }
+}
+
+String _buildRawMessage(
+  String? message,
+  Object? exception,
+  Map<String, dynamic>? extras,
+  StackTrace? stackTrace,
+) {
+  final parts = <String>[];
+  if (message?.isNotEmpty == true) parts.add(message!);
+  if (exception != null) parts.add('exception: $exception');
+  if (extras != null && extras.isNotEmpty) parts.add('extras: $extras');
+  if (stackTrace != null) parts.add('stackTrace: $stackTrace');
+  return parts.join(' | ');
+}
+
+
+String _formatMessage(Level level, String raw) {
+  return PlatformInfo.isWeb
+      ? _applyWebColor(level, raw)
+      : _applyMobileFormat(level, raw);
+}
+
+void _debugPrint(String formatted) {
+  if (!BuildUtils.isDebugMode) return;
+
   // ignore: avoid_print
-  print('[TwakeMail] $logsStr');
+  print('$appLogName $formatted');
 }
 
-void logError(String? value) => log(value, level: Level.error);
-
-// Take from: https://flutter.dev/docs/testing/errors
-void initLogger(VoidCallback runApp) {
-  runZonedGuarded(() async {
-    WidgetsFlutterBinding.ensureInitialized();
-    FlutterError.onError = (details) {
-      FlutterError.dumpErrorToConsole(details);
-      logError('AppLogger::initLogger::runZonedGuarded:FlutterError.onError: ${details.stack.toString()}');
-    };
-    runApp.call();
-  }, (error, stack) {
-    logError('AppLogger::initLogger::runZonedGuarded:onError: $error | stack: $stack');
-  });
+void _printWebConsole(Level level, String value) {
+  switch (level) {
+    case Level.error:
+    case Level.wtf:
+      html.window.console.error('$appLogName $value');
+      break;
+    case Level.warning:
+      html.window.console.warn('$appLogName $value');
+      break;
+    case Level.info:
+      html.window.console.info('$appLogName $value');
+      break;
+    case Level.debug:
+    case Level.verbose:
+      html.window.console.debug('$appLogName $value');
+      break;
+  }
 }
 
-class _Dispatcher extends ValueNotifier<String> {
-  _Dispatcher(String value) : super(value);
+void logError(
+  String? message, {
+  Object? exception,
+  StackTrace? stackTrace,
+  Map<String, dynamic>? extras,
+  bool webConsoleEnabled = false,
+}) {
+  _internalLog(
+    message,
+    level: Level.error,
+    exception: exception,
+    stackTrace: stackTrace,
+    extras: extras,
+    webConsoleEnabled: webConsoleEnabled,
+  );
 }
 
+void logWTF(
+  String? message, {
+  Object? exception,
+  StackTrace? stackTrace,
+  Map<String, dynamic>? extras,
+  bool webConsoleEnabled = false,
+}) {
+  _internalLog(
+    message,
+    level: Level.wtf,
+    exception: exception,
+    stackTrace: stackTrace,
+    extras: extras,
+    webConsoleEnabled: webConsoleEnabled,
+  );
+}
+
+void logWarning(
+  String? message, {
+  bool webConsoleEnabled = false,
+}) {
+  _internalLog(message,
+      level: Level.warning, webConsoleEnabled: webConsoleEnabled);
+}
+
+void logInfo(
+  String? message, {
+  bool webConsoleEnabled = false,
+}) {
+  _internalLog(
+    message,
+    level: Level.info,
+    webConsoleEnabled: webConsoleEnabled,
+  );
+}
+
+void logDebug(
+  String? message, {
+  bool webConsoleEnabled = false,
+}) {
+  _internalLog(
+    message,
+    level: Level.debug,
+    webConsoleEnabled: webConsoleEnabled,
+  );
+}
+
+void logVerbose(
+  String? message, {
+  bool webConsoleEnabled = false,
+}) {
+  _internalLog(
+    message,
+    level: Level.verbose,
+    webConsoleEnabled: webConsoleEnabled,
+  );
+}
+
+void log(
+  String? message, {
+  bool webConsoleEnabled = false,
+}) =>
+    logInfo(
+      message,
+      webConsoleEnabled: webConsoleEnabled,
+    );
 
 enum Level {
   wtf,
@@ -73,4 +204,18 @@ enum Level {
   info,
   debug,
   verbose,
+}
+
+// Take from: https://flutter.dev/docs/testing/errors
+void initLogger(VoidCallback runApp) {
+  runZonedGuarded(() async {
+    WidgetsFlutterBinding.ensureInitialized();
+    FlutterError.onError = (details) {
+      FlutterError.dumpErrorToConsole(details);
+      logWarning('AppLogger::initLogger::runZonedGuarded:FlutterError.onError: ${details.stack.toString()}');
+    };
+    runApp.call();
+  }, (error, stack) {
+    logWarning('AppLogger::initLogger::runZonedGuarded:onError: $error | stack: $stack');
+  });
 }

--- a/core/lib/utils/application_manager.dart
+++ b/core/lib/utils/application_manager.dart
@@ -35,7 +35,7 @@ class ApplicationManager {
       log('ApplicationManager::getUserAgent: $userAgent');
       return userAgent;
     } catch(e) {
-      logError('ApplicationManager::getUserAgent: Exception: $e');
+      logWarning('ApplicationManager::getUserAgent: Exception: $e');
       return '';
     }
   }

--- a/core/lib/utils/file_utils.dart
+++ b/core/lib/utils/file_utils.dart
@@ -97,7 +97,7 @@ class FileUtils {
       log('FileUtils::getFolder(): $folderPath');
       return Directory(folderPath);
     } catch (e) {
-      logError('FileUtils::getFolder():EXCEPTION: $e');
+      logWarning('FileUtils::getFolder():EXCEPTION: $e');
       return null;
     }
   }
@@ -113,7 +113,7 @@ class FileUtils {
         log('FileUtils::removeFolder: Remove ${dir.path} success');
       }
     } catch (e) {
-      logError('FileUtils::removeFolder():EXCEPTION: $e');
+      logWarning('FileUtils::removeFolder():EXCEPTION: $e');
     }
   }
 
@@ -134,7 +134,7 @@ class FileUtils {
         await file.delete();
       }
     } catch (e) {
-      logError('$runtimeType::deleteCompressedFileOnMobile: error: $e');
+      logWarning('$runtimeType::deleteCompressedFileOnMobile: error: $e');
     }
   }
 
@@ -144,7 +144,7 @@ class FileUtils {
       log('FileUtils::getCharsetFromBytes: FILE_CHARSET = ${decodedResult.charset}');
       return decodedResult.charset;
     } catch (e) {
-      logError('FileUtils::getCharsetFromBytes: Exception: $e');
+      logWarning('FileUtils::getCharsetFromBytes: Exception: $e');
       return DEFAULT_CHARSET;
     }
   }

--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -647,7 +647,7 @@ class HtmlUtils {
 
       return true;
     } catch (e) {
-      logError('AppUtils::openNewWindowByUrl:Exception = $e');
+      logWarning('AppUtils::openNewWindowByUrl:Exception = $e');
       return false;
     }
   }
@@ -659,7 +659,7 @@ class HtmlUtils {
         titleElements.first.text = title;
       }
     } catch (e) {
-      logError('AppUtils::setWindowBrowserTitle:Exception = $e');
+      logWarning('AppUtils::setWindowBrowserTitle:Exception = $e');
     }
   }
 
@@ -667,7 +667,7 @@ class HtmlUtils {
     try {
       return htmlUnescape.convert(input);
     } catch (e) {
-      logError('HtmlUtils::unescapeHtml:Exception = $e');
+      logWarning('HtmlUtils::unescapeHtml:Exception = $e');
       return input;
     }
   }
@@ -694,7 +694,7 @@ class HtmlUtils {
       log('HtmlUtils::isOldSafari:Version = $version');
       return version != null && version < 17;
     } catch (e) {
-      logError('HtmlUtils::isOldSafari:Exception = $e');
+      logWarning('HtmlUtils::isOldSafari:Exception = $e');
       return false;
     }
   }
@@ -880,7 +880,7 @@ class HtmlUtils {
 
       return container.innerHtml;
     } catch (e) {
-      logError('HtmlUtils::wrapPlainTextLinks:Exception = $e');
+      logWarning('HtmlUtils::wrapPlainTextLinks:Exception = $e');
       return htmlString;
     }
   }

--- a/core/lib/utils/mail/domain.dart
+++ b/core/lib/utils/mail/domain.dart
@@ -70,7 +70,7 @@ class Domain with EquatableMixin {
       InternetAddress(value);
       return true;
     } catch (e) {
-      logError('Domain::validIPAddress: Exception = $e');
+      logWarning('Domain::validIPAddress: Exception = $e');
       return false;
     }
   }

--- a/core/lib/utils/mail/mail_address.dart
+++ b/core/lib/utils/mail/mail_address.dart
@@ -100,7 +100,7 @@ class MailAddress with EquatableMixin {
         throw AddressException('No domain found at position ${pos + 1} in "$address"');
       }
     } catch (e) {
-      logError('MailAddress::validate: Exception = $e');
+      logWarning('MailAddress::validate: Exception = $e');
       if (e is AddressException) {
         rethrow;
       } else {

--- a/core/lib/utils/preview_eml_file_utils.dart
+++ b/core/lib/utils/preview_eml_file_utils.dart
@@ -65,7 +65,7 @@ class PreviewEmlFileUtils {
           ${listAttachment?.isNotEmpty == true ? _createAttachmentsElement(listAttachment: listAttachment ?? [], titleAttachment: titleAttachment) : ''}
       ''');
     } catch (e) {
-      logError('PreviewEmlFileUtils::_createEmailElement: Exception = $e');
+      logWarning('PreviewEmlFileUtils::_createEmailElement: Exception = $e');
       return null;
     }
   }
@@ -78,7 +78,7 @@ class PreviewEmlFileUtils {
         </div>
       ''';
     } catch (e) {
-      logError('PreviewEmlFileUtils::_createRecipientHtmlTag: Exception = $e');
+      logWarning('PreviewEmlFileUtils::_createRecipientHtmlTag: Exception = $e');
       return '';
     }
   }
@@ -127,7 +127,7 @@ class PreviewEmlFileUtils {
         </div>
       ''';
     } catch (e) {
-      logError('PreviewEmlFileUtils::_createAttachmentsElement: Exception = $e');
+      logWarning('PreviewEmlFileUtils::_createAttachmentsElement: Exception = $e');
       return '';
     }
   }

--- a/core/lib/utils/print_utils.dart
+++ b/core/lib/utils/print_utils.dart
@@ -35,7 +35,7 @@ class PrintUtils {
       </table>
     ''');
     } catch (e) {
-      logError('PrintUtils::_createUserInformationElement: Exception = $e');
+      logWarning('PrintUtils::_createUserInformationElement: Exception = $e');
       return null;
     }
   }
@@ -44,7 +44,7 @@ class PrintUtils {
     try {
       return Element.html('<hr />');
     } catch (e) {
-      logError('PrintUtils::dividerElement: Exception = $e');
+      logWarning('PrintUtils::dividerElement: Exception = $e');
       return null;
     }
   }
@@ -63,7 +63,7 @@ class PrintUtils {
       </table>
     ''');
     } catch (e) {
-      logError('PrintUtils::_createSubjectElement: Exception = $e');
+      logWarning('PrintUtils::_createSubjectElement: Exception = $e');
       return null;
     }
   }
@@ -88,7 +88,7 @@ class PrintUtils {
       </table>
     ''');
     } catch (e) {
-      logError('PrintUtils::_createSenderElement: Exception = $e');
+      logWarning('PrintUtils::_createSenderElement: Exception = $e');
       return null;
     }
   }
@@ -99,7 +99,7 @@ class PrintUtils {
       element.text = '$prefix: $emailAddress';
       return element.outerHtml;
     } catch (e) {
-      logError('PrintUtils::_createRecipientHtmlTag: Exception = $e');
+      logWarning('PrintUtils::_createRecipientHtmlTag: Exception = $e');
       return '';
     }
   }
@@ -126,7 +126,7 @@ class PrintUtils {
       </tr>
     ''');
     } catch (e) {
-      logError('PrintUtils::_createRecipientsElement: Exception = $e');
+      logWarning('PrintUtils::_createRecipientsElement: Exception = $e');
       return null;
     }
   }
@@ -147,7 +147,7 @@ class PrintUtils {
       </tr>
     ''');
     } catch (e) {
-      logError('PrintUtils::_createEmailContentElement: Exception = $e');
+      logWarning('PrintUtils::_createEmailContentElement: Exception = $e');
       return null;
     }
   }
@@ -198,7 +198,7 @@ class PrintUtils {
       </table>
     ''');
     } catch (e) {
-      logError('PrintUtils::_createAttachmentsElement: Exception = $e');
+      logWarning('PrintUtils::_createAttachmentsElement: Exception = $e');
       return null;
     }
   }

--- a/core/lib/utils/string_convert.dart
+++ b/core/lib/utils/string_convert.dart
@@ -24,7 +24,7 @@ class StringConvert {
     try {
       return utf8.decode(base64Decode(text));
     } catch (e) {
-      logError('StringConvert::decodeBase64ToString:Exception = $e');
+      logWarning('StringConvert::decodeBase64ToString:Exception = $e');
       return text;
     }
   }
@@ -106,7 +106,7 @@ class StringConvert {
       log('StringConvert::getMediaTypeFromBase64ImageTag:mimeType = $mimeType');
       return MediaType.parse(mimeType);
     } catch (e) {
-      logError('StringConvert::getMimeTypeFromBase64ImageTag:Exception = $e');
+      logWarning('StringConvert::getMimeTypeFromBase64ImageTag:Exception = $e');
       return null;
     }
   }
@@ -117,7 +117,7 @@ class StringConvert {
       final contentOriginal = emailDocument.body?.innerHtml ?? content;
       return contentOriginal;
     } catch (e) {
-      logError('StringConvert::getContentOriginal:Exception = $e');
+      logWarning('StringConvert::getContentOriginal:Exception = $e');
       return content;
     }
   }

--- a/core/lib/utils/web_link_generator.dart
+++ b/core/lib/utils/web_link_generator.dart
@@ -82,7 +82,7 @@ class WebLinkGenerator {
         searchParams: searchParams,
       );
     } catch (e) {
-      logError('[WebLinkGenerator] Error: $e');
+      logWarning('[WebLinkGenerator] Error: $e');
       return '';
     }
   }

--- a/docs/adr/0069-logging-standardization.md
+++ b/docs/adr/0069-logging-standardization.md
@@ -24,7 +24,7 @@ As part of PR #4205, the logging system was refactored to normalize log severity
 
 | Level | Function | Intended usage |
 |------|---------|----------------|
-| critical | logWTF | System-level, unrecoverable failures (extremely rare) |
+| critical | logCritical | System-level, unrecoverable failures (extremely rare) |
 | error | logError | Critical, actionable failures that must be monitored |
 | warning | logWarning | Recoverable issues or degraded behavior |
 | info | logInfo / log | Normal application lifecycle events |

--- a/docs/adr/0069-logging-standardization.md
+++ b/docs/adr/0069-logging-standardization.md
@@ -1,0 +1,72 @@
+# 69. Logger Standardization and Logging Best Practices
+
+Date: 2025-08-18
+
+## Status
+
+Accepted
+
+## Context
+
+The `tmail-flutter` application uses a custom `app_logger` abstraction to unify logging across platforms (Web and Mobile) and environments (debug vs production).
+
+Over time, logging usage became inconsistent:
+- `logError` was used in non-critical or recoverable scenarios.
+- Error-level logs generated excessive noise in monitoring tools (e.g. Sentry).
+- There was no clear, documented guideline describing when to use each log level.
+- Reviewers requested a descriptive piece of developer documentation explaining good logging practices.
+
+As part of PR #4205, the logging system was refactored to normalize log severity usage and prepare the codebase for reliable integration with Sentry and similar monitoring tools.
+
+## Decision
+
+### Defined log levels and intent
+
+| Level | Function | Intended usage |
+|------|---------|----------------|
+| critical | logWTF | System-level, unrecoverable failures (extremely rare) |
+| error | logError | Critical, actionable failures that must be monitored |
+| warning | logWarning | Recoverable issues or degraded behavior |
+| info | logInfo / log | Normal application lifecycle events |
+| debug | logDebug | Developer debugging information |
+| trace | logVerbose | High-volume diagnostic logs |
+
+### Restriction of logError usage
+
+`logError` is restricted to infrastructure-level classes where failures are non-recoverable and must be monitored.
+
+Allowed classes:
+- AuthorizationInterceptors
+- CacheExceptionThrower
+- RemoteExceptionThrower
+
+All other cases must use `logWarning`.
+
+### Logger behavior
+
+- Platform-aware formatting (Web vs Mobile)
+- Consistent message normalization
+- Debug-only printing unless explicitly enabled
+
+### Error boundary
+
+Global error handling is implemented via `initLogger`, ensuring framework and async errors are logged as warnings rather than errors.
+
+## Consequences
+
+### Benefits
+- Reduced noise in error monitoring
+- Clear logging conventions
+- Improved reviewability
+- Better Sentry signal quality
+
+### Trade-offs
+- Stricter logging rules
+- Reduced visibility for non-critical failures
+
+## Developer Logging Guidelines
+
+- Use logError only for critical, non-recoverable issues
+- Use logWarning for handled or recoverable failures
+- Avoid logging sensitive data
+- Prefer descriptive messages with context

--- a/integration_test/mixin/scenario_utils_mixin.dart
+++ b/integration_test/mixin/scenario_utils_mixin.dart
@@ -207,7 +207,7 @@ mixin ScenarioUtilsMixin {
           attachments.add(attachment);
         }
       } catch (e) {
-        logError('ScenarioUtilsMixin::uploadAttachments(): $e');
+        logWarning('ScenarioUtilsMixin::uploadAttachments(): $e');
         return attachments;
       }
     }

--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -143,7 +143,7 @@ abstract class BaseController extends GetxController
   }
 
   void onError(dynamic error, StackTrace stackTrace) {
-    logError('$runtimeType::onError():Error: $error | StackTrace: $stackTrace');
+    logWarning('$runtimeType::onError():Error: $error | StackTrace: $stackTrace');
     final isUrgentException = validateUrgentException(error);
     if (isUrgentException) {
       handleUrgentException(exception: error);
@@ -173,7 +173,7 @@ abstract class BaseController extends GetxController
   }
 
   void handleUrgentExceptionOnMobile({Failure? failure, Exception? exception}) {
-    logError('$runtimeType::handleUrgentExceptionOnMobile():Failure: $failure | Exception: $exception');
+    logWarning('$runtimeType::handleUrgentExceptionOnMobile():Failure: $failure | Exception: $exception');
     if (exception is ConnectionError) {
       _handleConnectionErrorException();
     } else if (exception is BadCredentialsException) {
@@ -182,7 +182,7 @@ abstract class BaseController extends GetxController
   }
 
   void handleUrgentExceptionOnWeb({Failure? failure, Exception? exception}) {
-    logError('$runtimeType::handleUrgentExceptionOnWeb():Failure: $failure | Exception: $exception');
+    logWarning('$runtimeType::handleUrgentExceptionOnWeb():Failure: $failure | Exception: $exception');
     if (exception is NoNetworkError) {
       _handleNotNetworkErrorException();
     } else if (exception is ConnectionError) {
@@ -258,7 +258,7 @@ abstract class BaseController extends GetxController
   }
 
   void handleFailureViewState(Failure failure) async {
-    logError('$runtimeType::handleFailureViewState():Failure = $failure');
+    logWarning('$runtimeType::handleFailureViewState():Failure = $failure');
     if (failure is LogoutOidcFailure) {
       if (_isFcmEnabled) {
         _getStoredFirebaseRegistrationFromCache();
@@ -313,7 +313,7 @@ abstract class BaseController extends GetxController
       requireCapability(session!, accountId!, [tmailContactCapabilityIdentifier]);
       TMailAutoCompleteBindings().dependencies();
     } catch (e) {
-      logError('$runtimeType::injectAutoCompleteBindings(): exception: $e');
+      logWarning('$runtimeType::injectAutoCompleteBindings(): exception: $e');
     }
   }
 
@@ -322,7 +322,7 @@ abstract class BaseController extends GetxController
       requireCapability(session!, accountId!, [CapabilityIdentifier.jmapMdn]);
       MdnInteractorBindings().dependencies();
     } catch(e) {
-      logError('$runtimeType::injectMdnBindings(): exception: $e');
+      logWarning('$runtimeType::injectMdnBindings(): exception: $e');
     }
   }
 
@@ -331,7 +331,7 @@ abstract class BaseController extends GetxController
       requireCapability(session!, accountId!, [capabilityForward]);
       ForwardingInteractorsBindings().dependencies();
     } catch(e) {
-      logError('$runtimeType::injectForwardBindings(): exception: $e');
+      logWarning('$runtimeType::injectForwardBindings(): exception: $e');
     }
   }
 
@@ -340,7 +340,7 @@ abstract class BaseController extends GetxController
       requireCapability(session!, accountId!, [capabilityRuleFilter]);
       EmailRulesInteractorBindings().dependencies();
     } catch(e) {
-      logError('$runtimeType::injectRuleFilterBindings(): exception: $e');
+      logWarning('$runtimeType::injectRuleFilterBindings(): exception: $e');
     }
   }
 
@@ -362,7 +362,7 @@ abstract class BaseController extends GetxController
         throw NotSupportFCMException();
       }
     } catch(e) {
-      logError('$runtimeType::injectFCMBindings(): exception: $e');
+      logWarning('$runtimeType::injectFCMBindings(): exception: $e');
     }
   }
 
@@ -386,7 +386,7 @@ abstract class BaseController extends GetxController
       WebSocketInteractorBindings().dependencies();
       WebSocketController.instance.initialize(accountId: accountId, session: session);
     } catch(e) {
-      logError('$runtimeType::injectWebSocket(): exception: $e');
+      logWarning('$runtimeType::injectWebSocket(): exception: $e');
     }
   }
 
@@ -491,7 +491,7 @@ abstract class BaseController extends GetxController
         onSuccessCallback();
       }
     } catch (e) {
-      logError('BaseController::logoutToSignInNewAccount:Exception = $e');
+      logWarning('BaseController::logoutToSignInNewAccount:Exception = $e');
       onFailureCallback();
     }
   }
@@ -510,8 +510,11 @@ abstract class BaseController extends GetxController
   }
 
   Future<void> _handleDeleteFCMRegistration() async {
+    _getStoredFirebaseRegistrationInteractor =
+        getBinding<GetStoredFirebaseRegistrationInteractor>();
+    if (_getStoredFirebaseRegistrationInteractor == null) return;
+
     try {
-      _getStoredFirebaseRegistrationInteractor = getBinding<GetStoredFirebaseRegistrationInteractor>();
       final fcmRegistration = await _getStoredFirebaseRegistrationInteractor?.execute().last;
 
       fcmRegistration?.foldSuccess<GetStoredFirebaseRegistrationSuccess>(
@@ -522,7 +525,7 @@ abstract class BaseController extends GetxController
         onFailure: (failure) {},
       );
     } catch (e) {
-      logError('BaseController::_handleDeleteFCMRegistration:Exception = $e');
+      logWarning('BaseController::_handleDeleteFCMRegistration:Exception = $e');
     }
   }
 
@@ -563,7 +566,7 @@ abstract class BaseController extends GetxController
         await _clearBasicAuthData();
       }
     } catch (e) {
-      logError('BaseController::clearAllData:Exception = $e');
+      logWarning('BaseController::clearAllData:Exception = $e');
     }
   }
 

--- a/lib/features/base/before_reconnect_manager.dart
+++ b/lib/features/base/before_reconnect_manager.dart
@@ -19,6 +19,6 @@ class BeforeReconnectManager {
 
   Future<void> executeBeforeReconnectListeners() async {
     await Future.wait(_listeners.map((listener) => listener.call()))
-      .onError((error, stackTrace) => [logError(error.toString())]);
+      .onError((error, stackTrace) => [logWarning(error.toString())]);
   }
 }

--- a/lib/features/base/isolate/isolate_manager.dart
+++ b/lib/features/base/isolate/isolate_manager.dart
@@ -21,7 +21,7 @@ abstract class IsolateManager {
       IsolateNameServer.registerPortWithName(_eventReceivePort.sendPort, isolateIdentityName);
       _streamSubscription = _eventReceivePort.listen(onData, onError: onError, onDone: onDone);
     } catch (e) {
-      logError('IsolateManager::initial():EXCEPTION: $e');
+      logWarning('IsolateManager::initial():EXCEPTION: $e');
     }
   }
 
@@ -32,10 +32,10 @@ abstract class IsolateManager {
       if (sendPort != null) {
         sendPort.send(value);
       } else {
-        logError('IsolateManager::addEvent(): sendPort is null');
+        logWarning('IsolateManager::addEvent(): sendPort is null');
       }
     } catch (e) {
-      logError('IsolateManager::addEvent():EXCEPTION: $e');
+      logWarning('IsolateManager::addEvent():EXCEPTION: $e');
     }
   }
 

--- a/lib/features/base/mixin/handle_error_mixin.dart
+++ b/lib/features/base/mixin/handle_error_mixin.dart
@@ -42,7 +42,7 @@ mixin HandleSetErrorMixin {
       handlers!.firstWhere((handler) => handler.call(setError));
       return const None<MapEntry<Id, SetError>>();
     } catch (e) {
-      logError('HandleSetErrorMixin::chainHandle(): [Exception] $e');
+      logWarning('HandleSetErrorMixin::chainHandle(): [Exception] $e');
       return Some<MapEntry<Id, SetError>>(setError);
     }
   }
@@ -50,7 +50,7 @@ mixin HandleSetErrorMixin {
   void _handleRemainedError(SetMethodErrorHandler? unCatchErrorHandler, Option<MapEntry<Id, SetError>> optionError) {
     final remainedError = optionError.toNullable();
     if (remainedError != null) {
-      logError('HandleSetErrorMixin::_handleRemainedError(): $remainedError');
+      logWarning('HandleSetErrorMixin::_handleRemainedError(): $remainedError');
       unCatchErrorHandler?.call(remainedError);
     }
   }
@@ -73,7 +73,7 @@ mixin HandleSetErrorMixin {
         }
       );
     }
-    logError('HandleSetErrorMixin::handleSetResponse():remainedErrors: $remainedErrors');
+    logWarning('HandleSetErrorMixin::handleSetResponse():remainedErrors: $remainedErrors');
     return remainedErrors;
   }
 }

--- a/lib/features/base/mixin/launcher_application_mixin.dart
+++ b/lib/features/base/mixin/launcher_application_mixin.dart
@@ -1,8 +1,8 @@
 
+import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:core/utils/string_convert.dart';
 import 'package:external_app_launcher/external_app_launcher.dart';
-import 'package:rich_text_composer/views/commons/logger.dart';
 import 'package:url_launcher/url_launcher.dart' as launcher;
 
 mixin LauncherApplicationMixin {
@@ -28,7 +28,7 @@ mixin LauncherApplicationMixin {
         await openOtherApplication(uri);
       }
     } catch (e) {
-      logError('LauncherApplicationMixin::launchApplication:Exception = $e');
+      logWarning('LauncherApplicationMixin::launchApplication:Exception = $e');
     }
   }
 

--- a/lib/features/base/reloadable/reloadable_controller.dart
+++ b/lib/features/base/reloadable/reloadable_controller.dart
@@ -33,13 +33,13 @@ abstract class ReloadableController extends BaseController {
   @override
   void handleFailureViewState(Failure failure) {
     if (isNotSignedIn(failure)) {
-      logError('$runtimeType::handleFailureViewState():Failure = $failure');
+      logWarning('$runtimeType::handleFailureViewState():Failure = $failure');
       goToLogin();
     } else if (failure is GetSessionFailure) {
-      logError('$runtimeType::handleFailureViewState():Failure = $failure');
+      logWarning('$runtimeType::handleFailureViewState():Failure = $failure');
       handleGetSessionFailure(failure);
     } else if (failure is UpdateAccountCacheFailure) {
-      logError('$runtimeType::handleFailureViewState():Failure = $failure');
+      logWarning('$runtimeType::handleFailureViewState():Failure = $failure');
       _handleUpdateAccountCacheCompleted(
         session: failure.session,
         apiUrl: failure.apiUrl);
@@ -153,7 +153,7 @@ abstract class ReloadableController extends BaseController {
       requireCapability(session!, accountId!, [CapabilityIdentifier.jmapVacationResponse]);
       VacationInteractorsBindings().dependencies();
     } catch(e) {
-      logError('$runtimeType::injectVacationBindings(): exception: $e');
+      logWarning('$runtimeType::injectVacationBindings(): exception: $e');
     }
   }
 

--- a/lib/features/caching/manager/session_cache_manger.dart
+++ b/lib/features/caching/manager/session_cache_manger.dart
@@ -33,7 +33,7 @@ class SessionCacheManager extends CacheManagerInteraction {
       await _cacheClient.insertMultipleItem(legacyMapItems);
       log('$runtimeType::migrateHiveToIsolatedHive(): ✅ Migrate Hive box "${_cacheClient.tableName}" → IsolatedHive DONE');
     } catch (e) {
-      logError('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_cacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
+      logWarning('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_cacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
     }
   }
 }

--- a/lib/features/cleanup/data/local/recent_login_url_cache_manager.dart
+++ b/lib/features/cleanup/data/local/recent_login_url_cache_manager.dart
@@ -87,7 +87,7 @@ class RecentLoginUrlCacheManager extends CacheManagerInteraction {
       await _recentLoginUrlCacheClient.insertMultipleItem(legacyMapItems);
       log('$runtimeType::migrateHiveToIsolatedHive(): ✅ Migrate Hive box "${_recentLoginUrlCacheClient.tableName}" → IsolatedHive DONE');
     } catch (e) {
-      logError('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_recentLoginUrlCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
+      logWarning('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_recentLoginUrlCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
     }
   }
 }

--- a/lib/features/cleanup/data/local/recent_login_username_cache_manager.dart
+++ b/lib/features/cleanup/data/local/recent_login_username_cache_manager.dart
@@ -89,7 +89,7 @@ class RecentLoginUsernameCacheManager extends CacheManagerInteraction {
       await _recentLoginUsernameCacheClient.insertMultipleItem(legacyMapItems);
       log('$runtimeType::migrateHiveToIsolatedHive(): ✅ Migrate Hive box "${_recentLoginUsernameCacheClient.tableName}" → IsolatedHive DONE');
     } catch (e) {
-      logError('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_recentLoginUsernameCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
+      logWarning('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_recentLoginUsernameCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
     }
   }
 }

--- a/lib/features/cleanup/data/local/recent_search_cache_manager.dart
+++ b/lib/features/cleanup/data/local/recent_search_cache_manager.dart
@@ -112,7 +112,7 @@ class RecentSearchCacheManager extends CacheManagerInteraction {
       await _recentSearchCacheClient.insertMultipleItem(legacyMapItems);
       log('$runtimeType::migrateHiveToIsolatedHive(): ✅ Migrate Hive box "${_recentSearchCacheClient.tableName}" → IsolatedHive DONE');
     } catch (e) {
-      logError('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_recentSearchCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
+      logWarning('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_recentSearchCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
     }
   }
 }

--- a/lib/features/composer/data/repository/composer_repository_impl.dart
+++ b/lib/features/composer/data/repository/composer_repository_impl.dart
@@ -102,7 +102,7 @@ class ComposerRepositoryImpl extends ComposerRepository {
         uploadUri: uploadUri,
       );
     } catch (e) {
-      logError('ComposerRepositoryImpl::_replaceImageBase64ToImageCID: Exception: $e');
+      logWarning('ComposerRepositoryImpl::_replaceImageBase64ToImageCID: Exception: $e');
       return Future.value(
         Tuple2(
           emailContent,
@@ -119,7 +119,7 @@ class ComposerRepositoryImpl extends ComposerRepository {
     try {
       return _htmlDataSource.removeCollapsedExpandedSignatureEffect(emailContent: emailContent);
     } catch (e) {
-      logError('ComposerRepositoryImpl::_removeCollapsedExpandedSignatureEffect: Exception: $e');
+      logWarning('ComposerRepositoryImpl::_removeCollapsedExpandedSignatureEffect: Exception: $e');
       return Future.value(emailContent);
     }
   }
@@ -129,7 +129,7 @@ class ComposerRepositoryImpl extends ComposerRepository {
     try {
       return _htmlDataSource.removeStyleLazyLoadDisplayInlineImages(emailContent: emailContent);
     } catch (e) {
-      logError('ComposerRepositoryImpl::removeStyleLazyLoadDisplayInlineImages: Exception: $e');
+      logWarning('ComposerRepositoryImpl::removeStyleLazyLoadDisplayInlineImages: Exception: $e');
       return Future.value(emailContent);
     }
   }

--- a/lib/features/composer/domain/usecases/create_new_and_save_email_to_drafts_interactor.dart
+++ b/lib/features/composer/domain/usecases/create_new_and_save_email_to_drafts_interactor.dart
@@ -68,7 +68,7 @@ class CreateNewAndSaveEmailToDraftsInteractor {
         yield dartz.Left<Failure, Success>(GenerateEmailFailure(CannotCreateEmailObjectException()));
       }
     } catch (e) {
-      logError('CreateNewAndSaveEmailToDraftsInteractor::execute: Exception: $e');
+      logWarning('CreateNewAndSaveEmailToDraftsInteractor::execute: Exception: $e');
       if (e is UnknownError && e.message is List<SavingEmailToDraftsCanceledException>) {
         if (createEmailRequest.draftsEmailId == null) {
           yield dartz.Left<Failure, Success>(SaveEmailAsDraftsFailure(SavingEmailToDraftsCanceledException()));
@@ -94,7 +94,7 @@ class CreateNewAndSaveEmailToDraftsInteractor {
       );
       return emailCreated;
     } catch (e) {
-      logError('CreateNewAndSaveEmailToDraftsInteractor::_createEmailObject: Exception: $e');
+      logWarning('CreateNewAndSaveEmailToDraftsInteractor::_createEmailObject: Exception: $e');
       return null;
     }
   }

--- a/lib/features/composer/domain/usecases/create_new_and_send_email_interactor.dart
+++ b/lib/features/composer/domain/usecases/create_new_and_send_email_interactor.dart
@@ -65,7 +65,7 @@ class CreateNewAndSendEmailInteractor {
         yield dartz.Left<Failure, Success>(GenerateEmailFailure(CannotCreateEmailObjectException()));
       }
     } catch (e) {
-      logError('CreateNewAndSendEmailInteractor::execute: Exception: $e');
+      logWarning('CreateNewAndSendEmailInteractor::execute: Exception: $e');
       if (e is UnknownError && e.message is List<SendingEmailCanceledException>) {
         yield dartz.Left<Failure, Success>(SendEmailFailure(
           exception: SendingEmailCanceledException(),
@@ -92,7 +92,7 @@ class CreateNewAndSendEmailInteractor {
       final sendingEmailArgument = createEmailRequest.toSendingEmailArguments(emailObject: emailCreated);
       return sendingEmailArgument;
     } catch (e) {
-      logError('CreateNewAndSendEmailInteractor::_createEmailObject: Exception: $e');
+      logWarning('CreateNewAndSendEmailInteractor::_createEmailObject: Exception: $e');
       return null;
     }
   }
@@ -111,7 +111,7 @@ class CreateNewAndSendEmailInteractor {
         cancelToken: cancelToken
       );
     } catch (e) {
-      logError('CreateNewAndSendEmailInteractor::_deleteOldDraftsEmail: Exception: $e');
+      logWarning('CreateNewAndSendEmailInteractor::_deleteOldDraftsEmail: Exception: $e');
     }
   }
 }

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -504,7 +504,7 @@ class ComposerController extends BaseController
     try {
       return session.getUploadUri(accountId, jmapUrl: dynamicUrlInterceptors.jmapUrl);
     } catch (e) {
-      logError('ComposerController::_getUploadUriFromSession:Exception = $e');
+      logWarning('ComposerController::_getUploadUriFromSession:Exception = $e');
       return null;
     }
   }
@@ -860,7 +860,7 @@ class ComposerController extends BaseController
         ? htmlTextEditor!.removeEditorStartTag()
         : '';
     } catch (e) {
-      logError('ComposerController::getContentInEditor:Exception = $e');
+      logWarning('ComposerController::getContentInEditor:Exception = $e');
       return '';
     }
   }
@@ -1105,12 +1105,12 @@ class ComposerController extends BaseController
               resultState: value,
               queryString: queryString,
               onFailureCallback: (failure) {
-                logError('ComposerController::getAutoCompleteSuggestion:onFailureCallback: $failure');
+                logWarning('ComposerController::getAutoCompleteSuggestion:onFailureCallback: $failure');
                 consumeState(Stream.value(Left(failure)));
               },
             ),
             onError: (error) {
-              logError('ComposerController::getAutoCompleteSuggestion:onError: $error');
+              logWarning('ComposerController::getAutoCompleteSuggestion:onError: $error');
               consumeState(Stream.value(Left(error)));
             },
         );
@@ -1133,12 +1133,12 @@ class ComposerController extends BaseController
             resultState: value,
             queryString: queryString,
             onFailureCallback: (failure) {
-              logError('ComposerController::getAutoCompleteSuggestion:onFailureCallback: $failure');
+              logWarning('ComposerController::getAutoCompleteSuggestion:onFailureCallback: $failure');
               consumeState(Stream.value(Left(failure)));
             },
           ),
           onError: (error) {
-            logError('ComposerController::getAutoCompleteSuggestion:onError: $error');
+            logWarning('ComposerController::getAutoCompleteSuggestion:onError: $error');
             consumeState(Stream.value(Left(error)));
           },
         ) ?? <EmailAddress>[];
@@ -1205,11 +1205,11 @@ class ComposerController extends BaseController
           uploadUri: uploadUri,
         );
       } catch (e) {
-        logError('ComposerController::uploadAttachmentsAction: $e');
+        logWarning('ComposerController::uploadAttachmentsAction: $e');
         uploadController.consumeState(Stream.value(Left(UploadAttachmentFailure(e, pickedFiles[0]))));
       }
     } else {
-      logError('ComposerController::uploadAttachmentsAction: SESSION OR ACCOUNT_ID is NULL');
+      logWarning('ComposerController::uploadAttachmentsAction: SESSION OR ACCOUNT_ID is NULL');
     }
   }
 
@@ -1690,7 +1690,7 @@ class ComposerController extends BaseController
     try {
       baseDownloadUrl = mailboxDashBoardController.sessionCurrent?.getDownloadUrl(jmapUrl: dynamicUrlInterceptors.jmapUrl);
     } catch (e) {
-      logError('ComposerController::_handleUploadInlineSuccess(): $e');
+      logWarning('ComposerController::_handleUploadInlineSuccess(): $e');
     }
     final accountId = mailboxDashBoardController.accountId.value;
 
@@ -2350,7 +2350,7 @@ class ComposerController extends BaseController
     String? base64,
     required UploadError uploadError
   }) {
-    logError('ComposerController::handleOnPasteImageFailureAction: $uploadError');
+    logWarning('ComposerController::handleOnPasteImageFailureAction: $uploadError');
     if (!context.mounted) return;
 
     appToast.showToastErrorMessage(

--- a/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
+++ b/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
@@ -44,10 +44,10 @@ class RichTextMobileTabletController extends GetxController {
           maxWidth: maxWidth
         );
       } else {
-        logError('RichTextMobileTabletController::insertImageData: path is null');
+        logWarning('RichTextMobileTabletController::insertImageData: path is null');
       }
     } catch (e) {
-      logError('RichTextMobileTabletController::insertImageData:Exception: $e');
+      logWarning('RichTextMobileTabletController::insertImageData:Exception: $e');
     }
   }
 

--- a/lib/features/composer/presentation/controller/rich_text_web_controller.dart
+++ b/lib/features/composer/presentation/controller/rich_text_web_controller.dart
@@ -300,7 +300,7 @@ class RichTextWebController extends GetxController {
         '<img src="${HtmlUtils.convertBase64ToImageResourceData(base64Data: base64Data, mimeType: mimeType)}" data-filename="${platformFile.name}" alt="Image in my signature" style="max-width:${maxWidth != null ? '${maxWidth}px' : '100%'};" data-mimetype="$mimeType"/>'
       );
     } else {
-      logError("RichTextWebController::insertImageAsBase64: bytes is null");
+      logWarning("RichTextWebController::insertImageAsBase64: bytes is null");
     }
   }
 

--- a/lib/features/composer/presentation/extensions/attachment_detection_extension.dart
+++ b/lib/features/composer/presentation/extensions/attachment_detection_extension.dart
@@ -23,7 +23,7 @@ extension AttachmentDetectionExtension on ComposerController {
         return keywords;
       }
     } catch (e) {
-      logError('$runtimeType::validateAttachmentReminder:Error $e');
+      logWarning('$runtimeType::validateAttachmentReminder:Error $e');
       return [];
     }
   }

--- a/lib/features/composer/presentation/extensions/sanitize_signature_in_email_content_extension.dart
+++ b/lib/features/composer/presentation/extensions/sanitize_signature_in_email_content_extension.dart
@@ -1,6 +1,5 @@
-
+import 'package:core/utils/app_logger.dart';
 import 'package:html/parser.dart';
-import 'package:rich_text_composer/views/commons/logger.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
 
 extension SanitizeSignatureInEmailContentExtension on ComposerController {
@@ -19,7 +18,7 @@ extension SanitizeSignatureInEmailContentExtension on ComposerController {
       restoringSignatureButton = true;
       await applySignature(signature.innerHtml);
     } catch (e) {
-      logError('SanitizeSignatureInEmailContentExtension::restoreCollapsibleSignatureButton:Exception = $e');
+      logWarning('SanitizeSignatureInEmailContentExtension::restoreCollapsibleSignatureButton:Exception = $e');
     }
   }
 
@@ -33,7 +32,7 @@ extension SanitizeSignatureInEmailContentExtension on ComposerController {
       synchronizeInitDraftHash = true;
       initEmailDraftHash();
     } catch (e) {
-      logError('SanitizeSignatureInEmailContentExtension::synchronizeInitEmailDraftHash:Exception = $e');
+      logWarning('SanitizeSignatureInEmailContentExtension::synchronizeInitEmailDraftHash:Exception = $e');
     }
   }
 }

--- a/lib/features/composer/presentation/widgets/saving_message_dialog_view.dart
+++ b/lib/features/composer/presentation/widgets/saving_message_dialog_view.dart
@@ -81,7 +81,7 @@ class _SavingMessageDialogViewState extends State<SavingMessageDialogView> {
   }
 
   void _handleErrorStream(Object error, StackTrace stackTrace) {
-    logError('_SavingMessageDialogViewState::_handleErrorStream: Exception = $error');
+    logWarning('_SavingMessageDialogViewState::_handleErrorStream: Exception = $error');
     if (error is UnknownError && error.message is List<SavingEmailToDraftsCanceledException>) {
       popBack(result: SaveEmailAsDraftsFailure(SavingEmailToDraftsCanceledException()));
     } else {

--- a/lib/features/composer/presentation/widgets/saving_template_dialog_view.dart
+++ b/lib/features/composer/presentation/widgets/saving_template_dialog_view.dart
@@ -77,7 +77,7 @@ class _SavingTemplateDialogViewState extends State<SavingTemplateDialogView> {
   }
 
   void _handleErrorStream(Object error, StackTrace stackTrace) {
-    logError('SavingTemplateDialogView::_handleErrorStream: Exception = $error');
+    logWarning('SavingTemplateDialogView::_handleErrorStream: Exception = $error');
     popBack(result: SaveTemplateEmailFailure(exception: error));
   }
 

--- a/lib/features/composer/presentation/widgets/sending_message_dialog_view.dart
+++ b/lib/features/composer/presentation/widgets/sending_message_dialog_view.dart
@@ -78,7 +78,7 @@ class _SendingMessageDialogViewState extends State<SendingMessageDialogView> {
   }
 
   void _handleErrorStream(Object error, StackTrace stackTrace) {
-    logError('_SendingMessageDialogViewState::_handleErrorStream: Exception = $error');
+    logWarning('_SendingMessageDialogViewState::_handleErrorStream: Exception = $error');
     if (error is UnknownError && error.message is List<SendingEmailCanceledException>) {
       popBack(result: SendEmailFailure(exception: SendingEmailCanceledException()));
     } else {

--- a/lib/features/composer/presentation/widgets/web/print_draft_dialog_view.dart
+++ b/lib/features/composer/presentation/widgets/web/print_draft_dialog_view.dart
@@ -63,7 +63,7 @@ class _PrintDraftDialogViewState extends State<PrintDraftDialogView> {
   }
 
   void _handleErrorStream(Object error, StackTrace stackTrace) {
-    logError('_PrintDraftDialogViewState::_handleErrorStream: Exception = $error');
+    logWarning('_PrintDraftDialogViewState::_handleErrorStream: Exception = $error');
     popBack(result: PrintEmailFailure(exception: error));
   }
 

--- a/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
@@ -318,13 +318,13 @@ class _WebEditorState extends State<WebEditorWidget> with TextSelectionMixin {
           _signatureTooltipReady = true;
           _signatureTooltipEntry?.markNeedsBuild();
         } catch (e) {
-          logError(
+          logWarning(
             '_WebEditorState::_showTooltipAtPosition:addPostFrameCallback:Exception = $e',
           );
         }
       });
     } catch (e) {
-      logError('_WebEditorState::_showTooltipAtPosition:Exception = $e');
+      logWarning('_WebEditorState::_showTooltipAtPosition:Exception = $e');
     }
   }
 

--- a/lib/features/download/domain/usecase/download_all_attachments_for_web_interactor.dart
+++ b/lib/features/download/domain/usecase/download_all_attachments_for_web_interactor.dart
@@ -77,7 +77,7 @@ class DownloadAllAttachmentsForWebInteractor {
 
       yield Right(DownloadAllAttachmentsForWebSuccess(taskId: taskId));
     } catch (e) {
-      logError('DownloadAllAttachmentsForWebInteractor::execute():EXCEPTION: $e');
+      logWarning('DownloadAllAttachmentsForWebInteractor::execute():EXCEPTION: $e');
       yield Left(DownloadAllAttachmentsForWebFailure(
         exception: e,
         taskId: taskId,

--- a/lib/features/download/domain/usecase/download_and_get_html_content_from_attachment_interactor.dart
+++ b/lib/features/download/domain/usecase/download_and_get_html_content_from_attachment_interactor.dart
@@ -87,7 +87,7 @@ class DownloadAndGetHtmlContentFromAttachmentInteractor {
         ));
       }
     } catch (e) {
-      logError('GetHtmlContentFromAttachmentInteractor:exception: $e');
+      logWarning('GetHtmlContentFromAttachmentInteractor:exception: $e');
       yield Left(DownloadAndGetHtmlContentFromAttachmentFailure(
         exception: e,
         blobId: attachment.blobId,

--- a/lib/features/download/domain/usecase/export_all_attachments_interactor.dart
+++ b/lib/features/download/domain/usecase/export_all_attachments_interactor.dart
@@ -61,7 +61,7 @@ class ExportAllAttachmentsInteractor {
 
       yield Right(ExportAllAttachmentsSuccess(result));
     } catch (e) {
-      logError('ExportAllAttachmentsInteractor::execute():EXCEPTION: $e');
+      logWarning('ExportAllAttachmentsInteractor::execute():EXCEPTION: $e');
       yield Left(ExportAllAttachmentsFailure(exception: e));
     }
   }

--- a/lib/features/email/data/datasource_impl/email_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_datasource_impl.dart
@@ -499,7 +499,7 @@ class EmailDataSourceImpl extends EmailDataSource {
 
       return listEmailContent.asHtmlString;
     } catch (e) {
-      logError('EmailDataSourceImpl::_transformEmailContent:Exception = $e');
+      logWarning('EmailDataSourceImpl::_transformEmailContent:Exception = $e');
       return '';
     }
   }

--- a/lib/features/email/data/datasource_impl/print_file_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/print_file_datasource_impl.dart
@@ -87,7 +87,7 @@ class PrintFileDataSourceImpl extends PrintFileDataSource {
 
       return htmlContentTransformed;
     } catch (e) {
-      logError('PrintFileDataSourceImpl::_transformHtmlEmailContent: Exception: $e');
+      logWarning('PrintFileDataSourceImpl::_transformHtmlEmailContent: Exception: $e');
       return '';
     }
   }

--- a/lib/features/email/data/local/html_analyzer.dart
+++ b/lib/features/email/data/local/html_analyzer.dart
@@ -104,7 +104,7 @@ class HtmlAnalyzer {
         return listEventAction;
       }
     } catch(e) {
-      logError('HtmlAnalyzer::getListEventAction:Exception: $e');
+      logWarning('HtmlAnalyzer::getListEventAction:Exception: $e');
       return [];
     }
   }
@@ -205,7 +205,7 @@ class HtmlAnalyzer {
       }));
       return document.body?.innerHtml ?? emailContent;
     } catch (e) {
-      logError('HtmlAnalyzer::removeCollapsedExpandedSignatureEffect:Exception = $e');
+      logWarning('HtmlAnalyzer::removeCollapsedExpandedSignatureEffect:Exception = $e');
       return emailContent;
     }
   }
@@ -233,7 +233,7 @@ class HtmlAnalyzer {
       log('HtmlAnalyzer::_retrieveAttachmentFromUpload:Attachment = $attachment | taskId = $taskId');
       return (attachment, taskId);
     } catch (e) {
-      logError('HtmlAnalyzer::_retrieveAttachmentFromUpload:Exception = $e');
+      logWarning('HtmlAnalyzer::_retrieveAttachmentFromUpload:Exception = $e');
       return null;
     }
   }
@@ -259,7 +259,7 @@ class HtmlAnalyzer {
       }));
       return document.body?.innerHtml ?? emailContent;
     } catch (e) {
-      logError('HtmlAnalyzer::removeStyleLazyLoadDisplayInlineImages:Exception = $e');
+      logWarning('HtmlAnalyzer::removeStyleLazyLoadDisplayInlineImages:Exception = $e');
       return emailContent;
     }
   }

--- a/lib/features/email/data/network/calendar_event_api.dart
+++ b/lib/features/email/data/network/calendar_event_api.dart
@@ -93,7 +93,7 @@ class CalendarEventAPI {
         methodCallId,
         GetCalendarEventAttendanceResponse.deserialize);
     } catch (e) {
-      logError('CalendarEventAPI.parse free/busy query error: $e');
+      logWarning('CalendarEventAPI.parse free/busy query error: $e');
       return null;
     }
   }

--- a/lib/features/email/data/network/email_api.dart
+++ b/lib/features/email/data/network/email_api.dart
@@ -668,7 +668,7 @@ class EmailAPI with HandleSetErrorMixin, MailAPIMixin {
         cancelToken: cancelToken
       );
     } catch (e) {
-      logError('EmailAPI::updateEmailDrafts: Exception = $e');
+      logWarning('EmailAPI::updateEmailDrafts: Exception = $e');
     }
 
     return emailCreated;
@@ -713,7 +713,7 @@ class EmailAPI with HandleSetErrorMixin, MailAPIMixin {
         cancelToken: cancelToken
       );
     } catch (e) {
-      logError('EmailAPI::updateEmailTemplate: Exception = $e');
+      logWarning('EmailAPI::updateEmailTemplate: Exception = $e');
     }
 
     return emailCreated;

--- a/lib/features/email/data/repository/email_repository_impl.dart
+++ b/lib/features/email/data/repository/email_repository_impl.dart
@@ -84,7 +84,7 @@ class EmailRepositoryImpl extends EmailRepository {
           [emailRequest.emailIdAnsweredOrForwarded!],
         );
       } catch (e) {
-        logError('EmailRepositoryImpl::sendEmail::markAsAnswered:Exception $e');
+        logWarning('EmailRepositoryImpl::sendEmail::markAsAnswered:Exception $e');
       }
     } else if (emailRequest.isEmailForwarded) {
       try {
@@ -94,7 +94,7 @@ class EmailRepositoryImpl extends EmailRepository {
           [emailRequest.emailIdAnsweredOrForwarded!],
         );
       } catch (e) {
-        logError('EmailRepositoryImpl::sendEmail::markAsForwarded:Exception $e');
+        logWarning('EmailRepositoryImpl::sendEmail::markAsForwarded:Exception $e');
       }
     }
 
@@ -126,7 +126,7 @@ class EmailRepositoryImpl extends EmailRepository {
         readActions,
       );
     } catch (e) {
-      logError('EmailRepositoryImpl::markAsRead:exception $e');
+      logWarning('EmailRepositoryImpl::markAsRead:exception $e');
     }
 
     return result;
@@ -168,7 +168,7 @@ class EmailRepositoryImpl extends EmailRepository {
           ),
         );
     } catch (e) {
-      logError('EmailRepositoryImpl::moveToMailbox:exception $e');
+      logWarning('EmailRepositoryImpl::moveToMailbox:exception $e');
     }
 
     return result;
@@ -198,7 +198,7 @@ class EmailRepositoryImpl extends EmailRepository {
         markStarAction
       );
     } catch (e) {
-      logError('EmailRepositoryImpl::markAsStar:exception $e');
+      logWarning('EmailRepositoryImpl::markAsStar:exception $e');
     }
     return result;
   }
@@ -241,7 +241,7 @@ class EmailRepositoryImpl extends EmailRepository {
         cancelToken: cancelToken
       );
     } catch (e) {
-      logError('EmailRepositoryImpl::saveEmailAsDrafts:exception $e');
+      logWarning('EmailRepositoryImpl::saveEmailAsDrafts:exception $e');
     }
     return result;
   }
@@ -267,7 +267,7 @@ class EmailRepositoryImpl extends EmailRepository {
         cancelToken: cancelToken
       );
     } catch (e) {
-      logError('EmailRepositoryImpl::removeEmailDrafts:exception $e');
+      logWarning('EmailRepositoryImpl::removeEmailDrafts:exception $e');
     }
     return result;
   }
@@ -295,7 +295,7 @@ class EmailRepositoryImpl extends EmailRepository {
         oldEmailId,
       );
     } catch (e) {
-      logError('EmailRepositoryImpl::updateEmailDrafts:exception $e');
+      logWarning('EmailRepositoryImpl::updateEmailDrafts:exception $e');
     }
     return result;
   }
@@ -326,7 +326,7 @@ class EmailRepositoryImpl extends EmailRepository {
         cancelToken: cancelToken
       );
     } catch (e) {
-      logError('EmailRepositoryImpl::saveEmailAsTemplate:exception $e');
+      logWarning('EmailRepositoryImpl::saveEmailAsTemplate:exception $e');
     }
     return result;
   }
@@ -354,7 +354,7 @@ class EmailRepositoryImpl extends EmailRepository {
         oldEmailId,
       );
     } catch (e) {
-      logError('EmailRepositoryImpl::updateEmailTemplate:exception $e');
+      logWarning('EmailRepositoryImpl::updateEmailTemplate:exception $e');
     }
     return result;
   }
@@ -378,7 +378,7 @@ class EmailRepositoryImpl extends EmailRepository {
       await emailDataSource[DataSourceType.hiveCache]
         !.deleteMultipleEmailsPermanently(session, accountId, result.emailIdsSuccess);
     } catch (e) {
-      logError('EmailRepositoryImpl::deleteMultipleEmailsPermanently:exception $e');
+      logWarning('EmailRepositoryImpl::deleteMultipleEmailsPermanently:exception $e');
     }
 
     return result;
@@ -404,7 +404,7 @@ class EmailRepositoryImpl extends EmailRepository {
         emailId,
       );
     } catch (e) {
-      logError('EmailRepositoryImpl::deleteEmailPermanently:exception $e');
+      logWarning('EmailRepositoryImpl::deleteEmailPermanently:exception $e');
     }
 
     return result;

--- a/lib/features/email/domain/usecases/get_email_content_interactor.dart
+++ b/lib/features/email/domain/usecases/get_email_content_interactor.dart
@@ -106,7 +106,7 @@ class GetEmailContentInteractor {
         ));
       }
     } catch (e) {
-      logError('GetEmailContentInteractor::_getContentEmailFromServer():EXCEPTION: $e');
+      logWarning('GetEmailContentInteractor::_getContentEmailFromServer():EXCEPTION: $e');
       yield Left<Failure, Success>(GetEmailContentFailure(
         e,
         onRetry: execute(
@@ -149,7 +149,7 @@ class GetEmailContentInteractor {
         )
       ));
     } catch (e) {
-      logError('GetEmailContentInteractor::_getStoredOpenedEmail():EXCEPTION: $e');
+      logWarning('GetEmailContentInteractor::_getStoredOpenedEmail():EXCEPTION: $e');
       yield* _getStoredNewEmail(
         session,
         accountId,
@@ -190,7 +190,7 @@ class GetEmailContentInteractor {
         )
       ));
     } catch (e) {
-      logError('GetEmailContentInteractor::_getStoredNewEmail():EXCEPTION: $e');
+      logWarning('GetEmailContentInteractor::_getStoredNewEmail():EXCEPTION: $e');
       yield* _getContentEmailFromServer(
         session,
         accountId,

--- a/lib/features/email/domain/usecases/save_template_email_interactor.dart
+++ b/lib/features/email/domain/usecases/save_template_email_interactor.dart
@@ -59,7 +59,7 @@ class SaveTemplateEmailInteractor {
         yield Right(SaveTemplateEmailSuccess(emailTemplateSaved.id!));
       }
     } catch (e) {
-      logError('SaveTemplateEmailInteractor::execute(): $e');
+      logWarning('SaveTemplateEmailInteractor::execute(): $e');
       if (createEmailRequest.templateEmailId != null) {
         yield Left(UpdateTemplateEmailFailure(exception: e));
       } else {
@@ -76,7 +76,7 @@ class SaveTemplateEmailInteractor {
         isTemplate: true);
       return emailCreated;
     } catch (e) {
-      logError('CreateNewAndSaveEmailToDraftsInteractor::_createEmailObject: Exception: $e');
+      logWarning('CreateNewAndSaveEmailToDraftsInteractor::_createEmailObject: Exception: $e');
       return null;
     }
   }

--- a/lib/features/email/domain/usecases/store_list_new_email_interator.dart
+++ b/lib/features/email/domain/usecases/store_list_new_email_interator.dart
@@ -41,7 +41,7 @@ class StoreListNewEmailInteractor {
       await _emailRepository.getStoredNewEmail(session, accountId, detailedEmail.emailId);
       return true;
     } catch (err) {
-      logError('StoreNewEmailInteractor::_isNewEmailAlreadyStored():EXCEPTION: $err');
+      logWarning('StoreNewEmailInteractor::_isNewEmailAlreadyStored():EXCEPTION: $err');
       return false;
     }
   }

--- a/lib/features/email/domain/usecases/store_opened_email_interactor.dart
+++ b/lib/features/email/domain/usecases/store_opened_email_interactor.dart
@@ -39,7 +39,7 @@ class StoreOpenedEmailInteractor {
       await _emailRepository.getStoredOpenedEmail(session, accountId, detailedEmail.emailId);
       return true;
     } catch (err) {
-      logError('StoreOpenedEmailInteractor::isOpenedEmailAlreadyStored():EXCEPTION: $err');
+      logWarning('StoreOpenedEmailInteractor::isOpenedEmailAlreadyStored():EXCEPTION: $err');
       return false;
     }
   }

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -482,7 +482,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
           transformConfiguration
         ));
       } catch (e) {
-        logError('SingleEmailController::_getEmailContentAction(): $e');
+        logWarning('SingleEmailController::_getEmailContentAction(): $e');
         consumeState(Stream.value(Left(GetEmailContentFailure(
           e,
           onRetry: e is UnknownUriException

--- a/lib/features/email/presentation/extensions/handle_open_attachment_list_extension.dart
+++ b/lib/features/email/presentation/extensions/handle_open_attachment_list_extension.dart
@@ -15,7 +15,7 @@ extension HandleOpenAttachmentListExtension on SingleEmailController {
   }) {
     final scrollController = threadDetailController?.scrollController;
     if (scrollController == null || !scrollController.hasClients) {
-      logError(
+      logWarning(
           '$runtimeType::jumpToAttachmentList(): scrollController is null');
       return;
     }

--- a/lib/features/email/presentation/utils/email_utils.dart
+++ b/lib/features/email/presentation/utils/email_utils.dart
@@ -106,7 +106,7 @@ class EmailUtils {
       MailAddress mailAddress = MailAddress.validateAddress(address);
       return GetUtils.isEmail(mailAddress.stripDetails().asString()) && mailAddress.asString().isNotEmpty;
     } catch(e) {
-      logError('EmailUtils::isEmailAddressValid: Exception = $e');
+      logWarning('EmailUtils::isEmailAddressValid: Exception = $e');
       return false;
     }
   }
@@ -137,7 +137,7 @@ class EmailUtils {
 
       return matches.map((match) => match.group(1)!).toList();
     } catch (e) {
-      logError('EmailUtils::extractMailtoLinksFromListPost:Exception = $e');
+      logWarning('EmailUtils::extractMailtoLinksFromListPost:Exception = $e');
       return [];
     }
   }
@@ -174,7 +174,7 @@ class EmailUtils {
         bccMailAddresses: bccMailAddresses
       );
     } catch (e) {
-      logError('EmailUtils::extractRecipientsFromListMailtoLink:Exception = $e');
+      logWarning('EmailUtils::extractRecipientsFromListMailtoLink:Exception = $e');
       return (
         toMailAddresses: [],
         ccMailAddresses: [],
@@ -207,7 +207,7 @@ class EmailUtils {
         bccMailAddresses: navigationRouter.bcc ?? [],
       );
     } catch (e) {
-      logError('EmailUtils::extractRecipientsFromMailtoLink:Exception = $e');
+      logWarning('EmailUtils::extractRecipientsFromMailtoLink:Exception = $e');
       return (
         toMailAddresses: [],
         ccMailAddresses: [],
@@ -240,7 +240,7 @@ class EmailUtils {
         type: type?.isNotEmpty == true ? MediaType.parse(type!) : null,
       );
     } catch (e) {
-      logError('EmailUtils::parsingAttachmentByUri:Exception = $e:');
+      logWarning('EmailUtils::parsingAttachmentByUri:Exception = $e:');
       return null;
     }
   }
@@ -329,7 +329,7 @@ class EmailUtils {
       MailAddress mailAddress = MailAddress.validateAddress(emailAddress);
       return mailAddress.domain.asString();
     } catch (e) {
-      logError('EmailUtils::getDomainByEmailAddress:Exception is $e');
+      logWarning('EmailUtils::getDomainByEmailAddress:Exception is $e');
       return '';
     }
   }

--- a/lib/features/email/presentation/widgets/pdf_viewer/pdf_viewer.dart
+++ b/lib/features/email/presentation/widgets/pdf_viewer/pdf_viewer.dart
@@ -161,7 +161,7 @@ class _PDFViewerState extends State<PDFViewer> {
               previewerOptions: PreviewerOptions(
                 previewerState: previewerState,
                 onError: (error) {
-                  logError('_PDFViewerState::build:openData:onError:: $error');
+                  logWarning('_PDFViewerState::build:openData:onError:: $error');
                   _pdfViewStateNotifier.value = DownloadAttachmentForWebFailure(exception: error);
                 },
                 errorMessage: AppLocalizations.of(context).noPreviewAvailable,

--- a/lib/features/email_previewer/email_previewer_controller.dart
+++ b/lib/features/email_previewer/email_previewer_controller.dart
@@ -294,7 +294,7 @@ class EmailPreviewerController extends ReloadableController {
         ),
       ));
     } catch (e) {
-      logError('EmailPreviewerController::_handleParseEmailByBlobIdSuccess(): $e');
+      logWarning('EmailPreviewerController::_handleParseEmailByBlobIdSuccess(): $e');
       consumeState(Stream.value(Left(PreviewEmailFromEmlFileFailure(e))));
     }
   }
@@ -336,7 +336,7 @@ class EmailPreviewerController extends ReloadableController {
               onReceiveController: _downloadAttachmentStreamController!)
           .listen(_handleDownloadAttachmentViewState);
     } catch (e) {
-      logError('EmailPreviewerController::_handleParseEmailByBlobIdSuccess(): $e');
+      logWarning('EmailPreviewerController::_handleParseEmailByBlobIdSuccess(): $e');
       consumeState(Stream.value(Left(DownloadAttachmentForWebFailure(
           attachment: attachment,
           taskId: attachment.downloadTaskId,

--- a/lib/features/home/domain/extensions/session_extensions.dart
+++ b/lib/features/home/domain/extensions/session_extensions.dart
@@ -74,7 +74,7 @@ extension SessionExtensions on Session {
     try {
       return getOwnEmailAddressOrEmpty().split('@').last;
     } catch (e) {
-      logError('SessionExtensions::internalDomain: Exception: $e');
+      logWarning('SessionExtensions::internalDomain: Exception: $e');
       return '';
     }
   }
@@ -88,7 +88,7 @@ extension SessionExtensions on Session {
       log('SessionExtensions::getMinInputLengthAutocomplete:minInputLength = $minInputLength');
       return minInputLength;
     } catch (e) {
-      logError('SessionExtensions::getMinInputLengthAutocomplete():[Exception] $e');
+      logWarning('SessionExtensions::getMinInputLengthAutocomplete():[Exception] $e');
       return null;
     }
   }
@@ -102,7 +102,7 @@ extension SessionExtensions on Session {
       log('SessionExtensions::getContactSupportCapability:contactSupportCapability = $contactSupportCapability');
       return contactSupportCapability;
     } catch (e) {
-      logError('SessionExtensions::getContactSupportCapability():[Exception] $e');
+      logWarning('SessionExtensions::getContactSupportCapability():[Exception] $e');
       return null;
     }
   }
@@ -142,7 +142,7 @@ extension SessionExtensions on Session {
       final props = capability?.props[0] as Map<String, dynamic>?;
       return props?[subaddressingSupported] ?? false;
     } catch (e) {
-      logError('SessionExtensions::isSubAddressingSupported:Exception = $e');
+      logWarning('SessionExtensions::isSubAddressingSupported:Exception = $e');
       return false;
     }
   }
@@ -164,7 +164,7 @@ extension SessionExtensions on Session {
       log('SessionExtensions::getSaaSAccountCapability:saaSAccountCapability = $saaSAccountCapability');
       return saaSAccountCapability;
     } catch (e) {
-      logError('SessionExtensions::getSaaSAccountCapability():[Exception] $e');
+      logWarning('SessionExtensions::getSaaSAccountCapability():[Exception] $e');
       return null;
     }
   }

--- a/lib/features/home/presentation/home_controller.dart
+++ b/lib/features/home/presentation/home_controller.dart
@@ -202,7 +202,7 @@ class HomeController extends ReloadableController {
         ),
       );
     } catch (e) {
-      logError('HomeController::_getSessionActionToLogOut:Exception = $e');
+      logWarning('HomeController::_getSessionActionToLogOut:Exception = $e');
       _handleGetSessionFailureToLogOut(authenticationViewStateSuccess);
     }
   }

--- a/lib/features/identity_creator/domain/usecase/get_identity_cache_on_web_interactor.dart
+++ b/lib/features/identity_creator/domain/usecase/get_identity_cache_on_web_interactor.dart
@@ -24,7 +24,7 @@ class GetIdentityCacheOnWebInteractor {
       
       yield Right(GetIdentityCacheOnWebSuccess(result));
     } catch (exception) {
-      logError("$runtimeType::execute: $exception");
+      logWarning("$runtimeType::execute: $exception");
       yield Left(GetIdentityCacheOnWebFailure(exception: exception));
     }
   }

--- a/lib/features/identity_creator/domain/usecase/remove_identity_cache_on_web_interactor.dart
+++ b/lib/features/identity_creator/domain/usecase/remove_identity_cache_on_web_interactor.dart
@@ -17,7 +17,7 @@ class RemoveIdentityCacheOnWebInteractor {
 
       yield Right(RemoveIdentityCacheOnWebSuccess());
     } catch (exception) {
-      logError("$runtimeType::execute: $exception");
+      logWarning("$runtimeType::execute: $exception");
       yield Left(RemoveIdentityCacheOnWebFailure(exception: exception));
     }
   }

--- a/lib/features/identity_creator/domain/usecase/save_identity_cache_on_web_interactor.dart
+++ b/lib/features/identity_creator/domain/usecase/save_identity_cache_on_web_interactor.dart
@@ -26,7 +26,7 @@ class SaveIdentityCacheOnWebInteractor {
         identityCache: identityCache);
       yield Right(SaveIdentityCacheOnWebSuccess());
     } catch (exception) {
-      logError("$runtimeType::execute: $exception");
+      logWarning("$runtimeType::execute: $exception");
       yield Left(SaveIdentityCacheOnWebFailure(exception: exception));
     }
   }

--- a/lib/features/identity_creator/presentation/identity_creator_controller.dart
+++ b/lib/features/identity_creator/presentation/identity_creator_controller.dart
@@ -701,7 +701,7 @@ class IdentityCreatorController extends BaseController with DragDropFileMixin im
         );
       }
     } else {
-      logError("IdentityCreatorController::pickImage: context is unmounted");
+      logWarning("IdentityCreatorController::pickImage: context is unmounted");
     }
   }
   
@@ -732,7 +732,7 @@ class IdentityCreatorController extends BaseController with DragDropFileMixin im
           )
         );
       } else {
-        logError("IdentityCreatorController::_insertInlineImage: context is unmounted");
+        logWarning("IdentityCreatorController::_insertInlineImage: context is unmounted");
       }
     } else if (publicAssetController != null) {
       publicAssetController!.uploadFileToBlob(file);
@@ -747,7 +747,7 @@ class IdentityCreatorController extends BaseController with DragDropFileMixin im
             pathContains: IdentityCreatorConstants.prefixCompressedInlineImageTemp);
         }
       } else {
-        logError("IdentityCreatorController::_insertInlineImage: Platform not supported");
+        logWarning("IdentityCreatorController::_insertInlineImage: Platform not supported");
       }
     }
   }
@@ -765,7 +765,7 @@ class IdentityCreatorController extends BaseController with DragDropFileMixin im
       isCompressingInlineImage.value = false;
       return compressedFile;
     } catch (e) {
-      logError("$runtimeType::_compressFileAction: compress image error: $e");
+      logWarning("$runtimeType::_compressFileAction: compress image error: $e");
       isCompressingInlineImage.value = false;
       if (context.mounted) {
         appToast.showToastErrorMessage(
@@ -888,7 +888,7 @@ class IdentityCreatorController extends BaseController with DragDropFileMixin im
     {String? base64,
     required UploadError uploadError}
   ) {
-    logError('$runtimeType::onPasteImageFailure: $uploadError');
+    logWarning('$runtimeType::onPasteImageFailure: $uploadError');
     appToast.showToastErrorMessage(
       context,
       AppLocalizations.of(context).thisImageCannotBePastedIntoTheEditor);
@@ -941,7 +941,7 @@ class IdentityCreatorController extends BaseController with DragDropFileMixin im
             )
           );
         } else {
-          logError("IdentityCreatorController::_uploadMultipleFilesToPublicAsset: context is unmounted");
+          logWarning("IdentityCreatorController::_uploadMultipleFilesToPublicAsset: context is unmounted");
         }
         return;
       }
@@ -959,7 +959,7 @@ class IdentityCreatorController extends BaseController with DragDropFileMixin im
         }
       );
     } catch (e) {
-      logError("IdentityCreatorController::_uploadMultipleFilesToPublicAsset: error: $e");
+      logWarning("IdentityCreatorController::_uploadMultipleFilesToPublicAsset: error: $e");
     }
   }
 

--- a/lib/features/login/data/local/account_cache_manager.dart
+++ b/lib/features/login/data/local/account_cache_manager.dart
@@ -61,7 +61,7 @@ class AccountCacheManager extends CacheManagerInteraction {
       await _accountCacheClient.insertMultipleItem(legacyMapItems);
       log('$runtimeType::migrateHiveToIsolatedHive(): ✅ Migrate Hive box "${_accountCacheClient.tableName}" → IsolatedHive DONE');
     } catch (e) {
-      logError('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_accountCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
+      logWarning('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_accountCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
     }
   }
 }

--- a/lib/features/login/data/local/authentication_info_cache_manager.dart
+++ b/lib/features/login/data/local/authentication_info_cache_manager.dart
@@ -38,7 +38,7 @@ class AuthenticationInfoCacheManager extends CacheManagerInteraction {
       await _authenticationInfoCacheClient.insertMultipleItem(legacyMapItems);
       log('$runtimeType::migrateHiveToIsolatedHive(): ✅ Migrate Hive box "${_authenticationInfoCacheClient.tableName}" → IsolatedHive DONE');
     } catch (e) {
-      logError('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_authenticationInfoCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
+      logWarning('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_authenticationInfoCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
     }
   }
 }

--- a/lib/features/login/data/local/encryption_key_cache_manager.dart
+++ b/lib/features/login/data/local/encryption_key_cache_manager.dart
@@ -28,7 +28,7 @@ class EncryptionKeyCacheManager extends CacheManagerInteraction {
       await _encryptionKeyCacheClient.insertMultipleItem(legacyMapItems);
       log('$runtimeType::migrateHiveToIsolatedHive(): ✅ Migrate Hive box "${_encryptionKeyCacheClient.tableName}" → IsolatedHive DONE');
     } catch (e) {
-      logError('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_encryptionKeyCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
+      logWarning('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_encryptionKeyCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
     }
   }
 }

--- a/lib/features/login/data/local/oidc_configuration_cache_manager.dart
+++ b/lib/features/login/data/local/oidc_configuration_cache_manager.dart
@@ -63,7 +63,7 @@ class OidcConfigurationCacheManager extends CacheManagerInteraction {
       await _oidcConfigurationCacheClient.insertMultipleItem(legacyMapItems);
       log('$runtimeType::migrateHiveToIsolatedHive(): ✅ Migrate Hive box "${_oidcConfigurationCacheClient.tableName}" → IsolatedHive DONE');
     } catch (e) {
-      logError('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_oidcConfigurationCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
+      logWarning('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_oidcConfigurationCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
     }
   }
 }

--- a/lib/features/login/data/local/token_oidc_cache_manager.dart
+++ b/lib/features/login/data/local/token_oidc_cache_manager.dart
@@ -46,7 +46,7 @@ class TokenOidcCacheManager extends CacheManagerInteraction {
       await _tokenOidcCacheClient.insertMultipleItem(legacyMapItems);
       log('$runtimeType::migrateHiveToIsolatedHive(): ✅ Migrate Hive box "${_tokenOidcCacheClient.tableName}" → IsolatedHive DONE');
     } catch (e) {
-      logError('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_tokenOidcCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
+      logWarning('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_tokenOidcCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
     }
   }
 }

--- a/lib/features/login/data/network/authentication_client/authentication_client_interaction_mixin.dart
+++ b/lib/features/login/data/network/authentication_client/authentication_client_interaction_mixin.dart
@@ -74,7 +74,7 @@ mixin AuthenticationClientInteractionMixin {
 
   dynamic handleException(dynamic exception) {
     if (exception is FlutterAppAuthPlatformException) {
-      logError('$runtimeType::handleException: ErrorDetails = ${exception.platformErrorDetails.toString()}');
+      logWarning('$runtimeType::handleException: ErrorDetails = ${exception.platformErrorDetails.toString()}');
       final errorCode = exception.platformErrorDetails.error;
       if (errorCode != null) {
         final oauthErrorCode = OAuthAuthorizationError.fromErrorCode(

--- a/lib/features/login/data/network/authentication_client/authentication_client_mobile.dart
+++ b/lib/features/login/data/network/authentication_client/authentication_client_mobile.dart
@@ -92,7 +92,7 @@ class AuthenticationClientMobile with AuthenticationClientInteractionMixin
         throw AccessTokenInvalidException();
       }
     } catch (e) {
-      logError('$runtimeType::refreshingTokensOIDC(): $e');
+      logWarning('$runtimeType::refreshingTokensOIDC(): $e');
       throw handleException(e);
     }
   }

--- a/lib/features/login/data/network/authentication_client/authentication_client_web.dart
+++ b/lib/features/login/data/network/authentication_client/authentication_client_web.dart
@@ -89,7 +89,7 @@ class AuthenticationClientWeb with AuthenticationClientInteractionMixin
         throw AccessTokenInvalidException();
       }
     } catch (e) {
-      logError('$runtimeType::refreshingTokensOIDC(): $e');
+      logWarning('$runtimeType::refreshingTokensOIDC(): $e');
       throw handleException(e);
     }
   }

--- a/lib/features/login/data/network/dns_lookup/dns_lookup_manager.dart
+++ b/lib/features/login/data/network/dns_lookup/dns_lookup_manager.dart
@@ -70,10 +70,10 @@ class DnsLookupManager {
         }
         log('$runtimeType::lookupJmapUrl → ⚠️ No records via ${priority.label}, continuing...');
       } on TimeoutException catch (_) {
-        logError(
+        logWarning(
             '$runtimeType::lookupJmapUrl → ⏱️ ${priority.label} lookup timed out');
       } catch (error, stack) {
-        logError(
+        logWarning(
             '$runtimeType::lookupJmapUrl → ❌ ${priority.label} lookup failed: $error, $stack');
       }
     }

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -83,7 +83,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
 
   @override
   void onError(DioError err, ErrorInterceptorHandler handler) async {
-    logError('AuthorizationInterceptors::onError(): DIO_ERROR = $err');
+    logWarning('AuthorizationInterceptors::onError(): DIO_ERROR = $err');
     try {
       final requestOptions = err.requestOptions;
       final extraInRequest = requestOptions.extra;
@@ -151,8 +151,12 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       } else {
         return super.onError(err, handler);
       }
-    } catch (e) {
-      logError('AuthorizationInterceptors::onError:Exception: $e');
+    } catch (e, stackTrace) {
+      logError(
+        'AuthorizationInterceptors::onError:Exception: $e',
+        exception: e,
+        stackTrace: stackTrace,
+      );
       if (e is ServerError || e is TemporarilyUnavailable) {
         return super.onError(
           DioError(requestOptions: err.requestOptions, error: e),
@@ -166,14 +170,17 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
 
   Stream<List<int>>? _getDataUploadRequest(dynamic mapUploadExtra) {
     try {
-      String? filePath = mapUploadExtra[FileUploader.filePathExtraKey];
+      if (mapUploadExtra is! Map) return null;
+      final filePath = mapUploadExtra[FileUploader.filePathExtraKey] as String?;
       if (filePath?.isNotEmpty == true) {
         return File(filePath!).openRead();
       } else {
-        return mapUploadExtra[FileUploader.streamDataExtraKey];
+        return mapUploadExtra[FileUploader.streamDataExtraKey] as Stream<List<int>>?;
       }
     } catch(e) {
-      log('AuthorizationInterceptors::_getDataUploadRequest: Exception = $e');
+      logWarning(
+        'AuthorizationInterceptors::_getDataUploadRequest: Exception = $e',
+      );
       return null;
     }
   }

--- a/lib/features/login/domain/usecases/authenticate_oidc_on_browser_interactor.dart
+++ b/lib/features/login/domain/usecases/authenticate_oidc_on_browser_interactor.dart
@@ -24,7 +24,7 @@ class AuthenticateOidcOnBrowserInteractor {
           config.scopes);
       yield Right<Failure, Success>(AuthenticateOidcOnBrowserSuccess());
     } catch (e) {
-      logError('AuthenticateOidcOnBrowserInteractor::execute(): $e');
+      logWarning('AuthenticateOidcOnBrowserInteractor::execute(): $e');
       yield Left<Failure, Success>(AuthenticateOidcOnBrowserFailure(e));
     }
   }

--- a/lib/features/login/domain/usecases/get_oidc_configuration_interactor.dart
+++ b/lib/features/login/domain/usecases/get_oidc_configuration_interactor.dart
@@ -28,7 +28,7 @@ class GetOIDCConfigurationInteractor {
         GetOIDCConfigurationSuccess(configWithLoginHint),
       );
     } catch (e) {
-      logError('$runtimeType::execute():oidcResponse = ${oidcResponse.runtimeType} | Exception = $e');
+      logWarning('$runtimeType::execute():oidcResponse = ${oidcResponse.runtimeType} | Exception = $e');
       if (oidcResponse is BaseUrlOidcResponse) {
         yield Left<Failure, Success>(GetOIDCConfigurationFromBaseUrlFailure(e));
       } else {

--- a/lib/features/login/domain/usecases/get_token_oidc_interactor.dart
+++ b/lib/features/login/domain/usecases/get_token_oidc_interactor.dart
@@ -53,14 +53,14 @@ class GetTokenOIDCInteractor {
         baseUri,
       ));
     } on PlatformException catch (e) {
-      logError('GetTokenOIDCInteractor::execute(): PlatformException ${e.message} - ${e.stacktrace}');
+      logWarning('GetTokenOIDCInteractor::execute(): PlatformException ${e.message} - ${e.stacktrace}');
       if (NoSuitableBrowserForOIDCException.verifyException(e)) {
         yield Left<Failure, Success>(GetTokenOIDCFailure(NoSuitableBrowserForOIDCException()));
       } else {
         yield Left<Failure, Success>(GetTokenOIDCFailure(e));
       }
     } catch (e) {
-      logError('GetTokenOIDCInteractor::execute(): $e');
+      logWarning('GetTokenOIDCInteractor::execute(): $e');
       yield Left<Failure, Success>(GetTokenOIDCFailure(e));
     }
   }

--- a/lib/features/login/domain/usecases/try_guessing_web_finger_interactor.dart
+++ b/lib/features/login/domain/usecases/try_guessing_web_finger_interactor.dart
@@ -43,7 +43,7 @@ class TryGuessingWebFingerInteractor {
         yield Right(TryGuessingWebFingerSuccess(firstNonNullResponse));
       }
     } catch (e) {
-      logError('$runtimeType::execute(): Exception = $e');
+      logWarning('$runtimeType::execute(): Exception = $e');
       yield Left(TryGuessingWebFingerFailure(exception: e));
     }
   }

--- a/lib/features/login/domain/usecases/update_account_cache_interactor.dart
+++ b/lib/features/login/domain/usecases/update_account_cache_interactor.dart
@@ -45,7 +45,7 @@ class UpdateAccountCacheInteractor {
     try {
       return session.getQualifiedApiUrl(baseUrl: baseUrl);
     } catch (e) {
-      logError('UpdateAccountCacheInteractor::_getQualifiedApiUrl:Exception = $e');
+      logWarning('UpdateAccountCacheInteractor::_getQualifiedApiUrl:Exception = $e');
       return '';
     }
   }

--- a/lib/features/login/presentation/login_controller.dart
+++ b/lib/features/login/presentation/login_controller.dart
@@ -224,7 +224,7 @@ class LoginController extends ReloadableController {
 
   @override
   void handleUrgentException({Failure? failure, Exception? exception}) {
-    logError('LoginController::handleUrgentException:Exception: $exception | Failure: $failure');
+    logWarning('LoginController::handleUrgentException:Exception: $exception | Failure: $failure');
     if (failure is CheckOIDCIsAvailableFailure) {
       _handleCheckOIDCIsAvailableFailure(failure);
     } else if (failure is GetOIDCConfigurationFromBaseUrlFailure) {
@@ -316,7 +316,7 @@ class LoginController extends ReloadableController {
       featureFailure = failure;
       tryGetOIDCConfigurationFromBaseUrl(_currentBaseUrl!);
     } catch (e) {
-      logError('LoginController::_handleCheckOIDCIsAvailableFailure:Exception = $e');
+      logWarning('LoginController::_handleCheckOIDCIsAvailableFailure:Exception = $e');
       handleOIDCIsNotAvailable(failure);
     }
   }

--- a/lib/features/mailbox/data/repository/mailbox_repository_impl.dart
+++ b/lib/features/mailbox/data/repository/mailbox_repository_impl.dart
@@ -78,7 +78,7 @@ class MailboxRepositoryImpl extends MailboxRepository {
       log('MailboxRepositoryImpl::_getAllMailboxFromCache: MAILBOX_CACHED = ${cacheMailboxResponse.mailboxes.length} | STATE_CACHED = ${cacheMailboxResponse.state?.value}');
       return cacheMailboxResponse;
     } catch (e) {
-      logError('MailboxRepositoryImpl::_getAllMailboxFromCache: Exception: $e');
+      logWarning('MailboxRepositoryImpl::_getAllMailboxFromCache: Exception: $e');
       return null;
     }
   }
@@ -106,7 +106,7 @@ class MailboxRepositoryImpl extends MailboxRepository {
       await _syncNewMailboxesInCache(accountId, userName, newMailboxes);
       await _syncNewMailboxStateInCache(accountId, userName, newState);
     } catch (e) {
-      logError('MailboxRepositoryImpl::_syncNewInCache: Exception = $e');
+      logWarning('MailboxRepositoryImpl::_syncNewInCache: Exception = $e');
     }
   }
 
@@ -220,7 +220,7 @@ class MailboxRepositoryImpl extends MailboxRepository {
       await mapDataSource[DataSourceType.local]
         !.renameMailbox(session, accountId, request);
     } catch (e) {
-      logError('MailboxRepositoryImpl::renameMailbox: Exception: $e');
+      logWarning('MailboxRepositoryImpl::renameMailbox: Exception: $e');
     }
 
     return result;
@@ -257,7 +257,7 @@ class MailboxRepositoryImpl extends MailboxRepository {
         ) ?? Future.value(),
       ]);
     } catch (e) {
-      logError('MailboxRepositoryImpl::markAsMailboxRead: Exception: $e');
+      logWarning('MailboxRepositoryImpl::markAsMailboxRead: Exception: $e');
     }
     return result;
   }

--- a/lib/features/mailbox/domain/usecases/create_new_default_mailbox_interactor.dart
+++ b/lib/features/mailbox/domain/usecases/create_new_default_mailbox_interactor.dart
@@ -60,7 +60,7 @@ class CreateDefaultMailboxInteractor {
       );
       return mailboxUpdatedRecord.$1;
     } catch (e) {
-      logError('CreateDefaultMailboxInteractor::_updateRoleToListMailbox:Exception = $e');
+      logWarning('CreateDefaultMailboxInteractor::_updateRoleToListMailbox:Exception = $e');
       return mailboxes;
     }
   }

--- a/lib/features/mailbox/domain/usecases/delete_multiple_mailbox_interactor.dart
+++ b/lib/features/mailbox/domain/usecases/delete_multiple_mailbox_interactor.dart
@@ -49,7 +49,7 @@ class DeleteMultipleMailboxInteractor {
             currentMailboxState: currentMailboxState));
       }
     } catch (e) {
-      logError('DeleteMultipleMailboxInteractor::execute(): exception: $e');
+      logWarning('DeleteMultipleMailboxInteractor::execute(): exception: $e');
       yield Left<Failure, Success>(DeleteMultipleMailboxFailure(e));
     }
   }

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -581,7 +581,7 @@ class MailboxController extends BaseMailboxController
         onDataFailureViewState(refreshState);
       }
     } catch (e, stackTrace) {
-      logError('MailboxController::_processMailboxStateQueue:Error processing state: $e');
+      logWarning('MailboxController::_processMailboxStateQueue:Error processing state: $e');
       onError(e, stackTrace);
     }
     if (currentMailboxState != null) {
@@ -637,7 +637,7 @@ class MailboxController extends BaseMailboxController
         mailboxDashBoardController.setOutboxMailbox(mailboxDashBoardController.mapMailboxById[outboxMailboxIdByRole]!);
       }
     } catch (e) {
-      logError('MailboxController::_setOutboxMailbox: Not found outbox mailbox');
+      logWarning('MailboxController::_setOutboxMailbox: Not found outbox mailbox');
       mailboxDashBoardController.setOutboxMailbox(null);
     }
   }
@@ -1308,7 +1308,7 @@ class MailboxController extends BaseMailboxController
   Future<void> _updateMailboxIdsBlockNotificationToKeychain(List<PresentationMailbox> mailboxes) async {
     _iosSharingManager = getBinding<IOSSharingManager>();
     if (accountId == null || _iosSharingManager == null || mailboxes.isEmpty) {
-      logError('MailboxController::_updateMailboxIdsBlockNotificationToKeychain: AccountId = $accountId | IosSharingManager = $_iosSharingManager | Mailboxes = ${mailboxes.length}');
+      logWarning('MailboxController::_updateMailboxIdsBlockNotificationToKeychain: AccountId = $accountId | IosSharingManager = $_iosSharingManager | Mailboxes = ${mailboxes.length}');
       return;
     }
 

--- a/lib/features/mailbox_dashboard/domain/app_dashboard/app_dashboard_configuration_parser.dart
+++ b/lib/features/mailbox_dashboard/domain/app_dashboard/app_dashboard_configuration_parser.dart
@@ -12,7 +12,7 @@ class AppDashboardConfigurationParser extends AppConfigParser<LinagoraApplicatio
       final jsonObject = jsonDecode(value);
       return LinagoraApplications.fromJson(jsonObject);
     } catch (e) {
-      logError('AppDashboardConfigurationParser::parse(): $e');
+      logWarning('AppDashboardConfigurationParser::parse(): $e');
       rethrow;
     }
   }

--- a/lib/features/mailbox_dashboard/domain/usecases/get_app_dashboard_configuration_interactor.dart
+++ b/lib/features/mailbox_dashboard/domain/usecases/get_app_dashboard_configuration_interactor.dart
@@ -16,7 +16,7 @@ class GetAppDashboardConfigurationInteractor {
       final linagoraApps = await _appGridRepository.getLinagoraApplicationsFromEnvironment(path);
       yield Right(GetAppDashboardConfigurationSuccess(linagoraApps.apps));
     } catch (e) {
-      logError('GetAppDashboardConfigurationInteractor::execute(): $e');
+      logWarning('GetAppDashboardConfigurationInteractor::execute(): $e');
       yield Left(GetAppDashboardConfigurationFailure(e));
     }
   }

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -614,7 +614,7 @@ class MailboxDashBoardController extends ReloadableController
       .listen(
         _emailReceiveManager.setPendingFileInfo,
         onError: (err) {
-          logError('MailboxDashBoardController::_registerReceivingFileSharingStream::receivingFileSharingStream:Exception = $err');
+          logWarning('MailboxDashBoardController::_registerReceivingFileSharingStream::receivingFileSharingStream:Exception = $err');
         },
       );
 
@@ -623,7 +623,7 @@ class MailboxDashBoardController extends ReloadableController
       .listen(
         _handleReceivingFileSharing,
         onError: (err) {
-          logError('MailboxDashBoardController::_registerReceivingFileSharingStream::pendingSharedFileInfo:Exception = $err');
+          logWarning('MailboxDashBoardController::_registerReceivingFileSharingStream::pendingSharedFileInfo:Exception = $err');
         },
       );
   }
@@ -827,7 +827,7 @@ class MailboxDashBoardController extends ReloadableController
       _getAllVacationInteractor = Get.find<GetAllVacationInteractor>();
       _updateVacationInteractor = Get.find<UpdateVacationInteractor>();
     } catch (e) {
-      logError('MailboxDashBoardController::injectVacationBindings(): $e');
+      logWarning('MailboxDashBoardController::injectVacationBindings(): $e');
     }
   }
 
@@ -838,7 +838,7 @@ class MailboxDashBoardController extends ReloadableController
       await LocalNotificationManager.instance.recreateStreamController();
       _registerLocalNotificationStreamListener();
     } catch (e) {
-      logError('MailboxDashBoardController::injectFCMBindings(): $e');
+      logWarning('MailboxDashBoardController::injectFCMBindings(): $e');
     }
   }
 
@@ -1932,7 +1932,7 @@ class MailboxDashBoardController extends ReloadableController
       }
       return null;
     } catch (e) {
-      logError('MailboxDashBoardController::maxSizeAttachmentsPerEmail(): [Exception] $e');
+      logWarning('MailboxDashBoardController::maxSizeAttachmentsPerEmail(): [Exception] $e');
       return null;
     }
   }
@@ -2507,7 +2507,7 @@ class MailboxDashBoardController extends ReloadableController
   bool get isDraggingMailbox => _isDraggingMailbox.value;
 
   void _handleSendEmailFailure(SendEmailFailure failure) {
-    logError('MailboxDashBoardController::_handleSendEmailFailure():failure: $failure');
+    logWarning('MailboxDashBoardController::_handleSendEmailFailure():failure: $failure');
     if (PlatformInfo.isMobile) {
       storeSendingEmailInCaseOfSendingFailureInMobile(failure);
     }
@@ -2516,7 +2516,7 @@ class MailboxDashBoardController extends ReloadableController
       return;
     }
     final exception = failure.exception;
-    logError('MailboxDashBoardController::_handleSendEmailFailure():exception: $exception');
+    logWarning('MailboxDashBoardController::_handleSendEmailFailure():exception: $exception');
     if (exception is SetMethodException) {
       final listErrors = exception.mapErrors.values.toList();
       final toastSuccess = _handleSetErrors(listErrors);
@@ -2558,13 +2558,13 @@ class MailboxDashBoardController extends ReloadableController
   }
 
   void _handleSaveEmailAsDraftsFailure(SaveEmailAsDraftsFailure failure) {
-    logError('MailboxDashBoardController::_handleSaveEmailAsDraftsFailure():failure: $failure');
+    logWarning('MailboxDashBoardController::_handleSaveEmailAsDraftsFailure():failure: $failure');
     if (currentContext == null) {
       clearState();
       return;
     }
     final exception = failure.exception;
-    logError('MailboxDashBoardController::_handleSaveEmailAsDraftsFailure():exception: $exception');
+    logWarning('MailboxDashBoardController::_handleSaveEmailAsDraftsFailure():exception: $exception');
     if (exception is SetMethodException) {
       final listErrors = exception.mapErrors.values.toList();
       final toastSuccess = _handleSetErrors(listErrors);
@@ -2579,13 +2579,13 @@ class MailboxDashBoardController extends ReloadableController
   }
 
   void _handleUpdateEmailAsDraftsFailure(UpdateEmailDraftsFailure failure) {
-    logError('MailboxDashBoardController::_handleUpdateEmailAsDraftsFailure():failure: $failure');
+    logWarning('MailboxDashBoardController::_handleUpdateEmailAsDraftsFailure():failure: $failure');
     if (currentContext == null) {
       clearState();
       return;
     }
     final exception = failure.exception;
-    logError('MailboxDashBoardController::_handleUpdateEmailAsDraftsFailure():exception: $exception');
+    logWarning('MailboxDashBoardController::_handleUpdateEmailAsDraftsFailure():exception: $exception');
     if (exception is SetMethodException) {
       final listErrors = exception.mapErrors.values.toList();
       final toastSuccess = _handleSetErrors(listErrors);
@@ -2673,7 +2673,7 @@ class MailboxDashBoardController extends ReloadableController
         sendingEmail
       ));
     } else {
-      logError('MailboxDashBoardController::_handleUpdateSendingEmail(): StoredSendingId is null');
+      logWarning('MailboxDashBoardController::_handleUpdateSendingEmail(): StoredSendingId is null');
       _handleStoreSendingEmail(
         session,
         accountId,
@@ -2805,7 +2805,7 @@ class MailboxDashBoardController extends ReloadableController
   void openDialogEmptySpamFolder(BuildContext context) {
     final spamMailbox = selectedMailbox.value;
     if (spamMailbox == null || !spamMailbox.isSpam) {
-      logError('MailboxDashBoardController::openDialogEmptySpamFolder: Selected mailbox is not spam');
+      logWarning('MailboxDashBoardController::openDialogEmptySpamFolder: Selected mailbox is not spam');
       return;
 
     }
@@ -2886,7 +2886,7 @@ class MailboxDashBoardController extends ReloadableController
     try {
       return sessionCurrent?.getDownloadUrl(jmapUrl: dynamicUrlInterceptors.jmapUrl) ?? '';
     } catch (e) {
-      logError('MailboxDashboardController::baseDownloadUrl(): $e');
+      logWarning('MailboxDashboardController::baseDownloadUrl(): $e');
       return '';
     }
   }

--- a/lib/features/mailbox_dashboard/presentation/extensions/cleanup_recent_search_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/cleanup_recent_search_extension.dart
@@ -13,7 +13,7 @@ extension CleanupRecentSearchExtension on MailboxDashBoardController {
     final username = sessionCurrent?.username;
 
     if (accountId == null || username == null || cleanupRecentSearchCacheInteractor == null) {
-      logError('CleanupRecentSearchExtension::cleanupRecentSearch: accountId == null || username == null || cleanupRecentSearchCacheInteractor == null');
+      logWarning('CleanupRecentSearchExtension::cleanupRecentSearch: accountId == null || username == null || cleanupRecentSearchCacheInteractor == null');
       return;
     }
 

--- a/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
@@ -113,7 +113,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
           final userName = _dashBoardController.sessionCurrent?.username;
 
           if (accountId == null || userName == null) {
-            logError('SearchInputFormWidget::fetchRecentActionCallback: accountId or userName is null');
+            logWarning('SearchInputFormWidget::fetchRecentActionCallback: accountId or userName is null');
             return <RecentSearch>[];
           } else {
             return _searchController.getAllRecentSearchAction(
@@ -196,7 +196,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
     final userName = _dashBoardController.sessionCurrent?.username;
 
     if (accountId == null || userName == null) {
-      logError('SearchInputFormWidget::_saveRecentSearch: accountId or userName is null');
+      logWarning('SearchInputFormWidget::_saveRecentSearch: accountId or userName is null');
       return;
     }
 

--- a/lib/features/manage_account/domain/usecases/save_language_to_server_settings_interactor.dart
+++ b/lib/features/manage_account/domain/usecases/save_language_to_server_settings_interactor.dart
@@ -35,7 +35,7 @@ class SaveLanguageToServerSettingsInteractor {
       );
       yield Right(SaveLanguageToServerSettingsSuccess(locale));
     } catch (e) {
-      logError('SaveLanguageToServerSettingsInteractor::execute(): $e');
+      logWarning('SaveLanguageToServerSettingsInteractor::execute(): $e');
       yield Left(SaveLanguageToServerSettingsFailure(exception: e));
     }
   }

--- a/lib/features/manage_account/domain/usecases/transform_list_signature_interactor.dart
+++ b/lib/features/manage_account/domain/usecases/transform_list_signature_interactor.dart
@@ -30,7 +30,7 @@ class TransformListSignatureInteractor {
     try {
       return await _identityRepository.transformHtmlSignature(identitySignature);
     } catch (e) {
-      logError('TransformListSignatureInteractor::_transformHtmlSignature:Exception = $e');
+      logWarning('TransformListSignatureInteractor::_transformHtmlSignature:Exception = $e');
       return identitySignature;
     }
   }

--- a/lib/features/manage_account/presentation/email_rules/email_rules_controller.dart
+++ b/lib/features/manage_account/presentation/email_rules/email_rules_controller.dart
@@ -55,7 +55,7 @@ class EmailRulesController extends BaseController {
       _createNewEmailRuleFilterInteractor = Get.find<CreateNewEmailRuleFilterInteractor>();
       _editEmailRuleFilterInteractor = Get.find<EditEmailRuleFilterInteractor>();
     } catch (e) {
-      logError('EmailRulesController::onInit(): ${e.toString()}');
+      logWarning('EmailRulesController::onInit(): ${e.toString()}');
     }
   }
 

--- a/lib/features/manage_account/presentation/forward/controller/forward_recipient_controller.dart
+++ b/lib/features/manage_account/presentation/forward/controller/forward_recipient_controller.dart
@@ -48,7 +48,7 @@ class ForwardRecipientController {
       requireCapability(session!, accountId!, [tmailContactCapabilityIdentifier]);
       TMailAutoCompleteBindings().dependencies();
     } catch (e) {
-      logError('ForwardRecipientController::injectAutoCompleteBindings(): exception: $e');
+      logWarning('ForwardRecipientController::injectAutoCompleteBindings(): exception: $e');
     }
   }
 

--- a/lib/features/manage_account/presentation/forward/extensions/handle_update_forward_extension.dart
+++ b/lib/features/manage_account/presentation/forward/extensions/handle_update_forward_extension.dart
@@ -9,7 +9,7 @@ import 'package:tmail_ui_user/features/manage_account/presentation/forward/forwa
 
 extension HandleUpdateForwardExtension on ForwardController {
   void handleErrorWhenUpdateForwardFail(Failure failure) {
-    logError(
+    logWarning(
       '$runtimeType::handleErrorWhenUpdateForwardFail: $failure',
     );
     if (failure is AddRecipientsInForwardingFailure) {

--- a/lib/features/manage_account/presentation/forward/forward_controller.dart
+++ b/lib/features/manage_account/presentation/forward/forward_controller.dart
@@ -70,7 +70,7 @@ class ForwardController extends BaseController {
       _addRecipientsInForwardingInteractor = Get.find<AddRecipientsInForwardingInteractor>();
       _editLocalCopyInForwardingInteractor = Get.find<EditLocalCopyInForwardingInteractor>();
     } catch (e) {
-      logError('ForwardController::onInit(): ${e.toString()}');
+      logWarning('ForwardController::onInit(): ${e.toString()}');
     }
   }
 

--- a/lib/features/manage_account/presentation/identities/identities_controller.dart
+++ b/lib/features/manage_account/presentation/identities/identities_controller.dart
@@ -428,7 +428,7 @@ class IdentitiesController extends ReloadableController implements BeforeReconne
       requireCapability(session!, accountId!, [CapabilityIdentifier.jmapPublicAsset]);
       CleanUpPublicAssetsInteractorBindings().dependencies();
     } catch(e) {
-      logError('$runtimeType::injectCleanUpPublicAssetsInteractorBindings(): exception: $e');
+      logWarning('$runtimeType::injectCleanUpPublicAssetsInteractorBindings(): exception: $e');
     }
   }
 

--- a/lib/features/manage_account/presentation/mailbox_visibility/mailbox_visibility_controller.dart
+++ b/lib/features/manage_account/presentation/mailbox_visibility/mailbox_visibility_controller.dart
@@ -59,7 +59,7 @@ class MailboxVisibilityController extends BaseMailboxController {
       _subscribeMailboxInteractor = Get.find<SubscribeMailboxInteractor>();
       _subscribeMultipleMailboxInteractor = Get.find<SubscribeMultipleMailboxInteractor>();
     } catch (e) {
-      logError('MailboxVisibilityController::onInit(): ${e.toString()}');
+      logWarning('MailboxVisibilityController::onInit(): ${e.toString()}');
     }
   }
 

--- a/lib/features/manage_account/presentation/manage_account_dashboard_controller.dart
+++ b/lib/features/manage_account/presentation/manage_account_dashboard_controller.dart
@@ -210,7 +210,7 @@ class ManageAccountDashBoardController extends ReloadableController
       _getAllVacationInteractor = Get.find<GetAllVacationInteractor>();
       _updateVacationInteractor = Get.find<UpdateVacationInteractor>();
     } catch (e) {
-      logError('ManageAccountDashBoardController::injectVacationBindings(): $e');
+      logWarning('ManageAccountDashBoardController::injectVacationBindings(): $e');
     }
   }
 

--- a/lib/features/network_connection/presentation/network_connection_controller.dart
+++ b/lib/features/network_connection/presentation/network_connection_controller.dart
@@ -71,7 +71,7 @@ class NetworkConnectionController extends GetxController {
         _setNetworkConnectivityState(result);
       },
       onError: (error, stackTrace) {
-        logError('NetworkConnectionController::_listenNetworkConnectionChanged()::onConnectivityChanged:error: $error | stackTrace: $stackTrace');
+        logWarning('NetworkConnectionController::_listenNetworkConnectionChanged()::onConnectivityChanged:error: $error | stackTrace: $stackTrace');
       }
     );
 
@@ -81,7 +81,7 @@ class NetworkConnectionController extends GetxController {
         _setInternetConnectivityStatus(status);
       },
       onError: (error, stackTrace) {
-        logError('NetworkConnectionController::_listenNetworkConnectionChanged()::onStatusChange:error: $error | stackTrace: $stackTrace');
+        logWarning('NetworkConnectionController::_listenNetworkConnectionChanged()::onStatusChange:error: $error | stackTrace: $stackTrace');
       }
     );
   }

--- a/lib/features/network_connection/presentation/web_network_connection_controller.dart
+++ b/lib/features/network_connection/presentation/web_network_connection_controller.dart
@@ -60,7 +60,7 @@ class NetworkConnectionController extends GetxController {
         _handleNetworkConnectionState();
       },
       onError: (error, stackTrace) {
-        logError('NetworkConnectionController::_listenNetworkConnectionChanged()::onConnectivityChanged:error: $error | stackTrace: $stackTrace');
+        logWarning('NetworkConnectionController::_listenNetworkConnectionChanged()::onConnectivityChanged:error: $error | stackTrace: $stackTrace');
       }
     );
   }

--- a/lib/features/offline_mode/manager/sending_email_cache_manager.dart
+++ b/lib/features/offline_mode/manager/sending_email_cache_manager.dart
@@ -115,7 +115,7 @@ class SendingEmailCacheManager extends CacheManagerInteraction {
       await _hiveCacheClient.insertMultipleItem(legacyMapItems);
       log('$runtimeType::migrateHiveToIsolatedHive(): ✅ Migrate Hive box "${_hiveCacheClient.tableName}" → IsolatedHive DONE');
     } catch (e) {
-      logError('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_hiveCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
+      logWarning('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_hiveCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
     }
   }
 }

--- a/lib/features/paywall/presentation/paywall_controller.dart
+++ b/lib/features/paywall/presentation/paywall_controller.dart
@@ -70,7 +70,7 @@ class PaywallController extends BaseController {
         _navigateToPaywallUseWorkplaceFqdn(workplaceFqdn);
       }
     } catch (e) {
-      logError('$runtimeType::navigateToPaywall: Failed to navigate to paywall $e');
+      logWarning('$runtimeType::navigateToPaywall: Failed to navigate to paywall $e');
       _navigateToPaywallUseEcoSystem();
     }
   }

--- a/lib/features/public_asset/domain/usecase/clean_up_public_assets_interactor.dart
+++ b/lib/features/public_asset/domain/usecase/clean_up_public_assets_interactor.dart
@@ -66,7 +66,7 @@ class CleanUpPublicAssetsInteractor {
       yield Right(CleanUpPublicAssetsSuccessState());
 
     } catch (exception) {
-      logError('CleanUpPublicAssetsInteractor::execute():error: $exception');
+      logWarning('CleanUpPublicAssetsInteractor::execute():error: $exception');
       yield Left(CleanUpPublicAssetsFailureState(exception: exception));
     }
   }

--- a/lib/features/public_asset/domain/usecase/create_public_asset_interactor.dart
+++ b/lib/features/public_asset/domain/usecase/create_public_asset_interactor.dart
@@ -32,7 +32,7 @@ class CreatePublicAssetInteractor {
         identityId: identityId);
       yield Right<Failure, Success>(CreatePublicAssetSuccessState(publicAsset));
     } catch (exception) {
-      logError('CreatePublicAssetInteractor::execute():error: $exception');
+      logWarning('CreatePublicAssetInteractor::execute():error: $exception');
 
       if (exception is PublicAssetQuotaExceededException) {
         yield Left<Failure, Success>(PublicAssetOverQuotaFailureState(

--- a/lib/features/public_asset/domain/usecase/delete_public_assets_interactor.dart
+++ b/lib/features/public_asset/domain/usecase/delete_public_assets_interactor.dart
@@ -26,7 +26,7 @@ class DeletePublicAssetsInteractor {
         publicAssetIds: publicAssetIds);
       yield Right(DeletePublicAssetsSuccessState());
     } catch (exception) {
-      logError('DeletePublicAssetsInteractor::execute():error: $exception');
+      logWarning('DeletePublicAssetsInteractor::execute():error: $exception');
       yield Left(DeletePublicAssetsFailureState(exception: exception));
     }
   }

--- a/lib/features/push_notification/data/local/fcm_cache_manager.dart
+++ b/lib/features/push_notification/data/local/fcm_cache_manager.dart
@@ -108,7 +108,7 @@ class FCMCacheManager extends CacheManagerInteraction {
       await _fcmCacheClient.insertMultipleItem(legacyMapItems);
       log('$runtimeType::migrateHiveToIsolatedHive(): ✅ Migrate Hive box "${_fcmCacheClient.tableName}" → IsolatedHive DONE');
     } catch (e) {
-      logError('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_fcmCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
+      logWarning('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_fcmCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
     }
   }
 
@@ -121,7 +121,7 @@ class FCMCacheManager extends CacheManagerInteraction {
       await _firebaseRegistrationCacheClient.insertMultipleItem(legacyMapItems);
       log('$runtimeType::migrateHiveToIsolatedHive(): ✅ Migrate Hive box "${_firebaseRegistrationCacheClient.tableName}" → IsolatedHive DONE');
     } catch (e) {
-      logError('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_firebaseRegistrationCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
+      logWarning('$runtimeType::migrateHiveToIsolatedHive(): ❌ Migrate Hive box "${_firebaseRegistrationCacheClient.tableName}" → IsolatedHive FAILED, Error: $e');
     }
   }
 }

--- a/lib/features/push_notification/domain/usecases/connect_web_socket_interactor.dart
+++ b/lib/features/push_notification/domain/usecases/connect_web_socket_interactor.dart
@@ -23,7 +23,7 @@ class ConnectWebSocketInteractor {
         accountId);
       yield Right(WebSocketConnectionSuccess(webSocketChannel));
     } catch (e) {
-      logError('ConnectWebSocketInteractor::execute: $e');
+      logWarning('ConnectWebSocketInteractor::execute: $e');
       yield Left(WebSocketConnectionFailed(exception: e));
     }
   }

--- a/lib/features/push_notification/presentation/config/fcm_configuration.dart
+++ b/lib/features/push_notification/presentation/config/fcm_configuration.dart
@@ -8,7 +8,7 @@ class FcmConfiguration {
     try {
       await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
     } catch (e) {
-      logError('FcmConfiguration::initialize: Exception = $e');
+      logWarning('FcmConfiguration::initialize: Exception = $e');
     }
   }
 }

--- a/lib/features/push_notification/presentation/controller/fcm_message_controller.dart
+++ b/lib/features/push_notification/presentation/controller/fcm_message_controller.dart
@@ -177,7 +177,7 @@ class FcmMessageController extends PushBaseController {
           session: success.session);
       }
     } catch (e) {
-      logError('FcmMessageController::_handleGetSessionSuccess: Exception $e');
+      logWarning('FcmMessageController::_handleGetSessionSuccess: Exception $e');
     }
   }
 

--- a/lib/features/push_notification/presentation/controller/push_base_controller.dart
+++ b/lib/features/push_notification/presentation/controller/push_base_controller.dart
@@ -34,7 +34,7 @@ abstract class PushBaseController {
   void handleSuccessViewState(Success success);
 
   void handleErrorViewState(Object error, StackTrace stackTrace) {
-    logError('PushBaseController::handleErrorViewState():error: $error | stackTrace: $stackTrace');
+    logWarning('PushBaseController::handleErrorViewState():error: $error | stackTrace: $stackTrace');
   }
 
   void initialize({AccountId? accountId, Session? session}) {

--- a/lib/features/push_notification/presentation/controller/web_socket_controller.dart
+++ b/lib/features/push_notification/presentation/controller/web_socket_controller.dart
@@ -50,7 +50,7 @@ class WebSocketController extends PushBaseController {
 
   @override
   void handleFailureViewState(Failure failure) {
-    logError('WebSocketController::handleFailureViewState():Failure $failure');
+    logWarning('WebSocketController::handleFailureViewState():Failure $failure');
     if (failure is WebSocketConnectionFailed) {
       _handleWebSocketConnectionRetry();
     }
@@ -128,11 +128,11 @@ class WebSocketController extends PushBaseController {
       log('WebSocketController::_isWebSocketConnected:webSocketChannel ready');
       return true;
     } on SocketException catch (e) {
-      logError('WebSocketController::_isWebSocketConnected:SocketException = $e');
+      logWarning('WebSocketController::_isWebSocketConnected:SocketException = $e');
     } on WebSocketChannelException catch (e) {
-      logError('WebSocketController::_isWebSocketConnected:WebSocketChannelException = $e');
+      logWarning('WebSocketController::_isWebSocketConnected:WebSocketChannelException = $e');
     } catch (e) {
-      logError('WebSocketController::_isWebSocketConnected:Exception = $e');
+      logWarning('WebSocketController::_isWebSocketConnected:Exception = $e');
     }
     return false;
   }
@@ -140,7 +140,7 @@ class WebSocketController extends PushBaseController {
   void _connectWebSocket() {
     _connectWebSocketInteractor = getBinding<ConnectWebSocketInteractor>();
     if (_connectWebSocketInteractor == null || accountId == null || session == null) {
-      logError('WebSocketController::_connectWebSocket: Skipping');
+      logWarning('WebSocketController::_connectWebSocket: Skipping');
       return;
     }
     if (_isConnecting) return;
@@ -211,12 +211,12 @@ class WebSocketController extends PushBaseController {
           final stateChange = StateChange.fromJson(data);
           _stateChangeDebouncer?.value = stateChange;
         } catch (e) {
-          logError('WebSocketController::_listenToWebSocket(): Data is not StateChange');
+          logWarning('WebSocketController::_listenToWebSocket(): Data is not StateChange');
         }
       },
       cancelOnError: true,
       onError: (error) {
-        logError('WebSocketController::_listenToWebSocket():Error: $error');
+        logWarning('WebSocketController::_listenToWebSocket():Error: $error');
         handleFailureViewState(WebSocketConnectionFailed(exception: error));
       },
       onDone: () {
@@ -251,7 +251,7 @@ class WebSocketController extends PushBaseController {
         session: session,
       );
     } catch (e) {
-      logError('WebSocketController::_handleStateChange:Exception = $e');
+      logWarning('WebSocketController::_handleStateChange:Exception = $e');
     }
   }
 

--- a/lib/features/push_notification/presentation/listener/change_listener.dart
+++ b/lib/features/push_notification/presentation/listener/change_listener.dart
@@ -12,8 +12,8 @@ abstract class ChangeListener {
     newStateStream.listen(
       _handleStateStream,
       onError: (error, stackTrace) {
-        logError('ChangeListener::consumeState():onError:error: $error');
-        logError('ChangeListener::consumeState():onError:stackTrace: $stackTrace');
+        logWarning('ChangeListener::consumeState():onError:error: $error');
+        logWarning('ChangeListener::consumeState():onError:stackTrace: $stackTrace');
       }
     );
   }

--- a/lib/features/push_notification/presentation/listener/email_change_listener.dart
+++ b/lib/features/push_notification/presentation/listener/email_change_listener.dart
@@ -78,7 +78,7 @@ class EmailChangeListener extends ChangeListener {
       _dynamicUrlInterceptors = getBinding<DynamicUrlInterceptors>();
       _storeListNewEmailInteractor = getBinding<StoreListNewEmailInteractor>();
     } catch (e) {
-      logError('EmailChangeListener::_internal(): IS NOT REGISTERED: ${e.toString()}');
+      logWarning('EmailChangeListener::_internal(): IS NOT REGISTERED: ${e.toString()}');
     }
   }
 
@@ -331,7 +331,7 @@ class EmailChangeListener extends ChangeListener {
             baseDownloadUrl
         ));
       } catch (e) {
-        logError('EmailChangeListener::_getListDetailedEmailByIdAction(): $e');
+        logWarning('EmailChangeListener::_getListDetailedEmailByIdAction(): $e');
         consumeState(Stream.value(Left(GetDetailedEmailByIdFailure(e))));
       }
     }

--- a/lib/features/push_notification/presentation/listener/mailbox_change_listener.dart
+++ b/lib/features/push_notification/presentation/listener/mailbox_change_listener.dart
@@ -16,7 +16,7 @@ class MailboxChangeListener extends ChangeListener {
     try {
       _dashBoardController = getBinding<MailboxDashBoardController>();
     } catch (e) {
-      logError(
+      logWarning(
           'MailboxChangeListener::_internal(): IS NOT REGISTERED: ${e.toString()}');
     }
   }

--- a/lib/features/push_notification/presentation/notification/local_notification_manager.dart
+++ b/lib/features/push_notification/presentation/notification/local_notification_manager.dart
@@ -40,7 +40,7 @@ class LocalNotificationManager {
         await _createAndroidNotificationChannel(groupId);
       }
     } catch (e) {
-      logError('LocalNotificationManager::setUp(): ERROR: ${e.toString()}');
+      logWarning('LocalNotificationManager::setUp(): ERROR: ${e.toString()}');
     }
   }
 
@@ -49,7 +49,7 @@ class LocalNotificationManager {
       _notificationAppLaunchDetails = await _localNotificationsPlugin.getNotificationAppLaunchDetails();
       return _notificationAppLaunchDetails?.notificationResponse;
     } catch (e) {
-      logError('LocalNotificationManager::getCurrentNotificationResponse(): ERROR: ${e.toString()}');
+      logWarning('LocalNotificationManager::getCurrentNotificationResponse(): ERROR: ${e.toString()}');
     }
     return null;
   }

--- a/lib/features/push_notification/presentation/services/fcm_receiver.dart
+++ b/lib/features/push_notification/presentation/services/fcm_receiver.dart
@@ -35,7 +35,7 @@ class FcmReceiver {
       log('FcmReceiver::_getInitialToken:token: $token');
       return token;
     } catch (e) {
-      logError('FcmReceiver::_getInitialToken: TYPE = ${e.runtimeType} | Exception = $e');
+      logWarning('FcmReceiver::_getInitialToken: TYPE = ${e.runtimeType} | Exception = $e');
       return null;
     }
   }

--- a/lib/features/push_notification/presentation/websocket/web_socket_queue_handler.dart
+++ b/lib/features/push_notification/presentation/websocket/web_socket_queue_handler.dart
@@ -44,7 +44,7 @@ class WebSocketQueueHandler {
         _messageQueue.removeFirst();
       }
     } catch (e) {
-      logError('WebSocketQueueHandler::enqueue:Exception = $e');
+      logWarning('WebSocketQueueHandler::enqueue:Exception = $e');
     }
 
     log('WebSocketQueueHandler::enqueue(): ${message.id}');
@@ -67,7 +67,7 @@ class WebSocketQueueHandler {
         try {
           await processMessageCallback(message);
         } catch (e, stackTrace) {
-          logError('WebSocketQueueHandler::_processQueue:Error processing message ${message.id}: $e');
+          logWarning('WebSocketQueueHandler::_processQueue:Error processing message ${message.id}: $e');
           onErrorCallback?.call(e, stackTrace);
         } finally {
           _addToProcessedMessages(message.id);
@@ -90,7 +90,7 @@ class WebSocketQueueHandler {
         _processedMessageIds.removeFirst();
       }
     } catch (e) {
-      logError('WebSocketQueueHandler::_addToProcessedMessages:Exception = $e');
+      logWarning('WebSocketQueueHandler::_addToProcessedMessages:Exception = $e');
     }
 
     _processedMessageIds.add(messageId);
@@ -116,7 +116,7 @@ class WebSocketQueueHandler {
       }
       log('WebSocketQueueHandler::removeMessagesUpToCurrent:Updated Queue: $queueSize');
     } catch (e) {
-      logError('WebSocketQueueHandler::removeMessagesUpToCurrent:Exception = $e');
+      logWarning('WebSocketQueueHandler::removeMessagesUpToCurrent:Exception = $e');
     }
   }
 

--- a/lib/features/quotas/presentation/quotas_controller.dart
+++ b/lib/features/quotas/presentation/quotas_controller.dart
@@ -90,7 +90,7 @@ class QuotasController extends BaseController {
   @override
   void handleFailureViewState(Failure failure) {
     if (failure is GetQuotasFailure) {
-      logError('$runtimeType::handleFailureViewState');
+      logWarning('$runtimeType::handleFailureViewState');
       mailboxDashBoardController.octetsQuota.value = null;
       isBannerEnabled.value = true;
     } else {

--- a/lib/features/search/email/presentation/search_email_controller.dart
+++ b/lib/features/search/email/presentation/search_email_controller.dart
@@ -366,7 +366,7 @@ class SearchEmailController extends BaseController
         _handleRefreshChangesSearchEmailsSuccess(searchState);
       }
     } catch (e, stackTrace) {
-      logError('SearchEmailController::_handleWebSocketMessage:Error processing state: $e');
+      logWarning('SearchEmailController::_handleWebSocketMessage:Error processing state: $e');
       onError(e, stackTrace);
     } finally {
       if (mailboxDashBoardController.currentEmailState != null) {
@@ -404,7 +404,7 @@ class SearchEmailController extends BaseController
     final userName = mailboxDashBoardController.sessionCurrent?.username;
 
     if (accountId == null || userName == null) {
-      logError('SearchEmailController::getAllRecentSearchAction: accountId or userName is null');
+      logWarning('SearchEmailController::getAllRecentSearchAction: accountId or userName is null');
       return <RecentSearch>[];
     }
 
@@ -441,7 +441,7 @@ class SearchEmailController extends BaseController
     final userName = mailboxDashBoardController.sessionCurrent?.username;
 
     if (accountId == null || userName == null) {
-      logError('SearchEmailController::_saveRecentSearch: accountId or userName is null');
+      logWarning('SearchEmailController::_saveRecentSearch: accountId or userName is null');
       return;
     }
 

--- a/lib/features/sending_queue/presentation/sending_queue_controller.dart
+++ b/lib/features/sending_queue/presentation/sending_queue_controller.dart
@@ -62,7 +62,7 @@ class SendingQueueController extends BaseController {
     _sendingQueueIsolateManager?.initial(
       onData: _handleSendingQueueEvent,
       onError: (error, stackTrace) {
-        logError('SendingQueueController::onInit():onError:error: $error | stackTrace: $stackTrace');
+        logWarning('SendingQueueController::onInit():onError:error: $error | stackTrace: $stackTrace');
       }
     );
   }
@@ -91,7 +91,7 @@ class SendingQueueController extends BaseController {
         }
       }
     } catch (e) {
-      logError('SendingQueueController::_handleSendingQueueEvent(): EXCEPTION: $e');
+      logWarning('SendingQueueController::_handleSendingQueueEvent(): EXCEPTION: $e');
     }
   }
 

--- a/lib/features/thread/data/network/thread_api.dart
+++ b/lib/features/thread/data/network/thread_api.dart
@@ -148,7 +148,7 @@ class ThreadAPI with HandleSetErrorMixin, MailAPIMixin {
           getSearchSnippetMethodCallId,
           SearchSnippetGetResponse.fromJson)?.list;
     } catch (e) {
-      logError('ThreadAPI::searchEmails:getSearchSnippetsFromResponse: Exception = $e');
+      logWarning('ThreadAPI::searchEmails:getSearchSnippetsFromResponse: Exception = $e');
       return null;
     }
   }

--- a/lib/features/thread/domain/usecases/get_email_by_id_interactor.dart
+++ b/lib/features/thread/domain/usecases/get_email_by_id_interactor.dart
@@ -42,7 +42,7 @@ class GetEmailByIdInteractor {
         );
       }
     } catch (e) {
-      logError('GetEmailByIdInteractor::execute():EXCEPTION: $e');
+      logWarning('GetEmailByIdInteractor::execute():EXCEPTION: $e');
       yield Left<Failure, Success>(GetEmailByIdFailure(e));
     }
   }
@@ -62,7 +62,7 @@ class GetEmailByIdInteractor {
         GetEmailByIdSuccess(email, mailboxContain: mailboxContain)
       );
     } catch (e) {
-      logError('GetEmailByIdInteractor::_getEmailByIdFromServer():EXCEPTION: $e');
+      logWarning('GetEmailByIdInteractor::_getEmailByIdFromServer():EXCEPTION: $e');
       yield Left<Failure, Success>(GetEmailByIdFailure(e));
     }
 
@@ -80,7 +80,7 @@ class GetEmailByIdInteractor {
       final email = await _emailRepository.getStoredEmail(session, accountId, emailId);
       yield Right<Failure, Success>(GetEmailByIdSuccess(email.toPresentationEmail()));
     } catch (e) {
-      logError('GetEmailByIdInteractor::_tryToGetEmailFromCache():EXCEPTION: $e');
+      logWarning('GetEmailByIdInteractor::_tryToGetEmailFromCache():EXCEPTION: $e');
       yield* _getEmailByIdFromServer(session, accountId, emailId, properties: properties);
     }
   }

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -222,7 +222,7 @@ class ThreadController extends BaseController with EmailActionController {
   @override
   void handleErrorViewState(Object error, StackTrace stackTrace) {
     super.handleErrorViewState(error, stackTrace);
-    logError('ThreadController::handleErrorViewState(): error: $error | stackTrace: $stackTrace');
+    logWarning('ThreadController::handleErrorViewState(): error: $error | stackTrace: $stackTrace');
     _resetLoadingMore();
     _handleErrorGetAllOrRefreshChangesEmail(error, stackTrace);
   }
@@ -474,7 +474,7 @@ class ThreadController extends BaseController with EmailActionController {
   }
 
   void _handleErrorGetAllOrRefreshChangesEmail(Object error, StackTrace stackTrace) async {
-    logError('ThreadController::_handleErrorGetAllOrRefreshChangesEmail():Error: $error');
+    logWarning('ThreadController::_handleErrorGetAllOrRefreshChangesEmail():Error: $error');
     if (error is CannotCalculateChangesMethodResponseException) {
       await cachingManager.clearAllEmailAndStateCache(
         accountId: _accountId,
@@ -715,7 +715,7 @@ class ThreadController extends BaseController with EmailActionController {
         await _refreshChangeListEmail();
       }
     } catch (e, stackTrace) {
-      logError('ThreadController::_handleWebSocketMessage:Error processing state: $e');
+      logWarning('ThreadController::_handleWebSocketMessage:Error processing state: $e');
       onError(e, stackTrace);
     } finally {
       if (mailboxDashBoardController.currentEmailState != null) {
@@ -1382,7 +1382,7 @@ class ThreadController extends BaseController with EmailActionController {
         mailboxContain: mailboxContain,
       ));
     } else {
-      logError('ThreadController::_getEmailByIdFromLocationBar: session & accountId is NULL');
+      logWarning('ThreadController::_getEmailByIdFromLocationBar: session & accountId is NULL');
       popAndPush(AppRoutes.unknownRoutePage);
     }
   }

--- a/lib/features/thread_detail/domain/usecases/get_emails_by_ids_interactor.dart
+++ b/lib/features/thread_detail/domain/usecases/get_emails_by_ids_interactor.dart
@@ -45,7 +45,7 @@ class GetEmailsByIdsInteractor {
         updateCurrentThreadDetail: updateCurrentThreadDetail,
       ));
     } catch (e) {
-      logError('GetEmailsByIdsInteractor::execute(): Exception: $e');
+      logWarning('GetEmailsByIdsInteractor::execute(): Exception: $e');
       yield Left(GetEmailsByIdsFailure(
         exception: e,
         onRetry: execute(session, accountId, emailIds, properties: properties),

--- a/lib/features/thread_detail/domain/usecases/get_thread_by_id_interactor.dart
+++ b/lib/features/thread_detail/domain/usecases/get_thread_by_id_interactor.dart
@@ -43,7 +43,7 @@ class GetThreadByIdInteractor {
         emailsInThreadDetailInfo: result,
       ));
     } catch (e) {
-      logError('GetEmailIdsByThreadIdInteractor::execute(): Exception: $e');
+      logWarning('GetEmailIdsByThreadIdInteractor::execute(): Exception: $e');
       yield Left(GetThreadByIdFailure(
         exception: e,
         onRetry: execute(

--- a/lib/features/thread_detail/domain/usecases/get_thread_detail_status_interactor.dart
+++ b/lib/features/thread_detail/domain/usecases/get_thread_detail_status_interactor.dart
@@ -16,7 +16,7 @@ class GetThreadDetailStatusInteractor {
       final result = await _threadDetailRepository.getThreadDetailStatus();
       yield Right(GetThreadDetailStatusSuccess(result));
     } catch (e) {
-      logError('GetThreadDetailStatusInteractor::execute(): Exception: $e');
+      logWarning('GetThreadDetailStatusInteractor::execute(): Exception: $e');
       yield Left(GetThreadDetailStatusFailure(exception: e));
     }
   }

--- a/lib/features/upload/data/network/file_uploader.dart
+++ b/lib/features/upload/data/network/file_uploader.dart
@@ -148,12 +148,12 @@ class FileUploader {
           fileName: argsUpload.fileInfo.fileName);
       }
     } on DioError catch (exception) {
-      logError('FileUploader::_handleUploadAttachmentAction():DioError: $exception');
+      logWarning('FileUploader::_handleUploadAttachmentAction():DioError: $exception');
 
       throw exception.copyWith(
         requestOptions: exception.requestOptions.copyWith(data: ''));
     } catch (exception) {
-      logError('FileUploader::_handleUploadAttachmentAction():OtherException: $exception');
+      logWarning('FileUploader::_handleUploadAttachmentAction():OtherException: $exception');
 
       rethrow;
     }
@@ -225,7 +225,7 @@ class FileUploader {
         nameFile: fileName,
         charset: fileCharset);
     } else {
-      logError('FileUploader::_parsingResponse(): DataResponseIsNullException');
+      logWarning('FileUploader::_parsingResponse(): DataResponseIsNullException');
       throw DataResponseIsNullException();
     }
   }

--- a/lib/features/upload/domain/model/upload_attachment.dart
+++ b/lib/features/upload/domain/model/upload_attachment.dart
@@ -61,7 +61,7 @@ class UploadAttachment with EquatableMixin {
 
       _updateEvent(Right(SuccessAttachmentUploadState(uploadTaskId, attachment, fileInfo)));
     } catch (error, stackTrace) {
-      logError('UploadAttachment::upload():ERROR: $error');
+      logWarning('UploadAttachment::upload():ERROR: $error');
       if (error is DioError && error.type == DioErrorType.cancel) {
         _updateEvent(Left(CancelAttachmentUploadState(uploadTaskId)));
       } else {

--- a/lib/features/upload/presentation/model/upload_file_state.dart
+++ b/lib/features/upload/presentation/model/upload_file_state.dart
@@ -76,7 +76,7 @@ class UploadFileState with EquatableMixin {
       }
       return mediaType?.getIcon(imagePaths, fileName: fileName) ?? imagePaths.icFileDefault;
     } catch (e) {
-      logError('UploadFileState::getIcon: Exception: $e');
+      logWarning('UploadFileState::getIcon: Exception: $e');
       return imagePaths.icFileDefault;
     }
   }

--- a/lib/main/deep_links/deep_links_manager.dart
+++ b/lib/main/deep_links/deep_links_manager.dart
@@ -62,7 +62,7 @@ class DeepLinksManager with OpenAppDeepLinkHandlerMixin {
         return DeepLinkData(actionType: DeepLinkActionType.unknown);
       }
     } catch (e) {
-      logError('DeepLinksManager::parseDeepLink:Exception = $e');
+      logWarning('DeepLinksManager::parseDeepLink:Exception = $e');
       return null;
     }
   }

--- a/lib/main/deep_links/open_app_deep_link_handler_mixin.dart
+++ b/lib/main/deep_links/open_app_deep_link_handler_mixin.dart
@@ -1,10 +1,10 @@
 import 'package:core/presentation/extensions/either_view_state_extension.dart';
 import 'package:core/presentation/utils/theme_utils.dart';
+import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/string_convert.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
-import 'package:rich_text_composer/views/commons/logger.dart';
 import 'package:tmail_ui_user/features/base/mixin/message_dialog_action_manager.dart';
 import 'package:tmail_ui_user/features/home/domain/state/auto_sign_in_via_deep_link_state.dart';
 import 'package:tmail_ui_user/features/home/domain/usecases/auto_sign_in_via_deep_link_interactor.dart';
@@ -42,7 +42,7 @@ mixin OpenAppDeepLinkHandlerMixin {
         username: usernameDecoded,
       );
     } catch (e) {
-      logError('DeepLinksManager::parseOpenAppDeepLink:Exception = $e');
+      logWarning('DeepLinksManager::parseOpenAppDeepLink:Exception = $e');
       return null;
     }
   }
@@ -106,7 +106,7 @@ mixin OpenAppDeepLinkHandlerMixin {
         onFailure: (failure) => onFailureCallback.call(),
       );
     } catch (e) {
-      logError('DeepLinksManager::_autoSignInViaDeepLink:Exception = $e');
+      logWarning('DeepLinksManager::_autoSignInViaDeepLink:Exception = $e');
       onFailureCallback.call();
     }
   }

--- a/lib/main/error/capability_validator.dart
+++ b/lib/main/error/capability_validator.dart
@@ -33,7 +33,7 @@ extension ListCapabilityIdentifierExtension on List<CapabilityIdentifier> {
       requireCapability(session, accountId, this);
       return true;
     } catch (error) {
-      logError('ListCapabilityIdentifierExtension::isSupported(): $error');
+      logWarning('ListCapabilityIdentifierExtension::isSupported(): $error');
       return false;
     }
   }
@@ -49,7 +49,7 @@ extension CapabilityIdentifierExtension on CapabilityIdentifier {
       requireCapability(session, accountId, [this]);
       return true;
     } catch (error) {
-      logError('CapabilityIdentifierExtension::isSupported(): $error');
+      logWarning('CapabilityIdentifierExtension::isSupported(): $error');
       return false;
     }
   }
@@ -63,7 +63,7 @@ extension CapabilityIdentifierSetExtension on Set<CapabilityIdentifier> {
       add(CapabilityIdentifier.jmapTeamMailboxes);
       return this;
     } catch (error) {
-      logError('CapabilityIdentifierExtension::toCapabilitiesSupportTeamMailboxes(): $error');
+      logWarning('CapabilityIdentifierSetExtension::toCapabilitiesSupportTeamMailboxes(): $error');
       return this;
     }
   }

--- a/lib/main/exceptions/cache_exception_thrower.dart
+++ b/lib/main/exceptions/cache_exception_thrower.dart
@@ -5,7 +5,11 @@ class CacheExceptionThrower extends ExceptionThrower {
 
   @override
   throwException(dynamic error, dynamic stackTrace) {
-    logError('CacheExceptionThrower::throwException():error: $error | stackTrace: $stackTrace');
+    logError(
+      'CacheExceptionThrower::throwException():error: $error',
+      exception: error,
+      stackTrace: stackTrace,
+    );
     throw error;
   }
 }

--- a/lib/main/exceptions/remote_exception_thrower.dart
+++ b/lib/main/exceptions/remote_exception_thrower.dart
@@ -17,10 +17,14 @@ class RemoteExceptionThrower extends ExceptionThrower {
 
   @override
   throwException(dynamic error, dynamic stackTrace) {
-    logError('RemoteExceptionThrower::throwException():error: $error | stackTrace: $stackTrace');
+    logError(
+      'RemoteExceptionThrower::throwException():error: $error | stackTrace: $stackTrace',
+      exception: error,
+      stackTrace: stackTrace,
+    );
     final networkConnectionController = getBinding<NetworkConnectionController>();
     if (networkConnectionController?.isNetworkConnectionAvailable() == false) {
-      logError('RemoteExceptionThrower::throwException():isNetworkConnectionAvailable');
+      logWarning('RemoteExceptionThrower::throwException():isNetworkConnectionAvailable');
       throw const NoNetworkError();
     } else {
       handleDioError(error);
@@ -29,7 +33,7 @@ class RemoteExceptionThrower extends ExceptionThrower {
 
   void handleDioError(dynamic error) {
     if (error is DioError) {
-      logError(
+      logWarning(
         'RemoteExceptionThrower::throwException():type: ${error.type} | response: ${error.response} | error: ${error.error}',
       );
 

--- a/lib/main/exceptions/send_email_exception_thrower.dart
+++ b/lib/main/exceptions/send_email_exception_thrower.dart
@@ -10,11 +10,15 @@ import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 class SendEmailExceptionThrower extends RemoteExceptionThrower {
   @override
   FutureOr<void> throwException(error, stackTrace) async {
-    log('SendEmailExceptionThrower::throwException(): $error | stackTrace: $stackTrace');
+    logError(
+      'SendEmailExceptionThrower::throwException():error: $error | stackTrace: $stackTrace',
+      exception: error,
+      stackTrace: stackTrace,
+    );
     final networkConnectionController = getBinding<NetworkConnectionController>();
     final realtimeNetworkConnectionStatus = await networkConnectionController?.hasInternetConnection();
     if (realtimeNetworkConnectionStatus == false) {
-      logError('SendEmailExceptionThrower::throwException(): No realtime network connection');
+      logWarning('SendEmailExceptionThrower::throwException(): No realtime network connection');
       throw const NoNetworkError();
     } else {
       handleDioError(error);

--- a/lib/main/exceptions/send_email_exception_thrower.dart
+++ b/lib/main/exceptions/send_email_exception_thrower.dart
@@ -18,7 +18,7 @@ class SendEmailExceptionThrower extends RemoteExceptionThrower {
     final networkConnectionController = getBinding<NetworkConnectionController>();
     final realtimeNetworkConnectionStatus = await networkConnectionController?.hasInternetConnection();
     if (realtimeNetworkConnectionStatus == false) {
-      logWarning('SendEmailExceptionThrower::throwException(): No realtime network connection');
+      logError('SendEmailExceptionThrower::throwException(): No realtime network connection');
       throw const NoNetworkError();
     } else {
       handleDioError(error);

--- a/lib/main/localizations/localization_service.dart
+++ b/lib/main/localizations/localization_service.dart
@@ -47,7 +47,7 @@ class LocalizationService extends Translations {
 
       return defaultLocale;
     } catch (e) {
-      logError('LocalizationService::getInitialLocale:Exception is $e');
+      logWarning('LocalizationService::getInitialLocale:Exception is $e');
       return defaultLocale;
     }
   }
@@ -57,7 +57,7 @@ class LocalizationService extends Translations {
       final languageCacheManager = getBinding<LanguageCacheManager>();
       return languageCacheManager?.getStoredLanguage();
     } catch (e) {
-      logError('LocalizationService::getCachedLocale: Exception: $e');
+      logWarning('LocalizationService::getCachedLocale: Exception: $e');
       return null;
     }
   }
@@ -92,7 +92,7 @@ class LocalizationService extends Translations {
 
       _useDefaultLocale();
     } catch (e) {
-      logError('LocalizationService::initializeAppLanguage: Exception: $e');
+      logWarning('LocalizationService::initializeAppLanguage: Exception: $e');
       _useDefaultLocale();
     }
   }

--- a/lib/main/utils/app_utils.dart
+++ b/lib/main/utils/app_utils.dart
@@ -20,7 +20,7 @@ class AppUtils {
    try {
      await loadFcmConfigFileToEnv(currentMapEnvData: mapEnvData);
    } catch (e) {
-     logError('AppUtils::loadEnvFile:loadFcmConfigFileToEnv: Exception = $e');
+     logWarning('AppUtils::loadEnvFile:loadFcmConfigFileToEnv: Exception = $e');
      await dotenv.load(fileName: AppConfig.envFileName);
    }
   }

--- a/lib/main/utils/asset_preloader.dart
+++ b/lib/main/utils/asset_preloader.dart
@@ -17,7 +17,7 @@ class AssetPreloader {
         HtmlEditorUtils.loadAsset(HtmlEditorConstants.summernoteFontTTFAssetPath),
       ]);
     } catch (e) {
-      logError('AssetPreloader::preloadHtmlEditorAssets:Exception = $e');
+      logWarning('AssetPreloader::preloadHtmlEditorAssets:Exception = $e');
     }
   }
 }

--- a/lib/main/utils/cozy_integration.dart
+++ b/lib/main/utils/cozy_integration.dart
@@ -14,7 +14,7 @@ class CozyIntegration {
       await cozyConfig.injectCozyScript(AppConfig.cozyExternalBridgeVersion);
       await cozyConfig.initialize();
     } catch (e) {
-      logError('CozyIntegration::integrateCozy:Exception = $e');
+      logWarning('CozyIntegration::integrateCozy:Exception = $e');
     }
   }
 }

--- a/lib/main/utils/ios_notification_manager.dart
+++ b/lib/main/utils/ios_notification_manager.dart
@@ -38,7 +38,7 @@ class IOSNotificationManager {
         }
       });
     } catch (e) {
-      logError('IOSNotificationManager::listenClickNotification:Exception = $e');
+      logWarning('IOSNotificationManager::listenClickNotification:Exception = $e');
     }
   }
 
@@ -53,7 +53,7 @@ class IOSNotificationManager {
         return null;
       }
     } catch (e) {
-      logError('IOSNotificationManager::getCurrentEmailIdInNotificationClick:Exception = $e');
+      logWarning('IOSNotificationManager::getCurrentEmailIdInNotificationClick:Exception = $e');
       return null;
     }
   }

--- a/lib/main/utils/ios_sharing_manager.dart
+++ b/lib/main/utils/ios_sharing_manager.dart
@@ -50,7 +50,7 @@ class IOSSharingManager {
       final keychainSharingStored = await getKeychainSharingSession(accountId);
       return keychainSharingStored?.emailDeliveryState;
     } catch (e) {
-      logError('IOSSharingManager::_getEmailDeliveryStateFromKeychain: Exception: $e');
+      logWarning('IOSSharingManager::getEmailDeliveryStateFromKeychain: Exception: $e');
       return null;
     }
   }
@@ -59,8 +59,8 @@ class IOSSharingManager {
     log('IOSSharingManager::saveKeyChainSharingSession: START');
     try {
       if (!_validateToSaveKeychain(personalAccount)) {
-        logError('IOSSharingManager::saveKeyChainSharingSession: AccountId | Username | ApiUrl is NULL');
-        return Future.value(null);
+        logWarning('IOSSharingManager::saveKeyChainSharingSession: AccountId | Username | ApiUrl is NULL');
+        return;
       }
 
       TokenOIDC? tokenOIDC;
@@ -107,7 +107,7 @@ class IOSSharingManager {
 
       log('IOSSharingManager::_saveKeyChainSharingSession: COMPLETED');
     } catch (e) {
-      logError('IOSSharingManager::_saveKeyChainSharingSession: Exception: $e');
+      logWarning('IOSSharingManager::_saveKeyChainSharingSession: Exception: $e');
     }
   }
 
@@ -119,7 +119,7 @@ class IOSSharingManager {
       }
       return null;
     } catch (e) {
-      logError('IOSSharingManager::getKeychainSharingSession: Exception: $e');
+      logWarning('IOSSharingManager::getKeychainSharingSession: Exception: $e');
       return null;
     }
   }
@@ -128,7 +128,7 @@ class IOSSharingManager {
     try {
       return await _tokenOidcCacheManager.getTokenOidc(tokeHashId);
     } catch (e) {
-      logError('IOSSharingManager::_getTokenOidc:Exception: $e');
+      logWarning('IOSSharingManager::_getTokenOidc:Exception: $e');
       return null;
     }
   }
@@ -138,7 +138,7 @@ class IOSSharingManager {
       final credentialInfo = await _authenticationInfoCacheManager.getAuthenticationInfoStored();
       return base64Encode(utf8.encode('${credentialInfo.username}:${credentialInfo.password}'));
     } catch (e) {
-      logError('IOSSharingManager::_getCredentialAuthentication:Exception: $e');
+      logWarning('IOSSharingManager::_getCredentialAuthentication:Exception: $e');
       return null;
     }
   }
@@ -150,7 +150,7 @@ class IOSSharingManager {
     try {
       return await getEmailDeliveryStateFromKeychain(accountId);
     } catch (e) {
-      logError('IOSSharingManager::_getEmailDeliveryState:Exception: $e');
+      logWarning('IOSSharingManager::_getEmailDeliveryState:Exception: $e');
       return null;
     }
   }
@@ -168,7 +168,7 @@ class IOSSharingManager {
       log('IOSSharingManager::_getEmailState:emailState: $emailState');
       return emailState?.value;
     } catch (e) {
-      logError('IOSSharingManager::_getEmailState:Exception: $e');
+      logWarning('IOSSharingManager::_getEmailState:Exception: $e');
       return null;
     }
   }
@@ -183,7 +183,7 @@ class IOSSharingManager {
         isTWP: oidcConfig.isTWP,
       );
     } catch (e) {
-      logError('IOSSharingManager::_getTokenEndpointAndScopes:Exception: $e');
+      logWarning('IOSSharingManager::_getTokenEndpointScopesAndIsTWP:Exception: $e');
       return null;
     }
   }
@@ -202,7 +202,7 @@ class IOSSharingManager {
       final keychainSharingStored = await getKeychainSharingSession(accountId);
       return keychainSharingStored?.mailboxIdsBlockNotification?.isNotEmpty == true;
     } catch (e) {
-      logError('IOSSharingManager::getMailboxIdsBlockNotificationInKeyChain:Exception = $e');
+      logWarning('IOSSharingManager::isExistMailboxIdsBlockNotificationInKeyChain:Exception = $e');
       return false;
     }
   }
@@ -219,7 +219,7 @@ class IOSSharingManager {
       final newKeychain = keychainSharingStored.updating(mailboxIdsBlockNotification: mailboxIds);
       await _keychainSharingManager.save(newKeychain);
     } catch (e) {
-      logError('IOSSharingManager::updateMailboxIdsBlockNotificationInKeyChain: Exception = $e');
+      logWarning('IOSSharingManager::updateMailboxIdsBlockNotificationInKeyChain: Exception = $e');
     }
   }
 
@@ -236,7 +236,7 @@ class IOSSharingManager {
       log('IOSSharingManager::_getMailboxIdsBlockNotification(): CACHE_MAILBOX_LIST = $listMailboxIdBlockNotification');
       return listMailboxIdBlockNotification;
     } catch (e) {
-      logError('IOSSharingManager::_getMailboxIdsBlockNotification:Exception: $e');
+      logWarning('IOSSharingManager::_getMailboxIdsBlockNotification:Exception: $e');
       return null;
     }
   }

--- a/lib/main/utils/toast_manager.dart
+++ b/lib/main/utils/toast_manager.dart
@@ -143,7 +143,7 @@ class ToastManager {
     final context = currentContext;
     final overlayContext = currentOverlayContext;
     if (context == null || overlayContext == null) {
-      logError('ToastManager::showMessageFailure: Context or OverlayContext is null');
+      logWarning('ToastManager::showMessageFailure: Context or OverlayContext is null');
       return;
     }
 
@@ -231,7 +231,7 @@ class ToastManager {
     final context = currentContext;
     final overlayContext = currentOverlayContext;
     if (context == null || overlayContext == null) {
-      logError('ToastManager::showMessageSuccess: Context or OverlayContext is null');
+      logWarning('ToastManager::showMessageSuccess: Context or OverlayContext is null');
       return;
     }
 
@@ -273,7 +273,7 @@ class ToastManager {
     final context = currentContext;
     final overlayContext = currentOverlayContext;
     if (context == null || overlayContext == null) {
-      logError('$runtimeType::showMessageSuccessWithAction: Context or OverlayContext is null');
+      logWarning('$runtimeType::showMessageSuccessWithAction: Context or OverlayContext is null');
       return;
     }
 

--- a/model/lib/extensions/session_extension.dart
+++ b/model/lib/extensions/session_extension.dart
@@ -90,7 +90,7 @@ extension SessionExtension on Session {
         return username.value;
       }
     } catch (e) {
-      logError('SessionExtension::getUserDisplayName:Exception: $e');
+      logWarning('SessionExtension::getUserDisplayName:Exception: $e');
       return '';
     }
   }
@@ -99,7 +99,7 @@ extension SessionExtension on Session {
     try {
       return getOwnEmailAddress();
     } catch (e) {
-      logError('SessionExtension::getOwnEmailAddressOrEmpty:Exception: $e');
+      logWarning('SessionExtension::getOwnEmailAddressOrEmpty:Exception: $e');
       return '';
     }
   }
@@ -145,7 +145,7 @@ extension SessionExtension on Session {
 
       return '$userName@$domain';
     } catch (e) {
-      logError('$runtimeType::generateOwnEmailAddressFromDomain: Exception: $e');
+      logWarning('$runtimeType::generateOwnEmailAddressFromDomain: Exception: $e');
       return '';
     }
   }
@@ -218,7 +218,7 @@ extension SessionExtension on Session {
         CapabilityIdentifier.jmapCore
       )?.maxObjectsInGet;
     } catch (e) {
-      logError('SessionExtensions::getMaxObjectsInGet():Exception: $e');
+      logWarning('SessionExtensions::getMaxObjectsInGet():Exception: $e');
       return null;
     }
   }


### PR DESCRIPTION
## Issue

#4136 

## Description

This PR focuses on separating and standardizing logger normalization logic to improve clarity and maintainability.

The main goal is to clearly distinguish between warning-level logs and error-level logs, ensuring that `logError` is reserved strictly for critical and actionable failures.

By consolidating and refactoring the logging logic, this change:

- Reduces noise in error monitoring tools such as Sentry
- Improves signal quality for issues that truly require investigation
- Makes the logging behavior easier to review and reason about
- Establishes a clearer convention for future logging usage

This separation also prepares the codebase for more consistent and reliable integration with Sentry going forward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced logging system with improved multi-platform formatting and support for web console output.
  * Implemented more granular error severity categorization—non-critical exceptions now logged as warnings rather than errors, reducing noise in logs while maintaining debugging capability.
  * Added stack trace inclusion in error logs for improved troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->