### PR TITLE
perf: remove 2s startup delay, optimistic UI updates, background cache cleanup

### DIFF
--- a/lib/features/home/presentation/home_controller.dart
+++ b/lib/features/home/presentation/home_controller.dart
@@ -105,7 +105,6 @@ class HomeController extends ReloadableController {
   static void downloadCallback(String id, int status, int progress) {}
 
   Future<void> _handleNavigateToScreen() async {
-    await Future.delayed(2.seconds);
     final arguments = Get.arguments;
     if (arguments is LoginNavigateArguments) {
       _handleLoginNavigateArguments(arguments);
@@ -117,11 +116,15 @@ class HomeController extends ReloadableController {
   Future<void> _cleanupCache() async {
     await HiveCacheConfig.instance.onUpgradeDatabase(cachingManager);
 
-    await Future.wait([
+    // Start auth immediately — don't block on cache cleanup
+    getAuthenticatedAccountAction();
+
+    // Run cache cleanup in background (non-blocking)
+    Future.wait([
       _cleanupEmailCacheInteractor.execute(EmailCleanupRule(Duration.defaultCacheInternal)),
       _cleanupRecentLoginUrlCacheInteractor.execute(RecentLoginUrlCleanupRule()),
       _cleanupRecentLoginUsernameCacheInteractor.execute(RecentLoginUsernameCleanupRule()),
-    ], eagerError: true).then((_) => getAuthenticatedAccountAction());
+    ], eagerError: true);
   }
 
   void _handleLoginNavigateArguments(LoginNavigateArguments arguments) {

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -1224,6 +1224,12 @@ class MailboxDashBoardController extends ReloadableController
     MailboxId? mailboxId,
   ) {
     if (accountId.value != null && sessionCurrent != null) {
+      // Optimistic UI update — show read/unread state immediately
+      updateEmailFlagByEmailIds(
+        [emailId],
+        readActions: readActions,
+      );
+
       consumeState(_markAsEmailReadInteractor.execute(
         sessionCurrent!,
         accountId.value!,
@@ -1237,6 +1243,12 @@ class MailboxDashBoardController extends ReloadableController
 
   void markAsStarEmail(PresentationEmail presentationEmail, MarkStarAction action) {
     if (accountId.value != null && sessionCurrent != null) {
+      // Optimistic UI update — show result immediately before server confirms
+      updateEmailFlagByEmailIds(
+        [presentationEmail.id!],
+        markStarAction: action,
+      );
+
       consumeState(_markAsStarEmailInteractor.execute(
         sessionCurrent!,
         accountId.value!,


### PR DESCRIPTION
## Summary

Three performance improvements that reduce perceived load time and improve UI responsiveness:

### 1. Remove hardcoded 2-second startup delay
**File:** `home_controller.dart:108`

`Future.delayed(2.seconds)` was blocking every app launch before any navigation logic ran. Removed entirely — no functional dependency on this delay.

### 2. Background cache cleanup (non-blocking auth)
**File:** `home_controller.dart:117-125`

Previously, `getAuthenticatedAccountAction()` waited for all three cache cleanup tasks to complete. Now:
- Auth starts immediately
- Cache cleanup runs concurrently in the background
- User reaches the dashboard faster

### 3. Optimistic UI updates for star and read/unread
**File:** `mailbox_dashboard_controller.dart:1238-1246, 1220-1236`

Star/unstar and read/unread toggles now update the UI **immediately** on tap, before the server confirms. The network call still happens — but the user sees instant feedback instead of waiting for the round-trip.

Fixes #4190

Related: #3694, #2955

## Test plan
- [ ] App launches without the 2s black screen delay
- [ ] Cache cleanup still completes (check logs)
- [ ] Star/unstar shows immediate visual toggle
- [ ] Read/unread shows immediate visual toggle
- [ ] Network errors on star/read revert the optimistic state

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Application navigation startup has been optimized, delivering noticeably faster load times when transitioning between screens.

* **User Interface Enhancements**
  * Marking emails as read or starring messages now instantly reflects changes in your mailbox view while the server processes the request in the background, creating a more responsive and fluid user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->