### PR TITLE
TF-4337 Fix translate properly in french sending failed modal

### DIFF
--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -4096,7 +4096,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "closeAnyway": "messages",
+  "closeAnyway": "Ignorer et fermer",
   "@closeAnyway": {
     "type": "text",
     "placeholders_order": [],


### PR DESCRIPTION
## Issue

#4337 

## Resolved


https://github.com/user-attachments/assets/764277d4-a267-4012-a992-a3b618d90176



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated French language translation for user interface messaging to improve clarity and localization quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->