### PR TITLE
[Scribe] Fix Scribe translations by using multiple_localization package

### DIFF
--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -5492,12 +5492,6 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "aiAssistant": "Assistant IA",
-  "@aiAssistant": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
   "createLabel": "Créer un libellé",
   "@createLabel": {
     "type": "text",

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2026-01-20T09:45:15.272706",
+  "@@last_modified": "2026-01-26T09:26:54.654131",
   "initializing_data": "Initializing data...",
   "@initializing_data": {
     "type": "text",

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -5510,12 +5510,6 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "aiAssistant": "Помощник ИИ",
-  "@aiAssistant": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
   "createLabel": "Создать метку",
   "@createLabel": {
     "type": "text",

--- a/lib/l10n/intl_vi.arb
+++ b/lib/l10n/intl_vi.arb
@@ -5498,12 +5498,6 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "aiAssistant": "Trợ lý AI",
-  "@aiAssistant": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
   "createLabel": "Tạo nhãn",
   "@createLabel": {
     "type": "text",

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1534,6 +1534,14 @@ packages:
       relative: true
     source: path
     version: "1.0.0+1"
+  multiple_localization:
+    dependency: transitive
+    description:
+      name: multiple_localization
+      sha256: "29c97a3fbf4d067ea5a63df1995465ea81ef28e2c817d9d0871983e50f4fd3f0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   nm:
     dependency: transitive
     description:

--- a/scribe/lib/scribe/ai/l10n/intl_ar.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_ar.arb
@@ -1,127 +1,127 @@
 {
-  "@@last_modified": "2026-01-26T09:26:56.495094",
-  "categoryCorrectGrammar": "Correct",
+  "@@last_modified": "2026-01-26T08:00:00.000000",
+  "categoryCorrectGrammar": "تصحيح",
   "@categoryCorrectGrammar": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "categoryImprove": "Improve",
+  "categoryImprove": "تحسين",
   "@categoryImprove": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "categoryChangeTone": "Change tone",
+  "categoryChangeTone": "تغيير النبرة",
   "@categoryChangeTone": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "categoryTranslate": "Translate",
+  "categoryTranslate": "ترجمة",
   "@categoryTranslate": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionMakeShorter": "Make it shorter",
+  "actionMakeShorter": "اجعله أقصر",
   "@actionMakeShorter": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionExpandContext": "Expand context",
+  "actionExpandContext": "توسيع السياق",
   "@actionExpandContext": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionEmojify": "Emojify",
+  "actionEmojify": "إضافة الرموز التعبيرية",
   "@actionEmojify": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionTransformToBullets": "Transform to bullets",
+  "actionTransformToBullets": "تحويل إلى نقاط",
   "@actionTransformToBullets": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionMoreProfessional": "More professional",
+  "actionMoreProfessional": "أكثر احترافية",
   "@actionMoreProfessional": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionMoreCasual": "More casual",
+  "actionMoreCasual": "أكثر عفوية",
   "@actionMoreCasual": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionMorePolite": "More polite",
+  "actionMorePolite": "أكثر تهذيباً",
   "@actionMorePolite": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "languageFrench": "French",
+  "languageFrench": "الفرنسية",
   "@languageFrench": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "languageEnglish": "English",
+  "languageEnglish": "الإنجليزية",
   "@languageEnglish": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "languageRussian": "Russian",
+  "languageRussian": "الروسية",
   "@languageRussian": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "languageVietnamese": "Vietnamese",
+  "languageVietnamese": "الفيتنامية",
   "@languageVietnamese": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "customPromptAction": "Help me write",
+  "customPromptAction": "ساعدني في الكتابة",
   "@customPromptAction": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "failedToGenerate": "Failed to generate AI response",
+  "failedToGenerate": "فشل في إنشاء استجابة الذكاء الاصطناعي",
   "@failedToGenerate": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "aiAssistant": "AI assistant",
-  "@aiAssistant": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "generatingResponse": "Generating response",
+  "generatingResponse": "إنشاء الاستجابة",
   "@generatingResponse": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "replace": "Replace",
+  "insert": "إدراج",
+  "@insert": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "replace": "استبدال",
   "@replace": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "insert": "Insert",
-  "@insert": {
+  "aiAssistant": "مساعد الذكاء الاصطناعي",
+  "@aiAssistant": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/scribe/lib/scribe/ai/l10n/intl_de.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_de.arb
@@ -1,127 +1,127 @@
 {
-  "@@last_modified": "2026-01-26T09:26:56.495094",
-  "categoryCorrectGrammar": "Correct",
+  "@@last_modified": "2026-01-26T07:59:00.000000",
+  "categoryCorrectGrammar": "Korrigieren",
   "@categoryCorrectGrammar": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "categoryImprove": "Improve",
+  "categoryImprove": "Verbessern",
   "@categoryImprove": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "categoryChangeTone": "Change tone",
+  "categoryChangeTone": "Ton ändern",
   "@categoryChangeTone": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "categoryTranslate": "Translate",
+  "categoryTranslate": "Übersetzen",
   "@categoryTranslate": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionMakeShorter": "Make it shorter",
+  "actionMakeShorter": "Kürzer machen",
   "@actionMakeShorter": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionExpandContext": "Expand context",
+  "actionExpandContext": "Kontext erweitern",
   "@actionExpandContext": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionEmojify": "Emojify",
+  "actionEmojify": "Emojis hinzufügen",
   "@actionEmojify": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionTransformToBullets": "Transform to bullets",
+  "actionTransformToBullets": "In Aufzählungspunkte umwandeln",
   "@actionTransformToBullets": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionMoreProfessional": "More professional",
+  "actionMoreProfessional": "Professioneller",
   "@actionMoreProfessional": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionMoreCasual": "More casual",
+  "actionMoreCasual": "Lockerer",
   "@actionMoreCasual": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionMorePolite": "More polite",
+  "actionMorePolite": "Höflicher",
   "@actionMorePolite": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "languageFrench": "French",
+  "languageFrench": "Französisch",
   "@languageFrench": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "languageEnglish": "English",
+  "languageEnglish": "Englisch",
   "@languageEnglish": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "languageRussian": "Russian",
+  "languageRussian": "Russisch",
   "@languageRussian": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "languageVietnamese": "Vietnamese",
+  "languageVietnamese": "Vietnamesisch",
   "@languageVietnamese": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "customPromptAction": "Help me write",
+  "customPromptAction": "Hilf mir beim Schreiben",
   "@customPromptAction": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "failedToGenerate": "Failed to generate AI response",
+  "failedToGenerate": "KI-Antwort konnte nicht generiert werden",
   "@failedToGenerate": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "aiAssistant": "AI assistant",
-  "@aiAssistant": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "generatingResponse": "Generating response",
+  "generatingResponse": "Antwort wird generiert",
   "@generatingResponse": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "replace": "Replace",
+  "insert": "Einfügen",
+  "@insert": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "replace": "Ersetzen",
   "@replace": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "insert": "Insert",
-  "@insert": {
+  "aiAssistant": "KI-Assistent",
+  "@aiAssistant": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/scribe/lib/scribe/ai/l10n/intl_en.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_en.arb
@@ -1,6 +1,6 @@
 {
   "@@last_modified": "2025-12-09T06:57:10.911448",
-  "categoryCorrectGrammar": "Correct grammar",
+  "categoryCorrectGrammar": "Correct",
   "@categoryCorrectGrammar": {
     "type": "text",
     "placeholders_order": [],
@@ -90,12 +90,6 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "inputPlaceholder": "Help me write",
-  "@inputPlaceholder": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
   "customPromptAction": "Help me write",
   "@customPromptAction": {
     "type": "text",
@@ -108,14 +102,26 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "insertButton": "Insert",
-  "@insertButton": {
+  "generatingResponse": "Generating response",
+  "@generatingResponse": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "replaceButton": "Replace",
-  "@replaceButton": {
+  "insert": "Insert",
+  "@insert": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "replace": "Replace",
+  "@replace": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "aiAssistant": "AI assistant",
+  "@aiAssistant": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/scribe/lib/scribe/ai/l10n/intl_fr.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_fr.arb
@@ -1,6 +1,6 @@
 {
   "@@last_modified": "2025-12-09T07:30:00.000000",
-  "categoryCorrectGrammar": "Corriger la grammaire",
+  "categoryCorrectGrammar": "Corriger",
   "@categoryCorrectGrammar": {
     "type": "text",
     "placeholders_order": [],
@@ -90,12 +90,6 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "inputPlaceholder": "Aidez-moi à écrire",
-  "@inputPlaceholder": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
   "customPromptAction": "Aidez-moi à écrire",
   "@customPromptAction": {
     "type": "text",
@@ -108,14 +102,26 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "insertButton": "Insérer",
-  "@insertButton": {
+  "generatingResponse": "Génération de la réponse",
+  "@generatingResponse": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "replaceButton": "Remplacer",
-  "@replaceButton": {
+  "insert": "Insérer",
+  "@insert": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "replace": "Remplacer",
+  "@replace": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "aiAssistant": "Assistant IA",
+  "@aiAssistant": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/scribe/lib/scribe/ai/l10n/intl_it.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_it.arb
@@ -1,127 +1,127 @@
 {
-  "@@last_modified": "2026-01-26T09:26:56.495094",
-  "categoryCorrectGrammar": "Correct",
+  "@@last_modified": "2026-01-26T08:00:00.000000",
+  "categoryCorrectGrammar": "Correggi",
   "@categoryCorrectGrammar": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "categoryImprove": "Improve",
+  "categoryImprove": "Migliora",
   "@categoryImprove": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "categoryChangeTone": "Change tone",
+  "categoryChangeTone": "Cambia tono",
   "@categoryChangeTone": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "categoryTranslate": "Translate",
+  "categoryTranslate": "Traduci",
   "@categoryTranslate": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionMakeShorter": "Make it shorter",
+  "actionMakeShorter": "Rendilo più breve",
   "@actionMakeShorter": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionExpandContext": "Expand context",
+  "actionExpandContext": "Espandi contesto",
   "@actionExpandContext": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionEmojify": "Emojify",
+  "actionEmojify": "Aggiungi emoji",
   "@actionEmojify": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionTransformToBullets": "Transform to bullets",
+  "actionTransformToBullets": "Trasforma in elenco puntato",
   "@actionTransformToBullets": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionMoreProfessional": "More professional",
+  "actionMoreProfessional": "Più professionale",
   "@actionMoreProfessional": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionMoreCasual": "More casual",
+  "actionMoreCasual": "Più informale",
   "@actionMoreCasual": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "actionMorePolite": "More polite",
+  "actionMorePolite": "Più cortese",
   "@actionMorePolite": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "languageFrench": "French",
+  "languageFrench": "Francese",
   "@languageFrench": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "languageEnglish": "English",
+  "languageEnglish": "Inglese",
   "@languageEnglish": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "languageRussian": "Russian",
+  "languageRussian": "Russo",
   "@languageRussian": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "languageVietnamese": "Vietnamese",
+  "languageVietnamese": "Vietnamita",
   "@languageVietnamese": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "customPromptAction": "Help me write",
+  "customPromptAction": "Aiutami a scrivere",
   "@customPromptAction": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "failedToGenerate": "Failed to generate AI response",
+  "failedToGenerate": "Generazione della risposta IA non riuscita",
   "@failedToGenerate": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "aiAssistant": "AI assistant",
-  "@aiAssistant": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "generatingResponse": "Generating response",
+  "generatingResponse": "Generazione della risposta",
   "@generatingResponse": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "replace": "Replace",
+  "insert": "Inserisci",
+  "@insert": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "replace": "Sostituisci",
   "@replace": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "insert": "Insert",
-  "@insert": {
+  "aiAssistant": "Assistente IA",
+  "@aiAssistant": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/scribe/lib/scribe/ai/l10n/intl_messages.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_messages.arb
@@ -1,6 +1,6 @@
 {
-  "@@last_modified": "2025-12-18T02:49:48.638213",
-  "categoryCorrectGrammar": "Correct grammar",
+  "@@last_modified": "2026-01-20T08:05:38.377619",
+  "categoryCorrectGrammar": "Correct",
   "@categoryCorrectGrammar": {
     "type": "text",
     "placeholders_order": [],
@@ -90,12 +90,6 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "inputPlaceholder": "Help me write",
-  "@inputPlaceholder": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
   "customPromptAction": "Help me write",
   "@customPromptAction": {
     "type": "text",
@@ -104,12 +98,6 @@
   },
   "failedToGenerate": "Failed to generate AI response",
   "@failedToGenerate": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "insertButton": "Insert",
-  "@insertButton": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/scribe/lib/scribe/ai/l10n/intl_ru.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_ru.arb
@@ -1,6 +1,6 @@
 {
   "@@last_modified": "2025-12-09T07:30:00.000000",
-  "categoryCorrectGrammar": "Исправить грамматику",
+  "categoryCorrectGrammar": "Исправить",
   "@categoryCorrectGrammar": {
     "type": "text",
     "placeholders_order": [],
@@ -90,12 +90,6 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "inputPlaceholder": "Помогите мне написать",
-  "@inputPlaceholder": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
   "customPromptAction": "Помогите мне написать",
   "@customPromptAction": {
     "type": "text",
@@ -108,14 +102,26 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "insertButton": "Вставить",
-  "@insertButton": {
+  "generatingResponse": "Генерация ответа",
+  "@generatingResponse": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "replaceButton": "Заменить",
-  "@replaceButton": {
+  "insert": "Вставить",
+  "@insert": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "replace": "Заменить",
+  "@replace": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "aiAssistant": "Помощник ИИ",
+  "@aiAssistant": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/scribe/lib/scribe/ai/l10n/intl_vi.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_vi.arb
@@ -1,6 +1,6 @@
 {
   "@@last_modified": "2025-12-09T07:30:00.000000",
-  "categoryCorrectGrammar": "Sửa ngữ pháp",
+  "categoryCorrectGrammar": "Sửa chữa",
   "@categoryCorrectGrammar": {
     "type": "text",
     "placeholders_order": [],
@@ -90,12 +90,6 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "inputPlaceholder": "Giúp tôi viết",
-  "@inputPlaceholder": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
   "customPromptAction": "Giúp tôi viết",
   "@customPromptAction": {
     "type": "text",
@@ -108,14 +102,26 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "insertButton": "Chèn",
-  "@insertButton": {
+  "generatingResponse": "Tạo phản hồi",
+  "@generatingResponse": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "replaceButton": "Thay thế",
-  "@replaceButton": {
+  "insert": "Chèn",
+  "@insert": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "replace": "Thay thế",
+  "@replace": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "aiAssistant": "Trợ lý AI",
+  "@aiAssistant": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/scribe/lib/scribe/ai/localizations/scribe_localizations.dart
+++ b/scribe/lib/scribe/ai/localizations/scribe_localizations.dart
@@ -4,16 +4,21 @@ import 'package:multiple_localization/multiple_localization.dart';
 import 'package:scribe/scribe/ai/l10n/messages_all.dart';
 
 class ScribeLocalizations {
+  static const List<String> _supportedLanguageCodes = ['en', 'fr', 'ru', 'vi'];
+
   static ScribeLocalizations of(BuildContext context) {
     return Localizations.of<ScribeLocalizations>(context, ScribeLocalizations)!;
   }
 
   static Future<ScribeLocalizations> load(Locale locale) {
+    final effectiveLocale = _supportedLanguageCodes.contains(locale.languageCode)
+        ? locale
+        : const Locale('en');
     return MultipleLocalizations.load(
       initializeMessages,
-      locale,
+      effectiveLocale,
       (locale) => ScribeLocalizations(),
-      setDefaultLocale: true,
+      setDefaultLocale: false,
     );
   }
 
@@ -179,8 +184,7 @@ class _ScribeLocalizationsDelegate
   const _ScribeLocalizationsDelegate();
 
   @override
-  bool isSupported(Locale locale) =>
-      ['en', 'fr', 'ru', 'vi'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => true;
 
   @override
   Future<ScribeLocalizations> load(Locale locale) =>

--- a/scribe/lib/scribe/ai/localizations/scribe_localizations.dart
+++ b/scribe/lib/scribe/ai/localizations/scribe_localizations.dart
@@ -4,7 +4,7 @@ import 'package:multiple_localization/multiple_localization.dart';
 import 'package:scribe/scribe/ai/l10n/messages_all.dart';
 
 class ScribeLocalizations {
-  static const List<String> _supportedLanguageCodes = ['en', 'fr', 'ru', 'vi'];
+  static const List<String> _supportedLanguageCodes = ['en', 'fr', 'ru', 'vi', 'de', 'it', 'ar'];
 
   static ScribeLocalizations of(BuildContext context) {
     return Localizations.of<ScribeLocalizations>(context, ScribeLocalizations)!;

--- a/scribe/lib/scribe/ai/localizations/scribe_localizations.dart
+++ b/scribe/lib/scribe/ai/localizations/scribe_localizations.dart
@@ -23,7 +23,7 @@ class ScribeLocalizations {
   // Menu Categories
   String get categoryCorrectGrammar {
     return Intl.message(
-      'Correct grammar',
+      'Correct',
       name: 'categoryCorrectGrammar',
     );
   }
@@ -130,13 +130,6 @@ class ScribeLocalizations {
   }
 
   // Input Bar
-  String get inputPlaceholder {
-    return Intl.message(
-      'Help me write',
-      name: 'inputPlaceholder',
-    );
-  }
-
   String get customPromptAction {
     return Intl.message(
       'Help me write',
@@ -149,13 +142,6 @@ class ScribeLocalizations {
     return Intl.message(
       'Failed to generate AI response',
       name: 'failedToGenerate',
-    );
-  }
-
-  String get insertButton {
-    return Intl.message(
-      'Insert',
-      name: 'insertButton',
     );
   }
 

--- a/scribe/lib/scribe/ai/localizations/scribe_localizations.dart
+++ b/scribe/lib/scribe/ai/localizations/scribe_localizations.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:multiple_localization/multiple_localization.dart';
 import 'package:scribe/scribe/ai/l10n/messages_all.dart';
 
 class ScribeLocalizations {
@@ -7,16 +8,13 @@ class ScribeLocalizations {
     return Localizations.of<ScribeLocalizations>(context, ScribeLocalizations)!;
   }
 
-  static Future<ScribeLocalizations> load(Locale locale) async {
-    final name =
-        locale.countryCode == null ? locale.languageCode : locale.toString();
-
-    final localeName = Intl.canonicalizedLocale(name);
-
-    return initializeMessages(localeName).then((_) {
-      Intl.defaultLocale = localeName;
-      return ScribeLocalizations();
-    });
+  static Future<ScribeLocalizations> load(Locale locale) {
+    return MultipleLocalizations.load(
+      initializeMessages,
+      locale,
+      (locale) => ScribeLocalizations(),
+      setDefaultLocale: true,
+    );
   }
 
   static const LocalizationsDelegate<ScribeLocalizations> delegate =

--- a/scribe/lib/scribe/ai/presentation/widgets/search/ai_scribe_bar.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/search/ai_scribe_bar.dart
@@ -80,7 +80,7 @@ class _AIScribeBarState extends State<AIScribeBar> {
                 child: TextField(
                   controller: _controller,
                   decoration: InputDecoration(
-                    hintText: ScribeLocalizations.of(context).inputPlaceholder,
+                    hintText: ScribeLocalizations.of(context).customPromptAction,
                     hintStyle: AIScribeTextStyles.searchBarHint,
                     border: InputBorder.none,
                     contentPadding: const EdgeInsets.symmetric(vertical: 8),

--- a/scribe/pubspec.lock
+++ b/scribe/pubspec.lock
@@ -798,6 +798,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
+  multiple_localization:
+    dependency: "direct main"
+    description:
+      name: multiple_localization
+      sha256: "29c97a3fbf4d067ea5a63df1995465ea81ef28e2c817d9d0871983e50f4fd3f0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   objective_c:
     dependency: transitive
     description:

--- a/scribe/pubspec.yaml
+++ b/scribe/pubspec.yaml
@@ -38,6 +38,8 @@ dependencies:
 
   flutter_svg: 2.1.0
 
+  multiple_localization: 0.6.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Even if all keys were translated, Scribe UI was always in default language.

In short, it is not possible to load multiple localization delegates with different .arb files. But we need these translations to be located in a separate file because in the future we will move Scribe in a separate module.

See https://github.com/Innim/flutter_multiple_localization for more explanation.

# Before

App in French, Scribe in English.

<img width="724" height="686" alt="image" src="https://github.com/user-attachments/assets/b9ac6c4c-6610-43c7-8cd9-3e1a86052bd8" />

# After

App in French, Scribe in French.

<img width="724" height="730" alt="Screenshot 2026-01-20 at 08 21 27" src="https://github.com/user-attachments/assets/a4f1c294-eadf-44a3-9165-6f33e4c682d6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized AI labels (generatingResponse, insert, replace, aiAssistant) and new locales: German, Italian, Arabic.

* **Bug Fixes**
  * Updated search bar hint text for clearer prompts.

* **Chores**
  * Removed obsolete localization keys across languages.
  * Standardized label "Correct grammar" → "Correct".
  * Simplified localization loading and fallback behavior to improve locale support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->