### PR TITLE
[Label] Implement auto-sync of tags via WebSocket

### DIFF
--- a/fcm/lib/model/type_name.dart
+++ b/fcm/lib/model/type_name.dart
@@ -5,6 +5,7 @@ class TypeName with EquatableMixin {
   static const mailboxType = TypeName('Mailbox');
   static const emailType = TypeName('Email');
   static const emailDelivery = TypeName('EmailDelivery');
+  static const labelType = TypeName('Label');
 
   final String value;
 

--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -365,9 +365,13 @@ abstract class BaseController extends GetxController
     }
   }
 
-  void injectWebSocket(Session? session, AccountId? accountId) {
+  void injectWebSocket({
+    Session? session,
+    AccountId? accountId,
+    bool isLabelAvailable = false,
+  }) {
     try {
-      log('$runtimeType::injectWebSocket:');
+      log('$runtimeType::injectWebSocket: isLabelAvailable is $isLabelAvailable');
       requireCapability(
         session!,
         accountId!,
@@ -383,7 +387,11 @@ abstract class BaseController extends GetxController
         throw WebSocketPushNotSupportedException();
       }
       WebSocketInteractorBindings().dependencies();
-      WebSocketController.instance.initialize(accountId: accountId, session: session);
+      WebSocketController.instance.initialize(
+        accountId: accountId,
+        session: session,
+        isLabelAvailable: isLabelAvailable,
+      );
     } catch(e) {
       logWarning('$runtimeType::injectWebSocket(): exception: $e');
     }

--- a/lib/features/base/mixin/batch_get_label_processing_mixin.dart
+++ b/lib/features/base/mixin/batch_get_label_processing_mixin.dart
@@ -1,0 +1,103 @@
+import 'dart:math' hide log;
+
+import 'package:core/utils/app_logger.dart';
+import 'package:jmap_dart_client/http/http_client.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart';
+import 'package:jmap_dart_client/jmap/jmap_request.dart';
+import 'package:labels/method/get/get_label_method.dart';
+import 'package:labels/method/get/get_label_response.dart';
+import 'package:labels/model/label.dart';
+import 'package:tmail_ui_user/features/base/mixin/handle_error_mixin.dart';
+import 'package:tmail_ui_user/features/base/mixin/session_mixin.dart';
+
+mixin BatchGetLabelProcessingMixin on HandleSetErrorMixin, SessionMixin {
+  Future<
+      ({
+        List<Label> labels,
+        List<Id> notFoundIds,
+        State? state,
+      })> executeBatchGetLabel({
+    required Session session,
+    required AccountId accountId,
+    required List<Id> labelIds,
+    required HttpClient httpClient,
+    String debugLabel = 'executeBatchGetLabel',
+  }) async {
+    if (labelIds.isEmpty) {
+      return (labels: <Label>[], notFoundIds: <Id>[], state: null);
+    }
+
+    final maxObjects = getMaxObjectsInGetMethod(session, accountId);
+    final totalEmails = labelIds.length;
+    final batchSize = max(1, min(totalEmails, maxObjects));
+
+    final List<Label> allLabels = [];
+    final List<Id> allNotFoundIds = [];
+    State? latestState;
+
+    for (int start = 0; start < totalEmails; start += batchSize) {
+      int end =
+          (start + batchSize < totalEmails) ? start + batchSize : totalEmails;
+      final currentListIds = labelIds.sublist(start, end);
+
+      log('BatchGetLabelProcessingMixin::$debugLabel: processing batch ${start + 1} to $end');
+
+      try {
+        final response = await _executeGetLabelBatch(
+          accountId: accountId,
+          httpClient: httpClient,
+          labelIds: currentListIds,
+        );
+
+        if (response == null) {
+          throw Exception('GetLabelResponse is null');
+        }
+
+        if (response.list.isNotEmpty) {
+          allLabels.addAll(response.list);
+        }
+
+        latestState = response.state;
+
+        final notFoundIds = response.notFound ?? [];
+        if (notFoundIds.isNotEmpty) {
+          allNotFoundIds.addAll(notFoundIds);
+        }
+      } catch (e) {
+        logWarning(
+          'BatchGetLabelProcessingMixin::$debugLabel: Error processing batch ${start + 1}-$end: $e',
+        );
+      }
+    }
+
+    return (labels: allLabels, notFoundIds: allNotFoundIds, state: latestState);
+  }
+
+  Future<GetLabelResponse?> _executeGetLabelBatch({
+    required AccountId accountId,
+    required HttpClient httpClient,
+    required List<Id> labelIds,
+  }) async {
+    final getLabelMethod = GetLabelMethod(accountId)..addIds(labelIds.toSet());
+
+    final requestBuilder = JmapRequestBuilder(
+      httpClient,
+      ProcessingInvocation(),
+    );
+
+    final invocation = requestBuilder.invocation(getLabelMethod);
+
+    final response = await (requestBuilder
+          ..usings(getLabelMethod.requiredCapabilities))
+        .build()
+        .execute();
+
+    return response.parse<GetLabelResponse>(
+      invocation.methodCallId,
+      GetLabelResponse.deserialize,
+    );
+  }
+}

--- a/lib/features/base/mixin/batch_get_label_processing_mixin.dart
+++ b/lib/features/base/mixin/batch_get_label_processing_mixin.dart
@@ -31,16 +31,16 @@ mixin BatchGetLabelProcessingMixin on HandleSetErrorMixin, SessionMixin {
     }
 
     final maxObjects = getMaxObjectsInGetMethod(session, accountId);
-    final totalEmails = labelIds.length;
-    final batchSize = max(1, min(totalEmails, maxObjects));
+    final totalLabels = labelIds.length;
+    final batchSize = max(1, min(totalLabels, maxObjects));
 
     final List<Label> allLabels = [];
     final List<Id> allNotFoundIds = [];
     State? latestState;
 
-    for (int start = 0; start < totalEmails; start += batchSize) {
+    for (int start = 0; start < totalLabels; start += batchSize) {
       int end =
-          (start + batchSize < totalEmails) ? start + batchSize : totalEmails;
+          (start + batchSize < totalLabels) ? start + batchSize : totalLabels;
       final currentListIds = labelIds.sublist(start, end);
 
       log('BatchGetLabelProcessingMixin::$debugLabel: processing batch ${start + 1} to $end');

--- a/lib/features/base/mixin/batch_get_label_processing_mixin.dart
+++ b/lib/features/base/mixin/batch_get_label_processing_mixin.dart
@@ -39,8 +39,7 @@ mixin BatchGetLabelProcessingMixin on HandleSetErrorMixin, SessionMixin {
     State? latestState;
 
     for (int start = 0; start < totalLabels; start += batchSize) {
-      int end =
-          (start + batchSize < totalLabels) ? start + batchSize : totalLabels;
+      int end = min(start + batchSize, totalLabels);
       final currentListIds = labelIds.sublist(start, end);
 
       log('BatchGetLabelProcessingMixin::$debugLabel: processing batch ${start + 1} to $end');

--- a/lib/features/base/mixin/batch_set_email_processing_mixin.dart
+++ b/lib/features/base/mixin/batch_set_email_processing_mixin.dart
@@ -15,13 +15,15 @@ import 'package:jmap_dart_client/jmap/mail/email/set/set_email_response.dart';
 import 'package:model/extensions/list_id_extension.dart';
 import 'package:tmail_ui_user/features/base/mixin/handle_error_mixin.dart';
 import 'package:tmail_ui_user/features/base/mixin/mail_api_mixin.dart';
+import 'package:tmail_ui_user/features/base/mixin/session_mixin.dart';
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
 
 typedef OnGeneratePatchObjectUpdates = Map<Id, PatchObject> Function(
   List<EmailId> batchIds,
 );
 
-mixin BatchSetEmailProcessingMixin on HandleSetErrorMixin, MailAPIMixin {
+mixin BatchSetEmailProcessingMixin
+    on HandleSetErrorMixin, SessionMixin, MailAPIMixin {
   Future<
       ({
         List<EmailId> emailIdsSuccess,

--- a/lib/features/base/mixin/mail_api_mixin.dart
+++ b/lib/features/base/mixin/mail_api_mixin.dart
@@ -7,8 +7,6 @@ import 'package:core/utils/app_logger.dart';
 import 'package:dartz/dartz.dart';
 import 'package:jmap_dart_client/http/http_client.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
-import 'package:jmap_dart_client/jmap/core/capability/capability_identifier.dart';
-import 'package:jmap_dart_client/jmap/core/capability/core_capability.dart';
 import 'package:jmap_dart_client/jmap/core/error/set_error.dart';
 import 'package:jmap_dart_client/jmap/core/filter/filter.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
@@ -33,8 +31,8 @@ import 'package:model/email/email_property.dart';
 import 'package:model/extensions/list_email_extension.dart';
 import 'package:model/extensions/list_email_id_extension.dart';
 import 'package:model/extensions/list_id_extension.dart';
-import 'package:model/extensions/session_extension.dart';
 import 'package:tmail_ui_user/features/base/mixin/handle_error_mixin.dart';
+import 'package:tmail_ui_user/features/base/mixin/session_mixin.dart';
 import 'package:tmail_ui_user/features/email/domain/model/move_action.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/exceptions/mailbox_exception.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/state/move_folder_content_state.dart';
@@ -43,24 +41,7 @@ import 'package:tmail_ui_user/features/thread/data/extensions/list_email_id_exte
 import 'package:tmail_ui_user/features/thread/domain/model/email_response.dart';
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
 
-mixin MailAPIMixin on HandleSetErrorMixin {
-  int getMaxObjectsInSetMethod(Session session, AccountId accountId) {
-    final coreCapability = session.getCapabilityProperties<CoreCapability>(
-      accountId,
-      CapabilityIdentifier.jmapCore,
-    );
-    final maxObjectsInSetMethod =
-        coreCapability?.maxObjectsInSet?.value.toInt() ??
-            CapabilityIdentifierExtension.defaultMaxObjectsInSet;
-
-    final minOfMaxObjectsInSetMethod = min(
-      maxObjectsInSetMethod,
-      CapabilityIdentifierExtension.defaultMaxObjectsInSet,
-    );
-    log('$runtimeType::_getMaxObjectsInSetMethod:minOfMaxObjectsInSetMethod = $minOfMaxObjectsInSetMethod');
-    return minOfMaxObjectsInSetMethod;
-  }
-
+mixin MailAPIMixin on HandleSetErrorMixin, SessionMixin {
   Future<({List<EmailId> emailIdsSuccess, Map<Id, SetError> mapErrors})>
       moveEmailsBetweenMailboxes({
     required HttpClient httpClient,

--- a/lib/features/base/mixin/mail_api_mixin.dart
+++ b/lib/features/base/mixin/mail_api_mixin.dart
@@ -92,10 +92,10 @@ mixin MailAPIMixin on HandleSetErrorMixin, SessionMixin {
       );
 
       final listEmailIds = setEmailResponse?.updated?.keys.toEmailIds() ?? [];
-      final mapErrors = handleSetResponse([setEmailResponse]);
+      final batchErrors = handleSetResponse([setEmailResponse]);
 
       updatedEmailIds.addAll(listEmailIds);
-      mapErrors.addAll(mapErrors);
+      mapErrors.addAll(batchErrors);
     }
 
     return (emailIdsSuccess: updatedEmailIds, mapErrors: mapErrors);

--- a/lib/features/base/mixin/session_mixin.dart
+++ b/lib/features/base/mixin/session_mixin.dart
@@ -22,7 +22,7 @@ mixin SessionMixin {
       maxObjectsInSetMethod,
       CapabilityIdentifierExtension.defaultMaxObjectsInSet,
     );
-    log('$runtimeType::_getMaxObjectsInSetMethod:minOfMaxObjectsInSetMethod = $minOfMaxObjectsInSetMethod');
+    log('$runtimeType::getMaxObjectsInSetMethod:minOfMaxObjectsInSetMethod = $minOfMaxObjectsInSetMethod');
     return minOfMaxObjectsInSetMethod;
   }
 

--- a/lib/features/base/mixin/session_mixin.dart
+++ b/lib/features/base/mixin/session_mixin.dart
@@ -1,0 +1,41 @@
+import 'dart:math' hide log;
+
+import 'package:core/utils/app_logger.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/capability/capability_identifier.dart';
+import 'package:jmap_dart_client/jmap/core/capability/core_capability.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:model/extensions/session_extension.dart';
+import 'package:tmail_ui_user/main/error/capability_validator.dart';
+
+mixin SessionMixin {
+  int getMaxObjectsInSetMethod(Session session, AccountId accountId) {
+    final coreCapability = session.getCapabilityProperties<CoreCapability>(
+      accountId,
+      CapabilityIdentifier.jmapCore,
+    );
+    final maxObjectsInSetMethod =
+        coreCapability?.maxObjectsInSet?.value.toInt() ??
+            CapabilityIdentifierExtension.defaultMaxObjectsInSet;
+
+    final minOfMaxObjectsInSetMethod = min(
+      maxObjectsInSetMethod,
+      CapabilityIdentifierExtension.defaultMaxObjectsInSet,
+    );
+    log('$runtimeType::_getMaxObjectsInSetMethod:minOfMaxObjectsInSetMethod = $minOfMaxObjectsInSetMethod');
+    return minOfMaxObjectsInSetMethod;
+  }
+
+  int getMaxObjectsInGetMethod(Session session, AccountId accountId) {
+    final maxObjectsInGetMethod =
+        session.getMaxObjectsInGet(accountId)?.value.toInt() ??
+            CapabilityIdentifierExtension.defaultMaxObjectsInGet;
+
+    final minOfMaxObjectsInGetMethod = min(
+      maxObjectsInGetMethod,
+      CapabilityIdentifierExtension.defaultMaxObjectsInGet,
+    );
+    log('$runtimeType::getMaxObjectsInGetMethod:minOfMaxObjectsInGetMethod = $minOfMaxObjectsInGetMethod');
+    return minOfMaxObjectsInGetMethod;
+  }
+}

--- a/lib/features/email/data/network/email_api.dart
+++ b/lib/features/email/data/network/email_api.dart
@@ -56,6 +56,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:tmail_ui_user/features/base/mixin/batch_set_email_processing_mixin.dart';
 import 'package:tmail_ui_user/features/base/mixin/handle_error_mixin.dart';
 import 'package:tmail_ui_user/features/base/mixin/mail_api_mixin.dart';
+import 'package:tmail_ui_user/features/base/mixin/session_mixin.dart';
 import 'package:tmail_ui_user/features/composer/domain/exceptions/set_method_exception.dart';
 import 'package:tmail_ui_user/features/composer/domain/model/email_request.dart';
 import 'package:tmail_ui_user/features/download/domain/model/download_source_view.dart';
@@ -70,11 +71,12 @@ import 'package:tmail_ui_user/main/error/capability_validator.dart';
 import 'package:uri/uri.dart';
 import 'package:uuid/uuid.dart';
 
-class EmailAPI with
-    HandleSetErrorMixin,
-    MailAPIMixin,
-    BatchSetEmailProcessingMixin {
-
+class EmailAPI
+    with
+        HandleSetErrorMixin,
+        SessionMixin,
+        MailAPIMixin,
+        BatchSetEmailProcessingMixin {
   final HttpClient _httpClient;
   final DownloadManager _downloadManager;
   final DioClient _dioClient;

--- a/lib/features/labels/data/datasource/label_datasource.dart
+++ b/lib/features/labels/data/datasource/label_datasource.dart
@@ -6,7 +6,7 @@ import 'package:tmail_ui_user/features/labels/domain/model/edit_label_request.da
 import 'package:tmail_ui_user/features/labels/data/model/label_change_response.dart';
 
 abstract class LabelDatasource {
-  Future<List<Label>> getAllLabels(AccountId accountId);
+  Future<({List<Label> labels, State? newState})> getAllLabels(AccountId accountId);
 
   Future<Label> createNewLabel(AccountId accountId, Label labelData);
 

--- a/lib/features/labels/data/datasource/label_datasource.dart
+++ b/lib/features/labels/data/datasource/label_datasource.dart
@@ -1,6 +1,9 @@
 import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart';
 import 'package:labels/model/label.dart';
 import 'package:tmail_ui_user/features/labels/domain/model/edit_label_request.dart';
+import 'package:tmail_ui_user/features/labels/data/model/label_change_response.dart';
 
 abstract class LabelDatasource {
   Future<List<Label>> getAllLabels(AccountId accountId);
@@ -10,4 +13,10 @@ abstract class LabelDatasource {
   Future<Label> editLabel(AccountId accountId, EditLabelRequest labelRequest);
 
   Future<void> deleteLabel(AccountId accountId, Label label);
+
+  Future<LabelChangeResponse> getLabelChanges(
+    Session session,
+    AccountId accountId,
+    State sinceState,
+  );
 }

--- a/lib/features/labels/data/datasource_impl/label_datasource_impl.dart
+++ b/lib/features/labels/data/datasource_impl/label_datasource_impl.dart
@@ -1,6 +1,9 @@
 import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart';
 import 'package:labels/model/label.dart';
 import 'package:tmail_ui_user/features/labels/data/datasource/label_datasource.dart';
+import 'package:tmail_ui_user/features/labels/data/model/label_change_response.dart';
 import 'package:tmail_ui_user/features/labels/data/network/label_api.dart';
 import 'package:tmail_ui_user/features/labels/domain/model/edit_label_request.dart';
 import 'package:tmail_ui_user/main/exceptions/exception_thrower.dart';
@@ -36,6 +39,21 @@ class LabelDatasourceImpl extends LabelDatasource {
   Future<void> deleteLabel(AccountId accountId, Label label) {
     return Future.sync(() async {
       return await _labelApi.deleteLabel(accountId, label);
+    }).catchError(_exceptionThrower.throwException);
+  }
+
+  @override
+  Future<LabelChangeResponse> getLabelChanges(
+    Session session,
+    AccountId accountId,
+    State sinceState,
+  ) {
+    return Future.sync(() async {
+      return await _labelApi.getLabelChangesWithResult(
+        session,
+        accountId,
+        sinceState,
+      );
     }).catchError(_exceptionThrower.throwException);
   }
 }

--- a/lib/features/labels/data/datasource_impl/label_datasource_impl.dart
+++ b/lib/features/labels/data/datasource_impl/label_datasource_impl.dart
@@ -15,7 +15,7 @@ class LabelDatasourceImpl extends LabelDatasource {
   LabelDatasourceImpl(this._labelApi, this._exceptionThrower);
 
   @override
-  Future<List<Label>> getAllLabels(AccountId accountId) {
+  Future<({List<Label> labels, State? newState})> getAllLabels(AccountId accountId) {
     return Future.sync(() async {
       return await _labelApi.getAllLabels(accountId);
     }).catchError(_exceptionThrower.throwException);

--- a/lib/features/labels/data/model/label_change_response.dart
+++ b/lib/features/labels/data/model/label_change_response.dart
@@ -1,0 +1,32 @@
+import 'package:equatable/equatable.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart';
+import 'package:labels/model/label.dart';
+
+class LabelChangeResponse with EquatableMixin {
+  final List<Label>? updated;
+  final List<Label>? created;
+  final List<Id>? destroyed;
+  final State? newStateLabel;
+  final State? newStateChanges;
+  final bool hasMoreChanges;
+
+  LabelChangeResponse({
+    this.updated,
+    this.created,
+    this.destroyed,
+    this.newStateLabel,
+    this.newStateChanges,
+    this.hasMoreChanges = false,
+  });
+
+  @override
+  List<Object?> get props => [
+        updated,
+        created,
+        destroyed,
+        newStateLabel,
+        newStateChanges,
+        hasMoreChanges,
+      ];
+}

--- a/lib/features/labels/data/network/label_api.dart
+++ b/lib/features/labels/data/network/label_api.dart
@@ -1,15 +1,24 @@
+import 'package:core/utils/app_logger.dart';
 import 'package:jmap_dart_client/http/http_client.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/core/patch_object.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart';
+import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
 import 'package:jmap_dart_client/jmap/jmap_request.dart';
 import 'package:labels/labels.dart';
+import 'package:tmail_ui_user/features/base/mixin/batch_get_label_processing_mixin.dart';
 import 'package:tmail_ui_user/features/base/mixin/handle_error_mixin.dart';
-import 'package:tmail_ui_user/features/labels/domain/model/edit_label_request.dart';
+import 'package:tmail_ui_user/features/base/mixin/session_mixin.dart';
+import 'package:tmail_ui_user/features/labels/data/model/label_change_response.dart';
 import 'package:tmail_ui_user/features/labels/domain/exceptions/label_exceptions.dart';
+import 'package:tmail_ui_user/features/labels/domain/model/edit_label_request.dart';
 import 'package:uuid/uuid.dart';
 
-class LabelApi with HandleSetErrorMixin {
+class LabelApi
+    with HandleSetErrorMixin, SessionMixin, BatchGetLabelProcessingMixin {
+
   final HttpClient _httpClient;
   final Uuid _uuid;
 
@@ -121,5 +130,129 @@ class LabelApi with HandleSetErrorMixin {
     if (response?.destroyed?.contains(labelId) != true) {
       throw parseErrorForSetResponse(response, labelId);
     }
+  }
+
+  Future<
+      ({
+        List<Label>? labels,
+        State? state,
+        List<Id> notFoundIds,
+      })> _fetchLabelsIfNeeded({
+    required Session session,
+    required AccountId accountId,
+    required List<Id> labelIds,
+    required State sinceState,
+    required String logPrefix,
+  }) async {
+    if (labelIds.isEmpty) {
+      return (labels: null, state: null, notFoundIds: <Id>[]);
+    }
+
+    final result = await executeBatchGetLabel(
+      session: session,
+      accountId: accountId,
+      httpClient: _httpClient,
+      labelIds: labelIds,
+    );
+
+    if (result.notFoundIds.isNotEmpty) {
+      log('LabelAPI::getChanges:notFoundIds$logPrefix = ${result.notFoundIds} | SinceState = ${sinceState.value}');
+    }
+
+    return (
+      labels: result.labels,
+      state: result.state,
+      notFoundIds: result.notFoundIds,
+    );
+  }
+
+  Future<ChangesLabelResponse> getLabelChanges(
+    AccountId accountId,
+    State sinceState,
+  ) async {
+    final processingInvocation = ProcessingInvocation();
+    final jmapRequestBuilder = JmapRequestBuilder(
+      _httpClient,
+      processingInvocation,
+    );
+
+    final changesLabelMethod = ChangesLabelMethod(
+      accountId,
+      sinceState,
+      maxChanges: UnsignedInt(128),
+    );
+    final changesLabelInvocation =
+        jmapRequestBuilder.invocation(changesLabelMethod);
+
+    final result = await (jmapRequestBuilder
+          ..usings(changesLabelMethod.requiredCapabilities))
+        .build()
+        .execute();
+
+    final resultChanges = result.parse<ChangesLabelResponse>(
+      changesLabelInvocation.methodCallId,
+      ChangesLabelResponse.deserialize,
+    );
+
+    if (resultChanges == null) {
+      throw Exception('Failed to parse ChangesLabelResponse');
+    }
+
+    return resultChanges;
+  }
+
+  Future<LabelChangeResponse> getLabelChangesWithResult(
+    Session session,
+    AccountId accountId,
+    State sinceState,
+  ) async {
+    final changesResult = await getLabelChanges(accountId, sinceState);
+
+    final List<Id> createdIds = changesResult.created.toList();
+    final List<Id> updatedIds = changesResult.updated.toList();
+    List<Id> destroyedLabelIds = changesResult.destroyed.toList();
+    final State newStateChanges = changesResult.newState;
+    final bool hasMoreChanges = changesResult.hasMoreChanges;
+
+    log('LabelAPI::getChanges:createdIds = ${createdIds.length} | updatedIds = ${updatedIds.length} | destroyedIds = ${destroyedLabelIds.length}');
+
+    State? newStateLabel;
+
+    final updatedResult = await _fetchLabelsIfNeeded(
+      session: session,
+      accountId: accountId,
+      labelIds: updatedIds,
+      sinceState: sinceState,
+      logPrefix: 'Updated',
+    );
+    if (updatedResult.notFoundIds.isNotEmpty) {
+      destroyedLabelIds.addAll(updatedResult.notFoundIds);
+    }
+    newStateLabel = updatedResult.state ?? newStateLabel;
+
+    final createdResult = await _fetchLabelsIfNeeded(
+      session: session,
+      accountId: accountId,
+      labelIds: createdIds,
+      sinceState: sinceState,
+      logPrefix: 'Created',
+    );
+    if (createdResult.notFoundIds.isNotEmpty) {
+      destroyedLabelIds.addAll(createdResult.notFoundIds);
+    }
+    newStateLabel = createdResult.state ?? newStateLabel;
+
+    log('LabelAPI::getChanges:newStateChanges = $newStateChanges | newStateLabel = $newStateLabel | hasMoreChanges = $hasMoreChanges');
+    log('LabelAPI::getChanges:updatedLabelSize = ${updatedResult.labels?.length} | createdLabelSize = ${createdResult.labels?.length}');
+    log('LabelAPI::getChanges:destroyedLabelIds = $destroyedLabelIds');
+
+    return LabelChangeResponse(
+      updated: updatedResult.labels,
+      created: createdResult.labels,
+      destroyed: destroyedLabelIds,
+      newStateLabel: newStateLabel,
+      newStateChanges: newStateChanges,
+      hasMoreChanges: hasMoreChanges,
+    );
   }
 }

--- a/lib/features/labels/data/network/label_api.dart
+++ b/lib/features/labels/data/network/label_api.dart
@@ -19,6 +19,8 @@ import 'package:uuid/uuid.dart';
 class LabelApi
     with HandleSetErrorMixin, SessionMixin, BatchGetLabelProcessingMixin {
 
+  static const int _defaultMaxChanges = 128;
+
   final HttpClient _httpClient;
   final Uuid _uuid;
 
@@ -179,7 +181,7 @@ class LabelApi
     final changesLabelMethod = ChangesLabelMethod(
       accountId,
       sinceState,
-      maxChanges: UnsignedInt(128),
+      maxChanges: UnsignedInt(_defaultMaxChanges),
     );
     final changesLabelInvocation =
         jmapRequestBuilder.invocation(changesLabelMethod);

--- a/lib/features/labels/data/network/label_api.dart
+++ b/lib/features/labels/data/network/label_api.dart
@@ -24,7 +24,7 @@ class LabelApi
 
   LabelApi(this._httpClient, this._uuid);
 
-  Future<List<Label>> getAllLabels(AccountId accountId) async {
+  Future<({List<Label> labels, State? newState})> getAllLabels(AccountId accountId) async {
     final builder = JmapRequestBuilder(_httpClient, ProcessingInvocation());
     final method = GetLabelMethod(accountId);
     final invocation = builder.invocation(method);
@@ -37,7 +37,7 @@ class LabelApi
       GetLabelResponse.deserialize,
     );
 
-    return response?.list ?? [];
+    return (labels: response?.list ?? [], newState: response?.state);
   }
 
   Future<Label> createNewLabel(AccountId accountId, Label labelData) async {

--- a/lib/features/labels/data/network/label_api.dart
+++ b/lib/features/labels/data/network/label_api.dart
@@ -5,7 +5,6 @@ import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/core/patch_object.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart';
-import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
 import 'package:jmap_dart_client/jmap/jmap_request.dart';
 import 'package:labels/labels.dart';
 import 'package:tmail_ui_user/features/base/mixin/batch_get_label_processing_mixin.dart';
@@ -18,8 +17,6 @@ import 'package:uuid/uuid.dart';
 
 class LabelApi
     with HandleSetErrorMixin, SessionMixin, BatchGetLabelProcessingMixin {
-
-  static const int _defaultMaxChanges = 128;
 
   final HttpClient _httpClient;
   final Uuid _uuid;
@@ -178,11 +175,7 @@ class LabelApi
       processingInvocation,
     );
 
-    final changesLabelMethod = ChangesLabelMethod(
-      accountId,
-      sinceState,
-      maxChanges: UnsignedInt(_defaultMaxChanges),
-    );
+    final changesLabelMethod = ChangesLabelMethod(accountId, sinceState);
     final changesLabelInvocation =
         jmapRequestBuilder.invocation(changesLabelMethod);
 

--- a/lib/features/labels/data/network/label_api.dart
+++ b/lib/features/labels/data/network/label_api.dart
@@ -236,7 +236,7 @@ class LabelApi
     log('LabelAPI::getChanges: '
         'newStateChanges=${changes.newState} | '
         'newStateLabel=$newStateLabel | '
-        'hasMore=${changes.hasMoreChanges}'
+        'hasMore=${changes.hasMoreChanges} | '
         'updatedFetched=${updatedResult.labels?.length} | '
         'createdFetched=${createdResult.labels?.length} | '
         'totalDestroyed=${allDestroyedIds.length}');

--- a/lib/features/labels/data/repository/label_repository_impl.dart
+++ b/lib/features/labels/data/repository/label_repository_impl.dart
@@ -50,7 +50,7 @@ class LabelRepositoryImpl extends LabelRepository {
       final changesResponse = await _labelDatasource.getLabelChanges(
         session,
         accountId,
-        sinceState,
+        newSinceState,
       );
 
       hasMoreChanges = changesResponse.hasMoreChanges;

--- a/lib/features/labels/data/repository/label_repository_impl.dart
+++ b/lib/features/labels/data/repository/label_repository_impl.dart
@@ -1,7 +1,11 @@
 import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart';
 import 'package:labels/model/label.dart';
 import 'package:tmail_ui_user/features/labels/data/datasource/label_datasource.dart';
 import 'package:tmail_ui_user/features/labels/domain/model/edit_label_request.dart';
+import 'package:tmail_ui_user/features/labels/domain/model/label_changes_result.dart';
 import 'package:tmail_ui_user/features/labels/domain/repository/label_repository.dart';
 
 class LabelRepositoryImpl extends LabelRepository {
@@ -27,5 +31,50 @@ class LabelRepositoryImpl extends LabelRepository {
   @override
   Future<void> deleteLabel(AccountId accountId, Label label) {
     return _labelDatasource.deleteLabel(accountId, label);
+  }
+
+  @override
+  Future<LabelChangesResult> getLabelChanges(
+    Session session,
+    AccountId accountId,
+    State sinceState,
+  ) async {
+    bool hasMoreChanges = true;
+    State? newSinceState = sinceState;
+    List<Label> createdLabels = [];
+    List<Label> updatedLabels = [];
+    List<Id> destroyedLabelIds = [];
+    State? newState;
+
+    while (hasMoreChanges && newSinceState != null) {
+      final changesResponse = await _labelDatasource.getLabelChanges(
+        session,
+        accountId,
+        sinceState,
+      );
+
+      hasMoreChanges = changesResponse.hasMoreChanges;
+      newSinceState = changesResponse.newStateChanges;
+
+      if (changesResponse.created?.isNotEmpty == true) {
+        createdLabels.addAll(changesResponse.created!);
+      }
+      if (changesResponse.updated?.isNotEmpty == true) {
+        updatedLabels.addAll(changesResponse.updated!);
+      }
+      if (changesResponse.destroyed?.isNotEmpty == true) {
+        destroyedLabelIds.addAll(changesResponse.destroyed!);
+      }
+      if (changesResponse.newStateChanges != null) {
+        newState = changesResponse.newStateChanges!;
+      }
+    }
+
+    return LabelChangesResult(
+      createdLabels: createdLabels,
+      updatedLabels: updatedLabels,
+      destroyedLabelIds: destroyedLabelIds,
+      newState: newState,
+    );
   }
 }

--- a/lib/features/labels/data/repository/label_repository_impl.dart
+++ b/lib/features/labels/data/repository/label_repository_impl.dart
@@ -14,7 +14,7 @@ class LabelRepositoryImpl extends LabelRepository {
   LabelRepositoryImpl(this._labelDatasource);
 
   @override
-  Future<List<Label>> getAllLabels(AccountId accountId) {
+  Future<({List<Label> labels, State? newState})> getAllLabels(AccountId accountId) {
     return _labelDatasource.getAllLabels(accountId);
   }
 

--- a/lib/features/labels/domain/model/label_changes_result.dart
+++ b/lib/features/labels/domain/model/label_changes_result.dart
@@ -1,0 +1,26 @@
+import 'package:equatable/equatable.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart';
+import 'package:labels/model/label.dart';
+
+class LabelChangesResult with EquatableMixin {
+  final List<Label> createdLabels;
+  final List<Label> updatedLabels;
+  final List<Id> destroyedLabelIds;
+  final State? newState;
+
+  LabelChangesResult({
+    required this.createdLabels,
+    required this.updatedLabels,
+    required this.destroyedLabelIds,
+    required this.newState,
+  });
+
+  @override
+  List<Object?> get props => [
+    createdLabels,
+    updatedLabels,
+    destroyedLabelIds,
+    newState,
+  ];
+}

--- a/lib/features/labels/domain/repository/label_repository.dart
+++ b/lib/features/labels/domain/repository/label_repository.dart
@@ -6,7 +6,7 @@ import 'package:tmail_ui_user/features/labels/domain/model/edit_label_request.da
 import 'package:tmail_ui_user/features/labels/domain/model/label_changes_result.dart';
 
 abstract class LabelRepository {
-  Future<List<Label>> getAllLabels(AccountId accountId);
+  Future<({List<Label> labels, State? newState})> getAllLabels(AccountId accountId);
 
   Future<Label> createNewLabel(AccountId accountId, Label labelData);
 

--- a/lib/features/labels/domain/repository/label_repository.dart
+++ b/lib/features/labels/domain/repository/label_repository.dart
@@ -1,6 +1,9 @@
 import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart';
 import 'package:labels/model/label.dart';
 import 'package:tmail_ui_user/features/labels/domain/model/edit_label_request.dart';
+import 'package:tmail_ui_user/features/labels/domain/model/label_changes_result.dart';
 
 abstract class LabelRepository {
   Future<List<Label>> getAllLabels(AccountId accountId);
@@ -10,4 +13,10 @@ abstract class LabelRepository {
   Future<Label> editLabel(AccountId accountId, EditLabelRequest labelRequest);
 
   Future<void> deleteLabel(AccountId accountId, Label label);
+
+  Future<LabelChangesResult> getLabelChanges(
+    Session session,
+    AccountId accountId,
+    State sinceState,
+  );
 }

--- a/lib/features/labels/domain/state/get_all_label_state.dart
+++ b/lib/features/labels/domain/state/get_all_label_state.dart
@@ -1,16 +1,18 @@
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart';
 import 'package:labels/model/label.dart';
 
 class GettingAllLabel extends LoadingState {}
 
 class GetAllLabelSuccess extends UIState {
   final List<Label> labels;
+  final State? newState;
 
-  GetAllLabelSuccess(this.labels);
+  GetAllLabelSuccess(this.labels, this.newState);
 
   @override
-  List<Object> get props => [labels];
+  List<Object?> get props => [labels, newState];
 }
 
 class GetAllLabelFailure extends FeatureFailure {

--- a/lib/features/labels/domain/state/get_label_changes_state.dart
+++ b/lib/features/labels/domain/state/get_label_changes_state.dart
@@ -1,0 +1,18 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:tmail_ui_user/features/labels/domain/model/label_changes_result.dart';
+
+class GettingLabelChanges extends LoadingState {}
+
+class GetLabelChangesSuccess extends UIState {
+  final LabelChangesResult changesResult;
+
+  GetLabelChangesSuccess(this.changesResult);
+
+  @override
+  List<Object> get props => [changesResult];
+}
+
+class GetLabelChangesFailure extends FeatureFailure {
+  GetLabelChangesFailure(dynamic exception) : super(exception: exception);
+}

--- a/lib/features/labels/domain/usecases/get_all_label_interactor.dart
+++ b/lib/features/labels/domain/usecases/get_all_label_interactor.dart
@@ -13,8 +13,8 @@ class GetAllLabelInteractor {
   Stream<Either<Failure, Success>> execute(AccountId accountId) async* {
     try {
       yield Right(GettingAllLabel());
-      final labels = await _labelRepository.getAllLabels(accountId);
-      yield Right(GetAllLabelSuccess(labels));
+      final result = await _labelRepository.getAllLabels(accountId);
+      yield Right(GetAllLabelSuccess(result.labels, result.newState));
     } catch (e) {
       yield Left(GetAllLabelFailure(e));
     }

--- a/lib/features/labels/domain/usecases/get_label_changes_interactor.dart
+++ b/lib/features/labels/domain/usecases/get_label_changes_interactor.dart
@@ -1,0 +1,32 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart' hide State;
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart';
+import 'package:tmail_ui_user/features/labels/domain/repository/label_repository.dart';
+import 'package:tmail_ui_user/features/labels/domain/state/get_label_changes_state.dart';
+
+class GetLabelChangesInteractor {
+  final LabelRepository _labelRepository;
+
+  GetLabelChangesInteractor(this._labelRepository);
+
+  Stream<Either<Failure, Success>> execute(
+    Session session,
+    AccountId accountId,
+    State sinceState,
+  ) async* {
+    try {
+      yield Right(GettingLabelChanges());
+      final changesResult = await _labelRepository.getLabelChanges(
+        session,
+        accountId,
+        sinceState,
+      );
+      yield Right(GetLabelChangesSuccess(changesResult));
+    } catch (e) {
+      yield Left(GetLabelChangesFailure(e));
+    }
+  }
+}

--- a/lib/features/labels/presentation/extensions/handle_label_websocket_extension.dart
+++ b/lib/features/labels/presentation/extensions/handle_label_websocket_extension.dart
@@ -1,0 +1,71 @@
+import 'package:core/presentation/extensions/either_view_state_extension.dart';
+import 'package:core/utils/app_logger.dart';
+import 'package:get/get.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
+import 'package:labels/extensions/list_label_extension.dart';
+import 'package:tmail_ui_user/features/labels/domain/state/get_label_changes_state.dart';
+import 'package:tmail_ui_user/features/labels/presentation/label_controller.dart';
+import 'package:tmail_ui_user/features/labels/presentation/utils/label_utils.dart';
+import 'package:tmail_ui_user/features/push_notification/presentation/websocket/web_socket_message.dart';
+
+extension HandleLabelWebsocketExtension on LabelController {
+  void refreshLabelChanges({required jmap.State newState}) {
+    if (accountId == null ||
+        session == null ||
+        currentLabelState == null ||
+        currentLabelState == newState ||
+        isLabelSettingEnabled.isFalse) {
+      return;
+    }
+
+    webSocketQueueHandler?.enqueue(WebSocketMessage(newState: newState));
+  }
+
+  Future<void> handleWebSocketMessage(WebSocketMessage message) async {
+    try {
+      final refreshViewState = await getLabelChangesInteractor!
+          .execute(
+            session!,
+            accountId!,
+            currentLabelState!,
+          )
+          .last;
+
+      final refreshState =
+          refreshViewState.foldSuccessWithResult<GetLabelChangesSuccess>();
+
+      if (refreshState is GetLabelChangesSuccess) {
+        await _handleGetLabelChangesSuccess(refreshState);
+      } else {
+        onDataFailureViewState(refreshState);
+      }
+    } catch (e, stackTrace) {
+      logWarning(
+          'HandleLabelWebsocketExtension::handleWebSocketMessage: Exception $e');
+      onError(e, stackTrace);
+    }
+
+    if (currentLabelState != null) {
+      webSocketQueueHandler
+          ?.removeMessagesUpToCurrent(currentLabelState!.value);
+    }
+  }
+
+  Future<void> _handleGetLabelChangesSuccess(
+    GetLabelChangesSuccess success,
+  ) async {
+    final result = success.changesResult;
+
+    setCurrentLabelState(result.newState);
+
+    LabelUtils.applyLabelChanges(
+      currentLabels: labels,
+      created: result.createdLabels,
+      updated: result.updatedLabels,
+      destroyedIds: result.destroyedLabelIds,
+    );
+
+    labels.sortByAlphabetically();
+    labels.refresh();
+  }
+}

--- a/lib/features/labels/presentation/extensions/handle_label_websocket_extension.dart
+++ b/lib/features/labels/presentation/extensions/handle_label_websocket_extension.dart
@@ -36,8 +36,10 @@ extension HandleLabelWebsocketExtension on LabelController {
 
       if (refreshState is GetLabelChangesSuccess) {
         await _handleGetLabelChangesSuccess(refreshState);
-      } else {
+      } else if (refreshState != null) {
         onDataFailureViewState(refreshState);
+      } else {
+        logWarning('HandleLabelWebsocketExtension::handleWebSocketMessage: refreshState is null');
       }
     } catch (e, stackTrace) {
       logWarning(

--- a/lib/features/labels/presentation/extensions/handle_label_websocket_extension.dart
+++ b/lib/features/labels/presentation/extensions/handle_label_websocket_extension.dart
@@ -10,12 +10,17 @@ import 'package:tmail_ui_user/features/push_notification/presentation/websocket/
 
 extension HandleLabelWebsocketExtension on LabelController {
   void refreshLabelChanges({required jmap.State newState}) {
-    if (accountId == null ||
-        session == null ||
-        currentLabelState == null ||
-        currentLabelState == newState ||
-        isLabelSettingEnabled.isFalse) {
-      logWarning('HandleLabelWebsocketExtension::refreshLabelChanges: accountId or session or currentLabelState or newState or isLabelSettingEnabled is null');
+    final skipReasons = <String>[
+      if (accountId == null) 'accountId is null',
+      if (session == null) 'session is null',
+      if (currentLabelState == null) 'currentLabelState is null',
+      if (currentLabelState == newState) 'state unchanged',
+      if (isLabelSettingEnabled.isFalse) 'label setting disabled',
+    ];
+    if (skipReasons.isNotEmpty) {
+      logWarning(
+        'HandleLabelWebsocketExtension::refreshLabelChanges: skip (${skipReasons.join(', ')})',
+      );
       return;
     }
 

--- a/lib/features/labels/presentation/extensions/handle_label_websocket_extension.dart
+++ b/lib/features/labels/presentation/extensions/handle_label_websocket_extension.dart
@@ -15,6 +15,7 @@ extension HandleLabelWebsocketExtension on LabelController {
         currentLabelState == null ||
         currentLabelState == newState ||
         isLabelSettingEnabled.isFalse) {
+      logWarning('HandleLabelWebsocketExtension::refreshLabelChanges: accountId or session or currentLabelState or newState or isLabelSettingEnabled is null');
       return;
     }
 

--- a/lib/features/labels/presentation/label_controller.dart
+++ b/lib/features/labels/presentation/label_controller.dart
@@ -1,10 +1,11 @@
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:core/utils/app_logger.dart';
-import 'package:dartz/dartz.dart';
+import 'package:dartz/dartz.dart' hide State;
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart';
 import 'package:labels/extensions/list_label_extension.dart';
 import 'package:labels/model/label.dart';
 import 'package:labels/utils/labels_constants.dart';
@@ -19,12 +20,15 @@ import 'package:tmail_ui_user/features/labels/domain/usecases/create_new_label_i
 import 'package:tmail_ui_user/features/labels/domain/usecases/edit_label_interactor.dart';
 import 'package:tmail_ui_user/features/labels/domain/usecases/delete_a_label_interactor.dart';
 import 'package:tmail_ui_user/features/labels/domain/usecases/get_all_label_interactor.dart';
+import 'package:tmail_ui_user/features/labels/domain/usecases/get_label_changes_interactor.dart';
 import 'package:tmail_ui_user/features/labels/presentation/extensions/handle_label_action_type_extension.dart';
+import 'package:tmail_ui_user/features/labels/presentation/extensions/handle_label_websocket_extension.dart';
 import 'package:tmail_ui_user/features/labels/presentation/label_interactor_bindings.dart';
 import 'package:tmail_ui_user/features/labels/presentation/mixin/label_context_menu_mixin.dart';
 import 'package:tmail_ui_user/features/labels/presentation/widgets/create_new_label_modal.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/state/get_label_setting_state.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_label_setting_state_interactor.dart';
+import 'package:tmail_ui_user/features/push_notification/presentation/websocket/web_socket_queue_handler.dart';
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
 import 'package:tmail_ui_user/main/exceptions/logic_exception.dart';
 import 'package:tmail_ui_user/main/routes/dialog_router.dart';
@@ -40,12 +44,26 @@ class LabelController extends BaseController with LabelContextMenuMixin {
   GetLabelSettingStateInteractor? _getLabelSettingStateInteractor;
   EditLabelInteractor? _editLabelInteractor;
   DeleteALabelInteractor? _deleteALabelInteractor;
+  GetLabelChangesInteractor? _getLabelChangesInteractor;
+
+  WebSocketQueueHandler? _webSocketQueueHandler;
+  State? _currentLabelState;
+  AccountId? _accountId;
+  Session? _session;
+
+  @override
+  void onInit() {
+    _initWebSocketQueueHandler();
+    super.onInit();
+  }
 
   bool isLabelCapabilitySupported(Session session, AccountId accountId) {
     return LabelsConstants.labelsCapability.isSupported(session, accountId);
   }
 
-  void checkLabelSettingState(AccountId accountId) {
+  void checkLabelSettingState(Session session, AccountId accountId) {
+    _session = session;
+    _accountId = accountId;
     _getLabelSettingStateInteractor =
         getBinding<GetLabelSettingStateInteractor>();
     if (_getLabelSettingStateInteractor != null) {
@@ -66,11 +84,33 @@ class LabelController extends BaseController with LabelContextMenuMixin {
     _createNewLabelInteractor = getBinding<CreateNewLabelInteractor>();
     _editLabelInteractor = getBinding<EditLabelInteractor>();
     _deleteALabelInteractor = getBinding<DeleteALabelInteractor>();
+    _getLabelChangesInteractor = getBinding<GetLabelChangesInteractor>();
   }
 
   EditLabelInteractor? get editLabelInteractor => _editLabelInteractor;
 
   DeleteALabelInteractor? get deleteALabelInteractor => _deleteALabelInteractor;
+
+  GetLabelChangesInteractor? get getLabelChangesInteractor =>
+      _getLabelChangesInteractor;
+
+  WebSocketQueueHandler? get webSocketQueueHandler =>
+      _webSocketQueueHandler;
+
+  AccountId? get accountId => _accountId;
+
+  Session? get session => _session;
+
+  State? get currentLabelState => _currentLabelState;
+
+  void setCurrentLabelState(State? newState) => _currentLabelState = newState;
+
+  void _initWebSocketQueueHandler() {
+    _webSocketQueueHandler = WebSocketQueueHandler(
+      processMessageCallback: handleWebSocketMessage,
+      onErrorCallback: onError,
+    );
+  }
 
   void getAllLabels(AccountId accountId) {
     if (_getAllLabelInteractor == null) return;
@@ -177,6 +217,11 @@ class LabelController extends BaseController with LabelContextMenuMixin {
     _editLabelInteractor = null;
     _deleteALabelInteractor = null;
     _getLabelSettingStateInteractor = null;
+    _webSocketQueueHandler?.dispose();
+    _webSocketQueueHandler = null;
+    _currentLabelState = null;
+    _accountId = null;
+    _session = null;
     super.onClose();
   }
 }

--- a/lib/features/labels/presentation/label_controller.dart
+++ b/lib/features/labels/presentation/label_controller.dart
@@ -179,6 +179,7 @@ class LabelController extends BaseController with LabelContextMenuMixin {
   void handleSuccessViewState(Success success) {
     if (success is GetAllLabelSuccess) {
       labels.value = success.labels..sortByAlphabetically();
+      setCurrentLabelState(success.newState);
     } else if (success is CreateNewLabelSuccess) {
       _handleCreateNewLabelSuccess(success);
     } else if (success is GetLabelSettingStateSuccess) {

--- a/lib/features/labels/presentation/label_controller.dart
+++ b/lib/features/labels/presentation/label_controller.dart
@@ -70,6 +70,7 @@ class LabelController extends BaseController with LabelContextMenuMixin {
       consumeState(_getLabelSettingStateInteractor!.execute(accountId));
     } else {
       isLabelSettingEnabled.value = false;
+      isLabelSettingEnabled.refresh();
       _clearLabelData();
     }
   }
@@ -168,7 +169,7 @@ class LabelController extends BaseController with LabelContextMenuMixin {
 
   void _handleGetLabelSettingStateSuccess(bool isEnabled, AccountId accountId) {
     isLabelSettingEnabled.value = isEnabled;
-
+    isLabelSettingEnabled.refresh();
     if (isEnabled) {
       injectLabelsBindings();
       getAllLabels(accountId);
@@ -201,6 +202,7 @@ class LabelController extends BaseController with LabelContextMenuMixin {
       _handleCreateNewLabelFailure(failure);
     } else if (failure is GetLabelSettingStateFailure) {
       isLabelSettingEnabled.value = false;
+      isLabelSettingEnabled.refresh();
       _clearLabelData();
     } else if (failure is EditLabelFailure) {
       handleEditLabelFailure(failure);

--- a/lib/features/labels/presentation/label_interactor_bindings.dart
+++ b/lib/features/labels/presentation/label_interactor_bindings.dart
@@ -10,6 +10,7 @@ import 'package:tmail_ui_user/features/labels/domain/usecases/create_new_label_i
 import 'package:tmail_ui_user/features/labels/domain/usecases/edit_label_interactor.dart';
 import 'package:tmail_ui_user/features/labels/domain/usecases/delete_a_label_interactor.dart';
 import 'package:tmail_ui_user/features/labels/domain/usecases/get_all_label_interactor.dart';
+import 'package:tmail_ui_user/features/labels/domain/usecases/get_label_changes_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/usecases/verify_name_interactor.dart';
 import 'package:tmail_ui_user/main/exceptions/remote_exception_thrower.dart';
 import 'package:uuid/uuid.dart';
@@ -37,6 +38,7 @@ class LabelInteractorBindings extends InteractorsBindings {
     Get.lazyPut(() => CreateNewLabelInteractor(Get.find<LabelRepository>()));
     Get.lazyPut(() => EditLabelInteractor(Get.find<LabelRepository>()));
     Get.lazyPut(() => DeleteALabelInteractor(Get.find<LabelRepository>()));
+    Get.lazyPut(() => GetLabelChangesInteractor(Get.find<LabelRepository>()));
     Get.lazyPut(() => VerifyNameInteractor());
   }
 

--- a/lib/features/labels/presentation/utils/label_utils.dart
+++ b/lib/features/labels/presentation/utils/label_utils.dart
@@ -244,6 +244,10 @@ class LabelUtils {
     }
   }
 
+  /// Applies label changes to [currentLabels] **in place**.
+  ///
+  /// Removes labels matching [destroyedIds], [created], and [updated] IDs,
+  /// then appends [created] and [updated] labels.
   static void applyLabelChanges({
     required List<Label> currentLabels,
     required List<Label> created,

--- a/lib/features/labels/presentation/utils/label_utils.dart
+++ b/lib/features/labels/presentation/utils/label_utils.dart
@@ -252,6 +252,7 @@ class LabelUtils {
   }) {
     final idsToRemove = {
       ...destroyedIds,
+      ...created.map((label) => label.id),
       ...updated.map((label) => label.id),
     };
 

--- a/lib/features/labels/presentation/utils/label_utils.dart
+++ b/lib/features/labels/presentation/utils/label_utils.dart
@@ -243,4 +243,28 @@ class LabelUtils {
       return name;
     }
   }
+
+  static void applyLabelChanges({
+    required List<Label> currentLabels,
+    required List<Label> created,
+    required List<Label> updated,
+    required List<Id> destroyedIds,
+  }) {
+    final idsToRemove = {
+      ...destroyedIds,
+      ...updated.map((label) => label.id),
+    };
+
+    if (idsToRemove.isNotEmpty) {
+      currentLabels.removeWhere((label) => idsToRemove.contains(label.id));
+    }
+
+    if (created.isNotEmpty) {
+      currentLabels.addAll(created);
+    }
+
+    if (updated.isNotEmpty) {
+      currentLabels.addAll(updated);
+    }
+  }
 }

--- a/lib/features/mailbox/data/network/mailbox_api.dart
+++ b/lib/features/mailbox/data/network/mailbox_api.dart
@@ -35,6 +35,7 @@ import 'package:model/mailbox/mailbox_constants.dart';
 import 'package:model/model.dart';
 import 'package:tmail_ui_user/features/base/mixin/handle_error_mixin.dart';
 import 'package:tmail_ui_user/features/base/mixin/mail_api_mixin.dart';
+import 'package:tmail_ui_user/features/base/mixin/session_mixin.dart';
 import 'package:tmail_ui_user/features/composer/domain/exceptions/set_method_exception.dart';
 import 'package:tmail_ui_user/features/mailbox/data/model/mailbox_change_response.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/exceptions/mailbox_exception.dart';
@@ -55,7 +56,7 @@ import 'package:tmail_ui_user/features/mailbox/domain/model/subscribe_multiple_m
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
 import 'package:uuid/uuid.dart';
 
-class MailboxAPI with HandleSetErrorMixin, MailAPIMixin {
+class MailboxAPI with HandleSetErrorMixin, SessionMixin, MailAPIMixin {
 
   final HttpClient httpClient;
   final Uuid _uuid;

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -920,7 +920,7 @@ class MailboxDashBoardController extends ReloadableController
     );
 
     if (isLabelCapabilitySupported) {
-      labelController.checkLabelSettingState(currentAccountId);
+      labelController.checkLabelSettingState(session, currentAccountId);
     }
   }
 
@@ -2094,8 +2094,10 @@ class MailboxDashBoardController extends ReloadableController
     getServerSetting();
     spamReportController.getSpamReportStateAction();
     loadAIScribeConfig();
-    if (isLabelCapabilitySupported && accountId.value != null) {
-      labelController.checkLabelSettingState(accountId.value!);
+    if (isLabelCapabilitySupported &&
+        accountId.value != null &&
+        sessionCurrent != null) {
+      labelController.checkLabelSettingState(sessionCurrent!, accountId.value!);
     }
   }
 
@@ -2174,8 +2176,10 @@ class MailboxDashBoardController extends ReloadableController
     getServerSetting();
     spamReportController.getSpamReportStateAction();
     loadAIScribeConfig();
-    if (isLabelCapabilitySupported && accountId.value != null) {
-      labelController.checkLabelSettingState(accountId.value!);
+    if (isLabelCapabilitySupported &&
+        accountId.value != null &&
+        sessionCurrent != null) {
+      labelController.checkLabelSettingState(sessionCurrent!, accountId.value!);
     }
   }
 

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -337,9 +337,7 @@ class MailboxDashBoardController extends ReloadableController
   int minInputLengthAutocomplete = AppConfig.defaultMinInputLengthAutocomplete;
   EmailSortOrderType currentSortOrder = SearchEmailFilter.defaultSortOrder;
   PaywallController? paywallController;
-  Worker? advancedSearchVisibleWorker;
-  Worker? searchInputFocusWorker;
-  Worker? _downloadUIActionWorker;
+  final workerObxVariables = <Worker>[];
 
   final StreamController<Either<Failure, Success>> progressStateController =
     StreamController<Either<Failure, Success>>.broadcast();
@@ -394,6 +392,7 @@ class MailboxDashBoardController extends ReloadableController
       _registerDeepLinks();
     }
     _registerStreamListener();
+    registerLabelReactiveObxListener();
     BackButtonInterceptor.add(onBackButtonInterceptor, name: AppRoutes.dashboard);
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       await ApplicationManager().initUserAgent();
@@ -804,7 +803,7 @@ class MailboxDashBoardController extends ReloadableController
   }
 
   void _registerDownloadUIActionListener() {
-    _downloadUIActionWorker = ever(
+    workerObxVariables.add(ever(
       downloadController.downloadUIAction,
       (action) {
         if (action is OpenComposerFromMailtoLinkAction) {
@@ -812,7 +811,7 @@ class MailboxDashBoardController extends ReloadableController
           downloadController.clearDownloadUIAction();
         }
       },
-    );
+    ));
   }
 
   Future<void> _handleClickNotificationOnAndroidInTerminated() async {
@@ -895,7 +894,6 @@ class MailboxDashBoardController extends ReloadableController
     injectAutoCompleteBindings(session, currentAccountId);
     injectRuleFilterBindings(session, currentAccountId);
     injectVacationBindings(session, currentAccountId);
-    injectWebSocket(session, currentAccountId);
     injectPreferencesBindings();
     injectAIScribeBindings(session, currentAccountId);
     if (PlatformInfo.isMobile) {
@@ -921,6 +919,8 @@ class MailboxDashBoardController extends ReloadableController
 
     if (isLabelCapabilitySupported) {
       labelController.checkLabelSettingState(session, currentAccountId);
+    } else {
+      injectWebSocket(session: session, accountId: currentAccountId);
     }
   }
 
@@ -3420,11 +3420,17 @@ class MailboxDashBoardController extends ReloadableController
   bool get isEmailListDisplayed =>
       dashboardRoute.value == DashboardRoutes.thread;
 
+  void _disposeWorkerObxVariables() {
+    for (var worker in workerObxVariables) {
+      worker.dispose();
+    }
+    workerObxVariables.clear();
+  }
+
   @override
   void onClose() {
     if (PlatformInfo.isWeb) {
       listSearchFilterScrollController?.dispose();
-      disposeReactiveObxVariableListener();
     }
     if (PlatformInfo.isIOS) {
       _iosNotificationManager?.dispose();
@@ -3453,8 +3459,7 @@ class MailboxDashBoardController extends ReloadableController
     twakeAppManager.setHasComposer(false);
     paywallController?.onClose();
     paywallController = null;
-    _downloadUIActionWorker?.dispose();
-    _downloadUIActionWorker = null;
+    _disposeWorkerObxVariables();
     super.onClose();
   }
 }

--- a/lib/features/mailbox_dashboard/presentation/extensions/handle_reactive_obx_variable_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/handle_reactive_obx_variable_extension.dart
@@ -8,15 +8,15 @@ import 'package:tmail_ui_user/features/thread_detail/presentation/action/thread_
 extension HandleReactiveObxVariableExtension on MailboxDashBoardController {
 
   void registerReactiveObxVariableListener() {
-    advancedSearchVisibleWorker = ever(
+    workerObxVariables.add(ever(
       searchController.isAdvancedSearchViewOpen,
       _onAdvancedSearchVisibleChanged
-    );
+    ));
 
-    searchInputFocusWorker = ever(
+    workerObxVariables.add(ever(
       searchController.isSearchInputFocused,
       onSearchInputFocusChanged
-    );
+    ));
   }
 
   void _onAdvancedSearchVisibleChanged(bool visible) {
@@ -51,12 +51,5 @@ extension HandleReactiveObxVariableExtension on MailboxDashBoardController {
         : ReclaimMailListKeyboardShortcutFocusAction();
 
     dispatchAction(dashboardAction);
-  }
-
-  void disposeReactiveObxVariableListener() {
-    advancedSearchVisibleWorker?.dispose();
-    advancedSearchVisibleWorker = null;
-    searchInputFocusWorker?.dispose();
-    searchInputFocusWorker = null;
   }
 }

--- a/lib/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart
@@ -1,3 +1,4 @@
+import 'package:core/utils/app_logger.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 
@@ -14,5 +15,23 @@ extension HandleLogicLabelExtension on MailboxDashBoardController {
   bool get isLabelAvailable {
     return labelController.isLabelSettingEnabled.isTrue &&
         isLabelCapabilitySupported;
+  }
+
+  void registerLabelReactiveObxListener() {
+    workerObxVariables.add(
+      ever(
+        labelController.isLabelSettingEnabled,
+        _onLabelSettingEnabledChanged,
+      ),
+    );
+  }
+
+  void _onLabelSettingEnabledChanged(bool isEnabled) {
+    log('$runtimeType::_onLabelSettingEnabledChanged: isEnabled is $isEnabled');
+    injectWebSocket(
+      session: sessionCurrent,
+      accountId: accountId.value,
+      isLabelAvailable: isEnabled,
+    );
   }
 }

--- a/lib/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart
@@ -28,10 +28,11 @@ extension HandleLogicLabelExtension on MailboxDashBoardController {
 
   void _onLabelSettingEnabledChanged(bool isEnabled) {
     log('$runtimeType::_onLabelSettingEnabledChanged: isEnabled is $isEnabled');
+    final isLabelAvailable = isEnabled && isLabelCapabilitySupported;
     injectWebSocket(
       session: sessionCurrent,
       accountId: accountId.value,
-      isLabelAvailable: isEnabled,
+      isLabelAvailable: isLabelAvailable,
     );
   }
 }

--- a/lib/features/push_notification/presentation/action/push_notification_state_change_action.dart
+++ b/lib/features/push_notification/presentation/action/push_notification_state_change_action.dart
@@ -87,3 +87,32 @@ class StoreMailboxStateToRefreshAction extends PushNotificationStateChangeAction
   @override
   List<Object?> get props => [typeName, newState, accountId, userName];
 }
+
+class SynchronizeLabelOnForegroundAction
+    extends PushNotificationStateChangeAction {
+  final AccountId accountId;
+
+  SynchronizeLabelOnForegroundAction(
+    TypeName typeName,
+    jmap.State newState,
+    this.accountId,
+  ) : super(typeName, newState);
+
+  @override
+  List<Object?> get props => [typeName, newState, accountId];
+}
+
+class StoreLabelStateToRefreshAction extends PushNotificationStateChangeAction {
+  final AccountId accountId;
+  final UserName userName;
+
+  StoreLabelStateToRefreshAction(
+    TypeName typeName,
+    jmap.State newState,
+    this.accountId,
+    this.userName,
+  ) : super(typeName, newState);
+
+  @override
+  List<Object?> get props => [typeName, newState, accountId, userName];
+}

--- a/lib/features/push_notification/presentation/controller/fcm_message_controller.dart
+++ b/lib/features/push_notification/presentation/controller/fcm_message_controller.dart
@@ -27,6 +27,7 @@ import 'package:tmail_ui_user/features/push_notification/presentation/controller
 import 'package:tmail_ui_user/features/push_notification/presentation/controller/push_base_controller.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/extensions/state_change_extension.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/listener/email_change_listener.dart';
+import 'package:tmail_ui_user/features/push_notification/presentation/listener/label_change_listener.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/listener/mailbox_change_listener.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/services/fcm_service.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/utils/fcm_utils.dart';
@@ -195,6 +196,7 @@ class FcmMessageController extends PushBaseController {
       userName,
       emailChangeListener: EmailChangeListener.instance,
       mailboxChangeListener: MailboxChangeListener.instance,
+      labelChangeListener: LabelChangeListener.instance,
       isForeground: false,
       session: session);
   }

--- a/lib/features/push_notification/presentation/controller/push_base_controller.dart
+++ b/lib/features/push_notification/presentation/controller/push_base_controller.dart
@@ -78,7 +78,7 @@ abstract class PushBaseController {
       .nonNulls
       .toList();
 
-    log('PushBaseController::mappingTypeStateToAction():listMailboxActions: $listEmailActions');
+    log('PushBaseController::mappingTypeStateToAction():listMailboxActions: $listMailboxActions');
 
     if (listMailboxActions.isNotEmpty) {
       mailboxChangeListener.dispatchActions(listMailboxActions);

--- a/lib/features/push_notification/presentation/controller/web_socket_controller.dart
+++ b/lib/features/push_notification/presentation/controller/web_socket_controller.dart
@@ -23,6 +23,7 @@ import 'package:tmail_ui_user/features/push_notification/domain/usecases/connect
 import 'package:tmail_ui_user/features/push_notification/presentation/controller/push_base_controller.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/extensions/state_change_extension.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/listener/email_change_listener.dart';
+import 'package:tmail_ui_user/features/push_notification/presentation/listener/label_change_listener.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/listener/mailbox_change_listener.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/utils/fcm_utils.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
@@ -185,7 +186,7 @@ class WebSocketController extends PushBaseController {
   void _enableWebSocketPush() {
     log('WebSocketController::_enableWebSocketPush:');
     _webSocketChannel?.sink.add(jsonEncode(WebSocketPushEnableRequest.toJson(
-      dataTypes: [TypeName.emailType, TypeName.mailboxType]
+      dataTypes: [TypeName.emailType, TypeName.mailboxType, TypeName.labelType]
     )));
   }
 
@@ -247,6 +248,7 @@ class WebSocketController extends PushBaseController {
         accountId!,
         emailChangeListener: EmailChangeListener.instance,
         mailboxChangeListener: MailboxChangeListener.instance,
+        labelChangeListener: LabelChangeListener.instance,
         session!.username,
         session: session,
       );

--- a/lib/features/push_notification/presentation/controller/web_socket_controller.dart
+++ b/lib/features/push_notification/presentation/controller/web_socket_controller.dart
@@ -41,8 +41,19 @@ class WebSocketController extends PushBaseController {
   NetworkConnectionController? _networkConnectionController;
   StreamSubscription<ConnectivityResult>? _connectivitySubscription;
 
+  static final List<TypeName> _mailTypePushSupported = [
+    TypeName.emailType,
+    TypeName.mailboxType,
+  ];
+  static final List<TypeName> _labelTypePushSupported = [
+    TypeName.emailType,
+    TypeName.mailboxType,
+    TypeName.labelType,
+  ];
+
   int _retryRemained = 3;
   bool _isConnecting = false;
+  bool _isLabelAvailable = false;
   WebSocketChannel? _webSocketChannel;
   Timer? _webSocketPingTimer;
   StreamSubscription? _webSocketSubscription;
@@ -72,10 +83,14 @@ class WebSocketController extends PushBaseController {
   }
 
   @override
-  void initialize({AccountId? accountId, Session? session}) {
-    log('WebSocketController::initialize:AccountId = ${accountId?.asString}');
+  void initialize({
+    AccountId? accountId,
+    Session? session,
+    bool isLabelAvailable = false,
+  }) {
+    log('WebSocketController::initialize:AccountId = ${accountId?.asString}, isLabelAvailable = $isLabelAvailable');
     super.initialize(accountId: accountId, session: session);
-
+    _isLabelAvailable = isLabelAvailable;
     _connectWebSocket();
     _listenToAppLifeCycle();
     if (PlatformInfo.isWeb) {
@@ -184,9 +199,12 @@ class WebSocketController extends PushBaseController {
   }
 
   void _enableWebSocketPush() {
-    log('WebSocketController::_enableWebSocketPush:');
+    final dataTypes = _isLabelAvailable
+        ? _labelTypePushSupported
+        : _mailTypePushSupported;
+    log('WebSocketController::_enableWebSocketPush: DataType is $dataTypes');
     _webSocketChannel?.sink.add(jsonEncode(WebSocketPushEnableRequest.toJson(
-      dataTypes: [TypeName.emailType, TypeName.mailboxType, TypeName.labelType]
+      dataTypes: dataTypes,
     )));
   }
 

--- a/lib/features/push_notification/presentation/listener/label_change_listener.dart
+++ b/lib/features/push_notification/presentation/listener/label_change_listener.dart
@@ -11,11 +11,10 @@ class LabelChangeListener extends ChangeListener {
   LabelController? _labelController;
 
   LabelChangeListener._internal() {
-    try {
-      _labelController = getBinding<LabelController>();
-    } catch (e) {
-      logError(
-          'LabelChangeListener::_internal(): IS NOT REGISTERED: ${e.toString()}');
+    _labelController = getBinding<LabelController>();
+    if (_labelController == null) {
+      logWarning(
+          'LabelChangeListener::_internal(): LabelController IS NOT REGISTERED');
     }
   }
 

--- a/lib/features/push_notification/presentation/listener/label_change_listener.dart
+++ b/lib/features/push_notification/presentation/listener/label_change_listener.dart
@@ -1,0 +1,38 @@
+import 'package:core/utils/app_logger.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
+import 'package:tmail_ui_user/features/base/action/ui_action.dart';
+import 'package:tmail_ui_user/features/labels/presentation/extensions/handle_label_websocket_extension.dart';
+import 'package:tmail_ui_user/features/labels/presentation/label_controller.dart';
+import 'package:tmail_ui_user/features/push_notification/presentation/action/push_notification_state_change_action.dart';
+import 'package:tmail_ui_user/features/push_notification/presentation/listener/change_listener.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+
+class LabelChangeListener extends ChangeListener {
+  LabelController? _labelController;
+
+  LabelChangeListener._internal() {
+    try {
+      _labelController = getBinding<LabelController>();
+    } catch (e) {
+      logError(
+          'LabelChangeListener::_internal(): IS NOT REGISTERED: ${e.toString()}');
+    }
+  }
+
+  static final LabelChangeListener _instance = LabelChangeListener._internal();
+
+  static LabelChangeListener get instance => _instance;
+
+  @override
+  void dispatchActions(List<Action> actions) {
+    for (var action in actions) {
+      if (action is SynchronizeLabelOnForegroundAction) {
+        _synchronizeLabelOnForegroundAction(action.newState);
+      }
+    }
+  }
+
+  void _synchronizeLabelOnForegroundAction(jmap.State newState) {
+    _labelController?.refreshLabelChanges(newState: newState);
+  }
+}

--- a/lib/features/push_notification/presentation/listener/label_change_listener.dart
+++ b/lib/features/push_notification/presentation/listener/label_change_listener.dart
@@ -11,10 +11,14 @@ class LabelChangeListener extends ChangeListener {
   LabelController? _labelController;
 
   LabelChangeListener._internal() {
-    _labelController = getBinding<LabelController>();
-    if (_labelController == null) {
-      logWarning(
-          'LabelChangeListener::_internal(): LabelController IS NOT REGISTERED');
+    try {
+      _labelController = getBinding<LabelController>();
+      if (_labelController == null) {
+        logWarning(
+            'LabelChangeListener::_internal(): LabelController IS NOT REGISTERED');
+      }
+    } catch (e) {
+      logWarning('LabelChangeListener::_internal(): $e');
     }
   }
 

--- a/lib/features/push_notification/presentation/listener/label_change_listener.dart
+++ b/lib/features/push_notification/presentation/listener/label_change_listener.dart
@@ -10,17 +10,7 @@ import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 class LabelChangeListener extends ChangeListener {
   LabelController? _labelController;
 
-  LabelChangeListener._internal() {
-    try {
-      _labelController = getBinding<LabelController>();
-      if (_labelController == null) {
-        logWarning(
-            'LabelChangeListener::_internal(): LabelController IS NOT REGISTERED');
-      }
-    } catch (e) {
-      logWarning('LabelChangeListener::_internal(): $e');
-    }
-  }
+  LabelChangeListener._internal();
 
   static final LabelChangeListener _instance = LabelChangeListener._internal();
 
@@ -36,6 +26,13 @@ class LabelChangeListener extends ChangeListener {
   }
 
   void _synchronizeLabelOnForegroundAction(jmap.State newState) {
-    _labelController?.refreshLabelChanges(newState: newState);
+    _labelController ??= getBinding<LabelController>();
+    if (_labelController == null) {
+      logWarning(
+        'LabelChangeListener::_synchronizeLabelOnForegroundAction(): LabelController IS NOT REGISTERED',
+      );
+      return;
+    }
+    _labelController!.refreshLabelChanges(newState: newState);
   }
 }

--- a/lib/features/thread/data/network/thread_api.dart
+++ b/lib/features/thread/data/network/thread_api.dart
@@ -26,13 +26,14 @@ import 'package:tmail_ui_user/features/base/mixin/mail_api_mixin.dart';
 import 'package:jmap_dart_client/jmap/mail/email/search_snippet/search_snippet.dart';
 import 'package:jmap_dart_client/jmap/mail/email/search_snippet/search_snippet_get_method.dart';
 import 'package:jmap_dart_client/jmap/mail/email/search_snippet/search_snippet_get_response.dart';
+import 'package:tmail_ui_user/features/base/mixin/session_mixin.dart';
 import 'package:tmail_ui_user/features/thread/data/extensions/list_email_id_extension.dart';
 import 'package:tmail_ui_user/features/thread/data/model/email_change_response.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/email_response.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/search_emails_response.dart';
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
 
-class ThreadAPI with HandleSetErrorMixin, MailAPIMixin {
+class ThreadAPI with HandleSetErrorMixin, SessionMixin, MailAPIMixin {
 
   final HttpClient httpClient;
 

--- a/lib/main/error/capability_validator.dart
+++ b/lib/main/error/capability_validator.dart
@@ -43,6 +43,7 @@ extension CapabilityIdentifierExtension on CapabilityIdentifier {
 
   static const int defaultMaxCallsInRequest = 1;
   static const int defaultMaxObjectsInSet = 50;
+  static const int defaultMaxObjectsInGet = 50;
 
   bool isSupported(Session session, AccountId accountId) {
     try {

--- a/test/features/base/mixin/batch_set_email_processing_mixin_test.dart
+++ b/test/features/base/mixin/batch_set_email_processing_mixin_test.dart
@@ -7,6 +7,7 @@ import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:tmail_ui_user/features/base/mixin/batch_set_email_processing_mixin.dart';
 import 'package:tmail_ui_user/features/base/mixin/handle_error_mixin.dart';
 import 'package:tmail_ui_user/features/base/mixin/mail_api_mixin.dart';
+import 'package:tmail_ui_user/features/base/mixin/session_mixin.dart';
 
 import '../../../fixtures/account_fixtures.dart';
 import '../../../fixtures/session_fixtures.dart';
@@ -55,7 +56,10 @@ class ManualMockHttpClient implements HttpClient {
 }
 
 class TestBatchSetEmailProcessing
-    with HandleSetErrorMixin, MailAPIMixin, BatchSetEmailProcessingMixin {}
+    with HandleSetErrorMixin,
+        SessionMixin,
+        MailAPIMixin,
+        BatchSetEmailProcessingMixin {}
 
 void main() {
   group('BatchSetEmailProcessingMixin test', () {

--- a/test/features/base/mixin/mail_api_mixin_test.dart
+++ b/test/features/base/mixin/mail_api_mixin_test.dart
@@ -12,12 +12,13 @@ import 'package:jmap_dart_client/jmap/mail/email/email_filter_condition.dart';
 import 'package:model/error_type_handler/set_method_error_handler_mixin.dart';
 import 'package:tmail_ui_user/features/base/mixin/handle_error_mixin.dart';
 import 'package:tmail_ui_user/features/base/mixin/mail_api_mixin.dart';
+import 'package:tmail_ui_user/features/base/mixin/session_mixin.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/email_response.dart';
 
 import '../../../fixtures/account_fixtures.dart';
 import '../../../fixtures/session_fixtures.dart';
 
-class TestMailApiMixin with HandleSetErrorMixin, MailAPIMixin {
+class TestMailApiMixin with HandleSetErrorMixin, SessionMixin, MailAPIMixin {
   @override
   void handleSetErrors({
     SetMethodErrors? notDestroyedError,

--- a/test/features/label/apply_label_changes_test.dart
+++ b/test/features/label/apply_label_changes_test.dart
@@ -1,0 +1,173 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:labels/model/label.dart';
+import 'package:tmail_ui_user/features/labels/presentation/utils/label_utils.dart';
+
+void main() {
+  group('LabelUtils.applyLabelChanges', () {
+    test('should add new labels when created list is not empty', () {
+      final currentLabels = <Label>[];
+      final newLabel = Label(id: Id('1'), displayName: 'Work');
+
+      LabelUtils.applyLabelChanges(
+        currentLabels: currentLabels,
+        created: [newLabel],
+        updated: [],
+        destroyedIds: [],
+      );
+
+      expect(currentLabels.length, 1);
+      expect(currentLabels.first.id?.value, '1');
+    });
+
+    test(
+        'should update existing label when an updated label with the same ID is provided',
+        () {
+      final oldLabel = Label(id: Id('1'), displayName: 'Old Name');
+      final currentLabels = <Label>[oldLabel];
+
+      final updatedLabel = Label(id: Id('1'), displayName: 'New Name');
+
+      LabelUtils.applyLabelChanges(
+        currentLabels: currentLabels,
+        created: [],
+        updated: [updatedLabel],
+        destroyedIds: [],
+      );
+
+      expect(currentLabels.length, 1);
+      expect(currentLabels.first.displayName, 'New Name');
+    });
+
+    test('should remove labels when their ID is present in destroyedIds', () {
+      final currentLabels = <Label>[
+        Label(id: Id('1'), displayName: 'To Delete'),
+        Label(id: Id('2'), displayName: 'Keep Me'),
+      ];
+
+      LabelUtils.applyLabelChanges(
+        currentLabels: currentLabels,
+        created: [],
+        updated: [],
+        destroyedIds: [Id('1')],
+      );
+
+      expect(currentLabels.length, 1);
+      expect(currentLabels.any((l) => l.id?.value == '1'), isFalse);
+      expect(currentLabels.any((l) => l.id?.value == '2'), isTrue);
+    });
+
+    test('should handle create, update, and destroy operations simultaneously',
+        () {
+      final currentLabels = <Label>[
+        Label(id: Id('1'), displayName: 'Old'),
+        Label(id: Id('2'), displayName: 'Remove'),
+      ];
+
+      LabelUtils.applyLabelChanges(
+        currentLabels: currentLabels,
+        created: [Label(id: Id('3'), displayName: 'New')],
+        updated: [Label(id: Id('1'), displayName: 'Updated')],
+        destroyedIds: [Id('2')],
+      );
+
+      expect(currentLabels.length, 2);
+      expect(currentLabels.any((l) => l.displayName == 'Updated'), isTrue);
+      expect(currentLabels.any((l) => l.displayName == 'New'), isTrue);
+      expect(currentLabels.any((l) => l.id?.value == '2'), isFalse);
+    });
+
+    test('should do nothing when all change lists are empty', () {
+      final currentLabels = <Label>[
+        Label(id: Id('1'), displayName: 'Existing'),
+      ];
+
+      LabelUtils.applyLabelChanges(
+        currentLabels: currentLabels,
+        created: [],
+        updated: [],
+        destroyedIds: [],
+      );
+
+      expect(currentLabels.length, 1);
+      expect(currentLabels.first.displayName, 'Existing');
+    });
+
+    test(
+        'should handle destroying IDs that do not exist in currentLabels gracefully',
+        () {
+      final currentLabels = <Label>[
+        Label(id: Id('1'), displayName: 'Keep Me'),
+      ];
+
+      LabelUtils.applyLabelChanges(
+        currentLabels: currentLabels,
+        created: [],
+        updated: [],
+        destroyedIds: [Id('999')],
+      );
+
+      expect(currentLabels.length, 1);
+      expect(currentLabels.first.id?.value, '1');
+    });
+
+    test(
+        'should treat updated labels as new additions if they do not exist in currentLabels (Upsert behavior)',
+        () {
+      final currentLabels = <Label>[];
+      final labelToUpdate = Label(id: Id('1'), displayName: 'Ghost Label');
+
+      LabelUtils.applyLabelChanges(
+        currentLabels: currentLabels,
+        created: [],
+        updated: [labelToUpdate],
+        destroyedIds: [],
+      );
+
+      expect(currentLabels.length, 1);
+      expect(currentLabels.first.displayName, 'Ghost Label');
+    });
+
+    test('should move updated labels to the end of the list', () {
+      final currentLabels = <Label>[
+        Label(id: Id('1'), displayName: 'A'),
+        Label(id: Id('2'), displayName: 'B'),
+        Label(id: Id('3'), displayName: 'C'),
+      ];
+
+      final updatedLabelA = Label(id: Id('1'), displayName: 'A Updated');
+
+      LabelUtils.applyLabelChanges(
+        currentLabels: currentLabels,
+        created: [],
+        updated: [updatedLabelA],
+        destroyedIds: [],
+      );
+
+      expect(currentLabels.length, 3);
+      expect(currentLabels[0].id?.value, '2');
+      expect(currentLabels[1].id?.value, '3');
+      expect(currentLabels[2].id?.value, '1');
+      expect(currentLabels[2].displayName, 'A Updated');
+    });
+
+    test('should prioritize update over destroy if an ID appears in both lists',
+        () {
+      final currentLabels = <Label>[
+        Label(id: Id('1'), displayName: 'Original'),
+      ];
+
+      final updatedLabel = Label(id: Id('1'), displayName: 'Revived');
+
+      LabelUtils.applyLabelChanges(
+        currentLabels: currentLabels,
+        created: [],
+        updated: [updatedLabel],
+        destroyedIds: [Id('1')],
+      );
+
+      expect(currentLabels.length, 1);
+      expect(currentLabels.first.displayName, 'Revived');
+    });
+  });
+}

--- a/test/features/label/apply_label_changes_test.dart
+++ b/test/features/label/apply_label_changes_test.dart
@@ -4,170 +4,199 @@ import 'package:labels/model/label.dart';
 import 'package:tmail_ui_user/features/labels/presentation/utils/label_utils.dart';
 
 void main() {
+  Label createLabel(String id, String name) {
+    return Label(id: Id(id), displayName: name);
+  }
+
   group('LabelUtils.applyLabelChanges', () {
-    test('should add new labels when created list is not empty', () {
-      final currentLabels = <Label>[];
-      final newLabel = Label(id: Id('1'), displayName: 'Work');
+    group('Create Operations', () {
+      test('should add new labels when created list is not empty', () {
+        final currentLabels = <Label>[];
+        final newLabel = createLabel('1', 'Work');
 
-      LabelUtils.applyLabelChanges(
-        currentLabels: currentLabels,
-        created: [newLabel],
-        updated: [],
-        destroyedIds: [],
-      );
+        LabelUtils.applyLabelChanges(
+          currentLabels: currentLabels,
+          created: [newLabel],
+          updated: [],
+          destroyedIds: [],
+        );
 
-      expect(currentLabels.length, 1);
-      expect(currentLabels.first.id?.value, '1');
+        expect(currentLabels.length, 1);
+        expect(currentLabels.first.id?.value, '1');
+      });
+
+      test(
+          'should replace existing label if the same ID appears in the created list (Overwrite/Sync Fix)',
+          () {
+        final currentLabels = [createLabel('1', 'Old Version')];
+        final newVersionLabel = createLabel('1', 'New Version');
+
+        LabelUtils.applyLabelChanges(
+          currentLabels: currentLabels,
+          created: [newVersionLabel],
+          updated: [],
+          destroyedIds: [],
+        );
+
+        expect(currentLabels.length, 1,
+            reason: 'List should not contain duplicates');
+        expect(currentLabels.first.displayName, 'New Version');
+      });
     });
 
-    test(
-        'should update existing label when an updated label with the same ID is provided',
-        () {
-      final oldLabel = Label(id: Id('1'), displayName: 'Old Name');
-      final currentLabels = <Label>[oldLabel];
+    group('Update Operations', () {
+      test('should update existing label when provided in updated list', () {
+        final currentLabels = [createLabel('1', 'Old Name')];
+        final updatedLabel = createLabel('1', 'New Name');
 
-      final updatedLabel = Label(id: Id('1'), displayName: 'New Name');
+        LabelUtils.applyLabelChanges(
+          currentLabels: currentLabels,
+          created: [],
+          updated: [updatedLabel],
+          destroyedIds: [],
+        );
 
-      LabelUtils.applyLabelChanges(
-        currentLabels: currentLabels,
-        created: [],
-        updated: [updatedLabel],
-        destroyedIds: [],
-      );
+        expect(currentLabels.length, 1);
+        expect(currentLabels.first.displayName, 'New Name');
+      });
 
-      expect(currentLabels.length, 1);
-      expect(currentLabels.first.displayName, 'New Name');
+      test(
+          'should treat updated labels as new additions if they do not exist (Upsert behavior)',
+          () {
+        final currentLabels = <Label>[];
+        final labelToUpdate = createLabel('1', 'Ghost Label');
+
+        LabelUtils.applyLabelChanges(
+          currentLabels: currentLabels,
+          created: [],
+          updated: [labelToUpdate],
+          destroyedIds: [],
+        );
+
+        expect(currentLabels.length, 1);
+        expect(currentLabels.first.displayName, 'Ghost Label');
+      });
+
+      test('should move updated labels to the end of the list', () {
+        final currentLabels = [
+          createLabel('1', 'A'),
+          createLabel('2', 'B'),
+          createLabel('3', 'C'),
+        ];
+
+        final updatedLabelA = createLabel('1', 'A Updated');
+
+        LabelUtils.applyLabelChanges(
+          currentLabels: currentLabels,
+          created: [],
+          updated: [updatedLabelA],
+          destroyedIds: [],
+        );
+
+        expect(currentLabels.length, 3);
+        expect(currentLabels[0].id?.value, '2');
+        expect(currentLabels[1].id?.value, '3');
+        expect(currentLabels[2].id?.value, '1');
+        expect(currentLabels[2].displayName, 'A Updated');
+      });
     });
 
-    test('should remove labels when their ID is present in destroyedIds', () {
-      final currentLabels = <Label>[
-        Label(id: Id('1'), displayName: 'To Delete'),
-        Label(id: Id('2'), displayName: 'Keep Me'),
-      ];
+    group('Destroy Operations', () {
+      test('should remove labels when their ID is present in destroyedIds', () {
+        final currentLabels = [
+          createLabel('1', 'To Delete'),
+          createLabel('2', 'Keep Me'),
+        ];
 
-      LabelUtils.applyLabelChanges(
-        currentLabels: currentLabels,
-        created: [],
-        updated: [],
-        destroyedIds: [Id('1')],
-      );
+        LabelUtils.applyLabelChanges(
+          currentLabels: currentLabels,
+          created: [],
+          updated: [],
+          destroyedIds: [Id('1')],
+        );
 
-      expect(currentLabels.length, 1);
-      expect(currentLabels.any((l) => l.id?.value == '1'), isFalse);
-      expect(currentLabels.any((l) => l.id?.value == '2'), isTrue);
+        expect(currentLabels.length, 1);
+        expect(currentLabels.any((l) => l.id?.value == '1'), isFalse);
+        expect(currentLabels.first.id?.value, '2');
+      });
+
+      test('should handle destroying IDs that do not exist gracefully', () {
+        final currentLabels = [createLabel('1', 'Keep Me')];
+
+        LabelUtils.applyLabelChanges(
+          currentLabels: currentLabels,
+          created: [],
+          updated: [],
+          destroyedIds: [Id('999')],
+        );
+
+        expect(currentLabels.length, 1);
+        expect(currentLabels.first.id?.value, '1');
+      });
     });
 
-    test('should handle create, update, and destroy operations simultaneously',
-        () {
-      final currentLabels = <Label>[
-        Label(id: Id('1'), displayName: 'Old'),
-        Label(id: Id('2'), displayName: 'Remove'),
-      ];
+    group('Complex Scenarios & Edge Cases', () {
+      test(
+          'should handle create, update, and destroy operations simultaneously',
+          () {
+        final currentLabels = [
+          createLabel('1', 'To Update'),
+          createLabel('2', 'To Destroy'),
+          createLabel('3', 'To Replace via Create'),
+        ];
 
-      LabelUtils.applyLabelChanges(
-        currentLabels: currentLabels,
-        created: [Label(id: Id('3'), displayName: 'New')],
-        updated: [Label(id: Id('1'), displayName: 'Updated')],
-        destroyedIds: [Id('2')],
-      );
+        LabelUtils.applyLabelChanges(
+          currentLabels: currentLabels,
+          created: [
+            createLabel('4', 'New 4'),
+            createLabel('3', 'Replaced 3'),
+          ],
+          updated: [
+            createLabel('1', 'Updated 1'),
+          ],
+          destroyedIds: [Id('2')],
+        );
 
-      expect(currentLabels.length, 2);
-      expect(currentLabels.any((l) => l.displayName == 'Updated'), isTrue);
-      expect(currentLabels.any((l) => l.displayName == 'New'), isTrue);
-      expect(currentLabels.any((l) => l.id?.value == '2'), isFalse);
-    });
+        expect(currentLabels.length, 3);
+        expect(currentLabels.any((l) => l.id?.value == '2'), isFalse);
+        expect(currentLabels.any((l) => l.displayName == 'Updated 1'), isTrue);
+        expect(currentLabels.any((l) => l.displayName == 'New 4'), isTrue);
+        expect(currentLabels.any((l) => l.displayName == 'Replaced 3'), isTrue);
+        expect(
+            currentLabels.any((l) => l.displayName == 'To Replace via Create'),
+            isFalse);
+      });
 
-    test('should do nothing when all change lists are empty', () {
-      final currentLabels = <Label>[
-        Label(id: Id('1'), displayName: 'Existing'),
-      ];
+      test('should do nothing when all change lists are empty', () {
+        final currentLabels = [createLabel('1', 'Existing')];
 
-      LabelUtils.applyLabelChanges(
-        currentLabels: currentLabels,
-        created: [],
-        updated: [],
-        destroyedIds: [],
-      );
+        LabelUtils.applyLabelChanges(
+          currentLabels: currentLabels,
+          created: [],
+          updated: [],
+          destroyedIds: [],
+        );
 
-      expect(currentLabels.length, 1);
-      expect(currentLabels.first.displayName, 'Existing');
-    });
+        expect(currentLabels.length, 1);
+        expect(currentLabels.first.displayName, 'Existing');
+      });
 
-    test(
-        'should handle destroying IDs that do not exist in currentLabels gracefully',
-        () {
-      final currentLabels = <Label>[
-        Label(id: Id('1'), displayName: 'Keep Me'),
-      ];
+      test(
+          'should prioritize update over destroy if an ID appears in both lists',
+          () {
+        final currentLabels = [createLabel('1', 'Original')];
+        final updatedLabel = createLabel('1', 'Revived');
 
-      LabelUtils.applyLabelChanges(
-        currentLabels: currentLabels,
-        created: [],
-        updated: [],
-        destroyedIds: [Id('999')],
-      );
+        LabelUtils.applyLabelChanges(
+          currentLabels: currentLabels,
+          created: [],
+          updated: [updatedLabel],
+          destroyedIds: [Id('1')],
+        );
 
-      expect(currentLabels.length, 1);
-      expect(currentLabels.first.id?.value, '1');
-    });
-
-    test(
-        'should treat updated labels as new additions if they do not exist in currentLabels (Upsert behavior)',
-        () {
-      final currentLabels = <Label>[];
-      final labelToUpdate = Label(id: Id('1'), displayName: 'Ghost Label');
-
-      LabelUtils.applyLabelChanges(
-        currentLabels: currentLabels,
-        created: [],
-        updated: [labelToUpdate],
-        destroyedIds: [],
-      );
-
-      expect(currentLabels.length, 1);
-      expect(currentLabels.first.displayName, 'Ghost Label');
-    });
-
-    test('should move updated labels to the end of the list', () {
-      final currentLabels = <Label>[
-        Label(id: Id('1'), displayName: 'A'),
-        Label(id: Id('2'), displayName: 'B'),
-        Label(id: Id('3'), displayName: 'C'),
-      ];
-
-      final updatedLabelA = Label(id: Id('1'), displayName: 'A Updated');
-
-      LabelUtils.applyLabelChanges(
-        currentLabels: currentLabels,
-        created: [],
-        updated: [updatedLabelA],
-        destroyedIds: [],
-      );
-
-      expect(currentLabels.length, 3);
-      expect(currentLabels[0].id?.value, '2');
-      expect(currentLabels[1].id?.value, '3');
-      expect(currentLabels[2].id?.value, '1');
-      expect(currentLabels[2].displayName, 'A Updated');
-    });
-
-    test('should prioritize update over destroy if an ID appears in both lists',
-        () {
-      final currentLabels = <Label>[
-        Label(id: Id('1'), displayName: 'Original'),
-      ];
-
-      final updatedLabel = Label(id: Id('1'), displayName: 'Revived');
-
-      LabelUtils.applyLabelChanges(
-        currentLabels: currentLabels,
-        created: [],
-        updated: [updatedLabel],
-        destroyedIds: [Id('1')],
-      );
-
-      expect(currentLabels.length, 1);
-      expect(currentLabels.first.displayName, 'Revived');
+        expect(currentLabels.length, 1);
+        expect(currentLabels.first.displayName, 'Revived');
+      });
     });
   });
 }

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -404,7 +404,8 @@ void main() {
 
       when(emailReceiveManager.pendingSharedFileInfo).thenAnswer((_) => BehaviorSubject.seeded([]));
       when(downloadController.downloadUIAction).thenAnswer((_) => Rxn(DownloadUIAction.idle));
-      when(labelController.isLabelSettingEnabled).thenAnswer((_) => RxBool(false));
+      final isLabelSettingEnabled = RxBool(false);
+      when(labelController.isLabelSettingEnabled).thenReturn(isLabelSettingEnabled);
 
       Get.put(mailboxDashboardController);
       mailboxDashboardController.onReady();
@@ -452,7 +453,8 @@ void main() {
       when(context.owner).thenReturn(BuildOwner(focusManager: FocusManager()));
       when(context.mounted).thenReturn(true);
       when(downloadController.downloadUIAction).thenAnswer((_) => Rxn(DownloadUIAction.idle));
-      when(labelController.isLabelSettingEnabled).thenAnswer((_) => RxBool(false));
+      final isLabelSettingEnabled = RxBool(false);
+      when(labelController.isLabelSettingEnabled).thenReturn(isLabelSettingEnabled);
       
       // expect query in search controller update as expected
       mailboxDashboardController.searchEmailByQueryString(queryString);
@@ -637,7 +639,8 @@ void main() {
 
       when(emailReceiveManager.pendingSharedFileInfo).thenAnswer((_) => BehaviorSubject.seeded([]));
       when(downloadController.downloadUIAction).thenAnswer((_) => Rxn(DownloadUIAction.idle));
-      when(labelController.isLabelSettingEnabled).thenAnswer((_) => RxBool(false));
+      final isLabelSettingEnabled = RxBool(false);
+      when(labelController.isLabelSettingEnabled).thenReturn(isLabelSettingEnabled);
 
       Get.put(mailboxDashboardController);
       mailboxDashboardController.onReady();

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -404,6 +404,7 @@ void main() {
 
       when(emailReceiveManager.pendingSharedFileInfo).thenAnswer((_) => BehaviorSubject.seeded([]));
       when(downloadController.downloadUIAction).thenAnswer((_) => Rxn(DownloadUIAction.idle));
+      when(labelController.isLabelSettingEnabled).thenAnswer((_) => RxBool(false));
 
       Get.put(mailboxDashboardController);
       mailboxDashboardController.onReady();
@@ -451,6 +452,7 @@ void main() {
       when(context.owner).thenReturn(BuildOwner(focusManager: FocusManager()));
       when(context.mounted).thenReturn(true);
       when(downloadController.downloadUIAction).thenAnswer((_) => Rxn(DownloadUIAction.idle));
+      when(labelController.isLabelSettingEnabled).thenAnswer((_) => RxBool(false));
       
       // expect query in search controller update as expected
       mailboxDashboardController.searchEmailByQueryString(queryString);
@@ -635,6 +637,7 @@ void main() {
 
       when(emailReceiveManager.pendingSharedFileInfo).thenAnswer((_) => BehaviorSubject.seeded([]));
       when(downloadController.downloadUIAction).thenAnswer((_) => Rxn(DownloadUIAction.idle));
+      when(labelController.isLabelSettingEnabled).thenAnswer((_) => RxBool(false));
 
       Get.put(mailboxDashboardController);
       mailboxDashboardController.onReady();

--- a/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
+++ b/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
@@ -365,6 +365,7 @@ void main() {
 
       when(emailReceiveManager.pendingSharedFileInfo).thenAnswer((_) => BehaviorSubject.seeded([]));
       when(downloadController.downloadUIAction).thenAnswer((_) => Rxn(DownloadUIAction.idle));
+      when(labelController.isLabelSettingEnabled).thenAnswer((_) => RxBool(false));
 
       searchController = SearchController(
         quickSearchEmailInteractor,

--- a/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
+++ b/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
@@ -365,7 +365,8 @@ void main() {
 
       when(emailReceiveManager.pendingSharedFileInfo).thenAnswer((_) => BehaviorSubject.seeded([]));
       when(downloadController.downloadUIAction).thenAnswer((_) => Rxn(DownloadUIAction.idle));
-      when(labelController.isLabelSettingEnabled).thenAnswer((_) => RxBool(false));
+      final isLabelSettingEnabled = RxBool(false);
+      when(labelController.isLabelSettingEnabled).thenReturn(isLabelSettingEnabled);
 
       searchController = SearchController(
         quickSearchEmailInteractor,

--- a/test/features/push_notification/presentation/controller/push_base_controller_test.dart
+++ b/test/features/push_notification/presentation/controller/push_base_controller_test.dart
@@ -11,6 +11,7 @@ import 'package:mockito/mockito.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/action/push_notification_state_change_action.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/controller/push_base_controller.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/listener/email_change_listener.dart';
+import 'package:tmail_ui_user/features/push_notification/presentation/listener/label_change_listener.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/listener/mailbox_change_listener.dart';
 
 import 'push_base_controller_test.mocks.dart';
@@ -26,6 +27,7 @@ class TestPushController extends PushBaseController {
 @GenerateNiceMocks([
   MockSpec<EmailChangeListener>(),
   MockSpec<MailboxChangeListener>(),
+  MockSpec<LabelChangeListener>(),
 ])
 void main() {
   final accountId = AccountId(Id('accountId'));
@@ -35,6 +37,7 @@ void main() {
     group('mappingTypeStateToAction:', () {
       final emailChangeListener = MockEmailChangeListener();
       final mailboxChangeListener = MockMailboxChangeListener();
+      final labelChangeListener = MockLabelChangeListener();
 
       test(
         'should call emailChangeListener.dispatchActions with SynchronizeEmailOnForegroundAction '
@@ -53,7 +56,8 @@ void main() {
           userName,
           isForeground: true,
           emailChangeListener: emailChangeListener,
-          mailboxChangeListener: mailboxChangeListener
+          mailboxChangeListener: mailboxChangeListener,
+          labelChangeListener: labelChangeListener,
         );
 
         // assert
@@ -68,6 +72,7 @@ void main() {
           ]),
         ).called(1);
         verifyNever(mailboxChangeListener.dispatchActions(any));
+        verifyNever(labelChangeListener.dispatchActions(any));
       });
 
       test(
@@ -87,7 +92,8 @@ void main() {
           userName,
           isForeground: false,
           emailChangeListener: emailChangeListener,
-          mailboxChangeListener: mailboxChangeListener
+          mailboxChangeListener: mailboxChangeListener,
+          labelChangeListener: labelChangeListener,
         );
 
         // assert
@@ -103,6 +109,7 @@ void main() {
           ]),
         ).called(1);
         verifyNever(mailboxChangeListener.dispatchActions(any));
+        verifyNever(labelChangeListener.dispatchActions(any));
       });
 
       test(
@@ -122,12 +129,14 @@ void main() {
           userName,
           isForeground: true,
           emailChangeListener: emailChangeListener,
-          mailboxChangeListener: mailboxChangeListener
+          mailboxChangeListener: mailboxChangeListener,
+          labelChangeListener: labelChangeListener,
         );
 
         // assert
         verifyNever(emailChangeListener.dispatchActions(any));
         verifyNever(mailboxChangeListener.dispatchActions(any));
+        verifyNever(labelChangeListener.dispatchActions(any));
       });
 
       test(
@@ -147,7 +156,8 @@ void main() {
           userName,
           isForeground: false,
           emailChangeListener: emailChangeListener,
-          mailboxChangeListener: mailboxChangeListener
+          mailboxChangeListener: mailboxChangeListener,
+          labelChangeListener: labelChangeListener,
         );
 
         // assert
@@ -163,6 +173,7 @@ void main() {
           ]),
         ).called(1);
         verifyNever(mailboxChangeListener.dispatchActions(any));
+        verifyNever(labelChangeListener.dispatchActions(any));
       });
       
       test(
@@ -182,7 +193,8 @@ void main() {
           userName,
           isForeground: true,
           emailChangeListener: emailChangeListener,
-          mailboxChangeListener: mailboxChangeListener
+          mailboxChangeListener: mailboxChangeListener,
+          labelChangeListener: labelChangeListener,
         );
 
         // assert
@@ -196,6 +208,7 @@ void main() {
           ]),
         ).called(1);
         verifyNever(emailChangeListener.dispatchActions(any));
+        verifyNever(labelChangeListener.dispatchActions(any));
       });
 
       test(
@@ -215,7 +228,8 @@ void main() {
           userName,
           isForeground: false,
           emailChangeListener: emailChangeListener,
-          mailboxChangeListener: mailboxChangeListener
+          mailboxChangeListener: mailboxChangeListener,
+          labelChangeListener: labelChangeListener,
         );
 
         // assert
@@ -230,6 +244,78 @@ void main() {
           ]),
         ).called(1);
         verifyNever(emailChangeListener.dispatchActions(any));
+        verifyNever(labelChangeListener.dispatchActions(any));
+      });
+
+      test(
+        'should call labelChangeListener.dispatchActions with SynchronizeLabelOnForegroundAction '
+        'when mapTypeState contains labelType '
+        'and isForeground is true',
+      () {
+        // arrange
+        final state = State('some-state');
+        final mapTypeState = {TypeName.labelType.value: state.value};
+
+        // act
+        final pushBaseController = TestPushController();
+        pushBaseController.mappingTypeStateToAction(
+          mapTypeState,
+          accountId,
+          userName,
+          isForeground: true,
+          emailChangeListener: emailChangeListener,
+          mailboxChangeListener: mailboxChangeListener,
+          labelChangeListener: labelChangeListener,
+        );
+
+        // assert
+        verify(
+          labelChangeListener.dispatchActions([
+            SynchronizeLabelOnForegroundAction(
+              TypeName.labelType,
+              state,
+              accountId,
+            ),
+          ]),
+        ).called(1);
+        verifyNever(emailChangeListener.dispatchActions(any));
+        verifyNever(mailboxChangeListener.dispatchActions(any));
+      });
+
+      test(
+        'should call labelChangeListener.dispatchActions with StoreLabelStateToRefreshAction '
+        'when mapTypeState contains labelType '
+        'and isForeground is false',
+      () {
+        // arrange
+        final state = State('some-state');
+        final mapTypeState = {TypeName.labelType.value: state.value};
+
+        // act
+        final pushBaseController = TestPushController();
+        pushBaseController.mappingTypeStateToAction(
+          mapTypeState,
+          accountId,
+          userName,
+          isForeground: false,
+          emailChangeListener: emailChangeListener,
+          mailboxChangeListener: mailboxChangeListener,
+          labelChangeListener: labelChangeListener,
+        );
+
+        // assert
+        verify(
+          labelChangeListener.dispatchActions([
+            StoreLabelStateToRefreshAction(
+              TypeName.labelType,
+              state,
+              accountId,
+              userName,
+            ),
+          ]),
+        ).called(1);
+        verifyNever(emailChangeListener.dispatchActions(any));
+        verifyNever(mailboxChangeListener.dispatchActions(any));
       });
     });
   });

--- a/test/features/search/verify_before_time_in_search_email_filter_test.dart
+++ b/test/features/search/verify_before_time_in_search_email_filter_test.dart
@@ -394,7 +394,8 @@ void main() {
 
     when(emailReceiveManager.pendingSharedFileInfo).thenAnswer((_) => BehaviorSubject.seeded([]));
     when(downloadController.downloadUIAction).thenAnswer((_) => Rxn(DownloadUIAction.idle));
-    when(labelController.isLabelSettingEnabled).thenAnswer((_) => RxBool(false));
+    final isLabelSettingEnabled = RxBool(false);
+    when(labelController.isLabelSettingEnabled).thenReturn(isLabelSettingEnabled);
 
     Get.put<MailboxDashBoardController>(mailboxDashboardController);
 

--- a/test/features/search/verify_before_time_in_search_email_filter_test.dart
+++ b/test/features/search/verify_before_time_in_search_email_filter_test.dart
@@ -394,6 +394,7 @@ void main() {
 
     when(emailReceiveManager.pendingSharedFileInfo).thenAnswer((_) => BehaviorSubject.seeded([]));
     when(downloadController.downloadUIAction).thenAnswer((_) => Rxn(DownloadUIAction.idle));
+    when(labelController.isLabelSettingEnabled).thenAnswer((_) => RxBool(false));
 
     Get.put<MailboxDashBoardController>(mailboxDashboardController);
 


### PR DESCRIPTION
## Issue

Implement auto-sync of tags via WebSocket


## Resolved


https://github.com/user-attachments/assets/4fdf9320-5274-40e0-a71a-0eeb676ef551



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time label updates via WebSocket and push notifications for immediate sync
  * Incremental label changes API with state-aware fetch and on-demand refresh
  * Batched label retrieval to reduce API calls and improve performance
  * Label change application logic to merge created/updated/destroyed items and preserve ordering
  * Controller/UI wiring to track per-session label state and enable/disable label push support

* **Tests**
  * Expanded tests covering label change application, batch operations, and push handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->