### PR TITLE
ADR-0073 Android Auto Backup & Session Restore

### DIFF
--- a/docs/adr/0073-android-auto-backup-and-session-restore.md
+++ b/docs/adr/0073-android-auto-backup-and-session-restore.md
@@ -8,124 +8,45 @@ Proposed
 
 ## Context
 
-### Background: Android Auto Backup
+Android 6.0+ enables Auto Backup by default, backing up Hive databases and SharedPreferences to Google Drive. On reinstall, this data is restored **before the app first launches** — causing the app to auto-login without re-authentication.
 
-Starting from Android 6.0 Marshmallow, the `allowBackup` flag is enabled by default (`true`), allowing the system to automatically back up app data including SharedPreferences, databases, and internal files to the user's Google Drive. When reinstalling the app or setting up a new device, the system automatically restores this data **before the app is launched for the first time**.
+The fix must handle three cases correctly:
 
-| Question | Answer |
-|---|---|
-| What is it? | Android's automatic backup mechanism that uploads SharedPreferences, databases, and files to Google Drive when the device is idle, charging, and connected to Wi-Fi. |
-| Why was it added? | To reduce friction when users switch devices or reinstall apps — preserving app state, keeping users logged in, and avoiding data loss. |
-| Is it common practice? | Yes. Auto Backup is enabled by default and widely used. However, apps handling sensitive data (auth tokens, encryption keys) often disable it or exclude specific data for security reasons. |
-| Does disabling it bring trade-offs? | Yes. Better security and avoids key mismatch issues, but users will lose local data on reinstall or device change and must log in again. |
+| # | Scenario | Required Behavior |
+|---|---|---|
+| 1 | Update from old → new version | ✅ Keep auto login (hard requirement) |
+| 2 | Backup → uninstall → reinstall new version | ❌ Force login |
+| 3 | Fresh install | ❌ Force login |
 
-### Current Problem
-
-The app currently does not set the `allowBackup` flag in `AndroidManifest.xml`. Android enables Auto Backup by default, causing all Hive database and SharedPreferences data to be backed up to Google Drive.
-
-When a user backs up their data, uninstalls the app, and reinstalls it, Android restores this data before the app runs for the first time. Since account information remains in Hive, the app reads the old session and **automatically logs in without requiring re-authentication**.
-
-### Three Cases to Handle After the Fix
-
-| # | Scenario | Current Behavior | Expected After Fix |
-|---|---|---|---|
-| 1 | Currently using old version → update to new version | ✅ Auto login | ✅ Must continue to auto login (**hard requirement**) |
-| 2 | Backed up data, uninstalled → reinstall new fixed version | ❌ Auto login (bug) | ✅ Must require login |
-| 3 | Fresh install (never used the app before) | ✅ Requires login | ✅ Must require login |
-
-## Problem Analysis
-
-### The Core Challenge
-
-The challenge is not just disabling backup — it's **distinguishing between two states** after the fix, because both produce identical technical results on the device:
-
-| State | Hive | Secure Storage | Requirement |
-|---|---|---|---|
-| Update app from old to new version | ✅ Has data | ❌ Empty (never written) | ✅ Allow auto login |
-| Uninstall (with backup) → reinstall new version | ✅ Has data (restored) | ❌ Empty (cleared on uninstall) | ❌ Force login |
-
-**These two cases are technically identical on the client side.** There is no information on the device that can reliably distinguish them without server support.
+**Core challenge:** Cases 1 and 2 are **technically identical on the client** — both have Hive data present and Secure Storage empty. No client-side signal can reliably distinguish them.
 
 ## Options Considered
 
-### Option 1: Disable Auto Backup (`allowBackup=false`)
-
-Set `allowBackup=false` in `AndroidManifest.xml` combined with `dataExtractionRules` to exclude all Hive and SharedPreferences data from backup.
-
-**Pros:** Simple, no additional logic required. Prevents backup from the new version onwards.
-
-**Cons:** Does not solve the Case 1 vs Case 2 distinction problem. Users updating from the old version will still be logged out because there is no mechanism to differentiate an update from a restore.
-
-| # | Case | Before Fix | After Fix | Requirement |
+| Option | Case 1 (update) | Case 2 (uninstall+backup) | Case 3 (fresh) | Backend? |
 |---|---|---|---|---|
-| 1 | Update app | ✅ Auto login | ❌ Logged out | Hard requirement |
-| 2 | Uninstall + reinstall (with backup) | ❌ Auto login (bug) | ❌ Still auto login (old backup persists) | Must fix |
-| 3 | Fresh install | ✅ Force login | ✅ Force login | Already correct |
+| 1. Disable backup only | ❌ Logged out | ❌ Still broken | ✅ | No |
+| 2. Disable backup + Secure Storage token | ❌ Logged out | ✅ | ✅ | No |
+| 3. File timestamp heuristic | ⚠️ Unreliable | ⚠️ Unreliable | ⚠️ | No |
+| 4. Backend session validation | ✅ | ✅ (2nd time+) | ✅ | **Yes** |
 
-> **Note:** On Android 12+, `allowBackup=false` only disables cloud backup (Google Drive) but **does not** disable device-to-device (D2D) transfers. `dataExtractionRules` is required to control D2D behavior.
+**Option 2** stores the auth token in `flutter_secure_storage` (Android Keystore, never backed up). Uninstall clears it → force login. But users updating from old version have no token yet → also logged out, violating Case 1.
 
-### Option 2: Disable Auto Backup + Flutter Secure Storage
+**Option 4** validates the session token server-side on each startup. The server invalidates old tokens on re-login, making Case 2 correct on the second reinstall. Only complete solution but requires backend changes and adds startup latency.
 
-Combines Option 1 with moving the auth token to `flutter_secure_storage` (backed by Android Keystore — never included in any backup). On app startup, check Secure Storage: token present → auto login, token absent → force login.
-
-**Pros:** Correctly handles Case 2 and Case 3. Secure Storage is never backed up — when the app is uninstalled the token is cleared, so reinstalling requires login.
-
-**Cons:** Still cannot distinguish Case 1 from Case 2. Both produce the same result: Secure Storage empty + Hive has data. Users updating from the old version (who have never written a token to Secure Storage) will be logged out — **violating the hard requirement**.
-
-| # | Case | Secure Storage | Result | Requirement |
-|---|---|---|---|---|
-| 1 | Update from old version | ❌ Empty (never written) | ❌ Logged out | Hard requirement |
-| 2 | Uninstall + reinstall (with backup) | ❌ Empty (cleared) | ❌ Force login | ✅ Correct |
-| 3 | Fresh install | ❌ Not present | ❌ Force login | ✅ Correct |
-
-### Option 3: File Timestamp Detection
-
-Based on the hypothesis that when Android restores a backup, the `.hive` file is written fresh → the creation timestamp would reflect the restore time, which differs from a user who has been continuously using the app.
-
-**Pros:** No backend required. If it works, could potentially distinguish update from restore.
-
-**Cons / Reason for rejection:** No official Google documentation confirms timestamp behavior during backup restore. Behavior depends on Android version, filesystem (FUSE vs SDCardFS), and OEM implementation. Not reliable enough to use as a security gate.
-
-### Option 4: Backend Session Validation
-
-On successful login, the server issues and stores a session token. Each time the app starts, it calls an API to validate the token. When the user logs in again (after uninstall + reinstall), the server issues a new token and invalidates the old one.
-
-**Pros:** The only solution that correctly handles all 3 cases. The server is the source of truth — independent of client state.
-
-**Cons:** Requires backend API changes. Adds latency on app startup (requires a network call).
-
-| # | Case | Server Token | Result | Requirement |
-|---|---|---|---|---|
-| 1 | Update app | ✅ Still valid | ✅ Auto login | ✅ Correct |
-| 2 | Uninstall + reinstall (with backup, 1st time) | ✅ Still valid (not yet re-logged in) | ✅ Auto login | Acceptable |
-| 2b | Uninstall + reinstall (with backup, 2nd time+) | ❌ Invalidated | ❌ Force login | ✅ Correct |
-| 3 | Fresh install | ❌ Not present | ❌ Force login | ✅ Correct |
-
-## Options Summary
-
-| Option | Case 1 (update) | Case 2 (uninstall+backup) | Case 3 (fresh install) | Needs Backend? |
-|---|---|---|---|---|
-| Option 1: Disable Backup only | ❌ Logged out | ❌ Still broken | ✅ | No |
-| Option 2: Disable Backup + Secure Storage | ❌ Logged out | ✅ | ✅ | No |
-| Option 3: File timestamp | ⚠️ Unreliable | ⚠️ Unreliable | ⚠️ | No |
-| Option 4: Backend validation | ✅ | ✅ (2nd time+) | ✅ | **Yes** |
-
-**No client-only solution can correctly handle both Case 1 (hard requirement) and Case 2 simultaneously.** This is a technical limitation: after a backup restore, the device leaves no reliable signal that the app can use to determine whether data came from an update or a restore.
+> Note: On Android 12+, `allowBackup=false` only disables cloud backup. `dataExtractionRules` is required to also block device-to-device (D2D) transfers.
 
 ## Open Questions
 
-- Is the team willing to accept the trade-off in Option 2 — users updating from the old version are logged out **exactly once** when upgrading? If this hard requirement can be relaxed → Option 2 is the simplest viable solution.
-- Can the backend be extended to support session validation? If yes → Option 4 is the only complete solution.
-- If Option 4 is chosen, how should offline behavior be handled (trust local session when there is no network)?
+- Can the team accept Option 2's trade-off — users updating from the old version are logged out **exactly once**? If yes → Option 2 is the simplest path.
+- Can the backend support session validation? If yes → Option 4 is the only complete solution.
+- If Option 4: how to handle offline startup (trust local session when no network)?
 
 ## Decision
 
-No decision has been made. This ADR is in **Proposed** status, pending team discussion and trade-off evaluation across the options above.
+Pending team discussion. No decision made yet.
 
 ## References
 
-- [Android Developers — Back up user data with Auto Backup](https://developer.android.com/identity/data/autobackup)
-- [Google One Help — Backup retention policy (57-day device inactivity)](https://support.google.com/googleone/answer/9149304)
-- [Android Developers — Data backup overview](https://developer.android.com/identity/data/backup)
-- [flutter\_secure\_storage package](https://pub.dev/packages/flutter_secure_storage)
+- [Android Auto Backup](https://developer.android.com/identity/data/autobackup)
+- [flutter\_secure\_storage](https://pub.dev/packages/flutter_secure_storage)
 - [Android Keystore System](https://developer.android.com/privacy-and-security/keystore)

--- a/docs/adr/0073-android-auto-backup-and-session-restore.md
+++ b/docs/adr/0073-android-auto-backup-and-session-restore.md
@@ -1,0 +1,131 @@
+# 0073 - Android Auto Backup & Session Restore
+
+Date: 2026-03-31
+
+## Status
+
+Proposed
+
+## Context
+
+### Background: Android Auto Backup
+
+Starting from Android 6.0 Marshmallow, the `allowBackup` flag is enabled by default (`true`), allowing the system to automatically back up app data including SharedPreferences, databases, and internal files to the user's Google Drive. When reinstalling the app or setting up a new device, the system automatically restores this data **before the app is launched for the first time**.
+
+| Question | Answer |
+|---|---|
+| What is it? | Android's automatic backup mechanism that uploads SharedPreferences, databases, and files to Google Drive when the device is idle, charging, and connected to Wi-Fi. |
+| Why was it added? | To reduce friction when users switch devices or reinstall apps — preserving app state, keeping users logged in, and avoiding data loss. |
+| Is it common practice? | Yes. Auto Backup is enabled by default and widely used. However, apps handling sensitive data (auth tokens, encryption keys) often disable it or exclude specific data for security reasons. |
+| Does disabling it bring trade-offs? | Yes. Better security and avoids key mismatch issues, but users will lose local data on reinstall or device change and must log in again. |
+
+### Current Problem
+
+The app currently does not set the `allowBackup` flag in `AndroidManifest.xml`. Android enables Auto Backup by default, causing all Hive database and SharedPreferences data to be backed up to Google Drive.
+
+When a user backs up their data, uninstalls the app, and reinstalls it, Android restores this data before the app runs for the first time. Since account information remains in Hive, the app reads the old session and **automatically logs in without requiring re-authentication**.
+
+### Three Cases to Handle After the Fix
+
+| # | Scenario | Current Behavior | Expected After Fix |
+|---|---|---|---|
+| 1 | Currently using old version → update to new version | ✅ Auto login | ✅ Must continue to auto login (**hard requirement**) |
+| 2 | Backed up data, uninstalled → reinstall new fixed version | ❌ Auto login (bug) | ✅ Must require login |
+| 3 | Fresh install (never used the app before) | ✅ Requires login | ✅ Must require login |
+
+## Problem Analysis
+
+### The Core Challenge
+
+The challenge is not just disabling backup — it's **distinguishing between two states** after the fix, because both produce identical technical results on the device:
+
+| State | Hive | Secure Storage | Requirement |
+|---|---|---|---|
+| Update app from old to new version | ✅ Has data | ❌ Empty (never written) | ✅ Allow auto login |
+| Uninstall (with backup) → reinstall new version | ✅ Has data (restored) | ❌ Empty (cleared on uninstall) | ❌ Force login |
+
+**These two cases are technically identical on the client side.** There is no information on the device that can reliably distinguish them without server support.
+
+## Options Considered
+
+### Option 1: Disable Auto Backup (`allowBackup=false`)
+
+Set `allowBackup=false` in `AndroidManifest.xml` combined with `dataExtractionRules` to exclude all Hive and SharedPreferences data from backup.
+
+**Pros:** Simple, no additional logic required. Prevents backup from the new version onwards.
+
+**Cons:** Does not solve the Case 1 vs Case 2 distinction problem. Users updating from the old version will still be logged out because there is no mechanism to differentiate an update from a restore.
+
+| # | Case | Before Fix | After Fix | Requirement |
+|---|---|---|---|---|
+| 1 | Update app | ✅ Auto login | ❌ Logged out | Hard requirement |
+| 2 | Uninstall + reinstall (with backup) | ❌ Auto login (bug) | ❌ Still auto login (old backup persists) | Must fix |
+| 3 | Fresh install | ✅ Force login | ✅ Force login | Already correct |
+
+> **Note:** On Android 12+, `allowBackup=false` only disables cloud backup (Google Drive) but **does not** disable device-to-device (D2D) transfers. `dataExtractionRules` is required to control D2D behavior.
+
+### Option 2: Disable Auto Backup + Flutter Secure Storage
+
+Combines Option 1 with moving the auth token to `flutter_secure_storage` (backed by Android Keystore — never included in any backup). On app startup, check Secure Storage: token present → auto login, token absent → force login.
+
+**Pros:** Correctly handles Case 2 and Case 3. Secure Storage is never backed up — when the app is uninstalled the token is cleared, so reinstalling requires login.
+
+**Cons:** Still cannot distinguish Case 1 from Case 2. Both produce the same result: Secure Storage empty + Hive has data. Users updating from the old version (who have never written a token to Secure Storage) will be logged out — **violating the hard requirement**.
+
+| # | Case | Secure Storage | Result | Requirement |
+|---|---|---|---|---|
+| 1 | Update from old version | ❌ Empty (never written) | ❌ Logged out | Hard requirement |
+| 2 | Uninstall + reinstall (with backup) | ❌ Empty (cleared) | ❌ Force login | ✅ Correct |
+| 3 | Fresh install | ❌ Not present | ❌ Force login | ✅ Correct |
+
+### Option 3: File Timestamp Detection
+
+Based on the hypothesis that when Android restores a backup, the `.hive` file is written fresh → the creation timestamp would reflect the restore time, which differs from a user who has been continuously using the app.
+
+**Pros:** No backend required. If it works, could potentially distinguish update from restore.
+
+**Cons / Reason for rejection:** No official Google documentation confirms timestamp behavior during backup restore. Behavior depends on Android version, filesystem (FUSE vs SDCardFS), and OEM implementation. Not reliable enough to use as a security gate.
+
+### Option 4: Backend Session Validation
+
+On successful login, the server issues and stores a session token. Each time the app starts, it calls an API to validate the token. When the user logs in again (after uninstall + reinstall), the server issues a new token and invalidates the old one.
+
+**Pros:** The only solution that correctly handles all 3 cases. The server is the source of truth — independent of client state.
+
+**Cons:** Requires backend API changes. Adds latency on app startup (requires a network call).
+
+| # | Case | Server Token | Result | Requirement |
+|---|---|---|---|---|
+| 1 | Update app | ✅ Still valid | ✅ Auto login | ✅ Correct |
+| 2 | Uninstall + reinstall (with backup, 1st time) | ✅ Still valid (not yet re-logged in) | ✅ Auto login | Acceptable |
+| 2b | Uninstall + reinstall (with backup, 2nd time+) | ❌ Invalidated | ❌ Force login | ✅ Correct |
+| 3 | Fresh install | ❌ Not present | ❌ Force login | ✅ Correct |
+
+## Options Summary
+
+| Option | Case 1 (update) | Case 2 (uninstall+backup) | Case 3 (fresh install) | Needs Backend? |
+|---|---|---|---|---|
+| Option 1: Disable Backup only | ❌ Logged out | ❌ Still broken | ✅ | No |
+| Option 2: Disable Backup + Secure Storage | ❌ Logged out | ✅ | ✅ | No |
+| Option 3: File timestamp | ⚠️ Unreliable | ⚠️ Unreliable | ⚠️ | No |
+| Option 4: Backend validation | ✅ | ✅ (2nd time+) | ✅ | **Yes** |
+
+**No client-only solution can correctly handle both Case 1 (hard requirement) and Case 2 simultaneously.** This is a technical limitation: after a backup restore, the device leaves no reliable signal that the app can use to determine whether data came from an update or a restore.
+
+## Open Questions
+
+- Is the team willing to accept the trade-off in Option 2 — users updating from the old version are logged out **exactly once** when upgrading? If this hard requirement can be relaxed → Option 2 is the simplest viable solution.
+- Can the backend be extended to support session validation? If yes → Option 4 is the only complete solution.
+- If Option 4 is chosen, how should offline behavior be handled (trust local session when there is no network)?
+
+## Decision
+
+No decision has been made. This ADR is in **Proposed** status, pending team discussion and trade-off evaluation across the options above.
+
+## References
+
+- [Android Developers — Back up user data with Auto Backup](https://developer.android.com/identity/data/autobackup)
+- [Google One Help — Backup retention policy (57-day device inactivity)](https://support.google.com/googleone/answer/9149304)
+- [Android Developers — Data backup overview](https://developer.android.com/identity/data/backup)
+- [flutter\_secure\_storage package](https://pub.dev/packages/flutter_secure_storage)
+- [Android Keystore System](https://developer.android.com/privacy-and-security/keystore)

--- a/docs/adr/0073-android-auto-backup-and-session-restore.md
+++ b/docs/adr/0073-android-auto-backup-and-session-restore.md
@@ -4,49 +4,122 @@ Date: 2026-03-31
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
-Android 6.0+ enables Auto Backup by default, backing up Hive databases and SharedPreferences to Google Drive. On reinstall, this data is restored **before the app first launches** — causing the app to auto-login without re-authentication.
+Android 6.0+ (API 23+) enables Auto Backup by default. App data is automatically backed up to the user's private Google Drive folder (up to 25 MB per app) and **restored before the app first launches** after reinstall.
 
-The fix must handle three cases correctly:
+**The problem:** Hive databases and `SharedPreferences` restored from backup cause the app to auto-login with stale credentials without re-authentication.
+
+The fix must handle all cases correctly:
+
+**Old user** (prior version had backup enabled):
 
 | # | Scenario | Required Behavior |
 |---|---|---|
-| 1 | Update from old → new version | ✅ Keep auto login (hard requirement) |
-| 2 | Backup → uninstall → reinstall new version | ❌ Force login |
-| 3 | Fresh install | ❌ Force login |
+| 1 | Update old version → new version | Keep auto login |
+| 2 | Uninstall → reinstall new version | Force login |
 
-**Core challenge:** Cases 1 and 2 are **technically identical on the client** — both have Hive data present and Secure Storage empty. No client-side signal can reliably distinguish them.
+**New user** (installs new version directly):
 
-## Options Considered
-
-| Option | Case 1 (update) | Case 2 (uninstall+backup) | Case 3 (fresh) | Backend? |
-|---|---|---|---|---|
-| 1. Disable backup only | ❌ Logged out | ❌ Still broken | ✅ | No |
-| 2. Disable backup + Secure Storage token | ❌ Logged out | ✅ | ✅ | No |
-| 3. File timestamp heuristic | ⚠️ Unreliable | ⚠️ Unreliable | ⚠️ | No |
-| 4. Backend session validation | ✅ | ✅ (2nd time+) | ✅ | **Yes** |
-
-**Option 2** stores the auth token in `flutter_secure_storage` (Android Keystore, never backed up). Uninstall clears it → force login. But users updating from old version have no token yet → also logged out, violating Case 1.
-
-**Option 4** validates the session token server-side on each startup. The server invalidates old tokens on re-login, making Case 2 correct on the second reinstall. Only complete solution but requires backend changes and adds startup latency.
-
-> Note: On Android 12+, `allowBackup=false` only disables cloud backup. `dataExtractionRules` is required to also block device-to-device (D2D) transfers.
-
-## Open Questions
-
-- Can the team accept Option 2's trade-off — users updating from the old version are logged out **exactly once**? If yes → Option 2 is the simplest path.
-- Can the backend support session validation? If yes → Option 4 is the only complete solution.
-- If Option 4: how to handle offline startup (trust local session when no network)?
+| # | Scenario | Required Behavior |
+|---|---|---|
+| 3 | Fresh install | Force login |
+| 4 | Uninstall → reinstall | Force login |
 
 ## Decision
 
-Pending team discussion. No decision made yet.
+**Disable Android Auto Backup** by:
+
+1. Setting `android:allowBackup="false"` — disables cloud backup on all Android versions.
+2. Adding `android:dataExtractionRules` (Android 12+ / API 31+) with empty `<cloud-backup>` and `<device-transfer>` blocks — because `allowBackup=false` alone does **not** block device-to-device (D2D) transfers on Android 12+. An empty block means no data is included, so no explicit `<exclude>` rules are needed.
+
+> `fullBackupContent` (Android ≤ 11) is not required here — it only applies when backup is enabled. Since `allowBackup=false` already disables cloud backup on those versions, there is nothing to configure.
+
+**`AndroidManifest.xml`:**
+```xml
+<application
+    android:allowBackup="false"
+    android:dataExtractionRules="@xml/data_extraction_rules"
+    ...>
+```
+
+**`res/xml/data_extraction_rules.xml`** (Android 12+):
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup/>
+    <device-transfer/>
+</data-extraction-rules>
+```
+
+## Consequences
+
+### Positive
+- **No logout regression on update** — app data stays on device through updates; no startup detection logic required.
+- No backend changes required — fully client-side.
+- Covers both cloud backup and D2D transfers across all Android versions (6.0+).
+- Minimal config: one XML file + one manifest attribute. No verbose exclude rules needed.
+
+### Negative / Trade-offs
+- User still be auto login in case of **Backup → uninstall → reinstall new version**
+- `allowBackup=false` alone is insufficient on Android 12+ — a `dataExtractionRules` file with empty `<device-transfer>` is mandatory to also block D2D transfers.
+
+**Scenario matrix post-decision:**
+
+**Old user** — previously installed a version with `allowBackup=true` (backup was created):
+
+| # | Scenario | Behavior |
+|---|---|---|
+| 1 | Update old version → new version | Data stays on device, no logout |
+| 2 | Uninstall → reinstall new version | Old backup still restored, auto login |
+
+**New user** — installed new version directly (no prior backup ever created):
+
+| # | Scenario | Behavior |
+|---|---|---|
+| 3 | Fresh install | No data, force login |
+| 4 | Uninstall → reinstall | No backup to restore, force login |
+
+## Alternatives
+
+### Option 2 — Disable backup + Secure Storage sentinel token
+Store a sentinel token in `flutter_secure_storage` (Android Keystore — hardware-bound, never exported in backups). On startup: Hive data present + sentinel absent → data is from a backup → force login.
+
+| Case | Result |
+|---|---|
+| Update (Case 1) | ❌ Logged out (no sentinel in old install) |
+| Uninstall + reinstall (Case 2) | ✅ Force login (Keystore cleared on uninstall) |
+| Fresh install (Case 3) | ✅ Force login |
+
+**Why not chosen:** Same Case 1 regression as the chosen option, with added complexity. Requires a `flutter_secure_storage` dependency, an extra Keystore read on every cold start, and additional failure surface (Keystore unavailable on some low-end devices). No improvement for the affected case.
+
+### Option 3 — File timestamp heuristic
+Compare Hive database file timestamps against `PackageInfo.firstInstallTime` to infer whether files were restored from backup.
+
+| Case | Result |
+|---|---|
+| Update (Case 1) | ⚠️ Unreliable |
+| Uninstall + reinstall (Case 2) | ⚠️ Unreliable |
+| Fresh install (Case 3) | ⚠️ Unreliable |
+
+**Why not chosen:** Android Auto Backup can preserve original file timestamps on restore. Behavior varies by OEM and Android version — `firstInstallTime` reflects the current install but restored files may carry timestamps from the previous install, which is indistinguishable from a normal update. Not deterministically testable.
+
+### Option 4 — Backend session validation
+Validate the local session token server-side on every cold start. The server invalidates tokens from a previous install upon re-login; the next reinstall then correctly rejects the stale token.
+
+| Case | Result |
+|---|---|
+| Update (Case 1) | ✅ Keep auto login |
+| Uninstall + reinstall (Case 2) | ✅ Force login (from 2nd reinstall onward) |
+| Fresh install (Case 3) | ✅ Force login |
+
+**Why not chosen:** Requires backend API changes, adds startup latency on every cold start, and introduces an offline failure mode: if there is no network on startup the app must decide whether to trust the local session or block login — either choice creates a security/UX trade-off. The only complete solution for Case 1, but out of scope for the current release cycle.
 
 ## References
 
 - [Android Auto Backup](https://developer.android.com/identity/data/autobackup)
+- [Data extraction rules — Android 12+](https://developer.android.com/identity/data/autobackup#xml-syntax-android-12)
 - [flutter\_secure\_storage](https://pub.dev/packages/flutter_secure_storage)
 - [Android Keystore System](https://developer.android.com/privacy-and-security/keystore)


### PR DESCRIPTION
## Descriptions

An ADR suggests a solution to the problem https://github.com/linagora/james-project-private/issues/1177


## Related

https://github.com/linagora/tmail-flutter/pull/4393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an accepted ADR documenting Android Auto Backup behavior that can restore credentials and cause auto-login after reinstall. It defines user scenarios (update, uninstall+reinstall with prior backup, fresh install), recommends disabling platform backups and blocking device-to-device transfers on newer Android versions, outlines trade-offs (existing users may still see restored sessions; fix is client-side), and records alternatives considered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->