### PR TITLE
[HOT-FIX] Missing select icon in dropdown label quick search

### DIFF
--- a/lib/features/base/widget/popup_menu/popup_menu_item_action_widget.dart
+++ b/lib/features/base/widget/popup_menu/popup_menu_item_action_widget.dart
@@ -221,7 +221,7 @@ class _PopupMenuItemActionWidgetState extends State<PopupMenuItemActionWidget> {
             child: Row(
               children: [
                 if (iconWidget != null) iconWidget,
-                if (!isArrangeRTL && isSelected && selectedIconWidget != null)
+                if (!isArrangeRTL && selectedIconWidget != null)
                   Padding(
                     padding: const EdgeInsetsDirectional.only(end: 16),
                     child: selectedIconWidget,

--- a/lib/features/email/presentation/utils/email_action_reactor/email_action_reactor.dart
+++ b/lib/features/email/presentation/utils/email_action_reactor/email_action_reactor.dart
@@ -507,7 +507,7 @@ class EmailActionReactor {
       if (EmailUtils.isReplyToListEnabled(presentationEmail.listPost ?? '') &&
           additionalActions.contains(EmailActionType.replyToList))
         EmailActionType.replyToList,
-      if (isLabelAvailable)
+      if (isLabelAvailable && labels?.isNotEmpty == true)
         EmailActionType.labelAs,
       if (PlatformInfo.isWeb &&
           PlatformInfo.isCanvasKit &&

--- a/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart
+++ b/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart
@@ -650,6 +650,7 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
       final isThreadRoute =
           controller.dashboardRoute.value == DashboardRoutes.thread;
       final isLabelAvailable = controller.isLabelAvailable;
+      final labelList = controller.labelController.labels;
 
       if (isSearchEmailRunning && isThreadRoute) {
         return Padding(
@@ -678,7 +679,7 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
                       children: [
                         _buildQuickSearchFilterButton(context, QuickSearchFilter.folder),
                         MailboxDashboardViewWebStyle.searchFilterSizeBoxMargin,
-                        if (isLabelAvailable)
+                        if (isLabelAvailable && labelList.isNotEmpty)
                           ...[
                             _buildQuickSearchFilterButton(
                               context,

--- a/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_input_form.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_input_form.dart
@@ -131,7 +131,7 @@ class AdvancedSearchInputForm extends GetWidget<AdvancedFilterController> {
 
             final labelSelected = controller.selectedLabel.value;
 
-            if (isLabelAvailable) {
+            if (isLabelAvailable && labels.isNotEmpty) {
               return AdvancedSearchFieldWidget(
                 filterField: FilterField.labels,
                 padding: const EdgeInsets.only(bottom: 12),

--- a/lib/features/search/email/presentation/model/popup_menu_item_label_type_action.dart
+++ b/lib/features/search/email/presentation/model/popup_menu_item_label_type_action.dart
@@ -1,6 +1,6 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
-import 'package:flutter/animation.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:labels/extensions/label_extension.dart';
 import 'package:labels/model/label.dart';
 import 'package:tmail_ui_user/features/base/model/popup_menu_item_action.dart';
@@ -32,4 +32,9 @@ class PopupMenuItemLabelTypeAction
 
   @override
   bool get isArrangeRTL => false;
+
+  @override
+  EdgeInsetsGeometry get itemPadding =>  const EdgeInsetsDirectional.only(
+    end: 12,
+  );
 }

--- a/lib/features/search/email/presentation/search_email_view.dart
+++ b/lib/features/search/email/presentation/search_email_view.dart
@@ -270,6 +270,8 @@ class SearchEmailView extends GetWidget<SearchEmailController>
               child: Obx(() {
                 final isLabelAvailable =
                     controller.mailboxDashBoardController.isLabelAvailable;
+                final labelList = controller
+                    .mailboxDashBoardController.labelController.labels;
 
                 return ListView(
                   key: const Key('search_filter_list_view'),
@@ -283,7 +285,7 @@ class SearchEmailView extends GetWidget<SearchEmailController>
                   children: [
                     _buildSearchFilterButton(context, QuickSearchFilter.folder),
                     SearchEmailViewStyle.searchFilterSizeBoxMargin,
-                    if (isLabelAvailable)
+                    if (isLabelAvailable && labelList.isNotEmpty)
                      ...[
                        _buildSearchFilterButton(context, QuickSearchFilter.labels),
                        SearchEmailViewStyle.searchFilterSizeBoxMargin,

--- a/lib/features/thread_detail/presentation/extension/on_thread_detail_action_click.dart
+++ b/lib/features/thread_detail/presentation/extension/on_thread_detail_action_click.dart
@@ -137,7 +137,8 @@ extension OnThreadDetailActionClick on ThreadDetailController {
     if (currentContext == null) return;
 
     final moreActions = [
-      if (mailboxDashBoardController.isLabelAvailable)
+      if (mailboxDashBoardController.isLabelAvailable &&
+          mailboxDashBoardController.labelController.labels.isNotEmpty)
         EmailActionType.labelAs,
       threadDetailIsRead
           ? EmailActionType.markAsUnread


### PR DESCRIPTION
## Issue

- [x] Always show checkbox icon in Label Quick search dropdown

<img width="743" height="370" alt="Screenshot 2026-02-02 at 11 18 42" src="https://github.com/user-attachments/assets/3e59a82f-56ac-4d7c-a70c-6717957e958b" />


- [x] Show label search filter only when label list is not empty

<img width="667" height="164" alt="Screenshot 2026-02-02 at 11 41 44" src="https://github.com/user-attachments/assets/2625b235-4e67-440d-b6ff-68c099f63137" />

## Resolved

- Always show checkbox icon in Label Quick search dropdown


<img width="474" height="452" alt="Screenshot 2026-02-02 at 11 42 39" src="https://github.com/user-attachments/assets/7c73616b-5e41-44d0-9095-eff5eddf8fca" />

- Show label search filter only when label list is not empty


 

https://github.com/user-attachments/assets/62d90d3f-f08b-4c08-9b56-9567e6ad2477




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Label filter options and actions are now hidden when no labels are configured in the system.
  * Fixed inconsistent display of selection indicators in popup menus for certain layout modes.

* **Style**
  * Adjusted spacing for label selection menu items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->