### PR TITLE
Patrol isolate Android tests

### DIFF
--- a/.github/workflows/patrol-integration-test.yaml
+++ b/.github/workflows/patrol-integration-test.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Run prebuild
         run: ./scripts/prebuild.sh
 
-      - name: Run integration tests
+      - name: Run integration tests for mobile apps
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ env.API_LEVEL }}
@@ -56,7 +56,7 @@ jobs:
           force-avd-creation: true
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          emulator-boot-timeout: 900
+          emulator-boot-timeout: 1000
           pre-emulator-launch-script: |
             adb kill-server
             adb start-server

--- a/.github/workflows/patrol-integration-test.yaml
+++ b/.github/workflows/patrol-integration-test.yaml
@@ -8,31 +8,24 @@ on:
 env:
   JAVA_VERSION: 17
   FLUTTER_VERSION: 3.38.9
+  API_LEVEL: 30
+  TARGET: default
+  ARCH: x86_64
+  PROFILE: pixel_6
 
 jobs:
   mobile_integration_test:
-    permissions:
-      contents: "read"
-      id-token: "write"
-
-    name: Run integration tests for mobile apps
+    name: Run integration tests
     runs-on: ubuntu-latest
-    concurrency:
-      group: ngrok
-      cancel-in-progress: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Authenticate to Google Cloud
-        uses: "google-github-actions/auth@v2"
-        with:
-          project_id: ${{ secrets.GOOGLE_CLOUD_PROJECT_ID }}
-          workload_identity_provider: ${{ secrets.GOOGLE_CLOUD_WORKLOAD_IDENTITY_PROVIDER_ID }}
-          service_account: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT }}
-
-      - name: Setup Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -47,10 +40,24 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: "temurin"
 
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Run prebuild
         run: ./scripts/prebuild.sh
 
-      - name: Test
-        env:
-          NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
-        run: ./scripts/patrol-integration-test-with-docker.sh
+      - name: Run integration tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ env.API_LEVEL }}
+          target: ${{ env.TARGET }}
+          arch: ${{ env.ARCH }}
+          profile: ${{ env.PROFILE }}
+          force-avd-creation: true
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          emulator-boot-timeout: 900
+          pre-emulator-launch-script: |
+            adb kill-server
+            adb start-server
+          script: ./scripts/patrol-integration-test-with-docker.sh

--- a/core/lib/presentation/utils/keyboard_utils.dart
+++ b/core/lib/presentation/utils/keyboard_utils.dart
@@ -6,7 +6,7 @@ class KeyboardUtils {
     FocusScope.of(context).unfocus();
   }
 
-  static void hideSystemKeyboardMobile() {
-    SystemChannels.textInput.invokeMethod('TextInput.hide');
+  static Future<void> hideSystemKeyboardMobile() {
+    return SystemChannels.textInput.invokeMethod('TextInput.hide');
   }
 }

--- a/integration_test/base/test_base.dart
+++ b/integration_test/base/test_base.dart
@@ -30,7 +30,9 @@ class TestBase {
       description,
       config: const PatrolTesterConfig(
         settlePolicy: SettlePolicy.trySettle,
+        existsTimeout: Duration(seconds: 10),
         visibleTimeout: Duration(seconds: 10),
+        settleTimeout: Duration(seconds: 10),
         printLogs: true,
       ),
       tags: tags.map((t) => t.name).toList(),

--- a/integration_test/base/test_base.dart
+++ b/integration_test/base/test_base.dart
@@ -6,6 +6,7 @@ import 'package:patrol/patrol.dart';
 import 'package:tmail_ui_user/main/main_entry.dart';
 
 import '../models/test_tags.dart';
+import '../utils/backend_reset_client.dart';
 import 'base_scenario.dart';
 import '../factories/robot_factory.dart';
 import '../factories/robot_factory_provider.dart';
@@ -29,7 +30,7 @@ class TestBase {
       description,
       config: const PatrolTesterConfig(
         settlePolicy: SettlePolicy.trySettle,
-        visibleTimeout: Duration(seconds: 30),
+        visibleTimeout: Duration(seconds: 10),
         printLogs: true,
       ),
       tags: tags.map((t) => t.name).toList(),
@@ -60,5 +61,6 @@ class TestBase {
 
   Future<void> _tearDown() async {
     PlatformInfo.isIntegrationTesting = false;
+    await BackendResetClient.reset();
   }
 }

--- a/integration_test/extensions/patrol_file_extensions.dart
+++ b/integration_test/extensions/patrol_file_extensions.dart
@@ -1,0 +1,17 @@
+import 'dart:io';
+
+import 'package:model/upload/file_info.dart';
+
+extension PatrolFileExtensions on File {
+  Future<FileInfo> toFileInfo() async {
+    final bytes = await readAsBytes();
+    final size = bytes.lengthInBytes;
+    final name = path.split('/').last;
+    return FileInfo(
+      filePath: path,
+      fileSize: size,
+      fileName: name,
+      bytes: bytes,
+    );
+  }
+}

--- a/integration_test/mixin/open_calendar_event_scenario_mixin.dart
+++ b/integration_test/mixin/open_calendar_event_scenario_mixin.dart
@@ -58,7 +58,7 @@ mixin OpenCalendarEventScenarioMixin on BaseScenario {
   ) async {
     final mailToAttendeesButton =
         $(CalendarEventActionButtonWidget).$(appLocalizations.mailToAttendees);
-    await mailToAttendeesButton.scrollTo();
+    await mailToAttendeesButton.scrollTo(scrollDirection: AxisDirection.down);
     await expectViewVisible(mailToAttendeesButton);
   }
 

--- a/integration_test/mixin/scenario_utils_mixin.dart
+++ b/integration_test/mixin/scenario_utils_mixin.dart
@@ -63,6 +63,13 @@ mixin ScenarioUtilsMixin {
         break;
       }
     }
+    if (mailboxDashBoardController == null ||
+        mailboxDashBoardController.sessionCurrent == null ||
+        mailboxDashBoardController.accountId.value == null) {
+      throw StateError(
+        'MailboxDashBoardController is not ready for provisioning email.',
+      );
+    }
     final createNewAndSendEmailInteractor =
         Get.find<CreateNewAndSendEmailInteractor>();
     final threadController = Get.find<ThreadController>();

--- a/integration_test/mixin/scenario_utils_mixin.dart
+++ b/integration_test/mixin/scenario_utils_mixin.dart
@@ -34,8 +34,10 @@ import 'package:tmail_ui_user/features/manage_account/presentation/identities/id
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
 import 'package:tmail_ui_user/features/upload/domain/state/attachment_upload_state.dart';
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:uuid/uuid.dart';
 
+import '../extensions/patrol_file_extensions.dart';
 import '../models/provisioning_email.dart';
 import '../models/provisioning_identity.dart';
 import '../resources/test_images.dart';
@@ -49,7 +51,18 @@ mixin ScenarioUtilsMixin {
   }) async {
     ComposerBindings().dependencies();
 
-    final mailboxDashBoardController = Get.find<MailboxDashBoardController>();
+    MailboxDashBoardController? mailboxDashBoardController;
+    int retry = 0;
+    while (retry < 3) {
+      await Future.delayed(Duration(seconds: retry + 1));
+      if (getBinding<MailboxDashBoardController>() == null) {
+        retry++;
+        continue;
+      } else {
+        mailboxDashBoardController = getBinding<MailboxDashBoardController>();
+        break;
+      }
+    }
     final createNewAndSendEmailInteractor =
         Get.find<CreateNewAndSendEmailInteractor>();
     final threadController = Get.find<ThreadController>();
@@ -67,7 +80,7 @@ mixin ScenarioUtilsMixin {
       return await createNewAndSendEmailInteractor
           .execute(
             createEmailRequest: CreateEmailRequest(
-              session: mailboxDashBoardController.sessionCurrent!,
+              session: mailboxDashBoardController!.sessionCurrent!,
               accountId: mailboxDashBoardController.accountId.value!,
               emailActionType: EmailActionType.compose,
               ownEmailAddress: mailboxDashBoardController.ownEmailAddress.value,
@@ -92,7 +105,7 @@ mixin ScenarioUtilsMixin {
 
     // Refresh view after provisioning emails
     if (refreshEmailView) {
-      threadController.refreshAllEmail();
+      await threadController.refreshAllEmail();
     }
 
     ComposerBindings().dispose();
@@ -170,14 +183,7 @@ mixin ScenarioUtilsMixin {
 
     final attachments = <Attachment>[];
     for (final path in attachmentPaths) {
-      final file = File(path);
-      final fileName = path.split('/').last;
-
-      final fileInfo = FileInfo(
-        fileName: fileName,
-        filePath: path,
-        fileSize: await file.length(),
-      );
+      final fileInfo = await File(path).toFileInfo();
 
       try {
         final uploadUri =

--- a/integration_test/mixin/scenario_utils_mixin.dart
+++ b/integration_test/mixin/scenario_utils_mixin.dart
@@ -41,6 +41,7 @@ import '../extensions/patrol_file_extensions.dart';
 import '../models/provisioning_email.dart';
 import '../models/provisioning_identity.dart';
 import '../resources/test_images.dart';
+import '../utils/wait_for_condition.dart';
 
 mixin ScenarioUtilsMixin {
   Future<void> provisionEmail(
@@ -51,25 +52,10 @@ mixin ScenarioUtilsMixin {
   }) async {
     ComposerBindings().dependencies();
 
-    MailboxDashBoardController? mailboxDashBoardController;
-    int retry = 0;
-    while (retry < 3) {
-      await Future.delayed(Duration(seconds: retry + 1));
-      if (getBinding<MailboxDashBoardController>() == null) {
-        retry++;
-        continue;
-      } else {
-        mailboxDashBoardController = getBinding<MailboxDashBoardController>();
-        break;
-      }
-    }
-    if (mailboxDashBoardController == null ||
-        mailboxDashBoardController.sessionCurrent == null ||
-        mailboxDashBoardController.accountId.value == null) {
-      throw StateError(
-        'MailboxDashBoardController is not ready for provisioning email.',
-      );
-    }
+    await waitForCondition(
+      () => getBinding<MailboxDashBoardController>() != null,
+    );
+    final mailboxDashBoardController = Get.find<MailboxDashBoardController>();
     final createNewAndSendEmailInteractor =
         Get.find<CreateNewAndSendEmailInteractor>();
     final threadController = Get.find<ThreadController>();
@@ -87,7 +73,7 @@ mixin ScenarioUtilsMixin {
       return await createNewAndSendEmailInteractor
           .execute(
             createEmailRequest: CreateEmailRequest(
-              session: mailboxDashBoardController!.sessionCurrent!,
+              session: mailboxDashBoardController.sessionCurrent!,
               accountId: mailboxDashBoardController.accountId.value!,
               emailActionType: EmailActionType.compose,
               ownEmailAddress: mailboxDashBoardController.ownEmailAddress.value,

--- a/integration_test/robots/composer_robot.dart
+++ b/integration_test/robots/composer_robot.dart
@@ -7,7 +7,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:model/email/prefix_email_address.dart';
 import 'package:model/extensions/session_extension.dart';
-import 'package:model/upload/file_info.dart';
 import 'package:rich_text_composer/rich_text_composer.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/base/widget/popup_item_widget.dart';
@@ -26,6 +25,7 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
 import '../base/core_robot.dart';
+import '../extensions/patrol_file_extensions.dart';
 import '../extensions/patrol_finder_extension.dart';
 
 class ComposerRobot extends CoreRobot {
@@ -58,6 +58,7 @@ class ComposerRobot extends CoreRobot {
     if (!isTextFieldFocused) {
       await finder.tap();
     }
+    await $.pumpAndTrySettle();
     await finder.enterTextWithoutTapAction(subject);
   }
 
@@ -75,7 +76,7 @@ class ComposerRobot extends CoreRobot {
 
     await composerController?.htmlEditorApi?.requestFocusLastChild();
 
-    await composerController!.htmlEditorApi!.insertHtml('$content <br><br>');
+    await composerController?.htmlEditorApi?.insertHtml('$content <br><br>');
   }
 
   Future<void> sendEmail(ImagePaths imagePaths) async {
@@ -141,13 +142,10 @@ class ComposerRobot extends CoreRobot {
 
   Future<void> addAttachment(File file) async {
     final controller = Get.find<ComposerController>();
+    final fileInfo = await file.toFileInfo();
     controller.uploadController.justUploadAttachmentsAction(
       uploadFiles: [
-        FileInfo(
-          fileName: file.path.split('/').last,
-          fileSize: await file.length(),
-          filePath: file.path,
-        )
+        fileInfo,
       ],
       uploadUri:
           controller.mailboxDashBoardController.sessionCurrent!.getUploadUri(
@@ -159,11 +157,8 @@ class ComposerRobot extends CoreRobot {
 
   Future<void> addInline(File file) async {
     final controller = Get.find<ComposerController>();
-    controller.handleSuccessViewState(LocalImagePickerSuccess(FileInfo(
-      filePath: file.path,
-      fileSize: await file.length(),
-      fileName: file.path.split('/').last,
-    )));
+    final fileInfo = await file.toFileInfo();
+    controller.handleSuccessViewState(LocalImagePickerSuccess(fileInfo));
     await controller.viewState.stream.firstWhere((state) => state.fold(
       (failure) => false,
       (success) => success is DownloadImageAsBase64Success,
@@ -178,16 +173,8 @@ class ComposerRobot extends CoreRobot {
 
   Future<void> addInlineImageFromFile(File file) async {
     final controller = getBinding<ComposerController>();
+    final fileInfo = await file.toFileInfo();
 
-    final filePath = file.path;
-    final fileSize = await file.length();
-    final fileName = filePath.split('/').last;
-
-    final fileInfo = FileInfo(
-      filePath: filePath,
-      fileSize: fileSize,
-      fileName: fileName,
-    );
     controller?.handleSuccessViewState(LocalImagePickerSuccess(fileInfo));
   }
 

--- a/integration_test/robots/email_robot.dart
+++ b/integration_test/robots/email_robot.dart
@@ -20,7 +20,6 @@ class EmailRobot extends CoreRobot {
 
   Future<void> tapDownloadAllButton() async {
     await $(#download_all_attachments_button).tap();
-    await $.pumpAndSettle();
   }
 
   Future<void> onTapReplyEmail() async {

--- a/integration_test/robots/labels/create_label_modal_robot.dart
+++ b/integration_test/robots/labels/create_label_modal_robot.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/views/text/text_field_builder.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/patrol.dart';
 import 'package:tmail_ui_user/features/labels/presentation/models/label_action_type.dart';
 import 'package:tmail_ui_user/features/labels/presentation/widgets/create_new_label_modal.dart';
 
@@ -21,10 +22,13 @@ class CreateLabelModalRobot extends CoreRobot {
   }
 
   Future<void> tapPositiveActionButton(LabelActionType actionType) async {
+    late final PatrolFinder button;
     if (actionType == LabelActionType.create) {
-      await $(CreateNewLabelModal).$(#create_label_button_action).tap();
+      button = $(CreateNewLabelModal).$(#create_label_button_action);
     } else {
-      await $(CreateNewLabelModal).$(#save_label_button_action).tap();
+      button = $(CreateNewLabelModal).$(#save_label_button_action);
     }
+    await button.scrollTo();
+    await button.tap();
   }
 }

--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -27,6 +27,7 @@ class MailboxMenuRobot extends CoreRobot {
 
   Future<void> openFolderByName(String name) async {
     final mailboxItem = $(MailboxItemWidget).$(LabelMailboxItemWidget).$(name);
+    await $(mailboxItem).waitUntilExists();
     await $.scrollUntilVisible(finder: mailboxItem);
     await mailboxItem.tap();
   }

--- a/integration_test/robots/thread_robot.dart
+++ b/integration_test/robots/thread_robot.dart
@@ -132,11 +132,14 @@ class ThreadRobot extends CoreRobot {
     while (retry < 3) {
       await $(subject).longPress();
       if ($(#moreAction_selected_email_button).exists) {
-        break;
+        return;
       } else {
         retry++;
       }
     }
+    throw TestFailure(
+      'Failed to select email with subject "$subject" after 3 attempts.',
+    );
   }
 
   Future<void> moveEmailToMailboxWithName(String mailboxName) async {

--- a/integration_test/robots/thread_robot.dart
+++ b/integration_test/robots/thread_robot.dart
@@ -128,18 +128,23 @@ class ThreadRobot extends CoreRobot {
   }
 
   Future<void> longPressEmailWithSubject(String subject) async {
-    await $(subject).longPress();
+    int retry = 0;
+    while (retry < 3) {
+      await $(subject).longPress();
+      if ($(#moreAction_selected_email_button).exists) {
+        break;
+      } else {
+        retry++;
+      }
+    }
   }
 
   Future<void> moveEmailToMailboxWithName(String mailboxName) async {
     await $(#moreAction_selected_email_button).tap();
-    await $.pumpAndTrySettle();
 
     await $(#moveToMailbox_action).tap();
-    await $.pumpAndTrySettle();
 
     await $(mailboxName).tap();
-    await $.pumpAndTrySettle();
   }
 
   Future<void> moveEmailToTrash() async {

--- a/integration_test/robots/thread_robot.dart
+++ b/integration_test/robots/thread_robot.dart
@@ -9,6 +9,7 @@ import 'package:tmail_ui_user/features/thread/presentation/widgets/scroll_to_top
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../base/core_robot.dart';
+import '../utils/wait_for_condition.dart';
 
 class ThreadRobot extends CoreRobot {
   ThreadRobot(super.$);
@@ -127,20 +128,12 @@ class ThreadRobot extends CoreRobot {
     await $(AppLocalizations().deleteAllSpamEmails).tap();
   }
 
-  Future<void> longPressEmailWithSubject(String subject) async {
-    int retry = 0;
-    while (retry < 3) {
-      await $(subject).longPress();
-      if ($(#moreAction_selected_email_button).exists) {
-        return;
-      } else {
-        retry++;
-      }
-    }
-    throw TestFailure(
-      'Failed to select email with subject "$subject" after 3 attempts.',
-    );
-  }
+  Future<void> longPressEmailWithSubject(String subject) => waitForCondition(
+        () async {
+          await $(subject).longPress();
+          return $(#moreAction_selected_email_button).exists;
+        },
+      );
 
   Future<void> moveEmailToMailboxWithName(String mailboxName) async {
     await $(#moreAction_selected_email_button).tap();

--- a/integration_test/scenarios/app_grid_scenario.dart
+++ b/integration_test/scenarios/app_grid_scenario.dart
@@ -48,9 +48,7 @@ class AppGridScenario extends BaseTestScenario {
       await Future.delayed(const Duration(seconds: 2));
 
       await native.pressBack();
-      await native.pressBack();
-
-      await _expectMailboxViewVisible();
+      await _expectListViewAppGridVisible();
     } else if (PlatformInfo.isIOS) {
       await _expectMailboxViewInVisible();
     }

--- a/integration_test/scenarios/composer/change_identity_in_draft_email_scenario.dart
+++ b/integration_test/scenarios/composer/change_identity_in_draft_email_scenario.dart
@@ -98,11 +98,9 @@ class ChangeIdentityInDraftEmailScenario extends BaseTestScenario {
       expectViewVisible($(appLocalizations.drafts_saved));
 
   Future<void> _expectIdentityVisible(Identity identity) async {
-    expect(
-      $(FromComposerMobileWidget).which<FromComposerMobileWidget>(
-        (widget) => widget.selectedIdentity?.name == identity.name
-      ).visible,
-      isTrue,
+    final identityFinder = $(FromComposerMobileWidget).which<FromComposerMobileWidget>(
+      (widget) => widget.selectedIdentity?.name == identity.name
     );
+    await expectViewVisible(identityFinder);
   }
 }

--- a/integration_test/scenarios/composer/upload_attachment_and_inline_image_scenario.dart
+++ b/integration_test/scenarios/composer/upload_attachment_and_inline_image_scenario.dart
@@ -9,6 +9,7 @@ import '../../base/base_test_scenario.dart';
 import '../../resources/test_images.dart';
 import '../../robots/composer_robot.dart';
 import '../../robots/thread_robot.dart';
+import '../../utils/wait_for_condition.dart';
 
 class ComposerUploadAttachmentAndInlineImageScenario extends BaseTestScenario {
   const ComposerUploadAttachmentAndInlineImageScenario(super.$, super.robots);
@@ -41,17 +42,13 @@ class ComposerUploadAttachmentAndInlineImageScenario extends BaseTestScenario {
   }
 
   Future<void> _expectInline() async {
-    int retry = 0;
-    while (retry < 3) {
-      await $.pumpAndTrySettle(duration: Duration(seconds: retry + 1));
-      final currentHtmlContent = await Get
-        .find<ComposerController>()
-        .getContentInEditor();
-      if (currentHtmlContent.contains(TestImages.base64)) {
-        break;
-      }
-      retry++;
-    }
+    await waitForCondition(
+      () async {
+        final currentHtmlContent =
+            await Get.find<ComposerController>().getContentInEditor();
+        return currentHtmlContent.contains(TestImages.base64);
+      },
+    );
     final currentHtmlContent = await Get
       .find<ComposerController>()
       .getContentInEditor();

--- a/integration_test/scenarios/composer/upload_attachment_and_inline_image_scenario.dart
+++ b/integration_test/scenarios/composer/upload_attachment_and_inline_image_scenario.dart
@@ -31,7 +31,6 @@ class ComposerUploadAttachmentAndInlineImageScenario extends BaseTestScenario {
     await _expectAttachment(pngName);
 
     await composerRobot.addInline(png);
-    await $.pumpAndSettle(duration: const Duration(seconds: 1));
     await _expectInline();
 
     await composerRobot.addAttachment(png);
@@ -42,6 +41,17 @@ class ComposerUploadAttachmentAndInlineImageScenario extends BaseTestScenario {
   }
 
   Future<void> _expectInline() async {
+    int retry = 0;
+    while (retry < 3) {
+      await $.pumpAndTrySettle(duration: Duration(seconds: retry + 1));
+      final currentHtmlContent = await Get
+        .find<ComposerController>()
+        .getContentInEditor();
+      if (currentHtmlContent.contains(TestImages.base64)) {
+        break;
+      }
+      retry++;
+    }
     final currentHtmlContent = await Get
       .find<ComposerController>()
       .getContentInEditor();

--- a/integration_test/scenarios/download_all_attachments_scenario.dart
+++ b/integration_test/scenarios/download_all_attachments_scenario.dart
@@ -49,6 +49,7 @@ class DownloadAllAttachmentsScenario extends BaseTestScenario {
       MobileSelector(
         android: AndroidSelector(text: 'SAVE'),
       ),
+      timeout: const Duration(seconds: 20),
     );
     await expectLater(
       $.platformAutomator.tap(

--- a/integration_test/scenarios/download_all_attachments_scenario.dart
+++ b/integration_test/scenarios/download_all_attachments_scenario.dart
@@ -45,6 +45,17 @@ class DownloadAllAttachmentsScenario extends BaseTestScenario {
   }
 
   Future<void> _expectNativeSaveButtonVisible() async {
-    await expectLater($.platformAutomator.tap(Selector(text: 'SAVE')), completes);
+    await $.platformAutomator.mobile.waitUntilVisible(
+      MobileSelector(
+        android: AndroidSelector(text: 'SAVE'),
+      ),
+    );
+    await expectLater(
+      $.platformAutomator.tap(
+        Selector(text: 'SAVE'),
+        timeout: const Duration(seconds: 20),
+      ),
+      completes,
+    );
   }
 }

--- a/integration_test/scenarios/email_detailed/display_and_scroll_email_with_long_content_scenario.dart
+++ b/integration_test/scenarios/email_detailed/display_and_scroll_email_with_long_content_scenario.dart
@@ -55,16 +55,22 @@ class DisplayAndScrollEmailWithLongContentScenario extends BaseTestScenario {
   }
 
   Future<void> _expectEmailViewWithLongContent() async {
-    expect(
-      $(HtmlContentViewer).which<HtmlContentViewer>((view) {
-        return view.contentHtml.contains('Lorem ipsum dolor sit amet, consectetur adipiscing elit.');
-      }),
-      findsOneWidget,
-    );
+    final view = $(HtmlContentViewer).which<HtmlContentViewer>((view) {
+      return view.contentHtml
+          .contains('Lorem ipsum dolor sit amet, consectetur adipiscing elit.');
+    });
+    await $.waitUntilExists(view);
+    expect(view, findsOneWidget);
   }
 
   Future<void> _expectEmailViewScrollableWithLongContent() async {
     expect($(EmailSubjectWidget).visible, isTrue);
+    int retry = 0;
+    while (retry < 3 &&
+        $(#integration_testing_email_detailed_divider).hitTestable().exists) {
+      await $.pumpAndTrySettle(duration: Duration(seconds: retry + 1));
+      retry++;
+    }
 
     await $.scrollUntilVisible(
       finder: $(#integration_testing_email_detailed_divider),

--- a/integration_test/scenarios/email_detailed/display_and_scroll_email_with_long_content_scenario.dart
+++ b/integration_test/scenarios/email_detailed/display_and_scroll_email_with_long_content_scenario.dart
@@ -9,6 +9,7 @@ import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_bu
 import '../../base/base_test_scenario.dart';
 import '../../models/provisioning_email.dart';
 import '../../robots/thread_robot.dart';
+import '../../utils/wait_for_condition.dart';
 
 class DisplayAndScrollEmailWithLongContentScenario extends BaseTestScenario {
 
@@ -65,12 +66,9 @@ class DisplayAndScrollEmailWithLongContentScenario extends BaseTestScenario {
 
   Future<void> _expectEmailViewScrollableWithLongContent() async {
     expect($(EmailSubjectWidget).visible, isTrue);
-    int retry = 0;
-    while (retry < 3 &&
-        $(#integration_testing_email_detailed_divider).hitTestable().exists) {
-      await $.pumpAndTrySettle(duration: Duration(seconds: retry + 1));
-      retry++;
-    }
+    await waitForCondition(
+      () => $(#integration_testing_email_detailed_divider).hitTestable().exists,
+    );
 
     await $.scrollUntilVisible(
       finder: $(#integration_testing_email_detailed_divider),
@@ -78,7 +76,7 @@ class DisplayAndScrollEmailWithLongContentScenario extends BaseTestScenario {
       delta: 150,
       maxScrolls: 100,
     );
-    await $.pumpAndSettle();
+    await $.pumpAndTrySettle();
 
     expect($(EmailSubjectWidget).visible, isFalse);
   }

--- a/integration_test/scenarios/email_detailed/reply_email_when_change_language_scenario.dart
+++ b/integration_test/scenarios/email_detailed/reply_email_when_change_language_scenario.dart
@@ -1,4 +1,6 @@
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/keyboard_utils.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/subject_composer_widget.dart';
@@ -77,6 +79,9 @@ class ReplyEmailWhenChangeLanguageScenario extends BaseTestScenario
   }) async {
     await threadRobot.openEmailWithSubject(subject);
     await _expectEmailViewVisible();
+    if (PlatformInfo.isMobile) {
+      await KeyboardUtils.hideSystemKeyboardMobile();
+    }
     await _expectReplyEmailButtonVisible();
 
     await emailRobot.onTapReplyEmail();

--- a/integration_test/scenarios/email_detailed/view_inline_image_scenario.dart
+++ b/integration_test/scenarios/email_detailed/view_inline_image_scenario.dart
@@ -11,6 +11,7 @@ import '../../base/base_test_scenario.dart';
 import '../../resources/image_resources.dart';
 import '../../robots/composer_robot.dart';
 import '../../robots/thread_robot.dart';
+import '../../utils/wait_for_condition.dart';
 
 class ViewInlineImageScenario extends BaseTestScenario {
 
@@ -78,16 +79,13 @@ class ViewInlineImageScenario extends BaseTestScenario {
         currentHtmlContent.contains('data:image/') &&
         currentHtmlContent.contains(';base64') &&
         currentHtmlContent.contains('cid:');
-    int retry = 0;
-    while (retry < 3) {
-      await $.pumpAndTrySettle(duration: Duration(seconds: retry + 1));
-      currentHtmlContent =
-          await getBinding<ComposerController>()?.getContentInEditor() ?? '';
-      if (conditionPassed()) {
-        break;
-      }
-      retry++;
-    }
+    await waitForCondition(
+      () async {
+        currentHtmlContent =
+            await getBinding<ComposerController>()?.getContentInEditor() ?? '';
+        return conditionPassed();
+      },
+    );
     expect(conditionPassed(), isTrue);
   }
 

--- a/integration_test/scenarios/email_detailed/view_inline_image_scenario.dart
+++ b/integration_test/scenarios/email_detailed/view_inline_image_scenario.dart
@@ -61,7 +61,6 @@ class ViewInlineImageScenario extends BaseTestScenario {
       base64Data: ImageResources.base64,
     );
     await composerRobot.addInlineImageFromFile(imageFile);
-    await $.pumpAndSettle(duration: const Duration(seconds: 3));
 
     await _expectInlineImageVisible();
 
@@ -74,13 +73,22 @@ class ViewInlineImageScenario extends BaseTestScenario {
   Future<void> _expectComposerViewVisible() => expectViewVisible($(ComposerView));
 
   Future<void> _expectInlineImageVisible() async {
-    final currentHtmlContent = await getBinding<ComposerController>()?.getContentInEditor() ?? '';
-    expect(
-      currentHtmlContent.contains('data:image/') &&
-          currentHtmlContent.contains(';base64') &&
-          currentHtmlContent.contains('cid:'),
-      isTrue,
-    );
+    String currentHtmlContent = '';
+    bool conditionPassed() =>
+        currentHtmlContent.contains('data:image/') &&
+        currentHtmlContent.contains(';base64') &&
+        currentHtmlContent.contains('cid:');
+    int retry = 0;
+    while (retry < 3) {
+      await $.pumpAndTrySettle(duration: Duration(seconds: retry + 1));
+      currentHtmlContent =
+          await getBinding<ComposerController>()?.getContentInEditor() ?? '';
+      if (conditionPassed()) {
+        break;
+      }
+      retry++;
+    }
+    expect(conditionPassed(), isTrue);
   }
 
   Future<void> _expectEmailWithInlineImageVisible(String emailSubject) async {

--- a/integration_test/scenarios/labels/display_empty_view_when_open_tag_scenario.dart
+++ b/integration_test/scenarios/labels/display_empty_view_when_open_tag_scenario.dart
@@ -39,7 +39,7 @@ class DisplayEmptyViewWhenOpenTagScenario extends BaseTestScenario
       ),
       requestReadReceipt: false,
     );
-    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+    await $.waitUntilVisible($(EmailTileBuilder));
 
     await threadRobot.openMailbox();
     await _expectLabelListViewVisible();
@@ -67,6 +67,15 @@ class DisplayEmptyViewWhenOpenTagScenario extends BaseTestScenario
     required int emailCount,
   }) async {
     final tagDisplayName = label.safeDisplayName;
+    await $(EmailTileBuilder).waitUntilVisible();
+    for (int i = 0; i < 5; i++) {
+      final count = $.tester.widgetList<EmailTileBuilder>(
+        $(EmailTileBuilder).which<EmailTileBuilder>((widget) =>
+            widget.presentationEmail.subject?.contains(tagDisplayName) == true),
+      ).length;
+      if (count >= emailCount) break;
+      await $.pump(const Duration(seconds: 1));
+    }
 
     final listEmailTileWithTag = $.tester.widgetList<EmailTileBuilder>(
       $(EmailTileBuilder).which<EmailTileBuilder>((widget) =>

--- a/integration_test/scenarios/labels/display_empty_view_when_open_tag_scenario.dart
+++ b/integration_test/scenarios/labels/display_empty_view_when_open_tag_scenario.dart
@@ -8,6 +8,7 @@ import '../../base/base_test_scenario.dart';
 import '../../mixin/provisioning_label_scenario_mixin.dart';
 import '../../robots/labels/label_robot.dart';
 import '../../robots/thread_robot.dart';
+import '../../utils/wait_for_condition.dart';
 
 class DisplayEmptyViewWhenOpenTagScenario extends BaseTestScenario
     with ProvisioningLabelScenarioMixin {
@@ -68,14 +69,21 @@ class DisplayEmptyViewWhenOpenTagScenario extends BaseTestScenario
   }) async {
     final tagDisplayName = label.safeDisplayName;
     await $(EmailTileBuilder).waitUntilVisible();
-    for (int i = 0; i < 5; i++) {
-      final count = $.tester.widgetList<EmailTileBuilder>(
-        $(EmailTileBuilder).which<EmailTileBuilder>((widget) =>
-            widget.presentationEmail.subject?.contains(tagDisplayName) == true),
-      ).length;
-      if (count >= emailCount) break;
-      await $.pump(const Duration(seconds: 1));
-    }
+    await waitForCondition(
+      () {
+        final count = $.tester
+            .widgetList<EmailTileBuilder>(
+              $(EmailTileBuilder).which<EmailTileBuilder>(
+                (widget) {
+                  final subject = widget.presentationEmail.subject;
+                  return subject?.contains(tagDisplayName) == true;
+                },
+              ),
+            )
+            .length;
+        return count >= emailCount;
+      },
+    );
 
     final listEmailTileWithTag = $.tester.widgetList<EmailTileBuilder>(
       $(EmailTileBuilder).which<EmailTileBuilder>((widget) =>

--- a/integration_test/scenarios/labels/display_folder_info_when_open_mail_from_tag_scenario.dart
+++ b/integration_test/scenarios/labels/display_folder_info_when_open_mail_from_tag_scenario.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:labels/labels.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/labels/label_list_view.dart';
+import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../../base/base_test_scenario.dart';
@@ -39,7 +40,7 @@ class DisplayFolderInfoWhenOpenMailFromTagScenario extends BaseTestScenario
       requestReadReceipt: false,
       folderLocationRole: PresentationMailbox.roleTrash,
     );
-    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+    await $.waitUntilVisible($(EmailTileBuilder));
 
     await threadRobot.openMailbox();
     await _expectLabelListViewVisible();

--- a/integration_test/scenarios/labels/display_view_with_all_email_with_tag_scenario.dart
+++ b/integration_test/scenarios/labels/display_view_with_all_email_with_tag_scenario.dart
@@ -35,8 +35,7 @@ class DisplayViewWithAllEmailWithTagScenario extends BaseTestScenario
         requestReadReceipt: false,
       );
     }
-    await $.pumpAndSettle(duration: const Duration(seconds: 2));
-
+    await $.waitUntilVisible($(EmailTileBuilder));
 
     for (final label in labels) {
       await threadRobot.openMailbox();
@@ -47,8 +46,6 @@ class DisplayViewWithAllEmailWithTagScenario extends BaseTestScenario
         label: label,
         emailCount: emailCount,
       );
-
-      await $.pumpAndSettle(duration: const Duration(seconds: 1));
     }
   }
 
@@ -60,6 +57,7 @@ class DisplayViewWithAllEmailWithTagScenario extends BaseTestScenario
     required int emailCount,
   }) async {
     final tagDisplayName = label.safeDisplayName;
+    await $(EmailTileBuilder).waitUntilVisible();
 
     final listEmailTileWithTag = $.tester.widgetList<EmailTileBuilder>(
       $(EmailTileBuilder).which<EmailTileBuilder>((widget) =>

--- a/integration_test/scenarios/labels/edit_a_tag_scenario.dart
+++ b/integration_test/scenarios/labels/edit_a_tag_scenario.dart
@@ -36,6 +36,7 @@ class EditATagScenario extends BaseTestScenario
     const newLabelName = 'New edit tag 1';
     await createLabelModalRobot.enterNewLabelName(newLabelName);
     await createLabelModalRobot.tapPositiveActionButton(LabelActionType.edit);
+    await threadRobot.openMailbox();
     await _expectLabelWithNewNameUpdated(newLabelName);
   }
 
@@ -48,6 +49,8 @@ class EditATagScenario extends BaseTestScenario
   }
 
   Future<void> _expectLabelWithNewNameUpdated(String name) async {
+    await $.waitUntilExists($(name));
+    await $(name).scrollTo();
     await expectViewVisible($(name));
   }
 }

--- a/integration_test/scenarios/mailbox/empty_trash_scenario.dart
+++ b/integration_test/scenarios/mailbox/empty_trash_scenario.dart
@@ -43,7 +43,6 @@ class EmptyTrashScenario extends BaseTestScenario {
     await mailboxMenuRobot.openFolderByName(
       appLocalizations.trashMailboxDisplayName,
     );
-    await $.pumpAndSettle();
     await _expectEmptyTrashBannerVisible();
     await _expectEmailWithSubjectVisible(subject);
 
@@ -64,8 +63,9 @@ class EmptyTrashScenario extends BaseTestScenario {
         .$(find.text(folderName)));
   }
 
-  Future<void> _expectEmptyTrashBannerVisible() =>
-      expectViewVisible($(#empty_trash_banner));
+  Future<void> _expectEmptyTrashBannerVisible() async {
+    await expectViewVisible($(#empty_trash_banner));
+  }
 
   Future<void> _expectEmailWithSubjectVisible(String subject) =>
       expectViewVisible($(subject));

--- a/integration_test/scenarios/mailbox/mailbox_move_email_scenario.dart
+++ b/integration_test/scenarios/mailbox/mailbox_move_email_scenario.dart
@@ -30,7 +30,7 @@ class MailboxMoveEmailScenario extends BaseTestScenario {
         content: '',
       ),
     ]);
-    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+    await $.waitUntilVisible($(templatesSubject));
 
     await threadRobot.longPressEmailWithSubject(templatesSubject);
     await threadRobot.moveEmailToMailboxWithName(appLocalizations.templatesMailboxDisplayName);

--- a/integration_test/scenarios/mailbox/move_folder_content_scenario.dart
+++ b/integration_test/scenarios/mailbox/move_folder_content_scenario.dart
@@ -64,8 +64,17 @@ class MoveFolderContentScenario extends BaseTestScenario {
     await expectViewVisible($(subject));
   }
 
-  Future<void> _expectEmailWithSubjectInVisible(String subject) async {
-    await expectViewInvisible($(subject));
+  Future<void> _expectEmailWithSubjectInVisible(String subject, {int attempt = 0,}) async {
+    // While the emails are being move, pumpAndTrySettle might resolve,
+    // causing some emails are still waiting to be moved
+    // and this expectation is triggered
+    try {
+      await expectViewInvisible($(subject));
+    } catch (e) {
+      if (attempt == 3) rethrow;
+      await $.pumpAndTrySettle(duration: Duration(seconds: attempt + 1));
+      await _expectEmailWithSubjectInVisible(subject, attempt: attempt + 1);
+    }
   }
 
   Future<void> _expectEmptyViewVisibleInInboxFolder() async {

--- a/integration_test/scenarios/mailbox/quick_filter_scenario.dart
+++ b/integration_test/scenarios/mailbox/quick_filter_scenario.dart
@@ -41,7 +41,7 @@ class QuickFilterScenario extends BaseTestScenario {
       starredEmail,
       attachmentEmail,
     ]);
-    await $.pumpAndSettle(); 
+    await $.waitUntilVisible($(unreadEmail.subject));
 
     await simulateUpdateFlagsOfEmailsWithSubjectsFromOutsideCurrentClient(
       subjects: ['quick filter read email'],

--- a/integration_test/scenarios/mailbox/team_mailbox_receive_email_scenario.dart
+++ b/integration_test/scenarios/mailbox/team_mailbox_receive_email_scenario.dart
@@ -53,6 +53,7 @@ class TeamMailboxReceiveEmailScenario extends BaseTestScenario {
   }
 
   Future<void> _expectTeamMailboxVisible(String name) async {
+    await $.waitUntilExists($(name));
     await $.scrollUntilVisible(finder: $(name));
     await expectViewVisible($(name));
   }

--- a/integration_test/scenarios/reply_email_with_content_contain_image_base64_data_scenario.dart
+++ b/integration_test/scenarios/reply_email_with_content_contain_image_base64_data_scenario.dart
@@ -56,10 +56,8 @@ class ReplyEmailWithContentContainImageBase64DataScenario extends BaseTestScenar
 
     await composerRobot.sendEmail(imagePaths);
     await _expectSendEmailSuccessToast(appLocalizations);
-    await Future.delayed(const Duration(seconds: 3));
 
     await emailRobot.onTapBackButton();
-    await $.pumpAndSettle(duration: const Duration(seconds: 3));
     await searchRobot.tapBackButton();
     await _expectEmailCidWithSubject(emailSubject);
 
@@ -94,7 +92,7 @@ class ReplyEmailWithContentContainImageBase64DataScenario extends BaseTestScenar
 
   Future<void> _expectSendEmailSuccessToast(AppLocalizations appLocalizations) async {
     await expectViewVisible(
-      $(find.text(appLocalizations.message_has_been_sent_successfully)),
+      $(appLocalizations.message_has_been_sent_successfully),
     );
   }
 

--- a/integration_test/scenarios/search/persist_filter_when_change_search_input_text_scenario.dart
+++ b/integration_test/scenarios/search/persist_filter_when_change_search_input_text_scenario.dart
@@ -49,7 +49,8 @@ class PersistFilterWhenChangeSearchInputTextScenario
   }
 
   Future<void> _expectEmailWithSubjectVisible(String subject) async {
-    await expectViewVisible($(find.text(subject)));
+    await $.pumpAndTrySettle();
+    await expectViewVisible($(subject));
   }
 
   void _expectAttachmentFilterSelected() {

--- a/integration_test/scenarios/search/search_email_with_tag_scenario.dart
+++ b/integration_test/scenarios/search/search_email_with_tag_scenario.dart
@@ -37,7 +37,7 @@ class SearchEmailWithTagScenario extends BaseTestScenario
         requestReadReceipt: false,
       );
     }
-    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+    await $(EmailTileBuilder).waitUntilVisible();
 
     await threadRobot.openSearchView();
     await _expectSearchViewVisible();
@@ -70,12 +70,26 @@ class SearchEmailWithTagScenario extends BaseTestScenario
     required String tagDisplayName,
     required int emailCount,
   }) async {
+    await $(EmailTileBuilder).waitUntilVisible();
+    for (int i = 0; i < 3; i++) {
+      final count = $.tester.widgetList<EmailTileBuilder>(
+        $(EmailTileBuilder).which<EmailTileBuilder>((widget) =>
+            widget.subjectContains(tagDisplayName)),
+      ).length;
+      if (count >= emailCount) break;
+      await $.pump(const Duration(seconds: 1));
+    }
+
     // Emails provisioned by buildEmailsForLabel include the tag name in the subject
-    final listEmailTileWithTag = $.tester.widgetList<EmailTileBuilder>(
-      $(EmailTileBuilder).which<EmailTileBuilder>((widget) =>
-          widget.presentationEmail.subject?.contains(tagDisplayName) == true),
-    );
+    final listEmailTileWithTag = $(EmailTileBuilder).which<EmailTileBuilder>((widget) =>
+        widget.subjectContains(tagDisplayName)).allCandidates;
 
     expect(listEmailTileWithTag.length, greaterThanOrEqualTo(emailCount));
+  }
+}
+
+extension on EmailTileBuilder {
+  bool subjectContains(String text) {
+    return presentationEmail.subject?.contains(text) == true;
   }
 }

--- a/integration_test/scenarios/search_result_highlights_scenario.dart
+++ b/integration_test/scenarios/search_result_highlights_scenario.dart
@@ -1,5 +1,6 @@
 import 'package:core/core.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';
 
 import '../base/base_test_scenario.dart';
 import '../models/provisioning_email.dart';
@@ -39,7 +40,7 @@ class SearchResultHighlightsScenario extends BaseTestScenario {
         ),
       )
       .toList());
-    await $.pumpAndSettle();
+    await $(EmailTileBuilder).waitUntilVisible();
 
     // Search
     await threadRobot.tapOnSearchField();

--- a/integration_test/scenarios/search_suggestion_highlights_scenario.dart
+++ b/integration_test/scenarios/search_suggestion_highlights_scenario.dart
@@ -45,6 +45,7 @@ class SearchSuggestionHighlightsScenario extends BaseTestScenario {
     await threadRobot.tapOnSearchField();
     await searchRobot.enterKeyword(keyword);
     await $.waitUntilVisible($(RichTextBuilder));
+    // Maximum 10 suggestions
     expect($(RichTextBuilder).$(keyword.split(' ').first).evaluate().length, 10);
   }
 }

--- a/integration_test/scenarios/search_suggestion_highlights_scenario.dart
+++ b/integration_test/scenarios/search_suggestion_highlights_scenario.dart
@@ -39,12 +39,12 @@ class SearchSuggestionHighlightsScenario extends BaseTestScenario {
         ),
       )
       .toList());
-    await $.pumpAndSettle();
+    await $.waitUntilVisible($(keyword));
 
     // Search
     await threadRobot.tapOnSearchField();
     await searchRobot.enterKeyword(keyword);
-    await $.pump(const Duration(seconds: 5));
-    expect($(RichTextBuilder).$(keyword.split(' ').first).hitTestable().evaluate().length, 10);
+    await $.waitUntilVisible($(RichTextBuilder));
+    expect($(RichTextBuilder).$(keyword.split(' ').first).evaluate().length, 10);
   }
 }

--- a/integration_test/scenarios/setting/language/change_language_scenario.dart
+++ b/integration_test/scenarios/setting/language/change_language_scenario.dart
@@ -30,6 +30,10 @@ class ChangeLanguageScenario extends BaseTestScenario {
     await _expectLanguageMenuItemVisible();
     await settingRobot.openLanguageMenuItem();
     await $.pumpAndSettle(duration: seconds(1));
+
+    await languageRobot.openLanguageContextMenu();
+    await languageRobot.selectLanguage(const Locale('en'), appLocalizations);
+    await $.pumpAndSettle(duration: seconds(1));
     await _expectLanguageViewWithEnglishTitleVisible();
 
     await languageRobot.openLanguageContextMenu();

--- a/integration_test/utils/backend_reset_client.dart
+++ b/integration_test/utils/backend_reset_client.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+/// Calls the backend reset server running on the CI host.
+///
+/// The Android emulator reaches the host at 10.0.2.2. The reset server
+/// (scripts/backend-reset-server.py) stops the running tmail-backend
+/// container and starts a fresh one from the provisioned snapshot, then
+/// returns 200 once James reports "server started".
+///
+/// Only active when RESET_SERVER_URL is provided via --dart-define,
+/// so local runs without the reset server are unaffected.
+class BackendResetClient {
+  static const String _resetUrl = String.fromEnvironment(
+    'RESET_SERVER_URL',
+    defaultValue: '',
+  );
+
+  static bool get isEnabled => _resetUrl.isNotEmpty;
+
+  /// Sends POST /reset and waits for the backend to confirm readiness.
+  /// Times out after [timeout] (default 3 minutes to allow container restart).
+  static Future<void> reset({
+    Duration timeout = const Duration(minutes: 3),
+  }) async {
+    if (!isEnabled) return;
+
+    final uri = Uri.parse('$_resetUrl/reset');
+    final client = HttpClient()..connectionTimeout = timeout;
+
+    try {
+      final request = await client.postUrl(uri);
+      final response = await request.close().timeout(timeout);
+      if (response.statusCode != 200) {
+        throw Exception('Backend reset failed with status ${response.statusCode}');
+      }
+    } finally {
+      client.close();
+    }
+  }
+}

--- a/integration_test/utils/wait_for_condition.dart
+++ b/integration_test/utils/wait_for_condition.dart
@@ -1,0 +1,15 @@
+import 'dart:async';
+
+Future<void> waitForCondition(
+  FutureOr<bool> Function() condition, {
+  Duration timeout = const Duration(seconds: 10),
+  Duration interval = const Duration(seconds: 1),
+}) async {
+  await Future.doWhile(() async {
+    if (await condition()) {
+      return false;
+    }
+    await Future.delayed(interval);
+    return true;
+  }).timeout(timeout);
+}

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -226,10 +226,6 @@ class ComposerController extends BaseController
   StreamSubscription<String>? _composerCacheListener;
 
   RichTextMobileTabletController? richTextMobileTabletController;
-  late final _fallbackRichTextController = RichTextController();
-  RichTextController get effectiveRichTextController =>
-      richTextMobileTabletController?.richTextController ??
-      _fallbackRichTextController;
   RichTextWebController? richTextWebController;
   CustomPopupMenuController? menuMoreOptionController;
 

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -226,6 +226,10 @@ class ComposerController extends BaseController
   StreamSubscription<String>? _composerCacheListener;
 
   RichTextMobileTabletController? richTextMobileTabletController;
+  late final _fallbackRichTextController = RichTextController();
+  RichTextController get effectiveRichTextController =>
+      richTextMobileTabletController?.richTextController ??
+      _fallbackRichTextController;
   RichTextWebController? richTextWebController;
   CustomPopupMenuController? menuMoreOptionController;
 

--- a/lib/features/composer/presentation/composer_view.dart
+++ b/lib/features/composer/presentation/composer_view.dart
@@ -8,6 +8,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
 import 'package:model/email/prefix_email_address.dart';
+import 'package:rich_text_composer/rich_text_composer.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/handle_content_height_exceeded_extension.dart';
@@ -284,7 +285,7 @@ class ComposerView extends GetWidget<ComposerController> {
         ),
       ),
       tablet: TabletContainerView(
-        keyboardRichTextController: controller.richTextMobileTabletController!.richTextController,
+        keyboardRichTextController: controller.richTextMobileTabletController?.richTextController ?? RichTextController(),
         onCloseViewAction: () => controller.handleClickCloseComposer(context),
         onClearFocusAction: controller.clearFocus,
         childBuilder: (_, constraints) => ColoredBox(

--- a/lib/features/composer/presentation/composer_view.dart
+++ b/lib/features/composer/presentation/composer_view.dart
@@ -8,7 +8,6 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
 import 'package:model/email/prefix_email_address.dart';
-import 'package:rich_text_composer/rich_text_composer.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/handle_content_height_exceeded_extension.dart';
@@ -285,7 +284,7 @@ class ComposerView extends GetWidget<ComposerController> {
         ),
       ),
       tablet: TabletContainerView(
-        keyboardRichTextController: controller.richTextMobileTabletController?.richTextController ?? RichTextController(),
+        keyboardRichTextController: controller.effectiveRichTextController,
         onCloseViewAction: () => controller.handleClickCloseComposer(context),
         onClearFocusAction: controller.clearFocus,
         childBuilder: (_, constraints) => ColoredBox(

--- a/lib/features/composer/presentation/composer_view.dart
+++ b/lib/features/composer/presentation/composer_view.dart
@@ -284,7 +284,7 @@ class ComposerView extends GetWidget<ComposerController> {
         ),
       ),
       tablet: TabletContainerView(
-        keyboardRichTextController: controller.effectiveRichTextController,
+        keyboardRichTextController: controller.richTextMobileTabletController!.richTextController,
         onCloseViewAction: () => controller.handleClickCloseComposer(context),
         onClearFocusAction: controller.clearFocus,
         childBuilder: (_, constraints) => ColoredBox(

--- a/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
@@ -54,7 +54,15 @@ class _MobileEditorState extends State<MobileEditorWidget> with TextSelectionMix
         handlerName: registerSelectionChange!.name,
       );
     }
-    _editorController?.dispose();
+    if (PlatformInfo.isIntegrationTesting) {
+      try {
+        _editorController?.dispose();
+      } catch (e) {
+        log('MobileEditorWidget::_editorController.dispose: $e');
+      }
+    } else {
+      _editorController?.dispose();
+    }
     _editorController = null;
     super.dispose();
   }

--- a/lib/features/login/data/network/authentication_client/authentication_client_interaction_mixin.dart
+++ b/lib/features/login/data/network/authentication_client/authentication_client_interaction_mixin.dart
@@ -1,4 +1,5 @@
 import 'package:core/utils/app_logger.dart';
+import 'package:core/utils/build_utils.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter_appauth_platform_interface/flutter_appauth_platform_interface.dart';
 import 'package:model/oidc/oidc_configuration.dart';
@@ -69,6 +70,7 @@ mixin AuthenticationClientInteractionMixin {
       scopes: scopes,
       externalUserAgent: getExternalUserAgent(),
       loginHint: loginHint,
+      allowInsecureConnections: BuildUtils.isDebugMode,
     );
   }
 

--- a/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
+++ b/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
@@ -18,8 +18,10 @@ extension ThreadDetailOnSelectedEmailUpdated on ThreadDetailController {
     PresentationEmail? selectedEmail,
     BuildContext? context,
   ) {
-    if (selectedEmail?.id == null && mailboxDashBoardController.isEmailOpened) {
-      closeThreadDetailAction();
+    if (selectedEmail == null || selectedEmail.id == null) {
+      if (mailboxDashBoardController.isEmailOpened) {
+        closeThreadDetailAction();
+      }
       return;
     }
 
@@ -29,12 +31,12 @@ extension ThreadDetailOnSelectedEmailUpdated on ThreadDetailController {
 
     if (currentExpandedEmailId.value == null) {
       loadThreadOnThreadChanged = isThreadDetailEnabled;
-      _preloadSelectedEmail(selectedEmail!);
+      _preloadSelectedEmail(selectedEmail);
       return;
     }
 
     // Thread setting updated, no need to dispose current single email controller
-    if (currentExpandedEmailId.value == selectedEmail!.id) {
+    if (currentExpandedEmailId.value == selectedEmail.id) {
       _preloadSelectedEmail(selectedEmail);
 
       if (isThreadDetailEnabled && selectedEmail.threadId != null) {

--- a/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
+++ b/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
@@ -18,10 +18,8 @@ extension ThreadDetailOnSelectedEmailUpdated on ThreadDetailController {
     PresentationEmail? selectedEmail,
     BuildContext? context,
   ) {
-    if (selectedEmail == null || selectedEmail.id == null) {
-      if (mailboxDashBoardController.isEmailOpened) {
-        closeThreadDetailAction();
-      }
+    if (selectedEmail == null && mailboxDashBoardController.isEmailOpened) {
+      closeThreadDetailAction();
       return;
     }
 
@@ -29,14 +27,14 @@ extension ThreadDetailOnSelectedEmailUpdated on ThreadDetailController {
     onKeyboardShortcutInit();
     scrollController ??= ScrollController();
 
-    if (currentExpandedEmailId.value == null) {
+    if (currentExpandedEmailId.value == null && selectedEmail != null) {
       loadThreadOnThreadChanged = isThreadDetailEnabled;
       _preloadSelectedEmail(selectedEmail);
       return;
     }
 
     // Thread setting updated, no need to dispose current single email controller
-    if (currentExpandedEmailId.value == selectedEmail.id) {
+    if (selectedEmail != null && currentExpandedEmailId.value == selectedEmail.id) {
       _preloadSelectedEmail(selectedEmail);
 
       if (isThreadDetailEnabled && selectedEmail.threadId != null) {
@@ -62,7 +60,9 @@ extension ThreadDetailOnSelectedEmailUpdated on ThreadDetailController {
     }
 
     loadThreadOnThreadChanged = isThreadDetailEnabled;
-    _preloadSelectedEmail(selectedEmail);
+    if (selectedEmail != null) {
+      _preloadSelectedEmail(selectedEmail);
+    }
   }
 
   void _preloadSelectedEmail(PresentationEmail selectedEmail) {

--- a/provisioning/integration_test/provisioning.sh
+++ b/provisioning/integration_test/provisioning.sh
@@ -85,7 +85,7 @@ done
 
 wait
 
-# For test team mailbox — create first, then add members sequentially
+# For test team mailbox — create first, then add members in parallel
 curl -XPUT http://localhost:8000/domains/example.com/team-mailboxes/bob-guests
 curl -XPUT "http://localhost:8000/domains/example.com/team-mailboxes/bob-guests/members/bob@example.com?role=member" &
 curl -XPUT "http://localhost:8000/domains/example.com/team-mailboxes/bob-guests/members/alice@example.com?role=member" &

--- a/provisioning/integration_test/provisioning.sh
+++ b/provisioning/integration_test/provisioning.sh
@@ -4,16 +4,18 @@
 users=("alice" "bob" "brian" "charlotte" "david" "emma")
 bobFolders=("Search Emails" "Forward Emails" "Disposition" "MailBase64" "Calendar" "Reply Emails")
 
-# Add users
+# Add users in parallel
 for user in "${users[@]}"; do
-  james-cli AddUser "$user@example.com" "$user"
+  james-cli AddUser "$user@example.com" "$user" &
 done
+wait
 
-# Create folders for user Bob
+# Create folders for user Bob in parallel
 for folderName in "${bobFolders[@]}"; do
   echo "Creating $folderName folder for user bob"
-  james-cli CreateMailbox \#private "bob@example.com" "$folderName"
+  james-cli CreateMailbox \#private "bob@example.com" "$folderName" &
 done
+wait
 
 # Function to check if mailbox exists
 function wait_for_mailbox() {
@@ -36,37 +38,41 @@ function wait_for_mailbox() {
   return 1
 }
 
-# Ensure all mailboxes exist before importing emails
+# Ensure all mailboxes exist before importing emails (parallel polling)
 for folderName in "${bobFolders[@]}"; do
-  wait_for_mailbox "bob@example.com" "$folderName" || exit 1
+  wait_for_mailbox "bob@example.com" "$folderName" &
+done
+# Collect exit codes — fail fast if any mailbox was not created in time
+for pid in $(jobs -p); do
+  wait "$pid" || exit 1
 done
 
 # For test search email with sort order
 # Import emails into 'Search Emails' folder for user Bob
 for eml in {0..4}; do
   echo "Importing $eml.eml into 'Search Emails' folder for user bob"
-  james-cli ImportEml \#private "bob@example.com" "Search Emails" "/root/conf/integration_test/eml/search_email_with_sort_order/$eml.eml"
+  james-cli ImportEml \#private "bob@example.com" "Search Emails" "/root/conf/integration_test/eml/search_email_with_sort_order/$eml.eml" &
 done
 
 # For test forward email
 # Import emails into 'Forward Emails' folder for user Bob
 echo "Importing forward.eml into 'Forward Emails' folder for user bob"
-james-cli ImportEml \#private "bob@example.com" "Forward Emails" "/root/conf/integration_test/eml/forward_email/forward.eml"
+james-cli ImportEml \#private "bob@example.com" "Forward Emails" "/root/conf/integration_test/eml/forward_email/forward.eml" &
 
 # For test email with no-disposition inline image
 # Import email into 'Disposition' folder for user Bob
 echo "Importing no_disposition_inline.eml into 'Disposition' folder for user bob"
-james-cli ImportEml \#private "bob@example.com" "Disposition" "/root/conf/integration_test/eml/no_disposition_inline/no_disposition_inline.eml"
+james-cli ImportEml \#private "bob@example.com" "Disposition" "/root/conf/integration_test/eml/no_disposition_inline/no_disposition_inline.eml" &
 
 # For test reply email with image base64
 # Import email into 'MailBase64' folder for user Bob
 echo "Importing 0.eml into 'MailBase64' folder for user bob"
-james-cli ImportEml \#private "bob@example.com" "MailBase64" "/root/conf/integration_test/eml/reply_email_with_image_base64/0.eml"
+james-cli ImportEml \#private "bob@example.com" "MailBase64" "/root/conf/integration_test/eml/reply_email_with_image_base64/0.eml" &
 
 # For test calendar event
 # Import email into 'Calendar' folder for user Bob
 echo "Importing calendar eml into 'Calendar' folder for user bob"
-james-cli ImportEml \#private "bob@example.com" "Calendar" "/root/conf/integration_test/eml/calendar/calendar_counter.eml"
+james-cli ImportEml \#private "bob@example.com" "Calendar" "/root/conf/integration_test/eml/calendar/calendar_counter.eml" &
 
 # For test reply email
 # Import emails into 'Reply Emails' folder for user Bob
@@ -74,22 +80,17 @@ replyEmailsEML=("reply-all.eml" "reply-to-list.eml" "with-reply-to.eml" "without
 
 for eml in "${replyEmailsEML[@]}"; do
   echo "Importing $eml into 'Reply Emails' folder for user bob"
-  james-cli ImportEml \#private "bob@example.com" "Reply Emails" "/root/conf/integration_test/eml/reply_email/$eml"
+  james-cli ImportEml \#private "bob@example.com" "Reply Emails" "/root/conf/integration_test/eml/reply_email/$eml" &
 done
 
-# For test reply email
-# Import emails into 'Reply Emails' folder for user Bob
-replyEmailsEML=("reply-all.eml" "reply-to-list.eml" "with-reply-to.eml" "without-reply-to.eml")
+wait
 
-for eml in "${replyEmailsEML[@]}"; do
-  echo "Importing $eml into 'Reply Emails' folder for user bob"
-  james-cli ImportEml \#private "bob@example.com" "Reply Emails" "/root/conf/integration_test/eml/reply_email/$eml"
-done
-
-# For test team mailbox
-curl -XPUT http://172.18.0.2:8000/domains/example.com/team-mailboxes/bob-guests
-curl -XPUT http://172.18.0.2:8000/domains/example.com/team-mailboxes/bob-guests/members/bob@example.com?role=member
-curl -XPUT http://172.18.0.2:8000/domains/example.com/team-mailboxes/bob-guests/members/alice@example.com?role=member
+# For test team mailbox — create first, then add members sequentially
+curl -XPUT http://localhost:8000/domains/example.com/team-mailboxes/bob-guests
+curl -XPUT "http://localhost:8000/domains/example.com/team-mailboxes/bob-guests/members/bob@example.com?role=member" &
+curl -XPUT "http://localhost:8000/domains/example.com/team-mailboxes/bob-guests/members/alice@example.com?role=member" &
 
 # For test quota
-curl -X PUT http://172.18.0.2:8000/quota/users/bob@example.com -d '{"count":200,"size":50000000}' -H "Content-Type: application/json" # 200 emails, 50MB
+curl -X PUT http://localhost:8000/quota/users/bob@example.com -d '{"count":200,"size":50000000}' -H "Content-Type: application/json" &
+
+wait

--- a/scripts/backend-reset-server.py
+++ b/scripts/backend-reset-server.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+HTTP server that resets tmail-backend to a clean provisioned state.
+
+The Android emulator reaches the host at 10.0.2.2, so Dart tests call:
+  POST http://10.0.2.2:9999/reset
+
+On each reset the server restarts the container (wiping all in-memory
+James state) and re-runs provisioning.sh to restore users/mailboxes/emails.
+Returns 200 OK only once James reports "server started" and provisioning
+completes, so Dart tearDown blocks until the next test can safely start.
+
+Note: docker commit cannot capture JVM heap state, so the memory-based
+backend must always be restored by re-running provisioning after restart.
+
+Environment variables:
+  RESET_PORT   Listening port (default: 9999)
+  WORK_DIR     Repo root, used to resolve the compose file (default: cwd)
+"""
+
+import http.server
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+
+RESET_PORT = int(os.environ.get("RESET_PORT", "9999"))
+WORK_DIR   = os.environ.get("WORK_DIR", os.getcwd())
+COMPOSE    = os.path.join(WORK_DIR, "backend-docker", "docker-compose.yaml")
+PROVISION  = "/root/conf/integration_test/provisioning.sh"
+
+
+def _run(cmd: list[str], check: bool = False) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, check=check, capture_output=True, text=True)
+
+
+def _backend_ready_since(since: str) -> bool:
+    # Only inspect logs produced after `since` to avoid matching the previous run's startup message.
+    result = _run(["docker", "logs", "--since", since, "tmail-backend"])
+    combined = result.stdout + result.stderr
+    return "JAMES server started" in combined
+
+
+def reset_backend() -> None:
+    print("[reset-server] Restarting tmail-backend...", flush=True)
+    restart_time = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    _run(["docker", "compose", "-f", COMPOSE, "restart", "tmail-backend"], check=True)
+
+    deadline = time.time() + 120
+    while time.time() < deadline:
+        if _backend_ready_since(restart_time):
+            break
+        time.sleep(2)
+    else:
+        raise TimeoutError("tmail-backend did not start within 120 seconds")
+
+    print("[reset-server] Re-running provisioning...", flush=True)
+    _run(["docker", "exec", "tmail-backend", PROVISION], check=True)
+    print("[reset-server] Reset complete.", flush=True)
+
+
+class ResetHandler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        if self.path != "/reset":
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        try:
+            reset_backend()
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"ok")
+        except Exception as exc:
+            print(f"[reset-server] ERROR: {exc}", file=sys.stderr, flush=True)
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(str(exc).encode())
+
+    def log_message(self, fmt, *args):
+        print(f"[reset-server] {self.address_string()} - {fmt % args}", flush=True)
+
+
+if __name__ == "__main__":
+    server = http.server.HTTPServer(("0.0.0.0", RESET_PORT), ResetHandler)
+    print(f"[reset-server] Listening on port {RESET_PORT}", flush=True)
+    server.serve_forever()

--- a/scripts/patrol-integration-test-with-docker.sh
+++ b/scripts/patrol-integration-test-with-docker.sh
@@ -20,9 +20,15 @@ sed -i "s|url.prefix=.*|url.prefix=http://10.0.2.2|" jmap.properties
 sed -i "s|websocket.url.prefix=.*|websocket.url.prefix=ws://10.0.2.2|" jmap.properties
 
 echo "Starting tmail-backend..."
-docker compose up -d tmail-backend --quiet-pull 2>/dev/null
-
+docker compose up -d tmail-backend --quiet-pull
+# Cap the wait so a stuck backend fails fast instead of consuming the runner timeout.
+deadline=$(( SECONDS + 180 ))
 until docker compose logs tmail-backend 2>/dev/null | grep -qi "JAMES server started"; do
+    if (( SECONDS >= deadline )); then
+        echo "tmail-backend did not start within 180s; recent logs:"
+        docker compose logs --tail=200 tmail-backend
+        exit 1
+    fi
     echo "Waiting for tmail-backend..."
     sleep 2
 done

--- a/scripts/patrol-integration-test-with-docker.sh
+++ b/scripts/patrol-integration-test-with-docker.sh
@@ -1,64 +1,101 @@
 #!/bin/bash
+# CI integration test script.
+# The Android emulator is managed by reactivecircus/android-emulator-runner
+# and is already running when this script executes.
+#
+# Usage:
+#   ./scripts/patrol-integration-test-with-docker.sh
+set -e
 
-# Install ngrok
-echo "Installing ngrok..."
-curl -sSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null &&
-    echo "deb https://ngrok-agent.s3.amazonaws.com buster main" | sudo tee /etc/apt/sources.list.d/ngrok.list &&
-    sudo apt update && sudo apt install ngrok
-
-# Install patrol CLI
 echo "Installing patrol CLI..."
 dart pub global activate patrol_cli 4.3.1
-flutter build apk --config-only
-
-# Forward traffic to tmail-backend
-ngrok http http://localhost:80 --log=stdout >/dev/null &
-until [[ $(curl localhost:4040/api/status | jq -r ".status") == "online" ]]; do
-    echo "Waiting for ngrok to connect..."
-    sleep 2
-done
-
-export BASIC_AUTH_URL=$(curl -s localhost:4040/api/tunnels | jq -r '.tunnels[0].public_url')
 
 cd backend-docker
 
-# Generate keys for tmail backend
-echo "Generating keys for tmail-backend..."
-openssl genpkey -algorithm rsa -pkeyopt rsa_keygen_bits:4096 -out jwt_privatekey
-openssl rsa -in jwt_privatekey -pubout -out jwt_publickey
+openssl genpkey -algorithm rsa -pkeyopt rsa_keygen_bits:4096 -out jwt_privatekey 2>/dev/null
+openssl rsa -in jwt_privatekey -pubout -out jwt_publickey 2>/dev/null
 
-# Replace content of jmap.properties with url.prefix=$BASIC_AUTH_URL
-# and websocket.url.prefix=ws${BASIC_AUTH_URL:4}
-sed -i "s|url.prefix=.*|url.prefix=$BASIC_AUTH_URL|" jmap.properties
-sed -i '' "s|websocket.url.prefix=.*|websocket.url.prefix=ws${BASIC_AUTH_URL:4}|" jmap.properties
+# 10.0.2.2 is the QEMU alias for the host machine inside the Android emulator.
+sed -i "s|url.prefix=.*|url.prefix=http://10.0.2.2|" jmap.properties
+sed -i "s|websocket.url.prefix=.*|websocket.url.prefix=ws://10.0.2.2|" jmap.properties
 
-echo "Starting services and adding users..."
-docker compose up -d
-# Wait till the service is started to add users
-until (docker compose logs tmail-backend | grep -i "JAMES server started"); do
-    echo "Waiting for tmail-backend to start..."
+echo "Starting tmail-backend..."
+docker compose up -d tmail-backend --quiet-pull 2>/dev/null
+
+until docker compose logs tmail-backend 2>/dev/null | grep -qi "JAMES server started"; do
+    echo "Waiting for tmail-backend..."
     sleep 2
 done
+
 export BOB="bob"
 export ALICE="alice"
 export DOMAIN="example.com"
 
-docker exec tmail-backend ./root/conf/integration_test/provisioning.sh
+docker exec tmail-backend /root/conf/integration_test/provisioning.sh >/dev/null 2>&1
 
 cd ..
 
-echo "Building the app and running tests..."
-flutter build apk --config-only
-patrol build android -v \
+export BASIC_AUTH_URL="http://10.0.2.2"
+export RESET_PORT=9999
+
+RESET_SERVER_LOG="/tmp/backend-reset-server.log"
+echo "Starting backend reset server on port $RESET_PORT (logs: $RESET_SERVER_LOG)..."
+WORK_DIR="$(pwd)" RESET_PORT="$RESET_PORT" python3 scripts/backend-reset-server.py > "$RESET_SERVER_LOG" 2>&1 &
+RESET_SERVER_PID=$!
+
+cleanup() {
+    echo "Cleaning up..."
+    kill "$ADB_WATCHDOG_PID" 2>/dev/null || true
+    kill "$RESET_SERVER_PID" 2>/dev/null || true
+    cd backend-docker
+    docker compose down --remove-orphans 2>/dev/null
+    cd ..
+    # Stop the emulator before it can respawn crashpad_handler during its own
+    # graceful-shutdown sequence — that respawn is the root cause of the hang.
+    adb emu kill 2>/dev/null || true
+    sleep 2
+    # crashpad_handler ignores SIGTERM; use SIGKILL directly. Retry a few
+    # times to catch any instance that was mid-spawn when the emulator died.
+    for _i in 1 2 3; do
+        pkill -SIGKILL crashpad_handler 2>/dev/null || break
+        sleep 1
+    done
+}
+trap cleanup EXIT
+
+adb_watchdog() {
+    local fail_count=0
+    while sleep 5; do
+        if ! adb -s emulator-5554 shell echo ok >/dev/null 2>&1; then
+            (( fail_count++ )) || true
+            # Require 2 consecutive failures (~10s) before acting to avoid
+            # killing on a transient ADB blip during heavy test execution.
+            if (( fail_count >= 2 )); then
+                echo "ADB watchdog: emulator-5554 gone for $((fail_count * 5))s."
+                echo "ADB watchdog: killing Gradle JVM to unblock patrol teardown..."
+                # "adb uninstall" runs inside the Gradle JVM via DDMLIB (not a
+                # separate adb process), so we must kill Gradle directly.
+                pkill -SIGKILL -f "GradleMain" 2>/dev/null || true
+                pkill -SIGKILL -f "GradleDaemon" 2>/dev/null || true
+                # One-shot: break so the watchdog doesn't keep firing after acting.
+                break
+            fi
+        else
+            fail_count=0
+        fi
+    done
+}
+adb_watchdog &
+ADB_WATCHDOG_PID=$!
+
+echo "Running Patrol tests..."
+flutter build apk --config-only --quiet
+patrol test \
+    --exclude-tags=web \
+    --hide-test-steps \
     --dart-define=USERNAME="$BOB" \
     --dart-define=PASSWORD="$BOB" \
     --dart-define=ADDITIONAL_MAIL_RECIPIENT="$ALICE@$DOMAIN" \
     --dart-define=BASIC_AUTH_EMAIL="$BOB@$DOMAIN" \
-    --dart-define=BASIC_AUTH_URL="$BASIC_AUTH_URL"
-gcloud firebase test android run \
-    --type instrumentation \
-    --app build/app/outputs/apk/debug/app-debug.apk \
-    --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk \
-    --device 'model=MediumPhone.arm,version=33,locale=en,orientation=portrait' \
-    --use-orchestrator \
-    --environment-variables clearPackageData=true
+    --dart-define=BASIC_AUTH_URL="$BASIC_AUTH_URL" \
+    --dart-define=RESET_SERVER_URL="http://10.0.2.2:$RESET_PORT"

--- a/scripts/patrol-local-integration-test-with-docker.sh
+++ b/scripts/patrol-local-integration-test-with-docker.sh
@@ -1,40 +1,36 @@
 #!/bin/bash
 
 ## Pre-requisites
-# Install ngrok
-# Install patrol CLI
-# Open android emulator
+#   - patrol_cli installed: dart pub global activate patrol_cli 4.3.1
+#   - ADB installed (Android SDK platform-tools)
+#   - A local Android emulator running (e.g. via Android Studio AVD)
+#
+# Usage:
+#   ./scripts/patrol-local-integration-test-with-docker.sh
 
-# Stoping previous environment if any
-killall ngrok || true
+# Stop previous backend environment if any
 cd backend-docker
 docker compose down || true
 cd ..
 
-# Forward traffic to tmail-backend
-ngrok http http://localhost:80 --log=stdout >/dev/null &
-until [[ $(curl localhost:4040/api/status | jq -r ".status") == "online" ]]; do
-    echo "Waiting for ngrok to connect..."
-    sleep 2
-done
-
-export BASIC_AUTH_URL=$(curl -s localhost:4040/api/tunnels | jq -r '.tunnels[0].public_url')
-
 cd backend-docker
 
-# Generate keys for tmail backend
-echo "Generating keys for tmail-backend..."
-openssl genpkey -algorithm rsa -pkeyopt rsa_keygen_bits:4096 -out jwt_privatekey
-openssl rsa -in jwt_privatekey -pubout -out jwt_publickey
+# Generate JWT keys if not already present
+if [[ ! -f jwt_privatekey ]]; then
+    echo "Generating keys for tmail-backend..."
+    openssl genpkey -algorithm rsa -pkeyopt rsa_keygen_bits:4096 -out jwt_privatekey
+    openssl rsa -in jwt_privatekey -pubout -out jwt_publickey
+fi
 
-# Replace content of jmap.properties with url.prefix=$BASIC_AUTH_URL
-# and websocket.url.prefix=ws${BASIC_AUTH_URL:4}
-sed -i '' "s|url.prefix=.*|url.prefix=$BASIC_AUTH_URL|" jmap.properties
-sed -i '' "s|websocket.url.prefix=.*|websocket.url.prefix=ws${BASIC_AUTH_URL:4}|" jmap.properties
+# 10.0.2.2 is the QEMU alias for the host machine — the Android emulator uses this
+# to reach tmail-backend which is bound to host port 80.
+sed -i '' "s|url.prefix=.*|url.prefix=http://10.0.2.2|" jmap.properties
+sed -i '' "s|websocket.url.prefix=.*|websocket.url.prefix=ws://10.0.2.2|" jmap.properties
 
-echo "Starting services and adding users..."
-docker compose up -d
-# Wait till the service is started to add users
+echo "Starting tmail-backend via Docker..."
+docker compose up -d tmail-backend
+
+# Wait for tmail-backend
 until (docker compose logs tmail-backend | grep -i "JAMES server started"); do
     echo "Waiting for tmail-backend to start..."
     sleep 2
@@ -43,22 +39,35 @@ export BOB="bob"
 export ALICE="alice"
 export DOMAIN="example.com"
 
-docker exec tmail-backend ./root/conf/integration_test/provisioning.sh
+docker exec tmail-backend ./root/conf/integration_test/provisioning.sh >/dev/null 2>&1
 
 cd ..
 
+# 10.0.2.2 is QEMU's hardcoded alias for the host — reaches tmail-backend on port 80
+export BASIC_AUTH_URL="http://10.0.2.2"
+export RESET_PORT=9999
+
+RESET_SERVER_LOG="/tmp/backend-reset-server.log"
+echo "Starting backend reset server on port $RESET_PORT (logs: $RESET_SERVER_LOG)..."
+WORK_DIR="$(pwd)" RESET_PORT="$RESET_PORT" python3 scripts/backend-reset-server.py > "$RESET_SERVER_LOG" 2>&1 &
+RESET_SERVER_PID=$!
+
+cleanup() {
+    echo "Cleaning up test environment..."
+    kill "$RESET_SERVER_PID" 2>/dev/null || true
+    cd backend-docker
+    docker compose down
+    cd ..
+}
+trap cleanup EXIT
+
 echo "Building the app and running tests..."
 flutter build apk --config-only
-patrol test -v \
+patrol test \
+    --hide-test-steps \
     --dart-define=USERNAME="$BOB" \
     --dart-define=PASSWORD="$BOB" \
     --dart-define=ADDITIONAL_MAIL_RECIPIENT="$ALICE@$DOMAIN" \
     --dart-define=BASIC_AUTH_EMAIL="$BOB@$DOMAIN" \
-    --dart-define=BASIC_AUTH_URL="$BASIC_AUTH_URL"
-
-# Clean up
-echo "Cleaning up test environment..."
-killall ngrok
-cd backend-docker
-docker compose down
-cd ..
+    --dart-define=BASIC_AUTH_URL="$BASIC_AUTH_URL" \
+    --dart-define=RESET_SERVER_URL="http://10.0.2.2:$RESET_PORT"

--- a/scripts/patrol-local-integration-test-with-docker.sh
+++ b/scripts/patrol-local-integration-test-with-docker.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 ## Pre-requisites
 #   - patrol_cli installed: dart pub global activate patrol_cli 4.3.1
@@ -9,11 +10,11 @@
 #   ./scripts/patrol-local-integration-test-with-docker.sh
 
 # Stop previous backend environment if any
-cd backend-docker
+cd backend-docker || exit 1
 docker compose down || true
 cd ..
 
-cd backend-docker
+cd backend-docker || exit 1
 
 # Generate JWT keys if not already present
 if [[ ! -f jwt_privatekey ]]; then
@@ -24,6 +25,7 @@ fi
 
 # 10.0.2.2 is the QEMU alias for the host machine — the Android emulator uses this
 # to reach tmail-backend which is bound to host port 80.
+# Edit the sed commands if not using MacOS
 sed -i '' "s|url.prefix=.*|url.prefix=http://10.0.2.2|" jmap.properties
 sed -i '' "s|websocket.url.prefix=.*|websocket.url.prefix=ws://10.0.2.2|" jmap.properties
 
@@ -39,7 +41,7 @@ export BOB="bob"
 export ALICE="alice"
 export DOMAIN="example.com"
 
-docker exec tmail-backend ./root/conf/integration_test/provisioning.sh >/dev/null 2>&1
+docker exec tmail-backend /root/conf/integration_test/provisioning.sh >/dev/null 2>&1
 
 cd ..
 
@@ -55,7 +57,7 @@ RESET_SERVER_PID=$!
 cleanup() {
     echo "Cleaning up test environment..."
     kill "$RESET_SERVER_PID" 2>/dev/null || true
-    cd backend-docker
+    cd backend-docker || exit 0
     docker compose down
     cd ..
 }

--- a/scripts/prebuild.sh
+++ b/scripts/prebuild.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 # fail if any commands fails
 set -e
-# debug log
-set -x
+echo "Prebuild started..."
 
 # Add additional modules to the end of this, seperated by space
 modules=("core" "model" "contact" "forward" "rule_filter" "fcm" "email_recovery" "server_settings" "scribe" "labels")
@@ -10,8 +9,9 @@ modules=("core" "model" "contact" "forward" "rule_filter" "fcm" "email_recovery"
 for mod in "${modules[@]}"; do
     (
         cd "$mod"
-        flutter pub get
-        dart run build_runner build --delete-conflicting-outputs
+        flutter pub get > /dev/null 2>&1
+        dart run build_runner build --delete-conflicting-outputs > /dev/null 2>&1
+        echo "[$mod] Done."
     )
 done
 
@@ -19,16 +19,22 @@ done
 cd cozy
 flutter pub get
 cd ../
+echo "[cozy] Done."
 
 # For the parent module
-flutter pub get
-dart run build_runner build --delete-conflicting-outputs &&
-    dart run intl_generator:extract_to_arb --output-dir=./lib/l10n lib/main/localizations/app_localizations.dart &&
-    dart run intl_generator:generate_from_arb --output-dir=lib/l10n --no-use-deferred-loading lib/main/localizations/app_localizations.dart lib/l10n/intl*.arb
+flutter pub get > /dev/null 2>&1
+dart run build_runner build --delete-conflicting-outputs > /dev/null 2>&1 &&
+    dart run intl_generator:extract_to_arb --output-dir=./lib/l10n lib/main/localizations/app_localizations.dart > /dev/null 2>&1 &&
+    dart run intl_generator:generate_from_arb --output-dir=lib/l10n --no-use-deferred-loading lib/main/localizations/app_localizations.dart lib/l10n/intl*.arb > /dev/null 2>&1
+echo "[root] Done."
 
 # For scribe module localizations
+echo "[scribe/l10n] Starting..."
 (
    cd scribe
-   dart run intl_generator:extract_to_arb --output-dir=./lib/scribe/ai/l10n lib/scribe/ai/localizations/scribe_localizations.dart &&
-      dart run intl_generator:generate_from_arb --output-dir=lib/scribe/ai/l10n --no-use-deferred-loading lib/scribe/ai/localizations/scribe_localizations.dart lib/scribe/ai/l10n/intl*.arb
+   dart run intl_generator:extract_to_arb --output-dir=./lib/scribe/ai/l10n lib/scribe/ai/localizations/scribe_localizations.dart > /dev/null 2>&1 &&
+      dart run intl_generator:generate_from_arb --output-dir=lib/scribe/ai/l10n --no-use-deferred-loading lib/scribe/ai/localizations/scribe_localizations.dart lib/scribe/ai/l10n/intl*.arb > /dev/null 2>&1
 )
+echo "[scribe/l10n] Done."
+
+echo "Prebuild finished."


### PR DESCRIPTION
## Description
- Remove the dependency of Firebase Test Lab
- Use https://github.com/ReactiveCircus/android-emulator-runner
- Reset back-end after every test, ensuring isolation
- Fix some flaky tests (there maybe more)

## Test report
```console
✓ Completed building apk with entrypoint test_bundle.dart (20.1s)
• Executing tests of apk with entrypoint test_bundle.dart on emulator-5554...
✅ Should display and navigate app grid correctly when clicked (/tests/app_grid/app_grid_test.dart) (40s)
✅ Should see save dialog when download all attachments successfully (/tests/attachments/download_all_attachments_test.dart) (35s)
✅ Should see base64 inline image when attachment has no disposition but has cid (/tests/attachments/no_disposition_inline_test.dart) (29s)
✅ Should see yes and mail to attendees buttons and should not see no and maybe buttons when user view calendar event counter email (/tests/calendar/calendar_event_counter_test.dart) (30s)
✅ Should fill subject with reply prefix when user taps mail to attendees button on calendar event email (/tests/calendar/mail_to_attendees_event_email_test.dart) (34s)
✅ Should not see attachment reminder when send email with attachment keyword in signature (/tests/composer/attachment_reminder_test.dart) (39s)
✅ Should see new identity in From field when select new identity and save as draft successfully (/tests/composer/change_identity_in_draft_email_test.dart) (40s)
✅ Should see attachment and inline image when upload success in composer (/tests/composer/composer_upload_attachment_and_inline_image_test.dart) (28s)
✅ Should see HTML content contain enough: Subject, From, To, Cc, Bcc, Reply to (/tests/composer/forward_email_test.dart) (31s)
✅ Should see inline image with cid when reply email with content contain image base64 data (/tests/composer/reply_email_with_content_contain_image_base64_data_test.dart) (44s)
✅ Should all To recipients when reply to own sent email (/tests/composer/reply_to_own_sent_email_test.dart) (40s)
✅ Should save email as template successfully (/tests/composer/save_as_template_test.dart) (38s)
✅ Should not see email address in `Reply-To` field when save draft email without `Reply-To` then open draft email (/tests/composer/save_draft_then_close_composer_and_open_draft_test.dart) (44s)
✅ Should see success toast when send email successfully (/tests/composer/send_email_test.dart) (30s)
✅ Should see email item has important flag icon when send email with mark as important successfully (/tests/composer/send_email_with_mark_as_important_test.dart) (37s)
✅ Should see read receipt dialog when user toggle read receipt and open read receipt email (/tests/composer/send_email_with_read_receipt_enabled_test.dart) (55s)
✅ Should see all recipient fields when expand all recipients in composer (/tests/composer/show_full_recipient_fields_when_expand_all_test.dart) (31s)
✅ Should see message success toast when edit draft email and save draft successfully (/tests/composer/update_draft_email_with_messsage_success_toast_test.dart) (41s)
✅ Should see email in Archive folder when open detailed email and archive email successfully (/tests/email_detailed/archive_email_test.dart) (33s)
✅ Should see normalized inline image when open email with content contain inline image (/tests/email_detailed/deformed_inlined_image_test.dart) (35s)
✅ Should see email in Trash folder when open detailed email and delete email successfully (/tests/email_detailed/delete_email_test.dart) (32s)
✅ Should see toast message success when open detailed email and delete thread successfully (/tests/email_detailed/delete_thread_to_trash_test.dart) (29s)
✅ Should be visible and fully scrollable when opening a long email (/tests/email_detailed/display_and_scroll_email_with_long_content_test.dart) (53s)
✅ Should display full content when opening a short email (/tests/email_detailed/display_email_with_short_content_test.dart) (33s)
✅ Should not display alert dialog when opening an email containing content xss (/tests/email_detailed/display_email_with_xss_content_test.dart) (33s)
✅ Should open new composer with To field has email address when open detailed email and tap `Compose email` butt (/tests/email_detailed/email_address_dialog/compose_email_from_email_address_test.dart) (35s)
✅ Should see Clipboard SnackBar when open detailed email and tap `Copy email address` button in email address inf (/tests/email_detailed/email_address_dialog/copy_email_address_to_clipboard_test.dart) (30s)
✅ Should open new rule filter creator view with condition field has email address when open detailed email and tap (/tests/email_detailed/email_address_dialog/create_rule_with_email_address_test.dart) (29s)
✅ Should see email address info dialog when open detailed email and click email address if sender or recipient (/tests/email_detailed/email_address_dialog/display_email_address_info_dialog_test.dart) (31s)
✅ Should see Clipboard SnackBar when open detailed email and long press email address of sender or rec (/tests/email_detailed/email_address_dialog/long_press_copy_email_address_to_clipboard_test.dart) (31s)
✅ Should auto preview attachment when export attachment successfully (/tests/email_detailed/export_attachment_test.dart) (34s)
✅ The subject line of an email should not be changed when forwarding to an email that has already been forwarded to. (/tests/email_detailed/forward_email_forwarded_when_change_language_test.dart) (140s)
✅ The forward prefix should be displayed correctly when forwarding an email. (/tests/email_detailed/forward_email_when_change_language_test.dart) (141s)
✅ Should see attachment list in email view after forward email successfully (/tests/email_detailed/forwarding_email_lost_attachments_test.dart) (38s)
✅ Should see email in Spam folder when open detailed email and mark as spam email successfully (/tests/email_detailed/mark_as_spam_email_test.dart) (38s)
✅ Should see star and unStar icon when open detailed email and mark as star and unStar email successfully (/tests/email_detailed/mark_as_star_email_test.dart) (34s)
✅ Should see email item has unread icon when open detailed email and select mark as unread email successfully (/tests/email_detailed/mark_as_unread_email_test.dart) (36s)
✅ Should see email in destination folder when open detailed email and move email to destination folder successfully (/tests/email_detailed/move_email_to_folder_test.dart) (39s)
🧪 tests.email_detailed.reply_all_email_test SHOULD see the Subject contain the prefix `Re:`
✅ SHOULD see the Subject contain the prefix `Re:`
AND the To, Cc, Bcc field should display correctly (/tests/email_detailed/reply_all_email_test.dart) (38s)
✅ The subject line of an email should not be changed when replying to an email that has already been replied to. (/tests/email_detailed/reply_email_replied_when_change_language_test.dart) (133s)
✅ The reply prefix should be displayed correctly when replying to an email. (/tests/email_detailed/reply_email_when_change_language_test.dart) (129s)
🧪 tests.email_detailed.reply_email_with_reply_to_test SHOULD see the Subject contain the prefix `Re:`
✅ SHOULD see the Subject contain the prefix `Re:`
AND the To field should contain the email's `Reply-To` address. (/tests/email_detailed/reply_email_with_reply_to_test.dart) (36s)
🧪 tests.email_detailed.reply_email_without_reply_to_test SHOULD see the Subject contain the prefix `Re:`
✅ SHOULD see the Subject contain the prefix `Re:`
AND the To field should contain the email's `From` address. (/tests/email_detailed/reply_email_without_reply_to_test.dart) (36s)
🧪 tests.email_detailed.reply_to_list_email_test SHOULD see the Subject contain the prefix `Re:`
✅ SHOULD see the Subject contain the prefix `Re:`
AND the To field should contain the email's `List-Post` address. (/tests/email_detailed/reply_to_list_email_test.dart) (37s)
✅ Should see inline image when open email with inline image (/tests/email_detailed/view_inline_image_test.dart) (40s)
✅ Should create a new label and add to email when select "Create a new Label" button in add label modal of detailed email view (/tests/labels/create_a_new_tag_from_an_email_test.dart) (32s)
✅ Should show "Create a label" button in Choose Label modal when labels exist, and create a new label successfully (/tests/labels/create_label_from_choose_label_modal_with_existing_labels_test.dart) (32s)
✅ Should create a label from NoLabelYetWidget and show it in the Choose Label modal list (/tests/labels/create_label_from_no_label_yet_widget_test.dart) (30s)
✅ Should show toast success when create new a label successfully (/tests/labels/create_new_a_tag_test.dart) (25s)
✅ Should delete label in label list when delete a label successfully (/tests/labels/delete_a_tag_test.dart) (32s)
✅ Should display empty view when open tag with no email (/tests/labels/display_empty_view_when_open_tag_test.dart) (41s)
✅ Should display folder info when open mail list from tag (/tests/labels/display_folder_info_when_open_mail_from_tag_test.dart) (38s)
✅ Should display NoLabelYetWidget when opening Choose Label modal with no labels (/tests/labels/display_no_label_yet_widget_when_open_choose_label_modal_test.dart) (29s)
✅ Should display view with all email with tag correctly when open label (/tests/labels/display_view_with_all_email_with_tag_test.dart) (43s)
✅ Should update label display name when edit a label successfully (/tests/labels/edit_a_label_test.dart) (31s)
✅ Should remove tag on email subject when clicking on the cross on a tag in the opened mail (/tests/labels/remove_a_label_from_email_test.dart) (34s)
✅ Should see thread view when login with basic auth successfully (/tests/login/login_with_basic_auth_test.dart) (24s)
✅ Should create and hide sub folder successfully (/tests/mailbox/create_and_hide_sub_folder_test.dart) (34s)
✅ Should create personal mailbox successfully (/tests/mailbox/create_personal_folder_test.dart) (28s)
✅ Should create, rename, move and delete mailbox successfully (/tests/mailbox/create_rename_move_and_delete_mailbox_test.dart) (40s)
✅ Should display empty view when no mail favorites (/tests/mailbox/display_empty_view_for_favorite_folder_test.dart) (26s)
✅ Should empty and recover spam successfully (/tests/mailbox/empty_and_recover_spam_test.dart) (39s)
✅ Should empty and recover trash successfully (/tests/mailbox/empty_and_recover_trash_test.dart) (39s)
✅ Should empty view and hide empty trash banner when empty trash successfully (/tests/mailbox/empty_trash_test.dart) (31s)
✅ Should empty and recover spam by long press mailbox successfully (/tests/mailbox/long_press_empty_and_recover_spam_test.dart) (43s)
✅ Should empty and recover trash by long press mailbox successfully (/tests/mailbox/long_press_empty_and_recover_trash_test.dart) (43s)
✅ Should see mailbox unread count update real time (/tests/mailbox/mailbox_count_real_time_update_test.dart) (35s)
✅ Should move email to mailbox successfully (/tests/mailbox/mailbox_move_email_test.dart) (64s)
✅ Should not see unread counter when mark mailbox as read (/tests/mailbox/mark_mailbox_as_read_test.dart) (31s)
✅ Should see selected email mark as read successfully (/tests/mailbox/mark_single_selected_email_as_read_test.dart) (29s)
✅ Should see selected email mark as spam successfully (/tests/mailbox/mark_single_selected_email_as_spam_test.dart) (31s)
✅ Should see selected email mark as star successfully (/tests/mailbox/mark_single_selected_email_as_star_test.dart) (33s)
✅ Should see all Inbox emails in the Templates folder when perform move folder content action successfully (/tests/mailbox/move_folder_content_test.dart) (37s)
✅ Should refresh email list when pull to refresh (/tests/mailbox/pull_to_refresh_test.dart) (29s)
✅ Should see email with expected condition when quick filter email changed (/tests/mailbox/quick_filter_test.dart) (59s)
✅ Should see quota increase when send email successfully (/tests/mailbox/quota_count_test.dart) (28s)
✅ Should see back to top button when scroll list email in mailbox to bottom and not see back to top button when scroll list emai (/tests/mailbox/scroll_list_email_in_mailbox_and_back_to_top_test.dart) (32s)
✅ Should see expected mailbox when searching mailboxes (/tests/mailbox/search_mailbox_inbox_test.dart) (25s)
✅ Should switch and see emails in mailboxes (/tests/mailbox/switch_mailbox_test.dart) (33s)
✅ Should see email in team mailbox INBOX after sending to team mailbox address (/tests/mailbox/team_mailbox_receive_email_test.dart) (35s)
✅ Should see Twake welcome screen when log out successfully (/tests/misc/log_out_test.dart) (29s)
✅ Should see the same email when selecting filter and changing search input text (/tests/search/persist_filter_when_change_search_input_text_test.dart) (29s)
✅ Should see list email displayed by date time `Last 7 days` and sort order `Relevance` when search email successfully (/tests/search/search_email_by_date_time_and_sort_order_relevance_test.dart) (38s)
✅ Should see list email displayed by sort order `Relevance` by default when search email successfully (/tests/search/search_email_with_sort_order_relevance_by_default_test.dart) (28s)
✅ Should see list email displayed by sort order selected when search email successfully (/tests/search/search_email_with_sort_order_test.dart) (71s)
✅ Should display email list correctly when search with tag (/tests/search/search_email_with_tag_test.dart) (37s)
✅ Should see highlighted keyword in search result (/tests/search/search_result_highlights_test.dart) (31s)
✅ Should see email with subject escaped when search email successfully (/tests/search/search_snippets_with_html_escape_test.dart) (27s)
✅ Should see highlighted keyword in search suggestion (/tests/search/search_suggestion_highlights_test.dart) (26s)
✅ Should see identity as default when select identity as default (/tests/setting/identity/select_identity_as_default_test.dart) (36s)
✅ Should see title in Setting change language when successfully selecting another language (/tests/setting/language/change_language_test.dart) (33s)
✅ Should see reply of thread detail (/tests/thread_detail/thread_detail_reply_real_time_update_test.dart) (38s)
✅ Should see thread view updated per web socket message (/tests/web_socket/web_socket_test.dart) (30s)

Test summary:
📝 Total: 93
✅ Successful: 93
❌ Failed: 0
⏩ Skipped: 0
📊 Report: file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/build/app/reports/androidTests/connected/debug/index.html
⏱️  Duration: 1h 9m 5s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Improved integration test stability with stronger UI synchronization, polling/retry logic, and reduced flakiness.
  * Added backend reset capability for cleaner, repeatable test runs.
  * Updated Android emulator test workflow for more reliable local CI execution.

* **API Changes**
  * Converted hideSystemKeyboardMobile() to an asynchronous operation for safer mobile keyboard handling.

* **New Tools**
  * Added a test-side utility for polling conditions to simplify async waits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->