### PR TITLE
Fix email list does not automatically refill after bulk delete

### DIFF
--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -594,7 +594,9 @@ class MailboxController extends BaseMailboxController
         await _handleRefreshChangeMailboxSuccess(refreshState);
       } else {
         _clearNewFolderId();
-        onDataFailureViewState(refreshState);
+        if (refreshState != null) {
+          onDataFailureViewState(refreshState);
+        }
       }
     } catch (e, stackTrace) {
       logWarning('MailboxController::_processMailboxStateQueue:Error processing state: $e');

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -203,7 +203,7 @@ class ThreadController extends BaseController with EmailActionController {
     if (failure is SearchEmailFailure) {
       mailboxDashBoardController.updateRefreshAllEmailState(Left(RefreshAllEmailFailure()));
       canSearchMore = false;
-      _resetCurrentEmailList();
+      mailboxDashBoardController.emailsInCurrentMailbox.clear();
       showRetryToast(failure);
     } else if (failure is SearchMoreEmailFailure) {
       loadingMoreStatus.value = LoadingMoreStatus.completed;
@@ -342,7 +342,7 @@ class ThreadController extends BaseController with EmailActionController {
           listEmailController.jumpTo(0);
         }
         canSearchMore = true;
-        _resetCurrentEmailList();
+        mailboxDashBoardController.emailsInCurrentMailbox.clear();
       } else if (action is ReclaimMailListKeyboardShortcutFocusAction) {
         refocusMailShortcutFocus();
         mailboxDashBoardController.clearDashBoardAction();
@@ -411,13 +411,17 @@ class ThreadController extends BaseController with EmailActionController {
     });
 
     ever(mailboxDashBoardController.emailsInCurrentMailbox, (emails) {
+      final countEmails = emails.length;
       log(
         'ThreadController::Ever(mailboxDashBoardController.emailsInCurrentMailbox): '
-        'Count emails is ${emails.length}, '
+        'Count emails is $countEmails, '
         '_peakEmailCount is $_peakEmailCount',
       );
-      if (emails.length > _peakEmailCount) {
+      if (countEmails > _peakEmailCount) {
         _peakEmailCount = emails.length;
+      }
+      if (countEmails <= 0) {
+        _peakEmailCount = 0;
       }
     });
   }
@@ -507,7 +511,7 @@ class ThreadController extends BaseController with EmailActionController {
 
   void resetToOriginalValue() {
     log('ThreadController::resetToOriginalValue');
-    _resetCurrentEmailList();
+    mailboxDashBoardController.emailsInCurrentMailbox.clear();
     mailboxDashBoardController.listEmailSelected.clear();
     mailboxDashBoardController.currentSelectMode.value = SelectMode.INACTIVE;
     canLoadMore = true;
@@ -720,8 +724,7 @@ class ThreadController extends BaseController with EmailActionController {
       mailboxDashBoardController.updateRefreshAllEmailState(
           Left(RefreshAllEmailFailure()));
       canSearchMore = false;
-      _resetCurrentEmailList();
-
+      mailboxDashBoardController.emailsInCurrentMailbox.clear();
       if (searchState != null) {
         onDataFailureViewState(searchState);
       }
@@ -1026,7 +1029,7 @@ class ThreadController extends BaseController with EmailActionController {
         listEmailController.jumpTo(0);
       }
       if (!needRefreshSearchState) {
-        _resetCurrentEmailList();
+        mailboxDashBoardController.emailsInCurrentMailbox.clear();
       }
       canSearchMore = false;
 
@@ -1507,15 +1510,5 @@ class ThreadController extends BaseController with EmailActionController {
     } else  {
       _loadMoreEmails();
     }
-  }
-
-  @visibleForTesting
-  void setOriginalDisplayedEmailsCount(int count) {
-    _peakEmailCount = count;
-  }
-
-  void _resetCurrentEmailList() {
-    mailboxDashBoardController.emailsInCurrentMailbox.clear();
-    _peakEmailCount = 0;
   }
 }

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -417,11 +417,10 @@ class ThreadController extends BaseController with EmailActionController {
         'Count emails is $countEmails, '
         '_peakEmailCount is $_peakEmailCount',
       );
-      if (countEmails > _peakEmailCount) {
-        _peakEmailCount = emails.length;
-      }
-      if (countEmails <= 0) {
+      if (emails.isEmpty) {
         _peakEmailCount = 0;
+      } else if (countEmails > _peakEmailCount) {
+        _peakEmailCount = countEmails;
       }
     });
   }

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -1499,4 +1499,9 @@ class ThreadController extends BaseController with EmailActionController {
       _loadMoreEmails();
     }
   }
+
+  @visibleForTesting
+  void setOriginalDisplayedEmailsCount(int count) {
+    _originalDisplayedEmailsCount = count;
+  }
 }

--- a/test/features/search/verify_before_time_in_search_email_filter_test.dart
+++ b/test/features/search/verify_before_time_in_search_email_filter_test.dart
@@ -1090,6 +1090,7 @@ void main() {
 
       // Act
       mailboxDashboardController.updateEmailList(emailList);
+      threadController.setOriginalDisplayedEmailsCount(emailList.length);
       searchController.synchronizeSearchFilter(searchEmailFilter);
 
       mailboxDashboardController.setCurrentEmailState(State('current-state'));

--- a/test/features/search/verify_before_time_in_search_email_filter_test.dart
+++ b/test/features/search/verify_before_time_in_search_email_filter_test.dart
@@ -1090,7 +1090,7 @@ void main() {
 
       // Act
       mailboxDashboardController.updateEmailList(emailList);
-      threadController.setOriginalDisplayedEmailsCount(emailList.length);
+      mailboxDashboardController.emailsInCurrentMailbox.refresh();
       searchController.synchronizeSearchFilter(searchEmailFilter);
 
       mailboxDashboardController.setCurrentEmailState(State('current-state'));

--- a/test/features/search/verify_before_time_in_search_email_filter_test.dart
+++ b/test/features/search/verify_before_time_in_search_email_filter_test.dart
@@ -406,6 +406,7 @@ void main() {
       mockGetEmailByIdInteractor,
       mockCleanAndGetEmailsInMailboxInteractor,
     );
+    threadController.onInit();
 
     mailboxDashboardController.sessionCurrent = SessionFixtures.aliceSession;
     mailboxDashboardController.filterMessageOption.value = FilterMessageOption.all;
@@ -1090,7 +1091,6 @@ void main() {
 
       // Act
       mailboxDashboardController.updateEmailList(emailList);
-      mailboxDashboardController.emailsInCurrentMailbox.refresh();
       searchController.synchronizeSearchFilter(searchEmailFilter);
 
       mailboxDashboardController.setCurrentEmailState(State('current-state'));

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -327,7 +327,7 @@ void main() {
 
         // Act
         threadController.onInit();
-        threadController.setOriginalDisplayedEmailsCount(emailList.length);
+        mockMailboxDashBoardController.emailsInCurrentMailbox.refresh();
 
         mockMailboxDashBoardController.emailUIAction.value =
             RefreshChangeEmailAction(newState: State('new-state'));

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -491,9 +491,21 @@ void main() {
 
     group('limitEmailFetched::test', () {
       late RxList<PresentationEmail> emailsRxList;
+      late ThreadController limitEmailFetchedController;
 
       setUp(() {
         emailsRxList = RxList<PresentationEmail>();
+
+        limitEmailFetchedController = ThreadController(
+          mockGetEmailsInMailboxInteractor,
+          mockRefreshChangesEmailsInMailboxInteractor,
+          mockLoadMoreEmailsInMailboxInteractor,
+          mockSearchEmailInteractor,
+          mockSearchMoreEmailInteractor,
+          mockGetEmailByIdInteractor,
+          mockCleanAndGetEmailsInMailboxInteractor,
+        );
+
         when(mockMailboxDashBoardController.selectedMailbox).thenReturn(Rxn(null));
         when(mockMailboxDashBoardController.searchController).thenReturn(mockSearchController);
         when(mockMailboxDashBoardController.dashBoardAction).thenReturn(Rxn());
@@ -505,8 +517,7 @@ void main() {
         when(mockMailboxDashBoardController.filterMessageOption).thenReturn(Rx(FilterMessageOption.all));
         when(mockSearchController.searchState).thenReturn(SearchState(SearchStatus.INACTIVE).obs);
 
-        threadController.onInit();
-        emailsRxList.refresh();
+        limitEmailFetchedController.onInit();
       });
 
       List<PresentationEmail> generateEmails(int count, {String prefix = 'email'}) {
@@ -521,7 +532,7 @@ void main() {
         'WHEN no emails loaded',
       () {
         // Assert
-        expect(threadController.limitEmailFetched, ThreadConstants.defaultLimit);
+        expect(limitEmailFetchedController.limitEmailFetched, ThreadConstants.defaultLimit);
       });
 
       test(
@@ -532,7 +543,7 @@ void main() {
         emailsRxList.addAll(generateEmails(40));
 
         // Assert
-        expect(threadController.limitEmailFetched, UnsignedInt(40));
+        expect(limitEmailFetchedController.limitEmailFetched, UnsignedInt(40));
       });
 
       test(
@@ -546,7 +557,7 @@ void main() {
         emailsRxList.removeRange(0, 20);
 
         // Assert - peak should still be 40, not 20
-        expect(threadController.limitEmailFetched, UnsignedInt(40));
+        expect(limitEmailFetchedController.limitEmailFetched, UnsignedInt(40));
       });
 
       test(
@@ -555,13 +566,13 @@ void main() {
       () {
         // Arrange
         emailsRxList.addAll(generateEmails(40));
-        expect(threadController.limitEmailFetched, UnsignedInt(40));
+        expect(limitEmailFetchedController.limitEmailFetched, UnsignedInt(40));
 
         // Act
-        threadController.resetToOriginalValue();
+        limitEmailFetchedController.resetToOriginalValue();
 
         // Assert
-        expect(threadController.limitEmailFetched, ThreadConstants.defaultLimit);
+        expect(limitEmailFetchedController.limitEmailFetched, ThreadConstants.defaultLimit);
       });
 
       test(
@@ -572,13 +583,13 @@ void main() {
         emailsRxList.addAll(generateEmails(20, prefix: 'init'));
         emailsRxList.addAll(generateEmails(20, prefix: 'more1'));
         emailsRxList.addAll(generateEmails(20, prefix: 'more2'));
-        expect(threadController.limitEmailFetched, UnsignedInt(60));
+        expect(limitEmailFetchedController.limitEmailFetched, UnsignedInt(60));
 
         // Act - delete 30 emails
         emailsRxList.removeRange(0, 30);
 
         // Assert - peak was 60
-        expect(threadController.limitEmailFetched, UnsignedInt(60));
+        expect(limitEmailFetchedController.limitEmailFetched, UnsignedInt(60));
       });
 
       test(
@@ -587,14 +598,14 @@ void main() {
       () {
         // Arrange - first mailbox has 40 emails
         emailsRxList.addAll(generateEmails(40));
-        expect(threadController.limitEmailFetched, UnsignedInt(40));
+        expect(limitEmailFetchedController.limitEmailFetched, UnsignedInt(40));
 
         // Act - switch mailbox (reset) then load fewer emails
-        threadController.resetToOriginalValue();
+        limitEmailFetchedController.resetToOriginalValue();
         emailsRxList.addAll(generateEmails(15, prefix: 'new'));
 
         // Assert - peak should be 15, not stale 40
-        expect(threadController.limitEmailFetched, UnsignedInt(15));
+        expect(limitEmailFetchedController.limitEmailFetched, UnsignedInt(15));
       });
     });
   });

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -327,6 +327,7 @@ void main() {
 
         // Act
         threadController.onInit();
+        threadController.setOriginalDisplayedEmailsCount(emailList.length);
 
         mockMailboxDashBoardController.emailUIAction.value =
             RefreshChangeEmailAction(newState: State('new-state'));

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -266,6 +266,24 @@ void main() {
     });
 
     group('_refreshEmailChanges::test', () {
+      late ThreadController refreshChangesController;
+
+      setUp(() {
+        refreshChangesController = ThreadController(
+          mockGetEmailsInMailboxInteractor,
+          mockRefreshChangesEmailsInMailboxInteractor,
+          mockLoadMoreEmailsInMailboxInteractor,
+          mockSearchEmailInteractor,
+          mockSearchMoreEmailInteractor,
+          mockGetEmailByIdInteractor,
+          mockCleanAndGetEmailsInMailboxInteractor,
+        );
+      });
+
+      tearDown(() {
+        refreshChangesController.onClose();
+      });
+
       test(
         'WHEN thread controller in searching\n'
         'AND `MarkAsStarEmailSuccess` is coming\n'
@@ -310,23 +328,23 @@ void main() {
           properties: anyNamed('properties'),
           needRefreshSearchState: anyNamed('needRefreshSearchState'),
         )).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(emailList))));
-        
+
         when(mockRefreshChangesEmailsInMailboxInteractor.execute(
-          any, 
-          any, 
+          any,
+          any,
           any,
           sort: anyNamed('sort'),
           limit: anyNamed('limit'),
           propertiesCreated: anyNamed('propertiesCreated'),
           propertiesUpdated: anyNamed('propertiesUpdated'),
-          emailFilter: anyNamed('emailFilter'), 
+          emailFilter: anyNamed('emailFilter'),
         )).thenAnswer((_) => Stream.value(Right(RefreshChangesAllEmailSuccess(
-          emailList: emailList, 
+          emailList: emailList,
           currentEmailState: State('old-state'))))
         );
 
         // Act
-        threadController.onInit();
+        refreshChangesController.onInit();
         mockMailboxDashBoardController.emailsInCurrentMailbox.refresh();
 
         mockMailboxDashBoardController.emailUIAction.value =
@@ -358,7 +376,7 @@ void main() {
         )).called(1);
         expect(mockMailboxDashBoardController.emailsInCurrentMailbox.isNotEmpty, isTrue);
         expect(mockMailboxDashBoardController.emailsInCurrentMailbox.length, emailList.length);
-        expect(threadController.isListEmailScrollViewJumping, isFalse);
+        expect(refreshChangesController.isListEmailScrollViewJumping, isFalse);
         PlatformInfo.isTestingForWeb = false;
       });
 
@@ -407,7 +425,7 @@ void main() {
         )).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(emailList))));
 
         // Act
-        threadController.onInit();
+        refreshChangesController.onInit();
         mockMailboxDashBoardController.dashBoardAction.value = StartSearchEmailAction();
 
         await untilCalled(mockSearchEmailInteractor.execute(
@@ -440,6 +458,24 @@ void main() {
     });
 
     group('_registerObxStreamListener test:', () {
+      late ThreadController obxListenerController;
+
+      setUp(() {
+        obxListenerController = ThreadController(
+          mockGetEmailsInMailboxInteractor,
+          mockRefreshChangesEmailsInMailboxInteractor,
+          mockLoadMoreEmailsInMailboxInteractor,
+          mockSearchEmailInteractor,
+          mockSearchMoreEmailInteractor,
+          mockGetEmailByIdInteractor,
+          mockCleanAndGetEmailsInMailboxInteractor,
+        );
+      });
+
+      tearDown(() {
+        obxListenerController.onClose();
+      });
+
       test(
         'should call _getEmailsInMailboxInteractor.execute with getLatestChanges is false '
         'when mailboxDashBoardController.selectedMailbox updated',
@@ -460,9 +496,9 @@ void main() {
         when(mockMailboxDashBoardController.currentSelectMode).thenReturn(Rx(SelectMode.INACTIVE));
         when(mockMailboxDashBoardController.filterMessageOption).thenReturn(Rx(FilterMessageOption.all));
         when(mockSearchController.searchState).thenReturn(SearchState(SearchStatus.INACTIVE).obs);
-        
+
         // act
-        threadController.onInit();
+        obxListenerController.onInit();
         mockMailboxDashBoardController.selectedMailbox.value = mailboxAfter;
         await untilCalled(mockGetEmailsInMailboxInteractor.execute(
           any,
@@ -518,6 +554,10 @@ void main() {
         when(mockSearchController.searchState).thenReturn(SearchState(SearchStatus.INACTIVE).obs);
 
         limitEmailFetchedController.onInit();
+      });
+
+      tearDown(() {
+        limitEmailFetchedController.onClose();
       });
 
       List<PresentationEmail> generateEmails(int count, {String prefix = 'email'}) {


### PR DESCRIPTION
## Issue

Currently, when a user deletes multiple emails at once, the list shrinks but does not automatically trigger the pagination to load the next batch of emails. This leaves a large empty space at the bottom of the viewport or results in a very short list.

## Reproduce


https://github.com/user-attachments/assets/ef1f3e96-f7d2-4559-b014-34b00f7c0e05



## Root cause

The `refreshChange` function incorrectly uses the current (reduced) in-memory list length as the fetch limit, causing the function to request fewer items than needed to refill the list.

## Related issue

#4317

## Resolved

https://github.com/user-attachments/assets/100fa4a7-5794-4752-a8b0-873a318cab34






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable email list pagination and load-more behavior by tracking peak displayed counts; fixed loading-more state handling and reduced spurious failure/error views via null-guarding.

* **Refactor**
  * Centralized state-aware logic for fetch limits and unified refresh/search/sync/view-state flows for more consistent UX.

* **Tests**
  * Updated tests and initialization hooks to ensure deterministic load/refresh/search scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->