### PR TITLE
TF-4339 Fix CORS issue on openid-configuration call

### DIFF
--- a/core/lib/data/network/dio_client.dart
+++ b/core/lib/data/network/dio_client.dart
@@ -12,6 +12,9 @@ class DioClient {
 
   Map<String, dynamic> getHeaders() => Map.from(_dio.options.headers);
 
+  Dio _createNewDio() => Dio()
+    ..httpClientAdapter = _dio.httpClientAdapter;
+
   Future<dynamic> get(
     String path, {
     Map<String, dynamic>? queryParameters,
@@ -30,6 +33,25 @@ class DioClient {
         onReceiveProgress: onReceiveProgress)
       .then((value) => value.data)
       .catchError((error) => throw error);
+  }
+
+  Future<dynamic> getWithNewDio(
+    String path, {
+    Map<String, dynamic>? queryParameters,
+    Options? options,
+    CancelToken? cancelToken,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    return await _createNewDio()
+        .get(
+          path,
+          queryParameters: queryParameters,
+          options: options,
+          cancelToken: cancelToken,
+          onReceiveProgress: onReceiveProgress,
+        )
+        .then((value) => value.data)
+        .catchError((error) => throw error);
   }
 
   Future<dynamic> post(

--- a/lib/features/base/reloadable/reloadable_controller.dart
+++ b/lib/features/base/reloadable/reloadable_controller.dart
@@ -136,7 +136,7 @@ abstract class ReloadableController extends BaseController {
   }
 
   bool get _shouldCallUserInfo =>
-      (PlatformInfo.isWeb && AppConfig.isSaasPlatForm) || PlatformInfo.isMobile;
+      !PlatformInfo.isWeb || AppConfig.isSaasPlatForm;
 
   void getSessionAction() {
     consumeState(getSessionInteractor.execute());

--- a/lib/features/base/reloadable/reloadable_controller.dart
+++ b/lib/features/base/reloadable/reloadable_controller.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:core/utils/app_logger.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/capability/capability_identifier.dart';
@@ -23,6 +24,7 @@ import 'package:tmail_ui_user/features/login/domain/usecases/update_account_cach
 import 'package:tmail_ui_user/features/manage_account/presentation/vacation/vacation_interactors_bindings.dart';
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
 import 'package:tmail_ui_user/main/exceptions/remote_exception.dart';
+import 'package:tmail_ui_user/main/utils/app_config.dart';
 
 abstract class ReloadableController extends BaseController {
   final GetSessionInteractor getSessionInteractor = Get.find<GetSessionInteractor>();
@@ -127,9 +129,14 @@ abstract class ReloadableController extends BaseController {
       authorizationInterceptors.setTokenAndAuthorityOidc(newToken: tokenOIDC, newConfig: oidcConfiguration);
       authorizationIsolateInterceptors.setTokenAndAuthorityOidc(newToken: tokenOIDC, newConfig: oidcConfiguration);
 
-      getOidcUserInfo(oidcConfiguration);
+      if (_shouldCallUserInfo) {
+        getOidcUserInfo(oidcConfiguration);
+      }
     }
   }
+
+  bool get _shouldCallUserInfo =>
+      (PlatformInfo.isWeb && AppConfig.isSaasPlatForm) || PlatformInfo.isMobile;
 
   void getSessionAction() {
     consumeState(getSessionInteractor.execute());

--- a/lib/features/login/data/network/oidc_http_client.dart
+++ b/lib/features/login/data/network/oidc_http_client.dart
@@ -77,7 +77,7 @@ class OIDCHttpClient {
   }
 
   Future<OIDCDiscoveryResponse> discoverOIDC(OIDCConfiguration configuration) async {
-    final result = await _dioClient.get(configuration.discoveryUrl);
+    final result = await _dioClient.getWithNewDio(configuration.discoveryUrl);
     log('OIDCHttpClient::discoverOIDC(): RESULT: $result');
     if (result is Map<String, dynamic>) {
       return OIDCDiscoveryResponse.fromJson(result);


### PR DESCRIPTION
## Issue

#4339 

## Solution

- Only call user info when `saas` is enabled
- Use new dio without `Content-type` header


## Resolved

- When `saas` is disabled



https://github.com/user-attachments/assets/b0f41ce5-3478-453b-803a-3c6c41581748


- When `saas` is enabled




https://github.com/user-attachments/assets/3fb03ecb-6ce9-4167-81b0-447438af381e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Platform-aware authentication behavior: user info retrieval now respects web vs. non-web environments.
  * Enhanced HTTP request handling for authentication discovery operations.
  * More reliable authentication flows with improved request management.
  * Better platform-aware configuration for seamless sign-in experiences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->