### PR TITLE
[Scribe] Add toolbar with copy and retry action

### DIFF
--- a/scribe/lib/scribe.dart
+++ b/scribe/lib/scribe.dart
@@ -45,6 +45,7 @@ export 'scribe/ai/presentation/widgets/modal/suggestion/ai_scribe_suggestion_hea
 export 'scribe/ai/presentation/widgets/modal/suggestion/ai_scribe_suggestion_loading.dart';
 export 'scribe/ai/presentation/widgets/modal/suggestion/ai_scribe_suggestion_success.dart';
 export 'scribe/ai/presentation/widgets/modal/suggestion/ai_scribe_suggestion_success_list_actions.dart';
+export 'scribe/ai/presentation/widgets/modal/suggestion/ai_scribe_suggestion_success_toolbar.dart';
 export 'scribe/ai/presentation/widgets/overlay/ai_selection_overlay.dart';
 export 'scribe/ai/presentation/widgets/search/ai_scribe_bar.dart';
 export 'scribe/ai/presentation/widgets/mobile/ai_scribe_mobile_actions_bottom_sheet.dart';

--- a/scribe/lib/scribe/ai/l10n/intl_ar.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_ar.arb
@@ -125,5 +125,17 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
+  },
+  "copy": "نسخ",
+  "@copy": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "retry": "إعادة المحاولة",
+  "@retry": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
 }

--- a/scribe/lib/scribe/ai/l10n/intl_de.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_de.arb
@@ -125,5 +125,17 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
+  },
+  "copy": "Kopieren",
+  "@copy": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "retry": "Erneut versuchen",
+  "@retry": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
 }

--- a/scribe/lib/scribe/ai/l10n/intl_en.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_en.arb
@@ -125,5 +125,17 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
+  },
+  "copy": "Copy",
+  "@copy": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "retry": "Retry",
+  "@retry": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
 }

--- a/scribe/lib/scribe/ai/l10n/intl_fr.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_fr.arb
@@ -125,5 +125,17 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
+  },
+  "copy": "Copier",
+  "@copy": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "retry": "Réessayer",
+  "@retry": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
 }

--- a/scribe/lib/scribe/ai/l10n/intl_it.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_it.arb
@@ -125,5 +125,17 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
+  },
+  "copy": "Copia",
+  "@copy": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "retry": "Riprova",
+  "@retry": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
 }

--- a/scribe/lib/scribe/ai/l10n/intl_messages.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2026-01-26T09:26:56.495094",
+  "@@last_modified": "2026-02-04T15:15:31.191557",
   "categoryCorrectGrammar": "Correct",
   "@categoryCorrectGrammar": {
     "type": "text",
@@ -122,6 +122,18 @@
   },
   "insert": "Insert",
   "@insert": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "copy": "Copy",
+  "@copy": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "retry": "Retry",
+  "@retry": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/scribe/lib/scribe/ai/l10n/intl_ru.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_ru.arb
@@ -125,5 +125,17 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
+  },
+  "copy": "Копировать",
+  "@copy": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "retry": "Повторить",
+  "@retry": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
 }

--- a/scribe/lib/scribe/ai/l10n/intl_vi.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_vi.arb
@@ -125,5 +125,17 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
+  },
+  "copy": "Sao chép",
+  "@copy": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "retry": "Thử lại",
+  "@retry": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
 }

--- a/scribe/lib/scribe/ai/localizations/scribe_localizations.dart
+++ b/scribe/lib/scribe/ai/localizations/scribe_localizations.dart
@@ -177,6 +177,21 @@ class ScribeLocalizations {
       name: 'insert',
     );
   }
+
+  // Suggestion Success Toolbar
+  String get copy {
+    return Intl.message(
+      'Copy',
+      name: 'copy',
+    );
+  }
+
+  String get retry {
+    return Intl.message(
+      'Retry',
+      name: 'retry',
+    );
+  }
 }
 
 class _ScribeLocalizationsDelegate

--- a/scribe/lib/scribe/ai/presentation/styles/ai_scribe_styles.dart
+++ b/scribe/lib/scribe/ai/presentation/styles/ai_scribe_styles.dart
@@ -12,7 +12,7 @@ abstract final class AIScribeColors {
   // Icons
   static const Color scribeIcon = AppColor.primaryMain;
   static const Color aiAssistantIcon = AppColor.primaryMain;
-  static final Color bottomsheetIcon = AppColor.gray424244.withValues(alpha: 0.72);
+  static final Color secondaryIcon = AppColor.gray424244.withValues(alpha: 0.72);
 
   // Overlays
   static final Color dialogBarrier = Colors.black.withValues(alpha: 0.12);

--- a/scribe/lib/scribe/ai/presentation/utils/modal/ai_scribe_suggestion_state_mixin.dart
+++ b/scribe/lib/scribe/ai/presentation/utils/modal/ai_scribe_suggestion_state_mixin.dart
@@ -107,6 +107,7 @@ mixin AiScribeSuggestionStateMixin<T extends StatefulWidget> on State<T> {
       suggestionText: suggestionText,
       hasContent: hasContent,
       onSelectAction: onSelectAction,
+      onLoadSuggestion: loadSuggestion,
     );
   }
 

--- a/scribe/lib/scribe/ai/presentation/widgets/mobile/ai_scribe_mobile_actions_bottom_sheet.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/mobile/ai_scribe_mobile_actions_bottom_sheet.dart
@@ -58,7 +58,7 @@ class _AiScribeMobileActionsBottomSheetState
                   icon: widget.imagePaths.icArrowBackIos,
                   backgroundColor: Colors.transparent,
                   iconSize: AIScribeSizes.bottomsheetIcon,
-                  iconColor: AIScribeColors.bottomsheetIcon,
+                  iconColor: AIScribeColors.secondaryIcon,
                   padding: AIScribeSizes.backIconPadding,
                   onTapActionCallback: _goBackToCategories
                 )
@@ -80,7 +80,7 @@ class _AiScribeMobileActionsBottomSheetState
             icon: widget.imagePaths.icCloseDialog,
             backgroundColor: Colors.transparent,
             iconSize: AIScribeSizes.bottomsheetIcon,
-            iconColor: AIScribeColors.bottomsheetIcon,
+            iconColor: AIScribeColors.secondaryIcon,
             onTapActionCallback: () => Navigator.of(context).pop()
           )
         ],

--- a/scribe/lib/scribe/ai/presentation/widgets/modal/suggestion/ai_scribe_suggestion_success.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/modal/suggestion/ai_scribe_suggestion_success.dart
@@ -7,12 +7,14 @@ class AiScribeSuggestionSuccess extends StatelessWidget {
   final String suggestionText;
   final bool hasContent;
   final OnSelectAiScribeSuggestionAction onSelectAction;
+  final VoidCallback onLoadSuggestion;
 
   const AiScribeSuggestionSuccess({
     super.key,
     required this.imagePaths,
     required this.suggestionText,
     required this.onSelectAction,
+    required this.onLoadSuggestion,
     this.hasContent = false,
   });
 
@@ -42,6 +44,7 @@ class AiScribeSuggestionSuccess extends StatelessWidget {
             suggestionText: suggestionText,
             hasContent: hasContent,
             onSelectAction: onSelectAction,
+            onLoadSuggestion: onLoadSuggestion,
           ),
         ],
       ),

--- a/scribe/lib/scribe/ai/presentation/widgets/modal/suggestion/ai_scribe_suggestion_success_list_actions.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/modal/suggestion/ai_scribe_suggestion_success_list_actions.dart
@@ -14,12 +14,14 @@ class AiScribeSuggestionSuccessListActions extends StatelessWidget {
   final String suggestionText;
   final bool hasContent;
   final OnSelectAiScribeSuggestionAction onSelectAction;
+  final VoidCallback onLoadSuggestion;
 
   const AiScribeSuggestionSuccessListActions({
     super.key,
     required this.imagePaths,
     required this.suggestionText,
     required this.onSelectAction,
+    required this.onLoadSuggestion,
     this.hasContent = false,
   });
 
@@ -27,45 +29,50 @@ class AiScribeSuggestionSuccessListActions extends StatelessWidget {
   Widget build(BuildContext context) {
     final localizations = ScribeLocalizations.of(context);
 
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.end,
-      spacing: 8,
+    return Column(
       children: [
-        if (hasContent)
-          Flexible(
-            child: Container(
-              constraints: const BoxConstraints(minWidth: 67),
-              height: 36,
-              child: ConfirmDialogButton(
-                label: AiScribeSuggestionActions.replace.getLabel(localizations),
-                textColor: AppColor.primaryMain,
-                onTapAction: () {
-                  Navigator.of(context).pop();
-                  onSelectAction(
-                    AiScribeSuggestionActions.replace,
-                    suggestionText,
-                  );
-                },
+        AiScribeSuggestionSuccessToolbar(suggestionText: suggestionText, onLoadSuggestion: onLoadSuggestion, imagePaths: imagePaths),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          spacing: 8,
+          children: [
+            if (hasContent)
+              Flexible(
+                child: Container(
+                  constraints: const BoxConstraints(minWidth: 67),
+                  height: 36,
+                  child: ConfirmDialogButton(
+                    label: AiScribeSuggestionActions.replace.getLabel(localizations),
+                    textColor: AppColor.primaryMain,
+                    onTapAction: () {
+                      Navigator.of(context).pop();
+                      onSelectAction(
+                        AiScribeSuggestionActions.replace,
+                        suggestionText,
+                      );
+                    },
+                  ),
+                ),
+              ),
+            Flexible(
+              child: Container(
+                constraints: const BoxConstraints(minWidth: 72),
+                height: 36,
+                child: ConfirmDialogButton(
+                  label: AiScribeSuggestionActions.insert.getLabel(localizations),
+                  backgroundColor: AppColor.blueD2E9FF,
+                  textColor: AppColor.primaryMain,
+                  onTapAction: () {
+                    Navigator.of(context).pop();
+                    onSelectAction(
+                      AiScribeSuggestionActions.insert,
+                      suggestionText,
+                    );
+                  },
+                ),
               ),
             ),
-          ),
-        Flexible(
-          child: Container(
-            constraints: const BoxConstraints(minWidth: 72),
-            height: 36,
-            child: ConfirmDialogButton(
-              label: AiScribeSuggestionActions.insert.getLabel(localizations),
-              backgroundColor: AppColor.blueD2E9FF,
-              textColor: AppColor.primaryMain,
-              onTapAction: () {
-                Navigator.of(context).pop();
-                onSelectAction(
-                  AiScribeSuggestionActions.insert,
-                  suggestionText,
-                );
-              },
-            ),
-          ),
+          ],
         ),
       ],
     );

--- a/scribe/lib/scribe/ai/presentation/widgets/modal/suggestion/ai_scribe_suggestion_success_toolbar.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/modal/suggestion/ai_scribe_suggestion_success_toolbar.dart
@@ -1,0 +1,45 @@
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:scribe/scribe.dart';
+import 'package:core/presentation/resources/image_paths.dart';
+
+class AiScribeSuggestionSuccessToolbar extends StatelessWidget {
+  final String suggestionText;
+  final VoidCallback onLoadSuggestion;
+  final ImagePaths imagePaths;
+
+  const AiScribeSuggestionSuccessToolbar({
+    super.key,
+    required this.suggestionText,
+    required this.onLoadSuggestion,
+    required this.imagePaths,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.start,
+      children: [
+        TMailButtonWidget.fromIcon(
+          icon: imagePaths.icCopy,
+          iconSize: AIScribeSizes.icon,
+          iconColor: AIScribeColors.secondaryIcon,
+          backgroundColor: Colors.transparent,
+          tooltipMessage: ScribeLocalizations.of(context).copy,
+          onTapActionCallback: () {
+            Clipboard.setData(ClipboardData(text: suggestionText));
+          },
+        ),
+        TMailButtonWidget.fromIcon(
+          icon: imagePaths.icRefresh,
+          iconSize: AIScribeSizes.icon,
+          iconColor: AIScribeColors.secondaryIcon,
+          backgroundColor: Colors.transparent,
+          tooltipMessage: ScribeLocalizations.of(context).retry,
+          onTapActionCallback: onLoadSuggestion,
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Demo

https://github.com/user-attachments/assets/2162a41f-cc51-4eca-b1fe-793e7c916958

https://github.com/user-attachments/assets/5b3c0ebf-a9b2-4c22-a38a-7f64d5aa182b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toolbar to the suggestion success interface featuring copy and retry action buttons.
  * Expanded multilingual support with new "copy" and "retry" action labels across Arabic, German, English, French, Italian, Russian, and Vietnamese.

* **Style**
  * Updated internal icon styling for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->