### PR TITLE
TF-4344 In desktop view, selected language not well update

### DIFF
--- a/lib/features/manage_account/presentation/language_and_region/widgets/change_language_button_widget.dart
+++ b/lib/features/manage_account/presentation/language_and_region/widgets/change_language_button_widget.dart
@@ -113,7 +113,7 @@ class _ChangeLanguageButtonWidgetState extends State<ChangeLanguageButtonWidget>
               },
             ),
             visible: isVisible,
-            child: TMailDropDownWidget(
+            child: Obx(() => TMailDropDownWidget(
               text: _languageAndRegionController
                 .languageSelected
                 .value
@@ -123,7 +123,7 @@ class _ChangeLanguageButtonWidgetState extends State<ChangeLanguageButtonWidget>
                 ? AppColor.lightGrayEBEDF0.withValues(alpha: 0.6)
                 : null,
               onTap: () => _toggleLanguageMenuOverlay(true),
-            )
+            ))
           )
         );
       }


### PR DESCRIPTION
Issue: 

#4344 

### Root cause

The dropdown text is not inside Obx — it's inside a ValueListenableBuilder<bool> that only rebuilds when the 
  menu opens/closes, not when languageSelected changes.

### Reproduce


https://github.com/user-attachments/assets/c1319bfe-b1b8-42d2-a873-3fcfca571277


### Fixed

https://github.com/user-attachments/assets/e0bfe8ac-41a7-4184-9ee8-15cd17dc908a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed language selection dropdown to properly update and reflect changes when language preference is modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->