### PR TITLE
[Scribe mobile] Support Scribe when using a tablet 

### DIFF
--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -220,9 +220,12 @@ class HtmlUtils {
         const selection = window.getSelection();
         if (selection && selection.rangeCount > 0) {
           window._savedRange = selection.getRangeAt(0).cloneRange();
-          return selection.toString();
+          const result = selection.toString()
+          window.parent.postMessage(JSON.stringify({ "type": "toDart: saveSelection", result }), "*");
+          return result;
         }
         delete window._savedRange;
+        window.parent.postMessage(JSON.stringify({ "type": "toDart: saveSelection", result: "" }), "*");
         return "";
       })();''',
     name: 'saveSelection');
@@ -236,9 +239,12 @@ class HtmlUtils {
             selection.removeAllRanges();
             selection.addRange(window._savedRange);
             delete window._savedRange;
-            return selection.toString();
+            const result = selection.toString()
+            window.parent.postMessage(JSON.stringify({ "type": "toDart: restoreSelection", result }), "*");
+            return result;
           }
         }
+        window.parent.postMessage(JSON.stringify({ "type": "toDart: restoreSelection", result: "" }), "*");
         return "";
       })();''',
     name: 'restoreSelection');
@@ -247,8 +253,11 @@ class HtmlUtils {
     script: '''
       (() => {
         if(window._savedRange) {
-          return window._savedRange.toString();
+          const result = window._savedRange.toString();
+          window.parent.postMessage(JSON.stringify({ "type": "toDart: getSavedSelection", result }), "*");
+          return result;
         } else {
+          window.parent.postMessage(JSON.stringify({ "type": "toDart: getSavedSelection", result: "" }), "*");
           return "";
         }
       })();''',

--- a/lib/features/composer/presentation/composer_view_web.dart
+++ b/lib/features/composer/presentation/composer_view_web.dart
@@ -134,6 +134,9 @@ class ComposerView extends GetWidget<ComposerController> {
                       saveToDraftsAction: () => controller.handleClickSaveAsDraftsButton(context),
                       saveToTemplateAction: () => controller.handleClickSaveAsTemplateButton(context),
                       deleteComposerAction: controller.handleClickDeleteComposer,
+                      onOpenAiAssistantModal: controller.isAIScribeAvailable
+                        ? controller.openAIAssistantModal
+                        : null,
                     )),
                     ConstrainedBox(
                       constraints: BoxConstraints(

--- a/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
+++ b/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
@@ -3,6 +3,7 @@ import 'package:core/utils/html/html_utils.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:core/utils/string_convert.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:scribe/scribe.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/mixin/text_selection_mixin.dart';
@@ -19,6 +20,11 @@ extension HandleAiScribeInComposerExtension on ComposerController {
         mailboxDashBoardController.cachedAIScribeConfig.value.isEnabled;
 
     return isAIScribeConfigEnabled && isAIScribeEndpointAvailable;
+  }
+
+  bool get isScribeMobile {
+    final context = Get.context;
+    return AiScribeMobileUtils.isScribeInMobileMode(context);
   }
 
   Future<String> _getTextOnlyContentInEditor() async {
@@ -207,7 +213,7 @@ extension HandleAiScribeInComposerExtension on ComposerController {
   Future<void> onReplaceTextCallback(String text) async {
     final selection = editorTextSelection.value?.selectedText;
 
-    final savedSelection = PlatformInfo.isMobile ? await getSavedSelection() : "";
+    final savedSelection = isScribeMobile ? await getSavedSelection() : "";
 
     final shouldReplaceEverything = (selection == null || selection.isEmpty) && savedSelection.isEmpty;
 
@@ -232,7 +238,7 @@ extension HandleAiScribeInComposerExtension on ComposerController {
     clearFocusRecipients();
     clearFocusSubject();
 
-    if (PlatformInfo.isMobile) {
+    if (isScribeMobile) {
       await saveAndUnfocusForModal();
     }
 
@@ -247,6 +253,7 @@ extension HandleAiScribeInComposerExtension on ComposerController {
       preferredPlacement: ModalPlacement.top,
       crossAxisAlignment: ModalCrossAxisAlignment.start,
       onSelectAiScribeSuggestionAction: handleAiScribeSuggestionAction,
+      isScribeMobile: isScribeMobile,
     );
   }
 

--- a/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
+++ b/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
@@ -63,11 +63,12 @@ extension HandleAiScribeInComposerExtension on ComposerController {
   Future<void> setTextInEditor(String text) async {
     try {
       final escapedText = StringConvert.escapeTextContent(text);
+      final htmlContent = StringConvert.convertTextContentToHtmlContent(escapedText);
       
       if (PlatformInfo.isWeb) {
-        richTextWebController?.editorController.setText(escapedText);
+        richTextWebController?.editorController.setText(htmlContent);
       } else {
-        await richTextMobileTabletController?.htmlEditorApi?.setText(escapedText);
+        await richTextMobileTabletController?.htmlEditorApi?.setText(htmlContent);
       }
     } catch (e) {
       logWarning('$runtimeType::setTextInEditor:Exception = $e');

--- a/lib/features/composer/presentation/widgets/ai_scribe/composer_ai_scribe_selection_overlay.dart
+++ b/lib/features/composer/presentation/widgets/ai_scribe/composer_ai_scribe_selection_overlay.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:core/utils/platform_info.dart';
 import 'package:scribe/scribe/ai/presentation/widgets/overlay/ai_selection_overlay.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart';
@@ -34,7 +33,7 @@ class ComposerAiScribeSelectionOverlay extends StatelessWidget {
     controller.clearFocusRecipients();
     controller.clearFocusSubject();
 
-    if (PlatformInfo.isMobile) {
+    if (controller.isScribeMobile) {
       await controller.saveAndUnfocusForModal();
     }
   }

--- a/lib/features/composer/presentation/widgets/mobile/tablet_bottom_bar_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/tablet_bottom_bar_composer_widget.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
+import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:scribe/scribe/ai/presentation/widgets/button/ai_assistant_button.dart';
 import 'package:tmail_ui_user/features/composer/presentation/styles/mobile/tablet_bottom_bar_composer_widget_style.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
@@ -35,77 +36,79 @@ class TabletBottomBarComposerWidget extends StatelessWidget {
     return Container(
       padding: TabletBottomBarComposerWidgetStyle.padding,
       color: TabletBottomBarComposerWidgetStyle.backgroundColor,
-      child: Row(
-        children: [
-          const Spacer(),
-          if (onOpenAiAssistantModal != null)
-            AiAssistantButton(
-              imagePaths: imagePaths,
-              margin: const EdgeInsetsDirectional.only(
-                start: TabletBottomBarComposerWidgetStyle.space,
+      child: PointerInterceptor(
+        child: Row(
+          children: [
+            const Spacer(),
+            if (onOpenAiAssistantModal != null)
+              AiAssistantButton(
+                imagePaths: imagePaths,
+                margin: const EdgeInsetsDirectional.only(
+                  start: TabletBottomBarComposerWidgetStyle.space,
+                ),
+                onOpenAiAssistantModal: onOpenAiAssistantModal!,
               ),
-              onOpenAiAssistantModal: onOpenAiAssistantModal!,
+            const SizedBox(width: TabletBottomBarComposerWidgetStyle.space),
+            TMailButtonWidget.fromIcon(
+              icon: imagePaths.icDeleteMailbox,
+              borderRadius: TabletBottomBarComposerWidgetStyle.iconRadius,
+              padding: TabletBottomBarComposerWidgetStyle.iconPadding,
+              iconSize: TabletBottomBarComposerWidgetStyle.iconSize,
+              tooltipMessage: AppLocalizations.of(context).delete,
+              onTapActionCallback: deleteComposerAction,
             ),
-          const SizedBox(width: TabletBottomBarComposerWidgetStyle.space),
-          TMailButtonWidget.fromIcon(
-            icon: imagePaths.icDeleteMailbox,
-            borderRadius: TabletBottomBarComposerWidgetStyle.iconRadius,
-            padding: TabletBottomBarComposerWidgetStyle.iconPadding,
-            iconSize: TabletBottomBarComposerWidgetStyle.iconSize,
-            tooltipMessage: AppLocalizations.of(context).delete,
-            onTapActionCallback: deleteComposerAction,
-          ),
-          const SizedBox(width: TabletBottomBarComposerWidgetStyle.space),
-          TMailButtonWidget.fromIcon(
-            icon: imagePaths.icMarkAsImportant,
-            borderRadius: TabletBottomBarComposerWidgetStyle.iconRadius,
-            padding: TabletBottomBarComposerWidgetStyle.iconPadding,
-            iconSize: TabletBottomBarComposerWidgetStyle.iconSize,
-            iconColor: isMarkAsImportant
+            const SizedBox(width: TabletBottomBarComposerWidgetStyle.space),
+            TMailButtonWidget.fromIcon(
+              icon: imagePaths.icMarkAsImportant,
+              borderRadius: TabletBottomBarComposerWidgetStyle.iconRadius,
+              padding: TabletBottomBarComposerWidgetStyle.iconPadding,
+              iconSize: TabletBottomBarComposerWidgetStyle.iconSize,
+              iconColor: isMarkAsImportant
+                  ? TabletBottomBarComposerWidgetStyle.selectedIconColor
+                  : TabletBottomBarComposerWidgetStyle.iconColor,
+              tooltipMessage: isMarkAsImportant
+                  ? AppLocalizations.of(context).turnOffMarkAsImportant
+                  : AppLocalizations.of(context).turnOnMarkAsImportant,
+              onTapActionCallback: toggleMarkAsImportantAction,
+            ),
+            const SizedBox(width: TabletBottomBarComposerWidgetStyle.space),
+            TMailButtonWidget.fromIcon(
+              icon: imagePaths.icReadReceipt,
+              borderRadius: TabletBottomBarComposerWidgetStyle.iconRadius,
+              padding: TabletBottomBarComposerWidgetStyle.iconPadding,
+              iconSize: TabletBottomBarComposerWidgetStyle.iconSize,
+              iconColor: hasReadReceipt
                 ? TabletBottomBarComposerWidgetStyle.selectedIconColor
                 : TabletBottomBarComposerWidgetStyle.iconColor,
-            tooltipMessage: isMarkAsImportant
-                ? AppLocalizations.of(context).turnOffMarkAsImportant
-                : AppLocalizations.of(context).turnOnMarkAsImportant,
-            onTapActionCallback: toggleMarkAsImportantAction,
-          ),
-          const SizedBox(width: TabletBottomBarComposerWidgetStyle.space),
-          TMailButtonWidget.fromIcon(
-            icon: imagePaths.icReadReceipt,
-            borderRadius: TabletBottomBarComposerWidgetStyle.iconRadius,
-            padding: TabletBottomBarComposerWidgetStyle.iconPadding,
-            iconSize: TabletBottomBarComposerWidgetStyle.iconSize,
-            iconColor: hasReadReceipt
-              ? TabletBottomBarComposerWidgetStyle.selectedIconColor
-              : TabletBottomBarComposerWidgetStyle.iconColor,
-            tooltipMessage: hasReadReceipt
-              ? AppLocalizations.of(context).turnOffRequestReadReceipt
-              : AppLocalizations.of(context).turnOnRequestReadReceipt,
-            onTapActionCallback: requestReadReceiptAction,
-          ),
-          const SizedBox(width: TabletBottomBarComposerWidgetStyle.space),
-          TMailButtonWidget.fromIcon(
-            icon: imagePaths.icSaveToDraft,
-            borderRadius: TabletBottomBarComposerWidgetStyle.iconRadius,
-            padding: TabletBottomBarComposerWidgetStyle.iconPadding,
-            iconSize: TabletBottomBarComposerWidgetStyle.iconSize,
-            tooltipMessage: AppLocalizations.of(context).saveAsDraft,
-            onTapActionCallback: saveToDraftAction,
-          ),
-          const SizedBox(width: TabletBottomBarComposerWidgetStyle.sendButtonSpace),
-          TMailButtonWidget(
-            text: AppLocalizations.of(context).send,
-            icon: imagePaths.icSend,
-            iconAlignment: TextDirection.rtl,
-            padding: TabletBottomBarComposerWidgetStyle.sendButtonPadding,
-            iconSize: TabletBottomBarComposerWidgetStyle.iconSize,
-            iconSpace: TabletBottomBarComposerWidgetStyle.sendButtonIconSpace,
-            textStyle: TabletBottomBarComposerWidgetStyle.sendButtonTextStyle,
-            backgroundColor: TabletBottomBarComposerWidgetStyle.sendButtonBackgroundColor,
-            borderRadius: TabletBottomBarComposerWidgetStyle.sendButtonRadius,
-            onTapActionCallback: sendMessageAction,
-          )
-        ]
+              tooltipMessage: hasReadReceipt
+                ? AppLocalizations.of(context).turnOffRequestReadReceipt
+                : AppLocalizations.of(context).turnOnRequestReadReceipt,
+              onTapActionCallback: requestReadReceiptAction,
+            ),
+            const SizedBox(width: TabletBottomBarComposerWidgetStyle.space),
+            TMailButtonWidget.fromIcon(
+              icon: imagePaths.icSaveToDraft,
+              borderRadius: TabletBottomBarComposerWidgetStyle.iconRadius,
+              padding: TabletBottomBarComposerWidgetStyle.iconPadding,
+              iconSize: TabletBottomBarComposerWidgetStyle.iconSize,
+              tooltipMessage: AppLocalizations.of(context).saveAsDraft,
+              onTapActionCallback: saveToDraftAction,
+            ),
+            const SizedBox(width: TabletBottomBarComposerWidgetStyle.sendButtonSpace),
+            TMailButtonWidget(
+              text: AppLocalizations.of(context).send,
+              icon: imagePaths.icSend,
+              iconAlignment: TextDirection.rtl,
+              padding: TabletBottomBarComposerWidgetStyle.sendButtonPadding,
+              iconSize: TabletBottomBarComposerWidgetStyle.iconSize,
+              iconSpace: TabletBottomBarComposerWidgetStyle.sendButtonIconSpace,
+              textStyle: TabletBottomBarComposerWidgetStyle.sendButtonTextStyle,
+              backgroundColor: TabletBottomBarComposerWidgetStyle.sendButtonBackgroundColor,
+              borderRadius: TabletBottomBarComposerWidgetStyle.sendButtonRadius,
+              onTapActionCallback: sendMessageAction,
+            )
+          ]
+        ),
       ),
     );
   }

--- a/lib/features/composer/presentation/widgets/mobile/tablet_bottom_bar_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/tablet_bottom_bar_composer_widget.dart
@@ -40,7 +40,7 @@ class TabletBottomBarComposerWidget extends StatelessWidget {
         child: Row(
           children: [
             const Spacer(),
-            if (onOpenAiAssistantModal != null)
+            if (onOpenAiAssistantModal != null) ...[
               AiAssistantButton(
                 imagePaths: imagePaths,
                 margin: const EdgeInsetsDirectional.only(
@@ -48,7 +48,8 @@ class TabletBottomBarComposerWidget extends StatelessWidget {
                 ),
                 onOpenAiAssistantModal: onOpenAiAssistantModal!,
               ),
-            const SizedBox(width: TabletBottomBarComposerWidgetStyle.space),
+              const SizedBox(width: TabletBottomBarComposerWidgetStyle.space),
+            ],
             TMailButtonWidget.fromIcon(
               icon: imagePaths.icDeleteMailbox,
               borderRadius: TabletBottomBarComposerWidgetStyle.iconRadius,

--- a/lib/features/composer/presentation/widgets/web/mobile_responsive_app_bar_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/web/mobile_responsive_app_bar_composer_widget.dart
@@ -4,6 +4,7 @@ import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:custom_pop_up_menu/custom_pop_up_menu.dart';
 import 'package:flutter/material.dart';
+import 'package:scribe/scribe/ai/presentation/widgets/button/ai_assistant_button.dart';
 import 'package:tmail_ui_user/features/base/widget/highlight_svg_icon_on_hover.dart';
 import 'package:tmail_ui_user/features/base/widget/popup_item_widget.dart';
 import 'package:tmail_ui_user/features/base/widget/popup_menu_overlay_widget.dart';
@@ -32,6 +33,7 @@ class MobileResponsiveAppBarComposerWidget extends StatelessWidget {
   final VoidCallback saveToTemplateAction;
   final VoidCallback deleteComposerAction;
   final VoidCallback toggleMarkAsImportantAction;
+  final OnOpenAiAssistantModal? onOpenAiAssistantModal;
 
   const MobileResponsiveAppBarComposerWidget({
     super.key,
@@ -55,6 +57,7 @@ class MobileResponsiveAppBarComposerWidget extends StatelessWidget {
     required this.saveToTemplateAction,
     required this.deleteComposerAction,
     required this.toggleMarkAsImportantAction,
+    this.onOpenAiAssistantModal,
   });
 
   @override
@@ -74,6 +77,14 @@ class MobileResponsiveAppBarComposerWidget extends StatelessWidget {
             onTapActionCallback: onCloseViewAction
           ),
           const Spacer(),
+          if (onOpenAiAssistantModal != null)
+            AiAssistantButton(
+              imagePaths: imagePaths,
+              margin: const EdgeInsetsDirectional.only(
+                end: MobileAppBarComposerWidgetStyle.space,
+              ),
+              onOpenAiAssistantModal: onOpenAiAssistantModal!,
+            ),
           TMailButtonWidget.fromIcon(
             icon: imagePaths.icRichToolbar,
             padding: MobileAppBarComposerWidgetStyle.richTextIconPadding,

--- a/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
@@ -206,6 +206,22 @@ class _WebEditorState extends State<WebEditorWidget> with TextSelectionMixin {
             script: HtmlUtils.deleteSelectionContent.script,
           ),
           WebScript(
+            name: HtmlUtils.saveSelection.name,
+            script: HtmlUtils.saveSelection.script,
+          ),
+          WebScript(
+            name: HtmlUtils.restoreSelection.name,
+            script: HtmlUtils.restoreSelection.script,
+          ),
+          WebScript(
+            name: HtmlUtils.getSavedSelection.name,
+            script: HtmlUtils.getSavedSelection.script,
+          ),
+          WebScript(
+            name: HtmlUtils.clearSavedSelection.name,
+            script: HtmlUtils.clearSavedSelection.script,
+          ),
+          WebScript(
             name: HtmlUtils.recalculateEditorHeight(maxHeight: maxHeight).name,
             script: HtmlUtils.recalculateEditorHeight(maxHeight: maxHeight).script,
           ),

--- a/lib/features/manage_account/presentation/preferences/preferences_controller.dart
+++ b/lib/features/manage_account/presentation/preferences/preferences_controller.dart
@@ -1,6 +1,5 @@
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
-import 'package:core/utils/platform_info.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -57,8 +56,7 @@ class PreferencesController extends BaseController {
   }
 
   bool get isAIScribeCapabilityAvailable {
-    return accountDashboardController.isAIScribeCapabilityAvailable &&
-        !PlatformInfo.isMobile;
+    return accountDashboardController.isAIScribeCapabilityAvailable;
   }
 
   @override

--- a/scribe/lib/scribe.dart
+++ b/scribe/lib/scribe.dart
@@ -22,6 +22,7 @@ export 'scribe/ai/presentation/model/modal/modal_placement.dart';
 export 'scribe/ai/presentation/model/text_selection_model.dart';
 export 'scribe/ai/presentation/styles/ai_scribe_styles.dart';
 export 'scribe/ai/presentation/utils/ai_scribe_constants.dart';
+export 'scribe/ai/presentation/utils/ai_scribe_mobile_utils.dart';
 export 'scribe/ai/presentation/utils/context_menu/hover_submenu_controller.dart';
 export 'scribe/ai/presentation/utils/context_menu/context_submenu_controller.dart';
 export 'scribe/ai/presentation/utils/modal/ai_scribe_modal_manager.dart';

--- a/scribe/lib/scribe/ai/presentation/styles/ai_scribe_styles.dart
+++ b/scribe/lib/scribe/ai/presentation/styles/ai_scribe_styles.dart
@@ -161,6 +161,7 @@ abstract final class AIScribeSizes {
   static const double submenuSpacing = 6;
   static const double modalSpacing = 26;
   static const double modalWithoutContentSpacing = 12;
+  static const double keyboardSpacing = 12;
 
   // Elevation
   static const double dialogElevation = 8;

--- a/scribe/lib/scribe/ai/presentation/utils/ai_scribe_mobile_utils.dart
+++ b/scribe/lib/scribe/ai/presentation/utils/ai_scribe_mobile_utils.dart
@@ -1,0 +1,8 @@
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:flutter/material.dart';
+
+class AiScribeMobileUtils {
+  static bool isScribeInMobileMode(BuildContext? context) {
+    return context != null && ResponsiveUtils().isMobile(context);
+  }
+}

--- a/scribe/lib/scribe/ai/presentation/utils/ai_scribe_mobile_utils.dart
+++ b/scribe/lib/scribe/ai/presentation/utils/ai_scribe_mobile_utils.dart
@@ -1,8 +1,9 @@
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 
 class AiScribeMobileUtils {
   static bool isScribeInMobileMode(BuildContext? context) {
-    return context != null && ResponsiveUtils().isMobile(context);
+    return context != null && Get.find<ResponsiveUtils>().isMobile(context);
   }
 }

--- a/scribe/lib/scribe/ai/presentation/utils/modal/ai_scribe_modal_manager.dart
+++ b/scribe/lib/scribe/ai/presentation/utils/modal/ai_scribe_modal_manager.dart
@@ -1,5 +1,4 @@
 import 'package:core/presentation/resources/image_paths.dart';
-import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:scribe/scribe.dart';
@@ -8,6 +7,7 @@ class AiScribeModalManager {
   AiScribeModalManager._();
 
   static Future<void> showAIScribeMenuModal({
+    required bool isScribeMobile,
     required ImagePaths imagePaths,
     required List<AIScribeMenuCategory> availableCategories,
     required OnSelectAiScribeSuggestionAction onSelectAiScribeSuggestionAction,
@@ -19,7 +19,7 @@ class AiScribeModalManager {
   }) async {
     final AIAction? aiAction;
 
-    if (PlatformInfo.isMobile) {
+    if (isScribeMobile) {
       aiAction = await showMobileAIScribeMenuModal(
         imagePaths: imagePaths,
         content: content,
@@ -46,6 +46,7 @@ class AiScribeModalManager {
     if (aiAction != null) {
       await showAIScribeSuggestionModal(
         aiAction: aiAction,
+        isScribeMobile: isScribeMobile,
         imagePaths: imagePaths,
         content: content,
         buttonPosition: buttonPosition,
@@ -59,6 +60,7 @@ class AiScribeModalManager {
 
   static Future<void> showAIScribeSuggestionModal({
     required AIAction aiAction,
+    required bool isScribeMobile,
     required ImagePaths imagePaths,
     required OnSelectAiScribeSuggestionAction onSelectAiScribeSuggestionAction,
     String? content,
@@ -67,7 +69,7 @@ class AiScribeModalManager {
     ModalPlacement? preferredPlacement,
     ModalCrossAxisAlignment crossAxisAlignment = ModalCrossAxisAlignment.center,
   }) async {
-    if (PlatformInfo.isMobile) {
+    if (isScribeMobile) {
       await showMobileAIScribeSuggestionModal(
         aiAction: aiAction,
         imagePaths: imagePaths,

--- a/scribe/lib/scribe/ai/presentation/utils/modal/anchored_modal_layout_calculator.dart
+++ b/scribe/lib/scribe/ai/presentation/utils/modal/anchored_modal_layout_calculator.dart
@@ -154,10 +154,14 @@ class AnchoredModalLayoutCalculator {
     if (isTop) {
       final availableHeight = anchorPosition.dy - padding - gap;
       final positionBottom = screenSize.height - anchorPosition.dy + gap;
+      final clampedLeft = anchorPosition.dx.clamp(
+        padding,
+        screenSize.width - menuSize.width - padding,
+      );
 
       return AnchoredSuggestionLayoutResult(
         availableHeight: availableHeight,
-        left: anchorPosition.dx,
+        left: clampedLeft,
         bottom: positionBottom,
       );
     }

--- a/scribe/lib/scribe/ai/presentation/widgets/button/inline_ai_assist_button.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/button/inline_ai_assist_button.dart
@@ -45,7 +45,12 @@ class InlineAiAssistButton extends StatelessWidget {
 
     await onTapFallback?.call();
 
+    if (!context.mounted) return;
+
+    final isScribeMobile = AiScribeMobileUtils.isScribeInMobileMode(context);
+
     await AiScribeModalManager.showAIScribeMenuModal(
+      isScribeMobile: isScribeMobile,
       imagePaths: imagePaths,
       availableCategories: AIScribeMenuCategory.values,
       buttonPosition: position,

--- a/scribe/lib/scribe/ai/presentation/widgets/context_menu/ai_scribe_context_menu.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/context_menu/ai_scribe_context_menu.dart
@@ -53,7 +53,7 @@ class _AiScribeContextMenuContentState extends State<AiScribeContextMenu> {
               widget.submenuController?.hide();
               widget.onActionSelected(menuAction);
             },
-            onHoverShowSubmenu: (itemKey) =>
+            onSelectCategory: (itemKey) =>
                 menuAction.submenuActions?.isNotEmpty == true
                     ? _showSubmenu(
                         context: context,

--- a/scribe/lib/scribe/ai/presentation/widgets/context_menu/ai_scribe_context_menu_item.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/context_menu/ai_scribe_context_menu_item.dart
@@ -6,7 +6,7 @@ class AiScribeContextMenuItem extends StatefulWidget {
   final AiScribeContextMenuAction menuAction;
   final ImagePaths imagePaths;
   final ValueChanged<AiScribeContextMenuAction> onSelectAction;
-  final OnHoverShowSubmenu? onHoverShowSubmenu;
+  final OnHoverShowSubmenu onSelectCategory;
   final VoidCallback? onHoverOtherItem;
 
   const AiScribeContextMenuItem({
@@ -14,7 +14,7 @@ class AiScribeContextMenuItem extends StatefulWidget {
     required this.menuAction,
     required this.imagePaths,
     required this.onSelectAction,
-    this.onHoverShowSubmenu,
+    required this.onSelectCategory,
     this.onHoverOtherItem,
   });
 
@@ -44,7 +44,7 @@ class _AiScribeContextMenuItemState extends State<AiScribeContextMenuItem> {
           _hoverController?.enter();
 
           if (_itemKey != null) {
-            widget.onHoverShowSubmenu?.call(_itemKey!);
+            widget.onSelectCategory.call(_itemKey!);
           } else {
             widget.onHoverOtherItem?.call();
           }
@@ -55,7 +55,15 @@ class _AiScribeContextMenuItemState extends State<AiScribeContextMenuItem> {
         child: AiScribeMenuItem(
           itemKey: _itemKey,
           menuAction: widget.menuAction,
-          onSelectAction: widget.onSelectAction,
+          onSelectAction: (menuAction) {
+            if (menuAction.submenuActions?.isNotEmpty == true) {
+              if (_itemKey != null) {
+                widget.onSelectCategory.call(_itemKey!);
+              }
+            } else {
+              widget.onSelectAction(menuAction);
+            }
+          },
           imagePaths: widget.imagePaths,
         )
       );

--- a/scribe/lib/scribe/ai/presentation/widgets/context_menu/ai_scribe_submenu.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/context_menu/ai_scribe_submenu.dart
@@ -24,6 +24,7 @@ class AiScribeSubmenu extends StatelessWidget {
       clipBehavior: Clip.antiAlias,
       child: ListView.builder(
         shrinkWrap: true,
+        padding: EdgeInsets.zero,
         itemCount: menuActions.length,
         itemBuilder: (_, index) {
           final action = menuActions[index];

--- a/scribe/lib/scribe/ai/presentation/widgets/mobile/ai_scribe_mobile_actions_bottom_sheet.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/mobile/ai_scribe_mobile_actions_bottom_sheet.dart
@@ -2,6 +2,7 @@ import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
+import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:scribe/scribe.dart';
 
 class AiScribeMobileActionsBottomSheet extends StatefulWidget {
@@ -196,39 +197,41 @@ class _AiScribeMobileActionsBottomSheetState
     
     final hasContent = widget.content?.isNotEmpty ?? false;
 
-    return Container(
-      height: double.infinity,
-      decoration: const BoxDecoration(
-        color: AIScribeColors.background,
-      ),
-      child: SafeArea(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Expanded(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  _buildHeader(context, localizations),
-                  _buildTextCard(context),
-                  if(hasContent)
-                    Flexible(
-                      child: ValueListenableBuilder<AiScribeCategoryContextMenuAction?>(
-                        valueListenable: _selectedCategory,
-                        builder: (context, selectedCategory, _) {
-                          return selectedCategory == null
-                              ? _buildMenuListView(menuActions)
-                              : _buildSubmenuListView();
-                        },
+    return PointerInterceptor(
+      child: Container(
+        height: double.infinity,
+        decoration: const BoxDecoration(
+          color: AIScribeColors.background,
+        ),
+        child: SafeArea(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Expanded(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    _buildHeader(context, localizations),
+                    _buildTextCard(context),
+                    if(hasContent)
+                      Flexible(
+                        child: ValueListenableBuilder<AiScribeCategoryContextMenuAction?>(
+                          valueListenable: _selectedCategory,
+                          builder: (context, selectedCategory, _) {
+                            return selectedCategory == null
+                                ? _buildMenuListView(menuActions)
+                                : _buildSubmenuListView();
+                          },
+                        ),
                       ),
-                    ),
-                ],
+                  ],
+                ),
               ),
-            ),
-            _buildBottomBar(context),
-          ],
+              _buildBottomBar(context),
+            ],
+          ),
         ),
       ),
     );

--- a/scribe/lib/scribe/ai/presentation/widgets/mobile/ai_scribe_mobile_suggestion_bottom_sheet.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/mobile/ai_scribe_mobile_suggestion_bottom_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:flutter/material.dart';
+import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:scribe/scribe.dart';
 
 class AiScribeMobileSuggestionBottomSheet extends StatefulWidget {
@@ -41,27 +42,29 @@ class _AiScribeMobileSuggestionBottomSheetState
   Widget build(BuildContext context) {
     final localizations = ScribeLocalizations.of(context);
 
-    return Container(
-      height: double.infinity,
-      decoration: const BoxDecoration(
-        color: AIScribeColors.background,
-      ),
-      child: SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Padding(
-              padding: AIScribeSizes.suggestionHeaderPadding,
-              child: AiScribeSuggestionHeader(
-                title: aiAction.getLabel(localizations),
-                imagePaths: imagePaths,
+    return PointerInterceptor(
+      child: Container(
+        height: double.infinity,
+        decoration: const BoxDecoration(
+          color: AIScribeColors.background,
+        ),
+        child: SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: AIScribeSizes.suggestionHeaderPadding,
+                child: AiScribeSuggestionHeader(
+                  title: aiAction.getLabel(localizations),
+                  imagePaths: imagePaths,
+                ),
               ),
-            ),
-            Flexible(
-              child: buildStateContent(context),
-            ),
-          ],
+              Flexible(
+                child: buildStateContent(context),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/scribe/lib/scribe/ai/presentation/widgets/modal/ai_scribe_modal_widget.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/modal/ai_scribe_modal_widget.dart
@@ -72,6 +72,10 @@ class AiScribeModalWidget extends StatelessWidget {
     );
 
     if (buttonPosition != null && buttonSize != null) {
+      final keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
+      final screenSize = MediaQuery.of(context).size;
+      final availableHeight = screenSize.height - keyboardHeight;
+      
       final maxHeightModal = hasContent
           ? AIScribeSizes.searchBarMinHeight +
               AIScribeSizes.fieldSpacing +
@@ -81,7 +85,7 @@ class AiScribeModalWidget extends StatelessWidget {
 
       final layoutResult = AnchoredModalLayoutCalculator.calculate(
         input: AnchoredModalLayoutInput(
-          screenSize: MediaQuery.of(context).size,
+          screenSize: Size(screenSize.width, availableHeight),
           anchorPosition: buttonPosition!,
           anchorSize: buttonSize!,
           menuSize: Size(

--- a/scribe/lib/scribe/ai/presentation/widgets/modal/ai_scribe_modal_widget.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/modal/ai_scribe_modal_widget.dart
@@ -73,15 +73,21 @@ class AiScribeModalWidget extends StatelessWidget {
 
     if (buttonPosition != null && buttonSize != null) {
       final keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
+      final keyboardHeightWithSpacing = keyboardHeight > 0 ? keyboardHeight + AIScribeSizes.keyboardSpacing : 0; 
       final screenSize = MediaQuery.of(context).size;
-      final availableHeight = screenSize.height - keyboardHeight;
-      
+      final availableHeight = screenSize.height - keyboardHeightWithSpacing;
+
+      // in tablet mode where we can encounter keyboard and modal we have issues 
+      // with calculating the modal height and the search bar is frequently behind the keyboard
+      // that's why we take more space here
+      final searchBarHeight = keyboardHeight > 0 ? AIScribeSizes.searchBarMaxHeight : AIScribeSizes.searchBarMinHeight;
+
       final maxHeightModal = hasContent
-          ? AIScribeSizes.searchBarMinHeight +
+          ? searchBarHeight +
               AIScribeSizes.fieldSpacing +
               min(menuActions.length * AIScribeSizes.menuItemHeight,
                   AIScribeSizes.submenuMaxHeight)
-          : AIScribeSizes.searchBarMinHeight;
+          : searchBarHeight;
 
       final layoutResult = AnchoredModalLayoutCalculator.calculate(
         input: AnchoredModalLayoutInput(

--- a/scribe/lib/scribe/ai/presentation/widgets/modal/ai_scribe_suggestion_widget.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/modal/ai_scribe_suggestion_widget.dart
@@ -49,7 +49,9 @@ class _AiScribeSuggestionWidgetState extends State<AiScribeSuggestionWidget>
 
   @override
   Widget build(BuildContext context) {
-    final screenSize = MediaQuery.sizeOf(context);
+    final keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
+    final screenSize = MediaQuery.of(context).size;
+    final availableHeight = screenSize.height - keyboardHeight;
 
     final modalWidth = min(
       screenSize.width * AIScribeSizes.mobileFactor,
@@ -57,7 +59,7 @@ class _AiScribeSuggestionWidgetState extends State<AiScribeSuggestionWidget>
     );
 
     final modalMaxHeight = min(
-      screenSize.height * AIScribeSizes.mobileFactor,
+      availableHeight * AIScribeSizes.mobileFactor,
       AIScribeSizes.suggestionModalMaxHeight,
     );
 
@@ -76,7 +78,7 @@ class _AiScribeSuggestionWidgetState extends State<AiScribeSuggestionWidget>
     }
 
     final layout = AnchoredModalLayoutCalculator.calculateAnchoredSuggestLayout(
-      screenSize: screenSize,
+      screenSize: Size(screenSize.width, availableHeight),
       anchorPosition: widget.buttonPosition!,
       anchorSize: widget.buttonSize!,
       menuSize: Size(modalWidth, modalMaxHeight),

--- a/scribe/lib/scribe/ai/presentation/widgets/modal/ai_scribe_suggestion_widget.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/modal/ai_scribe_suggestion_widget.dart
@@ -50,8 +50,9 @@ class _AiScribeSuggestionWidgetState extends State<AiScribeSuggestionWidget>
   @override
   Widget build(BuildContext context) {
     final keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
+    final keyboardHeightWithSpacing = keyboardHeight > 0 ? keyboardHeight + AIScribeSizes.keyboardSpacing : 0; 
     final screenSize = MediaQuery.of(context).size;
-    final availableHeight = screenSize.height - keyboardHeight;
+    final availableHeight = screenSize.height - keyboardHeightWithSpacing;
 
     final modalWidth = min(
       screenSize.width * AIScribeSizes.mobileFactor,
@@ -97,7 +98,10 @@ class _AiScribeSuggestionWidgetState extends State<AiScribeSuggestionWidget>
           ),
           PositionedDirectional(
             start: layout.left,
-            bottom: layout.bottom,
+            // layout.bottom is calculated by taking keyboard into account
+            // but positionned without taking keyboard into account
+            // that's why we need to add keyboard height here
+            bottom: layout.bottom + keyboardHeightWithSpacing,
             child: _buildModalContainer(
               width: modalWidth,
               maxHeight: layout.availableHeight,

--- a/scribe/lib/scribe/ai/presentation/widgets/modal/ai_scribe_suggestion_widget.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/modal/ai_scribe_suggestion_widget.dart
@@ -1,6 +1,7 @@
-import 'dart:math';
+import 'dart:math' hide log;
 
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:scribe/scribe.dart';
@@ -87,6 +88,11 @@ class _AiScribeSuggestionWidgetState extends State<AiScribeSuggestionWidget>
       padding: AIScribeSizes.screenEdgePadding,
     );
 
+    final modalStartOffset = layout.left;
+    final modalBottomOffset =
+        _isMobileView ? null : layout.bottom + keyboardHeightWithSpacing;
+    final modalTopOffset = _isMobileView ? widget.buttonPosition!.dy : null;
+
     return PointerInterceptor(
       child: Stack(
         children: [
@@ -97,11 +103,12 @@ class _AiScribeSuggestionWidgetState extends State<AiScribeSuggestionWidget>
             ),
           ),
           PositionedDirectional(
-            start: layout.left,
+            start: modalStartOffset,
             // layout.bottom is calculated by taking keyboard into account
-            // but positionned without taking keyboard into account
+            // but positioned without taking keyboard into account
             // that's why we need to add keyboard height here
-            bottom: layout.bottom + keyboardHeightWithSpacing,
+            top: modalTopOffset,
+            bottom: modalBottomOffset,
             child: _buildModalContainer(
               width: modalWidth,
               maxHeight: layout.availableHeight,
@@ -159,6 +166,9 @@ class _AiScribeSuggestionWidgetState extends State<AiScribeSuggestionWidget>
 
   bool get _hasAnchor =>
       widget.buttonPosition != null && widget.buttonSize != null;
+
+  bool get _isMobileView =>
+      PlatformInfo.isMobile || PlatformInfo.isWebTouchDevice;
 
   void _handleClickOutside() {
     final shouldDismiss = suggestionState.value.fold(

--- a/scribe/lib/scribe/ai/presentation/widgets/search/ai_scribe_bar.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/search/ai_scribe_bar.dart
@@ -25,12 +25,20 @@ class AIScribeBar extends StatefulWidget {
 class _AIScribeBarState extends State<AIScribeBar> {
   final TextEditingController _controller = TextEditingController();
   final ValueNotifier<bool> _isButtonEnabled = ValueNotifier(false);
-  final FocusNode _focusNode = FocusNode();
+  final FocusNode _textFieldFocusNode = FocusNode();
+  final FocusNode _keyboardListenerFocusNode = FocusNode();
 
   @override
   void initState() {
     super.initState();
     _controller.addListener(_onTextChanged);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      Future.delayed(const Duration(milliseconds: 100), () {
+        if (mounted) {
+          _textFieldFocusNode.requestFocus();
+        }
+      });
+    });
   }
 
   @override
@@ -38,7 +46,8 @@ class _AIScribeBarState extends State<AIScribeBar> {
     _controller.removeListener(_onTextChanged);
     _controller.dispose();
     _isButtonEnabled.dispose();
-    _focusNode.dispose();
+    _textFieldFocusNode.dispose();
+    _keyboardListenerFocusNode.dispose();
     super.dispose();
   }
 
@@ -73,26 +82,23 @@ class _AIScribeBarState extends State<AIScribeBar> {
       child: Row(
         children: [
           Expanded(
-            child: GestureDetector(
-              behavior: HitTestBehavior.translucent,
-              onTap: _focusNode.requestFocus,
-              child: KeyboardListener(
-                focusNode: _focusNode,
-                onKeyEvent: _handleKeyboardEvent,
-                child: TextField(
-                  controller: _controller,
-                  decoration: InputDecoration(
-                    hintText: ScribeLocalizations.of(context).customPromptAction,
-                    hintStyle: AIScribeTextStyles.searchBarHint,
-                    border: InputBorder.none,
-                    contentPadding: const EdgeInsets.symmetric(vertical: 8),
-                    isDense: true,
-                  ),
-                  style: AIScribeTextStyles.searchBar,
-                  maxLines: null,
-                  keyboardType: TextInputType.multiline,
-                  cursorHeight: 16,
+            child: KeyboardListener(
+              focusNode: _keyboardListenerFocusNode,
+              onKeyEvent: _handleKeyboardEvent,
+              child: TextField(
+                controller: _controller,
+                focusNode: _textFieldFocusNode,
+                decoration: InputDecoration(
+                  hintText: ScribeLocalizations.of(context).customPromptAction,
+                  hintStyle: AIScribeTextStyles.searchBarHint,
+                  border: InputBorder.none,
+                  contentPadding: const EdgeInsets.symmetric(vertical: 8),
+                  isDense: true,
                 ),
+                style: AIScribeTextStyles.searchBar,
+                maxLines: null,
+                keyboardType: TextInputType.multiline,
+                cursorHeight: 16,
               ),
             ),
           ),


### PR DESCRIPTION
# Screenshots

<img width="200" alt="Simulator Screenshot - iPad Pro (M5) - 2026-01-26 at 15 05 19" src="https://github.com/user-attachments/assets/299f475f-b3c6-4032-9f59-f3a062fd2db2" />
<img width="200" alt="Simulator Screenshot - iPad Pro (M5) - 2026-01-26 at 15 06 16" src="https://github.com/user-attachments/assets/36ad5632-af3c-40d9-af6c-3c56fea7c29b" />
<img width="200" alt="Simulator Screenshot - iPad Pro (M5) - 2026-01-26 at 15 06 21" src="https://github.com/user-attachments/assets/7ee3d693-99f3-4bb7-b078-026798483307" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized mobile-mode detection for AI Scribe affecting assistant modals and buttons.
  * AI Assistant modal wiring added to composer app bar and bottom bar.
  * New delete, mark-important, and read-receipt actions added to the bottom bar.

* **Bug Fixes**
  * Improved modal placement to keep menus on-screen.
  * Safer UI interactions with mounted-context checks and refined focus/selection handling (web selection save/restore).
* **Style**
  * Submenu list padding tightened for a denser layout.
* **Refactor**
  * Context menu callback renamed to a clearer category-selection hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->