### PR TITLE
TF-4404 Fix missing subject when click `Mail to attendees` action in event email

### DIFF
--- a/integration_test/mixin/open_calendar_event_scenario_mixin.dart
+++ b/integration_test/mixin/open_calendar_event_scenario_mixin.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/email/presentation/email_view.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/calendar_event/calendar_event_action_button_widget.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/search_email_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../base/base_scenario.dart';
+import '../robots/search_robot.dart';
+import '../robots/thread_robot.dart';
+
+mixin OpenCalendarEventScenarioMixin on BaseScenario {
+  static const eventEmailSubject = 'Proposed new time';
+
+  Future<void> openCalendarEvent({
+    required ThreadRobot threadRobot,
+    required SearchRobot searchRobot,
+    required AppLocalizations appLocalizations,
+  }) async {
+    await threadRobot.openSearchView();
+    await _expectSearchViewVisible();
+
+    await searchRobot.enterQueryString(eventEmailSubject);
+    await searchRobot.tapOnShowAllResultsText();
+    await _expectSearchResultEmailListVisible();
+
+    await searchRobot.openEmailWithSubject(eventEmailSubject);
+    await _expectEmailViewVisible();
+    await _expectYesButtonVisible(appLocalizations);
+    await _expectMailToAttendeesButtonVisible(appLocalizations);
+    await _expectNoButtonInvisible(appLocalizations);
+    await _expectMaybeButtonInvisible(appLocalizations);
+  }
+
+  Future<void> _expectSearchViewVisible() async {
+    await expectViewVisible($(SearchEmailView));
+  }
+
+  Future<void> _expectSearchResultEmailListVisible() async {
+    await expectViewVisible($(#search_email_list_notification_listener));
+  }
+
+  Future<void> _expectEmailViewVisible() async {
+    await expectViewVisible($(EmailView), alignment: Alignment.topCenter);
+  }
+
+  Future<void> _expectYesButtonVisible(
+    AppLocalizations appLocalizations,
+  ) async {
+    final yesButton =
+        $(CalendarEventActionButtonWidget).$(appLocalizations.yes);
+    await yesButton.scrollTo(scrollDirection: AxisDirection.down);
+    await expectViewVisible(yesButton);
+  }
+
+  Future<void> _expectMailToAttendeesButtonVisible(
+    AppLocalizations appLocalizations,
+  ) async {
+    final mailToAttendeesButton =
+        $(CalendarEventActionButtonWidget).$(appLocalizations.mailToAttendees);
+    await mailToAttendeesButton.scrollTo();
+    await expectViewVisible(mailToAttendeesButton);
+  }
+
+  Future<void> _expectNoButtonInvisible(
+    AppLocalizations appLocalizations,
+  ) async {
+    final noButton = $(CalendarEventActionButtonWidget).$(appLocalizations.no);
+    await expectViewInvisible(noButton);
+  }
+
+  Future<void> _expectMaybeButtonInvisible(
+    AppLocalizations appLocalizations,
+  ) async {
+    final maybeButton =
+        $(CalendarEventActionButtonWidget).$(appLocalizations.maybe);
+    await expectViewInvisible(maybeButton);
+  }
+}

--- a/integration_test/robots/email_robot.dart
+++ b/integration_test/robots/email_robot.dart
@@ -99,4 +99,8 @@ class EmailRobot extends CoreRobot {
   Future<void> tapDeleteThreadButton() async {
     await $(#delete_thread_button).tap();
   }
+
+  Future<void> tapMailToAttendeesEventActionButton() async {
+    await $(#mailToAttendees_event_action_button).tap();
+  }
 }

--- a/integration_test/scenarios/calendar/calendar_event_counter_scenario.dart
+++ b/integration_test/scenarios/calendar/calendar_event_counter_scenario.dart
@@ -1,85 +1,28 @@
 import 'package:flutter/widgets.dart';
-import 'package:tmail_ui_user/features/email/presentation/email_view.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/calendar_event/calendar_event_action_banner_widget.dart';
-import 'package:tmail_ui_user/features/email/presentation/widgets/calendar_event/calendar_event_action_button_widget.dart';
-import 'package:tmail_ui_user/features/search/email/presentation/search_email_view.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../../base/base_test_scenario.dart';
+import '../../mixin/open_calendar_event_scenario_mixin.dart';
 import '../../robots/search_robot.dart';
 import '../../robots/thread_robot.dart';
 
-class CalendarEventCounterScenario extends BaseTestScenario {
+class CalendarEventCounterScenario extends BaseTestScenario
+    with OpenCalendarEventScenarioMixin {
   const CalendarEventCounterScenario(super.$);
-  
+
   @override
   Future<void> runTestLogic() async {
-    const emailSubject = 'Proposed new time';
-
     final threadRobot = ThreadRobot($);
     final searchRobot = SearchRobot($);
     final appLocalizations = AppLocalizations();
-    
-    await threadRobot.openSearchView();
-    await _expectSearchViewVisible();
 
-    await searchRobot.enterQueryString(emailSubject);
-    await searchRobot.tapOnShowAllResultsText();
-    await _expectSearchResultEmailListVisible();
-
-    await searchRobot.openEmailWithSubject(emailSubject);
-    await _expectEmailViewVisible();
-    await _expectYesButtonVisible(appLocalizations);
-    await _expectMailToAttendeesButtonVisible(appLocalizations);
-    await _expectNoButtonInvisible(appLocalizations);
-    await _expectMaybeButtonInvisible(appLocalizations);
+    await openCalendarEvent(
+      threadRobot: threadRobot,
+      searchRobot: searchRobot,
+      appLocalizations: appLocalizations,
+    );
     await _expectProposedEventChangesTextVisible(appLocalizations);
-  }
-
-  Future<void> _expectSearchViewVisible() async {
-    await expectViewVisible($(SearchEmailView));
-  }
-
-  Future<void> _expectSearchResultEmailListVisible() async {
-    await expectViewVisible($(#search_email_list_notification_listener));
-  }
-
-  Future<void> _expectEmailViewVisible() async {
-    await expectViewVisible($(EmailView), alignment: Alignment.topCenter);
-  }
-  
-  Future<void> _expectYesButtonVisible(
-    AppLocalizations appLocalizations,
-  ) async {
-    final yesButton = $(CalendarEventActionButtonWidget)
-      .$(appLocalizations.yes);
-    await yesButton.scrollTo(scrollDirection: AxisDirection.down);
-    await expectViewVisible(yesButton);
-  }
-
-  Future<void> _expectMailToAttendeesButtonVisible(
-    AppLocalizations appLocalizations,
-  ) async {
-    final mailToAttendeesButton = $(CalendarEventActionButtonWidget)
-      .$(appLocalizations.mailToAttendees);
-    await mailToAttendeesButton.scrollTo();
-    await expectViewVisible(mailToAttendeesButton);
-  }
-
-  Future<void> _expectNoButtonInvisible(
-    AppLocalizations appLocalizations,
-  ) async {
-    final noButton = $(CalendarEventActionButtonWidget)
-      .$(appLocalizations.no);
-    await expectViewInvisible(noButton);
-  }
-
-  Future<void> _expectMaybeButtonInvisible(
-    AppLocalizations appLocalizations,
-  ) async {
-    final maybeButton = $(CalendarEventActionButtonWidget)
-      .$(appLocalizations.maybe);
-    await expectViewInvisible(maybeButton);
   }
 
   Future<void> _expectProposedEventChangesTextVisible(

--- a/integration_test/scenarios/calendar/mail_to_attendees_event_email_scenario.dart
+++ b/integration_test/scenarios/calendar/mail_to_attendees_event_email_scenario.dart
@@ -17,6 +17,8 @@ class MailToAttendeesEventEmailScenario extends BaseTestScenario
     with OpenCalendarEventScenarioMixin {
   const MailToAttendeesEventEmailScenario(super.$);
 
+  static const _expectedEventTitle = 'Come for a chat';
+
   @override
   Future<void> runTestLogic() async {
     final threadRobot = ThreadRobot($);
@@ -51,7 +53,7 @@ class MailToAttendeesEventEmailScenario extends BaseTestScenario
     final actualSubject = composerController.subjectEmail.value ?? '';
 
     final expectedSubject = EmailUtils.applyPrefix(
-      subject: 'Come for a chat',
+      subject: _expectedEventTitle,
       defaultPrefix: EmailUtils.defaultReplyPrefix,
       localizedPrefix: appLocalizations.prefix_reply_email,
     );

--- a/integration_test/scenarios/calendar/mail_to_attendees_event_email_scenario.dart
+++ b/integration_test/scenarios/calendar/mail_to_attendees_event_email_scenario.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/subject_composer_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../mixin/open_calendar_event_scenario_mixin.dart';
+import '../../robots/composer_robot.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/search_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class MailToAttendeesEventEmailScenario extends BaseTestScenario
+    with OpenCalendarEventScenarioMixin {
+  const MailToAttendeesEventEmailScenario(super.$);
+
+  @override
+  Future<void> runTestLogic() async {
+    final threadRobot = ThreadRobot($);
+    final searchRobot = SearchRobot($);
+    final composerRobot = ComposerRobot($);
+    final emailRobot = EmailRobot($);
+    final appLocalizations = AppLocalizations();
+
+    await openCalendarEvent(
+      threadRobot: threadRobot,
+      searchRobot: searchRobot,
+      appLocalizations: appLocalizations,
+    );
+
+    await emailRobot.tapMailToAttendeesEventActionButton();
+    await _expectComposerViewVisible();
+    await composerRobot.grantContactPermission();
+
+    await _expectSubjectFilledCorrectly(appLocalizations);
+  }
+
+  Future<void> _expectComposerViewVisible() async {
+    await expectViewVisible($(ComposerView));
+  }
+
+  Future<void> _expectSubjectFilledCorrectly(
+    AppLocalizations appLocalizations,
+  ) async {
+    await expectViewVisible($(SubjectComposerWidget));
+
+    final composerController = Get.find<ComposerController>();
+    final actualSubject = composerController.subjectEmail.value ?? '';
+
+    final expectedSubject = EmailUtils.applyPrefix(
+      subject: 'Come for a chat',
+      defaultPrefix: EmailUtils.defaultReplyPrefix,
+      localizedPrefix: appLocalizations.prefix_reply_email,
+    );
+
+    expect(actualSubject, contains(appLocalizations.prefix_reply_email));
+    expect(actualSubject, equals(expectedSubject));
+  }
+}

--- a/integration_test/tests/calendar/mail_to_attendees_event_email_test.dart
+++ b/integration_test/tests/calendar/mail_to_attendees_event_email_test.dart
@@ -1,0 +1,11 @@
+import '../../base/test_base.dart';
+import '../../scenarios/calendar/mail_to_attendees_event_email_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should fill subject with reply prefix '
+        'when user taps mail to attendees button '
+        'on calendar event email',
+    scenarioBuilder: ($) => MailToAttendeesEventEmailScenario($),
+  );
+}

--- a/lib/features/composer/presentation/extensions/email_action_type_extension.dart
+++ b/lib/features/composer/presentation/extensions/email_action_type_extension.dart
@@ -7,12 +7,10 @@ import 'package:model/email/email_action_type.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:model/extensions/list_email_address_extension.dart';
 import 'package:model/extensions/utc_date_extension.dart';
+import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 extension EmailActionTypeExtension on EmailActionType {
-  static const String _defaultReplyPrefix = 'Re:';
-  static const String _defaultForwardPrefix = 'Fwd:';
-
   String getSubjectComposer(BuildContext? context, String subject) {
     final l10n = context != null ? AppLocalizations.of(context) : null;
 
@@ -20,15 +18,15 @@ extension EmailActionTypeExtension on EmailActionType {
       case EmailActionType.reply:
       case EmailActionType.replyToList:
       case EmailActionType.replyAll:
-        return _applyPrefix(
+        return EmailUtils.applyPrefix(
           subject: subject,
-          defaultPrefix: _defaultReplyPrefix,
+          defaultPrefix: EmailUtils.defaultReplyPrefix,
           localizedPrefix: l10n?.prefix_reply_email,
         );
       case EmailActionType.forward:
-        return _applyPrefix(
+        return EmailUtils.applyPrefix(
           subject: subject,
-          defaultPrefix: _defaultForwardPrefix,
+          defaultPrefix: EmailUtils.defaultForwardPrefix,
           localizedPrefix: l10n?.prefix_forward_email,
         );
       case EmailActionType.editDraft:
@@ -41,29 +39,6 @@ extension EmailActionTypeExtension on EmailActionType {
       default:
         return '';
     }
-  }
-
-  String _applyPrefix({
-    required String subject,
-    required String defaultPrefix,
-    String? localizedPrefix,
-  }) {
-    final trimmed = subject.trim();
-    final lowerSubject = trimmed.toLowerCase();
-
-    final prefixes = <String>[
-      defaultPrefix.toLowerCase(),
-      if (localizedPrefix != null) localizedPrefix.toLowerCase(),
-    ];
-
-    final hasPrefix = prefixes.any(lowerSubject.startsWith);
-
-    if (hasPrefix) {
-      return subject;
-    }
-
-    final prefix = localizedPrefix ?? defaultPrefix;
-    return '$prefix $subject';
   }
 
   String getToastMessageMoveToMailboxSuccess(BuildContext context, {String? destinationPath}) {

--- a/lib/features/email/domain/model/event_action.dart
+++ b/lib/features/email/domain/model/event_action.dart
@@ -24,6 +24,8 @@ enum EventActionType {
     }
   }
 
+  Key getKeyButton() => Key('${name}_event_action_button');
+
   String getToastMessageSuccess(BuildContext context) {
     switch(this) {
       case EventActionType.yes:

--- a/lib/features/email/domain/model/event_action.dart
+++ b/lib/features/email/domain/model/event_action.dart
@@ -24,7 +24,20 @@ enum EventActionType {
     }
   }
 
-  Key getKeyButton() => Key('${name}_event_action_button');
+  Key getKeyButton() {
+    switch (this) {
+      case EventActionType.yes:
+        return const Key('yes_event_action_button');
+      case EventActionType.acceptCounter:
+        return const Key('acceptCounter_event_action_button');
+      case EventActionType.maybe:
+        return const Key('maybe_event_action_button');
+      case EventActionType.no:
+        return const Key('no_event_action_button');
+      case EventActionType.mailToAttendees:
+        return const Key('mailToAttendees_event_action_button');
+    }
+  }
 
   String getToastMessageSuccess(BuildContext context) {
     switch(this) {

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -1499,7 +1499,11 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
     );
   }
 
-  void handleMailToAttendees(CalendarOrganizer? organizer, List<CalendarAttendee>? attendees) {
+  void handleMailToAttendees(
+    CalendarOrganizer? organizer,
+    List<CalendarAttendee>? attendees,
+    String? eventTitle,
+  ) {
     List<EmailAddress> listEmailAddressAttendees = [];
 
     if (organizer != null) {
@@ -1516,7 +1520,10 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
         listEmailAddressAttendees.removeInvalidEmails(ownEmailAddress);
     log('SingleEmailController::handleMailToAttendees: listEmailAddressMailTo = $listEmailAddressMailTo');
     mailboxDashBoardController.openComposer(
-      ComposerArguments.fromMailtoUri(listEmailAddress: listEmailAddressMailTo)
+      ComposerArguments.fromMailtoUri(
+        listEmailAddress: listEmailAddressMailTo,
+        subject: eventTitle,
+      )
     );
   }
 

--- a/lib/features/email/presentation/extensions/calendar_event_extension.dart
+++ b/lib/features/email/presentation/extensions/calendar_event_extension.dart
@@ -21,6 +21,7 @@ import 'package:jmap_dart_client/jmap/mail/calendar/properties/event_id.dart';
 import 'package:jmap_dart_client/jmap/mail/calendar/properties/event_method.dart';
 import 'package:jmap_dart_client/jmap/mail/calendar/properties/recurrence_rule/recurrence_rule.dart';
 import 'package:tmail_ui_user/features/email/domain/model/event_action.dart';
+import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/utils/app_utils.dart';
 
@@ -493,6 +494,14 @@ extension CalendarEventExtension on CalendarEvent {
       extensionFields: extensionFields ?? this.extensionFields,
       recurrenceRules: recurrenceRules ?? this.recurrenceRules,
       excludedCalendarEvents: excludedCalendarEvents ?? this.excludedCalendarEvents,
+    );
+  }
+
+  String getMailToAttendeesEventTitle(AppLocalizations appLocalizations) {
+    return EmailUtils.applyPrefix(
+      subject: title ?? '',
+      defaultPrefix: EmailUtils.defaultReplyPrefix,
+      localizedPrefix: appLocalizations.prefix_reply_email,
     );
   }
 }

--- a/lib/features/email/presentation/utils/email_utils.dart
+++ b/lib/features/email/presentation/utils/email_utils.dart
@@ -29,8 +29,33 @@ class EmailUtils {
   static const double attachmentItemHeight = 36;
   static const double attachmentIcon = 20;
   static const int maxMobileVisibleAttachments = 3;
+  static const String defaultReplyPrefix = 'Re:';
+  static const String defaultForwardPrefix = 'Fwd:';
 
   EmailUtils._();
+
+  static String applyPrefix({
+    required String subject,
+    required String defaultPrefix,
+    String? localizedPrefix,
+  }) {
+    final trimmed = subject.trim();
+    final lowerSubject = trimmed.toLowerCase();
+
+    final prefixes = <String>[
+      defaultPrefix.toLowerCase(),
+      if (localizedPrefix != null) localizedPrefix.toLowerCase(),
+    ];
+
+    final hasPrefix = prefixes.any(lowerSubject.startsWith);
+
+    if (hasPrefix) {
+      return subject;
+    }
+
+    final prefix = localizedPrefix ?? defaultPrefix;
+    return '$prefix $subject';
+  }
 
   static Properties getPropertiesForEmailGetMethod(Session session, AccountId accountId) {
     if (CapabilityIdentifier.jamesCalendarEvent.isSupported(session, accountId)) {

--- a/lib/features/email/presentation/widgets/calendar_event/calendar_event_action_button_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/calendar_event_action_button_widget.dart
@@ -40,6 +40,7 @@ class CalendarEventActionButtonWidget extends StatelessWidget {
           .map((action) => AbsorbPointer(
             absorbing: _getCallbackFunction(action) == null,
             child: TMailButtonWidget(
+              key: action.getKeyButton(),
               text: action.getLabelButton(context),
               backgroundColor: _getButtonBackgroundColor(action),
               borderRadius: CalendarEventActionButtonWidgetStyles.borderRadius,

--- a/lib/features/email/presentation/widgets/calendar_event/calendar_event_detail_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/calendar_event_detail_widget.dart
@@ -10,7 +10,11 @@ import 'package:tmail_ui_user/features/email/presentation/styles/calendar_event_
 import 'package:tmail_ui_user/features/email/presentation/widgets/calendar_event/event_body_content_widget.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/calendar_event/event_title_widget.dart';
 
-typedef OnMailtoAttendeesAction = Function(CalendarOrganizer? organizer, List<CalendarAttendee>? participants);
+typedef OnMailtoAttendeesAction = Function(
+  CalendarOrganizer? organizer,
+  List<CalendarAttendee>? participants,
+  String? eventTitle,
+);
 
 class CalendarEventDetailWidget extends StatelessWidget {
 

--- a/lib/features/email/presentation/widgets/calendar_event/calendar_event_information_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/calendar_event_information_widget.dart
@@ -185,6 +185,9 @@ class CalendarEventInformationWidget extends StatelessWidget {
               onMailToAttendeesAction: () => onMailtoAttendeesAction?.call(
                 calendarEvent.organizer,
                 calendarEvent.participants,
+                calendarEvent.getMailToAttendeesEventTitle(
+                  AppLocalizations.of(context),
+                ),
               ),
             ),
         ],

--- a/test/features/email/presentation/apply_prefix_test.dart
+++ b/test/features/email/presentation/apply_prefix_test.dart
@@ -184,6 +184,19 @@ void main() {
           equals('  Re: Hello'),
         );
       });
+
+      test(
+        'should add a standardized prefix for a legacy NBSP variant',
+        () {
+          expect(
+            EmailUtils.applyPrefix(
+              subject: 'Re\u00A0: Hello',
+              defaultPrefix: EmailUtils.defaultReplyPrefix,
+            ),
+            equals('Re: Re\u00A0: Hello'),
+          );
+        },
+      );
     });
   });
 }

--- a/test/features/email/presentation/apply_prefix_test.dart
+++ b/test/features/email/presentation/apply_prefix_test.dart
@@ -1,0 +1,189 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
+
+void main() {
+  group('EmailUtils::applyPrefix', () {
+    group('Reply prefix', () {
+      test('should add Re: prefix when subject has no prefix', () {
+        expect(
+          EmailUtils.applyPrefix(
+            subject: 'Hello',
+            defaultPrefix: EmailUtils.defaultReplyPrefix,
+          ),
+          equals('Re: Hello'),
+        );
+      });
+
+      test('should not add Re: prefix when subject already has Re:', () {
+        expect(
+          EmailUtils.applyPrefix(
+            subject: 'Re: Hello',
+            defaultPrefix: EmailUtils.defaultReplyPrefix,
+          ),
+          equals('Re: Hello'),
+        );
+      });
+
+      test('should not add prefix when subject has Re: case-insensitively', () {
+        expect(
+          EmailUtils.applyPrefix(
+            subject: 'RE: Hello',
+            defaultPrefix: EmailUtils.defaultReplyPrefix,
+          ),
+          equals('RE: Hello'),
+        );
+      });
+
+      test('should not add prefix when subject has re: lowercase', () {
+        expect(
+          EmailUtils.applyPrefix(
+            subject: 're: Hello',
+            defaultPrefix: EmailUtils.defaultReplyPrefix,
+          ),
+          equals('re: Hello'),
+        );
+      });
+    });
+
+    group('Forward prefix', () {
+      test('should add Fwd: prefix when subject has no prefix', () {
+        expect(
+          EmailUtils.applyPrefix(
+            subject: 'Hello',
+            defaultPrefix: EmailUtils.defaultForwardPrefix,
+          ),
+          equals('Fwd: Hello'),
+        );
+      });
+
+      test('should not add Fwd: prefix when subject already has Fwd:', () {
+        expect(
+          EmailUtils.applyPrefix(
+            subject: 'Fwd: Hello',
+            defaultPrefix: EmailUtils.defaultForwardPrefix,
+          ),
+          equals('Fwd: Hello'),
+        );
+      });
+
+      test('should not add prefix when subject has FWD: uppercase', () {
+        expect(
+          EmailUtils.applyPrefix(
+            subject: 'FWD: Hello',
+            defaultPrefix: EmailUtils.defaultForwardPrefix,
+          ),
+          equals('FWD: Hello'),
+        );
+      });
+    });
+
+    group('Localized prefix', () {
+      test('should use localized prefix when provided', () {
+        expect(
+          EmailUtils.applyPrefix(
+            subject: 'Hello',
+            defaultPrefix: EmailUtils.defaultReplyPrefix,
+            localizedPrefix: 'Rép:',
+          ),
+          equals('Rép: Hello'),
+        );
+      });
+
+      test(
+        'should not add prefix when subject already has localized prefix',
+        () {
+          expect(
+            EmailUtils.applyPrefix(
+              subject: 'Rép: Hello',
+              defaultPrefix: EmailUtils.defaultReplyPrefix,
+              localizedPrefix: 'Rép:',
+            ),
+            equals('Rép: Hello'),
+          );
+        },
+      );
+
+      test(
+        'should not add prefix when subject has localized prefix '
+        'case-insensitively',
+        () {
+          expect(
+            EmailUtils.applyPrefix(
+              subject: 'rép: Hello',
+              defaultPrefix: EmailUtils.defaultReplyPrefix,
+              localizedPrefix: 'Rép:',
+            ),
+            equals('rép: Hello'),
+          );
+        },
+      );
+
+      test(
+        'should not add prefix when subject has default prefix '
+        'even with localized prefix provided',
+        () {
+          expect(
+            EmailUtils.applyPrefix(
+              subject: 'Re: Hello',
+              defaultPrefix: EmailUtils.defaultReplyPrefix,
+              localizedPrefix: 'Rép:',
+            ),
+            equals('Re: Hello'),
+          );
+        },
+      );
+    });
+
+    group('Edge cases', () {
+      test('should handle empty subject', () {
+        expect(
+          EmailUtils.applyPrefix(
+            subject: '',
+            defaultPrefix: EmailUtils.defaultReplyPrefix,
+          ),
+          equals('Re: '),
+        );
+      });
+
+      test('should handle subject with only spaces', () {
+        expect(
+          EmailUtils.applyPrefix(
+            subject: '   ',
+            defaultPrefix: EmailUtils.defaultReplyPrefix,
+          ),
+          equals('Re:    '),
+        );
+      });
+
+      test('should preserve original subject when prefix already exists', () {
+        expect(
+          EmailUtils.applyPrefix(
+            subject: 'Re:   Hello  ',
+            defaultPrefix: EmailUtils.defaultReplyPrefix,
+          ),
+          equals('Re:   Hello  '),
+        );
+      });
+
+      test('should handle subject that contains prefix in middle', () {
+        expect(
+          EmailUtils.applyPrefix(
+            subject: 'Hello Re: World',
+            defaultPrefix: EmailUtils.defaultReplyPrefix,
+          ),
+          equals('Re: Hello Re: World'),
+        );
+      });
+
+      test('should handle subject with leading spaces before prefix', () {
+        expect(
+          EmailUtils.applyPrefix(
+            subject: '  Re: Hello',
+            defaultPrefix: EmailUtils.defaultReplyPrefix,
+          ),
+          equals('  Re: Hello'),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Issue

#4404 

## Root cause

The subject wasn't passed when composing the email from `Mail to attendees`.

## Solution 

Pass subject in format: `Re: {eventTitle}`

## Resolved

- Demo:


https://github.com/user-attachments/assets/99214b1c-6cdf-4f3a-b039-5214cfb3f7ca



- E2E test:

```console
🧪 Should fill subject with reply prefix when user taps mail to attendees button on calendar event email
        ✅   1. waitUntilVisible widgets with type "TwakeWelcomeView".
        ✅   2. tap widgets with text "Use company server".
        ✅   3. waitUntilVisible widgets with type "LoginView".
        ✅   4. tap widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   5. enterText widgets with type "TextField" descending from widgets with key [<'dns_lookup_input_form'>].
        ✅   6. waitUntilVisible widgets with text "bob".
        ✅   7. tap widgets with text "Next".
        ✅   8. waitUntilVisible widgets with key [<'base_url_form'>] descending from widgets with type "LoginView".
        ✅   9. enterText widgets with type "TextField" descending from widgets with key [<'base_url_form'>].
        ✅  10. waitUntilVisible widgets with text containing 0f46-222-252-23-73.ngrok-free.app.
        ✅  11. tap widgets with text "Next".
        ✅  12. waitUntilVisible widgets with key [<'credential_input_form'>] descending from widgets with type "LoginView".
        ✅  13. enterText widgets with type "TextField" descending from widgets with key [<'login_username_input'>].
        ✅  14. waitUntilVisible widgets with text "bob@example.com".
        ✅  15. tap widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
        ✅  16. enterText widgets with type "TextField" descending from widgets with key [<'login_password_input'>].
        ⏳  17. tap widgets with key [<'loginSubmitForm'>].
        : 
        ✅  17. tap widgets with key [<'loginSubmitForm'>].
        ✅  18. isPermissionDialogVisible (native)
        ✅  19. waitUntilVisible widgets with type "ThreadView".
        ✅  20. tap widgets with type "InkWell" descending from widgets with type "SearchBarView".
        ✅  21. waitUntilVisible widgets with type "SearchEmailView".
        ✅  22. enterText widgets with type "TextField" descending from widgets with key [<'search_email_text_field'>].
        ✅  23. waitUntilVisible widgets with text "Showing results for:".
        ✅  24. tap widgets with text "Showing results for:".
        ✅  25. waitUntilVisible widgets with key [<'search_email_list_notification_listener'>].
        ✅  26. waitUntilVisible widgets with widget matching predicate descending from widgets with type "EmailTileBuilder" inclusive.
        ✅  27. tap widgets with widget matching predicate descending from widgets with type "EmailTileBuilder" inclusive.
✅ Should fill subject with reply prefix when user taps mail to attendees button on calendar event email (integration_test/tests/calendar/mail_to_attendees_event_email_test.dart) (24s)

Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: file:///Users/datvu/WorkingSpace/tmail-flutter/build/app/reports/androidTests/connected/index.html
⏱️  Duration: 113s
```

[Screen_recording_20260325_110754.webm](https://github.com/user-attachments/assets/33e12e26-3cfa-4786-9010-454b5bb2c8cd)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Mail to attendees" action now opens the composer with the event title prefilled and applies localized reply prefixing.
  * Calendar event action buttons consistently expose stable identifiers for UI interaction.

* **Improvements**
  * Centralized and standardized email subject prefixing for replies/forwards, honoring localized prefixes.

* **Tests**
  * Added unit tests for prefix logic and integration tests covering the calendar event -> mail-to-attendees flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->