### PR TITLE
TF-4268 Add state-transition logs to monitor FCM push notification flow    

### DIFF
--- a/core/lib/presentation/state/failure.dart
+++ b/core/lib/presentation/state/failure.dart
@@ -10,10 +10,12 @@ abstract class Failure with EquatableMixin {
 
 abstract class FeatureFailure extends Failure {
   final dynamic exception;
+  final StackTrace? stackTrace;
   final Stream<Either<Failure, Success>>? onRetry;
 
-  FeatureFailure({this.exception, this.onRetry});
+  FeatureFailure({this.exception, this.stackTrace, this.onRetry});
 
+  // Including stackTrace in props may break Equatable equality semantics.
   @override
   List<Object?> get props => [exception, onRetry];
 }

--- a/lib/features/email/domain/state/get_stored_state_email_state.dart
+++ b/lib/features/email/domain/state/get_stored_state_email_state.dart
@@ -16,6 +16,5 @@ class GetStoredEmailStateSuccess extends UIState {
 class NotFoundEmailState extends FeatureFailure {}
 
 class GetStoredEmailStateFailure extends FeatureFailure {
-
-  GetStoredEmailStateFailure(dynamic exception) : super(exception: exception);
+  GetStoredEmailStateFailure({super.exception, super.stackTrace});
 }

--- a/lib/features/email/domain/usecases/get_stored_email_state_interactor.dart
+++ b/lib/features/email/domain/usecases/get_stored_email_state_interactor.dart
@@ -19,8 +19,11 @@ class GetStoredEmailStateInteractor {
       } else {
         yield Left<Failure, Success>(NotFoundEmailState());
       }
-    } catch (e) {
-      yield Left<Failure, Success>(GetStoredEmailStateFailure(e));
+    } catch (e, st) {
+      yield Left<Failure, Success>(GetStoredEmailStateFailure(
+        exception: e,
+        stackTrace: st,
+      ));
     }
   }
 }

--- a/lib/features/push_notification/domain/state/get_email_changes_to_push_notification_state.dart
+++ b/lib/features/push_notification/domain/state/get_email_changes_to_push_notification_state.dart
@@ -2,24 +2,39 @@
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:model/email/presentation_email.dart';
 
-class GetEmailChangesToPushNotificationLoading extends UIState {}
+class GetEmailChangesToPushNotificationLoading extends LoadingState {}
 
 class GetEmailChangesToPushNotificationSuccess extends UIState {
-
   final List<PresentationEmail> emailList;
   final AccountId accountId;
   final UserName userName;
+  final State currentState;
 
-  GetEmailChangesToPushNotificationSuccess(this.accountId, this.userName, this.emailList);
+  GetEmailChangesToPushNotificationSuccess(
+    this.accountId,
+    this.userName,
+    this.emailList,
+    this.currentState,
+  );
 
   @override
-  List<Object> get props => [accountId, userName, emailList];
+  List<Object> get props => [accountId, userName, emailList, currentState];
 }
 
 class GetEmailChangesToPushNotificationFailure extends FeatureFailure {
+  final State currentState;
 
-  GetEmailChangesToPushNotificationFailure(exception) : super(exception: exception);
+  GetEmailChangesToPushNotificationFailure({
+    super.exception,
+    super.stackTrace,
+    super.onRetry,
+    required this.currentState,
+  });
+
+  @override
+  List<Object?> get props => [...super.props, currentState];
 }

--- a/lib/features/push_notification/domain/state/get_mailboxes_not_put_notifications_state.dart
+++ b/lib/features/push_notification/domain/state/get_mailboxes_not_put_notifications_state.dart
@@ -1,25 +1,39 @@
 
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:model/email/presentation_email.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 
 class GetMailboxesNotPutNotificationsLoading extends UIState {}
 
 class GetMailboxesNotPutNotificationsSuccess extends UIState {
-
   final List<PresentationMailbox> mailboxes;
   final UserName userName;
+  final List<PresentationEmail> emails;
+  final State currentState;
 
-  GetMailboxesNotPutNotificationsSuccess(this.mailboxes, this.userName);
+  GetMailboxesNotPutNotificationsSuccess(
+    this.mailboxes,
+    this.userName,
+    this.emails,
+    this.currentState,
+  );
 
   @override
-  List<Object> get props => [mailboxes, userName];
+  List<Object> get props => [mailboxes, userName, emails, currentState];
 }
 
 class GetMailboxesNotPutNotificationsFailure extends FeatureFailure {
-
   final UserName userName;
+  final List<PresentationEmail> emails;
+  final State currentState;
 
-  GetMailboxesNotPutNotificationsFailure(exception, this.userName) : super(exception: exception);
+  GetMailboxesNotPutNotificationsFailure(
+    exception,
+    this.userName,
+    this.emails,
+    this.currentState,
+  ) : super(exception: exception);
 }

--- a/lib/features/push_notification/domain/usecases/get_email_changes_to_push_notification_interactor.dart
+++ b/lib/features/push_notification/domain/usecases/get_email_changes_to_push_notification_interactor.dart
@@ -39,9 +39,18 @@ class GetEmailChangesToPushNotificationInteractor {
         ?.map((email) => email.toPresentationEmail())
         .toList() ?? List.empty();
 
-      yield Right<Failure, Success>(GetEmailChangesToPushNotificationSuccess(accountId, userName, presentationEmailList));
-    } catch (e) {
-      yield Left<Failure, Success>(GetEmailChangesToPushNotificationFailure(e));
+      yield Right<Failure, Success>(GetEmailChangesToPushNotificationSuccess(
+        accountId,
+        userName,
+        presentationEmailList,
+        currentState,
+      ));
+    } catch (e, st) {
+      yield Left<Failure, Success>(GetEmailChangesToPushNotificationFailure(
+        exception: e,
+        stackTrace: st,
+        currentState: currentState,
+      ));
     }
   }
 }

--- a/lib/features/push_notification/domain/usecases/get_mailboxes_not_put_notifications_interactor.dart
+++ b/lib/features/push_notification/domain/usecases/get_mailboxes_not_put_notifications_interactor.dart
@@ -1,8 +1,10 @@
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
-import 'package:dartz/dartz.dart';
+import 'package:dartz/dartz.dart' hide State;
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart';
+import 'package:model/email/presentation_email.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/repository/fcm_repository.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/state/get_mailboxes_not_put_notifications_state.dart';
 
@@ -11,13 +13,31 @@ class GetMailboxesNotPutNotificationsInteractor {
 
   GetMailboxesNotPutNotificationsInteractor(this._fcmRepository);
 
-  Stream<Either<Failure, Success>> execute(Session session, AccountId accountId) async* {
+  Stream<Either<Failure, Success>> execute(
+    Session session,
+    AccountId accountId,
+    List<PresentationEmail> emails,
+    State currentState,
+  ) async* {
     try {
       yield Right<Failure, Success>(GetMailboxesNotPutNotificationsLoading());
-      final mailboxes = await _fcmRepository.getMailboxesNotPutNotifications(session, accountId);
-      yield Right<Failure, Success>(GetMailboxesNotPutNotificationsSuccess(mailboxes, session.username));
+      final mailboxes = await _fcmRepository.getMailboxesNotPutNotifications(
+        session,
+        accountId,
+      );
+      yield Right<Failure, Success>(GetMailboxesNotPutNotificationsSuccess(
+        mailboxes,
+        session.username,
+        emails,
+        currentState,
+      ));
     } catch (e) {
-      yield Left<Failure, Success>(GetMailboxesNotPutNotificationsFailure(e, session.username));
+      yield Left<Failure, Success>(GetMailboxesNotPutNotificationsFailure(
+        e,
+        session.username,
+        emails,
+        currentState,
+      ));
     }
   }
 }

--- a/lib/features/push_notification/presentation/listener/email_change_listener.dart
+++ b/lib/features/push_notification/presentation/listener/email_change_listener.dart
@@ -11,6 +11,7 @@ import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/email/email_property.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:model/extensions/list_presentation_email_extension.dart';
@@ -62,7 +63,6 @@ class EmailChangeListener extends ChangeListener {
   AccountId? _accountId;
   Session? _session;
   UserName? _userName;
-  List<PresentationEmail> _emailsAvailablePushNotification = [];
 
   EmailChangeListener._internal() {
     try {
@@ -99,6 +99,7 @@ class EmailChangeListener extends ChangeListener {
           _getNewReceiveEmailFromNotificationAction(action.session, action.accountId, action.newState);
         }
       } else if (action is PushNotificationAction) {
+        logTrace('EmailChangeListener::dispatchActions(): PushNotificationAction with new state ${action.newState.toString()}');
         _pushNotificationAction(action.newState, action.accountId, action.userName, action.session);
 
         if (PlatformInfo.isAndroid) {
@@ -138,16 +139,27 @@ class EmailChangeListener extends ChangeListener {
   void _getStoredEmailDeliveryState(AccountId accountId, UserName userName) {
     if (_getStoredEmailDeliveryStateInteractor != null) {
       consumeState(_getStoredEmailDeliveryStateInteractor!.execute(accountId, userName));
+    } else {
+      logTrace(
+        'GetStoredEmailDeliveryStateInteractor is null',
+      );
     }
   }
 
   void _getStoredEmailState() {
     if (_getStoredEmailStateInteractor != null && _session != null && _accountId != null) {
       consumeState(_getStoredEmailStateInteractor!.execute(_session!, _accountId!));
+    } else {
+      logError(
+        'GetStoredEmailStateInteractor/session/accountId missing '
+        '(interactorNull=${_getStoredEmailStateInteractor == null}, '
+        'sessionNull=${_session == null}, accountIdNull=${_accountId == null})',
+      );
     }
   }
 
   void _getEmailChangesAction(jmap.State state) {
+    logTrace('EmailChangeListener::_getEmailChangesAction(): from old state ${state.value} to new state ${_newStateEmailDelivery?.value}');
     if (_getEmailChangesToPushNotificationInteractor != null &&
         _accountId != null &&
         _session != null &&
@@ -162,12 +174,20 @@ class EmailChangeListener extends ChangeListener {
           _accountId!,
         ),
       ));
+    } else {
+      logTrace(
+        'GetEmailChangesToPushNotificationInteractor is null, or accountId is null, or session is null, or userName is null',
+      );
     }
   }
 
   void _storeEmailDeliveryStateAction(AccountId accountId, UserName userName, jmap.State state) {
     if (_storeEmailDeliveryStateInteractor != null) {
       consumeState(_storeEmailDeliveryStateInteractor!.execute(accountId, userName, state));
+    } else {
+      logTrace(
+        'StoreEmailDeliveryStateInteractor is null',
+      );
     }
   }
 
@@ -194,10 +214,22 @@ class EmailChangeListener extends ChangeListener {
         failure.exception is NotFoundEmailDeliveryStateException) {
       _getStoredEmailState();
     } else if (failure is GetMailboxesNotPutNotificationsFailure) {
-      final listEmails = _emailsAvailablePushNotification.toEmailsAvailablePushNotification();
       _handleLocalPushNotification(
         userName: failure.userName,
-        emailList: listEmails
+        emailList: failure.emails,
+        currentState: failure.currentState,
+      );
+    } else if (failure is GetEmailChangesToPushNotificationFailure) {
+      logError(
+        'EmailChangeListener::GetEmailChangesToPushNotificationFailure from current state ${failure.currentState.value} to new state ${_newStateEmailDelivery?.value}',
+        exception: failure.exception,
+        stackTrace: failure.stackTrace,
+      );
+    } else if (failure is GetStoredEmailStateFailure) {
+      logError(
+        'EmailChangeListener::GetStoredEmailStateFailure',
+        exception: failure.exception,
+        stackTrace: failure.stackTrace,
       );
     }
   }
@@ -205,25 +237,18 @@ class EmailChangeListener extends ChangeListener {
   @override
   void handleSuccessViewState(Success success) {
     log('EmailChangeListener::_handleSuccessViewState(): $success');
-    if (success is GetStoredEmailDeliveryStateSuccess && _newStateEmailDelivery != success.state) {
-      _getEmailChangesAction(success.state);
+    if (success is GetStoredEmailDeliveryStateSuccess) {
+      _handleGetStoredEmailDeliveryStateSuccess(success);
     } else if (success is GetStoredEmailStateSuccess) {
       _getEmailChangesAction(success.state);
-    } else if (success is GetEmailChangesToPushNotificationSuccess && _newStateEmailDelivery != null) {
-      _storeEmailDeliveryStateAction(success.accountId, success.userName, _newStateEmailDelivery!);
-
-      if (PlatformInfo.isAndroid) {
-        _handleListEmailToPushNotification(
-          userName: success.userName,
-          emailList: success.emailList
-        );
-      }
+    } else if (success is GetEmailChangesToPushNotificationSuccess) {
+      _handleGetEmailChangesToPushNotificationSuccess(success);
     } else if (success is GetMailboxesNotPutNotificationsSuccess) {
-      final listEmails = _emailsAvailablePushNotification.toEmailsAvailablePushNotification(
-        mailboxIdsNotPutNotifications: success.mailboxes.mailboxIds);
       _handleLocalPushNotification(
         userName: success.userName,
-        emailList: listEmails
+        emailList: success.emails,
+        currentState: success.currentState,
+        mailboxIdsNotPutNotifications: success.mailboxes.mailboxIds,
       );
     } else if (success is GetEmailChangesToRemoveNotificationSuccess) {
       _handleRemoveLocalNotification(
@@ -240,33 +265,70 @@ class EmailChangeListener extends ChangeListener {
     }
   }
 
-  void _handleListEmailToPushNotification({
-    required UserName userName,
-    required List<PresentationEmail> emailList
-  }) {
-    _emailsAvailablePushNotification = emailList;
-    if (_getMailboxesNotPutNotificationsInteractor != null && _accountId != null && _session != null) {
-      consumeState(_getMailboxesNotPutNotificationsInteractor!.execute(_session!, _accountId!));
-    } else {
-      final listEmails = _emailsAvailablePushNotification.toEmailsAvailablePushNotification();
-      _handleLocalPushNotification(
-        userName: userName,
-        emailList: listEmails
+  void _handleGetStoredEmailDeliveryStateSuccess(GetStoredEmailDeliveryStateSuccess success) {
+    logTrace('EmailChangeListener::GetStoredEmailDeliveryStateSuccess from current state ${success.state.value} to new state ${_newStateEmailDelivery?.value}');
+    if (_newStateEmailDelivery != success.state) {
+      _getEmailChangesAction(success.state);
+    }
+  }
+
+  void _handleGetEmailChangesToPushNotificationSuccess(GetEmailChangesToPushNotificationSuccess success) {
+    logTrace('EmailChangeListener::GetEmailChangesToPushNotificationSuccess from current state ${success.currentState.value} to new state ${_newStateEmailDelivery?.value}');
+    if (_newStateEmailDelivery == null) return;
+
+    _storeEmailDeliveryStateAction(
+      success.accountId,
+      success.userName,
+      _newStateEmailDelivery!,
+    );
+
+    if (PlatformInfo.isAndroid) {
+      _handleListEmailToPushNotification(
+        userName: success.userName,
+        emailList: success.emailList,
+        currentState: success.currentState,
       );
     }
   }
 
-  void _handleLocalPushNotification({
+  void _handleListEmailToPushNotification({
     required UserName userName,
-    required List<PresentationEmail> emailList
-  }) async {
-    log('EmailChangeListener::_handleLocalPushNotification(): EMAIL_LENGTH = ${emailList.length}');
-    if (emailList.isEmpty) {
-      _emailsAvailablePushNotification.clear();
-      return;
+    required List<PresentationEmail> emailList,
+    required jmap.State currentState,
+  }) {
+    logTrace('EmailChangeListener::_handleListEmailToPushNotification(): Count email received to push notification is ${emailList.length} ${_stateTransitionLog(currentState)}');
+    if (_getMailboxesNotPutNotificationsInteractor != null &&
+        _accountId != null &&
+        _session != null) {
+      consumeState(_getMailboxesNotPutNotificationsInteractor!.execute(
+        _session!,
+        _accountId!,
+        emailList,
+        currentState,
+      ));
+    } else {
+      _handleLocalPushNotification(
+        userName: userName,
+        emailList: emailList,
+        currentState: currentState,
+      );
     }
+  }
 
-    for (var presentationEmail in emailList) {
+  Future<void> _handleLocalPushNotification({
+    required UserName userName,
+    required List<PresentationEmail> emailList,
+    required jmap.State currentState,
+    List<MailboxId>? mailboxIdsNotPutNotifications,
+  }) async {
+    logTrace('EmailChangeListener::_handleLocalPushNotification(): Count email received to push notification = ${emailList.length} ${_stateTransitionLog(currentState)}');
+    final emailsAvailablePushNotification = emailList.toEmailsAvailablePushNotification(
+      mailboxIdsNotPutNotifications: mailboxIdsNotPutNotifications,
+    );
+    logTrace('EmailChangeListener::_handleLocalPushNotification(): Count email available to push notification = ${emailsAvailablePushNotification.length} ${_stateTransitionLog(currentState)}');
+    if (emailsAvailablePushNotification.isEmpty) return;
+
+    for (var presentationEmail in emailsAvailablePushNotification) {
       await _showLocalNotification(
         userName: userName,
         presentationEmail: presentationEmail,
@@ -283,7 +345,7 @@ class EmailChangeListener extends ChangeListener {
         countNotifications: countNotifications);
     }
 
-    _emailsAvailablePushNotification.clear();
+    logTrace('EmailChangeListener::_handleLocalPushNotification(): Count email push success = ${emailsAvailablePushNotification.length} ${_stateTransitionLog(currentState)}');
   }
 
   void _handleRemoveNotificationWhenEmailMarkAsRead(jmap.State newState, AccountId accountId, Session? session) {
@@ -301,7 +363,7 @@ class EmailChangeListener extends ChangeListener {
     required UserName userName,
     required List<EmailId> emailIds
   }) async {
-    log('EmailChangeListener::_handleRemoveLocalNotification():emailIds: $emailIds');
+    logTrace('EmailChangeListener::_handleRemoveLocalNotification: Count email is removed from notification = ${emailIds.length}');
     await Future.wait(emailIds.map((emailId) => LocalNotificationManager.instance.removeNotification(emailId.id.value)));
     await LocalNotificationManager.instance.removeGroupPushNotification(userName.value);
   }
@@ -351,4 +413,7 @@ class EmailChangeListener extends ChangeListener {
       ));
     }
   }
+
+  String _stateTransitionLog(jmap.State currentState) =>
+      'from state ${currentState.value} to new state ${_newStateEmailDelivery?.value}';
 }


### PR DESCRIPTION
## Description

Adds currentState and stackTrace to push notification states and interactors so each step of the FCM notification flow (email changes, mailbox filtering, local notification delivery) is traceable end-to-end through Sentry.    