### PR TITLE
TF-4292 Add folder info when open mail list from Label

### DIFF
--- a/integration_test/scenarios/labels/display_folder_info_when_open_mail_from_tag_scenario.dart
+++ b/integration_test/scenarios/labels/display_folder_info_when_open_mail_from_tag_scenario.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:labels/labels.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/widgets/labels/label_list_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../mixin/provisioning_label_scenario_mixin.dart';
+import '../../robots/label_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class DisplayFolderInfoWhenOpenMailFromTagScenario extends BaseTestScenario
+    with ProvisioningLabelScenarioMixin {
+  const DisplayFolderInfoWhenOpenMailFromTagScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
+
+    final threadRobot = ThreadRobot($);
+    final labelRobot = LabelRobot($);
+
+    final labels = await provisionLabelsByDisplayNames(
+      ['Tag 1'],
+    );
+    await $.pumpAndSettle();
+    final newLabel = labels.first;
+
+    await provisionEmail(
+      buildEmailsForLabel(
+        label: newLabel,
+        toEmail: emailUser,
+        count: 1,
+      ),
+      requestReadReceipt: false,
+      folderLocationRole: PresentationMailbox.roleTrash,
+    );
+    await provisionEmail(
+      buildEmailsForLabel(
+        label: newLabel,
+        toEmail: emailUser,
+        count: 1,
+      ),
+      requestReadReceipt: false,
+      folderLocationRole: PresentationMailbox.roleTrash,
+    );
+    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+
+    await threadRobot.openMailbox();
+    await _expectLabelListViewVisible();
+
+    await labelRobot.openLabelByName(newLabel.safeDisplayName);
+    await _expectFolderInfoDisplayed();
+  }
+
+  Future<void> _expectLabelListViewVisible() =>
+      expectViewVisible($(LabelListView));
+
+  Future<void> _expectFolderInfoDisplayed() async {
+    await expectViewVisible($(AppLocalizations().trashMailboxDisplayName));
+  }
+}

--- a/integration_test/tests/labels/display_folder_info_when_open_mail_from_tag_test.dart
+++ b/integration_test/tests/labels/display_folder_info_when_open_mail_from_tag_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/labels/display_folder_info_when_open_mail_from_tag_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should display folder info when open mail list from tag',
+    scenarioBuilder: ($) => DisplayFolderInfoWhenOpenMailFromTagScenario($),
+  );
+}

--- a/lib/features/mailbox/presentation/base_mailbox_view.dart
+++ b/lib/features/mailbox/presentation/base_mailbox_view.dart
@@ -15,6 +15,7 @@ import 'package:tmail_ui_user/features/labels/presentation/models/label_action_t
 import 'package:tmail_ui_user/features/mailbox/presentation/extensions/handle_label_action_type_extension.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/extensions/handle_mailbox_action_extension.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/extensions/open_app_grid_extension.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/extensions/toggle_expand_folders_extension.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/mailbox_controller.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_categories.dart';
@@ -405,8 +406,8 @@ abstract class BaseMailboxView extends GetWidget<MailboxController>
 
       final selectedMailbox = dashboardController.selectedMailbox.value;
       Id? labelIdSelected;
-      if (selectedMailbox is PresentationLabelMailbox) {
-        labelIdSelected = selectedMailbox.id.id;
+      if (selectedMailbox?.isLabelMailbox == true) {
+        labelIdSelected = selectedMailbox?.id.id;
       }
 
       if (isLabelAvailable) {

--- a/lib/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart
+++ b/lib/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart
@@ -14,7 +14,7 @@ import 'package:tmail_ui_user/main/routes/route_utils.dart';
 extension PresentationMailboxExtension on PresentationMailbox {
 
   String getDisplayName(BuildContext context) {
-    if (this is PresentationLabelMailbox) {
+    if (isLabelMailbox) {
       return (this as PresentationLabelMailbox).label.safeDisplayName;
     }
 
@@ -49,7 +49,7 @@ extension PresentationMailboxExtension on PresentationMailbox {
   }
 
   String getDisplayNameWithoutContext(AppLocalizations appLocalizations) {
-    if (this is PresentationLabelMailbox) {
+    if (isLabelMailbox) {
       return (this as PresentationLabelMailbox).label.safeDisplayName;
     }
 

--- a/lib/features/search/email/presentation/search_email_view.dart
+++ b/lib/features/search/email/presentation/search_email_view.dart
@@ -19,6 +19,7 @@ import 'package:tmail_ui_user/features/base/widget/keyboard/keyboard_handler_wra
 import 'package:tmail_ui_user/features/base/widget/popup_menu/popup_menu_item_action_widget.dart';
 import 'package:tmail_ui_user/features/base/widget/scrollbar_list_view.dart';
 import 'package:tmail_ui_user/features/email/presentation/extensions/presentation_email_extension.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/model/recent_search.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_ai_needs_action_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart';
@@ -757,6 +758,9 @@ class SearchEmailView extends GetWidget<SearchEmailController>
 
         final listLabels = dashboardController.labelController.labels;
 
+        final isLabelMailboxOpened =
+            dashboardController.selectedMailbox.value?.isLabelMailbox == true;
+
         List<Label>? emailLabels;
 
         if (isLabelAvailable) {
@@ -770,6 +774,7 @@ class SearchEmailView extends GetWidget<SearchEmailController>
           isShowingEmailContent: isShowingEmailContent,
           isSenderImportantFlagEnabled: isSenderImportantFlagEnabled,
           isSearchEmailRunning: true,
+          isLabelMailboxOpened: isLabelMailboxOpened,
           isAINeedsActionEnabled: isAINeedsActionEnabled,
           labels: emailLabels,
           padding: SearchEmailViewStyle.getPaddingSearchResultList(

--- a/lib/features/thread/presentation/mixin/base_email_item_tile.dart
+++ b/lib/features/thread/presentation/mixin/base_email_item_tile.dart
@@ -32,9 +32,10 @@ mixin BaseEmailItemTile {
   Widget buildMailboxContain(
     BuildContext context,
     bool isSearchEmailRunning,
+    bool isLabelMailboxOpened,
     PresentationEmail email
   ) {
-    if (hasMailboxLabel(isSearchEmailRunning, email)) {
+    if (hasMailboxLabel(isSearchEmailRunning, isLabelMailboxOpened, email)) {
       return Container(
           margin: const EdgeInsetsDirectional.only(start: 8),
           padding: const EdgeInsetsDirectional.symmetric(horizontal: 8),
@@ -68,8 +69,13 @@ mixin BaseEmailItemTile {
   Color buildTextColorForReadEmail(PresentationEmail email) =>
       email.hasRead ? AppColor.steelGray400 : Colors.black;
 
-  bool hasMailboxLabel(bool isSearchEmailRunning, PresentationEmail email) {
-    return isSearchEmailRunning && email.mailboxContain != null;
+  bool hasMailboxLabel(
+    bool isSearchEmailRunning,
+    bool isLabelMailboxOpened,
+    PresentationEmail email,
+  ) {
+    return (isSearchEmailRunning || isLabelMailboxOpened) &&
+        email.mailboxContain != null;
   }
 
   String informationSender(PresentationEmail email, PresentationMailbox? mailbox) {

--- a/lib/features/thread/presentation/mixin/base_email_item_tile.dart
+++ b/lib/features/thread/presentation/mixin/base_email_item_tile.dart
@@ -10,7 +10,6 @@ import 'package:core/presentation/views/text/text_overflow_builder.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:get/get.dart';
 import 'package:model/email/email_action_type.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:model/extensions/presentation_email_extension.dart';
@@ -26,8 +25,9 @@ typedef OnMoreActionClick = Future<void> Function(PresentationEmail, RelativeRec
 
 mixin BaseEmailItemTile {
 
-  final responsiveUtils = Get.find<ResponsiveUtils>();
-  final imagePaths = Get.find<ImagePaths>();
+  ResponsiveUtils get responsiveUtils;
+
+  ImagePaths get imagePaths;
 
   Widget buildMailboxContain(
     BuildContext context,

--- a/lib/features/thread/presentation/thread_view.dart
+++ b/lib/features/thread/presentation/thread_view.dart
@@ -21,7 +21,7 @@ import 'package:tmail_ui_user/features/email/presentation/model/popup_menu_item_
 import 'package:tmail_ui_user/features/mailbox/domain/state/clear_mailbox_state.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/state/mark_as_mailbox_read_state.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/state/move_folder_content_state.dart';
-import 'package:tmail_ui_user/features/mailbox/presentation/model/presentation_label_mailbox.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/model/spam_report_state.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_ai_needs_action_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_open_context_menu_extension.dart';
@@ -523,6 +523,9 @@ class ThreadView extends GetWidget<ThreadController>
 
       final isAINeedsActionEnabled = dashboardController.isAINeedsActionEnabled;
 
+      final isLabelMailboxOpened =
+          dashboardController.selectedMailbox.value?.isLabelMailbox == true;
+
       return EmailTileBuilder(
         key: Key('email_tile_builder_${presentationEmail.id?.asString}'),
         presentationEmail: presentationEmail,
@@ -531,6 +534,7 @@ class ThreadView extends GetWidget<ThreadController>
         searchQuery: controller.searchQuery,
         mailboxContain: presentationEmail.mailboxContain,
         isSearchEmailRunning: isSearchEmailRunning,
+        isLabelMailboxOpened: isLabelMailboxOpened,
         isDrag: true,
         isSenderImportantFlagEnabled: isSenderImportantFlagEnabled,
         isAINeedsActionEnabled: isAINeedsActionEnabled,
@@ -622,14 +626,17 @@ class ThreadView extends GetWidget<ThreadController>
       final isLabelAvailable = controller
           .mailboxDashBoardController.isLabelAvailable;
 
-        final listLabels =
-            controller.mailboxDashBoardController.labelController.labels;
+      final listLabels =
+          controller.mailboxDashBoardController.labelController.labels;
 
-        List<Label>? emailLabels;
+      final isLabelMailboxOpened =
+          controller.selectedMailbox?.isLabelMailbox == true;
 
-        if (isLabelAvailable) {
-          emailLabels = presentationEmail.getLabelList(listLabels);
-        }
+      List<Label>? emailLabels;
+
+      if (isLabelAvailable) {
+        emailLabels = presentationEmail.getLabelList(listLabels);
+      }
 
       return Dismissible(
         key: ValueKey<EmailId?>(presentationEmail.id),
@@ -654,6 +661,7 @@ class ThreadView extends GetWidget<ThreadController>
           mailboxContain: presentationEmail.mailboxContain,
           isSearchEmailRunning: isSearchEmailRunning,
           isAINeedsActionEnabled: isAINeedsActionEnabled,
+          isLabelMailboxOpened: isLabelMailboxOpened,
           labels: emailLabels,
           emailActionClick: _handleEmailActionClicked,
           onMoreActionClick: (email, position) =>
@@ -819,8 +827,7 @@ class ThreadView extends GetWidget<ThreadController>
               isFilterMessageActive: controller.mailboxDashBoardController.filterMessageOption.value != FilterMessageOption.all,
               isFavoriteFolder: controller.selectedMailbox?.isFavorite == true,
               isActionRequiredFolder: controller.selectedMailbox?.isActionRequired == true,
-              isLabelMailbox:
-                controller.selectedMailbox is PresentationLabelMailbox,
+              isLabelMailbox: controller.selectedMailbox?.isLabelMailbox == true,
             ),
           );
         }

--- a/lib/features/thread/presentation/widgets/desktop_list_email_action_hover_widget.dart
+++ b/lib/features/thread/presentation/widgets/desktop_list_email_action_hover_widget.dart
@@ -15,6 +15,7 @@ class DesktopListEmailActionHoverWidget extends StatefulWidget {
   final bool isHovered;
   final bool canDeletePermanently;
   final bool isSearchEmailRunning;
+  final bool isLabelMailboxOpened;
   final PresentationMailbox? mailboxContain;
   final OnPressEmailActionClick? emailActionClick;
   final OnMoreActionClick? onMoreActionClick;
@@ -25,6 +26,7 @@ class DesktopListEmailActionHoverWidget extends StatefulWidget {
     required this.isHovered,
     required this.canDeletePermanently,
     required this.isSearchEmailRunning,
+    required this.isLabelMailboxOpened,
     required this.mailboxContain,
     required this.emailActionClick,
     required this.onMoreActionClick,
@@ -135,6 +137,7 @@ class _DesktopListEmailActionHoverWidgetState
         buildMailboxContain(
           context,
           widget.isSearchEmailRunning,
+          widget.isLabelMailboxOpened,
           widget.presentationEmail,
         ),
         if (widget.presentationEmail.hasAttachment == true)

--- a/lib/features/thread/presentation/widgets/desktop_list_email_action_hover_widget.dart
+++ b/lib/features/thread/presentation/widgets/desktop_list_email_action_hover_widget.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -39,8 +40,6 @@ class DesktopListEmailActionHoverWidget extends StatefulWidget {
 
 class _DesktopListEmailActionHoverWidgetState
     extends State<DesktopListEmailActionHoverWidget> with BaseEmailItemTile {
-  final _imagePaths = Get.find<ImagePaths>();
-
   bool _popupMenuVisible = false;
 
   @override
@@ -48,7 +47,7 @@ class _DesktopListEmailActionHoverWidgetState
     final listActionWidget = [
       if (widget.isHovered) ...[
         TMailButtonWidget.fromIcon(
-          icon: _imagePaths.icOpenInNewTab,
+          icon: imagePaths.icOpenInNewTab,
           iconColor: ItemEmailTileStyles.actionIconHoverColor,
           iconSize: _getIconSize(),
           padding: _getPaddingIcon(),
@@ -62,8 +61,8 @@ class _DesktopListEmailActionHoverWidgetState
         if (!widget.presentationEmail.isDraft)
           TMailButtonWidget.fromIcon(
             icon: widget.presentationEmail.hasRead
-                ? _imagePaths.icUnread
-                : _imagePaths.icRead,
+                ? imagePaths.icUnread
+                : imagePaths.icRead,
             iconColor: ItemEmailTileStyles.actionIconHoverColor,
             iconSize: _getIconSize(),
             padding: _getPaddingIcon(),
@@ -82,7 +81,7 @@ class _DesktopListEmailActionHoverWidgetState
         if (widget.mailboxContain != null &&
             widget.mailboxContain?.isDrafts == false) ...[
           TMailButtonWidget.fromIcon(
-            icon: _imagePaths.icMove,
+            icon: imagePaths.icMove,
             iconColor: ItemEmailTileStyles.actionIconHoverColor,
             iconSize: _getIconSize(),
             padding: _getPaddingIcon(),
@@ -96,7 +95,7 @@ class _DesktopListEmailActionHoverWidgetState
           ),
         ],
         TMailButtonWidget.fromIcon(
-          icon: _imagePaths.icDeleteComposer,
+          icon: imagePaths.icDeleteComposer,
           iconColor: ItemEmailTileStyles.actionIconHoverColor,
           iconSize: _getIconSize(),
           padding: _getPaddingIcon(),
@@ -115,7 +114,7 @@ class _DesktopListEmailActionHoverWidgetState
       ],
       if (_shouldShowPopupMenu) ...[
         TMailButtonWidget.fromIcon(
-          icon: _imagePaths.icMoreVertical,
+          icon: imagePaths.icMoreVertical,
           iconColor: ItemEmailTileStyles.actionIconHoverColor,
           iconSize: _getIconSize(),
           padding: _getPaddingIcon(),
@@ -176,4 +175,10 @@ class _DesktopListEmailActionHoverWidgetState
       });
     }
   }
+
+  @override
+  ImagePaths get imagePaths => Get.find<ImagePaths>();
+
+  @override
+  ResponsiveUtils get responsiveUtils => Get.find<ResponsiveUtils>();
 }

--- a/lib/features/thread/presentation/widgets/email_tile_builder.dart
+++ b/lib/features/thread/presentation/widgets/email_tile_builder.dart
@@ -24,6 +24,7 @@ class EmailTileBuilder extends StatelessWidget with BaseEmailItemTile {
   final bool isSenderImportantFlagEnabled;
   final bool isAINeedsActionEnabled;
   final bool autoWrapTagsByMaxWidth;
+  final bool isLabelMailboxOpened;
   final List<Label>? labels;
   final OnPressEmailActionClick? emailActionClick;
   final OnMoreActionClick? onMoreActionClick;
@@ -39,6 +40,7 @@ class EmailTileBuilder extends StatelessWidget with BaseEmailItemTile {
     this.isSenderImportantFlagEnabled = true,
     this.isAINeedsActionEnabled = true,
     this.autoWrapTagsByMaxWidth = false,
+    this.isLabelMailboxOpened = false,
     this.mailboxContain,
     this.padding,
     this.isDrag = false,
@@ -121,6 +123,7 @@ class EmailTileBuilder extends StatelessWidget with BaseEmailItemTile {
                     buildMailboxContain(
                       context,
                       isSearchEmailRunning,
+                      isLabelMailboxOpened,
                       presentationEmail),
                     if (presentationEmail.hasStarred)
                       Padding(

--- a/lib/features/thread/presentation/widgets/email_tile_builder.dart
+++ b/lib/features/thread/presentation/widgets/email_tile_builder.dart
@@ -1,5 +1,8 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:labels/model/label.dart';
 import 'package:model/email/email_action_type.dart';
 import 'package:model/email/presentation_email.dart';
@@ -232,4 +235,10 @@ class EmailTileBuilder extends StatelessWidget with BaseEmailItemTile {
 
   bool get _shouldShowAIAction =>
       isAINeedsActionEnabled && presentationEmail.hasNeedAction;
+
+  @override
+  ImagePaths get imagePaths => Get.find<ImagePaths>();
+
+  @override
+  ResponsiveUtils get responsiveUtils => Get.find<ResponsiveUtils>();
 }

--- a/lib/features/thread/presentation/widgets/email_tile_web_builder.dart
+++ b/lib/features/thread/presentation/widgets/email_tile_web_builder.dart
@@ -31,6 +31,7 @@ class EmailTileBuilder extends StatefulWidget {
   final bool isSenderImportantFlagEnabled;
   final bool isAINeedsActionEnabled;
   final bool autoWrapTagsByMaxWidth;
+  final bool isLabelMailboxOpened;
   final List<Label>? labels;
   final OnPressEmailActionClick? emailActionClick;
   final OnMoreActionClick? onMoreActionClick;
@@ -45,6 +46,7 @@ class EmailTileBuilder extends StatefulWidget {
     this.isSearchEmailRunning = false,
     this.isSenderImportantFlagEnabled = true,
     this.autoWrapTagsByMaxWidth = false,
+    this.isLabelMailboxOpened = false,
     this.mailboxContain,
     this.padding,
     this.isDrag = false,
@@ -161,6 +163,7 @@ class _EmailTileBuilderState extends State<EmailTileBuilder>  with BaseEmailItem
                           buildMailboxContain(
                             context,
                             widget.isSearchEmailRunning,
+                            widget.isLabelMailboxOpened,
                             widget.presentationEmail
                           ),
                           if (widget.presentationEmail.hasStarred)
@@ -185,6 +188,7 @@ class _EmailTileBuilderState extends State<EmailTileBuilder>  with BaseEmailItem
         selectAllMode: widget.selectAllMode,
         canDeletePermanently: canDeletePermanently,
         isSearchEmailRunning: widget.isSearchEmailRunning,
+        isLabelMailboxOpened: widget.isLabelMailboxOpened,
         isShowingEmailContent: widget.isShowingEmailContent,
         isDrag: widget.isDrag,
         isSenderImportantFlagEnabled: widget.isSenderImportantFlagEnabled,
@@ -324,6 +328,7 @@ class _EmailTileBuilderState extends State<EmailTileBuilder>  with BaseEmailItem
                       isHovered: value,
                       canDeletePermanently: canDeletePermanently,
                       isSearchEmailRunning: widget.isSearchEmailRunning,
+                      isLabelMailboxOpened: widget.isLabelMailboxOpened,
                       mailboxContain: widget.mailboxContain,
                       emailActionClick: widget.emailActionClick,
                       onMoreActionClick: widget.onMoreActionClick,

--- a/lib/features/thread/presentation/widgets/email_tile_web_builder.dart
+++ b/lib/features/thread/presentation/widgets/email_tile_web_builder.dart
@@ -1,9 +1,12 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/icon_button_web.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/presentation/views/responsive/responsive_widget.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:labels/model/label.dart';
 import 'package:model/email/email_action_type.dart';
 import 'package:model/email/presentation_email.dart';
@@ -626,4 +629,10 @@ class _EmailTileBuilderState extends State<EmailTileBuilder>  with BaseEmailItem
     _hoverNotifier.dispose();
     super.dispose();
   }
+
+  @override
+  ImagePaths get imagePaths => Get.find<ImagePaths>();
+
+  @override
+  ResponsiveUtils get responsiveUtils => Get.find<ResponsiveUtils>();
 }

--- a/lib/features/thread/presentation/widgets/web_tablet_body_email_item_widget.dart
+++ b/lib/features/thread/presentation/widgets/web_tablet_body_email_item_widget.dart
@@ -22,6 +22,7 @@ class WebTabletBodyEmailItemWidget extends StatefulWidget {
   final bool canDeletePermanently;
   final bool isSearchEmailRunning;
   final bool isShowingEmailContent;
+  final bool isLabelMailboxOpened;
   final bool isShowDateTimeView;
   final bool isDrag;
   final bool isSenderImportantFlagEnabled;
@@ -40,6 +41,7 @@ class WebTabletBodyEmailItemWidget extends StatefulWidget {
     required this.selectAllMode,
     required this.canDeletePermanently,
     required this.isSearchEmailRunning,
+    required this.isLabelMailboxOpened,
     required this.isShowingEmailContent,
     required this.isDrag,
     required this.isSenderImportantFlagEnabled,
@@ -153,6 +155,7 @@ class _WebTabletBodyEmailItemWidgetState
                             buildMailboxContain(
                               context,
                               widget.isSearchEmailRunning,
+                              widget.isLabelMailboxOpened,
                               widget.presentationEmail,
                             ),
                             if (widget.presentationEmail.hasStarred)

--- a/lib/features/thread/presentation/widgets/web_tablet_body_email_item_widget.dart
+++ b/lib/features/thread/presentation/widgets/web_tablet_body_email_item_widget.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -63,8 +64,6 @@ class WebTabletBodyEmailItemWidget extends StatefulWidget {
 
 class _WebTabletBodyEmailItemWidgetState
     extends State<WebTabletBodyEmailItemWidget> with BaseEmailItemTile {
-  final _imagePaths = Get.find<ImagePaths>();
-
   bool _isHover = false;
   bool _popupMenuVisible = false;
 
@@ -187,7 +186,7 @@ class _WebTabletBodyEmailItemWidgetState
                     children: [
                       if (_isHover) ...[
                         TMailButtonWidget.fromIcon(
-                          icon: _imagePaths.icOpenInNewTab,
+                          icon: imagePaths.icOpenInNewTab,
                           iconColor: ItemEmailTileStyles.actionIconHoverColor,
                           iconSize: _getIconSize(),
                           padding: _getPaddingIcon(),
@@ -203,8 +202,8 @@ class _WebTabletBodyEmailItemWidgetState
                         if (!widget.presentationEmail.isDraft)
                           TMailButtonWidget.fromIcon(
                             icon: widget.presentationEmail.hasRead
-                                ? _imagePaths.icUnread
-                                : _imagePaths.icRead,
+                                ? imagePaths.icUnread
+                                : imagePaths.icRead,
                             iconColor: ItemEmailTileStyles.actionIconHoverColor,
                             iconSize: _getIconSize(),
                             padding: _getPaddingIcon(),
@@ -223,7 +222,7 @@ class _WebTabletBodyEmailItemWidgetState
                         if (widget.mailboxContain != null &&
                             widget.mailboxContain?.isDrafts == false) ...[
                           TMailButtonWidget.fromIcon(
-                            icon: _imagePaths.icMove,
+                            icon: imagePaths.icMove,
                             iconColor: ItemEmailTileStyles.actionIconHoverColor,
                             iconSize: _getIconSize(),
                             padding: _getPaddingIcon(),
@@ -237,7 +236,7 @@ class _WebTabletBodyEmailItemWidgetState
                           ),
                         ],
                         TMailButtonWidget.fromIcon(
-                          icon: _imagePaths.icDeleteComposer,
+                          icon: imagePaths.icDeleteComposer,
                           iconColor: ItemEmailTileStyles.actionIconHoverColor,
                           iconSize: _getIconSize(),
                           padding: _getPaddingIcon(),
@@ -256,7 +255,7 @@ class _WebTabletBodyEmailItemWidgetState
                       ],
                       if (_shouldShowPopupMenu)
                         TMailButtonWidget.fromIcon(
-                          icon: _imagePaths.icMoreVertical,
+                          icon: imagePaths.icMoreVertical,
                           iconColor: ItemEmailTileStyles.actionIconHoverColor,
                           iconSize: _getIconSize(),
                           padding: _getPaddingIcon(),
@@ -467,4 +466,10 @@ class _WebTabletBodyEmailItemWidgetState
       },
     );
   }
+
+  @override
+  ImagePaths get imagePaths => Get.find<ImagePaths>();
+
+  @override
+  ResponsiveUtils get responsiveUtils => Get.find<ResponsiveUtils>();
 }

--- a/test/features/thread/presentation/widgets/base_email_item_tile_test.dart
+++ b/test/features/thread/presentation/widgets/base_email_item_tile_test.dart
@@ -1,0 +1,83 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/email/presentation_email.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/thread/presentation/mixin/base_email_item_tile.dart';
+
+class _TestEmailItemTile with BaseEmailItemTile {
+  @override
+  ImagePaths get imagePaths => ImagePaths();
+
+  @override
+  ResponsiveUtils get responsiveUtils => ResponsiveUtils();
+}
+
+void main() {
+  late _TestEmailItemTile tile;
+
+  setUp(() {
+    tile = _TestEmailItemTile();
+  });
+
+  final inboxFolder = PresentationMailbox(MailboxId(Id('inbox')));
+
+  group('BaseEmailItemTile.hasMailboxLabel', () {
+    test('should return false when both flags false and mailboxContain null', () {
+      final email = PresentationEmail();
+
+      final result = tile.hasMailboxLabel(false, false, email);
+
+      expect(result, isFalse);
+    });
+
+    test('should return false when both flags false even if mailboxContain exists',
+        () {
+      final email = PresentationEmail(
+        mailboxContain: inboxFolder,
+      );
+
+      final result = tile.hasMailboxLabel(false, false, email);
+
+      expect(result, isFalse);
+    });
+
+    test('should return false when search running but mailboxContain null', () {
+      final email = PresentationEmail();
+
+      final result = tile.hasMailboxLabel(true, false, email);
+
+      expect(result, isFalse);
+    });
+
+    test('should return false when label mailbox opened but mailboxContain null', () {
+      final email = PresentationEmail();
+
+      final result = tile.hasMailboxLabel(false, true, email);
+
+      expect(result, isFalse);
+    });
+
+    test('should return true when search running and mailboxContain exists', () {
+      final email = PresentationEmail(
+        mailboxContain: inboxFolder,
+      );
+
+      final result = tile.hasMailboxLabel(true, false, email);
+
+      expect(result, isTrue);
+    });
+
+    test('should return true when label mailbox opened and mailboxContain exists', () {
+      final email = PresentationEmail(
+        mailboxContain: inboxFolder,
+      );
+
+      final result = tile.hasMailboxLabel(false, true, email);
+
+      expect(result, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Issue

#4292 

## Resolved


https://github.com/user-attachments/assets/d61f1d4b-e969-44e1-9cad-856e2f0d0ecd



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of label mailbox state across email views by replacing type-based checks with property-based logic.
  * Standardized how the app tracks and displays label mailbox status when viewing emails in search, thread, and desktop views.
  * Enhanced consistency of mailbox label display behavior across different UI contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->