### PR TITLE
[Proposal] Add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Twake Mail
+
+ ## Build
+
+ To update Flutter packages, run `./scripts/prebuild.sh` instead of `flutter pub get`.


### PR DESCRIPTION
I encountered multiple times the case where my AI agent did some work and then wanted to update Flutter packages by running `flutter pub get`. However because we use module we must run the prebuild script instead. It is a good example of what make sense in the [AGENTS.md](https://agents.md/) file that is more and more used.

What do you think
- about adding this file ?
- with this first content ?

It solved the issue in my case.
 
For the record, my current AI agent, but I think it will be the same for every other AI agent:
- tool: Kilo Code extension for VS Code
- model: Mistral Devstral 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AGENTS.md documentation file with build setup guidance, including instructions for updating Flutter packages via the prebuild script.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->