### PR TITLE
TF-4392 [Team Mailbox] Create / delete / rename sub folder

### DIFF
--- a/lib/features/mailbox/presentation/mixin/mailbox_widget_mixin.dart
+++ b/lib/features/mailbox/presentation/mixin/mailbox_widget_mixin.dart
@@ -87,6 +87,8 @@ mixin MailboxWidgetMixin {
     return [
       if (PlatformInfo.isWeb && mailbox.isSubscribedMailbox)
         MailboxActions.openInNewTab,
+      if (mailbox.myRights?.mayCreateChild == true)
+        MailboxActions.newSubfolder,
       if (mailbox.countUnReadEmailsAsString.isNotEmpty)
         MailboxActions.markAsRead,
       if (mailbox.isTeamMailboxes)

--- a/lib/features/mailbox/presentation/mixin/mailbox_widget_mixin.dart
+++ b/lib/features/mailbox/presentation/mixin/mailbox_widget_mixin.dart
@@ -97,7 +97,9 @@ mixin MailboxWidgetMixin {
         if (mailbox.isSubscribedMailbox)
           MailboxActions.disableMailbox
         else
-          MailboxActions.enableMailbox
+          MailboxActions.enableMailbox,
+      if (mailbox.myRights?.mayDelete == true)
+        MailboxActions.delete,
     ];
   }
 

--- a/lib/features/mailbox/presentation/mixin/mailbox_widget_mixin.dart
+++ b/lib/features/mailbox/presentation/mixin/mailbox_widget_mixin.dart
@@ -91,6 +91,8 @@ mixin MailboxWidgetMixin {
         MailboxActions.newSubfolder,
       if (mailbox.countUnReadEmailsAsString.isNotEmpty)
         MailboxActions.markAsRead,
+      if (mailbox.myRights?.mayRename == true)
+        MailboxActions.rename,
       if (mailbox.isTeamMailboxes)
         if (mailbox.isSubscribedMailbox)
           MailboxActions.disableMailbox


### PR DESCRIPTION
## Issue

#4392 
#3832

User story 5
```
As a team mailbox member 
I can create subfolder
I can delete / rename those folder within the team mailbox
```

## Resolved



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mailbox actions now properly display based on user permissions for creating subfolders, renaming, and deleting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->