### PR TITLE
[HOT-FIX] Download attachment is failed on iOS

### DIFF
--- a/lib/features/email/data/network/email_api.dart
+++ b/lib/features/email/data/network/email_api.dart
@@ -277,7 +277,7 @@ class EmailAPI
     return _downloadManager.downloadFile(
       attachment.getDownloadUrl(baseDownloadUrl, accountId),
       getTemporaryDirectory(),
-      attachment.name ?? '',
+      attachment.generateFileName(),
       authentication,
       cancelToken: cancelToken);
   }

--- a/model/lib/email/attachment.dart
+++ b/model/lib/email/attachment.dart
@@ -73,16 +73,16 @@ class Attachment with EquatableMixin {
   }
 
   String generateFileName() {
-    if (name?.trim().isNotEmpty == true) {
-      return name!;
-    } else if (blobId != null) {
-      final extension = type?.subtype;
-      return extension != null
-          ? '${blobId!.value}.$extension'
-          : blobId!.value;
-    } else {
-      return _defaultName;
-    }
+    final rawName = (name?.trim().isNotEmpty == true)
+        ? name!.trim()
+        : (blobId != null
+            ? (type?.subtype != null
+                ? '${blobId!.value}.${type!.subtype}'
+                : blobId!.value)
+            : _defaultName);
+
+    final sanitized = rawName.replaceAll(RegExp(r'[\\/:*?"<>|]'), '_').trim();
+    return sanitized.isNotEmpty ? sanitized : _defaultName;
   }
 
   factory Attachment.fromJson(Map<String, dynamic> json) => _$AttachmentFromJson(json);

--- a/model/lib/email/attachment.dart
+++ b/model/lib/email/attachment.dart
@@ -29,6 +29,7 @@ class Attachment with EquatableMixin {
   static const String eventICSSubtype = 'ics';
   static const String eventCalendarSubtype = 'calendar';
   static const String applicationRTFType = 'application/rtf';
+  static const String _defaultName = 'unknown-attachment';
 
   final PartId? partId;
   final Id? blobId;
@@ -72,10 +73,15 @@ class Attachment with EquatableMixin {
   }
 
   String generateFileName() {
-    if (name?.isNotEmpty == true) {
+    if (name?.trim().isNotEmpty == true) {
       return name!;
+    } else if (blobId != null) {
+      final extension = type?.subtype;
+      return extension != null
+          ? '${blobId!.value}.$extension'
+          : blobId!.value;
     } else {
-      return '${blobId?.value}.${type?.subtype}';
+      return _defaultName;
     }
   }
 

--- a/model/lib/email/attachment.dart
+++ b/model/lib/email/attachment.dart
@@ -82,7 +82,8 @@ class Attachment with EquatableMixin {
             : _defaultName);
 
     final sanitized = rawName.replaceAll(RegExp(r'[\\/:*?"<>|]'), '_').trim();
-    return sanitized.isNotEmpty ? sanitized : _defaultName;
+    // Fall back if sanitized name has no meaningful content (e.g. '???' → '___')
+    return sanitized.contains(RegExp(r'[^_\s]')) ? sanitized : _defaultName;
   }
 
   factory Attachment.fromJson(Map<String, dynamic> json) => _$AttachmentFromJson(json);

--- a/model/test/email/attachment_test.dart
+++ b/model/test/email/attachment_test.dart
@@ -143,6 +143,42 @@ void main() {
 
         expect(attachment.generateFileName(), 'unknown-attachment');
       });
+
+      test(
+        'should sanitize name with question mark character',
+      () {
+        final attachment = Attachment(
+          blobId: Id('some-blob-id'),
+          name: 'doc?.pdf',
+          type: MediaType.parse('application/pdf'),
+        );
+
+        expect(attachment.generateFileName(), 'doc_.pdf');
+      });
+
+      test(
+        'should sanitize name with forward slash character',
+      () {
+        final attachment = Attachment(
+          blobId: Id('some-blob-id'),
+          name: 'folder/document.pdf',
+          type: MediaType.parse('application/pdf'),
+        );
+
+        expect(attachment.generateFileName(), 'folder_document.pdf');
+      });
+
+      test(
+        'should return default name when name consists entirely of illegal characters',
+      () {
+        final attachment = Attachment(
+          blobId: Id('some-blob-id'),
+          name: '???',
+          type: MediaType.parse('application/pdf'),
+        );
+
+        expect(attachment.generateFileName(), 'unknown-attachment');
+      });
     });
   });
 }

--- a/model/test/email/attachment_test.dart
+++ b/model/test/email/attachment_test.dart
@@ -78,7 +78,7 @@ void main() {
       });
 
       test(
-        'should return name when name has leading/trailing spaces',
+        'should return name is trimmed when name has leading/trailing spaces',
       () {
         final attachment = Attachment(
           blobId: Id('some-blob-id'),
@@ -86,7 +86,7 @@ void main() {
           type: MediaType.parse('application/pdf'),
         );
 
-        expect(attachment.generateFileName(), '  document.pdf  ');
+        expect(attachment.generateFileName(), 'document.pdf');
       });
 
       test(

--- a/model/test/email/attachment_test.dart
+++ b/model/test/email/attachment_test.dart
@@ -63,5 +63,86 @@ void main() {
         expect(result, 'http://localhost/download/1/some-blob-id/ti%C3%AAu%20%C4%91%E1%BB%81%20attachment?name=ti%C3%AAu%20%C4%91%E1%BB%81%20attachment&type=application%2Foctet-stream');
       });
     });
+
+    group('generateFileName:', () {
+      test(
+        'should return name when name is not empty',
+      () {
+        final attachment = Attachment(
+          blobId: Id('some-blob-id'),
+          name: 'document.pdf',
+          type: MediaType.parse('application/pdf'),
+        );
+
+        expect(attachment.generateFileName(), 'document.pdf');
+      });
+
+      test(
+        'should return name when name has leading/trailing spaces',
+      () {
+        final attachment = Attachment(
+          blobId: Id('some-blob-id'),
+          name: '  document.pdf  ',
+          type: MediaType.parse('application/pdf'),
+        );
+
+        expect(attachment.generateFileName(), '  document.pdf  ');
+      });
+
+      test(
+        'should return blobId with extension when name is null',
+      () {
+        final attachment = Attachment(
+          blobId: Id('some-blob-id'),
+          type: MediaType.parse('image/png'),
+        );
+
+        expect(attachment.generateFileName(), 'some-blob-id.png');
+      });
+
+      test(
+        'should return blobId with extension when name is empty',
+      () {
+        final attachment = Attachment(
+          blobId: Id('some-blob-id'),
+          name: '',
+          type: MediaType.parse('image/png'),
+        );
+
+        expect(attachment.generateFileName(), 'some-blob-id.png');
+      });
+
+      test(
+        'should return blobId with extension when name is only whitespace',
+      () {
+        final attachment = Attachment(
+          blobId: Id('some-blob-id'),
+          name: '   ',
+          type: MediaType.parse('image/jpeg'),
+        );
+
+        expect(attachment.generateFileName(), 'some-blob-id.jpeg');
+      });
+
+      test(
+        'should return blobId without extension when name is null and type is null',
+      () {
+        final attachment = Attachment(
+          blobId: Id('some-blob-id'),
+        );
+
+        expect(attachment.generateFileName(), 'some-blob-id');
+      });
+
+      test(
+        'should return default name when both name and blobId are null',
+      () {
+        final attachment = Attachment(
+          type: MediaType.parse('image/png'),
+        );
+
+        expect(attachment.generateFileName(), 'unknown-attachment');
+      });
+    });
   });
 }


### PR DESCRIPTION
## Issue

Some attachments in email events cannot be downloaded on iOS.

## Reproduce


https://github.com/user-attachments/assets/ce75ccf4-d4da-4416-8be2-0b878fe15174

## Root cause

Because the attachments have an empty `name` field, the download_manager function returns the error: `FileSystemException: Cannot create file`

## Solution 

Always create a default name for the attachment when the `name` or `blobId` fields are null.

## Resolved


https://github.com/user-attachments/assets/48da4383-d6e2-47f9-bfc5-950dd4772035



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Attachment filenames for downloads are now trimmed, sanitized, and derived from attachment metadata when needed; downloads fall back to a stable default ("unknown-attachment") instead of blank names.

* **Tests**
  * New unit tests covering filename generation: trimmed names, metadata-derived names/extensions, sanitization, and default fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->