### PR TITLE
TF-4283 fix: normalize "$needs-action" keyword to "needs-action"

### DIFF
--- a/model/lib/extensions/keyword_identifier_extension.dart
+++ b/model/lib/extensions/keyword_identifier_extension.dart
@@ -5,7 +5,7 @@ import 'package:model/email/read_actions.dart';
 
 extension KeyWordIdentifierExtension on KeyWordIdentifier {
   static final unsubscribeMail = KeyWordIdentifier('\$unsubscribe');
-  static final needsActionMail = KeyWordIdentifier('\$needs-action');
+  static final needsActionMail = KeyWordIdentifier('needs-action');
 
   String generatePath() => '${PatchObject.keywordsProperty}/$value';
 


### PR DESCRIPTION
# Issue

#4283 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue with the identification and processing of emails marked as requiring action.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->