### PR TITLE
[Label] Add `Label as` option to context menu of each email in list

### DIFF
--- a/lib/features/email/presentation/action/email_ui_action.dart
+++ b/lib/features/email/presentation/action/email_ui_action.dart
@@ -1,6 +1,7 @@
 
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
 import 'package:labels/model/label.dart';
 import 'package:model/email/email_action_type.dart';
 import 'package:model/email/presentation_email.dart';
@@ -126,4 +127,23 @@ class RemoveLabelFromEmailAction extends EmailUIAction {
 
   @override
   List<Object?> get props => [emailId, label];
+}
+
+class SyncUpdateLabelForEmailOnMemory extends EmailUIAction {
+  final EmailId emailId;
+  final KeyWordIdentifier labelKeyword;
+  final bool shouldRemove;
+
+  SyncUpdateLabelForEmailOnMemory({
+    required this.emailId,
+    required this.labelKeyword,
+    required this.shouldRemove,
+  });
+
+  @override
+  List<Object?> get props => [
+        emailId,
+        labelKeyword,
+        shouldRemove,
+      ];
 }

--- a/lib/features/email/presentation/bindings/email_bindings.dart
+++ b/lib/features/email/presentation/bindings/email_bindings.dart
@@ -1,11 +1,9 @@
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
-import 'package:tmail_ui_user/features/email/domain/usecases/add_a_label_to_an_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_email_content_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_email_read_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_star_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/print_email_interactor.dart';
-import 'package:tmail_ui_user/features/email/domain/usecases/remove_a_label_from_an_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/store_opened_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/presentation/bindings/email_interactor_bindings.dart';
 import 'package:tmail_ui_user/features/email/presentation/controller/single_email_controller.dart';
@@ -25,8 +23,6 @@ class EmailBindings extends Bindings {
       Get.find<MarkAsStarEmailInteractor>(),
       Get.find<GetAllIdentitiesInteractor>(),
       Get.find<StoreOpenedEmailInteractor>(),
-      Get.find<AddALabelToAnEmailInteractor>(),
-      Get.find<RemoveALabelFromAnEmailInteractor>(),
       Get.find<PrintEmailInteractor>(),
       currentEmailId: currentEmailId,
     ), tag: tag);

--- a/lib/features/email/presentation/bindings/email_interactor_bindings.dart
+++ b/lib/features/email/presentation/bindings/email_interactor_bindings.dart
@@ -16,7 +16,6 @@ import 'package:tmail_ui_user/features/email/data/local/html_analyzer.dart';
 import 'package:tmail_ui_user/features/email/data/network/email_api.dart';
 import 'package:tmail_ui_user/features/email/data/repository/email_repository_impl.dart';
 import 'package:tmail_ui_user/features/email/domain/repository/email_repository.dart';
-import 'package:tmail_ui_user/features/email/domain/usecases/add_a_label_to_an_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_email_content_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_entire_message_as_document_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_stored_email_state_interactor.dart';
@@ -24,7 +23,6 @@ import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_email_read_
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_star_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/move_to_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/print_email_interactor.dart';
-import 'package:tmail_ui_user/features/email/domain/usecases/remove_a_label_from_an_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/store_opened_email_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox/data/datasource/mailbox_datasource.dart';
 import 'package:tmail_ui_user/features/mailbox/data/datasource/state_datasource.dart';
@@ -37,6 +35,7 @@ import 'package:tmail_ui_user/features/mailbox/data/network/mailbox_api.dart';
 import 'package:tmail_ui_user/features/mailbox/data/network/mailbox_isolate_worker.dart';
 import 'package:tmail_ui_user/features/mailbox/data/repository/mailbox_repository_impl.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/repository/mailbox_repository.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/bindings/email_action_interactor_bindings.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/identities/identity_interactors_bindings.dart';
 import 'package:tmail_ui_user/features/offline_mode/manager/new_email_cache_manager.dart';
 import 'package:tmail_ui_user/features/offline_mode/manager/new_email_cache_worker_queue.dart';
@@ -119,12 +118,7 @@ class EmailInteractorBindings extends InteractorsBindings {
         Get.find<EmailRepository>(),
       ));
     }
-    Get.lazyPut<AddALabelToAnEmailInteractor>(
-      () => AddALabelToAnEmailInteractor(Get.find<EmailRepository>()),
-    );
-    Get.lazyPut<RemoveALabelFromAnEmailInteractor>(
-      () => RemoveALabelFromAnEmailInteractor(Get.find<EmailRepository>()),
-    );
+    EmailActionInteractorBindings(Get.find<EmailRepository>()).dependencies();
   }
 
   @override

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -344,8 +344,8 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
         );
       } else if (action is RemoveLabelFromEmailAction) {
         mailboxDashBoardController.clearEmailUIAction();
-        if (_currentEmailId == null ||
-            action.emailId != _currentEmailId) {
+        final displayedEmailId = _currentEmailId ?? currentEmail?.id;
+        if (displayedEmailId == null || action.emailId != displayedEmailId) {
           return;
         }
         mailboxDashBoardController.toggleLabelToEmail(
@@ -355,8 +355,8 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
         );
       } else if (action is SyncUpdateLabelForEmailOnMemory) {
         mailboxDashBoardController.clearEmailUIAction();
-        if (_currentEmailId == null ||
-            action.emailId != _currentEmailId) {
+        final displayedEmailId = _currentEmailId ?? currentEmail?.id;
+        if (displayedEmailId == null || action.emailId != displayedEmailId) {
           return;
         }
 

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -35,7 +35,6 @@ import 'package:tmail_ui_user/features/email/domain/model/event_action.dart';
 import 'package:tmail_ui_user/features/email/domain/model/mark_read_action.dart';
 import 'package:tmail_ui_user/features/email/domain/model/send_receipt_to_sender_request.dart';
 import 'package:tmail_ui_user/features/email/domain/model/view_entire_message_request.dart';
-import 'package:tmail_ui_user/features/email/domain/state/add_a_label_to_an_email_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/calendar_event_accept_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/calendar_event_counter_accept_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/calendar_event_maybe_state.dart';
@@ -47,10 +46,8 @@ import 'package:tmail_ui_user/features/email/domain/state/mark_as_email_read_sta
 import 'package:tmail_ui_user/features/email/domain/state/mark_as_email_star_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/parse_calendar_event_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/print_email_state.dart';
-import 'package:tmail_ui_user/features/email/domain/state/remove_a_label_from_an_email_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/send_receipt_to_sender_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/unsubscribe_email_state.dart';
-import 'package:tmail_ui_user/features/email/domain/usecases/add_a_label_to_an_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/calendar_event_accept_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/calendar_event_counter_accept_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/calendar_event_reject_interactor.dart';
@@ -61,7 +58,6 @@ import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_star_email_
 import 'package:tmail_ui_user/features/email/domain/usecases/maybe_calendar_event_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/parse_calendar_event_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/print_email_interactor.dart';
-import 'package:tmail_ui_user/features/email/domain/usecases/remove_a_label_from_an_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/send_receipt_to_sender_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/store_opened_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/presentation/action/email_ui_action.dart';
@@ -121,8 +117,6 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
   final GetAllIdentitiesInteractor _getAllIdentitiesInteractor;
   final StoreOpenedEmailInteractor _storeOpenedEmailInteractor;
   final PrintEmailInteractor _printEmailInteractor;
-  final AddALabelToAnEmailInteractor addALabelToAnEmailInteractor;
-  final RemoveALabelFromAnEmailInteractor removeALabelFromAnEmailInteractor;
   final EmailId? _currentEmailId;
 
   CreateNewEmailRuleFilterInteractor? _createNewEmailRuleFilterInteractor;
@@ -192,8 +186,6 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
     this._markAsStarEmailInteractor,
     this._getAllIdentitiesInteractor,
     this._storeOpenedEmailInteractor,
-    this.addALabelToAnEmailInteractor,
-    this.removeALabelFromAnEmailInteractor,
     this._printEmailInteractor, {
     EmailId? currentEmailId,
   }) : _currentEmailId = currentEmailId;
@@ -250,10 +242,6 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
       _handlePrintEmailSuccess(success);
     } else if (success is CalendarEventReplySuccess) {
       calendarEventSuccess(success);
-    } else if (success is AddALabelToAnEmailSuccess) {
-      handleAddLabelToEmailSuccess(success);
-    } else if (success is RemoveALabelFromAnEmailSuccess) {
-      handleRemoveLabelFromEmailSuccess(success);
     } else {
       super.handleSuccessViewState(success);
     }
@@ -271,10 +259,6 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
       _showMessageWhenEmailPrintingFailed(failure);
     } else if (failure is CalendarEventReplyFailure) {
       _calendarEventFailure(failure);
-    } else if (failure is AddALabelToAnEmailFailure) {
-      handleAddLabelToEmailFailure(failure);
-    } else if (failure is RemoveALabelFromAnEmailFailure) {
-      handleRemoveLabelFromEmailFailure(failure);
     } else {
       super.handleFailureViewState(failure);
     }
@@ -364,7 +348,23 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
             action.emailId != _currentEmailId) {
           return;
         }
-        toggleLabelToEmail(action.emailId, action.label, false);
+        mailboxDashBoardController.toggleLabelToEmail(
+          action.emailId,
+          action.label,
+          false,
+        );
+      } else if (action is SyncUpdateLabelForEmailOnMemory) {
+        mailboxDashBoardController.clearEmailUIAction();
+        if (_currentEmailId == null ||
+            action.emailId != _currentEmailId) {
+          return;
+        }
+
+        syncLabelToSelectedEmailOnMemory(
+          emailId: action.emailId,
+          labelKeyword: action.labelKeyword,
+          remove: action.shouldRemove,
+        );
       }
     }));
 
@@ -914,7 +914,8 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
         break;
       case EmailActionType.labelAs:
         if (!isLabelAvailable) return;
-        openAddLabelToEmailDialogModal(presentationEmail);
+        mailboxDashBoardController
+            .openAddLabelToEmailDialogModal(presentationEmail);
         break;
       default:
         break;

--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -109,8 +109,8 @@ class EmailView extends GetWidget<SingleEmailController> {
                         openBottomSheetContextMenu: controller.mailboxDashBoardController.openBottomSheetContextMenu,
                         openPopupMenu: controller.mailboxDashBoardController.openPopupMenuActionGroup,
                         onSelectLabelAction: (label, isSelected) =>
-                            controller.toggleLabelToEmail(
-                              presentationEmail.id!,
+                            controller.onToggleLabelAction(
+                              presentationEmail.id,
                               label,
                               isSelected,
                             ),
@@ -275,8 +275,8 @@ class EmailView extends GetWidget<SingleEmailController> {
               imagePaths: controller.imagePaths,
               isMobileResponsive: isMobileResponsive,
               labels: emailLabels,
-              onDeleteLabelAction: (label) => controller.toggleLabelToEmail(
-                presentationEmail.id!,
+              onDeleteLabelAction: (label) => controller.onToggleLabelAction(
+                presentationEmail.id,
                 label,
                 false,
               ),
@@ -320,8 +320,8 @@ class EmailView extends GetWidget<SingleEmailController> {
             openBottomSheetContextMenu: controller.mailboxDashBoardController.openBottomSheetContextMenu,
             openPopupMenu: controller.mailboxDashBoardController.openPopupMenuActionGroup,
             onSelectLabelAction: (label, isSelected) =>
-                controller.toggleLabelToEmail(
-                  presentationEmail.id!,
+                controller.onToggleLabelAction(
+                  presentationEmail.id,
                   label,
                   isSelected,
                 ),

--- a/lib/features/email/presentation/extensions/handle_label_for_email_extension.dart
+++ b/lib/features/email/presentation/extensions/handle_label_for_email_extension.dart
@@ -1,118 +1,33 @@
+import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/platform_info.dart';
-import 'package:jmap_dart_client/jmap/account_id.dart';
-import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
-import 'package:labels/extensions/label_extension.dart';
 import 'package:labels/model/label.dart';
-import 'package:model/email/presentation_email.dart';
-import 'package:tmail_ui_user/features/email/domain/state/add_a_label_to_an_email_state.dart';
-import 'package:tmail_ui_user/features/email/domain/state/remove_a_label_from_an_email_state.dart';
 import 'package:tmail_ui_user/features/email/presentation/controller/single_email_controller.dart';
 import 'package:tmail_ui_user/features/email/presentation/extensions/email_loaded_extension.dart';
-import 'package:tmail_ui_user/features/email/presentation/extensions/presentation_email_extension.dart';
-import 'package:tmail_ui_user/features/home/data/exceptions/session_exceptions.dart';
-import 'package:tmail_ui_user/features/labels/domain/exceptions/label_exceptions.dart';
-import 'package:tmail_ui_user/features/labels/presentation/widgets/add_label_to_email_modal.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/update_current_emails_flags_extension.dart';
 import 'package:tmail_ui_user/features/thread/data/extensions/map_keywords_extension.dart';
 import 'package:tmail_ui_user/features/thread/domain/extensions/presentation_email_map_extension.dart';
 import 'package:tmail_ui_user/features/thread_detail/domain/extensions/list_email_in_thread_detail_info_extension.dart';
-import 'package:tmail_ui_user/main/routes/dialog_router.dart';
 
 extension HandleLabelForEmailExtension on SingleEmailController {
   bool get isLabelAvailable {
     return mailboxDashBoardController.isLabelAvailable;
   }
 
-  void toggleLabelToEmail(EmailId emailId, Label label, bool isSelected) {
-    final accountId = mailboxDashBoardController.accountId.value;
-    final session = mailboxDashBoardController.sessionCurrent;
-
-    if (isSelected) {
-      _addALabelToAnEmail(
-        session: session,
-        accountId: accountId,
-        emailId: emailId,
-        label: label,
-      );
-    } else {
-      _removeALabelFromAnEmail(
-        session: session,
-        accountId: accountId,
-        emailId: emailId,
-        label: label,
-      );
-    }
-  }
-
-  void _addALabelToAnEmail({
-    required Session? session,
-    required AccountId? accountId,
-    required Label label,
-    required EmailId emailId,
-  }) {
-    final labelDisplay = label.safeDisplayName;
-
-    if (session == null) {
-      emitFailure(
-        controller: this,
-        failure: AddALabelToAnEmailFailure(
-          exception: NotFoundSessionException(),
-          labelDisplay: labelDisplay,
-        ),
-      );
+  void onToggleLabelAction(EmailId? emailId, Label label, bool isSelected) {
+    if (emailId == null) {
+      logWarning('HandleLabelForEmailExtension::onToggleLabelAction: Email id is null');
       return;
     }
-
-    if (accountId == null) {
-      emitFailure(
-        controller: this,
-        failure: AddALabelToAnEmailFailure(
-          exception: NotFoundAccountIdException(),
-          labelDisplay: labelDisplay,
-        ),
-      );
-      return;
-    }
-
-    final labelKeyword = label.keyword;
-    if (labelKeyword == null) {
-      emitFailure(
-        controller: this,
-        failure: AddALabelToAnEmailFailure(
-          exception: const LabelKeywordIsNull(),
-          labelDisplay: labelDisplay,
-        ),
-      );
-      return;
-    }
-
-    consumeState(addALabelToAnEmailInteractor.execute(
-      session,
-      accountId,
+    mailboxDashBoardController.toggleLabelToEmail(
       emailId,
-      labelKeyword,
-      label.safeDisplayName,
-    ));
-  }
-
-  void handleAddLabelToEmailSuccess(AddALabelToAnEmailSuccess success) {
-    toastManager.showMessageSuccess(success);
-
-    _autoSyncLabelToSelectedEmailOnMemory(
-      emailId: success.emailId,
-      labelKeyword: success.labelKeyword,
-      remove: false,
+      label,
+      isSelected,
     );
   }
 
-  void handleAddLabelToEmailFailure(AddALabelToAnEmailFailure failure) {
-    toastManager.showMessageFailure(failure);
-  }
-
-  void _autoSyncLabelToSelectedEmailOnMemory({
+  void syncLabelToSelectedEmailOnMemory({
     required EmailId emailId,
     required KeyWordIdentifier labelKeyword,
     required bool remove,
@@ -146,12 +61,6 @@ extension HandleLabelForEmailExtension on SingleEmailController {
     );
 
     _updateLabelOnCurrentEmailLoaded(
-      emailId: emailId,
-      labelKeyword: labelKeyword,
-      remove: remove,
-    );
-
-    _notifyLabelUpdated(
       emailId: emailId,
       labelKeyword: labelKeyword,
       remove: remove,
@@ -215,112 +124,5 @@ extension HandleLabelForEmailExtension on SingleEmailController {
       keyword: labelKeyword,
       remove: remove,
     );
-  }
-
-  void _notifyLabelUpdated({
-    required EmailId emailId,
-    required KeyWordIdentifier labelKeyword,
-    required bool remove,
-  }) {
-    mailboxDashBoardController.updateEmailFlagByEmailIds(
-      [emailId],
-      isLabelAdded: !remove,
-      labelKeyword: labelKeyword,
-    );
-
-    mailboxDashBoardController.labelController.isLabelSettingEnabled.refresh();
-  }
-
-  Future<void> openAddLabelToEmailDialogModal(PresentationEmail email) async {
-    if (!isLabelAvailable) return;
-    final labels = mailboxDashBoardController.labelController.labels;
-    final emailLabels = email.getLabelList(labels);
-    final emailId = email.id;
-    if (emailId == null || labels.isEmpty) {
-      return;
-    }
-
-    await DialogRouter().openDialogModal(
-      child: AddLabelToEmailModal(
-        labels: labels,
-        emailLabels: emailLabels,
-        emailIds: [emailId],
-        onAddLabelToEmailsCallback: (emailIds, label, isSelected) {
-          if (emailIds.length == 1) {
-            toggleLabelToEmail(emailIds.first, label, isSelected);
-          }
-        },
-      ),
-      dialogLabel: 'add-label-to-email-modal',
-    );
-  }
-
-  void _removeALabelFromAnEmail({
-    required Session? session,
-    required AccountId? accountId,
-    required Label label,
-    required EmailId emailId,
-  }) {
-    final labelDisplay = label.safeDisplayName;
-
-    if (session == null) {
-      emitFailure(
-        controller: this,
-        failure: RemoveALabelFromAnEmailFailure(
-          exception: NotFoundSessionException(),
-          labelDisplay: labelDisplay,
-        ),
-      );
-      return;
-    }
-
-    if (accountId == null) {
-      emitFailure(
-        controller: this,
-        failure: RemoveALabelFromAnEmailFailure(
-          exception: NotFoundAccountIdException(),
-          labelDisplay: labelDisplay,
-        ),
-      );
-      return;
-    }
-
-    final labelKeyword = label.keyword;
-    if (labelKeyword == null) {
-      emitFailure(
-        controller: this,
-        failure: RemoveALabelFromAnEmailFailure(
-          exception: const LabelKeywordIsNull(),
-          labelDisplay: labelDisplay,
-        ),
-      );
-      return;
-    }
-
-    consumeState(removeALabelFromAnEmailInteractor.execute(
-      session,
-      accountId,
-      emailId,
-      labelKeyword,
-      label.safeDisplayName,
-    ));
-  }
-
-  void handleRemoveLabelFromEmailSuccess(
-    RemoveALabelFromAnEmailSuccess success,
-  ) {
-    toastManager.showMessageSuccess(success);
-
-    _autoSyncLabelToSelectedEmailOnMemory(
-      emailId: success.emailId,
-      labelKeyword: success.labelKeyword,
-      remove: true,
-    );
-  }
-
-  void handleRemoveLabelFromEmailFailure(
-    RemoveALabelFromAnEmailFailure failure,
-  ) {
-    toastManager.showMessageFailure(failure);
   }
 }

--- a/lib/features/email/presentation/utils/email_action_reactor/email_action_reactor.dart
+++ b/lib/features/email/presentation/utils/email_action_reactor/email_action_reactor.dart
@@ -81,6 +81,12 @@ typedef OpenPopupMenuActionGroup = Future<void> Function(
   PopupMenuActionGroupWidget popupMenuWidget,
 );
 
+typedef OnHandleEmailByActionType = void Function(
+  EmailActionType actionType,
+  PresentationEmail presentationEmail,
+  PresentationMailbox? mailboxContain,
+);
+
 class EmailActionReactor with LabelSubMenuMixin {
   EmailActionReactor(
     this._markAsEmailReadInteractor,

--- a/lib/features/email/presentation/utils/email_action_reactor/email_action_reactor.dart
+++ b/lib/features/email/presentation/utils/email_action_reactor/email_action_reactor.dart
@@ -45,7 +45,6 @@ import 'package:tmail_ui_user/features/email/domain/usecases/get_email_content_i
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_email_read_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_star_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/print_email_interactor.dart';
-import 'package:tmail_ui_user/features/email/presentation/extensions/presentation_email_extension.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/context_item_email_action.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/email_loaded.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/email_unsubscribe.dart';
@@ -53,8 +52,8 @@ import 'package:tmail_ui_user/features/email/presentation/model/popup_menu_item_
 import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/email_address_bottom_sheet_builder.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/email_address_dialog_builder.dart';
+import 'package:tmail_ui_user/features/labels/presentation/mixin/label_sub_menu_mixin.dart';
 import 'package:tmail_ui_user/features/labels/presentation/widgets/label_item_context_menu.dart';
-import 'package:tmail_ui_user/features/labels/presentation/widgets/label_list_context_menu.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_actions.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/create_new_email_rule_filter_request.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/create_new_email_rule_filter_interactor.dart';
@@ -82,7 +81,7 @@ typedef OpenPopupMenuActionGroup = Future<void> Function(
   PopupMenuActionGroupWidget popupMenuWidget,
 );
 
-class EmailActionReactor {
+class EmailActionReactor with LabelSubMenuMixin {
   EmailActionReactor(
     this._markAsEmailReadInteractor,
     this._markAsStarEmailInteractor,
@@ -575,7 +574,7 @@ class EmailActionReactor {
           imagePaths,
           key: '${actionType.name}_action',
           category: actionType.category,
-          submenu: _getEmailActionSubmenu(
+          submenu: buildLabelSubmenuForEmail(
             actionType: actionType,
             imagePaths: imagePaths,
             presentationEmail: presentationEmail,
@@ -593,7 +592,7 @@ class EmailActionReactor {
         actions: popupMenuItemEmailActions,
         submenuController: submenuController,
         onActionSelected: (action) {
-          if (_shouldHandleAction(action.action)) {
+          if (shouldHandleAction(action.action)) {
             handleEmailAction(presentationEmail, action.action);
           }
         },
@@ -605,36 +604,6 @@ class EmailActionReactor {
         popupMenuWidget,
       ).whenComplete(submenuController.hide);
     }
-  }
-
-  bool _shouldHandleAction(EmailActionType action) {
-    if (action != EmailActionType.labelAs) {
-      return true;
-    }
-
-    return PlatformInfo.isWebTouchDevice || PlatformInfo.isMobile;
-  }
-
-  Widget? _getEmailActionSubmenu({
-    required EmailActionType actionType,
-    required ImagePaths imagePaths,
-    required PresentationEmail presentationEmail,
-    required List<Label>? labels,
-    OnSelectLabelAction? onSelectLabelAction,
-  }) {
-    if (actionType == EmailActionType.labelAs && labels?.isNotEmpty == true) {
-      final listLabels = labels ?? [];
-      final emailLabels = presentationEmail.getLabelList(listLabels);
-
-      return LabelListContextMenu(
-        labelList: listLabels,
-        emailLabels: emailLabels,
-        imagePaths: imagePaths,
-        onSelectLabelAction: (label, isSelected) =>
-            onSelectLabelAction?.call(label, isSelected),
-      );
-    }
-    return null;
   }
 
   bool _canDeletePermanently(

--- a/lib/features/labels/presentation/mixin/add_label_to_email_mixin.dart
+++ b/lib/features/labels/presentation/mixin/add_label_to_email_mixin.dart
@@ -1,0 +1,255 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:core/utils/app_logger.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
+import 'package:labels/extensions/label_extension.dart';
+import 'package:labels/model/label.dart';
+import 'package:model/email/presentation_email.dart';
+import 'package:tmail_ui_user/features/base/base_controller.dart';
+import 'package:tmail_ui_user/features/base/mixin/emit_state_mixin.dart';
+import 'package:tmail_ui_user/features/email/domain/state/add_a_label_to_an_email_state.dart';
+import 'package:tmail_ui_user/features/email/domain/state/remove_a_label_from_an_email_state.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/add_a_label_to_an_email_interactor.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/remove_a_label_from_an_email_interactor.dart';
+import 'package:tmail_ui_user/features/email/presentation/extensions/presentation_email_extension.dart';
+import 'package:tmail_ui_user/features/home/data/exceptions/session_exceptions.dart';
+import 'package:tmail_ui_user/features/labels/domain/exceptions/label_exceptions.dart';
+import 'package:tmail_ui_user/features/labels/presentation/widgets/add_label_to_email_modal.dart';
+import 'package:tmail_ui_user/features/thread/domain/exceptions/thread_exceptions.dart';
+import 'package:tmail_ui_user/main/routes/dialog_router.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
+
+typedef OnSyncLabelForEmail = void Function(
+  EmailId emailId,
+  KeyWordIdentifier labelKeyword,
+  bool shouldRemove,
+);
+
+mixin AddLabelToEmailMixin on EmitStateMixin {
+  bool get isCurrentLabelAvailable;
+
+  List<Label> get currentLabelList;
+
+  AccountId? get currentAccountId;
+
+  Session? get currentSession;
+
+  ToastManager get currentToastManager;
+
+  BaseController get currentController;
+
+  AddALabelToAnEmailInteractor? get addALabelToAnEmailInteractor;
+
+  RemoveALabelFromAnEmailInteractor? get removeALabelFromAnEmailInteractor;
+
+  OnSyncLabelForEmail? get onSyncLabelForEmail;
+
+  void toggleLabelToEmail(EmailId emailId, Label label, bool isSelected) {
+    if (isSelected) {
+      _addALabelToAnEmail(emailId: emailId, label: label);
+    } else {
+      _removeALabelFromAnEmail(emailId: emailId, label: label);
+    }
+  }
+
+  void _addALabelToAnEmail({required Label label, required EmailId emailId}) {
+    final labelDisplay = label.safeDisplayName;
+    final currentAccountId = this.currentAccountId;
+    final currentSession = this.currentSession;
+
+    if (currentSession == null) {
+      emitFailure(
+        controller: currentController,
+        failure: AddALabelToAnEmailFailure(
+          exception: NotFoundSessionException(),
+          labelDisplay: labelDisplay,
+        ),
+      );
+      return;
+    }
+
+    if (currentAccountId == null) {
+      emitFailure(
+        controller: currentController,
+        failure: AddALabelToAnEmailFailure(
+          exception: NotFoundAccountIdException(),
+          labelDisplay: labelDisplay,
+        ),
+      );
+      return;
+    }
+
+    final labelKeyword = label.keyword;
+    if (labelKeyword == null) {
+      emitFailure(
+        controller: currentController,
+        failure: AddALabelToAnEmailFailure(
+          exception: LabelKeywordIsNull(),
+          labelDisplay: labelDisplay,
+        ),
+      );
+      return;
+    }
+
+    if (addALabelToAnEmailInteractor == null) {
+      emitFailure(
+        controller: currentController,
+        failure: AddALabelToAnEmailFailure(
+          exception: InteractorIsNullException(),
+          labelDisplay: labelDisplay,
+        ),
+      );
+      return;
+    }
+
+    currentController.consumeState(
+      addALabelToAnEmailInteractor!.execute(
+        currentSession,
+        currentAccountId,
+        emailId,
+        labelKeyword,
+        labelDisplay,
+      ),
+    );
+  }
+
+  void _removeALabelFromAnEmail({
+    required Label label,
+    required EmailId emailId,
+  }) {
+    final labelDisplay = label.safeDisplayName;
+    final currentAccountId = this.currentAccountId;
+    final currentSession = this.currentSession;
+
+    if (currentSession == null) {
+      emitFailure(
+        controller: currentController,
+        failure: RemoveALabelFromAnEmailFailure(
+          exception: NotFoundSessionException(),
+          labelDisplay: labelDisplay,
+        ),
+      );
+      return;
+    }
+
+    if (currentAccountId == null) {
+      emitFailure(
+        controller: currentController,
+        failure: RemoveALabelFromAnEmailFailure(
+          exception: NotFoundAccountIdException(),
+          labelDisplay: labelDisplay,
+        ),
+      );
+      return;
+    }
+
+    final labelKeyword = label.keyword;
+    if (labelKeyword == null) {
+      emitFailure(
+        controller: currentController,
+        failure: RemoveALabelFromAnEmailFailure(
+          exception: LabelKeywordIsNull(),
+          labelDisplay: labelDisplay,
+        ),
+      );
+      return;
+    }
+
+    if (removeALabelFromAnEmailInteractor == null) {
+      emitFailure(
+        controller: currentController,
+        failure: RemoveALabelFromAnEmailFailure(
+          exception: InteractorIsNullException(),
+          labelDisplay: labelDisplay,
+        ),
+      );
+      return;
+    }
+
+    currentController.consumeState(
+      removeALabelFromAnEmailInteractor!.execute(
+        currentSession,
+        currentAccountId,
+        emailId,
+        labelKeyword,
+        labelDisplay,
+      ),
+    );
+  }
+
+  Future<void> openAddLabelToEmailDialogModal(PresentationEmail email) async {
+    final emailId = email.id;
+    if (emailId == null) {
+      logWarning(
+        'AddLabelToEmailMixin::openAddLabelToEmailDialogModal: Email id is null',
+      );
+      return;
+    }
+
+    final labels = currentLabelList;
+    final emailLabels = email.getLabelList(labels);
+
+    await DialogRouter().openDialogModal(
+      child: AddLabelToEmailModal(
+        labels: labels,
+        emailLabels: emailLabels,
+        emailIds: [emailId],
+        onAddLabelToEmailsCallback: (emailIds, label, isSelected) {
+          if (emailIds.length == 1) {
+            toggleLabelToEmail(emailIds.first, label, isSelected);
+          }
+        },
+      ),
+      dialogLabel: 'add-label-to-email-modal',
+    );
+  }
+
+  void subscribeLabelViewStateSuccess(Success success) {
+    if (success is AddALabelToAnEmailSuccess) {
+      _handleAddLabelToEmailSuccess(success);
+    } else if (success is RemoveALabelFromAnEmailSuccess) {
+      _handleRemoveLabelFromEmailSuccess(success);
+    }
+  }
+
+  void subscribeLabelViewStateFailure(Failure failure) {
+    if (failure is AddALabelToAnEmailFailure) {
+      _handleAddLabelToEmailFailure(failure);
+    } else if (failure is RemoveALabelFromAnEmailFailure) {
+      _handleRemoveLabelFromEmailFailure(failure);
+    }
+  }
+
+  void _handleAddLabelToEmailSuccess(AddALabelToAnEmailSuccess success) {
+    currentToastManager.showMessageSuccess(success);
+    onSyncLabelForEmail?.call(
+      success.emailId,
+      success.labelKeyword,
+      false,
+    );
+  }
+
+  void _handleAddLabelToEmailFailure(AddALabelToAnEmailFailure failure) {
+    currentToastManager.showMessageFailure(failure);
+  }
+
+  void _handleRemoveLabelFromEmailSuccess(
+    RemoveALabelFromAnEmailSuccess success,
+  ) {
+    currentToastManager.showMessageSuccess(success);
+    onSyncLabelForEmail?.call(
+      success.emailId,
+      success.labelKeyword,
+      true,
+    );
+  }
+
+  void _handleRemoveLabelFromEmailFailure(
+    RemoveALabelFromAnEmailFailure failure,
+  ) {
+    currentToastManager.showMessageFailure(failure);
+  }
+}

--- a/lib/features/labels/presentation/mixin/add_label_to_email_mixin.dart
+++ b/lib/features/labels/presentation/mixin/add_label_to_email_mixin.dart
@@ -87,7 +87,7 @@ mixin AddLabelToEmailMixin on EmitStateMixin {
       emitFailure(
         controller: currentController,
         failure: AddALabelToAnEmailFailure(
-          exception: LabelKeywordIsNull(),
+          exception: const LabelKeywordIsNull(),
           labelDisplay: labelDisplay,
         ),
       );
@@ -151,7 +151,7 @@ mixin AddLabelToEmailMixin on EmitStateMixin {
       emitFailure(
         controller: currentController,
         failure: RemoveALabelFromAnEmailFailure(
-          exception: LabelKeywordIsNull(),
+          exception: const LabelKeywordIsNull(),
           labelDisplay: labelDisplay,
         ),
       );

--- a/lib/features/labels/presentation/mixin/label_sub_menu_mixin.dart
+++ b/lib/features/labels/presentation/mixin/label_sub_menu_mixin.dart
@@ -1,0 +1,38 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/utils/platform_info.dart';
+import 'package:flutter/material.dart';
+import 'package:labels/model/label.dart';
+import 'package:model/email/email_action_type.dart';
+import 'package:model/email/presentation_email.dart';
+import 'package:tmail_ui_user/features/email/presentation/extensions/presentation_email_extension.dart';
+import 'package:tmail_ui_user/features/labels/presentation/widgets/label_item_context_menu.dart';
+import 'package:tmail_ui_user/features/labels/presentation/widgets/label_list_context_menu.dart';
+
+mixin LabelSubMenuMixin {
+  Widget? buildLabelSubmenuForEmail({
+    required EmailActionType actionType,
+    required ImagePaths imagePaths,
+    required PresentationEmail presentationEmail,
+    required List<Label>? labels,
+    required OnSelectLabelAction onSelectLabelAction,
+  }) {
+    if (actionType == EmailActionType.labelAs && labels?.isNotEmpty == true) {
+      final listLabels = labels ?? [];
+      final emailLabels = presentationEmail.getLabelList(listLabels);
+      return LabelListContextMenu(
+        labelList: listLabels,
+        emailLabels: emailLabels,
+        imagePaths: imagePaths,
+        onSelectLabelAction: onSelectLabelAction,
+      );
+    }
+    return null;
+  }
+
+  bool shouldHandleAction(EmailActionType action) {
+    if (action != EmailActionType.labelAs) {
+      return true;
+    }
+    return PlatformInfo.isWebTouchDevice || PlatformInfo.isMobile;
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/bindings/email_action_interactor_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/email_action_interactor_bindings.dart
@@ -1,0 +1,17 @@
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/email/domain/repository/email_repository.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/add_a_label_to_an_email_interactor.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/remove_a_label_from_an_email_interactor.dart';
+
+class EmailActionInteractorBindings extends Bindings {
+
+  final EmailRepository _emailRepository;
+
+  EmailActionInteractorBindings(this._emailRepository);
+
+  @override
+  void dependencies() {
+    Get.lazyPut(() => AddALabelToAnEmailInteractor(_emailRepository));
+    Get.lazyPut(() => RemoveALabelFromAnEmailInteractor(_emailRepository));
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
@@ -17,8 +17,16 @@ import 'package:tmail_ui_user/features/composer/data/repository/contact_reposito
 import 'package:tmail_ui_user/features/composer/domain/repository/contact_repository.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/send_email_interactor.dart';
 import 'package:tmail_ui_user/features/composer/presentation/manager/composer_manager.dart';
+import 'package:tmail_ui_user/features/download/domain/usecase/download_all_attachments_for_web_interactor.dart';
+import 'package:tmail_ui_user/features/download/domain/usecase/download_and_get_html_content_from_attachment_interactor.dart';
+import 'package:tmail_ui_user/features/download/domain/usecase/download_attachment_for_web_interactor.dart';
 import 'package:tmail_ui_user/features/download/domain/usecase/export_all_attachments_interactor.dart';
 import 'package:tmail_ui_user/features/download/domain/usecase/export_attachment_interactor.dart';
+import 'package:tmail_ui_user/features/download/domain/usecase/get_html_content_from_upload_file_interactor.dart';
+import 'package:tmail_ui_user/features/download/domain/usecase/parse_email_by_blob_id_interactor.dart';
+import 'package:tmail_ui_user/features/download/domain/usecase/preview_email_from_eml_file_interactor.dart';
+import 'package:tmail_ui_user/features/download/presentation/bindings/download_interactor_bindings.dart';
+import 'package:tmail_ui_user/features/download/presentation/controllers/download_controller.dart';
 import 'package:tmail_ui_user/features/email/data/datasource/email_datasource.dart';
 import 'package:tmail_ui_user/features/email/data/datasource/html_datasource.dart';
 import 'package:tmail_ui_user/features/email/data/datasource/print_file_datasource.dart';
@@ -35,17 +43,11 @@ import 'package:tmail_ui_user/features/email/domain/repository/email_repository.
 import 'package:tmail_ui_user/features/email/domain/usecases/add_a_label_to_a_thread_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/delete_email_permanently_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/delete_multiple_emails_permanently_interactor.dart';
-import 'package:tmail_ui_user/features/download/domain/usecase/download_all_attachments_for_web_interactor.dart';
-import 'package:tmail_ui_user/features/download/domain/usecase/download_attachment_for_web_interactor.dart';
-import 'package:tmail_ui_user/features/download/domain/usecase/download_and_get_html_content_from_attachment_interactor.dart';
-import 'package:tmail_ui_user/features/download/domain/usecase/get_html_content_from_upload_file_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_restored_deleted_message_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/labels/remove_a_label_from_a_thread_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_email_read_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_star_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/move_to_mailbox_interactor.dart';
-import 'package:tmail_ui_user/features/download/domain/usecase/parse_email_by_blob_id_interactor.dart';
-import 'package:tmail_ui_user/features/download/domain/usecase/preview_email_from_eml_file_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/restore_deleted_message_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/unsubscribe_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/presentation/bindings/email_bindings.dart';
@@ -110,10 +112,9 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/save_te
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/store_email_sort_order_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/store_last_time_dismissed_spam_reported_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/store_spam_report_state_interactor.dart';
-import 'package:tmail_ui_user/features/download/presentation/bindings/download_interactor_bindings.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/bindings/email_action_interactor_bindings.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/app_grid_dashboard_controller.dart';
-import 'package:tmail_ui_user/features/download/presentation/controllers/download_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/search_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/spam_report_controller.dart';
@@ -432,6 +433,8 @@ class MailboxDashBoardBindings extends BaseBindings {
     Get.lazyPut(
       () => GetAIScribeConfigInteractor(Get.find<ManageAccountRepository>()),
     );
+
+    EmailActionInteractorBindings(Get.find<EmailRepository>()).dependencies();
   }
 
   @override

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -26,12 +26,14 @@ import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:jmap_dart_client/jmap/mail/vacation/vacation_response.dart';
 import 'package:jmap_dart_client/jmap/quotas/quota.dart';
+import 'package:labels/model/label.dart';
 import 'package:model/model.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 import 'package:rxdart/transformers.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:server_settings/server_settings/tmail_server_settings_extension.dart';
 import 'package:tmail_ui_user/features/base/action/ui_action.dart';
+import 'package:tmail_ui_user/features/base/base_controller.dart';
 import 'package:tmail_ui_user/features/base/mixin/ai_scribe_mixin.dart';
 import 'package:tmail_ui_user/features/base/mixin/contact_support_mixin.dart';
 import 'package:tmail_ui_user/features/base/mixin/message_dialog_action_manager.dart';
@@ -67,12 +69,14 @@ import 'package:tmail_ui_user/features/email/domain/state/move_to_mailbox_state.
 import 'package:tmail_ui_user/features/email/domain/state/restore_deleted_message_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/store_sending_email_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/unsubscribe_email_state.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/add_a_label_to_an_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/delete_email_permanently_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/delete_multiple_emails_permanently_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_restored_deleted_message_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_email_read_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_star_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/move_to_mailbox_interactor.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/remove_a_label_from_an_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/restore_deleted_message_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/unsubscribe_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/presentation/action/email_ui_action.dart';
@@ -85,6 +89,7 @@ import 'package:tmail_ui_user/features/home/domain/usecases/store_session_intera
 import 'package:tmail_ui_user/features/identity_creator/domain/state/get_identity_cache_on_web_state.dart';
 import 'package:tmail_ui_user/features/identity_creator/domain/usecase/get_identity_cache_on_web_interactor.dart';
 import 'package:tmail_ui_user/features/labels/presentation/label_controller.dart';
+import 'package:tmail_ui_user/features/labels/presentation/mixin/add_label_to_email_mixin.dart';
 import 'package:tmail_ui_user/features/login/domain/exceptions/logout_exception.dart';
 import 'package:tmail_ui_user/features/login/domain/state/get_authentication_info_state.dart';
 import 'package:tmail_ui_user/features/login/domain/state/get_stored_oidc_configuration_state.dart';
@@ -225,6 +230,7 @@ import 'package:tmail_ui_user/main/universal_import/html_stub.dart' as html;
 import 'package:tmail_ui_user/main/utils/app_config.dart';
 import 'package:tmail_ui_user/main/utils/email_receive_manager.dart';
 import 'package:tmail_ui_user/main/utils/ios_notification_manager.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:uuid/uuid.dart';
 
 class MailboxDashBoardController extends ReloadableController
@@ -232,7 +238,8 @@ class MailboxDashBoardController extends ReloadableController
         OwnEmailAddressMixin,
         SaaSPremiumMixin,
         AiScribeMixin,
-        SearchLabelFilterModalMixin {
+        SearchLabelFilterModalMixin,
+        AddLabelToEmailMixin {
 
   final RemoveEmailDraftsInteractor _removeEmailDraftsInteractor = Get.find<RemoveEmailDraftsInteractor>();
   final EmailReceiveManager _emailReceiveManager = Get.find<EmailReceiveManager>();
@@ -549,6 +556,7 @@ class MailboxDashBoardController extends ReloadableController
     } else if (success is GetLinagoraEcosystemSuccess) {
       handleGetLinagoraEcosystemSuccess(success);
     } else {
+      subscribeLabelViewStateSuccess(success);
       super.handleSuccessViewState(success);
     }
   }
@@ -601,6 +609,7 @@ class MailboxDashBoardController extends ReloadableController
     } else if (failure is GetLinagoraEcosystemFailure) {
       handleGetLinagoraEcosystemFailure(failure);
     } else {
+      subscribeLabelViewStateFailure(failure);
       super.handleFailureViewState(failure);
     }
   }
@@ -3474,4 +3483,33 @@ class MailboxDashBoardController extends ReloadableController
     _disposeWorkerObxVariables();
     super.onClose();
   }
+
+  @override
+  AddALabelToAnEmailInteractor? get addALabelToAnEmailInteractor =>
+      getBinding<AddALabelToAnEmailInteractor>();
+
+  @override
+  AccountId? get currentAccountId => accountId.value;
+
+  @override
+  BaseController get currentController => this;
+
+  @override
+  List<Label> get currentLabelList => labelController.labels;
+
+  @override
+  Session? get currentSession => sessionCurrent;
+
+  @override
+  ToastManager get currentToastManager => toastManager;
+
+  @override
+  bool get isCurrentLabelAvailable => isLabelAvailable;
+
+  @override
+  RemoveALabelFromAnEmailInteractor? get removeALabelFromAnEmailInteractor =>
+      getBinding<RemoveALabelFromAnEmailInteractor>();
+
+  @override
+  OnSyncLabelForEmail? get onSyncLabelForEmail => syncLabelForEmail;
 }

--- a/lib/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart
@@ -49,14 +49,22 @@ extension HandleLogicLabelExtension on MailboxDashBoardController  {
     _refreshLabelSettingEnabled();
 
     if (isEmailOpened) {
-      dispatchEmailUIAction(
-        SyncUpdateLabelForEmailOnMemory(
-          emailId: emailId,
-          labelKeyword: labelKeyword,
-          shouldRemove: shouldRemove,
-        ),
-      );
+      _syncLabelForOpenedEmail(emailId, labelKeyword, shouldRemove);
     }
+  }
+
+  void _syncLabelForOpenedEmail(
+    EmailId emailId,
+    KeyWordIdentifier labelKeyword,
+    bool shouldRemove,
+  ) {
+    dispatchEmailUIAction(
+      SyncUpdateLabelForEmailOnMemory(
+        emailId: emailId,
+        labelKeyword: labelKeyword,
+        shouldRemove: shouldRemove,
+      ),
+    );
   }
 
   void _syncLabelForEmailList(

--- a/lib/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart
@@ -1,8 +1,12 @@
 import 'package:core/utils/app_logger.dart';
 import 'package:get/get.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
+import 'package:tmail_ui_user/features/email/presentation/action/email_ui_action.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/update_current_emails_flags_extension.dart';
 
-extension HandleLogicLabelExtension on MailboxDashBoardController {
+extension HandleLogicLabelExtension on MailboxDashBoardController  {
   bool get isLabelCapabilitySupported {
     final accountId = this.accountId.value;
     final session = sessionCurrent;
@@ -34,5 +38,40 @@ extension HandleLogicLabelExtension on MailboxDashBoardController {
       accountId: accountId.value,
       isLabelAvailable: isLabelAvailable,
     );
+  }
+
+  void syncLabelForEmail(
+    EmailId emailId,
+    KeyWordIdentifier labelKeyword,
+    bool shouldRemove,
+  ) {
+    _syncLabelForEmailList(emailId, labelKeyword, shouldRemove);
+    _refreshLabelSettingEnabled();
+
+    if (isEmailOpened) {
+      dispatchEmailUIAction(
+        SyncUpdateLabelForEmailOnMemory(
+          emailId: emailId,
+          labelKeyword: labelKeyword,
+          shouldRemove: shouldRemove,
+        ),
+      );
+    }
+  }
+
+  void _syncLabelForEmailList(
+    EmailId emailId,
+    KeyWordIdentifier labelKeyword,
+    bool shouldRemove,
+  ) {
+    updateEmailFlagByEmailIds(
+      [emailId],
+      isLabelAdded: !shouldRemove,
+      labelKeyword: labelKeyword,
+    );
+  }
+
+  void _refreshLabelSettingEnabled() {
+    labelController.isLabelSettingEnabled.refresh();
   }
 }

--- a/lib/features/search/email/presentation/extension/handle_email_more_action_extension.dart
+++ b/lib/features/search/email/presentation/extension/handle_email_more_action_extension.dart
@@ -3,8 +3,10 @@ import 'package:model/email/email_action_type.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:model/extensions/presentation_mailbox_extension.dart';
 import 'package:tmail_ui_user/features/base/widget/popup_menu/popup_menu_action_group_widget.dart';
+import 'package:tmail_ui_user/features/base/widget/popup_menu/popup_submenu_controller.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/context_item_email_action.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/popup_menu_item_email_action.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_controller.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
@@ -21,10 +23,14 @@ extension HandleEmailMoreActionExtension on SearchEmailController {
     final isRead = presentationEmail.hasRead;
     final isTrash = mailboxContain?.isTrash ?? false;
     final canPermanentlyDelete = isDrafts || isSpam || isTrash;
+    final isLabelAvailable = mailboxDashBoardController.isLabelAvailable;
+    final listLabels = mailboxDashBoardController.labelController.labels;
+    final shouldShowLabelAs = isLabelAvailable && listLabels.isNotEmpty;
 
     final listEmailActions = [
       isRead ? EmailActionType.markAsUnread : EmailActionType.markAsRead,
       EmailActionType.moveToMailbox,
+      if (shouldShowLabelAs) EmailActionType.labelAs,
       canPermanentlyDelete ? EmailActionType.deletePermanently : EmailActionType.moveToTrash,
       isSpam ? EmailActionType.unSpam : EmailActionType.moveToSpam,
       if (!isDrafts) EmailActionType.editAsNewEmail,
@@ -57,31 +63,46 @@ extension HandleEmailMoreActionExtension on SearchEmailController {
         useGroupedActions: true,
       );
     } else {
+      final submenuController = PopupSubmenuController();
+
       final popupMenuItemEmailActions = listEmailActions.map((actionType) {
         return PopupMenuItemEmailAction(
           actionType,
           AppLocalizations.of(context),
           imagePaths,
           category: actionType.category,
+          submenu: buildLabelSubmenuForEmail(
+            actionType: actionType,
+            imagePaths: imagePaths,
+            presentationEmail: presentationEmail,
+            labels: listLabels,
+            onSelectLabelAction: (label, isSelected) {
+              submenuController.hide();
+              popBack();
+            },
+          ),
         );
       }).toList();
 
       final popupMenuWidget = PopupMenuActionGroupWidget(
         actions: popupMenuItemEmailActions,
+        submenuController: submenuController,
         onActionSelected: (action) {
-          pressEmailAction(
-            context,
-            action.action,
-            presentationEmail,
-            mailboxContain: mailboxContain,
-          );
+          if (shouldHandleAction(action.action)) {
+            pressEmailAction(
+              context,
+              action.action,
+              presentationEmail,
+              mailboxContain: mailboxContain,
+            );
+          }
         },
       );
 
       return popupMenuWidget.show(
         context,
         position,
-      );
+      ).whenComplete(submenuController.hide);
     }
   }
 }

--- a/lib/features/search/email/presentation/extension/handle_email_more_action_extension.dart
+++ b/lib/features/search/email/presentation/extension/handle_email_more_action_extension.dart
@@ -1,3 +1,4 @@
+import 'package:core/core.dart';
 import 'package:flutter/material.dart';
 import 'package:labels/model/label.dart';
 import 'package:model/email/presentation_email.dart';
@@ -24,7 +25,18 @@ extension HandleEmailMoreActionExtension on SearchEmailController {
         openPopupMenu: (context, position, popupMenuWidget) =>
             popupMenuWidget.show(context, position),
         onHandleEmailByActionType: pressEmailAction,
-        onSelectLabelAction: (label, isSelected) {},
+        onSelectLabelAction: (label, isSelected) {
+          final emailId = presentationEmail.id;
+          if (emailId == null) {
+            logWarning('HandleEmailMoreActionExtension::onSelectLabelAction: Email id is null');
+            return;
+          }
+          mailboxDashBoardController.toggleLabelToEmail(
+            emailId,
+            label,
+            isSelected,
+          );
+        },
       ),
     );
   }

--- a/lib/features/search/email/presentation/extension/handle_email_more_action_extension.dart
+++ b/lib/features/search/email/presentation/extension/handle_email_more_action_extension.dart
@@ -1,108 +1,31 @@
 import 'package:flutter/material.dart';
-import 'package:model/email/email_action_type.dart';
+import 'package:labels/model/label.dart';
 import 'package:model/email/presentation_email.dart';
-import 'package:model/extensions/presentation_mailbox_extension.dart';
-import 'package:tmail_ui_user/features/base/widget/popup_menu/popup_menu_action_group_widget.dart';
-import 'package:tmail_ui_user/features/base/widget/popup_menu/popup_submenu_controller.dart';
-import 'package:tmail_ui_user/features/email/presentation/model/context_item_email_action.dart';
-import 'package:tmail_ui_user/features/email/presentation/model/popup_menu_item_email_action.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_controller.dart';
-import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
-import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+import 'package:tmail_ui_user/features/thread/presentation/mixin/email_more_action_context_menu_mixin.dart';
 
 extension HandleEmailMoreActionExtension on SearchEmailController {
   Future<void> handleEmailMoreAction(
     BuildContext context,
     PresentationEmail presentationEmail,
     RelativeRect? position,
-  ) {
-    final mailboxContain = presentationEmail.mailboxContain;
-    final isDrafts = mailboxContain?.isDrafts ?? false;
-    final isSpam = mailboxContain?.isSpam ?? false;
-    final isRead = presentationEmail.hasRead;
-    final isTrash = mailboxContain?.isTrash ?? false;
-    final canPermanentlyDelete = isDrafts || isSpam || isTrash;
-    final isLabelAvailable = mailboxDashBoardController.isLabelAvailable;
-    final listLabels = mailboxDashBoardController.labelController.labels;
-    final shouldShowLabelAs = isLabelAvailable && listLabels.isNotEmpty;
-
-    final listEmailActions = [
-      isRead ? EmailActionType.markAsUnread : EmailActionType.markAsRead,
-      EmailActionType.moveToMailbox,
-      if (shouldShowLabelAs) EmailActionType.labelAs,
-      canPermanentlyDelete ? EmailActionType.deletePermanently : EmailActionType.moveToTrash,
-      isSpam ? EmailActionType.unSpam : EmailActionType.moveToSpam,
-      if (!isDrafts) EmailActionType.editAsNewEmail,
-    ];
-
-    if (listEmailActions.isEmpty) return Future.value();
-
-    if (position == null) {
-      final contextMenuActions = listEmailActions
-          .map((action) => ContextItemEmailAction(
-                action,
-                AppLocalizations.of(context),
-                imagePaths,
-                category: action.category,
-              ))
-          .toList();
-
-      return openBottomSheetContextMenuAction(
+    bool isLabelAvailable,
+    List<Label>? listLabels,
+  ) async {
+    await openMoreActionContextMenu(
+      EmailContextMenuParams(
         context: context,
-        itemActions: contextMenuActions,
-        onContextMenuActionClick: (menuAction) {
-          popBack();
-          pressEmailAction(
-            context,
-            menuAction.action,
-            presentationEmail,
-            mailboxContain: mailboxContain,
-          );
-        },
-        useGroupedActions: true,
-      );
-    } else {
-      final submenuController = PopupSubmenuController();
-
-      final popupMenuItemEmailActions = listEmailActions.map((actionType) {
-        return PopupMenuItemEmailAction(
-          actionType,
-          AppLocalizations.of(context),
-          imagePaths,
-          category: actionType.category,
-          submenu: buildLabelSubmenuForEmail(
-            actionType: actionType,
-            imagePaths: imagePaths,
-            presentationEmail: presentationEmail,
-            labels: listLabels,
-            onSelectLabelAction: (label, isSelected) {
-              submenuController.hide();
-              popBack();
-            },
-          ),
-        );
-      }).toList();
-
-      final popupMenuWidget = PopupMenuActionGroupWidget(
-        actions: popupMenuItemEmailActions,
-        submenuController: submenuController,
-        onActionSelected: (action) {
-          if (shouldHandleAction(action.action)) {
-            pressEmailAction(
-              context,
-              action.action,
-              presentationEmail,
-              mailboxContain: mailboxContain,
-            );
-          }
-        },
-      );
-
-      return popupMenuWidget.show(
-        context,
-        position,
-      ).whenComplete(submenuController.hide);
-    }
+        email: presentationEmail,
+        imagePaths: imagePaths,
+        isLabelAvailable: isLabelAvailable,
+        labels: listLabels,
+        position: position,
+        openBottomSheetContextMenu: openBottomSheetContextMenuAction,
+        openPopupMenu: (context, position, popupMenuWidget) =>
+            popupMenuWidget.show(context, position),
+        onHandleEmailByActionType: pressEmailAction,
+        onSelectLabelAction: (label, isSelected) {},
+      ),
+    );
   }
 }

--- a/lib/features/search/email/presentation/search_email_controller.dart
+++ b/lib/features/search/email/presentation/search_email_controller.dart
@@ -77,6 +77,7 @@ import 'package:tmail_ui_user/features/thread/domain/usecases/search_email_inter
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_more_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/presentation/extensions/list_presentation_email_extensions.dart';
 import 'package:tmail_ui_user/features/thread/presentation/mixin/email_action_controller.dart';
+import 'package:tmail_ui_user/features/thread/presentation/mixin/email_more_action_context_menu_mixin.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/delete_action_type.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/mail_list_shortcut_action_view_event.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
@@ -90,7 +91,8 @@ class SearchEmailController extends BaseController
     with EmailActionController,
         DateRangePickerMixin,
         SearchLabelFilterModalMixin,
-        LabelSubMenuMixin {
+        LabelSubMenuMixin,
+        EmailMoreActionContextMenu {
 
   final networkConnectionController = Get.find<NetworkConnectionController>();
 
@@ -915,10 +917,9 @@ class SearchEmailController extends BaseController
   }
 
   void pressEmailAction(
-      BuildContext context,
       EmailActionType actionType,
       PresentationEmail selectedEmail,
-      {required PresentationMailbox? mailboxContain}
+      PresentationMailbox? mailboxContain,
   ) {
     switch(actionType) {
       case EmailActionType.preview:
@@ -929,7 +930,7 @@ class SearchEmailController extends BaseController
         }
         break;
       case EmailActionType.selection:
-        selectEmail(context, selectedEmail);
+        selectEmail(selectedEmail);
         break;
       case EmailActionType.markAsRead:
         markAsEmailRead(selectedEmail, ReadActions.markAsRead, MarkReadAction.tap);
@@ -950,7 +951,11 @@ class SearchEmailController extends BaseController
         moveToTrash(selectedEmail, mailboxContain: mailboxContain);
         break;
       case EmailActionType.deletePermanently:
-        deleteEmailPermanently(context, selectedEmail);
+        if (currentContext != null) {
+          deleteEmailPermanently(currentContext!, selectedEmail);
+        } else {
+          logWarning('SearchEmailController.pressEmailAction: currentContext is null');
+        }
         break;
       case EmailActionType.moveToSpam:
         moveToSpam(selectedEmail, mailboxContain: mailboxContain);
@@ -966,7 +971,7 @@ class SearchEmailController extends BaseController
     }
   }
 
-  void selectEmail(BuildContext context, PresentationEmail presentationEmailSelected) {
+  void selectEmail(PresentationEmail presentationEmailSelected) {
     listResultSearch.value = listResultSearch
         .map((email) => email.id == presentationEmailSelected.id ? email.toggleSelect() : email)
         .toList();

--- a/lib/features/search/email/presentation/search_email_controller.dart
+++ b/lib/features/search/email/presentation/search_email_controller.dart
@@ -40,6 +40,7 @@ import 'package:tmail_ui_user/features/email/presentation/action/email_ui_action
 import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
 import 'package:tmail_ui_user/features/home/data/exceptions/session_exceptions.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart';
+import 'package:tmail_ui_user/features/labels/presentation/mixin/label_sub_menu_mixin.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_actions.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/model/recent_search.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/get_all_recent_search_latest_state.dart';
@@ -88,7 +89,8 @@ import 'package:tmail_ui_user/main/routes/route_utils.dart';
 class SearchEmailController extends BaseController
     with EmailActionController,
         DateRangePickerMixin,
-        SearchLabelFilterModalMixin {
+        SearchLabelFilterModalMixin,
+        LabelSubMenuMixin {
 
   final networkConnectionController = Get.find<NetworkConnectionController>();
 

--- a/lib/features/search/email/presentation/search_email_view.dart
+++ b/lib/features/search/email/presentation/search_email_view.dart
@@ -643,10 +643,10 @@ class SearchEmailView extends GetWidget<SearchEmailController>
                 final mailboxContain = emailPreview
                     .findMailboxContain(controller.mailboxDashBoardController.mapMailboxById);
                 controller.pressEmailAction(
-                    context,
                     EmailActionType.preview,
                     emailPreview,
-                    mailboxContain: mailboxContain);
+                    mailboxContain,
+                );
               },
             ),
           );
@@ -779,10 +779,9 @@ class SearchEmailView extends GetWidget<SearchEmailController>
           mailboxContain: presentationEmail.mailboxContain,
           emailActionClick: (action, email) {
             controller.pressEmailAction(
-              context,
               action,
               email,
-              mailboxContain: presentationEmail.mailboxContain,
+              presentationEmail.mailboxContain,
             );
           },
           onMoreActionClick: (email, position) =>
@@ -790,6 +789,8 @@ class SearchEmailView extends GetWidget<SearchEmailController>
             context,
             email,
             position,
+            isLabelAvailable,
+            listLabels,
           ),
         );
       },

--- a/lib/features/thread/presentation/mixin/email_more_action_context_menu_mixin.dart
+++ b/lib/features/thread/presentation/mixin/email_more_action_context_menu_mixin.dart
@@ -1,0 +1,163 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/utils/platform_info.dart';
+import 'package:flutter/material.dart';
+import 'package:labels/model/label.dart';
+import 'package:model/email/email_action_type.dart';
+import 'package:model/email/presentation_email.dart';
+import 'package:model/extensions/presentation_mailbox_extension.dart';
+import 'package:tmail_ui_user/features/base/widget/popup_menu/popup_menu_action_group_widget.dart';
+import 'package:tmail_ui_user/features/base/widget/popup_menu/popup_submenu_controller.dart';
+import 'package:tmail_ui_user/features/email/presentation/model/context_item_email_action.dart';
+import 'package:tmail_ui_user/features/email/presentation/model/popup_menu_item_email_action.dart';
+import 'package:tmail_ui_user/features/email/presentation/utils/email_action_reactor/email_action_reactor.dart';
+import 'package:tmail_ui_user/features/labels/presentation/mixin/label_sub_menu_mixin.dart';
+import 'package:tmail_ui_user/features/labels/presentation/widgets/label_item_context_menu.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+
+class EmailContextMenuParams {
+  final BuildContext context;
+  final PresentationEmail email;
+  final ImagePaths imagePaths;
+  final bool isLabelAvailable;
+  final List<Label>? labels;
+  final RelativeRect? position;
+  final OpenBottomSheetContextMenuAction openBottomSheetContextMenu;
+  final OpenPopupMenuActionGroup openPopupMenu;
+  final OnHandleEmailByActionType onHandleEmailByActionType;
+  final OnSelectLabelAction onSelectLabelAction;
+
+  EmailContextMenuParams({
+    required this.context,
+    required this.email,
+    required this.imagePaths,
+    required this.isLabelAvailable,
+    required this.labels,
+    required this.position,
+    required this.openBottomSheetContextMenu,
+    required this.openPopupMenu,
+    required this.onHandleEmailByActionType,
+    required this.onSelectLabelAction,
+  });
+}
+
+mixin EmailMoreActionContextMenu on LabelSubMenuMixin {
+  Future<void> openMoreActionContextMenu(EmailContextMenuParams params) async {
+    final actions = _generateActionList(params);
+
+    if (params.position == null) {
+      return _openBottomSheet(params, actions);
+    } else {
+      return _openPopupMenu(params, actions);
+    }
+  }
+
+  List<EmailActionType> _generateActionList(EmailContextMenuParams params) {
+    final email = params.email;
+    final mb = email.mailboxContain;
+
+    final isRead = email.hasRead;
+    final isDrafts = mb?.isDrafts ?? false;
+    final isSpam = mb?.isSpam ?? false;
+    final isTrash = mb?.isTrash ?? false;
+    final isArchive = mb?.isArchive ?? false;
+    final isTemplates = mb?.isTemplates ?? false;
+    final isChildOfTeam = mb?.isChildOfTeamMailboxes ?? false;
+
+    final canPermanentlyDelete = isDrafts || isSpam || isTrash;
+    final shouldShowLabelAs =
+        params.isLabelAvailable && (params.labels?.isNotEmpty ?? false);
+
+    return [
+      isRead ? EmailActionType.markAsUnread : EmailActionType.markAsRead,
+      EmailActionType.moveToMailbox,
+      if (shouldShowLabelAs) EmailActionType.labelAs,
+      canPermanentlyDelete
+          ? EmailActionType.deletePermanently
+          : EmailActionType.moveToTrash,
+      if (PlatformInfo.isWeb) EmailActionType.openInNewTab,
+      if (!isDrafts && !isChildOfTeam)
+        isSpam ? EmailActionType.unSpam : EmailActionType.moveToSpam,
+      if (!isArchive) EmailActionType.archiveMessage,
+      if (!isDrafts && !isTemplates) EmailActionType.editAsNewEmail,
+    ];
+  }
+
+  Future<void> _openBottomSheet(
+    EmailContextMenuParams params,
+    List<EmailActionType> actions,
+  ) {
+    final appLocalizations = AppLocalizations.of(params.context);
+
+    final contextMenuActions = actions.map((action) {
+      return ContextItemEmailAction(
+        action,
+        appLocalizations,
+        params.imagePaths,
+        category: action.category,
+      );
+    }).toList();
+
+    return params.openBottomSheetContextMenu(
+      context: params.context,
+      itemActions: contextMenuActions,
+      useGroupedActions: true,
+      onContextMenuActionClick: (menuAction) {
+        popBack();
+        params.onHandleEmailByActionType(
+          menuAction.action,
+          params.email,
+          params.email.mailboxContain,
+        );
+      },
+    );
+  }
+
+  Future<void> _openPopupMenu(
+    EmailContextMenuParams params,
+    List<EmailActionType> actions,
+  ) {
+    final appLocalizations = AppLocalizations.of(params.context);
+    final submenuController = PopupSubmenuController();
+
+    final popupMenuItemActions = actions.map((actionType) {
+      return PopupMenuItemEmailAction(
+        actionType,
+        appLocalizations,
+        params.imagePaths,
+        category: actionType.category,
+        submenu: buildLabelSubmenuForEmail(
+          actionType: actionType,
+          imagePaths: params.imagePaths,
+          presentationEmail: params.email,
+          labels: params.labels,
+          onSelectLabelAction: (label, isSelected) {
+            submenuController.hide();
+            popBack();
+            params.onSelectLabelAction(label, isSelected);
+          },
+        ),
+      );
+    }).toList();
+
+    return params
+        .openPopupMenu(
+          params.context,
+          params.position!,
+          PopupMenuActionGroupWidget(
+            actions: popupMenuItemActions,
+            submenuController: submenuController,
+            onActionSelected: (action) {
+              if (shouldHandleAction(action.action)) {
+                params.onHandleEmailByActionType(
+                  action.action,
+                  params.email,
+                  params.email.mailboxContain,
+                );
+              }
+            },
+          ),
+        )
+        .whenComplete(submenuController.hide);
+  }
+}

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -309,7 +309,7 @@ class ThreadController extends BaseController with EmailActionController {
         handleEmailActionType(
           EmailActionType.preview,
           newEmail,
-          mailboxContain: mailboxContain,
+          mailboxContain,
         );
         mailboxDashBoardController.clearDashBoardAction();
       } else if (action is StartSearchEmailAction
@@ -1332,9 +1332,7 @@ class ThreadController extends BaseController with EmailActionController {
   void handleEmailActionType(
     EmailActionType actionType,
     PresentationEmail selectedEmail,
-    {
-      required PresentationMailbox? mailboxContain,
-    }
+    PresentationMailbox? mailboxContain,
   ) {
     switch(actionType) {
       case EmailActionType.preview:
@@ -1477,7 +1475,7 @@ class ThreadController extends BaseController with EmailActionController {
     handleEmailActionType(
       EmailActionType.preview,
       presentationEmailWithRouter,
-      mailboxContain: mailboxContain
+      mailboxContain,
     );
   }
 
@@ -1496,7 +1494,7 @@ class ThreadController extends BaseController with EmailActionController {
       handleEmailActionType(
         EmailActionType.preview,
         presentationEmailWithRouter,
-        mailboxContain: mailboxContain
+        mailboxContain,
       );
     } else {
       searchController.enableSearch();
@@ -1512,7 +1510,7 @@ class ThreadController extends BaseController with EmailActionController {
       handleEmailActionType(
         EmailActionType.preview,
         presentationEmailWithRouter,
-        mailboxContain: mailboxContain
+        mailboxContain,
       );
     }
   }
@@ -1532,7 +1530,7 @@ class ThreadController extends BaseController with EmailActionController {
     handleEmailActionType(
       EmailActionType.preview,
       presentationEmailWithRouter,
-      mailboxContain: email.findMailboxContain(mailboxDashBoardController.mapMailboxById)
+      email.findMailboxContain(mailboxDashBoardController.mapMailboxById),
     );
   }
 

--- a/lib/features/thread/presentation/thread_view.dart
+++ b/lib/features/thread/presentation/thread_view.dart
@@ -669,7 +669,18 @@ class ThreadView extends GetWidget<ThreadController>
                 openBottomSheetContextMenu: dashboardController.openBottomSheetContextMenu,
                 openPopupMenu: dashboardController.openPopupMenuActionGroup,
                 onHandleEmailByActionType: controller.handleEmailActionType,
-                onSelectLabelAction: (label, isSelected) {},
+                onSelectLabelAction: (label, isSelected) {
+                  final emailId = presentationEmail.id;
+                  if (emailId == null) {
+                    logWarning('ThreadView::onSelectLabelAction: Email id is null');
+                    return;
+                  }
+                  dashboardController.toggleLabelToEmail(
+                    emailId,
+                    label,
+                    isSelected,
+                  );
+                },
               ),
             );
           }

--- a/test/features/email/presentation/controller/single_email_controller_test.dart
+++ b/test/features/email/presentation/controller/single_email_controller_test.dart
@@ -20,6 +20,7 @@ import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:tmail_ui_user/features/caching/caching_manager.dart';
+import 'package:tmail_ui_user/features/download/presentation/controllers/download_controller.dart';
 import 'package:tmail_ui_user/features/email/data/datasource/calendar_event_datasource.dart';
 import 'package:tmail_ui_user/features/email/data/datasource_impl/html_datasource_impl.dart';
 import 'package:tmail_ui_user/features/email/data/local/html_analyzer.dart';
@@ -27,7 +28,6 @@ import 'package:tmail_ui_user/features/email/data/repository/calendar_event_repo
 import 'package:tmail_ui_user/features/email/domain/model/event_action.dart';
 import 'package:tmail_ui_user/features/email/domain/state/get_email_content_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/parse_calendar_event_state.dart';
-import 'package:tmail_ui_user/features/email/domain/usecases/add_a_label_to_an_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/calendar_event_accept_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/calendar_event_reject_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_email_content_interactor.dart';
@@ -36,7 +36,6 @@ import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_star_email_
 import 'package:tmail_ui_user/features/email/domain/usecases/maybe_calendar_event_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/parse_calendar_event_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/print_email_interactor.dart';
-import 'package:tmail_ui_user/features/email/domain/usecases/remove_a_label_from_an_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/store_opened_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/presentation/action/email_ui_action.dart';
 import 'package:tmail_ui_user/features/email/presentation/controller/single_email_controller.dart';
@@ -45,7 +44,6 @@ import 'package:tmail_ui_user/features/login/data/network/interceptors/authoriza
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oidc_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/action/download_ui_action.dart';
-import 'package:tmail_ui_user/features/download/presentation/controllers/download_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_all_identities_interactor.dart';
@@ -75,8 +73,6 @@ const fallbackGenerators = {
   MockSpec<MarkAsStarEmailInteractor>(),
   MockSpec<GetAllIdentitiesInteractor>(),
   MockSpec<StoreOpenedEmailInteractor>(),
-  MockSpec<AddALabelToAnEmailInteractor>(),
-  MockSpec<RemoveALabelFromAnEmailInteractor>(),
   MockSpec<MailboxDashBoardController>(fallbackGenerators: fallbackGenerators),
   MockSpec<DownloadController>(fallbackGenerators: fallbackGenerators),
   MockSpec<DownloadManager>(fallbackGenerators: fallbackGenerators),
@@ -110,8 +106,6 @@ void main() {
   final markAsStarEmailInteractor = MockMarkAsStarEmailInteractor();
   final getAllIdentitiesInteractor = MockGetAllIdentitiesInteractor();
   final storeOpenedEmailInteractor = MockStoreOpenedEmailInteractor();
-  final addALabelToAnEmailInteractor = MockAddALabelToAnEmailInteractor();
-  final removeALabelFromAnEmailInteractor = MockRemoveALabelFromAnEmailInteractor();
   final mailboxDashboardController = MockMailboxDashBoardController();
   final downloadController = MockDownloadController();
   final downloadManager = MockDownloadManager();
@@ -177,8 +171,6 @@ void main() {
       markAsStarEmailInteractor,
       getAllIdentitiesInteractor,
       storeOpenedEmailInteractor,
-      addALabelToAnEmailInteractor,
-      removeALabelFromAnEmailInteractor,
       printEmailInteractor,
     );
   });


### PR DESCRIPTION
## Issue


<img width="468" height="430" alt="Screenshot 2026-02-05 at 13 17 36" src="https://github.com/user-attachments/assets/c08613c8-7768-4427-9db5-149cb4ef0ec8" />

## Resolved


https://github.com/user-attachments/assets/a7179852-4d06-4ee7-b5c4-7924dcc82b91



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified “More actions” menu with a label submenu and in-memory label sync for opened emails.

* **Bug Fixes**
  * Safer label flows with fewer null-assertions and warnings when email/context is missing.

* **Refactor**
  * Centralized and simplified label action wiring across search, thread, mailbox, and single-email views via mixins and shared bindings.

* **Tests**
  * Updated controller tests to match the simplified label action surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->