### PR TITLE
fix(web): Cannot typing text when create new folder on Safari for the first time

### DIFF
--- a/lib/features/mailbox_creator/presentation/mailbox_creator_controller.dart
+++ b/lib/features/mailbox_creator/presentation/mailbox_creator_controller.dart
@@ -1,3 +1,4 @@
+import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
@@ -52,6 +53,9 @@ class MailboxCreatorController extends BaseController
     MailboxCreatorArguments? arguments = Get.arguments;
     if (arguments != null) {
       _buildMailboxTree(arguments);
+    }
+    if (PlatformInfo.isWeb) {
+      nameInputFocusNode.requestFocus();
     }
   }
 

--- a/lib/features/mailbox_creator/presentation/mailbox_creator_controller.dart
+++ b/lib/features/mailbox_creator/presentation/mailbox_creator_controller.dart
@@ -54,6 +54,11 @@ class MailboxCreatorController extends BaseController
     if (arguments != null) {
       _buildMailboxTree(arguments);
     }
+  }
+
+  @override
+  void onReady() {
+    super.onReady();
     if (PlatformInfo.isWeb) {
       nameInputFocusNode.requestFocus();
     }

--- a/lib/features/mailbox_creator/presentation/mailbox_creator_view.dart
+++ b/lib/features/mailbox_creator/presentation/mailbox_creator_view.dart
@@ -256,17 +256,17 @@ class MailboxCreatorView extends GetWidget<MailboxCreatorController> {
         ),
       );
 
-      bodyWidget = Center(child: bodyWidget);
+      bodyWidget = GestureDetector(
+        onTap: controller.nameInputFocusNode.unfocus,
+        child: Center(child: bodyWidget),
+      );
 
       if (PlatformInfo.isMobile) {
         bodyWidget = GestureDetector(
           onTap: controller.closeView,
           child: Scaffold(
             backgroundColor: AppColor.blackAlpha20,
-            body: GestureDetector(
-              onTap: controller.nameInputFocusNode.unfocus,
-              child: bodyWidget,
-            ),
+            body: bodyWidget,
           ),
         );
       }


### PR DESCRIPTION
## Issue 

Cannot typing text when create new folder on Safari in the first time

## Root cause

Safari's strict `DOM` focus policies and stacking context conflicts prevent Flutter's hidden `<input>` element from surfacing and receiving focus over an `HtmlElementView`.

## Resolved


https://github.com/user-attachments/assets/0270429e-d898-4f7c-b169-99de43c9a6dd



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On Web, the mailbox name field now auto-focuses when opening the mailbox creator for faster input.
  * You can dismiss the name input by tapping anywhere outside it (global tap-to-unfocus), giving a more consistent and intuitive experience across devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->