### PR TITLE
Fix email content not displayed on Tablet when enabling thread view

### DIFF
--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -417,10 +417,11 @@ class EmailView extends GetWidget<SingleEmailController> {
                 );
               } else if (PlatformInfo.isIOS) {
                 return Obx(() {
-                  if (controller.isEmailContentHidden.isTrue && !controller.responsiveUtils.isScreenWithShortestSide(context)) {
-                    return const SizedBox.shrink();
-                  } else {
-                    return Column(
+                  return Visibility(
+                    visible: !controller.isEmailContentHidden.isTrue ||
+                        controller.responsiveUtils.isScreenWithShortestSide(context),
+                    maintainState: true,
+                    child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Padding(
@@ -458,8 +459,8 @@ class EmailView extends GetWidget<SingleEmailController> {
                           }
                         }),
                       ],
-                    );
-                  }
+                    ),
+                  );
                 });
               } else {
                 return Padding(

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -970,7 +970,11 @@ class MailboxDashBoardController extends ReloadableController
 
   void openEmailDetailedView(PresentationEmail presentationEmail) {
     setSelectedEmail(presentationEmail);
-    dispatchRoute(DashboardRoutes.threadDetailed);
+    if (isEmailOpened) {
+      dashboardRoute.refresh();
+    } else {
+      dispatchRoute(DashboardRoutes.threadDetailed);
+    }
     if (PlatformInfo.isWeb && presentationEmail.routeWeb != null) {
       RouteUtils.replaceBrowserHistory(
         title: 'Email-${presentationEmail.id?.id.value ?? ''}',
@@ -3392,9 +3396,6 @@ class MailboxDashBoardController extends ReloadableController
   }
 
   jmap.State? get currentEmailState => _currentEmailState;
-
-  bool get isThreadDetailedViewVisible =>
-      dashboardRoute.value == DashboardRoutes.threadDetailed;
 
   void _loadAppGrid() {
     if (PlatformInfo.isWeb && AppConfig.appGridDashboardAvailable) {

--- a/lib/features/thread_detail/presentation/extension/refresh_thread_detail_on_setting_changed.dart
+++ b/lib/features/thread_detail/presentation/extension/refresh_thread_detail_on_setting_changed.dart
@@ -13,6 +13,9 @@ extension RefreshThreadDetailOnSettingChanged on ThreadDetailManager {
         );
       } else {
         mailboxDashBoardController.selectedEmail.refresh();
+        if (PlatformInfo.isMobile) {
+          mailboxDashBoardController.dashboardRoute.refresh();
+        }
       }
     }
   }

--- a/lib/features/thread_detail/presentation/extension/refresh_thread_detail_on_setting_changed.dart
+++ b/lib/features/thread_detail/presentation/extension/refresh_thread_detail_on_setting_changed.dart
@@ -7,7 +7,7 @@ extension RefreshThreadDetailOnSettingChanged on ThreadDetailManager {
     if (threadDetailWasEnabled != isThreadDetailEnabled) {
       threadDetailWasEnabled = isThreadDetailEnabled;
       if (PlatformInfo.isWeb &&
-          mailboxDashBoardController.isThreadDetailedViewVisible) {
+          mailboxDashBoardController.isEmailOpened) {
         mailboxDashBoardController.dispatchThreadDetailUIAction(
           ResyncThreadDetailWhenSettingChangedAction(),
         );


### PR DESCRIPTION
## Issue

- 1. On Tablet, when switching thread mode from disabled to enabled, the email content is not displayed. The `PageView` has no items to render, so the `EmailView` is also not shown.
- 2. Email view becomes blank when opening multiple emails quickly on tablet

## Reproduce



https://github.com/user-attachments/assets/ed95d8a6-6bc3-487e-83d7-31a561080916





## Root cause

- 1. When switching thread mode from disabled to enabled on Tablet, the value of `availableThreadIds` is not updated. As a result: `availableThreadIds` becomes empty, `PageView` has no items to display, `EmailView` is not rendered.

- 2. The email content widget (`HtmlContentViewer`) was conditionally removed from the widget tree using `if/else` and `SizedBox.shrink()` when certain states changed (e.g. `isEmailContentHidden`). On tablet, when users quickly open multiple emails, this condition toggles frequently, causing the widget to be removed and recreated many times. Each removal triggers dispose() on the `HtmlContentViewer`, which also disposes the underlying `InAppWebView`. Because of this rapid destroy–recreate cycle, the WebView sometimes fails to reload its content correctly, leading to a blank email view.

## Solution

- 1. When the thread setting changes, we need to re-trigger `dashboardRoute `in order to: rebuild related logic, update `availableThreadIds` with the correct values.
- 2. Replacing the conditional removal with `Visibility(maintainState: true)`, so the widget stays in the tree and is only hidden instead of being disposed and recreated.

## Resolved



https://github.com/user-attachments/assets/d3609eee-b7d6-452c-bba3-d5c8bb964e11



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-detail refresh so dashboard updates correctly on mobile when settings change.

* **UX Improvements**
  * Email content visibility now preserves state across screen sizes, preventing loss of content when toggling.
  * Opening an email avoids redundant navigation when the detail view is already open, smoothing navigation and reducing unnecessary refreshes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->