### PR TITLE
HOTFIX Scribe Broken multi line replace

### DIFF
--- a/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
+++ b/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
@@ -33,7 +33,10 @@ extension HandleAiScribeInComposerExtension on ComposerController {
     final htmlContent = text.replaceAll('\n', '<br>');
 
     if (PlatformInfo.isWeb) {
-      richTextWebController?.editorController.insertHtml(htmlContent);
+      richTextWebController?.editorController.execCommand(
+        'insertHTML',
+        argument: htmlContent,
+      );
     } else {
       richTextMobileTabletController?.htmlEditorApi?.insertHtml(htmlContent);
     }


### PR DESCRIPTION
## Issue
- When select 3 lines and prompt, and the response also contains multiple lines text, click "Replace", only the last response's line is insert

## Resolved
### Before

https://github.com/user-attachments/assets/0a849fc9-2ce2-4d98-9c54-eb89ecf95444


### After

https://github.com/user-attachments/assets/c0ce5b2d-c3be-422d-967c-7e85d5cf24a2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI-generated text insertion on web platforms for more reliable content handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->