### PR TITLE
ADR-71 CollapseThread

### DIFF
--- a/docs/adr/0071-collapse-threads-in-email-query.md
+++ b/docs/adr/0071-collapse-threads-in-email-query.md
@@ -1,0 +1,64 @@
+# 0071 - Enable collapseThreads in Email/query
+
+Date: 2026-03-12
+
+## Status
+
+Proposed
+
+## Context
+
+JMAP `Email/query` supports `collapseThreads` (RFC 8621 §4.4). When `true`, server returns only the **latest email per thread**, avoiding duplicate rows in the mail list.
+
+Currently, our app does **not** set `collapseThreads`. When thread is enabled, users see multiple emails from the same thread as separate rows.
+
+### Two Query Paths (see ADR-0070)
+
+| Path | `FORCE_EMAIL_QUERY` | Method | Cache |
+|------|---------------------|--------|-------|
+| Force query | `true` | `forceQueryAllEmailsForWeb()` | No local cache — server only |
+| Cache-first | `false` | `getAllEmail()` | Local DB first, then sync |
+
+### Problem: Cache Inconsistency on Toggle
+
+On the cache-first path, the local DB reflects the `collapseThreads` mode it was built under. When thread mode changes:
+
+- **OFF → ON**: Cache has individual emails (5 rows) but server now returns collapsed (3 rows) → stale first yield
+- **ON → OFF**: Cache has collapsed emails (3 rows) but server now returns all individuals (5 rows) → missing emails in first yield
+
+Force-query path has **no problem** — always queries server directly.
+
+## Decision
+
+### 1. Set `collapseThreads: true` in Email/query When Thread Is Enabled
+
+In `MailAPIMixin.fetchAllEmail()` and `ThreadAPI.searchEmails()`, pass `collapseThreads: true` when thread is enabled.
+
+### 2. Clear Email Cache on Thread Setting Toggle
+
+Reuse the existing thread-enabled setting. **No new flag needed.** When thread is toggled (enable ↔ disable), clear email cache immediately in the toggle handler. Next `getAllEmail()` will rebuild cache under correct mode.
+
+### 3. No Change for Force-Query Path
+
+Already server-only. Just pass `collapseThreads: true` in the query.
+
+## Consequences
+
+**Positive**: Correct thread display, reduced data per page, spec-compliant.
+
+**Negative**: One-time full reload on each toggle; toggle handler coupled with cache management.
+
+## Implementation Steps
+
+1. Add `collapseThreads` to `QueryEmailMethod` in `MailAPIMixin.fetchAllEmail()` and `ThreadAPI.searchEmails()`
+2. Pass thread-enabled status from `Session` to query builder
+3. Clear email cache in thread setting toggle handler
+4. Update `GetEmailsInMailboxInteractor` and related interactors to propagate thread status
+
+## References
+
+- [RFC 8621 §4.4](https://www.rfc-editor.org/rfc/rfc8621#section-4.4)
+- [ADR-0070](./0070-sync-strategy-disappearing-emails.md)
+- `lib/features/base/mixin/mail_api_mixin.dart` — `fetchAllEmail()`
+- `lib/features/thread/data/repository/thread_repository_impl.dart` — `getAllEmail()`
+- `lib/features/thread/domain/usecases/get_emails_in_mailbox_interactor.dart`

--- a/docs/adr/0071-collapse-threads-in-email-query.md
+++ b/docs/adr/0071-collapse-threads-in-email-query.md
@@ -51,7 +51,7 @@ Already server-only. Just pass `collapseThreads: true` in the query.
 ## Implementation Steps
 
 1. Add `collapseThreads` to `QueryEmailMethod` in `MailAPIMixin.fetchAllEmail()` and `ThreadAPI.searchEmails()`
-2. Pass thread-enabled status from `Session` to query builder
+2. Pass thread-enabled status from Settings to query builder
 3. Clear email cache in thread setting toggle handler
 4. Update `GetEmailsInMailboxInteractor` and related interactors to propagate thread status
 

--- a/docs/adr/0072-thread-aware-bulk-actions-email-list-collapse-threads.md
+++ b/docs/adr/0072-thread-aware-bulk-actions-email-list-collapse-threads.md
@@ -56,14 +56,14 @@ When users perform actions on:
 the system must resolve:
 
 ```text
-ThreadId → List<EmailId>
+ThreadId → List<EmailInThreadDetailInfo>
 ```
 
 Key challenges:
 
 * N+1 API calls (`getThreadById`)
 * Partial failures (one thread fails while others succeed)
-* Duplicate `EmailId`s when merging results
+* Duplicate `EmailInThreadDetailInfo`s when merging results
 * High latency with large selections
 * Existing interactors are not designed for thread-level inputs
 
@@ -82,7 +82,7 @@ Thread-aware Interactor (Stream<UIState>)
     ↓
 ThreadExpansionService
     ↓
-List<EmailId> (deduplicated & pagination-safe)
+List<EmailInThreadDetailInfo> (deduplicated & pagination-safe)
     ↓
 Existing Email Interactor (Stream)
     ↓
@@ -93,7 +93,7 @@ UI State Update (Optimistic + Server Sync)
 
 ### Responsibility
 
-* Convert `List<ThreadId>` → `List<EmailId>`
+* Convert `List<ThreadId>` → `List<EmailInThreadDetailInfo>`
 * Reuse `ThreadDetailRepository.getThreadById`
 * Handle:
 
@@ -112,11 +112,11 @@ so we just need to call and use them.
 
 ```dart
 class ThreadExpansionResult {
-  final List<EmailId> emailIds;
+  final List<EmailInThreadDetailInfo> emailThreadInfos;
   final Map<ThreadId, Object> errors;
 
   ThreadExpansionResult({
-    required this.emailIds,
+    required this.emailThreadInfos,
     required this.errors,
   });
 }
@@ -128,7 +128,7 @@ class ThreadExpansionResult {
 class ThreadExpansionService {
   final ThreadDetailRepository threadDetailRepository;
 
-  final Map<ThreadId, List<EmailId>> _cache = {};
+  final Map<ThreadId, List<EmailInThreadDetailInfo>> _cache = {};
 
   ThreadExpansionService(this.threadDetailRepository);
 
@@ -139,7 +139,7 @@ class ThreadExpansionService {
     required MailboxId sentMailboxId,
     required String ownEmailAddress,
   }) async {
-    final emailIds = <EmailId>{};
+    final emailThreadInfos = <EmailInThreadDetailInfo>{};
     final errors = <ThreadId, Object>{};
 
     final futures = threadIds.map((threadId) async {
@@ -158,13 +158,8 @@ class ThreadExpansionService {
           ownEmailAddress,
         );
 
-        final ids = threadDetails
-            .map((e) => e.emailId)
-            .whereType<EmailId>()
-            .toList();
-
-        _cache[threadId] = ids;
-        emailIds.addAll(ids);
+        _cache[threadId] = threadDetails;
+        emailIds.addAll(threadDetails);
       } catch (e) {
         // Error isolation
         errors[threadId] = e;
@@ -174,7 +169,7 @@ class ThreadExpansionService {
     await Future.wait(futures);
 
     return ThreadExpansionResult(
-      emailIds: emailIds.toList(),
+      emailThreadInfos: emailThreadInfos.toList(),
       errors: errors,
     );
   }
@@ -201,7 +196,7 @@ import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/core/error/set_error.dart';
 
 class ThreadActionResult {
-  final List<EmailId> success;
+  final List<EmailInThreadDetailInfo> success;
   final Map<Id, SetError> actionErrors;
   final Map<ThreadId, Object> expansionErrors;
 
@@ -234,7 +229,7 @@ class MarkAsThreadReadInteractor {
     required String ownEmailAddress,
     required ReadActions readAction,
     List<ThreadId> threadIds = const [],
-    List<EmailId> emailIds = const [],
+    List<EmailInThreadDetailInfo> emailThreadInfos = const [],
   }) async* {
     yield Right(LoadingMarkAsThreadRead());
     
@@ -246,12 +241,12 @@ class MarkAsThreadReadInteractor {
       ownEmailAddress: ownEmailAddress,
     );
 
-    final allEmailIds = {
-      ...emailIds,
-      ...expansion.emailIds,
+    final allEmailThreadInfos = {
+      ...emailThreadInfos,
+      ...expansion.emailThreadInfos,
     }.toList();
 
-    if (allEmailIds.isEmpty) {
+    if (allEmailThreadInfos.isEmpty) {
       yield Left(MarkAsThreadReadFailure(ThreadActionResult(
         success: [],
         actionErrors: {},
@@ -263,7 +258,7 @@ class MarkAsThreadReadInteractor {
     final result = await emailRepository.markAsRead(
       session,
       accountId,
-      emailIds,
+      allEmailThreadInfos.emailIds,
       readAction,
     );
 
@@ -293,9 +288,9 @@ class MoveThreadInteractor {
     required AccountId accountId,
     required MailboxId sentMailboxId,
     required String ownEmailAddress,
-    required MoveToMailboxRequest moveRequest,
+    required MailboxId destinationMailboxId,
     List<ThreadId> threadIds = const [],
-    List<EmailId> emailIds = const [],
+    List<EmailInThreadDetailInfo> emailThreadInfos = const [],
   }) async* {
     yield Right(LoadingMoveThread());
     
@@ -307,12 +302,12 @@ class MoveThreadInteractor {
       ownEmailAddress: ownEmailAddress,
     );
 
-     final allEmailIds = {
-       ...emailIds,
-      ...expansion.emailIds,
-     }.toList();
+    final allEmailThreadInfos = {
+      ...emailThreadInfos,
+      ...expansion.emailThreadInfos,
+    }.toList();
     
-     if (allEmailIds.isEmpty) {
+     if (allEmailThreadInfos.isEmpty) {
        yield Left(MarkAsThreadReadFailure(ThreadActionResult(
          success: [],
          actionErrors: {},
@@ -321,6 +316,8 @@ class MoveThreadInteractor {
        return;
     }
 
+    final moveRequest = MoveToMailboxRequest.fromThreadInfos(threadInfos: allEmailThreadInfos);
+     
     final result = await emailRepository.moveToMailbox(session, accountId, moveRequest);
 
     yield Right(MarkAsThreadReadSuccess(ThreadActionResult(
@@ -559,16 +556,16 @@ If WebSocket pushes state:
 
 ```dart
 
-final allEmailIds = {
-  ...emailIds,
-  ...expandedEmailIds,
+final allEmailThreadInfos = {
+  ...emailThreadInfos,
+  ...expandedEmailThreadInfos,
 };
 ```
 
 ### Cache
 
 ```dart
-Map<ThreadId, List<EmailId>>
+Map<ThreadId, List<EmailInThreadDetailInfo>>
 ```
 
 * Reduces repeated calls to `getThreadById`
@@ -587,7 +584,6 @@ await Future.wait(...);
 Cache must be cleared when:
 
 * Mailbox sync occurs
-* Email state changes (read, star, move, delete)
 * Thread content changes
 * Websocket event (Refresh change invoke )
 * `collapseThreads` is toggled
@@ -600,10 +596,10 @@ expansionService.clearCache();
 
 Hook `expansionService.clearCache()` in:
 
-- `ThreadController.refreshAllEmail()`, `ThreadController.refreshChangeEmail()` after mailbox sync completes (see lib/features/thread/presentation/thread_controller.dart)
-- `MarkAsThreadReadInteractor`, `MoveThreadInteractor`, etc. after calling `clearCache()` post-action
+- `ThreadController.refreshAllEmail()` after mailbox sync completes (see lib/features/thread/presentation/thread_controller.dart)
+- `ThreadController.refreshChangeEmail()` after calling `clearCache()` post-action
 - Settings controller's `onCollapseThreadsToggled()` callback (or equivalent setter)
-- `ThreadDetailRepository` observers when `getThreadById` detects membership changes
+- Thread actions are performed
 
 ## Consequences
 
@@ -630,7 +626,7 @@ Thread Action Flow:
 
 ThreadIds
   → expandThreads (parallel + cache + error-isolated)
-  → extract EmailIds
+  → extract EmailInThreadDetailInfo
   → deduplicate
   → call existing Email Interactor
   → return (success + actionErrors + expansionErrors)

--- a/docs/adr/0072-thread-aware-bulk-actions-email-list-collapse-threads.md
+++ b/docs/adr/0072-thread-aware-bulk-actions-email-list-collapse-threads.md
@@ -184,6 +184,9 @@ class ThreadExpansionService {
 ### Result Model
 
 ```dart
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/error/set_error.dart';
+
 class ThreadActionResult {
   final List<EmailId> success;
   final Map<Id, SetError> actionErrors;
@@ -204,16 +207,19 @@ class ThreadActionResult {
 ```dart
 class MarkAsThreadReadInteractor {
   final ThreadExpansionService expansionService;
-  final MarkAsMultipleEmailReadInteractor emailInteractor;
+  final EmailRepository emailRepository;
 
-  MarkAsThreadReadInteractor(this.expansionService,
-      this.emailInteractor,);
+  MarkAsThreadReadInteractor(
+    this.expansionService,
+    this.emailRepository,
+  );
 
   Future<ThreadActionResult> execute({
     required Session session,
     required AccountId accountId,
     required MailboxId sentMailboxId,
     required String ownEmailAddress,
+    required ReadActions readAction,
     List<ThreadId> threadIds = const [],
     List<EmailId> emailIds = const [],
   }) async {
@@ -238,10 +244,11 @@ class MarkAsThreadReadInteractor {
       );
     }
 
-    final result = await emailInteractor.execute(
-      session: session,
-      accountId: accountId,
-      emailIds: allEmailIds,
+    final result = await emailRepository.markAsRead(
+      session,
+      accountId,
+      emailIds,
+      readAction,
     );
 
     return ThreadActionResult(
@@ -258,17 +265,19 @@ class MarkAsThreadReadInteractor {
 ```dart
 class MoveThreadInteractor {
   final ThreadExpansionService expansionService;
-  final MoveMultipleEmailInteractor moveInteractor;
+  final EmailRepository emailRepository;
 
-  MoveThreadInteractor(this.expansionService,
-      this.moveInteractor,);
+  MoveThreadInteractor(
+    this.expansionService,
+    this.emailRepository,
+  );
 
   Future<ThreadActionResult> execute({
     required Session session,
     required AccountId accountId,
-    required MailboxId destinationMailboxId,
     required MailboxId sentMailboxId,
     required String ownEmailAddress,
+    required MoveToMailboxRequest moveRequest,
     List<ThreadId> threadIds = const [],
     List<EmailId> emailIds = const [],
   }) async {
@@ -293,12 +302,7 @@ class MoveThreadInteractor {
       );
     }
 
-    final result = await moveInteractor.execute(
-      session: session,
-      accountId: accountId,
-      emailIds: allEmailIds,
-      destinationMailboxId: destinationMailboxId,
-    );
+    final result = await emailRepository.moveToMailbox(session, accountId, moveRequest);
 
     return ThreadActionResult(
       success: result.emailIdsSuccess,
@@ -356,6 +360,15 @@ Cache must be cleared when:
 expansionService.clearCache();
 ```
 
+### Implementation Points
+
+Hook `expansionService.clearCache()` in:
+
+- `MailboxRepository` after successful sync completion
+- Email interactor wrappers after successful state mutations (read/unread, star, move, delete)
+- Settings controller when `collapseThreads` toggle changes
+- Thread detail update callbacks when thread membership changes
+
 ## Consequences
 
 ### Positive
@@ -371,6 +384,8 @@ expansionService.clearCache();
 * Increased number of interactors
 * Requires careful cache invalidation
 * Still involves multiple API calls (mitigated via cache + parallelism)
+* Stream-based integration adds complexity (async iteration, result collection, state management)
+* Complex request object construction (MoveToMailboxRequest, emailIdsByMailboxId) requires additional context gathering
 
 ## Summary
 

--- a/docs/adr/0072-thread-aware-bulk-actions-email-list-collapse-threads.md
+++ b/docs/adr/0072-thread-aware-bulk-actions-email-list-collapse-threads.md
@@ -1,0 +1,372 @@
+# 0072 - Thread-aware bulk actions for EmailList with collapseThreads using expansion and dedicated Interactors
+
+Date: 2026-03-17
+
+## Status
+
+Proposed
+
+## Context
+
+After enabling `collapseThreads = true` (ADR-0071), each item in the `EmailList` represents a **ThreadId** instead of an individual `EmailId`.
+
+However, the current system:
+
+* All actions (`markAsRead`, `move`, `star`, etc.) operate on:
+
+```dart
+List<EmailId>
+```
+
+* Existing interactors:
+
+    * `MarkAsEmailReadInteractor` (single email)
+    * `MarkAsMultipleEmailReadInteractor` (bulk email)
+
+* Existing repository:
+
+```dart
+abstract class ThreadDetailRepository {
+  Future<List<EmailInThreadDetailInfo>> getThreadById(ThreadId threadId,
+      Session session,
+      AccountId accountId,
+      MailboxId sentMailboxId,
+      String ownEmailAddress,);
+}
+```
+
+## Problem
+
+When users perform actions on:
+
+* a single thread
+* multiple threads (multi-select)
+* or a mix of threads and emails
+
+the system must resolve:
+
+```
+ThreadId → List<EmailId>
+```
+
+Key challenges:
+
+* N+1 API calls (`getThreadById`)
+* Partial failures (one thread fails while others succeed)
+* Duplicate `EmailId`s when merging results
+* High latency with large selections
+* Existing interactors are not designed for thread-level inputs
+
+## Decision
+
+### Adopt:
+
+> **Thread-aware Interactors + Thread Expansion Service (cached, parallel, error-isolated) + reuse existing Email Interactors**
+
+## Architecture Overview
+
+```
+Thread Interactor
+    ↓
+ThreadExpansionService
+    ↓
+List<EmailId>
+    ↓
+Existing Email Interactor
+```
+
+## 1. Thread Expansion Service
+
+### Responsibility
+
+* Convert `List<ThreadId>` → `List<EmailId>`
+* Reuse `ThreadDetailRepository.getThreadById`
+* Handle:
+
+    * caching
+    * parallel execution
+    * error isolation
+
+### Data Model
+
+```dart
+class ThreadExpansionResult {
+  final List<EmailId> emailIds;
+  final Map<ThreadId, Object> errors;
+
+  ThreadExpansionResult({
+    required this.emailIds,
+    required this.errors,
+  });
+}
+```
+
+### Implementation
+
+```dart
+class ThreadExpansionService {
+  final ThreadDetailRepository threadDetailRepository;
+
+  final Map<ThreadId, List<EmailId>> _cache = {};
+
+  ThreadExpansionService(this.threadDetailRepository);
+
+  Future<ThreadExpansionResult> expandThreads({
+    required List<ThreadId> threadIds,
+    required Session session,
+    required AccountId accountId,
+    required MailboxId sentMailboxId,
+    required String ownEmailAddress,
+  }) async {
+    final emailIds = <EmailId>{};
+    final errors = <ThreadId, Object>{};
+
+    final futures = threadIds.map((threadId) async {
+      try {
+        // Cache hit
+        if (_cache.containsKey(threadId)) {
+          emailIds.addAll(_cache[threadId]!);
+          return;
+        }
+
+        final threadDetails = await threadDetailRepository.getThreadById(
+          threadId,
+          session,
+          accountId,
+          sentMailboxId,
+          ownEmailAddress,
+        );
+
+        final ids = threadDetails
+            .map((e) => e.emailId)
+            .whereType<EmailId>()
+            .toList();
+
+        _cache[threadId] = ids;
+        emailIds.addAll(ids);
+      } catch (e) {
+        // Error isolation
+        errors[threadId] = e;
+      }
+    });
+
+    await Future.wait(futures);
+
+    return ThreadExpansionResult(
+      emailIds: emailIds.toList(),
+      errors: errors,
+    );
+  }
+
+  void clearCache() => _cache.clear();
+}
+```
+
+## 2. Thread-aware Interactor Pattern
+
+### Principles
+
+* Do not modify existing email interactors
+* Do not duplicate business logic
+* Only:
+
+    * expand threads
+    * delegate to existing email interactors
+
+### Result Model
+
+```dart
+class ThreadActionResult {
+  final List<EmailId> success;
+  final Map<Id, SetError> actionErrors;
+  final Map<ThreadId, Object> expansionErrors;
+
+  ThreadActionResult({
+    required this.success,
+    required this.actionErrors,
+    required this.expansionErrors,
+  });
+}
+```
+
+## 3. Example Implementations
+
+### 3.1 MarkAsThreadReadInteractor
+
+```dart
+class MarkAsThreadReadInteractor {
+  final ThreadExpansionService expansionService;
+  final MarkAsMultipleEmailReadInteractor emailInteractor;
+
+  MarkAsThreadReadInteractor(this.expansionService,
+      this.emailInteractor,);
+
+  Future<ThreadActionResult> execute({
+    required Session session,
+    required AccountId accountId,
+    required MailboxId sentMailboxId,
+    required String ownEmailAddress,
+    List<ThreadId> threadIds = const [],
+    List<EmailId> emailIds = const [],
+  }) async {
+    final expansion = await expansionService.expandThreads(
+      threadIds: threadIds,
+      session: session,
+      accountId: accountId,
+      sentMailboxId: sentMailboxId,
+      ownEmailAddress: ownEmailAddress,
+    );
+
+    final allEmailIds = {
+      ...emailIds,
+      ...expansion.emailIds,
+    }.toList();
+
+    if (allEmailIds.isEmpty) {
+      return ThreadActionResult(
+        success: [],
+        actionErrors: {},
+        expansionErrors: expansion.errors,
+      );
+    }
+
+    final result = await emailInteractor.execute(
+      session: session,
+      accountId: accountId,
+      emailIds: allEmailIds,
+    );
+
+    return ThreadActionResult(
+      success: result.emailIdsSuccess,
+      actionErrors: result.mapErrors,
+      expansionErrors: expansion.errors,
+    );
+  }
+}
+```
+
+### 3.2 MoveThreadInteractor
+
+```dart
+class MoveThreadInteractor {
+  final ThreadExpansionService expansionService;
+  final MoveMultipleEmailInteractor moveInteractor;
+
+  MoveThreadInteractor(this.expansionService,
+      this.moveInteractor,);
+
+  Future<ThreadActionResult> execute({
+    required Session session,
+    required AccountId accountId,
+    required MailboxId destinationMailboxId,
+    required MailboxId sentMailboxId,
+    required String ownEmailAddress,
+    List<ThreadId> threadIds = const [],
+  }) async {
+    final expansion = await expansionService.expandThreads(
+      threadIds: threadIds,
+      session: session,
+      accountId: accountId,
+      sentMailboxId: sentMailboxId,
+      ownEmailAddress: ownEmailAddress,
+    );
+
+    if (expansion.emailIds.isEmpty) {
+      return ThreadActionResult(
+        success: [],
+        actionErrors: {},
+        expansionErrors: expansion.errors,
+      );
+    }
+
+    final result = await moveInteractor.execute(
+      session: session,
+      accountId: accountId,
+      emailIds: expansion.emailIds,
+      destinationMailboxId: destinationMailboxId,
+    );
+
+    return ThreadActionResult(
+      success: result.emailIdsSuccess,
+      actionErrors: result.mapErrors,
+      expansionErrors: expansion.errors,
+    );
+  }
+}
+```
+
+## 4. Key Design Properties
+
+### Error Isolation
+
+* Each thread expansion is wrapped in `try/catch`
+* Failure of one thread does not affect others
+
+### Deduplication
+
+```dart
+
+final allEmailIds = {
+  ...emailIds,
+  ...expandedEmailIds,
+};
+```
+
+### Cache
+
+```dart
+Map<ThreadId, List<EmailId>>
+```
+
+* Reduces repeated calls to `getThreadById`
+* Improves performance for repeated actions
+
+### Parallel Execution
+
+```dart
+await Future.wait(...);
+```
+
+* Minimizes latency for multi-thread operations
+
+## 5. Cache Invalidation
+
+Cache must be cleared when:
+
+* Mailbox sync occurs
+* Email state changes (read, star, move, delete)
+* Thread content changes
+* `collapseThreads` is toggled
+
+```dart
+expansionService.clearCache();
+```
+
+## Consequences
+
+### Positive
+
+* Reuses all existing email business logic
+* No backend changes required
+* Scales well for multi-selection
+* Supports partial success (better UX)
+* Clear separation between Thread and Email domains
+
+### Negative
+
+* Increased number of interactors
+* Requires careful cache invalidation
+* Still involves multiple API calls (mitigated via cache + parallelism)
+
+## Summary
+
+```
+Thread Action Flow:
+
+ThreadIds
+  → expandThreads (parallel + cache + error-isolated)
+  → extract EmailIds
+  → deduplicate
+  → call existing Email Interactor
+  → return (success + actionErrors + expansionErrors)
+```

--- a/docs/adr/0072-thread-aware-bulk-actions-email-list-collapse-threads.md
+++ b/docs/adr/0072-thread-aware-bulk-actions-email-list-collapse-threads.md
@@ -329,7 +329,16 @@ class MoveThreadInteractor {
 
 ### Problem
 
-> Delay from user click → UI updated
+Delay between:
+
+```text
+User action → Interactor → Server → UI update
+```
+
+causes:
+
+* Perceived lag
+* Poor UX in bulk/thread actions
 
 ### Decision: Optimistic UI Update
 
@@ -369,6 +378,168 @@ Reason:
 
 * Thread UI derived from Email states
 * Avoid inconsistent UI
+
+## Implementation Strategy
+
+Instead of maintaining a separate snapshot system, we **reuse existing domain logic**:
+
+```dart
+updateEmailFlagByEmailIds(...)
+```
+
+### Key Principle
+
+> UI is updated by mutating `PresentationEmail.keywords` immediately
+
+## Optimistic Update Flow
+
+```text
+User click (mark read/star)
+    ↓
+MailboxDashboardController.updateEmailFlagByEmailIds(...)   ← (optimistic)
+    ↓
+UI updates instantly (via RxList.refresh)
+    ↓
+Interactor.execute() (async)
+    ↓
+Server response:
+    - success → do nothing
+    - partial → reconcile (optional)
+    - failure → rollback (via reverse update)
+```
+
+## Controller-Level Implementation
+
+### ✅ Optimistic Update Trigger
+
+```dart
+controller.updateEmailFlagByEmailIds(
+  emailIds,
+  readAction: ReadActions.markAsRead,
+);
+```
+
+OR
+
+```dart
+controller.updateEmailFlagByEmailIds(
+  emailIds,
+  markStarAction: MarkStarAction.markStar,
+);
+```
+
+## 🔁 Rollback Strategy
+
+Instead of snapshot map, rollback is performed by **inverse operation**:
+
+| Action     | Rollback     |
+| ---------- | ------------ |
+| markAsRead | markAsUnread |
+| markStar   | unMarkStar   |
+
+### Example
+
+```dart
+controller.updateEmailFlagByEmailIds(
+  emailIds,
+  readAction: ReadActions.markAsUnread, // rollback
+);
+```
+
+## ⚠️ Partial Success Handling
+
+When:
+
+```text
+Some emailIds succeed, some fail
+```
+
+We perform:
+
+```dart
+final failedIds = allIds - successIds;
+
+controller.updateEmailFlagByEmailIds(
+  failedIds,
+  readAction: ReadActions.markAsUnread,
+);
+```
+
+## 🔄 Keyword-based Update Model
+
+### Core Mechanism
+
+```dart
+presentationEmail.keywords?[keyword] = true;
+presentationEmail.keywords?.remove(keyword);
+```
+
+This ensures:
+
+* Fine-grained update (no full object replace)
+* No unnecessary rebuilds
+* Compatible with JMAP keyword model
+
+## 📡 UI Sync Behavior
+
+### Why this works well
+
+Because:
+
+```dart
+currentEmails.refresh();
+```
+
+ensures:
+
+* Immediate UI re-render
+* Works for both:
+
+  * mailbox list
+  * search result list
+
+## 🔗 Thread Detail Synchronization
+
+When updating single email:
+
+```dart
+dispatchThreadDetailUIAction(UpdatedEmailKeywordsAction(...));
+```
+
+ensures:
+
+* Thread detail UI stays consistent
+* Avoids mismatch between:
+
+  * EmailList
+  * ThreadDetail screen
+
+## ⚠️ Limitations
+
+### 1. No Snapshot → No True Rollback
+
+Trade-off:
+
+* ✅ Simpler implementation
+* ❌ Cannot restore original complex state (only inverse action)
+
+### 2. Concurrent Actions Risk
+
+Example:
+
+```text
+Action A: mark as read
+Action B: mark as unread (before A completes)
+```
+
+👉 May cause inconsistency
+
+### 3. WebSocket Override
+
+If WebSocket pushes state:
+
+* It may override optimistic state
+* This is acceptable (server is source of truth)
 
 ## 5. Key Design Properties
 

--- a/docs/adr/0072-thread-aware-bulk-actions-email-list-collapse-threads.md
+++ b/docs/adr/0072-thread-aware-bulk-actions-email-list-collapse-threads.md
@@ -78,13 +78,13 @@ Key challenges:
 ```text
 User Action (UI)
     ↓
-Thread-aware Interactor
+Thread-aware Interactor (Stream<UIState>)
     ↓
 ThreadExpansionService
     ↓
-List<EmailId>
+List<EmailId> (deduplicated & pagination-safe)
     ↓
-Existing Email Interactor
+Existing Email Interactor (Stream)
     ↓
 UI State Update (Optimistic + Server Sync)
 ```
@@ -100,6 +100,13 @@ UI State Update (Optimistic + Server Sync)
     * caching
     * parallel execution
     * error isolation
+    * pagination awareness
+
+### Pagination Awareness
+
+We've already handled pagination for the `Email/set` and `Email/get` methods 
+in the mixins `BatchSetEmailProcessingMixin` and `BatchGetEmailProcessingMixin`, 
+so we just need to call and use them.
 
 ### Data Model
 

--- a/docs/adr/0072-thread-aware-bulk-actions-email-list-collapse-threads.md
+++ b/docs/adr/0072-thread-aware-bulk-actions-email-list-collapse-threads.md
@@ -10,6 +10,14 @@ Proposed
 
 After enabling `collapseThreads = true` (ADR-0071), each item in the `EmailList` represents a **ThreadId** instead of an individual `EmailId`.
 
+### Preconditions (from ADR-0071)
+
+Thread-aware flow is enabled only when:
+1. Session capability indicates `collapseThreads` is supported.
+2. User Settings toggle for thread mode is enabled.
+
+If either condition is false, keep existing EmailId-based flow.
+
 However, the current system:
 
 * All actions (`markAsRead`, `move`, `star`, etc.) operate on:
@@ -45,7 +53,7 @@ When users perform actions on:
 
 the system must resolve:
 
-```
+```text
 ThreadId → List<EmailId>
 ```
 
@@ -65,7 +73,7 @@ Key challenges:
 
 ## Architecture Overview
 
-```
+```text
 Thread Interactor
     ↓
 ThreadExpansionService
@@ -262,6 +270,7 @@ class MoveThreadInteractor {
     required MailboxId sentMailboxId,
     required String ownEmailAddress,
     List<ThreadId> threadIds = const [],
+    List<EmailId> emailIds = const [],
   }) async {
     final expansion = await expansionService.expandThreads(
       threadIds: threadIds,
@@ -271,7 +280,12 @@ class MoveThreadInteractor {
       ownEmailAddress: ownEmailAddress,
     );
 
-    if (expansion.emailIds.isEmpty) {
+     final allEmailIds = {
+       ...emailIds,
+      ...expansion.emailIds,
+     }.toList();
+    
+     if (allEmailIds.isEmpty) {
       return ThreadActionResult(
         success: [],
         actionErrors: {},
@@ -282,7 +296,7 @@ class MoveThreadInteractor {
     final result = await moveInteractor.execute(
       session: session,
       accountId: accountId,
-      emailIds: expansion.emailIds,
+      emailIds: allEmailIds,
       destinationMailboxId: destinationMailboxId,
     );
 
@@ -360,7 +374,7 @@ expansionService.clearCache();
 
 ## Summary
 
-```
+```text
 Thread Action Flow:
 
 ThreadIds

--- a/docs/adr/0072-thread-aware-bulk-actions-email-list-collapse-threads.md
+++ b/docs/adr/0072-thread-aware-bulk-actions-email-list-collapse-threads.md
@@ -364,10 +364,10 @@ expansionService.clearCache();
 
 Hook `expansionService.clearCache()` in:
 
-- `MailboxRepository` after successful sync completion
-- Email interactor wrappers after successful state mutations (read/unread, star, move, delete)
-- Settings controller when `collapseThreads` toggle changes
-- Thread detail update callbacks when thread membership changes
+- `ThreadController.refreshAllEmail()` after mailbox sync completes (see lib/features/thread/presentation/thread_controller.dart)
+- `MarkAsThreadReadInteractor`, `MoveThreadInteractor`, etc. after calling `clearCache()` post-action
+- Settings controller's `onCollapseThreadsToggled()` callback (or equivalent setter)
+- `ThreadDetailRepository` observers when `getThreadById` detects membership changes
 
 ## Consequences
 

--- a/docs/adr/0072-thread-aware-bulk-actions-email-list-collapse-threads.md
+++ b/docs/adr/0072-thread-aware-bulk-actions-email-list-collapse-threads.md
@@ -35,11 +35,13 @@ List<EmailId>
 
 ```dart
 abstract class ThreadDetailRepository {
-  Future<List<EmailInThreadDetailInfo>> getThreadById(ThreadId threadId,
-      Session session,
-      AccountId accountId,
-      MailboxId sentMailboxId,
-      String ownEmailAddress,);
+  Future<List<EmailInThreadDetailInfo>> getThreadById(
+    ThreadId threadId,
+    Session session,
+    AccountId accountId,
+    MailboxId sentMailboxId,
+    String ownEmailAddress,
+  );
 }
 ```
 
@@ -74,13 +76,17 @@ Key challenges:
 ## Architecture Overview
 
 ```text
-Thread Interactor
+User Action (UI)
+    ↓
+Thread-aware Interactor
     ↓
 ThreadExpansionService
     ↓
 List<EmailId>
     ↓
 Existing Email Interactor
+    ↓
+UI State Update (Optimistic + Server Sync)
 ```
 
 ## 1. Thread Expansion Service
@@ -214,7 +220,7 @@ class MarkAsThreadReadInteractor {
     this.emailRepository,
   );
 
-  Future<ThreadActionResult> execute({
+  Stream<Either<Failure, Success>> execute({
     required Session session,
     required AccountId accountId,
     required MailboxId sentMailboxId,
@@ -222,7 +228,9 @@ class MarkAsThreadReadInteractor {
     required ReadActions readAction,
     List<ThreadId> threadIds = const [],
     List<EmailId> emailIds = const [],
-  }) async {
+  }) async* {
+    yield Right(LoadingMarkAsThreadRead());
+    
     final expansion = await expansionService.expandThreads(
       threadIds: threadIds,
       session: session,
@@ -237,11 +245,12 @@ class MarkAsThreadReadInteractor {
     }.toList();
 
     if (allEmailIds.isEmpty) {
-      return ThreadActionResult(
+      yield Left(MarkAsThreadReadFailure(ThreadActionResult(
         success: [],
         actionErrors: {},
         expansionErrors: expansion.errors,
-      );
+      )));
+      return;
     }
 
     final result = await emailRepository.markAsRead(
@@ -251,11 +260,11 @@ class MarkAsThreadReadInteractor {
       readAction,
     );
 
-    return ThreadActionResult(
+    yield Right(MarkAsThreadReadSuccess(ThreadActionResult(
       success: result.emailIdsSuccess,
       actionErrors: result.mapErrors,
       expansionErrors: expansion.errors,
-    );
+    )));
   }
 }
 ```
@@ -272,7 +281,7 @@ class MoveThreadInteractor {
     this.emailRepository,
   );
 
-  Future<ThreadActionResult> execute({
+  Stream<Either<Failure, Success>> execute({
     required Session session,
     required AccountId accountId,
     required MailboxId sentMailboxId,
@@ -280,7 +289,9 @@ class MoveThreadInteractor {
     required MoveToMailboxRequest moveRequest,
     List<ThreadId> threadIds = const [],
     List<EmailId> emailIds = const [],
-  }) async {
+  }) async* {
+    yield Right(LoadingMoveThread());
+    
     final expansion = await expansionService.expandThreads(
       threadIds: threadIds,
       session: session,
@@ -295,25 +306,71 @@ class MoveThreadInteractor {
      }.toList();
     
      if (allEmailIds.isEmpty) {
-      return ThreadActionResult(
-        success: [],
-        actionErrors: {},
-        expansionErrors: expansion.errors,
-      );
+       yield Left(MarkAsThreadReadFailure(ThreadActionResult(
+         success: [],
+         actionErrors: {},
+         expansionErrors: expansion.errors,
+       )));
+       return;
     }
 
     final result = await emailRepository.moveToMailbox(session, accountId, moveRequest);
 
-    return ThreadActionResult(
+    yield Right(MarkAsThreadReadSuccess(ThreadActionResult(
       success: result.emailIdsSuccess,
       actionErrors: result.mapErrors,
       expansionErrors: expansion.errors,
-    );
+    )));
   }
 }
 ```
 
-## 4. Key Design Properties
+## 3. UI Responsiveness
+
+### Problem
+
+> Delay from user click → UI updated
+
+### Decision: Optimistic UI Update
+
+Immediately update UI before server response.
+
+### Flow
+
+```text
+User click "Mark as read"
+    ↓
+UI updates instantly (optimistic)
+    ↓
+Interactor executes
+    ↓
+Server response:
+    - success → keep state
+    - partial → reconcile
+    - failure → rollback
+```
+
+### UI State Strategy
+
+| Case    | Behavior           |
+| ------- | ------------------ |
+| Loading | Already updated UI |
+| Success | Confirm            |
+| Partial | Patch missing      |
+| Failure | Rollback           |
+
+### Per Email UI Update
+
+Even when acting on thread:
+
+👉 UI updates must happen at **Email level**, not Thread only.
+
+Reason:
+
+* Thread UI derived from Email states
+* Avoid inconsistent UI
+
+## 5. Key Design Properties
 
 ### Error Isolation
 
@@ -347,13 +404,14 @@ await Future.wait(...);
 
 * Minimizes latency for multi-thread operations
 
-## 5. Cache Invalidation
+## 6. Cache Invalidation
 
 Cache must be cleared when:
 
 * Mailbox sync occurs
 * Email state changes (read, star, move, delete)
 * Thread content changes
+* Websocket event (Refresh change invoke )
 * `collapseThreads` is toggled
 
 ```dart
@@ -364,7 +422,7 @@ expansionService.clearCache();
 
 Hook `expansionService.clearCache()` in:
 
-- `ThreadController.refreshAllEmail()` after mailbox sync completes (see lib/features/thread/presentation/thread_controller.dart)
+- `ThreadController.refreshAllEmail()`, `ThreadController.refreshChangeEmail()` after mailbox sync completes (see lib/features/thread/presentation/thread_controller.dart)
 - `MarkAsThreadReadInteractor`, `MoveThreadInteractor`, etc. after calling `clearCache()` post-action
 - Settings controller's `onCollapseThreadsToggled()` callback (or equivalent setter)
 - `ThreadDetailRepository` observers when `getThreadById` detects membership changes


### PR DESCRIPTION
ADR to implement `collapseThreads` in `Email/Query`

cc @chibenwa @Crash-- @poupotte 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ADR describing collapseThreads behavior: explains the two query paths (force vs cache-first), the cache inconsistency when toggling grouped/ungrouped views, and the decision to clear the email cache on toggle while leaving force-query unchanged.
  * Added ADR for thread-aware bulk actions: defines a thread-expansion approach, thread-aware bulk read/move flows, per-thread error isolation, deduplication, caching/invalidation rules, and expected results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->