### PR TITLE
TW-4308 Add labels for several messages part 1

### DIFF
--- a/lib/features/email/data/datasource/email_datasource.dart
+++ b/lib/features/email/data/datasource/email_datasource.dart
@@ -238,4 +238,14 @@ abstract class EmailDataSource {
     List<EmailId> emailIds,
     KeyWordIdentifier labelKeyword,
   );
+
+  Future<({
+    List<EmailId> emailIdsSuccess,
+    Map<Id, SetError> mapErrors,
+  })> addListLabelToListEmail(
+    Session session,
+    AccountId accountId,
+    List<EmailId> emailIds,
+    List<KeyWordIdentifier> labelKeywords,
+  );
 }

--- a/lib/features/email/data/datasource_impl/email_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_datasource_impl.dart
@@ -627,4 +627,24 @@ class EmailDataSourceImpl extends EmailDataSource {
       );
     }).catchError(_exceptionThrower.throwException);
   }
+
+  @override
+  Future<({
+    List<EmailId> emailIdsSuccess,
+    Map<Id, SetError> mapErrors,
+  })> addListLabelToListEmail(
+    Session session,
+    AccountId accountId,
+    List<EmailId> emailIds,
+    List<KeyWordIdentifier> labelKeywords,
+  ) {
+    return Future.sync(() async {
+      return await emailAPI.addListLabelToListEmail(
+        session,
+        accountId,
+        emailIds,
+        labelKeywords,
+      );
+    }).catchError(_exceptionThrower.throwException);
+  }
 }

--- a/lib/features/email/data/datasource_impl/email_hive_cache_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_hive_cache_datasource_impl.dart
@@ -601,4 +601,17 @@ class EmailHiveCacheDataSourceImpl extends EmailDataSource {
   })> removeLabelFromThread(Session session, AccountId accountId, List<EmailId> emailIds, KeyWordIdentifier labelKeyword) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<({
+    List<EmailId> emailIdsSuccess,
+    Map<Id, SetError> mapErrors,
+  })> addListLabelToListEmail(
+    Session session,
+    AccountId accountId,
+    List<EmailId> emailIds,
+    List<KeyWordIdentifier> labelKeywords,
+  ) {
+    throw UnimplementedError();
+  }
 }

--- a/lib/features/email/data/datasource_impl/email_local_storage_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_local_storage_datasource_impl.dart
@@ -377,4 +377,17 @@ class EmailLocalStorageDataSourceImpl extends EmailDataSource {
   })> removeLabelFromThread(Session session, AccountId accountId, List<EmailId> emailIds, KeyWordIdentifier labelKeyword) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<({
+    List<EmailId> emailIdsSuccess,
+    Map<Id, SetError> mapErrors,
+  })> addListLabelToListEmail(
+    Session session,
+    AccountId accountId,
+    List<EmailId> emailIds,
+    List<KeyWordIdentifier> labelKeywords,
+  ) {
+    throw UnimplementedError();
+  }
 }

--- a/lib/features/email/data/datasource_impl/email_session_storage_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_session_storage_datasource_impl.dart
@@ -291,4 +291,17 @@ class EmailSessionStorageDatasourceImpl extends EmailDataSource {
   })> removeLabelFromThread(Session session, AccountId accountId, List<EmailId> emailIds, KeyWordIdentifier labelKeyword) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<({
+    List<EmailId> emailIdsSuccess,
+    Map<Id, SetError> mapErrors,
+  })> addListLabelToListEmail(
+    Session session,
+    AccountId accountId,
+    List<EmailId> emailIds,
+    List<KeyWordIdentifier> labelKeywords,
+  ) {
+    throw UnimplementedError();
+  }
 }

--- a/lib/features/email/data/network/email_api.dart
+++ b/lib/features/email/data/network/email_api.dart
@@ -970,4 +970,24 @@ class EmailAPI
       ),
     );
   }
+
+  Future<({
+    List<EmailId> emailIdsSuccess,
+    Map<Id, SetError> mapErrors,
+  })> addListLabelToListEmail(
+    Session session,
+    AccountId accountId,
+    List<EmailId> emailIds,
+    List<KeyWordIdentifier> labelKeywords,
+  ) async {
+    return executeBatchSetEmail(
+      session: session,
+      accountId: accountId,
+      emailIds: emailIds,
+      httpClient: _httpClient,
+      debugLabel: 'addListLabelToListEmail',
+      onGenerateUpdates: (batchIds) =>
+          batchIds.generateMapUpdateObjectListLabel(labelKeywords),
+    );
+  }
 }

--- a/lib/features/email/data/repository/email_repository_impl.dart
+++ b/lib/features/email/data/repository/email_repository_impl.dart
@@ -546,4 +546,22 @@ class EmailRepositoryImpl extends EmailRepository {
       labelKeyword,
     );
   }
+
+  @override
+  Future<({
+    List<EmailId> emailIdsSuccess,
+    Map<Id, SetError> mapErrors,
+  })> addListLabelToListEmail(
+    Session session,
+    AccountId accountId,
+    List<EmailId> emailIds,
+    List<KeyWordIdentifier> labelKeywords,
+  ) {
+    return emailDataSource[DataSourceType.network]!.addListLabelToListEmail(
+      session,
+      accountId,
+      emailIds,
+      labelKeywords,
+    );
+  }
 }

--- a/lib/features/email/domain/repository/email_repository.dart
+++ b/lib/features/email/domain/repository/email_repository.dart
@@ -195,4 +195,14 @@ abstract class EmailRepository {
     List<EmailId> emailIds,
     KeyWordIdentifier labelKeyword,
   );
+
+  Future<({
+    List<EmailId> emailIdsSuccess,
+    Map<Id, SetError> mapErrors,
+  })> addListLabelToListEmail(
+    Session session,
+    AccountId accountId,
+    List<EmailId> emailIds,
+    List<KeyWordIdentifier> labelKeywords,
+  );
 }

--- a/lib/features/email/domain/state/labels/add_list_label_to_list_email_state.dart
+++ b/lib/features/email/domain/state/labels/add_list_label_to_list_email_state.dart
@@ -1,0 +1,45 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
+
+class AddingListLabelsToListEmails extends LoadingState {}
+
+class AddListLabelsToListEmailsSuccess extends UIState {
+  final List<EmailId> emailIds;
+  final List<KeyWordIdentifier> labelKeywords;
+  final List<String> labelDisplays;
+
+  AddListLabelsToListEmailsSuccess(
+    this.emailIds,
+    this.labelKeywords,
+    this.labelDisplays,
+  );
+
+  @override
+  List<Object> get props => [emailIds, labelKeywords, labelDisplays];
+}
+
+class AddListLabelsToListEmailsHasSomeFailure
+    extends AddListLabelsToListEmailsSuccess {
+  AddListLabelsToListEmailsHasSomeFailure(
+    super.emailIds,
+    super.labelKeywords,
+    super.labelDisplays,
+  );
+
+  @override
+  List<Object> get props => [...super.props, 'hasSomeFailure'];
+}
+
+class AddListLabelsToListEmailsFailure extends FeatureFailure {
+  final List<String> labelDisplays;
+
+  AddListLabelsToListEmailsFailure({
+    dynamic exception,
+    required this.labelDisplays,
+  }) : super(exception: exception);
+
+  @override
+  List<Object?> get props => [...super.props, labelDisplays];
+}

--- a/lib/features/email/domain/usecases/labels/add_list_label_to_list_emails_interactor.dart
+++ b/lib/features/email/domain/usecases/labels/add_list_label_to_list_emails_interactor.dart
@@ -1,0 +1,67 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
+import 'package:tmail_ui_user/features/composer/domain/exceptions/set_method_exception.dart';
+import 'package:tmail_ui_user/features/email/domain/exceptions/email_exceptions.dart';
+import 'package:tmail_ui_user/features/email/domain/repository/email_repository.dart';
+import 'package:tmail_ui_user/features/email/domain/state/labels/add_list_label_to_list_email_state.dart';
+
+class AddListLabelToListEmailsInteractor {
+  final EmailRepository _emailRepository;
+
+  AddListLabelToListEmailsInteractor(this._emailRepository);
+
+  Stream<Either<Failure, Success>> execute(
+    Session session,
+    AccountId accountId,
+    List<EmailId> emailIds,
+    List<KeyWordIdentifier> labelKeywords,
+    List<String> labelDisplays,
+  ) async* {
+    try {
+      if (emailIds.isEmpty) {
+        yield Left(AddListLabelsToListEmailsFailure(
+          exception: EmailIdsSuccessIsEmptyException(),
+          labelDisplays: labelDisplays,
+        ));
+        return;
+      }
+      yield Right(AddingListLabelsToListEmails());
+      final result = await _emailRepository.addListLabelToListEmail(
+        session,
+        accountId,
+        emailIds,
+        labelKeywords,
+      );
+      if (emailIds.length == result.emailIdsSuccess.length) {
+        yield Right(AddListLabelsToListEmailsSuccess(
+          result.emailIdsSuccess,
+          labelKeywords,
+          labelDisplays,
+        ));
+      } else if (result.emailIdsSuccess.isEmpty) {
+        yield Left(AddListLabelsToListEmailsFailure(
+          exception: result.mapErrors.isNotEmpty
+              ? SetMethodException(result.mapErrors)
+              : EmailIdsSuccessIsEmptyException(),
+          labelDisplays: labelDisplays,
+        ));
+      } else {
+        yield Right(AddListLabelsToListEmailsHasSomeFailure(
+          result.emailIdsSuccess,
+          labelKeywords,
+          labelDisplays,
+        ));
+      }
+    } catch (e) {
+      yield Left(AddListLabelsToListEmailsFailure(
+        exception: e,
+        labelDisplays: labelDisplays,
+      ));
+    }
+  }
+}

--- a/lib/features/thread/presentation/extensions/email_selection_action_type_extension.dart
+++ b/lib/features/thread/presentation/extensions/email_selection_action_type_extension.dart
@@ -27,6 +27,8 @@ extension EmailSelectionActionTypeExtension on EmailSelectionActionType {
       case EmailSelectionActionType.selectAll:
       case EmailSelectionActionType.moreAction:
         return null;
+      case EmailSelectionActionType.labelAs:
+        return EmailActionType.labelAs;
     }
   }
 }

--- a/lib/features/thread/presentation/model/email_selection_action_type.dart
+++ b/lib/features/thread/presentation/model/email_selection_action_type.dart
@@ -10,6 +10,7 @@ enum EmailSelectionActionType {
   markAsStarred,
   unMarkAsStarred,
   moveToFolder,
+  labelAs,
   moveToTrash,
   markAsSpam,
   markAsNotSpam,
@@ -43,6 +44,8 @@ enum EmailSelectionActionType {
         return appLocalizations.delete_permanently;
       case EmailSelectionActionType.moreAction:
         return appLocalizations.more;
+      case EmailSelectionActionType.labelAs:
+        return appLocalizations.labelAs;
     }
   }
 
@@ -71,6 +74,8 @@ enum EmailSelectionActionType {
         return imagePaths.icMailboxArchived;
       case EmailSelectionActionType.moreAction:
         return imagePaths.icMoreVertical;
+      case EmailSelectionActionType.labelAs:
+        return imagePaths.icTag;
     }
   }
 

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -5483,5 +5483,35 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
+  },
+  "chooseLabel": "Choose label",
+  "@chooseLabel": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "selectLabel": "Select label",
+  "@selectLabel": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "addListLabelToListEmailSuccessfullyMessage": "Labels have been successfully added to these emails.",
+  "@addListLabelToListEmailSuccessfullyMessage": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "addListLabelToListEmailHasSomeFailureMessage": "Labels have been successfully added to some emails.",
+  "@addListLabelToListEmailHasSomeFailureMessage": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "addListLabelToListEmailFailureMessage": "Adding labels to these emails failed",
+  "@addListLabelToListEmailFailureMessage": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
 }

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -5804,4 +5804,39 @@ class AppLocalizations {
       name: 'allEmailTrashAndSpam',
     );
   }
+
+  String get chooseLabel {
+    return Intl.message(
+      'Choose label',
+      name: 'chooseLabel',
+    );
+  }
+
+  String get selectLabel {
+    return Intl.message(
+      'Select label',
+      name: 'selectLabel',
+    );
+  }
+
+  String get addListLabelToListEmailSuccessfullyMessage {
+    return Intl.message(
+      'Labels have been successfully added to these emails.',
+      name: 'addListLabelToListEmailSuccessfullyMessage',
+    );
+  }
+
+  String get addListLabelToListEmailHasSomeFailureMessage {
+    return Intl.message(
+      'Labels have been successfully added to some emails.',
+      name: 'addListLabelToListEmailHasSomeFailureMessage',
+    );
+  }
+
+  String get addListLabelToListEmailFailureMessage {
+    return Intl.message(
+      'Adding labels to these emails failed',
+      name: 'addListLabelToListEmailFailureMessage',
+    );
+  }
 }

--- a/lib/main/utils/toast_manager.dart
+++ b/lib/main/utils/toast_manager.dart
@@ -26,6 +26,7 @@ import 'package:tmail_ui_user/features/email/domain/model/move_action.dart';
 import 'package:tmail_ui_user/features/email/domain/state/add_a_label_to_a_thread_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/add_a_label_to_an_email_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/calendar_event_reply_state.dart';
+import 'package:tmail_ui_user/features/email/domain/state/labels/add_list_label_to_list_email_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/labels/remove_a_label_from_a_thread_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/mark_as_email_star_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/remove_a_label_from_an_email_state.dart';
@@ -229,6 +230,9 @@ class ToastManager {
           );
     } else if (failure is DeleteALabelFailure) {
       message = message ?? appLocalizations.deleteALabelFailure;
+    } else if (failure is AddListLabelsToListEmailsFailure) {
+      message =
+          message ?? appLocalizations.addListLabelToListEmailFailureMessage;
     }
     log('ToastManager::showMessageFailure: Message: $message');
     if (message?.trim().isNotEmpty == true) {
@@ -320,6 +324,10 @@ class ToastManager {
       message = appLocalizations.deleteLabelSuccessfullyMessage(
         success.deletedLabel.safeDisplayName,
       );
+    } else if (success is AddListLabelsToListEmailsHasSomeFailure) {
+      message = appLocalizations.addListLabelToListEmailHasSomeFailureMessage;
+    } else if (success is AddListLabelsToListEmailsSuccess) {
+      message = appLocalizations.addListLabelToListEmailSuccessfullyMessage;
     }
     log('ToastManager::showMessageSuccess: Message: $message');
     if (message?.trim().isNotEmpty == true) {

--- a/model/lib/extensions/list_email_id_extension.dart
+++ b/model/lib/extensions/list_email_id_extension.dart
@@ -62,4 +62,17 @@ extension ListEmailIdExtension on List<EmailId> {
         emailId.id: labelKeyword.generateLabelActionPath(remove: remove)
     };
   }
+
+  Map<Id, PatchObject> generateMapUpdateObjectListLabel(
+    List<KeyWordIdentifier> labelKeywords, {
+    bool remove = false,
+  }) {
+    return {
+      for (var emailId in this)
+        emailId.id: PatchObject({
+          for (var key in labelKeywords)
+            key.generatePath(): remove ? null : true,
+        }),
+    };
+  }
 }


### PR DESCRIPTION
## Data preparation only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apply multiple labels to multiple selected emails at once via a new "Label As" action in selection mode.
  * Batch label operation with partial-success reporting.
  * UI shows a progress state while labels are being applied.

* **User-facing Messages**
  * New success, partial-failure, and failure messages for batch label operations.
  * New label selection texts: "Choose label" and "Select label".
  * New icon/title for the "Label As" selection action.

* **Notifications**
  * Toasts show appropriate messages for batch labeling outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->