### PR TITLE
TF-4400 Enable collapse threads on Force Query path

### DIFF
--- a/lib/features/base/mixin/mail_api_mixin.dart
+++ b/lib/features/base/mixin/mail_api_mixin.dart
@@ -38,6 +38,7 @@ import 'package:tmail_ui_user/features/mailbox/domain/exceptions/mailbox_excepti
 import 'package:tmail_ui_user/features/mailbox/domain/state/move_folder_content_state.dart';
 import 'package:tmail_ui_user/features/thread/data/extensions/list_email_extension.dart';
 import 'package:tmail_ui_user/features/thread/data/extensions/list_email_id_extension.dart';
+import 'package:tmail_ui_user/features/thread/data/extensions/query_email_method_extension.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/email_response.dart';
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
 
@@ -109,6 +110,7 @@ mixin MailAPIMixin on HandleSetErrorMixin, SessionMixin {
     int? position,
     Set<Comparator>? sort,
     Filter? filter,
+    bool? collapseThreads,
     Properties? properties,
   }) async {
     final processingInvocation = ProcessingInvocation();
@@ -118,15 +120,12 @@ mixin MailAPIMixin on HandleSetErrorMixin, SessionMixin {
       processingInvocation,
     );
 
-    final queryEmailMethod = QueryEmailMethod(accountId);
-
-    if (limit != null) queryEmailMethod.addLimit(limit);
-
-    if (position != null && position > 0) queryEmailMethod.addPosition(position);
-
-    if (sort != null) queryEmailMethod.addSorts(sort);
-
-    if (filter != null) queryEmailMethod.addFilters(filter);
+    final queryEmailMethod = QueryEmailMethod(accountId)
+      ..addLimitIfNotNull(limit)
+      ..addPositionIfAvailable(position)
+      ..addSortsIfNotNull(sort)
+      ..addFiltersIfNotNull(filter)
+      ..addCollapseThreadsIfAvailable(collapseThreads);
 
     final queryEmailInvocation =
         jmapRequestBuilder.invocation(queryEmailMethod);

--- a/lib/features/thread/data/datasource/thread_datasource.dart
+++ b/lib/features/thread/data/datasource/thread_datasource.dart
@@ -28,6 +28,7 @@ abstract class ThreadDataSource {
       int? position,
       Set<Comparator>? sort,
       Filter? filter,
+      bool? collapseThreads,
       Properties? properties
     }
   );

--- a/lib/features/thread/data/datasource_impl/local_thread_datasource_impl.dart
+++ b/lib/features/thread/data/datasource_impl/local_thread_datasource_impl.dart
@@ -44,6 +44,7 @@ class LocalThreadDataSourceImpl extends ThreadDataSource {
       int? position,
       Set<Comparator>? sort,
       Filter? filter,
+      bool? collapseThreads,
       Properties? properties
     }
   ) {

--- a/lib/features/thread/data/datasource_impl/thread_datasource_impl.dart
+++ b/lib/features/thread/data/datasource_impl/thread_datasource_impl.dart
@@ -45,6 +45,7 @@ class ThreadDataSourceImpl extends ThreadDataSource {
       int? position,
       Set<Comparator>? sort,
       Filter? filter,
+      bool? collapseThreads,
       Properties? properties,
     }
   ) {
@@ -56,6 +57,7 @@ class ThreadDataSourceImpl extends ThreadDataSource {
         position: position,
         sort: sort,
         filter: filter,
+        collapseThreads: collapseThreads,
         properties: properties);
     }).catchError(_exceptionThrower.throwException);
   }

--- a/lib/features/thread/data/extensions/email_change_response_extension.dart
+++ b/lib/features/thread/data/extensions/email_change_response_extension.dart
@@ -1,0 +1,8 @@
+import 'package:tmail_ui_user/features/thread/data/model/email_change_response.dart';
+
+extension EmailChangeResponseExtension on EmailChangeResponse? {
+  bool get hasChanged =>
+      this?.created?.isNotEmpty == true
+      || this?.updated?.isNotEmpty == true
+      || this?.destroyed?.isNotEmpty == true;
+}

--- a/lib/features/thread/data/extensions/query_email_method_extension.dart
+++ b/lib/features/thread/data/extensions/query_email_method_extension.dart
@@ -3,11 +3,17 @@ import 'package:jmap_dart_client/jmap/core/sort/comparator.dart';
 import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
 import 'package:jmap_dart_client/jmap/mail/email/query/query_email_method.dart';
 
+/// Naming convention:
+/// - `IfNotNull`  — applies the method only when the value is non-null.
+/// - `IfAvailable` — applies the method when the value meets an additional
+///   semantic condition beyond null (e.g. position > 0, collapseThreads == true).
 extension QueryEmailMethodExtension on QueryEmailMethod {
   void addLimitIfNotNull(UnsignedInt? limit) {
     if (limit != null) addLimit(limit);
   }
 
+  /// Only sets position when it is positive; position 0 is the default start
+  /// and does not need to be sent explicitly.
   void addPositionIfAvailable(int? position) {
     if (position != null && position > 0) addPosition(position);
   }
@@ -20,6 +26,8 @@ extension QueryEmailMethodExtension on QueryEmailMethod {
     if (filter != null) addFilters(filter);
   }
 
+  /// Only enables collapse-threads when the flag is explicitly `true`;
+  /// null or false means the feature is not requested.
   void addCollapseThreadsIfAvailable(bool? collapseThreads) {
     if (collapseThreads == true) {
       addCollapseThreads(true);

--- a/lib/features/thread/data/network/thread_api.dart
+++ b/lib/features/thread/data/network/thread_api.dart
@@ -48,6 +48,7 @@ class ThreadAPI with HandleSetErrorMixin, SessionMixin, MailAPIMixin {
       int? position,
       Set<Comparator>? sort,
       Filter? filter,
+      bool? collapseThreads,
       Properties? properties
     }
   ) async {
@@ -59,6 +60,7 @@ class ThreadAPI with HandleSetErrorMixin, SessionMixin, MailAPIMixin {
       position: position,
       sort: sort,
       filter: filter,
+      collapseThreads: collapseThreads,
       properties: properties,
     );
   }

--- a/lib/features/thread/data/repository/thread_repository_impl.dart
+++ b/lib/features/thread/data/repository/thread_repository_impl.dart
@@ -165,6 +165,7 @@ class ThreadRepositoryImpl extends ThreadRepository {
     int? position,
     Set<Comparator>? sort,
     EmailFilter? emailFilter,
+    bool? collapseThreads,
     Properties? propertiesCreated,
   }) async* {
     jmap.State? cachedState;
@@ -196,6 +197,7 @@ class ThreadRepositoryImpl extends ThreadRepository {
       position: position,
       sort: sort,
       filter: emailFilter?.filter,
+      collapseThreads: collapseThreads,
       properties: propertiesCreated,
     );
 
@@ -205,6 +207,7 @@ class ThreadRepositoryImpl extends ThreadRepository {
 
     logTrace(
       'ThreadRepositoryImpl::forceQueryAllEmailsForWeb(): '
+      'collapseThreads = $collapseThreads, '
       'ServerEmailCount = $serverCount, '
       'ServerNotFoundEmailIds = ${notFoundEmailIds.length}, '
       'StateResponse = ${stateResponse?.value}',
@@ -240,6 +243,7 @@ class ThreadRepositoryImpl extends ThreadRepository {
       MailboxId? mailboxId,
       Properties? propertiesCreated,
       Filter? filter,
+      bool? collapseThreads,
     }
   ) async {
       final networkEmailResponse = await mapDataSource[DataSourceType.network]!.getAllEmail(
@@ -250,6 +254,7 @@ class ThreadRepositoryImpl extends ThreadRepository {
         sort: sort,
         filter: filter ?? EmailFilterCondition(inMailbox: mailboxId),
         properties: propertiesCreated,
+        collapseThreads: collapseThreads,
       );
       await _updateEmailCache(
         accountId,
@@ -360,6 +365,7 @@ class ThreadRepositoryImpl extends ThreadRepository {
       EmailFilter? emailFilter,
       Properties? propertiesCreated,
       Properties? propertiesUpdated,
+      bool? collapseThreads,
     }
   ) async* {
     log('ThreadRepositoryImpl::refreshChanges(): $currentState');
@@ -395,9 +401,11 @@ class ThreadRepositoryImpl extends ThreadRepository {
         filter: emailFilter?.filter,
         mailboxId: emailFilter?.mailboxId,
         propertiesCreated: propertiesCreated,
+        collapseThreads: collapseThreads,
       );
       logTrace(
         'ThreadRepositoryImpl::refreshChanges():'
+        'collapseThreads = $collapseThreads, '
         'CountEmailCached = ${newEmailResponse.emailList?.length}, '
         'EmailStateCache = ${newEmailResponse.state?.value}, '
         'InMailboxId = ${emailFilter?.mailboxId?.asString}, '
@@ -410,6 +418,7 @@ class ThreadRepositoryImpl extends ThreadRepository {
     } else {
       logTrace(
         'ThreadRepositoryImpl::refreshChanges():'
+        'collapseThreads = $collapseThreads, '
         'CountEmailCached = ${newEmailResponse.emailList?.length}, '
         'EmailStateCache = ${newEmailResponse.state?.value}, '
         'InMailboxId = ${emailFilter?.mailboxId?.asString}, '
@@ -432,7 +441,9 @@ class ThreadRepositoryImpl extends ThreadRepository {
       );
     }
     logTrace(
-      'ThreadRepositoryImpl::loadMoreEmails(): emailList = ${response.emailList?.length},'
+      'ThreadRepositoryImpl::loadMoreEmails(): '
+      'collapseThreads = ${emailRequest.collapseThreads},'
+      'emailList = ${response.emailList?.length},'
       'notFoundEmailIds = ${response.notFoundEmailIds?.length}, '
       'existNotFoundEmails = ${response.existNotFoundEmails}, '
       'state = ${response.state?.value}',
@@ -449,6 +460,7 @@ class ThreadRepositoryImpl extends ThreadRepository {
           position: emailRequest.position,
           sort: emailRequest.sort,
           filter: emailRequest.filter,
+          collapseThreads: emailRequest.collapseThreads,
           properties: emailRequest.properties)
         .then((response) {
           final listEmails = response.emailList;

--- a/lib/features/thread/data/repository/thread_repository_impl.dart
+++ b/lib/features/thread/data/repository/thread_repository_impl.dart
@@ -392,7 +392,8 @@ class ThreadRepositoryImpl extends ThreadRepository {
     });
 
     if (!newEmailResponse.hasEmails()
-        || (newEmailResponse.emailList?.length ?? 0) < ThreadConstants.defaultLimit.value) {
+        || (newEmailResponse.emailList?.length ?? 0) < ThreadConstants.defaultLimit.value
+        || collapseThreads == true) {
       final networkEmailResponse = await _getFirstPage(
         session,
         accountId,

--- a/lib/features/thread/domain/model/get_email_request.dart
+++ b/lib/features/thread/domain/model/get_email_request.dart
@@ -19,6 +19,7 @@ class GetEmailRequest with EquatableMixin {
   final Properties? properties;
   final EmailId? lastEmailId;
   final bool useCache;
+  final bool? collapseThreads;
 
   GetEmailRequest(
     this.session,
@@ -32,6 +33,7 @@ class GetEmailRequest with EquatableMixin {
       this.properties,
       this.lastEmailId,
       this.useCache = true,
+      this.collapseThreads,
     }
   );
 
@@ -47,5 +49,6 @@ class GetEmailRequest with EquatableMixin {
     lastEmailId,
     filterOption,
     useCache,
+    collapseThreads,
   ];
 }

--- a/lib/features/thread/domain/repository/thread_repository.dart
+++ b/lib/features/thread/domain/repository/thread_repository.dart
@@ -50,6 +50,7 @@ abstract class ThreadRepository {
     int? position,
     Set<Comparator>? sort,
     EmailFilter? emailFilter,
+    bool? collapseThreads,
     Properties? propertiesCreated,
   });
 
@@ -63,6 +64,7 @@ abstract class ThreadRepository {
       EmailFilter? emailFilter,
       Properties? propertiesCreated,
       Properties? propertiesUpdated,
+      bool? collapseThreads,
     }
   );
 

--- a/lib/features/thread/domain/usecases/get_emails_in_mailbox_interactor.dart
+++ b/lib/features/thread/domain/usecases/get_emails_in_mailbox_interactor.dart
@@ -27,6 +27,7 @@ class GetEmailsInMailboxInteractor {
       EmailFilter? emailFilter,
       Properties? propertiesCreated,
       Properties? propertiesUpdated,
+      bool? collapseThreads,
       bool getLatestChanges = true,
       bool useCache = true,
       bool forceEmailQuery = false,
@@ -44,6 +45,7 @@ class GetEmailsInMailboxInteractor {
           limit: limit,
           sort: sort,
           emailFilter: emailFilter,
+          collapseThreads: collapseThreads,
           propertiesCreated: propertiesCreated,
         );
       } else if (useCache) {

--- a/lib/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor.dart
+++ b/lib/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor.dart
@@ -28,6 +28,7 @@ class RefreshChangesEmailsInMailboxInteractor {
       Properties? propertiesCreated,
       Properties? propertiesUpdated,
       EmailFilter? emailFilter,
+      bool? collapseThreads,
     }
   ) async* {
     yield Right<Failure, Success>(RefreshChangesAllEmailLoading());
@@ -42,6 +43,7 @@ class RefreshChangesEmailsInMailboxInteractor {
           limit: limit,
           propertiesCreated: propertiesCreated,
           propertiesUpdated: propertiesUpdated,
+          collapseThreads: collapseThreads,
           emailFilter: emailFilter)
         .map((emailResponse) => _toGetEmailState(
           emailResponse: emailResponse,

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -684,7 +684,9 @@ class ThreadController extends BaseController with EmailActionController {
     if (mailboxDashBoardController.isSelectionEnabled()) {
       mailboxDashBoardController.listEmailSelected.value = listEmailSelected;
     }
-    canLoadMore = emailsAfterChanges.isNotEmpty;
+    if (success.emailChangeResponse?.created?.isNotEmpty == true && !canLoadMore) {
+      canLoadMore = true;
+    }
     logTrace(
       'ThreadController::_refreshChangesAllEmailSuccess():'
       'MailboxId = ${success.currentMailboxId?.asString}, '

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -684,14 +684,15 @@ class ThreadController extends BaseController with EmailActionController {
     if (mailboxDashBoardController.isSelectionEnabled()) {
       mailboxDashBoardController.listEmailSelected.value = listEmailSelected;
     }
-
+    canLoadMore = emailsAfterChanges.isNotEmpty;
     logTrace(
       'ThreadController::_refreshChangesAllEmailSuccess():'
       'MailboxId = ${success.currentMailboxId?.asString}, '
       'CurrentEmailCount = ${emailsBeforeChanges.length}, '
       'ServerEmailCount = ${success.emailList.length}, '
       'DisplayedEmailCount = ${emailListSynced.length}, '
-      'EmailState = ${success.currentEmailState?.value}',
+      'EmailState = ${success.currentEmailState?.value}, '
+      'canLoadMore = $canLoadMore',
     );
 
     if (_isAutoLoadMore) {
@@ -922,8 +923,10 @@ class ThreadController extends BaseController with EmailActionController {
 
     if (emailSuccessState is GetAllEmailSuccess) {
       _getAllEmailSuccess(emailSuccessState, shouldJumpToFirstEmail: false);
+      _handleOnDoneGetAllEmailSuccess(emailSuccessState);
     } else if (emailSuccessState != null) {
       onDataFailureViewState(emailSuccessState);
+      _handleOnDoneGetAllEmailFailure();
     }
   }
 

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -842,7 +842,7 @@ class ThreadController extends BaseController with EmailActionController {
     }
   }
 
-  Future<Either<Failure, Success>> _refreshChangeListEmailCache() async {
+  Future<Either<Failure, Success>> _refreshChangeListEmailCache({bool collapseThreads = false}) async {
     final refreshState = await _refreshChangesEmailsInMailboxInteractor.execute(
       _session!,
       _accountId!,
@@ -858,7 +858,7 @@ class ThreadController extends BaseController with EmailActionController {
         _accountId!,
       ),
       emailFilter: getEmailFilterForLoadMailbox(),
-      collapseThreads: forceEmailQuery && _isCollapseThreadsEnabled,
+      collapseThreads: collapseThreads,
     ).last;
 
     refreshState.fold(
@@ -875,7 +875,9 @@ class ThreadController extends BaseController with EmailActionController {
 
   Future<void> _refreshChangeListEmail() async {
     log('ThreadController::_refreshChangeListEmail:');
-    final refreshViewState = await _refreshChangeListEmailCache();
+    final refreshViewState = await _refreshChangeListEmailCache(
+      collapseThreads: forceEmailQuery && _isCollapseThreadsEnabled,
+    );
 
     final refreshState = refreshViewState
         .foldSuccessWithResult<RefreshChangesAllEmailSuccess>();

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -44,6 +44,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/providers/local_settings_notifier.dart';
+import 'package:tmail_ui_user/features/thread/data/model/email_change_response.dart';
 import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_bindings.dart';
 import 'package:tmail_ui_user/features/thread/data/extensions/email_change_response_extension.dart';
@@ -687,9 +688,7 @@ class ThreadController extends BaseController with EmailActionController {
     if (mailboxDashBoardController.isSelectionEnabled()) {
       mailboxDashBoardController.listEmailSelected.value = listEmailSelected;
     }
-    if (success.emailChangeResponse.hasChanged && !canLoadMore) {
-      canLoadMore = true;
-    }
+    _refreshLoadMoreState(success.emailChangeResponse);
     logTrace(
       'ThreadController::_refreshChangesAllEmailSuccess():'
       'MailboxId = ${success.currentMailboxId?.asString}, '
@@ -702,6 +701,12 @@ class ThreadController extends BaseController with EmailActionController {
 
     if (_isAutoLoadMore) {
       _performAutomaticallyLoadMoreEmails();
+    }
+  }
+
+  void _refreshLoadMoreState(EmailChangeResponse? emailChangeResponse) {
+    if (emailChangeResponse.hasChanged && !canLoadMore) {
+      canLoadMore = true;
     }
   }
 

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -684,7 +684,12 @@ class ThreadController extends BaseController with EmailActionController {
     if (mailboxDashBoardController.isSelectionEnabled()) {
       mailboxDashBoardController.listEmailSelected.value = listEmailSelected;
     }
-    if (success.emailChangeResponse?.created?.isNotEmpty == true && !canLoadMore) {
+    final emailChangeResponse = success.emailChangeResponse;
+    final isEmailChanged = emailChangeResponse?.created?.isNotEmpty == true
+        || emailChangeResponse?.updated?.isNotEmpty == true
+        || emailChangeResponse?.destroyed?.isNotEmpty == true;
+
+    if (isEmailChanged && !canLoadMore) {
       canLoadMore = true;
     }
     logTrace(

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -702,14 +702,13 @@ class ThreadController extends BaseController with EmailActionController {
   void getAllEmailAction({
     bool getLatestChanges = true,
     bool forceEmailQuery = false,
-    UnsignedInt? limit,
   }) {
     log('ThreadController::_getAllEmailAction:getLatestChanges = $getLatestChanges');
     if (_session != null &&_accountId != null) {
       consumeState(_getEmailsInMailboxInteractor.execute(
         _session!,
         _accountId!,
-        limit: limit ?? ThreadConstants.defaultLimit,
+        limit: ThreadConstants.defaultLimit,
         sort: EmailSortOrderType.mostRecent.getSortOrder().toNullable(),
         emailFilter: getEmailFilterForLoadMailbox(),
         propertiesCreated: EmailUtils.getPropertiesForEmailGetMethod(_session!, _accountId!),

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -46,6 +46,7 @@ import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/p
 import 'package:tmail_ui_user/features/manage_account/presentation/providers/local_settings_notifier.dart';
 import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_bindings.dart';
+import 'package:tmail_ui_user/features/thread/data/extensions/email_change_response_extension.dart';
 import 'package:tmail_ui_user/features/thread/domain/constants/thread_constants.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/get_email_request.dart';
@@ -133,6 +134,8 @@ class ThreadController extends BaseController with EmailActionController {
 
   bool get _isCollapseThreadsEnabled =>
       appProviderContainer.read(localSettingsNotifierProvider).threadConfig.isEnabled;
+
+  bool get _shouldCollapseThreads => forceEmailQuery && _isCollapseThreadsEnabled;
 
   SearchQuery? get searchQuery => _searchEmailFilter.text;
 
@@ -684,12 +687,7 @@ class ThreadController extends BaseController with EmailActionController {
     if (mailboxDashBoardController.isSelectionEnabled()) {
       mailboxDashBoardController.listEmailSelected.value = listEmailSelected;
     }
-    final emailChangeResponse = success.emailChangeResponse;
-    final isEmailChanged = emailChangeResponse?.created?.isNotEmpty == true
-        || emailChangeResponse?.updated?.isNotEmpty == true
-        || emailChangeResponse?.destroyed?.isNotEmpty == true;
-
-    if (isEmailChanged && !canLoadMore) {
+    if (success.emailChangeResponse.hasChanged && !canLoadMore) {
       canLoadMore = true;
     }
     logTrace(
@@ -727,7 +725,7 @@ class ThreadController extends BaseController with EmailActionController {
         getLatestChanges: getLatestChanges,
         useCache: selectedMailbox?.isCacheable ?? false,
         forceEmailQuery: forceEmailQuery,
-        collapseThreads: forceEmailQuery && _isCollapseThreadsEnabled,
+        collapseThreads: _shouldCollapseThreads,
       ));
     } else {
       consumeState(Stream.value(Left(GetAllEmailFailure(NotFoundSessionException()))));
@@ -883,7 +881,7 @@ class ThreadController extends BaseController with EmailActionController {
   Future<void> _refreshChangeListEmail() async {
     log('ThreadController::_refreshChangeListEmail:');
     final refreshViewState = await _refreshChangeListEmailCache(
-      collapseThreads: forceEmailQuery && _isCollapseThreadsEnabled,
+      collapseThreads: _shouldCollapseThreads,
     );
 
     final refreshState = refreshViewState
@@ -919,7 +917,7 @@ class ThreadController extends BaseController with EmailActionController {
             _accountId!,
           ),
           useCache: false,
-          collapseThreads: forceEmailQuery && _isCollapseThreadsEnabled,
+          collapseThreads: _shouldCollapseThreads,
         )
         .last;
 
@@ -967,7 +965,7 @@ class ThreadController extends BaseController with EmailActionController {
           properties: EmailUtils.getPropertiesForEmailGetMethod(_session!, _accountId!),
           lastEmailId: oldestEmail?.id,
           useCache: useCache,
-          collapseThreads: forceEmailQuery && _isCollapseThreadsEnabled,
+          collapseThreads: _shouldCollapseThreads,
         )
       ));
     } else {

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -449,7 +449,6 @@ class ThreadController extends BaseController with EmailActionController {
         } else if (forceEmailQuery) {
           getAllEmailAction(
             forceEmailQuery: forceEmailQuery,
-            limit: limitEmailFetched,
           );
         }
       },
@@ -721,7 +720,7 @@ class ThreadController extends BaseController with EmailActionController {
         getLatestChanges: getLatestChanges,
         useCache: selectedMailbox?.isCacheable ?? false,
         forceEmailQuery: forceEmailQuery,
-        collapseThreads: _isCollapseThreadsEnabled,
+        collapseThreads: forceEmailQuery && _isCollapseThreadsEnabled,
       ));
     } else {
       consumeState(Stream.value(Left(GetAllEmailFailure(NotFoundSessionException()))));
@@ -859,7 +858,7 @@ class ThreadController extends BaseController with EmailActionController {
         _accountId!,
       ),
       emailFilter: getEmailFilterForLoadMailbox(),
-      collapseThreads: _isCollapseThreadsEnabled,
+      collapseThreads: forceEmailQuery && _isCollapseThreadsEnabled,
     ).last;
 
     refreshState.fold(

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -446,6 +446,11 @@ class ThreadController extends BaseController with EmailActionController {
         if (previous?.threadConfig == next.threadConfig) return;
         if (searchController.isSearchEmailRunning) {
           _searchEmail(limit: limitEmailFetched);
+        } else if (forceEmailQuery) {
+          getAllEmailAction(
+            forceEmailQuery: forceEmailQuery,
+            limit: limitEmailFetched,
+          );
         }
       },
       fireImmediately: false,
@@ -570,7 +575,7 @@ class ThreadController extends BaseController with EmailActionController {
     logWarning('ThreadController::_handleErrorGetAllOrRefreshChangesEmail():Error: $error');
     if (error is CannotCalculateChangesMethodResponseException) {
       await cachingManager.clearAllEmailAndStateCache();
-      getAllEmailAction();
+      getAllEmailAction(forceEmailQuery: forceEmailQuery);
     } else if (error is MethodLevelErrors) {
       if (currentOverlayContext != null && error.message != null) {
         appToast.showToastErrorMessage(
@@ -698,13 +703,14 @@ class ThreadController extends BaseController with EmailActionController {
   void getAllEmailAction({
     bool getLatestChanges = true,
     bool forceEmailQuery = false,
+    UnsignedInt? limit,
   }) {
     log('ThreadController::_getAllEmailAction:getLatestChanges = $getLatestChanges');
     if (_session != null &&_accountId != null) {
       consumeState(_getEmailsInMailboxInteractor.execute(
         _session!,
         _accountId!,
-        limit: ThreadConstants.defaultLimit,
+        limit: limit ?? ThreadConstants.defaultLimit,
         sort: EmailSortOrderType.mostRecent.getSortOrder().toNullable(),
         emailFilter: getEmailFilterForLoadMailbox(),
         propertiesCreated: EmailUtils.getPropertiesForEmailGetMethod(_session!, _accountId!),
@@ -715,6 +721,7 @@ class ThreadController extends BaseController with EmailActionController {
         getLatestChanges: getLatestChanges,
         useCache: selectedMailbox?.isCacheable ?? false,
         forceEmailQuery: forceEmailQuery,
+        collapseThreads: _isCollapseThreadsEnabled,
       ));
     } else {
       consumeState(Stream.value(Left(GetAllEmailFailure(NotFoundSessionException()))));
@@ -739,7 +746,7 @@ class ThreadController extends BaseController with EmailActionController {
     if (searchController.isSearchEmailRunning) {
       _searchEmail(limit: limitEmailFetched);
     } else {
-      getAllEmailAction();
+      getAllEmailAction(forceEmailQuery: forceEmailQuery);
     }
   }
 
@@ -852,6 +859,7 @@ class ThreadController extends BaseController with EmailActionController {
         _accountId!,
       ),
       emailFilter: getEmailFilterForLoadMailbox(),
+      collapseThreads: _isCollapseThreadsEnabled,
     ).last;
 
     refreshState.fold(
@@ -903,6 +911,7 @@ class ThreadController extends BaseController with EmailActionController {
             _accountId!,
           ),
           useCache: false,
+          collapseThreads: forceEmailQuery && _isCollapseThreadsEnabled,
         )
         .last;
 
@@ -948,6 +957,7 @@ class ThreadController extends BaseController with EmailActionController {
           properties: EmailUtils.getPropertiesForEmailGetMethod(_session!, _accountId!),
           lastEmailId: oldestEmail?.id,
           useCache: useCache,
+          collapseThreads: forceEmailQuery && _isCollapseThreadsEnabled,
         )
       ));
     } else {

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -481,7 +481,11 @@ void main() {
         emailFilter: anyNamed('emailFilter'),
         getLatestChanges: anyNamed('getLatestChanges'),
         propertiesCreated: anyNamed('propertiesCreated'),
-        propertiesUpdated: anyNamed('propertiesUpdated')));
+        propertiesUpdated: anyNamed('propertiesUpdated'),
+        useCache: anyNamed('useCache'),
+        forceEmailQuery: anyNamed('forceEmailQuery'),
+        collapseThreads: anyNamed('collapseThreads'),
+      ));
       expect(searchController.sortOrderFiltered, EmailSortOrderType.oldest);
       expect(searchController.searchEmailFilter.value, SearchEmailFilter.withSortOrder(EmailSortOrderType.oldest));
       verify(getEmailsInMailboxInteractor.execute(
@@ -491,7 +495,11 @@ void main() {
         emailFilter: threadController.getEmailFilterForLoadMailbox(),
         getLatestChanges: false,
         propertiesCreated: ThreadConstants.propertiesDefault,
-        propertiesUpdated: ThreadConstants.propertiesUpdatedDefault));
+        propertiesUpdated: ThreadConstants.propertiesUpdatedDefault,
+        useCache: true,
+        forceEmailQuery: false,
+        collapseThreads: false,
+      ));
     });
 
     test('WHEN user use advanced search/sort/filter feature, '
@@ -539,7 +547,11 @@ void main() {
         emailFilter: anyNamed('emailFilter'),
         getLatestChanges: anyNamed('getLatestChanges'),
         propertiesCreated: anyNamed('propertiesCreated'),
-        propertiesUpdated: anyNamed('propertiesUpdated')));
+        propertiesUpdated: anyNamed('propertiesUpdated'),
+        useCache: anyNamed('useCache'),
+        forceEmailQuery: anyNamed('forceEmailQuery'),
+        collapseThreads: anyNamed('collapseThreads'),
+      ));
       expect(searchController.sortOrderFiltered, SearchEmailFilter.defaultSortOrder);
       expect(searchController.searchEmailFilter.value, SearchEmailFilter.initial());
       verify(getEmailsInMailboxInteractor.execute(
@@ -549,7 +561,10 @@ void main() {
         emailFilter: threadController.getEmailFilterForLoadMailbox(),
         getLatestChanges: false,
         propertiesCreated: ThreadConstants.propertiesDefault,
-        propertiesUpdated: ThreadConstants.propertiesUpdatedDefault
+        propertiesUpdated: ThreadConstants.propertiesUpdatedDefault,
+        useCache: true,
+        forceEmailQuery: false,
+        collapseThreads: false,
       )).called(1);
     });
 

--- a/test/features/search/verify_before_time_in_search_email_filter_test.dart
+++ b/test/features/search/verify_before_time_in_search_email_filter_test.dart
@@ -853,6 +853,7 @@ void main() {
         propertiesCreated: anyNamed('propertiesCreated'),
         propertiesUpdated: anyNamed('propertiesUpdated'),
         emailFilter: anyNamed('emailFilter'),
+        collapseThreads: anyNamed('collapseThreads'),
       )).thenAnswer((_) => Stream.value(Right(RefreshChangesAllEmailSuccess(emailList: emailList))));
 
       when(mockSearchEmailInteractor.execute(
@@ -887,6 +888,7 @@ void main() {
         ),
         propertiesUpdated: ThreadConstants.propertiesUpdatedDefault,
         emailFilter: threadController.getEmailFilterForLoadMailbox(),
+        collapseThreads: false,
       )).called(1);
 
       verify(mockSearchEmailInteractor.execute(
@@ -1022,6 +1024,7 @@ void main() {
         propertiesCreated: anyNamed('propertiesCreated'),
         propertiesUpdated: anyNamed('propertiesUpdated'),
         emailFilter: anyNamed('emailFilter'),
+        collapseThreads: anyNamed('collapseThreads'),
       )).thenAnswer((_) => Stream.value(Right(RefreshChangesAllEmailSuccess(emailList: emailList))));
 
       when(mockSearchEmailInteractor.execute(
@@ -1056,6 +1059,7 @@ void main() {
         ),
         propertiesUpdated: ThreadConstants.propertiesUpdatedDefault,
         emailFilter: threadController.getEmailFilterForLoadMailbox(),
+        collapseThreads: false,
       )).called(1);
 
       verify(mockSearchEmailInteractor.execute(
@@ -1133,6 +1137,7 @@ void main() {
         propertiesCreated: anyNamed('propertiesCreated'),
         propertiesUpdated: anyNamed('propertiesUpdated'),
         emailFilter: anyNamed('emailFilter'),
+        collapseThreads: anyNamed('collapseThreads'),
       )).thenAnswer((_) => Stream.value(Right(RefreshChangesAllEmailSuccess(emailList: emailList))));
 
       when(mockSearchEmailInteractor.execute(
@@ -1167,6 +1172,7 @@ void main() {
         ),
         propertiesUpdated: ThreadConstants.propertiesUpdatedDefault,
         emailFilter: threadController.getEmailFilterForLoadMailbox(),
+        collapseThreads: false,
       )).called(1);
 
       verify(mockSearchEmailInteractor.execute(

--- a/test/features/thread/data/repository/thread_repository_impl_test.dart
+++ b/test/features/thread/data/repository/thread_repository_impl_test.dart
@@ -1454,6 +1454,80 @@ void main() {
       },
     );
 
+    test(
+      'SHOULD always call network\n'
+      'WHEN collapseThreads is true even if cache has enough emails',
+      () async {
+        final cacheEmails = List.generate(
+          ThreadConstants.defaultLimit.value.toInt(),
+          (i) => Email(id: EmailId(Id('cache_$i'))),
+        );
+
+        when(localDataSource.getAllEmailCache(
+          any,
+          any,
+          filterOption: anyNamed('filterOption'),
+          inMailboxId: anyNamed('inMailboxId'),
+          limit: anyNamed('limit'),
+          sort: anyNamed('sort'),
+        )).thenAnswer((_) async => cacheEmails);
+
+        when(refreshChangesStateDataSource.getState(any, any, any))
+            .thenAnswer((_) async => State('cache_state'));
+
+        when(networkDataSource.getChanges(
+          any,
+          any,
+          any,
+          propertiesCreated: anyNamed('propertiesCreated'),
+          propertiesUpdated: anyNamed('propertiesUpdated'),
+        )).thenAnswer((_) async => EmailChangeResponse(
+              hasMoreChanges: false,
+            ));
+
+        final networkEmails = List.generate(
+          ThreadConstants.defaultLimit.value.toInt(),
+          (i) => Email(id: EmailId(Id('collapsed_$i'))),
+        );
+
+        when(networkDataSource.getAllEmail(
+          any,
+          any,
+          limit: anyNamed('limit'),
+          position: anyNamed('position'),
+          sort: anyNamed('sort'),
+          filter: anyNamed('filter'),
+          properties: anyNamed('properties'),
+          collapseThreads: anyNamed('collapseThreads'),
+        )).thenAnswer((_) async => EmailsResponse(
+              emailList: networkEmails,
+              state: State('network_state'),
+            ));
+
+        final result = await refreshChangesThreadRepository
+            .refreshChanges(
+              SessionFixtures.aliceSession,
+              AccountFixtures.aliceAccountId,
+              State('initial'),
+              collapseThreads: true,
+            )
+            .first;
+
+        verify(networkDataSource.getAllEmail(
+          any,
+          any,
+          limit: anyNamed('limit'),
+          position: anyNamed('position'),
+          sort: anyNamed('sort'),
+          filter: anyNamed('filter'),
+          properties: anyNamed('properties'),
+          collapseThreads: true,
+        )).called(1);
+
+        expect(result.emailList, networkEmails);
+      },
+    );
+
     tearDown(() {
       reset(networkDataSource);
       reset(localDataSource);

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -339,6 +339,7 @@ void main() {
           propertiesCreated: anyNamed('propertiesCreated'),
           propertiesUpdated: anyNamed('propertiesUpdated'),
           emailFilter: anyNamed('emailFilter'),
+          collapseThreads: anyNamed('collapseThreads'),
         )).thenAnswer((_) => Stream.value(Right(RefreshChangesAllEmailSuccess(
           emailList: emailList,
           currentEmailState: State('old-state'))))
@@ -514,6 +515,9 @@ void main() {
           emailFilter: anyNamed('emailFilter'),
           propertiesCreated: anyNamed('propertiesCreated'),
           propertiesUpdated: anyNamed('propertiesUpdated'),
+          useCache: anyNamed('useCache'),
+          forceEmailQuery: anyNamed('forceEmailQuery'),
+          collapseThreads: anyNamed('collapseThreads'),
           getLatestChanges: false,
         ));
         
@@ -526,6 +530,9 @@ void main() {
           emailFilter: anyNamed('emailFilter'),
           propertiesCreated: anyNamed('propertiesCreated'),
           propertiesUpdated: anyNamed('propertiesUpdated'),
+          useCache: anyNamed('useCache'),
+          forceEmailQuery: anyNamed('forceEmailQuery'),
+          collapseThreads: anyNamed('collapseThreads'),
           getLatestChanges: false,
         ));
       });


### PR DESCRIPTION
## Issue

#4400 

## Blocker

- https://github.com/linagora/tmail-flutter/pull/4364 

## Resolved


https://github.com/user-attachments/assets/8bc559af-29b1-45a1-9ca9-ccbcc0832734



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added thread collapsing functionality to organize email conversations
  * Introduced local settings management to control thread display preferences on web

* **Refactor**
  * Improved internal method signatures to support thread configuration across email operations
  * Enhanced query construction patterns for cleaner parameter handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->