### PR TITLE
Bugfix/get error 400 when refresh token

### DIFF
--- a/core/lib/utils/app_logger.dart
+++ b/core/lib/utils/app_logger.dart
@@ -81,14 +81,18 @@ void _internalLog(
   }
 
   if (shouldSentry) {
-    unawaited(
-      SentryManager.instance.captureException(
-        exception ?? rawMessage,
-        stackTrace: stackTrace,
-        message: rawMessage,
-        extras: extras,
-      ),
-    );
+    if (level == Level.trace) {
+      SentryManager.instance.captureMessage(rawMessage, extras: extras);
+    } else {
+      unawaited(
+        SentryManager.instance.captureException(
+          exception ?? rawMessage,
+          stackTrace: stackTrace,
+          message: rawMessage,
+          extras: extras,
+        ),
+      );
+    }
   }
 }
 
@@ -132,7 +136,9 @@ void _printWebConsole(Level level, String value) {
 }
 
 bool _shouldReportToSentry(Level level) {
-  return level == Level.error || level == Level.critical;
+  return level == Level.error ||
+      level == Level.critical ||
+      level == Level.trace;
 }
 
 void logError(

--- a/core/lib/utils/app_logger.dart
+++ b/core/lib/utils/app_logger.dart
@@ -82,7 +82,9 @@ void _internalLog(
 
   if (shouldSentry) {
     if (level == Level.trace) {
-      SentryManager.instance.captureMessage(rawMessage, extras: extras);
+      unawaited(
+        SentryManager.instance.captureMessage(rawMessage, extras: extras),
+      );
     } else {
       unawaited(
         SentryManager.instance.captureException(
@@ -208,11 +210,13 @@ void logDebug(
 void logTrace(
   String? message, {
   bool webConsoleEnabled = false,
+  Map<String, dynamic>? extras,
 }) {
   _internalLog(
     message,
     level: Level.trace,
     webConsoleEnabled: webConsoleEnabled,
+    extras: extras,
   );
 }
 

--- a/docs/adr/0031-fix-refresh-token-with-oidc.md
+++ b/docs/adr/0031-fix-refresh-token-with-oidc.md
@@ -4,9 +4,9 @@ Date: 2023-09-11
 
 ## Status
 
-- Issue: 
+Superseded by [ADR-0035](0035-error-handling-on-no-longer-valid-oidc-token.md)
 
-[1974](https://github.com/linagora/tmail-flutter/issues/1974)
+- Issue: [1974](https://github.com/linagora/tmail-flutter/issues/1974)
 
 ## Context
 

--- a/docs/adr/0035-error-handling-on-no-longer-valid-oidc-token.md
+++ b/docs/adr/0035-error-handling-on-no-longer-valid-oidc-token.md
@@ -1,19 +1,37 @@
-# 35. Error handling on no longer valid OIDC token (Issue #2592)
+# 35. OIDC Token Refresh Mechanism in AuthorizationInterceptors
 
 Date: 2024-02-15
+Updated: 2026-02-09
 
 ## Status
 
-Accepted
+Accepted (supersedes [ADR-0031](0031-fix-refresh-token-with-oidc.md))
 
 ## Context
 
-- When my OIDC token is expired, I see an awful red error message while being redirected
+Multiple issues drove the evolution of the refresh token logic:
+
+1. **Concurrent 401s caused logout** ([#1974](https://github.com/linagora/tmail-flutter/issues/1974)) — parallel requests with stale headers all triggered independent refresh attempts.
+2. **Ugly error on expired token** ([#2592](https://github.com/linagora/tmail-flutter/issues/2592)) — users saw a red error instead of a silent redirect.
+3. **400 on refresh not handled** — when the refresh token itself was revoked/expired, the server returned 400 (invalid_grant) but the interceptor did not distinguish this from transient errors, leading to confusing failures.
+4. **Server-side revocation before local expiry** — relying on local `isExpired` check caused the interceptor to skip refresh when the server had already revoked the token.
 
 ## Decision
 
-- When my OIDC token is expired, I am just redirected to the OIDC provider portal. No need to show an awful error.
+`AuthorizationInterceptors` extends `QueuedInterceptorsWrapper` (Dio). The `onError` handler processes errors one at a time with the following ordered checks:
+
+1. **`_refreshAttemptedKey` guard** — if the request already attempted a refresh/retry, skip everything and propagate the error. Prevents infinite loops.
+2. **`validateToRetryTheRequestWithNewToken`** (checked first) — only on **401** responses: if `_token` was already updated by a preceding queued request, retry immediately with the new token. No refresh call needed. Non-401 errors (500, 403, etc.) are never retried here — they are server errors unrelated to authentication.
+3. **`validateToRefreshToken`** — if status is 401, auth type is OIDC, and access/refresh tokens are present, attempt refresh. The local `isExpired` check was **removed**; we trust the server's 401.
+   - **Success (different token):** update `_token`, persist to cache, mark `_refreshAttemptedKey`, retry.
+   - **Success (same token — duplicate):** propagate original error, no retry.
+   - **`DioException` 400:** call `clear()` (wipe auth state) and reject with `RefreshTokenFailedException` — triggers silent logout.
+   - **`DioException` other:** propagate original error, preserve OIDC state.
+4. **Outer catch:** `ServerError`/`TemporarilyUnavailable` wrapped in `DioException`; other exceptions forwarded via `err.copyWith`.
 
 ## Consequences
 
-- In case of receiving a `BadCredentials` error, the system automatically logs out and returns to the login screen without any notification to the user.
+- Queued requests after a successful refresh retry without redundant refresh calls.
+- 400 from the OIDC provider causes immediate session cleanup and silent redirect to login.
+- No infinite retry loops thanks to the `_refreshAttemptedKey` per-request flag.
+- Server-side token revocation is handled correctly regardless of local expiry time.

--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -156,7 +156,8 @@ abstract class BaseController extends GetxController
   bool validateUrgentException(dynamic exception) {
     return exception is NoNetworkError
       || exception is BadCredentialsException
-      || exception is ConnectionError;
+      || exception is ConnectionError
+      || exception is RefreshTokenFailedException;
   }
 
   void handleErrorViewState(Object error, StackTrace stackTrace) {}
@@ -177,6 +178,8 @@ abstract class BaseController extends GetxController
       _handleConnectionErrorException();
     } else if (exception is BadCredentialsException) {
       handleBadCredentialsException();
+    } else if (exception is RefreshTokenFailedException) {
+      handleRefreshTokenFailedException();
     }
   }
 
@@ -188,6 +191,8 @@ abstract class BaseController extends GetxController
       _handleConnectionErrorException();
     } else if (exception is BadCredentialsException) {
       handleBadCredentialsException();
+    } else if (exception is RefreshTokenFailedException) {
+      handleRefreshTokenFailedException();
     }
   }
 
@@ -240,6 +245,15 @@ abstract class BaseController extends GetxController
 
   void _performReconnection() {
     clearDataAndGoToLoginPage();
+  }
+
+  void handleRefreshTokenFailedException() {
+    log('$runtimeType::handleRefreshTokenFailedException:');
+    if (twakeAppManager.hasComposer) {
+      _performSaveAndReconnection();
+    } else {
+      _performReconnection();
+    }
   }
 
   void onDataFailureViewState(Failure failure) {

--- a/lib/features/login/data/datasource/authentication_oidc_datasource.dart
+++ b/lib/features/login/data/datasource/authentication_oidc_datasource.dart
@@ -28,13 +28,6 @@ abstract class AuthenticationOIDCDataSource {
 
   Future<OIDCConfiguration> getStoredOidcConfiguration();
 
-  Future<TokenOIDC> refreshingTokensOIDC(
-      String clientId,
-      String redirectUrl,
-      String discoveryUrl,
-      List<String> scopes,
-      String refreshToken);
-
   Future<bool> logout(TokenId tokenId, OIDCConfiguration config, OIDCDiscoveryResponse oidcRescovery);
 
   Future<void> authenticateOidcOnBrowser(

--- a/lib/features/login/data/datasource_impl/authentication_oidc_datasource_impl.dart
+++ b/lib/features/login/data/datasource_impl/authentication_oidc_datasource_impl.dart
@@ -104,24 +104,6 @@ class AuthenticationOIDCDataSourceImpl extends AuthenticationOIDCDataSource {
   }
 
   @override
-  Future<TokenOIDC> refreshingTokensOIDC(
-    String clientId,
-    String redirectUrl,
-    String discoveryUrl,
-    List<String> scopes,
-    String refreshToken
-  ) {
-    return Future.sync(() async {
-      return await _authenticationClient.refreshingTokensOIDC(
-        clientId,
-        redirectUrl,
-        discoveryUrl,
-        scopes,
-        refreshToken);
-    }).catchError(_exceptionThrower.throwException);
-  }
-
-  @override
   Future<bool> logout(TokenId tokenId, OIDCConfiguration config, OIDCDiscoveryResponse oidcRescovery) {
     return Future.sync(() async {
        return await _authenticationClient.logoutOidc(tokenId, config, oidcRescovery);

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -91,13 +91,10 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       final extraInRequest = requestOptions.extra;
       bool isRetryRequest = false;
 
-      // Check if this request has already attempted a refresh/retry
       final hasAttemptedRefresh = extraInRequest[_refreshAttemptedKey] == true;
 
-      // FIRST: Check if token was already updated by another request in the queue
-      // If so, just retry with the new token - no refresh needed
-      // But skip if we've already attempted (to prevent infinite loops)
       if (!hasAttemptedRefresh && validateToRetryTheRequestWithNewToken(
+        responseStatusCode: err.response?.statusCode,
         authHeader: requestOptions.headers[HttpHeaders.authorizationHeader],
         tokenOIDC: _token
       )) {
@@ -107,7 +104,6 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         responseStatusCode: err.response?.statusCode,
         tokenOIDC: _token
       )) {
-        // SECOND: Check if we should attempt to refresh the token
         try {
           log('AuthorizationInterceptors::onError: Perform get New Token');
           final newTokenOidc = PlatformInfo.isIOS
@@ -126,7 +122,6 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
             await _iosSharingManager.saveKeyChainSharingSession(personalAccount);
           }
 
-          // Mark that we've attempted refresh for this request
           requestOptions.extra[_refreshAttemptedKey] = true;
           isRetryRequest = true;
         } on DioException catch (refreshError, st) {
@@ -149,12 +144,30 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
             return handler.reject(sessionExpiredError);
           }
 
-          return super.onError(err, handler);
+          logError(
+            'AuthorizationInterceptors: Refresh token failed with '
+            'statusCode=${refreshError.response?.statusCode}',
+            exception: refreshError,
+            stackTrace: st,
+          );
+
+          if (refreshError is ServerError ||
+              refreshError is TemporarilyUnavailable) {
+            return super.onError(
+              DioException(
+                requestOptions: err.requestOptions,
+                error: refreshError,
+              ),
+              handler,
+            );
+          } else {
+            return super.onError(err.copyWith(error: refreshError), handler);
+          }
         }
       } else {
         logTrace(
           'AuthorizationInterceptors::onError: '
-          '401 received but refresh skipped. '
+          'No retry or refresh applicable. '
           'statusCode = ${err.response?.statusCode} | '
           'authType = $_authenticationType | '
           'hasConfig = ${_configOIDC != null} | '
@@ -249,9 +262,6 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     final hasAccessToken = _isTokenNotEmpty(tokenOIDC);
     final hasRefreshToken = _isRefreshTokenNotEmpty(tokenOIDC);
 
-    // Note: We removed isExpired check. If server returns 401, we trust it
-    // and attempt refresh regardless of local expiry time. This handles cases
-    // where server clock is ahead or token was revoked server-side.
     final canProceedRefresh = isStatusCode401 &&
         isLoginWithOIDC &&
         hasAccessToken &&
@@ -271,21 +281,25 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
   }
 
   bool validateToRetryTheRequestWithNewToken(
-      {required String? authHeader, required TokenOIDC? tokenOIDC}) {
+      {required int? responseStatusCode,
+      required String? authHeader,
+      required TokenOIDC? tokenOIDC}) {
+    final isStatusCode401 = responseStatusCode == 401;
     final hasAuthHeader = authHeader != null;
     final hasAccessToken = _isTokenNotEmpty(tokenOIDC);
     final isTokenStillValid = !_isTokenExpired(tokenOIDC);
     final isTokenUpdated =
         tokenOIDC != null && authHeader?.contains(tokenOIDC.token) != true;
 
-    // Note: We don't check isTokenExpired here. If another request already
-    // refreshed the token, we should retry with the new token regardless of
-    // its expiry status. The key check is isTokenUpdated.
-    final shouldRetry =
-        hasAuthHeader && hasAccessToken && isTokenStillValid && isTokenUpdated;
+    final shouldRetry = isStatusCode401 &&
+        hasAuthHeader &&
+        hasAccessToken &&
+        isTokenStillValid &&
+        isTokenUpdated;
 
     logTrace(
       'AuthorizationInterceptors::validateToRetryWithNewToken: '
+      'isStatusCode401 = $isStatusCode401 | '
       'hasHeader = $hasAuthHeader | '
       'hasAccessToken = $hasAccessToken | '
       'isTokenValid = $isTokenStillValid | '

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -142,6 +142,15 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         log('AuthorizationInterceptors::onError: Request using old token');
         isRetryRequest = true;
       } else {
+        logTrace(
+          'AuthorizationInterceptors::onError: '
+          '401 received but refresh skipped. '
+          'statusCode = ${err.response?.statusCode} | '
+          'authType = $_authenticationType | '
+          'hasConfig = ${_configOIDC != null} | '
+          'url = ${err.requestOptions.uri}',
+          webConsoleEnabled: true,
+        );
         return super.onError(err, handler);
       }
 
@@ -238,6 +247,8 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       'hasAccessToken = $hasAccessToken | '
       'hasRefreshToken = $hasRefreshToken | '
       'isExpired = $isExpired | '
+      'expiredTime = ${tokenOIDC?.expiredTime} | '
+      'now = ${DateTime.now()} | '
       'canProceedRefresh = $canProceedRefresh',
       webConsoleEnabled: true,
     );

--- a/lib/features/login/data/repository/authentication_oidc_repository_impl.dart
+++ b/lib/features/login/data/repository/authentication_oidc_repository_impl.dart
@@ -66,22 +66,6 @@ class AuthenticationOIDCRepositoryImpl extends AuthenticationOIDCRepository {
   }
 
   @override
-  Future<TokenOIDC> refreshingTokensOIDC(
-      String clientId,
-      String redirectUrl,
-      String discoveryUrl,
-      List<String> scopes,
-      String refreshToken
-  ) {
-    return _oidcDataSource.refreshingTokensOIDC(
-        clientId,
-        redirectUrl,
-        discoveryUrl,
-        scopes,
-        refreshToken);
-  }
-
-  @override
   Future<bool> logout(TokenId tokenId, OIDCConfiguration config, OIDCDiscoveryResponse oidcRescovery) {
     return _oidcDataSource.logout(tokenId, config, oidcRescovery);
   }

--- a/lib/features/login/domain/repository/authentication_oidc_repository.dart
+++ b/lib/features/login/domain/repository/authentication_oidc_repository.dart
@@ -28,13 +28,6 @@ abstract class AuthenticationOIDCRepository {
 
   Future<OIDCConfiguration> getStoredOidcConfiguration();
 
-  Future<TokenOIDC> refreshingTokensOIDC(
-      String clientId,
-      String redirectUrl,
-      String discoveryUrl,
-      List<String> scopes,
-      String refreshToken);
-
   Future<bool> logout(TokenId tokenId, OIDCConfiguration config, OIDCDiscoveryResponse oidcRescovery);
 
   Future<void> authenticateOidcOnBrowser(

--- a/lib/main/exceptions/remote_exception.dart
+++ b/lib/main/exceptions/remote_exception.dart
@@ -63,3 +63,17 @@ class CannotCalculateChangesMethodResponseException extends MethodLevelErrors {
 class NoNetworkError extends RemoteException {
   const NoNetworkError() : super(message: RemoteException.noNetworkError);
 }
+
+class RefreshTokenFailedException extends RemoteException {
+  final int? statusCode;
+
+  RefreshTokenFailedException({
+    super.message =
+        'Refresh Token failed with 400 Bad Request. The session is invalid/revoked.',
+    this.statusCode = 400,
+  });
+
+  @override
+  String toString() =>
+      "RefreshTokenFailedException(status: $statusCode): $message";
+}

--- a/lib/main/exceptions/remote_exception_thrower.dart
+++ b/lib/main/exceptions/remote_exception_thrower.dart
@@ -37,6 +37,10 @@ class RemoteExceptionThrower extends ExceptionThrower {
         'RemoteExceptionThrower::throwException():type: ${error.type} | response: ${error.response} | error: ${error.error}',
       );
 
+      if (error.error is RefreshTokenFailedException) {
+        throw RefreshTokenFailedException();
+      }
+
       final response = error.response;
       final statusCode = response?.statusCode;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.24.9-rc1
+version: 0.24.9-rc2
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.24.9-rc2
+version: 0.24.9-rc3
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.24.8
+version: 0.24.9-rc1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -225,10 +225,11 @@ void main() {
   // ============================================================
   group('validateToRetryTheRequestWithNewToken', () {
     test(
-      'should return TRUE when auth header present, token updated, and token not expired',
+      'should return TRUE when 401, auth header present, token updated, and token not expired',
       () {
         final result =
             authorizationInterceptors.validateToRetryTheRequestWithNewToken(
+          responseStatusCode: 401,
           authHeader: 'Bearer old_token',
           tokenOIDC: OIDCFixtures.newTokenOidc,
         );
@@ -237,9 +238,32 @@ void main() {
       },
     );
 
+    test('should return FALSE when status code is not 401 (e.g. 500)', () {
+      final result =
+          authorizationInterceptors.validateToRetryTheRequestWithNewToken(
+        responseStatusCode: 500,
+        authHeader: 'Bearer old_token',
+        tokenOIDC: OIDCFixtures.newTokenOidc,
+      );
+
+      expect(result, false);
+    });
+
+    test('should return FALSE when status code is null', () {
+      final result =
+          authorizationInterceptors.validateToRetryTheRequestWithNewToken(
+        responseStatusCode: null,
+        authHeader: 'Bearer old_token',
+        tokenOIDC: OIDCFixtures.newTokenOidc,
+      );
+
+      expect(result, false);
+    });
+
     test('should return FALSE when auth header is null', () {
       final result =
           authorizationInterceptors.validateToRetryTheRequestWithNewToken(
+        responseStatusCode: 401,
         authHeader: null,
         tokenOIDC: OIDCFixtures.newTokenOidc,
       );
@@ -252,6 +276,7 @@ void main() {
       () {
         final result =
             authorizationInterceptors.validateToRetryTheRequestWithNewToken(
+          responseStatusCode: 401,
           authHeader: 'Bearer ${OIDCFixtures.newTokenOidc.token}',
           tokenOIDC: OIDCFixtures.newTokenOidc,
         );
@@ -263,6 +288,7 @@ void main() {
     test('should return FALSE when token is expired', () {
       final result =
           authorizationInterceptors.validateToRetryTheRequestWithNewToken(
+        responseStatusCode: 401,
         authHeader: 'Bearer some_other_token',
         tokenOIDC: OIDCFixtures.tokenOidcExpiredTime,
       );
@@ -273,6 +299,7 @@ void main() {
     test('should return FALSE when token is empty', () {
       final result =
           authorizationInterceptors.validateToRetryTheRequestWithNewToken(
+        responseStatusCode: 401,
         authHeader: 'Bearer some_token',
         tokenOIDC: OIDCFixtures.tokenOidcExpiredTimeAndTokenEmpty,
       );
@@ -283,6 +310,7 @@ void main() {
     test('should return FALSE when tokenOIDC is null', () {
       final result =
           authorizationInterceptors.validateToRetryTheRequestWithNewToken(
+        responseStatusCode: 401,
         authHeader: 'Bearer some_token',
         tokenOIDC: null,
       );

--- a/test/fixtures/oidc_fixtures.dart
+++ b/test/fixtures/oidc_fixtures.dart
@@ -28,6 +28,13 @@ class OIDCFixtures {
     'test456',
     expiredTime: DateTime.now().add(const Duration(days: 1)));
 
+  /// Token that is NOT expired yet - for testing 401 before expiry scenario
+  static final tokenOidcNotExpiredYet = TokenOIDC(
+    'valid_token_123',
+    TokenId('valid_token_123'),
+    'valid_refresh_456',
+    expiredTime: DateTime.now().add(const Duration(hours: 1)));
+
   static final oidcConfiguration = OIDCConfiguration(
     authority: 'https://example.com',
     clientId: 'client-id',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trace-level logs are now reported to Sentry.

* **Bug Fixes**
  * Improved 401 handling with clearer retry-vs-refresh decisions, per-request guards to avoid infinite loops, and immediate session clear on invalid refresh responses.

* **Tests**
  * Expanded coverage for refresh/retry flows, concurrent 401s, and 400 refresh-failure scenarios.

* **Chores**
  * Removed legacy direct OIDC token-refresh API; bumped package version to 0.24.9-rc1.

* **Documentation**
  * Updated ADRs describing the revised refresh/error-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->