### PR TITLE
[Scribe mobile] Fix Scribe mobile insert and replace not working because of focus

### DIFF
--- a/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
+++ b/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
@@ -18,6 +18,14 @@ class RichTextMobileTabletController extends GetxController {
 
   Future<bool> get isEditorFocused async => await htmlEditorApi?.hasFocus() ?? false;
 
+  Future<void> focus() async {
+    try {
+      await htmlEditorApi?.webViewController.evaluateJavascript(source: "document.getElementById('editor').focus();");
+    } catch (e) {
+      logWarning('RichTextMobileTabletController::focus:Exception: $e');
+    }
+  }
+
   void insertImage(InlineImage inlineImage) async {
     final isFocused = await isEditorFocused;
     log('RichTextMobileTabletController::insertImage: isEditorFocused = $isFocused');

--- a/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
+++ b/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
@@ -148,6 +148,14 @@ extension HandleAiScribeInComposerExtension on ComposerController {
     }
   }
 
+  Future<void> ensureMobileEditorFocused() async {
+    try {
+      await richTextMobileTabletController?.focus();
+    } catch (e) {
+      logError('$runtimeType::ensureMobileEditorFocused:Exception = $e');
+    }
+  }
+
   void clearTextInEditor() {
     try {
       if (PlatformInfo.isWeb) {
@@ -207,6 +215,10 @@ extension HandleAiScribeInComposerExtension on ComposerController {
     AiScribeSuggestionActions action,
     String suggestionText,
   ) async {
+    if (PlatformInfo.isMobile) {
+      await ensureMobileEditorFocused();
+    }
+
     switch (action) {
       case AiScribeSuggestionActions.replace:
         await onReplaceTextCallback(suggestionText);


### PR DESCRIPTION
Asnwering to https://github.com/linagora/tmail-flutter/pull/4245#issuecomment-3747595733 and https://github.com/linagora/tmail-flutter/pull/4245#issuecomment-3747599078

It was also more easily reproductible: open the Scribe from app bar button without any content and without having clicked on the composer before. You will get the same outcome when inserting or replacing (nothing).

I am creating a separated PR because I am not sure about the way to fix it. Should I modify instead the requestFocus from the fork instead ? Why was it iOS only ? https://github.com/linagora/enough_html_editor/blob/235dc4ec3e07940510173d34ddeaafcdde36fbe2/lib/src/editor_api.dart#L457 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the editor is properly focused on mobile before processing AI Scribe suggestions, improving reliability and providing a smoother experience when using AI-powered writing assistance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->