### PR TITLE
Spam banner: apply larger interval each time it is shown

### DIFF
--- a/lib/features/mailbox_dashboard/domain/usecases/get_spam_mailbox_cached_interactor.dart
+++ b/lib/features/mailbox_dashboard/domain/usecases/get_spam_mailbox_cached_interactor.dart
@@ -9,7 +9,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/spam_
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/get_spam_mailbox_cached_state.dart';
 
 class GetSpamMailboxCachedInteractor {
-  static const int spamReportBannerDisplayIntervalInHour = 12;
+  static const int spamReportBannerDisplayIntervalInHour = 24;
 
   final SpamReportRepository _spamReportRepository;
 
@@ -22,6 +22,7 @@ class GetSpamMailboxCachedInteractor {
         final spamMailbox =  await _spamReportRepository.getSpamMailboxCached(accountId, userName);
         final countUnreadSpamMailbox = spamMailbox.unreadEmails?.value.value.toInt() ?? 0;
         if (countUnreadSpamMailbox > 0) {
+          await _spamReportRepository.storeLastTimeDismissedSpamReported(DateTime.now());
           yield Right<Failure, Success>(GetSpamMailboxCachedSuccess(spamMailbox));
         } else {
           yield Left<Failure, Success>(InvalidSpamReportCondition());


### PR DESCRIPTION
Problem: The spam banner was only storing a timestamp when the user explicitly dismissed it (close button or "view spam"). If the user manually marked spam emails as read instead, no timestamp was      
  stored, so the banner would reappear on every app resume.                                                                                                                                                 

  Fix in get_spam_mailbox_cached_interactor.dart:                                                                                                                                                           
  - Changed interval from 12 → 24 hours to match the "max once per day" spec
  - Added storeLastTimeDismissedSpamReported(DateTime.now()) at the moment the banner is shown, not just when dismissed                                                                                     
                  
  Now the 24h cooldown starts as soon as the banner is displayed, regardless of how the user handles it. 