### PR TITLE
TF-4329 Fix rogue mailbox set request for favorite

### DIFF
--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -891,7 +891,10 @@ class MailboxController extends BaseMailboxController
 
   void goToCreateNewMailboxView(BuildContext context, {PresentationMailbox? parentMailbox}) async {
     if (session != null && accountId != null) {
-      final arguments = MailboxCreatorArguments(allMailboxes, parentMailbox);
+      final arguments = MailboxCreatorArguments(
+        allMailboxes.withoutVirtualMailbox,
+        parentMailbox,
+      );
 
       final result = PlatformInfo.isWeb
         ? await DialogRouter().pushGeneralDialog(routeName: AppRoutes.mailboxCreator, arguments: arguments)

--- a/lib/features/search/mailbox/presentation/search_mailbox_controller.dart
+++ b/lib/features/search/mailbox/presentation/search_mailbox_controller.dart
@@ -15,6 +15,7 @@ import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/email/presentation_email.dart';
+import 'package:model/extensions/list_presentation_mailbox_extension.dart';
 import 'package:model/extensions/presentation_email_extension.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:tmail_ui_user/features/base/base_mailbox_controller.dart';
@@ -824,7 +825,10 @@ class SearchMailboxController extends BaseMailboxController with MailboxActionHa
 
   void goToCreateNewMailboxView(BuildContext context, {PresentationMailbox? parentMailbox}) async {
     if (session != null && accountId != null) {
-      final arguments = MailboxCreatorArguments(allMailboxes, parentMailbox);
+      final arguments = MailboxCreatorArguments(
+        allMailboxes.withoutVirtualMailbox,
+        parentMailbox,
+      );
 
       final result = PlatformInfo.isWeb
         ? await DialogRouter().pushGeneralDialog(routeName: AppRoutes.mailboxCreator, arguments: arguments)

--- a/model/lib/extensions/list_presentation_mailbox_extension.dart
+++ b/model/lib/extensions/list_presentation_mailbox_extension.dart
@@ -1,4 +1,4 @@
-
+import 'package:collection/collection.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/extensions/presentation_mailbox_extension.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
@@ -18,4 +18,7 @@ extension ListPresentationMailboxExtension on List<PresentationMailbox> {
   bool get isAllUnreadMailboxes => every((mailbox) => mailbox.countUnReadEmailsAsString.isNotEmpty);
 
   List<MailboxId> get mailboxIds => map((mailbox) => mailbox.id).toList();
+
+  List<PresentationMailbox> get withoutVirtualMailbox =>
+      whereNot((mailbox) => mailbox.isVirtualFolder).toList();
 }

--- a/model/test/extensions/list_presentation_mailbox_extension_test.dart
+++ b/model/test/extensions/list_presentation_mailbox_extension_test.dart
@@ -1,0 +1,212 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/extensions/list_presentation_mailbox_extension.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+
+void main() {
+  group('ListPresentationMailboxExtension - withoutVirtualMailbox', () {
+    PresentationMailbox createMailbox(
+      String idVal, {
+      Role? role,
+      String? name,
+      String? parentIdVal,
+    }) {
+      return PresentationMailbox(
+        MailboxId(Id(idVal)),
+        role: role,
+        name: name != null ? MailboxName(name) : null,
+        parentId: parentIdVal != null ? MailboxId(Id(parentIdVal)) : null,
+      );
+    }
+
+    late PresentationMailbox inbox;
+    late PresentationMailbox sent;
+    late PresentationMailbox trash;
+    late PresentationMailbox customFolder;
+    late PresentationMailbox favorite;
+    late PresentationMailbox actionRequired;
+    late PresentationMailbox subFolderOfVirtual;
+
+    setUp(() {
+      inbox = createMailbox(
+        'mb_inbox',
+        role: PresentationMailbox.roleInbox,
+        name: 'Inbox',
+      );
+      sent = createMailbox(
+        'mb_sent',
+        role: PresentationMailbox.roleSent,
+        name: 'Sent',
+      );
+      trash = createMailbox(
+        'mb_trash',
+        role: PresentationMailbox.roleTrash,
+        name: 'Trash',
+      );
+      customFolder = createMailbox(
+        'mb_custom',
+        role: null,
+        name: 'User Custom Folder',
+      );
+
+      favorite = createMailbox(
+        'mb_fav',
+        role: PresentationMailbox.roleFavorite,
+        name: 'Starred',
+      );
+      actionRequired = createMailbox(
+        'mb_act',
+        role: PresentationMailbox.roleActionRequired,
+        name: 'Needs Action',
+      );
+
+      subFolderOfVirtual = createMailbox(
+        'mb_sub',
+        parentIdVal: 'mb_fav',
+        role: null,
+        name: 'Sub of Favorite',
+      );
+    });
+
+    test('Should remove "Favorite" (Starred) folder', () {
+      final input = [inbox, favorite, sent];
+      final result = input.withoutVirtualMailbox;
+
+      expect(result.length, 2);
+      expect(result, containsAll([inbox, sent]));
+      expect(result, isNot(contains(favorite)));
+    });
+
+    test('Should remove "Action Required" folder', () {
+      final input = [inbox, actionRequired, sent];
+      final result = input.withoutVirtualMailbox;
+
+      expect(result.length, 2);
+      expect(result, containsAll([inbox, sent]));
+      expect(result, isNot(contains(actionRequired)));
+    });
+
+    test('Should remove BOTH virtual folders if present', () {
+      final input = [inbox, favorite, actionRequired, sent];
+      final result = input.withoutVirtualMailbox;
+
+      expect(result.length, 2);
+      expect(result, containsAll([inbox, sent]));
+    });
+
+    test('Should keep all standard folders (Inbox, Sent, Trash, Custom)', () {
+      final input = [inbox, sent, trash, customFolder];
+      final result = input.withoutVirtualMailbox;
+
+      expect(result.length, 4);
+      expect(result, equals(input));
+    });
+
+    test('Should return empty list if input is empty', () {
+      final List<PresentationMailbox> input = [];
+      final result = input.withoutVirtualMailbox;
+      expect(result, isEmpty);
+    });
+
+    test('Should return empty list if input contains ONLY virtual folders', () {
+      final input = [favorite, actionRequired];
+      final result = input.withoutVirtualMailbox;
+      expect(result, isEmpty);
+    });
+
+    test('Should handle duplicates of virtual folders (remove all instances)',
+        () {
+      final input = [inbox, favorite, favorite, sent];
+      final result = input.withoutVirtualMailbox;
+
+      expect(result.length, 2);
+      expect(result, containsAll([inbox, sent]));
+    });
+
+    test(
+        'Should NOT remove folders with similar role names (e.g., "favorites" vs "favorite")',
+        () {
+      final similarRoleBox = createMailbox('mb_sim', role: Role('favorites'));
+
+      final input = [inbox, similarRoleBox];
+      final result = input.withoutVirtualMailbox;
+
+      expect(result.length, 2);
+      expect(result, contains(similarRoleBox));
+    });
+
+    test(
+        'Should NOT remove folders with different case roles (e.g., "FAVORITE")',
+        () {
+      final upperCaseRoleBox =
+          createMailbox('mb_upper', role: Role('FAVORITE'));
+
+      final input = [inbox, upperCaseRoleBox];
+      final result = input.withoutVirtualMailbox;
+
+      expect(result.length, 2);
+      expect(result, contains(upperCaseRoleBox));
+    });
+
+    test('Should NOT mutate the original list', () {
+      final input = [inbox, favorite, sent];
+      final originalLength = input.length;
+
+      final _ = input.withoutVirtualMailbox;
+
+      expect(input.length, originalLength);
+      expect(input, contains(favorite));
+    });
+
+    test('Should preserve object identity (return same instances)', () {
+      final input = [inbox, sent];
+      final result = input.withoutVirtualMailbox;
+
+      expect(result[0], same(inbox));
+      expect(result[1], same(sent));
+    });
+
+    test('Should preserve the relative order of remaining items', () {
+      final input = [inbox, favorite, customFolder, actionRequired, sent];
+      final result = input.withoutVirtualMailbox;
+
+      expect(result.length, 3);
+      expect(result[0], inbox);
+      expect(result[1], customFolder);
+      expect(result[2], sent);
+    });
+
+    test('Should NOT remove a child folder just because its parent is virtual',
+        () {
+      final input = [favorite, subFolderOfVirtual];
+      final result = input.withoutVirtualMailbox;
+
+      expect(result.length, 1);
+      expect(result.first, subFolderOfVirtual);
+    });
+
+    test('Should handle large lists efficiently', () {
+      final largeList = List.generate(1000, (index) {
+        if (index % 2 == 0) {
+          return createMailbox(
+            'id_$index',
+            role: PresentationMailbox.roleInbox,
+          );
+        } else {
+          return createMailbox(
+            'id_$index',
+            role: PresentationMailbox.roleFavorite,
+          );
+        }
+      });
+
+      final stopwatch = Stopwatch()..start();
+      final result = largeList.withoutVirtualMailbox;
+      stopwatch.stop();
+
+      expect(result.length, 500);
+      expect(stopwatch.elapsedMilliseconds, lessThan(100));
+    });
+  });
+}


### PR DESCRIPTION
## Issue

#4329 

## Reproduce


https://github.com/user-attachments/assets/fb58e6b5-3012-4604-a62d-f97d77d44e92


## Root Cause

The `Starred` folder is currently included in the parent mailbox list within the folder creation modal. Since `Starred` is a virtual folder with the ID `"favorite"` (instead of a standard UUID), selecting it as a parent triggers an `Invalid UUID string: favorite` error. Virtual folders do not possess a valid UUID and cannot support child folders.

## Solution

Filter out the `Starred` folder from the parent folder selection list. As a virtual folder, it does not support nesting, so users should be prevented from selecting it as a parent directory.


## Resolved


https://github.com/user-attachments/assets/e13b7cf6-e292-4c6b-93ba-993100b2de0e




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Virtual mailboxes are now excluded from the mailbox creation interface.

* **Tests**
  * Added comprehensive tests to verify virtual mailbox filtering, order preservation, non-mutation, and performance on large lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->