### PR TITLE
TF-4475 Fix mobile misplaced inline when picked

### DIFF
--- a/integration_test/mocks/fake_file_picker.dart
+++ b/integration_test/mocks/fake_file_picker.dart
@@ -1,0 +1,24 @@
+import 'package:file_picker/file_picker.dart';
+
+class FakeFilePicker extends FilePicker {
+  final FilePickerResult _result;
+
+  FakeFilePicker(this._result);
+
+  @override
+  Future<FilePickerResult?> pickFiles({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    // ignore: deprecated_member_use
+    bool allowCompression = false,
+    int compressionQuality = 0,
+    bool allowMultiple = false,
+    bool withData = false,
+    bool withReadStream = false,
+    bool lockParentWindow = false,
+    bool readSequential = false,
+  }) async => _result;
+}

--- a/integration_test/robots/abstract/abstract_composer_robot.dart
+++ b/integration_test/robots/abstract/abstract_composer_robot.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:model/email/prefix_email_address.dart';
 
 abstract class AbstractComposerRobot {
@@ -7,4 +9,7 @@ abstract class AbstractComposerRobot {
   Future<void> addSubject(String subject);
   Future<void> addContent(String content);
   Future<void> send();
+  Future<void> focusEditorAboveReplyBody();
+  Future<void> addInlineAtCursorPosition(File file);
+  Future<void> waitForSignatureToLoad();
 }

--- a/integration_test/robots/mobile/mobile_composer_robot.dart
+++ b/integration_test/robots/mobile/mobile_composer_robot.dart
@@ -1,8 +1,16 @@
+import 'dart:io';
+
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
 import 'package:model/email/prefix_email_address.dart';
 import 'package:patrol/patrol.dart';
+import 'package:tmail_ui_user/features/composer/domain/state/download_image_as_base64_state.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
 
+import '../../mocks/fake_file_picker.dart';
 import '../abstract/abstract_composer_robot.dart';
 import '../composer_robot.dart';
 
@@ -20,4 +28,112 @@ class MobileComposerRobot extends ComposerRobot implements AbstractComposerRobot
 
   @override
   Future<void> send() => sendEmail(ImagePaths());
+
+  /// Places cursor immediately before the `<blockquote>` element via JS,
+  /// simulating a user tap in the composing area above the quoted reply body.
+  @override
+  Future<void> focusEditorAboveReplyBody() async {
+    final controller = Get.find<ComposerController>();
+    await _waitForBlockquote(controller);
+    await controller.htmlEditorApi?.webViewController.evaluateJavascript(
+      source: '''
+        (function() {
+          const editor = document.getElementById('editor');
+          const blockquote = editor.querySelector('blockquote');
+          if (!blockquote) return;
+          const range = document.createRange();
+          range.setStartBefore(blockquote);
+          range.collapse(true);
+          const sel = window.getSelection();
+          sel.removeAllRanges();
+          sel.addRange(range);
+          editor.focus();
+        })();
+      ''',
+    );
+  }
+
+  /// Injects [FakeFilePicker], calls the real [ComposerController.insertImage]
+  /// (which triggers `storeSelectionRange()`), waits for the base64 download,
+  /// then polls the editor HTML until `data:image/` appears (3 retries,
+  /// exponential backoff: 1 s → 2 s). Restores the original picker in `finally`.
+  @override
+  Future<void> addInlineAtCursorPosition(File file) async {
+    final controller = Get.find<ComposerController>();
+    final context = $.tester.element(find.byType(ComposerView));
+    final fakeResult = FilePickerResult([
+      PlatformFile(
+        name: file.path.split('/').last,
+        size: await file.length(),
+        path: file.path,
+      ),
+    ]);
+    final original = FilePicker.platform;
+    try {
+      FilePicker.platform = FakeFilePicker(fakeResult);
+      await controller.insertImage(context, 400.0);
+      await controller.viewState.stream.firstWhere((state) => state.fold(
+        (failure) => failure is DownloadImageAsBase64Failure,
+        (success) => success is DownloadImageAsBase64Success,
+      ));
+    } finally {
+      FilePicker.platform = original;
+    }
+    await _waitForInlineImage(controller);
+  }
+
+  /// Polls the editor HTML until `data:image/` is present.
+  /// Max 3 attempts with exponential backoff: 1 s → 2 s.
+  Future<void> _waitForInlineImage(ComposerController controller) async {
+    const maxAttempts = 3;
+    for (int attempt = 0; attempt < maxAttempts; attempt++) {
+      if (attempt > 0) {
+        await $.pumpAndTrySettle(
+          duration: Duration(milliseconds: 500 * (1 << attempt)),
+        );
+      }
+      final html = await controller.getContentInEditor();
+      if (html.contains('data:image/')) return;
+    }
+  }
+
+  /// Polls the editor DOM until `.tmail-signature` appears.
+  /// Max 3 attempts with exponential backoff: 1 s → 2 s.
+  @override
+  Future<void> waitForSignatureToLoad() async {
+    const maxAttempts = 3;
+    for (int attempt = 0; attempt < maxAttempts; attempt++) {
+      if (attempt > 0) {
+        await $.pumpAndTrySettle(
+          duration: Duration(milliseconds: 500 * (1 << attempt)),
+        );
+      }
+      final ready = await Get.find<ComposerController>()
+          .htmlEditorApi
+          ?.webViewController
+          .evaluateJavascript(
+            source:
+                "document.getElementById('editor')?.querySelector('.tmail-signature') != null",
+          );
+      if (ready == true) return;
+    }
+  }
+
+  /// Polls until `<blockquote>` appears in the editor DOM.
+  /// Max 3 attempts with exponential backoff: 500 ms → 1 s → 2 s.
+  Future<void> _waitForBlockquote(ComposerController controller) async {
+    const maxAttempts = 3;
+    for (int attempt = 0; attempt < maxAttempts; attempt++) {
+      if (attempt > 0) {
+        await $.pumpAndTrySettle(
+          duration: Duration(milliseconds: 500 * (1 << attempt)),
+        );
+      }
+      final ready = await controller.htmlEditorApi?.webViewController
+          .evaluateJavascript(
+            source: "document.getElementById('editor')?.querySelector('blockquote') != null",
+          );
+      if (ready == true) return;
+    }
+  }
 }

--- a/integration_test/scenarios/composer/reply_inline_focused_with_signature_inserts_under_signature_scenario.dart
+++ b/integration_test/scenarios/composer/reply_inline_focused_with_signature_inserts_under_signature_scenario.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:jmap_dart_client/jmap/identities/identity.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../models/provisioning_identity.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class ReplyInlineFocusedWithSignatureInsertsUnderSignatureScenario
+    extends BaseTestScenario {
+  const ReplyInlineFocusedWithSignatureInsertsUnderSignatureScenario(
+      super.$, super.robots);
+
+  @override
+  Future<void> runTestLogic() async {
+    const subject = 'reply inline with signature';
+    const signatureMarker = 'SIGNATURE_MARKER';
+    final threadRobot = ThreadRobot($);
+    final emailRobot = EmailRobot($);
+    final png = await preparingPngWithName('inline-png');
+
+    const email = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    await provisionIdentities([
+      ProvisioningIdentity(
+        identity: Identity(
+          name: 'Test Identity',
+          email: email,
+          htmlSignature: Signature(signatureMarker),
+        ),
+        isDefault: true,
+      ),
+    ]);
+    await provisionEmail([
+      ProvisioningEmail(
+        toEmail: email,
+        subject: subject,
+        content: 'body',
+      ),
+    ], requestReadReceipt: false);
+
+    await threadRobot.openEmailWithSubject(subject);
+    await emailRobot.onTapReplyEmail();
+    await robots.composerRobot().expectComposerViewVisible();
+    await robots.composerRobot().grantContactPermission();
+    await robots.composerRobot().waitForSignatureToLoad();
+    await robots.composerRobot().focusEditorAboveReplyBody();
+    await robots.composerRobot().addInlineAtCursorPosition(png);
+
+    final html = await Get.find<ComposerController>().getContentInEditor();
+    _expectSignatureExists(html);
+    _expectInlineExists(html);
+    _expectBlockquoteExists(html);
+    _expectSignatureAboveInline(html);
+    _expectInlineAboveBlockquote(html);
+  }
+
+  void _expectSignatureExists(String html) {
+    final sigIdx = html.indexOf('SIGNATURE_MARKER');
+    expect(sigIdx, greaterThan(-1));
+  }
+
+  void _expectInlineExists(String html) {
+    final imgIdx = html.indexOf('data:image/');
+    expect(imgIdx, greaterThan(-1));
+  }
+
+  void _expectBlockquoteExists(String html) {
+    final bqIdx = html.indexOf('<blockquote');
+    expect(bqIdx, greaterThan(-1));
+  }
+
+  void _expectSignatureAboveInline(String html) {
+    final sigIdx = html.indexOf('SIGNATURE_MARKER');
+    final imgIdx = html.indexOf('data:image/');
+    expect(sigIdx, lessThan(imgIdx));
+  }
+
+  void _expectInlineAboveBlockquote(String html) {
+    final imgIdx = html.indexOf('data:image/');
+    final bqIdx = html.indexOf('<blockquote');
+    expect(imgIdx, lessThan(bqIdx));
+  }
+}

--- a/integration_test/scenarios/composer/reply_inline_focused_without_signature_inserts_above_reply_body_scenario.dart
+++ b/integration_test/scenarios/composer/reply_inline_focused_without_signature_inserts_above_reply_body_scenario.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class ReplyInlineFocusedWithoutSignatureInsertsAboveReplyBodyScenario
+    extends BaseTestScenario {
+  const ReplyInlineFocusedWithoutSignatureInsertsAboveReplyBodyScenario(
+      super.$, super.robots);
+
+  @override
+  Future<void> runTestLogic() async {
+    const subject = 'reply inline no signature';
+    final threadRobot = ThreadRobot($);
+    final emailRobot = EmailRobot($);
+    final png = await preparingPngWithName('inline-png');
+
+    await provisionEmail([
+      ProvisioningEmail(
+        toEmail: const String.fromEnvironment('BASIC_AUTH_EMAIL'),
+        subject: subject,
+        content: 'body',
+      ),
+    ], requestReadReceipt: false);
+
+    await threadRobot.openEmailWithSubject(subject);
+    await emailRobot.onTapReplyEmail();
+    await robots.composerRobot().expectComposerViewVisible();
+    await robots.composerRobot().grantContactPermission();
+    await robots.composerRobot().focusEditorAboveReplyBody();
+    await robots.composerRobot().addInlineAtCursorPosition(png);
+
+    await _expectInlineAboveBlockquote();
+  }
+
+  Future<void> _expectInlineAboveBlockquote() async {
+    final html = await Get.find<ComposerController>().getContentInEditor();
+    expect(html.indexOf('data:image/'), lessThan(html.indexOf('<blockquote')));
+  }
+}

--- a/integration_test/scenarios/composer/reply_inline_focused_without_signature_inserts_above_reply_body_scenario.dart
+++ b/integration_test/scenarios/composer/reply_inline_focused_without_signature_inserts_above_reply_body_scenario.dart
@@ -39,6 +39,10 @@ class ReplyInlineFocusedWithoutSignatureInsertsAboveReplyBodyScenario
 
   Future<void> _expectInlineAboveBlockquote() async {
     final html = await Get.find<ComposerController>().getContentInEditor();
-    expect(html.indexOf('data:image/'), lessThan(html.indexOf('<blockquote')));
+    final imgIdx = html.indexOf('data:image/');
+    final bqIdx = html.indexOf('<blockquote');
+    expect(imgIdx, greaterThan(-1));
+    expect(bqIdx, greaterThan(-1));
+    expect(imgIdx, lessThan(bqIdx));
   }
 }

--- a/integration_test/scenarios/composer/reply_inline_no_focus_at_first_line_scenario.dart
+++ b/integration_test/scenarios/composer/reply_inline_no_focus_at_first_line_scenario.dart
@@ -37,6 +37,10 @@ class ReplyInlineNoFocusAtFirstLineScenario extends BaseTestScenario {
 
   Future<void> _expectInlineAboveBlockquote() async {
     final html = await Get.find<ComposerController>().getContentInEditor();
-    expect(html.indexOf('data:image/'), lessThan(html.indexOf('<blockquote')));
+    final imgIdx = html.indexOf('data:image/');
+    final bqIdx = html.indexOf('<blockquote');
+    expect(imgIdx, greaterThan(-1));
+    expect(bqIdx, greaterThan(-1));
+    expect(imgIdx, lessThan(bqIdx));
   }
 }

--- a/integration_test/scenarios/composer/reply_inline_no_focus_at_first_line_scenario.dart
+++ b/integration_test/scenarios/composer/reply_inline_no_focus_at_first_line_scenario.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/thread_robot.dart';
+
+class ReplyInlineNoFocusAtFirstLineScenario extends BaseTestScenario {
+  const ReplyInlineNoFocusAtFirstLineScenario(super.$, super.robots);
+
+  @override
+  Future<void> runTestLogic() async {
+    const subject = 'reply inline no focus';
+    final threadRobot = ThreadRobot($);
+    final emailRobot = EmailRobot($);
+    final png = await preparingPngWithName('inline-png');
+
+    await provisionEmail([
+      ProvisioningEmail(
+        toEmail: const String.fromEnvironment('BASIC_AUTH_EMAIL'),
+        subject: subject,
+        content: 'body',
+      ),
+    ], requestReadReceipt: false);
+
+    await threadRobot.openEmailWithSubject(subject);
+    await emailRobot.onTapReplyEmail();
+    await robots.composerRobot().expectComposerViewVisible();
+    await robots.composerRobot().grantContactPermission();
+    // [do NOT focus editor — tests the no-focus code path]
+    await robots.composerRobot().addInlineAtCursorPosition(png);
+
+    await _expectInlineAboveBlockquote();
+  }
+
+  Future<void> _expectInlineAboveBlockquote() async {
+    final html = await Get.find<ComposerController>().getContentInEditor();
+    expect(html.indexOf('data:image/'), lessThan(html.indexOf('<blockquote')));
+  }
+}

--- a/integration_test/tests/composer/reply_inline_focused_with_signature_test.dart
+++ b/integration_test/tests/composer/reply_inline_focused_with_signature_test.dart
@@ -1,0 +1,10 @@
+import '../../base/test_base.dart';
+import '../../scenarios/composer/reply_inline_focused_with_signature_inserts_under_signature_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should insert inline under signature and above reply body when user focused composer with signature',
+    scenarioBuilder: ($, robots) =>
+        ReplyInlineFocusedWithSignatureInsertsUnderSignatureScenario($, robots),
+  );
+}

--- a/integration_test/tests/composer/reply_inline_focused_without_signature_test.dart
+++ b/integration_test/tests/composer/reply_inline_focused_without_signature_test.dart
@@ -1,0 +1,10 @@
+import '../../base/test_base.dart';
+import '../../scenarios/composer/reply_inline_focused_without_signature_inserts_above_reply_body_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should insert inline above reply body when user focused composer without signature',
+    scenarioBuilder: ($, robots) =>
+        ReplyInlineFocusedWithoutSignatureInsertsAboveReplyBodyScenario($, robots),
+  );
+}

--- a/integration_test/tests/composer/reply_inline_no_focus_at_first_line_test.dart
+++ b/integration_test/tests/composer/reply_inline_no_focus_at_first_line_test.dart
@@ -1,0 +1,9 @@
+import '../../base/test_base.dart';
+import '../../scenarios/composer/reply_inline_no_focus_at_first_line_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should insert inline at first line when user never focused composer on reply',
+    scenarioBuilder: ($, robots) => ReplyInlineNoFocusAtFirstLineScenario($, robots),
+  );
+}

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1690,13 +1690,22 @@ class ComposerController extends BaseController
     }
   }
 
-  void insertImage(BuildContext context, double maxWith) {
+  Future<void> insertImage(BuildContext context, double maxWith) async {
+    if (PlatformInfo.isMobile) {
+      try {
+        await htmlEditorApi?.storeSelectionRange();
+      } catch (e) {
+        log('ComposerController::insertImage(): $e');
+      }
+    }
     clearFocus();
 
-    if (responsiveUtils.isMobile(context)) {
-      maxWithEditor = maxWith - 40;
-    } else {
-      maxWithEditor = maxWith - 70;
+    if (context.mounted) {
+      if (responsiveUtils.isMobile(context)) {
+        maxWithEditor = maxWith - 40;
+      } else {
+        maxWithEditor = maxWith - 70;
+      }
     }
 
     consumeState(_localImagePickerInteractor.execute());

--- a/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
+++ b/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
@@ -33,7 +33,7 @@ class RichTextMobileTabletController extends GetxController {
     }
   }
 
-  void insertImage(InlineImage inlineImage) async {
+  Future<void> insertImage(InlineImage inlineImage) async {
     await restoreMobileEditorFocus();
     if (inlineImage.base64Uri?.isNotEmpty == true) {
       await htmlEditorApi?.insertHtml('${inlineImage.base64Uri ?? ''}<br/><br/>');
@@ -51,7 +51,7 @@ class RichTextMobileTabletController extends GetxController {
         await htmlEditorApi?.requestFocusFirstChild();
       }
     } catch (e) {
-      log('RichTextMobileTabletController::insertImage(): $e');
+      log('RichTextMobileTabletController::restoreMobileEditorFocus(): $e');
     }
   }
 

--- a/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
+++ b/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart
@@ -34,13 +34,24 @@ class RichTextMobileTabletController extends GetxController {
   }
 
   void insertImage(InlineImage inlineImage) async {
-    final isFocused = await isEditorFocused;
-    log('RichTextMobileTabletController::insertImage: isEditorFocused = $isFocused');
-    if (!isFocused) {
-      await htmlEditorApi?.requestFocusLastChild();
-    }
+    await restoreMobileEditorFocus();
     if (inlineImage.base64Uri?.isNotEmpty == true) {
       await htmlEditorApi?.insertHtml('${inlineImage.base64Uri ?? ''}<br/><br/>');
+    }
+  }
+
+  Future<void> restoreMobileEditorFocus() async {
+    if (!PlatformInfo.isMobile) return;
+    try {
+      final selectionRangeAvailable =
+          await htmlEditorApi?.isSelectionRangeAvailable();
+      if (selectionRangeAvailable == true) {
+        await htmlEditorApi?.restoreSelectionRange();
+      } else {
+        await htmlEditorApi?.requestFocusFirstChild();
+      }
+    } catch (e) {
+      log('RichTextMobileTabletController::insertImage(): $e');
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -495,11 +495,11 @@ packages:
     source: path
     version: "1.0.0+1"
   enough_html_editor:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       path: "."
-      ref: "hotfix/editor-selection"
-      resolved-ref: "9ebc9d980f994b32a26df3bc37fd0ad0d820d5d8"
+      ref: master
+      resolved-ref: e1302796a79e8689e09de65544f343db2b798dff
       url: "https://github.com/linagora/enough_html_editor.git"
     source: git
     version: "0.1.6"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -495,11 +495,11 @@ packages:
     source: path
     version: "1.0.0+1"
   enough_html_editor:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       path: "."
-      ref: master
-      resolved-ref: "4c997183694961f376a85f56a426eb87a8fd2458"
+      ref: "hotfix/editor-selection"
+      resolved-ref: "9ebc9d980f994b32a26df3bc37fd0ad0d820d5d8"
       url: "https://github.com/linagora/enough_html_editor.git"
     source: git
     version: "0.1.6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -317,12 +317,6 @@ dependency_overrides:
       ref: 18f92b53295e9eb77ebd4830d905a72cd404a126
       path: overrides/hive
 
-  # TODO: Remove when https://github.com/linagora/enough_html_editor/pull/41 is merged
-  enough_html_editor:
-    git:
-      url: https://github.com/linagora/enough_html_editor.git
-      ref: hotfix/editor-selection
-
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -317,6 +317,12 @@ dependency_overrides:
       ref: 18f92b53295e9eb77ebd4830d905a72cd404a126
       path: overrides/hive
 
+  # TODO: Remove when https://github.com/linagora/enough_html_editor/pull/41 is merged
+  enough_html_editor:
+    git:
+      url: https://github.com/linagora/enough_html_editor.git
+      ref: hotfix/editor-selection
+
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 


### PR DESCRIPTION
## Issue
- #4475 
- Additional finding:
```story
When user open composer
And in the composer there is signature
Then user pick an inline image
Then the inline image will always be just above the signature, even when the caret is under the signature
```

## Root cause
When pick inline button is tapped, this method is called:
https://github.com/linagora/tmail-flutter/blob/b0e349029f2d141c36d592b9fe6b45ad8f8e6742/lib/features/composer/presentation/composer_controller.dart#L1693-L1703
The focus is cleared in line `1694`. Then when the image is uploaded and ready to be inserted into the composer, this method is called:
https://github.com/linagora/tmail-flutter/blob/b0e349029f2d141c36d592b9fe6b45ad8f8e6742/lib/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart#L36-L45
Due to the focus is always cleared before inserting the inline, `await htmlEditorApi?.requestFocusLastChild();` is always called. It eventually called this js method:
https://github.com/linagora/enough_html_editor/blob/4c997183694961f376a85f56a426eb87a8fd2458/lib/src/editor.dart#L382-L404
```js
  function requestFocusLastNode() {
    const nodeSignature = document.getElementsByClassName('tmail-signature');
    const editor = document.getElementById('editor');
    const textNode = document.createTextNode('');
    editor.appendChild(textNode);
    editor.focus();
    
    const range = document.createRange();
    const sel = window.getSelection();
    
    var lastChild; 
    if (nodeSignature.length <= 0) {
      lastChild = editor.lastElementChild;
      range.setStartAfter(lastChild);
    } else {
      lastChild = nodeSignature[0];
      range.setStart(lastChild, 0);
    }
    range.collapse(true);

    sel.removeAllRanges();
    sel.addRange(range);
  }
```

This leads to 2 different bugs:
- When the signature is present (`tmail-signature` is available), the caret is placed right before that signature.
- Else, the caret is placed right after the last element (In the case of #4475 , it's the quote)

Then the image tag is inserted at that caret.

## Solution
- `enough_html_editor` already provides 2 methods: `storeSelectionRange` and `restoreSelectionRange`
- Before `clearFocus` is called, call `storeSelectionRange`
- Before `insertHtml` is called, call `restoreSelectionRange` and remove the previous focus check.

## Dependency
- https://github.com/linagora/enough_html_editor/pull/41

## Reproduce
### With signature

https://github.com/user-attachments/assets/91616754-8058-4508-a363-2e410cf49762

### Without signature

https://github.com/user-attachments/assets/96eeb391-59b3-421b-96ce-9ef3060114f8

## Resolved
### With signature

https://github.com/user-attachments/assets/b546a560-12d9-4a88-a1b1-66eb97280afa

### Without signature

https://github.com/user-attachments/assets/5755372d-3491-4380-bf30-8a7331d9dec6

## Integration test report
```console
🧪 tests.composer.reply_inline_no_focus_at_first_line_test Should insert inline at first line when user never f✅ Should insert inline at first line when user never focused composer on reply (/tests/composer/reply_inline_no_focus_at_first_line_test.dart) (17s)
🧪 tests.composer.reply_inline_focused_with_signature_test Should insert inline under signature and above reply✅ Should insert inline under signature and above reply body when user focused composer with signature (/tests/composer/reply_inline_focused_with_signature_test.dart) (19s)
🧪 tests.composer.reply_inline_focused_without_signature_test Should insert inline above reply body when user f✅ Should insert inline above reply body when user focused composer without signature (/tests/composer/reply_inline_focused_without_signature_test.dart) (16s)

Test summary:
📝 Total: 3
✅ Successful: 3
❌ Failed: 0
⏩ Skipped: 0
📊 Report: file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/build/app/reports/androidTests/connected/debug/index.html
⏱️  Duration: 1m 16s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image insertion on mobile: preserves/restores editor selection, restores focus reliably, and prevents UI updates when the composer is unmounted.

* **Tests**
  * Added integration tests, scenarios, and test helpers covering inline image insertion with/without signature and unfocused composer flows; included a fake file picker and robot actions to automate these cases.

* **Chores**
  * Pinned HTML editor dependency to a hotfix revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->