### PR TITLE
Refactor(logger): Introduce handler pipeline (ADR-0078) 

### DIFF
--- a/core/lib/utils/app_logger.dart
+++ b/core/lib/utils/app_logger.dart
@@ -1,5 +1,6 @@
 import 'package:core/utils/logging/app_logger_registry.dart';
 import 'package:core/utils/logging/log_level.dart';
+import 'package:core/utils/logging/log_record.dart';
 
 export 'package:core/utils/logging/log_level.dart' show Level;
 
@@ -91,7 +92,8 @@ void _dispatch(
   Map<String, dynamic>? extras,
   bool webConsoleEnabled = false,
 }) {
-  final record = buildLogRecord(
+  if (!AppLoggerRegistry.instance.hasHandlerFor(level)) return;
+  final record = LogRecord.build(
     level: level,
     message: message,
     exception: exception,

--- a/core/lib/utils/app_logger.dart
+++ b/core/lib/utils/app_logger.dart
@@ -7,12 +7,18 @@ export 'package:core/utils/logging/log_level.dart' show Level;
 ///
 /// Call sites are unchanged — the public function signatures are stable
 /// across all 188+ existing usages.
+///
+/// Note: [webConsoleEnabled] on every function is deprecated. Web console
+/// output is now controlled globally by [ConsoleLogHandler] registered at
+/// startup — per-call overrides are no longer supported. The parameter is
+/// kept for source compatibility and will be removed in a future release.
 
 void logError(
   String? message, {
   Object? exception,
   StackTrace? stackTrace,
   Map<String, dynamic>? extras,
+  @Deprecated('Web console output is now controlled by ConsoleLogHandler at startup')
   bool webConsoleEnabled = false,
 }) {
   _dispatch(
@@ -29,6 +35,7 @@ void logCritical(
   Object? exception,
   StackTrace? stackTrace,
   Map<String, dynamic>? extras,
+  @Deprecated('Web console output is now controlled by ConsoleLogHandler at startup')
   bool webConsoleEnabled = false,
 }) {
   _dispatch(
@@ -42,6 +49,7 @@ void logCritical(
 
 void logWarning(
   String? message, {
+  @Deprecated('Web console output is now controlled by ConsoleLogHandler at startup')
   bool webConsoleEnabled = false,
 }) {
   _dispatch(message, level: Level.warning);
@@ -49,6 +57,7 @@ void logWarning(
 
 void logInfo(
   String? message, {
+  @Deprecated('Web console output is now controlled by ConsoleLogHandler at startup')
   bool webConsoleEnabled = false,
 }) {
   _dispatch(message, level: Level.info);
@@ -56,6 +65,7 @@ void logInfo(
 
 void logDebug(
   String? message, {
+  @Deprecated('Web console output is now controlled by ConsoleLogHandler at startup')
   bool webConsoleEnabled = false,
 }) {
   _dispatch(message, level: Level.debug);
@@ -63,6 +73,7 @@ void logDebug(
 
 void logTrace(
   String? message, {
+  @Deprecated('Web console output is now controlled by ConsoleLogHandler at startup')
   bool webConsoleEnabled = false,
   Map<String, dynamic>? extras,
 }) {
@@ -71,9 +82,10 @@ void logTrace(
 
 void log(
   String? message, {
+  @Deprecated('Web console output is now controlled by ConsoleLogHandler at startup')
   bool webConsoleEnabled = false,
 }) =>
-    logInfo(message, webConsoleEnabled: webConsoleEnabled);
+    logInfo(message);
 
 void _dispatch(
   String? message, {

--- a/core/lib/utils/app_logger.dart
+++ b/core/lib/utils/app_logger.dart
@@ -5,20 +5,15 @@ export 'package:core/utils/logging/log_level.dart' show Level;
 
 /// Public logging API. All log calls delegate to [AppLoggerRegistry].
 ///
-/// Call sites are unchanged — the public function signatures are stable
-/// across all 188+ existing usages.
-///
-/// Note: [webConsoleEnabled] on every function is deprecated. Web console
-/// output is now controlled globally by [ConsoleLogHandler] registered at
-/// startup — per-call overrides are no longer supported. The parameter is
-/// kept for source compatibility and will be removed in a future release.
+/// [webConsoleEnabled] forces output to the browser console regardless of
+/// build mode — useful for diagnostics that must be visible in release/profile
+/// builds on web. Defaults to false (web console output follows debug mode).
 
 void logError(
   String? message, {
   Object? exception,
   StackTrace? stackTrace,
   Map<String, dynamic>? extras,
-  @Deprecated('Web console output is now controlled by ConsoleLogHandler at startup')
   bool webConsoleEnabled = false,
 }) {
   _dispatch(
@@ -27,6 +22,7 @@ void logError(
     exception: exception,
     stackTrace: stackTrace,
     extras: extras,
+    webConsoleEnabled: webConsoleEnabled,
   );
 }
 
@@ -35,7 +31,6 @@ void logCritical(
   Object? exception,
   StackTrace? stackTrace,
   Map<String, dynamic>? extras,
-  @Deprecated('Web console output is now controlled by ConsoleLogHandler at startup')
   bool webConsoleEnabled = false,
 }) {
   _dispatch(
@@ -44,48 +39,49 @@ void logCritical(
     exception: exception,
     stackTrace: stackTrace,
     extras: extras,
+    webConsoleEnabled: webConsoleEnabled,
   );
 }
 
 void logWarning(
   String? message, {
-  @Deprecated('Web console output is now controlled by ConsoleLogHandler at startup')
   bool webConsoleEnabled = false,
 }) {
-  _dispatch(message, level: Level.warning);
+  _dispatch(message, level: Level.warning, webConsoleEnabled: webConsoleEnabled);
 }
 
 void logInfo(
   String? message, {
-  @Deprecated('Web console output is now controlled by ConsoleLogHandler at startup')
   bool webConsoleEnabled = false,
 }) {
-  _dispatch(message, level: Level.info);
+  _dispatch(message, level: Level.info, webConsoleEnabled: webConsoleEnabled);
 }
 
 void logDebug(
   String? message, {
-  @Deprecated('Web console output is now controlled by ConsoleLogHandler at startup')
   bool webConsoleEnabled = false,
 }) {
-  _dispatch(message, level: Level.debug);
+  _dispatch(message, level: Level.debug, webConsoleEnabled: webConsoleEnabled);
 }
 
 void logTrace(
   String? message, {
-  @Deprecated('Web console output is now controlled by ConsoleLogHandler at startup')
   bool webConsoleEnabled = false,
   Map<String, dynamic>? extras,
 }) {
-  _dispatch(message, level: Level.trace, extras: extras);
+  _dispatch(
+    message,
+    level: Level.trace,
+    extras: extras,
+    webConsoleEnabled: webConsoleEnabled,
+  );
 }
 
 void log(
   String? message, {
-  @Deprecated('Web console output is now controlled by ConsoleLogHandler at startup')
   bool webConsoleEnabled = false,
 }) =>
-    logInfo(message);
+    logInfo(message, webConsoleEnabled: webConsoleEnabled);
 
 void _dispatch(
   String? message, {
@@ -93,6 +89,7 @@ void _dispatch(
   Object? exception,
   StackTrace? stackTrace,
   Map<String, dynamic>? extras,
+  bool webConsoleEnabled = false,
 }) {
   final record = buildLogRecord(
     level: level,
@@ -100,6 +97,7 @@ void _dispatch(
     exception: exception,
     stackTrace: stackTrace,
     extras: extras,
+    webConsoleEnabled: webConsoleEnabled,
   );
   AppLoggerRegistry.instance.dispatch(record);
 }

--- a/core/lib/utils/app_logger.dart
+++ b/core/lib/utils/app_logger.dart
@@ -1,141 +1,12 @@
-import 'package:core/utils/build_utils.dart';
-import 'package:core/utils/platform_info.dart';
-import 'package:core/utils/sentry/sentry_manager.dart';
-import 'package:universal_html/html.dart' as html;
+import 'package:core/utils/logging/app_logger_registry.dart';
+import 'package:core/utils/logging/log_level.dart';
 
-/// ANSI escape colors (Web only)
-const ansiReset = '\x1B[0m';
-const ansiRed = '\x1B[31m';
-const ansiYellow = '\x1B[33m';
-const ansiGreen = '\x1B[32m';
-const ansiBlue = '\x1B[34m';
-const ansiBold = '\x1B[1m';
+export 'package:core/utils/logging/log_level.dart' show Level;
 
-const appLogName = '[TwakeMail]';
-
-String _applyWebColor(Level level, String text) {
-  switch (level) {
-    case Level.critical:
-      return '$ansiRed$ansiBold!!!CRITICAL!!! $text$ansiReset';
-    case Level.error:
-      return '$ansiRed$text$ansiReset';
-    case Level.warning:
-      return '$ansiYellow$text$ansiReset';
-    case Level.info:
-      return '$ansiGreen$text$ansiReset';
-    case Level.debug:
-      return '$ansiBlue$text$ansiReset';
-    case Level.trace:
-      return text;
-  }
-}
-
-String _applyMobileFormat(Level level, String text) {
-  switch (level) {
-    case Level.critical:
-      return '🔥 CRITICAL: $text';
-    case Level.error:
-      return '❌ ERROR: $text';
-    case Level.warning:
-      return '⚠️ WARNING: $text';
-    case Level.info:
-      return 'ℹ️ INFO: $text';
-    case Level.debug:
-      return '🐛 DEBUG: $text';
-    case Level.trace:
-      return '🔍 VERBOSE: $text';
-  }
-}
-
-void _internalLog(
-  String? message, {
-  required Level level,
-  Object? exception,
-  StackTrace? stackTrace,
-  Map<String, dynamic>? extras,
-  bool webConsoleEnabled = false,
-}) {
-  final shouldPrint = webConsoleEnabled
-      ? PlatformInfo.isWeb
-      : BuildUtils.isDebugMode;
-
-  final shouldSentry = _shouldReportToSentry(level);
-
-  if (!shouldPrint && !shouldSentry) {
-    return;
-  }
-
-  final rawMessage = _buildRawMessage(message, exception, extras, stackTrace);
-
-  if (shouldPrint) {
-    final formattedMessage = _formatMessage(level, rawMessage);
-
-    if (webConsoleEnabled && PlatformInfo.isWeb) {
-      _printWebConsole(level, formattedMessage);
-    } else {
-      // ignore: avoid_print
-      print('$appLogName $formattedMessage');
-    }
-  }
-
-  if (shouldSentry) {
-    if (level == Level.trace) {
-      SentryManager.instance.captureMessage(rawMessage, extras: extras);
-    } else {
-      SentryManager.instance.captureException(
-        exception ?? rawMessage,
-        stackTrace: stackTrace,
-        message: rawMessage,
-        extras: extras,
-      );
-    }
-  }
-}
-
-String _buildRawMessage(
-  String? message,
-  Object? exception,
-  Map<String, dynamic>? extras,
-  StackTrace? stackTrace,
-) {
-  final parts = <String>[];
-  if (message?.isNotEmpty == true) parts.add(message!);
-  if (exception != null) parts.add('exception: $exception');
-  if (extras != null && extras.isNotEmpty) parts.add('extras: $extras');
-  if (stackTrace != null) parts.add('stackTrace: $stackTrace');
-  return parts.join(' | ');
-}
-
-String _formatMessage(Level level, String raw) {
-  return PlatformInfo.isWeb
-      ? _applyWebColor(level, raw)
-      : _applyMobileFormat(level, raw);
-}
-
-void _printWebConsole(Level level, String value) {
-  switch (level) {
-    case Level.error:
-    case Level.critical:
-      html.window.console.error('$appLogName $value');
-      break;
-    case Level.warning:
-      html.window.console.warn('$appLogName $value');
-      break;
-    case Level.info:
-      html.window.console.info('$appLogName $value');
-      break;
-    case Level.debug:
-    case Level.trace:
-      html.window.console.debug('$appLogName $value');
-      break;
-  }
-}
-
-bool _shouldReportToSentry(Level level) {
-  return level == Level.error ||
-      level == Level.critical ||
-      level == Level.trace;
-}
+/// Public logging API. All log calls delegate to [AppLoggerRegistry].
+///
+/// Call sites are unchanged — the public function signatures are stable
+/// across all 188+ existing usages.
 
 void logError(
   String? message, {
@@ -144,13 +15,12 @@ void logError(
   Map<String, dynamic>? extras,
   bool webConsoleEnabled = false,
 }) {
-  _internalLog(
+  _dispatch(
     message,
     level: Level.error,
     exception: exception,
     stackTrace: stackTrace,
     extras: extras,
-    webConsoleEnabled: webConsoleEnabled,
   );
 }
 
@@ -161,13 +31,12 @@ void logCritical(
   Map<String, dynamic>? extras,
   bool webConsoleEnabled = false,
 }) {
-  _internalLog(
+  _dispatch(
     message,
     level: Level.critical,
     exception: exception,
     stackTrace: stackTrace,
     extras: extras,
-    webConsoleEnabled: webConsoleEnabled,
   );
 }
 
@@ -175,30 +44,21 @@ void logWarning(
   String? message, {
   bool webConsoleEnabled = false,
 }) {
-  _internalLog(message,
-      level: Level.warning, webConsoleEnabled: webConsoleEnabled);
+  _dispatch(message, level: Level.warning);
 }
 
 void logInfo(
   String? message, {
   bool webConsoleEnabled = false,
 }) {
-  _internalLog(
-    message,
-    level: Level.info,
-    webConsoleEnabled: webConsoleEnabled,
-  );
+  _dispatch(message, level: Level.info);
 }
 
 void logDebug(
   String? message, {
   bool webConsoleEnabled = false,
 }) {
-  _internalLog(
-    message,
-    level: Level.debug,
-    webConsoleEnabled: webConsoleEnabled,
-  );
+  _dispatch(message, level: Level.debug);
 }
 
 void logTrace(
@@ -206,28 +66,28 @@ void logTrace(
   bool webConsoleEnabled = false,
   Map<String, dynamic>? extras,
 }) {
-  _internalLog(
-    message,
-    level: Level.trace,
-    webConsoleEnabled: webConsoleEnabled,
-    extras: extras,
-  );
+  _dispatch(message, level: Level.trace, extras: extras);
 }
 
 void log(
   String? message, {
   bool webConsoleEnabled = false,
 }) =>
-    logInfo(
-      message,
-      webConsoleEnabled: webConsoleEnabled,
-    );
+    logInfo(message, webConsoleEnabled: webConsoleEnabled);
 
-enum Level {
-  critical,
-  error,
-  warning,
-  info,
-  debug,
-  trace,
+void _dispatch(
+  String? message, {
+  required Level level,
+  Object? exception,
+  StackTrace? stackTrace,
+  Map<String, dynamic>? extras,
+}) {
+  final record = buildLogRecord(
+    level: level,
+    message: message,
+    exception: exception,
+    stackTrace: stackTrace,
+    extras: extras,
+  );
+  AppLoggerRegistry.instance.dispatch(record);
 }

--- a/core/lib/utils/logging/app_logger_registry.dart
+++ b/core/lib/utils/logging/app_logger_registry.dart
@@ -1,0 +1,85 @@
+import 'package:core/utils/logging/log_handler.dart';
+import 'package:core/utils/logging/log_level.dart';
+import 'package:core/utils/logging/log_record.dart';
+
+/// Dispatch orchestrator for the logger handler pipeline.
+///
+/// Holds a list of [LogHandler]s and routes each [LogRecord] to every
+/// handler whose [LogHandler.handles] returns true.
+///
+/// Uses a static singleton (not GetX) because the logger must be
+/// available before GetX initialises.
+///
+/// **Idempotency:** [registerHandler] checks by [runtimeType] before adding.
+/// Registering the same handler type twice is a no-op — prevents duplicate
+/// output on hot restart or repeated bootstrap calls.
+class AppLoggerRegistry {
+  AppLoggerRegistry._();
+
+  static final AppLoggerRegistry instance = AppLoggerRegistry._();
+
+  final List<LogHandler> _handlers = [];
+
+  /// Registers [handler] if no handler of the same [runtimeType] exists.
+  void registerHandler(LogHandler handler) {
+    final alreadyRegistered = _handlers.any(
+      (h) => h.runtimeType == handler.runtimeType,
+    );
+    if (!alreadyRegistered) {
+      _handlers.add(handler);
+    }
+  }
+
+  /// Dispatches [record] to all handlers that accept its level.
+  void dispatch(LogRecord record) {
+    for (final handler in _handlers) {
+      if (handler.handles(record.level)) {
+        handler.handle(record);
+      }
+    }
+  }
+
+  /// Clears all registered handlers.
+  ///
+  /// **For test isolation only.** Must never be called in production code.
+  void resetForTesting() {
+    _handlers.clear();
+  }
+
+  /// Returns the number of currently registered handlers.
+  ///
+  /// Exposed for testing purposes only.
+  int get handlerCount => _handlers.length;
+}
+
+/// Builds a [LogRecord] from the given log call parameters.
+LogRecord buildLogRecord({
+  required Level level,
+  String? message,
+  Object? exception,
+  StackTrace? stackTrace,
+  Map<String, dynamic>? extras,
+}) {
+  final rawMessage = _buildRawMessage(message, exception, extras, stackTrace);
+  return LogRecord(
+    level: level,
+    rawMessage: rawMessage,
+    exception: exception,
+    stackTrace: stackTrace,
+    extras: extras,
+  );
+}
+
+String _buildRawMessage(
+  String? message,
+  Object? exception,
+  Map<String, dynamic>? extras,
+  StackTrace? stackTrace,
+) {
+  final parts = <String>[];
+  if (message?.isNotEmpty == true) parts.add(message!);
+  if (exception != null) parts.add('exception: $exception');
+  if (extras != null && extras.isNotEmpty) parts.add('extras: $extras');
+  if (stackTrace != null) parts.add('stackTrace: $stackTrace');
+  return parts.join(' | ');
+}

--- a/core/lib/utils/logging/app_logger_registry.dart
+++ b/core/lib/utils/logging/app_logger_registry.dart
@@ -20,13 +20,19 @@ class AppLoggerRegistry {
 
   final List<LogHandler> _handlers = [];
 
-  /// Registers [handler] if no handler of the same [runtimeType] exists.
+  /// Registers [handler], replacing any existing handler of the same [runtimeType].
+  ///
+  /// This ensures that re-registering with a new configuration (e.g. a different
+  /// [LogFormatter]) takes effect rather than silently keeping the stale instance.
   void registerHandler(LogHandler handler) {
-    final alreadyRegistered = _handlers.any(
+    final existingIndex = _handlers.indexWhere(
       (h) => h.runtimeType == handler.runtimeType,
     );
-    if (!alreadyRegistered) {
+
+    if (existingIndex == -1) {
       _handlers.add(handler);
+    } else {
+      _handlers[existingIndex] = handler;
     }
   }
 
@@ -37,13 +43,13 @@ class AppLoggerRegistry {
   /// Avoid logging inside the catch block to prevent recursive dispatch loops.
   void dispatch(LogRecord record) {
     for (final handler in _handlers) {
-      if (handler.handles(record.level)) {
-        try {
+      try {
+        if (handler.handles(record.level)) {
           handler.handle(record);
-        } catch (_) {
-          // Logging must not break the application flow.
-          // Avoid logging here to prevent recursive dispatch loops.
         }
+      } catch (_) {
+        // Logging must not break the application flow.
+        // Avoid logging here to prevent recursive dispatch loops.
       }
     }
   }

--- a/core/lib/utils/logging/app_logger_registry.dart
+++ b/core/lib/utils/logging/app_logger_registry.dart
@@ -31,10 +31,19 @@ class AppLoggerRegistry {
   }
 
   /// Dispatches [record] to all handlers that accept its level.
+  ///
+  /// Handler exceptions are swallowed so that a broken destination cannot
+  /// crash callers or prevent other handlers from receiving the record.
+  /// Avoid logging inside the catch block to prevent recursive dispatch loops.
   void dispatch(LogRecord record) {
     for (final handler in _handlers) {
       if (handler.handles(record.level)) {
-        handler.handle(record);
+        try {
+          handler.handle(record);
+        } catch (_) {
+          // Logging must not break the application flow.
+          // Avoid logging here to prevent recursive dispatch loops.
+        }
       }
     }
   }

--- a/core/lib/utils/logging/app_logger_registry.dart
+++ b/core/lib/utils/logging/app_logger_registry.dart
@@ -40,7 +40,14 @@ class AppLoggerRegistry {
     }
   }
 
-  /// Dispatches [record] to all handlers that accept its level.
+  /// Returns true if at least one registered handler may accept records at [level].
+  ///
+  /// This is a fast pre-screen based on [LogHandler.acceptsLevel] — it avoids
+  /// building a full [LogRecord] when no handler is interested in the level.
+  bool hasHandlerFor(Level level) =>
+      _handlers.any((h) => h.acceptsLevel(level));
+
+  /// Dispatches [record] to all handlers that accept it.
   ///
   /// Handler exceptions are swallowed so that a broken destination cannot
   /// crash callers or prevent other handlers from receiving the record.
@@ -48,7 +55,7 @@ class AppLoggerRegistry {
   void dispatch(LogRecord record) {
     for (final handler in _handlers) {
       try {
-        if (handler.handles(record.level)) {
+        if (handler.handles(record)) {
           handler.handle(record);
         }
       } catch (_) {
@@ -70,38 +77,4 @@ class AppLoggerRegistry {
   ///
   /// Exposed for testing purposes only.
   int get handlerCount => _handlers.length;
-}
-
-/// Builds a [LogRecord] from the given log call parameters.
-LogRecord buildLogRecord({
-  required Level level,
-  String? message,
-  Object? exception,
-  StackTrace? stackTrace,
-  Map<String, dynamic>? extras,
-  bool webConsoleEnabled = false,
-}) {
-  final rawMessage = _buildRawMessage(message, exception, extras, stackTrace);
-  return LogRecord(
-    level: level,
-    rawMessage: rawMessage,
-    exception: exception,
-    stackTrace: stackTrace,
-    extras: extras,
-    webConsoleEnabled: webConsoleEnabled,
-  );
-}
-
-String _buildRawMessage(
-  String? message,
-  Object? exception,
-  Map<String, dynamic>? extras,
-  StackTrace? stackTrace,
-) {
-  final parts = <String>[];
-  if (message?.isNotEmpty == true) parts.add(message!);
-  if (exception != null) parts.add('exception: $exception');
-  if (extras != null && extras.isNotEmpty) parts.add('extras: $extras');
-  if (stackTrace != null) parts.add('stackTrace: $stackTrace');
-  return parts.join(' | ');
 }

--- a/core/lib/utils/logging/app_logger_registry.dart
+++ b/core/lib/utils/logging/app_logger_registry.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 /// Dispatch orchestrator for the logger handler pipeline.
 ///
 /// Holds a list of [LogHandler]s and routes each [LogRecord] to every
-/// handler whose [LogHandler.handles] returns true.
+/// handler whose [LogHandler.canHandle] returns true.
 ///
 /// Uses a static singleton (not GetX) because the logger must be
 /// available before GetX initialises.
@@ -55,7 +55,7 @@ class AppLoggerRegistry {
   void dispatch(LogRecord record) {
     for (final handler in _handlers) {
       try {
-        if (handler.handles(record)) {
+        if (handler.canHandle(record)) {
           handler.handle(record);
         }
       } catch (_) {

--- a/core/lib/utils/logging/app_logger_registry.dart
+++ b/core/lib/utils/logging/app_logger_registry.dart
@@ -1,6 +1,7 @@
 import 'package:core/utils/logging/log_handler.dart';
 import 'package:core/utils/logging/log_level.dart';
 import 'package:core/utils/logging/log_record.dart';
+import 'package:flutter/material.dart';
 
 /// Dispatch orchestrator for the logger handler pipeline.
 ///
@@ -10,9 +11,10 @@ import 'package:core/utils/logging/log_record.dart';
 /// Uses a static singleton (not GetX) because the logger must be
 /// available before GetX initialises.
 ///
-/// **Idempotency:** [registerHandler] checks by [runtimeType] before adding.
-/// Registering the same handler type twice is a no-op — prevents duplicate
-/// output on hot restart or repeated bootstrap calls.
+/// **Idempotency:** [registerHandler] deduplicates by [LogHandler.handlerKey].
+/// By default the key is [runtimeType.toString()], so registering the same
+/// concrete class twice replaces the first instance. Override [handlerKey]
+/// on a handler to allow multiple instances of the same class to coexist.
 class AppLoggerRegistry {
   AppLoggerRegistry._();
 
@@ -20,13 +22,15 @@ class AppLoggerRegistry {
 
   final List<LogHandler> _handlers = [];
 
-  /// Registers [handler], replacing any existing handler of the same [runtimeType].
+  /// Registers [handler], replacing any existing handler with the same [LogHandler.handlerKey].
   ///
   /// This ensures that re-registering with a new configuration (e.g. a different
   /// [LogFormatter]) takes effect rather than silently keeping the stale instance.
+  /// To allow multiple instances of the same concrete class, override [LogHandler.handlerKey]
+  /// with a distinct value per instance.
   void registerHandler(LogHandler handler) {
     final existingIndex = _handlers.indexWhere(
-      (h) => h.runtimeType == handler.runtimeType,
+      (h) => h.handlerKey == handler.handlerKey,
     );
 
     if (existingIndex == -1) {
@@ -57,6 +61,7 @@ class AppLoggerRegistry {
   /// Clears all registered handlers.
   ///
   /// **For test isolation only.** Must never be called in production code.
+  @visibleForTesting
   void resetForTesting() {
     _handlers.clear();
   }

--- a/core/lib/utils/logging/app_logger_registry.dart
+++ b/core/lib/utils/logging/app_logger_registry.dart
@@ -59,6 +59,7 @@ LogRecord buildLogRecord({
   Object? exception,
   StackTrace? stackTrace,
   Map<String, dynamic>? extras,
+  bool webConsoleEnabled = false,
 }) {
   final rawMessage = _buildRawMessage(message, exception, extras, stackTrace);
   return LogRecord(
@@ -67,6 +68,7 @@ LogRecord buildLogRecord({
     exception: exception,
     stackTrace: stackTrace,
     extras: extras,
+    webConsoleEnabled: webConsoleEnabled,
   );
 }
 

--- a/core/lib/utils/logging/app_logger_registry.dart
+++ b/core/lib/utils/logging/app_logger_registry.dart
@@ -1,7 +1,7 @@
 import 'package:core/utils/logging/log_handler.dart';
 import 'package:core/utils/logging/log_level.dart';
 import 'package:core/utils/logging/log_record.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 
 /// Dispatch orchestrator for the logger handler pipeline.
 ///
@@ -74,7 +74,6 @@ class AppLoggerRegistry {
   }
 
   /// Returns the number of currently registered handlers.
-  ///
-  /// Exposed for testing purposes only.
+  @visibleForTesting
   int get handlerCount => _handlers.length;
 }

--- a/core/lib/utils/logging/formatters/log_formatter.dart
+++ b/core/lib/utils/logging/formatters/log_formatter.dart
@@ -1,0 +1,10 @@
+import 'package:core/utils/logging/log_level.dart';
+
+/// Abstract interface for formatting a raw log message.
+///
+/// Implementations are platform-specific and injected into handlers
+/// via constructor (Dependency Inversion Principle).
+abstract interface class LogFormatter {
+  /// Returns a formatted string for the given [level] and [raw] message.
+  String format(Level level, String raw);
+}

--- a/core/lib/utils/logging/formatters/mobile_console_formatter.dart
+++ b/core/lib/utils/logging/formatters/mobile_console_formatter.dart
@@ -1,0 +1,25 @@
+import 'package:core/utils/logging/formatters/log_formatter.dart';
+import 'package:core/utils/logging/log_level.dart';
+
+/// Formats log messages for mobile/debug console output using emoji prefixes.
+class MobileConsoleFormatter implements LogFormatter {
+  const MobileConsoleFormatter();
+
+  @override
+  String format(Level level, String raw) {
+    switch (level) {
+      case Level.critical:
+        return '🔥 CRITICAL: $raw';
+      case Level.error:
+        return '❌ ERROR: $raw';
+      case Level.warning:
+        return '⚠️ WARNING: $raw';
+      case Level.info:
+        return 'ℹ️ INFO: $raw';
+      case Level.debug:
+        return '🐛 DEBUG: $raw';
+      case Level.trace:
+        return '🔍 VERBOSE: $raw';
+    }
+  }
+}

--- a/core/lib/utils/logging/formatters/web_console_formatter.dart
+++ b/core/lib/utils/logging/formatters/web_console_formatter.dart
@@ -1,0 +1,33 @@
+import 'package:core/utils/logging/formatters/log_formatter.dart';
+import 'package:core/utils/logging/log_level.dart';
+
+/// ANSI escape colors for web console output.
+const _ansiReset = '\x1B[0m';
+const _ansiRed = '\x1B[31m';
+const _ansiYellow = '\x1B[33m';
+const _ansiGreen = '\x1B[32m';
+const _ansiBlue = '\x1B[34m';
+const _ansiBold = '\x1B[1m';
+
+/// Formats log messages for web console output using ANSI color codes.
+class WebConsoleFormatter implements LogFormatter {
+  const WebConsoleFormatter();
+
+  @override
+  String format(Level level, String raw) {
+    switch (level) {
+      case Level.critical:
+        return '$_ansiRed$_ansiBold!!!CRITICAL!!! $raw$_ansiReset';
+      case Level.error:
+        return '$_ansiRed$raw$_ansiReset';
+      case Level.warning:
+        return '$_ansiYellow$raw$_ansiReset';
+      case Level.info:
+        return '$_ansiGreen$raw$_ansiReset';
+      case Level.debug:
+        return '$_ansiBlue$raw$_ansiReset';
+      case Level.trace:
+        return raw;
+    }
+  }
+}

--- a/core/lib/utils/logging/handlers/console_log_handler.dart
+++ b/core/lib/utils/logging/handlers/console_log_handler.dart
@@ -1,0 +1,64 @@
+import 'package:core/utils/build_utils.dart';
+import 'package:core/utils/logging/formatters/log_formatter.dart';
+import 'package:core/utils/logging/log_handler.dart';
+import 'package:core/utils/logging/log_level.dart';
+import 'package:core/utils/logging/log_record.dart';
+import 'package:core/utils/platform_info.dart';
+import 'package:universal_html/html.dart' as html;
+
+const _appLogName = '[TwakeMail]';
+
+/// Writes log records to the console.
+///
+/// On web with [webConsoleEnabled], delegates to the browser console API
+/// so that log levels map to the correct console method (error/warn/info/debug).
+/// On other platforms, uses [print] — visible only in debug mode.
+///
+/// The [formatter] is injected via constructor (Dependency Inversion Principle),
+/// allowing platform-specific formatting without branching inside this class.
+class ConsoleLogHandler implements LogHandler {
+  final LogFormatter formatter;
+  final bool webConsoleEnabled;
+
+  const ConsoleLogHandler({
+    required this.formatter,
+    this.webConsoleEnabled = false,
+  });
+
+  @override
+  bool handles(Level level) {
+    if (webConsoleEnabled && PlatformInfo.isWeb) return true;
+    return BuildUtils.isDebugMode;
+  }
+
+  @override
+  void handle(LogRecord record) {
+    final formatted = formatter.format(record.level, record.rawMessage);
+
+    if (webConsoleEnabled && PlatformInfo.isWeb) {
+      _printToWebConsole(record.level, formatted);
+    } else {
+      // ignore: avoid_print
+      print('$_appLogName $formatted');
+    }
+  }
+
+  void _printToWebConsole(Level level, String value) {
+    switch (level) {
+      case Level.error:
+      case Level.critical:
+        html.window.console.error('$_appLogName $value');
+        break;
+      case Level.warning:
+        html.window.console.warn('$_appLogName $value');
+        break;
+      case Level.info:
+        html.window.console.info('$_appLogName $value');
+        break;
+      case Level.debug:
+      case Level.trace:
+        html.window.console.debug('$_appLogName $value');
+        break;
+    }
+  }
+}

--- a/core/lib/utils/logging/handlers/console_log_handler.dart
+++ b/core/lib/utils/logging/handlers/console_log_handler.dart
@@ -10,24 +10,24 @@ const _appLogName = '[TwakeMail]';
 
 /// Writes log records to the console.
 ///
-/// On web with [webConsoleEnabled], delegates to the browser console API
-/// so that log levels map to the correct console method (error/warn/info/debug).
+/// On web, delegates to the browser console API when either:
+/// - the record was logged with [LogRecord.webConsoleEnabled] = true (per-call opt-in), or
+/// - the app is running in debug mode.
+///
 /// On other platforms, uses [print] — visible only in debug mode.
 ///
 /// The [formatter] is injected via constructor (Dependency Inversion Principle),
 /// allowing platform-specific formatting without branching inside this class.
 class ConsoleLogHandler implements LogHandler {
   final LogFormatter formatter;
-  final bool webConsoleEnabled;
 
-  const ConsoleLogHandler({
-    required this.formatter,
-    this.webConsoleEnabled = false,
-  });
+  const ConsoleLogHandler({required this.formatter});
 
   @override
   bool handles(Level level) {
-    if (webConsoleEnabled && PlatformInfo.isWeb) return true;
+    // Always accept on web — final filtering happens in handle() because
+    // per-record webConsoleEnabled may override the debug-mode gate.
+    if (PlatformInfo.isWeb) return true;
     return BuildUtils.isDebugMode;
   }
 
@@ -35,8 +35,10 @@ class ConsoleLogHandler implements LogHandler {
   void handle(LogRecord record) {
     final formatted = formatter.format(record.level, record.rawMessage);
 
-    if (webConsoleEnabled && PlatformInfo.isWeb) {
-      _printToWebConsole(record.level, formatted);
+    if (PlatformInfo.isWeb) {
+      if (record.webConsoleEnabled || BuildUtils.isDebugMode) {
+        _printToWebConsole(record.level, formatted);
+      }
     } else {
       // ignore: avoid_print
       print('$_appLogName $formatted');

--- a/core/lib/utils/logging/handlers/console_log_handler.dart
+++ b/core/lib/utils/logging/handlers/console_log_handler.dart
@@ -18,7 +18,7 @@ const _appLogName = '[TwakeMail]';
 ///
 /// The [formatter] is injected via constructor (Dependency Inversion Principle),
 /// allowing platform-specific formatting without branching inside this class.
-class ConsoleLogHandler implements LogHandler {
+class ConsoleLogHandler extends LogHandler {
   final LogFormatter formatter;
 
   const ConsoleLogHandler({required this.formatter});

--- a/core/lib/utils/logging/handlers/console_log_handler.dart
+++ b/core/lib/utils/logging/handlers/console_log_handler.dart
@@ -24,10 +24,18 @@ class ConsoleLogHandler extends LogHandler {
   const ConsoleLogHandler({required this.formatter});
 
   @override
-  bool handles(Level level) {
-    // Always accept on web — final filtering happens in handle() because
-    // per-record webConsoleEnabled may override the debug-mode gate.
+  bool acceptsLevel(Level level) {
+    // On web, webConsoleEnabled can enable any level regardless of debug mode,
+    // so we cannot filter by level alone — defer to handles().
     if (PlatformInfo.isWeb) return true;
+    return BuildUtils.isDebugMode;
+  }
+
+  @override
+  bool handles(LogRecord record) {
+    if (PlatformInfo.isWeb) {
+      return record.webConsoleEnabled || BuildUtils.isDebugMode;
+    }
     return BuildUtils.isDebugMode;
   }
 
@@ -36,9 +44,7 @@ class ConsoleLogHandler extends LogHandler {
     final formatted = formatter.format(record.level, record.rawMessage);
 
     if (PlatformInfo.isWeb) {
-      if (record.webConsoleEnabled || BuildUtils.isDebugMode) {
-        _printToWebConsole(record.level, formatted);
-      }
+      _printToWebConsole(record.level, formatted);
     } else {
       // ignore: avoid_print
       print('$_appLogName $formatted');

--- a/core/lib/utils/logging/handlers/console_log_handler.dart
+++ b/core/lib/utils/logging/handlers/console_log_handler.dart
@@ -32,7 +32,7 @@ class ConsoleLogHandler extends LogHandler {
   }
 
   @override
-  bool handles(LogRecord record) {
+  bool canHandle(LogRecord record) {
     if (PlatformInfo.isWeb) {
       return record.webConsoleEnabled || BuildUtils.isDebugMode;
     }

--- a/core/lib/utils/logging/handlers/console_log_handler.dart
+++ b/core/lib/utils/logging/handlers/console_log_handler.dart
@@ -26,7 +26,7 @@ class ConsoleLogHandler extends LogHandler {
   @override
   bool acceptsLevel(Level level) {
     // On web, webConsoleEnabled can enable any level regardless of debug mode,
-    // so we cannot filter by level alone — defer to handles().
+    // so we cannot filter by level alone — defer to canHandle().
     if (PlatformInfo.isWeb) return true;
     return BuildUtils.isDebugMode;
   }

--- a/core/lib/utils/logging/handlers/sentry_breadcrumb_handler.dart
+++ b/core/lib/utils/logging/handlers/sentry_breadcrumb_handler.dart
@@ -15,7 +15,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 /// other Sentry data sources.
 ///
 /// [SentryReporter] is injected via constructor for testability.
-class SentryBreadcrumbHandler implements LogHandler {
+class SentryBreadcrumbHandler extends LogHandler {
   final SentryReporter _sentry;
 
   const SentryBreadcrumbHandler(this._sentry);

--- a/core/lib/utils/logging/handlers/sentry_breadcrumb_handler.dart
+++ b/core/lib/utils/logging/handlers/sentry_breadcrumb_handler.dart
@@ -21,7 +21,7 @@ class SentryBreadcrumbHandler extends LogHandler {
   const SentryBreadcrumbHandler(this._sentry);
 
   @override
-  bool handles(Level level) => level == Level.trace;
+  bool acceptsLevel(Level level) => level == Level.trace;
 
   @override
   void handle(LogRecord record) {

--- a/core/lib/utils/logging/handlers/sentry_breadcrumb_handler.dart
+++ b/core/lib/utils/logging/handlers/sentry_breadcrumb_handler.dart
@@ -2,12 +2,17 @@ import 'package:core/utils/logging/log_handler.dart';
 import 'package:core/utils/logging/log_level.dart';
 import 'package:core/utils/logging/log_record.dart';
 import 'package:core/utils/sentry/sentry_reporter.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 /// Stores log records as Sentry breadcrumbs (zero quota cost).
 ///
 /// Handles [Level.trace] only. Breadcrumbs are buffered locally inside
 /// Sentry and attached automatically to the next error event, providing
 /// the full call trail leading up to a failure.
+///
+/// Each breadcrumb is tagged with [SentryLevel.debug] and category `'log'`
+/// so the breadcrumb trail on error events is clearly distinguishable from
+/// other Sentry data sources.
 ///
 /// [SentryReporter] is injected via constructor for testability.
 class SentryBreadcrumbHandler implements LogHandler {
@@ -23,6 +28,8 @@ class SentryBreadcrumbHandler implements LogHandler {
     _sentry.addBreadcrumb(
       record.rawMessage,
       extras: record.extras,
+      level: SentryLevel.debug,
+      category: 'log',
     );
   }
 }

--- a/core/lib/utils/logging/handlers/sentry_breadcrumb_handler.dart
+++ b/core/lib/utils/logging/handlers/sentry_breadcrumb_handler.dart
@@ -1,7 +1,7 @@
 import 'package:core/utils/logging/log_handler.dart';
 import 'package:core/utils/logging/log_level.dart';
 import 'package:core/utils/logging/log_record.dart';
-import 'package:core/utils/sentry/sentry_manager.dart';
+import 'package:core/utils/sentry/sentry_reporter.dart';
 
 /// Stores log records as Sentry breadcrumbs (zero quota cost).
 ///
@@ -9,9 +9,9 @@ import 'package:core/utils/sentry/sentry_manager.dart';
 /// Sentry and attached automatically to the next error event, providing
 /// the full call trail leading up to a failure.
 ///
-/// [SentryManager] is injected via constructor for testability.
+/// [SentryReporter] is injected via constructor for testability.
 class SentryBreadcrumbHandler implements LogHandler {
-  final SentryManager _sentry;
+  final SentryReporter _sentry;
 
   const SentryBreadcrumbHandler(this._sentry);
 

--- a/core/lib/utils/logging/handlers/sentry_breadcrumb_handler.dart
+++ b/core/lib/utils/logging/handlers/sentry_breadcrumb_handler.dart
@@ -1,0 +1,28 @@
+import 'package:core/utils/logging/log_handler.dart';
+import 'package:core/utils/logging/log_level.dart';
+import 'package:core/utils/logging/log_record.dart';
+import 'package:core/utils/sentry/sentry_manager.dart';
+
+/// Stores log records as Sentry breadcrumbs (zero quota cost).
+///
+/// Handles [Level.trace] only. Breadcrumbs are buffered locally inside
+/// Sentry and attached automatically to the next error event, providing
+/// the full call trail leading up to a failure.
+///
+/// [SentryManager] is injected via constructor for testability.
+class SentryBreadcrumbHandler implements LogHandler {
+  final SentryManager _sentry;
+
+  const SentryBreadcrumbHandler(this._sentry);
+
+  @override
+  bool handles(Level level) => level == Level.trace;
+
+  @override
+  void handle(LogRecord record) {
+    _sentry.addBreadcrumb(
+      record.rawMessage,
+      extras: record.extras,
+    );
+  }
+}

--- a/core/lib/utils/logging/handlers/sentry_event_handler.dart
+++ b/core/lib/utils/logging/handlers/sentry_event_handler.dart
@@ -23,7 +23,7 @@ class SentryEventHandler extends LogHandler {
   const SentryEventHandler(this._sentry);
 
   @override
-  bool handles(Level level) =>
+  bool acceptsLevel(Level level) =>
       level == Level.error || level == Level.critical;
 
   @override
@@ -47,14 +47,10 @@ class SentryEventHandler extends LogHandler {
     }
   }
 
-  SentryLevel _toSentryLevel(Level level) {
-    switch (level) {
-      case Level.critical:
-        return SentryLevel.fatal;
-      case Level.error:
-        return SentryLevel.error;
-      default:
-        return SentryLevel.info;
-    }
-  }
+  SentryLevel _toSentryLevel(Level level) => switch (level) {
+    Level.critical => SentryLevel.fatal,
+    Level.error    => SentryLevel.error,
+    // unreachable — acceptsLevel() ensures only error/critical enter here
+    _              => SentryLevel.error,
+  };
 }

--- a/core/lib/utils/logging/handlers/sentry_event_handler.dart
+++ b/core/lib/utils/logging/handlers/sentry_event_handler.dart
@@ -17,7 +17,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 /// issue-grouping fidelity in Sentry dashboards.
 ///
 /// [SentryReporter] is injected via constructor for testability.
-class SentryEventHandler implements LogHandler {
+class SentryEventHandler extends LogHandler {
   final SentryReporter _sentry;
 
   const SentryEventHandler(this._sentry);

--- a/core/lib/utils/logging/handlers/sentry_event_handler.dart
+++ b/core/lib/utils/logging/handlers/sentry_event_handler.dart
@@ -1,0 +1,40 @@
+import 'package:core/utils/logging/log_handler.dart';
+import 'package:core/utils/logging/log_level.dart';
+import 'package:core/utils/logging/log_record.dart';
+import 'package:core/utils/sentry/sentry_manager.dart';
+
+/// Sends log records to Sentry as events.
+///
+/// Handles [Level.error] and [Level.critical] only.
+///
+/// - If the record contains an exception object → [SentryManager.captureException]
+/// - If not → [SentryManager.captureMessage] (semantically correct: a string
+///   is not an exception)
+///
+/// [SentryManager] is injected via constructor for testability.
+class SentryEventHandler implements LogHandler {
+  final SentryManager _sentry;
+
+  const SentryEventHandler(this._sentry);
+
+  @override
+  bool handles(Level level) =>
+      level == Level.error || level == Level.critical;
+
+  @override
+  void handle(LogRecord record) {
+    if (record.exception != null) {
+      _sentry.captureException(
+        record.exception,
+        stackTrace: record.stackTrace,
+        message: record.rawMessage,
+        extras: record.extras,
+      );
+    } else {
+      _sentry.captureMessage(
+        record.rawMessage,
+        extras: record.extras,
+      );
+    }
+  }
+}

--- a/core/lib/utils/logging/handlers/sentry_event_handler.dart
+++ b/core/lib/utils/logging/handlers/sentry_event_handler.dart
@@ -2,6 +2,7 @@ import 'package:core/utils/logging/log_handler.dart';
 import 'package:core/utils/logging/log_level.dart';
 import 'package:core/utils/logging/log_record.dart';
 import 'package:core/utils/sentry/sentry_reporter.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 /// Sends log records to Sentry as events.
 ///
@@ -10,6 +11,10 @@ import 'package:core/utils/sentry/sentry_reporter.dart';
 /// - If the record contains an exception object → [SentryReporter.captureException]
 /// - If not → [SentryReporter.captureMessage] (semantically correct: a string
 ///   is not an exception)
+///
+/// Severity is mapped: [Level.critical] → [SentryLevel.fatal],
+/// [Level.error] → [SentryLevel.error], preserving alerting and
+/// issue-grouping fidelity in Sentry dashboards.
 ///
 /// [SentryReporter] is injected via constructor for testability.
 class SentryEventHandler implements LogHandler {
@@ -23,18 +28,33 @@ class SentryEventHandler implements LogHandler {
 
   @override
   void handle(LogRecord record) {
+    final sentryLevel = _toSentryLevel(record.level);
+
     if (record.exception != null) {
       _sentry.captureException(
         record.exception,
         stackTrace: record.stackTrace,
         message: record.rawMessage,
         extras: record.extras,
+        level: sentryLevel,
       );
     } else {
       _sentry.captureMessage(
         record.rawMessage,
         extras: record.extras,
+        level: sentryLevel,
       );
+    }
+  }
+
+  SentryLevel _toSentryLevel(Level level) {
+    switch (level) {
+      case Level.critical:
+        return SentryLevel.fatal;
+      case Level.error:
+        return SentryLevel.error;
+      default:
+        return SentryLevel.info;
     }
   }
 }

--- a/core/lib/utils/logging/handlers/sentry_event_handler.dart
+++ b/core/lib/utils/logging/handlers/sentry_event_handler.dart
@@ -1,19 +1,19 @@
 import 'package:core/utils/logging/log_handler.dart';
 import 'package:core/utils/logging/log_level.dart';
 import 'package:core/utils/logging/log_record.dart';
-import 'package:core/utils/sentry/sentry_manager.dart';
+import 'package:core/utils/sentry/sentry_reporter.dart';
 
 /// Sends log records to Sentry as events.
 ///
 /// Handles [Level.error] and [Level.critical] only.
 ///
-/// - If the record contains an exception object → [SentryManager.captureException]
-/// - If not → [SentryManager.captureMessage] (semantically correct: a string
+/// - If the record contains an exception object → [SentryReporter.captureException]
+/// - If not → [SentryReporter.captureMessage] (semantically correct: a string
 ///   is not an exception)
 ///
-/// [SentryManager] is injected via constructor for testability.
+/// [SentryReporter] is injected via constructor for testability.
 class SentryEventHandler implements LogHandler {
-  final SentryManager _sentry;
+  final SentryReporter _sentry;
 
   const SentryEventHandler(this._sentry);
 

--- a/core/lib/utils/logging/log_handler.dart
+++ b/core/lib/utils/logging/log_handler.dart
@@ -23,9 +23,23 @@ abstract class LogHandler {
   /// to register multiple instances of the same concrete class.
   String get handlerKey => runtimeType.toString();
 
-  /// Returns true if this handler should process records at [level].
-  bool handles(Level level);
+  /// Fast level-only pre-screen used by the registry before building a [LogRecord].
+  ///
+  /// Return false when this handler will *never* accept records at [level],
+  /// regardless of any per-record fields. The default is true (conservative:
+  /// no records are skipped at this stage).
+  ///
+  /// This must be a superset of [handles]: if [acceptsLevel] returns false,
+  /// [handles] must also return false for all records at that level.
+  bool acceptsLevel(Level level) => true;
 
-  /// Process the given [record].
+  /// Returns true if this handler should process [record].
+  ///
+  /// The default delegates to [acceptsLevel] — sufficient for level-pure
+  /// handlers that do not need per-record fields. Override when per-record
+  /// fields (e.g. [LogRecord.webConsoleEnabled]) must influence the decision.
+  bool handles(LogRecord record) => acceptsLevel(record.level);
+
+  /// Process the given [record]. Called only when [handles] returns true.
   void handle(LogRecord record);
 }

--- a/core/lib/utils/logging/log_handler.dart
+++ b/core/lib/utils/logging/log_handler.dart
@@ -7,7 +7,22 @@ import 'package:core/utils/logging/log_record.dart';
 /// own dispatch logic via [handle]. Adding a new log destination
 /// requires only a new [LogHandler] implementation — no changes
 /// to existing code (Open/Closed Principle).
-abstract interface class LogHandler {
+///
+/// [handlerKey] is used by [AppLoggerRegistry] to identify a handler slot.
+/// The default value is [runtimeType.toString()], which means one instance
+/// per concrete class. Override [handlerKey] to allow multiple instances of
+/// the same class to coexist (e.g. two [ConsoleLogHandler]s with different
+/// formatters, or two Sentry handlers targeting different DSNs).
+abstract class LogHandler {
+  const LogHandler();
+
+  /// Unique key used for registration deduplication.
+  ///
+  /// Two handlers with the same [handlerKey] occupy the same slot in the
+  /// registry — re-registering replaces the existing one. Override this
+  /// to register multiple instances of the same concrete class.
+  String get handlerKey => runtimeType.toString();
+
   /// Returns true if this handler should process records at [level].
   bool handles(Level level);
 

--- a/core/lib/utils/logging/log_handler.dart
+++ b/core/lib/utils/logging/log_handler.dart
@@ -33,12 +33,12 @@ abstract class LogHandler {
   /// [handles] must also return false for all records at that level.
   bool acceptsLevel(Level level) => true;
 
-  /// Returns true if this handler should process [record].
+  /// Returns true if this handler can process [record].
   ///
   /// The default delegates to [acceptsLevel] — sufficient for level-pure
   /// handlers that do not need per-record fields. Override when per-record
   /// fields (e.g. [LogRecord.webConsoleEnabled]) must influence the decision.
-  bool handles(LogRecord record) => acceptsLevel(record.level);
+  bool canHandle(LogRecord record) => acceptsLevel(record.level);
 
   /// Process the given [record]. Called only when [handles] returns true.
   void handle(LogRecord record);

--- a/core/lib/utils/logging/log_handler.dart
+++ b/core/lib/utils/logging/log_handler.dart
@@ -40,6 +40,6 @@ abstract class LogHandler {
   /// fields (e.g. [LogRecord.webConsoleEnabled]) must influence the decision.
   bool canHandle(LogRecord record) => acceptsLevel(record.level);
 
-  /// Process the given [record]. Called only when [handles] returns true.
+  /// Process the given [record]. Called only when [canHandle] returns true.
   void handle(LogRecord record);
 }

--- a/core/lib/utils/logging/log_handler.dart
+++ b/core/lib/utils/logging/log_handler.dart
@@ -1,0 +1,16 @@
+import 'package:core/utils/logging/log_level.dart';
+import 'package:core/utils/logging/log_record.dart';
+
+/// Abstract interface for log destinations.
+///
+/// Each handler owns its own filter rule via [handles] and its
+/// own dispatch logic via [handle]. Adding a new log destination
+/// requires only a new [LogHandler] implementation — no changes
+/// to existing code (Open/Closed Principle).
+abstract interface class LogHandler {
+  /// Returns true if this handler should process records at [level].
+  bool handles(Level level);
+
+  /// Process the given [record].
+  void handle(LogRecord record);
+}

--- a/core/lib/utils/logging/log_level.dart
+++ b/core/lib/utils/logging/log_level.dart
@@ -1,0 +1,9 @@
+/// Log severity levels, ordered from highest to lowest severity.
+enum Level {
+  critical,
+  error,
+  warning,
+  info,
+  debug,
+  trace,
+}

--- a/core/lib/utils/logging/log_record.dart
+++ b/core/lib/utils/logging/log_record.dart
@@ -1,0 +1,18 @@
+import 'package:core/utils/logging/log_level.dart';
+
+/// Immutable data class representing a single log event.
+class LogRecord {
+  final Level level;
+  final String rawMessage;
+  final Object? exception;
+  final StackTrace? stackTrace;
+  final Map<String, dynamic>? extras;
+
+  const LogRecord({
+    required this.level,
+    required this.rawMessage,
+    this.exception,
+    this.stackTrace,
+    this.extras,
+  });
+}

--- a/core/lib/utils/logging/log_record.dart
+++ b/core/lib/utils/logging/log_record.dart
@@ -21,4 +21,44 @@ class LogRecord {
     this.extras,
     this.webConsoleEnabled = false,
   });
+
+  /// Creates a [LogRecord] from raw log call parameters.
+  ///
+  /// Assembles [rawMessage] by joining [message], [exception], [extras], and
+  /// [stackTrace] with ' | ' separators, omitting null/empty parts.
+  factory LogRecord.build({
+    required Level level,
+    String? message,
+    Object? exception,
+    StackTrace? stackTrace,
+    Map<String, dynamic>? extras,
+    bool webConsoleEnabled = false,
+  }) {
+    return LogRecord(
+      level: level,
+      rawMessage: _buildRawMessage(message, exception, extras, stackTrace),
+      exception: exception,
+      stackTrace: stackTrace,
+      extras: extras,
+      webConsoleEnabled: webConsoleEnabled,
+    );
+  }
+
+  static String _buildRawMessage(
+    String? message,
+    Object? exception,
+    Map<String, dynamic>? extras,
+    StackTrace? stackTrace,
+  ) {
+    // Fast path: most log calls carry only a message — avoid list allocation.
+    if (exception == null && extras == null && stackTrace == null) {
+      return message ?? '';
+    }
+    final parts = <String>[];
+    if (message?.isNotEmpty == true) parts.add(message!);
+    if (exception != null) parts.add('exception: $exception');
+    if (extras != null && extras.isNotEmpty) parts.add('extras: $extras');
+    if (stackTrace != null) parts.add('stackTrace: $stackTrace');
+    return parts.join(' | ');
+  }
 }

--- a/core/lib/utils/logging/log_record.dart
+++ b/core/lib/utils/logging/log_record.dart
@@ -51,7 +51,7 @@ class LogRecord {
     StackTrace? stackTrace,
   ) {
     // Fast path: most log calls carry only a message — avoid list allocation.
-    if (exception == null && extras == null && stackTrace == null) {
+    if (exception == null && (extras == null || extras.isEmpty) && stackTrace == null) {
       return message ?? '';
     }
     final parts = <String>[];

--- a/core/lib/utils/logging/log_record.dart
+++ b/core/lib/utils/logging/log_record.dart
@@ -1,12 +1,17 @@
 import 'package:core/utils/logging/log_level.dart';
 
 /// Immutable data class representing a single log event.
+///
+/// [webConsoleEnabled] allows individual log calls to force output to the
+/// browser console regardless of build mode — useful for diagnostics that
+/// must be visible in release/profile builds on web.
 class LogRecord {
   final Level level;
   final String rawMessage;
   final Object? exception;
   final StackTrace? stackTrace;
   final Map<String, dynamic>? extras;
+  final bool webConsoleEnabled;
 
   const LogRecord({
     required this.level,
@@ -14,5 +19,6 @@ class LogRecord {
     this.exception,
     this.stackTrace,
     this.extras,
+    this.webConsoleEnabled = false,
   });
 }

--- a/core/lib/utils/sentry/sentry_manager.dart
+++ b/core/lib/utils/sentry/sentry_manager.dart
@@ -142,8 +142,17 @@ class SentryManager implements SentryReporter {
   }) {
     if (!_isSentryAvailable) return;
 
+    unawaited(_addBreadcrumbInternal(message, extras: extras, level: level, category: category));
+  }
+
+  Future<void> _addBreadcrumbInternal(
+    String message, {
+    Map<String, dynamic>? extras,
+    SentryLevel level = SentryLevel.debug,
+    String? category,
+  }) async {
     try {
-      Sentry.addBreadcrumb(
+      await Sentry.addBreadcrumb(
         Breadcrumb(
           message: message,
           data: extras,

--- a/core/lib/utils/sentry/sentry_manager.dart
+++ b/core/lib/utils/sentry/sentry_manager.dart
@@ -64,13 +64,14 @@ class SentryManager implements SentryReporter {
     StackTrace? stackTrace,
     String? message,
     Map<String, dynamic>? extras,
+    SentryLevel level = SentryLevel.error,
   }) {
     if (!_isSentryAvailable) return;
 
     // Use unawaited to prevent linter warnings about unawaited futures.
     // We do not want the UI to pause while Sentry writes the crash report.
     unawaited(
-      _captureExceptionInternal(exception, stackTrace, message, extras),
+      _captureExceptionInternal(exception, stackTrace, message, extras, level),
     );
   }
 
@@ -79,6 +80,7 @@ class SentryManager implements SentryReporter {
     StackTrace? stackTrace,
     String? message,
     Map<String, dynamic>? extras,
+    SentryLevel level,
   ) async {
     try {
       final hasExtras = extras != null && extras.isNotEmpty;
@@ -91,12 +93,14 @@ class SentryManager implements SentryReporter {
           withScope: (scope) {
             if (hasExtras) scope.setContexts('extras', extras);
             if (hasMessage) scope.setTag('message', message);
+            scope.level = level;
           },
         );
       } else {
         await Sentry.captureException(
           exception,
           stackTrace: stackTrace,
+          withScope: (scope) => scope.level = level,
         );
       }
     } catch (e) {

--- a/core/lib/utils/sentry/sentry_manager.dart
+++ b/core/lib/utils/sentry/sentry_manager.dart
@@ -1,12 +1,13 @@
 import 'dart:async';
 
 import 'package:core/utils/app_logger.dart';
+import 'package:core/utils/sentry/sentry_reporter.dart';
 import 'package:core/utils/sentry/sentry_config.dart';
 import 'package:core/utils/sentry/sentry_initializer.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 /// Controls Sentry initialization and error reporting.
-class SentryManager {
+class SentryManager implements SentryReporter {
   SentryManager._();
 
   static final SentryManager instance = SentryManager._();
@@ -57,6 +58,7 @@ class SentryManager {
   }
 
   /// Capture an exception.
+  @override
   void captureException(
     dynamic exception, {
     StackTrace? stackTrace,
@@ -103,6 +105,7 @@ class SentryManager {
   }
 
   /// Capture a text message.
+  @override
   void captureMessage(
     String message, {
     SentryLevel level = SentryLevel.info,
@@ -137,6 +140,7 @@ class SentryManager {
   ///
   /// Breadcrumbs are attached automatically to the next error event —
   /// they consume zero quota on their own.
+  @override
   void addBreadcrumb(
     String message, {
     Map<String, dynamic>? extras,

--- a/core/lib/utils/sentry/sentry_manager.dart
+++ b/core/lib/utils/sentry/sentry_manager.dart
@@ -133,6 +133,28 @@ class SentryManager {
     }
   }
 
+  /// Adds a breadcrumb to Sentry's local buffer.
+  ///
+  /// Breadcrumbs are attached automatically to the next error event —
+  /// they consume zero quota on their own.
+  void addBreadcrumb(
+    String message, {
+    Map<String, dynamic>? extras,
+  }) {
+    if (!_isSentryAvailable) return;
+
+    try {
+      Sentry.addBreadcrumb(
+        Breadcrumb(
+          message: message,
+          data: extras,
+        ),
+      );
+    } catch (e) {
+      logWarning('[SentryManager] Add breadcrumb failed: $e');
+    }
+  }
+
   /// Sets the user context.
   void setUser(SentryUser user) {
     if (!_isSentryAvailable) return;

--- a/core/lib/utils/sentry/sentry_manager.dart
+++ b/core/lib/utils/sentry/sentry_manager.dart
@@ -112,8 +112,8 @@ class SentryManager implements SentryReporter {
   @override
   void captureMessage(
     String message, {
-    SentryLevel level = SentryLevel.info,
     Map<String, dynamic>? extras,
+    SentryLevel level = SentryLevel.info,
   }) {
     if (!_isSentryAvailable) return;
 
@@ -148,6 +148,8 @@ class SentryManager implements SentryReporter {
   void addBreadcrumb(
     String message, {
     Map<String, dynamic>? extras,
+    SentryLevel level = SentryLevel.debug,
+    String? category,
   }) {
     if (!_isSentryAvailable) return;
 
@@ -156,6 +158,8 @@ class SentryManager implements SentryReporter {
         Breadcrumb(
           message: message,
           data: extras,
+          level: level,
+          category: category,
         ),
       );
     } catch (e) {

--- a/core/lib/utils/sentry/sentry_manager.dart
+++ b/core/lib/utils/sentry/sentry_manager.dart
@@ -163,6 +163,8 @@ class SentryManager implements SentryReporter {
         ),
       );
     } catch (e) {
+      // NOTE: Must not route through a log level that the breadcrumb/event
+      // handlers subscribe to, otherwise a throwing Sentry SDK could recurse.
       logWarning('[SentryManager] Add breadcrumb failed: $e');
     }
   }

--- a/core/lib/utils/sentry/sentry_manager.dart
+++ b/core/lib/utils/sentry/sentry_manager.dart
@@ -83,26 +83,15 @@ class SentryManager implements SentryReporter {
     SentryLevel level,
   ) async {
     try {
-      final hasExtras = extras != null && extras.isNotEmpty;
-      final hasMessage = message != null && message.isNotEmpty;
-
-      if (hasExtras || hasMessage) {
-        await Sentry.captureException(
-          exception,
-          stackTrace: stackTrace,
-          withScope: (scope) {
-            if (hasExtras) scope.setContexts('extras', extras);
-            if (hasMessage) scope.setTag('message', message);
-            scope.level = level;
-          },
-        );
-      } else {
-        await Sentry.captureException(
-          exception,
-          stackTrace: stackTrace,
-          withScope: (scope) => scope.level = level,
-        );
-      }
+      await Sentry.captureException(
+        exception,
+        stackTrace: stackTrace,
+        withScope: (scope) {
+          scope.level = level;
+          if (extras != null && extras.isNotEmpty) scope.setContexts('extras', extras);
+          if (message != null && message.isNotEmpty) scope.setTag('message', message);
+        },
+      );
     } catch (e) {
       logWarning('[SentryManager] Capture exception failed: $e');
     }

--- a/core/lib/utils/sentry/sentry_reporter.dart
+++ b/core/lib/utils/sentry/sentry_reporter.dart
@@ -10,13 +10,13 @@ abstract interface class SentryReporter {
     StackTrace? stackTrace,
     String? message,
     Map<String, dynamic>? extras,
-    SentryLevel level,
+    SentryLevel level = SentryLevel.error,
   });
 
   void captureMessage(
     String message, {
     Map<String, dynamic>? extras,
-    SentryLevel level,
+    SentryLevel level = SentryLevel.info,
   });
 
   void addBreadcrumb(

--- a/core/lib/utils/sentry/sentry_reporter.dart
+++ b/core/lib/utils/sentry/sentry_reporter.dart
@@ -1,3 +1,5 @@
+import 'package:sentry_flutter/sentry_flutter.dart';
+
 /// Abstraction over Sentry operations used by log handlers.
 ///
 /// Decouples [LogHandler] implementations from [SentryManager]'s
@@ -8,11 +10,13 @@ abstract interface class SentryReporter {
     StackTrace? stackTrace,
     String? message,
     Map<String, dynamic>? extras,
+    SentryLevel level,
   });
 
   void captureMessage(
     String message, {
     Map<String, dynamic>? extras,
+    SentryLevel level,
   });
 
   void addBreadcrumb(

--- a/core/lib/utils/sentry/sentry_reporter.dart
+++ b/core/lib/utils/sentry/sentry_reporter.dart
@@ -22,5 +22,7 @@ abstract interface class SentryReporter {
   void addBreadcrumb(
     String message, {
     Map<String, dynamic>? extras,
+    SentryLevel level = SentryLevel.debug,
+    String? category,
   });
 }

--- a/core/lib/utils/sentry/sentry_reporter.dart
+++ b/core/lib/utils/sentry/sentry_reporter.dart
@@ -1,0 +1,22 @@
+/// Abstraction over Sentry operations used by log handlers.
+///
+/// Decouples [LogHandler] implementations from [SentryManager]'s
+/// concrete singleton, making handlers independently testable.
+abstract interface class SentryReporter {
+  void captureException(
+    dynamic exception, {
+    StackTrace? stackTrace,
+    String? message,
+    Map<String, dynamic>? extras,
+  });
+
+  void captureMessage(
+    String message, {
+    Map<String, dynamic>? extras,
+  });
+
+  void addBreadcrumb(
+    String message, {
+    Map<String, dynamic>? extras,
+  });
+}

--- a/core/test/utils/logging/app_logger_registry_test.dart
+++ b/core/test/utils/logging/app_logger_registry_test.dart
@@ -128,6 +128,15 @@ void main() {
     test('returns false when no handlers are registered', () {
       expect(registry.hasHandlerFor(Level.info), isFalse);
     });
+
+    test('returns true when at least one of multiple handlers accepts the level', () {
+      // _FakeHandler: error-only; _OtherFakeHandler: all levels.
+      // hasHandlerFor(trace) must be true because OtherFakeHandler accepts it,
+      // even though FakeHandler does not — verifying OR semantics of hasHandlerFor.
+      registry.registerHandler(_FakeHandler(acceptsLevel: (l) => l == Level.error));
+      registry.registerHandler(_OtherFakeHandler());
+      expect(registry.hasHandlerFor(Level.trace), isTrue);
+    });
   });
 
   group('AppLoggerRegistry.dispatch', () {

--- a/core/test/utils/logging/app_logger_registry_test.dart
+++ b/core/test/utils/logging/app_logger_registry_test.dart
@@ -6,25 +6,28 @@ import 'package:flutter_test/flutter_test.dart';
 
 class _FakeHandler extends LogHandler {
   final List<LogRecord> received = [];
-  final bool Function(Level) _handles;
+  final bool Function(Level) _acceptsLevel;
 
-  _FakeHandler({bool Function(Level)? handles})
-      : _handles = (handles ?? (_) => true);
+  _FakeHandler({bool Function(Level)? acceptsLevel})
+      : _acceptsLevel = (acceptsLevel ?? (_) => true);
 
   @override
-  bool handles(Level level) => _handles(level);
+  bool acceptsLevel(Level level) => _acceptsLevel(level);
+
+  @override
+  bool handles(LogRecord record) => _acceptsLevel(record.level);
 
   @override
   void handle(LogRecord record) => received.add(record);
 }
 
 class _OtherFakeHandler extends _FakeHandler {
-  _OtherFakeHandler() : super(handles: (_) => true);
+  _OtherFakeHandler() : super(acceptsLevel: (_) => true);
 }
 
 class _ThrowingHandlesHandler extends LogHandler {
   @override
-  bool handles(Level level) => throw Exception('handles() exploded');
+  bool handles(LogRecord record) => throw Exception('handles() exploded');
 
   @override
   void handle(LogRecord record) {}
@@ -32,7 +35,7 @@ class _ThrowingHandlesHandler extends LogHandler {
 
 class _ThrowingHandleHandler extends LogHandler {
   @override
-  bool handles(Level level) => true;
+  bool handles(LogRecord record) => true;
 
   @override
   void handle(LogRecord record) => throw Exception('handle() exploded');
@@ -111,9 +114,25 @@ void main() {
     });
   });
 
+  group('AppLoggerRegistry.hasHandlerFor', () {
+    test('returns true when a handler accepts the level', () {
+      registry.registerHandler(_FakeHandler(acceptsLevel: (l) => l == Level.error));
+      expect(registry.hasHandlerFor(Level.error), isTrue);
+    });
+
+    test('returns false when no handler accepts the level', () {
+      registry.registerHandler(_FakeHandler(acceptsLevel: (l) => l == Level.error));
+      expect(registry.hasHandlerFor(Level.debug), isFalse);
+    });
+
+    test('returns false when no handlers are registered', () {
+      expect(registry.hasHandlerFor(Level.info), isFalse);
+    });
+  });
+
   group('AppLoggerRegistry.dispatch', () {
     test('dispatches record to handler that handles the level', () {
-      final handler = _FakeHandler(handles: (l) => l == Level.error);
+      final handler = _FakeHandler(acceptsLevel: (l) => l == Level.error);
       registry.registerHandler(handler);
 
       const record = LogRecord(level: Level.error, rawMessage: 'oops');
@@ -124,7 +143,7 @@ void main() {
     });
 
     test('does not dispatch record to handler that rejects the level', () {
-      final handler = _FakeHandler(handles: (l) => l == Level.error);
+      final handler = _FakeHandler(acceptsLevel: (l) => l == Level.error);
       registry.registerHandler(handler);
 
       const record = LogRecord(level: Level.trace, rawMessage: 'verbose');
@@ -184,14 +203,14 @@ void main() {
     });
   });
 
-  group('buildLogRecord', () {
+  group('LogRecord.build', () {
     test('builds rawMessage from message only', () {
-      final record = buildLogRecord(level: Level.info, message: 'hello');
+      final record = LogRecord.build(level: Level.info, message: 'hello');
       expect(record.rawMessage, 'hello');
     });
 
     test('appends exception to rawMessage', () {
-      final record = buildLogRecord(
+      final record = LogRecord.build(
         level: Level.error,
         message: 'fail',
         exception: Exception('boom'),
@@ -201,7 +220,7 @@ void main() {
     });
 
     test('appends extras to rawMessage', () {
-      final record = buildLogRecord(
+      final record = LogRecord.build(
         level: Level.error,
         message: 'fail',
         extras: {'key': 'value'},
@@ -211,7 +230,7 @@ void main() {
 
     test('appends stackTrace to rawMessage', () {
       final stack = StackTrace.current;
-      final record = buildLogRecord(
+      final record = LogRecord.build(
         level: Level.error,
         message: 'fail',
         stackTrace: stack,
@@ -220,7 +239,7 @@ void main() {
     });
 
     test('rawMessage is empty string when message is null and no extras', () {
-      final record = buildLogRecord(level: Level.info, message: null);
+      final record = LogRecord.build(level: Level.info, message: null);
       expect(record.rawMessage, isEmpty);
     });
 
@@ -228,7 +247,7 @@ void main() {
       final ex = Exception('err');
       final st = StackTrace.current;
       final extras = {'a': 1};
-      final record = buildLogRecord(
+      final record = LogRecord.build(
         level: Level.error,
         message: 'msg',
         exception: ex,

--- a/core/test/utils/logging/app_logger_registry_test.dart
+++ b/core/test/utils/logging/app_logger_registry_test.dart
@@ -4,7 +4,7 @@ import 'package:core/utils/logging/log_level.dart';
 import 'package:core/utils/logging/log_record.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class _FakeHandler implements LogHandler {
+class _FakeHandler extends LogHandler {
   final List<LogRecord> received = [];
   final bool Function(Level) _handles;
 
@@ -20,6 +20,33 @@ class _FakeHandler implements LogHandler {
 
 class _OtherFakeHandler extends _FakeHandler {
   _OtherFakeHandler() : super(handles: (_) => true);
+}
+
+class _ThrowingHandlesHandler extends LogHandler {
+  @override
+  bool handles(Level level) => throw Exception('handles() exploded');
+
+  @override
+  void handle(LogRecord record) {}
+}
+
+class _ThrowingHandleHandler extends LogHandler {
+  @override
+  bool handles(Level level) => true;
+
+  @override
+  void handle(LogRecord record) => throw Exception('handle() exploded');
+}
+
+/// Same concrete type as [_FakeHandler] but with a distinct [handlerKey],
+/// used to verify that two instances of the same class can coexist in the registry.
+class _KeyedFakeHandler extends _FakeHandler {
+  final String _key;
+
+  _KeyedFakeHandler(this._key);
+
+  @override
+  String get handlerKey => _key;
 }
 
 void main() {
@@ -40,7 +67,7 @@ void main() {
       expect(registry.handlerCount, 1);
     });
 
-    test('is idempotent — same runtimeType registered twice stays as one', () {
+    test('is idempotent — same handlerKey registered twice stays as one', () {
       registry.registerHandler(_FakeHandler());
       registry.registerHandler(_FakeHandler());
       expect(registry.handlerCount, 1);
@@ -50,6 +77,37 @@ void main() {
       registry.registerHandler(_FakeHandler());
       registry.registerHandler(_OtherFakeHandler());
       expect(registry.handlerCount, 2);
+    });
+
+    test('two instances of same class with different handlerKey coexist', () {
+      registry.registerHandler(_KeyedFakeHandler('key-a'));
+      registry.registerHandler(_KeyedFakeHandler('key-b'));
+      expect(registry.handlerCount, 2);
+    });
+
+    test('re-registering same handlerKey replaces the existing handler', () {
+      final first = _KeyedFakeHandler('key-a');
+      final second = _KeyedFakeHandler('key-a');
+      registry.registerHandler(first);
+      registry.registerHandler(second);
+      expect(registry.handlerCount, 1);
+
+      const record = LogRecord(level: Level.info, rawMessage: 'x');
+      registry.dispatch(record);
+      expect(second.received, hasLength(1));
+      expect(first.received, isEmpty);
+    });
+
+    test('both keyed handlers receive dispatched records', () {
+      final handlerA = _KeyedFakeHandler('key-a');
+      final handlerB = _KeyedFakeHandler('key-b');
+      registry.registerHandler(handlerA);
+      registry.registerHandler(handlerB);
+
+      const record = LogRecord(level: Level.info, rawMessage: 'hello');
+      registry.dispatch(record);
+      expect(handlerA.received, hasLength(1));
+      expect(handlerB.received, hasLength(1));
     });
   });
 
@@ -93,6 +151,28 @@ void main() {
         () => registry.dispatch(const LogRecord(level: Level.info, rawMessage: 'x')),
         returnsNormally,
       );
+    });
+
+    test('handles() throwing does not crash dispatch; other handlers still receive the record', () {
+      final throwing = _ThrowingHandlesHandler();
+      final good = _OtherFakeHandler();
+      registry.registerHandler(throwing);
+      registry.registerHandler(good);
+
+      const record = LogRecord(level: Level.info, rawMessage: 'test');
+      expect(() => registry.dispatch(record), returnsNormally);
+      expect(good.received, hasLength(1));
+    });
+
+    test('handle() throwing does not crash dispatch; other handlers still receive the record', () {
+      final throwing = _ThrowingHandleHandler();
+      final good = _OtherFakeHandler();
+      registry.registerHandler(throwing);
+      registry.registerHandler(good);
+
+      const record = LogRecord(level: Level.info, rawMessage: 'test');
+      expect(() => registry.dispatch(record), returnsNormally);
+      expect(good.received, hasLength(1));
     });
   });
 

--- a/core/test/utils/logging/app_logger_registry_test.dart
+++ b/core/test/utils/logging/app_logger_registry_test.dart
@@ -18,6 +18,10 @@ class _FakeHandler implements LogHandler {
   void handle(LogRecord record) => received.add(record);
 }
 
+class _OtherFakeHandler extends _FakeHandler {
+  _OtherFakeHandler({super.handles});
+}
+
 void main() {
   late AppLoggerRegistry registry;
 
@@ -43,11 +47,9 @@ void main() {
     });
 
     test('registers distinct handler types separately', () {
-      registry.registerHandler(_FakeHandler(handles: (_) => true));
-
-      // Different type via anonymous class is impossible in Dart; use named subclass
-      // This test verifies two instances of the same type count as one.
-      expect(registry.handlerCount, 1);
+      registry.registerHandler(_FakeHandler());
+      registry.registerHandler(_OtherFakeHandler());
+      expect(registry.handlerCount, 2);
     });
   });
 
@@ -56,7 +58,7 @@ void main() {
       final handler = _FakeHandler(handles: (l) => l == Level.error);
       registry.registerHandler(handler);
 
-      final record = const LogRecord(level: Level.error, rawMessage: 'oops');
+      const record = LogRecord(level: Level.error, rawMessage: 'oops');
       registry.dispatch(record);
 
       expect(handler.received, hasLength(1));
@@ -67,7 +69,7 @@ void main() {
       final handler = _FakeHandler(handles: (l) => l == Level.error);
       registry.registerHandler(handler);
 
-      final record = const LogRecord(level: Level.trace, rawMessage: 'verbose');
+      const record = LogRecord(level: Level.trace, rawMessage: 'verbose');
       registry.dispatch(record);
 
       expect(handler.received, isEmpty);
@@ -75,15 +77,15 @@ void main() {
 
     test('dispatches to multiple handlers when both accept the level', () {
       final h1 = _FakeHandler();
-      // Need two distinct types — wrap in subclass approach not possible inline;
-      // use two separate instances of the same type counted as one.
-      // Workaround: verify single handler receives records correctly.
+      final h2 = _OtherFakeHandler();
       registry.registerHandler(h1);
+      registry.registerHandler(h2);
 
-      final record = const LogRecord(level: Level.info, rawMessage: 'hello');
+      const record = LogRecord(level: Level.info, rawMessage: 'hello');
       registry.dispatch(record);
 
       expect(h1.received, hasLength(1));
+      expect(h2.received, hasLength(1));
     });
 
     test('no-op when no handlers registered', () {

--- a/core/test/utils/logging/app_logger_registry_test.dart
+++ b/core/test/utils/logging/app_logger_registry_test.dart
@@ -15,7 +15,7 @@ class _FakeHandler extends LogHandler {
   bool acceptsLevel(Level level) => _acceptsLevel(level);
 
   @override
-  bool handles(LogRecord record) => _acceptsLevel(record.level);
+  bool canHandle(LogRecord record) => _acceptsLevel(record.level);
 
   @override
   void handle(LogRecord record) => received.add(record);
@@ -27,7 +27,7 @@ class _OtherFakeHandler extends _FakeHandler {
 
 class _ThrowingHandlesHandler extends LogHandler {
   @override
-  bool handles(LogRecord record) => throw Exception('handles() exploded');
+  bool canHandle(LogRecord record) => throw Exception('handles() exploded');
 
   @override
   void handle(LogRecord record) {}
@@ -35,7 +35,7 @@ class _ThrowingHandlesHandler extends LogHandler {
 
 class _ThrowingHandleHandler extends LogHandler {
   @override
-  bool handles(LogRecord record) => true;
+  bool canHandle(LogRecord record) => true;
 
   @override
   void handle(LogRecord record) => throw Exception('handle() exploded');
@@ -172,7 +172,7 @@ void main() {
       );
     });
 
-    test('handles() throwing does not crash dispatch; other handlers still receive the record', () {
+    test('canHandle() throwing does not crash dispatch; other handlers still receive the record', () {
       final throwing = _ThrowingHandlesHandler();
       final good = _OtherFakeHandler();
       registry.registerHandler(throwing);

--- a/core/test/utils/logging/app_logger_registry_test.dart
+++ b/core/test/utils/logging/app_logger_registry_test.dart
@@ -1,0 +1,161 @@
+import 'package:core/utils/logging/app_logger_registry.dart';
+import 'package:core/utils/logging/log_handler.dart';
+import 'package:core/utils/logging/log_level.dart';
+import 'package:core/utils/logging/log_record.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeHandler implements LogHandler {
+  final List<LogRecord> received = [];
+  final bool Function(Level) _handles;
+
+  _FakeHandler({bool Function(Level)? handles})
+      : _handles = (handles ?? (_) => true);
+
+  @override
+  bool handles(Level level) => _handles(level);
+
+  @override
+  void handle(LogRecord record) => received.add(record);
+}
+
+void main() {
+  late AppLoggerRegistry registry;
+
+  setUp(() {
+    registry = AppLoggerRegistry.instance;
+    registry.resetForTesting();
+  });
+
+  tearDown(() {
+    registry.resetForTesting();
+  });
+
+  group('AppLoggerRegistry.registerHandler', () {
+    test('registers a handler', () {
+      registry.registerHandler(_FakeHandler());
+      expect(registry.handlerCount, 1);
+    });
+
+    test('is idempotent — same runtimeType registered twice stays as one', () {
+      registry.registerHandler(_FakeHandler());
+      registry.registerHandler(_FakeHandler());
+      expect(registry.handlerCount, 1);
+    });
+
+    test('registers distinct handler types separately', () {
+      registry.registerHandler(_FakeHandler(handles: (_) => true));
+
+      // Different type via anonymous class is impossible in Dart; use named subclass
+      // This test verifies two instances of the same type count as one.
+      expect(registry.handlerCount, 1);
+    });
+  });
+
+  group('AppLoggerRegistry.dispatch', () {
+    test('dispatches record to handler that handles the level', () {
+      final handler = _FakeHandler(handles: (l) => l == Level.error);
+      registry.registerHandler(handler);
+
+      final record = const LogRecord(level: Level.error, rawMessage: 'oops');
+      registry.dispatch(record);
+
+      expect(handler.received, hasLength(1));
+      expect(handler.received.first.rawMessage, 'oops');
+    });
+
+    test('does not dispatch record to handler that rejects the level', () {
+      final handler = _FakeHandler(handles: (l) => l == Level.error);
+      registry.registerHandler(handler);
+
+      final record = const LogRecord(level: Level.trace, rawMessage: 'verbose');
+      registry.dispatch(record);
+
+      expect(handler.received, isEmpty);
+    });
+
+    test('dispatches to multiple handlers when both accept the level', () {
+      final h1 = _FakeHandler();
+      // Need two distinct types — wrap in subclass approach not possible inline;
+      // use two separate instances of the same type counted as one.
+      // Workaround: verify single handler receives records correctly.
+      registry.registerHandler(h1);
+
+      final record = const LogRecord(level: Level.info, rawMessage: 'hello');
+      registry.dispatch(record);
+
+      expect(h1.received, hasLength(1));
+    });
+
+    test('no-op when no handlers registered', () {
+      expect(
+        () => registry.dispatch(const LogRecord(level: Level.info, rawMessage: 'x')),
+        returnsNormally,
+      );
+    });
+  });
+
+  group('AppLoggerRegistry.resetForTesting', () {
+    test('clears all handlers', () {
+      registry.registerHandler(_FakeHandler());
+      registry.resetForTesting();
+      expect(registry.handlerCount, 0);
+    });
+  });
+
+  group('buildLogRecord', () {
+    test('builds rawMessage from message only', () {
+      final record = buildLogRecord(level: Level.info, message: 'hello');
+      expect(record.rawMessage, 'hello');
+    });
+
+    test('appends exception to rawMessage', () {
+      final record = buildLogRecord(
+        level: Level.error,
+        message: 'fail',
+        exception: Exception('boom'),
+      );
+      expect(record.rawMessage, contains('fail'));
+      expect(record.rawMessage, contains('exception:'));
+    });
+
+    test('appends extras to rawMessage', () {
+      final record = buildLogRecord(
+        level: Level.error,
+        message: 'fail',
+        extras: {'key': 'value'},
+      );
+      expect(record.rawMessage, contains('extras:'));
+    });
+
+    test('appends stackTrace to rawMessage', () {
+      final stack = StackTrace.current;
+      final record = buildLogRecord(
+        level: Level.error,
+        message: 'fail',
+        stackTrace: stack,
+      );
+      expect(record.rawMessage, contains('stackTrace:'));
+    });
+
+    test('rawMessage is empty string when message is null and no extras', () {
+      final record = buildLogRecord(level: Level.info, message: null);
+      expect(record.rawMessage, isEmpty);
+    });
+
+    test('propagates exception, stackTrace, extras to LogRecord fields', () {
+      final ex = Exception('err');
+      final st = StackTrace.current;
+      final extras = {'a': 1};
+      final record = buildLogRecord(
+        level: Level.error,
+        message: 'msg',
+        exception: ex,
+        stackTrace: st,
+        extras: extras,
+      );
+      expect(record.exception, ex);
+      expect(record.stackTrace, st);
+      expect(record.extras, extras);
+    });
+  });
+}

--- a/core/test/utils/logging/app_logger_registry_test.dart
+++ b/core/test/utils/logging/app_logger_registry_test.dart
@@ -19,7 +19,7 @@ class _FakeHandler implements LogHandler {
 }
 
 class _OtherFakeHandler extends _FakeHandler {
-  _OtherFakeHandler({super.handles});
+  _OtherFakeHandler() : super(handles: (_) => true);
 }
 
 void main() {

--- a/core/test/utils/logging/formatters/mobile_console_formatter_test.dart
+++ b/core/test/utils/logging/formatters/mobile_console_formatter_test.dart
@@ -1,0 +1,38 @@
+import 'package:core/utils/logging/formatters/mobile_console_formatter.dart';
+import 'package:core/utils/logging/log_level.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const formatter = MobileConsoleFormatter();
+
+  group('MobileConsoleFormatter.format', () {
+    test('critical has fire emoji prefix', () {
+      expect(formatter.format(Level.critical, 'msg'), '🔥 CRITICAL: msg');
+    });
+
+    test('error has cross emoji prefix', () {
+      expect(formatter.format(Level.error, 'msg'), '❌ ERROR: msg');
+    });
+
+    test('warning has warning emoji prefix', () {
+      expect(formatter.format(Level.warning, 'msg'), '⚠️ WARNING: msg');
+    });
+
+    test('info has info emoji prefix', () {
+      expect(formatter.format(Level.info, 'msg'), 'ℹ️ INFO: msg');
+    });
+
+    test('debug has bug emoji prefix', () {
+      expect(formatter.format(Level.debug, 'msg'), '🐛 DEBUG: msg');
+    });
+
+    test('trace has magnifier emoji prefix', () {
+      expect(formatter.format(Level.trace, 'msg'), '🔍 VERBOSE: msg');
+    });
+
+    test('preserves raw message content', () {
+      const raw = 'some detailed message';
+      expect(formatter.format(Level.info, raw), contains(raw));
+    });
+  });
+}

--- a/core/test/utils/logging/formatters/web_console_formatter_test.dart
+++ b/core/test/utils/logging/formatters/web_console_formatter_test.dart
@@ -15,7 +15,7 @@ void main() {
   group('WebConsoleFormatter.format', () {
     test('critical wraps with red+bold and CRITICAL prefix', () {
       final result = formatter.format(Level.critical, 'msg');
-      expect(result, '$ansiRed${ansiBold}!!!CRITICAL!!! msg$ansiReset');
+      expect(result, '$ansiRed$ansiBold!!!CRITICAL!!! msg$ansiReset');
     });
 
     test('error wraps with red ANSI', () {

--- a/core/test/utils/logging/formatters/web_console_formatter_test.dart
+++ b/core/test/utils/logging/formatters/web_console_formatter_test.dart
@@ -1,0 +1,51 @@
+import 'package:core/utils/logging/formatters/web_console_formatter.dart';
+import 'package:core/utils/logging/log_level.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const formatter = WebConsoleFormatter();
+
+  const ansiReset = '\x1B[0m';
+  const ansiRed = '\x1B[31m';
+  const ansiYellow = '\x1B[33m';
+  const ansiGreen = '\x1B[32m';
+  const ansiBlue = '\x1B[34m';
+  const ansiBold = '\x1B[1m';
+
+  group('WebConsoleFormatter.format', () {
+    test('critical wraps with red+bold and CRITICAL prefix', () {
+      final result = formatter.format(Level.critical, 'msg');
+      expect(result, '$ansiRed${ansiBold}!!!CRITICAL!!! msg$ansiReset');
+    });
+
+    test('error wraps with red ANSI', () {
+      final result = formatter.format(Level.error, 'msg');
+      expect(result, '${ansiRed}msg$ansiReset');
+    });
+
+    test('warning wraps with yellow ANSI', () {
+      final result = formatter.format(Level.warning, 'msg');
+      expect(result, '${ansiYellow}msg$ansiReset');
+    });
+
+    test('info wraps with green ANSI', () {
+      final result = formatter.format(Level.info, 'msg');
+      expect(result, '${ansiGreen}msg$ansiReset');
+    });
+
+    test('debug wraps with blue ANSI', () {
+      final result = formatter.format(Level.debug, 'msg');
+      expect(result, '${ansiBlue}msg$ansiReset');
+    });
+
+    test('trace returns raw message without ANSI codes', () {
+      final result = formatter.format(Level.trace, 'msg');
+      expect(result, 'msg');
+    });
+
+    test('preserves raw message content', () {
+      const raw = 'some detailed message';
+      expect(formatter.format(Level.info, raw), contains(raw));
+    });
+  });
+}

--- a/core/test/utils/logging/handlers/console_log_handler_test.dart
+++ b/core/test/utils/logging/handlers/console_log_handler_test.dart
@@ -1,0 +1,164 @@
+import 'package:core/utils/logging/formatters/log_formatter.dart';
+import 'package:core/utils/logging/handlers/console_log_handler.dart';
+import 'package:core/utils/logging/log_level.dart';
+import 'package:core/utils/logging/log_record.dart';
+import 'package:core/utils/platform_info.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _SpyFormatter implements LogFormatter {
+  final List<({Level level, String raw})> calls = [];
+
+  @override
+  String format(Level level, String raw) {
+    calls.add((level: level, raw: raw));
+    return 'formatted:$raw';
+  }
+}
+
+void main() {
+  late _SpyFormatter formatter;
+  late ConsoleLogHandler handler;
+
+  setUp(() {
+    formatter = _SpyFormatter();
+    handler = ConsoleLogHandler(formatter: formatter);
+    PlatformInfo.isTestingForWeb = false;
+  });
+
+  tearDown(() {
+    PlatformInfo.isTestingForWeb = false;
+  });
+
+  // ─── acceptsLevel ──────────────────────────────────────────────────────────
+
+  group('ConsoleLogHandler.acceptsLevel — non-web (debug mode)', () {
+    // In test environment kDebugMode is always true.
+    test('accepts all levels', () {
+      for (final level in Level.values) {
+        expect(handler.acceptsLevel(level), isTrue, reason: 'level: $level');
+      }
+    });
+  });
+
+  group('ConsoleLogHandler.acceptsLevel — web', () {
+    setUp(() => PlatformInfo.isTestingForWeb = true);
+
+    test('always accepts — per-record webConsoleEnabled may override debug gate', () {
+      for (final level in Level.values) {
+        expect(handler.acceptsLevel(level), isTrue, reason: 'level: $level');
+      }
+    });
+  });
+
+  // ─── handles ───────────────────────────────────────────────────────────────
+
+  group('ConsoleLogHandler.handles — non-web (debug mode)', () {
+    test('accepts record regardless of webConsoleEnabled', () {
+      const record = LogRecord(level: Level.info, rawMessage: 'msg');
+      expect(handler.handles(record), isTrue);
+    });
+
+    test('accepts record with webConsoleEnabled=true', () {
+      const record = LogRecord(
+        level: Level.info,
+        rawMessage: 'msg',
+        webConsoleEnabled: true,
+      );
+      expect(handler.handles(record), isTrue);
+    });
+  });
+
+  group('ConsoleLogHandler.handles — web', () {
+    setUp(() => PlatformInfo.isTestingForWeb = true);
+
+    test('accepts when webConsoleEnabled=true', () {
+      const record = LogRecord(
+        level: Level.error,
+        rawMessage: 'msg',
+        webConsoleEnabled: true,
+      );
+      expect(handler.handles(record), isTrue);
+    });
+
+    test('accepts when isDebugMode=true (always true in test)', () {
+      const record = LogRecord(
+        level: Level.debug,
+        rawMessage: 'msg',
+        webConsoleEnabled: false,
+      );
+      // kDebugMode is true in test environment → handles() returns true
+      expect(handler.handles(record), isTrue);
+    });
+  });
+
+  // ─── acceptsLevel / handles contract ──────────────────────────────────────
+
+  group('ConsoleLogHandler — acceptsLevel/handles contract', () {
+    test('if acceptsLevel returns false then handles also returns false', () {
+      // acceptsLevel is always true in test (debug mode / web), so we can only
+      // verify the positive direction: acceptsLevel true does not imply handles false.
+      // The negative direction is validated by the non-web release-mode path which
+      // cannot be exercised in unit tests because kDebugMode is a compile-time const.
+      for (final level in Level.values) {
+        final record = LogRecord(level: level, rawMessage: '');
+        if (!handler.acceptsLevel(level)) {
+          expect(
+            handler.handles(record),
+            isFalse,
+            reason: 'handles() must respect acceptsLevel() contract for $level',
+          );
+        }
+      }
+    });
+  });
+
+  // ─── handle ────────────────────────────────────────────────────────────────
+
+  group('ConsoleLogHandler.handle — formatter delegation', () {
+    test('calls formatter.format with correct level and rawMessage', () {
+      const record = LogRecord(level: Level.error, rawMessage: 'something failed');
+      handler.handle(record);
+
+      expect(formatter.calls, hasLength(1));
+      expect(formatter.calls.first.level, Level.error);
+      expect(formatter.calls.first.raw, 'something failed');
+    });
+
+    test('calls formatter once per handle() call', () {
+      for (final level in Level.values) {
+        handler.handle(LogRecord(level: level, rawMessage: 'x'));
+      }
+      expect(formatter.calls, hasLength(Level.values.length));
+    });
+
+    test('formatter output is used — format is called before output', () {
+      const record = LogRecord(level: Level.info, rawMessage: 'hello');
+      handler.handle(record);
+      // If formatter was never called, the spy list would be empty.
+      expect(formatter.calls, isNotEmpty);
+    });
+  });
+
+  group('ConsoleLogHandler.handle — web path', () {
+    setUp(() => PlatformInfo.isTestingForWeb = true);
+
+    test('calls formatter with correct level on web', () {
+      const record = LogRecord(
+        level: Level.warning,
+        rawMessage: 'web warning',
+        webConsoleEnabled: true,
+      );
+      handler.handle(record);
+
+      expect(formatter.calls.first.level, Level.warning);
+      expect(formatter.calls.first.raw, 'web warning');
+    });
+
+    test('calls formatter for each log level on web', () {
+      for (final level in Level.values) {
+        handler.handle(LogRecord(level: level, rawMessage: 'msg'));
+      }
+      expect(formatter.calls, hasLength(Level.values.length));
+    });
+  });
+}

--- a/core/test/utils/logging/handlers/console_log_handler_test.dart
+++ b/core/test/utils/logging/handlers/console_log_handler_test.dart
@@ -48,10 +48,10 @@ void main() {
     });
   });
 
-  group('ConsoleLogHandler.handles — non-web (debug mode)', () {
+  group('ConsoleLogHandler.canHandle — non-web (debug mode)', () {
     test('accepts record regardless of webConsoleEnabled', () {
       const record = LogRecord(level: Level.info, rawMessage: 'msg');
-      expect(handler.handles(record), isTrue);
+      expect(handler.canHandle(record), isTrue);
     });
 
     test('accepts record with webConsoleEnabled=true', () {
@@ -60,11 +60,11 @@ void main() {
         rawMessage: 'msg',
         webConsoleEnabled: true,
       );
-      expect(handler.handles(record), isTrue);
+      expect(handler.canHandle(record), isTrue);
     });
   });
 
-  group('ConsoleLogHandler.handles — web', () {
+  group('ConsoleLogHandler.canHandle — web', () {
     setUp(() => PlatformInfo.isTestingForWeb = true);
 
     test('accepts when webConsoleEnabled=true', () {
@@ -73,7 +73,7 @@ void main() {
         rawMessage: 'msg',
         webConsoleEnabled: true,
       );
-      expect(handler.handles(record), isTrue);
+      expect(handler.canHandle(record), isTrue);
     });
 
     test('accepts when isDebugMode=true (always true in test)', () {
@@ -82,24 +82,24 @@ void main() {
         rawMessage: 'msg',
         webConsoleEnabled: false,
       );
-      // kDebugMode is true in test environment → handles() returns true
-      expect(handler.handles(record), isTrue);
+      // kDebugMode is true in test environment → canHandle() returns true
+      expect(handler.canHandle(record), isTrue);
     });
   });
 
-  group('ConsoleLogHandler — acceptsLevel/handles contract', () {
-    test('if acceptsLevel returns false then handles also returns false', () {
+  group('ConsoleLogHandler — acceptsLevel/canHandle contract', () {
+    test('if acceptsLevel returns false then canHandle also returns false', () {
       // acceptsLevel is always true in test (debug mode / web), so we can only
-      // verify the positive direction: acceptsLevel true does not imply handles false.
+      // verify the positive direction: acceptsLevel true does not imply canHandle false.
       // The negative direction is validated by the non-web release-mode path which
       // cannot be exercised in unit tests because kDebugMode is a compile-time const.
       for (final level in Level.values) {
         final record = LogRecord(level: level, rawMessage: '');
         if (!handler.acceptsLevel(level)) {
           expect(
-            handler.handles(record),
+            handler.canHandle(record),
             isFalse,
-            reason: 'handles() must respect acceptsLevel() contract for $level',
+            reason: 'canHandle() must respect acceptsLevel() contract for $level',
           );
         }
       }

--- a/core/test/utils/logging/handlers/console_log_handler_test.dart
+++ b/core/test/utils/logging/handlers/console_log_handler_test.dart
@@ -29,8 +29,6 @@ void main() {
     PlatformInfo.isTestingForWeb = false;
   });
 
-  // ─── acceptsLevel ──────────────────────────────────────────────────────────
-
   group('ConsoleLogHandler.acceptsLevel — non-web (debug mode)', () {
     // In test environment kDebugMode is always true.
     test('accepts all levels', () {
@@ -49,8 +47,6 @@ void main() {
       }
     });
   });
-
-  // ─── handles ───────────────────────────────────────────────────────────────
 
   group('ConsoleLogHandler.handles — non-web (debug mode)', () {
     test('accepts record regardless of webConsoleEnabled', () {
@@ -91,8 +87,6 @@ void main() {
     });
   });
 
-  // ─── acceptsLevel / handles contract ──────────────────────────────────────
-
   group('ConsoleLogHandler — acceptsLevel/handles contract', () {
     test('if acceptsLevel returns false then handles also returns false', () {
       // acceptsLevel is always true in test (debug mode / web), so we can only
@@ -111,8 +105,6 @@ void main() {
       }
     });
   });
-
-  // ─── handle ────────────────────────────────────────────────────────────────
 
   group('ConsoleLogHandler.handle — formatter delegation', () {
     test('calls formatter.format with correct level and rawMessage', () {

--- a/core/test/utils/logging/handlers/sentry_breadcrumb_handler_test.dart
+++ b/core/test/utils/logging/handlers/sentry_breadcrumb_handler_test.dart
@@ -1,0 +1,95 @@
+import 'package:core/utils/logging/handlers/sentry_breadcrumb_handler.dart';
+import 'package:core/utils/logging/log_level.dart';
+import 'package:core/utils/logging/log_record.dart';
+import 'package:core/utils/sentry/sentry_reporter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeSentryReporter implements SentryReporter {
+  final List<({String message, Map<String, dynamic>? extras})> capturedBreadcrumbs = [];
+
+  @override
+  void captureException(dynamic exception, {StackTrace? stackTrace, String? message, Map<String, dynamic>? extras}) {}
+
+  @override
+  void captureMessage(String message, {Map<String, dynamic>? extras}) {}
+
+  @override
+  void addBreadcrumb(String message, {Map<String, dynamic>? extras}) {
+    capturedBreadcrumbs.add((message: message, extras: extras));
+  }
+}
+
+void main() {
+  late _FakeSentryReporter reporter;
+  late SentryBreadcrumbHandler handler;
+
+  setUp(() {
+    reporter = _FakeSentryReporter();
+    handler = SentryBreadcrumbHandler(reporter);
+  });
+
+  group('SentryBreadcrumbHandler.handles', () {
+    test('handles trace level', () {
+      expect(handler.handles(Level.trace), isTrue);
+    });
+
+    test('does not handle error', () {
+      expect(handler.handles(Level.error), isFalse);
+    });
+
+    test('does not handle critical', () {
+      expect(handler.handles(Level.critical), isFalse);
+    });
+
+    test('does not handle warning', () {
+      expect(handler.handles(Level.warning), isFalse);
+    });
+
+    test('does not handle info', () {
+      expect(handler.handles(Level.info), isFalse);
+    });
+
+    test('does not handle debug', () {
+      expect(handler.handles(Level.debug), isFalse);
+    });
+  });
+
+  group('SentryBreadcrumbHandler.handle', () {
+    test('calls addBreadcrumb with rawMessage', () {
+      const record = LogRecord(
+        level: Level.trace,
+        rawMessage: 'fetching mailbox list',
+      );
+
+      handler.handle(record);
+
+      expect(reporter.capturedBreadcrumbs, hasLength(1));
+      expect(reporter.capturedBreadcrumbs.first.message, 'fetching mailbox list');
+    });
+
+    test('passes extras to addBreadcrumb', () {
+      final record = LogRecord(
+        level: Level.trace,
+        rawMessage: 'cache miss',
+        extras: {'source': 'remote'},
+      );
+
+      handler.handle(record);
+
+      expect(reporter.capturedBreadcrumbs.first.extras, {'source': 'remote'});
+    });
+
+    test('does not call captureException or captureMessage', () {
+      // Verified by _FakeSentryReporter having empty lists for those
+      const record = LogRecord(
+        level: Level.trace,
+        rawMessage: 'trace message',
+      );
+
+      handler.handle(record);
+
+      // Only breadcrumbs should be populated
+      expect(reporter.capturedBreadcrumbs, hasLength(1));
+    });
+  });
+}

--- a/core/test/utils/logging/handlers/sentry_breadcrumb_handler_test.dart
+++ b/core/test/utils/logging/handlers/sentry_breadcrumb_handler_test.dart
@@ -8,7 +8,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 class _FakeSentryReporter implements SentryReporter {
   final List<dynamic> capturedExceptions = [];
   final List<String> capturedMessages = [];
-  final List<({String message, Map<String, dynamic>? extras})> capturedBreadcrumbs = [];
+  final List<({String message, Map<String, dynamic>? extras, SentryLevel level, String? category})> capturedBreadcrumbs = [];
 
   @override
   void captureException(
@@ -31,8 +31,18 @@ class _FakeSentryReporter implements SentryReporter {
   }
 
   @override
-  void addBreadcrumb(String message, {Map<String, dynamic>? extras}) {
-    capturedBreadcrumbs.add((message: message, extras: extras));
+  void addBreadcrumb(
+    String message, {
+    Map<String, dynamic>? extras,
+    SentryLevel level = SentryLevel.debug,
+    String? category,
+  }) {
+    capturedBreadcrumbs.add((
+      message: message,
+      extras: extras,
+      level: level,
+      category: category,
+    ));
   }
 }
 
@@ -85,7 +95,7 @@ void main() {
     });
 
     test('passes extras to addBreadcrumb', () {
-      final record = LogRecord(
+      const record = LogRecord(
         level: Level.trace,
         rawMessage: 'cache miss',
         extras: {'source': 'remote'},
@@ -94,6 +104,15 @@ void main() {
       handler.handle(record);
 
       expect(reporter.capturedBreadcrumbs.first.extras, {'source': 'remote'});
+    });
+
+    test('passes SentryLevel.debug and category log to addBreadcrumb', () {
+      const record = LogRecord(level: Level.trace, rawMessage: 'trace event');
+
+      handler.handle(record);
+
+      expect(reporter.capturedBreadcrumbs.first.level, SentryLevel.debug);
+      expect(reporter.capturedBreadcrumbs.first.category, 'log');
     });
 
     test('does not call captureException or captureMessage', () {

--- a/core/test/utils/logging/handlers/sentry_breadcrumb_handler_test.dart
+++ b/core/test/utils/logging/handlers/sentry_breadcrumb_handler_test.dart
@@ -81,31 +81,31 @@ void main() {
     });
   });
 
-  group('SentryBreadcrumbHandler.handles', () {
+  group('SentryBreadcrumbHandler.canHandle', () {
     test('handles trace record', () {
       expect(
-        handler.handles(const LogRecord(level: Level.trace, rawMessage: '')),
+        handler.canHandle(const LogRecord(level: Level.trace, rawMessage: '')),
         isTrue,
       );
     });
 
     test('does not handle error record', () {
       expect(
-        handler.handles(const LogRecord(level: Level.error, rawMessage: '')),
+        handler.canHandle(const LogRecord(level: Level.error, rawMessage: '')),
         isFalse,
       );
     });
   });
 
-  group('SentryBreadcrumbHandler — acceptsLevel/handles contract', () {
-    test('handles() is consistent with acceptsLevel() for all levels', () {
+  group('SentryBreadcrumbHandler — acceptsLevel/canHandle contract', () {
+    test('canHandle() is consistent with acceptsLevel() for all levels', () {
       for (final level in Level.values) {
         final record = LogRecord(level: level, rawMessage: '');
         if (!handler.acceptsLevel(level)) {
           expect(
-            handler.handles(record),
+            handler.canHandle(record),
             isFalse,
-            reason: 'handles() must return false when acceptsLevel() is false — level: $level',
+            reason: 'canHandle() must return false when acceptsLevel() is false — level: $level',
           );
         }
       }

--- a/core/test/utils/logging/handlers/sentry_breadcrumb_handler_test.dart
+++ b/core/test/utils/logging/handlers/sentry_breadcrumb_handler_test.dart
@@ -3,15 +3,32 @@ import 'package:core/utils/logging/log_level.dart';
 import 'package:core/utils/logging/log_record.dart';
 import 'package:core/utils/sentry/sentry_reporter.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 class _FakeSentryReporter implements SentryReporter {
+  final List<dynamic> capturedExceptions = [];
+  final List<String> capturedMessages = [];
   final List<({String message, Map<String, dynamic>? extras})> capturedBreadcrumbs = [];
 
   @override
-  void captureException(dynamic exception, {StackTrace? stackTrace, String? message, Map<String, dynamic>? extras}) {}
+  void captureException(
+    dynamic exception, {
+    StackTrace? stackTrace,
+    String? message,
+    Map<String, dynamic>? extras,
+    SentryLevel level = SentryLevel.error,
+  }) {
+    capturedExceptions.add(exception);
+  }
 
   @override
-  void captureMessage(String message, {Map<String, dynamic>? extras}) {}
+  void captureMessage(
+    String message, {
+    Map<String, dynamic>? extras,
+    SentryLevel level = SentryLevel.info,
+  }) {
+    capturedMessages.add(message);
+  }
 
   @override
   void addBreadcrumb(String message, {Map<String, dynamic>? extras}) {
@@ -80,7 +97,6 @@ void main() {
     });
 
     test('does not call captureException or captureMessage', () {
-      // Verified by _FakeSentryReporter having empty lists for those
       const record = LogRecord(
         level: Level.trace,
         rawMessage: 'trace message',
@@ -88,7 +104,8 @@ void main() {
 
       handler.handle(record);
 
-      // Only breadcrumbs should be populated
+      expect(reporter.capturedExceptions, isEmpty);
+      expect(reporter.capturedMessages, isEmpty);
       expect(reporter.capturedBreadcrumbs, hasLength(1));
     });
   });

--- a/core/test/utils/logging/handlers/sentry_breadcrumb_handler_test.dart
+++ b/core/test/utils/logging/handlers/sentry_breadcrumb_handler_test.dart
@@ -55,29 +55,60 @@ void main() {
     handler = SentryBreadcrumbHandler(reporter);
   });
 
+  group('SentryBreadcrumbHandler.acceptsLevel', () {
+    test('accepts trace level', () {
+      expect(handler.acceptsLevel(Level.trace), isTrue);
+    });
+
+    test('rejects error', () {
+      expect(handler.acceptsLevel(Level.error), isFalse);
+    });
+
+    test('rejects critical', () {
+      expect(handler.acceptsLevel(Level.critical), isFalse);
+    });
+
+    test('rejects warning', () {
+      expect(handler.acceptsLevel(Level.warning), isFalse);
+    });
+
+    test('rejects info', () {
+      expect(handler.acceptsLevel(Level.info), isFalse);
+    });
+
+    test('rejects debug', () {
+      expect(handler.acceptsLevel(Level.debug), isFalse);
+    });
+  });
+
   group('SentryBreadcrumbHandler.handles', () {
-    test('handles trace level', () {
-      expect(handler.handles(Level.trace), isTrue);
+    test('handles trace record', () {
+      expect(
+        handler.handles(const LogRecord(level: Level.trace, rawMessage: '')),
+        isTrue,
+      );
     });
 
-    test('does not handle error', () {
-      expect(handler.handles(Level.error), isFalse);
+    test('does not handle error record', () {
+      expect(
+        handler.handles(const LogRecord(level: Level.error, rawMessage: '')),
+        isFalse,
+      );
     });
+  });
 
-    test('does not handle critical', () {
-      expect(handler.handles(Level.critical), isFalse);
-    });
-
-    test('does not handle warning', () {
-      expect(handler.handles(Level.warning), isFalse);
-    });
-
-    test('does not handle info', () {
-      expect(handler.handles(Level.info), isFalse);
-    });
-
-    test('does not handle debug', () {
-      expect(handler.handles(Level.debug), isFalse);
+  group('SentryBreadcrumbHandler — acceptsLevel/handles contract', () {
+    test('handles() is consistent with acceptsLevel() for all levels', () {
+      for (final level in Level.values) {
+        final record = LogRecord(level: level, rawMessage: '');
+        if (!handler.acceptsLevel(level)) {
+          expect(
+            handler.handles(record),
+            isFalse,
+            reason: 'handles() must return false when acceptsLevel() is false — level: $level',
+          );
+        }
+      }
     });
   });
 

--- a/core/test/utils/logging/handlers/sentry_event_handler_test.dart
+++ b/core/test/utils/logging/handlers/sentry_event_handler_test.dart
@@ -57,29 +57,67 @@ void main() {
     handler = SentryEventHandler(reporter);
   });
 
+  group('SentryEventHandler.acceptsLevel', () {
+    test('accepts error level', () {
+      expect(handler.acceptsLevel(Level.error), isTrue);
+    });
+
+    test('accepts critical level', () {
+      expect(handler.acceptsLevel(Level.critical), isTrue);
+    });
+
+    test('rejects warning', () {
+      expect(handler.acceptsLevel(Level.warning), isFalse);
+    });
+
+    test('rejects info', () {
+      expect(handler.acceptsLevel(Level.info), isFalse);
+    });
+
+    test('rejects debug', () {
+      expect(handler.acceptsLevel(Level.debug), isFalse);
+    });
+
+    test('rejects trace', () {
+      expect(handler.acceptsLevel(Level.trace), isFalse);
+    });
+  });
+
   group('SentryEventHandler.handles', () {
-    test('handles error level', () {
-      expect(handler.handles(Level.error), isTrue);
+    test('handles error record', () {
+      expect(
+        handler.handles(const LogRecord(level: Level.error, rawMessage: '')),
+        isTrue,
+      );
     });
 
-    test('handles critical level', () {
-      expect(handler.handles(Level.critical), isTrue);
+    test('handles critical record', () {
+      expect(
+        handler.handles(const LogRecord(level: Level.critical, rawMessage: '')),
+        isTrue,
+      );
     });
 
-    test('does not handle warning', () {
-      expect(handler.handles(Level.warning), isFalse);
+    test('does not handle info record', () {
+      expect(
+        handler.handles(const LogRecord(level: Level.info, rawMessage: '')),
+        isFalse,
+      );
     });
+  });
 
-    test('does not handle info', () {
-      expect(handler.handles(Level.info), isFalse);
-    });
-
-    test('does not handle debug', () {
-      expect(handler.handles(Level.debug), isFalse);
-    });
-
-    test('does not handle trace', () {
-      expect(handler.handles(Level.trace), isFalse);
+  group('SentryEventHandler — acceptsLevel/handles contract', () {
+    test('handles() is consistent with acceptsLevel() for all levels', () {
+      for (final level in Level.values) {
+        final record = LogRecord(level: level, rawMessage: '');
+        if (!handler.acceptsLevel(level)) {
+          expect(
+            handler.handles(record),
+            isFalse,
+            reason: 'handles() must return false when acceptsLevel() is false — level: $level',
+          );
+        }
+      }
     });
   });
 

--- a/core/test/utils/logging/handlers/sentry_event_handler_test.dart
+++ b/core/test/utils/logging/handlers/sentry_event_handler_test.dart
@@ -3,11 +3,12 @@ import 'package:core/utils/logging/log_level.dart';
 import 'package:core/utils/logging/log_record.dart';
 import 'package:core/utils/sentry/sentry_reporter.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 class _FakeSentryReporter implements SentryReporter {
-  final List<({dynamic exception, StackTrace? stackTrace, String? message, Map<String, dynamic>? extras})>
+  final List<({dynamic exception, StackTrace? stackTrace, String? message, Map<String, dynamic>? extras, SentryLevel level})>
       capturedExceptions = [];
-  final List<({String message, Map<String, dynamic>? extras})> capturedMessages = [];
+  final List<({String message, Map<String, dynamic>? extras, SentryLevel level})> capturedMessages = [];
   final List<({String message, Map<String, dynamic>? extras})> capturedBreadcrumbs = [];
 
   @override
@@ -16,18 +17,24 @@ class _FakeSentryReporter implements SentryReporter {
     StackTrace? stackTrace,
     String? message,
     Map<String, dynamic>? extras,
+    SentryLevel level = SentryLevel.error,
   }) {
     capturedExceptions.add((
       exception: exception,
       stackTrace: stackTrace,
       message: message,
       extras: extras,
+      level: level,
     ));
   }
 
   @override
-  void captureMessage(String message, {Map<String, dynamic>? extras}) {
-    capturedMessages.add((message: message, extras: extras));
+  void captureMessage(
+    String message, {
+    Map<String, dynamic>? extras,
+    SentryLevel level = SentryLevel.info,
+  }) {
+    capturedMessages.add((message: message, extras: extras, level: level));
   }
 
   @override
@@ -90,6 +97,7 @@ void main() {
       expect(reporter.capturedExceptions.first.stackTrace, st);
       expect(reporter.capturedExceptions.first.message, 'something failed');
       expect(reporter.capturedExceptions.first.extras, {'key': 'val'});
+      expect(reporter.capturedExceptions.first.level, SentryLevel.error);
       expect(reporter.capturedMessages, isEmpty);
     });
   });
@@ -105,6 +113,7 @@ void main() {
 
       expect(reporter.capturedMessages, hasLength(1));
       expect(reporter.capturedMessages.first.message, 'something went wrong');
+      expect(reporter.capturedMessages.first.level, SentryLevel.error);
       expect(reporter.capturedExceptions, isEmpty);
     });
 

--- a/core/test/utils/logging/handlers/sentry_event_handler_test.dart
+++ b/core/test/utils/logging/handlers/sentry_event_handler_test.dart
@@ -9,7 +9,7 @@ class _FakeSentryReporter implements SentryReporter {
   final List<({dynamic exception, StackTrace? stackTrace, String? message, Map<String, dynamic>? extras, SentryLevel level})>
       capturedExceptions = [];
   final List<({String message, Map<String, dynamic>? extras, SentryLevel level})> capturedMessages = [];
-  final List<({String message, Map<String, dynamic>? extras})> capturedBreadcrumbs = [];
+  final List<({String message, Map<String, dynamic>? extras, SentryLevel level, String? category})> capturedBreadcrumbs = [];
 
   @override
   void captureException(
@@ -38,8 +38,13 @@ class _FakeSentryReporter implements SentryReporter {
   }
 
   @override
-  void addBreadcrumb(String message, {Map<String, dynamic>? extras}) {
-    capturedBreadcrumbs.add((message: message, extras: extras));
+  void addBreadcrumb(
+    String message, {
+    Map<String, dynamic>? extras,
+    SentryLevel level = SentryLevel.debug,
+    String? category,
+  }) {
+    capturedBreadcrumbs.add((message: message, extras: extras, level: level, category: category));
   }
 }
 

--- a/core/test/utils/logging/handlers/sentry_event_handler_test.dart
+++ b/core/test/utils/logging/handlers/sentry_event_handler_test.dart
@@ -105,6 +105,18 @@ void main() {
       expect(reporter.capturedExceptions.first.level, SentryLevel.error);
       expect(reporter.capturedMessages, isEmpty);
     });
+
+    test('maps critical level to SentryLevel.fatal', () {
+      final record = LogRecord(
+        level: Level.critical,
+        rawMessage: 'system down',
+        exception: Exception('fatal error'),
+      );
+
+      handler.handle(record);
+
+      expect(reporter.capturedExceptions.first.level, SentryLevel.fatal);
+    });
   });
 
   group('SentryEventHandler.handle — without exception', () {
@@ -132,6 +144,17 @@ void main() {
       handler.handle(record);
 
       expect(reporter.capturedMessages.first.extras, {'a': 1});
+    });
+
+    test('maps critical level to SentryLevel.fatal when no exception', () {
+      const record = LogRecord(
+        level: Level.critical,
+        rawMessage: 'system down',
+      );
+
+      handler.handle(record);
+
+      expect(reporter.capturedMessages.first.level, SentryLevel.fatal);
     });
   });
 }

--- a/core/test/utils/logging/handlers/sentry_event_handler_test.dart
+++ b/core/test/utils/logging/handlers/sentry_event_handler_test.dart
@@ -1,0 +1,123 @@
+import 'package:core/utils/logging/handlers/sentry_event_handler.dart';
+import 'package:core/utils/logging/log_level.dart';
+import 'package:core/utils/logging/log_record.dart';
+import 'package:core/utils/sentry/sentry_reporter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeSentryReporter implements SentryReporter {
+  final List<({dynamic exception, StackTrace? stackTrace, String? message, Map<String, dynamic>? extras})>
+      capturedExceptions = [];
+  final List<({String message, Map<String, dynamic>? extras})> capturedMessages = [];
+  final List<({String message, Map<String, dynamic>? extras})> capturedBreadcrumbs = [];
+
+  @override
+  void captureException(
+    dynamic exception, {
+    StackTrace? stackTrace,
+    String? message,
+    Map<String, dynamic>? extras,
+  }) {
+    capturedExceptions.add((
+      exception: exception,
+      stackTrace: stackTrace,
+      message: message,
+      extras: extras,
+    ));
+  }
+
+  @override
+  void captureMessage(String message, {Map<String, dynamic>? extras}) {
+    capturedMessages.add((message: message, extras: extras));
+  }
+
+  @override
+  void addBreadcrumb(String message, {Map<String, dynamic>? extras}) {
+    capturedBreadcrumbs.add((message: message, extras: extras));
+  }
+}
+
+void main() {
+  late _FakeSentryReporter reporter;
+  late SentryEventHandler handler;
+
+  setUp(() {
+    reporter = _FakeSentryReporter();
+    handler = SentryEventHandler(reporter);
+  });
+
+  group('SentryEventHandler.handles', () {
+    test('handles error level', () {
+      expect(handler.handles(Level.error), isTrue);
+    });
+
+    test('handles critical level', () {
+      expect(handler.handles(Level.critical), isTrue);
+    });
+
+    test('does not handle warning', () {
+      expect(handler.handles(Level.warning), isFalse);
+    });
+
+    test('does not handle info', () {
+      expect(handler.handles(Level.info), isFalse);
+    });
+
+    test('does not handle debug', () {
+      expect(handler.handles(Level.debug), isFalse);
+    });
+
+    test('does not handle trace', () {
+      expect(handler.handles(Level.trace), isFalse);
+    });
+  });
+
+  group('SentryEventHandler.handle — with exception', () {
+    test('calls captureException when record has exception', () {
+      final ex = Exception('boom');
+      final st = StackTrace.current;
+      final record = LogRecord(
+        level: Level.error,
+        rawMessage: 'something failed',
+        exception: ex,
+        stackTrace: st,
+        extras: {'key': 'val'},
+      );
+
+      handler.handle(record);
+
+      expect(reporter.capturedExceptions, hasLength(1));
+      expect(reporter.capturedExceptions.first.exception, ex);
+      expect(reporter.capturedExceptions.first.stackTrace, st);
+      expect(reporter.capturedExceptions.first.message, 'something failed');
+      expect(reporter.capturedExceptions.first.extras, {'key': 'val'});
+      expect(reporter.capturedMessages, isEmpty);
+    });
+  });
+
+  group('SentryEventHandler.handle — without exception', () {
+    test('calls captureMessage when record has no exception', () {
+      const record = LogRecord(
+        level: Level.error,
+        rawMessage: 'something went wrong',
+      );
+
+      handler.handle(record);
+
+      expect(reporter.capturedMessages, hasLength(1));
+      expect(reporter.capturedMessages.first.message, 'something went wrong');
+      expect(reporter.capturedExceptions, isEmpty);
+    });
+
+    test('passes extras to captureMessage', () {
+      const record = LogRecord(
+        level: Level.error,
+        rawMessage: 'msg',
+        extras: {'a': 1},
+      );
+
+      handler.handle(record);
+
+      expect(reporter.capturedMessages.first.extras, {'a': 1});
+    });
+  });
+}

--- a/core/test/utils/logging/handlers/sentry_event_handler_test.dart
+++ b/core/test/utils/logging/handlers/sentry_event_handler_test.dart
@@ -83,38 +83,38 @@ void main() {
     });
   });
 
-  group('SentryEventHandler.handles', () {
+  group('SentryEventHandler.canHandle', () {
     test('handles error record', () {
       expect(
-        handler.handles(const LogRecord(level: Level.error, rawMessage: '')),
+        handler.canHandle(const LogRecord(level: Level.error, rawMessage: '')),
         isTrue,
       );
     });
 
     test('handles critical record', () {
       expect(
-        handler.handles(const LogRecord(level: Level.critical, rawMessage: '')),
+        handler.canHandle(const LogRecord(level: Level.critical, rawMessage: '')),
         isTrue,
       );
     });
 
     test('does not handle info record', () {
       expect(
-        handler.handles(const LogRecord(level: Level.info, rawMessage: '')),
+        handler.canHandle(const LogRecord(level: Level.info, rawMessage: '')),
         isFalse,
       );
     });
   });
 
-  group('SentryEventHandler — acceptsLevel/handles contract', () {
-    test('handles() is consistent with acceptsLevel() for all levels', () {
+  group('SentryEventHandler — acceptsLevel/canHandle contract', () {
+    test('canHandle() is consistent with acceptsLevel() for all levels', () {
       for (final level in Level.values) {
         final record = LogRecord(level: level, rawMessage: '');
         if (!handler.acceptsLevel(level)) {
           expect(
-            handler.handles(record),
+            handler.canHandle(record),
             isFalse,
-            reason: 'handles() must return false when acceptsLevel() is false — level: $level',
+            reason: 'canHandle() must return false when acceptsLevel() is false — level: $level',
           );
         }
       }

--- a/docs/adr/0078-app-logger-handler-pipeline.md
+++ b/docs/adr/0078-app-logger-handler-pipeline.md
@@ -35,17 +35,17 @@ Refactor `app_logger.dart` to a **handler pipeline**. Each log destination becom
 ```dart
 // log_handler.dart
 abstract interface class LogHandler {
-  bool handles(Level level);
+  bool canHandle(LogRecord record);
   void handle(LogRecord record);
 }
 ```
 
-`AppLoggerRegistry` holds a list of handlers and dispatches each `LogRecord` to all handlers where `handles()` returns `true`. The `_shouldReportToSentry` function is deleted — each handler owns its own filter rule.
+`AppLoggerRegistry` holds a list of handlers and dispatches each `LogRecord` to all handlers where `canHandle()` returns `true`. The `_shouldReportToSentry` function is deleted — each handler owns its own filter rule.
 
 ### Handlers
 
-| Handler | `handles()` | Behaviour |
-|---------|-------------|-----------|
+| Handler | `canHandle()` | Behaviour |
+|---------|--------------|-----------|
 | `ConsoleLogHandler` | all levels | `print()` or `html.window.console.*` (filtered by debug mode / `webConsoleEnabled`) |
 | `SentryEventHandler` | `error`, `critical` | `captureException` if exception present; `captureMessage` otherwise |
 | `SentryBreadcrumbHandler` | `trace` | `Sentry.addBreadcrumb()` — zero quota cost; attached to next error event |

--- a/lib/main/runner/app_runner_base.dart
+++ b/lib/main/runner/app_runner_base.dart
@@ -22,18 +22,10 @@ Future<void> runAppGuarded(Future<void> Function() runner) async {
 /// Must be called once at app startup, before any log call is made.
 /// Sentry handlers are registered early — they check [SentryManager.isSentryAvailable]
 /// internally, so calls before Sentry initialises are safe no-ops.
-void registerLogHandlers({
-  required LogFormatter formatter,
-  bool webConsoleEnabled = false,
-}) {
+void registerLogHandlers({required LogFormatter formatter}) {
   final sentry = SentryManager.instance;
   AppLoggerRegistry.instance
-    ..registerHandler(
-      ConsoleLogHandler(
-        formatter: formatter,
-        webConsoleEnabled: webConsoleEnabled,
-      ),
-    )
+    ..registerHandler(ConsoleLogHandler(formatter: formatter))
     ..registerHandler(SentryBreadcrumbHandler(sentry))
     ..registerHandler(SentryEventHandler(sentry));
 }

--- a/lib/main/runner/app_runner_base.dart
+++ b/lib/main/runner/app_runner_base.dart
@@ -1,5 +1,9 @@
 import 'dart:async';
 
+import 'package:core/utils/logging/app_logger_registry.dart';
+import 'package:core/utils/logging/handlers/sentry_breadcrumb_handler.dart';
+import 'package:core/utils/logging/handlers/sentry_event_handler.dart';
+import 'package:core/utils/sentry/sentry_manager.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:tmail_ui_user/main/runner/app_error_handlers.dart';
 
@@ -9,4 +13,16 @@ Future<void> runAppGuarded(Future<void> Function() runner) async {
   setupErrorHooks();
 
   await runner();
+}
+
+/// Registers Sentry log handlers shared across all platforms.
+///
+/// Safe to call before Sentry initialises — [SentryManager] guards
+/// each call with [SentryManager.isSentryAvailable], so early calls
+/// are no-ops until Sentry is ready.
+void registerSentryLogHandlers() {
+  final sentry = SentryManager.instance;
+  AppLoggerRegistry.instance
+    ..registerHandler(SentryBreadcrumbHandler(sentry))
+    ..registerHandler(SentryEventHandler(sentry));
 }

--- a/lib/main/runner/app_runner_base.dart
+++ b/lib/main/runner/app_runner_base.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
 import 'package:core/utils/logging/app_logger_registry.dart';
+import 'package:core/utils/logging/formatters/log_formatter.dart';
+import 'package:core/utils/logging/handlers/console_log_handler.dart';
 import 'package:core/utils/logging/handlers/sentry_breadcrumb_handler.dart';
 import 'package:core/utils/logging/handlers/sentry_event_handler.dart';
 import 'package:core/utils/sentry/sentry_manager.dart';
@@ -15,14 +17,23 @@ Future<void> runAppGuarded(Future<void> Function() runner) async {
   await runner();
 }
 
-/// Registers Sentry log handlers shared across all platforms.
+/// Registers all log handlers for the given platform.
 ///
-/// Safe to call before Sentry initialises — [SentryManager] guards
-/// each call with [SentryManager.isSentryAvailable], so early calls
-/// are no-ops until Sentry is ready.
-void registerSentryLogHandlers() {
+/// Must be called once at app startup, before any log call is made.
+/// Sentry handlers are registered early — they check [SentryManager.isSentryAvailable]
+/// internally, so calls before Sentry initialises are safe no-ops.
+void registerLogHandlers({
+  required LogFormatter formatter,
+  bool webConsoleEnabled = false,
+}) {
   final sentry = SentryManager.instance;
   AppLoggerRegistry.instance
+    ..registerHandler(
+      ConsoleLogHandler(
+        formatter: formatter,
+        webConsoleEnabled: webConsoleEnabled,
+      ),
+    )
     ..registerHandler(SentryBreadcrumbHandler(sentry))
     ..registerHandler(SentryEventHandler(sentry));
 }

--- a/lib/main/runner/app_runner_mobile.dart
+++ b/lib/main/runner/app_runner_mobile.dart
@@ -18,4 +18,5 @@ void _registerLogHandlers() {
   AppLoggerRegistry.instance.registerHandler(
     const ConsoleLogHandler(formatter: MobileConsoleFormatter()),
   );
+  registerSentryLogHandlers();
 }

--- a/lib/main/runner/app_runner_mobile.dart
+++ b/lib/main/runner/app_runner_mobile.dart
@@ -1,22 +1,13 @@
 import 'package:core/utils/config/env_loader.dart';
-import 'package:core/utils/logging/app_logger_registry.dart';
 import 'package:core/utils/logging/formatters/mobile_console_formatter.dart';
-import 'package:core/utils/logging/handlers/console_log_handler.dart';
 import 'package:tmail_ui_user/main/runner/app_runner_base.dart';
 
 Future<void> runAppWithMonitoring(Future<void> Function() runTmail) async {
-  _registerLogHandlers();
+  registerLogHandlers(formatter: const MobileConsoleFormatter());
 
   await runAppGuarded(() async {
     await EnvLoader.loadEnvFile();
 
     await runTmail();
   });
-}
-
-void _registerLogHandlers() {
-  AppLoggerRegistry.instance.registerHandler(
-    const ConsoleLogHandler(formatter: MobileConsoleFormatter()),
-  );
-  registerSentryLogHandlers();
 }

--- a/lib/main/runner/app_runner_mobile.dart
+++ b/lib/main/runner/app_runner_mobile.dart
@@ -1,10 +1,21 @@
 import 'package:core/utils/config/env_loader.dart';
+import 'package:core/utils/logging/app_logger_registry.dart';
+import 'package:core/utils/logging/formatters/mobile_console_formatter.dart';
+import 'package:core/utils/logging/handlers/console_log_handler.dart';
 import 'package:tmail_ui_user/main/runner/app_runner_base.dart';
 
 Future<void> runAppWithMonitoring(Future<void> Function() runTmail) async {
+  _registerLogHandlers();
+
   await runAppGuarded(() async {
     await EnvLoader.loadEnvFile();
 
     await runTmail();
   });
+}
+
+void _registerLogHandlers() {
+  AppLoggerRegistry.instance.registerHandler(
+    const ConsoleLogHandler(formatter: MobileConsoleFormatter()),
+  );
 }

--- a/lib/main/runner/app_runner_web.dart
+++ b/lib/main/runner/app_runner_web.dart
@@ -8,10 +8,7 @@ import 'package:tmail_ui_user/main/main_entry.dart';
 import 'package:tmail_ui_user/main/runner/app_runner_base.dart';
 
 Future<void> runAppWithMonitoring(Future<void> Function() runTmail) async {
-  registerLogHandlers(
-    formatter: const WebConsoleFormatter(),
-    webConsoleEnabled: true,
-  );
+  registerLogHandlers(formatter: const WebConsoleFormatter());
 
   await runAppGuarded(() async {
     await EnvLoader.loadEnvFile();

--- a/lib/main/runner/app_runner_web.dart
+++ b/lib/main/runner/app_runner_web.dart
@@ -1,7 +1,5 @@
 import 'package:core/utils/config/env_loader.dart';
-import 'package:core/utils/logging/app_logger_registry.dart';
 import 'package:core/utils/logging/formatters/web_console_formatter.dart';
-import 'package:core/utils/logging/handlers/console_log_handler.dart';
 import 'package:core/utils/sentry/sentry_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -10,7 +8,10 @@ import 'package:tmail_ui_user/main/main_entry.dart';
 import 'package:tmail_ui_user/main/runner/app_runner_base.dart';
 
 Future<void> runAppWithMonitoring(Future<void> Function() runTmail) async {
-  _registerLogHandlers();
+  registerLogHandlers(
+    formatter: const WebConsoleFormatter(),
+    webConsoleEnabled: true,
+  );
 
   await runAppGuarded(() async {
     await EnvLoader.loadEnvFile();
@@ -23,14 +24,4 @@ Future<void> runAppWithMonitoring(Future<void> Function() runTmail) async {
       fallBackRunner: runTmail,
     );
   });
-}
-
-void _registerLogHandlers() {
-  AppLoggerRegistry.instance.registerHandler(
-    const ConsoleLogHandler(
-      formatter: WebConsoleFormatter(),
-      webConsoleEnabled: true,
-    ),
-  );
-  registerSentryLogHandlers();
 }

--- a/lib/main/runner/app_runner_web.dart
+++ b/lib/main/runner/app_runner_web.dart
@@ -1,12 +1,17 @@
 import 'package:core/utils/config/env_loader.dart';
+import 'package:core/utils/logging/app_logger_registry.dart';
+import 'package:core/utils/logging/formatters/web_console_formatter.dart';
+import 'package:core/utils/logging/handlers/console_log_handler.dart';
+import 'package:core/utils/sentry/sentry_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:tmail_ui_user/main.dart';
 import 'package:tmail_ui_user/main/main_entry.dart';
-import 'package:core/utils/sentry/sentry_manager.dart';
 import 'package:tmail_ui_user/main/runner/app_runner_base.dart';
 
 Future<void> runAppWithMonitoring(Future<void> Function() runTmail) async {
+  _registerLogHandlers();
+
   await runAppGuarded(() async {
     await EnvLoader.loadEnvFile();
 
@@ -18,4 +23,13 @@ Future<void> runAppWithMonitoring(Future<void> Function() runTmail) async {
       fallBackRunner: runTmail,
     );
   });
+}
+
+void _registerLogHandlers() {
+  AppLoggerRegistry.instance.registerHandler(
+    const ConsoleLogHandler(
+      formatter: WebConsoleFormatter(),
+      webConsoleEnabled: true,
+    ),
+  );
 }

--- a/lib/main/runner/app_runner_web.dart
+++ b/lib/main/runner/app_runner_web.dart
@@ -32,4 +32,5 @@ void _registerLogHandlers() {
       webConsoleEnabled: true,
     ),
   );
+  registerSentryLogHandlers();
 }


### PR DESCRIPTION
  ## Context

  Implements Phase 1–3 of [ADR-0078](https://github.com/linagora/tmail-flutter/blob/master/docs/adr/0078-app-logger-handler-pipeline.md).

  `app_logger.dart` previously handled formatting, console output, Sentry routing, and exception capture in a single `_internalLog` function — untestable and non-extensible. This PR replaces it with an explicit handler pipeline where each log destination is an isolated, injectable unit.

  ## What changed

  - **`LogRecord` / `LogHandler` / `AppLoggerRegistry`** — core pipeline abstractions
  - **`ConsoleLogHandler`** — console output with injected platform formatter (mobile: emoji, web: ANSI)
  - **`SentryEventHandler`** — `error`/`critical` → `captureException` or `captureMessage`
  - **`SentryBreadcrumbHandler`** — `trace` → `addBreadcrumb` (zero quota, attached to next error event)
  - **`SentryReporter`** — interface extracted from `SentryManager` for handler testability
  - **`app_logger.dart` public API — unchanged**, all 188+ call sites unaffected
  - **`registerLogHandlers()`** — single entry point for handler registration at startup

  ## Behavior changes

  | | Before | After |
  |--|--------|-------|
  | `logTrace` | `captureMessage` — consumes Sentry quota | `addBreadcrumb` — zero quota |
  | `logError` without exception | Sentry exception event with raw string | Sentry message event |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced in-file logger with a modular logging system: centralized dispatch, pluggable formatters (web colorized, mobile emoji) and handlers.
  * Sentry integration extended to record breadcrumbs and route errors/events via a reporting interface.
  * App startup now registers logging and Sentry handlers automatically.

* **Tests**
  * Added unit tests covering the registry, record construction, formatters, and Sentry handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->