### PR TITLE
TF-4385 Fix spam banner show it once per day

### DIFF
--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -284,7 +284,7 @@ class MailboxController extends BaseMailboxController
           mailboxDashBoardController.updateRefreshAllMailboxState(Right(RefreshAllMailboxSuccess()));
           _handleCreateDefaultFolderIfMissing(mailboxDashBoardController.mapDefaultMailboxIdByRole);
           _handleDataFromNavigationRouter();
-          mailboxDashBoardController.getSpamReportBanner();
+          mailboxDashBoardController.refreshSpamReportBanner();
           if (PlatformInfo.isIOS) {
             _updateMailboxIdsBlockNotificationToKeychain(success.mailboxList);
           }

--- a/lib/features/mailbox_dashboard/data/datasource/spam_report_datasource.dart
+++ b/lib/features/mailbox_dashboard/data/datasource/spam_report_datasource.dart
@@ -10,7 +10,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/domain/model/unread_spa
 abstract class SpamReportDataSource {
   Future<void> storeLastTimeDismissedSpamReported(DateTime lastTimeDismissedSpamReported);
 
-  Future<DateTime> getLastTimeDismissedSpamReported();
+  Future<int> getLastTimeDismissedSpamReportedMilliseconds();
 
   Future<void> deleteLastTimeDismissedSpamReported();
 

--- a/lib/features/mailbox_dashboard/data/datasource_impl/hive_spam_report_datasource_impl.dart
+++ b/lib/features/mailbox_dashboard/data/datasource_impl/hive_spam_report_datasource_impl.dart
@@ -28,7 +28,7 @@ class HiveSpamReportDataSourceImpl extends SpamReportDataSource {
   }
 
   @override
-  Future<DateTime> getLastTimeDismissedSpamReported() {
+  Future<int> getLastTimeDismissedSpamReportedMilliseconds() {
     throw UnimplementedError();
   }
 

--- a/lib/features/mailbox_dashboard/data/datasource_impl/local_spam_report_datasource_impl.dart
+++ b/lib/features/mailbox_dashboard/data/datasource_impl/local_spam_report_datasource_impl.dart
@@ -21,12 +21,10 @@ class LocalSpamReportDataSourceImpl extends SpamReportDataSource {
   );
 
   @override
-  Future<DateTime> getLastTimeDismissedSpamReported() async {
+  Future<int> getLastTimeDismissedSpamReportedMilliseconds() async {
     return Future.sync(() async {
       final spamReportConfig = await _preferencesSettingManager.getSpamReportConfig();
-      return DateTime.fromMillisecondsSinceEpoch(
-        spamReportConfig.lastTimeDismissedMilliseconds,
-      );
+      return spamReportConfig.lastTimeDismissedMilliseconds;
     }).catchError(_exceptionThrower.throwException);
   }
 

--- a/lib/features/mailbox_dashboard/data/repository/spam_report_repository_impl.dart
+++ b/lib/features/mailbox_dashboard/data/repository/spam_report_repository_impl.dart
@@ -12,8 +12,8 @@ class SpamReportRepositoryImpl extends SpamReportRepository {
   SpamReportRepositoryImpl(this.mapDataSource);
 
   @override
-  Future<DateTime> getLastTimeDismissedSpamReported() async {
-   return await mapDataSource[DataSourceType.local]!.getLastTimeDismissedSpamReported();
+  Future<int> getLastTimeDismissedSpamReportedMilliseconds() async {
+   return await mapDataSource[DataSourceType.local]!.getLastTimeDismissedSpamReportedMilliseconds();
   }
   
   @override

--- a/lib/features/mailbox_dashboard/domain/exceptions/spam_report_exception.dart
+++ b/lib/features/mailbox_dashboard/domain/exceptions/spam_report_exception.dart
@@ -1,10 +1,10 @@
 import 'package:core/domain/exceptions/app_base_exception.dart';
 
-class NotFoundLastTimeDismissedSpamReportException extends AppBaseException {
-  NotFoundLastTimeDismissedSpamReportException([super.message]);
+class SpamDismissCooldownActiveException extends AppBaseException {
+  SpamDismissCooldownActiveException([super.message]);
 
   @override
-  String get exceptionName => 'NotFoundLastTimeDismissedSpamReportException';
+  String get exceptionName => 'SpamDismissCooldownActiveException';
 }
 
 class NotFoundSpamMailboxCachedException extends AppBaseException {
@@ -19,4 +19,11 @@ class NotFoundSpamMailboxException extends AppBaseException {
 
   @override
   String get exceptionName => 'NotFoundSpamMailboxException';
+}
+
+class NoUnreadSpamEmailsException extends AppBaseException {
+  NoUnreadSpamEmailsException([super.message]);
+
+  @override
+  String get exceptionName => 'NoUnreadSpamEmailsException';
 }

--- a/lib/features/mailbox_dashboard/domain/repository/spam_report_repository.dart
+++ b/lib/features/mailbox_dashboard/domain/repository/spam_report_repository.dart
@@ -6,7 +6,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/domain/model/spam_repor
 abstract class SpamReportRepository {
   Future<void> storeLastTimeDismissedSpamReported(DateTime lastTimeDismissedSpamReported);
 
-  Future<DateTime> getLastTimeDismissedSpamReported();
+  Future<int> getLastTimeDismissedSpamReportedMilliseconds();
 
   Future<void> deleteLastTimeDismissedSpamReported();
 

--- a/lib/features/mailbox_dashboard/domain/state/get_spam_mailbox_cached_state.dart
+++ b/lib/features/mailbox_dashboard/domain/state/get_spam_mailbox_cached_state.dart
@@ -18,5 +18,3 @@ class GetSpamMailboxCachedFailure extends FeatureFailure {
 
   GetSpamMailboxCachedFailure(exception) : super(exception: exception);
 }
-
-class InvalidSpamReportCondition extends FeatureFailure {}

--- a/lib/features/mailbox_dashboard/domain/usecases/get_spam_mailbox_cached_interactor.dart
+++ b/lib/features/mailbox_dashboard/domain/usecases/get_spam_mailbox_cached_interactor.dart
@@ -1,15 +1,15 @@
 
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
-import 'package:core/utils/app_logger.dart';
 import 'package:dartz/dartz.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/exceptions/spam_report_exception.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/spam_report_repository.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/get_spam_mailbox_cached_state.dart';
 
 class GetSpamMailboxCachedInteractor {
-  static const int spamReportBannerDisplayIntervalInHour = 12;
+  static const int spamReportBannerDisplayIntervalInHours = 24;
 
   final SpamReportRepository _spamReportRepository;
 
@@ -19,15 +19,19 @@ class GetSpamMailboxCachedInteractor {
     try {
       yield Right<Failure, Success>(GetSpamMailboxCachedLoading());
       if (await _validateIntervalToShowBanner()) {
-        final spamMailbox =  await _spamReportRepository.getSpamMailboxCached(accountId, userName);
+        final spamMailbox = await _spamReportRepository.getSpamMailboxCached(accountId, userName);
         final countUnreadSpamMailbox = spamMailbox.unreadEmails?.value.value.toInt() ?? 0;
         if (countUnreadSpamMailbox > 0) {
           yield Right<Failure, Success>(GetSpamMailboxCachedSuccess(spamMailbox));
         } else {
-          yield Left<Failure, Success>(InvalidSpamReportCondition());
+          yield Left<Failure, Success>(
+            GetSpamMailboxCachedFailure(NoUnreadSpamEmailsException()),
+          );
         }
       } else {
-        yield Left<Failure, Success>(InvalidSpamReportCondition());
+        yield Left<Failure, Success>(
+          GetSpamMailboxCachedFailure(SpamDismissCooldownActiveException()),
+        );
       }
     } catch (e) {
       yield Left<Failure, Success>(GetSpamMailboxCachedFailure(e));
@@ -35,9 +39,19 @@ class GetSpamMailboxCachedInteractor {
   }
 
   Future<bool> _validateIntervalToShowBanner() async {
-    final lastTimeDismissedSpamReported = await _spamReportRepository.getLastTimeDismissedSpamReported();
-    final currentTime = DateTime.now().difference(lastTimeDismissedSpamReported);
-    log('GetSpamMailboxCachedInteractor::_compareSpamReportTime:lastTimeDismissedSpamReported: $lastTimeDismissedSpamReported | currentTime: $currentTime');
-    return currentTime.inHours > spamReportBannerDisplayIntervalInHour;
+    final lastTimeDismissedMs = await _spamReportRepository
+        .getLastTimeDismissedSpamReportedMilliseconds();
+
+    if (lastTimeDismissedMs <= 0) {
+      return true;
+    }
+
+    final lastTime = DateTime.fromMillisecondsSinceEpoch(lastTimeDismissedMs);
+    final now = DateTime.now();
+    final elapsed = now.difference(lastTime);
+    final isIntervalElapsed =
+        elapsed.inHours > spamReportBannerDisplayIntervalInHours;
+
+    return isIntervalElapsed;
   }
 }

--- a/lib/features/mailbox_dashboard/domain/usecases/get_spam_mailbox_cached_interactor.dart
+++ b/lib/features/mailbox_dashboard/domain/usecases/get_spam_mailbox_cached_interactor.dart
@@ -49,8 +49,12 @@ class GetSpamMailboxCachedInteractor {
     final lastTime = DateTime.fromMillisecondsSinceEpoch(lastTimeDismissedMs);
     final now = DateTime.now();
     final elapsed = now.difference(lastTime);
+    if (elapsed.isNegative) {
+      if (elapsed.abs() < const Duration(days: 1)) return false;
+      return true;
+    }
     final isIntervalElapsed =
-        elapsed.inHours > spamReportBannerDisplayIntervalInHours;
+        elapsed.inHours >= spamReportBannerDisplayIntervalInHours;
 
     return isIntervalElapsed;
   }

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -2525,24 +2525,6 @@ class MailboxDashBoardController extends ReloadableController
 
   bool get enableSpamReport => spamReportController.enableSpamReport;
 
-  void getSpamReportBanner() {
-    if (enableSpamReport) {
-      final spamId = spamMailboxId;
-      if (spamId == null) {
-        spamReportController.setSpamPresentationMailbox(null);
-        return;
-      }
-
-      final spamMailbox = mapMailboxById[spamId];
-      final unreadEmails = spamMailbox?.unreadEmails?.value.value ?? 0;
-      if (unreadEmails > 0) {
-        spamReportController.setSpamPresentationMailbox(spamMailbox);
-      } else {
-        spamReportController.setSpamPresentationMailbox(null);
-      }
-    }
-  }
-
   void refreshSpamReportBanner() {
     if (enableSpamReport && sessionCurrent != null && accountId.value != null) {
       spamReportController.getSpamMailboxCached(accountId.value!, sessionCurrent!.username);

--- a/lib/features/mailbox_dashboard/presentation/controller/spam_report_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/spam_report_controller.dart
@@ -9,6 +9,7 @@ import 'package:model/extensions/presentation_mailbox_extension.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:tmail_ui_user/features/base/base_controller.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/exceptions/spam_report_exception.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/model/spam_report_state.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/get_spam_mailbox_cached_state.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/get_spam_report_state.dart';
@@ -75,7 +76,7 @@ class SpamReportController extends BaseController {
   @override
   void handleFailureViewState(Failure failure) {
     if (failure is GetSpamMailboxCachedFailure) {
-      presentationSpamMailbox.value = null;
+      _validateSpamMailboxChanged(failure);
     } else if (failure is GetSpamReportStateFailure) {
       _spamReportLoaderStatus = LoaderStatus.completed;
     } else {
@@ -145,6 +146,16 @@ class SpamReportController extends BaseController {
 
   void setSpamPresentationMailbox(PresentationMailbox? spamMailbox) {
     presentationSpamMailbox.value = spamMailbox;
+  }
+
+  void _validateSpamMailboxChanged(GetSpamMailboxCachedFailure failure) {
+    if (failure.exception is NoUnreadSpamEmailsException) {
+      final currentSpamMailbox = presentationSpamMailbox.value;
+      if (currentSpamMailbox != null && currentSpamMailbox.countUnreadEmails > 0) {
+        _storeLastTimeDismissedSpamReportedAction();
+      }
+    }
+    setSpamPresentationMailbox(null);
   }
 
   @override

--- a/test/features/mailbox_dashboard/domain/usecases/get_spam_mailbox_cached_interactor_test.dart
+++ b/test/features/mailbox_dashboard/domain/usecases/get_spam_mailbox_cached_interactor_test.dart
@@ -170,6 +170,43 @@ void main() {
       });
     });
 
+    group('clock-skew (future timestamp)', () {
+      test(
+          'does not show banner when stored timestamp is 12 hours in the future (< 1 day clock skew)',
+          () {
+        when(spamReportRepository
+                .getLastTimeDismissedSpamReportedMilliseconds())
+            .thenAnswer((_) async => msAgo(-12));
+
+        expect(
+          interactor.execute(accountId, userName),
+          emitsInOrder([
+            Right(GetSpamMailboxCachedLoading()),
+            leftWithException<SpamDismissCooldownActiveException>(),
+          ]),
+        );
+      });
+
+      test(
+          'shows banner when stored timestamp is 25 hours in the future (>= 1 day clock skew, likely clock reset)',
+          () {
+        final spamMailbox = makeSpamMailbox(unreadCount: 3);
+        when(spamReportRepository
+                .getLastTimeDismissedSpamReportedMilliseconds())
+            .thenAnswer((_) async => msAgo(-25));
+        when(spamReportRepository.getSpamMailboxCached(accountId, userName))
+            .thenAnswer((_) async => spamMailbox);
+
+        expect(
+          interactor.execute(accountId, userName),
+          emitsInOrder([
+            Right(GetSpamMailboxCachedLoading()),
+            Right(GetSpamMailboxCachedSuccess(spamMailbox)),
+          ]),
+        );
+      });
+    });
+
     group('error handling', () {
       test('wraps repository exception in GetSpamMailboxCachedFailure', () {
         final exception = Exception('cache error');

--- a/test/features/mailbox_dashboard/domain/usecases/get_spam_mailbox_cached_interactor_test.dart
+++ b/test/features/mailbox_dashboard/domain/usecases/get_spam_mailbox_cached_interactor_test.dart
@@ -86,6 +86,20 @@ void main() {
     });
 
     group('cooldown active (dismissed less than 24h ago)', () {
+      test('does not show banner when dismissed 13 hours ago', () {
+        when(spamReportRepository
+                .getLastTimeDismissedSpamReportedMilliseconds())
+            .thenAnswer((_) async => msAgo(13));
+
+        expect(
+          interactor.execute(accountId, userName),
+          emitsInOrder([
+            Right(GetSpamMailboxCachedLoading()),
+            leftWithException<SpamDismissCooldownActiveException>(),
+          ]),
+        );
+      });
+
       test('does not show banner when dismissed 1 hour ago', () {
         when(spamReportRepository
                 .getLastTimeDismissedSpamReportedMilliseconds())
@@ -101,7 +115,25 @@ void main() {
       });
     });
 
-    group('cooldown expired (dismissed 24h+ ago)', () {
+    group('cooldown expired (dismissed 24h ago)', () {
+      test('shows banner when dismissed exactly 24 hours ago and unread > 0',
+          () {
+        final spamMailbox = makeSpamMailbox(unreadCount: 3);
+        when(spamReportRepository
+                .getLastTimeDismissedSpamReportedMilliseconds())
+            .thenAnswer((_) async => msAgo(24));
+        when(spamReportRepository.getSpamMailboxCached(accountId, userName))
+            .thenAnswer((_) async => spamMailbox);
+
+        expect(
+          interactor.execute(accountId, userName),
+          emitsInOrder([
+            Right(GetSpamMailboxCachedLoading()),
+            Right(GetSpamMailboxCachedSuccess(spamMailbox)),
+          ]),
+        );
+      });
+
       test('shows banner when dismissed 25 hours ago and unread > 0', () {
         final spamMailbox = makeSpamMailbox(unreadCount: 3);
         when(spamReportRepository

--- a/test/features/mailbox_dashboard/domain/usecases/get_spam_mailbox_cached_interactor_test.dart
+++ b/test/features/mailbox_dashboard/domain/usecases/get_spam_mailbox_cached_interactor_test.dart
@@ -1,0 +1,177 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/exceptions/spam_report_exception.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/spam_report_repository.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/get_spam_mailbox_cached_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/get_spam_mailbox_cached_interactor.dart';
+
+import 'get_spam_mailbox_cached_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<SpamReportRepository>()])
+void main() {
+  final accountId = AccountId(Id('account-1'));
+  final userName = UserName('user@example.com');
+
+  late MockSpamReportRepository spamReportRepository;
+  late GetSpamMailboxCachedInteractor interactor;
+
+  setUp(() {
+    spamReportRepository = MockSpamReportRepository();
+    interactor = GetSpamMailboxCachedInteractor(spamReportRepository);
+  });
+
+  Mailbox makeSpamMailbox({required int unreadCount}) => Mailbox(
+        id: MailboxId(Id('spam-id')),
+        unreadEmails:
+            unreadCount > 0 ? UnreadEmails(UnsignedInt(unreadCount)) : null,
+      );
+
+  int msAgo(int hours) =>
+      DateTime.now().subtract(Duration(hours: hours)).millisecondsSinceEpoch;
+
+  // Predicate matchers for Left states — EquatableMixin compares exception by value,
+  // so isA<>() inside Left(...) breaks equality. Use predicate instead.
+  Matcher leftWithException<E>() => predicate<Either<Failure, Success>>(
+        (either) => either.fold(
+          (f) => f is GetSpamMailboxCachedFailure && f.exception is E,
+          (_) => false,
+        ),
+        'Left(GetSpamMailboxCachedFailure($E))',
+      );
+
+  group('GetSpamMailboxCachedInteractor', () {
+    group('first-time user (no stored dismiss timestamp)', () {
+      test('shows banner when there are unread spam emails', () {
+        final spamMailbox = makeSpamMailbox(unreadCount: 5);
+        when(spamReportRepository
+                .getLastTimeDismissedSpamReportedMilliseconds())
+            .thenAnswer((_) async => 0);
+        when(spamReportRepository.getSpamMailboxCached(accountId, userName))
+            .thenAnswer((_) async => spamMailbox);
+
+        expect(
+          interactor.execute(accountId, userName),
+          emitsInOrder([
+            Right(GetSpamMailboxCachedLoading()),
+            Right(GetSpamMailboxCachedSuccess(spamMailbox)),
+          ]),
+        );
+      });
+
+      test('does not show banner when spam folder has no unread emails', () {
+        final spamMailbox = makeSpamMailbox(unreadCount: 0);
+        when(spamReportRepository
+                .getLastTimeDismissedSpamReportedMilliseconds())
+            .thenAnswer((_) async => 0);
+        when(spamReportRepository.getSpamMailboxCached(accountId, userName))
+            .thenAnswer((_) async => spamMailbox);
+
+        expect(
+          interactor.execute(accountId, userName),
+          emitsInOrder([
+            Right(GetSpamMailboxCachedLoading()),
+            leftWithException<NoUnreadSpamEmailsException>(),
+          ]),
+        );
+      });
+    });
+
+    group('cooldown active (dismissed less than 24h ago)', () {
+      test('does not show banner when dismissed 1 hour ago', () {
+        when(spamReportRepository
+                .getLastTimeDismissedSpamReportedMilliseconds())
+            .thenAnswer((_) async => msAgo(1));
+
+        expect(
+          interactor.execute(accountId, userName),
+          emitsInOrder([
+            Right(GetSpamMailboxCachedLoading()),
+            leftWithException<SpamDismissCooldownActiveException>(),
+          ]),
+        );
+      });
+    });
+
+    group('cooldown expired (dismissed 24h+ ago)', () {
+      test('shows banner when dismissed 25 hours ago and unread > 0', () {
+        final spamMailbox = makeSpamMailbox(unreadCount: 3);
+        when(spamReportRepository
+                .getLastTimeDismissedSpamReportedMilliseconds())
+            .thenAnswer((_) async => msAgo(25));
+        when(spamReportRepository.getSpamMailboxCached(accountId, userName))
+            .thenAnswer((_) async => spamMailbox);
+
+        expect(
+          interactor.execute(accountId, userName),
+          emitsInOrder([
+            Right(GetSpamMailboxCachedLoading()),
+            Right(GetSpamMailboxCachedSuccess(spamMailbox)),
+          ]),
+        );
+      });
+
+      test('does not show banner when dismissed 25 hours ago but unread = 0',
+          () {
+        final spamMailbox = makeSpamMailbox(unreadCount: 0);
+        when(spamReportRepository
+                .getLastTimeDismissedSpamReportedMilliseconds())
+            .thenAnswer((_) async => msAgo(25));
+        when(spamReportRepository.getSpamMailboxCached(accountId, userName))
+            .thenAnswer((_) async => spamMailbox);
+
+        expect(
+          interactor.execute(accountId, userName),
+          emitsInOrder([
+            Right(GetSpamMailboxCachedLoading()),
+            leftWithException<NoUnreadSpamEmailsException>(),
+          ]),
+        );
+      });
+    });
+
+    group('error handling', () {
+      test('wraps repository exception in GetSpamMailboxCachedFailure', () {
+        final exception = Exception('cache error');
+        when(spamReportRepository
+                .getLastTimeDismissedSpamReportedMilliseconds())
+            .thenThrow(exception);
+
+        expect(
+          interactor.execute(accountId, userName),
+          emitsInOrder([
+            Right(GetSpamMailboxCachedLoading()),
+            Left(GetSpamMailboxCachedFailure(exception)),
+          ]),
+        );
+      });
+
+      test(
+          'wraps getSpamMailboxCached exception in GetSpamMailboxCachedFailure',
+          () {
+        final exception = Exception('mailbox not found');
+        when(spamReportRepository
+                .getLastTimeDismissedSpamReportedMilliseconds())
+            .thenAnswer((_) async => 0);
+        when(spamReportRepository.getSpamMailboxCached(accountId, userName))
+            .thenThrow(exception);
+
+        expect(
+          interactor.execute(accountId, userName),
+          emitsInOrder([
+            Right(GetSpamMailboxCachedLoading()),
+            Left(GetSpamMailboxCachedFailure(exception)),
+          ]),
+        );
+      });
+    });
+  });
+}

--- a/test/features/mailbox_dashboard/presentation/controller/spam_report_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/spam_report_controller_test.dart
@@ -1,0 +1,196 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:core/presentation/utils/app_toast.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart' as jmap_mailbox;
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/caching/caching_manager.dart';
+import 'package:core/data/network/config/dynamic_url_interceptors.dart';
+import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oidc_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/exceptions/spam_report_exception.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/get_spam_mailbox_cached_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/get_spam_mailbox_cached_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/get_spam_report_state_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/store_last_time_dismissed_spam_reported_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/store_spam_report_state_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/spam_report_controller.dart';
+import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
+import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
+import 'package:uuid/uuid.dart';
+
+import 'spam_report_controller_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<StoreSpamReportInteractor>(),
+  MockSpec<StoreSpamReportStateInteractor>(),
+  MockSpec<GetSpamReportStateInteractor>(),
+  MockSpec<GetSpamMailboxCachedInteractor>(),
+  // BaseController dependencies
+  MockSpec<CachingManager>(),
+  MockSpec<LanguageCacheManager>(),
+  MockSpec<AuthorizationInterceptors>(),
+  MockSpec<DynamicUrlInterceptors>(),
+  MockSpec<DeleteCredentialInteractor>(),
+  MockSpec<LogoutOidcInteractor>(),
+  MockSpec<DeleteAuthorityOidcInteractor>(),
+  MockSpec<AppToast>(),
+  MockSpec<ImagePaths>(),
+  MockSpec<ResponsiveUtils>(),
+  MockSpec<ToastManager>(),
+  MockSpec<TwakeAppManager>(),
+])
+void main() {
+  late MockStoreSpamReportInteractor storeSpamReportInteractor;
+  late MockStoreSpamReportStateInteractor storeSpamReportStateInteractor;
+  late MockGetSpamReportStateInteractor getSpamReportStateInteractor;
+  late MockGetSpamMailboxCachedInteractor getSpamMailboxCachedInteractor;
+  late SpamReportController controller;
+
+  PresentationMailbox makeMailboxWithUnread(int count) => PresentationMailbox(
+    jmap_mailbox.MailboxId(Id('spam')),
+    unreadEmails: jmap_mailbox.UnreadEmails(UnsignedInt(count)),
+  );
+
+  void putBaseControllerDependencies() {
+    Get.put<CachingManager>(MockCachingManager());
+    Get.put<LanguageCacheManager>(MockLanguageCacheManager());
+    final authInterceptors = MockAuthorizationInterceptors();
+    Get.put<AuthorizationInterceptors>(authInterceptors);
+    Get.put<AuthorizationInterceptors>(authInterceptors, tag: BindingTag.isolateTag);
+    Get.put<DynamicUrlInterceptors>(MockDynamicUrlInterceptors());
+    Get.put<DeleteCredentialInteractor>(MockDeleteCredentialInteractor());
+    Get.put<LogoutOidcInteractor>(MockLogoutOidcInteractor());
+    Get.put<DeleteAuthorityOidcInteractor>(MockDeleteAuthorityOidcInteractor());
+    Get.put<AppToast>(MockAppToast());
+    Get.put<ImagePaths>(MockImagePaths());
+    Get.put<ResponsiveUtils>(MockResponsiveUtils());
+    Get.put<Uuid>(const Uuid());
+    Get.put<ToastManager>(MockToastManager());
+    Get.put<TwakeAppManager>(MockTwakeAppManager());
+  }
+
+  setUp(() {
+    storeSpamReportInteractor = MockStoreSpamReportInteractor();
+    storeSpamReportStateInteractor = MockStoreSpamReportStateInteractor();
+    getSpamReportStateInteractor = MockGetSpamReportStateInteractor();
+    getSpamMailboxCachedInteractor = MockGetSpamMailboxCachedInteractor();
+
+    when(storeSpamReportInteractor.execute(any))
+        .thenAnswer((_) => const Stream.empty());
+    when(getSpamReportStateInteractor.execute())
+        .thenAnswer((_) => const Stream.empty());
+
+    putBaseControllerDependencies();
+
+    controller = SpamReportController(
+      storeSpamReportInteractor,
+      storeSpamReportStateInteractor,
+      getSpamReportStateInteractor,
+      getSpamMailboxCachedInteractor,
+    );
+    Get.put(controller);
+  });
+
+  tearDown(Get.deleteAll);
+
+  Stream<Either<Failure, Success>> failureStream(Exception exception) =>
+      Stream.fromIterable([
+        Right(GetSpamMailboxCachedLoading()),
+        Left(GetSpamMailboxCachedFailure(exception)),
+      ]);
+
+  final testAccountId = AccountId(Id('acc'));
+  final testUserName = UserName('user@example.com');
+
+  group('SpamReportController._validateSpamMailboxChanged', () {
+    group('NoUnreadSpamEmailsException', () {
+      test('stores dismissal time when banner was showing with unread > 0', () async {
+        controller.setSpamPresentationMailbox(makeMailboxWithUnread(3));
+
+        when(getSpamMailboxCachedInteractor.execute(any, any))
+            .thenAnswer((_) => failureStream(NoUnreadSpamEmailsException()));
+
+        controller.getSpamMailboxCached(testAccountId, testUserName);
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        verify(storeSpamReportInteractor.execute(any)).called(1);
+        expect(controller.presentationSpamMailbox.value, isNull);
+      });
+
+      test('does not store dismissal when banner was not showing', () async {
+        controller.setSpamPresentationMailbox(null);
+
+        when(getSpamMailboxCachedInteractor.execute(any, any))
+            .thenAnswer((_) => failureStream(NoUnreadSpamEmailsException()));
+
+        controller.getSpamMailboxCached(testAccountId, testUserName);
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        verifyNever(storeSpamReportInteractor.execute(any));
+        expect(controller.presentationSpamMailbox.value, isNull);
+      });
+
+      test('does not store dismissal when banner mailbox has 0 unread', () async {
+        controller.setSpamPresentationMailbox(makeMailboxWithUnread(0));
+
+        when(getSpamMailboxCachedInteractor.execute(any, any))
+            .thenAnswer((_) => failureStream(NoUnreadSpamEmailsException()));
+
+        controller.getSpamMailboxCached(testAccountId, testUserName);
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        verifyNever(storeSpamReportInteractor.execute(any));
+        expect(controller.presentationSpamMailbox.value, isNull);
+      });
+    });
+
+    group('SpamDismissCooldownActiveException', () {
+      test('hides banner without storing dismissal time', () async {
+        controller.setSpamPresentationMailbox(makeMailboxWithUnread(5));
+
+        when(getSpamMailboxCachedInteractor.execute(any, any))
+            .thenAnswer((_) => failureStream(SpamDismissCooldownActiveException()));
+
+        controller.getSpamMailboxCached(testAccountId, testUserName);
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        verifyNever(storeSpamReportInteractor.execute(any));
+        expect(controller.presentationSpamMailbox.value, isNull);
+      });
+    });
+
+    group('GetSpamMailboxCachedSuccess', () {
+      test('shows banner with the returned mailbox', () async {
+        final domainMailbox = jmap_mailbox.Mailbox(
+          id: jmap_mailbox.MailboxId(Id('spam')),
+          unreadEmails: jmap_mailbox.UnreadEmails(UnsignedInt(7)),
+        );
+        when(getSpamMailboxCachedInteractor.execute(any, any)).thenAnswer((_) =>
+            Stream.fromIterable([
+              Right(GetSpamMailboxCachedLoading()),
+              Right(GetSpamMailboxCachedSuccess(domainMailbox)),
+            ]));
+
+        controller.getSpamMailboxCached(testAccountId, testUserName);
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        expect(controller.presentationSpamMailbox.value, isNotNull);
+      });
+    });
+  });
+}

--- a/test/features/mailbox_dashboard/presentation/controller/spam_report_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/spam_report_controller_test.dart
@@ -126,7 +126,7 @@ void main() {
             .thenAnswer((_) => failureStream(NoUnreadSpamEmailsException()));
 
         controller.getSpamMailboxCached(testAccountId, testUserName);
-        await Future.delayed(const Duration(milliseconds: 100));
+        await untilCalled(storeSpamReportInteractor.execute(any));
 
         verify(storeSpamReportInteractor.execute(any)).called(1);
         expect(controller.presentationSpamMailbox.value, isNull);
@@ -139,7 +139,7 @@ void main() {
             .thenAnswer((_) => failureStream(NoUnreadSpamEmailsException()));
 
         controller.getSpamMailboxCached(testAccountId, testUserName);
-        await Future.delayed(const Duration(milliseconds: 100));
+        await pumpEventQueue();
 
         verifyNever(storeSpamReportInteractor.execute(any));
         expect(controller.presentationSpamMailbox.value, isNull);
@@ -152,7 +152,7 @@ void main() {
             .thenAnswer((_) => failureStream(NoUnreadSpamEmailsException()));
 
         controller.getSpamMailboxCached(testAccountId, testUserName);
-        await Future.delayed(const Duration(milliseconds: 100));
+        await pumpEventQueue();
 
         verifyNever(storeSpamReportInteractor.execute(any));
         expect(controller.presentationSpamMailbox.value, isNull);
@@ -167,7 +167,7 @@ void main() {
             .thenAnswer((_) => failureStream(SpamDismissCooldownActiveException()));
 
         controller.getSpamMailboxCached(testAccountId, testUserName);
-        await Future.delayed(const Duration(milliseconds: 100));
+        await pumpEventQueue();
 
         verifyNever(storeSpamReportInteractor.execute(any));
         expect(controller.presentationSpamMailbox.value, isNull);
@@ -187,7 +187,7 @@ void main() {
             ]));
 
         controller.getSpamMailboxCached(testAccountId, testUserName);
-        await Future.delayed(const Duration(milliseconds: 100));
+        await pumpEventQueue();
 
         expect(controller.presentationSpamMailbox.value, isNotNull);
       });


### PR DESCRIPTION
## Issue

#4385 

## Resolved


https://github.com/user-attachments/assets/15b63f7a-4990-473c-900f-08ff43014617



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Spam report banner cooldown extended from 12 to 24 hours; improved handling when unread spam is zero or when stored dismissal timestamps are abnormal
  * Spam banner updates consolidated to a single refresh path to prevent inconsistent state and ensure correct dismissal tracking
* **Behavior**
  * Dismissing the spam banner records the dismissal timestamp more reliably to avoid premature re-showing
* **Tests**
  * Added comprehensive tests covering cooldown boundaries, dismissal behavior, clock-skew and error scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->