### PR TITLE
HOTFIX Create identity memory leak

### DIFF
--- a/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
+++ b/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
@@ -75,6 +75,7 @@ class RichTextMobileTabletController extends GetxController {
   @override
   void onClose() {
     richTextController.dispose();
+    htmlEditorApi?.webViewController.dispose();
     htmlEditorApi = null;
     super.onClose();
   }

--- a/lib/features/public_asset/presentation/public_asset_bindings.dart
+++ b/lib/features/public_asset/presentation/public_asset_bindings.dart
@@ -43,7 +43,7 @@ class PublicAssetBindings extends BaseBindings {
 
   @override
   void bindingsController() {
-    Get.create(
+    Get.lazyPut(
       () => PublicAssetController(
         Get.find<UploadAttachmentInteractor>(tag: BindingTag.publicAssetBindingsTag),
         Get.find<CreatePublicAssetInteractor>(tag: BindingTag.publicAssetBindingsTag),

--- a/test/features/identity_creator/presentation/identity_creator_controller_test.dart
+++ b/test/features/identity_creator/presentation/identity_creator_controller_test.dart
@@ -44,6 +44,7 @@ import 'package:tmail_ui_user/features/manage_account/presentation/model/identit
 import 'package:tmail_ui_user/features/public_asset/domain/model/public_assets_in_identity_arguments.dart';
 import 'package:tmail_ui_user/features/public_asset/domain/usecase/create_public_asset_interactor.dart';
 import 'package:tmail_ui_user/features/public_asset/domain/usecase/delete_public_assets_interactor.dart';
+import 'package:tmail_ui_user/features/public_asset/presentation/public_asset_controller.dart';
 import 'package:tmail_ui_user/features/upload/data/network/file_uploader.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
 import 'package:tmail_ui_user/main/exceptions/remote_exception_thrower.dart';
@@ -178,6 +179,10 @@ void main() {
       mockGetAllIdentitiesInteractor,
       mockSaveIdentityCacheOnWebInteractor,
       mockIdentityUtils);
+  });
+
+  tearDown(() {
+    Get.delete<PublicAssetController>(tag: BindingTag.publicAssetBindingsTag);
   });
 
   group("IdentityCreatorController test:", () {


### PR DESCRIPTION
## Related issue
- https://github.com/linagora/tmail-flutter/issues/4293

## Before
### Mobile

<img width="4064" height="2384" alt="heavy-identity-mobile-before" src="https://github.com/user-attachments/assets/78db57fa-313f-478e-bb12-f103762c00e2" />

### Web

<img width="1552" height="1012" alt="heavy-identity-web-before" src="https://github.com/user-attachments/assets/2a18c18c-c2c1-4b0b-8f38-0b4a4422bbd6" />

## After
### Mobile

<img width="4064" height="2384" alt="heavy-identity-mobile-after" src="https://github.com/user-attachments/assets/8e61bf59-1c8c-414d-b110-c410c9a8168b" />

### Web

<img width="1552" height="1012" alt="heavy-identity-web-after" src="https://github.com/user-attachments/assets/5c546c95-800b-4b4f-a127-573d036537ee" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resource cleanup in the rich-text editor to ensure proper disposal during controller teardown.

* **Refactor**
  * Optimized controller initialization timing for asset management via lazy loading.

* **Tests**
  * Added teardown cleanup in tests to remove controller bindings after execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->