### PR TITLE
TF-4391 Fix last menu item inaccessible due to system navigation bar overlap

### DIFF
--- a/lib/features/base/mixin/popup_context_menu_action_mixin.dart
+++ b/lib/features/base/mixin/popup_context_menu_action_mixin.dart
@@ -52,10 +52,12 @@ mixin PopupContextMenuActionMixin {
             key: key,
             color: Colors.white,
             padding: const EdgeInsetsDirectional.only(bottom: 24),
-            child: ContextMenuDialogView(
-              actions: itemActions,
-              onContextMenuActionClick: onContextMenuActionClick,
-              useGroupedActions: useGroupedActions,
+            child: SafeArea(
+              child: ContextMenuDialogView(
+                actions: itemActions,
+                onContextMenuActionClick: onContextMenuActionClick,
+                useGroupedActions: useGroupedActions,
+              ),
             ),
           ),
         );


### PR DESCRIPTION
## Issue

#4391 

## Root cause

In `openBottomSheetContextMenuAction`, the bottom sheet content only has a hardcoded bottom: `24 padding`.  Although `useSafeArea: true` prevents the sheet from extending into the status bar area at the top, the content inside the sheet is not protected from the system navigation bar at the bottom. On Android devices with a navigation bar (`3-button or gesture bar overlay`), the last items of the context menu are obscured.   

## Solution

Wrap `ContextMenuDialogView` with a SafeArea widget to automatically add appropriate padding for the system  navigation bar across all platforms. `SafeArea` uses `MediaQuery.padding` internally, only adding padding when needed  (navigation bar overlay present) and zero when not, ensuring compatibility on both Android and iOS.     


## Resolved

[Screen_recording_20260325_123626.webm](https://github.com/user-attachments/assets/0ce88fce-3076-4f2e-a759-a9a5971ca2c0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context menu positioning to properly account for device safe areas, including notches and system UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->