### PR TITLE
[Memory leak] Remove listener and dispose

### DIFF
--- a/core/lib/presentation/views/floating_button/scrolling_floating_button_animated.dart
+++ b/core/lib/presentation/views/floating_button/scrolling_floating_button_animated.dart
@@ -72,6 +72,7 @@ class _ScrollingFloatingButtonAnimatedState
 
   @override
   void initState() {
+    super.initState();
     _animationController = AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 250),
@@ -80,22 +81,19 @@ class _ScrollingFloatingButtonAnimatedState
       lowerBound: 0,
       upperBound: 120,
     );
-    super.initState();
-    _handleScroll();
+    widget.scrollController?.addListener(_scrollListener);
   }
 
   @override
   void dispose() {
-    widget.scrollController!.removeListener(() {});
+    widget.scrollController?.removeListener(_scrollListener);
     _animationController.dispose();
     super.dispose();
   }
 
-  /// Function to add listener for scroll
-  void _handleScroll() {
+  void _scrollListener() {
     ScrollController scrollController = widget.scrollController!;
-    scrollController.addListener(() {
-      if (scrollController.position.pixels > widget.limitIndicator! &&
+    if (scrollController.position.pixels > widget.limitIndicator! &&
           scrollController.position.userScrollDirection ==
               ScrollDirection.reverse) {
         if (widget.animateIcon!) _animationController.forward();
@@ -114,7 +112,6 @@ class _ScrollingFloatingButtonAnimatedState
           });
         }
       }
-    });
   }
 
   @override

--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -48,8 +48,11 @@ class HtmlUtils {
       editor.parentNode.replaceChild(newEditor, editor);''',
     name: 'unregisterDropListener');
 
-  static registerSelectionChangeListener(String viewId) => (
-    script: '''
+  static ({String name, String script}) registerSelectionChangeListener(
+    String viewId,
+  ) =>
+      (
+        script: '''
       let lastSelectedText = '';
 
       const sendSelectionChangeMessage = (data) => {
@@ -149,7 +152,8 @@ class HtmlUtils {
         }
       });
     ''',
-    name: 'onSelectionChange');
+        name: 'onSelectionChange',
+      );
 
   static const collapseSelectionToEnd = (
     script: '''

--- a/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
@@ -38,6 +38,8 @@ class MobileEditorWidget extends StatefulWidget {
 class _MobileEditorState extends State<MobileEditorWidget> with TextSelectionMixin {
 
   late String _createdViewId;
+  InAppWebViewController? _editorController;
+  ({String name, String script})? registerSelectionChange;
 
   @override
   void initState() {
@@ -46,16 +48,28 @@ class _MobileEditorState extends State<MobileEditorWidget> with TextSelectionMix
   }
 
   @override
+  void dispose() {
+    if (registerSelectionChange != null) {
+      _editorController?.removeJavaScriptHandler(
+        handlerName: registerSelectionChange!.name,
+      );
+    }
+    _editorController?.dispose();
+    _editorController = null;
+    super.dispose();
+  }
+
+  @override
   void Function(TextSelectionData?)? get onSelectionChanged => widget.onTextSelectionChanged;
 
   Future<void> _setupSelectionListener(HtmlEditorApi editorApi) async {
-    final webViewController = editorApi.webViewController;
+    _editorController = editorApi.webViewController;
 
-    final registerSelectionChange =
+    registerSelectionChange =
         HtmlUtils.registerSelectionChangeListener(_createdViewId);
 
-    webViewController.addJavaScriptHandler(
-      handlerName: registerSelectionChange.name,
+    _editorController?.addJavaScriptHandler(
+      handlerName: registerSelectionChange!.name,
       callback: (args) {
         if (!mounted) return;
 
@@ -68,8 +82,8 @@ class _MobileEditorState extends State<MobileEditorWidget> with TextSelectionMix
       },
     );
 
-    await webViewController.evaluateJavascript(
-      source: registerSelectionChange.script,
+    await _editorController?.evaluateJavascript(
+      source: registerSelectionChange!.script,
     );
   }
 

--- a/lib/features/thread_detail/presentation/thread_detail_controller.dart
+++ b/lib/features/thread_detail/presentation/thread_detail_controller.dart
@@ -227,6 +227,7 @@ class ThreadDetailController extends BaseController {
 
   void reset() {
     emailIdsPresentation.clear();
+    emailsInThreadDetailInfo.clear();
     scrollController?.dispose();
     scrollController = null;
     currentExpandedEmailId.value = null;


### PR DESCRIPTION
## Issue
Profile memory on mobile, open any email and close it.

## Leak points
- When Thread is closed, all its resources are cleared except EmailInThreadDetailInfo
- A lot of resources is being kept in memory due to improper listener management of ScrollController in ScrollingFloatingButtonAnimated

## Resolved
### Before
<img width="4064" height="2384" alt="Screenshot 2025-12-22 at 4 59 48 PM" src="https://github.com/user-attachments/assets/6bb8f793-0e16-44e6-99b8-6dda58362040" />

### After
<img width="4064" height="2384" alt="after" src="https://github.com/user-attachments/assets/5d62c54e-8f8d-484e-b7a9-90d4fb07be34" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Thread detail reset now clears all presentation data to avoid stale items.
  * Editor properly unregisters selection handlers and disposes its controller to prevent leaks.

* **Refactor**
  * Floating action button scroll handling simplified for smoother, more reliable show/hide behavior.
  * Selection-change listener and editor wiring updated; selection listener API now returns a named-value descriptor for cleaner integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->