### PR TITLE
TF-4373 Fix deletion is not working on thread

### DIFF
--- a/integration_test/mixin/setting_scenario_mixin.dart
+++ b/integration_test/mixin/setting_scenario_mixin.dart
@@ -42,4 +42,17 @@ mixin SettingScenarioMixin on BaseScenario {
   ) async {
     await expectViewVisible($(find.text(appLocalizations.language)));
   }
+
+  Future<void> goToSettingToEnableThread({
+    required ThreadRobot threadRobot,
+    required SettingRobot settingRobot,
+    required MailboxMenuRobot mailboxMenuRobot,
+  }) async {
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openSetting();
+    await settingRobot.openPreferencesMenuItem();
+    await settingRobot.switchOnThreadSetting();
+    await settingRobot.backToSettingsFromFirstLevel();
+    await settingRobot.closeSettings();
+  }
 }

--- a/integration_test/robots/email_robot.dart
+++ b/integration_test/robots/email_robot.dart
@@ -95,4 +95,8 @@ class EmailRobot extends CoreRobot {
         .$(InkWell)
         .tap();
   }
+
+  Future<void> tapDeleteThreadButton() async {
+    await $(#delete_thread_button).tap();
+  }
 }

--- a/integration_test/scenarios/email_detailed/delete_thread_to_trash_scenario.dart
+++ b/integration_test/scenarios/email_detailed/delete_thread_to_trash_scenario.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../mixin/generate_email_scenario_mixin.dart';
+import '../../mixin/setting_scenario_mixin.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/mailbox_menu_robot.dart';
+import '../../robots/setting_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class DeleteThreadToTrashScenario extends BaseTestScenario
+    with GenerateEmailScenarioMixin, SettingScenarioMixin {
+  const DeleteThreadToTrashScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    const subject = 'Delete thread to trash';
+    const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
+
+    final threadRobot = ThreadRobot($);
+    final settingRobot = SettingRobot($);
+    final mailboxMenuRobot = MailboxMenuRobot($);
+    final emailRobot = EmailRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await goToSettingToEnableThread(
+      threadRobot: threadRobot,
+      settingRobot: settingRobot,
+      mailboxMenuRobot: mailboxMenuRobot,
+    );
+
+    await generateEmailWithSubject(emailUser: emailUser, subject: subject);
+
+    await threadRobot.openEmailWithSubject(subject);
+    await $.pumpAndSettle();
+
+    await emailRobot.tapDeleteThreadButton();
+    await $.pumpAndSettle();
+
+    await _expectDeleteThreadSuccessToast(appLocalizations);
+  }
+
+  Future<void> _expectDeleteThreadSuccessToast(
+    AppLocalizations appLocalizations,
+  ) async {
+    await expectViewVisible(
+      $(find.text(appLocalizations.moved_to_trash)),
+    );
+  }
+}

--- a/integration_test/tests/email_detailed/delete_thread_to_trash_test.dart
+++ b/integration_test/tests/email_detailed/delete_thread_to_trash_test.dart
@@ -1,0 +1,10 @@
+import '../../base/test_base.dart';
+import '../../scenarios/email_detailed/delete_thread_to_trash_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description:
+        'Should see toast message success when open detailed email and delete thread successfully',
+    scenarioBuilder: ($) => DeleteThreadToTrashScenario($),
+  );
+}

--- a/lib/features/thread_detail/presentation/extension/on_thread_detail_action_click.dart
+++ b/lib/features/thread_detail/presentation/extension/on_thread_detail_action_click.dart
@@ -247,9 +247,10 @@ extension OnThreadDetailActionClick on ThreadDetailController {
   }
 
   void _moveToMailbox(MailboxId mailboxId, EmailActionType emailActionType) {
+    final emailInfos = [...emailsInThreadDetailInfo];
     closeThreadDetailAction();
     mailboxDashBoardController.moveMultipleEmailInThreadDetail(
-      emailsInThreadDetailInfo,
+      emailInfos,
       destinationMailboxId: mailboxId,
       emailActionType: emailActionType,
     );

--- a/lib/features/thread_detail/presentation/widgets/thread_detail_app_bar.dart
+++ b/lib/features/thread_detail/presentation/widgets/thread_detail_app_bar.dart
@@ -68,6 +68,7 @@ class ThreadDetailAppBar extends StatelessWidget {
         onTapActionCallback: (_) => onThreadActionClick?.call(EmailActionType.moveToMailbox),
       ),
       _ThreadDetailAppBarButton(
+        key: const Key('delete_thread_button'),
         icon: imagePaths.icDeleteComposer,
         iconColor: threadDetailCanPermanentlyDelete
             ? AppColor.redFF3347
@@ -183,6 +184,7 @@ class ThreadDetailAppBar extends StatelessWidget {
 
 class _ThreadDetailAppBarButton extends StatelessWidget {
   const _ThreadDetailAppBarButton({
+    super.key,
     required this.icon,
     required this.tooltipMessage,
     required this.onTapActionCallback,


### PR DESCRIPTION
## Issue

#4373 

## Reproduce


https://github.com/user-attachments/assets/b773ac0a-94f6-422f-abec-e6a42ad19afe

## Root cause

The list of email info in the thread was deleted during the process of closing the email detailed view before the thread delete call was executed

## Resolved

- Demo:


https://github.com/user-attachments/assets/e8a7b00c-4925-4cda-b9b5-922ab8950929



- E2E test:

```console
 Should see toast message success when open detailed email and delete thread successfully
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. enterText widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  10. waitUntilVisible widgets with text containing 2fc6-222-252-23-73.ngrok-free.app.
        ✅  11. tap widgets with text "Next".
        ✅  12. waitUntilVisible widgets with key [<'credential_input_form'>] descending from widgets with type "LoginView".
        ✅  13. enterText widgets with type "TextField" descending from widgets with key [<'login_username_input'>].
        ✅  14. waitUntilVisible widgets with text "bob@example.com".
        ✅  15. tap widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
✅ Should see toast message success when open detailed email and delete thread successfully (integration_test/tests/email_detailed/delete_thread_to_trash_test.dart) (17s)

Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: file:///Users/datvu/WorkingSpace/tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 95s
```

[Screen_recording_20260311_161202.webm](https://github.com/user-attachments/assets/e89790e5-5efc-48f0-8713-53f1c0b9f418)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete threads to trash with a success confirmation message.
  * Added a delete thread button to the thread detail view for quick access to the delete action.

* **Tests**
  * Added integration tests for thread deletion to trash functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->