### PR TITLE
TF-4392 [Team Mailbox] Edit email in Template folder as new in the composer

### DIFF
--- a/model/lib/extensions/presentation_mailbox_extension.dart
+++ b/model/lib/extensions/presentation_mailbox_extension.dart
@@ -44,7 +44,19 @@ extension PresentationMailboxExtension on PresentationMailbox {
 
   bool get isDrafts => role == PresentationMailbox.roleDrafts;
 
-  bool get isTemplates => role == PresentationMailbox.roleTemplates;
+  bool get isTemplates {
+    if (isPersonal) {
+      return role == PresentationMailbox.roleTemplates;
+    } else {
+      return isTemplatesTeamMailbox;
+    }
+  }
+
+  bool get isTemplatesTeamMailbox {
+    return isChildOfTeamMailboxes &&
+        name?.name.toLowerCase() ==
+            PresentationMailbox.templatesRole.toLowerCase();
+  }
 
   bool get isSent => role == PresentationMailbox.roleSent;
 


### PR DESCRIPTION
## Issue

#4392 
#4333

User story 4

```
AS a team mailbox member
WHEN I open an email in the Template folder
THEN I edit it as new in the composer
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template mailbox detection logic for team mailboxes using case-insensitive name matching
  * Enhanced handling to properly distinguish between personal and team mailbox templates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->