### PR TITLE
TF-4367 Fix duplicated `Re:` prefix when reply email with French locale

### DIFF
--- a/integration_test/mixin/generate_email_scenario_mixin.dart
+++ b/integration_test/mixin/generate_email_scenario_mixin.dart
@@ -2,7 +2,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../base/base_scenario.dart';
 import '../models/provisioning_email.dart';
-import '../robots/email_robot.dart';
 import 'scenario_utils_mixin.dart';
 
 mixin GenerateEmailScenarioMixin on BaseScenario, ScenarioUtilsMixin {
@@ -21,9 +20,5 @@ mixin GenerateEmailScenarioMixin on BaseScenario, ScenarioUtilsMixin {
       requestReadReceipt: false,
     );
     await $.pumpAndTrySettle();
-  }
-
-  Future<void> closeEmailDetailedView({required EmailRobot emailRobot}) async {
-    await emailRobot.onTapBackButton();
   }
 }

--- a/integration_test/mixin/generate_email_scenario_mixin.dart
+++ b/integration_test/mixin/generate_email_scenario_mixin.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../base/base_scenario.dart';
+import '../models/provisioning_email.dart';
+import '../robots/email_robot.dart';
+import 'scenario_utils_mixin.dart';
+
+mixin GenerateEmailScenarioMixin on BaseScenario, ScenarioUtilsMixin {
+  Future<void> generateEmailWithSubject({
+    required String emailUser,
+    required String subject,
+  }) async {
+    await provisionEmail(
+      [
+        ProvisioningEmail(
+          toEmail: emailUser,
+          subject: subject,
+          content: subject,
+        ),
+      ],
+      requestReadReceipt: false,
+    );
+    await $.pumpAndTrySettle();
+  }
+
+  Future<void> closeEmailDetailedView({required EmailRobot emailRobot}) async {
+    await emailRobot.onTapBackButton();
+  }
+}

--- a/integration_test/mixin/screen_scenario_mixin.dart
+++ b/integration_test/mixin/screen_scenario_mixin.dart
@@ -1,0 +1,19 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../robots/composer_robot.dart';
+import '../robots/email_robot.dart';
+
+mixin ScreenScenarioMixin {
+  Future<void> closeEmailDetailedView({required EmailRobot emailRobot}) async {
+    await emailRobot.onTapBackButton();
+  }
+
+  Future<void> closeComposer({
+    required ComposerRobot composerRobot,
+    required ImagePaths imagePaths,
+  }) async {
+    await composerRobot.tapCloseComposer(imagePaths);
+    await composerRobot.tapDiscardChanges();
+  }
+}

--- a/integration_test/mixin/setting_scenario_mixin.dart
+++ b/integration_test/mixin/setting_scenario_mixin.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../base/base_scenario.dart';
+import '../robots/language_robot.dart';
+import '../robots/mailbox_menu_robot.dart';
+import '../robots/setting_robot.dart';
+import '../robots/thread_robot.dart';
+
+mixin SettingScenarioMixin on BaseScenario {
+  Future<void> goToSettingToChangeLanguage({
+    required ThreadRobot threadRobot,
+    required SettingRobot settingRobot,
+    required MailboxMenuRobot mailboxMenuRobot,
+    required LanguageRobot languageRobot,
+    required AppLocalizations appLocalizations,
+    required Locale locale,
+  }) async {
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openSetting();
+    await _expectLanguageMenuItemVisible();
+
+    await settingRobot.openLanguageMenuItem();
+    await languageRobot.openLanguageContextMenu();
+    await languageRobot.selectLanguage(locale, appLocalizations);
+    await _expectLanguageViewByLocaleTitleVisible(appLocalizations);
+
+    await settingRobot.backToSettingsFromFirstLevel();
+    await settingRobot.closeSettings();
+  }
+
+  Future<void> _expectLanguageMenuItemVisible() async {
+    await $(#setting_language_region).scrollTo(
+      scrollDirection: AxisDirection.down,
+    );
+    await expectViewVisible($(#setting_language_region));
+  }
+
+  Future<void> _expectLanguageViewByLocaleTitleVisible(
+    AppLocalizations appLocalizations,
+  ) async {
+    await expectViewVisible($(find.text(appLocalizations.language)));
+  }
+}

--- a/integration_test/scenarios/email_detailed/forward_email_forwarded_when_change_language_scenario.dart
+++ b/integration_test/scenarios/email_detailed/forward_email_forwarded_when_change_language_scenario.dart
@@ -86,10 +86,7 @@ class ForwardEmailForwardedWhenChangeLanguageScenario extends BaseTestScenario
     await composerRobot.grantContactPermission();
     await $.pumpAndTrySettle();
 
-    await _expectComposerSubjectIsNotChanged(
-      appLocalizations: appLocalizations,
-      subject: subject,
-    );
+    await _expectComposerSubjectIsNotChanged(subject: subject);
   }
 
   Future<void> _expectEmailViewVisible() async {
@@ -105,7 +102,6 @@ class ForwardEmailForwardedWhenChangeLanguageScenario extends BaseTestScenario
   }
 
   Future<void> _expectComposerSubjectIsNotChanged({
-    required AppLocalizations appLocalizations,
     required String subject,
   }) async {
     expect(

--- a/integration_test/scenarios/email_detailed/forward_email_forwarded_when_change_language_scenario.dart
+++ b/integration_test/scenarios/email_detailed/forward_email_forwarded_when_change_language_scenario.dart
@@ -17,9 +17,9 @@ import '../../robots/mailbox_menu_robot.dart';
 import '../../robots/setting_robot.dart';
 import '../../robots/thread_robot.dart';
 
-class ReplyEmailWhenChangeLanguageScenario extends BaseTestScenario
+class ForwardEmailForwardedWhenChangeLanguageScenario extends BaseTestScenario
     with SettingScenarioMixin, GenerateEmailScenarioMixin, ScreenScenarioMixin {
-  const ReplyEmailWhenChangeLanguageScenario(super.$);
+  const ForwardEmailForwardedWhenChangeLanguageScenario(super.$);
 
   @override
   Future<void> runTestLogic() async {
@@ -34,9 +34,10 @@ class ReplyEmailWhenChangeLanguageScenario extends BaseTestScenario
     final imagePaths = ImagePaths();
 
     for (var locale in LocalizationService.supportedLocales) {
-      String subject = 'Reply email by locale ${locale.languageCode}';
-
       final appLocalizations = await AppLocalizations.load(locale);
+
+      String subject =
+          '${appLocalizations.prefix_forward_email} Email by locale ${locale.languageCode}';
 
       await goToSettingToChangeLanguage(
         threadRobot: threadRobot,
@@ -49,7 +50,7 @@ class ReplyEmailWhenChangeLanguageScenario extends BaseTestScenario
 
       await generateEmailWithSubject(emailUser: emailUser, subject: subject);
 
-      await _replyEmailBySubject(
+      await _forwardEmailBySubject(
         threadRobot: threadRobot,
         emailRobot: emailRobot,
         composerRobot: composerRobot,
@@ -68,7 +69,7 @@ class ReplyEmailWhenChangeLanguageScenario extends BaseTestScenario
     }
   }
 
-  Future<void> _replyEmailBySubject({
+  Future<void> _forwardEmailBySubject({
     required ThreadRobot threadRobot,
     required EmailRobot emailRobot,
     required ComposerRobot composerRobot,
@@ -77,15 +78,15 @@ class ReplyEmailWhenChangeLanguageScenario extends BaseTestScenario
   }) async {
     await threadRobot.openEmailWithSubject(subject);
     await _expectEmailViewVisible();
-    await _expectReplyEmailButtonVisible();
+    await _expectForwardEmailButtonVisible();
 
-    await emailRobot.onTapReplyEmail();
+    await emailRobot.onTapForwardEmail();
     await _expectComposerViewVisible();
 
     await composerRobot.grantContactPermission();
     await $.pumpAndTrySettle();
 
-    await _expectComposerSubjectDisplayedCorrectly(
+    await _expectComposerSubjectIsNotChanged(
       appLocalizations: appLocalizations,
       subject: subject,
     );
@@ -95,23 +96,22 @@ class ReplyEmailWhenChangeLanguageScenario extends BaseTestScenario
     await expectViewVisible($(EmailView));
   }
 
-  Future<void> _expectReplyEmailButtonVisible() async {
-    await expectViewVisible($(#reply_email_button));
+  Future<void> _expectForwardEmailButtonVisible() async {
+    await expectViewVisible($(#forward_email_button));
   }
 
   Future<void> _expectComposerViewVisible() async {
     await expectViewVisible($(ComposerView));
   }
 
-  Future<void> _expectComposerSubjectDisplayedCorrectly({
+  Future<void> _expectComposerSubjectIsNotChanged({
     required AppLocalizations appLocalizations,
     required String subject,
   }) async {
     expect(
       $(SubjectComposerWidget)
-          .which<SubjectComposerWidget>((widget) =>
-              widget.textController.text ==
-              '${appLocalizations.prefix_reply_email} $subject')
+          .which<SubjectComposerWidget>(
+              (widget) => widget.textController.text == subject)
           .visible,
       isTrue,
     );

--- a/integration_test/scenarios/email_detailed/forward_email_when_change_language_scenario.dart
+++ b/integration_test/scenarios/email_detailed/forward_email_when_change_language_scenario.dart
@@ -1,0 +1,177 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/subject_composer_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/email_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/localizations/localization_service.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/composer_robot.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/language_robot.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/setting_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class ForwardEmailWhenChangeLanguageScenario extends BaseTestScenario {
+  const ForwardEmailWhenChangeLanguageScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
+
+    final threadRobot = ThreadRobot($);
+    final emailRobot = EmailRobot($);
+    final composerRobot = ComposerRobot($);
+    final settingRobot = SettingRobot($);
+    final languageRobot = LanguageRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+    final imagePaths = ImagePaths();
+
+    for (var locale in LocalizationService.supportedLocales) {
+      String subject = 'Forward email by locale ${locale.languageCode}';
+
+      final appLocalizations = await AppLocalizations.load(locale);
+
+      await _goToSettingToChangeLanguage(
+        threadRobot: threadRobot,
+        settingRobot: settingRobot,
+        mailboxMenuRobot: mailboxMenuRobot,
+        languageRobot: languageRobot,
+        appLocalizations: appLocalizations,
+        locale: locale,
+      );
+
+      await _generateEmail(emailUser, subject);
+
+      await _forwardEmailBySubject(
+        threadRobot: threadRobot,
+        emailRobot: emailRobot,
+        composerRobot: composerRobot,
+        subject: subject,
+        appLocalizations: appLocalizations,
+      );
+
+      await _closeComposer(
+        composerRobot: composerRobot,
+        imagePaths: imagePaths,
+      );
+
+      await _closeEmailDetailedView(emailRobot: emailRobot);
+
+      await $.pumpAndTrySettle();
+    }
+  }
+
+  Future<void> _goToSettingToChangeLanguage({
+    required ThreadRobot threadRobot,
+    required SettingRobot settingRobot,
+    required MailboxMenuRobot mailboxMenuRobot,
+    required LanguageRobot languageRobot,
+    required AppLocalizations appLocalizations,
+    required Locale locale,
+  }) async {
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openSetting();
+    await _expectLanguageMenuItemVisible();
+
+    await settingRobot.openLanguageMenuItem();
+    await languageRobot.openLanguageContextMenu();
+    await languageRobot.selectLanguage(locale, appLocalizations);
+    await _expectLanguageViewByLocaleTitleVisible(appLocalizations);
+
+    await settingRobot.backToSettingsFromFirstLevel();
+    await settingRobot.closeSettings();
+  }
+
+  Future<void> _generateEmail(String emailUser, String subject) async {
+    await provisionEmail(
+      [
+        ProvisioningEmail(
+          toEmail: emailUser,
+          subject: subject,
+          content: subject,
+        ),
+      ],
+      requestReadReceipt: false,
+    );
+    await $.pumpAndTrySettle();
+  }
+
+  Future<void> _forwardEmailBySubject({
+    required ThreadRobot threadRobot,
+    required EmailRobot emailRobot,
+    required ComposerRobot composerRobot,
+    required String subject,
+    required AppLocalizations appLocalizations,
+  }) async {
+    await threadRobot.openEmailWithSubject(subject);
+    await _expectEmailViewVisible();
+    await _expectForwardEmailButtonVisible();
+
+    await emailRobot.onTapForwardEmail();
+    await _expectComposerViewVisible();
+
+    await composerRobot.grantContactPermission();
+    await $.pumpAndTrySettle();
+
+    await _expectComposerSubjectDisplayedCorrectly(
+      appLocalizations: appLocalizations,
+      subject: subject,
+    );
+  }
+
+  Future<void> _closeComposer({
+    required ComposerRobot composerRobot,
+    required ImagePaths imagePaths,
+  }) async {
+    await composerRobot.tapCloseComposer(imagePaths);
+    await composerRobot.tapDiscardChanges();
+  }
+
+  Future<void> _closeEmailDetailedView({required EmailRobot emailRobot}) async {
+    await emailRobot.onTapBackButton();
+  }
+
+  Future<void> _expectLanguageMenuItemVisible() async {
+    await $(#setting_language_region).scrollTo(
+      scrollDirection: AxisDirection.down,
+    );
+    await expectViewVisible($(#setting_language_region));
+  }
+
+  Future<void> _expectLanguageViewByLocaleTitleVisible(
+    AppLocalizations appLocalizations,
+  ) async {
+    await expectViewVisible($(find.text(appLocalizations.language)));
+  }
+
+  Future<void> _expectEmailViewVisible() async {
+    await expectViewVisible($(EmailView));
+  }
+
+  Future<void> _expectForwardEmailButtonVisible() async {
+    await expectViewVisible($(#forward_email_button));
+  }
+
+  Future<void> _expectComposerViewVisible() async {
+    await expectViewVisible($(ComposerView));
+  }
+
+  Future<void> _expectComposerSubjectDisplayedCorrectly({
+    required AppLocalizations appLocalizations,
+    required String subject,
+  }) async {
+    expect(
+      $(SubjectComposerWidget)
+          .which<SubjectComposerWidget>((widget) =>
+              widget.textController.text ==
+              '${appLocalizations.prefix_forward_email} $subject')
+          .visible,
+      isTrue,
+    );
+  }
+}

--- a/integration_test/scenarios/email_detailed/forward_email_when_change_language_scenario.dart
+++ b/integration_test/scenarios/email_detailed/forward_email_when_change_language_scenario.dart
@@ -1,5 +1,4 @@
 import 'package:core/presentation/resources/image_paths.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/subject_composer_widget.dart';
@@ -8,7 +7,9 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/localizations/localization_service.dart';
 
 import '../../base/base_test_scenario.dart';
-import '../../models/provisioning_email.dart';
+import '../../mixin/generate_email_scenario_mixin.dart';
+import '../../mixin/screen_scenario_mixin.dart';
+import '../../mixin/setting_scenario_mixin.dart';
 import '../../robots/composer_robot.dart';
 import '../../robots/email_robot.dart';
 import '../../robots/language_robot.dart';
@@ -16,7 +17,8 @@ import '../../robots/mailbox_menu_robot.dart';
 import '../../robots/setting_robot.dart';
 import '../../robots/thread_robot.dart';
 
-class ForwardEmailWhenChangeLanguageScenario extends BaseTestScenario {
+class ForwardEmailWhenChangeLanguageScenario extends BaseTestScenario
+    with SettingScenarioMixin, GenerateEmailScenarioMixin, ScreenScenarioMixin {
   const ForwardEmailWhenChangeLanguageScenario(super.$);
 
   @override
@@ -36,7 +38,7 @@ class ForwardEmailWhenChangeLanguageScenario extends BaseTestScenario {
 
       final appLocalizations = await AppLocalizations.load(locale);
 
-      await _goToSettingToChangeLanguage(
+      await goToSettingToChangeLanguage(
         threadRobot: threadRobot,
         settingRobot: settingRobot,
         mailboxMenuRobot: mailboxMenuRobot,
@@ -45,7 +47,7 @@ class ForwardEmailWhenChangeLanguageScenario extends BaseTestScenario {
         locale: locale,
       );
 
-      await _generateEmail(emailUser, subject);
+      await generateEmailWithSubject(emailUser: emailUser, subject: subject);
 
       await _forwardEmailBySubject(
         threadRobot: threadRobot,
@@ -55,50 +57,15 @@ class ForwardEmailWhenChangeLanguageScenario extends BaseTestScenario {
         appLocalizations: appLocalizations,
       );
 
-      await _closeComposer(
+      await closeComposer(
         composerRobot: composerRobot,
         imagePaths: imagePaths,
       );
 
-      await _closeEmailDetailedView(emailRobot: emailRobot);
+      await closeEmailDetailedView(emailRobot: emailRobot);
 
       await $.pumpAndTrySettle();
     }
-  }
-
-  Future<void> _goToSettingToChangeLanguage({
-    required ThreadRobot threadRobot,
-    required SettingRobot settingRobot,
-    required MailboxMenuRobot mailboxMenuRobot,
-    required LanguageRobot languageRobot,
-    required AppLocalizations appLocalizations,
-    required Locale locale,
-  }) async {
-    await threadRobot.openMailbox();
-    await mailboxMenuRobot.openSetting();
-    await _expectLanguageMenuItemVisible();
-
-    await settingRobot.openLanguageMenuItem();
-    await languageRobot.openLanguageContextMenu();
-    await languageRobot.selectLanguage(locale, appLocalizations);
-    await _expectLanguageViewByLocaleTitleVisible(appLocalizations);
-
-    await settingRobot.backToSettingsFromFirstLevel();
-    await settingRobot.closeSettings();
-  }
-
-  Future<void> _generateEmail(String emailUser, String subject) async {
-    await provisionEmail(
-      [
-        ProvisioningEmail(
-          toEmail: emailUser,
-          subject: subject,
-          content: subject,
-        ),
-      ],
-      requestReadReceipt: false,
-    );
-    await $.pumpAndTrySettle();
   }
 
   Future<void> _forwardEmailBySubject({
@@ -122,31 +89,6 @@ class ForwardEmailWhenChangeLanguageScenario extends BaseTestScenario {
       appLocalizations: appLocalizations,
       subject: subject,
     );
-  }
-
-  Future<void> _closeComposer({
-    required ComposerRobot composerRobot,
-    required ImagePaths imagePaths,
-  }) async {
-    await composerRobot.tapCloseComposer(imagePaths);
-    await composerRobot.tapDiscardChanges();
-  }
-
-  Future<void> _closeEmailDetailedView({required EmailRobot emailRobot}) async {
-    await emailRobot.onTapBackButton();
-  }
-
-  Future<void> _expectLanguageMenuItemVisible() async {
-    await $(#setting_language_region).scrollTo(
-      scrollDirection: AxisDirection.down,
-    );
-    await expectViewVisible($(#setting_language_region));
-  }
-
-  Future<void> _expectLanguageViewByLocaleTitleVisible(
-    AppLocalizations appLocalizations,
-  ) async {
-    await expectViewVisible($(find.text(appLocalizations.language)));
   }
 
   Future<void> _expectEmailViewVisible() async {

--- a/integration_test/scenarios/email_detailed/reply_email_replied_when_change_language_scenario.dart
+++ b/integration_test/scenarios/email_detailed/reply_email_replied_when_change_language_scenario.dart
@@ -86,10 +86,7 @@ class ReplyEmailRepliedWhenChangeLanguageScenario extends BaseTestScenario
     await composerRobot.grantContactPermission();
     await $.pumpAndTrySettle();
 
-    await _expectComposerSubjectIsNotChanged(
-      appLocalizations: appLocalizations,
-      subject: subject,
-    );
+    await _expectComposerSubjectIsNotChanged(subject: subject);
   }
 
   Future<void> _expectEmailViewVisible() async {
@@ -105,7 +102,6 @@ class ReplyEmailRepliedWhenChangeLanguageScenario extends BaseTestScenario
   }
 
   Future<void> _expectComposerSubjectIsNotChanged({
-    required AppLocalizations appLocalizations,
     required String subject,
   }) async {
     expect(

--- a/integration_test/scenarios/email_detailed/reply_email_replied_when_change_language_scenario.dart
+++ b/integration_test/scenarios/email_detailed/reply_email_replied_when_change_language_scenario.dart
@@ -1,0 +1,177 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/subject_composer_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/email_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/localizations/localization_service.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/composer_robot.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/language_robot.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/setting_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class ReplyEmailRepliedWhenChangeLanguageScenario extends BaseTestScenario {
+  const ReplyEmailRepliedWhenChangeLanguageScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
+
+    final threadRobot = ThreadRobot($);
+    final emailRobot = EmailRobot($);
+    final composerRobot = ComposerRobot($);
+    final settingRobot = SettingRobot($);
+    final languageRobot = LanguageRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+    final imagePaths = ImagePaths();
+
+    for (var locale in LocalizationService.supportedLocales) {
+      final appLocalizations = await AppLocalizations.load(locale);
+
+      String subject =
+          '${appLocalizations.prefix_reply_email} Email by locale ${locale.languageCode}';
+
+      await _goToSettingToChangeLanguage(
+        threadRobot: threadRobot,
+        settingRobot: settingRobot,
+        mailboxMenuRobot: mailboxMenuRobot,
+        languageRobot: languageRobot,
+        appLocalizations: appLocalizations,
+        locale: locale,
+      );
+
+      await _generateEmail(emailUser, subject);
+
+      await _replyEmailBySubject(
+        threadRobot: threadRobot,
+        emailRobot: emailRobot,
+        composerRobot: composerRobot,
+        subject: subject,
+        appLocalizations: appLocalizations,
+      );
+
+      await _closeComposer(
+        composerRobot: composerRobot,
+        imagePaths: imagePaths,
+      );
+
+      await _closeEmailDetailedView(emailRobot: emailRobot);
+
+      await $.pumpAndTrySettle();
+    }
+  }
+
+  Future<void> _goToSettingToChangeLanguage({
+    required ThreadRobot threadRobot,
+    required SettingRobot settingRobot,
+    required MailboxMenuRobot mailboxMenuRobot,
+    required LanguageRobot languageRobot,
+    required AppLocalizations appLocalizations,
+    required Locale locale,
+  }) async {
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openSetting();
+    await _expectLanguageMenuItemVisible();
+
+    await settingRobot.openLanguageMenuItem();
+    await languageRobot.openLanguageContextMenu();
+    await languageRobot.selectLanguage(locale, appLocalizations);
+    await _expectLanguageViewByLocaleTitleVisible(appLocalizations);
+
+    await settingRobot.backToSettingsFromFirstLevel();
+    await settingRobot.closeSettings();
+  }
+
+  Future<void> _generateEmail(String emailUser, String subject) async {
+    await provisionEmail(
+      [
+        ProvisioningEmail(
+          toEmail: emailUser,
+          subject: subject,
+          content: subject,
+        ),
+      ],
+      requestReadReceipt: false,
+    );
+    await $.pumpAndTrySettle();
+  }
+
+  Future<void> _replyEmailBySubject({
+    required ThreadRobot threadRobot,
+    required EmailRobot emailRobot,
+    required ComposerRobot composerRobot,
+    required String subject,
+    required AppLocalizations appLocalizations,
+  }) async {
+    await threadRobot.openEmailWithSubject(subject);
+    await _expectEmailViewVisible();
+    await _expectReplyEmailButtonVisible();
+
+    await emailRobot.onTapReplyEmail();
+    await _expectComposerViewVisible();
+
+    await composerRobot.grantContactPermission();
+    await $.pumpAndTrySettle();
+
+    await _expectComposerSubjectIsNotChanged(
+      appLocalizations: appLocalizations,
+      subject: subject,
+    );
+  }
+
+  Future<void> _closeComposer({
+    required ComposerRobot composerRobot,
+    required ImagePaths imagePaths,
+  }) async {
+    await composerRobot.tapCloseComposer(imagePaths);
+    await composerRobot.tapDiscardChanges();
+  }
+
+  Future<void> _closeEmailDetailedView({required EmailRobot emailRobot}) async {
+    await emailRobot.onTapBackButton();
+  }
+
+  Future<void> _expectLanguageMenuItemVisible() async {
+    await $(#setting_language_region).scrollTo(
+      scrollDirection: AxisDirection.down,
+    );
+    await expectViewVisible($(#setting_language_region));
+  }
+
+  Future<void> _expectLanguageViewByLocaleTitleVisible(
+    AppLocalizations appLocalizations,
+  ) async {
+    await expectViewVisible($(find.text(appLocalizations.language)));
+  }
+
+  Future<void> _expectEmailViewVisible() async {
+    await expectViewVisible($(EmailView));
+  }
+
+  Future<void> _expectReplyEmailButtonVisible() async {
+    await expectViewVisible($(#reply_email_button));
+  }
+
+  Future<void> _expectComposerViewVisible() async {
+    await expectViewVisible($(ComposerView));
+  }
+
+  Future<void> _expectComposerSubjectIsNotChanged({
+    required AppLocalizations appLocalizations,
+    required String subject,
+  }) async {
+    expect(
+      $(SubjectComposerWidget)
+          .which<SubjectComposerWidget>(
+              (widget) => widget.textController.text == subject)
+          .visible,
+      isTrue,
+    );
+  }
+}

--- a/integration_test/scenarios/email_detailed/reply_email_replied_when_change_language_scenario.dart
+++ b/integration_test/scenarios/email_detailed/reply_email_replied_when_change_language_scenario.dart
@@ -1,5 +1,4 @@
 import 'package:core/presentation/resources/image_paths.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/subject_composer_widget.dart';
@@ -8,7 +7,9 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/localizations/localization_service.dart';
 
 import '../../base/base_test_scenario.dart';
-import '../../models/provisioning_email.dart';
+import '../../mixin/generate_email_scenario_mixin.dart';
+import '../../mixin/screen_scenario_mixin.dart';
+import '../../mixin/setting_scenario_mixin.dart';
 import '../../robots/composer_robot.dart';
 import '../../robots/email_robot.dart';
 import '../../robots/language_robot.dart';
@@ -16,7 +17,8 @@ import '../../robots/mailbox_menu_robot.dart';
 import '../../robots/setting_robot.dart';
 import '../../robots/thread_robot.dart';
 
-class ReplyEmailRepliedWhenChangeLanguageScenario extends BaseTestScenario {
+class ReplyEmailRepliedWhenChangeLanguageScenario extends BaseTestScenario
+    with SettingScenarioMixin, GenerateEmailScenarioMixin, ScreenScenarioMixin {
   const ReplyEmailRepliedWhenChangeLanguageScenario(super.$);
 
   @override
@@ -37,7 +39,7 @@ class ReplyEmailRepliedWhenChangeLanguageScenario extends BaseTestScenario {
       String subject =
           '${appLocalizations.prefix_reply_email} Email by locale ${locale.languageCode}';
 
-      await _goToSettingToChangeLanguage(
+      await goToSettingToChangeLanguage(
         threadRobot: threadRobot,
         settingRobot: settingRobot,
         mailboxMenuRobot: mailboxMenuRobot,
@@ -46,7 +48,7 @@ class ReplyEmailRepliedWhenChangeLanguageScenario extends BaseTestScenario {
         locale: locale,
       );
 
-      await _generateEmail(emailUser, subject);
+      await generateEmailWithSubject(emailUser: emailUser, subject: subject);
 
       await _replyEmailBySubject(
         threadRobot: threadRobot,
@@ -56,50 +58,15 @@ class ReplyEmailRepliedWhenChangeLanguageScenario extends BaseTestScenario {
         appLocalizations: appLocalizations,
       );
 
-      await _closeComposer(
+      await closeComposer(
         composerRobot: composerRobot,
         imagePaths: imagePaths,
       );
 
-      await _closeEmailDetailedView(emailRobot: emailRobot);
+      await closeEmailDetailedView(emailRobot: emailRobot);
 
       await $.pumpAndTrySettle();
     }
-  }
-
-  Future<void> _goToSettingToChangeLanguage({
-    required ThreadRobot threadRobot,
-    required SettingRobot settingRobot,
-    required MailboxMenuRobot mailboxMenuRobot,
-    required LanguageRobot languageRobot,
-    required AppLocalizations appLocalizations,
-    required Locale locale,
-  }) async {
-    await threadRobot.openMailbox();
-    await mailboxMenuRobot.openSetting();
-    await _expectLanguageMenuItemVisible();
-
-    await settingRobot.openLanguageMenuItem();
-    await languageRobot.openLanguageContextMenu();
-    await languageRobot.selectLanguage(locale, appLocalizations);
-    await _expectLanguageViewByLocaleTitleVisible(appLocalizations);
-
-    await settingRobot.backToSettingsFromFirstLevel();
-    await settingRobot.closeSettings();
-  }
-
-  Future<void> _generateEmail(String emailUser, String subject) async {
-    await provisionEmail(
-      [
-        ProvisioningEmail(
-          toEmail: emailUser,
-          subject: subject,
-          content: subject,
-        ),
-      ],
-      requestReadReceipt: false,
-    );
-    await $.pumpAndTrySettle();
   }
 
   Future<void> _replyEmailBySubject({
@@ -123,31 +90,6 @@ class ReplyEmailRepliedWhenChangeLanguageScenario extends BaseTestScenario {
       appLocalizations: appLocalizations,
       subject: subject,
     );
-  }
-
-  Future<void> _closeComposer({
-    required ComposerRobot composerRobot,
-    required ImagePaths imagePaths,
-  }) async {
-    await composerRobot.tapCloseComposer(imagePaths);
-    await composerRobot.tapDiscardChanges();
-  }
-
-  Future<void> _closeEmailDetailedView({required EmailRobot emailRobot}) async {
-    await emailRobot.onTapBackButton();
-  }
-
-  Future<void> _expectLanguageMenuItemVisible() async {
-    await $(#setting_language_region).scrollTo(
-      scrollDirection: AxisDirection.down,
-    );
-    await expectViewVisible($(#setting_language_region));
-  }
-
-  Future<void> _expectLanguageViewByLocaleTitleVisible(
-    AppLocalizations appLocalizations,
-  ) async {
-    await expectViewVisible($(find.text(appLocalizations.language)));
   }
 
   Future<void> _expectEmailViewVisible() async {

--- a/integration_test/scenarios/email_detailed/reply_email_when_change_language_scenario.dart
+++ b/integration_test/scenarios/email_detailed/reply_email_when_change_language_scenario.dart
@@ -1,0 +1,177 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/subject_composer_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/email_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/localizations/localization_service.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/composer_robot.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/language_robot.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/setting_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class ReplyEmailWhenChangeLanguageScenario extends BaseTestScenario {
+  const ReplyEmailWhenChangeLanguageScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
+
+    final threadRobot = ThreadRobot($);
+    final emailRobot = EmailRobot($);
+    final composerRobot = ComposerRobot($);
+    final settingRobot = SettingRobot($);
+    final languageRobot = LanguageRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+    final imagePaths = ImagePaths();
+
+    for (var locale in LocalizationService.supportedLocales) {
+      String subject = 'Reply email by locale ${locale.languageCode}';
+
+      final appLocalizations = await AppLocalizations.load(locale);
+
+      await _goToSettingToChangeLanguage(
+        threadRobot: threadRobot,
+        settingRobot: settingRobot,
+        mailboxMenuRobot: mailboxMenuRobot,
+        languageRobot: languageRobot,
+        appLocalizations: appLocalizations,
+        locale: locale,
+      );
+
+      await _generateEmail(emailUser, subject);
+
+      await _replyEmailBySubject(
+        threadRobot: threadRobot,
+        emailRobot: emailRobot,
+        composerRobot: composerRobot,
+        subject: subject,
+        appLocalizations: appLocalizations,
+      );
+
+      await _closeComposer(
+        composerRobot: composerRobot,
+        imagePaths: imagePaths,
+      );
+
+      await _closeEmailDetailedView(emailRobot: emailRobot);
+
+      await $.pumpAndTrySettle();
+    }
+  }
+
+  Future<void> _goToSettingToChangeLanguage({
+    required ThreadRobot threadRobot,
+    required SettingRobot settingRobot,
+    required MailboxMenuRobot mailboxMenuRobot,
+    required LanguageRobot languageRobot,
+    required AppLocalizations appLocalizations,
+    required Locale locale,
+  }) async {
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openSetting();
+    await _expectLanguageMenuItemVisible();
+
+    await settingRobot.openLanguageMenuItem();
+    await languageRobot.openLanguageContextMenu();
+    await languageRobot.selectLanguage(locale, appLocalizations);
+    await _expectLanguageViewByLocaleTitleVisible(appLocalizations);
+
+    await settingRobot.backToSettingsFromFirstLevel();
+    await settingRobot.closeSettings();
+  }
+
+  Future<void> _generateEmail(String emailUser, String subject) async {
+    await provisionEmail(
+      [
+        ProvisioningEmail(
+          toEmail: emailUser,
+          subject: subject,
+          content: subject,
+        ),
+      ],
+      requestReadReceipt: false,
+    );
+    await $.pumpAndTrySettle();
+  }
+
+  Future<void> _replyEmailBySubject({
+    required ThreadRobot threadRobot,
+    required EmailRobot emailRobot,
+    required ComposerRobot composerRobot,
+    required String subject,
+    required AppLocalizations appLocalizations,
+  }) async {
+    await threadRobot.openEmailWithSubject(subject);
+    await _expectEmailViewVisible();
+    await _expectReplyEmailButtonVisible();
+
+    await emailRobot.onTapReplyEmail();
+    await _expectComposerViewVisible();
+
+    await composerRobot.grantContactPermission();
+    await $.pumpAndTrySettle();
+
+    await _expectComposerSubjectDisplayedCorrectly(
+      appLocalizations: appLocalizations,
+      subject: subject,
+    );
+  }
+
+  Future<void> _closeComposer({
+    required ComposerRobot composerRobot,
+    required ImagePaths imagePaths,
+  }) async {
+    await composerRobot.tapCloseComposer(imagePaths);
+    await composerRobot.tapDiscardChanges();
+  }
+
+  Future<void> _closeEmailDetailedView({required EmailRobot emailRobot}) async {
+    await emailRobot.onTapBackButton();
+  }
+
+  Future<void> _expectLanguageMenuItemVisible() async {
+    await $(#setting_language_region).scrollTo(
+      scrollDirection: AxisDirection.down,
+    );
+    await expectViewVisible($(#setting_language_region));
+  }
+
+  Future<void> _expectLanguageViewByLocaleTitleVisible(
+    AppLocalizations appLocalizations,
+  ) async {
+    await expectViewVisible($(find.text(appLocalizations.language)));
+  }
+
+  Future<void> _expectEmailViewVisible() async {
+    await expectViewVisible($(EmailView));
+  }
+
+  Future<void> _expectReplyEmailButtonVisible() async {
+    await expectViewVisible($(#reply_email_button));
+  }
+
+  Future<void> _expectComposerViewVisible() async {
+    await expectViewVisible($(ComposerView));
+  }
+
+  Future<void> _expectComposerSubjectDisplayedCorrectly({
+    required AppLocalizations appLocalizations,
+    required String subject,
+  }) async {
+    expect(
+      $(SubjectComposerWidget)
+          .which<SubjectComposerWidget>((widget) =>
+              widget.textController.text ==
+              '${appLocalizations.prefix_reply_email} $subject')
+          .visible,
+      isTrue,
+    );
+  }
+}

--- a/integration_test/tests/email_detailed/forward_email_forwarded_when_change_language_test.dart
+++ b/integration_test/tests/email_detailed/forward_email_forwarded_when_change_language_test.dart
@@ -1,0 +1,10 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/forward_email_forwarded_when_change_language_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description:
+        'The subject line of an email should not be changed when forwarding to an email that has already been forwarded to.',
+    scenarioBuilder: ($) => ForwardEmailForwardedWhenChangeLanguageScenario($),
+  );
+}

--- a/integration_test/tests/email_detailed/forward_email_when_change_language_test.dart
+++ b/integration_test/tests/email_detailed/forward_email_when_change_language_test.dart
@@ -4,7 +4,7 @@ import '../../scenarios/email_detailed/forward_email_when_change_language_scenar
 void main() {
   TestBase().runPatrolTest(
     description:
-        'The forward prefix should be displayed correctly when forwarding to an email.',
+        'The forward prefix should be displayed correctly when forwarding an email.',
     scenarioBuilder: ($) => ForwardEmailWhenChangeLanguageScenario($),
   );
 }

--- a/integration_test/tests/email_detailed/forward_email_when_change_language_test.dart
+++ b/integration_test/tests/email_detailed/forward_email_when_change_language_test.dart
@@ -1,0 +1,10 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/forward_email_when_change_language_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description:
+        'The forward prefix should be displayed correctly when forwarding to an email.',
+    scenarioBuilder: ($) => ForwardEmailWhenChangeLanguageScenario($),
+  );
+}

--- a/integration_test/tests/email_detailed/reply_email_replied_when_change_language_test.dart
+++ b/integration_test/tests/email_detailed/reply_email_replied_when_change_language_test.dart
@@ -1,0 +1,10 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/reply_email_replied_when_change_language_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description:
+        'The subject line of an email should not be changed when replying to an email that has already been replied to.',
+    scenarioBuilder: ($) => ReplyEmailRepliedWhenChangeLanguageScenario($),
+  );
+}

--- a/integration_test/tests/email_detailed/reply_email_when_change_language_test.dart
+++ b/integration_test/tests/email_detailed/reply_email_when_change_language_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/reply_email_when_change_language_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'The reply prefix should be displayed correctly when replying to an email.',
+    scenarioBuilder: ($) => ReplyEmailWhenChangeLanguageScenario($),
+  );
+}

--- a/lib/features/composer/presentation/extensions/email_action_type_extension.dart
+++ b/lib/features/composer/presentation/extensions/email_action_type_extension.dart
@@ -10,26 +10,27 @@ import 'package:model/extensions/utc_date_extension.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 extension EmailActionTypeExtension on EmailActionType {
+  static const String _defaultReplyPrefix = 'Re:';
+  static const String _defaultForwardPrefix = 'Fwd:';
+
   String getSubjectComposer(BuildContext? context, String subject) {
-    switch(this) {
+    final l10n = context != null ? AppLocalizations.of(context) : null;
+
+    switch (this) {
       case EmailActionType.reply:
       case EmailActionType.replyToList:
       case EmailActionType.replyAll:
-        if (subject.toLowerCase().startsWith('re:')) {
-          return subject;
-        } else {
-          return context != null
-            ? '${AppLocalizations.of(context).prefix_reply_email} $subject'
-            : 'Re: $subject';
-        }
+        return _applyPrefix(
+          subject: subject,
+          defaultPrefix: _defaultReplyPrefix,
+          localizedPrefix: l10n?.prefix_reply_email,
+        );
       case EmailActionType.forward:
-        if (subject.toLowerCase().startsWith('fwd:')) {
-          return subject;
-        } else {
-          return context != null
-            ? '${AppLocalizations.of(context).prefix_forward_email} $subject'
-            : 'Fwd: $subject';
-        }
+        return _applyPrefix(
+          subject: subject,
+          defaultPrefix: _defaultForwardPrefix,
+          localizedPrefix: l10n?.prefix_forward_email,
+        );
       case EmailActionType.editDraft:
       case EmailActionType.editSendingEmail:
       case EmailActionType.reopenComposerBrowser:
@@ -40,6 +41,29 @@ extension EmailActionTypeExtension on EmailActionType {
       default:
         return '';
     }
+  }
+
+  String _applyPrefix({
+    required String subject,
+    required String defaultPrefix,
+    String? localizedPrefix,
+  }) {
+    final trimmed = subject.trim();
+    final lowerSubject = trimmed.toLowerCase();
+
+    final prefixes = <String>[
+      defaultPrefix.toLowerCase(),
+      if (localizedPrefix != null) localizedPrefix.toLowerCase(),
+    ];
+
+    final hasPrefix = prefixes.any(lowerSubject.startsWith);
+
+    if (hasPrefix) {
+      return subject;
+    }
+
+    final prefix = localizedPrefix ?? defaultPrefix;
+    return '$prefix $subject';
   }
 
   String getToastMessageMoveToMailboxSuccess(BuildContext context, {String? destinationPath}) {

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -162,13 +162,13 @@
       "emailAddress": {}
     }
   },
-  "prefix_reply_email": "Re :",
+  "prefix_reply_email": "Re:",
   "@prefix_reply_email": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "prefix_forward_email": "Tr :",
+  "prefix_forward_email": "Tr:",
   "@prefix_forward_email": {
     "type": "text",
     "placeholders_order": [],

--- a/test/features/composer/presentation/extensions/get_subject_composer_test.dart
+++ b/test/features/composer/presentation/extensions/get_subject_composer_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/email/email_action_type.dart';
+import 'package:tmail_ui_user/features/composer/presentation/extensions/email_action_type_extension.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations_delegate.dart';
+import 'package:tmail_ui_user/main/localizations/localization_service.dart';
+
+void main() {
+  Future<BuildContext> pumpLocalizedWidget(
+    WidgetTester tester,
+    Locale locale,
+  ) async {
+    late BuildContext context;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: locale,
+        supportedLocales: LocalizationService.supportedLocales,
+        localizationsDelegates: const [
+          AppLocalizationsDelegate(),
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        home: Builder(
+          builder: (ctx) {
+            context = ctx;
+            return const SizedBox();
+          },
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    return context;
+  }
+
+  group('EmailActionTypeExtension.getSubjectComposer', () {
+    const subject = 'Hello world';
+
+    group('reply actions', () {
+      test('should add default Re prefix when context is null', () {
+        final result = EmailActionType.reply.getSubjectComposer(null, subject);
+
+        expect(result, 'Re: Hello world');
+      });
+
+      test('should not duplicate Re prefix', () {
+        const subjectWithPrefix = 'Re: Hello world';
+
+        final result =
+            EmailActionType.reply.getSubjectComposer(null, subjectWithPrefix);
+
+        expect(result, subjectWithPrefix);
+      });
+
+      test('should ignore case when checking prefix', () {
+        const subjectWithPrefix = 're: Hello world';
+
+        final result =
+            EmailActionType.reply.getSubjectComposer(null, subjectWithPrefix);
+
+        expect(result, subjectWithPrefix);
+      });
+    });
+
+    group('forward actions', () {
+      test('should add default Fwd prefix when context is null', () {
+        final result =
+            EmailActionType.forward.getSubjectComposer(null, subject);
+
+        expect(result, 'Fwd: Hello world');
+      });
+
+      test('should not duplicate Fwd prefix', () {
+        const subjectWithPrefix = 'Fwd: Hello world';
+
+        final result =
+            EmailActionType.forward.getSubjectComposer(null, subjectWithPrefix);
+
+        expect(result, subjectWithPrefix);
+      });
+
+      test('should ignore case when checking prefix', () {
+        const subjectWithPrefix = 'fwd: Hello world';
+
+        final result =
+            EmailActionType.forward.getSubjectComposer(null, subjectWithPrefix);
+
+        expect(result, subjectWithPrefix);
+      });
+    });
+
+    group('edit actions', () {
+      test('editDraft should return original subject', () {
+        final result =
+            EmailActionType.editDraft.getSubjectComposer(null, subject);
+
+        expect(result, subject);
+      });
+
+      test('editSendingEmail should return original subject', () {
+        final result =
+            EmailActionType.editSendingEmail.getSubjectComposer(null, subject);
+
+        expect(result, subject);
+      });
+
+      test('editAsNewEmail should return original subject', () {
+        final result =
+            EmailActionType.editAsNewEmail.getSubjectComposer(null, subject);
+
+        expect(result, subject);
+      });
+    });
+
+    group('default case', () {
+      test('should return empty string for unsupported action', () {
+        final result =
+            EmailActionType.markAsRead.getSubjectComposer(null, subject);
+
+        expect(result, '');
+      });
+    });
+
+    group('localized prefix', () {
+      testWidgets('should use localized reply prefix (vi)', (tester) async {
+        final context = await pumpLocalizedWidget(
+          tester,
+          const Locale('vi'),
+        );
+
+        const subject = 'Hello world';
+
+        final result =
+            EmailActionType.reply.getSubjectComposer(context, subject);
+
+        final prefix = AppLocalizations.of(context).prefix_reply_email;
+
+        expect(result, '$prefix Hello world');
+      });
+
+      testWidgets('should not duplicate localized reply prefix',
+          (tester) async {
+        final context = await pumpLocalizedWidget(
+          tester,
+          const Locale('vi'),
+        );
+
+        final prefix = AppLocalizations.of(context).prefix_reply_email;
+
+        final subject = '$prefix Hello world';
+
+        final result =
+            EmailActionType.reply.getSubjectComposer(context, subject);
+
+        expect(result, subject);
+      });
+
+      testWidgets('should use localized forward prefix', (tester) async {
+        final context = await pumpLocalizedWidget(
+          tester,
+          const Locale('fr'),
+        );
+
+        const subject = 'Hello world';
+
+        final result =
+            EmailActionType.forward.getSubjectComposer(context, subject);
+
+        final prefix = AppLocalizations.of(context).prefix_forward_email;
+
+        expect(result, '$prefix Hello world');
+      });
+
+      testWidgets('should not duplicate localized forward prefix',
+          (tester) async {
+        final context = await pumpLocalizedWidget(
+          tester,
+          const Locale('fr'),
+        );
+
+        final prefix = AppLocalizations.of(context).prefix_forward_email;
+
+        final subject = '$prefix Hello world';
+
+        final result =
+            EmailActionType.forward.getSubjectComposer(context, subject);
+
+        expect(result, subject);
+      });
+
+      for (final locale in LocalizationService.supportedLocales) {
+        testWidgets('reply prefix works for $locale', (tester) async {
+          final context = await pumpLocalizedWidget(tester, locale);
+
+          final result =
+              EmailActionType.reply.getSubjectComposer(context, 'Hello');
+
+          final prefix = AppLocalizations.of(context).prefix_reply_email;
+
+          expect(result, '$prefix Hello');
+        });
+      }
+    });
+  });
+}

--- a/test/features/composer/presentation/extensions/get_subject_composer_test.dart
+++ b/test/features/composer/presentation/extensions/get_subject_composer_test.dart
@@ -65,6 +65,19 @@ void main() {
 
         expect(result, subjectWithPrefix);
       });
+
+      test('Reply: does not dedupe legacy French NBSP prefix', () {
+        const original = 'Re\u00A0: Legacy subject';
+        final result = EmailActionType.reply.getSubjectComposer(null, original);
+        expect(result, 'Re: $original');
+      });
+
+      test('Forward: does not dedupe legacy French NBSP prefix', () {
+        const original = 'Tr\u00A0: Legacy subject';
+        final result =
+            EmailActionType.forward.getSubjectComposer(null, original);
+        expect(result, 'Fwd: $original');
+      });
     });
 
     group('forward actions', () {


### PR DESCRIPTION
## Issue

#4367 

## Root cause

Because the French prefix `Re:` intl has been changed to `Re:`, the validation logic ignores it.


![Screenshot 2026-03-09 at 15 03 30](https://github.com/user-attachments/assets/4515b6ed-7c02-450e-ae38-3df3a92d7a5e)


## Resolved



https://github.com/user-attachments/assets/221369fd-c48b-4e17-a666-cc8608706f01



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized French reply/forward labels to "Re:" and "Tr:" and updated composer logic to avoid duplicate or incorrect reply/forward prefixes across locales.

* **Tests**
  * Added unit and integration tests covering localized subject-prefix behavior, prefix deduplication, and multi-locale reply/forward scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->