### PR TITLE
Upload source maps to Sentry for web

### DIFF
--- a/.github/actions/build-flutter-web/action.yml
+++ b/.github/actions/build-flutter-web/action.yml
@@ -1,0 +1,85 @@
+name: "Build Flutter Web"
+description: "Setup Flutter, build web, upload source maps to Sentry & GitHub Artifacts, remove .map files"
+
+inputs:
+  flutter-version:
+    description: "Flutter SDK version"
+    required: true
+  build-command:
+    description: "Build command to execute"
+    required: false
+    default: "flutter build web --release --source-maps"
+  sentry-enabled:
+    description: "Whether to upload source maps to Sentry (true/false)"
+    required: false
+    default: "true"
+  artifact-name:
+    description: "Name for the uploaded source map artifact"
+    required: false
+    default: "source-maps"
+  artifact-retention-days:
+    description: "Retention days for the source map artifact"
+    required: false
+    default: "30"
+
+outputs:
+  version:
+    description: "Version extracted from pubspec.yaml"
+    value: ${{ steps.version.outputs.VERSION }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Flutter
+      uses: subosito/flutter-action@v2
+      with:
+        flutter-version: ${{ inputs.flutter-version }}
+        channel: "stable"
+        cache: true
+        cache-key: deps-${{ hashFiles('**/pubspec.lock') }}
+        cache-path: ${{ runner.tool_cache }}/flutter
+
+    - name: Flutter clean
+      shell: bash
+      run: flutter clean
+
+    - name: Run prebuild
+      shell: bash
+      run: ./scripts/prebuild.sh
+
+    - name: Read version from pubspec.yaml
+      id: version
+      shell: bash
+      run: |
+        VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //;s/[[:space:]]//g')
+        if [ -z "$VERSION" ]; then
+          echo "::error::Could not extract version from pubspec.yaml"
+          exit 1
+        fi
+        echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "Version found: $VERSION"
+
+    - name: Export SENTRY_RELEASE
+      shell: bash
+      run: echo "SENTRY_RELEASE=${{ steps.version.outputs.VERSION }}" >> "$GITHUB_ENV"
+
+    - name: Build Flutter Web
+      shell: bash
+      run: ${{ inputs.build-command }}
+
+    - name: Upload source maps to Sentry
+      if: inputs.sentry-enabled == 'true' && env.SENTRY_AUTH_TOKEN != ''
+      shell: bash
+      run: dart run sentry_dart_plugin
+
+    - name: Upload source maps as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: build/web/**/*.map
+        retention-days: ${{ inputs.artifact-retention-days }}
+        if-no-files-found: warn
+
+    - name: Remove source maps
+      shell: bash
+      run: find build/web -type f -name '*.map' -delete

--- a/.github/workflows/build-web-image.yaml
+++ b/.github/workflows/build-web-image.yaml
@@ -1,0 +1,125 @@
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: "Deployment environment (dev/prod)"
+        type: string
+        required: true
+      docker-tags:
+        description: "Docker metadata tags (passed to docker/metadata-action)"
+        type: string
+        required: true
+      artifact-name:
+        description: "Name for the source map artifact"
+        type: string
+        required: false
+        default: "source-maps"
+
+name: Build and push web Docker image
+
+env:
+  FLUTTER_VERSION: 3.32.8
+
+jobs:
+  build:
+    name: Build and push
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build the Flutter build stage and load locally for source map extraction
+      - name: Build Flutter Web (Docker build stage)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: build-env
+          load: true
+          tags: tmail-build:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Extract source maps from the build stage container
+      - name: Extract source maps from Docker
+        run: |
+          CONTAINER_ID=$(docker create tmail-build:latest)
+          mkdir -p ./source-maps
+          docker cp "$CONTAINER_ID:/app/build/web" ./source-maps/web
+          docker rm "$CONTAINER_ID"
+
+      - name: Read version from pubspec.yaml
+        id: version
+        run: |
+          VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //;s/[[:space:]]//g')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not extract version from pubspec.yaml"
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+
+      # Upload source maps to Sentry via sentry-cli
+      - name: Upload source maps to Sentry
+        if: env.SENTRY_AUTH_TOKEN != ''
+        env:
+          SENTRY_RELEASE: ${{ steps.version.outputs.VERSION }}
+        run: |
+          npx @sentry/cli releases new "$SENTRY_RELEASE"
+          npx @sentry/cli releases files "$SENTRY_RELEASE" \
+            upload-sourcemaps ./source-maps/web/ \
+            --url-prefix '~/'
+          npx @sentry/cli releases finalize "$SENTRY_RELEASE"
+
+      # Upload source maps as GitHub Artifact
+      - name: Upload source maps as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: source-maps/web/**/*.map
+          retention-days: 30
+          if-no-files-found: warn
+
+      # Docker metadata for tagging
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ github.repository_owner }}/tmail-web
+            ghcr.io/${{ github.repository_owner }}/tmail-web
+          tags: ${{ inputs.docker-tags }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build and push the final multi-platform image
+      # The build-env stage is cached from the extraction step above
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: "linux/amd64,linux/arm64"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-web-image.yaml
+++ b/.github/workflows/build-web-image.yaml
@@ -19,7 +19,13 @@ name: Build and push web Docker image
 
 permissions:
   contents: read
+name: Build and push web Docker image
+
+permissions:
+  contents: read
   packages: write
+  actions: write
+  artifact-metadata: write
 
 env:
   FLUTTER_VERSION: 3.32.8
@@ -34,7 +40,6 @@ jobs:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
       SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-web-image.yaml
+++ b/.github/workflows/build-web-image.yaml
@@ -17,6 +17,10 @@ on:
 
 name: Build and push web Docker image
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   FLUTTER_VERSION: 3.32.8
 

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -68,7 +68,7 @@ jobs:
         run: |
           # Take the line containing the version, remove 'version: ', and discard the space.
           VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //;s/[[:space:]]//g')
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Version found: $VERSION"
 
       # 🧱 Build Flutter Web (release)
@@ -84,6 +84,7 @@ jobs:
 
       # Upload source maps via sentry_dart_plugin
       - name: Upload source maps to Sentry
+        if: ${{ secrets.SENTRY_AUTH_TOKEN != '' && github.event.pull_request.head.repo.fork == false }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -19,8 +19,12 @@ jobs:
       name: PR-${{ github.event.pull_request.number }}
       url: ${{ steps.configure.outputs.URL }}
 
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+
     steps:
-      # 🧹 Free up space before building
       - name: Free up disk space before build
         run: |
           echo "=== Disk space before cleanup ==="
@@ -33,84 +37,24 @@ jobs:
           echo "=== Disk space after cleanup ==="
           df -h
 
-      # 🔄 Checkout code
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # 🧰 Setup Flutter
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: "stable"
-          cache: true
-          cache-key: deps-${{ hashFiles('**/pubspec.lock') }} # optional, change this to force refresh cache
-          cache-path: ${{ runner.tool_cache }}/flutter # optional, change this to specify the cache path
-
-      # 🧹 Clean Flutter cache before building
-      - name: Flutter clean
-        run: flutter clean
-
-      # 📦 Run prebuild (if any)
-      - name: Run prebuild
-        run: ./scripts/prebuild.sh
-
-      # ⚙️ Configure environment for PR
       - name: Configure environments
         id: configure
         env:
           FOLDER: ${{ github.event.pull_request.number }}
         run: ./scripts/configure-web-environment.sh
 
-      # 🏷️ Read the version from pubspec.yaml
-      - name: Read version from pubspec.yaml
-        id: pubspec_version
-        run: |
-          # Take the line containing the version, remove 'version: ', and discard the space.
-          VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //;s/[[:space:]]//g')
-          if [ -z "$VERSION" ]; then
-            echo "::error::Could not extract version from pubspec.yaml"
-              exit 1
-          fi
-          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Version found: $VERSION"
-
-      # 🧱 Build Flutter Web (release)
-      - name: Build Web (Release)
+      - name: Build Flutter Web
+        uses: ./.github/actions/build-flutter-web
         env:
           FOLDER: ${{ github.event.pull_request.number }}
-        run: |
-          echo "=== Disk usage before build ==="
-          df -h
-          ./scripts/build-web.sh
-          echo "=== Disk usage after build ==="
-          df -h
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          build-command: "./scripts/build-web.sh"
+          artifact-name: source-maps-pr-${{ github.event.pull_request.number }}
 
-      # Check if Sentry secrets are available
-      - name: Check Sentry availability
-        id: sentry_check
-        run: |
-          if [ -n "${{ secrets.SENTRY_AUTH_TOKEN }}" ]; then
-           echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-           echo "available=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      # Upload source maps via sentry_dart_plugin
-      - name: Upload source maps to Sentry
-        if: ${{ steps.sentry_check.outputs.available == 'true' && github.event.pull_request.head.repo.fork == false }}
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-          SENTRY_RELEASE: ${{ steps.pubspec_version.outputs.VERSION }}
-        run: dart run sentry_dart_plugin
-
-      # 🛡️ Delete the source map before deploying to GitHub Pages.
-      - name: Remove source maps before deploy
-        run: find build/web -type f -name '*.map' -delete
-
-      # 🚀 Deploy to GitHub Pages
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
@@ -119,7 +63,6 @@ jobs:
           keep_files: true
           publish_dir: "build/web"
 
-      # 🧹 Clean up after build to save space
       - name: Cleanup after deploy
         if: always()
         run: |
@@ -128,7 +71,6 @@ jobs:
           echo "=== Disk usage after cleanup ==="
           df -h
 
-      # 💬 Create or update comments on PR
       - name: Find deployment comment
         uses: peter-evans/find-comment@v3
         id: fc

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -62,6 +62,15 @@ jobs:
           FOLDER: ${{ github.event.pull_request.number }}
         run: ./scripts/configure-web-environment.sh
 
+      # 🏷️ Read the version from pubspec.yaml
+      - name: Read version from pubspec.yaml
+        id: pubspec_version
+        run: |
+          # Take the line containing the version, remove 'version: ', and discard the space.
+          VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //;s/[[:space:]]//g')
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version found: $VERSION"
+
       # 🧱 Build Flutter Web (release)
       - name: Build Web (Release)
         env:
@@ -72,6 +81,19 @@ jobs:
           ./scripts/build-web.sh
           echo "=== Disk usage after build ==="
           df -h
+
+      # Upload source maps via sentry_dart_plugin
+      - name: Upload source maps to Sentry
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_RELEASE: ${{ steps.pubspec_version.outputs.VERSION }}
+        run: dart run sentry_dart_plugin
+
+      # 🛡️ Delete the source map before deploying to GitHub Pages.
+      - name: Remove source maps before deploy
+        run: rm -rf build/web/*.js.map
 
       # 🚀 Deploy to GitHub Pages
       - name: Deploy to GitHub Pages

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -68,6 +68,10 @@ jobs:
         run: |
           # Take the line containing the version, remove 'version: ', and discard the space.
           VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //;s/[[:space:]]//g')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not extract version from pubspec.yaml"
+              exit 1
+          fi
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Version found: $VERSION"
 
@@ -82,9 +86,19 @@ jobs:
           echo "=== Disk usage after build ==="
           df -h
 
+      # Check if Sentry secrets are available
+      - name: Check Sentry availability
+        id: sentry_check
+        run: |
+          if [ -n "${{ secrets.SENTRY_AUTH_TOKEN }}" ]; then
+           echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+           echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # Upload source maps via sentry_dart_plugin
       - name: Upload source maps to Sentry
-        if: ${{ secrets.SENTRY_AUTH_TOKEN != '' && github.event.pull_request.head.repo.fork == false }}
+        if: ${{ steps.sentry_check.outputs.available == 'true' && github.event.pull_request.head.repo.fork == false }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
@@ -94,7 +108,7 @@ jobs:
 
       # 🛡️ Delete the source map before deploying to GitHub Pages.
       - name: Remove source maps before deploy
-        run: rm -rf build/web/*.js.map
+        run: find build/web -type f -name '*.map' -delete
 
       # 🚀 Deploy to GitHub Pages
       - name: Deploy to GitHub Pages

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -50,7 +50,7 @@ jobs:
         id: version
         run: |
           VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //')
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 
       # Export SENTRY_RELEASE to sentry_dart_plugin to upload source maps
       - name: Export release
@@ -98,6 +98,7 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@v5
         with:
+          context: .
           push: true
           platforms: "linux/amd64,linux/arm64"
           cache-from: |
@@ -195,6 +196,7 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@v5
         with:
+          context: .
           push: true
           platforms: "linux/amd64,linux/arm64"
           cache-from: |

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -54,7 +54,7 @@ jobs:
 
       # Export SENTRY_RELEASE to sentry_dart_plugin to upload source maps
       - name: Export release
-        run: echo "SENTRY_RELEASE=${{ steps.version.outputs.VERSION }}" >> $GITHUB_ENV
+        run: echo "SENTRY_RELEASE=${{ steps.version.outputs.VERSION }}" >> "$GITHUB_ENV"
 
       # Build Flutter Web
       - name: Build Flutter Web
@@ -63,6 +63,10 @@ jobs:
       # Upload source maps via sentry_dart_plugin
       - name: Upload source maps to Sentry via sentry_dart_plugin
         run: dart run sentry_dart_plugin
+
+      # Remove source maps before Docker build
+      - name: Remove source maps before Docker build
+        run: find build/web -type f -name '*.map' -delete
 
       # ------------- DOCKER SECTION ---------------
       - name: Set up Docker Buildx
@@ -94,13 +98,12 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@v5
         with:
-          context: .
-          build-args: |
-            SENTRY_RELEASE=${{ env.SENTRY_RELEASE }}
           push: true
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha
+          platforms: "linux/amd64,linux/arm64"
+          cache-from: |
+            type=gha
+          cache-to: |
+            type=gha
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -143,11 +146,11 @@ jobs:
         id: version
         run: |
           VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //')
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 
       # Export SENTRY_RELEASE to sentry_dart_plugin to upload source maps
       - name: Export release
-        run: echo "SENTRY_RELEASE=${{ steps.version.outputs.VERSION }}" >> $GITHUB_ENV
+        run: echo "SENTRY_RELEASE=${{ steps.version.outputs.VERSION }}" >> "$GITHUB_ENV"
 
       # Build Flutter Web
       - name: Build Flutter Web
@@ -159,7 +162,7 @@ jobs:
 
       # 🛡️ Remove source maps so the Docker image doesn't contain original code.
       - name: Remove source maps before Docker build
-        run: rm -rf build/web/*.js.map
+        run: find build/web -type f -name '*.map' -delete
 
       # ---- DOCKER BUILD ----
       - name: Set up Docker Buildx
@@ -192,12 +195,11 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@v5
         with:
-          context: .
-          build-args: |
-            SENTRY_RELEASE=${{ env.SENTRY_RELEASE }}
           push: true
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha
+          platforms: "linux/amd64,linux/arm64"
+          cache-from: |
+            type=gha
+          cache-to: |
+            type=gha
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -7,201 +7,25 @@ on:
 
 name: Build Docker images
 
-env:
-  FLUTTER_VERSION: 3.32.8
-
 jobs:
   build-dev-image:
     name: Build development image
     if: github.ref_type == 'branch' && github.ref_name == 'master'
-    runs-on: ubuntu-latest
-    environment: dev
+    uses: ./.github/workflows/build-web-image.yaml
+    with:
+      environment: dev
+      docker-tags: type=ref,event=branch
+      artifact-name: source-maps-dev
+    secrets: inherit
 
-    env:
-      # Sentry ENV for sentry_dart_plugin
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      # ----------- FLUTTER WEB BUILD -------------
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: "stable"
-          cache: true
-          cache-key: deps-${{ hashFiles('**/pubspec.lock') }} # optional, change this to force refresh cache
-          cache-path: ${{ runner.tool_cache }}/flutter # optional, change this to specify the cache path
-
-      # 🧹 Clean Flutter cache before building
-      - name: Flutter clean
-        run: flutter clean
-
-      # 📦 Run prebuild (if any)
-      - name: Run prebuild
-        run: ./scripts/prebuild.sh
-
-      # Get version from pubspec.yaml for Sentry Release
-      - name: Read version from pubspec.yaml
-        id: version
-        run: |
-          VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //')
-          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
-
-      # Export SENTRY_RELEASE to sentry_dart_plugin to upload source maps
-      - name: Export release
-        run: echo "SENTRY_RELEASE=${{ steps.version.outputs.VERSION }}" >> "$GITHUB_ENV"
-
-      # Build Flutter Web
-      - name: Build Flutter Web
-        run: flutter build web --release --source-maps
-
-      # Upload source maps via sentry_dart_plugin
-      - name: Upload source maps to Sentry via sentry_dart_plugin
-        run: dart run sentry_dart_plugin
-
-      # Remove source maps before Docker build
-      - name: Remove source maps before Docker build
-        run: find build/web -type f -name '*.map' -delete
-
-      # ------------- DOCKER SECTION ---------------
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ github.repository_owner }}/tmail-web
-            ghcr.io/${{ github.repository_owner }}/tmail-web
-          tags: |
-            type=ref,event=branch
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          platforms: "linux/amd64,linux/arm64"
-          cache-from: |
-            type=gha
-          cache-to: |
-            type=gha
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-  # ================= RELEASE IMAGE JOB ===================
   build-release-image:
     name: Build release image
     if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    environment: prod
-
-    env:
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      # ----------- FLUTTER WEB BUILD -------------
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: "stable"
-          cache: true
-          cache-key: deps-${{ hashFiles('**/pubspec.lock') }} # optional, change this to force refresh cache
-          cache-path: ${{ runner.tool_cache }}/flutter # optional, change this to specify the cache path
-
-      # 🧹 Clean Flutter cache before building
-      - name: Flutter clean
-        run: flutter clean
-
-      # 📦 Run prebuild (if any)
-      - name: Run prebuild
-        run: ./scripts/prebuild.sh
-
-      # Get version from pubspec.yaml for Sentry Release
-      - name: Read version from pubspec.yaml
-        id: version
-        run: |
-          VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //')
-          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
-
-      # Export SENTRY_RELEASE to sentry_dart_plugin to upload source maps
-      - name: Export release
-        run: echo "SENTRY_RELEASE=${{ steps.version.outputs.VERSION }}" >> "$GITHUB_ENV"
-
-      # Build Flutter Web
-      - name: Build Flutter Web
-        run: flutter build web --release --source-maps
-
-      # Upload source maps via sentry_dart_plugin
-      - name: Upload source maps to Sentry via sentry_dart_plugin
-        run: dart run sentry_dart_plugin
-
-      # 🛡️ Remove source maps so the Docker image doesn't contain original code.
-      - name: Remove source maps before Docker build
-        run: find build/web -type f -name '*.map' -delete
-
-      # ---- DOCKER BUILD ----
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ github.repository_owner }}/tmail-web
-            ghcr.io/${{ github.repository_owner }}/tmail-web
-          tags: |
-            type=ref,event=tag
-            type=raw,value=release
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          platforms: "linux/amd64,linux/arm64"
-          cache-from: |
-            type=gha
-          cache-to: |
-            type=gha
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+    uses: ./.github/workflows/build-web-image.yaml
+    with:
+      environment: prod
+      docker-tags: |
+        type=ref,event=tag
+        type=raw,value=release
+      artifact-name: source-maps-release
+    secrets: inherit

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -7,6 +7,9 @@ on:
 
 name: Build Docker images
 
+env:
+  FLUTTER_VERSION: 3.32.8
+
 jobs:
   build-dev-image:
     name: Build development image
@@ -14,7 +17,54 @@ jobs:
     runs-on: ubuntu-latest
     environment: dev
 
+    env:
+      # Sentry ENV for sentry_dart_plugin
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # ----------- FLUTTER WEB BUILD -------------
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: "stable"
+          cache: true
+          cache-key: deps-${{ hashFiles('**/pubspec.lock') }} # optional, change this to force refresh cache
+          cache-path: ${{ runner.tool_cache }}/flutter # optional, change this to specify the cache path
+
+      # 🧹 Clean Flutter cache before building
+      - name: Flutter clean
+        run: flutter clean
+
+      # 📦 Run prebuild (if any)
+      - name: Run prebuild
+        run: ./scripts/prebuild.sh
+
+      # Get version from pubspec.yaml for Sentry Release
+      - name: Read version from pubspec.yaml
+        id: version
+        run: |
+          VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //')
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      # Export SENTRY_RELEASE to sentry_dart_plugin to upload source maps
+      - name: Export release
+        run: echo "SENTRY_RELEASE=${{ steps.version.outputs.VERSION }}" >> $GITHUB_ENV
+
+      # Build Flutter Web
+      - name: Build Flutter Web
+        run: flutter build web --release --source-maps
+
+      # Upload source maps via sentry_dart_plugin
+      - name: Upload source maps to Sentry via sentry_dart_plugin
+        run: dart run sentry_dart_plugin
+
+      # ------------- DOCKER SECTION ---------------
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -44,22 +94,74 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@v5
         with:
+          context: .
+          build-args: |
+            SENTRY_RELEASE=${{ env.SENTRY_RELEASE }}
           push: true
-          platforms: "linux/amd64,linux/arm64"
-          cache-from: |
-            type=gha
-          cache-to: |
-            type=gha
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+  # ================= RELEASE IMAGE JOB ===================
   build-release-image:
     name: Build release image
     if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: prod
 
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # ----------- FLUTTER WEB BUILD -------------
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: "stable"
+          cache: true
+          cache-key: deps-${{ hashFiles('**/pubspec.lock') }} # optional, change this to force refresh cache
+          cache-path: ${{ runner.tool_cache }}/flutter # optional, change this to specify the cache path
+
+      # 🧹 Clean Flutter cache before building
+      - name: Flutter clean
+        run: flutter clean
+
+      # 📦 Run prebuild (if any)
+      - name: Run prebuild
+        run: ./scripts/prebuild.sh
+
+      # Get version from pubspec.yaml for Sentry Release
+      - name: Read version from pubspec.yaml
+        id: version
+        run: |
+          VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //')
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      # Export SENTRY_RELEASE to sentry_dart_plugin to upload source maps
+      - name: Export release
+        run: echo "SENTRY_RELEASE=${{ steps.version.outputs.VERSION }}" >> $GITHUB_ENV
+
+      # Build Flutter Web
+      - name: Build Flutter Web
+        run: flutter build web --release --source-maps
+
+      # Upload source maps via sentry_dart_plugin
+      - name: Upload source maps to Sentry via sentry_dart_plugin
+        run: dart run sentry_dart_plugin
+
+      # 🛡️ Remove source maps so the Docker image doesn't contain original code.
+      - name: Remove source maps before Docker build
+        run: rm -rf build/web/*.js.map
+
+      # ---- DOCKER BUILD ----
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -90,11 +192,12 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@v5
         with:
+          context: .
+          build-args: |
+            SENTRY_RELEASE=${{ env.SENTRY_RELEASE }}
           push: true
-          platforms: "linux/amd64,linux/arm64"
-          cache-from: |
-            type=gha
-          cache-to: |
-            type=gha
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,7 @@ COPY build/web /usr/share/nginx/html
 EXPOSE 80
 
 # Re-gzip assets to ensure correct compression
-CMD gzip -k -r -f /usr/share/nginx/html/ && nginx -g 'daemon off;'
+# Pre-compress static assets at build time
+RUN gzip -k -r -f /usr/share/nginx/html/
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/docs/adr/0070-upload-source-maps-to-sentry-and-github-artifacts.md
+++ b/docs/adr/0070-upload-source-maps-to-sentry-and-github-artifacts.md
@@ -1,0 +1,28 @@
+# 70. Upload source maps to Sentry and GitHub Artifacts
+
+Date: 2026-01-28
+
+## Status
+
+Accepted
+
+## Context
+
+- Minified JS in Sentry error reports is unreadable without source maps
+- Source maps must not ship to production (exposes original code)
+- Source maps must match the exact build deployed
+
+## Decision
+
+- Build Flutter web with `--source-maps` inside Docker (multi-stage)
+- Extract `.map` files from Docker build stage via `docker cp`
+- Upload to Sentry (`sentry-cli`) and GitHub Artifacts (30-day retention)
+- Delete `.map` files in Docker runtime stage
+- DRY `image.yaml` via reusable workflow (`build-web-image.yaml`)
+
+## Consequences
+
+- Readable Sentry stack traces
+- Source maps guaranteed consistent with deployed build
+- Final Docker image contains no `.map` files
+- `image.yaml` reduced from ~208 to ~32 lines

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -25,6 +25,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.13.0"
+  ansicolor:
+    dependency: transitive
+    description:
+      name: ansicolor
+      sha256: "50e982d500bc863e1d703448afdbf9e5a72eb48840a4f766fa361ffd6877055f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3"
   app_links:
     dependency: "direct main"
     description:
@@ -1211,6 +1219,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  globbing:
+    dependency: transitive
+    description:
+      name: globbing
+      sha256: "4f89cfaf6fa74c9c1740a96259da06bd45411ede56744e28017cc534a12b6e2d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   graphs:
     dependency: transitive
     description:
@@ -1325,6 +1341,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  injector:
+    dependency: transitive
+    description:
+      name: injector
+      sha256: ed389bed5b48a699d5b9561c985023d0d5cc88dd5ff2237aadcce5a5ab433e4e
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   internet_connection_checker:
     dependency: "direct main"
     description:
@@ -1950,6 +1974,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.4"
+  properties:
+    dependency: transitive
+    description:
+      name: properties
+      sha256: "333f427dd4ed07bdbe8c75b9ff864a1e70b5d7a8426a2e8bdd457b65ae5ac598"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   pub_semver:
     dependency: transitive
     description:
@@ -2047,6 +2079,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.8.0"
+  sentry_dart_plugin:
+    dependency: "direct dev"
+    description:
+      name: sentry_dart_plugin
+      sha256: "4b25aa60b5cbb46bb23859ac9212c4de5b22e2b3bc3fecbcd611756ada8973b5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   sentry_dio:
     dependency: "direct main"
     description:
@@ -2291,6 +2331,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.0"
+  system_info2:
+    dependency: transitive
+    description:
+      name: system_info2
+      sha256: b937736ecfa63c45b10dde1ceb6bb30e5c0c340e14c441df024150679d65ac43
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -302,6 +302,8 @@ dev_dependencies:
 
   plugin_platform_interface: 2.1.8
 
+  sentry_dart_plugin: 3.2.0
+
 dependency_overrides:
   firebase_core_platform_interface: 4.8.0
 
@@ -446,3 +448,8 @@ patrol:
   app_name: Twake Mail
   android:
     package_name: com.linagora.android.teammail
+
+sentry:
+  release: "${SENTRY_RELEASE}"
+  upload_source_maps: true
+  ignore_missing: true

--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -3,4 +3,4 @@
 set -eux
 
 # Build web in release mode (lightweight, optimized)
-flutter build web --release --base-href "/${GITHUB_REPOSITORY##*/}/$FOLDER/"
+flutter build web --release  --source-maps --base-href "/${GITHUB_REPOSITORY##*/}/$FOLDER/"


### PR DESCRIPTION
## Resolved

- Upload source maps success

<img width="879" height="342" alt="Screenshot 2026-01-27 at 15 02 28" src="https://github.com/user-attachments/assets/4748cb94-c26c-4f4d-a86c-9188a81dbf0e" />


- Build docker image success

<img width="639" height="640" alt="Screenshot 2026-01-27 at 14 46 38" src="https://github.com/user-attachments/assets/9d70532e-80fd-4e79-b708-60f817bc9d0f" />

- Build  gh-page skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure & Build Improvements**
  * CI simplified: consolidated build steps into reusable actions/workflows, replaced many step-level scripts, and unified image build/push flows; PR job-level Sentry env vars added.
  * Web builds now generate source maps but remove them from runtime artifacts before publishing.

* **New Features**
  * Optional automated upload of source maps and release metadata to error-tracking when configured.

* **Chores**
  * Added tooling and CI config to support source-map handling, artifact uploads, and release management.

* **Documentation**
  * Added design notes on source-map and artifact handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->