### PR TITLE
TF-4394 Fix TXT preview is broken

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2359,11 +2359,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "fix/preview-txt-file"
-      resolved-ref: "934212724aa302101a2cd49272f1d5a641a79aae"
+      ref: main
+      resolved-ref: "9e65dce2bb6c3cd43dce962fc7f546434fce6b55"
       url: "https://github.com/linagora/twake-previewer-flutter.git"
     source: git
-    version: "0.0.15"
+    version: "0.1.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2359,8 +2359,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "update/flutter-3.32.8"
-      resolved-ref: a67d478c6d73582e37f49f78c2d83ca7c240db73
+      ref: "fix/preview-txt-file"
+      resolved-ref: "934212724aa302101a2cd49272f1d5a641a79aae"
       url: "https://github.com/linagora/twake-previewer-flutter.git"
     source: git
     version: "0.0.15"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -262,7 +262,7 @@ dependencies:
   twake_previewer_flutter:
     git:
       url: https://github.com/linagora/twake-previewer-flutter.git
-      ref: update/flutter-3.32.8
+      ref: fix/preview-txt-file
 
   lottie_native: 0.1.2
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -262,7 +262,7 @@ dependencies:
   twake_previewer_flutter:
     git:
       url: https://github.com/linagora/twake-previewer-flutter.git
-      ref: fix/preview-txt-file
+      ref: main
 
   lottie_native: 0.1.2
 


### PR DESCRIPTION
## Issue

#4394

## Root cause

Missing extension byte (at offset 12)

## Solution

https://github.com/linagora/twake-previewer-flutter/pull/4

## Resolved



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency reference to align with the upstream source; no functional or public API changes expected for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->