### PR TITLE
TF-4392 [Team Mailbox] Delete email in Trash

### DIFF
--- a/lib/features/base/mixin/mailbox_action_handler_mixin.dart
+++ b/lib/features/base/mixin/mailbox_action_handler_mixin.dart
@@ -68,10 +68,7 @@ mixin MailboxActionHandlerMixin {
         ..onConfirmAction(AppLocalizations.of(context).delete, () {
             popBack();
             if (mailbox.countTotalEmails > 0) {
-              dashboardController.emptyTrashFolderAction(
-                trashFolderId: mailbox.id,
-                totalEmails: mailbox.countTotalEmails
-              );
+              dashboardController.emptyTrashFolderAction(trashMailbox: mailbox);
             } else {
               appToast.showToastWarningMessage(
                 context,
@@ -92,10 +89,7 @@ mixin MailboxActionHandlerMixin {
         onConfirmAction: () {
           popBack();
           if (mailbox.countTotalEmails > 0) {
-            dashboardController.emptyTrashFolderAction(
-              trashFolderId: mailbox.id,
-              totalEmails: mailbox.countTotalEmails
-            );
+            dashboardController.emptyTrashFolderAction(trashMailbox: mailbox);
           } else {
             appToast.showToastWarningMessage(
               context,

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -1600,8 +1600,7 @@ class MailboxController extends BaseMailboxController
     log('MailboxController::emptyMailboxAction:presentationMailbox: ${presentationMailbox.name}');
     if (presentationMailbox.isTrash) {
       mailboxDashBoardController.emptyTrashFolderAction(
-        trashFolderId: presentationMailbox.id,
-        totalEmails: presentationMailbox.countTotalEmails
+        trashMailbox: presentationMailbox,
       );
     } else if (presentationMailbox.isSpam) {
       mailboxDashBoardController.emptySpamFolderAction(

--- a/lib/features/mailbox/presentation/mixin/mailbox_widget_mixin.dart
+++ b/lib/features/mailbox/presentation/mixin/mailbox_widget_mixin.dart
@@ -93,7 +93,9 @@ mixin MailboxWidgetMixin {
         if (mailbox.isSubscribedMailbox)
           MailboxActions.disableMailbox
         else
-          MailboxActions.enableMailbox
+          MailboxActions.enableMailbox,
+      if (mailbox.isTrash && mailbox.myRights?.mayRemoveItems == true)
+        MailboxActions.emptyTrash,
     ];
   }
 

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -1832,41 +1832,40 @@ class MailboxDashBoardController extends ReloadableController
 
   void emptyTrashFolderAction({
     Function? onCancelSelectionEmail,
-    MailboxId? trashFolderId,
-    int totalEmails = 0,
+    PresentationMailbox? trashMailbox,
   }) {
     onCancelSelectionEmail?.call();
 
-    final trashMailboxId = trashFolderId ?? mapDefaultMailboxIdByRole[PresentationMailbox.roleTrash];
+    final trashFolder = trashMailbox
+        ?? (selectedMailbox.value?.isTrash == true ? selectedMailbox.value : null)
+        ?? mapMailboxById[mapDefaultMailboxIdByRole[PresentationMailbox.roleTrash]];
     final accountId = this.accountId.value;
+    final session = sessionCurrent;
 
-    if (accountId == null || sessionCurrent == null) {
+    if (accountId == null || session == null) {
       consumeState(Stream.value(Left(EmptyTrashFolderFailure(NotFoundSessionException()))));
       return;
     }
 
-    if (trashMailboxId == null) {
+    if (trashFolder == null) {
       consumeState(Stream.value(Left(EmptyTrashFolderFailure(NotFoundMailboxException()))));
       return;
     }
 
-    if (CapabilityIdentifier.jmapMailboxClear.isSupported(sessionCurrent!, accountId)) {
+    if (CapabilityIdentifier.jmapMailboxClear.isSupported(session, accountId) &&
+        trashFolder.isTrashTeamMailbox != true) {
       clearMailbox(
-        sessionCurrent!,
+        session,
         accountId,
-        trashMailboxId,
+        trashFolder.id,
         PresentationMailbox.roleTrash,
       );
     } else {
-      final totalEmailsInTrash = totalEmails == 0
-          ? mapMailboxById[trashMailboxId]?.countTotalEmails ?? 0
-          : totalEmails;
-
       consumeState(_emptyTrashFolderInteractor.execute(
-        sessionCurrent!,
+        session,
         accountId,
-        trashMailboxId,
-        totalEmailsInTrash,
+        trashFolder.id,
+        trashFolder.countTotalEmails,
         progressStateController,
       ));
     }
@@ -2397,6 +2396,7 @@ class MailboxDashBoardController extends ReloadableController
   ) {
     return mailbox != null &&
       mailbox.isTrash &&
+      mailbox.myRights?.mayRemoveItems == true &&
       mailbox.countTotalEmails > 0 &&
       !searchController.isSearchActive() &&
       responsiveUtils.isWebDesktop(context);
@@ -2408,6 +2408,7 @@ class MailboxDashBoardController extends ReloadableController
   ) {
     return mailbox != null &&
       mailbox.isTrash &&
+      mailbox.myRights?.mayRemoveItems == true &&
       mailbox.countTotalEmails > 0 &&
       !searchController.isSearchActive() &&
       !responsiveUtils.isWebDesktop(context);

--- a/model/lib/extensions/presentation_mailbox_extension.dart
+++ b/model/lib/extensions/presentation_mailbox_extension.dart
@@ -40,7 +40,15 @@ extension PresentationMailboxExtension on PresentationMailbox {
 
   bool get isVirtualFolder => isFavorite || isActionRequired;
 
-  bool get isTrash => role == PresentationMailbox.roleTrash;
+  bool get isTrash {
+    if (isPersonal) {
+      return role == PresentationMailbox.roleTrash;
+    } else {
+      return isChildOfTeamMailboxes &&
+          name?.name.toLowerCase() ==
+              PresentationMailbox.trashRole.toLowerCase();
+    }
+  }
 
   bool get isDrafts => role == PresentationMailbox.roleDrafts;
 

--- a/model/lib/extensions/presentation_mailbox_extension.dart
+++ b/model/lib/extensions/presentation_mailbox_extension.dart
@@ -44,10 +44,13 @@ extension PresentationMailboxExtension on PresentationMailbox {
     if (isPersonal) {
       return role == PresentationMailbox.roleTrash;
     } else {
-      return isChildOfTeamMailboxes &&
-          name?.name.toLowerCase() ==
-              PresentationMailbox.trashRole.toLowerCase();
+      return isTrashTeamMailbox;
     }
+  }
+
+  bool get isTrashTeamMailbox {
+    return isChildOfTeamMailboxes &&
+        name?.name.toLowerCase() == PresentationMailbox.trashRole.toLowerCase();
   }
 
   bool get isDrafts => role == PresentationMailbox.roleDrafts;


### PR DESCRIPTION
## Issue

#4392

User story 3

```
AS a team mailbox member
I can delete emails within the team mailbox trash
I can empty the team mailbox trash
```

## Resolved



https://github.com/user-attachments/assets/4ee0ebb4-5a74-4f21-9147-a35b29df0b6c




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced trash emptying functionality to properly support team mailboxes with appropriate permission validation.
  * Improved trash folder detection to correctly distinguish between personal and team mailbox trash.

* **New Features**
  * Permission checks now prevent unauthorized users from emptying trash, ensuring only those with appropriate rights can perform this action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->