### PR TITLE
hotfix(ai-scribe): Hide AI scribe option in user setting on mobile

### DIFF
--- a/lib/features/composer/presentation/composer_view.dart
+++ b/lib/features/composer/presentation/composer_view.dart
@@ -248,9 +248,7 @@ class ComposerView extends GetWidget<ComposerController> {
                                       onCreatedEditorAction: controller.onCreatedMobileEditorAction,
                                       onLoadCompletedEditorAction: controller.onLoadCompletedMobileEditorAction,
                                       onEditorContentHeightChanged: controller.onEditorContentHeightChangedOnIOS,
-                                      onTextSelectionChanged: controller.isAIScribeAvailable
-                                          ? controller.handleTextSelection
-                                          : null,
+                                      onTextSelectionChanged: controller.textSelectionHandler,
                                     ),
                                   )),
                                   Obx(() {
@@ -439,9 +437,7 @@ class ComposerView extends GetWidget<ComposerController> {
                                   onCreatedEditorAction: controller.onCreatedMobileEditorAction,
                                   onLoadCompletedEditorAction: controller.onLoadCompletedMobileEditorAction,
                                   onEditorContentHeightChanged: controller.onEditorContentHeightChangedOnIOS,
-                                  onTextSelectionChanged: controller.isAIScribeAvailable
-                                      ? controller.handleTextSelection
-                                      : null,
+                                  onTextSelectionChanged: controller.textSelectionHandler,
                                 ),
                               )),
                               Obx(() {

--- a/lib/features/composer/presentation/composer_view.dart
+++ b/lib/features/composer/presentation/composer_view.dart
@@ -248,7 +248,9 @@ class ComposerView extends GetWidget<ComposerController> {
                                       onCreatedEditorAction: controller.onCreatedMobileEditorAction,
                                       onLoadCompletedEditorAction: controller.onLoadCompletedMobileEditorAction,
                                       onEditorContentHeightChanged: controller.onEditorContentHeightChangedOnIOS,
-                                      onTextSelectionChanged: controller.handleTextSelection,
+                                      onTextSelectionChanged: controller.isAIScribeAvailable
+                                          ? controller.handleTextSelection
+                                          : null,
                                     ),
                                   )),
                                   Obx(() {
@@ -437,7 +439,9 @@ class ComposerView extends GetWidget<ComposerController> {
                                   onCreatedEditorAction: controller.onCreatedMobileEditorAction,
                                   onLoadCompletedEditorAction: controller.onLoadCompletedMobileEditorAction,
                                   onEditorContentHeightChanged: controller.onEditorContentHeightChangedOnIOS,
-                                  onTextSelectionChanged: controller.handleTextSelection,
+                                  onTextSelectionChanged: controller.isAIScribeAvailable
+                                      ? controller.handleTextSelection
+                                      : null,
                                 ),
                               )),
                               Obx(() {

--- a/lib/features/composer/presentation/composer_view_web.dart
+++ b/lib/features/composer/presentation/composer_view_web.dart
@@ -268,9 +268,7 @@ class ComposerView extends GetWidget<ComposerController> {
                                         ),
                                       onInitialContentLoadComplete: controller.onInitialContentLoadCompleteWeb,
                                       onKeyDownEditorAction: controller.onKeyDownEditorAction,
-                                      onTextSelectionChanged: controller.isAIScribeAvailable
-                                          ? controller.handleTextSelection
-                                          : null,
+                                      onTextSelectionChanged: controller.textSelectionHandler,
                                     ));
                                   }
                                 ),
@@ -514,9 +512,7 @@ class ComposerView extends GetWidget<ComposerController> {
                                                 ),
                                               onInitialContentLoadComplete: controller.onInitialContentLoadCompleteWeb,
                                               onKeyDownEditorAction: controller.onKeyDownEditorAction,
-                                              onTextSelectionChanged: controller.isAIScribeAvailable
-                                                  ? controller.handleTextSelection
-                                                  : null,
+                                              onTextSelectionChanged: controller.textSelectionHandler,
                                             );
                                           });
                                         }
@@ -794,9 +790,7 @@ class ComposerView extends GetWidget<ComposerController> {
                                               ),
                                             onInitialContentLoadComplete: controller.onInitialContentLoadCompleteWeb,
                                             onKeyDownEditorAction: controller.onKeyDownEditorAction,
-                                            onTextSelectionChanged: controller.isAIScribeAvailable
-                                                ? controller.handleTextSelection
-                                                : null,
+                                            onTextSelectionChanged: controller.textSelectionHandler,
                                           ));
                                         }
                                       ),

--- a/lib/features/composer/presentation/composer_view_web.dart
+++ b/lib/features/composer/presentation/composer_view_web.dart
@@ -268,7 +268,9 @@ class ComposerView extends GetWidget<ComposerController> {
                                         ),
                                       onInitialContentLoadComplete: controller.onInitialContentLoadCompleteWeb,
                                       onKeyDownEditorAction: controller.onKeyDownEditorAction,
-                                      onTextSelectionChanged: controller.handleTextSelection,
+                                      onTextSelectionChanged: controller.isAIScribeAvailable
+                                          ? controller.handleTextSelection
+                                          : null,
                                     ));
                                   }
                                 ),
@@ -512,7 +514,9 @@ class ComposerView extends GetWidget<ComposerController> {
                                                 ),
                                               onInitialContentLoadComplete: controller.onInitialContentLoadCompleteWeb,
                                               onKeyDownEditorAction: controller.onKeyDownEditorAction,
-                                              onTextSelectionChanged: controller.handleTextSelection,
+                                              onTextSelectionChanged: controller.isAIScribeAvailable
+                                                  ? controller.handleTextSelection
+                                                  : null,
                                             );
                                           });
                                         }
@@ -790,7 +794,9 @@ class ComposerView extends GetWidget<ComposerController> {
                                               ),
                                             onInitialContentLoadComplete: controller.onInitialContentLoadCompleteWeb,
                                             onKeyDownEditorAction: controller.onKeyDownEditorAction,
-                                            onTextSelectionChanged: controller.handleTextSelection,
+                                            onTextSelectionChanged: controller.isAIScribeAvailable
+                                                ? controller.handleTextSelection
+                                                : null,
                                           ));
                                         }
                                       ),

--- a/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
+++ b/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
@@ -144,4 +144,8 @@ extension HandleAiScribeInComposerExtension on ComposerController {
       editorTextSelection.value = null;
     }
   }
+
+  void Function(TextSelectionData? textSelectionData)?
+      get textSelectionHandler =>
+          isAIScribeAvailable ? handleTextSelection : null;
 }

--- a/lib/features/manage_account/presentation/preferences/preferences_view.dart
+++ b/lib/features/manage_account/presentation/preferences/preferences_view.dart
@@ -1,3 +1,4 @@
+import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/mixin/app_loader_mixin.dart';
@@ -74,7 +75,7 @@ class PreferencesView extends GetWidget<PreferencesController> with AppLoaderMix
                           (optionType) => optionType.isLocal,
                         ).where((optionType) {
                           if (optionType == PreferencesOptionType.aiScribe) {
-                            return controller.isAIScribeAvailable;
+                            return controller.isAIScribeAvailable && !PlatformInfo.isMobile;
                           }
                           return true;
                         }),


### PR DESCRIPTION
## Issue

- The AI ​​Scribe option in user settings should be hidden on mobile.
- Only implement OnTextSelectionChanged when isAIScribeAvailable is true.

## Resolved


[Screen_recording_20251223_133343.webm](https://github.com/user-attachments/assets/9be756d6-0ae0-4658-b2af-ba583586afa4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Text selection handling in the editor is now consistently routed through a conditional handler based on AIScribe availability, fixing inconsistencies across mobile, tablet and web views.
* **Behavior Change**
  * AIScribe is now hidden on mobile devices, ensuring the feature appears only where supported.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->