### PR TITLE
[Scribe mobile] Hide keyboard and selection icons when Scribe mobile modal opened

### DIFF
--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -214,6 +214,40 @@ class HtmlUtils {
       })();''',
     name: 'deleteSelectionContent');
 
+  static const saveSelection = (
+    script: '''
+      (() => {
+        const selection = window.getSelection();
+        if (selection && selection.rangeCount > 0) {
+          window._savedRange = selection.getRangeAt(0).cloneRange();
+          return true;
+        }
+        return false;
+      })();''',
+    name: 'saveSelection');
+
+  static const restoreSelection = (
+    script: '''
+      (() => {
+        if (window._savedRange) {
+          const selection = window.getSelection();
+          if (selection) {
+            selection.removeAllRanges();
+            selection.addRange(window._savedRange);
+            return true;
+          }
+        }
+        return false;
+      })();''',
+    name: 'restoreSelection');
+
+  static const clearSavedSelection = (
+    script: '''
+      (() => {
+        delete window._savedRange;
+      })();''',
+    name: 'clearSavedSelection');
+
   static recalculateEditorHeight({double? maxHeight}) => (
     script: '''
       const editable = document.querySelector('.note-editable');

--- a/lib/features/composer/presentation/widgets/ai_scribe/composer_ai_scribe_selection_overlay.dart
+++ b/lib/features/composer/presentation/widgets/ai_scribe/composer_ai_scribe_selection_overlay.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:scribe/scribe/ai/presentation/widgets/overlay/ai_selection_overlay.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart';
@@ -29,8 +30,12 @@ class ComposerAiScribeSelectionOverlay extends StatelessWidget {
     });
   }
 
-  void _clearComposerInputFocus() {
+  Future<void> _clearComposerInputFocus() async {
     controller.clearFocusRecipients();
     controller.clearFocusSubject();
+
+    if (PlatformInfo.isMobile) {
+      await controller.saveAndUnfocusForModal();
+    }
   }
 }

--- a/scribe/lib/scribe/ai/presentation/widgets/button/inline_ai_assist_button.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/button/inline_ai_assist_button.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:scribe/scribe.dart';
 
@@ -7,7 +8,7 @@ class InlineAiAssistButton extends StatelessWidget {
   final ImagePaths imagePaths;
   final String? selectedText;
   final OnSelectAiScribeSuggestionAction onSelectAiScribeSuggestionAction;
-  final VoidCallback? onTapFallback;
+  final AsyncCallback? onTapFallback;
 
   const InlineAiAssistButton({
     super.key,
@@ -42,7 +43,7 @@ class InlineAiAssistButton extends StatelessWidget {
       size = renderBox.size;
     }
 
-    onTapFallback?.call();
+    await onTapFallback?.call();
 
     await AiScribeModalManager.showAIScribeMenuModal(
       imagePaths: imagePaths,

--- a/scribe/lib/scribe/ai/presentation/widgets/overlay/ai_selection_overlay.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/overlay/ai_selection_overlay.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:scribe/scribe.dart';
@@ -15,7 +16,7 @@ class AiSelectionOverlay extends StatelessWidget {
   final TextSelectionModel? selection;
   final ImagePaths imagePaths;
   final OnSelectAiScribeSuggestionAction onSelectAiScribeSuggestionAction;
-  final VoidCallback? onTapFallback;
+  final AsyncCallback? onTapFallback;
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
When opening Scribe mobile modal, we now unfocus the composer to hide the keyboard and the selection start and end icons from the OS.

Add new methods to save, restore, and clear text selection in HTML editor. These methods allow preserving and restoring user selection state when opening the Scribe mobile modal so that the "replace" action still works.

**With**

<img width="200"  alt="Screenshot_1768208987" src="https://github.com/user-attachments/assets/2ec4d9ae-8edf-41ef-b070-9b41ba7fd715" />

**Before**

<img width="200" alt="Screenshot_1768208991" src="https://github.com/user-attachments/assets/4ad29eb3-9600-4f25-a56c-0f6aa4e332fb" />

**After**

<img width="200" alt="Screenshot_1768212589" src="https://github.com/user-attachments/assets/da896ca4-cbb1-4071-bcf0-6ded719bf2de" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved AI Scribe assistant modal experience with better state preservation during interactions
  * Enhanced editor responsiveness on mobile devices when using AI features

* **Improvements**
  * More reliable editor state management when opening and closing the AI assistant
  * Better consistency across platforms for text editing operations with AI Scribe

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->