### PR TITLE
[Scribe mobile] Add and enable Scribe mobile

### DIFF
--- a/assets/images/ic_arrow_back_ios.svg
+++ b/assets/images/ic_arrow_back_ios.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14.8617 3.225L13.3784 1.75L5.13672 10L13.3867 18.25L14.8617 16.775L8.08672 10L14.8617 3.225Z" fill="#424244" fill-opacity="0.72"/>
+</svg>

--- a/core/lib/presentation/resources/image_paths.dart
+++ b/core/lib/presentation/resources/image_paths.dart
@@ -241,6 +241,7 @@ class ImagePaths {
   String get icRefreshQuotas => _getImagePath('ic_refresh_quotas.svg');
   String get icCreateFilter => _getImagePath('ic_create_filter.svg');
   String get icArrowBack => _getImagePath('ic_arrow_back.svg');
+  String get icArrowBackIos => _getImagePath('ic_arrow_back_ios.svg');
   String get icRadio => _getImagePath('ic_radio.svg');
   String get icRadioSelected => _getImagePath('ic_radio_selected.svg');
   String get icCheck => _getImagePath('ic_check.svg');

--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -73,11 +73,14 @@ class HtmlUtils {
     name: 'unregisterDropListener');
 
   static ({String name, String script}) registerSelectionChangeListener(
-    String viewId,
-  ) =>
+    String viewId, {
+    bool isWebPlatform = false,
+  }) =>
       (
         script: '''
       let lastSelectedText = '';
+
+      const isWebPlatform = $isWebPlatform;
 
       const sendSelectionChangeMessage = (data) => {
         // When iframe
@@ -101,10 +104,17 @@ class HtmlUtils {
       function getEditableFromSelection(selection) {
         const node = selection?.focusNode || selection?.anchorNode;
         const el = node?.nodeType === Node.ELEMENT_NODE ? node : node?.parentElement;
-        return (
-          el?.closest('.note-editor .note-editable') ||
-          document.querySelector('.note-editor .note-editable')
-        );
+
+        if (isWebPlatform) {
+          return (
+            el?.closest('.note-editor .note-editable') ||
+            document.querySelector('.note-editor .note-editable')
+          );
+        } else {
+          return (
+            el?.closest('#editor')
+          );
+        }
       }
       
       function clamp(v, min, max) {
@@ -142,9 +152,13 @@ class HtmlUtils {
           }
       
           const lastRect = rects[rects.length - 1];
-      
-          let x = lastRect.right - editableRect.left;
-          let y = lastRect.bottom - editableRect.top;
+
+          // Avoid native selection marks in mobile
+          // Offset has been arbitrary determined to avoid selection marks on Android and iOS
+          const buttonOffset = isWebPlatform ? { x: 0, y: 0 } : { x: 22, y: -20 };
+
+          let x = lastRect.right - editableRect.left + buttonOffset.x;
+          let y = lastRect.bottom - editableRect.top + buttonOffset.y;
       
           const isInside =
             lastRect.bottom >= editableRect.top &&

--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -197,7 +197,7 @@ class HtmlUtils {
     script: '''
       (() => {
         const selection = window.getSelection();
-        if (selection) {
+        if (selection && selection.rangeCount > 0) {
           selection.collapseToEnd()
         }
       })();''',
@@ -220,9 +220,10 @@ class HtmlUtils {
         const selection = window.getSelection();
         if (selection && selection.rangeCount > 0) {
           window._savedRange = selection.getRangeAt(0).cloneRange();
-          return true;
+          return selection.toString();
         }
-        return false;
+        delete window._savedRange;
+        return "";
       })();''',
     name: 'saveSelection');
 
@@ -234,10 +235,10 @@ class HtmlUtils {
           if (selection) {
             selection.removeAllRanges();
             selection.addRange(window._savedRange);
-            return true;
+            return selection.toString();
           }
         }
-        return false;
+        return "";
       })();''',
     name: 'restoreSelection');
 

--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -235,12 +235,24 @@ class HtmlUtils {
           if (selection) {
             selection.removeAllRanges();
             selection.addRange(window._savedRange);
+            delete window._savedRange;
             return selection.toString();
           }
         }
         return "";
       })();''',
     name: 'restoreSelection');
+
+  static const getSavedSelection = (
+    script: '''
+      (() => {
+        if(window._savedRange) {
+          return window._savedRange.toString();
+        } else {
+          return "";
+        }
+      })();''',
+    name: 'getSavedSelection');
 
   static const clearSavedSelection = (
     script: '''

--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -214,6 +214,40 @@ class HtmlUtils {
       })();''',
     name: 'deleteSelectionContent');
 
+  static const saveSelection = (
+    script: '''
+      (() => {
+        const selection = window.getSelection();
+        if (selection && selection.rangeCount > 0) {
+          window._savedRange = selection.getRangeAt(0).cloneRange();
+          return true;
+        }
+        return false;
+      })();''',
+    name: 'saveSelection');
+
+  static const restoreSelection = (
+    script: '''
+      (() => {
+        if (window._savedRange) {
+          const selection = window.getSelection();
+          if (selection) {
+            selection.removeAllRanges();
+            selection.addRange(window._savedRange);
+            return true;
+          }
+        }
+        return false;
+      })();''',
+    name: 'restoreSelection');
+
+  static const clearSavedSelection = (
+    script: '''
+      (() => {
+        delete window._savedRange;
+      })();''',
+    name: 'clearSavedSelection');
+
   static recalculateEditorHeight({double? maxHeight}) => (
     script: '''
       const editable = document.querySelector('.note-editable');

--- a/core/lib/utils/string_convert.dart
+++ b/core/lib/utils/string_convert.dart
@@ -251,16 +251,14 @@ class StringConvert {
     }
   }
 
-  static String convertTextContentToHtmlContent(String textContent) {
-    // Escape HTML entities first to prevent interpretation as HTML
-    final escapedContent = textContent
-        .replaceAll('&', '&amp;')
-        .replaceAll('<', '&lt;')
-        .replaceAll('>', '&gt;')
-        .replaceAll('"', '&quot;')
-        .replaceAll("'", '&#39;');
+  static String escapeTextContent(String textContent) {
+    const HtmlEscape htmlEscape = HtmlEscape();
 
-    final htmlContent = escapedContent.replaceAll('\n', '<br>');
+    return htmlEscape.convert(textContent);
+  }
+
+  static String convertTextContentToHtmlContent(String textContent) {
+    final htmlContent = textContent.replaceAll('\n', '<br>');
 
     return '<div>$htmlContent</div>';
   }

--- a/lib/features/base/mixin/ai_scribe_mixin.dart
+++ b/lib/features/base/mixin/ai_scribe_mixin.dart
@@ -1,5 +1,4 @@
 import 'package:core/utils/app_logger.dart';
-import 'package:core/utils/platform_info.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:scribe/scribe.dart';
@@ -29,8 +28,6 @@ mixin AiScribeMixin {
 
   void injectAIScribeBindings(Session? session, AccountId? accountId) {
     try {
-      if (PlatformInfo.isMobile) return;
-
       final aiCapability = getAICapability(
         session: session,
         accountId: accountId,

--- a/lib/features/composer/presentation/composer_view.dart
+++ b/lib/features/composer/presentation/composer_view.dart
@@ -66,6 +66,9 @@ class ComposerView extends GetWidget<ComposerController> {
                       controller.handleOpenContextMenu(context, position);
                     },
                     isNetworkConnectionAvailable: controller.isNetworkConnectionAvailable,
+                    onOpenAiAssistantModal: controller.isAIScribeAvailable
+                      ? controller.openAIAssistantModal
+                      : null,
                     attachFileAction: () => controller.openPickAttachmentMenu(
                       context,
                       _pickAttachmentsActionTiles(context)
@@ -87,6 +90,9 @@ class ComposerView extends GetWidget<ComposerController> {
                       controller.handleOpenContextMenu(context, position);
                     },
                     isNetworkConnectionAvailable: controller.isNetworkConnectionAvailable,
+                    onOpenAiAssistantModal: controller.isAIScribeAvailable
+                      ? controller.openAIAssistantModal
+                      : null,
                     attachFileAction: () => controller.openPickAttachmentMenu(
                       context,
                       _pickAttachmentsActionTiles(context)

--- a/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
+++ b/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
@@ -18,6 +18,14 @@ class RichTextMobileTabletController extends GetxController {
 
   Future<bool> get isEditorFocused async => await htmlEditorApi?.hasFocus() ?? false;
 
+  Future<void> focus() async {
+    try {
+      await htmlEditorApi?.webViewController.evaluateJavascript(source: "document.getElementById('editor').focus();");
+    } catch (e) {
+      logWarning('RichTextMobileTabletController::focus:Exception: $e');
+    }
+  }
+
   void insertImage(InlineImage inlineImage) async {
     final isFocused = await isEditorFocused;
     log('RichTextMobileTabletController::insertImage: isEditorFocused = $isFocused');

--- a/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
+++ b/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
@@ -20,7 +20,10 @@ class RichTextMobileTabletController extends GetxController {
 
   Future<void> focus() async {
     try {
-      await htmlEditorApi?.webViewController.evaluateJavascript(source: "document.getElementById('editor').focus();");
+      await htmlEditorApi?.webViewController.evaluateJavascript(source: '''
+      (() => {
+        document.getElementById('editor').focus();
+      })();''');
     } catch (e) {
       logWarning('RichTextMobileTabletController::focus:Exception: $e');
     }

--- a/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
+++ b/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
@@ -18,9 +18,7 @@ extension HandleAiScribeInComposerExtension on ComposerController {
     final isAIScribeConfigEnabled =
         mailboxDashBoardController.cachedAIScribeConfig.value.isEnabled;
 
-    return isAIScribeConfigEnabled &&
-        isAIScribeEndpointAvailable &&
-        !PlatformInfo.isMobile;
+    return isAIScribeConfigEnabled && isAIScribeEndpointAvailable;
   }
 
   Future<String> _getTextOnlyContentInEditor() async {

--- a/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
+++ b/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
@@ -61,7 +61,7 @@ extension HandleAiScribeInComposerExtension on ComposerController {
         await richTextMobileTabletController?.htmlEditorApi?.setText(text);
       }
     } catch (e) {
-      logError('$runtimeType::insertTextInEditor:Exception = $e');
+      logWarning('$runtimeType::insertTextInEditor:Exception = $e');
     }
   }
 
@@ -99,7 +99,7 @@ extension HandleAiScribeInComposerExtension on ComposerController {
         return result;
       }
     } catch (e) {
-      logError('$runtimeType::saveSelection:Exception = $e');
+      logWarning('$runtimeType::saveSelection:Exception = $e');
       return "";
     }
   }
@@ -120,7 +120,7 @@ extension HandleAiScribeInComposerExtension on ComposerController {
         return result;
       }
     } catch (e) {
-      logError('$runtimeType::restoreSelection:Exception = $e');
+      logWarning('$runtimeType::restoreSelection:Exception = $e');
       return "";
     }
   }
@@ -141,7 +141,7 @@ extension HandleAiScribeInComposerExtension on ComposerController {
         return result;
       }
     } catch (e) {
-      logError('$runtimeType::getSavedSelection:Exception = $e');
+      logWarning('$runtimeType::getSavedSelection:Exception = $e');
       return "";
     }
   }
@@ -161,7 +161,7 @@ extension HandleAiScribeInComposerExtension on ComposerController {
         );
       }
     } catch (e) {
-      logError('$runtimeType::clearSavedSelection:Exception = $e');
+      logWarning('$runtimeType::clearSavedSelection:Exception = $e');
     }
   }
 
@@ -184,7 +184,7 @@ extension HandleAiScribeInComposerExtension on ComposerController {
     try {
       await richTextMobileTabletController?.focus();
     } catch (e) {
-      logError('$runtimeType::ensureMobileEditorFocused:Exception = $e');
+      logWarning('$runtimeType::ensureMobileEditorFocused:Exception = $e');
     }
   }
 
@@ -212,7 +212,7 @@ extension HandleAiScribeInComposerExtension on ComposerController {
       try {
         await setTextInEditor(text);
       } catch (e) {
-        logError('$runtimeType::onReplaceTextCallback:Exception = $e');
+        logWarning('$runtimeType::onReplaceTextCallback:Exception = $e');
       }
     } else {
       if (PlatformInfo.isMobile) {

--- a/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
+++ b/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
@@ -148,6 +148,14 @@ extension HandleAiScribeInComposerExtension on ComposerController {
     }
   }
 
+  Future<void> ensureMobileEditorFocused() async {
+    try {
+      await richTextMobileTabletController?.focus();
+    } catch (e) {
+      logError('$runtimeType::ensureMobileEditorFocused:Exception = $e');
+    }
+  }
+
   void clearTextInEditor() {
     try {
       if (PlatformInfo.isWeb) {
@@ -207,6 +215,10 @@ extension HandleAiScribeInComposerExtension on ComposerController {
     AiScribeSuggestionActions action,
     String suggestionText,
   ) async {
+    if (PlatformInfo.isMobile) {
+      await ensureMobileEditorFocused();
+    }
+
     switch (action) {
       case AiScribeSuggestionActions.replace:
         await onReplaceTextCallback(suggestionText);

--- a/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
+++ b/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
@@ -36,7 +36,8 @@ extension HandleAiScribeInComposerExtension on ComposerController {
 
   Future<void> insertTextInEditor(String text) async {    
     try {
-      final htmlContent = StringConvert.convertTextContentToHtmlContent(text);
+      final escapedText = StringConvert.escapeTextContent(text);
+      final htmlContent = StringConvert.convertTextContentToHtmlContent(escapedText);
 
       if (PlatformInfo.isWeb) {
         await richTextWebController?.editorController.evaluateJavascriptWeb(
@@ -55,13 +56,15 @@ extension HandleAiScribeInComposerExtension on ComposerController {
 
   Future<void> setTextInEditor(String text) async {
     try {
+      final escapedText = StringConvert.escapeTextContent(text);
+      
       if (PlatformInfo.isWeb) {
-        richTextWebController?.editorController.setText(text);
+        richTextWebController?.editorController.setText(escapedText);
       } else {
-        await richTextMobileTabletController?.htmlEditorApi?.setText(text);
+        await richTextMobileTabletController?.htmlEditorApi?.setText(escapedText);
       }
     } catch (e) {
-      logWarning('$runtimeType::insertTextInEditor:Exception = $e');
+      logWarning('$runtimeType::setTextInEditor:Exception = $e');
     }
   }
 

--- a/lib/features/composer/presentation/widgets/ai_scribe/composer_ai_scribe_selection_overlay.dart
+++ b/lib/features/composer/presentation/widgets/ai_scribe/composer_ai_scribe_selection_overlay.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:scribe/scribe/ai/presentation/widgets/overlay/ai_selection_overlay.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart';
@@ -29,8 +30,12 @@ class ComposerAiScribeSelectionOverlay extends StatelessWidget {
     });
   }
 
-  void _clearComposerInputFocus() {
+  Future<void> _clearComposerInputFocus() async {
     controller.clearFocusRecipients();
     controller.clearFocusSubject();
+
+    if (PlatformInfo.isMobile) {
+      await controller.saveAndUnfocusForModal();
+    }
   }
 }

--- a/lib/features/composer/presentation/widgets/mobile/app_bar_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/app_bar_composer_widget.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
+import 'package:scribe/scribe/ai/presentation/widgets/button/ai_assistant_button.dart';
 import 'package:tmail_ui_user/features/composer/presentation/styles/mobile_app_bar_composer_widget_style.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
@@ -17,6 +18,7 @@ class AppBarComposerWidget extends StatelessWidget {
   final VoidCallback? insertImageAction;
   final VoidCallback openRichToolbarAction;
   final OnOpenContextMenuAction openContextMenuAction;
+  final OnOpenAiAssistantModal? onOpenAiAssistantModal;
 
   const AppBarComposerWidget({
     super.key,
@@ -29,6 +31,7 @@ class AppBarComposerWidget extends StatelessWidget {
     this.isNetworkConnectionAvailable = false,
     this.attachFileAction,
     this.insertImageAction,
+    this.onOpenAiAssistantModal,
   });
 
   @override
@@ -48,6 +51,15 @@ class AppBarComposerWidget extends StatelessWidget {
             onTapActionCallback: onCloseViewAction
           ),
           const Spacer(),
+          if (onOpenAiAssistantModal != null)
+            AiAssistantButton(
+              imagePaths: imagePaths,
+              margin: const EdgeInsetsDirectional.only(
+                start: MobileAppBarComposerWidgetStyle.space,
+                end: MobileAppBarComposerWidgetStyle.space,
+              ),
+              onOpenAiAssistantModal: onOpenAiAssistantModal!,
+            ),
           TMailButtonWidget.fromIcon(
             icon: imagePaths.icRichToolbar,
             iconColor: MobileAppBarComposerWidgetStyle.iconColor,

--- a/lib/features/composer/presentation/widgets/mobile/landscape_app_bar_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/landscape_app_bar_composer_widget.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
+import 'package:scribe/scribe/ai/presentation/widgets/button/ai_assistant_button.dart';
 import 'package:tmail_ui_user/features/composer/presentation/styles/mobile_app_bar_composer_widget_style.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/mobile/app_bar_composer_widget.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
@@ -16,6 +17,7 @@ class LandscapeAppBarComposerWidget extends StatelessWidget {
   final VoidCallback? insertImageAction;
   final VoidCallback openRichToolbarAction;
   final OnOpenContextMenuAction openContextMenuAction;
+  final OnOpenAiAssistantModal? onOpenAiAssistantModal;
 
   const LandscapeAppBarComposerWidget({
     super.key,
@@ -28,6 +30,7 @@ class LandscapeAppBarComposerWidget extends StatelessWidget {
     this.isNetworkConnectionAvailable = false,
     this.attachFileAction,
     this.insertImageAction,
+    this.onOpenAiAssistantModal,
   });
 
   @override
@@ -50,6 +53,15 @@ class LandscapeAppBarComposerWidget extends StatelessWidget {
               onTapActionCallback: onCloseViewAction
             ),
             const Spacer(),
+            if (onOpenAiAssistantModal != null)
+              AiAssistantButton(
+                imagePaths: imagePaths,
+                margin: const EdgeInsetsDirectional.only(
+                  start: MobileAppBarComposerWidgetStyle.space,
+                  end: MobileAppBarComposerWidgetStyle.space,
+                ),
+                onOpenAiAssistantModal: onOpenAiAssistantModal!,
+              ),
             TMailButtonWidget.fromIcon(
               icon: imagePaths.icRichToolbar,
               iconColor: MobileAppBarComposerWidgetStyle.iconColor,

--- a/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
@@ -89,12 +89,17 @@ class _MobileEditorState extends State<MobileEditorWidget> with TextSelectionMix
 
   Future<void> _onWebViewCreated(HtmlEditorApi editorApi) async {
     widget.onCreatedEditorAction.call(context, editorApi, widget.content);
+  }
+
+  Future<void> _onWebViewCompleted(HtmlEditorApi editorApi, WebUri? webUri) async {
+    widget.onLoadCompletedEditorAction(editorApi, webUri);
     try {
       await _setupSelectionListener(editorApi);
     } catch (e) {
       logWarning('Error onWebViewCreated: $e');
     }
   }
+
 
   @override
   Widget build(BuildContext context) {
@@ -109,7 +114,7 @@ class _MobileEditorState extends State<MobileEditorWidget> with TextSelectionMix
         useDefaultFontStyle: true,
       ),
       onCreated: _onWebViewCreated,
-      onCompleted: widget.onLoadCompletedEditorAction,
+      onCompleted: _onWebViewCompleted,
       onContentHeightChanged: PlatformInfo.isIOS ? widget.onEditorContentHeightChanged : null,
     );
   }

--- a/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
@@ -66,7 +66,7 @@ class _MobileEditorState extends State<MobileEditorWidget> with TextSelectionMix
     _editorController = editorApi.webViewController;
 
     registerSelectionChange =
-        HtmlUtils.registerSelectionChangeListener(_createdViewId);
+        HtmlUtils.registerSelectionChangeListener(_createdViewId, isWebPlatform: PlatformInfo.isWeb);
 
     _editorController?.addJavaScriptHandler(
       handlerName: registerSelectionChange!.name,

--- a/lib/features/composer/presentation/widgets/mobile/tablet_bottom_bar_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/tablet_bottom_bar_composer_widget.dart
@@ -38,6 +38,15 @@ class TabletBottomBarComposerWidget extends StatelessWidget {
       child: Row(
         children: [
           const Spacer(),
+          if (onOpenAiAssistantModal != null)
+            AiAssistantButton(
+              imagePaths: imagePaths,
+              margin: const EdgeInsetsDirectional.only(
+                start: TabletBottomBarComposerWidgetStyle.space,
+              ),
+              onOpenAiAssistantModal: onOpenAiAssistantModal!,
+            ),
+          const SizedBox(width: TabletBottomBarComposerWidgetStyle.space),
           TMailButtonWidget.fromIcon(
             icon: imagePaths.icDeleteMailbox,
             borderRadius: TabletBottomBarComposerWidgetStyle.iconRadius,
@@ -74,14 +83,6 @@ class TabletBottomBarComposerWidget extends StatelessWidget {
               : AppLocalizations.of(context).turnOnRequestReadReceipt,
             onTapActionCallback: requestReadReceiptAction,
           ),
-          if (onOpenAiAssistantModal != null)
-            AiAssistantButton(
-              imagePaths: imagePaths,
-              margin: const EdgeInsetsDirectional.only(
-                start: TabletBottomBarComposerWidgetStyle.space,
-              ),
-              onOpenAiAssistantModal: onOpenAiAssistantModal!,
-            ),
           const SizedBox(width: TabletBottomBarComposerWidgetStyle.space),
           TMailButtonWidget.fromIcon(
             icon: imagePaths.icSaveToDraft,

--- a/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/html/html_template.dart';
 import 'package:core/utils/html/html_utils.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 import 'package:html_editor_enhanced/html_editor.dart';
 import 'package:tmail_ui_user/features/composer/presentation/mixin/text_selection_mixin.dart';
@@ -104,7 +105,7 @@ class _WebEditorState extends State<WebEditorWidget> with TextSelectionMixin {
     _editorController = widget.editorController;
 
     final registerSelectionChange =
-      HtmlUtils.registerSelectionChangeListener(_createdViewId);
+      HtmlUtils.registerSelectionChangeListener(_createdViewId, isWebPlatform: PlatformInfo.isWeb);
     _selectionChangeScript = WebScript(
       name: registerSelectionChange.name,
       script: registerSelectionChange.script,
@@ -224,7 +225,7 @@ class _WebEditorState extends State<WebEditorWidget> with TextSelectionMixin {
             _editorController.evaluateJavascriptWeb(
               HtmlUtils.registerDropListener.name);
             _editorController.evaluateJavascriptWeb(
-              HtmlUtils.registerSelectionChangeListener(_createdViewId).name);
+              _selectionChangeScript.name);
             _editorListenerRegistered = true;
           }
         },

--- a/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
@@ -4,7 +4,6 @@ import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/html_transformer/html_transform.dart';
 import 'package:core/utils/config/app_config_loader.dart';
 import 'package:core/utils/file_utils.dart';
-import 'package:core/utils/platform_info.dart';
 import 'package:core/utils/preview_eml_file_utils.dart';
 import 'package:core/utils/print_utils.dart';
 import 'package:get/get.dart';
@@ -426,11 +425,9 @@ class MailboxDashBoardBindings extends BaseBindings {
         Get.find<ManageAccountRepository>(),
       ),
     );
-    if (!PlatformInfo.isMobile) {
-      Get.lazyPut(
-        () => GetAIScribeConfigInteractor(Get.find<ManageAccountRepository>()),
-      );
-    }
+    Get.lazyPut(
+      () => GetAIScribeConfigInteractor(Get.find<ManageAccountRepository>()),
+    );
   }
 
   @override

--- a/lib/features/mailbox_dashboard/presentation/extensions/ai_scribe/setup_cached_ai_scribe_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/ai_scribe/setup_cached_ai_scribe_extension.dart
@@ -1,4 +1,3 @@
-import 'package:core/utils/platform_info.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/ai_scribe_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_ai_scribe_config_interactor.dart';
@@ -6,11 +5,6 @@ import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
 extension SetupCachedAiScribeExtension on MailboxDashBoardController {
   void loadAIScribeConfig() {
-    if (PlatformInfo.isMobile) {
-      cachedAIScribeConfig.value = AIScribeConfig(isEnabled: false);
-      return;
-    }
-
     getAIScribeConfigInteractor = getBinding<GetAIScribeConfigInteractor>();
 
     if (getAIScribeConfigInteractor != null) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -499,7 +499,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: "235dc4ec3e07940510173d34ddeaafcdde36fbe2"
+      resolved-ref: "4c997183694961f376a85f56a426eb87a8fd2458"
       url: "https://github.com/linagora/enough_html_editor.git"
     source: git
     version: "0.1.6"

--- a/scribe/lib/scribe.dart
+++ b/scribe/lib/scribe.dart
@@ -46,3 +46,6 @@ export 'scribe/ai/presentation/widgets/modal/suggestion/ai_scribe_suggestion_suc
 export 'scribe/ai/presentation/widgets/modal/suggestion/ai_scribe_suggestion_success_list_actions.dart';
 export 'scribe/ai/presentation/widgets/overlay/ai_selection_overlay.dart';
 export 'scribe/ai/presentation/widgets/search/ai_scribe_bar.dart';
+export 'scribe/ai/presentation/widgets/mobile/ai_scribe_mobile_actions_bottom_sheet.dart';
+export 'scribe/ai/presentation/widgets/mobile/ai_scribe_mobile_actions_item.dart';
+export 'scribe/ai/presentation/widgets/mobile/ai_scribe_mobile_suggestion_bottom_sheet.dart';

--- a/scribe/lib/scribe/ai/presentation/model/ai_scribe_menu_action.dart
+++ b/scribe/lib/scribe/ai/presentation/model/ai_scribe_menu_action.dart
@@ -76,6 +76,8 @@ enum AIScribeMenuAction {
 
   String? getIcon(ImagePaths imagePaths) {
     switch (this) {
+      case AIScribeMenuAction.correctGrammar:
+        return imagePaths.icAiGrammar;
       case AIScribeMenuAction.improveMakeShorter:
         return imagePaths.icAiShorter;
       case AIScribeMenuAction.improveExpandContext:

--- a/scribe/lib/scribe/ai/presentation/styles/ai_scribe_styles.dart
+++ b/scribe/lib/scribe/ai/presentation/styles/ai_scribe_styles.dart
@@ -181,4 +181,7 @@ abstract final class AIScribeSizes {
 
   static const EdgeInsetsGeometry sendIconPadding =
       EdgeInsetsDirectional.all(8);
+
+  static const EdgeInsetsGeometry backIconPadding =
+      EdgeInsetsDirectional.only(end: 8.0, top: 8.0, bottom: 8.0);
 }

--- a/scribe/lib/scribe/ai/presentation/styles/ai_scribe_styles.dart
+++ b/scribe/lib/scribe/ai/presentation/styles/ai_scribe_styles.dart
@@ -12,6 +12,7 @@ abstract final class AIScribeColors {
   // Icons
   static const Color scribeIcon = AppColor.primaryMain;
   static const Color aiAssistantIcon = AppColor.primaryMain;
+  static final Color bottomsheetIcon = AppColor.gray424244.withValues(alpha: 0.72);
 
   // Overlays
   static final Color dialogBarrier = Colors.black.withValues(alpha: 0.12);
@@ -144,6 +145,7 @@ abstract final class AIScribeSizes {
   static const double sendIcon = 16;
   static const double scribeIcon = 12;
   static const double aiAssistantIcon = 24;
+  static const double bottomsheetIcon = 20;
 
   // Padding
   static const EdgeInsetsGeometry menuItemPadding =

--- a/scribe/lib/scribe/ai/presentation/utils/modal/ai_scribe_modal_manager.dart
+++ b/scribe/lib/scribe/ai/presentation/utils/modal/ai_scribe_modal_manager.dart
@@ -22,6 +22,7 @@ class AiScribeModalManager {
     if (PlatformInfo.isMobile) {
       aiAction = await showMobileAIScribeMenuModal(
         imagePaths: imagePaths,
+        content: content,
         availableCategories: availableCategories,
       );
     } else {
@@ -93,6 +94,7 @@ class AiScribeModalManager {
   static Future<AIAction?> showMobileAIScribeMenuModal({
     required ImagePaths imagePaths,
     required List<AIScribeMenuCategory> availableCategories,
+    String? content,
   }) async {
     final context = Get.context;
 
@@ -105,6 +107,7 @@ class AiScribeModalManager {
       builder: (context) => AiScribeMobileActionsBottomSheet(
         imagePaths: imagePaths,
         availableCategories: availableCategories,
+        content: content,
       ),
     );
   }

--- a/scribe/lib/scribe/ai/presentation/widgets/button/inline_ai_assist_button.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/button/inline_ai_assist_button.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:scribe/scribe.dart';
 
@@ -7,7 +8,7 @@ class InlineAiAssistButton extends StatelessWidget {
   final ImagePaths imagePaths;
   final String? selectedText;
   final OnSelectAiScribeSuggestionAction onSelectAiScribeSuggestionAction;
-  final VoidCallback? onTapFallback;
+  final AsyncCallback? onTapFallback;
 
   const InlineAiAssistButton({
     super.key,
@@ -42,7 +43,7 @@ class InlineAiAssistButton extends StatelessWidget {
       size = renderBox.size;
     }
 
-    onTapFallback?.call();
+    await onTapFallback?.call();
 
     await AiScribeModalManager.showAIScribeMenuModal(
       imagePaths: imagePaths,

--- a/scribe/lib/scribe/ai/presentation/widgets/mobile/ai_scribe_mobile_actions_bottom_sheet.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/mobile/ai_scribe_mobile_actions_bottom_sheet.dart
@@ -7,11 +7,13 @@ import 'package:scribe/scribe.dart';
 class AiScribeMobileActionsBottomSheet extends StatefulWidget {
   final ImagePaths imagePaths;
   final List<AIScribeMenuCategory> availableCategories;
+  final String? content;
 
   const AiScribeMobileActionsBottomSheet({
     super.key,
     required this.imagePaths,
     required this.availableCategories,
+    this.content,
   });
 
   @override
@@ -164,6 +166,8 @@ class _AiScribeMobileActionsBottomSheetState
               widget.imagePaths,
             ))
         .toList();
+    
+    final hasContent = widget.content?.isNotEmpty ?? false;
 
     return Container(
       height: double.infinity,
@@ -181,16 +185,17 @@ class _AiScribeMobileActionsBottomSheetState
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
                   _buildHeader(context, localizations),
-                  Flexible(
-                    child: ValueListenableBuilder<AiScribeCategoryContextMenuAction?>(
-                      valueListenable: _selectedCategory,
-                      builder: (context, selectedCategory, _) {
-                        return selectedCategory == null
-                            ? _buildMenuListView(menuActions)
-                            : _buildSubmenuListView();
-                      },
+                  if(hasContent)
+                    Flexible(
+                      child: ValueListenableBuilder<AiScribeCategoryContextMenuAction?>(
+                        valueListenable: _selectedCategory,
+                        builder: (context, selectedCategory, _) {
+                          return selectedCategory == null
+                              ? _buildMenuListView(menuActions)
+                              : _buildSubmenuListView();
+                        },
+                      ),
                     ),
-                  ),
                 ],
               ),
             ),

--- a/scribe/lib/scribe/ai/presentation/widgets/mobile/ai_scribe_mobile_actions_bottom_sheet.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/mobile/ai_scribe_mobile_actions_bottom_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:scribe/scribe.dart';
 
@@ -50,17 +51,14 @@ class _AiScribeMobileActionsBottomSheetState
             valueListenable: _selectedCategory,
             builder: (context, selectedCategory, _) {
               return selectedCategory != null
-                ? GestureDetector(
-                    onTap: _goBackToCategories,
-                    child: Padding(
-                      padding: AIScribeSizes.backIconPadding,
-                      child: Icon(
-                        Icons.chevron_left,
-                        size: AIScribeSizes.aiAssistantIcon,
-                        color: AppColor.gray424244.withValues(alpha: 0.72),
-                      ),
-                    ),
-                  )
+                ? TMailButtonWidget.fromIcon(
+                  icon: widget.imagePaths.icArrowBackIos,
+                  backgroundColor: Colors.transparent,
+                  iconSize: AIScribeSizes.bottomsheetIcon,
+                  iconColor: AIScribeColors.bottomsheetIcon,
+                  padding: AIScribeSizes.backIconPadding,
+                  onTapActionCallback: _goBackToCategories
+                )
                 : const SizedBox.shrink();
             },
           ),
@@ -75,14 +73,13 @@ class _AiScribeMobileActionsBottomSheetState
               },
             ),
           ),
-          IconButton(
-            icon: const Icon(
-              Icons.close,
-              size: AIScribeSizes.aiAssistantIcon,
-            ),
-            color: AppColor.gray424244.withValues(alpha: 0.72),
-            onPressed: () => Navigator.of(context).pop(),
-          ),
+          TMailButtonWidget.fromIcon(
+            icon: widget.imagePaths.icCloseDialog,
+            backgroundColor: Colors.transparent,
+            iconSize: AIScribeSizes.bottomsheetIcon,
+            iconColor: AIScribeColors.bottomsheetIcon,
+            onTapActionCallback: () => Navigator.of(context).pop()
+          )
         ],
       ),
     );

--- a/scribe/lib/scribe/ai/presentation/widgets/mobile/ai_scribe_mobile_actions_bottom_sheet.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/mobile/ai_scribe_mobile_actions_bottom_sheet.dart
@@ -1,0 +1,206 @@
+import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:flutter/material.dart';
+import 'package:scribe/scribe.dart';
+
+class AiScribeMobileActionsBottomSheet extends StatefulWidget {
+  final ImagePaths imagePaths;
+  final List<AIScribeMenuCategory> availableCategories;
+
+  const AiScribeMobileActionsBottomSheet({
+    super.key,
+    required this.imagePaths,
+    required this.availableCategories,
+  });
+
+  @override
+  State<AiScribeMobileActionsBottomSheet> createState() =>
+      _AiScribeMobileActionsBottomSheetState();
+}
+
+class _AiScribeMobileActionsBottomSheetState
+    extends State<AiScribeMobileActionsBottomSheet> {
+  final ValueNotifier<AiScribeCategoryContextMenuAction?> _selectedCategory =
+      ValueNotifier(null);
+
+  void _onActionSelected(AiScribeContextMenuAction menuAction) {
+    if (menuAction is AiScribeActionContextMenuAction) {
+      Navigator.of(context).pop(PredefinedAction(menuAction.action));
+    }
+  }
+
+  void _onCustomPromptSubmit(String prompt) {
+    Navigator.of(context).pop(CustomPromptAction(prompt));
+  }
+
+  void _onCategorySelected(AiScribeCategoryContextMenuAction category) {
+    _selectedCategory.value = category;
+  }
+
+  void _goBackToCategories() {
+    _selectedCategory.value = null;
+  }
+
+  Widget _buildHeader(BuildContext context, ScribeLocalizations localizations) {
+    return Container(
+      padding: AIScribeSizes.suggestionHeaderPadding,
+      child: Row(
+        children: [
+          ValueListenableBuilder<AiScribeCategoryContextMenuAction?>(
+            valueListenable: _selectedCategory,
+            builder: (context, selectedCategory, _) {
+              return selectedCategory != null
+                ? GestureDetector(
+                    onTap: _goBackToCategories,
+                    child: Padding(
+                      padding: AIScribeSizes.backIconPadding,
+                      child: Icon(
+                        Icons.chevron_left,
+                        size: AIScribeSizes.aiAssistantIcon,
+                        color: AppColor.gray424244.withValues(alpha: 0.72),
+                      ),
+                    ),
+                  )
+                : const SizedBox.shrink();
+            },
+          ),
+          Expanded(
+            child: ValueListenableBuilder<AiScribeCategoryContextMenuAction?>(
+              valueListenable: _selectedCategory,
+              builder: (context, selectedCategory, _) {
+                return Text(
+                  selectedCategory?.actionName ?? localizations.aiAssistant,
+                  style: AIScribeTextStyles.suggestionTitle,
+                );
+              },
+            ),
+          ),
+          IconButton(
+            icon: const Icon(
+              Icons.close,
+              size: AIScribeSizes.aiAssistantIcon,
+            ),
+            color: AppColor.gray424244.withValues(alpha: 0.72),
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMenuListView(List<AiScribeCategoryContextMenuAction> menuActions) {
+    return ListView.builder(
+      physics: const ClampingScrollPhysics(),
+      shrinkWrap: true,
+      itemCount: menuActions.length,
+      itemBuilder: (context, index) {
+        final menuAction = menuActions[index];
+        return AiScribeMobileActionsItem(
+          menuAction: menuAction,
+          imagePaths: widget.imagePaths,
+          onCategorySelected: _onCategorySelected,
+          onActionSelected: _onActionSelected,
+        );
+      },
+    );
+  }
+
+  Widget _buildSubmenuListView() {
+    return ValueListenableBuilder<AiScribeCategoryContextMenuAction?>(
+      valueListenable: _selectedCategory,
+      builder: (context, selectedCategory, _) {
+        return ListView.builder(
+          physics: const ClampingScrollPhysics(),
+          shrinkWrap: true,
+          itemCount: selectedCategory?.submenuActions?.length ?? 0,
+          itemBuilder: (context, index) {
+            final submenuAction = selectedCategory!.submenuActions![index];
+            return AiScribeSubmenuItem(
+              menuAction: submenuAction,
+              onSelectAction: _onActionSelected,
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildBottomBar(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const Divider(
+          height: 1,
+          thickness: 1,
+          color: AppColor.colorDividerComposer,
+        ),
+        Padding(
+          padding: EdgeInsets.only(
+            bottom: MediaQuery.of(context).viewInsets.bottom + 8.0,
+            left: 16.0,
+            right: 16.0,
+            top: 8.0,
+          ),
+          child: AIScribeBar(
+            onCustomPrompt: _onCustomPromptSubmit,
+            imagePaths: widget.imagePaths,
+            boxShadow: const [],
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  void dispose() {
+    _selectedCategory.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final localizations = ScribeLocalizations.of(context);
+    final menuActions = widget.availableCategories
+        .map((category) => AiScribeCategoryContextMenuAction(
+              category,
+              localizations,
+              widget.imagePaths,
+            ))
+        .toList();
+
+    return Container(
+      height: double.infinity,
+      decoration: const BoxDecoration(
+        color: AIScribeColors.background,
+      ),
+      child: SafeArea(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  _buildHeader(context, localizations),
+                  Flexible(
+                    child: ValueListenableBuilder<AiScribeCategoryContextMenuAction?>(
+                      valueListenable: _selectedCategory,
+                      builder: (context, selectedCategory, _) {
+                        return selectedCategory == null
+                            ? _buildMenuListView(menuActions)
+                            : _buildSubmenuListView();
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            _buildBottomBar(context),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/scribe/lib/scribe/ai/presentation/widgets/mobile/ai_scribe_mobile_actions_item.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/mobile/ai_scribe_mobile_actions_item.dart
@@ -1,0 +1,52 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:flutter/material.dart';
+import 'package:scribe/scribe.dart';
+
+class AiScribeMobileActionsItem extends StatelessWidget {
+  final AiScribeContextMenuAction menuAction;
+  final ImagePaths imagePaths;
+  final ValueChanged<AiScribeCategoryContextMenuAction>? onCategorySelected;
+  final ValueChanged<AiScribeContextMenuAction> onActionSelected;
+
+  const AiScribeMobileActionsItem({
+    super.key,
+    required this.menuAction,
+    required this.imagePaths,
+    this.onCategorySelected,
+    required this.onActionSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // When category
+    if (menuAction.hasSubmenu) {
+      return AiScribeMenuItem(
+        menuAction: menuAction,
+        imagePaths: imagePaths,
+        onSelectAction: (menuAction) {
+          if (menuAction is AiScribeCategoryContextMenuAction) {
+            onCategorySelected?.call(menuAction);
+          } else {
+            onActionSelected.call(menuAction);
+          }
+        }
+      );
+    }
+
+    // When action alongside category
+    final submenuActions = menuAction.submenuActions;
+    if (submenuActions?.length == 1) {
+      return AiScribeSubmenuItem(
+        menuAction: submenuActions!.first,
+        onSelectAction: onActionSelected,
+      );
+    }
+
+    // When action inside category
+    return AiScribeMenuItem(
+      menuAction: menuAction,
+      imagePaths: imagePaths,
+      onSelectAction: onActionSelected,
+    );
+  }
+}

--- a/scribe/lib/scribe/ai/presentation/widgets/mobile/ai_scribe_mobile_suggestion_bottom_sheet.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/mobile/ai_scribe_mobile_suggestion_bottom_sheet.dart
@@ -1,0 +1,96 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:flutter/material.dart';
+import 'package:scribe/scribe.dart';
+
+class AiScribeMobileSuggestionBottomSheet extends StatefulWidget {
+  final AIAction aiAction;
+  final ImagePaths imagePaths;
+  final String? content;
+  final OnSelectAiScribeSuggestionAction onSelectAction;
+
+  const AiScribeMobileSuggestionBottomSheet({
+    super.key,
+    required this.aiAction,
+    required this.imagePaths,
+    required this.onSelectAction,
+    this.content,
+  });
+
+  @override
+  State<AiScribeMobileSuggestionBottomSheet> createState() =>
+      _AiScribeMobileSuggestionBottomSheetState();
+}
+
+class _AiScribeMobileSuggestionBottomSheetState
+    extends State<AiScribeMobileSuggestionBottomSheet>
+    with AiScribeSuggestionStateMixin {
+  @override
+  AIAction get aiAction => widget.aiAction;
+
+  @override
+  String? get content => widget.content;
+
+  @override
+  ImagePaths get imagePaths => widget.imagePaths;
+
+  @override
+  OnSelectAiScribeSuggestionAction get onSelectAction =>
+      widget.onSelectAction;
+
+  @override
+  Widget build(BuildContext context) {
+    final localizations = ScribeLocalizations.of(context);
+
+    return Container(
+      height: double.infinity,
+      decoration: const BoxDecoration(
+        color: AIScribeColors.background,
+      ),
+      child: SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: AIScribeSizes.suggestionHeaderPadding,
+              child: AiScribeSuggestionHeader(
+                title: aiAction.getLabel(localizations),
+                imagePaths: imagePaths,
+              ),
+            ),
+            Flexible(
+              child: buildStateContent(context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget buildLoadingState() {
+    return Padding(
+      padding: AIScribeSizes.suggestionContentPadding,
+      child: super.buildLoadingState(),
+    );
+  }
+
+  @override
+  Widget buildErrorState() {
+    return Padding(
+      padding: AIScribeSizes.suggestionContentPadding,
+      child: super.buildErrorState(),
+    );
+  }
+
+  @override
+  Widget buildSuccessState(
+    String suggestionText,
+    bool hasContent,
+  ) {
+    return Padding(
+      padding: AIScribeSizes.suggestionContentPadding,
+      child: super.buildSuccessState(suggestionText, hasContent),
+    );
+  }
+}

--- a/scribe/lib/scribe/ai/presentation/widgets/overlay/ai_selection_overlay.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/overlay/ai_selection_overlay.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:scribe/scribe.dart';
@@ -15,7 +16,7 @@ class AiSelectionOverlay extends StatelessWidget {
   final TextSelectionModel? selection;
   final ImagePaths imagePaths;
   final OnSelectAiScribeSuggestionAction onSelectAiScribeSuggestionAction;
-  final VoidCallback? onTapFallback;
+  final AsyncCallback? onTapFallback;
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
Before merging the Scribe desktop PR, we left the scribe as is (unfinished) after disabling it.

Here I:
- Enable Scribe in mobile
- Add Scribe mobile UI (a full screen modal)
- Fix various bugs related to mobile

See PR https://github.com/linagora/tmail-flutter/pull/4247 for the keyboard and selection visible in the modal fix.

https://github.com/user-attachments/assets/59610075-3d1b-405b-8477-c158b4210aab


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI Assistant available on mobile with AI button in composer app bars and mobile bottom sheets for actions and suggestions
  * Selection save/restore helpers to improve editor workflows on mobile

* **Bug Fixes**
  * Improved text selection detection, positioning and collapse behavior across platforms

* **Refactor**
  * Platform-aware modal handling and mobile editor focus/flow adjustments

* **Style**
  * New visual tokens for mobile AI components (icons, sizes, padding)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->