### PR TITLE
TF-4444 Enable User Control for Needs Action Label Removal

### DIFF
--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -40,6 +40,7 @@ import 'package:tmail_ui_user/features/email/presentation/widgets/email_view_loa
 import 'package:tmail_ui_user/features/email/presentation/widgets/information_sender_and_receiver_builder.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/mail_unsubscribed_banner.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/view_entire_message_with_message_clipped_widget.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_ai_needs_action_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_open_context_menu_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/verify_display_overlay_view_on_iframe_extension.dart';
@@ -275,6 +276,20 @@ class EmailView extends GetWidget<SingleEmailController> {
               imagePaths: controller.imagePaths,
               isMobileResponsive: isMobileResponsive,
               labels: emailLabels,
+              showNeedsAction: controller
+                      .mailboxDashBoardController.isAINeedsActionEnabled &&
+                  presentationEmail.hasNeedAction,
+              onDeleteNeedsAction: () {
+                final context = Get.context;
+                final labelDisplay = context == null
+                    ? 'Action Required'
+                    : AppLocalizations.of(context).actionRequired;
+
+                controller.onRemoveNeedsActionKeyword(
+                  presentationEmail.id,
+                  labelDisplay: labelDisplay,
+                );
+              },
               onDeleteLabelAction: (label) => controller.onToggleLabelAction(
                 presentationEmail.id,
                 label,

--- a/lib/features/email/presentation/widgets/email_subject_widget.dart
+++ b/lib/features/email/presentation/widgets/email_subject_widget.dart
@@ -5,24 +5,29 @@ import 'package:flutter/material.dart';
 import 'package:labels/model/label.dart';
 import 'package:tmail_ui_user/features/email/presentation/styles/email_subject_styles.dart';
 import 'package:tmail_ui_user/features/labels/presentation/widgets/label_widget.dart';
+import 'package:tmail_ui_user/features/labels/presentation/widgets/ai_action_widget.dart';
 
 typedef OnDeleteLabelAction = void Function(Label label);
+typedef OnDeleteNeedsAction = void Function();
 
 class EmailSubjectWidget extends StatefulWidget {
   final String emailSubject;
   final ImagePaths imagePaths;
   final bool isMobileResponsive;
   final List<Label>? labels;
+  final bool showNeedsAction;
   final OnDeleteLabelAction? onDeleteLabelAction;
+  final OnDeleteNeedsAction? onDeleteNeedsAction;
 
-  const EmailSubjectWidget({
-    super.key,
-    required this.emailSubject,
-    required this.imagePaths,
-    this.isMobileResponsive = false,
-    this.labels,
-    this.onDeleteLabelAction,
-  });
+  const EmailSubjectWidget(
+      {super.key,
+      required this.emailSubject,
+      required this.imagePaths,
+      this.isMobileResponsive = false,
+      this.labels,
+      this.showNeedsAction = false,
+      this.onDeleteLabelAction,
+      this.onDeleteNeedsAction});
 
   @override
   State<EmailSubjectWidget> createState() => _EmailSubjectWidgetState();
@@ -31,7 +36,8 @@ class EmailSubjectWidget extends StatefulWidget {
 class _EmailSubjectWidgetState extends State<EmailSubjectWidget> {
   String get _title => widget.emailSubject;
 
-  bool get _hasLabels => _currentLabels?.isNotEmpty == true;
+  bool get _hasLabels =>
+      (_currentLabels?.isNotEmpty == true) || widget.showNeedsAction;
 
   List<Label>? _currentLabels;
 
@@ -83,9 +89,37 @@ class _EmailSubjectWidgetState extends State<EmailSubjectWidget> {
       crossAxisAlignment: WrapCrossAlignment.center,
       children: [
         _buildTitle(),
+        if (widget.showNeedsAction) _buildNeedsActionWidget(context),
         ..._buildLabelWidgets(),
       ],
     );
+  }
+
+  Widget _buildNeedsActionWidget(BuildContext context) {
+    final canRemove = widget.onDeleteNeedsAction != null;
+
+    return AiActionWidget(
+      horizontalPadding: 6,
+      actionWidget: canRemove ? _buildRemoveNeedsActionWidget() : null,
+      padding:
+          canRemove ? const EdgeInsetsDirectional.only(start: 4, end: 2) : null,
+    );
+  }
+
+  Widget _buildRemoveNeedsActionWidget() {
+    return TMailButtonWidget.fromIcon(
+      icon: widget.imagePaths.icDeleteSelection,
+      iconSize: 8,
+      iconColor: Colors.white,
+      padding: const EdgeInsets.all(6),
+      backgroundColor: Colors.transparent,
+      onTapActionCallback: _onDeleteNeedsAction,
+    );
+  }
+
+  void _onDeleteNeedsAction() {
+    if (!mounted || widget.onDeleteNeedsAction == null) return;
+    widget.onDeleteNeedsAction!.call();
   }
 
   Widget _buildTitle() {

--- a/lib/features/labels/presentation/widgets/ai_action_widget.dart
+++ b/lib/features/labels/presentation/widgets/ai_action_widget.dart
@@ -1,0 +1,44 @@
+import 'package:core/core.dart';
+import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/features/base/widget/labels/tag_widget.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+class AiActionWidget extends StatelessWidget {
+  final double horizontalPadding;
+  final double? maxWidth;
+  final Widget? actionWidget;
+  final EdgeInsetsGeometry? padding;
+
+  const AiActionWidget({
+    super.key,
+    this.horizontalPadding = 4,
+    this.maxWidth,
+    this.actionWidget,
+    this.padding,
+  });
+
+  factory AiActionWidget.create({
+    required Widget removeLabelAction,
+    EdgeInsetsGeometry? padding,
+  }) =>
+      AiActionWidget(
+        actionWidget: removeLabelAction,
+        padding: padding,
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    final showTooltip = PlatformInfo.isWeb;
+
+    return TagWidget(
+      text: AppLocalizations.of(context).actionRequired,
+      backgroundColor: AppColor.aiActionTag,
+      textColor: Colors.white,
+      horizontalPadding: horizontalPadding,
+      maxWidth: maxWidth,
+      showTooltip: showTooltip,
+      actionWidget: actionWidget,
+      padding: padding,
+    );
+  }
+}


### PR DESCRIPTION
 This PR enables users  to remove `action-required` label when it is incorrectly assigned.

**Notes:** Running Tmail front locally with a backend Docker image documentation needs to be updated.

closes #4444

[Screencast from 24-04-26 10:25:00.webm](https://github.com/user-attachments/assets/828393e6-397c-46e3-bbde-54e973778f12)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added visual "Action Required" indicator on emails that need attention.
  * Users can now remove the "Action Required" status from individual emails with a dedicated action button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
