### PR TITLE
fix: Update `pubspec.lock` to resolve stale `worker_manager` git ref

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2577,7 +2577,7 @@ packages:
     description:
       path: "."
       ref: "hotfix/worker-init-memory-leak"
-      resolved-ref: dd04544217c9fcc08b2a32634583f38d22cc2309
+      resolved-ref: "5c70ecc12f459b97c476ce3dd7a2da4218d71121"
       url: "https://github.com/linagora/worker_manager.git"
     source: git
     version: "7.2.7"


### PR DESCRIPTION
## Issue


<img width="1039" height="444" alt="Screenshot 2026-04-10 at 12 22 40" src="https://github.com/user-attachments/assets/4b8a054a-b023-42c8-8726-6806b1503a42" />




## Root cause

The locked commit (`dd04544`) on branch `hotfix/worker-init-memory-leak` in `linagora/worker_manager` was no longer resolvable, causing `flutter pub get` to fail with `Could not find a file named pubspec.yaml`. This happens when the remote branch is force-pushed or rebased after the lock file was last generated. Regenerated `pubspec.lock` to point to the current HEAD of the branch.  

## Side effect

https://github.com/linagora/tmail-flutter/pull/4435