### PR TITLE
TF-4392 [Team Mailbox] Edit email in Drafts folder as new in the composer

### DIFF
--- a/model/lib/extensions/presentation_mailbox_extension.dart
+++ b/model/lib/extensions/presentation_mailbox_extension.dart
@@ -42,7 +42,19 @@ extension PresentationMailboxExtension on PresentationMailbox {
 
   bool get isTrash => role == PresentationMailbox.roleTrash;
 
-  bool get isDrafts => role == PresentationMailbox.roleDrafts;
+  bool get isDrafts {
+    if (isPersonal) {
+      return role == PresentationMailbox.roleDrafts;
+    } else {
+      return isDraftsTeamMailbox;
+    }
+  }
+
+  bool get isDraftsTeamMailbox {
+    return isChildOfTeamMailboxes &&
+        name?.name.toLowerCase() ==
+            PresentationMailbox.draftsRole.toLowerCase();
+  }
 
   bool get isTemplates => role == PresentationMailbox.roleTemplates;
 


### PR DESCRIPTION
## Issue

#4392 

User story 2

```
AS a team mailbox member
GIVEN I edit an email with a team mailbox member identity
WHEN I close my composer
THEN it is saved in the team mailbox Draft folder
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed draft mailbox detection to work reliably across all mailbox types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->