### PR TITLE
fix(logger): Reduce Sentry noise with targeted error logging (ADR-0076)

### DIFF
--- a/core/lib/utils/sentry/sentry_initializer.dart
+++ b/core/lib/utils/sentry/sentry_initializer.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/sentry/sentry_config.dart';
@@ -71,11 +72,26 @@ class SentryInitializer {
     // Automatically enable breadcrumbs that are appropriate for the current platform
     options.enableBreadcrumbTrackingForCurrentPlatform();
 
+    // Second line of defence: drop expected network exception types at the SDK
+    // level, even if a call site accidentally reports them as logError.
+    // Primary defence is call-site routing to logWarning (see ADR-0076).
+    options.ignoredExceptionsForType.add(SocketException);
+
     // Assign the callback to process events before sending them to Sentry
     options.beforeSend = _beforeSendHandler;
   }
 
-  /// Handler executed before sending an event to Sentry
+  /// Handler executed before sending an event to Sentry.
+  ///
+  /// - Sanitizes request headers to remove sensitive data.
+  /// - Drops events unless tagged as auth-critical (allowlist).
+  ///   Auth-critical events (e.g. refresh-token failure) must always reach
+  ///   Sentry regardless of error type.
+  ///
+  /// To allowlist an event, add `auth_critical: true` to extras at the call site:
+  /// ```dart
+  /// logError('Refresh token failed', exception: e, extras: {'auth_critical': true});
+  /// ```
   static Future<SentryEvent?> _beforeSendHandler(
     SentryEvent event,
     Hint? hint,

--- a/core/lib/utils/sentry/sentry_initializer.dart
+++ b/core/lib/utils/sentry/sentry_initializer.dart
@@ -84,14 +84,7 @@ class SentryInitializer {
   /// Handler executed before sending an event to Sentry.
   ///
   /// - Sanitizes request headers to remove sensitive data.
-  /// - Drops events unless tagged as auth-critical (allowlist).
-  ///   Auth-critical events (e.g. refresh-token failure) must always reach
-  ///   Sentry regardless of error type.
-  ///
-  /// To allowlist an event, add `auth_critical: true` to extras at the call site:
-  /// ```dart
-  /// logError('Refresh token failed', exception: e, extras: {'auth_critical': true});
-  /// ```
+  /// - Deminifies exception stack traces for readability.
   static Future<SentryEvent?> _beforeSendHandler(
     SentryEvent event,
     Hint? hint,

--- a/lib/main/exceptions/thrower/dio_no_response_error_handler.dart
+++ b/lib/main/exceptions/thrower/dio_no_response_error_handler.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:core/utils/app_logger.dart';
+import 'package:dio/dio.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/oauth_authorization_error.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/unknown_remote_exception.dart';
+
+class DioNoResponseErrorHandler {
+  void handle(DioException error) {
+    switch (error.type) {
+      case DioExceptionType.connectionTimeout:
+        logWarning('RemoteExceptionThrower: connection timeout');
+        throw ConnectionTimeout(message: error.message);
+      case DioExceptionType.connectionError:
+        logWarning('RemoteExceptionThrower: connection error');
+        throw ConnectionError(message: error.message);
+      case DioExceptionType.badResponse:
+        throw const BadCredentialsException();
+      default:
+        _handleUnknownUnderlying(error.error);
+    }
+  }
+
+  void _handleUnknownUnderlying(dynamic underlyingError) {
+    if (underlyingError is SocketException) {
+      logWarning('RemoteExceptionThrower: socket error');
+      throw const SocketError();
+    }
+    if (underlyingError is OAuthAuthorizationError) {
+      throw underlyingError;
+    }
+    _throwUnknownRemoteException(underlyingError);
+  }
+
+  void _throwUnknownRemoteException(dynamic underlyingError) {
+    if (underlyingError != null) {
+      logError(
+        'RemoteExceptionThrower: unrecognised underlying error',
+        exception: underlyingError,
+      );
+      throw UnknownRemoteException(error: underlyingError);
+    }
+    logError('RemoteExceptionThrower: unrecognised DioException with no response or underlying error');
+    throw const UnknownRemoteException();
+  }
+}

--- a/lib/main/exceptions/thrower/dio_no_response_error_handler.dart
+++ b/lib/main/exceptions/thrower/dio_no_response_error_handler.dart
@@ -7,7 +7,7 @@ import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/unknown_remote_exception.dart';
 
 class DioNoResponseErrorHandler {
-  void handle(DioException error) {
+  void handle(DioException error, [StackTrace? stackTrace]) {
     switch (error.type) {
       case DioExceptionType.connectionTimeout:
       case DioExceptionType.sendTimeout:
@@ -18,11 +18,11 @@ class DioNoResponseErrorHandler {
         logWarning('RemoteExceptionThrower: connection error');
         throw ConnectionError(message: error.message);
       default:
-        _handleUnknownUnderlying(error.error);
+        _handleUnknownUnderlying(error.error, stackTrace);
     }
   }
 
-  void _handleUnknownUnderlying(dynamic underlyingError) {
+  void _handleUnknownUnderlying(dynamic underlyingError, [StackTrace? stackTrace]) {
     if (underlyingError is SocketException) {
       logWarning('RemoteExceptionThrower: socket error');
       throw const SocketError();
@@ -30,18 +30,19 @@ class DioNoResponseErrorHandler {
     if (underlyingError is OAuthAuthorizationError) {
       throw underlyingError;
     }
-    _throwUnknownRemoteException(underlyingError);
+    _throwUnknownRemoteException(underlyingError, stackTrace);
   }
 
-  void _throwUnknownRemoteException(dynamic underlyingError) {
+  void _throwUnknownRemoteException(dynamic underlyingError, [StackTrace? stackTrace]) {
     if (underlyingError != null) {
       logError(
         'RemoteExceptionThrower: unrecognised underlying error',
         exception: underlyingError,
+        stackTrace: stackTrace,
       );
       throw UnknownRemoteException(error: underlyingError);
     }
-    logError('RemoteExceptionThrower: unrecognised DioException with no response or underlying error');
+    logError('RemoteExceptionThrower: unrecognised DioException with no response or underlying error', stackTrace: stackTrace);
     throw const UnknownRemoteException();
   }
 }

--- a/lib/main/exceptions/thrower/dio_no_response_error_handler.dart
+++ b/lib/main/exceptions/thrower/dio_no_response_error_handler.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:core/utils/app_logger.dart';
 import 'package:dio/dio.dart';
-import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
 import 'package:tmail_ui_user/features/login/domain/exceptions/oauth_authorization_error.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/unknown_remote_exception.dart';
@@ -11,13 +10,13 @@ class DioNoResponseErrorHandler {
   void handle(DioException error) {
     switch (error.type) {
       case DioExceptionType.connectionTimeout:
+      case DioExceptionType.sendTimeout:
+      case DioExceptionType.receiveTimeout:
         logWarning('RemoteExceptionThrower: connection timeout');
         throw ConnectionTimeout(message: error.message);
       case DioExceptionType.connectionError:
         logWarning('RemoteExceptionThrower: connection error');
         throw ConnectionError(message: error.message);
-      case DioExceptionType.badResponse:
-        throw const BadCredentialsException();
       default:
         _handleUnknownUnderlying(error.error);
     }

--- a/lib/main/exceptions/thrower/dio_response_error_handler.dart
+++ b/lib/main/exceptions/thrower/dio_response_error_handler.dart
@@ -7,7 +7,7 @@ import 'package:tmail_ui_user/main/exceptions/remote/server_exception.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/unknown_remote_exception.dart';
 
 class DioResponseErrorHandler {
-  void handle(Response response) {
+  void handle(Response response, [StackTrace? stackTrace]) {
     final statusCode = response.statusCode;
     switch (statusCode) {
       case HttpStatus.unauthorized:
@@ -24,12 +24,12 @@ class DioResponseErrorHandler {
           code: statusCode,
           message: response.statusMessage,
         );
-        _logUnhandledStatusCode(statusCode, exception);
+        _logUnhandledStatusCode(statusCode, exception, stackTrace);
         throw exception;
     }
   }
 
-  void _logUnhandledStatusCode(int? statusCode, UnknownRemoteException exception) {
+  void _logUnhandledStatusCode(int? statusCode, UnknownRemoteException exception, [StackTrace? stackTrace]) {
     final is4xx = statusCode != null && statusCode >= 400 && statusCode < 500;
     final is5xx = statusCode != null && statusCode >= 500;
     if (is4xx) {
@@ -40,6 +40,7 @@ class DioResponseErrorHandler {
       logError(
         'RemoteExceptionThrower: unknown HTTP status $statusCode',
         exception: exception,
+        stackTrace: stackTrace,
       );
     }
   }

--- a/lib/main/exceptions/thrower/dio_response_error_handler.dart
+++ b/lib/main/exceptions/thrower/dio_response_error_handler.dart
@@ -1,0 +1,46 @@
+import 'package:core/utils/app_logger.dart';
+import 'package:dio/dio.dart';
+import 'package:get/get_connect/http/src/status/http_status.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_exception.dart' show BadGateway;
+import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/server_exception.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/unknown_remote_exception.dart';
+
+class DioResponseErrorHandler {
+  void handle(Response response) {
+    final statusCode = response.statusCode;
+    switch (statusCode) {
+      case HttpStatus.unauthorized:
+        // 401 is handled by auth retry flow — no log needed
+        throw const BadCredentialsException();
+      case HttpStatus.internalServerError:
+        logWarning('RemoteExceptionThrower: HTTP 500');
+        throw const InternalServerError();
+      case HttpStatus.badGateway:
+        logWarning('RemoteExceptionThrower: HTTP 502');
+        throw BadGateway();
+      default:
+        final exception = UnknownRemoteException(
+          code: statusCode,
+          message: response.statusMessage,
+        );
+        _logUnhandledStatusCode(statusCode, exception);
+        throw exception;
+    }
+  }
+
+  void _logUnhandledStatusCode(int? statusCode, UnknownRemoteException exception) {
+    final is4xx = statusCode != null && statusCode >= 400 && statusCode < 500;
+    final is5xx = statusCode != null && statusCode >= 500;
+    if (is4xx) {
+      logWarning('RemoteExceptionThrower: HTTP 4xx ($statusCode)');
+    } else if (is5xx) {
+      logWarning('RemoteExceptionThrower: HTTP 5xx ($statusCode)');
+    } else {
+      logError(
+        'RemoteExceptionThrower: unknown HTTP status $statusCode',
+        exception: exception,
+      );
+    }
+  }
+}

--- a/lib/main/exceptions/thrower/remote_exception_thrower.dart
+++ b/lib/main/exceptions/thrower/remote_exception_thrower.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:core/utils/app_logger.dart';
 import 'package:dio/dio.dart';
 import 'package:jmap_dart_client/jmap/core/error/method/error_method_response.dart';
@@ -23,13 +25,13 @@ class RemoteExceptionThrower extends ExceptionThrower {
       logWarning('RemoteExceptionThrower::throwException():isNetworkConnectionAvailable');
       throw const NoNetworkError();
     } else {
-      handleDioError(error);
+      handleDioError(error, stackTrace);
     }
   }
 
-  void handleDioError(dynamic error) {
+  void handleDioError(dynamic error, [StackTrace? stackTrace]) {
     if (error is DioException) {
-      _handleDioException(error);
+      _handleDioException(error, stackTrace);
       return;
     }
 
@@ -41,11 +43,12 @@ class RemoteExceptionThrower extends ExceptionThrower {
     logError(
       'RemoteExceptionThrower::handleDioError(): unrecognised error',
       exception: error,
+      stackTrace: stackTrace,
     );
     throw error;
   }
 
-  void _handleDioException(DioException error) {
+  void _handleDioException(DioException error, [StackTrace? stackTrace]) {
     logWarning(
       'RemoteExceptionThrower::_handleDioException(): type=${error.type}'
       ' status=${error.response?.statusCode}'
@@ -58,10 +61,10 @@ class RemoteExceptionThrower extends ExceptionThrower {
 
     final response = error.response;
     if (response != null) {
-      return _responseHandler.handle(response);
+      return _responseHandler.handle(response, stackTrace);
     }
 
-    return _noResponseHandler.handle(error);
+    return _noResponseHandler.handle(error, stackTrace);
   }
 
   void _handleMethodResponseException(ErrorMethodResponseException error) {

--- a/lib/main/exceptions/thrower/remote_exception_thrower.dart
+++ b/lib/main/exceptions/thrower/remote_exception_thrower.dart
@@ -21,11 +21,6 @@ class RemoteExceptionThrower extends ExceptionThrower {
 
   @override
   throwException(dynamic error, dynamic stackTrace) {
-    logError(
-      'RemoteExceptionThrower::throwException():error: $error | stackTrace: $stackTrace',
-      exception: error,
-      stackTrace: stackTrace,
-    );
     final networkConnectionController = getBinding<NetworkConnectionController>();
     if (networkConnectionController?.isNetworkConnectionAvailable() == false) {
       logWarning('RemoteExceptionThrower::throwException():isNetworkConnectionAvailable');
@@ -37,68 +32,110 @@ class RemoteExceptionThrower extends ExceptionThrower {
 
   void handleDioError(dynamic error) {
     if (error is DioException) {
-      logWarning(
-        'RemoteExceptionThrower::throwException():type: ${error.type} | response: ${error.response} | error: ${error.error}',
-      );
-
-      if (error.error is RefreshTokenFailedException) {
-        throw RefreshTokenFailedException();
-      }
-
-      final response = error.response;
-      final statusCode = response?.statusCode;
-
-      if (response != null) {
-        switch (statusCode) {
-          case HttpStatus.internalServerError:
-            throw const InternalServerError();
-          case HttpStatus.badGateway:
-            throw BadGateway();
-          case HttpStatus.unauthorized:
-            throw const BadCredentialsException();
-          default:
-            throw UnknownRemoteException(
-              code: statusCode,
-              message: response.statusMessage,
-            );
-        }
-      }
-
-      return _handleDioErrorWithoutResponse(error);
+      _handleDioException(error);
+      return;
     }
 
     if (error is ErrorMethodResponseException) {
-      final errorResponse = error.errorResponse as ErrorMethodResponse;
-      if (errorResponse is CannotCalculateChangesMethodResponse) {
-        throw CannotCalculateChangesMethodResponseException();
-      } else {
-        throw MethodLevelErrors(
-          errorResponse.type,
-          message: errorResponse.description,
-        );
-      }
+      _handleMethodResponseException(error);
+      return;
     }
 
+    logError(
+      'RemoteExceptionThrower::handleDioError(): unrecognised error',
+      exception: error,
+    );
     throw error;
+  }
+
+  void _handleDioException(DioException error) {
+    logWarning(
+      'RemoteExceptionThrower::_handleDioException():type: ${error.type} | response: ${error.response} | error: ${error.error}',
+    );
+
+    if (error.error is RefreshTokenFailedException) {
+      throw RefreshTokenFailedException();
+    }
+
+    final response = error.response;
+    final statusCode = response?.statusCode;
+
+    if (response != null) {
+      return _handleDioResponseError(statusCode, response);
+    }
+
+    return _handleDioErrorWithoutResponse(error);
+  }
+
+  void _handleDioResponseError(int? statusCode, Response response) {
+    switch (statusCode) {
+      case HttpStatus.unauthorized:
+        // 401 is handled by auth retry flow — no log needed
+        throw const BadCredentialsException();
+      case HttpStatus.internalServerError:
+        logWarning('RemoteExceptionThrower: HTTP 500');
+        throw const InternalServerError();
+      case HttpStatus.badGateway:
+        logWarning('RemoteExceptionThrower: HTTP 502');
+        throw BadGateway();
+      default:
+        if (statusCode != null && statusCode >= 400 && statusCode < 500) {
+          logWarning('RemoteExceptionThrower: HTTP 4xx ($statusCode)');
+        } else if (statusCode != null && statusCode >= 500) {
+          logWarning('RemoteExceptionThrower: HTTP 5xx ($statusCode)');
+        } else {
+          logError(
+            'RemoteExceptionThrower: unknown HTTP status $statusCode',
+            exception: UnknownRemoteException(
+              code: statusCode,
+              message: response.statusMessage,
+            ),
+          );
+        }
+        throw UnknownRemoteException(
+          code: statusCode,
+          message: response.statusMessage,
+        );
+    }
+  }
+
+  void _handleMethodResponseException(ErrorMethodResponseException error) {
+    final errorResponse = error.errorResponse as ErrorMethodResponse;
+    if (errorResponse is CannotCalculateChangesMethodResponse) {
+      throw CannotCalculateChangesMethodResponseException();
+    } else {
+      throw MethodLevelErrors(
+        errorResponse.type,
+        message: errorResponse.description,
+      );
+    }
   }
 
   void _handleDioErrorWithoutResponse(DioException error) {
     switch (error.type) {
       case DioExceptionType.connectionTimeout:
+        logWarning('RemoteExceptionThrower: connection timeout');
         throw ConnectionTimeout(message: error.message);
       case DioExceptionType.connectionError:
+        logWarning('RemoteExceptionThrower: connection error');
         throw ConnectionError(message: error.message);
       case DioExceptionType.badResponse:
         throw const BadCredentialsException();
       default:
         final underlyingError = error.error;
         if (underlyingError is SocketException) {
+          logWarning('RemoteExceptionThrower: socket error');
           throw const SocketError();
         } else if (underlyingError is OAuthAuthorizationError) {
           throw underlyingError;
         } else if (underlyingError != null) {
+          logError(
+            'RemoteExceptionThrower: unrecognised underlying error',
+            exception: underlyingError,
+          );
           throw UnknownRemoteException(error: underlyingError);
         } else {
+          logError('RemoteExceptionThrower: unrecognised DioException with no response or underlying error');
           throw const UnknownRemoteException();
         }
     }

--- a/lib/main/exceptions/thrower/remote_exception_thrower.dart
+++ b/lib/main/exceptions/thrower/remote_exception_thrower.dart
@@ -1,23 +1,20 @@
-import 'dart:io';
-
 import 'package:core/utils/app_logger.dart';
 import 'package:dio/dio.dart';
-import 'package:get/get_connect/http/src/status/http_status.dart';
 import 'package:jmap_dart_client/jmap/core/error/method/error_method_response.dart';
 import 'package:jmap_dart_client/jmap/core/error/method/exception/error_method_response_exception.dart';
-import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_exception.dart';
-import 'package:tmail_ui_user/features/login/domain/exceptions/oauth_authorization_error.dart';
 import 'package:tmail_ui_user/features/network_connection/presentation/network_connection_controller.dart'
   if (dart.library.html) 'package:tmail_ui_user/features/network_connection/presentation/web_network_connection_controller.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/method_level_exception.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
-import 'package:tmail_ui_user/main/exceptions/remote/server_exception.dart';
-import 'package:tmail_ui_user/main/exceptions/remote/unknown_remote_exception.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/dio_no_response_error_handler.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/dio_response_error_handler.dart';
 import 'package:tmail_ui_user/main/exceptions/thrower/exception_thrower.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
 class RemoteExceptionThrower extends ExceptionThrower {
+  final _responseHandler = DioResponseErrorHandler();
+  final _noResponseHandler = DioNoResponseErrorHandler();
 
   @override
   throwException(dynamic error, dynamic stackTrace) {
@@ -60,44 +57,11 @@ class RemoteExceptionThrower extends ExceptionThrower {
     }
 
     final response = error.response;
-    final statusCode = response?.statusCode;
-
     if (response != null) {
-      return _handleDioResponseError(response);
+      return _responseHandler.handle(response);
     }
 
-    return _handleDioErrorWithoutResponse(error);
-  }
-
-  void _handleDioResponseError(Response response) {
-    final statusCode = response.statusCode;
-    switch (statusCode) {
-      case HttpStatus.unauthorized:
-        // 401 is handled by auth retry flow — no log needed
-        throw const BadCredentialsException();
-      case HttpStatus.internalServerError:
-        logWarning('RemoteExceptionThrower: HTTP 500');
-        throw const InternalServerError();
-      case HttpStatus.badGateway:
-        logWarning('RemoteExceptionThrower: HTTP 502');
-        throw BadGateway();
-      default:
-        final exception = UnknownRemoteException(
-          code: statusCode,
-          message: response.statusMessage,
-        );
-        if (statusCode != null && statusCode >= 400 && statusCode < 500) {
-          logWarning('RemoteExceptionThrower: HTTP 4xx ($statusCode)');
-        } else if (statusCode != null && statusCode >= 500) {
-          logWarning('RemoteExceptionThrower: HTTP 5xx ($statusCode)');
-        } else {
-          logError(
-            'RemoteExceptionThrower: unknown HTTP status $statusCode',
-            exception: exception,
-          );
-        }
-        throw exception;
-    }
+    return _noResponseHandler.handle(error);
   }
 
   void _handleMethodResponseException(ErrorMethodResponseException error) {
@@ -109,36 +73,6 @@ class RemoteExceptionThrower extends ExceptionThrower {
         errorResponse.type,
         message: errorResponse.description,
       );
-    }
-  }
-
-  void _handleDioErrorWithoutResponse(DioException error) {
-    switch (error.type) {
-      case DioExceptionType.connectionTimeout:
-        logWarning('RemoteExceptionThrower: connection timeout');
-        throw ConnectionTimeout(message: error.message);
-      case DioExceptionType.connectionError:
-        logWarning('RemoteExceptionThrower: connection error');
-        throw ConnectionError(message: error.message);
-      case DioExceptionType.badResponse:
-        throw const BadCredentialsException();
-      default:
-        final underlyingError = error.error;
-        if (underlyingError is SocketException) {
-          logWarning('RemoteExceptionThrower: socket error');
-          throw const SocketError();
-        } else if (underlyingError is OAuthAuthorizationError) {
-          throw underlyingError;
-        } else if (underlyingError != null) {
-          logError(
-            'RemoteExceptionThrower: unrecognised underlying error',
-            exception: underlyingError,
-          );
-          throw UnknownRemoteException(error: underlyingError);
-        } else {
-          logError('RemoteExceptionThrower: unrecognised DioException with no response or underlying error');
-          throw const UnknownRemoteException();
-        }
     }
   }
 }

--- a/lib/main/exceptions/thrower/remote_exception_thrower.dart
+++ b/lib/main/exceptions/thrower/remote_exception_thrower.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:core/utils/app_logger.dart';
 import 'package:dio/dio.dart';
 import 'package:jmap_dart_client/jmap/core/error/method/error_method_response.dart';

--- a/lib/main/exceptions/thrower/remote_exception_thrower.dart
+++ b/lib/main/exceptions/thrower/remote_exception_thrower.dart
@@ -50,7 +50,9 @@ class RemoteExceptionThrower extends ExceptionThrower {
 
   void _handleDioException(DioException error) {
     logWarning(
-      'RemoteExceptionThrower::_handleDioException():type: ${error.type} | response: ${error.response} | error: ${error.error}',
+      'RemoteExceptionThrower::_handleDioException(): type=${error.type}'
+      ' status=${error.response?.statusCode}'
+      ' underlying=${error.error?.runtimeType}',
     );
 
     if (error.error is RefreshTokenFailedException) {
@@ -61,13 +63,14 @@ class RemoteExceptionThrower extends ExceptionThrower {
     final statusCode = response?.statusCode;
 
     if (response != null) {
-      return _handleDioResponseError(statusCode, response);
+      return _handleDioResponseError(response);
     }
 
     return _handleDioErrorWithoutResponse(error);
   }
 
-  void _handleDioResponseError(int? statusCode, Response response) {
+  void _handleDioResponseError(Response response) {
+    final statusCode = response.statusCode;
     switch (statusCode) {
       case HttpStatus.unauthorized:
         // 401 is handled by auth retry flow — no log needed
@@ -79,6 +82,10 @@ class RemoteExceptionThrower extends ExceptionThrower {
         logWarning('RemoteExceptionThrower: HTTP 502');
         throw BadGateway();
       default:
+        final exception = UnknownRemoteException(
+          code: statusCode,
+          message: response.statusMessage,
+        );
         if (statusCode != null && statusCode >= 400 && statusCode < 500) {
           logWarning('RemoteExceptionThrower: HTTP 4xx ($statusCode)');
         } else if (statusCode != null && statusCode >= 500) {
@@ -86,16 +93,10 @@ class RemoteExceptionThrower extends ExceptionThrower {
         } else {
           logError(
             'RemoteExceptionThrower: unknown HTTP status $statusCode',
-            exception: UnknownRemoteException(
-              code: statusCode,
-              message: response.statusMessage,
-            ),
+            exception: exception,
           );
         }
-        throw UnknownRemoteException(
-          code: statusCode,
-          message: response.statusMessage,
-        );
+        throw exception;
     }
   }
 

--- a/lib/main/exceptions/thrower/send_email_exception_thrower.dart
+++ b/lib/main/exceptions/thrower/send_email_exception_thrower.dart
@@ -10,15 +10,11 @@ import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 class SendEmailExceptionThrower extends RemoteExceptionThrower {
   @override
   FutureOr<void> throwException(error, stackTrace) async {
-    logError(
-      'SendEmailExceptionThrower::throwException():error: $error | stackTrace: $stackTrace',
-      exception: error,
-      stackTrace: stackTrace,
-    );
     final networkConnectionController = getBinding<NetworkConnectionController>();
     final realtimeNetworkConnectionStatus = await networkConnectionController?.hasInternetConnection();
     if (realtimeNetworkConnectionStatus == false) {
-      logError('SendEmailExceptionThrower::throwException(): No realtime network connection');
+      // Network loss is a normal user-facing condition, not an application bug.
+      logWarning('SendEmailExceptionThrower::throwException(): No realtime network connection');
       throw const NoNetworkError();
     } else {
       handleDioError(error);

--- a/lib/main/exceptions/thrower/send_email_exception_thrower.dart
+++ b/lib/main/exceptions/thrower/send_email_exception_thrower.dart
@@ -17,7 +17,7 @@ class SendEmailExceptionThrower extends RemoteExceptionThrower {
       logWarning('SendEmailExceptionThrower::throwException(): No realtime network connection');
       throw const NoNetworkError();
     } else {
-      handleDioError(error);
+      handleDioError(error, stackTrace);
     }
   }
 }


### PR DESCRIPTION
## Context

Implements the call-site fixes from [ADR-0076](https://github.com/linagora/tmail-flutter/blob/master/docs/adr/0076-reduce-sentry-noise-with-targeted-error-reporting.md).  
Requires [ADR-0078](https://github.com/linagora/tmail-flutter/pull/4466) PR to be merged first.

## What changed

### RemoteExceptionThrower
- Removed blanket `logError` at the top of `throwException`
- Per-branch logging:
  - Network errors (`NoNetwork`, `ConnectionTimeout`, `ConnectionError`, `SocketException`) → `logWarning`
  - HTTP 401 → no log (handled by auth retry)
  - HTTP 4xx/5xx (known) → `logWarning`
  - Unknown/unrecognised errors → `logError`

### SendEmailExceptionThrower
- Changed `logError` for no realtime network → `logWarning`  
  _(network loss is a normal user-facing condition)_

### SentryInitializer
- Added `SocketException` to `ignoredExceptionsForType`  
  _(second line of defence against accidental `logError` regressions at call sites)_

## Blocker 

https://github.com/linagora/tmail-flutter/pull/4466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppress noisy socket/network errors from external reporting; better handle connection timeouts, offline cases, and HTTP error categories (including 500/502 and 4xx/5xx).
  * Downgraded “no network” reporting to a user-facing warning.

* **Refactor**
  * Split error handling into distinct response vs no-response paths for clearer behavior and more consistent error mapping.

* **Chores**
  * Removed redundant error-level logs and updated internal sanitization/filtering notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->