### PR TITLE
ADR-0072: Prevent notification storm on Android

### DIFF
--- a/docs/adr/0072-prevent-notification-storm-android.md
+++ b/docs/adr/0072-prevent-notification-storm-android.md
@@ -1,0 +1,433 @@
+# 72. Prevent notification storm on Android
+
+Date: 2026-03-13
+
+## Status
+
+Proposed
+
+# Context
+
+Some Android users reported a **notification storm** when reopening their mobile device after a long idle period (for example overnight).
+
+When the device reconnects to the network, the server may send a large number of push notifications in a very short time.
+
+Example scenario:
+
+```
+100 push events at T0
+100 push events at T0 + 31 seconds
+```
+
+This results in:
+
+* Hundreds of **local notifications**
+* Android notification service overload
+* Device freezing for several minutes
+
+
+
+# Root Causes
+
+## 1. Each FCM event triggers the full notification pipeline
+
+Current flow:
+
+```
+FCM message
+   ↓
+handleFirebaseBackgroundMessage
+   ↓
+FcmMessageController
+   ↓
+EmailChangeListener
+   ↓
+LocalNotificationManager.showPushNotification()
+```
+
+Each email generates **one notification**.
+
+When many pushes arrive simultaneously, the application generates **hundreds of notifications**.
+
+
+
+## 2. Notification grouping happens too late
+
+`groupPushNotificationOnAndroid()` is executed **after notifications are already created**.
+
+Grouping therefore does **not reduce the number of notifications generated**, it only affects how they are displayed.
+
+
+
+## 3. Push bursts during device reconnection
+
+When the device reconnects to the network, the push system may deliver many push events within a short time window.
+
+Without protection, every push event is processed independently, which repeatedly triggers the notification pipeline.
+
+
+
+## 4. Local notification removal occasionally fails
+
+Sentry reports the following error:
+
+```
+PlatformException: Missing type parameter
+FlutterLocalNotificationsPlugin.removeNotificationFromCache
+```
+
+This error prevents some notifications from being removed correctly from the notification cache.
+
+When notification removal fails:
+
+* stale notifications remain active
+* notification grouping becomes inconsistent
+* the total number of active notifications increases
+
+
+
+# Decision
+
+To prevent notification storms, we introduce **four defensive mechanisms**.
+
+
+
+# 1. Push debounce in background handler (30s window)
+
+The background push handler introduces a **30 second debounce window**.
+
+If multiple push events arrive within this window, only the first push will be processed.
+
+The timestamp of the last processed push is stored using `SharedPreferences`.
+
+Example implementation:
+
+```dart
+Future<bool> shouldProcessPush() async {
+  final prefs = await SharedPreferences.getInstance();
+
+  final lastTime = prefs.getInt('last_push_processed_time');
+  final now = DateTime.now().millisecondsSinceEpoch;
+
+  if (lastTime != null && now - lastTime < 30000) {
+    return false;
+  }
+
+  await prefs.setInt('last_push_processed_time', now);
+
+  return true;
+}
+```
+
+Usage:
+
+```dart
+Future<void> handleFirebaseBackgroundMessage(RemoteMessage message) async {
+
+  if (!await shouldProcessPush()) {
+    return;
+  }
+
+  FcmService.instance.handleFirebaseBackgroundMessage(message);
+}
+```
+
+This mechanism prevents repeated push bursts from triggering the notification pipeline multiple times.
+
+
+
+# 2. Notification limiter
+
+When a push burst is processed, the system limits the number of generated notifications.
+
+Rules:
+
+* maximum **20 notifications**
+* prioritize emails requiring user action
+* remaining emails sorted by newest first
+
+Example scenario:
+
+```
+200 emails arrive in a burst
+```
+
+Result:
+
+```
+Only 20 notifications are generated
+```
+
+This ensures the system always has a **strict upper bound** on notification count.
+
+
+
+# Action-required Email Detection
+
+Emails requiring user action are detected using the `keywords` field.
+
+Example structure:
+
+```dart
+final Map<KeyWordIdentifier, bool>? keywords;
+```
+
+Emails containing the keyword `"needs-action"` are considered actionable.
+
+Example:
+
+```dart
+keywords[KeyWordIdentifier('needs-action')] == true
+```
+
+Helper function:
+
+```dart
+bool isActionRequiredEmail(PresentationEmail email) {
+  final keywords = email.keywords;
+  if (keywords == null) return false;
+
+  return keywords[KeyWordIdentifier('needs-action')] == true;
+}
+```
+
+
+
+# Optimized Notification Selection Algorithm
+
+To efficiently select notifications from large bursts of emails, the system keeps only the **top 20 most relevant emails**.
+
+Selection priority:
+
+1. actionable emails (`needs-action`)
+2. newest emails
+
+Example implementation:
+
+```dart
+import 'package:collection/collection.dart';
+
+List<PresentationEmail> selectEmailsForNotification(
+  List<PresentationEmail> emails,
+) {
+  const maxNotifications = 20;
+
+  final actionEmails =
+      emails.where((e) => isActionRequiredEmail(e)).toList();
+
+  final heap = HeapPriorityQueue<PresentationEmail>(
+    (a, b) => a.receivedAt.compareTo(b.receivedAt),
+  );
+
+  for (final email in emails) {
+
+    if (isActionRequiredEmail(email)) continue;
+
+    heap.add(email);
+
+    if (heap.length > maxNotifications) {
+      heap.removeFirst();
+    }
+  }
+
+  final newestEmails = heap.toList()
+    ..sort((a, b) => b.receivedAt.compareTo(a.receivedAt));
+
+  return [...actionEmails, ...newestEmails]
+      .take(maxNotifications)
+      .toList();
+}
+```
+
+Time complexity:
+
+```
+O(n log 20) ≈ O(n)
+```
+
+This avoids sorting the entire email list when bursts contain many emails.
+
+
+
+# 3. Update delivery state during foreground synchronization
+
+The application already stores the **email delivery state** when push notifications are processed.
+
+To ensure state consistency, the delivery state will also be updated when the email state cache is updated during **foreground synchronization**.
+
+Example integration:
+
+```dart
+await stateCacheManager.saveState(
+  accountId,
+  userName,
+  StateCache(StateType.email, newState),
+);
+
+await FCMCacheManager.storeStateToRefresh(
+  accountId,
+  userName,
+  TypeName.emailDelivery,
+  newState,
+);
+```
+
+This ensures the latest delivery state is always persisted, even when updates originate from foreground synchronization.
+
+
+
+# 4. Fix local notification removal error
+
+The notification removal logic will be updated to handle failures safely.
+
+Current implementation:
+
+```dart
+await _localNotificationsPlugin.cancel(id.hashCode);
+```
+
+Improved implementation:
+
+```dart
+Future<void> removeNotification(String id) async {
+  try {
+    await _localNotificationsPlugin.cancel(id.hashCode);
+  } catch (e) {
+    logWarning("cancel notification failed: $e");
+  }
+}
+```
+
+This ensures notification removal failures do not interrupt the notification pipeline.
+
+
+
+# Architecture Flow (after fix)
+
+```
+FCM message
+   ↓
+handleFirebaseBackgroundMessage
+   ↓
+(push debounce)
+   ↓
+FcmMessageController
+   ↓
+EmailChangeListener
+   ↓
+Notification selection limiter
+   ↓
+LocalNotificationManager
+   ↓
+Safe notification removal
+```
+
+
+
+# Code Changes
+
+## 1. handleFirebaseBackgroundMessage
+
+Add push debounce logic.
+
+```dart
+if (!await shouldProcessPush()) {
+  return;
+}
+```
+
+
+
+## 2. EmailChangeListener
+
+Limit notifications using the selection algorithm.
+
+```dart
+final selectedEmails =
+    selectEmailsForNotification(emailList);
+
+for (final email in selectedEmails) {
+  LocalNotificationManager.instance.showPushNotification(
+    id: email.id?.id.value ?? '',
+    title: email.subject ?? '',
+    message: email.preview,
+  );
+}
+```
+
+
+
+## 3. Foreground email synchronization
+
+Update delivery state when saving email state cache.
+
+```dart
+FCMCacheManager.storeStateToRefresh(
+  accountId,
+  userName,
+  TypeName.emailDelivery,
+  newState,
+);
+```
+
+
+
+## 4. LocalNotificationManager
+
+Add defensive notification cancellation.
+
+```dart
+Future<void> removeNotification(String id) async {
+  try {
+    await _localNotificationsPlugin.cancel(id.hashCode);
+  } catch (e) {
+    logWarning("cancel notification failed: $e");
+  }
+}
+```
+
+
+
+# Consequences
+
+## Positive
+
+* Prevents Android notification storms
+* Guarantees maximum **20 notifications per burst**
+* Reduces device overload
+* Improves notification reliability
+
+
+
+## Negative
+
+* Some emails may not generate notifications during bursts
+* Notifications may be delayed due to push debounce
+
+However this trade-off significantly improves system stability.
+
+
+
+# Future Improvements
+
+Possible enhancements:
+
+## Notification digest
+
+Instead of multiple notifications:
+
+```
+You have 120 new emails
+```
+
+## Server-side push aggregation
+
+The server may send multiple email IDs in a single push event.
+
+## Adaptive rate limiting
+
+Adjust notification limits depending on:
+
+* device performance
+* Android version
+* notification load

--- a/docs/adr/0072-prevent-notification-storm-android.md
+++ b/docs/adr/0072-prevent-notification-storm-android.md
@@ -123,7 +123,7 @@ Future<void> handleFirebaseBackgroundMessage(RemoteMessage message) async {
 
 This mechanism prevents repeated push bursts from triggering the notification pipeline multiple times.
 
-### Background execution constraints
+## Background execution constraints
 
 The FCM background handler runs inside a short-lived Flutter isolate.
 
@@ -223,7 +223,11 @@ List<PresentationEmail> selectEmailsForNotification(
   const maxNotifications = 20;
 
   final actionEmails =
-      emails.where((e) => isActionRequiredEmail(e)).toList();
+      emails.where((e) => isActionRequiredEmail(e))
+          .take(maxNotifications)
+          .toList();
+
+  final remainingSlots = maxNotifications - actionEmails.length;
 
   final heap = HeapPriorityQueue<PresentationEmail>(
     (a, b) => a.receivedAt.compareTo(b.receivedAt),
@@ -236,7 +240,7 @@ List<PresentationEmail> selectEmailsForNotification(
 
     heap.add(email);
 
-    if (heap.length > maxNotifications) {
+    if (heap.length > remainingSlots) {
       heap.removeFirst();
     }
   }
@@ -244,9 +248,7 @@ List<PresentationEmail> selectEmailsForNotification(
   final newestInboxEmails = heap.toList()
     ..sort((a, b) => b.receivedAt.compareTo(a.receivedAt));
 
-  return [...actionEmails, ...newestInboxEmails]
-      .take(maxNotifications)
-      .toList();
+  return [...actionEmails, ...newestInboxEmails];
 }
 ```
 

--- a/docs/adr/0072-prevent-notification-storm-android.md
+++ b/docs/adr/0072-prevent-notification-storm-android.md
@@ -14,7 +14,7 @@ When the device reconnects to the network, the server may send a large number of
 
 Example scenario:
 
-```
+```text
 100 push events at T0
 100 push events at T0 + 31 seconds
 ```
@@ -25,15 +25,13 @@ This results in:
 * Android notification service overload
 * Device freezing for several minutes
 
-
-
 # Root Causes
 
 ## 1. Each FCM event triggers the full notification pipeline
 
 Current flow:
 
-```
+```text
 FCM message
    ↓
 handleFirebaseBackgroundMessage
@@ -49,15 +47,11 @@ Each email generates **one notification**.
 
 When many pushes arrive simultaneously, the application generates **hundreds of notifications**.
 
-
-
 ## 2. Notification grouping happens too late
 
 `groupPushNotificationOnAndroid()` is executed **after notifications are already created**.
 
 Grouping therefore does **not reduce the number of notifications generated**, it only affects how they are displayed.
-
-
 
 ## 3. Push bursts during device reconnection
 
@@ -65,13 +59,11 @@ When the device reconnects to the network, the push system may deliver many push
 
 Without protection, every push event is processed independently, which repeatedly triggers the notification pipeline.
 
-
-
 ## 4. Local notification removal occasionally fails
 
 Sentry reports the following error:
 
-```
+```text
 PlatformException: Missing type parameter
 FlutterLocalNotificationsPlugin.removeNotificationFromCache
 ```
@@ -84,17 +76,13 @@ When notification removal fails:
 * notification grouping becomes inconsistent
 * the total number of active notifications increases
 
-
-
 # Decision
 
 To prevent notification storms, we introduce **four defensive mechanisms**.
 
-
-
 # 1. Push debounce in background handler (30s window)
 
-The background push handler introduces a **30 second debounce window**.
+The background push handler introduces a **30-second debounce window**.
 
 If multiple push events arrive within this window, only the first push will be processed.
 
@@ -123,7 +111,8 @@ Usage:
 
 ```dart
 Future<void> handleFirebaseBackgroundMessage(RemoteMessage message) async {
-
+  WidgetsFlutterBinding.ensureInitialized();
+  
   if (!await shouldProcessPush()) {
     return;
   }
@@ -134,7 +123,17 @@ Future<void> handleFirebaseBackgroundMessage(RemoteMessage message) async {
 
 This mechanism prevents repeated push bursts from triggering the notification pipeline multiple times.
 
+### Background execution constraints
 
+The FCM background handler runs inside a short-lived Flutter isolate.
+
+Background handlers are designed to execute quickly and may be terminated by the Android system at any time after the push event is delivered.
+
+Because of this limitation, long-running operations such as delaying processing for an aggregation window (for example waiting 1 minute before generating notifications) are not reliable.
+
+If the isolate is terminated before the delay completes, notifications may never be generated.
+
+For this reason, the system uses a lightweight debounce mechanism that immediately processes the first push event and ignores subsequent push events during a short time window.
 
 # 2. Notification limiter
 
@@ -144,23 +143,22 @@ Rules:
 
 * maximum **20 notifications**
 * prioritize emails requiring user action
+* regular emails generate notifications **only if they belong to the Inbox mailbox**
 * remaining emails sorted by newest first
 
 Example scenario:
 
-```
+```text
 200 emails arrive in a burst
 ```
 
 Result:
 
-```
+```text
 Only 20 notifications are generated
 ```
 
 This ensures the system always has a **strict upper bound** on notification count.
-
-
 
 # Action-required Email Detection
 
@@ -191,7 +189,17 @@ bool isActionRequiredEmail(PresentationEmail email) {
 }
 ```
 
+# Inbox Email Detection
 
+Regular emails will only generate notifications if they belong to the **Inbox mailbox**.
+
+Helper function:
+
+```dart
+bool isInboxEmail(PresentationEmail email) {
+  return email.mailboxIds?.contains("inbox-id") ?? false;
+}
+```
 
 # Optimized Notification Selection Algorithm
 
@@ -200,7 +208,9 @@ To efficiently select notifications from large bursts of emails, the system keep
 Selection priority:
 
 1. actionable emails (`needs-action`)
-2. newest emails
+2. newest **Inbox emails**
+
+Emails outside the Inbox mailbox will not generate notifications unless they are actionable.
 
 Example implementation:
 
@@ -222,6 +232,7 @@ List<PresentationEmail> selectEmailsForNotification(
   for (final email in emails) {
 
     if (isActionRequiredEmail(email)) continue;
+    if (!isInboxEmail(email)) continue;
 
     heap.add(email);
 
@@ -230,10 +241,10 @@ List<PresentationEmail> selectEmailsForNotification(
     }
   }
 
-  final newestEmails = heap.toList()
+  final newestInboxEmails = heap.toList()
     ..sort((a, b) => b.receivedAt.compareTo(a.receivedAt));
 
-  return [...actionEmails, ...newestEmails]
+  return [...actionEmails, ...newestInboxEmails]
       .take(maxNotifications)
       .toList();
 }
@@ -241,13 +252,11 @@ List<PresentationEmail> selectEmailsForNotification(
 
 Time complexity:
 
-```
+```text
 O(n log 20) ≈ O(n)
 ```
 
 This avoids sorting the entire email list when bursts contain many emails.
-
-
 
 # 3. Update delivery state during foreground synchronization
 
@@ -274,8 +283,6 @@ await FCMCacheManager.storeStateToRefresh(
 
 This ensures the latest delivery state is always persisted, even when updates originate from foreground synchronization.
 
-
-
 # 4. Fix local notification removal error
 
 The notification removal logic will be updated to handle failures safely.
@@ -300,11 +307,9 @@ Future<void> removeNotification(String id) async {
 
 This ensures notification removal failures do not interrupt the notification pipeline.
 
-
-
 # Architecture Flow (after fix)
 
-```
+```text
 FCM message
    ↓
 handleFirebaseBackgroundMessage
@@ -322,8 +327,6 @@ LocalNotificationManager
 Safe notification removal
 ```
 
-
-
 # Code Changes
 
 ## 1. handleFirebaseBackgroundMessage
@@ -335,8 +338,6 @@ if (!await shouldProcessPush()) {
   return;
 }
 ```
-
-
 
 ## 2. EmailChangeListener
 
@@ -355,8 +356,6 @@ for (final email in selectedEmails) {
 }
 ```
 
-
-
 ## 3. Foreground email synchronization
 
 Update delivery state when saving email state cache.
@@ -369,8 +368,6 @@ FCMCacheManager.storeStateToRefresh(
   newState,
 );
 ```
-
-
 
 ## 4. LocalNotificationManager
 
@@ -386,8 +383,6 @@ Future<void> removeNotification(String id) async {
 }
 ```
 
-
-
 # Consequences
 
 ## Positive
@@ -395,9 +390,7 @@ Future<void> removeNotification(String id) async {
 * Prevents Android notification storms
 * Guarantees maximum **20 notifications per burst**
 * Reduces device overload
-* Improves notification reliability
-
-
+* Improves notification relevance by prioritizing Inbox emails
 
 ## Negative
 
@@ -405,8 +398,6 @@ Future<void> removeNotification(String id) async {
 * Notifications may be delayed due to push debounce
 
 However this trade-off significantly improves system stability.
-
-
 
 # Future Improvements
 
@@ -416,7 +407,7 @@ Possible enhancements:
 
 Instead of multiple notifications:
 
-```
+```text
 You have 120 new emails
 ```
 

--- a/docs/adr/0073-prevent-notification-storm-android.md
+++ b/docs/adr/0073-prevent-notification-storm-android.md
@@ -107,7 +107,7 @@ The measures below complement the server-side `collapse_key` mechanism. Given th
 | Skip notifications when in foreground | **MUST** | |
 | Limit number of notifications | **MUST** | |
 | Fix local notification removal error | **SHOULD** | |
-| Heuristic for important push (`need-action` + INBOX) | **SHOULD** | Needs product validation |
+| Heuristic for important push (`needs-action` + INBOX) | **SHOULD** | Needs product validation |
 | Separate subscription for `resync` and `notifs` | **WON'T** | Correlated with app removal — tracked separately |
 | Debounce on app side | **WON'T** | Other steps make this an edge case not worth the team time to fix |
 
@@ -159,7 +159,7 @@ Only 20 notifications are generated
 
 This ensures the system always has a **strict upper bound** on notification count.
 
-## 3. Heuristic for important push (need-action + INBOX)
+## 3. Heuristic for important push (needs-action + INBOX)
 
 Emails requiring user action are detected using the `keywords` field.
 
@@ -177,7 +177,7 @@ Regular emails only generate notifications if they belong to the **Inbox mailbox
 
 ```dart
 bool isInboxEmail(PresentationEmail email, MailboxId inboxMailboxId) {
-  return email.mailboxIds?.contains(inboxMailboxId) ?? false;
+  return email.mailboxIds?.containsKey(inboxMailboxId) ?? false;
 }
 ```
 
@@ -201,6 +201,7 @@ import 'package:collection/collection.dart';
 
 List<PresentationEmail> selectEmailsForNotification(
   List<PresentationEmail> emails,
+  MailboxId inboxMailboxId,
 ) {
   const maxNotifications = 20;
 
@@ -217,7 +218,7 @@ List<PresentationEmail> selectEmailsForNotification(
 
   for (final email in emails) {
     if (isActionRequiredEmail(email)) continue;
-    if (!isInboxEmail(email)) continue;
+    if (!isInboxEmail(email, inboxMailboxId)) continue;
 
     heap.add(email);
 
@@ -359,7 +360,7 @@ This is deferred because it is correlated with a broader app-removal / subscript
 ## Negative
 
 * Some emails may not generate notifications during bursts
-* Requires product validation for the heuristic (`need-action` + INBOX priority)
+* Requires product validation for the heuristic (`needs-action` + INBOX priority)
 
 # References
 

--- a/docs/adr/0073-prevent-notification-storm-android.md
+++ b/docs/adr/0073-prevent-notification-storm-android.md
@@ -141,7 +141,7 @@ When a push burst is processed, the system limits the number of generated notifi
 Rules:
 
 * maximum **20 notifications**
-* prioritize emails requiring user action
+* prioritise emails requiring user action
 * regular emails generate notifications **only if they belong to the Inbox mailbox**
 * remaining emails sorted by newest first
 
@@ -176,10 +176,12 @@ bool isActionRequiredEmail(PresentationEmail email) {
 Regular emails only generate notifications if they belong to the **Inbox mailbox**.
 
 ```dart
-bool isInboxEmail(PresentationEmail email) {
-  return email.mailboxIds?.contains("inbox-id") ?? false;
+bool isInboxEmail(PresentationEmail email, MailboxId inboxMailboxId) {
+  return email.mailboxIds?.contains(inboxMailboxId) ?? false;
 }
 ```
+
+The inbox `MailboxId` must be resolved upstream from the mailbox list before calling this helper — `PresentationEmail` stores only `mailboxIds` and has no knowledge of which one is the Inbox.
 
 ### Optimized Notification Selection Algorithm
 

--- a/docs/adr/0073-prevent-notification-storm-android.md
+++ b/docs/adr/0073-prevent-notification-storm-android.md
@@ -1,4 +1,4 @@
-# 72. Prevent notification storm on Android
+# 73. Prevent notification storm on Android
 
 Date: 2026-03-13
 
@@ -24,6 +24,28 @@ This results in:
 * Hundreds of **local notifications**
 * Android notification service overload
 * Device freezing for several minutes
+
+## How Android push notifications work
+
+FCM (Firebase Cloud Messaging) delivers push events to the app via a background handler (`handleFirebaseBackgroundMessage`).
+
+The FCM background handler runs inside a short-lived Flutter isolate.
+
+Background handlers are designed to execute quickly and may be terminated by the Android system at any time after the push event is delivered.
+
+Because of this limitation, long-running operations such as delaying processing for an aggregation window (for example waiting 1 minute before generating notifications) are not reliable.
+
+If the isolate is terminated before the delay completes, notifications may never be generated.
+
+## collapse_key
+
+FCM supports a `collapse_key` field that instructs the platform to deliver only the most recent message of a given key when multiple messages have been queued while the device was offline.
+
+This is a server-side mechanism that the backend team configures when sending push events. If `collapse_key` is applied, the device receives a single push event instead of a burst, which prevents the storm at the source.
+
+The measures described in this ADR are **complementary** to `collapse_key`: they protect the client in cases where burst delivery still occurs (e.g. `collapse_key` not yet deployed, or multiple collapse groups arriving at once).
+
+See the backend issue for details on how `collapse_key` is configured server-side (Reference section).
 
 # Root Causes
 
@@ -78,64 +100,41 @@ When notification removal fails:
 
 # Decision
 
-To prevent notification storms, we introduce **four defensive mechanisms**.
+The measures below complement the server-side `collapse_key` mechanism. Given the scope of work, items are prioritised using MoSCoW to guide sprint planning.
 
-# 1. Push debounce in background handler (30s window)
+| Item | Priority | Comment |
+|------|----------|---------|
+| Skip notifications when in foreground | **MUST** | |
+| Limit number of notifications | **MUST** | |
+| Fix local notification removal error | **SHOULD** | |
+| Heuristic for important push (`need-action` + INBOX) | **SHOULD** | Needs product validation |
+| Separate subscription for `resync` and `notifs` | **WON'T** | Correlated with app removal — tracked separately |
+| Debounce on app side | **WON'T** | Other steps make this an edge case not worth the team time to fix |
 
-The background push handler introduces a **30-second debounce window**.
+## 1. Skip notifications when in foreground
 
-If multiple push events arrive within this window, only the first push will be processed.
+When the user is actively using the app, local push notifications should **not** be displayed — the user can see new emails directly in the UI.
 
-The timestamp of the last processed push is stored using `SharedPreferences`.
+The delivery state must still be updated when the email state cache is refreshed during foreground synchronization, to ensure state consistency for the next background wake.
 
-Example implementation:
-
-```dart
-Future<bool> shouldProcessPush() async {
-  final prefs = await SharedPreferences.getInstance();
-
-  final lastTime = prefs.getInt('last_push_processed_time');
-  final now = DateTime.now().millisecondsSinceEpoch;
-
-  if (lastTime != null && now - lastTime < 30000) {
-    return false;
-  }
-
-  await prefs.setInt('last_push_processed_time', now);
-
-  return true;
-}
-```
-
-Usage:
+Example integration:
 
 ```dart
-Future<void> handleFirebaseBackgroundMessage(RemoteMessage message) async {
-  WidgetsFlutterBinding.ensureInitialized();
-  
-  if (!await shouldProcessPush()) {
-    return;
-  }
+await stateCacheManager.saveState(
+  accountId,
+  userName,
+  StateCache(StateType.email, newState),
+);
 
-  FcmService.instance.handleFirebaseBackgroundMessage(message);
-}
+await FCMCacheManager.storeStateToRefresh(
+  accountId,
+  userName,
+  TypeName.emailDelivery,
+  newState,
+);
 ```
 
-This mechanism prevents repeated push bursts from triggering the notification pipeline multiple times.
-
-## Background execution constraints
-
-The FCM background handler runs inside a short-lived Flutter isolate.
-
-Background handlers are designed to execute quickly and may be terminated by the Android system at any time after the push event is delivered.
-
-Because of this limitation, long-running operations such as delaying processing for an aggregation window (for example waiting 1 minute before generating notifications) are not reliable.
-
-If the isolate is terminated before the delay completes, notifications may never be generated.
-
-For this reason, the system uses a lightweight debounce mechanism that immediately processes the first push event and ignores subsequent push events during a short time window.
-
-# 2. Notification limiter
+## 2. Limit number of notifications
 
 When a push burst is processed, the system limits the number of generated notifications.
 
@@ -160,40 +159,21 @@ Only 20 notifications are generated
 
 This ensures the system always has a **strict upper bound** on notification count.
 
-# Action-required Email Detection
+## 3. Heuristic for important push (need-action + INBOX)
 
 Emails requiring user action are detected using the `keywords` field.
 
-Example structure:
-
-```dart
-final Map<KeyWordIdentifier, bool>? keywords;
-```
-
 Emails containing the keyword `"needs-action"` are considered actionable.
-
-Example:
-
-```dart
-keywords[KeyWordIdentifier('needs-action')] == true
-```
-
-Helper function:
 
 ```dart
 bool isActionRequiredEmail(PresentationEmail email) {
   final keywords = email.keywords;
   if (keywords == null) return false;
-
   return keywords[KeyWordIdentifier('needs-action')] == true;
 }
 ```
 
-# Inbox Email Detection
-
-Regular emails will only generate notifications if they belong to the **Inbox mailbox**.
-
-Helper function:
+Regular emails only generate notifications if they belong to the **Inbox mailbox**.
 
 ```dart
 bool isInboxEmail(PresentationEmail email) {
@@ -201,7 +181,7 @@ bool isInboxEmail(PresentationEmail email) {
 }
 ```
 
-# Optimized Notification Selection Algorithm
+### Optimized Notification Selection Algorithm
 
 To efficiently select notifications from large bursts of emails, the system keeps only the **top 20 most relevant emails**.
 
@@ -234,7 +214,6 @@ List<PresentationEmail> selectEmailsForNotification(
   );
 
   for (final email in emails) {
-
     if (isActionRequiredEmail(email)) continue;
     if (!isInboxEmail(email)) continue;
 
@@ -252,40 +231,9 @@ List<PresentationEmail> selectEmailsForNotification(
 }
 ```
 
-Time complexity:
+Time complexity: `O(n log 20) ≈ O(n)`
 
-```text
-O(n log 20) ≈ O(n)
-```
-
-This avoids sorting the entire email list when bursts contain many emails.
-
-# 3. Update delivery state during foreground synchronization
-
-The application already stores the **email delivery state** when push notifications are processed.
-
-To ensure state consistency, the delivery state will also be updated when the email state cache is updated during **foreground synchronization**.
-
-Example integration:
-
-```dart
-await stateCacheManager.saveState(
-  accountId,
-  userName,
-  StateCache(StateType.email, newState),
-);
-
-await FCMCacheManager.storeStateToRefresh(
-  accountId,
-  userName,
-  TypeName.emailDelivery,
-  newState,
-);
-```
-
-This ensures the latest delivery state is always persisted, even when updates originate from foreground synchronization.
-
-# 4. Fix local notification removal error
+## 4. Fix local notification removal error
 
 The notification removal logic will be updated to handle failures safely.
 
@@ -316,13 +264,13 @@ FCM message
    ↓
 handleFirebaseBackgroundMessage
    ↓
-(push debounce)
+[skip if app in foreground]
    ↓
 FcmMessageController
    ↓
 EmailChangeListener
    ↓
-Notification selection limiter
+Notification selection limiter (heuristic + max 20)
    ↓
 LocalNotificationManager
    ↓
@@ -331,23 +279,16 @@ Safe notification removal
 
 # Code Changes
 
-## 1. handleFirebaseBackgroundMessage
+## 1. FcmMessageController / handleFirebaseBackgroundMessage
 
-Add push debounce logic.
-
-```dart
-if (!await shouldProcessPush()) {
-  return;
-}
-```
+Skip notification display when app is in foreground.
 
 ## 2. EmailChangeListener
 
 Limit notifications using the selection algorithm.
 
 ```dart
-final selectedEmails =
-    selectEmailsForNotification(emailList);
+final selectedEmails = selectEmailsForNotification(emailList);
 
 for (final email in selectedEmails) {
   LocalNotificationManager.instance.showPushNotification(
@@ -385,6 +326,24 @@ Future<void> removeNotification(String id) async {
 }
 ```
 
+# Alternatives
+
+The following approaches were considered but will **not** be implemented in this iteration (WON'T items from MoSCoW).
+
+## Debounce on app side
+
+Introduce a 30-second debounce window in the background push handler so that only the first push in a burst is processed.
+
+This approach is no longer prioritised because the other MUST/SHOULD steps already eliminate the storm. Once notification display is skipped in foreground and the count is capped at 20, a residual burst during background reconnection is an edge case that does not justify the added complexity.
+
+## Separate subscription for `resync` and `notifs`
+
+Currently the same FCM subscription is used both to trigger a background resync and to generate visible notifications. Separating these would allow finer control (e.g. suppress notification-generating pushes while still allowing resync pushes).
+
+This is deferred because it is correlated with a broader app-removal / subscription-cleanup initiative and should be tackled together.
+
+**Open question:** For resync, is FCM actually necessary? If the app only uses FCM to leverage an offline cache, an alternative would be to drop FCM entirely for resync and replace it with a WebSocket connection when the app is in foreground. This would remove a whole class of background-push issues and is worth evaluating as part of the subscription-separation work.
+
 # Consequences
 
 ## Positive
@@ -392,35 +351,14 @@ Future<void> removeNotification(String id) async {
 * Prevents Android notification storms
 * Guarantees maximum **20 notifications per burst**
 * Reduces device overload
-* Improves notification relevance by prioritizing Inbox emails
+* Improves notification relevance by prioritizing actionable and Inbox emails
+* No notifications shown when user is already in the app
 
 ## Negative
 
 * Some emails may not generate notifications during bursts
-* Notifications may be delayed due to push debounce
+* Requires product validation for the heuristic (`need-action` + INBOX priority)
 
-However this trade-off significantly improves system stability.
+# References
 
-# Future Improvements
-
-Possible enhancements:
-
-## Notification digest
-
-Instead of multiple notifications:
-
-```text
-You have 120 new emails
-```
-
-## Server-side push aggregation
-
-The server may send multiple email IDs in a single push event.
-
-## Adaptive rate limiting
-
-Adjust notification limits depending on:
-
-* device performance
-* Android version
-* notification load
+* [tmail-backend#2301 — Use `collapse_key` for push notifications](https://github.com/linagora/tmail-backend/issues/2301) — Backend issue describing how `collapse_key` is configured server-side to collapse queued push messages on device reconnect


### PR DESCRIPTION
## Add ADR-0072: Prevent notification storm on Android

### Summary

This PR introduces a new Architecture Decision Record (ADR) that defines how the application prevents **notification storms on Android** when a device reconnects after a long idle period.

The ADR documents the root causes of the issue and proposes several defensive mechanisms to stabilize the push notification system and limit excessive local notifications.

---

### Related Issue

Fixes #4366

---

# Problem

Some Android users experience a **large burst of notifications** when their device reconnects to the network after being idle (for example overnight).

When reconnection occurs, **Firebase Cloud Messaging (FCM)** may deliver many push events within a short time window.

Each push currently triggers the full notification pipeline and may generate multiple local notifications.

Example scenario:

```
100 push events at T0
100 push events at T0 + 31 seconds
```

This can lead to:

* notification flooding
* hundreds of local notifications
* Android notification service overload
* device UI freezing for several minutes
* degraded user experience

---

# Decision

To mitigate this issue, the ADR proposes **four defensive mechanisms**.

---

## 1. Push debounce in background handler

A **debounce window** is introduced in the background push handler to prevent repeated push bursts from triggering the notification pipeline multiple times.

When multiple FCM messages arrive within a short period of time:

* only the **first push** within the debounce window is processed
* subsequent pushes within the window are ignored

This prevents push bursts from repeatedly executing the full notification pipeline.

---

## 2. Notification limiter

When a push burst is processed, the application limits the number of generated notifications.

Rules:

* maximum **20 notifications**
* notifications are generated **only for Inbox emails**
* emails requiring user action (`needs-action`) are prioritized
* remaining emails are selected by **newest first**

Selection priority:

```
1. actionable emails (needs-action)
2. newest emails (Inbox only)
```

Emails delivered to other mailboxes (Sent, Drafts, Spam, Trash, etc.) will not generate notifications.

This significantly reduces unnecessary notifications during large synchronization bursts.

---

## 3. Foreground delivery state synchronization

The email delivery state is currently stored when push notifications are processed.

To maintain state consistency, the delivery state will also be updated during **foreground synchronization** when the email state cache is refreshed.

This ensures the latest delivery state is always persisted even if updates originate outside the push pipeline.

---

## 4. Fix local notification removal error

The notification cancellation logic will be improved to safely handle failures.

Sentry reports the following error:

```
PlatformException: Missing type parameter
FlutterLocalNotificationsPlugin.removeNotificationFromCache
```

When cancellation fails:

* stale notifications may remain active
* notification grouping becomes inconsistent
* notification count increases

The updated logic introduces **defensive cancellation handling** and safer notification removal.

---

# Expected Benefits

This design provides several improvements:

* prevents Android notification storms
* guarantees a **maximum of 20 notifications per push burst**
* reduces unnecessary notifications from non-Inbox mailboxes
* stabilizes notification behavior during device reconnection
* reduces Android notification service overload
* improves overall user experience

---

# Scope

This PR **adds documentation only**.

The ADR defines the architecture and design decisions.
Implementation will be delivered in follow-up issues and pull requests.

---

# Files Added

```
docs/adr/0072-prevent-notification-storm-android.md
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an architecture decision record describing a client-side strategy to prevent Android notification storms after long offline periods: suppress foreground display, cap generated local notifications to 20 per burst, prioritize actionable emails and Inbox messages, fall back to newest-first selection, and harden local-notification removal to avoid interrupting delivery. Also references complementary server-side collapse behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->