### PR TITLE
TF-4272 Fix events always display email body

### DIFF
--- a/lib/features/email/presentation/widgets/calendar_event/calendar_event_detail_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/calendar_event_detail_widget.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/extensions/string_extension.dart';
 import 'package:core/presentation/views/html_viewer/html_content_viewer_on_web_widget.dart';
 import 'package:core/presentation/views/html_viewer/html_content_viewer_widget.dart';
 import 'package:flutter/material.dart';
@@ -34,9 +35,7 @@ class CalendarEventDetailWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final eventDesc = calendarEvent.description?.isNotEmpty == true
-      ? calendarEvent.description!
-      : emailContent;
+    final eventDesc = _generateEventDescriptionAsHtml();
 
     return Container(
       clipBehavior: Clip.antiAlias,
@@ -74,5 +73,20 @@ class CalendarEventDetailWidget extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  String _generateEventDescriptionAsHtml() {
+    final descriptions = calendarEvent.description?.trimmed ?? '';
+    final emailContentTrimmed = emailContent.trimmed;
+
+    if (descriptions.isEmpty || emailContentTrimmed.isEmpty) {
+      return '';
+    }
+
+    return '''
+      $descriptions
+      <br>
+      $emailContentTrimmed
+    ''';
   }
 }

--- a/lib/features/email/presentation/widgets/calendar_event/calendar_event_detail_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/calendar_event_detail_widget.dart
@@ -79,7 +79,7 @@ class CalendarEventDetailWidget extends StatelessWidget {
     final descriptions = calendarEvent.description?.trimmed ?? '';
     final emailContentTrimmed = emailContent.trimmed;
 
-    if (descriptions.isEmpty || emailContentTrimmed.isEmpty) {
+    if (descriptions.isEmpty && emailContentTrimmed.isEmpty) {
       return '';
     }
 

--- a/lib/features/thread/presentation/extensions/handle_pull_to_refresh_list_email_extension.dart
+++ b/lib/features/thread/presentation/extensions/handle_pull_to_refresh_list_email_extension.dart
@@ -19,7 +19,7 @@ extension HandlePullToRefreshListEmailExtension on ThreadController {
     consumeState(Stream.value(Right(GetAllEmailLoading())));
     await Future.delayed(const Duration(milliseconds: 300)); // Create loading effect
     canLoadMore = false;
-    loadingMoreStatus.value == LoadingMoreStatus.idle;
+    loadingMoreStatus.value = LoadingMoreStatus.idle;
     getAllEmailAction();
   }
 


### PR DESCRIPTION
## Issue

#4272 

## Resolved

- Before


https://github.com/user-attachments/assets/08aff428-dc68-4e34-8d8a-edf86945e08e

- After


https://github.com/user-attachments/assets/a99e76e4-6a6c-4575-9566-7d0f5c86934e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure pull-to-refresh resets the loading status so refresh behaves reliably.

* **Improvements**
  * Calendar event details now generate and render descriptions as HTML with better trimming and empty-content handling, hiding the body when no description exists.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->