### PR TITLE
TF-4363 [Thread] Display by collapsed thread in search

### DIFF
--- a/docs/adr/0085-riverpod-state-management-for-local-settings.md
+++ b/docs/adr/0085-riverpod-state-management-for-local-settings.md
@@ -17,7 +17,7 @@ As part of implementing the collapsed thread feature in search email (TF-4363), 
 - `ThreadController` — must react when the setting changes to re-trigger search
 - `SearchEmailController` — must read the current value at query time
 
-The setting is written by `PreferencesController` via `UpdateLocalSettingsInteractor` when the user toggles it in `PreferencesView`, and must also be reset on logout to prevent stale cross-account data.
+The setting is written by `PreferencesController` via `UpdateLocalSettingsInteractor` when the user toggles it in `PreferencesView`.
 
 Rather than routing this through a GetX-based `LocalSettingsService` with a reactive `Rx` field and `ever(...)` listeners — which would require manual equality tracking and expose mutable state broadly — we chose to use Riverpod's `StateNotifier` as the single source of truth from the start.
 
@@ -30,17 +30,17 @@ Introduce `localSettingsNotifierProvider` (`StateNotifier<PreferencesSetting>`) 
 ### Architecture
 
 ```text
-┌─────────────────────────────────────────────────────┐
-│  appProviderContainer  (global ProviderContainer)   │
-│                                                     │
-│   localSettingsNotifierProvider                     │
-│   StateNotifier<PreferencesSetting>                 │
-│       ▲ write          ▲ write         read ▼       │
-│       │                │                   │        │
-│  LocalSettings    Preferences         Thread /      │
-│  Service          Controller          Search        │
-│  (initial load)   (on toggle)         Controllers   │
-└─────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────┐
+│  appProviderContainer  (global ProviderContainer)        │
+│                                                          │
+│   localSettingsNotifierProvider                          │
+│   StateNotifier<PreferencesSetting>                      │
+│       ▲ write              ▲ write        read ▼         │
+│       │                    │                  │          │
+│  LocalSettingsService  PreferencesController  Thread /   │
+│  (app start /          (on toggle)            Search     │
+│   route reload)                               Controllers│
+└──────────────────────────────────────────────────────────┘
 ```
 
 ### Write paths
@@ -50,9 +50,6 @@ Introduce `localSettingsNotifierProvider` (`StateNotifier<PreferencesSetting>`) 
 
 **On user toggle in PreferencesView:**
 `PreferencesController.handleSuccessViewState(UpdateLocalSettingsSuccess)` → `localSettingsNotifierProvider.notifier.update()`
-
-**On logout:**
-`BaseController.clearAllData()` → `localSettingsNotifierProvider.notifier.update(PreferencesSetting.initial())`
 
 ### Read paths
 

--- a/docs/adr/0085-riverpod-state-management-for-local-settings.md
+++ b/docs/adr/0085-riverpod-state-management-for-local-settings.md
@@ -1,0 +1,90 @@
+# 85. Riverpod State Management Pilot — Local Settings & Collapsed Thread in Search
+
+Date: 2026-04-23
+
+## Status
+
+Accepted
+
+## Related ADRs
+
+- [ADR-0071](./0071-collapse-threads-in-email-query.md) — collapseThreads in Email/query
+
+## Context
+
+As part of implementing the collapsed thread feature in search email (TF-4363), two controllers need to read the `collapseThreads` local setting:
+
+- `ThreadController` — must react when the setting changes to re-trigger search
+- `SearchEmailController` — must read the current value at query time
+
+The setting is written by `PreferencesController` via `UpdateLocalSettingsInteractor` when the user toggles it in `PreferencesView`, and must also be reset on logout to prevent stale cross-account data.
+
+Rather than routing this through a GetX-based `LocalSettingsService` with a reactive `Rx` field and `ever(...)` listeners — which would require manual equality tracking and expose mutable state broadly — we chose to use Riverpod's `StateNotifier` as the single source of truth from the start.
+
+This is also a **pilot** to validate the GetX + Riverpod coexistence pattern before applying it more broadly across the codebase.
+
+## Decision
+
+Introduce `localSettingsNotifierProvider` (`StateNotifier<PreferencesSetting>`) backed by a global `ProviderContainer` (`appProviderContainer`). All reads and writes go through this provider directly.
+
+### Architecture
+
+```text
+┌─────────────────────────────────────────────────────┐
+│  appProviderContainer  (global ProviderContainer)   │
+│                                                     │
+│   localSettingsNotifierProvider                     │
+│   StateNotifier<PreferencesSetting>                 │
+│       ▲ write          ▲ write         read ▼       │
+│       │                │                   │        │
+│  LocalSettings    Preferences         Thread /      │
+│  Service          Controller          Search        │
+│  (initial load)   (on toggle)         Controllers   │
+└─────────────────────────────────────────────────────┘
+```
+
+### Write paths
+
+**On app start / settings route reload:**
+`LocalSettingsService.onInit()` → `_loadInitialSettings()` → cache read → `localSettingsNotifierProvider.notifier.update()`
+
+**On user toggle in PreferencesView:**
+`PreferencesController.handleSuccessViewState(UpdateLocalSettingsSuccess)` → `localSettingsNotifierProvider.notifier.update()`
+
+**On logout:**
+`BaseController.clearAllData()` → `localSettingsNotifierProvider.notifier.update(PreferencesSetting.initial())`
+
+### Read paths
+
+**`ThreadController`** — subscribes via `appProviderContainer.listen(localSettingsNotifierProvider, ...)`. Riverpod skips notification when `PreferencesSetting` equality is unchanged (`EquatableMixin`), so no manual dedup is needed.
+
+**`SearchEmailController`** — reads on demand via `appProviderContainer.read(localSettingsNotifierProvider)`.
+
+### `LocalSettingsService` role
+
+`LocalSettingsService` is a `GetxService` acting as a **temporary bridge** between the GetX DI graph and Riverpod. It remains a `GetxService` because all DI wiring in the project uses GetX bindings — introducing a plain class would be inconsistent with the existing layer. Its sole responsibility is loading the initial value from cache into the provider on startup via `onInit`.
+
+It will be removed entirely once `ManageAccountRepository` and its datasources are migrated to Riverpod providers, at which point `LocalSettingsNotifier` can inject and call `GetLocalSettingsInteractor` directly.
+
+### Settings route reload on web
+
+When the user reloads the browser directly on the settings route, `MailboxDashBoardBindings` does not run. `ManageAccountDashBoardBindings` guards against this:
+
+```dart
+if (!Get.isRegistered<LocalSettingsService>()) {
+  Get.put(LocalSettingsService(Get.find<GetLocalSettingsInteractor>()));
+}
+```
+
+## Consequences
+
+**Positive**
+- No redundant cache round-trip — provider is updated directly from `UpdateLocalSettingsSuccess` result
+- No manual equality tracking needed — Riverpod + `EquatableMixin` handles it
+- Single write surface for `PreferencesSetting`; no mutable `Rx` exposed across the codebase
+- Validates the GetX + Riverpod coexistence pattern for future migrations
+
+**Negative**
+- `appProviderContainer` is a global singleton — controllers depend directly on a concrete implementation rather than an abstraction, which is a known DIP violation. The correct solution is to wrap it behind an interface (e.g. `LocalSettingsRepository`), but doing so now would add complexity before the pattern is proven at scale. This should be addressed when the migration reaches the repository layer.
+- Two DI systems (GetX + Riverpod) coexist during the migration period; developers must know which layer owns which state
+- `LocalSettingsService` is a temporary class that must be removed when the migration reaches the repository layer

--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -62,9 +62,6 @@ import 'package:tmail_ui_user/main/exceptions/remote/method_level_exception.dart
 import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/app_routes.dart';
-import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/providers/local_settings_notifier.dart';
-import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:tmail_ui_user/main/utils/app_config.dart';
 import 'package:tmail_ui_user/main/universal_import/html_stub.dart' as html;
@@ -604,11 +601,6 @@ abstract class BaseController extends GetxController
       logWarning('BaseController::clearAllData: Cannot clear all data: $e');
     } finally {
       AttachmentKeywordConfigManager().clearCache();
-      // Reset local settings to the default value so that stale account data
-      // is not visible if another account logs in before the next reload completes.
-      appProviderContainer
-          .read(localSettingsNotifierProvider.notifier)
-          .update(PreferencesSetting.initial());
     }
   }
 

--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -62,6 +62,9 @@ import 'package:tmail_ui_user/main/exceptions/remote/method_level_exception.dart
 import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/app_routes.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/providers/local_settings_notifier.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:tmail_ui_user/main/utils/app_config.dart';
 import 'package:tmail_ui_user/main/universal_import/html_stub.dart' as html;
@@ -601,6 +604,11 @@ abstract class BaseController extends GetxController
       logWarning('BaseController::clearAllData: Cannot clear all data: $e');
     } finally {
       AttachmentKeywordConfigManager().clearCache();
+      // Reset local settings to the default value so that stale account data
+      // is not visible if another account logs in before the next reload completes.
+      appProviderContainer
+          .read(localSettingsNotifierProvider.notifier)
+          .update(PreferencesSetting.initial());
     }
   }
 

--- a/lib/features/mailbox_dashboard/domain/usecases/quick_search_email_interactor.dart
+++ b/lib/features/mailbox_dashboard/domain/usecases/quick_search_email_interactor.dart
@@ -24,6 +24,7 @@ class QuickSearchEmailInteractor {
       UnsignedInt? limit,
       Set<Comparator>? sort,
       Filter? filter,
+      bool? collapseThreads,
       Properties? properties,
     }
   ) async {
@@ -34,6 +35,7 @@ class QuickSearchEmailInteractor {
         limit: limit,
         sort: sort,
         filter: filter,
+        collapseThreads: collapseThreads,
         properties: properties);
 
       final presentationEmailList = emailList

--- a/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
@@ -123,7 +123,9 @@ import 'package:tmail_ui_user/features/manage_account/domain/repository/identity
 import 'package:tmail_ui_user/features/manage_account/domain/repository/manage_account_repository.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_ai_scribe_config_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_all_identities_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_local_settings_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/bindings/setting_interactor_bindings.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_service.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/identities/identity_interactors_bindings.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/identities/utils/identity_utils.dart';
 import 'package:tmail_ui_user/features/offline_mode/manager/new_email_cache_manager.dart';
@@ -174,6 +176,10 @@ class MailboxDashBoardBindings extends BaseBindings {
   void dependencies() {
     CleanupBindings().dependencies();
     super.dependencies();
+    Get.put(LocalSettingsService(
+      Get.find<GetLocalSettingsInteractor>(),
+      Get.find<MailboxDashBoardController>().threadDetailUIAction,
+    ));
     SendingQueueBindings().dependencies();
     MailboxBindings().dependencies();
     ThreadBindings().dependencies();

--- a/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
@@ -178,7 +178,6 @@ class MailboxDashBoardBindings extends BaseBindings {
     super.dependencies();
     Get.put(LocalSettingsService(
       Get.find<GetLocalSettingsInteractor>(),
-      Get.find<MailboxDashBoardController>().threadDetailUIAction,
     ));
     SendingQueueBindings().dependencies();
     MailboxBindings().dependencies();

--- a/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
@@ -176,9 +176,6 @@ class MailboxDashBoardBindings extends BaseBindings {
   void dependencies() {
     CleanupBindings().dependencies();
     super.dependencies();
-    Get.put(LocalSettingsService(
-      Get.find<GetLocalSettingsInteractor>(),
-    ));
     SendingQueueBindings().dependencies();
     MailboxBindings().dependencies();
     ThreadBindings().dependencies();
@@ -190,6 +187,10 @@ class MailboxDashBoardBindings extends BaseBindings {
 
   @override
   void bindingsController() {
+    // Must be registered first so [localSettingsNotifierProvider] is populated
+    // before any controller reads local settings.
+    Get.put(LocalSettingsService(Get.find<GetLocalSettingsInteractor>()));
+
     Get.put(AppGridDashboardController(
       Get.find<GetAppDashboardConfigurationInteractor>(),
       Get.find<GetAppGridLinagraEcosystemInteractor>(),

--- a/lib/features/mailbox_dashboard/presentation/extensions/notify_thread_detail_setting_updated.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/notify_thread_detail_setting_updated.dart
@@ -1,11 +1,8 @@
-import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_service.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/action/thread_detail_ui_action.dart';
 
 extension NotifyThreadDetailSettingUpdated on MailboxDashBoardController {
-  Future<void> notifyThreadDetailSettingUpdated() async {
-    await Get.find<LocalSettingsService>().reload();
+  void notifyThreadDetailSettingUpdated() {
     dispatchThreadDetailUIAction(UpdatedThreadDetailSettingAction());
   }
 }

--- a/lib/features/mailbox_dashboard/presentation/extensions/notify_thread_detail_setting_updated.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/notify_thread_detail_setting_updated.dart
@@ -1,8 +1,13 @@
+import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_service.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/action/thread_detail_ui_action.dart';
 
 extension NotifyThreadDetailSettingUpdated on MailboxDashBoardController {
   void notifyThreadDetailSettingUpdated() {
+    if (Get.isRegistered<LocalSettingsService>()) {
+      Get.find<LocalSettingsService>().refresh();
+    }
     dispatchThreadDetailUIAction(UpdatedThreadDetailSettingAction());
   }
 }

--- a/lib/features/mailbox_dashboard/presentation/extensions/notify_thread_detail_setting_updated.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/notify_thread_detail_setting_updated.dart
@@ -4,9 +4,9 @@ import 'package:tmail_ui_user/features/manage_account/presentation/services/loca
 import 'package:tmail_ui_user/features/thread_detail/presentation/action/thread_detail_ui_action.dart';
 
 extension NotifyThreadDetailSettingUpdated on MailboxDashBoardController {
-  void notifyThreadDetailSettingUpdated() {
+  Future<void> notifyThreadDetailSettingUpdated() async {
     if (Get.isRegistered<LocalSettingsService>()) {
-      Get.find<LocalSettingsService>().refresh();
+      await Get.find<LocalSettingsService>().refresh();
     }
     dispatchThreadDetailUIAction(UpdatedThreadDetailSettingAction());
   }

--- a/lib/features/mailbox_dashboard/presentation/extensions/notify_thread_detail_setting_updated.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/notify_thread_detail_setting_updated.dart
@@ -5,9 +5,7 @@ import 'package:tmail_ui_user/features/thread_detail/presentation/action/thread_
 
 extension NotifyThreadDetailSettingUpdated on MailboxDashBoardController {
   Future<void> notifyThreadDetailSettingUpdated() async {
-    if (Get.isRegistered<LocalSettingsService>()) {
-      await Get.find<LocalSettingsService>().reload();
-    }
+    await Get.find<LocalSettingsService>().reload();
     dispatchThreadDetailUIAction(UpdatedThreadDetailSettingAction());
   }
 }

--- a/lib/features/mailbox_dashboard/presentation/extensions/notify_thread_detail_setting_updated.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/notify_thread_detail_setting_updated.dart
@@ -6,7 +6,7 @@ import 'package:tmail_ui_user/features/thread_detail/presentation/action/thread_
 extension NotifyThreadDetailSettingUpdated on MailboxDashBoardController {
   Future<void> notifyThreadDetailSettingUpdated() async {
     if (Get.isRegistered<LocalSettingsService>()) {
-      await Get.find<LocalSettingsService>().refresh();
+      await Get.find<LocalSettingsService>().reload();
     }
     dispatchThreadDetailUIAction(UpdatedThreadDetailSettingAction());
   }

--- a/lib/features/manage_account/presentation/bindings/setting_interactor_bindings.dart
+++ b/lib/features/manage_account/presentation/bindings/setting_interactor_bindings.dart
@@ -7,6 +7,7 @@ import 'package:tmail_ui_user/features/manage_account/data/local/preferences_set
 import 'package:tmail_ui_user/features/manage_account/data/repository/manage_account_repository_impl.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/repository/manage_account_repository.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_label_setting_state_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_local_settings_interactor.dart';
 import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.dart';
 
 class SettingInteractorBindings extends InteractorsBindings {
@@ -32,6 +33,9 @@ class SettingInteractorBindings extends InteractorsBindings {
   void bindingsInteractor() {
     Get.lazyPut(
       () => GetLabelSettingStateInteractor(Get.find<ManageAccountRepository>()),
+    );
+    Get.lazyPut(
+      () => GetLocalSettingsInteractor(Get.find<ManageAccountRepository>()),
     );
   }
 

--- a/lib/features/manage_account/presentation/manage_account_dashboard_bindings.dart
+++ b/lib/features/manage_account/presentation/manage_account_dashboard_bindings.dart
@@ -1,9 +1,11 @@
 import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_local_settings_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/bindings/setting_interactor_bindings.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/identities/identity_bindings.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/manage_account_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/menu/manage_account_menu_bindings.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/menu/settings/settings_bindings.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_service.dart';
 import 'package:tmail_ui_user/features/paywall/presentation/paywall_bindings.dart';
 
 class ManageAccountDashBoardBindings extends Bindings {
@@ -12,6 +14,12 @@ class ManageAccountDashBoardBindings extends Bindings {
   void dependencies() {
     SettingInteractorBindings().dependencies();
     PaywallBindings().dependencies();
+    // Ensure [LocalSettingsService] is available when the user navigates
+    // directly to the settings route (e.g. web page reload), bypassing
+    // [MailboxDashBoardBindings] which also registers it during a normal session.
+    if (!Get.isRegistered<LocalSettingsService>()) {
+      Get.put(LocalSettingsService(Get.find<GetLocalSettingsInteractor>()));
+    }
     Get.put(ManageAccountDashBoardController());
     SettingsBindings().dependencies();
     ManageAccountMenuBindings().dependencies();

--- a/lib/features/manage_account/presentation/preferences/preferences_controller.dart
+++ b/lib/features/manage_account/presentation/preferences/preferences_controller.dart
@@ -18,6 +18,8 @@ import 'package:tmail_ui_user/features/manage_account/domain/state/update_local_
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_local_settings_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/update_local_settings_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/manage_account_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/providers/local_settings_notifier.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/preferences_option_type.dart';
 import 'package:tmail_ui_user/features/server_settings/domain/state/get_server_setting_state.dart';
 import 'package:tmail_ui_user/features/server_settings/domain/state/update_server_setting_state.dart';
@@ -85,6 +87,9 @@ class PreferencesController extends BaseController {
       _updateLocalSettingOptionValue(success.preferencesSetting);
     } else if (success is UpdateLocalSettingsSuccess) {
       _updateLocalSettingOptionValue(success.preferencesSetting);
+      appProviderContainer
+          .read(localSettingsNotifierProvider.notifier)
+          .update(success.preferencesSetting);
     } else if (success is GettingLocalSettingsState) {
       _localSettingLoaderStatus = LoaderStatus.loading;
     } else {

--- a/lib/features/manage_account/presentation/providers/local_settings_notifier.dart
+++ b/lib/features/manage_account/presentation/providers/local_settings_notifier.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
+
+class LocalSettingsNotifier extends StateNotifier<PreferencesSetting> {
+  LocalSettingsNotifier() : super(PreferencesSetting.initial());
+
+  void update(PreferencesSetting settings) {
+    state = settings;
+  }
+}
+
+final localSettingsNotifierProvider =
+    StateNotifierProvider<LocalSettingsNotifier, PreferencesSetting>(
+  (ref) => LocalSettingsNotifier(),
+);

--- a/lib/features/manage_account/presentation/services/local_settings_service.dart
+++ b/lib/features/manage_account/presentation/services/local_settings_service.dart
@@ -17,10 +17,10 @@ class LocalSettingsService extends GetxService {
     _loadLocalSettings();
   }
 
-  void refresh() => _loadLocalSettings();
+  Future<void> refresh() => _loadLocalSettings();
 
-  void _loadLocalSettings() {
-    _getLocalSettingsInteractor.execute().last.then(
+  Future<void> _loadLocalSettings() {
+    return _getLocalSettingsInteractor.execute().last.then(
       (result) => result.fold(
         (failure) => logWarning(
           'LocalSettingsService::_loadLocalSettings:failure: $failure',
@@ -31,6 +31,10 @@ class LocalSettingsService extends GetxService {
           }
         },
       ),
-    );
+    ).catchError((error, stackTrace) {
+      logWarning(
+        'LocalSettingsService::_loadLocalSettings:error: $error | stackTrace: $stackTrace',
+      );
+    });
   }
 }

--- a/lib/features/manage_account/presentation/services/local_settings_service.dart
+++ b/lib/features/manage_account/presentation/services/local_settings_service.dart
@@ -1,0 +1,59 @@
+import 'package:core/utils/app_logger.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/state/get_local_settings_state.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_local_settings_interactor.dart';
+import 'package:tmail_ui_user/features/thread_detail/presentation/action/thread_detail_ui_action.dart';
+
+class LocalSettingsService extends GetxService {
+  final GetLocalSettingsInteractor _getLocalSettingsInteractor;
+  final Rxn<ThreadDetailUIAction> _threadDetailUIAction;
+
+  LocalSettingsService(
+    this._getLocalSettingsInteractor,
+    this._threadDetailUIAction,
+  );
+
+  final localSettings = PreferencesSetting.initial().obs;
+
+  Worker? _settingsWorker;
+
+  @override
+  void onInit() {
+    super.onInit();
+    _listenToSettingsChanges();
+    _loadLocalSettings();
+  }
+
+  @override
+  void onClose() {
+    _settingsWorker?.dispose();
+    super.onClose();
+  }
+
+  void _listenToSettingsChanges() {
+    _settingsWorker = ever(
+      _threadDetailUIAction,
+      (action) {
+        if (action is UpdatedThreadDetailSettingAction) {
+          _loadLocalSettings();
+        }
+      },
+    );
+  }
+
+  void _loadLocalSettings() {
+    _getLocalSettingsInteractor.execute().last.then(
+      (result) => result.fold(
+        (failure) => logWarning(
+          'LocalSettingsService::_loadLocalSettings:failure: $failure',
+        ),
+        (success) {
+          if (success is GetLocalSettingsSuccess) {
+            localSettings.value = success.preferencesSetting;
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/manage_account/presentation/services/local_settings_service.dart
+++ b/lib/features/manage_account/presentation/services/local_settings_service.dart
@@ -1,42 +1,41 @@
 import 'package:core/utils/app_logger.dart';
 import 'package:get/get.dart';
-import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/state/get_local_settings_state.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_local_settings_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/providers/local_settings_notifier.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 
+/// Responsible for loading local settings from cache on startup and pushing
+/// the result into [localSettingsNotifierProvider] so all Riverpod consumers
+/// receive the initial value automatically.
 class LocalSettingsService extends GetxService {
   final GetLocalSettingsInteractor _getLocalSettingsInteractor;
 
   LocalSettingsService(this._getLocalSettingsInteractor);
 
-  final localSettings = PreferencesSetting.initial().obs;
-
-  Future<void>? _pendingLoad;
-
   @override
   void onInit() {
     super.onInit();
-    reload();
+    _loadInitialSettings();
   }
 
-  Future<void> reload() => _pendingLoad ??= _loadLocalSettings()
-      .whenComplete(() => _pendingLoad = null);
-
-  Future<void> _loadLocalSettings() {
+  Future<void> _loadInitialSettings() {
     return _getLocalSettingsInteractor.execute().last.then(
       (result) => result.fold(
         (failure) => logWarning(
-          'LocalSettingsService::_loadLocalSettings:failure: $failure',
+          'LocalSettingsService::_loadInitialSettings:failure: $failure',
         ),
         (success) {
           if (success is GetLocalSettingsSuccess) {
-            localSettings.value = success.preferencesSetting;
+            appProviderContainer
+                .read(localSettingsNotifierProvider.notifier)
+                .update(success.preferencesSetting);
           }
         },
       ),
     ).catchError((error, stackTrace) {
       logWarning(
-        'LocalSettingsService::_loadLocalSettings:error: $error | stackTrace: $stackTrace',
+        'LocalSettingsService::_loadInitialSettings:error: $error | stackTrace: $stackTrace',
       );
     });
   }

--- a/lib/features/manage_account/presentation/services/local_settings_service.dart
+++ b/lib/features/manage_account/presentation/services/local_settings_service.dart
@@ -11,13 +11,16 @@ class LocalSettingsService extends GetxService {
 
   final localSettings = PreferencesSetting.initial().obs;
 
+  Future<void>? _pendingLoad;
+
   @override
   void onInit() {
     super.onInit();
-    _loadLocalSettings();
+    reload();
   }
 
-  Future<void> refresh() => _loadLocalSettings();
+  Future<void> reload() => _pendingLoad ??= _loadLocalSettings()
+      .whenComplete(() => _pendingLoad = null);
 
   Future<void> _loadLocalSettings() {
     return _getLocalSettingsInteractor.execute().last.then(

--- a/lib/features/manage_account/presentation/services/local_settings_service.dart
+++ b/lib/features/manage_account/presentation/services/local_settings_service.dart
@@ -3,44 +3,21 @@ import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/state/get_local_settings_state.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_local_settings_interactor.dart';
-import 'package:tmail_ui_user/features/thread_detail/presentation/action/thread_detail_ui_action.dart';
 
 class LocalSettingsService extends GetxService {
   final GetLocalSettingsInteractor _getLocalSettingsInteractor;
-  final Rxn<ThreadDetailUIAction> _threadDetailUIAction;
 
-  LocalSettingsService(
-    this._getLocalSettingsInteractor,
-    this._threadDetailUIAction,
-  );
+  LocalSettingsService(this._getLocalSettingsInteractor);
 
   final localSettings = PreferencesSetting.initial().obs;
-
-  Worker? _settingsWorker;
 
   @override
   void onInit() {
     super.onInit();
-    _listenToSettingsChanges();
     _loadLocalSettings();
   }
 
-  @override
-  void onClose() {
-    _settingsWorker?.dispose();
-    super.onClose();
-  }
-
-  void _listenToSettingsChanges() {
-    _settingsWorker = ever(
-      _threadDetailUIAction,
-      (action) {
-        if (action is UpdatedThreadDetailSettingAction) {
-          _loadLocalSettings();
-        }
-      },
-    );
-  }
+  void refresh() => _loadLocalSettings();
 
   void _loadLocalSettings() {
     _getLocalSettingsInteractor.execute().last.then(

--- a/lib/features/search/email/domain/usecases/refresh_changes_search_email_interactor.dart
+++ b/lib/features/search/email/domain/usecases/refresh_changes_search_email_interactor.dart
@@ -26,6 +26,7 @@ class RefreshChangesSearchEmailInteractor {
       int? position,
       Set<Comparator>? sort,
       Filter? filter,
+      bool? collapseThreads,
       Properties? properties,
     }
   ) async* {
@@ -39,6 +40,7 @@ class RefreshChangesSearchEmailInteractor {
         position: position,
         sort: sort,
         filter: filter,
+        collapseThreads: collapseThreads,
         properties: properties);
 
       final presentationEmailList = emailList

--- a/lib/features/search/email/presentation/search_email_controller.dart
+++ b/lib/features/search/email/presentation/search_email_controller.dart
@@ -53,6 +53,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/quick_s
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/save_recent_search_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/action/dashboard_action.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_store_email_sort_order_extension.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_service.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/update_emails_with_new_mailbox_id_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
@@ -160,6 +161,13 @@ class SearchEmailController extends BaseController
   Set<String> get listAddressOfFromFiltered => searchEmailFilter.value.from;
 
   Set<String> get listHasKeywordFiltered => searchEmailFilter.value.hasKeyword;
+
+  late final LocalSettingsService _localSettingsService = Get.find<LocalSettingsService>();
+
+  bool get _isCollapseThreadsEnabled {
+    if (!Get.isRegistered<LocalSettingsService>()) return false;
+    return _localSettingsService.localSettings.value.threadConfig.isEnabled;
+  }
 
   SearchEmailController(
       this._quickSearchEmailInteractor,
@@ -373,6 +381,7 @@ class SearchEmailController extends BaseController
           trashSpamMailboxIds: mailboxDashBoardController.trashSpamMailboxIds,
         ),
         properties: EmailUtils.getPropertiesForEmailGetMethod(session!, accountId!),
+        collapseThreads: _isCollapseThreadsEnabled,
       ).last;
 
       final searchState = searchViewState
@@ -446,7 +455,9 @@ class SearchEmailController extends BaseController
           filter: searchEmailFilter.value.mappingToEmailFilterCondition(
             trashSpamMailboxIds: mailboxDashBoardController.trashSpamMailboxIds,
           ),
-          properties: EmailUtils.getPropertiesForEmailGetMethod(session, accountId))
+          properties: EmailUtils.getPropertiesForEmailGetMethod(session, accountId),
+          collapseThreads: _isCollapseThreadsEnabled,
+        )
         .then((result) => result.fold(
             (failure) => <PresentationEmail>[],
             (success) => success is QuickSearchEmailSuccess
@@ -515,6 +526,7 @@ class SearchEmailController extends BaseController
         trashSpamMailboxIds: mailboxDashBoardController.trashSpamMailboxIds,
       ),
       properties: EmailUtils.getPropertiesForEmailGetMethod(session!, accountId!),
+      collapseThreads: _isCollapseThreadsEnabled,
     ));
   }
 
@@ -575,6 +587,7 @@ class SearchEmailController extends BaseController
           trashSpamMailboxIds: mailboxDashBoardController.trashSpamMailboxIds,
         ),
         properties: EmailUtils.getPropertiesForEmailGetMethod(session!, accountId!),
+        collapseThreads: _isCollapseThreadsEnabled,
         lastEmailId: lastEmail.id
       ));
     }

--- a/lib/features/search/email/presentation/search_email_controller.dart
+++ b/lib/features/search/email/presentation/search_email_controller.dart
@@ -164,10 +164,8 @@ class SearchEmailController extends BaseController
 
   late final LocalSettingsService _localSettingsService = Get.find<LocalSettingsService>();
 
-  bool get _isCollapseThreadsEnabled {
-    if (!Get.isRegistered<LocalSettingsService>()) return false;
-    return _localSettingsService.localSettings.value.threadConfig.isEnabled;
-  }
+  bool get _isCollapseThreadsEnabled =>
+      _localSettingsService.localSettings.value.threadConfig.isEnabled;
 
   SearchEmailController(
       this._quickSearchEmailInteractor,

--- a/lib/features/search/email/presentation/search_email_controller.dart
+++ b/lib/features/search/email/presentation/search_email_controller.dart
@@ -53,7 +53,8 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/quick_s
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/save_recent_search_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/action/dashboard_action.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_store_email_sort_order_extension.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_service.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/providers/local_settings_notifier.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/update_emails_with_new_mailbox_id_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
@@ -162,10 +163,8 @@ class SearchEmailController extends BaseController
 
   Set<String> get listHasKeywordFiltered => searchEmailFilter.value.hasKeyword;
 
-  late final LocalSettingsService _localSettingsService = Get.find<LocalSettingsService>();
-
   bool get _isCollapseThreadsEnabled =>
-      _localSettingsService.localSettings.value.threadConfig.isEnabled;
+      appProviderContainer.read(localSettingsNotifierProvider).threadConfig.isEnabled;
 
   SearchEmailController(
       this._quickSearchEmailInteractor,

--- a/lib/features/thread/data/datasource/thread_datasource.dart
+++ b/lib/features/thread/data/datasource/thread_datasource.dart
@@ -40,6 +40,7 @@ abstract class ThreadDataSource {
       int? position,
       Set<Comparator>? sort,
       Filter? filter,
+      bool? collapseThreads,
       Properties? properties
     }
   );

--- a/lib/features/thread/data/datasource_impl/local_thread_datasource_impl.dart
+++ b/lib/features/thread/data/datasource_impl/local_thread_datasource_impl.dart
@@ -59,6 +59,7 @@ class LocalThreadDataSourceImpl extends ThreadDataSource {
       int? position,
       Set<Comparator>? sort,
       Filter? filter,
+      bool? collapseThreads,
       Properties? properties
     }
   ) {

--- a/lib/features/thread/data/datasource_impl/thread_datasource_impl.dart
+++ b/lib/features/thread/data/datasource_impl/thread_datasource_impl.dart
@@ -69,6 +69,7 @@ class ThreadDataSourceImpl extends ThreadDataSource {
       int? position,
       Set<Comparator>? sort,
       Filter? filter,
+      bool? collapseThreads,
       Properties? properties,
     }
   ) {
@@ -80,6 +81,7 @@ class ThreadDataSourceImpl extends ThreadDataSource {
         position: position,
         sort: sort,
         filter: filter,
+        collapseThreads: collapseThreads,
         properties: properties);
     }).catchError(_exceptionThrower.throwException);
   }

--- a/lib/features/thread/data/extensions/query_email_method_extension.dart
+++ b/lib/features/thread/data/extensions/query_email_method_extension.dart
@@ -21,8 +21,8 @@ extension QueryEmailMethodExtension on QueryEmailMethod {
   }
 
   void addCollapseThreadsIfAvailable(bool? collapseThreads) {
-    if (collapseThreads != null && collapseThreads) {
-      addCollapseThreads(collapseThreads);
+    if (collapseThreads == true) {
+      addCollapseThreads(true);
     }
   }
 }

--- a/lib/features/thread/data/extensions/query_email_method_extension.dart
+++ b/lib/features/thread/data/extensions/query_email_method_extension.dart
@@ -1,0 +1,28 @@
+import 'package:jmap_dart_client/jmap/core/filter/filter.dart';
+import 'package:jmap_dart_client/jmap/core/sort/comparator.dart';
+import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
+import 'package:jmap_dart_client/jmap/mail/email/query/query_email_method.dart';
+
+extension QueryEmailMethodExtension on QueryEmailMethod {
+  void addLimitIfNotNull(UnsignedInt? limit) {
+    if (limit != null) addLimit(limit);
+  }
+
+  void addPositionIfValid(int? position) {
+    if (position != null && position > 0) addPosition(position);
+  }
+
+  void addSortsIfNotNull(Set<Comparator>? sort) {
+    if (sort != null) addSorts(sort);
+  }
+
+  void addFiltersIfNotNull(Filter? filter) {
+    if (filter != null) addFilters(filter);
+  }
+
+  void addCollapseThreadsIfValid(bool? collapseThreads) {
+    if (collapseThreads != null && collapseThreads) {
+      addCollapseThreads(collapseThreads);
+    }
+  }
+}

--- a/lib/features/thread/data/extensions/query_email_method_extension.dart
+++ b/lib/features/thread/data/extensions/query_email_method_extension.dart
@@ -8,7 +8,7 @@ extension QueryEmailMethodExtension on QueryEmailMethod {
     if (limit != null) addLimit(limit);
   }
 
-  void addPositionIfValid(int? position) {
+  void addPositionIfAvailable(int? position) {
     if (position != null && position > 0) addPosition(position);
   }
 
@@ -20,7 +20,7 @@ extension QueryEmailMethodExtension on QueryEmailMethod {
     if (filter != null) addFilters(filter);
   }
 
-  void addCollapseThreadsIfValid(bool? collapseThreads) {
+  void addCollapseThreadsIfAvailable(bool? collapseThreads) {
     if (collapseThreads != null && collapseThreads) {
       addCollapseThreads(collapseThreads);
     }

--- a/lib/features/thread/data/network/thread_api.dart
+++ b/lib/features/thread/data/network/thread_api.dart
@@ -28,6 +28,7 @@ import 'package:jmap_dart_client/jmap/mail/email/search_snippet/search_snippet_g
 import 'package:jmap_dart_client/jmap/mail/email/search_snippet/search_snippet_get_response.dart';
 import 'package:tmail_ui_user/features/base/mixin/session_mixin.dart';
 import 'package:tmail_ui_user/features/thread/data/extensions/list_email_id_extension.dart';
+import 'package:tmail_ui_user/features/thread/data/extensions/query_email_method_extension.dart';
 import 'package:tmail_ui_user/features/thread/data/model/email_change_response.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/email_response.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/search_emails_response.dart';
@@ -70,6 +71,7 @@ class ThreadAPI with HandleSetErrorMixin, SessionMixin, MailAPIMixin {
       int? position,
       Set<Comparator>? sort,
       Filter? filter,
+      bool? collapseThreads,
       Properties? properties
     }
   ) async {
@@ -78,15 +80,12 @@ class ThreadAPI with HandleSetErrorMixin, SessionMixin, MailAPIMixin {
     final jmapRequestBuilder = JmapRequestBuilder(httpClient, processingInvocation);
 
     // Email/query
-    final queryEmailMethod = QueryEmailMethod(accountId);
-
-    if (limit != null) queryEmailMethod.addLimit(limit);
-
-    if (position != null && position > 0) queryEmailMethod.addPosition(position);
-
-    if (sort != null) queryEmailMethod.addSorts(sort);
-
-    if (filter != null) queryEmailMethod.addFilters(filter);
+    final queryEmailMethod = QueryEmailMethod(accountId)
+      ..addLimitIfNotNull(limit)
+      ..addPositionIfValid(position)
+      ..addSortsIfNotNull(sort)
+      ..addFiltersIfNotNull(filter)
+      ..addCollapseThreadsIfValid(collapseThreads);
 
     final queryEmailInvocation = jmapRequestBuilder.invocation(queryEmailMethod);
 

--- a/lib/features/thread/data/network/thread_api.dart
+++ b/lib/features/thread/data/network/thread_api.dart
@@ -82,10 +82,10 @@ class ThreadAPI with HandleSetErrorMixin, SessionMixin, MailAPIMixin {
     // Email/query
     final queryEmailMethod = QueryEmailMethod(accountId)
       ..addLimitIfNotNull(limit)
-      ..addPositionIfValid(position)
+      ..addPositionIfAvailable(position)
       ..addSortsIfNotNull(sort)
       ..addFiltersIfNotNull(filter)
-      ..addCollapseThreadsIfValid(collapseThreads);
+      ..addCollapseThreadsIfAvailable(collapseThreads);
 
     final queryEmailInvocation = jmapRequestBuilder.invocation(queryEmailMethod);
 

--- a/lib/features/thread/data/repository/thread_repository_impl.dart
+++ b/lib/features/thread/data/repository/thread_repository_impl.dart
@@ -474,6 +474,7 @@ class ThreadRepositoryImpl extends ThreadRepository {
       int? position,
       Set<Comparator>? sort,
       Filter? filter,
+      bool? collapseThreads,
       Properties? properties
     }
   ) async {
@@ -484,6 +485,7 @@ class ThreadRepositoryImpl extends ThreadRepository {
       position: position,
       sort: sort,
       filter: filter,
+      collapseThreads: collapseThreads,
       properties: properties);
 
     return searchEmailsResponse.toSearchEmails ?? [];

--- a/lib/features/thread/domain/repository/thread_repository.dart
+++ b/lib/features/thread/domain/repository/thread_repository.dart
@@ -76,6 +76,7 @@ abstract class ThreadRepository {
       int? position,
       Set<Comparator>? sort,
       Filter? filter,
+      bool? collapseThreads,
       Properties? properties,
     }
   );

--- a/lib/features/thread/domain/usecases/search_email_interactor.dart
+++ b/lib/features/thread/domain/usecases/search_email_interactor.dart
@@ -27,6 +27,7 @@ class SearchEmailInteractor {
       Set<Comparator>? sort,
       Filter? filter,
       Properties? properties,
+      bool? collapseThreads,
       bool needRefreshSearchState = false,
     }
   ) async* {
@@ -44,6 +45,7 @@ class SearchEmailInteractor {
         position: position,
         sort: sort,
         filter: filter,
+        collapseThreads: collapseThreads,
         properties: properties);
 
       final presentationEmailList = emailList
@@ -65,6 +67,7 @@ class SearchEmailInteractor {
           position: position,
           sort: sort,
           properties: properties,
+          collapseThreads: collapseThreads,
           needRefreshSearchState: true,
         ),
       ));

--- a/lib/features/thread/domain/usecases/search_more_email_interactor.dart
+++ b/lib/features/thread/domain/usecases/search_more_email_interactor.dart
@@ -27,6 +27,7 @@ class SearchMoreEmailInteractor {
       int? position,
       Filter? filter,
       Properties? properties,
+      bool? collapseThreads,
       EmailId? lastEmailId
     }
   ) async* {
@@ -40,6 +41,7 @@ class SearchMoreEmailInteractor {
         position: position,
         sort: sort,
         filter: filter,
+        collapseThreads: collapseThreads,
         properties: properties);
 
       final presentationEmailList = emailList

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -114,6 +114,7 @@ class ThreadController extends BaseController with EmailActionController {
   StreamSubscription<MailListShortcutActionViewEvent>? shortcutActionEventSubscription;
 
   StreamSubscription<html.Event>? _resizeBrowserStreamSubscription;
+  Worker? _localSettingsWorker;
 
   AccountId? get _accountId => mailboxDashBoardController.accountId.value;
 
@@ -172,6 +173,7 @@ class ThreadController extends BaseController with EmailActionController {
       onKeyboardShortcutDispose();
     }
     _webSocketQueueHandler?.dispose();
+    _localSettingsWorker?.dispose();
     super.onClose();
   }
 
@@ -439,7 +441,7 @@ class ThreadController extends BaseController with EmailActionController {
 
   void _registerLocalSettingsListener() {
     if (!Get.isRegistered<LocalSettingsService>()) return;
-    ever(_localSettingsService.localSettings, (_) {
+    _localSettingsWorker = ever(_localSettingsService.localSettings, (_) {
       if (searchController.isSearchEmailRunning) {
         _refreshChangeSearchEmail();
       }

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -132,7 +132,7 @@ class ThreadController extends BaseController with EmailActionController {
   late final LocalSettingsService _localSettingsService = Get.find<LocalSettingsService>();
 
   bool get _isCollapseThreadsEnabled {
-    if (!forceEmailQuery || !Get.isRegistered<LocalSettingsService>()) return false;
+    if (!forceEmailQuery) return false;
     return _localSettingsService.localSettings.value.threadConfig.isEnabled;
   }
 
@@ -441,7 +441,7 @@ class ThreadController extends BaseController with EmailActionController {
   }
 
   void _registerLocalSettingsListener() {
-    if (!forceEmailQuery || !Get.isRegistered<LocalSettingsService>()) return;
+    if (!forceEmailQuery) return;
     _lastCollapseThreadsEnabled = _isCollapseThreadsEnabled;
     _localSettingsWorker = ever(_localSettingsService.localSettings, (_) {
       final collapseThreadsEnabled = _isCollapseThreadsEnabled;

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -41,6 +41,7 @@ import 'package:tmail_ui_user/features/push_notification/presentation/websocket/
 import 'package:tmail_ui_user/features/push_notification/presentation/websocket/web_socket_queue_handler.dart';
 import 'package:tmail_ui_user/features/labels/presentation/delegates/add_list_label_to_list_emails_delegate.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_service.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_bindings.dart';
 import 'package:tmail_ui_user/features/thread/domain/constants/thread_constants.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
@@ -125,6 +126,13 @@ class ThreadController extends BaseController with EmailActionController {
   search.SearchController get searchController => mailboxDashBoardController.searchController;
 
   SearchEmailFilter get _searchEmailFilter => searchController.searchEmailFilter.value;
+
+  late final LocalSettingsService _localSettingsService = Get.find<LocalSettingsService>();
+
+  bool get _isCollapseThreadsEnabled {
+    if (!Get.isRegistered<LocalSettingsService>()) return false;
+    return _localSettingsService.localSettings.value.threadConfig.isEnabled;
+  }
 
   SearchQuery? get searchQuery => _searchEmailFilter.text;
 
@@ -423,6 +431,17 @@ class ThreadController extends BaseController with EmailActionController {
         _peakEmailCount = 0;
       } else if (countEmails > _peakEmailCount) {
         _peakEmailCount = countEmails;
+      }
+    });
+
+    _registerLocalSettingsListener();
+  }
+
+  void _registerLocalSettingsListener() {
+    if (!Get.isRegistered<LocalSettingsService>()) return;
+    ever(_localSettingsService.localSettings, (_) {
+      if (searchController.isSearchEmailRunning) {
+        _refreshChangeSearchEmail();
       }
     });
   }
@@ -782,6 +801,7 @@ class ThreadController extends BaseController with EmailActionController {
         _session!,
         _accountId!,
       ),
+      collapseThreads: _isCollapseThreadsEnabled,
       needRefreshSearchState: true,
     ).last;
 
@@ -1152,6 +1172,7 @@ class ThreadController extends BaseController with EmailActionController {
           trashSpamMailboxIds: mailboxDashBoardController.trashSpamMailboxIds,
         ),
         properties: EmailUtils.getPropertiesForEmailGetMethod(_session!, _accountId!),
+        collapseThreads: _isCollapseThreadsEnabled,
         needRefreshSearchState: needRefreshSearchState
       ));
     } else {
@@ -1239,6 +1260,7 @@ class ThreadController extends BaseController with EmailActionController {
           trashSpamMailboxIds: mailboxDashBoardController.trashSpamMailboxIds,
         ),
         properties: EmailUtils.getPropertiesForEmailGetMethod(_session!, _accountId!),
+        collapseThreads: _isCollapseThreadsEnabled,
         lastEmailId: lastEmail?.id
       ));
     } else {

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -41,7 +41,10 @@ import 'package:tmail_ui_user/features/push_notification/presentation/websocket/
 import 'package:tmail_ui_user/features/push_notification/presentation/websocket/web_socket_queue_handler.dart';
 import 'package:tmail_ui_user/features/labels/presentation/delegates/add_list_label_to_list_emails_delegate.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_service.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/providers/local_settings_notifier.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_bindings.dart';
 import 'package:tmail_ui_user/features/thread/domain/constants/thread_constants.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
@@ -114,8 +117,7 @@ class ThreadController extends BaseController with EmailActionController {
   StreamSubscription<MailListShortcutActionViewEvent>? shortcutActionEventSubscription;
 
   StreamSubscription<html.Event>? _resizeBrowserStreamSubscription;
-  Worker? _localSettingsWorker;
-  bool _lastCollapseThreadsEnabled = false;
+  ProviderSubscription<PreferencesSetting>? _localSettingsSubscription;
 
   AccountId? get _accountId => mailboxDashBoardController.accountId.value;
 
@@ -129,11 +131,8 @@ class ThreadController extends BaseController with EmailActionController {
 
   SearchEmailFilter get _searchEmailFilter => searchController.searchEmailFilter.value;
 
-  late final LocalSettingsService _localSettingsService = Get.find<LocalSettingsService>();
-
-  bool get _isCollapseThreadsEnabled {
-    return _localSettingsService.localSettings.value.threadConfig.isEnabled;
-  }
+  bool get _isCollapseThreadsEnabled =>
+      appProviderContainer.read(localSettingsNotifierProvider).threadConfig.isEnabled;
 
   SearchQuery? get searchQuery => _searchEmailFilter.text;
 
@@ -173,7 +172,7 @@ class ThreadController extends BaseController with EmailActionController {
       onKeyboardShortcutDispose();
     }
     _webSocketQueueHandler?.dispose();
-    _localSettingsWorker?.dispose();
+    _localSettingsSubscription?.close();
     super.onClose();
   }
 
@@ -440,15 +439,17 @@ class ThreadController extends BaseController with EmailActionController {
   }
 
   void _registerLocalSettingsListener() {
-    _lastCollapseThreadsEnabled = _isCollapseThreadsEnabled;
-    _localSettingsWorker = ever(_localSettingsService.localSettings, (_) {
-      final collapseThreadsEnabled = _isCollapseThreadsEnabled;
-      if (_lastCollapseThreadsEnabled == collapseThreadsEnabled) return;
-      _lastCollapseThreadsEnabled = collapseThreadsEnabled;
-      if (searchController.isSearchEmailRunning) {
-        _searchEmail(limit: limitEmailFetched);
-      }
-    });
+    if (_localSettingsSubscription != null) return;
+    _localSettingsSubscription = appProviderContainer.listen(
+      localSettingsNotifierProvider,
+      (previous, next) {
+        if (previous?.threadConfig == next.threadConfig) return;
+        if (searchController.isSearchEmailRunning) {
+          _searchEmail(limit: limitEmailFetched);
+        }
+      },
+      fireImmediately: false,
+    );
   }
 
   void _handleMarkEmailsAsReadByMailboxId(MailboxId mailboxId) {

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -442,6 +442,7 @@ class ThreadController extends BaseController with EmailActionController {
 
   void _registerLocalSettingsListener() {
     if (!Get.isRegistered<LocalSettingsService>()) return;
+    _lastCollapseThreadsEnabled = _isCollapseThreadsEnabled;
     _localSettingsWorker = ever(_localSettingsService.localSettings, (_) {
       final collapseThreadsEnabled = _isCollapseThreadsEnabled;
       if (_lastCollapseThreadsEnabled == collapseThreadsEnabled) return;

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -441,7 +441,7 @@ class ThreadController extends BaseController with EmailActionController {
   }
 
   void _registerLocalSettingsListener() {
-    if (!Get.isRegistered<LocalSettingsService>()) return;
+    if (!forceEmailQuery || !Get.isRegistered<LocalSettingsService>()) return;
     _lastCollapseThreadsEnabled = _isCollapseThreadsEnabled;
     _localSettingsWorker = ever(_localSettingsService.localSettings, (_) {
       final collapseThreadsEnabled = _isCollapseThreadsEnabled;

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -115,6 +115,7 @@ class ThreadController extends BaseController with EmailActionController {
 
   StreamSubscription<html.Event>? _resizeBrowserStreamSubscription;
   Worker? _localSettingsWorker;
+  bool _lastCollapseThreadsEnabled = false;
 
   AccountId? get _accountId => mailboxDashBoardController.accountId.value;
 
@@ -131,7 +132,7 @@ class ThreadController extends BaseController with EmailActionController {
   late final LocalSettingsService _localSettingsService = Get.find<LocalSettingsService>();
 
   bool get _isCollapseThreadsEnabled {
-    if (!Get.isRegistered<LocalSettingsService>()) return false;
+    if (!forceEmailQuery || !Get.isRegistered<LocalSettingsService>()) return false;
     return _localSettingsService.localSettings.value.threadConfig.isEnabled;
   }
 
@@ -442,8 +443,11 @@ class ThreadController extends BaseController with EmailActionController {
   void _registerLocalSettingsListener() {
     if (!Get.isRegistered<LocalSettingsService>()) return;
     _localSettingsWorker = ever(_localSettingsService.localSettings, (_) {
+      final collapseThreadsEnabled = _isCollapseThreadsEnabled;
+      if (_lastCollapseThreadsEnabled == collapseThreadsEnabled) return;
+      _lastCollapseThreadsEnabled = collapseThreadsEnabled;
       if (searchController.isSearchEmailRunning) {
-        _refreshChangeSearchEmail();
+        _searchEmail(limit: limitEmailFetched);
       }
     });
   }
@@ -553,8 +557,14 @@ class ThreadController extends BaseController with EmailActionController {
     handleLoadMoreEmailsRequest();
   }
 
-  bool get forceEmailQuery =>
-      PlatformInfo.isWeb && AppConfig.isForceEmailQueryEnabled;
+  bool get forceEmailQuery {
+    if (!PlatformInfo.isWeb) return false;
+    try {
+      return AppConfig.isForceEmailQueryEnabled;
+    } catch (_) {
+      return false;
+    }
+  }
 
   void _handleErrorGetAllOrRefreshChangesEmail(Object error, StackTrace stackTrace) async {
     logWarning('ThreadController::_handleErrorGetAllOrRefreshChangesEmail():Error: $error');

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -132,7 +132,6 @@ class ThreadController extends BaseController with EmailActionController {
   late final LocalSettingsService _localSettingsService = Get.find<LocalSettingsService>();
 
   bool get _isCollapseThreadsEnabled {
-    if (!forceEmailQuery) return false;
     return _localSettingsService.localSettings.value.threadConfig.isEnabled;
   }
 
@@ -441,7 +440,6 @@ class ThreadController extends BaseController with EmailActionController {
   }
 
   void _registerLocalSettingsListener() {
-    if (!forceEmailQuery) return;
     _lastCollapseThreadsEnabled = _isCollapseThreadsEnabled;
     _localSettingsWorker = ever(_localSettingsService.localSettings, (_) {
       final collapseThreadsEnabled = _isCollapseThreadsEnabled;

--- a/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
+++ b/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
@@ -18,6 +18,8 @@ extension ThreadDetailOnSelectedEmailUpdated on ThreadDetailController {
     PresentationEmail? selectedEmail,
     BuildContext? context,
   ) {
+    if (!mailboxDashBoardController.isEmailOpened) return;
+
     if (selectedEmail?.id == null) {
       closeThreadDetailAction();
       return;

--- a/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
+++ b/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
@@ -18,12 +18,12 @@ extension ThreadDetailOnSelectedEmailUpdated on ThreadDetailController {
     PresentationEmail? selectedEmail,
     BuildContext? context,
   ) {
+    if (!mailboxDashBoardController.isEmailOpened) return;
+
     if (selectedEmail?.id == null) {
       closeThreadDetailAction();
       return;
     }
-
-    if (!mailboxDashBoardController.isEmailOpened) return;
 
     emailIdsPresentation.clear();
     onKeyboardShortcutInit();

--- a/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
+++ b/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
@@ -18,9 +18,7 @@ extension ThreadDetailOnSelectedEmailUpdated on ThreadDetailController {
     PresentationEmail? selectedEmail,
     BuildContext? context,
   ) {
-    if (!mailboxDashBoardController.isEmailOpened) return;
-
-    if (selectedEmail?.id == null) {
+    if (selectedEmail?.id == null && mailboxDashBoardController.isEmailOpened) {
       closeThreadDetailAction();
       return;
     }

--- a/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
+++ b/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
@@ -18,12 +18,12 @@ extension ThreadDetailOnSelectedEmailUpdated on ThreadDetailController {
     PresentationEmail? selectedEmail,
     BuildContext? context,
   ) {
-    if (!mailboxDashBoardController.isEmailOpened) return;
-
     if (selectedEmail?.id == null) {
       closeThreadDetailAction();
       return;
     }
+
+    if (!mailboxDashBoardController.isEmailOpened) return;
 
     emailIdsPresentation.clear();
     onKeyboardShortcutInit();

--- a/lib/main/providers/app_provider_container.dart
+++ b/lib/main/providers/app_provider_container.dart
@@ -1,0 +1,5 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Singleton [ProviderContainer] shared between the [ProviderScope] and
+/// non-widget code (e.g. GetX controllers / services).
+final appProviderContainer = ProviderContainer();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1026,6 +1026,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.3"
+  flutter_riverpod:
+    dependency: "direct main"
+    description:
+      name: flutter_riverpod
+      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -2016,6 +2024,14 @@ packages:
       url: "https://github.com/linagora/rich-text-composer.git"
     source: git
     version: "0.1.1"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   rule_filter:
     dependency: "direct main"
     description:
@@ -2211,6 +2227,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.1"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -272,6 +272,8 @@ dependencies:
 
   sentry_dio: 9.8.0
 
+  flutter_riverpod: ^2.6.1
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/features/mailbox_dashboard/domain/usecases/quick_search_email_interactor_test.dart
+++ b/test/features/mailbox_dashboard/domain/usecases/quick_search_email_interactor_test.dart
@@ -38,6 +38,7 @@ void main() {
           limit: anyNamed('limit'),
           sort: anyNamed('sort'),
           filter: anyNamed('filter'),
+          collapseThreads: anyNamed('collapseThreads'),
           properties: anyNamed('properties'),
         ),
       ).thenAnswer((_) async => [searchEmail]);
@@ -72,6 +73,7 @@ void main() {
           limit: anyNamed('limit'),
           sort: anyNamed('sort'),
           filter: anyNamed('filter'),
+          collapseThreads: anyNamed('collapseThreads'),
           properties: anyNamed('properties'),
         ),
       ).thenThrow(exception);

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -573,6 +573,7 @@ void main() {
       position: anyNamed('position'),
       sort: anyNamed('sort'),
       filter: anyNamed('filter'),
+      collapseThreads: anyNamed('collapseThreads'),
       properties: anyNamed('properties')));
 
     // assert

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -80,8 +80,10 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/sear
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_all_identities_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_service.dart';
 import 'package:tmail_ui_user/features/network_connection/presentation/network_connection_controller.dart'
     if (dart.library.html) 'package:tmail_ui_user/features/network_connection/presentation/web_network_connection_controller.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/usecases/delete_sending_email_interactor.dart';
@@ -201,6 +203,7 @@ const fallbackGenerators = {
   MockSpec<GetAuthenticationInfoInteractor>(),
   MockSpec<GetStoredOidcConfigurationInteractor>(),
   MockSpec<GetTokenOIDCInteractor>(),
+  MockSpec<LocalSettingsService>(fallbackGenerators: fallbackGenerators),
 ])
 void main() {
   // mock mailbox dashboard controller direct dependencies
@@ -308,6 +311,7 @@ void main() {
   final searchEmailInteractor = MockSearchEmailInteractor();
   final searchMoreEmailInteractor = MockSearchMoreEmailInteractor();
   late ThreadController threadController;
+  late MockLocalSettingsService mockLocalSettingsService;
 
   late AdvancedFilterController advancedFilterController;
 
@@ -362,6 +366,10 @@ void main() {
       saveRecentSearchInteractor,
       getAllRecentSearchLatestInteractor);
     Get.put(searchController);
+
+    mockLocalSettingsService = MockLocalSettingsService();
+    when(mockLocalSettingsService.localSettings).thenReturn(PreferencesSetting.initial().obs);
+    Get.put<LocalSettingsService>(mockLocalSettingsService);
 
     Get.testMode = true;
 

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -80,10 +80,8 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/sear
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
-import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_all_identities_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_service.dart';
 import 'package:tmail_ui_user/features/network_connection/presentation/network_connection_controller.dart'
     if (dart.library.html) 'package:tmail_ui_user/features/network_connection/presentation/web_network_connection_controller.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/usecases/delete_sending_email_interactor.dart';
@@ -203,7 +201,6 @@ const fallbackGenerators = {
   MockSpec<GetAuthenticationInfoInteractor>(),
   MockSpec<GetStoredOidcConfigurationInteractor>(),
   MockSpec<GetTokenOIDCInteractor>(),
-  MockSpec<LocalSettingsService>(fallbackGenerators: fallbackGenerators),
 ])
 void main() {
   // mock mailbox dashboard controller direct dependencies
@@ -311,7 +308,6 @@ void main() {
   final searchEmailInteractor = MockSearchEmailInteractor();
   final searchMoreEmailInteractor = MockSearchMoreEmailInteractor();
   late ThreadController threadController;
-  late MockLocalSettingsService mockLocalSettingsService;
 
   late AdvancedFilterController advancedFilterController;
 
@@ -366,10 +362,6 @@ void main() {
       saveRecentSearchInteractor,
       getAllRecentSearchLatestInteractor);
     Get.put(searchController);
-
-    mockLocalSettingsService = MockLocalSettingsService();
-    when(mockLocalSettingsService.localSettings).thenReturn(PreferencesSetting.initial().obs);
-    Get.put<LocalSettingsService>(mockLocalSettingsService);
 
     Get.testMode = true;
 

--- a/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
+++ b/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
@@ -83,10 +83,8 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/spam_report_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
-import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_all_identities_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_service.dart';
 import 'package:tmail_ui_user/features/network_connection/presentation/network_connection_controller.dart'
  if (dart.library.html) 'package:tmail_ui_user/features/network_connection/presentation/web_network_connection_controller.dart';
 import 'package:tmail_ui_user/features/quotas/domain/use_case/get_quotas_interactor.dart';
@@ -215,7 +213,6 @@ const fallbackGenerators = {
   MockSpec<GetAuthenticationInfoInteractor>(),
   MockSpec<GetStoredOidcConfigurationInteractor>(),
   MockSpec<GetTokenOIDCInteractor>(),
-  MockSpec<LocalSettingsService>(fallbackGenerators: fallbackGenerators),
 ])
 void main() {
   final moveToMailboxInteractor = MockMoveToMailboxInteractor();
@@ -311,7 +308,6 @@ void main() {
   late MailboxController mailboxController;
   late ThreadController threadController;
   late QuotasController quotasController;
-  late MockLocalSettingsService mockLocalSettingsService;
 
   Widget makeTestableWidget({required Widget child}) {
     return GetMaterialApp(
@@ -372,10 +368,6 @@ void main() {
       when(downloadController.downloadUIAction).thenAnswer((_) => Rxn(DownloadUIAction.idle));
       final isLabelSettingEnabled = RxBool(false);
       when(labelController.isLabelSettingEnabled).thenReturn(isLabelSettingEnabled);
-
-      mockLocalSettingsService = MockLocalSettingsService();
-      when(mockLocalSettingsService.localSettings).thenReturn(PreferencesSetting.initial().obs);
-      Get.put<LocalSettingsService>(mockLocalSettingsService);
 
       searchController = SearchController(
         quickSearchEmailInteractor,

--- a/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
+++ b/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
@@ -83,8 +83,10 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/spam_report_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_all_identities_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_service.dart';
 import 'package:tmail_ui_user/features/network_connection/presentation/network_connection_controller.dart'
  if (dart.library.html) 'package:tmail_ui_user/features/network_connection/presentation/web_network_connection_controller.dart';
 import 'package:tmail_ui_user/features/quotas/domain/use_case/get_quotas_interactor.dart';
@@ -213,6 +215,7 @@ const fallbackGenerators = {
   MockSpec<GetAuthenticationInfoInteractor>(),
   MockSpec<GetStoredOidcConfigurationInteractor>(),
   MockSpec<GetTokenOIDCInteractor>(),
+  MockSpec<LocalSettingsService>(fallbackGenerators: fallbackGenerators),
 ])
 void main() {
   final moveToMailboxInteractor = MockMoveToMailboxInteractor();
@@ -308,6 +311,7 @@ void main() {
   late MailboxController mailboxController;
   late ThreadController threadController;
   late QuotasController quotasController;
+  late MockLocalSettingsService mockLocalSettingsService;
 
   Widget makeTestableWidget({required Widget child}) {
     return GetMaterialApp(
@@ -368,6 +372,10 @@ void main() {
       when(downloadController.downloadUIAction).thenAnswer((_) => Rxn(DownloadUIAction.idle));
       final isLabelSettingEnabled = RxBool(false);
       when(labelController.isLabelSettingEnabled).thenReturn(isLabelSettingEnabled);
+
+      mockLocalSettingsService = MockLocalSettingsService();
+      when(mockLocalSettingsService.localSettings).thenReturn(PreferencesSetting.initial().obs);
+      Get.put<LocalSettingsService>(mockLocalSettingsService);
 
       searchController = SearchController(
         quickSearchEmailInteractor,

--- a/test/features/search/email/domain/usecases/refresh_changes_search_email_interactor_test.dart
+++ b/test/features/search/email/domain/usecases/refresh_changes_search_email_interactor_test.dart
@@ -36,6 +36,7 @@ void main() {
           limit: anyNamed('limit'),
           sort: anyNamed('sort'),
           filter: anyNamed('filter'),
+          collapseThreads: anyNamed('collapseThreads'),
           properties: anyNamed('properties'),
         ),
       ).thenAnswer((_) async => [searchEmail]);
@@ -73,6 +74,7 @@ void main() {
             limit: anyNamed('limit'),
             sort: anyNamed('sort'),
             filter: anyNamed('filter'),
+            collapseThreads: anyNamed('collapseThreads'),
             properties: anyNamed('properties'),
           ),
         ).thenThrow(exception);

--- a/test/features/search/email/domain/usecases/refresh_changes_search_email_interactor_test.dart
+++ b/test/features/search/email/domain/usecases/refresh_changes_search_email_interactor_test.dart
@@ -16,39 +16,53 @@ import 'refresh_changes_search_email_interactor_test.mocks.dart';
 @GenerateNiceMocks([MockSpec<ThreadRepository>()])
 void main() {
   final threadRepository = MockThreadRepository();
-  final refreshChangesSearchEmailInteractor = RefreshChangesSearchEmailInteractor(
-    threadRepository);
+  final interactor = RefreshChangesSearchEmailInteractor(threadRepository);
 
-  group('refresh changes search email interactor test:', () {
-    test(
-      'should return list of presentation emails '
-      'when threadRepository.searchEmails returns list of emails',
+  group('refresh changes search email interactor test:',
+    () => _refreshChangesSearchEmailTests(threadRepository, interactor));
+}
+
+void _stubSearchEmails(
+  MockThreadRepository repo, {
+  List<SearchEmail>? returns,
+  Object? throws,
+}) {
+  final stub = when(repo.searchEmails(
+    any,
+    any,
+    limit: anyNamed('limit'),
+    sort: anyNamed('sort'),
+    filter: anyNamed('filter'),
+    collapseThreads: anyNamed('collapseThreads'),
+    properties: anyNamed('properties'),
+  ));
+  if (throws != null) {
+    stub.thenThrow(throws);
+  } else {
+    stub.thenAnswer((_) async => returns ?? []);
+  }
+}
+
+void _refreshChangesSearchEmailTests(
+  MockThreadRepository threadRepository,
+  RefreshChangesSearchEmailInteractor interactor,
+) {
+  test(
+    'should return list of presentation emails '
+    'when threadRepository.searchEmails returns list of emails',
     () {
-      // arrange
       final searchEmail = SearchEmail(
         searchSnippetSubject: 'searchSnippetSubject',
         searchSnippetPreview: 'searchSnippetPreview',
       );
-      when(
-        threadRepository.searchEmails(
-          any,
-          any,
-          limit: anyNamed('limit'),
-          sort: anyNamed('sort'),
-          filter: anyNamed('filter'),
-          collapseThreads: anyNamed('collapseThreads'),
-          properties: anyNamed('properties'),
-        ),
-      ).thenAnswer((_) async => [searchEmail]);
-      
-      // act
-      final result = refreshChangesSearchEmailInteractor.execute(
+      _stubSearchEmails(threadRepository, returns: [searchEmail]);
+
+      final result = interactor.execute(
         SessionFixtures.aliceSession,
         AccountFixtures.aliceAccountId,
         filter: EmailFilterCondition(text: 'test'),
       );
-      
-      // assert
+
       expect(
         result,
         emitsInOrder([
@@ -59,42 +73,29 @@ void main() {
           )])),
         ])
       );
-    });
+    },
+  );
 
-    test(
-      'should return failure '
-      'when threadRepository.searchEmails throw exception',
-      () {
-        // arrange
-        final exception = Exception();
-        when(
-          threadRepository.searchEmails(
-            any,
-            any,
-            limit: anyNamed('limit'),
-            sort: anyNamed('sort'),
-            filter: anyNamed('filter'),
-            collapseThreads: anyNamed('collapseThreads'),
-            properties: anyNamed('properties'),
-          ),
-        ).thenThrow(exception);
-        
-        // act
-        final result = refreshChangesSearchEmailInteractor.execute(
-          SessionFixtures.aliceSession,
-          AccountFixtures.aliceAccountId,
-          filter: EmailFilterCondition(text: 'test'),
-        );
-        
-        // assert
-        expect(
-          result,
-          emitsInOrder([
-            Right(RefreshingChangeSearchEmailState()),
-            Left(RefreshChangesSearchEmailFailure(exception)),
-          ])
-        );
-      },
-    );
-  });
+  test(
+    'should return failure '
+    'when threadRepository.searchEmails throw exception',
+    () {
+      final exception = Exception();
+      _stubSearchEmails(threadRepository, throws: exception);
+
+      final result = interactor.execute(
+        SessionFixtures.aliceSession,
+        AccountFixtures.aliceAccountId,
+        filter: EmailFilterCondition(text: 'test'),
+      );
+
+      expect(
+        result,
+        emitsInOrder([
+          Right(RefreshingChangeSearchEmailState()),
+          Left(RefreshChangesSearchEmailFailure(exception)),
+        ])
+      );
+    },
+  );
 }

--- a/test/features/search/verify_before_time_in_search_email_filter_test.dart
+++ b/test/features/search/verify_before_time_in_search_email_filter_test.dart
@@ -62,8 +62,10 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_all_identities_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_service.dart';
 import 'package:tmail_ui_user/features/network_connection/presentation/network_connection_controller.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/usecases/delete_sending_email_interactor.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/usecases/get_all_sending_email_interactor.dart';
@@ -173,6 +175,7 @@ const fallbackGenerators = {
   MockSpec<GetTokenOIDCInteractor>(),
   MockSpec<StoreEmailSortOrderInteractor>(),
   MockSpec<GetStoredEmailSortOrderInteractor>(),
+  MockSpec<LocalSettingsService>(fallbackGenerators: fallbackGenerators),
 ])
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -254,6 +257,7 @@ void main() {
   late MockUuid mockUuid;
   late MockToastManager mockToastManager;
   late MockTwakeAppManager mockTwakeAppManager;
+  late MockLocalSettingsService mockLocalSettingsService;
 
   setUpAll(() {
     Get.testMode = true;
@@ -397,6 +401,10 @@ void main() {
     final isLabelSettingEnabled = RxBool(false);
     when(labelController.isLabelSettingEnabled).thenReturn(isLabelSettingEnabled);
 
+    mockLocalSettingsService = MockLocalSettingsService();
+    when(mockLocalSettingsService.localSettings).thenReturn(PreferencesSetting.initial().obs);
+    Get.put<LocalSettingsService>(mockLocalSettingsService);
+
     Get.put<MailboxDashBoardController>(mailboxDashboardController);
 
     threadController = ThreadController(
@@ -517,6 +525,7 @@ void main() {
         position: searchController.searchEmailFilter.value.position,
         sort: searchController.searchEmailFilter.value.sortOrderType.getSortOrder().toNullable(),
         filter: searchController.searchEmailFilter.value.mappingToEmailFilterCondition(),
+        collapseThreads: false,
         properties: EmailUtils.getPropertiesForEmailGetMethod(
           SessionFixtures.aliceSession,
           AccountFixtures.aliceAccountId,
@@ -570,6 +579,7 @@ void main() {
         sort: searchController.searchEmailFilter.value.sortOrderType.getSortOrder().toNullable(),
         position: searchController.searchEmailFilter.value.position,
         filter: filterInJMapRequest,
+        collapseThreads: false,
         properties: EmailUtils.getPropertiesForEmailGetMethod(
           SessionFixtures.aliceSession,
           AccountFixtures.aliceAccountId,
@@ -625,6 +635,7 @@ void main() {
         position: anyNamed('position'),
         sort: anyNamed('sort'),
         filter: anyNamed('filter'),
+        collapseThreads: anyNamed('collapseThreads'),
         properties: anyNamed('properties'),
         needRefreshSearchState: anyNamed('needRefreshSearchState'),
       )).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(emailList))));
@@ -641,6 +652,7 @@ void main() {
         position: anyNamed('position'),
         sort: anyNamed('sort'),
         filter: anyNamed('filter'),
+        collapseThreads: anyNamed('collapseThreads'),
         properties: anyNamed('properties'),
         needRefreshSearchState: anyNamed('needRefreshSearchState'),
       ));
@@ -653,6 +665,7 @@ void main() {
         position: searchController.searchEmailFilter.value.position,
         sort: searchController.searchEmailFilter.value.sortOrderType.getSortOrder().toNullable(),
         filter: searchController.searchEmailFilter.value.mappingToEmailFilterCondition(),
+        collapseThreads: false,
         properties: EmailUtils.getPropertiesForEmailGetMethod(
           SessionFixtures.aliceSession,
           AccountFixtures.aliceAccountId,
@@ -692,6 +705,7 @@ void main() {
         position: anyNamed('position'),
         sort: anyNamed('sort'),
         filter: anyNamed('filter'),
+        collapseThreads: anyNamed('collapseThreads'),
         properties: anyNamed('properties'),
         lastEmailId: anyNamed('lastEmailId'),
       ));
@@ -709,6 +723,7 @@ void main() {
         sort: searchController.searchEmailFilter.value.sortOrderType.getSortOrder().toNullable(),
         position: searchController.searchEmailFilter.value.position,
         filter: filterInJMapRequest,
+        collapseThreads: false,
         properties: EmailUtils.getPropertiesForEmailGetMethod(
           SessionFixtures.aliceSession,
           AccountFixtures.aliceAccountId,
@@ -767,6 +782,7 @@ void main() {
         position: anyNamed('position'),
         sort: anyNamed('sort'),
         filter: anyNamed('filter'),
+        collapseThreads: anyNamed('collapseThreads'),
         properties: anyNamed('properties'),
         needRefreshSearchState: anyNamed('needRefreshSearchState'),
       )).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(emailList))));
@@ -783,6 +799,7 @@ void main() {
         position: anyNamed('position'),
         sort: anyNamed('sort'),
         filter: anyNamed('filter'),
+        collapseThreads: anyNamed('collapseThreads'),
         properties: anyNamed('properties'),
         needRefreshSearchState: anyNamed('needRefreshSearchState'),
       ));
@@ -795,6 +812,7 @@ void main() {
         position: searchController.searchEmailFilter.value.position,
         sort: searchController.searchEmailFilter.value.sortOrderType.getSortOrder().toNullable(),
         filter: searchController.searchEmailFilter.value.mappingToEmailFilterCondition(),
+        collapseThreads: false,
         properties: EmailUtils.getPropertiesForEmailGetMethod(
           SessionFixtures.aliceSession,
           AccountFixtures.aliceAccountId,
@@ -841,6 +859,7 @@ void main() {
         position: anyNamed('position'),
         sort: anyNamed('sort'),
         filter: anyNamed('filter'),
+        collapseThreads: anyNamed('collapseThreads'),
         properties: anyNamed('properties'),
         needRefreshSearchState: anyNamed('needRefreshSearchState'),
       )).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(emailList))));
@@ -874,6 +893,7 @@ void main() {
         position: searchController.searchEmailFilter.value.position,
         sort: searchController.searchEmailFilter.value.sortOrderType.getSortOrder().toNullable(),
         filter: searchController.searchEmailFilter.value.mappingToEmailFilterCondition(),
+        collapseThreads: false,
         properties: EmailUtils.getPropertiesForEmailGetMethod(
           SessionFixtures.aliceSession,
           AccountFixtures.aliceAccountId,
@@ -929,6 +949,7 @@ void main() {
         position: anyNamed('position'),
         sort: anyNamed('sort'),
         filter: anyNamed('filter'),
+        collapseThreads: anyNamed('collapseThreads'),
         properties: anyNamed('properties'),
         needRefreshSearchState: anyNamed('needRefreshSearchState'),
       )).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(emailList))));
@@ -945,6 +966,7 @@ void main() {
         position: anyNamed('position'),
         sort: anyNamed('sort'),
         filter: anyNamed('filter'),
+        collapseThreads: anyNamed('collapseThreads'),
         properties: anyNamed('properties'),
         needRefreshSearchState: anyNamed('needRefreshSearchState'),
       ));
@@ -957,6 +979,7 @@ void main() {
         position: searchController.searchEmailFilter.value.position,
         sort: searchController.searchEmailFilter.value.sortOrderType.getSortOrder().toNullable(),
         filter: searchController.searchEmailFilter.value.mappingToEmailFilterCondition(),
+        collapseThreads: false,
         properties: EmailUtils.getPropertiesForEmailGetMethod(
           SessionFixtures.aliceSession,
           AccountFixtures.aliceAccountId,
@@ -1007,6 +1030,7 @@ void main() {
         position: anyNamed('position'),
         sort: anyNamed('sort'),
         filter: anyNamed('filter'),
+        collapseThreads: anyNamed('collapseThreads'),
         properties: anyNamed('properties'),
         needRefreshSearchState: anyNamed('needRefreshSearchState'),
       )).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(emailList))));
@@ -1040,6 +1064,7 @@ void main() {
         position: searchController.searchEmailFilter.value.position,
         sort: searchController.searchEmailFilter.value.sortOrderType.getSortOrder().toNullable(),
         filter: searchController.searchEmailFilter.value.mappingToEmailFilterCondition(),
+        collapseThreads: false,
         properties: EmailUtils.getPropertiesForEmailGetMethod(
           SessionFixtures.aliceSession,
           AccountFixtures.aliceAccountId,
@@ -1118,6 +1143,7 @@ void main() {
         position: anyNamed('position'),
         sort: anyNamed('sort'),
         filter: anyNamed('filter'),
+        collapseThreads: anyNamed('collapseThreads'),
         properties: anyNamed('properties'),
         needRefreshSearchState: anyNamed('needRefreshSearchState'),
       )).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(emailList))));
@@ -1151,6 +1177,7 @@ void main() {
         position: searchController.searchEmailFilter.value.position,
         sort: searchController.searchEmailFilter.value.sortOrderType.getSortOrder().toNullable(),
         filter: searchController.searchEmailFilter.value.mappingToEmailFilterCondition(),
+        collapseThreads: false,
         properties: EmailUtils.getPropertiesForEmailGetMethod(
           SessionFixtures.aliceSession,
           AccountFixtures.aliceAccountId,

--- a/test/features/search/verify_before_time_in_search_email_filter_test.dart
+++ b/test/features/search/verify_before_time_in_search_email_filter_test.dart
@@ -487,6 +487,7 @@ void main() {
         position: anyNamed('position'),
         sort: anyNamed('sort'),
         filter: anyNamed('filter'),
+        collapseThreads: anyNamed('collapseThreads'),
         properties: anyNamed('properties'),
         needRefreshSearchState: anyNamed('needRefreshSearchState'),
       )).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(emailList))));
@@ -503,6 +504,7 @@ void main() {
         position: anyNamed('position'),
         sort: anyNamed('sort'),
         filter: anyNamed('filter'),
+        collapseThreads: anyNamed('collapseThreads'),
         properties: anyNamed('properties'),
         needRefreshSearchState: anyNamed('needRefreshSearchState'),
       ));
@@ -550,6 +552,7 @@ void main() {
         position: anyNamed('position'),
         sort: anyNamed('sort'),
         filter: anyNamed('filter'),
+        collapseThreads: anyNamed('collapseThreads'),
         properties: anyNamed('properties'),
         lastEmailId: anyNamed('lastEmailId'),
       ));

--- a/test/features/search/verify_before_time_in_search_email_filter_test.dart
+++ b/test/features/search/verify_before_time_in_search_email_filter_test.dart
@@ -62,10 +62,8 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
-import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_all_identities_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_service.dart';
 import 'package:tmail_ui_user/features/network_connection/presentation/network_connection_controller.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/usecases/delete_sending_email_interactor.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/usecases/get_all_sending_email_interactor.dart';
@@ -175,7 +173,6 @@ const fallbackGenerators = {
   MockSpec<GetTokenOIDCInteractor>(),
   MockSpec<StoreEmailSortOrderInteractor>(),
   MockSpec<GetStoredEmailSortOrderInteractor>(),
-  MockSpec<LocalSettingsService>(fallbackGenerators: fallbackGenerators),
 ])
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -257,7 +254,6 @@ void main() {
   late MockUuid mockUuid;
   late MockToastManager mockToastManager;
   late MockTwakeAppManager mockTwakeAppManager;
-  late MockLocalSettingsService mockLocalSettingsService;
 
   setUpAll(() {
     Get.testMode = true;
@@ -400,10 +396,6 @@ void main() {
     when(downloadController.downloadUIAction).thenAnswer((_) => Rxn(DownloadUIAction.idle));
     final isLabelSettingEnabled = RxBool(false);
     when(labelController.isLabelSettingEnabled).thenReturn(isLabelSettingEnabled);
-
-    mockLocalSettingsService = MockLocalSettingsService();
-    when(mockLocalSettingsService.localSettings).thenReturn(PreferencesSetting.initial().obs);
-    Get.put<LocalSettingsService>(mockLocalSettingsService);
 
     Get.put<MailboxDashBoardController>(mailboxDashboardController);
 

--- a/test/features/thread/domain/usecases/search_email_interactor_test.dart
+++ b/test/features/thread/domain/usecases/search_email_interactor_test.dart
@@ -37,6 +37,7 @@ void main() {
           limit: anyNamed('limit'),
           sort: anyNamed('sort'),
           filter: anyNamed('filter'),
+          collapseThreads: anyNamed('collapseThreads'),
           properties: anyNamed('properties'),
         ),
       ).thenAnswer((_) async => [searchEmail]);
@@ -79,6 +80,7 @@ void main() {
           limit: anyNamed('limit'),
           sort: anyNamed('sort'),
           filter: anyNamed('filter'),
+          collapseThreads: anyNamed('collapseThreads'),
           properties: anyNamed('properties'),
         ),
       ).thenAnswer((_) async => [searchEmail]);
@@ -112,6 +114,7 @@ void main() {
             limit: anyNamed('limit'),
             sort: anyNamed('sort'),
             filter: anyNamed('filter'),
+            collapseThreads: anyNamed('collapseThreads'),
             properties: anyNamed('properties'),
           ),
         ).thenThrow(exception);

--- a/test/features/thread/domain/usecases/search_email_interactor_test.dart
+++ b/test/features/thread/domain/usecases/search_email_interactor_test.dart
@@ -20,36 +20,51 @@ void main() {
   final threadRepository = MockThreadRepository();
   final searchEmailInteractor = SearchEmailInteractor(threadRepository);
 
-  group('search email interactor test:', () {
-    test(
-      'should return list of presentation emails '
-      'when threadRepository.searchEmails returns list of emails with search snippets',
+  group('search email interactor test:',
+    () => _searchEmailInteractorTests(threadRepository, searchEmailInteractor));
+}
+
+void _stubSearchEmails(
+  MockThreadRepository repo, {
+  List<SearchEmail>? returns,
+  Object? throws,
+}) {
+  final stub = when(repo.searchEmails(
+    any,
+    any,
+    limit: anyNamed('limit'),
+    sort: anyNamed('sort'),
+    filter: anyNamed('filter'),
+    collapseThreads: anyNamed('collapseThreads'),
+    properties: anyNamed('properties'),
+  ));
+  if (throws != null) {
+    stub.thenThrow(throws);
+  } else {
+    stub.thenAnswer((_) async => returns ?? []);
+  }
+}
+
+void _searchEmailInteractorTests(
+  MockThreadRepository threadRepository,
+  SearchEmailInteractor searchEmailInteractor,
+) {
+  test(
+    'should return list of presentation emails '
+    'when threadRepository.searchEmails returns list of emails with search snippets',
     () {
-      // arrange
       final searchEmail = SearchEmail(
         searchSnippetSubject: 'searchSnippetSubject',
         searchSnippetPreview: 'searchSnippetPreview',
       );
-      when(
-        threadRepository.searchEmails(
-          any,
-          any,
-          limit: anyNamed('limit'),
-          sort: anyNamed('sort'),
-          filter: anyNamed('filter'),
-          collapseThreads: anyNamed('collapseThreads'),
-          properties: anyNamed('properties'),
-        ),
-      ).thenAnswer((_) async => [searchEmail]);
-      
-      // act
+      _stubSearchEmails(threadRepository, returns: [searchEmail]);
+
       final result = searchEmailInteractor.execute(
         SessionFixtures.aliceSession,
         AccountFixtures.aliceAccountId,
         filter: EmailFilterCondition(text: 'test'),
       );
-      
-      // assert
+
       expect(
         result,
         emitsInOrder([
@@ -62,37 +77,25 @@ void main() {
           ))
         ]),
       );
-    });
+    },
+  );
 
-    test(
-      'should return list of presentation emails '
-      'when threadRepository.searchEmails returns list of emails without search snippets',
+  test(
+    'should return list of presentation emails '
+    'when threadRepository.searchEmails returns list of emails without search snippets',
     () {
-      // arrange
       final searchEmail = SearchEmail(
         searchSnippetSubject: null,
         searchSnippetPreview: null,
       );
-      when(
-        threadRepository.searchEmails(
-          any,
-          any,
-          limit: anyNamed('limit'),
-          sort: anyNamed('sort'),
-          filter: anyNamed('filter'),
-          collapseThreads: anyNamed('collapseThreads'),
-          properties: anyNamed('properties'),
-        ),
-      ).thenAnswer((_) async => [searchEmail]);
-      
-      // act
+      _stubSearchEmails(threadRepository, returns: [searchEmail]);
+
       final result = searchEmailInteractor.execute(
         SessionFixtures.aliceSession,
         AccountFixtures.aliceAccountId,
         filter: EmailFilterCondition(text: 'test'),
       );
-      
-      // assert
+
       expect(
         result,
         emitsInOrder([
@@ -100,45 +103,32 @@ void main() {
           Right(SearchEmailSuccess([searchEmail.toPresentationEmail()]))
         ]),
       );
-    });
+    },
+  );
 
-    test(
-      'should return Failure when threadRepository.searchEmails returns Failure',
-      () async {
-        // arrange
-        final exception = Exception();
-        when(
-          threadRepository.searchEmails(
-            any,
-            any,
-            limit: anyNamed('limit'),
-            sort: anyNamed('sort'),
-            filter: anyNamed('filter'),
-            collapseThreads: anyNamed('collapseThreads'),
-            properties: anyNamed('properties'),
-          ),
-        ).thenThrow(exception);
-        
-        // act
-        final result = searchEmailInteractor.execute(
-          SessionFixtures.aliceSession,
-          AccountFixtures.aliceAccountId,
-          filter: EmailFilterCondition(text: 'test'),
-        ).asBroadcastStream();
-        
-        // assert
-        final firstState = await result.first;
-        final lastState = await result.last;
-        expect(firstState, Right(SearchingState()));
-        expect(
-          lastState.fold((failure) {
-            return failure is SearchEmailFailure
-              && failure.exception == exception
-              && failure.onRetry is Stream<Either<Failure, Success>>;
-          }, (success) => false),
-          true,
-        );
-      },
-    );
-  });
+  test(
+    'should return Failure when threadRepository.searchEmails returns Failure',
+    () async {
+      final exception = Exception();
+      _stubSearchEmails(threadRepository, throws: exception);
+
+      final result = searchEmailInteractor.execute(
+        SessionFixtures.aliceSession,
+        AccountFixtures.aliceAccountId,
+        filter: EmailFilterCondition(text: 'test'),
+      ).asBroadcastStream();
+
+      final firstState = await result.first;
+      final lastState = await result.last;
+      expect(firstState, Right(SearchingState()));
+      expect(
+        lastState.fold((failure) {
+          return failure is SearchEmailFailure
+            && failure.exception == exception
+            && failure.onRetry is Stream<Either<Failure, Success>>;
+        }, (success) => false),
+        true,
+      );
+    },
+  );
 }

--- a/test/features/thread/domain/usecases/search_more_email_interactor_test.dart
+++ b/test/features/thread/domain/usecases/search_more_email_interactor_test.dart
@@ -37,6 +37,7 @@ void main() {
           limit: anyNamed('limit'),
           sort: anyNamed('sort'),
           filter: anyNamed('filter'),
+          collapseThreads: anyNamed('collapseThreads'),
           properties: anyNamed('properties'),
         ),
       ).thenAnswer((_) async => [searchEmail]);
@@ -76,6 +77,7 @@ void main() {
           limit: anyNamed('limit'),
           sort: anyNamed('sort'),
           filter: anyNamed('filter'),
+          collapseThreads: anyNamed('collapseThreads'),
           properties: anyNamed('properties'),
         ),
       ).thenThrow(exception);

--- a/test/features/thread/domain/usecases/search_more_email_interactor_test.dart
+++ b/test/features/thread/domain/usecases/search_more_email_interactor_test.dart
@@ -19,37 +19,53 @@ import 'search_more_email_interactor_test.mocks.dart';
 void main() {
   final threadRepository = MockThreadRepository();
   final searchMoreEmailInteractor = SearchMoreEmailInteractor(threadRepository);
-  group('search more email interactor test:', () {
-    test(
-      'should return list of presentation emails '
-      'when threadRepository.searchEmails returns list of emails',
+
+  group('search more email interactor test:',
+    () => _searchMoreEmailTests(threadRepository, searchMoreEmailInteractor));
+}
+
+void _stubSearchEmails(
+  MockThreadRepository repo, {
+  List<SearchEmail>? returns,
+  Object? throws,
+}) {
+  final stub = when(repo.searchEmails(
+    any,
+    any,
+    limit: anyNamed('limit'),
+    sort: anyNamed('sort'),
+    filter: anyNamed('filter'),
+    collapseThreads: anyNamed('collapseThreads'),
+    properties: anyNamed('properties'),
+  ));
+  if (throws != null) {
+    stub.thenThrow(throws);
+  } else {
+    stub.thenAnswer((_) async => returns ?? []);
+  }
+}
+
+void _searchMoreEmailTests(
+  MockThreadRepository threadRepository,
+  SearchMoreEmailInteractor searchMoreEmailInteractor,
+) {
+  test(
+    'should return list of presentation emails '
+    'when threadRepository.searchEmails returns list of emails',
     () {
-      // arrange
       final searchEmail = SearchEmail(
         id: EmailId(Id('someId')),
         searchSnippetSubject: 'searchSnippetSubject',
         searchSnippetPreview: 'searchSnippetPreview',
       );
-      when(
-        threadRepository.searchEmails(
-          any,
-          any,
-          limit: anyNamed('limit'),
-          sort: anyNamed('sort'),
-          filter: anyNamed('filter'),
-          collapseThreads: anyNamed('collapseThreads'),
-          properties: anyNamed('properties'),
-        ),
-      ).thenAnswer((_) async => [searchEmail]);
+      _stubSearchEmails(threadRepository, returns: [searchEmail]);
 
-      // act
       final result = searchMoreEmailInteractor.execute(
         SessionFixtures.aliceSession,
         AccountFixtures.aliceAccountId,
         filter: EmailFilterCondition(text: 'test'),
       );
 
-      // assert
       expect(
         result,
         emitsInOrder([
@@ -62,34 +78,22 @@ void main() {
           )),
         ]),
       );
-    });
+    },
+  );
 
-    test(
-      'should return failure '
-      'when threadRepository.searchEmails throw exception',
+  test(
+    'should return failure '
+    'when threadRepository.searchEmails throw exception',
     () {
-      // arrange
       final exception = Exception();
-      when(
-        threadRepository.searchEmails(
-          any,
-          any,
-          limit: anyNamed('limit'),
-          sort: anyNamed('sort'),
-          filter: anyNamed('filter'),
-          collapseThreads: anyNamed('collapseThreads'),
-          properties: anyNamed('properties'),
-        ),
-      ).thenThrow(exception);
-      
-      // act
+      _stubSearchEmails(threadRepository, throws: exception);
+
       final result = searchMoreEmailInteractor.execute(
         SessionFixtures.aliceSession,
         AccountFixtures.aliceAccountId,
         filter: EmailFilterCondition(text: 'test'),
       );
-      
-      // assert
+
       expect(
         result,
         emitsInOrder([
@@ -97,6 +101,6 @@ void main() {
           Left(SearchMoreEmailFailure(exception)),
         ]),
       );
-    });
-  });
+    },
+  );
 }

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -29,9 +29,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/search_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
-import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_service.dart';
 import 'package:tmail_ui_user/features/network_connection/presentation/network_connection_controller.dart';
 import 'package:tmail_ui_user/features/thread/domain/constants/thread_constants.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
@@ -89,7 +87,6 @@ const fallbackGenerators = {
   MockSpec<SearchMoreEmailInteractor>(),
   MockSpec<GetEmailByIdInteractor>(),
   MockSpec<CleanAndGetEmailsInMailboxInteractor>(),
-  MockSpec<LocalSettingsService>(fallbackGenerators: fallbackGenerators),
 ])
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -106,7 +103,6 @@ void main() {
   late MockSearchMoreEmailInteractor mockSearchMoreEmailInteractor;
   late MockGetEmailByIdInteractor mockGetEmailByIdInteractor;
   late MockCleanAndGetEmailsInMailboxInteractor mockCleanAndGetEmailsInMailboxInteractor;
-  late MockLocalSettingsService mockLocalSettingsService;
 
   // Declaration base controller
   late MockCachingManager mockCachingManager;
@@ -157,10 +153,6 @@ void main() {
     Get.put<Uuid>(mockUuid);
     Get.put<ToastManager>(mockToastManager);
     Get.put<TwakeAppManager>(mockTwakeAppManager);
-
-    mockLocalSettingsService = MockLocalSettingsService();
-    when(mockLocalSettingsService.localSettings).thenReturn(PreferencesSetting.initial().obs);
-    Get.put<LocalSettingsService>(mockLocalSettingsService);
 
     // Mock thread controller
     mockNetworkConnectionController = MockNetworkConnectionController();

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -29,7 +29,9 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/search_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_service.dart';
 import 'package:tmail_ui_user/features/network_connection/presentation/network_connection_controller.dart';
 import 'package:tmail_ui_user/features/thread/domain/constants/thread_constants.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
@@ -87,6 +89,7 @@ const fallbackGenerators = {
   MockSpec<SearchMoreEmailInteractor>(),
   MockSpec<GetEmailByIdInteractor>(),
   MockSpec<CleanAndGetEmailsInMailboxInteractor>(),
+  MockSpec<LocalSettingsService>(fallbackGenerators: fallbackGenerators),
 ])
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -103,6 +106,7 @@ void main() {
   late MockSearchMoreEmailInteractor mockSearchMoreEmailInteractor;
   late MockGetEmailByIdInteractor mockGetEmailByIdInteractor;
   late MockCleanAndGetEmailsInMailboxInteractor mockCleanAndGetEmailsInMailboxInteractor;
+  late MockLocalSettingsService mockLocalSettingsService;
 
   // Declaration base controller
   late MockCachingManager mockCachingManager;
@@ -153,6 +157,10 @@ void main() {
     Get.put<Uuid>(mockUuid);
     Get.put<ToastManager>(mockToastManager);
     Get.put<TwakeAppManager>(mockTwakeAppManager);
+
+    mockLocalSettingsService = MockLocalSettingsService();
+    when(mockLocalSettingsService.localSettings).thenReturn(PreferencesSetting.initial().obs);
+    Get.put<LocalSettingsService>(mockLocalSettingsService);
 
     // Mock thread controller
     mockNetworkConnectionController = MockNetworkConnectionController();
@@ -325,6 +333,7 @@ void main() {
           position: anyNamed('position'),
           sort:anyNamed('sort'),
           filter: anyNamed('filter'),
+          collapseThreads: anyNamed('collapseThreads'),
           properties: anyNamed('properties'),
           needRefreshSearchState: anyNamed('needRefreshSearchState'),
         )).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(emailList))));
@@ -357,6 +366,7 @@ void main() {
           position: anyNamed('position'),
           sort:anyNamed('sort'),
           filter: anyNamed('filter'),
+          collapseThreads: anyNamed('collapseThreads'),
           properties: anyNamed('properties'),
           needRefreshSearchState: anyNamed('needRefreshSearchState'),
         ));
@@ -369,6 +379,7 @@ void main() {
           position: null,
           sort: SearchEmailFilter.defaultSortOrder.getSortOrder().toNullable(),
           filter: SearchEmailFilter.initial().mappingToEmailFilterCondition(),
+          collapseThreads: false,
           properties: EmailUtils.getPropertiesForEmailGetMethod(
             SessionFixtures.aliceSession,
             AccountFixtures.aliceAccountId),
@@ -420,6 +431,7 @@ void main() {
           position: anyNamed('position'),
           sort:anyNamed('sort'),
           filter: anyNamed('filter'),
+          collapseThreads: anyNamed('collapseThreads'),
           properties: anyNamed('properties'),
           needRefreshSearchState: anyNamed('needRefreshSearchState'),
         )).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(emailList))));
@@ -435,6 +447,7 @@ void main() {
           position: anyNamed('position'),
           sort:anyNamed('sort'),
           filter: anyNamed('filter'),
+          collapseThreads: anyNamed('collapseThreads'),
           properties: anyNamed('properties'),
           needRefreshSearchState: anyNamed('needRefreshSearchState'),
         ));
@@ -447,6 +460,7 @@ void main() {
           position: null,
           sort: SearchEmailFilter.defaultSortOrder.getSortOrder().toNullable(),
           filter: SearchEmailFilter.initial().mappingToEmailFilterCondition(),
+          collapseThreads: false,
           properties: EmailUtils.getPropertiesForEmailGetMethod(
             SessionFixtures.aliceSession,
             AccountFixtures.aliceAccountId),

--- a/test/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated_test.dart
+++ b/test/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated_test.dart
@@ -37,6 +37,7 @@ void main() {
       .thenReturn(Properties.empty());
     when(threadDetailController.mailboxDashBoardController)
       .thenReturn(mailboxDashboardController);
+    when(mailboxDashboardController.isEmailOpened).thenReturn(true);
   });
   
   group('thread detail on selected email updated test:', () {


### PR DESCRIPTION
## Issue

#4363 

## Resolved

- With `Thread is enabled`:


https://github.com/user-attachments/assets/85ca430f-d04e-4db3-a3a0-b3cfacaaba6a




- With `Thread is disabled`:

https://github.com/user-attachments/assets/78c4fc59-d366-4574-a3f6-ce6469f50126



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thread-collapse option for searches/lists tied to local settings; UI reacts and refreshes when the setting changes.
  * Local settings service added to persist and reload thread-collapse preferences.

* **Refactor**
  * Search requests and controllers now propagate the collapse-threads flag end-to-end; query construction uses availability-safe helpers.

* **Bug Fixes**
  * Thread-detail selection now no-ops when no email is opened.

* **Tests**
  * Tests updated to cover collapse-setting behavior and integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->