### PR TITLE
TF-4384 Fix page not found 404 error when refreshing label views

### DIFF
--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -82,6 +82,7 @@ import 'package:tmail_ui_user/features/email/presentation/utils/email_action_rea
 import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
 import 'package:tmail_ui_user/features/home/domain/extensions/session_extensions.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/action/mailbox_ui_action.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/action/download_ui_action.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_download_attachment_extension.dart';
@@ -1069,18 +1070,19 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
 
   void _replaceBrowserHistory() {
     if (PlatformInfo.isWeb) {
-      final selectedMailboxId = mailboxDashBoardController.selectedMailbox.value?.id;
+      final selectedMailbox = mailboxDashBoardController.selectedMailbox.value;
       final isSearchRunning = mailboxDashBoardController.searchController.isSearchEmailRunning;
       RouteUtils.replaceBrowserHistory(
         title: isSearchRunning
           ? 'SearchEmail'
-          : 'Mailbox-${selectedMailboxId?.id.value}',
+          : selectedMailbox?.browserRouteTitle ?? '',
         url: RouteUtils.createUrlWebLocationBar(
           AppRoutes.dashboard,
           router: NavigationRouter(
             mailboxId: isSearchRunning
               ? null
-              : selectedMailboxId,
+              : selectedMailbox?.browserRouteMailboxId,
+            labelId: selectedMailbox?.labelId,
             dashboardType: isSearchRunning
               ? DashboardType.search
               : DashboardType.normal,

--- a/lib/features/labels/presentation/label_controller.dart
+++ b/lib/features/labels/presentation/label_controller.dart
@@ -39,6 +39,7 @@ class LabelController extends BaseController with LabelContextMenuMixin {
   final labels = <Label>[].obs;
   final labelListExpandMode = Rx(ExpandMode.EXPAND);
   final isLabelSettingEnabled = RxBool(false);
+  final isLabelsLoaded = RxBool(false);
   final GlobalKey labelAppBarKey = GlobalKey();
 
   GetAllLabelInteractor? _getAllLabelInteractor;
@@ -74,11 +75,17 @@ class LabelController extends BaseController with LabelContextMenuMixin {
       isLabelSettingEnabled.value = false;
       isLabelSettingEnabled.refresh();
       _clearLabelData();
+      setLabelLoaded();
     }
+  }
+
+  void setLabelLoaded() {
+    isLabelsLoaded.value = true;
   }
 
   void _clearLabelData() {
     labels.clear();
+    isLabelsLoaded.value = false;
   }
 
   void injectLabelsBindings() {
@@ -116,7 +123,11 @@ class LabelController extends BaseController with LabelContextMenuMixin {
   }
 
   void getAllLabels(AccountId accountId) {
-    if (_getAllLabelInteractor == null) return;
+    if (_getAllLabelInteractor == null) {
+      labels.value = [];
+      setLabelLoaded();
+      return;
+    }
 
     consumeState(_getAllLabelInteractor!.execute(accountId));
   }
@@ -175,6 +186,9 @@ class LabelController extends BaseController with LabelContextMenuMixin {
     if (isEnabled) {
       injectLabelsBindings();
       getAllLabels(accountId);
+    } else {
+      _clearLabelData();
+      setLabelLoaded();
     }
   }
 
@@ -183,6 +197,7 @@ class LabelController extends BaseController with LabelContextMenuMixin {
     if (success is GetAllLabelSuccess) {
       labels.value = success.labels..sortByAlphabetically();
       setCurrentLabelState(success.newState);
+      setLabelLoaded();
     } else if (success is CreateNewLabelSuccess) {
       _handleCreateNewLabelSuccess(success);
     } else if (success is GetLabelSettingStateSuccess) {
@@ -200,12 +215,14 @@ class LabelController extends BaseController with LabelContextMenuMixin {
   void handleFailureViewState(Failure failure) {
     if (failure is GetAllLabelFailure) {
       labels.value = [];
+      setLabelLoaded();
     } else if (failure is CreateNewLabelFailure) {
       _handleCreateNewLabelFailure(failure);
     } else if (failure is GetLabelSettingStateFailure) {
       isLabelSettingEnabled.value = false;
       isLabelSettingEnabled.refresh();
       _clearLabelData();
+      setLabelLoaded();
     } else if (failure is EditLabelFailure) {
       handleEditLabelFailure(failure);
     } else if (failure is DeleteALabelFailure) {

--- a/lib/features/labels/presentation/label_controller.dart
+++ b/lib/features/labels/presentation/label_controller.dart
@@ -2,6 +2,7 @@ import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:dartz/dartz.dart' hide State;
+import 'package:flutter/material.dart' hide State;
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
@@ -38,6 +39,7 @@ class LabelController extends BaseController with LabelContextMenuMixin {
   final labels = <Label>[].obs;
   final labelListExpandMode = Rx(ExpandMode.EXPAND);
   final isLabelSettingEnabled = RxBool(false);
+  final GlobalKey labelAppBarKey = GlobalKey();
 
   GetAllLabelInteractor? _getAllLabelInteractor;
   CreateNewLabelInteractor? _createNewLabelInteractor;

--- a/lib/features/mailbox/presentation/base_mailbox_view.dart
+++ b/lib/features/mailbox/presentation/base_mailbox_view.dart
@@ -368,6 +368,7 @@ abstract class BaseMailboxView extends GetWidget<MailboxController>
         final countLabels = labelController.labels.length;
 
         return LabelsBarWidget(
+          key: labelController.labelAppBarKey,
           imagePaths: controller.imagePaths,
           isDesktop: isDesktop,
           height: isDesktop ? 48 : 40,

--- a/lib/features/mailbox/presentation/extensions/handle_label_action_type_extension.dart
+++ b/lib/features/mailbox/presentation/extensions/handle_label_action_type_extension.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:labels/model/label.dart';
 import 'package:tmail_ui_user/features/labels/presentation/extensions/handle_label_action_type_extension.dart';
 import 'package:tmail_ui_user/features/labels/presentation/models/label_action_type.dart';
@@ -62,6 +63,24 @@ extension HandleLabelActionTypeExtension on MailboxDashBoardController {
         label: label,
         actionType: actionType,
       ),
+    );
+  }
+
+  Label? getLabelById(Id labelId) {
+    return labelController.labels
+        .where((label) => label.id == labelId)
+        .firstOrNull;
+  }
+
+  void scrollToLabelListView() {
+    final context = labelController.labelAppBarKey.currentContext;
+    if (context == null) return;
+
+    Scrollable.ensureVisible(
+      context,
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeOut,
+      alignment: 0.5,
     );
   }
 }

--- a/lib/features/mailbox/presentation/extensions/handle_navigation_extension.dart
+++ b/lib/features/mailbox/presentation/extensions/handle_navigation_extension.dart
@@ -1,35 +1,80 @@
+import 'dart:ui';
+
+import 'package:get/get_rx/src/rx_workers/rx_workers.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/extensions/handle_label_action_type_extension.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/mailbox_controller.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/presentation_label_mailbox.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart';
 import 'package:tmail_ui_user/main/routes/app_routes.dart';
+import 'package:tmail_ui_user/main/routes/navigation_router.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
 extension HandleNavigationExtension on MailboxController {
-  void handleLabelNavigation() {
-    final router = navigationRouter;
-    if (router == null) return;
+  void handleLabelNavigation(NavigationRouter router, Id labelId) {
+    if (!_isLabelCapabilityValid()) {
+      _navigateToUnknown();
+      return;
+    }
 
-    final labelId = router.labelId;
-    if (labelId == null) return;
+    if (!_isLabelsReady()) {
+      _waitForLabelsLoaded(() {
+        _handleLabelNavigationInternal(router, labelId);
+      });
+      return;
+    }
 
+    _handleLabelNavigationInternal(router, labelId);
+  }
+
+  bool _isLabelCapabilityValid() {
+    return mailboxDashBoardController.isLabelCapabilitySupported;
+  }
+
+  bool _isLabelsReady() {
+    return mailboxDashBoardController.labelController.isLabelsLoaded.value;
+  }
+
+  void _waitForLabelsLoaded(VoidCallback onLoaded) {
+    late Worker worker;
+
+    worker = ever(
+      mailboxDashBoardController.labelController.isLabelsLoaded,
+      (isLoaded) {
+        if (isLoaded != true) return;
+        worker.dispose();
+        onLoaded();
+      },
+    );
+  }
+
+  void _handleLabelNavigationInternal(
+    NavigationRouter router,
+    Id labelId,
+  ) {
     final matchedLabel = mailboxDashBoardController.getLabelById(labelId);
 
-    if (matchedLabel != null) {
-      final labelMailbox = PresentationLabelMailbox.initial(matchedLabel);
-
-      if (router.emailId != null) {
-        openEmailInsideMailboxFromLocationBar(
-          labelMailbox,
-          router.emailId!,
-        );
-      } else {
-        openMailboxFromLocationBar(labelMailbox);
-      }
-
-      mailboxDashBoardController.scrollToLabelListView();
-    } else {
-      clearNavigationRouter();
-      popAndPush(AppRoutes.unknownRoutePage);
+    if (matchedLabel == null) {
+      _navigateToUnknown();
+      return;
     }
+
+    final labelMailbox = PresentationLabelMailbox.initial(matchedLabel);
+
+    if (router.emailId != null) {
+      openEmailInsideMailboxFromLocationBar(
+        labelMailbox,
+        router.emailId!,
+      );
+    } else {
+      openMailboxFromLocationBar(labelMailbox);
+    }
+
+    mailboxDashBoardController.scrollToLabelListView();
+  }
+
+  void _navigateToUnknown() {
+    clearNavigationRouter();
+    popAndPush(AppRoutes.unknownRoutePage);
   }
 }

--- a/lib/features/mailbox/presentation/extensions/handle_navigation_extension.dart
+++ b/lib/features/mailbox/presentation/extensions/handle_navigation_extension.dart
@@ -1,0 +1,35 @@
+import 'package:tmail_ui_user/features/mailbox/presentation/extensions/handle_label_action_type_extension.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/mailbox_controller.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/model/presentation_label_mailbox.dart';
+import 'package:tmail_ui_user/main/routes/app_routes.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+
+extension HandleNavigationExtension on MailboxController {
+  void handleLabelNavigation() {
+    final router = navigationRouter;
+    if (router == null) return;
+
+    final labelId = router.labelId;
+    if (labelId == null) return;
+
+    final matchedLabel = mailboxDashBoardController.getLabelById(labelId);
+
+    if (matchedLabel != null) {
+      final labelMailbox = PresentationLabelMailbox.initial(matchedLabel);
+
+      if (router.emailId != null) {
+        openEmailInsideMailboxFromLocationBar(
+          labelMailbox,
+          router.emailId!,
+        );
+      } else {
+        openMailboxFromLocationBar(labelMailbox);
+      }
+
+      mailboxDashBoardController.scrollToLabelListView();
+    } else {
+      clearNavigationRouter();
+      popAndPush(AppRoutes.unknownRoutePage);
+    }
+  }
+}

--- a/lib/features/mailbox/presentation/extensions/handle_navigation_extension.dart
+++ b/lib/features/mailbox/presentation/extensions/handle_navigation_extension.dart
@@ -38,22 +38,38 @@ extension HandleNavigationExtension on MailboxController {
 
   void _waitForLabelsLoaded(VoidCallback onLoaded) {
     isLabelsLoadedWorker?.dispose();
+    isLabelsLoadedWorker = null;
+
+    final observable = mailboxDashBoardController.labelController.isLabelsLoaded;
+
+    if (observable.value) {
+      onLoaded();
+      return;
+    }
+
     isLabelsLoadedWorker = ever(
-      mailboxDashBoardController.labelController.isLabelsLoaded,
+      observable,
       (isLoaded) {
         try {
           if (!isLoaded) return;
-          final worker = isLabelsLoadedWorker;
-          isLabelsLoadedWorker = null;
-          worker?.dispose();
-          if (!isClosed) {
-            onLoaded();
-          }
+          _completeLabelsLoaded(onLoaded);
         } catch (e) {
           logWarning('HandleNavigationExtension::_waitForLabelsLoaded: Exception: $e');
         }
       },
     );
+  }
+
+  void _completeLabelsLoaded(VoidCallback onLoaded) {
+    final worker = isLabelsLoadedWorker;
+    if (worker == null) return;
+
+    isLabelsLoadedWorker = null;
+    worker.dispose();
+
+    if (!isClosed) {
+      onLoaded();
+    }
   }
 
   void _handleLabelNavigationInternal(

--- a/lib/features/mailbox/presentation/extensions/handle_navigation_extension.dart
+++ b/lib/features/mailbox/presentation/extensions/handle_navigation_extension.dart
@@ -37,7 +37,8 @@ extension HandleNavigationExtension on MailboxController {
   }
 
   void _waitForLabelsLoaded(VoidCallback onLoaded) {
-    isLabelsLoadedWorker ??= ever(
+    isLabelsLoadedWorker?.dispose();
+    isLabelsLoadedWorker = ever(
       mailboxDashBoardController.labelController.isLabelsLoaded,
       (isLoaded) {
         try {

--- a/lib/features/mailbox/presentation/extensions/handle_navigation_extension.dart
+++ b/lib/features/mailbox/presentation/extensions/handle_navigation_extension.dart
@@ -42,7 +42,9 @@ extension HandleNavigationExtension on MailboxController {
       (isLoaded) {
         try {
           if (!isLoaded) return;
-          isLabelsLoadedWorker?.dispose();
+          final worker = isLabelsLoadedWorker;
+          isLabelsLoadedWorker = null;
+          worker?.dispose();
           if (!isClosed) {
             onLoaded();
           }

--- a/lib/features/mailbox/presentation/extensions/handle_navigation_extension.dart
+++ b/lib/features/mailbox/presentation/extensions/handle_navigation_extension.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:core/utils/app_logger.dart';
 import 'package:get/get_rx/src/rx_workers/rx_workers.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/extensions/handle_label_action_type_extension.dart';
@@ -36,14 +37,18 @@ extension HandleNavigationExtension on MailboxController {
   }
 
   void _waitForLabelsLoaded(VoidCallback onLoaded) {
-    late Worker worker;
-
-    worker = ever(
+    isLabelsLoadedWorker ??= ever(
       mailboxDashBoardController.labelController.isLabelsLoaded,
       (isLoaded) {
-        if (isLoaded != true) return;
-        worker.dispose();
-        onLoaded();
+        try {
+          if (!isLoaded) return;
+          isLabelsLoadedWorker?.dispose();
+          if (!isClosed) {
+            onLoaded();
+          }
+        } catch (e) {
+          logWarning('HandleNavigationExtension::_waitForLabelsLoaded: Exception: $e');
+        }
       },
     );
   }

--- a/lib/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart
+++ b/lib/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart
@@ -1,8 +1,11 @@
 
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:flutter/material.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:labels/extensions/label_extension.dart';
+import 'package:model/extensions/mailbox_id_extension.dart';
 import 'package:model/extensions/presentation_mailbox_extension.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/presentation_label_mailbox.dart';
@@ -160,4 +163,13 @@ extension PresentationMailboxExtension on PresentationMailbox {
   bool get isCacheable => !isVirtualFolder && this is! PresentationLabelMailbox;
 
   bool get isLabelMailbox => this is PresentationLabelMailbox;
+
+  String get browserRouteTitle => isLabelMailbox
+      ? 'Label-${(this as PresentationLabelMailbox).label.id?.value}'
+      : 'Mailbox-${mailboxId?.asString}';
+
+  Id? get labelId =>
+      isLabelMailbox ? (this as PresentationLabelMailbox).label.id : null;
+
+  MailboxId? get browserRouteMailboxId => isLabelMailbox ? null : mailboxId;
 }

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -70,6 +70,7 @@ import 'package:tmail_ui_user/features/mailbox/domain/usecases/subscribe_mailbox
 import 'package:tmail_ui_user/features/mailbox/domain/usecases/subscribe_multiple_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/action/mailbox_ui_action.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/extensions/handle_action_required_tab_extension.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/extensions/handle_navigation_extension.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/mixin/mailbox_widget_mixin.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_actions.dart';
@@ -145,6 +146,8 @@ class MailboxController extends BaseMailboxController
   AccountId? get accountId => mailboxDashBoardController.accountId.value;
 
   Session? get session => mailboxDashBoardController.sessionCurrent;
+
+  NavigationRouter? get navigationRouter => _navigationRouter;
 
   MailboxController(
     this._createNewMailboxInteractor,
@@ -787,7 +790,9 @@ class MailboxController extends BaseMailboxController
         }
         break;
       case DashboardType.normal:
-        if (_navigationRouter!.mailboxId != null) {
+        if (_navigationRouter!.labelId != null) {
+          handleLabelNavigation();
+        } else if (_navigationRouter!.mailboxId != null) {
           final matchedMailboxNode = findMailboxNodeById(_navigationRouter!.mailboxId!);
           if (matchedMailboxNode != null) {
             if (_navigationRouter!.emailId != null) {
@@ -813,6 +818,11 @@ class MailboxController extends BaseMailboxController
     }
   }
 
+  void openEmailInsideMailboxFromLocationBar(
+    PresentationMailbox presentationMailbox,
+    EmailId emailId
+  ) => _openEmailInsideMailboxFromLocationBar(presentationMailbox, emailId);
+
   void _openEmailInsideMailboxFromLocationBar(
     PresentationMailbox presentationMailbox,
     EmailId emailId
@@ -822,15 +832,19 @@ class MailboxController extends BaseMailboxController
     _clearNavigationRouter();
   }
 
+  void openMailboxFromLocationBar(PresentationMailbox presentationMailbox) =>
+      _openMailboxFromLocationBar(presentationMailbox);
+
   void _openMailboxFromLocationBar(PresentationMailbox presentationMailbox) {
     mailboxDashBoardController.setSelectedMailbox(presentationMailbox);
     if (PlatformInfo.isWeb) {
       RouteUtils.replaceBrowserHistory(
-        title: 'Mailbox-${presentationMailbox.mailboxId?.id.value}',
+        title: presentationMailbox.browserRouteTitle,
         url: RouteUtils.createUrlWebLocationBar(
           AppRoutes.dashboard,
           router: NavigationRouter(
-            mailboxId: presentationMailbox.mailboxId,
+            mailboxId: presentationMailbox.browserRouteMailboxId,
+            labelId: presentationMailbox.labelId,
             dashboardType: DashboardType.normal
           )
         )
@@ -867,6 +881,8 @@ class MailboxController extends BaseMailboxController
     );
     _clearNavigationRouter();
   }
+
+  void clearNavigationRouter() => _clearNavigationRouter();
 
   void _clearNavigationRouter() {
     _navigationRouter = null;
@@ -1279,13 +1295,14 @@ class MailboxController extends BaseMailboxController
   }
 
   void _replaceBrowserHistory() {
-    log('MailboxController::_replaceBrowserHistory:selectedMailbox: ${selectedMailbox?.id}');
+    final currentMailbox = selectedMailbox;
+    log('MailboxController::_replaceBrowserHistory:selectedMailbox: ${currentMailbox?.id.asString}');
     if (PlatformInfo.isWeb && Get.currentRoute.startsWith(AppRoutes.dashboard)) {
-      final selectedMailboxId = selectedMailbox?.id;
       final route = RouteUtils.createUrlWebLocationBar(
         AppRoutes.dashboard,
         router: NavigationRouter(
-          mailboxId: selectedMailboxId,
+          mailboxId: currentMailbox?.browserRouteMailboxId,
+          labelId: currentMailbox?.labelId,
           searchQuery: mailboxDashBoardController.searchController.isSearchEmailRunning
             ? mailboxDashBoardController.searchController.searchQuery
             : null,
@@ -1295,7 +1312,7 @@ class MailboxController extends BaseMailboxController
         )
       );
       RouteUtils.replaceBrowserHistory(
-        title: 'Mailbox-${selectedMailboxId?.id.value}',
+        title: currentMailbox?.browserRouteTitle ?? '',
         url: route
       );
     }

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -134,6 +134,7 @@ class MailboxController extends BaseMailboxController
   MailboxId? _newFolderId;
   NavigationRouter? _navigationRouter;
   WebSocketQueueHandler? _webSocketQueueHandler;
+  Worker? isLabelsLoadedWorker;
 
   final _openMailboxEventController = StreamController<OpenMailboxViewEvent>();
   StreamSubscription? _openMailboxEventStreamSubscription;
@@ -146,8 +147,6 @@ class MailboxController extends BaseMailboxController
   AccountId? get accountId => mailboxDashBoardController.accountId.value;
 
   Session? get session => mailboxDashBoardController.sessionCurrent;
-
-  NavigationRouter? get navigationRouter => _navigationRouter;
 
   MailboxController(
     this._createNewMailboxInteractor,
@@ -201,6 +200,8 @@ class MailboxController extends BaseMailboxController
     _openMailboxEventController.close();
     mailboxListScrollController.dispose();
     _webSocketQueueHandler?.dispose();
+    isLabelsLoadedWorker?.dispose();
+    isLabelsLoadedWorker = null;
     super.onClose();
   }
 

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -791,7 +791,7 @@ class MailboxController extends BaseMailboxController
         break;
       case DashboardType.normal:
         if (_navigationRouter!.labelId != null) {
-          handleLabelNavigation();
+          handleLabelNavigation(_navigationRouter!, _navigationRouter!.labelId!);
         } else if (_navigationRouter!.mailboxId != null) {
           final matchedMailboxNode = findMailboxNodeById(_navigationRouter!.mailboxId!);
           if (matchedMailboxNode != null) {

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -3064,7 +3064,7 @@ class MailboxDashBoardController extends ReloadableController
   void _replaceBrowserHistory({Uri? uri}) {
     log('MailboxDashBoardController::_replaceBrowserHistory:uri: $uri');
     if (PlatformInfo.isWeb) {
-      final selectedMailboxId = selectedMailbox.value?.id;
+      final currentMailbox = selectedMailbox.value;
       final selectedEmailId = selectedEmail.value?.id;
       final isSearchRunning = searchController.isSearchEmailRunning;
       String title = '';
@@ -3073,7 +3073,7 @@ class MailboxDashBoardController extends ReloadableController
       } else if (isSearchRunning) {
         title = 'SearchEmail';
       } else {
-        title = 'Mailbox-${selectedMailboxId?.asString}';
+        title = currentMailbox?.browserRouteTitle ?? '';
       }
       RouteUtils.replaceBrowserHistory(
         title: title,
@@ -3083,7 +3083,8 @@ class MailboxDashBoardController extends ReloadableController
             emailId: selectedEmail.value?.id,
             mailboxId: isSearchRunning
               ? null
-              : selectedMailboxId,
+              : currentMailbox?.browserRouteMailboxId,
+            labelId: currentMailbox?.labelId,
             dashboardType: isSearchRunning
               ? DashboardType.search
               : DashboardType.normal,

--- a/lib/features/search/email/presentation/search_email_controller.dart
+++ b/lib/features/search/email/presentation/search_email_controller.dart
@@ -39,6 +39,7 @@ import 'package:tmail_ui_user/features/email/domain/state/move_to_mailbox_state.
 import 'package:tmail_ui_user/features/email/presentation/action/email_ui_action.dart';
 import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
 import 'package:tmail_ui_user/features/home/data/exceptions/session_exceptions.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_actions.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/model/recent_search.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/get_all_recent_search_latest_state.dart';
@@ -895,12 +896,14 @@ class SearchEmailController extends BaseController
     mailboxDashBoardController.searchController.disableAllSearchEmail();
     mailboxDashBoardController.dispatchRoute(DashboardRoutes.thread);
     if (PlatformInfo.isWeb) {
+      final currentMailbox = mailboxDashBoardController.selectedMailbox.value;
       RouteUtils.replaceBrowserHistory(
-        title: 'Mailbox-${mailboxDashBoardController.selectedMailbox.value?.id.id.value}',
+        title: currentMailbox?.browserRouteTitle ?? '',
         url: RouteUtils.createUrlWebLocationBar(
           AppRoutes.dashboard,
           router: NavigationRouter(
-            mailboxId: mailboxDashBoardController.selectedMailbox.value?.id,
+            mailboxId: currentMailbox?.browserRouteMailboxId,
+            labelId: currentMailbox?.labelId,
             dashboardType: DashboardType.normal
           )
         )

--- a/lib/features/thread/presentation/extensions/list_presentation_email_extensions.dart
+++ b/lib/features/thread/presentation/extensions/list_presentation_email_extensions.dart
@@ -5,6 +5,7 @@ import 'package:model/email/presentation_email.dart';
 import 'package:model/extensions/presentation_email_extension.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:tmail_ui_user/features/email/presentation/extensions/email_extension.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
 import 'package:tmail_ui_user/features/thread_detail/domain/model/email_in_thread_detail_info.dart';
 import 'package:tmail_ui_user/main/routes/app_routes.dart';
@@ -48,7 +49,10 @@ extension ListPresentationEmailExtensions on List<PresentationEmail> {
         AppRoutes.dashboard,
         router: NavigationRouter(
           emailId: currentEmail.id,
-          mailboxId: isSearchEmailRunning ? null : selectedMailbox?.id,
+          mailboxId: isSearchEmailRunning
+              ? null
+              : selectedMailbox?.browserRouteMailboxId,
+          labelId: selectedMailbox?.labelId,
           searchQuery: isSearchEmailRunning ? searchQuery : null,
           dashboardType: isSearchEmailRunning ? DashboardType.search : DashboardType.normal
         )

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -1360,7 +1360,8 @@ class ThreadController extends BaseController with EmailActionController {
       AppRoutes.dashboard,
       router: NavigationRouter(
         emailId: email.id,
-        mailboxId: mailboxContain.mailboxId,
+        mailboxId: mailboxContain.browserRouteMailboxId,
+        labelId: mailboxContain.labelId,
         dashboardType: DashboardType.normal
       )
     ));

--- a/lib/main/routes/navigation_router.dart
+++ b/lib/main/routes/navigation_router.dart
@@ -1,5 +1,6 @@
 
 import 'package:equatable/equatable.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
@@ -14,6 +15,7 @@ enum DashboardType {
 class NavigationRouter with EquatableMixin {
   final EmailId? emailId;
   final MailboxId? mailboxId;
+  final Id? labelId;
   final DashboardType dashboardType;
   final SearchQuery? searchQuery;
   final String? routeName;
@@ -36,6 +38,7 @@ class NavigationRouter with EquatableMixin {
     this.accountMenuItem = AccountMenuItem.none,
     this.cc,
     this.bcc,
+    this.labelId,
   });
 
   factory NavigationRouter.initial() => NavigationRouter();
@@ -53,5 +56,6 @@ class NavigationRouter with EquatableMixin {
     accountMenuItem,
     cc,
     bcc,
+    labelId,
   ];
 }

--- a/lib/main/routes/navigation_router.dart
+++ b/lib/main/routes/navigation_router.dart
@@ -39,7 +39,10 @@ class NavigationRouter with EquatableMixin {
     this.cc,
     this.bcc,
     this.labelId,
-  });
+  }) : assert(
+          !(mailboxId != null && labelId != null),
+          'NavigationRouter accepts either mailboxId or labelId, not both.',
+        );
 
   factory NavigationRouter.initial() => NavigationRouter();
 

--- a/lib/main/routes/route_utils.dart
+++ b/lib/main/routes/route_utils.dart
@@ -61,10 +61,10 @@ abstract class RouteUtils {
       }
       servicePath = servicePath.withQueryParameters([
         StringQueryParameter(paramType, router.dashboardType.name),
-        if (router.mailboxId != null)
-          StringQueryParameter(paramContext, router.mailboxId!.id.value),
         if (router.labelId != null)
-          StringQueryParameter(paramLabelId, router.labelId!.value),
+          StringQueryParameter(paramLabelId, router.labelId!.value)
+        else if (router.mailboxId != null)
+          StringQueryParameter(paramContext, router.mailboxId!.id.value),
         if (router.searchQuery != null)
           StringQueryParameter(paramQuery, router.searchQuery!.value),
       ]);
@@ -137,8 +137,10 @@ abstract class RouteUtils {
     final body = parameters[paramBody];
 
     final emailId = idParam != null ? EmailId(Id(idParam)) : null;
-    final mailboxId = contextPram != null ? MailboxId(Id(contextPram)) : null;
     final labelId = labelIdPram != null ? Id(labelIdPram) : null;
+    final mailboxId = labelId == null && contextPram != null
+        ? MailboxId(Id(contextPram))
+        : null;
     final searchQuery = queryParam != null ? SearchQuery(queryParam) : null;
     final dashboardType = DashboardType.values.firstWhereOrNull((type) => type.name == typeParam) ?? DashboardType.normal;
     final settingType = AccountMenuItem.values.firstWhereOrNull((type) => type.getAliasBrowser() == typeParam) ?? AccountMenuItem.none;

--- a/lib/main/routes/route_utils.dart
+++ b/lib/main/routes/route_utils.dart
@@ -20,6 +20,7 @@ abstract class RouteUtils {
   static const String paramID = 'id';
   static const String paramType = 'type';
   static const String paramContext = 'context';
+  static const String paramLabelId = 'labelId';
   static const String paramQuery = 'q';
   static const String paramRouteName = 'routeName';
   static const String paramMailtoAddress = 'mailtoAddress';
@@ -62,6 +63,8 @@ abstract class RouteUtils {
         StringQueryParameter(paramType, router.dashboardType.name),
         if (router.mailboxId != null)
           StringQueryParameter(paramContext, router.mailboxId!.id.value),
+        if (router.labelId != null)
+          StringQueryParameter(paramLabelId, router.labelId!.value),
         if (router.searchQuery != null)
           StringQueryParameter(paramQuery, router.searchQuery!.value),
       ]);
@@ -124,6 +127,7 @@ abstract class RouteUtils {
     final idParam = parameters[paramID];
     final typeParam = parameters[paramType];
     final contextPram = parameters[paramContext];
+    final labelIdPram = parameters[paramLabelId];
     final queryParam = parameters[paramQuery];
     final routeName = parameters[paramRouteName];
     final mailtoAddress = parameters[paramMailtoAddress];
@@ -134,6 +138,7 @@ abstract class RouteUtils {
 
     final emailId = idParam != null ? EmailId(Id(idParam)) : null;
     final mailboxId = contextPram != null ? MailboxId(Id(contextPram)) : null;
+    final labelId = labelIdPram != null ? Id(labelIdPram) : null;
     final searchQuery = queryParam != null ? SearchQuery(queryParam) : null;
     final dashboardType = DashboardType.values.firstWhereOrNull((type) => type.name == typeParam) ?? DashboardType.normal;
     final settingType = AccountMenuItem.values.firstWhereOrNull((type) => type.getAliasBrowser() == typeParam) ?? AccountMenuItem.none;
@@ -147,6 +152,7 @@ abstract class RouteUtils {
     return NavigationRouter(
       emailId: emailId,
       mailboxId: mailboxId,
+      labelId: labelId,
       searchQuery: searchQuery,
       dashboardType: dashboardType,
       routeName: routeName,


### PR DESCRIPTION
## Issue

#4384 

## ADR

https://github.com/linagora/tmail-flutter/pull/4387 

## Technical Details 

### Root cause

* Label IDs were stored in `context` (mailboxId field)
* Routing layer is type-agnostic → misinterpretation

### Implementation

* Add `labelId` to `NavigationRouter`
* Update URL parsing & generation

```dart
if (_navigationRouter!.labelId != null) {
    handleLabelNavigation();
  } 
```

### Impacted components

* RouteUtils
* NavigationRouter
* Controllers handling routing state

## Resolved

https://github.com/user-attachments/assets/77c762c0-897d-4f59-94a9-561b0b968e2f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Label-aware browser/location-bar navigation with explicit label routing and new public navigation entry points.

* **Improvements**
  * Routing now preserves label context for mailbox and email views, improving back/forward behavior.
  * Browser history titles are more descriptive and context-aware.
  * Labels list auto-scrolls into view on navigation.
  * Exposed labels-loaded state and a stable labels app-bar key for more consistent UI updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->