### PR TITLE
TF-4368 Fix cannot scroll in email list

### DIFF
--- a/lib/features/thread/data/repository/thread_repository_impl.dart
+++ b/lib/features/thread/data/repository/thread_repository_impl.dart
@@ -89,6 +89,17 @@ class ThreadRepositoryImpl extends ThreadRepository {
           propertiesCreated: propertiesCreated,
         );
       }
+      logTrace(
+        'ThreadRepositoryImpl::getAllEmail(): '
+        'CachedEmail = ${localEmailResponse.emailList?.length}, '
+        'CachedNotFoundEmailIds = ${localEmailResponse.notFoundEmailIds?.length}, '
+        'CachedState = ${localEmailResponse.state?.value}, '
+        'NetworkEmail = ${networkEmailResponse.emailList?.length}, '
+        'NetworkNotFoundEmailIds = ${networkEmailResponse.notFoundEmailIds?.length}, '
+        'NetworkState = ${networkEmailResponse.state?.value}, '
+        'Limit = ${limit?.value}, '
+        'MailboxId = ${emailFilter?.mailboxId?.asString}',
+      );
       yield networkEmailResponse;
     } else {
       yield localEmailResponse;
@@ -136,6 +147,13 @@ class ThreadRepositoryImpl extends ThreadRepository {
       return EmailsResponse(emailList: response.first, state: response.last);
     });
 
+    logTrace(
+      'ThreadRepositoryImpl::getAllEmail(): '
+      'DisplayedCachedEmail = ${newEmailResponse.emailList?.length}, '
+      'DisplayedNotFoundEmailIds = ${newEmailResponse.notFoundEmailIds?.length}, '
+      'DisplayedState = ${newEmailResponse.state?.value}',
+    );
+
     yield newEmailResponse;
   }
 
@@ -182,14 +200,17 @@ class ThreadRepositoryImpl extends ThreadRepository {
     );
 
     final serverCount = serverResponse.emailList?.length ?? 0;
+    final notFoundEmailIds = serverResponse.notFoundEmailIds ?? [];
+    final stateResponse = cachedState ?? serverResponse.state;
 
-    log(
+    logTrace(
       'ThreadRepositoryImpl::forceQueryAllEmailsForWeb(): '
-      'Server email count = $serverCount',
+      'ServerEmailCount = $serverCount, '
+      'ServerNotFoundEmailIds = ${notFoundEmailIds.length}, '
+      'StateResponse = ${stateResponse?.value}',
     );
 
-    if (serverCount > 0 ||
-        (serverResponse.notFoundEmailIds?.isNotEmpty ?? false)) {
+    if (serverCount > 0 || notFoundEmailIds.isNotEmpty) {
       await _updateEmailCache(
         accountId,
         session.username,
@@ -201,7 +222,7 @@ class ThreadRepositoryImpl extends ThreadRepository {
     // Combine server list + keep existing state
     yield EmailsResponse(
       emailList: serverResponse.emailList,
-      state: cachedState ?? serverResponse.state,
+      state: stateResponse,
     );
   }
 

--- a/lib/features/thread/data/repository/thread_repository_impl.dart
+++ b/lib/features/thread/data/repository/thread_repository_impl.dart
@@ -364,13 +364,8 @@ class ThreadRepositoryImpl extends ThreadRepository {
       return EmailsResponse(emailList: response.first, state: response.last);
     });
 
-    final currentLimitEmails =
-        limit?.value ?? ThreadConstants.defaultLimit.value;
-
-    log('ThreadRepositoryImpl::refreshChanges: Current limit emails is $currentLimitEmails');
-
     if (!newEmailResponse.hasEmails()
-        || (newEmailResponse.emailList?.length ?? 0) < currentLimitEmails) {
+        || (newEmailResponse.emailList?.length ?? 0) < ThreadConstants.defaultLimit.value) {
       final networkEmailResponse = await _getFirstPage(
         session,
         accountId,

--- a/lib/features/thread/data/repository/thread_repository_impl.dart
+++ b/lib/features/thread/data/repository/thread_repository_impl.dart
@@ -375,9 +375,26 @@ class ThreadRepositoryImpl extends ThreadRepository {
         mailboxId: emailFilter?.mailboxId,
         propertiesCreated: propertiesCreated,
       );
-
+      logTrace(
+        'ThreadRepositoryImpl::refreshChanges():'
+        'CountEmailCached = ${newEmailResponse.emailList?.length}, '
+        'EmailStateCache = ${newEmailResponse.state?.value}, '
+        'InMailboxId = ${emailFilter?.mailboxId?.asString}, '
+        'Limit = ${limit?.value.toInt()}, '
+        'DefaultLimit = ${ThreadConstants.defaultLimit.value.toInt()}, '
+        'CountEmailNetwork = ${networkEmailResponse.emailList?.length}, '
+        'EmailStateNetwork = ${networkEmailResponse.state?.value}, ',
+      );
       yield networkEmailResponse.copyWith(emailChangeResponse: emailChangeResponse);
     } else {
+      logTrace(
+        'ThreadRepositoryImpl::refreshChanges():'
+        'CountEmailCached = ${newEmailResponse.emailList?.length}, '
+        'EmailStateCache = ${newEmailResponse.state?.value}, '
+        'InMailboxId = ${emailFilter?.mailboxId?.asString}, '
+        'Limit = ${limit?.value.toInt()}, '
+        'DefaultLimit = ${ThreadConstants.defaultLimit.value.toInt()}, ',
+      );
       yield newEmailResponse.copyWith(emailChangeResponse: emailChangeResponse);
     }
   }

--- a/lib/features/thread/data/repository/thread_repository_impl.dart
+++ b/lib/features/thread/data/repository/thread_repository_impl.dart
@@ -410,6 +410,12 @@ class ThreadRepositoryImpl extends ThreadRepository {
         newDestroyed: response.notFoundEmailIds,
       );
     }
+    logTrace(
+      'ThreadRepositoryImpl::loadMoreEmails(): emailList = ${response.emailList?.length},'
+      'notFoundEmailIds = ${response.notFoundEmailIds?.length}, '
+      'existNotFoundEmails = ${response.existNotFoundEmails}, '
+      'state = ${response.state?.value}',
+    );
     yield response;
   }
 

--- a/lib/features/thread/domain/constants/thread_constants.dart
+++ b/lib/features/thread/domain/constants/thread_constants.dart
@@ -73,7 +73,6 @@ class ThreadConstants {
   });
 
   static const int defaultMaxHeightEmailItemOnBrowser = 40;
-  static const int defaultMaxHeightBrowser = 1200;
 
   static final propertiesParseEmailByBlobId = Properties({
     EmailProperty.id,

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -477,8 +477,20 @@ class ThreadController extends BaseController with EmailActionController {
     final totalHeightListEmails = currentListEmails.isEmpty
       ? 0
       : currentListEmails.length * ThreadConstants.defaultMaxHeightEmailItemOnBrowser;
-    if (browserInnerHeight >= ThreadConstants.defaultMaxHeightBrowser &&
-        totalHeightListEmails <= browserInnerHeight) {
+    final isAutoLoadMore =
+        browserInnerHeight >= ThreadConstants.defaultMaxHeightBrowser &&
+            totalHeightListEmails <= browserInnerHeight;
+    logTrace(
+      'ThreadController::_validateBrowserHeight():'
+      'BrowserInnerHeight = $browserInnerHeight, '
+      'TotalHeightListEmails = $totalHeightListEmails, '
+      'ThreadConstants.defaultMaxHeightBrowser = ${ThreadConstants.defaultMaxHeightBrowser}, '
+      'ThreadConstants.defaultMaxHeightEmailItemOnBrowser = ${ThreadConstants.defaultMaxHeightEmailItemOnBrowser}, '
+      'CanLoadMore = $canLoadMore, '
+      'isAutoLoadMore = $isAutoLoadMore, '
+      'CountCurrentListEmails = ${currentListEmails.length}',
+    );
+    if (isAutoLoadMore) {
       _performAutomaticallyLoadMoreEmails();
     }
   }
@@ -557,7 +569,9 @@ class ThreadController extends BaseController with EmailActionController {
   }
 
   void _handleOnDoneGetAllEmailFailure() {
-    canLoadMore = false;
+    if (PlatformInfo.isWeb) {
+      _validateBrowserHeight();
+    }
     if (PlatformInfo.isWeb && mailboxDashBoardController.isEmailListDisplayed) {
       refocusMailShortcutFocus();
     }
@@ -630,7 +644,7 @@ class ThreadController extends BaseController with EmailActionController {
       consumeState(Stream.value(Right(GetAllEmailLoading())));
     }
 
-    canLoadMore = false;
+    canLoadMore = true;
     loadingMoreStatus.value = LoadingMoreStatus.idle;
     cancelSelectEmail();
 

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -216,7 +216,6 @@ class ThreadController extends BaseController with EmailActionController {
       popAndPush(AppRoutes.unknownRoutePage);
     } else if (failure is GetAllEmailFailure || failure is CleanAndGetAllEmailFailure) {
       mailboxDashBoardController.updateRefreshAllEmailState(Left(RefreshAllEmailFailure()));
-      canLoadMore = true;
     }
   }
 
@@ -540,6 +539,7 @@ class ThreadController extends BaseController with EmailActionController {
       mailboxDashBoardController.listEmailSelected.value = listEmailSelected;
     }
     canLoadMore = newListEmail.length >= ThreadConstants.maxCountEmails;
+    loadingMoreStatus.value = LoadingMoreStatus.completed;
 
     if (listEmailController.hasClients) {
       listEmailController.jumpTo(0);
@@ -557,6 +557,7 @@ class ThreadController extends BaseController with EmailActionController {
   }
 
   void _handleOnDoneGetAllEmailFailure() {
+    canLoadMore = false;
     if (PlatformInfo.isWeb && mailboxDashBoardController.isEmailListDisplayed) {
       refocusMailShortcutFocus();
     }
@@ -586,7 +587,6 @@ class ThreadController extends BaseController with EmailActionController {
     if (mailboxDashBoardController.isSelectionEnabled()) {
       mailboxDashBoardController.listEmailSelected.value = listEmailSelected;
     }
-    canLoadMore = emailListSynced.length >= ThreadConstants.maxCountEmails;
 
     if (PlatformInfo.isWeb) {
       _validateBrowserHeight();
@@ -814,7 +814,9 @@ class ThreadController extends BaseController with EmailActionController {
 
   void _loadMoreEmails() {
     log('ThreadController::_loadMoreEmails()::canLoadMore = $canLoadMore');
-    if (canLoadMore && _session != null && _accountId != null) {
+    if (!canLoadMore) return;
+
+    if (_session != null && _accountId != null) {
       final oldestEmail = mailboxDashBoardController.emailsInCurrentMailbox.isNotEmpty
         ? mailboxDashBoardController.emailsInCurrentMailbox.last
         : null;
@@ -832,6 +834,10 @@ class ThreadController extends BaseController with EmailActionController {
           useCache: selectedMailbox?.isCacheable ?? false,
         )
       ));
+    } else {
+      consumeState(
+        Stream.value(Left(LoadMoreEmailsFailure(NotFoundSessionException()))),
+      );
     }
   }
 
@@ -1095,6 +1101,7 @@ class ThreadController extends BaseController with EmailActionController {
       mailboxDashBoardController.listEmailSelected.value = listEmailSelected;
     }
     canSearchMore = newEmailListSynced.length >= ThreadConstants.maxCountEmails;
+    loadingMoreStatus.value = LoadingMoreStatus.completed;
 
     if (PlatformInfo.isWeb) {
       _validateBrowserHeight();
@@ -1106,7 +1113,9 @@ class ThreadController extends BaseController with EmailActionController {
 
   void _searchMoreEmails() {
     log('ThreadController::_searchMoreEmails:');
-    if (canSearchMore && _session != null && _accountId != null) {
+    if (!canSearchMore) return;
+
+    if (_session != null && _accountId != null) {
       final lastEmail = mailboxDashBoardController.emailsInCurrentMailbox.isNotEmpty
         ? mailboxDashBoardController.emailsInCurrentMailbox.last
         : null;
@@ -1133,6 +1142,10 @@ class ThreadController extends BaseController with EmailActionController {
         properties: EmailUtils.getPropertiesForEmailGetMethod(_session!, _accountId!),
         lastEmailId: lastEmail?.id
       ));
+    } else {
+      consumeState(
+        Stream.value(Left(SearchMoreEmailFailure(NotFoundSessionException()))),
+      );
     }
   }
 

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -97,8 +97,8 @@ class ThreadController extends BaseController with EmailActionController {
   final openingEmail = RxBool(false);
   final loadingMoreStatus = Rx(LoadingMoreStatus.idle);
 
-  bool canLoadMore = false;
-  bool canSearchMore = false;
+  bool canLoadMore = true;
+  bool canSearchMore = true;
   MailboxId? _currentMemoryMailboxId;
   int _peakEmailCount = 0;
   final ScrollController listEmailController = ScrollController();
@@ -203,6 +203,7 @@ class ThreadController extends BaseController with EmailActionController {
     if (failure is SearchEmailFailure) {
       mailboxDashBoardController.updateRefreshAllEmailState(Left(RefreshAllEmailFailure()));
       canSearchMore = false;
+      loadingMoreStatus.value = LoadingMoreStatus.idle;
       mailboxDashBoardController.emailsInCurrentMailbox.clear();
       showRetryToast(failure);
     } else if (failure is SearchMoreEmailFailure) {
@@ -245,7 +246,7 @@ class ThreadController extends BaseController with EmailActionController {
       },
       (success) {
         if (success is GetAllEmailSuccess) {
-          _handleOnDoneGetAllEmailSuccess();
+          _handleOnDoneGetAllEmailSuccess(success);
         }
       },
     );
@@ -411,7 +412,7 @@ class ThreadController extends BaseController with EmailActionController {
 
     ever(mailboxDashBoardController.emailsInCurrentMailbox, (emails) {
       final countEmails = emails.length;
-      log(
+      logTrace(
         'ThreadController::Ever(mailboxDashBoardController.emailsInCurrentMailbox): '
         'Count emails is $countEmails, '
         '_peakEmailCount is $_peakEmailCount',
@@ -472,27 +473,56 @@ class ThreadController extends BaseController with EmailActionController {
   }
 
   void _validateBrowserHeight() {
+    if (_isAutoLoadMore) {
+      _performAutomaticallyLoadMoreEmails();
+    }
+  }
+
+  bool get _isAutoLoadMore {
+    if (!PlatformInfo.isWeb) {
+      return _isNonWebAutoLoadMore;
+    }
     final browserInnerHeight = html.window.innerHeight ?? 0;
     final currentListEmails = mailboxDashBoardController.emailsInCurrentMailbox;
     final totalHeightListEmails = currentListEmails.isEmpty
-      ? 0
-      : currentListEmails.length * ThreadConstants.defaultMaxHeightEmailItemOnBrowser;
-    final isAutoLoadMore =
-        browserInnerHeight >= ThreadConstants.defaultMaxHeightBrowser &&
-            totalHeightListEmails <= browserInnerHeight;
+        ? 0
+        : currentListEmails.length *
+            ThreadConstants.defaultMaxHeightEmailItemOnBrowser;
+    final isAutoLoadMore = totalHeightListEmails > 0 &&
+        totalHeightListEmails <= browserInnerHeight;
     logTrace(
-      'ThreadController::_validateBrowserHeight():'
+      'ThreadController::_isAutoLoadMore():'
       'BrowserInnerHeight = $browserInnerHeight, '
       'TotalHeightListEmails = $totalHeightListEmails, '
-      'ThreadConstants.defaultMaxHeightBrowser = ${ThreadConstants.defaultMaxHeightBrowser}, '
       'ThreadConstants.defaultMaxHeightEmailItemOnBrowser = ${ThreadConstants.defaultMaxHeightEmailItemOnBrowser}, '
+      'CountCurrentListEmails = ${currentListEmails.length}, '
       'CanLoadMore = $canLoadMore, '
-      'isAutoLoadMore = $isAutoLoadMore, '
-      'CountCurrentListEmails = ${currentListEmails.length}',
+      'isAutoLoadMore = $isAutoLoadMore ',
     );
-    if (isAutoLoadMore) {
-      _performAutomaticallyLoadMoreEmails();
+    return isAutoLoadMore;
+  }
+
+  bool get _isNonWebAutoLoadMore {
+    if (!listEmailController.hasClients) {
+      logTrace(
+        'ThreadController::_isNonWebAutoLoadMore(): listEmailController.hasClients = false',
+      );
+      return false;
     }
+
+    final maxScroll = listEmailController.position.maxScrollExtent;
+    final viewport = listEmailController.position.viewportDimension;
+    final isAutoLoadMore = maxScroll <= viewport;
+
+    logTrace(
+      'ThreadController::_isNonWebAutoLoadMore():'
+      'maxScroll = $maxScroll, '
+      'viewport = $viewport, '
+      'CanLoadMore = $canLoadMore, '
+      'isAutoLoadMore = $isAutoLoadMore ',
+    );
+
+    return isAutoLoadMore;
   }
 
   void _performAutomaticallyLoadMoreEmails() {
@@ -525,10 +555,14 @@ class ThreadController extends BaseController with EmailActionController {
     mailboxDashBoardController.listEmailSelected.clear();
     mailboxDashBoardController.currentSelectMode.value = SelectMode.INACTIVE;
     canLoadMore = true;
+    canSearchMore = true;
     loadingMoreStatus.value = LoadingMoreStatus.idle;
   }
 
-  void _getAllEmailSuccess(GetAllEmailSuccess success) {
+  void _getAllEmailSuccess(
+    GetAllEmailSuccess success, {
+    bool shouldJumpToFirstEmail = true,
+  }) {
     log('ThreadController::_getAllEmailSuccess: GetAllForMailboxId = ${success.currentMailboxId?.asString} | SELECTED_MAILBOX_ID = ${selectedMailboxId?.asString} | SELECTED_MAILBOX_NAME = ${selectedMailbox?.name?.name}');
     mailboxDashBoardController.updateRefreshAllEmailState(Right(RefreshAllEmailSuccess()));
     final currentMailboxId = success.currentMailboxId;
@@ -539,41 +573,53 @@ class ThreadController extends BaseController with EmailActionController {
       return;
     }
     mailboxDashBoardController.setCurrentEmailState(success.currentEmailState);
-    log('ThreadController::_getAllEmailSuccess():COUNT = ${success.emailList.length} | EMAIL_STATE = ${mailboxDashBoardController.currentEmailState}');
     final newListEmail = success.emailList.syncPresentationEmail(
       mapMailboxById: mailboxDashBoardController.mapMailboxById,
       selectedMailbox: selectedMailbox,
       searchQuery: searchController.searchQuery,
       isSearchEmailRunning: searchController.isSearchEmailRunning
     );
+    logTrace(
+      'ThreadController::_getAllEmailSuccess():'
+      'MailboxId = ${success.currentMailboxId?.asString}, '
+      'ServerEmailCount = ${success.emailList.length}, '
+      'DisplayedEmailCount = ${newListEmail.length}, '
+      'EmailState = ${success.currentEmailState?.value}',
+    );
     mailboxDashBoardController.updateEmailList(newListEmail);
     if (mailboxDashBoardController.isSelectionEnabled()) {
       mailboxDashBoardController.listEmailSelected.value = listEmailSelected;
     }
-    canLoadMore = newListEmail.length >= ThreadConstants.maxCountEmails;
-    loadingMoreStatus.value = LoadingMoreStatus.completed;
 
-    if (listEmailController.hasClients) {
+    if (shouldJumpToFirstEmail && listEmailController.hasClients) {
       listEmailController.jumpTo(0);
     }
   }
 
-  void _handleOnDoneGetAllEmailSuccess() {
-    if (PlatformInfo.isWeb) {
-      _validateBrowserHeight();
-
-      if (mailboxDashBoardController.isEmailListDisplayed) {
-        refocusMailShortcutFocus();
-      }
+  void _handleOnDoneGetAllEmailSuccess(GetAllEmailSuccess success) {
+    if (PlatformInfo.isWeb && mailboxDashBoardController.isEmailListDisplayed) {
+      refocusMailShortcutFocus();
+    }
+    final emailList = success.emailList;
+    log('ThreadController::_handleOnDoneGetAllEmailSuccess: EmailCount = ${emailList.length}');
+    if (_isAutoLoadMore && emailList.isNotEmpty) {
+      _performAutomaticallyLoadMoreEmails();
+    } else {
+      canLoadMore = emailList.isNotEmpty;
     }
   }
 
   void _handleOnDoneGetAllEmailFailure() {
-    if (PlatformInfo.isWeb) {
-      _validateBrowserHeight();
-    }
+    log('ThreadController::_handleOnDoneGetAllEmailFailure');
     if (PlatformInfo.isWeb && mailboxDashBoardController.isEmailListDisplayed) {
       refocusMailShortcutFocus();
+    }
+
+    if (_isAutoLoadMore) {
+      _performAutomaticallyLoadMoreEmails();
+    } else {
+      canLoadMore = false;
+      loadingMoreStatus.value = LoadingMoreStatus.idle;
     }
   }
 
@@ -602,8 +648,17 @@ class ThreadController extends BaseController with EmailActionController {
       mailboxDashBoardController.listEmailSelected.value = listEmailSelected;
     }
 
-    if (PlatformInfo.isWeb) {
-      _validateBrowserHeight();
+    logTrace(
+      'ThreadController::_refreshChangesAllEmailSuccess():'
+      'MailboxId = ${success.currentMailboxId?.asString}, '
+      'CurrentEmailCount = ${emailsBeforeChanges.length}, '
+      'ServerEmailCount = ${success.emailList.length}, '
+      'DisplayedEmailCount = ${emailListSynced.length}, '
+      'EmailState = ${success.currentEmailState?.value}',
+    );
+
+    if (_isAutoLoadMore) {
+      _performAutomaticallyLoadMoreEmails();
     }
   }
 
@@ -700,7 +755,8 @@ class ThreadController extends BaseController with EmailActionController {
     await _refreshChangeListEmailCache();
 
     log('ThreadController::_refreshChangeSearchEmail:');
-    canSearchMore = false;
+    canSearchMore = true;
+    loadingMoreStatus.value = LoadingMoreStatus.idle;
     searchController.updateFilterEmail(
       positionOption: option(
         _searchEmailFilter.sortOrderType.isScrollByPosition(),
@@ -737,6 +793,7 @@ class ThreadController extends BaseController with EmailActionController {
       mailboxDashBoardController.updateRefreshAllEmailState(
           Left(RefreshAllEmailFailure()));
       canSearchMore = false;
+      loadingMoreStatus.value = LoadingMoreStatus.completed;
       mailboxDashBoardController.emailsInCurrentMailbox.clear();
       if (searchState != null) {
         onDataFailureViewState(searchState);
@@ -820,7 +877,7 @@ class ThreadController extends BaseController with EmailActionController {
         .foldSuccessWithResult<GetAllEmailSuccess>();
 
     if (emailSuccessState is GetAllEmailSuccess) {
-      _getAllEmailSuccess(emailSuccessState);
+      _getAllEmailSuccess(emailSuccessState, shouldJumpToFirstEmail: false);
     } else if (emailSuccessState != null) {
       onDataFailureViewState(emailSuccessState);
     }
@@ -831,16 +888,20 @@ class ThreadController extends BaseController with EmailActionController {
     if (!canLoadMore) return;
 
     if (_session != null && _accountId != null) {
-      final oldestEmail = mailboxDashBoardController.emailsInCurrentMailbox.isNotEmpty
-        ? mailboxDashBoardController.emailsInCurrentMailbox.last
-        : null;
+      final currentListEmail =
+          mailboxDashBoardController.emailsInCurrentMailbox;
+      final oldestEmail =
+          currentListEmail.isNotEmpty ? currentListEmail.last : null;
       final useCache = selectedMailbox?.isCacheable ?? false;
       final filterOption = mailboxDashBoardController.filterMessageOption.value;
+
       logTrace(
-        'ThreadController::_loadMoreEmails: OldestEmailID = ${oldestEmail?.id?.asString}, '
+        'ThreadController::_loadMoreEmails: '
+        'OldestEmailID = ${oldestEmail?.id?.asString}, '
         'useCache = $useCache, '
         'filterOption = ${filterOption.name}',
       );
+
       consumeState(_loadMoreEmailsInMailboxInteractor.execute(
         GetEmailRequest(
           _session!,
@@ -851,7 +912,7 @@ class ThreadController extends BaseController with EmailActionController {
           filter: getFilterConditionForLoadMailbox(oldestEmail: oldestEmail),
           properties: EmailUtils.getPropertiesForEmailGetMethod(_session!, _accountId!),
           lastEmailId: oldestEmail?.id,
-          useCache: selectedMailbox?.isCacheable ?? false,
+          useCache: useCache,
         )
       ));
     } else {
@@ -879,18 +940,24 @@ class ThreadController extends BaseController with EmailActionController {
   }
 
   void _loadMoreEmailsSuccess(LoadMoreEmailsSuccess success) {
-    canLoadMore = success.emailList.isNotEmpty;
-    loadingMoreStatus.value = LoadingMoreStatus.completed;
-    final appendableList = validateListEmailsLoadMore(success.emailList);
+    final emailList = success.emailList;
+    final appendableList = validateListEmailsLoadMore(emailList);
+
     logTrace(
-      'ThreadController::_loadMoreEmailsSuccess: emailList = ${success.emailList.length}, '
-      'appendableList = ${appendableList.length}',
+      'ThreadController::_loadMoreEmailsSuccess: '
+      'ServerEmailCount = ${emailList.length}, '
+      'EmailAppendableCount = ${appendableList.length}',
     );
+
     if (appendableList.isNotEmpty) {
       mailboxDashBoardController.emailsInCurrentMailbox.addAll(appendableList);
     }
-    if (PlatformInfo.isWeb) {
-      _validateBrowserHeight();
+
+    if (_isAutoLoadMore && emailList.isNotEmpty) {
+      _performAutomaticallyLoadMoreEmails();
+    } else {
+      canLoadMore = emailList.isNotEmpty;
+      loadingMoreStatus.value = LoadingMoreStatus.completed;
     }
   }
 
@@ -1059,7 +1126,8 @@ class ThreadController extends BaseController with EmailActionController {
       if (!needRefreshSearchState) {
         mailboxDashBoardController.emailsInCurrentMailbox.clear();
       }
-      canSearchMore = false;
+      canSearchMore = true;
+      loadingMoreStatus.value = LoadingMoreStatus.idle;
 
       searchController.updateFilterEmail(
         positionOption: option(_searchEmailFilter.sortOrderType.isScrollByPosition(), 0),
@@ -1105,8 +1173,9 @@ class ThreadController extends BaseController with EmailActionController {
 
   void _searchEmailsSuccess(SearchEmailSuccess success) {
     mailboxDashBoardController.updateRefreshAllEmailState(Right(RefreshAllEmailSuccess()));
-    log('ThreadController::_searchEmailsSuccess: COUNT = ${success.emailList.length}');
-    final resultEmailSearchList = success.emailList
+    final emailList = success.emailList;
+    log('ThreadController::_searchEmailsSuccess: COUNT = ${emailList.length}');
+    final resultEmailSearchList = emailList
         .map((email) => email.toSearchPresentationEmail(mailboxDashBoardController.mapMailboxById))
         .toList();
 
@@ -1123,11 +1192,12 @@ class ThreadController extends BaseController with EmailActionController {
     if (mailboxDashBoardController.isSelectionEnabled()) {
       mailboxDashBoardController.listEmailSelected.value = listEmailSelected;
     }
-    canSearchMore = newEmailListSynced.length >= ThreadConstants.maxCountEmails;
-    loadingMoreStatus.value = LoadingMoreStatus.completed;
 
-    if (PlatformInfo.isWeb) {
-      _validateBrowserHeight();
+    if (_isAutoLoadMore && emailList.isNotEmpty) {
+      _performAutomaticallyLoadMoreEmails();
+    } else {
+      canSearchMore = emailList.isNotEmpty;
+      loadingMoreStatus.value = LoadingMoreStatus.completed;
     }
   }
 
@@ -1139,12 +1209,13 @@ class ThreadController extends BaseController with EmailActionController {
     if (!canSearchMore) return;
 
     if (_session != null && _accountId != null) {
-      final lastEmail = mailboxDashBoardController.emailsInCurrentMailbox.isNotEmpty
-        ? mailboxDashBoardController.emailsInCurrentMailbox.last
-        : null;
+      final currentEmailList =
+          mailboxDashBoardController.emailsInCurrentMailbox;
+      final lastEmail =
+          currentEmailList.isNotEmpty ? currentEmailList.last : null;
 
       if (_searchEmailFilter.sortOrderType.isScrollByPosition()) {
-        final nextPosition = mailboxDashBoardController.emailsInCurrentMailbox.length;
+        final nextPosition = currentEmailList.length;
         log('ThreadController::_searchMoreEmails:nextPosition: $nextPosition');
         searchController.updateFilterEmail(positionOption: Some(nextPosition));
       } else if (_searchEmailFilter.sortOrderType == EmailSortOrderType.oldest) {
@@ -1173,9 +1244,10 @@ class ThreadController extends BaseController with EmailActionController {
   }
 
   void _searchMoreEmailsSuccess(SearchMoreEmailSuccess success) {
-    log('ThreadController::_searchMoreEmailsSuccess: COUNT = ${success.emailList.length}');
-    if (success.emailList.isNotEmpty) {
-      final resultEmailSearchList = success.emailList
+    final emailList = success.emailList;
+    log('ThreadController::_searchMoreEmailsSuccess: COUNT = ${emailList.length}');
+    if (emailList.isNotEmpty) {
+      final resultEmailSearchList = emailList
           .map((email) => email.toSearchPresentationEmail(mailboxDashBoardController.mapMailboxById))
           .where((email) => mailboxDashBoardController.emailsInCurrentMailbox.every((emailInCurrentMailbox) => emailInCurrentMailbox.id != email.id))
           .toList()
@@ -1187,11 +1259,12 @@ class ThreadController extends BaseController with EmailActionController {
           );
       mailboxDashBoardController.emailsInCurrentMailbox.addAll(resultEmailSearchList);
     }
-    canSearchMore = success.emailList.isNotEmpty;
-    loadingMoreStatus.value = LoadingMoreStatus.completed;
 
-    if (PlatformInfo.isWeb) {
-      _validateBrowserHeight();
+    if (_isAutoLoadMore && emailList.isNotEmpty) {
+      _performAutomaticallyLoadMoreEmails();
+    } else {
+      canSearchMore = emailList.isNotEmpty;
+      loadingMoreStatus.value = LoadingMoreStatus.completed;
     }
   }
 

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -834,7 +834,13 @@ class ThreadController extends BaseController with EmailActionController {
       final oldestEmail = mailboxDashBoardController.emailsInCurrentMailbox.isNotEmpty
         ? mailboxDashBoardController.emailsInCurrentMailbox.last
         : null;
-      log('ThreadController::_loadMoreEmails: OldestEmailID = ${oldestEmail?.id?.asString}');
+      final useCache = selectedMailbox?.isCacheable ?? false;
+      final filterOption = mailboxDashBoardController.filterMessageOption.value;
+      logTrace(
+        'ThreadController::_loadMoreEmails: OldestEmailID = ${oldestEmail?.id?.asString}, '
+        'useCache = $useCache, '
+        'filterOption = ${filterOption.name}',
+      );
       consumeState(_loadMoreEmailsInMailboxInteractor.execute(
         GetEmailRequest(
           _session!,
@@ -876,7 +882,10 @@ class ThreadController extends BaseController with EmailActionController {
     canLoadMore = success.emailList.isNotEmpty;
     loadingMoreStatus.value = LoadingMoreStatus.completed;
     final appendableList = validateListEmailsLoadMore(success.emailList);
-    log('ThreadController::_loadMoreEmailsSuccess: emailList = ${success.emailList.length} | appendableList = ${appendableList.length}');
+    logTrace(
+      'ThreadController::_loadMoreEmailsSuccess: emailList = ${success.emailList.length}, '
+      'appendableList = ${appendableList.length}',
+    );
     if (appendableList.isNotEmpty) {
       mailboxDashBoardController.emailsInCurrentMailbox.addAll(appendableList);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.26.3
+version: 0.26.4
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.26.2
+version: 0.26.3
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.26.1
+version: 0.26.2
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/test/features/thread/data/repository/thread_repository_impl_test.dart
+++ b/test/features/thread/data/repository/thread_repository_impl_test.dart
@@ -1331,5 +1331,11 @@ void main() {
         expect(result.emailList, isNotNull);
       },
     );
+
+    tearDown(() {
+      reset(networkDataSource);
+      reset(localDataSource);
+      reset(stateDataSource);
+    });
   });
 }

--- a/test/features/thread/data/repository/thread_repository_impl_test.dart
+++ b/test/features/thread/data/repository/thread_repository_impl_test.dart
@@ -1060,32 +1060,38 @@ void main() {
   });
 
   group('ThreadRepositoryImpl::refreshChanges', () {
-    late ThreadRepositoryImpl threadRepository;
+    late ThreadRepositoryImpl refreshChangesThreadRepository;
     late MockThreadDataSource networkDataSource;
     late MockThreadDataSource localDataSource;
-    late MockStateDataSource stateDataSource;
+    late MockStateDataSource refreshChangesStateDataSource;
 
     setUp(() {
       networkDataSource = MockThreadDataSource();
       localDataSource = MockThreadDataSource();
-      stateDataSource = MockStateDataSource();
+      refreshChangesStateDataSource = MockStateDataSource();
 
-      threadRepository = ThreadRepositoryImpl(
+      refreshChangesThreadRepository = ThreadRepositoryImpl(
         {
           DataSourceType.network: networkDataSource,
           DataSourceType.local: localDataSource,
         },
-        stateDataSource,
+        refreshChangesStateDataSource,
       );
     });
 
     test(
       'should call network when cache is empty',
       () async {
-        when(localDataSource.getAllEmailCache(any, any))
-            .thenAnswer((_) async => []);
+        when(localDataSource.getAllEmailCache(
+          any,
+          any,
+          filterOption: anyNamed('filterOption'),
+          inMailboxId: anyNamed('inMailboxId'),
+          limit: anyNamed('limit'),
+          sort: anyNamed('sort'),
+        )).thenAnswer((_) async => []);
 
-        when(stateDataSource.getState(any, any, any))
+        when(refreshChangesStateDataSource.getState(any, any, any))
             .thenAnswer((_) async => State('cache_state'));
 
         when(networkDataSource.getChanges(
@@ -1111,7 +1117,7 @@ void main() {
               state: State('network_state'),
             ));
 
-        final result = await threadRepository
+        final result = await refreshChangesThreadRepository
             .refreshChanges(
               SessionFixtures.aliceSession,
               AccountFixtures.aliceAccountId,
@@ -1141,10 +1147,16 @@ void main() {
           (i) => Email(id: EmailId(Id('cache_$i'))),
         );
 
-        when(localDataSource.getAllEmailCache(any, any))
-            .thenAnswer((_) async => cacheEmails);
+        when(localDataSource.getAllEmailCache(
+          any,
+          any,
+          filterOption: anyNamed('filterOption'),
+          inMailboxId: anyNamed('inMailboxId'),
+          limit: anyNamed('limit'),
+          sort: anyNamed('sort'),
+        )).thenAnswer((_) async => cacheEmails);
 
-        when(stateDataSource.getState(any, any, any))
+        when(refreshChangesStateDataSource.getState(any, any, any))
             .thenAnswer((_) async => State('cache_state'));
 
         when(networkDataSource.getChanges(
@@ -1170,7 +1182,7 @@ void main() {
               state: State('network_state'),
             ));
 
-        await threadRepository
+        await refreshChangesThreadRepository
             .refreshChanges(
               SessionFixtures.aliceSession,
               AccountFixtures.aliceAccountId,
@@ -1198,10 +1210,16 @@ void main() {
           (i) => Email(id: EmailId(Id('cache_$i'))),
         );
 
-        when(localDataSource.getAllEmailCache(any, any))
-            .thenAnswer((_) async => cacheEmails);
+        when(localDataSource.getAllEmailCache(
+          any,
+          any,
+          filterOption: anyNamed('filterOption'),
+          inMailboxId: anyNamed('inMailboxId'),
+          limit: anyNamed('limit'),
+          sort: anyNamed('sort'),
+        )).thenAnswer((_) async => cacheEmails);
 
-        when(stateDataSource.getState(any, any, any))
+        when(refreshChangesStateDataSource.getState(any, any, any))
             .thenAnswer((_) async => State('cache_state'));
 
         when(networkDataSource.getChanges(
@@ -1214,7 +1232,7 @@ void main() {
               hasMoreChanges: false,
             ));
 
-        final result = await threadRepository
+        final result = await refreshChangesThreadRepository
             .refreshChanges(
               SessionFixtures.aliceSession,
               AccountFixtures.aliceAccountId,
@@ -1244,10 +1262,16 @@ void main() {
           (i) => Email(id: EmailId(Id('cache_$i'))),
         );
 
-        when(localDataSource.getAllEmailCache(any, any))
-            .thenAnswer((_) async => cacheEmails);
+        when(localDataSource.getAllEmailCache(
+          any,
+          any,
+          filterOption: anyNamed('filterOption'),
+          inMailboxId: anyNamed('inMailboxId'),
+          limit: anyNamed('limit'),
+          sort: anyNamed('sort'),
+        )).thenAnswer((_) async => cacheEmails);
 
-        when(stateDataSource.getState(any, any, any))
+        when(refreshChangesStateDataSource.getState(any, any, any))
             .thenAnswer((_) async => State('cache_state'));
 
         int callCount = 0;
@@ -1276,7 +1300,7 @@ void main() {
           );
         });
 
-        final result = await threadRepository
+        final result = await refreshChangesThreadRepository
             .refreshChanges(
               SessionFixtures.aliceSession,
               AccountFixtures.aliceAccountId,
@@ -1293,6 +1317,11 @@ void main() {
         )).called(2);
 
         expect(result.emailChangeResponse, isNotNull);
+        expect(
+          result.emailChangeResponse?.created?.length,
+          equals(2),
+          reason: 'Should merge created emails from both pages',
+        );
       },
     );
 
@@ -1304,10 +1333,16 @@ void main() {
           (i) => Email(id: EmailId(Id('cache_$i'))),
         );
 
-        when(localDataSource.getAllEmailCache(any, any))
-            .thenAnswer((_) async => cacheEmails);
+        when(localDataSource.getAllEmailCache(
+          any,
+          any,
+          filterOption: anyNamed('filterOption'),
+          inMailboxId: anyNamed('inMailboxId'),
+          limit: anyNamed('limit'),
+          sort: anyNamed('sort'),
+        )).thenAnswer((_) async => cacheEmails);
 
-        when(stateDataSource.getState(any, any, any))
+        when(refreshChangesStateDataSource.getState(any, any, any))
             .thenAnswer((_) async => State('cache_state'));
 
         when(networkDataSource.getChanges(
@@ -1320,7 +1355,7 @@ void main() {
               hasMoreChanges: false,
             ));
 
-        final result = await threadRepository
+        final result = await refreshChangesThreadRepository
             .refreshChanges(
               SessionFixtures.aliceSession,
               AccountFixtures.aliceAccountId,

--- a/test/features/thread/data/repository/thread_repository_impl_test.dart
+++ b/test/features/thread/data/repository/thread_repository_impl_test.dart
@@ -1367,10 +1367,89 @@ void main() {
       },
     );
 
+    test(
+      'should fetch first page with defaultLimit after changes shrink current list',
+      () async {
+        final cacheEmails = List.generate(
+          ThreadConstants.defaultLimit.value.toInt(),
+          (i) => Email(id: EmailId(Id('cache_$i'))),
+        );
+
+        final cacheAfterDestroyed = cacheEmails.skip(5).toList();
+
+        final destroyedIds = List.generate(
+          5,
+          (i) => EmailId(Id('cache_$i')),
+        );
+
+        int cacheCall = 0;
+
+        when(localDataSource.getAllEmailCache(
+          any,
+          any,
+          filterOption: anyNamed('filterOption'),
+          inMailboxId: anyNamed('inMailboxId'),
+          limit: anyNamed('limit'),
+          sort: anyNamed('sort'),
+        )).thenAnswer((_) async {
+          cacheCall++;
+          return cacheCall == 1 ? cacheEmails : cacheAfterDestroyed;
+        });
+
+        when(refreshChangesStateDataSource.getState(any, any, any))
+            .thenAnswer((_) async => State('cache_state'));
+
+        when(networkDataSource.getChanges(
+          any,
+          any,
+          any,
+          propertiesCreated: anyNamed('propertiesCreated'),
+          propertiesUpdated: anyNamed('propertiesUpdated'),
+        )).thenAnswer((_) async => EmailChangeResponse(
+              hasMoreChanges: false,
+              destroyed: destroyedIds,
+              newStateEmail: State('new_state'),
+            ));
+
+        when(networkDataSource.getAllEmail(
+          any,
+          any,
+          limit: anyNamed('limit'),
+          position: anyNamed('position'),
+          sort: anyNamed('sort'),
+          filter: anyNamed('filter'),
+          properties: anyNamed('properties'),
+        )).thenAnswer((_) async => EmailsResponse(
+              emailList: [],
+              state: State('network_state'),
+            ));
+
+        await refreshChangesThreadRepository
+            .refreshChanges(
+              SessionFixtures.aliceSession,
+              AccountFixtures.aliceAccountId,
+              State('initial'),
+            )
+            .first;
+
+        final capturedLimit = verify(networkDataSource.getAllEmail(
+          any,
+          any,
+          limit: captureAnyNamed('limit'),
+          position: anyNamed('position'),
+          sort: anyNamed('sort'),
+          filter: anyNamed('filter'),
+          properties: anyNamed('properties'),
+        )).captured.single;
+
+        expect(capturedLimit, ThreadConstants.defaultLimit);
+      },
+    );
+
     tearDown(() {
       reset(networkDataSource);
       reset(localDataSource);
-      reset(stateDataSource);
+      reset(refreshChangesStateDataSource);
     });
   });
 }

--- a/test/features/thread/data/repository/thread_repository_impl_test.dart
+++ b/test/features/thread/data/repository/thread_repository_impl_test.dart
@@ -1322,6 +1322,14 @@ void main() {
           equals(2),
           reason: 'Should merge created emails from both pages',
         );
+        final createdIds = result.emailChangeResponse?.created
+            ?.map((e) => e.id?.id.value)
+            .toSet();
+        expect(
+          createdIds,
+          containsAll(['created1', 'created2']),
+          reason: 'Should contain both created emails from different pages',
+        );
       },
     );
 

--- a/test/features/thread/data/repository/thread_repository_impl_test.dart
+++ b/test/features/thread/data/repository/thread_repository_impl_test.dart
@@ -1058,4 +1058,278 @@ void main() {
       ));
     });
   });
+
+  group('ThreadRepositoryImpl::refreshChanges', () {
+    late ThreadRepositoryImpl threadRepository;
+    late MockThreadDataSource networkDataSource;
+    late MockThreadDataSource localDataSource;
+    late MockStateDataSource stateDataSource;
+
+    setUp(() {
+      networkDataSource = MockThreadDataSource();
+      localDataSource = MockThreadDataSource();
+      stateDataSource = MockStateDataSource();
+
+      threadRepository = ThreadRepositoryImpl(
+        {
+          DataSourceType.network: networkDataSource,
+          DataSourceType.local: localDataSource,
+        },
+        stateDataSource,
+      );
+    });
+
+    test(
+      'should call network when cache is empty',
+      () async {
+        when(localDataSource.getAllEmailCache(any, any))
+            .thenAnswer((_) async => []);
+
+        when(stateDataSource.getState(any, any, any))
+            .thenAnswer((_) async => State('cache_state'));
+
+        when(networkDataSource.getChanges(
+          any,
+          any,
+          any,
+          propertiesCreated: anyNamed('propertiesCreated'),
+          propertiesUpdated: anyNamed('propertiesUpdated'),
+        )).thenAnswer((_) async => EmailChangeResponse(
+              hasMoreChanges: false,
+            ));
+
+        when(networkDataSource.getAllEmail(
+          any,
+          any,
+          limit: anyNamed('limit'),
+          position: anyNamed('position'),
+          sort: anyNamed('sort'),
+          filter: anyNamed('filter'),
+          properties: anyNamed('properties'),
+        )).thenAnswer((_) async => EmailsResponse(
+              emailList: [],
+              state: State('network_state'),
+            ));
+
+        final result = await threadRepository
+            .refreshChanges(
+              SessionFixtures.aliceSession,
+              AccountFixtures.aliceAccountId,
+              State('initial'),
+            )
+            .first;
+
+        verify(networkDataSource.getAllEmail(
+          any,
+          any,
+          limit: anyNamed('limit'),
+          position: anyNamed('position'),
+          sort: anyNamed('sort'),
+          filter: anyNamed('filter'),
+          properties: anyNamed('properties'),
+        ));
+
+        expect(result, isA<EmailsResponse>());
+      },
+    );
+
+    test(
+      'should call network when cache smaller than defaultLimit',
+      () async {
+        final cacheEmails = List.generate(
+          5,
+          (i) => Email(id: EmailId(Id('cache_$i'))),
+        );
+
+        when(localDataSource.getAllEmailCache(any, any))
+            .thenAnswer((_) async => cacheEmails);
+
+        when(stateDataSource.getState(any, any, any))
+            .thenAnswer((_) async => State('cache_state'));
+
+        when(networkDataSource.getChanges(
+          any,
+          any,
+          any,
+          propertiesCreated: anyNamed('propertiesCreated'),
+          propertiesUpdated: anyNamed('propertiesUpdated'),
+        )).thenAnswer((_) async => EmailChangeResponse(
+              hasMoreChanges: false,
+            ));
+
+        when(networkDataSource.getAllEmail(
+          any,
+          any,
+          limit: anyNamed('limit'),
+          position: anyNamed('position'),
+          sort: anyNamed('sort'),
+          filter: anyNamed('filter'),
+          properties: anyNamed('properties'),
+        )).thenAnswer((_) async => EmailsResponse(
+              emailList: cacheEmails,
+              state: State('network_state'),
+            ));
+
+        await threadRepository
+            .refreshChanges(
+              SessionFixtures.aliceSession,
+              AccountFixtures.aliceAccountId,
+              State('initial'),
+            )
+            .first;
+
+        verify(networkDataSource.getAllEmail(
+          any,
+          any,
+          limit: anyNamed('limit'),
+          position: anyNamed('position'),
+          sort: anyNamed('sort'),
+          filter: anyNamed('filter'),
+          properties: anyNamed('properties'),
+        ));
+      },
+    );
+
+    test(
+      'should use cache when cache size >= defaultLimit',
+      () async {
+        final cacheEmails = List.generate(
+          ThreadConstants.defaultLimit.value.toInt(),
+          (i) => Email(id: EmailId(Id('cache_$i'))),
+        );
+
+        when(localDataSource.getAllEmailCache(any, any))
+            .thenAnswer((_) async => cacheEmails);
+
+        when(stateDataSource.getState(any, any, any))
+            .thenAnswer((_) async => State('cache_state'));
+
+        when(networkDataSource.getChanges(
+          any,
+          any,
+          any,
+          propertiesCreated: anyNamed('propertiesCreated'),
+          propertiesUpdated: anyNamed('propertiesUpdated'),
+        )).thenAnswer((_) async => EmailChangeResponse(
+              hasMoreChanges: false,
+            ));
+
+        final result = await threadRepository
+            .refreshChanges(
+              SessionFixtures.aliceSession,
+              AccountFixtures.aliceAccountId,
+              State('initial'),
+            )
+            .first;
+
+        verifyNever(networkDataSource.getAllEmail(
+          any,
+          any,
+          limit: anyNamed('limit'),
+          position: anyNamed('position'),
+          sort: anyNamed('sort'),
+          filter: anyNamed('filter'),
+          properties: anyNamed('properties'),
+        ));
+
+        expect(result.emailList?.length, cacheEmails.length);
+      },
+    );
+
+    test(
+      'should merge changes when getChanges has multiple pages',
+      () async {
+        final cacheEmails = List.generate(
+          ThreadConstants.defaultLimit.value.toInt(),
+          (i) => Email(id: EmailId(Id('cache_$i'))),
+        );
+
+        when(localDataSource.getAllEmailCache(any, any))
+            .thenAnswer((_) async => cacheEmails);
+
+        when(stateDataSource.getState(any, any, any))
+            .thenAnswer((_) async => State('cache_state'));
+
+        int callCount = 0;
+
+        when(networkDataSource.getChanges(
+          any,
+          any,
+          any,
+          propertiesCreated: anyNamed('propertiesCreated'),
+          propertiesUpdated: anyNamed('propertiesUpdated'),
+        )).thenAnswer((_) async {
+          callCount++;
+
+          if (callCount == 1) {
+            return EmailChangeResponse(
+              hasMoreChanges: true,
+              created: [Email(id: EmailId(Id('created1')))],
+              newStateChanges: State('mid'),
+            );
+          }
+
+          return EmailChangeResponse(
+            hasMoreChanges: false,
+            created: [Email(id: EmailId(Id('created2')))],
+            newStateChanges: State('final'),
+          );
+        });
+
+        final result = await threadRepository
+            .refreshChanges(
+              SessionFixtures.aliceSession,
+              AccountFixtures.aliceAccountId,
+              State('initial'),
+            )
+            .first;
+
+        verify(networkDataSource.getChanges(
+          any,
+          any,
+          any,
+          propertiesCreated: anyNamed('propertiesCreated'),
+          propertiesUpdated: anyNamed('propertiesUpdated'),
+        )).called(2);
+
+        expect(result.emailChangeResponse, isNotNull);
+      },
+    );
+
+    test(
+      'should handle when getChanges returns no changes',
+      () async {
+        final cacheEmails = List.generate(
+          ThreadConstants.defaultLimit.value.toInt(),
+          (i) => Email(id: EmailId(Id('cache_$i'))),
+        );
+
+        when(localDataSource.getAllEmailCache(any, any))
+            .thenAnswer((_) async => cacheEmails);
+
+        when(stateDataSource.getState(any, any, any))
+            .thenAnswer((_) async => State('cache_state'));
+
+        when(networkDataSource.getChanges(
+          any,
+          any,
+          any,
+          propertiesCreated: anyNamed('propertiesCreated'),
+          propertiesUpdated: anyNamed('propertiesUpdated'),
+        )).thenAnswer((_) async => EmailChangeResponse(
+              hasMoreChanges: false,
+            ));
+
+        final result = await threadRepository
+            .refreshChanges(
+              SessionFixtures.aliceSession,
+              AccountFixtures.aliceAccountId,
+              State('initial'),
+            )
+            .first;
+
+        expect(result.emailList, isNotNull);
+      },
+    );
+  });
 }


### PR DESCRIPTION
## Issue

#4368 

## Reproduce

https://github.com/user-attachments/assets/4c2b8b34-9e66-4975-a6ec-d5a5852847b1

## Root cause


After performing email actions (e.g., deleting an email), the application updates the in-memory email list and triggers a refresh of email changes via WebSocket. The current number of emails in memory is used as the `limit` when requesting additional emails from the server. If this value is smaller than the number of emails already available in the cache, the response only returns cached emails. Since the returned email count is less than `DefaultLimit` (20), the load-more logic is not triggered, preventing additional emails from being fetched from the server.

## Solution

- Use `DefaultLimit` (20) as the condition to trigger `_getFirstPage` during the refresh change process.
- Update the load-more logic by removing the update of the `canLoadMore` flag after a successful refresh change.


## Resolved


https://github.com/user-attachments/assets/77f0ef35-d451-41e6-84c0-5339883cfdb7



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refresh now uses a fixed default threshold for first-page fetches.
  * Improved session/account error handling to emit failures when missing and prevent redundant loads.
  * Load-more and search flows now early-return when no more data is expected and mark loading completion correctly.

* **Tests**
  * Added extensive tests covering refresh, merge, cache and paging scenarios (includes a duplicated test group).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->