### PR TITLE
TF-4303 Change order for label action

### DIFF
--- a/lib/features/email/presentation/utils/email_action_reactor/email_action_reactor.dart
+++ b/lib/features/email/presentation/utils/email_action_reactor/email_action_reactor.dart
@@ -507,14 +507,14 @@ class EmailActionReactor {
       if (EmailUtils.isReplyToListEnabled(presentationEmail.listPost ?? '') &&
           additionalActions.contains(EmailActionType.replyToList))
         EmailActionType.replyToList,
-      if (isLabelAvailable && labels?.isNotEmpty == true)
-        EmailActionType.labelAs,
       if (PlatformInfo.isWeb &&
           PlatformInfo.isCanvasKit &&
           additionalActions.contains(EmailActionType.printAll))
         EmailActionType.printAll,
       if (additionalActions.contains(EmailActionType.moveToMailbox))
         EmailActionType.moveToMailbox,
+      if (isLabelAvailable && labels?.isNotEmpty == true)
+        EmailActionType.labelAs,
       if (additionalActions.contains(EmailActionType.markAsStarred) &&
           additionalActions.contains(EmailActionType.unMarkAsStarred))
         presentationEmail.hasStarred

--- a/lib/features/thread_detail/presentation/extension/on_thread_detail_action_click.dart
+++ b/lib/features/thread_detail/presentation/extension/on_thread_detail_action_click.dart
@@ -137,9 +137,6 @@ extension OnThreadDetailActionClick on ThreadDetailController {
     if (currentContext == null) return;
 
     final moreActions = [
-      if (mailboxDashBoardController.isLabelAvailable &&
-          mailboxDashBoardController.labelController.labels.isNotEmpty)
-        EmailActionType.labelAs,
       threadDetailIsRead
           ? EmailActionType.markAsUnread
           : EmailActionType.markAsRead,
@@ -147,6 +144,9 @@ extension OnThreadDetailActionClick on ThreadDetailController {
           ? EmailActionType.unMarkAsStarred
           : EmailActionType.markAsStarred,
       EmailActionType.moveToMailbox,
+      if (mailboxDashBoardController.isLabelAvailable &&
+          mailboxDashBoardController.labelController.labels.isNotEmpty)
+        EmailActionType.labelAs,
       if (!threadDetailIsArchived) EmailActionType.archiveMessage,
       threadDetailIsSpam ? EmailActionType.unSpam : EmailActionType.moveToSpam,
       threadDetailIsTrashed

--- a/model/lib/email/email_action_type.dart
+++ b/model/lib/email/email_action_type.dart
@@ -4,7 +4,7 @@ enum EmailActionType {
   replyToList(1),
   forward(1),
   replyAll(1),
-  labelAs(1),
+  labelAs(2),
   compose(),
   markAsRead(2),
   markAsUnread(2),


### PR DESCRIPTION
## Issue

#4303

## Resolved

- Web:

https://github.com/user-attachments/assets/c14b8d59-3dd5-43bf-94ff-57d8b7caf60e




- Mobile

https://github.com/user-attachments/assets/e9d542a3-437d-430b-8c61-a10c9d0f3cff




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reordered email action menu items; "Label As" action now appears after "Move to Mailbox" in email action lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->