### PR TITLE
TF-4425 Fix load more not triggered on iOS 18 when fast scrolling to bottom    

### DIFF
--- a/docs/adr/0075-fix-load-more-not-triggered-on-ios-fast-scroll.md
+++ b/docs/adr/0075-fix-load-more-not-triggered-on-ios-fast-scroll.md
@@ -1,0 +1,66 @@
+# 0075. Fix load more not triggered on iOS when fast scrolling to bottom
+
+Date: 2026-03-31
+
+## Status
+
+- Issues:
+  - [TF-4425 Bug: load more is not working](https://github.com/linagora/tmail-flutter/issues/TF-4425)
+
+## Context
+
+On iOS 18, the `handleLoadMoreEmailsRequest()` was not called when users fast-scrolled to the bottom of the email list.
+
+The scroll listener in `thread_view.dart` used an exact equality check to detect when the user had reached the bottom:
+
+```dart
+bool _handleScrollNotificationListener(ScrollNotification scrollInfo) {
+  if (scrollInfo is ScrollEndNotification &&
+      scrollInfo.metrics.pixels == scrollInfo.metrics.maxScrollExtent &&
+      !controller.loadingMoreStatus.value.isRunning &&
+      scrollInfo.metrics.axisDirection == AxisDirection.down
+  ) {
+    controller.handleLoadMoreEmailsRequest();
+  }
+  return false;
+}
+```
+
+**Root cause: iOS `BouncingScrollPhysics` causes overscroll past `maxScrollExtent`.**
+
+The `ListView` uses `AlwaysScrollableScrollPhysics()` without an explicit `parent`. This means the effective physics inherits from the platform's ambient `ScrollConfiguration`:
+- **Android** → `ClampingScrollPhysics`: clamps `pixels` within `[0, maxScrollExtent]`. When the user reaches the bottom, `pixels` is always exactly equal to `maxScrollExtent` when `ScrollEndNotification` fires.
+- **iOS** → `BouncingScrollPhysics`: allows `pixels` to overshoot `maxScrollExtent` (the rubber-band/bounce effect). When the user fast-scrolls and lifts their finger, `pixels > maxScrollExtent` at the moment `ScrollEndNotification` fires. The spring-back animation that follows only emits `ScrollUpdateNotification` — no second `ScrollEndNotification` is ever fired once the content settles at `maxScrollExtent`.
+
+As a result, the condition `pixels == maxScrollExtent` is **never true** at `ScrollEndNotification` time on iOS during fast scrolling, so `handleLoadMoreEmailsRequest()` is never called.
+
+This became more pronounced on iOS 18 because Apple increased scroll momentum and overscroll sensitivity, making the overshoot happen more frequently and with a larger delta.
+
+## Decision
+
+Change the equality check to a greater-than-or-equal check:
+
+```dart
+bool _handleScrollNotificationListener(ScrollNotification scrollInfo) {
+  if (scrollInfo is ScrollEndNotification &&
+      scrollInfo.metrics.pixels >= scrollInfo.metrics.maxScrollExtent &&
+      !controller.loadingMoreStatus.value.isRunning &&
+      scrollInfo.metrics.axisDirection == AxisDirection.down
+  ) {
+    controller.handleLoadMoreEmailsRequest();
+  }
+  return false;
+}
+```
+
+Using `>=` instead of `==` ensures that:
+- On **iOS**: when `pixels > maxScrollExtent` (overscroll) at `ScrollEndNotification` time, the condition is still satisfied and load more is triggered correctly.
+- On **Android**: behaviour is unchanged — `pixels == maxScrollExtent` still satisfies `>=`.
+
+The `loadingMoreStatus.isRunning` guard already prevents duplicate requests, so triggering on overscroll does not cause multiple concurrent load-more calls.
+
+## Consequences
+
+- Load more is correctly triggered on iOS 18 when fast-scrolling to the bottom of the email list.
+- No change in behavior on Android.
+- No risk of duplicate requests due to the existing `isRunning` guard.

--- a/docs/adr/0075-fix-load-more-not-triggered-on-ios-fast-scroll.md
+++ b/docs/adr/0075-fix-load-more-not-triggered-on-ios-fast-scroll.md
@@ -9,36 +9,23 @@ Date: 2026-03-31
 
 ## Context
 
-On iOS 18, the `handleLoadMoreEmailsRequest()` was not called when users fast-scrolled to the bottom of the email list.
+On iOS 18, `handleLoadMoreEmailsRequest()` was never called when users fast-scrolled to the bottom of the email list.
 
-The scroll listener in `thread_view.dart` used an exact equality check to detect when the user had reached the bottom:
+**Root cause:** iOS uses `BouncingScrollPhysics`, which allows `pixels` to overshoot `maxScrollExtent` during fast scrolls. The scroll listener used an exact equality check:
 
 ```dart
-bool _handleScrollNotificationListener(ScrollNotification scrollInfo) {
-  if (scrollInfo is ScrollEndNotification &&
-      scrollInfo.metrics.pixels == scrollInfo.metrics.maxScrollExtent &&
-      !controller.loadingMoreStatus.value.isRunning &&
-      scrollInfo.metrics.axisDirection == AxisDirection.down
-  ) {
-    controller.handleLoadMoreEmailsRequest();
-  }
-  return false;
-}
+scrollInfo.metrics.pixels == scrollInfo.metrics.maxScrollExtent
 ```
 
-**Root cause: iOS `BouncingScrollPhysics` causes overscroll past `maxScrollExtent`.**
+This condition is **never true** on iOS when overscrolling — `pixels > maxScrollExtent` at the moment `ScrollEndNotification` fires, and no second `ScrollEndNotification` is emitted once the content snaps back.
 
-The `ListView` uses `AlwaysScrollableScrollPhysics()` without an explicit `parent`. This means the effective physics inherits from the platform's ambient `ScrollConfiguration`:
-- **Android** → `ClampingScrollPhysics`: clamps `pixels` within `[0, maxScrollExtent]`. When the user reaches the bottom, `pixels` is always exactly equal to `maxScrollExtent` when `ScrollEndNotification` fires.
-- **iOS** → `BouncingScrollPhysics`: allows `pixels` to overshoot `maxScrollExtent` (the rubber-band/bounce effect). When the user fast-scrolls and lifts their finger, `pixels > maxScrollExtent` at the moment `ScrollEndNotification` fires. The spring-back animation that follows only emits `ScrollUpdateNotification` — no second `ScrollEndNotification` is ever fired once the content settles at `maxScrollExtent`.
+Android is unaffected because `ClampingScrollPhysics` clamps `pixels` within `[0, maxScrollExtent]`.
 
-As a result, the condition `pixels == maxScrollExtent` is **never true** at `ScrollEndNotification` time on iOS during fast scrolling, so `handleLoadMoreEmailsRequest()` is never called.
-
-This became more pronounced on iOS 18 because Apple increased scroll momentum and overscroll sensitivity, making the overshoot happen more frequently and with a larger delta.
+iOS 18 increased scroll momentum, making this overshoot more frequent.
 
 ## Decision
 
-Change the equality check to a greater-than-or-equal check:
+Replace `==` with `>=` in the scroll notification listener:
 
 ```dart
 bool _handleScrollNotificationListener(ScrollNotification scrollInfo) {
@@ -53,14 +40,10 @@ bool _handleScrollNotificationListener(ScrollNotification scrollInfo) {
 }
 ```
 
-Using `>=` instead of `==` ensures that:
-- On **iOS**: when `pixels > maxScrollExtent` (overscroll) at `ScrollEndNotification` time, the condition is still satisfied and load more is triggered correctly.
-- On **Android**: behaviour is unchanged — `pixels == maxScrollExtent` still satisfies `>=`.
-
-The `loadingMoreStatus.isRunning` guard already prevents duplicate requests, so triggering on overscroll does not cause multiple concurrent load-more calls.
+The existing `isRunning` guard prevents duplicate load-more requests.
 
 ## Consequences
 
-- Load more is correctly triggered on iOS 18 when fast-scrolling to the bottom of the email list.
-- No change in behavior on Android.
+- Load more works correctly on iOS 18 with fast scrolling.
+- No behavior change on Android.
 - No risk of duplicate requests due to the existing `isRunning` guard.

--- a/docs/adr/0075-fix-load-more-not-triggered-on-ios-fast-scroll.md
+++ b/docs/adr/0075-fix-load-more-not-triggered-on-ios-fast-scroll.md
@@ -9,41 +9,35 @@ Date: 2026-03-31
 
 ## Context
 
-On iOS 18, `handleLoadMoreEmailsRequest()` was never called when users fast-scrolled to the bottom of the email list.
-
-**Root cause:** iOS uses `BouncingScrollPhysics`, which allows `pixels` to overshoot `maxScrollExtent` during fast scrolls. The scroll listener used an exact equality check:
+On iOS, `handleLoadMoreEmailsRequest()` was never triggered when users scrolled to the bottom of the email list. The original condition used exact equality:
 
 ```dart
 scrollInfo.metrics.pixels == scrollInfo.metrics.maxScrollExtent
 ```
 
-This condition is **never true** on iOS when overscrolling — `pixels > maxScrollExtent` at the moment `ScrollEndNotification` fires, and no second `ScrollEndNotification` is emitted once the content snaps back.
+**Root cause:** iOS uses `BouncingScrollPhysics` (spring-based simulation), which causes `pixels` to either overshoot or settle slightly short of `maxScrollExtent` depending on scroll speed and device performance. In both cases, `ScrollEndNotification` fires when `pixels != maxScrollExtent`, so the condition is never satisfied.
 
-Android is unaffected because `ClampingScrollPhysics` clamps `pixels` within `[0, maxScrollExtent]`.
-
-iOS 18 increased scroll momentum, making this overshoot more frequent.
+This behavior is device-dependent — newer/faster devices (iPhone 13 Pro Max, iOS 18) are less affected, while older/slower devices (iPhone 7, iOS 15) exhibit larger deviations. Android is unaffected because `ClampingScrollPhysics` clamps `pixels` exactly within `[0, maxScrollExtent]`.
 
 ## Decision
 
-Replace `==` with `>=` in the scroll notification listener:
+Apply `ClampingScrollPhysics` on iOS only, and replace `==` with `>=`:
 
 ```dart
-bool _handleScrollNotificationListener(ScrollNotification scrollInfo) {
-  if (scrollInfo is ScrollEndNotification &&
-      scrollInfo.metrics.pixels >= scrollInfo.metrics.maxScrollExtent &&
-      !controller.loadingMoreStatus.value.isRunning &&
-      scrollInfo.metrics.axisDirection == AxisDirection.down
-  ) {
-    controller.handleLoadMoreEmailsRequest();
-  }
-  return false;
-}
+// physics
+physics: PlatformInfo.isIOS
+    ? const ClampingScrollPhysics()
+    : const AlwaysScrollableScrollPhysics(),
+
+// condition
+scrollInfo.metrics.pixels >= scrollInfo.metrics.maxScrollExtent
 ```
 
-The existing `isRunning` guard prevents duplicate load-more requests.
+`ClampingScrollPhysics` ensures `pixels` is clamped exactly to `maxScrollExtent` at the boundary, making the condition deterministic. The `>=` adds a defensive guard for any residual edge cases.
 
 ## Consequences
 
-- Load more works correctly on iOS 18 with fast scrolling.
-- No behavior change on Android.
+- Load more works correctly across all iOS versions and device generations.
+- No behavior change on Android or Web.
+- iOS loses the native bounce feel at list boundaries. Acceptable for an email list UI.
 - No risk of duplicate requests due to the existing `isRunning` guard.

--- a/lib/features/search/email/presentation/search_email_view.dart
+++ b/lib/features/search/email/presentation/search_email_view.dart
@@ -685,7 +685,7 @@ class SearchEmailView extends GetWidget<SearchEmailController>
         onNotification: (ScrollNotification scrollInfo) {
           if (scrollInfo is ScrollEndNotification
               && controller.searchMoreState != SearchMoreState.waiting
-              && scrollInfo.metrics.pixels == scrollInfo.metrics.maxScrollExtent
+              && scrollInfo.metrics.pixels >= scrollInfo.metrics.maxScrollExtent
               && scrollInfo.metrics.axisDirection == AxisDirection.down) {
             controller.searchMoreEmailsAction();
           }

--- a/lib/features/search/email/presentation/search_email_view.dart
+++ b/lib/features/search/email/presentation/search_email_view.dart
@@ -693,7 +693,9 @@ class SearchEmailView extends GetWidget<SearchEmailController>
         },
         child: ListView.separated(
           controller: controller.resultSearchScrollController,
-          physics: const AlwaysScrollableScrollPhysics(),
+          physics: PlatformInfo.isIOS
+              ? const ClampingScrollPhysics()
+              : const AlwaysScrollableScrollPhysics(),
           key: const PageStorageKey('list_presentation_email_in_search_view'),
           itemCount: listPresentationEmail.length,
           itemBuilder: (context, index) => _buildEmailItem(

--- a/lib/features/thread/presentation/thread_view.dart
+++ b/lib/features/thread/presentation/thread_view.dart
@@ -440,7 +440,7 @@ class ThreadView extends GetWidget<ThreadController>
 
   bool _handleScrollNotificationListener(ScrollNotification scrollInfo) {
     if (scrollInfo is ScrollEndNotification &&
-        scrollInfo.metrics.pixels == scrollInfo.metrics.maxScrollExtent &&
+        scrollInfo.metrics.pixels >= scrollInfo.metrics.maxScrollExtent &&
         !controller.loadingMoreStatus.value.isRunning &&
         scrollInfo.metrics.axisDirection == AxisDirection.down
     ) {

--- a/lib/features/thread/presentation/thread_view.dart
+++ b/lib/features/thread/presentation/thread_view.dart
@@ -366,7 +366,9 @@ class ThreadView extends GetWidget<ThreadController>
     Widget listView = ListView.separated(
       key: const PageStorageKey('list_presentation_email_in_threads'),
       controller: controller.listEmailController,
-      physics: const AlwaysScrollableScrollPhysics(),
+      physics: PlatformInfo.isIOS
+          ? const ClampingScrollPhysics()
+          : const AlwaysScrollableScrollPhysics(),
       itemCount: listPresentationEmail.length + 2,
       itemBuilder: (context, index) => Obx(() {
         if (index == listPresentationEmail.length) {


### PR DESCRIPTION
 ## Issue

#4425 
                                                                                                                                                                                                 
## Root cause

The scroll listener used exact equality (`pixels == maxScrollExtent`) to detect bottom-of-list. On iOS, `BouncingScrollPhysics` allows `pixels` to overshoot `maxScrollExtent` during fast scroll. `ScrollEndNotification` fires while `pixels > maxScrollExtent`, so the condition was never satisfied. On Android, `ClampingScrollPhysics` prevents overscroll, so `pixels` is always exactly `maxScrollExtent` — unaffected.                                                    

## Resolved



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed load-more not triggering on iOS during fast scrolling in email lists and thread views by making edge detection more tolerant and applying iOS-specific scroll behavior, ensuring consistent pagination and avoiding duplicate requests.

* **Documentation**
  * Added an Architecture Decision Record describing the iOS scroll behavior issue, chosen adjustments, and expected outcomes (including reduced bounce at list boundaries).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->