### PR TITLE
Cherry pick v26

### DIFF
--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -5791,18 +5791,5 @@
     "placeholders": {
       "labelName": {}
     }
-  },
-  "labelDescription": "Description (optionnelle)",
-  "@labelDescription": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "labelDescriptionHintText": "Ajoutez une courte description pour expliquer à quoi sert ce libellé",
-  "@labelDescriptionHintText": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
   }
-
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -4096,7 +4096,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "closeAnyway": "messages",
+  "closeAnyway": "Ignorer et fermer",
   "@closeAnyway": {
     "type": "text",
     "placeholders_order": [],

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1802,7 +1802,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "requestReadReceipt": "Demander un accusé de réception",
+  "requestReadReceipt": "Demander un accusé de lecture",
   "@requestReadReceipt": {
     "type": "text",
     "placeholders_order": [],
@@ -1814,7 +1814,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "titleReadReceiptRequestNotificationMessage": "Demander un accusé de réception",
+  "titleReadReceiptRequestNotificationMessage": "Demande d'accusé de lecture",
   "@titleReadReceiptRequestNotificationMessage": {
     "type": "text",
     "placeholders_order": [],
@@ -2222,7 +2222,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "subTitleReadReceiptRequestNotificationMessage": "L'expéditeur a demandé l'envoi d'un accusé de réception pour ce message. Envoyer un accusé de réception ?",
+  "subTitleReadReceiptRequestNotificationMessage": "L'expéditeur a demandé l'envoi d'un accusé de lecture pour ce message. Envoyer un accusé de lecture ?",
   "@subTitleReadReceiptRequestNotificationMessage": {
     "type": "text",
     "placeholders_order": [],
@@ -2596,7 +2596,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "textBodySendReceiptToSender": "Le message a été lu par {receiver} le {time}\n\nSujet : {subject}\n\nRemarque : Cet accusé de réception confirme uniquement que le message a été affiché sur l'ordinateur du destinataire. Il n'y a aucune garantie que le destinataire ait lu ou compris le contenu du message.",
+  "textBodySendReceiptToSender": "Le message a été lu par {receiver} le {time}\n\nSujet : {subject}\n\nRemarque : Cet accusé de lecture confirme uniquement que le message a été affiché sur l'ordinateur du destinataire. Il n'y a aucune garantie que le destinataire ait lu ou compris le contenu du message.",
   "@textBodySendReceiptToSender": {
     "type": "text",
     "placeholders_order": [
@@ -2610,7 +2610,7 @@
       "time": {}
     }
   },
-  "toastMessageSendReceiptSuccess": "Un accusé de réception a été envoyé.",
+  "toastMessageSendReceiptSuccess": "Un accusé de lecture a été envoyé.",
   "@toastMessageSendReceiptSuccess": {
     "type": "text",
     "placeholders_order": [],
@@ -3858,19 +3858,19 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "emailReadReceiptsToggleDescription": "Toujours exiger des accusés de réception pour les messages sortants",
+  "emailReadReceiptsToggleDescription": "Toujours exiger des accusés de lecture pour les messages sortants",
   "@emailReadReceiptsToggleDescription": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "emailReadReceipts": "Accusés de réception",
+  "emailReadReceipts": "Accusés de lecture",
   "@emailReadReceipts": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "emailReadReceiptsSettingExplanation": "Les accusés de réception sont des notifications qui peuvent être envoyées à l'expéditeur pour confirmer que le destinataire a bien ouvert le message.",
+  "emailReadReceiptsSettingExplanation": "Les accusés de lecture sont des notifications qui peuvent être envoyées à l'expéditeur pour confirmer que le destinataire a bien ouvert le message.",
   "@emailReadReceiptsSettingExplanation": {
     "type": "text",
     "placeholders_order": [],
@@ -4138,19 +4138,19 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "turnOffRequestReadReceipt": "Désactiver l'accusé de réception",
+  "turnOffRequestReadReceipt": "Désactiver l'accusé de lecture",
   "@turnOffRequestReadReceipt": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "turnOnRequestReadReceipt": "Activer l'accusé de réception",
+  "turnOnRequestReadReceipt": "Activer l'accusé de lecture",
   "@turnOnRequestReadReceipt": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "requestReadReceiptHasBeenEnabled": "L'accusé de réception a été activé",
+  "requestReadReceiptHasBeenEnabled": "L'accusé de lecture a été activé",
   "@requestReadReceiptHasBeenEnabled": {
     "type": "text",
     "placeholders_order": [],
@@ -4192,7 +4192,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "requestReadReceiptHasBeenDisabled": "L'accusé de réception a été désactivé",
+  "requestReadReceiptHasBeenDisabled": "L'accusé de lecture a été désactivé",
   "@requestReadReceiptHasBeenDisabled": {
     "type": "text",
     "placeholders_order": [],

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -5733,5 +5733,76 @@
     "placeholders": {
       "labelName": {}
     }
+  },
+  "pleaseEnterNameYourNewLabel": "Veuillez saisir le nom de votre nouveau libellé",
+  "@pleaseEnterNameYourNewLabel": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "chooseALabelColor": "Choisir une couleur de libellé",
+  "@chooseALabelColor": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tagNameAlreadyExists": "Un libellé avec ce nom existe déjà. Veuillez choisir un nom différent.",
+  "@tagNameAlreadyExists": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "chooseCustomColour": "Choisir une couleur personnalisée",
+  "@chooseCustomColour": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "createNewLabelFailure": "Échec de la création du libellé",
+  "@createNewLabelFailure": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "labelVisibilitySettingExplanation": "Afficher les libellés assignés aux e-mails directement dans votre liste de messages pour une catégorisation plus facile.",
+  "@labelVisibilitySettingExplanation": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "labelVisibilityToggleDescription": "Afficher les libellés",
+  "@labelVisibilityToggleDescription": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "updateTheLabelName": "Mettre à jour le nom du libellé",
+  "@updateTheLabelName": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "areYouSureYouWantToDeleteTheLabel": "Êtes-vous sûr de vouloir supprimer le libellé \"{labelName}\" ?",
+  "@areYouSureYouWantToDeleteTheLabel": {
+    "type": "text",
+    "placeholders_order": [
+      "labelName"
+    ],
+    "placeholders": {
+      "labelName": {}
+    }
+  },
+  "labelDescription": "Description (optionnelle)",
+  "@labelDescription": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "labelDescriptionHintText": "Ajoutez une courte description pour expliquer à quoi sert ce libellé",
+  "@labelDescriptionHintText": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
+
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -4096,7 +4096,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "closeAnyway": "Ignorer et fermer",
+  "closeAnyway": "messages",
   "@closeAnyway": {
     "type": "text",
     "placeholders_order": [],
@@ -4840,7 +4840,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "threadToggleDescription": "Activité les fil de discussion",
+  "threadToggleDescription": "Activer les fils de discussion",
   "@threadToggleDescription": {
     "type": "text",
     "placeholders_order": [],
@@ -5390,7 +5390,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "mailboxListWithSelectedMail": "Boite mail (mail sélectionné)",
+  "mailboxListWithSelectedMail": "Liste des boîtes aux lettres (e-mail sélectionné)",
   "@mailboxListWithSelectedMail": {
     "type": "text",
     "placeholders_order": [],

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -5752,19 +5752,19 @@
       "labelName": {}
     }
   },
-  "pleaseEnterNameYourNewLabel": "Пожалуйста, введите название нового ярлыка",
+  "pleaseEnterNameYourNewLabel": "Пожалуйста, введите название новой метки",
   "@pleaseEnterNameYourNewLabel": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "chooseALabelColor": "Выберите цвет ярлыка",
+  "chooseALabelColor": "Выберите цвет метки",
   "@chooseALabelColor": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "tagNameAlreadyExists": "Ярлык с таким названием уже существует. Пожалуйста, выберите другое название.",
+  "tagNameAlreadyExists": "Метка с таким названием уже существует. Пожалуйста, выберите другое название.",
   "@tagNameAlreadyExists": {
     "type": "text",
     "placeholders_order": [],
@@ -5776,31 +5776,31 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "createNewLabelFailure": "Ошибка создания нового ярлыка",
+  "createNewLabelFailure": "Ошибка создания новой метки",
   "@createNewLabelFailure": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "labelVisibilitySettingExplanation": "Показывать ярлыки, назначенные письмам, непосредственно в списке сообщений для удобной категоризации.",
+  "labelVisibilitySettingExplanation": "Показывать метки, назначенные письмам, непосредственно в списке сообщений для удобной категоризации.",
   "@labelVisibilitySettingExplanation": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "labelVisibilityToggleDescription": "Показывать ярлыки",
+  "labelVisibilityToggleDescription": "Показывать метки",
   "@labelVisibilityToggleDescription": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "updateTheLabelName": "Обновить название ярлыка",
+  "updateTheLabelName": "Обновить название метки",
   "@updateTheLabelName": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "areYouSureYouWantToDeleteTheLabel": "Вы уверены, что хотите удалить ярлык \"{labelName}\"?",
+  "areYouSureYouWantToDeleteTheLabel": "Вы уверены, что хотите удалить метку \"{labelName}\"?",
   "@areYouSureYouWantToDeleteTheLabel": {
     "type": "text",
     "placeholders_order": [

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -5809,18 +5809,5 @@
     "placeholders": {
       "labelName": {}
     }
-  },
-  "labelDescription": "Описание (необязательно)",
-  "@labelDescription": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "labelDescriptionHintText": "Добавьте краткое описание, объясняющее назначение этого ярлыка",
-  "@labelDescriptionHintText": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
   }
-
 }

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -5751,5 +5751,76 @@
     "placeholders": {
       "labelName": {}
     }
+  },
+  "pleaseEnterNameYourNewLabel": "Пожалуйста, введите название нового ярлыка",
+  "@pleaseEnterNameYourNewLabel": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "chooseALabelColor": "Выберите цвет ярлыка",
+  "@chooseALabelColor": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tagNameAlreadyExists": "Ярлык с таким названием уже существует. Пожалуйста, выберите другое название.",
+  "@tagNameAlreadyExists": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "chooseCustomColour": "Выбрать произвольный цвет",
+  "@chooseCustomColour": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "createNewLabelFailure": "Ошибка создания нового ярлыка",
+  "@createNewLabelFailure": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "labelVisibilitySettingExplanation": "Показывать ярлыки, назначенные письмам, непосредственно в списке сообщений для удобной категоризации.",
+  "@labelVisibilitySettingExplanation": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "labelVisibilityToggleDescription": "Показывать ярлыки",
+  "@labelVisibilityToggleDescription": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "updateTheLabelName": "Обновить название ярлыка",
+  "@updateTheLabelName": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "areYouSureYouWantToDeleteTheLabel": "Вы уверены, что хотите удалить ярлык \"{labelName}\"?",
+  "@areYouSureYouWantToDeleteTheLabel": {
+    "type": "text",
+    "placeholders_order": [
+      "labelName"
+    ],
+    "placeholders": {
+      "labelName": {}
+    }
+  },
+  "labelDescription": "Описание (необязательно)",
+  "@labelDescription": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "labelDescriptionHintText": "Добавьте краткое описание, объясняющее назначение этого ярлыка",
+  "@labelDescriptionHintText": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
+
 }

--- a/lib/l10n/intl_vi.arb
+++ b/lib/l10n/intl_vi.arb
@@ -5797,18 +5797,5 @@
     "placeholders": {
       "labelName": {}
     }
-  },
-  "labelDescription": "Mô tả (tùy chọn)",
-  "@labelDescription": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "labelDescriptionHintText": "Thêm mô tả ngắn để giải thích nhãn này dùng để làm gì",
-  "@labelDescriptionHintText": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
   }
-
 }

--- a/lib/l10n/intl_vi.arb
+++ b/lib/l10n/intl_vi.arb
@@ -5739,5 +5739,76 @@
     "placeholders": {
       "labelName": {}
     }
+  },
+  "pleaseEnterNameYourNewLabel": "Vui lòng nhập tên nhãn mới của bạn",
+  "@pleaseEnterNameYourNewLabel": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "chooseALabelColor": "Chọn màu nhãn",
+  "@chooseALabelColor": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tagNameAlreadyExists": "Một nhãn với tên này đã tồn tại. Vui lòng chọn tên khác.",
+  "@tagNameAlreadyExists": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "chooseCustomColour": "Chọn màu tùy chỉnh",
+  "@chooseCustomColour": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "createNewLabelFailure": "Tạo nhãn mới thất bại",
+  "@createNewLabelFailure": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "labelVisibilitySettingExplanation": "Hiển thị các nhãn được gán cho email trực tiếp trong danh sách tin nhắn để phân loại dễ dàng hơn.",
+  "@labelVisibilitySettingExplanation": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "labelVisibilityToggleDescription": "Hiển thị nhãn",
+  "@labelVisibilityToggleDescription": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "updateTheLabelName": "Cập nhật tên nhãn",
+  "@updateTheLabelName": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "areYouSureYouWantToDeleteTheLabel": "Bạn có chắc chắn muốn xóa nhãn \"{labelName}\" không?",
+  "@areYouSureYouWantToDeleteTheLabel": {
+    "type": "text",
+    "placeholders_order": [
+      "labelName"
+    ],
+    "placeholders": {
+      "labelName": {}
+    }
+  },
+  "labelDescription": "Mô tả (tùy chọn)",
+  "@labelDescription": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "labelDescriptionHintText": "Thêm mô tả ngắn để giải thích nhãn này dùng để làm gì",
+  "@labelDescriptionHintText": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
+
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated French read receipt wording and corrected thread discussion and mailbox list labels.

* **Localization**
  * Added/updated label-management UI strings in French, Russian, and Vietnamese: prompts for creating/renaming labels, color selection (including custom color), duplicate-name and creation error messages, visibility setting text/toggle, and delete confirmation referencing the label name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->