### PR TITLE
Disable Audo backup and Device-to_device transfer

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -36,7 +36,9 @@
    <application
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules">
 
        <meta-data
            android:name="com.google.firebase.messaging.default_notification_icon"

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup />
+    <device-transfer />
+</data-extraction-rules>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,5 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
-    <cloud-backup />
-    <device-transfer />
+    <cloud-backup>
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="device_root" path="." />
+        <exclude domain="device_file" path="." />
+        <exclude domain="device_database" path="." />
+        <exclude domain="device_sharedpref" path="." />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="device_root" path="." />
+        <exclude domain="device_file" path="." />
+        <exclude domain="device_database" path="." />
+        <exclude domain="device_sharedpref" path="." />
+    </device-transfer>
 </data-extraction-rules>


### PR DESCRIPTION
Implement for ADR in https://github.com/linagora/tmail-flutter/pull/4427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled automatic cloud/device backups and added explicit data-extraction rules so app data will be excluded from cloud backup and device transfer flows.
  * No changes to app behavior, visible UI, or exported components; app icon and functionality remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->