### PR TITLE
fix(web): Sometime cannot typing text when create new rule filter on Safari

### DIFF
--- a/lib/features/rules_filter_creator/presentation/rules_filter_creator_controller.dart
+++ b/lib/features/rules_filter_creator/presentation/rules_filter_creator_controller.dart
@@ -694,4 +694,14 @@ class RulesFilterCreatorController extends BaseMailboxController {
         ForwardActionArguments(forwardEmail: value);
     listEmailRuleFilterActionSelected.refresh();
   }
+
+  void clearAllFocus() {
+    inputRuleNameFocusNode.unfocus();
+    if (listRuleConditionValueArguments.isNotEmpty) {
+      for (var ruleConditionValueArguments in listRuleConditionValueArguments) {
+        ruleConditionValueArguments.focusNode.unfocus();
+      }
+    }
+    FocusManager.instance.primaryFocus?.unfocus();
+  }
 }

--- a/lib/features/rules_filter_creator/presentation/rules_filter_creator_view.dart
+++ b/lib/features/rules_filter_creator/presentation/rules_filter_creator_view.dart
@@ -87,7 +87,12 @@ class RuleFilterCreatorView extends GetWidget<RulesFilterCreatorController> {
         ),
       );
     } else {
-      bodyWidget = Center(child: bodyWidget);
+      bodyWidget = Center(
+        child: GestureDetector(
+          onTap: controller.clearAllFocus,
+          child: bodyWidget,
+        ),
+      );
     }
 
     return bodyWidget;


### PR DESCRIPTION
## Issue 

Sometime cannot typing text when create new rule filter on Safari

## Root cause

Safari's strict `DOM` focus policies and stacking context conflicts prevent Flutter's hidden `<input>` element from surfacing and receiving focus over an `HtmlElementView`.

## Resolved


https://github.com/user-attachments/assets/e5edbc3c-45ab-401f-b67f-ec3f45d2e13c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic focus clearing when tapping outside interactive input areas, improving form usability by allowing users to easily dismiss keyboard input and reset focus states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->