### PR TITLE
hotfix(ai-scribe): fix Safari keyboard input issue in AI Scribe search bar dialog

### DIFF
--- a/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
+++ b/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
@@ -101,6 +101,9 @@ extension HandleAiScribeInComposerExtension on ComposerController {
   }
 
   Future<void> openAIAssistantModal(Offset? position, Size? size) async {
+    clearFocusRecipients();
+    clearFocusSubject();
+
     final fullText = await _getTextOnlyContentInEditor();
 
     await AiScribeModalManager.showAIScribeMenuModal(

--- a/lib/features/composer/presentation/widgets/ai_scribe/composer_ai_scribe_selection_overlay.dart
+++ b/lib/features/composer/presentation/widgets/ai_scribe/composer_ai_scribe_selection_overlay.dart
@@ -24,7 +24,13 @@ class ComposerAiScribeSelectionOverlay extends StatelessWidget {
         imagePaths: controller.imagePaths,
         onSelectAiScribeSuggestionAction:
             controller.handleAiScribeSuggestionAction,
+        onTapFallback: _clearComposerInputFocus,
       );
     });
+  }
+
+  void _clearComposerInputFocus() {
+    controller.clearFocusRecipients();
+    controller.clearFocusSubject();
   }
 }

--- a/scribe/lib/scribe/ai/presentation/widgets/button/inline_ai_assist_button.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/button/inline_ai_assist_button.dart
@@ -7,12 +7,14 @@ class InlineAiAssistButton extends StatelessWidget {
   final ImagePaths imagePaths;
   final String? selectedText;
   final OnSelectAiScribeSuggestionAction onSelectAiScribeSuggestionAction;
+  final VoidCallback? onTapFallback;
 
   const InlineAiAssistButton({
     super.key,
     required this.imagePaths,
     required this.onSelectAiScribeSuggestionAction,
     this.selectedText,
+    this.onTapFallback,
   });
 
   @override
@@ -39,6 +41,8 @@ class InlineAiAssistButton extends StatelessWidget {
       position = renderBox.localToGlobal(Offset.zero);
       size = renderBox.size;
     }
+
+    onTapFallback?.call();
 
     await AiScribeModalManager.showAIScribeMenuModal(
       imagePaths: imagePaths,

--- a/scribe/lib/scribe/ai/presentation/widgets/overlay/ai_selection_overlay.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/overlay/ai_selection_overlay.dart
@@ -9,11 +9,13 @@ class AiSelectionOverlay extends StatelessWidget {
     required this.selection,
     required this.imagePaths,
     required this.onSelectAiScribeSuggestionAction,
+    this.onTapFallback,
   });
 
   final TextSelectionModel? selection;
   final ImagePaths imagePaths;
   final OnSelectAiScribeSuggestionAction onSelectAiScribeSuggestionAction;
+  final VoidCallback? onTapFallback;
 
   @override
   Widget build(BuildContext context) {
@@ -34,6 +36,7 @@ class AiSelectionOverlay extends StatelessWidget {
           imagePaths: imagePaths,
           selectedText: selectedText,
           onSelectAiScribeSuggestionAction: onSelectAiScribeSuggestionAction,
+          onTapFallback: onTapFallback,
         ),
       ),
     );

--- a/scribe/lib/scribe/ai/presentation/widgets/search/ai_scribe_bar.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/search/ai_scribe_bar.dart
@@ -71,22 +71,26 @@ class _AIScribeBarState extends State<AIScribeBar> {
       child: Row(
         children: [
           Expanded(
-            child: KeyboardListener(
-              focusNode: _focusNode,
-              onKeyEvent: _handleKeyboardEvent,
-              child: TextField(
-                controller: _controller,
-                decoration: InputDecoration(
-                  hintText: ScribeLocalizations.of(context).inputPlaceholder,
-                  hintStyle: AIScribeTextStyles.searchBarHint,
-                  border: InputBorder.none,
-                  contentPadding: const EdgeInsets.symmetric(vertical: 8),
-                  isDense: true,
+            child: GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onTap: _focusNode.requestFocus,
+              child: KeyboardListener(
+                focusNode: _focusNode,
+                onKeyEvent: _handleKeyboardEvent,
+                child: TextField(
+                  controller: _controller,
+                  decoration: InputDecoration(
+                    hintText: ScribeLocalizations.of(context).inputPlaceholder,
+                    hintStyle: AIScribeTextStyles.searchBarHint,
+                    border: InputBorder.none,
+                    contentPadding: const EdgeInsets.symmetric(vertical: 8),
+                    isDense: true,
+                  ),
+                  style: AIScribeTextStyles.searchBar,
+                  maxLines: null,
+                  keyboardType: TextInputType.multiline,
+                  cursorHeight: 16,
                 ),
-                style: AIScribeTextStyles.searchBar,
-                maxLines: null,
-                keyboardType: TextInputType.multiline,
-                cursorHeight: 16,
               ),
             ),
           ),


### PR DESCRIPTION
## Issue

On Safari, keyboard input issue in AI Scribe search bar dialog

https://github.com/user-attachments/assets/1f2d885c-3fcb-4ce6-8567-92961e3c01b6

## Root cause

On Flutter Web (`Safari`), `KeyboardListener` inside a dialog overlay (`Get.dialog`) blocks text input because the focus is not recognized as user-initiated. Although the `TextField` appears focused, `Safari` does not dispatch keyboard events unless the focus change originates from a trusted pointer interaction.

## Solution

- Preserve the existing implementation and wrap the `KeyboardListener` with a `GestureDetector` that explicitly requests focus inside a user tap event:

```dart
GestureDetector(
  behavior: HitTestBehavior.translucent,
  onTap: _focusNode.requestFocus,
  child: KeyboardListener(
    focusNode: _focusNode,
    child: ...
  ),
)
```

This ensures Safari treats the focus as user-initiated, allowing text input and Enter handling to work correctly.

- Simultaneously clear the focus of both recipients and the subject when showing the AI ​​Scribe dialog.

## Resolved

https://github.com/user-attachments/assets/b8119a30-8a51-42a5-be86-ef6db6bfeca8



