### PR TITLE
TF-4314 Fix unread emails disappear blink

### DIFF
--- a/lib/features/thread/data/repository/thread_repository_impl.dart
+++ b/lib/features/thread/data/repository/thread_repository_impl.dart
@@ -188,7 +188,8 @@ class ThreadRepositoryImpl extends ThreadRepository {
       'Server email count = $serverCount',
     );
 
-    if (serverCount > 0) {
+    if (serverCount > 0 ||
+        (serverResponse.notFoundEmailIds?.isNotEmpty ?? false)) {
       await _updateEmailCache(
         accountId,
         session.username,

--- a/lib/features/thread/domain/repository/thread_repository.dart
+++ b/lib/features/thread/domain/repository/thread_repository.dart
@@ -59,6 +59,7 @@ abstract class ThreadRepository {
     jmap.State currentState,
     {
       Set<Comparator>? sort,
+      UnsignedInt? limit,
       EmailFilter? emailFilter,
       Properties? propertiesCreated,
       Properties? propertiesUpdated,

--- a/lib/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor.dart
+++ b/lib/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor.dart
@@ -4,6 +4,7 @@ import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/properties/properties.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/sort/comparator.dart';
+import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/email_filter.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/email_response.dart';
@@ -23,6 +24,7 @@ class RefreshChangesEmailsInMailboxInteractor {
     jmap.State currentState,
     {
       Set<Comparator>? sort,
+      UnsignedInt? limit,
       Properties? propertiesCreated,
       Properties? propertiesUpdated,
       EmailFilter? emailFilter,
@@ -37,6 +39,7 @@ class RefreshChangesEmailsInMailboxInteractor {
           accountId,
           currentState,
           sort: sort,
+          limit: limit,
           propertiesCreated: propertiesCreated,
           propertiesUpdated: propertiesUpdated,
           emailFilter: emailFilter)

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -807,7 +807,7 @@ class ThreadController extends BaseController with EmailActionController {
           filter: getFilterConditionForLoadMailbox(oldestEmail: oldestEmail),
           properties: EmailUtils.getPropertiesForEmailGetMethod(_session!, _accountId!),
           lastEmailId: oldestEmail?.id,
-          useCache: selectedMailbox?.isCacheable ?? false,
+          useCache: (selectedMailbox?.isCacheable ?? false) && !forceEmailQuery,
         )
       ));
     }

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -719,6 +719,7 @@ class ThreadController extends BaseController with EmailActionController {
       _accountId!,
       mailboxDashBoardController.currentEmailState!,
       sort: EmailSortOrderType.mostRecent.getSortOrder().toNullable(),
+      limit: limitEmailFetched,
       propertiesCreated: EmailUtils.getPropertiesForEmailGetMethod(
         _session!,
         _accountId!,
@@ -807,7 +808,7 @@ class ThreadController extends BaseController with EmailActionController {
           filter: getFilterConditionForLoadMailbox(oldestEmail: oldestEmail),
           properties: EmailUtils.getPropertiesForEmailGetMethod(_session!, _accountId!),
           lastEmailId: oldestEmail?.id,
-          useCache: (selectedMailbox?.isCacheable ?? false) && !forceEmailQuery,
+          useCache: selectedMailbox?.isCacheable ?? false,
         )
       ));
     }

--- a/test/features/search/verify_before_time_in_search_email_filter_test.dart
+++ b/test/features/search/verify_before_time_in_search_email_filter_test.dart
@@ -822,6 +822,7 @@ void main() {
         any,
         any,
         sort: anyNamed('sort'),
+        limit: anyNamed('limit'),
         propertiesCreated: anyNamed('propertiesCreated'),
         propertiesUpdated: anyNamed('propertiesUpdated'),
         emailFilter: anyNamed('emailFilter'),
@@ -851,6 +852,7 @@ void main() {
         AccountFixtures.aliceAccountId,
         mailboxDashboardController.currentEmailState!,
         sort: EmailSortOrderType.mostRecent.getSortOrder().toNullable(),
+        limit: threadController.limitEmailFetched,
         propertiesCreated: EmailUtils.getPropertiesForEmailGetMethod(
           SessionFixtures.aliceSession,
           AccountFixtures.aliceAccountId,
@@ -986,6 +988,7 @@ void main() {
         any,
         any,
         sort: anyNamed('sort'),
+        limit: anyNamed('limit'),
         propertiesCreated: anyNamed('propertiesCreated'),
         propertiesUpdated: anyNamed('propertiesUpdated'),
         emailFilter: anyNamed('emailFilter'),
@@ -1015,6 +1018,7 @@ void main() {
         AccountFixtures.aliceAccountId,
         mailboxDashboardController.currentEmailState!,
         sort: EmailSortOrderType.mostRecent.getSortOrder().toNullable(),
+        limit: threadController.limitEmailFetched,
         propertiesCreated: EmailUtils.getPropertiesForEmailGetMethod(
           SessionFixtures.aliceSession,
           AccountFixtures.aliceAccountId,
@@ -1095,6 +1099,7 @@ void main() {
         any,
         any,
         sort: anyNamed('sort'),
+        limit: anyNamed('limit'),
         propertiesCreated: anyNamed('propertiesCreated'),
         propertiesUpdated: anyNamed('propertiesUpdated'),
         emailFilter: anyNamed('emailFilter'),
@@ -1124,6 +1129,7 @@ void main() {
         AccountFixtures.aliceAccountId,
         mailboxDashboardController.currentEmailState!,
         sort: EmailSortOrderType.mostRecent.getSortOrder().toNullable(),
+        limit: threadController.limitEmailFetched,
         propertiesCreated: EmailUtils.getPropertiesForEmailGetMethod(
           SessionFixtures.aliceSession,
           AccountFixtures.aliceAccountId,

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -316,6 +316,7 @@ void main() {
           any, 
           any,
           sort: anyNamed('sort'),
+          limit: anyNamed('limit'),
           propertiesCreated: anyNamed('propertiesCreated'),
           propertiesUpdated: anyNamed('propertiesUpdated'),
           emailFilter: anyNamed('emailFilter'), 


### PR DESCRIPTION
## Issue

#4314

## Reproduce

https://github.com/user-attachments/assets/82b077fa-db6d-4a9c-bbbd-4a30599ce060




## Root cause

Inconsistent caching strategy when `FORCE_EMAIL_QUERY=true`. While the `Open Folder` action bypasses caching, the `Load More` action persists data to the cache. This leads to state inconsistency upon app restart. The app initializes with the latest server state, prompting the WebSocket to push only incremental updates. However, the UI hydrates with stale data from the `Load More` cache, resulting in a discrepancy between the displayed list and the actual server state.

## Solution

- Update email to cache when load mailbox with `FORCE_EMAIL_QUERY=true`
- Add `limit` property for refresh change emails method

## Resolved


https://github.com/user-attachments/assets/12af14c2-0f31-40b4-bf5a-89d5395a3c94



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional per-request limit when fetching emails, allowing refreshes and forced queries to return a capped number of items.

* **Bug Fixes**
  * Prevented local email data from being overwritten by empty server responses during refresh.
  * More consistent paging during email loads and refreshes to honor per-request limits.

* **Tests**
  * Updated tests to cover the new per-request limit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->