### PR TITLE
TF-4223 Fix welcome email is not well displayed

### DIFF
--- a/contact/pubspec.lock
+++ b/contact/pubspec.lock
@@ -1020,10 +1020,10 @@ packages:
     description:
       path: sanitize_html
       ref: support_mail
-      resolved-ref: fda32cde4d4baadaa988477f498ab6622ee79987
+      resolved-ref: "6627e13f2236bdea5d25f648e6d55b214a4569df"
       url: "https://github.com/linagora/dart-neats.git"
     source: git
-    version: "2.1.0"
+    version: "3.0.0"
   shelf:
     dependency: transitive
     description:

--- a/contact/pubspec.lock
+++ b/contact/pubspec.lock
@@ -1020,10 +1020,10 @@ packages:
     description:
       path: sanitize_html
       ref: support_mail
-      resolved-ref: "6627e13f2236bdea5d25f648e6d55b214a4569df"
+      resolved-ref: "21f9da9bc177f5f29bc871d70f0b5f5fa2085d89"
       url: "https://github.com/linagora/dart-neats.git"
     source: git
-    version: "3.0.0"
+    version: "3.0.1"
   shelf:
     dependency: transitive
     description:

--- a/core/lib/presentation/utils/html_transformer/dom/sanitize_hyper_link_tag_in_html_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/sanitize_hyper_link_tag_in_html_transformers.dart
@@ -16,7 +16,7 @@ class SanitizeHyperLinkTagInHtmlTransformer extends DomTransformer {
     Map<String, String>? mapUrlDownloadCID,
   }) async {
     try {
-      final elements = document.querySelectorAll('a');
+      final elements = document.querySelectorAll('a[href]');
 
       if (elements.isEmpty) return;
 

--- a/core/lib/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart
@@ -3,40 +3,13 @@ import 'package:core/presentation/utils/html_transformer/base/text_transformer.d
 import 'package:core/presentation/utils/html_transformer/sanitize_html.dart';
 
 class StandardizeHtmlSanitizingTransformers extends TextTransformer {
-
-  static const List<String> mailAllowedHtmlAttributes = [
-    'style',
-    'public-asset-id',
-    'data-filename',
-    'bgcolor',
-    'id',
-    'class',
-    'data-mimetype',
-  ];
-
-  static const List<String> mailAllowedHtmlTags = [
-    'font',
-    'u',
-    'center',
-    'style',
-    'body',
-    'section',
-    'google-sheets-html-origin',
-    'colgroup',
-    'col',
-    'nav',
-    'main',
-    'footer',
-    'supress_time_adjustment',
-  ];
+  static final SanitizeHtml _sanitizer = SanitizeHtml();
 
   const StandardizeHtmlSanitizingTransformers();
 
   @override
-  String process(String text, HtmlEscape htmlEscape) =>
-    SanitizeHtml().process(
-      inputHtml: text,
-      allowAttributes: mailAllowedHtmlAttributes,
-      allowTags: mailAllowedHtmlTags,
-    );
+  String process(String text, HtmlEscape htmlEscape) {
+    if (text.isEmpty) return '';
+    return _sanitizer.process(inputHtml: text);
+  }
 }

--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -325,6 +325,10 @@ class HtmlUtils {
           }
         }
         
+        table, td, th {
+          word-break: normal !important;
+        }
+        
         ${styleCSS ?? ''}
       </style>
       </head>

--- a/core/pubspec.lock
+++ b/core/pubspec.lock
@@ -973,10 +973,10 @@ packages:
     description:
       path: sanitize_html
       ref: support_mail
-      resolved-ref: fda32cde4d4baadaa988477f498ab6622ee79987
+      resolved-ref: "6627e13f2236bdea5d25f648e6d55b214a4569df"
       url: "https://github.com/linagora/dart-neats.git"
     source: git
-    version: "2.1.0"
+    version: "3.0.0"
   shelf:
     dependency: transitive
     description:

--- a/core/pubspec.lock
+++ b/core/pubspec.lock
@@ -973,10 +973,10 @@ packages:
     description:
       path: sanitize_html
       ref: support_mail
-      resolved-ref: "6627e13f2236bdea5d25f648e6d55b214a4569df"
+      resolved-ref: "21f9da9bc177f5f29bc871d70f0b5f5fa2085d89"
       url: "https://github.com/linagora/dart-neats.git"
     source: git
-    version: "3.0.0"
+    version: "3.0.1"
   shelf:
     dependency: transitive
     description:

--- a/core/test/utils/standardize_html_sanitizing_transformers_test.dart
+++ b/core/test/utils/standardize_html_sanitizing_transformers_test.dart
@@ -1,12 +1,13 @@
-import 'package:core/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:core/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart';
 
 void main() {
   group('StandardizeHtmlSanitizingTransformers.process', () {
     const transformer = StandardizeHtmlSanitizingTransformers();
     const htmlEscape = HtmlEscape();
-    const listHTMLTags = [
+
+    const allowedTags = <String>[
       'div',
       'span',
       'p',
@@ -16,12 +17,10 @@ void main() {
       'font',
       'u',
       'center',
-      'style',
       'section',
-      'google-sheets-html-origin',
-      'supress_time_adjustment',
     ];
-    const listOnEventAttributes = [
+
+    const eventAttributes = <String>[
       'mousedown',
       'mouseenter',
       'mouseleave',
@@ -80,124 +79,368 @@ void main() {
       'touchcancel',
     ];
 
-    test('SHOULD remove all `on*` attributes tag', () {
-      for (var i = 0; i < listOnEventAttributes.length; i++) {
-        final inputHtml = '<img src="1" href="1" on${listOnEventAttributes[i]}="javascript:alert(1)">';
-        final result = transformer.process(inputHtml, htmlEscape);
+    String sanitize(String input) =>
+        transformer.process(input, htmlEscape).trim();
 
-        expect(result, equals('<img src="1">'));
-      }
-    });
-
-    test('SHOULD remove all `on*` attributes for any tags', () {
-      for (var tag in listHTMLTags) {
-        for (var event in listOnEventAttributes) {
-          final inputHtml = '<$tag on$event="javascript:alert(1)"></$tag>';
-          final result = transformer.process(inputHtml, htmlEscape);
-
-          expect(result, equals('<$tag></$tag>'));
+    group('Event attributes, script, iframe – fully sanitized', () {
+      test('SHOULD remove all on* event attributes from IMG WHEN event attributes exist', () {
+        for (final evt in eventAttributes) {
+          final html = '<img src="1" href="1" on$evt="javascript:alert(1)">';
+          expect(sanitize(html), equals('<img src="1">'));
         }
-      }
+      });
+
+      test('SHOULD remove all on* event attributes FROM any allowed tag FOR all events', () {
+        for (final tag in allowedTags) {
+          for (final evt in eventAttributes) {
+            final html = '<$tag on$evt="javascript:alert(1)"></$tag>';
+            expect(sanitize(html), equals('<$tag></$tag>'));
+          }
+        }
+      });
+
+      test('SHOULD remove all on* event attributes FROM <colgroup>', () {
+        for (final evt in eventAttributes) {
+          final html = '<table><colgroup on$evt="javascript:alert(1)"></colgroup></table>';
+          expect(sanitize(html), equals('<table><colgroup></colgroup></table>'));
+        }
+      });
+
+      test('SHOULD remove all on* event attributes FROM <col>', () {
+        for (final evt in eventAttributes) {
+          final html =
+              '<table><colgroup><col on$evt="javascript:alert(1)"></colgroup></table>';
+          expect(sanitize(html),
+              equals('<table><colgroup><col></colgroup></table>'));
+        }
+      });
+
+      test('SHOULD remove <script> elements entirely', () {
+        expect(sanitize('<script>alert("x")</script>'), equals(''));
+      });
+
+      test('SHOULD remove <iframe> elements entirely', () {
+        expect(sanitize('<iframe onmouseover="prompt(1)"></iframe>'), equals(''));
+      });
+
+      test('SHOULD remove nested <script> elements', () {
+        const html = '<div><p>Hello<script>alert(1)</script></p></div>';
+        expect(sanitize(html), equals('<div><p>Hello</p></div>'));
+      });
     });
 
-    test('SHOULD remove all `on*` attributes for `colgroup` tag', () {
-      for (var event in listOnEventAttributes) {
-        final inputHtml = '<table><colgroup on$event="javascript:alert(1)"></colgroup></table>';
-        final result = transformer.process(inputHtml, htmlEscape);
+    group('Href/src sanitization – unsafe removed, safe preserved', () {
+      test('SHOULD remove javascript: href FROM <a>', () {
+        const html = '<a href="javascript:alert(1)" id="id1">test</a>';
+        expect(sanitize(html), equals('<a id="id1">test</a>'));
+      });
 
-        expect(result, equals('<table><colgroup></colgroup></table>'));
-      }
+      test('SHOULD remove invalid JS event attributes FROM <img>', () {
+        const html = '<img src="1" href="1" onerror="javascript:alert(1)">';
+        expect(sanitize(html), equals('<img src="1">'));
+      });
+
+      test('SHOULD keep base64 image sources intact', () {
+        const html = '<img src="data:image/jpeg;base64,AAAABBBBCCCC==">';
+        expect(
+            sanitize(html),
+            equals('<img src="data:image/jpeg;base64,AAAABBBBCCCC==">'));
+      });
+
+      test('SHOULD keep cid: image sources intact', () {
+        expect(
+            sanitize('<img src="cid:email123">'),
+            equals('<img src="cid:email123">'));
+      });
     });
 
-    test('SHOULD remove all `on*` attributes for `col` tag', () {
-      for (var event in listOnEventAttributes) {
-        final inputHtml = '<table><colgroup><col on$event="javascript:alert(1)"></colgroup></table>';
-        final result = transformer.process(inputHtml, htmlEscape);
+    group('Unknown tags, structural tags – unwrap or preserve safely', () {
+      test('SHOULD preserve nav/main/footer but strip dangerous attributes', () {
+        expect(sanitize('<nav href="javascript:1"></nav>'), equals('<nav></nav>'));
+        expect(sanitize('<main href="javascript:1"></main>'), equals('<main></main>'));
+        expect(sanitize('<footer href="javascript:1"></footer>'), equals('<footer></footer>'));
+      });
 
-        expect(result, equals('<table><colgroup><col></colgroup></table>'));
-      }
+      test('SHOULD unwrap <supress_time_adjustment> AND keep children', () {
+        const html =
+            '<supress_time_adjustment href="javascript:1"><div><p>Hello</p></div></supress_time_adjustment>';
+        expect(sanitize(html), equals('<div><p>Hello</p></div>'));
+      });
+
+      test('SHOULD unwrap <google-sheets-html-origin> AND keep children', () {
+        const html =
+            '<google-sheets-html-origin href="javascript:1"><div><p>Hello</p></div></google-sheets-html-origin>';
+        expect(sanitize(html), equals('<div><p>Hello</p></div>'));
+      });
+
+      test('SHOULD unwrap unknown tags AND keep children', () {
+        expect(sanitize('<custom><p>Hello</p></custom>'), equals('<p>Hello</p>'));
+      });
+
+      test('SHOULD unwrap nested unknown tags AND keep children', () {
+        expect(
+            sanitize('<x1><x2><p>Hello</p></x2></x1>'),
+            equals('<p>Hello</p>'));
+      });
     });
 
-    test('SHOULD remove attributes of IMG tag WHEN they are invalid', () {
-      const inputHtml = '<img src="1" href="1" onerror="javascript:alert(1)">';
-      final result = transformer.process(inputHtml, htmlEscape);
+    group('CSS sanitization – unsafe styles removed', () {
+      test('SHOULD keep plain text containing JS-like keywords', () {
+        const html = 'hello <p>document.cookie</p> world';
 
-      expect(result, equals('<img src="1">'));
+        expect(
+          sanitize(html),
+          equals('hello <p>document.cookie</p> world'),
+        );
+      });
+
+      test('SHOULD remove HTML comments entirely', () {
+        const html = '<div><!--test--><p>A</p><!--x--></div>';
+        expect(sanitize(html), equals('<div><p>A</p></div>'));
+      });
+
+      test('SHOULD remove unsafe CSS FROM <style>', () {
+        const html =
+            '<style>p{position:absolute;color:red;background:url(javascript:evil);}</style>';
+        expect(sanitize(html), equals(''));
+      });
+
+      test('SHOULD sanitize inline CSS by removing dangerous properties', () {
+        const html =
+            '<p style="color:red;position:absolute;background:url(javascript:evil)">X</p>';
+        expect(sanitize(html), equals('<p style="color: red">X</p>'));
+      });
     });
 
-    test('SHOULD remove all SCRIPTS tags', () {
-      const inputHtml = '<script>alert("This is an alert message!");</script>';
-      final result = transformer.process(inputHtml, htmlEscape).trim();
+    group('ID and class validation – valid preserved, invalid removed', () {
+      test('SHOULD preserve valid id/class values', () {
+        const html = '<div id="abc123" class="valid_class"></div>';
+        expect(
+            sanitize(html),
+            equals('<div id="abc123" class="valid_class"></div>'));
+      });
 
-      expect(result, equals(''));
+      test('SHOULD remove invalid id/class values', () {
+        const html = '<div id="!!!" class="@@@"></div>';
+        expect(sanitize(html), equals('<div></div>'));
+      });
     });
 
-    test('SHOULD remove all IFRAME tags', () {
-      const inputHtml = '<iframe style="xg-p:absolute;top:0;left:0;width:100%;height:100%" onmouseover="prompt(1)">';
-      final result = transformer.process(inputHtml, htmlEscape);
+    group('Complex nested HTML – sanitized safely', () {
+      test('SHOULD remove all dangerous content AND preserve safe nodes', () {
+        const html = '''
+          <div onclick="x">
+            <p>Hello<script>alert(1)</script></p>
+            <img src="cid:x1" onerror="hack()">
+            <a href="javascript:evil()" id="ok">link</a>
+          </div>
+        ''';
 
-      expect(result, equals(''));
+        final out = sanitize(html);
+
+        expect(out.contains('javascript'), false);
+        expect(out.contains('hack'), false);
+        expect(out.contains('script'), false);
+        expect(out.contains('evil'), false);
+        expect(out.contains('onclick'), false);
+        expect(out.contains('<img'), true);
+        expect(out.contains('<div'), true);
+        expect(out.contains('<a'), true);
+        expect(out.contains('Hello'), true);
+      });
     });
 
-    test('SHOULD remove href attribute of A tag WHEN it is invalid', () {
-      const inputHtml = '<a href="javascript:alert(1)" id="id1">test</a>';
-      final result = transformer.process(inputHtml, htmlEscape);
+    group('FORM attributes – dangerous removed', () {
+      final dangerousFormAttributes = [
+        'action="https://malicious.com/x"',
+        'action="javascript:1"',
+        'method="POST"',
+        'target="_blank"',
+        'enctype="multipart/form-data"',
+        'formaction="https://evil.com"',
+        'formmethod="POST"',
+        'formtarget="_blank"',
+        'formenctype="text/plain"',
+        'autocomplete="off"',
+        'novalidate',
+        'accept-charset="UTF-8"',
+        'name="myForm"',
+      ];
 
-      expect(result, equals('<a id="id1">test</a>'));
+      test('SHOULD remove every dangerous FORM attribute', () {
+        for (final attr in dangerousFormAttributes) {
+          final html = '<form $attr></form>';
+          expect(sanitize(html), equals(''));
+        }
+      });
     });
 
-    test('SHOULD persist value src attribute of IMG tag WHEN it is base64 string', () {
-      const inputHtml = '<img src="data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA">';
-      final result = transformer.process(inputHtml, htmlEscape);
+    group('FORM child elements – all removed', () {
+      final forbiddenChildren = [
+        '<input type="text">',
+        '<input type="password">',
+        '<input type="hidden">',
+        '<input type="file">',
+        '<button>Submit</button>',
+        '<textarea></textarea>',
+        '<select><option>A</option></select>',
+        '<option>A</option>',
+      ];
 
-      expect(result, equals('<img src="data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA">'));
+      test('SHOULD remove dangerous FORM child elements', () {
+        for (final child in forbiddenChildren) {
+          expect(sanitize('<form>$child</form>'), equals(''));
+        }
+      });
     });
 
-    test('SHOULD persist value src attribute of IMG tag WHEN it is CID string', () {
-      const inputHtml = '<img src="cid:email123">';
-      final result = transformer.process(inputHtml, htmlEscape);
+    group('FORM combined vectors – fully sanitized', () {
+      test('SHOULD remove dangerous FORM attributes AND dangerous children', () {
+        const html =
+            '<form action="https://evil.com" method="POST"><input type="text"></form>';
+        expect(sanitize(html), equals(''));
+      });
 
-      expect(result, equals('<img src="cid:email123">'));
+      test('SHOULD remove multiple dangerous items inside complex FORM', () {
+        const html = '''
+          <form action="javascript:1" method="POST">
+            <input type="text">
+            <input type="password">
+            <button>Submit</button>
+          </form>
+        ''';
+
+        final out = sanitize(html);
+        expect(out.contains('input'), isFalse);
+        expect(out.contains('button'), isFalse);
+        expect(out.contains('action'), isFalse);
+        expect(out.contains('method'), isFalse);
+      });
+
+      test('SHOULD remove nested FORM elements', () {
+        const html = '<form action="outer"><form action="inner"></form></form>';
+        final out = sanitize(html);
+        expect(out.contains('action'), isFalse);
+      });
+
+      test('SHOULD keep safe nested elements even when FORM wrapper is removed', () {
+        const html =
+            '<form action="test"><div><div><p>Content</p></div></div></form>';
+        final out = sanitize(html);
+        expect(out.contains('action'), isFalse);
+        expect(out.contains('<p>'), isTrue);
+      });
     });
 
-    test(
-      'SHOULD persist nav tag and remove href attribute of A tag '
-      'WHEN href is invalid',
-    () {
-      const inputHtml = '<nav href="javascript:alert(1)"></nav>';
-      final result = transformer.process(inputHtml, htmlEscape);
+    group('FORM safe attributes – safely unwrapped', () {
+      test('SHOULD unwrap FORM with safe style', () {
+        expect(sanitize('<form style="color: red;"></form>'), contains(''));
+      });
 
-      expect(result, equals('<nav></nav>'));
+      test('SHOULD unwrap FORM with safe class', () {
+        expect(sanitize('<form class="email-form"></form>'), contains(''));
+      });
+
+      test('SHOULD unwrap FORM with safe id', () {
+        expect(sanitize('<form id="my-form"></form>'), contains(''));
+      });
+
+      test('SHOULD unwrap FORM with safe bgcolor', () {
+        expect(sanitize('<form bgcolor="#fff"></form>'), contains(''));
+      });
+
+      test('SHOULD remove dangerous attributes even when safe attributes exist', () {
+        const html =
+            '<form style="color:red;" action="https://evil" class="a" method="POST"></form>';
+        final out = sanitize(html);
+        expect(out.contains('style'), isFalse);
+        expect(out.contains('class'), isFalse);
+        expect(out.contains('action'), isFalse);
+        expect(out.contains('method'), isFalse);
+      });
+
+      test('SHOULD preserve nested safe elements when FORM wrapper is removed', () {
+        const html =
+            '<form><div><p>Safe</p><table><tr><td>X</td></tr></table></div></form>';
+        final out = sanitize(html);
+        expect(out.contains('<div>'), isTrue);
+        expect(out.contains('Safe'), isTrue);
+        expect(out.contains('<table>'), isTrue);
+      });
     });
 
-    test(
-      'SHOULD persist main tag and remove href attribute of A tag '
-      'WHEN href is invalid',
-    () {
-      const inputHtml = '<main href="javascript:alert(1)"></main>';
-      final result = transformer.process(inputHtml, htmlEscape);
+    group('Real-world phishing/XSS form attacks – fully sanitized', () {
+      test('SHOULD remove credential phishing forms', () {
+        const html = '''
+          <form action="https://attacker.com" method="POST">
+            <input type="text">
+            <input type="password">
+            <button>Login</button>
+          </form>
+        ''';
 
-      expect(result, equals('<main></main>'));
-    });
+        final out = sanitize(html);
+        expect(out.contains('action'), isFalse);
+        expect(out.contains('input'), isFalse);
+        expect(out.contains('button'), isFalse);
+      });
 
-    test(
-      'SHOULD persist footer tag and remove href attribute of A tag '
-      'WHEN href is invalid',
-    () {
-      const inputHtml = '<footer href="javascript:alert(1)"></footer>';
-      final result = transformer.process(inputHtml, htmlEscape);
+      test('SHOULD prevent CSRF token stealing by removing hidden inputs', () {
+        const html =
+            '<form action="https://bank.com"><input type="hidden" name="csrf"></form>';
+        final out = sanitize(html);
+        expect(out.contains('input'), isFalse);
+        expect(out.contains('csrf'), isFalse);
+      });
 
-      expect(result, equals('<footer></footer>'));
-    });
+      test('SHOULD remove javascript-based form actions', () {
+        expect(sanitize('<form action="javascript:alert(1)"></form>'), equals(''));
+      });
 
-    test(
-      'SHOULD persist supress_time_adjustment tag and remove href attribute of A tag '
-      'WHEN href is invalid',
-    () {
-      const inputHtml = '<supress_time_adjustment href="javascript:alert(1)"></supress_time_adjustment>';
-      final result = transformer.process(inputHtml, htmlEscape);
+      test('SHOULD remove data URI form actions', () {
+        expect(sanitize('<form action="data:text/html,<script>x</script>"></form>'),
+            equals(''));
+      });
 
-      expect(result, equals('<supress_time_adjustment></supress_time_adjustment>'));
+      test('SHOULD prevent file upload exploitation', () {
+        const html =
+            '<form action="/upload" enctype="multipart/form-data"><input type="file"></form>';
+        final out = sanitize(html);
+        expect(out.contains('input'), isFalse);
+        expect(out.contains('enctype'), isFalse);
+      });
+
+      test('SHOULD allow safe cosmetic FORM usage while removing wrapper', () {
+        const html = '''
+          <form style="border:1px solid #ccc">
+            <div><p>This is a survey notification</p></div>
+          </form>
+        ''';
+
+        final out = sanitize(html);
+        expect(out.contains('<form'), isFalse);
+        expect(out.contains('style'), isFalse);
+        expect(out.contains('This is a survey notification'), isTrue);
+        expect(out.contains('<div'), isTrue);
+        expect(out.contains('<p'), isTrue);
+      });
+
+      test('SHOULD remove mixed XSS and phishing vectors inside FORM', () {
+        const html = '''
+          <form action="https://evil.com" onsubmit="alert(1)">
+            <script>steal()</script>
+            <input type="text" onclick="hack()">
+            <iframe src="x"></iframe>
+          </form>
+        ''';
+
+        final out = sanitize(html);
+        expect(out.contains('action'), isFalse);
+        expect(out.contains('onsubmit'), isFalse);
+        expect(out.contains('script'), isFalse);
+        expect(out.contains('input'), isFalse);
+        expect(out.contains('iframe'), isFalse);
+      });
     });
   });
 }

--- a/core/test/utils/standardize_html_sanitizing_transformers_test.dart
+++ b/core/test/utils/standardize_html_sanitizing_transformers_test.dart
@@ -77,6 +77,22 @@ void main() {
       'touchmove',
       'touchend',
       'touchcancel',
+      'wheel',
+      'animationstart',
+      'animationend',
+      'animationiteration',
+      'transitionstart',
+      'transitionend',
+      'transitionrun',
+      'transitioncancel',
+      'pointerdown',
+      'pointerup',
+      'pointermove',
+      'pointerenter',
+      'pointerleave',
+      'pointerover',
+      'pointerout',
+      'pointercancel',
     ];
 
     String sanitize(String input) =>
@@ -161,9 +177,9 @@ void main() {
         expect(sanitize('<footer href="javascript:1"></footer>'), equals('<footer></footer>'));
       });
 
-      test('SHOULD unwrap <supress_time_adjustment> AND keep children', () {
+      test('SHOULD unwrap <suppress_time_adjustment> AND keep children', () {
         const html =
-            '<supress_time_adjustment href="javascript:1"><div><p>Hello</p></div></supress_time_adjustment>';
+            '<suppress_time_adjustment href="javascript:1"><div><p>Hello</p></div></suppress_time_adjustment>';
         expect(sanitize(html), equals('<div><p>Hello</p></div>'));
       });
 
@@ -334,19 +350,19 @@ void main() {
 
     group('FORM safe attributes – safely unwrapped', () {
       test('SHOULD unwrap FORM with safe style', () {
-        expect(sanitize('<form style="color: red;"></form>'), contains(''));
+        expect(sanitize('<form style="color: red;"></form>'), equals(''));
       });
 
       test('SHOULD unwrap FORM with safe class', () {
-        expect(sanitize('<form class="email-form"></form>'), contains(''));
+        expect(sanitize('<form class="email-form"></form>'), equals(''));
       });
 
       test('SHOULD unwrap FORM with safe id', () {
-        expect(sanitize('<form id="my-form"></form>'), contains(''));
+        expect(sanitize('<form id="my-form"></form>'), equals(''));
       });
 
       test('SHOULD unwrap FORM with safe bgcolor', () {
-        expect(sanitize('<form bgcolor="#fff"></form>'), contains(''));
+        expect(sanitize('<form bgcolor="#fff"></form>'), equals(''));
       });
 
       test('SHOULD remove dangerous attributes even when safe attributes exist', () {

--- a/lib/features/email/data/local/html_analyzer.dart
+++ b/lib/features/email/data/local/html_analyzer.dart
@@ -4,6 +4,7 @@ import 'package:core/data/constants/constant.dart';
 import 'package:core/presentation/utils/html_transformer/html_transform.dart';
 import 'package:core/presentation/utils/html_transformer/text/persist_preformatted_text_transformer.dart';
 import 'package:core/presentation/utils/html_transformer/text/sanitize_autolink_html_transformers.dart';
+import 'package:core/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart';
 import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/string_convert.dart';
@@ -48,6 +49,7 @@ class HtmlAnalyzer {
         final message = _htmlTransform.transformToTextPlain(
           content: emailContent.content,
           transformConfiguration: TransformConfiguration.fromTextTransformers([
+            const StandardizeHtmlSanitizingTransformers(),
             const SanitizeAutolinkHtmlTransformers(),
             const PersistPreformattedTextTransformer(),
           ]),

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -1175,11 +1175,16 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
     consumeState(_parseCalendarEventInteractor!.execute(
       accountId,
       blobIds,
-      TransformConfiguration.fromTextTransformers(const [
-        SanitizeAutolinkUnescapeHtmlTransformer(),
-        StandardizeHtmlSanitizingTransformers(),
-        NewLineTransformer(),
-      ])
+      TransformConfiguration.create(
+        customTextTransformers: const [
+          SanitizeAutolinkUnescapeHtmlTransformer(),
+          StandardizeHtmlSanitizingTransformers(),
+          NewLineTransformer(),
+        ],
+        customDomTransformers: [
+          SanitizeHyperLinkTagInHtmlTransformer(),
+        ]
+      )
     ));
   }
 

--- a/model/lib/email/email_content.dart
+++ b/model/lib/email/email_content.dart
@@ -1,4 +1,3 @@
-import 'package:core/utils/string_convert.dart';
 import 'package:equatable/equatable.dart';
 import 'package:model/email/email_content_type.dart';
 
@@ -21,6 +20,6 @@ extension EmailContentExtension on EmailContent {
           .replaceAll('\n', '<br/>')
           .replaceAll('\n\n', '<br/>');
     }
-    return StringConvert.getContentOriginal(content);
+    return content;
   }
 }

--- a/model/pubspec.lock
+++ b/model/pubspec.lock
@@ -997,10 +997,10 @@ packages:
     description:
       path: sanitize_html
       ref: support_mail
-      resolved-ref: fda32cde4d4baadaa988477f498ab6622ee79987
+      resolved-ref: "6627e13f2236bdea5d25f648e6d55b214a4569df"
       url: "https://github.com/linagora/dart-neats.git"
     source: git
-    version: "2.1.0"
+    version: "3.0.0"
   shelf:
     dependency: transitive
     description:

--- a/model/pubspec.lock
+++ b/model/pubspec.lock
@@ -997,10 +997,10 @@ packages:
     description:
       path: sanitize_html
       ref: support_mail
-      resolved-ref: "6627e13f2236bdea5d25f648e6d55b214a4569df"
+      resolved-ref: "21f9da9bc177f5f29bc871d70f0b5f5fa2085d89"
       url: "https://github.com/linagora/dart-neats.git"
     source: git
-    version: "3.0.0"
+    version: "3.0.1"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1997,10 +1997,10 @@ packages:
     description:
       path: sanitize_html
       ref: support_mail
-      resolved-ref: fda32cde4d4baadaa988477f498ab6622ee79987
+      resolved-ref: "6627e13f2236bdea5d25f648e6d55b214a4569df"
       url: "https://github.com/linagora/dart-neats.git"
     source: git
-    version: "2.1.0"
+    version: "3.0.0"
   scribe:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1997,10 +1997,10 @@ packages:
     description:
       path: sanitize_html
       ref: support_mail
-      resolved-ref: "6627e13f2236bdea5d25f648e6d55b214a4569df"
+      resolved-ref: "21f9da9bc177f5f29bc871d70f0b5f5fa2085d89"
       url: "https://github.com/linagora/dart-neats.git"
     source: git
-    version: "3.0.0"
+    version: "3.0.1"
   scribe:
     dependency: "direct main"
     description:

--- a/scribe/pubspec.lock
+++ b/scribe/pubspec.lock
@@ -1003,10 +1003,10 @@ packages:
     description:
       path: sanitize_html
       ref: support_mail
-      resolved-ref: fda32cde4d4baadaa988477f498ab6622ee79987
+      resolved-ref: "21f9da9bc177f5f29bc871d70f0b5f5fa2085d89"
       url: "https://github.com/linagora/dart-neats.git"
     source: git
-    version: "2.1.0"
+    version: "3.0.1"
   shelf:
     dependency: transitive
     description:

--- a/test/features/email/presentation/controller/single_email_controller_test.dart
+++ b/test/features/email/presentation/controller/single_email_controller_test.dart
@@ -316,10 +316,9 @@ void main() {
       // arrange
       const eventDescription = '\nhttps://example1.com\nhttps://example2.com';
       const expectedEventDescription = '<html><head></head><body>'
+        '<a href="https://example1.com" rel="noreferrer" style="white-space: nowrap; word-break: keep-all" target="_blank">example1.com</a>'
         '<br>'
-        '<a href="https://example1.com" target="_blank" rel="noreferrer" style="white-space: nowrap; word-break: keep-all;">example1.com</a>'
-        '<br>'
-        '<a href="https://example2.com" target="_blank" rel="noreferrer" style="white-space: nowrap; word-break: keep-all;">example2.com</a>'
+        '<a href="https://example2.com" rel="noreferrer" style="white-space: nowrap; word-break: keep-all" target="_blank">example2.com</a>'
         '</body></html>';
       final blobId = Id('abc123');
       final calendarEvent = CalendarEvent(
@@ -373,10 +372,9 @@ void main() {
         '\n<script>alert(1)</script>'
         '\n<a href="javascript:alert(1)">href xss</a>';
       const expectedEventDescription = '<html><head></head><body>'
+        '<a href="https://example1.com" rel="noreferrer" style="white-space: nowrap; word-break: keep-all" target="_blank">example1.com</a>'
         '<br>'
-        '<a href="https://example1.com" target="_blank" rel="noreferrer" style="white-space: nowrap; word-break: keep-all;">example1.com</a>'
-        '<br>'
-        '<a href="https://example2.com" target="_blank" rel="noreferrer" style="white-space: nowrap; word-break: keep-all;">example2.com</a>'
+        '<a href="https://example2.com" rel="noreferrer" style="white-space: nowrap; word-break: keep-all" target="_blank">example2.com</a>'
         '<br>'
         '<br>'
         '<a>href xss</a>'


### PR DESCRIPTION
## Issue

#4223 

## Root cause


The sanitizer parsed the HTML document but applied `NodeSanitizer` only to `document.body`, while internal CSS `<style>` tags typically reside in `document.head`. As a result, all `<style>` elements were implicitly dropped.

## Solution

https://github.com/linagora/dart-neats/pull/2 


## Dependency

- Need merged: https://github.com/linagora/dart-neats/pull/2 

## Resolved


https://github.com/user-attachments/assets/ff4e0be8-4f08-494c-a19a-c54ba3876b42



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Links: stricter handling so only anchors with href are processed; anchors without href are ignored.
  * Table display: improved word-break for tables and table cells for cleaner rendering.
  * Link attributes: generated links now include noreferrer for safer external linking.

* **Bug Fixes**
  * Sanitization updated for better performance and consistency (cached sanitizer).
  * Content handling: for certain HTML content the raw HTML is preserved instead of an extracted variant.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->