### PR TITLE
TF-4473 Implement Android composer auto-save draft on background

### DIFF
--- a/docs/adr/0086-android-composer-draft-loss-on-background.md
+++ b/docs/adr/0086-android-composer-draft-loss-on-background.md
@@ -95,13 +95,13 @@ The `isCleanClose` flag, persisted alongside the cached content, is the discrimi
 
 #### Layer 1 — Proactive Local Cache at `AppLifecycleState.inactive`
 
-Add an `AppLifecycleListener` to `ComposerController` (mobile only). On `onInactive`, extract the current editor HTML, build a `CreateEmailRequest` from all composer fields (recipients, subject, identity, attachments), then call `SaveComposerCacheOnMobileInteractor` which generates the full `Email` object via `ComposerRepository.generateEmail()` and persists a `ComposerCache` entry to the Hive box (`composerMobileCache`) keyed by `_mobileSessionId`.
+Add an `AppLifecycleListener` to `ComposerController` (**Android only**). On `onInactive`, extract the current editor HTML, build a `CreateEmailRequest` from all composer fields (recipients, subject, identity, attachments), then call `SaveComposerCacheInteractor` (with `isPersistent: true`) which generates the full `Email` object via `ComposerRepository.generateEmail()` and persists a `ComposerPersistentCache` entry to the Hive box (`composer_hive_cache_box`) keyed by `autoSaveComposerId`.
 
-> **`composerId`** is a web-only concept managed by `ComposerManager` to support multiple simultaneous composer instances on desktop browsers. On mobile, `ComposerBindings` is always instantiated without a `composerId` (it is `null`). Therefore, the mobile cache uses a separate **`_mobileSessionId`**: a UUID generated inside `ComposerController.onInit()` on mobile only. Since mobile allows only one composer at a time (full-screen route), a single UUID per session is sufficient as the direct cache key. It is passed to the repository methods at every call site — no computed getter is needed. On mobile, `_mobileSessionId` is stored as the `composerId` field value inside `ComposerCache` (see "Reusing `ComposerCache` for mobile" below).
+> **`autoSaveComposerId`** is the composerId value from the current route arguments. On mobile, `ComposerBindings` receives a timestamp-based UUID generated when the composer route is opened. This UUID is stored as the `composerId` field inside `ComposerPersistentCache` (see "New `ComposerPersistentCache` subclass" below).
 
 This is the primary fix for both RC1 and RC2. It is fast, offline, and does not depend on network connectivity.
 
-**Fallback for `getText()` failure**: a periodic content snapshot (`Timer.periodic(30s)`) runs while the editor is loaded, storing the last known HTML in `_lastKnownContent`. At `inactive`, extraction uses `try/catch` around `getText().timeout(2s)`. On any exception — timeout, renderer crash, or empty result — the fallback is `_lastKnownContent`. This ensures Layer 1 persistence is never silently skipped.
+**Fallback for `getText()` failure**: a periodic content snapshot (`Timer.periodic(30s)`) runs while the editor is loaded, storing the last known HTML in `notifier.lastKnownHtmlContent`. At `inactive`, extraction calls `_fetchEditorContent()` which wraps `getText()` in a `try/catch` with a 2 s timeout. The timeout prevents an indefinite hang if the JS bridge freezes (distinct from a renderer crash, which throws immediately). If the result is `null` (renderer crash or timeout), the fallback is `notifier.lastKnownHtmlContent` from the last periodic tick. The resolved effective content — either fresh or fallback, even if empty — is always passed as `htmlContent` to `buildCreateEmailRequestForAutoSave(htmlContent: effectiveContent)`, so `getText()` is never called a second time inside that method.
 
 **System dialog false positive**: `AppLifecycleState.inactive` is also triggered by system overlays (permission dialogs, incoming calls, notification shade). To avoid unnecessary saves in these cases, the save is preceded by a short guard delay (~300 ms). If the state returns to `active` within that window, the save is cancelled. This prevents both the Layer 1 Hive write and the Layer 2 network call from triggering unnecessarily when the user never actually leaves the app.
 
@@ -121,44 +121,45 @@ This is **fire-and-forget** — failure is reported via `SentryManager.instance.
 
 **Deduplication guard**: a boolean `_isSavingToDraftInProgress` flag on `ComposerController` ensures only one server-side save runs at a time. If `onInactive` fires again (e.g., user rapidly switches apps back and forth) while a save is still in flight, the duplicate trigger is silently skipped. The flag is cleared on completion (success or failure). Note that Layer 1 (Hive write) is also protected by the 300 ms guard described above — the deduplication flag applies only to the Layer 2 network call.
 
-#### Layer 3 — Recovery at `AppLifecycleState.resumed` / `onReady` (RC1)
+#### Layer 3 — Recovery at `AppLifecycleState.resumed` (RC1)
 
-On `ComposerController.onReady()` (mobile only), check whether a non-clean-close cache entry exists for the current `_mobileSessionId`. If found, inject the cached HTML into the editor and restore all composer fields. Delete the cache entry after successful restoration.
+On `AppLifecycleState.resumed`, `_restoreIfEditorBlank()` checks if the editor content is empty (renderer was killed while the app stayed alive). If so, it calls `ResolveComposerCacheForRestoreInteractor` to fetch the newest restorable snapshot and reinjects the cached HTML into the editor via `htmlEditorApi.setText()`. The snapshot is then cleared so the periodic timer can write a fresh one.
 
-On `AppLifecycleState.resumed`, check if the editor is blank (renderer was killed while app stayed alive) and a non-clean cache entry exists. If so, reinject the cached content.
+**Layer 4 → Layer 3 bridge (RC2)**: when `MailboxDashBoardController` re-opens the composer with `EmailActionType.restoreComposerFromPersistentCache`, `setupEmailContent()` routes to `_loadMobileRestoredEmailContent()` which loads the cached HTML directly. No additional `onReady()` check is required in this path — the content is delivered via `ComposerArguments`.
 
-**Cache-cleared edge case**: if Layer 2 succeeded and cleared the local cache before the user returns, Layer 3 `onResumed` will find no cache entry and will not reinject. In this case the draft is safely persisted in the Drafts folder on the server; the user can open it from there. No data is lost.
+**Cache not cleared after Layer 2**: Layer 2 deliberately does NOT clear the Hive cache on server-save success (see Layer 2 note). If the cache happens to be absent when the user returns, Layer 3 `_restoreIfEditorBlank()` finds nothing and leaves the editor as-is. The draft is safely persisted in the Drafts folder; the user can open it from there. No data is lost.
 
 #### Layer 4 — Re-open Composer on App Restart (RC2)
 
 When Android kills the entire app process, `ComposerController` is destroyed along with the route stack. Any recovery logic inside `ComposerController` will never be called because the controller no longer exists.
 
-Recovery for RC2 must happen at a higher level — `MailboxDashBoardController.onReady()` — which always runs when the app restarts. On startup:
+Recovery for RC2 must happen at a higher level — `_handleSessionFromArguments()` inside `MailboxDashBoardController`, which always runs when the session is established on app restart. On startup:
 
-1. `MailboxDashBoardController` reads all valid entries (mobile only) via `appProviderContainer.read(composerAutoSaveProvider.notifier).restoreAll()` (filter: `isCleanClose = false`, age < 24 h). `MailboxDashBoardController` is a GetX controller and follows the same `appProviderContainer.read(...)` pattern as `ComposerController`.
-2. If one or more entries exist, the dashboard MUST select exactly one deterministically — the **newest by `timestampMs`** — and open the composer with that snapshot as `ComposerArguments`. Any older stale entries are cleared immediately.
-3. `ComposerController.onReady()` then proceeds with Layer 3 to inject the content into the editor.
-4. The restored cache entry is cleared after successful injection.
+1. `HandleComposerRestoreOnMobileExtension.checkAndRestoreComposerOnMobile()` calls `appProviderContainer.read(resolveComposerCacheForRestoreProvider).execute(accountId, userName)`. `ResolveComposerCacheForRestoreInteractor` fetches all cached entries, picks the **newest by `timestampMs`** via `newestLocalCache`, discards non-restorable entries, and returns the single best candidate (filter: `isRestorable == true`, age < 24 h).
+2. If a restorable entry is found, the dashboard opens the composer with `ComposerArguments.fromComposerPersistentCache(cache)` which sets `emailActionType = EmailActionType.restoreComposerFromPersistentCache`.
+3. `ComposerController.setupEmailContent()` detects `restoreComposerFromPersistentCache` and calls `_loadMobileRestoredEmailContent()` to inject the cached HTML. Inline images are restored via `_restoreInlineImages()`.
+4. Non-restorable entries (expired or `isCleanClose=true`) are removed as a side-effect of step 1.
 
 ```text
 App process restarted
         │
         ▼
-MailboxDashBoardController.onReady()  [mobile only]
+MailboxDashBoardController._handleSessionFromArguments()  [Android only]
         │
-        ├── appProviderContainer.read(composerAutoSaveProvider.notifier).restoreAll()
-        │                                          ← filter: !cleanClose, age < 24h
+        ├── checkAndRestoreComposerOnMobile()
+        │       └── resolveComposerCacheForRestoreProvider.execute(accountId, userName)
+        │               ← newestLocalCache: pick newest by timestampMs
+        │               ← non-restorable entries removed as side-effect
         │
-        ├── entries found?
-        │       ├── pick newest by timestampMs
-        │       ├── clear remaining stale entries
-        │       └── openComposer(ComposerArguments.fromSnapshot(snapshot))
+        ├── cache found?
+        │       └── openComposer(ComposerArguments.fromComposerPersistentCache(cache))
+        │               emailActionType = restoreComposerFromPersistentCache
         │                           │
         │                           ▼
-        │                   ComposerController.onReady()
-        │                           └── Layer 3: inject content into editor
+        │               ComposerController.setupEmailContent()
+        │                           └── _loadMobileRestoredEmailContent()
         │
-        └── no entries / all clean → normal startup flow
+        └── no restorable entry → normal startup flow
 ```
 
 This mirrors the existing web behaviour where `reopenComposerBrowser` (`EmailActionType`) restores a cached composer on page reload.
@@ -166,156 +167,166 @@ This mirrors the existing web behaviour where `reopenComposerBrowser` (`EmailAct
 ### Architecture
 
 ```text
-ComposerController (GetX)  [mobile only]
+ComposerController (GetX)  [Android only]
     │
     ├── AppLifecycleListener
-    │       ├── onInactive → _onAppInactive()
-    │       └── onResume   → _onAppResumed()
+    │       ├── onInactive → 300ms guard → _saveSnapshotToCache()
+    │       └── onResume   → _restoreIfEditorBlank()
     │
-    ├── _onAppInactive()
-    │       ├── [300ms guard — cancels if state → active]
-    │       ├── try { content = await getText().timeout(2s) }
-    │       │   catch (_) { content = _lastKnownContent }
-    │       ├── await Layer 1: appProviderContainer.read(composerAutoSaveProvider(_saveComposerCacheInteractor).notifier)
-    │       │                       .save(_mobileSessionId, ...)          ← Hive write
-    │       └── fire Layer 2: CreateNewAndSaveEmailToDraftsInteractor     ← unawaited
+    ├── _saveSnapshotToCache()
+    │       ├── freshContent = _fetchEditorContent()  ← getText().timeout(2s)
+    │       ├── effectiveContent = freshContent ?? notifier.lastKnownHtmlContent
+    │       ├── await Layer 1: saveComposerCacheInteractor.execute(
+    │       │                       createEmailRequest: ...(htmlContent: effectiveContent),
+    │       │                       isPersistent: true,
+    │       │                  )                                         ← Hive write
+    │       └── fire Layer 2: CreateNewAndSaveEmailToDraftsInteractor   ← unawaited
     │
-    ├── onReady() [RC1 Scenario A — fresh open after renderer kill]
-    │       └── _checkAndRestoreComposerCache(_mobileSessionId)
+    ├── _restoreIfEditorBlank()  [RC1 — user returns, editor blank]
+    │       └── editor blank + resolveComposerCacheForRestoreProvider returns cache?
+    │               └── htmlEditorApi.setText(cache.email.emailContentList.asHtmlString)
     │
-    ├── _onAppResumed() [RC1 Scenario B — user returns, editor blank]
-    │       └── editor blank + cache entry exists?
-    │               └── _checkAndRestoreComposerCache(_mobileSessionId)
+    ├── _closeComposerAction() [mark clean — Android only]
+    │       ├── markCleanClose()  ← notifier.setCleanClose() + MarkComposerCacheCleanCloseInteractor (unawaited)
+    │       └── closeComposer()   ← navigation (after clean-close is already persisting)
     │
-    ├── _closeComposerAction() [mark clean — mobile only]
-    │       └── appProviderContainer.read(composerAutoSaveProvider(_saveComposerCacheInteractor).notifier)
-    │                   .markCleanClose(_mobileSessionId)
-    │
-    └── onClose() [mobile only]
-            └── appProviderContainer.invalidate(composerAutoSaveProvider(_saveComposerCacheInteractor))
+    └── onClose() [Android only]
+            └── appProviderContainer.invalidate(composerAutoSaveProvider(autoSaveComposerId))
 ```
 
 ```text
 ComposerAutoSaveNotifier (Riverpod StateNotifier)
-    │   [family param: SaveComposerCacheOnMobileInteractor — constructed by ComposerController]
+    │   [family param: String — autoSaveComposerId]
     │
-    ├── save(sessionId, CreateEmailRequest)   → SaveComposerCacheOnMobileInteractor (family param)
-    │                                               └── ComposerRepository (GetX) + ComposerMobileCacheRepository
-    ├── restore(sessionId)                    → GetComposerCacheOnMobileInteractor
-    ├── restoreAll()                          → GetAllComposerCacheOnMobileInteractor  [Layer 4]
-    ├── markCleanClose(sessionId)             → SaveComposerCacheOnMobileInteractor (isCleanClose=true)
-    └── clearById(sessionId)                  → RemoveComposerCacheByIdOnMobileInteractor
+    ├── state fields: hasRecoverableSnapshot, isCleanClose,
+    │                 isSavingToDraftInProgress, lastKnownHtmlContent
+    │
+    ├── onSnapshotSaved()          — sets hasRecoverableSnapshot = true
+    ├── setCleanClose()            — sets isCleanClose = true (Hive write fired immediately in markCleanClose)
+    ├── updateLastKnownContent(s)  — stores periodic snapshot for fallback
+    ├── beginDraftSave() / endDraftSave()  — deduplication guard for Layer 2
+    ├── restore(accountId, userName)  → ResolveComposerCacheForRestoreInteractor
+    └── clearCache(accountId, userName) → RemoveAllComposerCacheInteractor
         │
-        └── Get/GetAll/RemoveById → ComposerMobileCacheRepository (domain interface — NEW)
-                                        └── ComposerMobileCacheRepositoryImpl (data — NEW)
-                                                └── ComposerMobileCacheClient (HiveCacheClient<String> — NEW)
+        └── Restore/Clear → ComposerCacheRepository (existing)
+                                └── ComposerHiveCacheClient (HiveCacheClient<String>, encryption=true)
+                                        └── box: composer_hive_cache_box
 ```
 
-### Reusing `ComposerCache` for mobile
+```text
+Riverpod providers  [composer_cache_providers.dart]
 
-Rather than introducing a new model, the existing `ComposerCache` (in `mailbox_dashboard/data/model/`) is reused for mobile persistence. `ComposerCache` already carries the full `Email` object — generated via `ComposerRepository.generateEmail()` the same way `SaveComposerCacheOnWebInteractor` does — including inline images as base64 attachments, regular attachments, recipients, subject, identity, action type, and draft ID.
+    _composerHiveCacheClientProvider  (private)
+    _composerCacheDatasourceProvider  (private)
+    composerCacheRepositoryProvider   (public)
+    removeAllComposerCacheProvider    (public)
+    markComposerLocalCacheCleanCloseProvider  (public)
+    resolveComposerCacheForRestoreProvider    (public)
 
-Two nullable fields are added to `ComposerCache` for mobile recovery logic:
+    composerAutoSaveProvider = StateNotifierProvider.family<
+        ComposerAutoSaveNotifier, ComposerAutoSaveState, String>
+```
+
+### New `ComposerPersistentCache` subclass
+
+A new subclass `ComposerPersistentCache extends ComposerCache` (in `mailbox_dashboard/data/model/`) is introduced for Android persistence. It extends `ComposerCache` — which already carries the full `Email` object generated via `ComposerRepository.generateEmail()`, including inline images as base64 attachments, regular attachments, recipients, subject, identity, action type, and draft ID — with two new nullable fields:
 
 ```dart
-// New mobile-only fields (null on all web entries — no impact on web serialisation)
 final bool? isCleanClose;   // null/false = involuntary kill → restore; true = deliberate discard → skip
 final int? timestampMs;     // snapshot time (ms); used for Layer 4 deterministic selection
 ```
 
-`@JsonSerializable(includeIfNull: false)` is already on `ComposerCache`, so these fields are omitted from web-generated JSON entirely — zero impact on web.
+`@JsonSerializable(includeIfNull: false)` ensures these fields are omitted from JSON when null, so existing `ComposerCache` entries (web) are unaffected.
 
-`composerId` field (already in `ComposerCache`) is reused as the mobile session key: on mobile, `composerId = _mobileSessionId` (UUID generated in `onInit()`).
+`composerId` (already in `ComposerCache`) is used as the cache key: on mobile, `composerId = autoSaveComposerId` (timestamp-based UUID generated when the composer route is opened).
 
-**Required enum change**: `EmailActionType.reopenComposerMobile` must be added to the existing `EmailActionType` enum (`model/` package). This is the action type used when restoring a cached mobile composer — analogous to the existing `reopenComposerBrowser` for web.
+`ComposerPersistentCache` also provides:
+- `isRestorable` — `true` iff `isCleanClose != true && !isExpired && !isEmpty`
+- `isExpired` — `true` when `timestampMs` is older than 24 hours
+- `newestLocalCache` extension on `Iterable<ComposerCache>` — picks the `ComposerPersistentCache` with the highest `timestampMs`
 
-**Inline images for `reopenComposerMobile`**: `setup_email_attachments_extension.dart` treats `EmailActionType.reopenComposerMobile` identically to `reopenComposerBrowser` — both restore `attachments` and `inlineImages` from `ComposerCache.email`. `SaveComposerCacheOnMobileInteractor` calls `ComposerRepository.generateEmail()` at snapshot time, which embeds inline images as base64 data URIs in the `Email` body and records them in the attachment list. On restore, they are available immediately without any network fetch.
+**Enum change**: `EmailActionType.restoreComposerFromPersistentCache` was added to `EmailActionType` (`model/` package). This is the action type used when restoring a cached Android composer — analogous to `reopenComposerBrowser` for web.
+
+**Inline images for `restoreComposerFromPersistentCache`**: `setup_email_attachments_extension.dart` treats `EmailActionType.restoreComposerFromPersistentCache` identically to `reopenComposerBrowser` — both restore `attachments` and `inlineImages` from `ComposerCache.email`. `SaveComposerCacheInteractor` calls `ComposerRepository.generateEmail()` at snapshot time, which embeds inline images as base64 data URIs in the `Email` body. On restore, they are available immediately without any network fetch.
 
 ### Riverpod pattern
 
-`ComposerAutoSaveNotifier` (Riverpod `StateNotifier`) receives mobile interactors as dependencies, mirroring the web pattern (`SaveComposerCacheOnWebInteractor`, `GetComposerCacheOnWebInteractor`, etc.). Riverpod is chosen to keep the auto-save concern isolated, independently testable, and aligned with the ADR-0075 migration roadmap. `ComposerController` (GetX) is a consumer only, via `appProviderContainer.read(...)`.
+`ComposerAutoSaveNotifier` (Riverpod `StateNotifier`) holds the in-flight auto-save state and delegates restore/clear operations to domain interactors. Riverpod is chosen to keep the auto-save concern isolated, independently testable, and aligned with the ADR-0075 migration roadmap. `ComposerController` (GetX) is a consumer only, via `appProviderContainer.read(...)`.
 
 The dependency chain is managed **purely by Riverpod** via `ref.read()` — no `Get.find<>()` inside any provider.
 
-`SaveComposerCacheOnMobileInteractor` requires `ComposerRepository` (GetX-managed). Rather than leaking `ComposerRepository` into the provider signature (ISP violation — the notifier doesn't use it directly), `ComposerController` constructs `SaveComposerCacheOnMobileInteractor` itself in `onInit()` using its own injected `_composerRepository`, then passes the ready interactor as the `family` parameter. The provider only sees interactors — its natural dependencies.
+`SaveComposerCacheInteractor` (which needs `ComposerRepository`, a GetX-managed dependency) is **not** a Riverpod provider. It is obtained via `Get.find<SaveComposerCacheInteractor>(tag: composerId)` in `ComposerController` and called directly from `HandleMobileAutoSaveExtension._saveSnapshotToCache()`, keeping GetX at the controller boundary (SOLID: ISP, SRP).
 
-**Memory management**: `StateNotifierProvider.family` on a global `appProviderContainer` caches one entry per unique parameter. `ComposerController.onClose()` calls `appProviderContainer.invalidate(...)` to remove the entry when the composer closes. Using `autoDispose + listen` was rejected: maintaining a keep-alive listener from a GetX controller is an anti-pattern that fights the framework and risks accidental early disposal.
+The `composerAutoSaveProvider` family is keyed by `String` (the `autoSaveComposerId`) rather than by the interactor, because the notifier itself does not call save — only the controller extension does. The notifier handles state tracking and restore/clear operations only.
 
-`composerMobileCacheRepositoryProvider` is intentionally public — `ComposerController` reads it to construct `SaveComposerCacheOnMobileInteractor`.
+**Memory management**: `StateNotifierProvider.family` on a global `appProviderContainer` caches one entry per unique parameter. `ComposerController.onClose()` calls `appProviderContainer.invalidate(composerAutoSaveProvider(autoSaveComposerId))` to remove the entry when the composer closes. Using `autoDispose + listen` was rejected: maintaining a keep-alive listener from a GetX controller is an anti-pattern that fights the framework and risks accidental early disposal.
 
 Follows [ADR-0085](./0085-riverpod-state-management-for-local-settings.md): providers are registered on the global `appProviderContainer`.
 
 ```dart
-// All providers co-located in composer_auto_save_notifier.dart — internal providers are private (_)
+// All providers co-located in composer_cache_providers.dart — internal providers are private (_)
 
-final _composerMobileCacheClientProvider = Provider<ComposerMobileCacheClient>(
-  (_) => ComposerMobileCacheClient(),
-);
+final _composerHiveCacheClientProvider =
+    Provider<ComposerHiveCacheClient>((_) => ComposerHiveCacheClient());
 
-// Public: ComposerController reads this to construct SaveComposerCacheOnMobileInteractor.
-final composerMobileCacheRepositoryProvider = Provider<ComposerMobileCacheRepository>(
-  (ref) => ComposerMobileCacheRepositoryImpl(
-    ref.read(_composerMobileCacheClientProvider),
+final _composerCacheDatasourceProvider = Provider<ComposerCacheDatasource>(
+  (ref) => ComposerPersistentCacheDatasourceImpl(
+    ref.read(_composerHiveCacheClientProvider),
+    ref.read(_cacheExceptionThrowerProvider),
   ),
 );
 
-final _getOnMobileProvider = Provider(
-  (ref) => GetComposerCacheOnMobileInteractor(
-    ref.read(composerMobileCacheRepositoryProvider),
-  ),
+final composerCacheRepositoryProvider = Provider<ComposerCacheRepository>(
+  (ref) => ComposerCacheRepositoryImpl(ref.read(_composerCacheDatasourceProvider)),
 );
 
-final _getAllOnMobileProvider = Provider(
-  (ref) => GetAllComposerCacheOnMobileInteractor(
-    ref.read(composerMobileCacheRepositoryProvider),
-  ),
+final removeAllComposerCacheProvider = Provider<RemoveAllComposerCacheInteractor>(
+  (ref) => RemoveAllComposerCacheInteractor(ref.read(composerCacheRepositoryProvider)),
 );
 
-final _removeByIdOnMobileProvider = Provider(
-  (ref) => RemoveComposerCacheByIdOnMobileInteractor(
-    ref.read(composerMobileCacheRepositoryProvider),
-  ),
+final markComposerLocalCacheCleanCloseProvider = Provider<MarkComposerCacheCleanCloseInteractor>(
+  (ref) => MarkComposerCacheCleanCloseInteractor(ref.read(composerCacheRepositoryProvider)),
 );
 
-// SaveComposerCacheOnMobileInteractor is NOT wired inside this file — it needs
-// ComposerRepository (GetX-managed). ComposerController constructs it and passes it as
-// the family parameter, keeping GetX at the controller boundary (SOLID: ISP, SRP).
+final resolveComposerCacheForRestoreProvider = Provider<ResolveComposerCacheForRestoreInteractor>(
+  (ref) => ResolveComposerCacheForRestoreInteractor(ref.read(composerCacheRepositoryProvider)),
+);
+
+// Keyed by String (autoSaveComposerId). The notifier handles restore/clear; save is
+// called directly by HandleMobileAutoSaveExtension via saveComposerCacheInteractor.
 final composerAutoSaveProvider = StateNotifierProvider
-    .family<ComposerAutoSaveNotifier, ComposerAutoSaveState, SaveComposerCacheOnMobileInteractor>(
-  (ref, saveInteractor) => ComposerAutoSaveNotifier(
-    saveInteractor,
-    ref.read(_getOnMobileProvider),
-    ref.read(_getAllOnMobileProvider),
-    ref.read(_removeByIdOnMobileProvider),
+    .family<ComposerAutoSaveNotifier, ComposerAutoSaveState, String>(
+  (ref, composerId) => ComposerAutoSaveNotifier(
+    ref.read(resolveComposerCacheForRestoreProvider),
+    ref.read(removeAllComposerCacheProvider),
   ),
 );
 ```
 
-`ComposerController` (mobile only):
+`ComposerController` (Android only):
 
 ```dart
-// onInit() — construct interactor using own GetX-injected repository
-_saveComposerCacheInteractor = SaveComposerCacheOnMobileInteractor(
-  appProviderContainer.read(composerMobileCacheRepositoryProvider),
-  _composerRepository,  // injected via ComposerBindings
+// _saveSnapshotToCache — calls save interactor directly (not through the notifier)
+final createEmailRequest = await buildCreateEmailRequestForAutoSave(
+  htmlContent: effectiveContent,  // always pass; never null to avoid a second getText() call
 );
-
-// usage
-appProviderContainer
-    .read(composerAutoSaveProvider(_saveComposerCacheInteractor).notifier)
-    .save(_mobileSessionId, ...);
+await saveComposerCacheInteractor.execute(
+  createEmailRequest: createEmailRequest,
+  isPersistent: true,
+);
+notifier.onSnapshotSaved();
 
 // onClose() — invalidate family entry to prevent memory leak on appProviderContainer
-appProviderContainer.invalidate(composerAutoSaveProvider(_saveComposerCacheInteractor));
+appProviderContainer.invalidate(composerAutoSaveProvider(autoSaveComposerId));
 ```
 
 ### Cache eviction
 
 - Entries older than 24 hours are ignored on restore (treated as expired).
 - Entries are deleted after successful restoration or after `markCleanClose`.
-- On successful server-side draft save (Layer 2), the local cache entry is also cleared.
+- On successful server-side draft save (Layer 2), the local cache entry is **not** cleared. Clearing on success introduces a race condition: the periodic 30 s timer may have written a newer snapshot while the JMAP call was in flight on a slow network, and clearing would discard it. Cleanup is handled exclusively by `markCleanClose` (intentional close) and the 24 h TTL.
 - If the close is **not** a clean close (system kill, swipe from Recents, or any scenario where `isCleanClose` is not explicitly set to `true`), the entry remains in cache indefinitely until it is either restored by Layer 3/4, replaced by a newer snapshot, or expires after 24 hours. This is intentional: every involuntary kill must result in a restore attempt.
-- `composerMobileCache` MUST use encrypted Hive storage (AES-256 cipher) with keys provided by `HiveCacheConfig`. Plaintext storage is not permitted for draft body content. The AES key is generated once by `HiveCacheConfig.initializeEncryptionKey()` on first launch and stored in device secure storage via `EncryptionKeyCacheManager` (backed by `flutter_secure_storage`). There is no scheduled key rotation — the key is stable for the lifetime of the app installation. If the key is missing after a backup/restore (Android backup does not include `flutter_secure_storage` data by default), the Hive box will fail to open; in that case the cache is treated as empty and the user must re-compose.
+- `composer_hive_cache_box` MUST use encrypted Hive storage (AES-256 cipher) with keys provided by `HiveCacheConfig`. Plaintext storage is not permitted for draft body content. The AES key is generated once by `HiveCacheConfig.initializeEncryptionKey()` on first launch and stored in device secure storage via `EncryptionKeyCacheManager` (backed by `flutter_secure_storage`). There is no scheduled key rotation — the key is stable for the lifetime of the app installation. If the key is missing after a backup/restore (Android backup does not include `flutter_secure_storage` data by default), the Hive box will fail to open; in that case the cache is treated as empty and the user must re-compose.
 
 ### What is NOT in scope
 
@@ -331,7 +342,7 @@ appProviderContainer.invalidate(composerAutoSaveProvider(_saveComposerCacheInter
 ### Positive
 
 - Draft content is preserved across Android background kills (both renderer-only and full process), without any user action required. On full process kill (RC2), the composer is automatically re-opened on next app launch.
-- Although the root cause (RC1 — WebView renderer kill) is Android-specific, Layers 1–4 run on iOS as well. iOS users benefit from the same protection if the app is terminated in the background, even though the WKWebView renderer is less aggressively killed on iOS than Android.
+- Layers 1–4 are **Android-only**. iOS has a less aggressive memory management policy (WKWebView renderer is not independently killable by the OS), so the feature is intentionally scoped to Android to limit complexity.
 - The fix is additive — no existing save/close/send logic is changed in behaviour.
 - Follows the established Riverpod coexistence pattern (ADR-0085) for the new state logic.
 - Layer 2 (silent server save) gives users a fallback in Drafts even if local cache is unavailable.
@@ -340,7 +351,7 @@ appProviderContainer.invalidate(composerAutoSaveProvider(_saveComposerCacheInter
 
 ### Negative
 
-- Two `AppLifecycleListener` instances will exist on mobile per open composer (one already exists in `WebSocketController`). This is acceptable; each is scoped to its owning controller's lifecycle.
+- Two `AppLifecycleListener` instances will exist on **Android** per open composer (one already exists in `WebSocketController`). This is acceptable; each is scoped to its owning controller's lifecycle.
 - The periodic snapshot timer (30 s) adds a minor recurring async cost while the composer is open. This is negligible compared to the existing WebView overhead.
 - The `isCleanClose` write path must be added to **all** explicit-discard code paths. Missing one would cause a phantom restore. This must be enforced via code review and covered by unit tests.
 - `enough_html_editor`'s `onRenderProcessGone` gap remains unaddressed. If the renderer is killed between the `inactive` snapshot and the user returning (rare), the snapshot may be stale by a few seconds.

--- a/lib/features/caching/clients/composer_hive_cache_client.dart
+++ b/lib/features/caching/clients/composer_hive_cache_client.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+
+import 'package:core/core.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:model/extensions/account_id_extensions.dart';
+import 'package:tmail_ui_user/features/caching/config/hive_cache_client.dart';
+import 'package:tmail_ui_user/features/caching/utils/cache_utils.dart';
+import 'package:tmail_ui_user/features/caching/utils/caching_constants.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+
+class ComposerHiveCacheClient extends HiveCacheClient<String> {
+  @override
+  String get tableName => CachingConstants.composerHiveCacheBoxName;
+
+  @override
+  bool get encryption => true;
+
+  String _entryKey(AccountId accountId, UserName userName, String? composerId) =>
+      TupleKey(
+        composerId ?? CachingConstants.composerHiveCacheKeyName,
+        accountId.asString,
+        userName.value,
+      ).encodeKey;
+
+  String _accountKey(AccountId accountId, UserName userName) =>
+      TupleKey(accountId.asString, userName.value).encodeKey;
+
+  ComposerPersistentCache? _decodeEntry(String raw) {
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is Map<String, dynamic>) {
+        return ComposerPersistentCache.fromJson(decoded);
+      }
+    } catch (e) {
+      logWarning('ComposerHiveCacheClient::_decodeEntry: corrupted entry, skipping: $e');
+    }
+    return null;
+  }
+
+  Future<void> saveCache(
+    AccountId accountId,
+    UserName userName,
+    ComposerCache cache,
+  ) =>
+      insertItem(
+        _entryKey(accountId, userName, cache.composerId),
+        jsonEncode(cache.toJson()),
+      );
+
+  Future<List<ComposerCache>> getCache(
+    AccountId accountId,
+    UserName userName,
+  ) async {
+    final rawList = await getListByNestedKey(_accountKey(accountId, userName));
+    return rawList.map(_decodeEntry).nonNulls.toList();
+  }
+
+  Future<void> deleteCache(AccountId accountId, UserName userName) =>
+      clearAllDataContainKey(_accountKey(accountId, userName));
+
+  Future<void> deleteCacheById(
+    AccountId accountId,
+    UserName userName,
+    String composerId,
+  ) =>
+      deleteItem(_entryKey(accountId, userName, composerId));
+}

--- a/lib/features/caching/utils/caching_constants.dart
+++ b/lib/features/caching/utils/caching_constants.dart
@@ -32,10 +32,12 @@ class CachingConstants {
   static const String oidcConfigurationCacheBoxName = 'oidc_configuration_cache_box';
   static const String sentryConfigurationCacheBoxName = 'sentry_configuration_cache_box';
   static const String sentryUserCacheBoxName = 'sentry_user_cache_box';
+  static const String composerHiveCacheBoxName = 'composer_hive_cache_box';
 
   static const String oidcConfigurationCacheKeyName = 'oidc_configuration_cache_key';
   static const String sentryConfigurationCacheKeyName = 'sentry_configuration_cache_key';
   static const String sentryUserCacheKeyName = 'sentry_user_cache_key';
+  static const String composerHiveCacheKeyName = 'composer_hive_cache_key';
 
   static const String newEmailsContentFolderName = 'new_emails';
   static const String openedEmailContentFolderName = 'opened_email';

--- a/lib/features/composer/data/adapter/html_email_transformer_adapter.dart
+++ b/lib/features/composer/data/adapter/html_email_transformer_adapter.dart
@@ -1,0 +1,22 @@
+import 'package:core/presentation/utils/html_transformer/html_transform.dart';
+import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
+import 'package:tmail_ui_user/features/composer/domain/transformer/html_email_transformer.dart';
+
+class HtmlEmailTransformerAdapter implements HtmlEmailTransformer {
+  final HtmlTransform _htmlTransform;
+
+  HtmlEmailTransformerAdapter(this._htmlTransform);
+
+  @override
+  Future<String> transformToHtml({
+    required String htmlContent,
+    required TransformConfiguration transformConfiguration,
+    Map<String, String>? mapCidImageDownloadUrl,
+  }) {
+    return _htmlTransform.transformToHtml(
+      htmlContent: htmlContent,
+      transformConfiguration: transformConfiguration,
+      mapCidImageDownloadUrl: mapCidImageDownloadUrl,
+    );
+  }
+}

--- a/lib/features/composer/domain/transformer/html_email_transformer.dart
+++ b/lib/features/composer/domain/transformer/html_email_transformer.dart
@@ -1,0 +1,9 @@
+import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
+
+abstract class HtmlEmailTransformer {
+  Future<String> transformToHtml({
+    required String htmlContent,
+    required TransformConfiguration transformConfiguration,
+    Map<String, String>? mapCidImageDownloadUrl,
+  });
+}

--- a/lib/features/composer/domain/usecases/restore_email_inline_images_interactor.dart
+++ b/lib/features/composer/domain/usecases/restore_email_inline_images_interactor.dart
@@ -3,25 +3,26 @@ import 'package:core/presentation/state/success.dart';
 import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:dartz/dartz.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/restore_email_inline_images_state.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
+import 'package:tmail_ui_user/features/composer/domain/transformer/html_email_transformer.dart';
 
 class RestoreEmailInlineImagesInteractor {
-  RestoreEmailInlineImagesInteractor(this._composerCacheRepository);
+  final HtmlEmailTransformer _htmlEmailTransformer;
 
-  final ComposerCacheRepository _composerCacheRepository;
+  RestoreEmailInlineImagesInteractor(this._htmlEmailTransformer);
 
   Stream<Either<Failure, Success>> execute({
     required String htmlContent,
     required TransformConfiguration transformConfiguration,
-    required Map<String, String> mapUrlDownloadCID
+    required Map<String, String> mapUrlDownloadCID,
   }) async* {
     try {
       yield Right(RestoringEmailInlineImages());
-      
-      final emailContent = await _composerCacheRepository.restoreEmailInlineImages(
-        htmlContent,
-        transformConfiguration,
-        mapUrlDownloadCID);
+
+      final emailContent = await _htmlEmailTransformer.transformToHtml(
+        htmlContent: htmlContent,
+        transformConfiguration: transformConfiguration,
+        mapCidImageDownloadUrl: mapUrlDownloadCID,
+      );
       yield Right(RestoreEmailInlineImagesSuccess(emailContent));
     } catch (exception) {
       yield Left(RestoreEmailInlineImagesFailure(exception: exception));

--- a/lib/features/composer/domain/usecases/save_composer_cache_interactor.dart
+++ b/lib/features/composer/domain/usecases/save_composer_cache_interactor.dart
@@ -18,6 +18,7 @@ class SaveComposerCacheInteractor {
 
   Future<Either<Failure, Success>> execute({
     required CreateEmailRequest createEmailRequest,
+    bool isPersistent = false,
   }) async {
     try {
       final emailCreated = await _composerRepository.generateEmail(
@@ -29,6 +30,7 @@ class SaveComposerCacheInteractor {
       final userName = createEmailRequest.session.username;
       final composerCache = createEmailRequest.generateComposerCache(
         emailCreated: emailCreated,
+        isPersistent: isPersistent,
       );
       await _composerCacheRepository.saveComposerCache(
         accountId,

--- a/lib/features/composer/presentation/composer_bindings.dart
+++ b/lib/features/composer/presentation/composer_bindings.dart
@@ -84,7 +84,6 @@ abstract class ComposerBindings extends BaseBindings {
       : _composerId = composerId;
 
   factory ComposerBindings({String? composerId, ComposerArguments? composerArguments}) {
-    log('>> dab >> ComposerBindings >> factory ${PlatformInfo.isWeb}');
     if (PlatformInfo.isWeb) {
       return WebComposerBindings(composerId: composerId, composerArguments: composerArguments);
     }

--- a/lib/features/composer/presentation/composer_bindings.dart
+++ b/lib/features/composer/presentation/composer_bindings.dart
@@ -52,7 +52,6 @@ import 'package:tmail_ui_user/features/mailbox/data/network/mailbox_isolate_work
 import 'package:tmail_ui_user/features/mailbox/data/repository/mailbox_repository_impl.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/repository/mailbox_repository.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_session_cache_datasource_impl.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/repository/composer_cache_repository_impl.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/remove_composer_cache_by_id_interactor.dart';
@@ -100,8 +99,11 @@ abstract class ComposerBindings extends BaseBindings {
   /// composerId for the controller's auto-save feature.
   /// Falls back to route arguments on the phone path so the controller
   /// always receives a composerId for Riverpod provider keying.
-  String? get _autoSaveComposerId =>
-      _composerId ?? (Get.arguments as ComposerArguments?)?.composerId;
+  String? get _autoSaveComposerId {
+    if (_composerId != null) return _composerId;
+    final args = Get.arguments;
+    return args is ComposerArguments ? args.composerId : null;
+  }
 
   void bindPlatformCacheDatasourceImpl();
   void bindPlatformComposerCacheDatasource();
@@ -385,7 +387,6 @@ abstract class ComposerBindings extends BaseBindings {
     Get.delete<EmailHiveCacheDataSourceImpl>(tag: composerId);
     Get.delete<EmailLocalStorageDataSourceImpl>(tag: composerId);
     Get.delete<EmailSessionStorageDatasourceImpl>(tag: composerId);
-    Get.delete<ComposerSessionCacheDatasourceImpl>(tag: composerId);
     disposePlatformCacheImpl();
 
     Get.delete<AttachmentUploadDataSource>(tag: composerId);
@@ -396,22 +397,16 @@ abstract class ComposerBindings extends BaseBindings {
     Get.delete<HtmlDataSource>(tag: composerId);
     Get.delete<StateDataSource>(tag: composerId);
     Get.delete<PrintFileDataSource>(tag: composerId);
-    if (composerId != null) {
-      Get.delete<ComposerCacheDatasource>(tag: composerId);
-    }
+    Get.delete<ComposerCacheDatasource>(tag: composerId);
 
     Get.delete<ComposerRepositoryImpl>(tag: composerId);
-    if (composerId != null) {
-      Get.delete<ComposerCacheRepositoryImpl>(tag: composerId);
-    }
+    Get.delete<ComposerCacheRepositoryImpl>(tag: composerId);
     Get.delete<ContactRepositoryImpl>(tag: composerId);
     Get.delete<MailboxRepositoryImpl>(tag: composerId);
     Get.delete<EmailRepositoryImpl>(tag: composerId);
 
     Get.delete<ComposerRepository>(tag: composerId);
-    if (composerId != null) {
-      Get.delete<ComposerCacheRepository>(tag: composerId);
-    }
+    Get.delete<ComposerCacheRepository>(tag: composerId);
     Get.delete<ContactRepository>(tag: composerId);
     Get.delete<MailboxRepository>(tag: composerId);
     Get.delete<EmailRepository>(tag: composerId);
@@ -420,9 +415,7 @@ abstract class ComposerBindings extends BaseBindings {
     Get.delete<LocalImagePickerInteractor>(tag: composerId);
     Get.delete<UploadAttachmentInteractor>(tag: composerId);
     Get.delete<GetEmailContentInteractor>(tag: composerId);
-    if (composerId != null) {
-      Get.delete<RemoveComposerCacheByIdInteractor>(tag: composerId);
-    }
+    Get.delete<RemoveComposerCacheByIdInteractor>(tag: composerId);
     Get.delete<SaveComposerCacheInteractor>(tag: composerId);
     Get.delete<DownloadImageAsBase64Interactor>(tag: composerId);
     Get.delete<TransformHtmlEmailContentInteractor>(tag: composerId);

--- a/lib/features/composer/presentation/composer_bindings.dart
+++ b/lib/features/composer/presentation/composer_bindings.dart
@@ -18,8 +18,8 @@ import 'package:tmail_ui_user/features/composer/domain/usecases/restore_email_in
 import 'package:tmail_ui_user/features/composer/domain/usecases/save_composer_cache_interactor.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/upload_attachment_interactor.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
-import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart';
-import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_web_controller.dart';
+import 'package:tmail_ui_user/features/composer/presentation/mobile_composer_bindings.dart';
+import 'package:tmail_ui_user/features/composer/presentation/web_composer_bindings.dart';
 import 'package:tmail_ui_user/features/email/data/datasource/email_datasource.dart';
 import 'package:tmail_ui_user/features/email/data/datasource/html_datasource.dart';
 import 'package:tmail_ui_user/features/email/data/datasource/print_file_datasource.dart';
@@ -51,8 +51,6 @@ import 'package:tmail_ui_user/features/mailbox/data/repository/mailbox_repositor
 import 'package:tmail_ui_user/features/mailbox/domain/repository/mailbox_repository.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_session_cache_datasource_impl.dart';
-import 'package:tmail_ui_user/features/caching/clients/composer_hive_cache_client.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_persistent_cache_datasource_impl.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/repository/composer_cache_repository_impl.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/remove_composer_cache_by_id_interactor.dart';
@@ -77,19 +75,38 @@ import 'package:tmail_ui_user/main/exceptions/thrower/remote_exception_thrower.d
 import 'package:tmail_ui_user/main/utils/ios_sharing_manager.dart';
 import 'package:uuid/uuid.dart';
 
-class ComposerBindings extends BaseBindings {
+abstract class ComposerBindings extends BaseBindings {
 
   final String? _composerId;
   final ComposerArguments? composerArguments;
 
-  ComposerBindings({String? composerId, this.composerArguments})
+  ComposerBindings.base({String? composerId, this.composerArguments})
       : _composerId = composerId;
 
-  /// Returns the composerId passed at construction time, or falls back to the
-  /// one embedded in the route arguments (phone path where AppPages creates
-  /// ComposerBindings() without a composerId).
-  String? get composerId =>
+  factory ComposerBindings({String? composerId, ComposerArguments? composerArguments}) {
+    log('>> dab >> ComposerBindings >> factory ${PlatformInfo.isWeb}');
+    if (PlatformInfo.isWeb) {
+      return WebComposerBindings(composerId: composerId, composerArguments: composerArguments);
+    }
+    return MobileComposerBindings(composerId: composerId, composerArguments: composerArguments);
+  }
+
+  /// GetX registration tag. Null on the phone path (ComposerBindings() in
+  /// app_pages.dart has no explicit composerId), matching ComposerView's
+  /// GetWidget<ComposerController> default tag of null.
+  String? get composerId => _composerId;
+
+  /// composerId for the controller's auto-save feature.
+  /// Falls back to route arguments on the phone path so the controller
+  /// always receives a composerId for Riverpod provider keying.
+  String? get _autoSaveComposerId =>
       _composerId ?? (Get.arguments as ComposerArguments?)?.composerId;
+
+  void bindPlatformCacheDatasourceImpl();
+  void bindPlatformComposerCacheDatasource();
+  void bindPlatformRichTextController();
+  void disposePlatformRichTextController();
+  void disposePlatformCacheImpl();
 
   @override
   void bindingsDataSourceImpl() {
@@ -153,21 +170,7 @@ class ComposerBindings extends BaseBindings {
       Get.find<SessionStorageManager>(),
       Get.find<CacheExceptionThrower>(),
     ), tag: composerId);
-    _bindComposerCacheDatasourceImpl();
-  }
-
-  void _bindComposerCacheDatasourceImpl() {
-    Get.lazyPut(() => ComposerSessionCacheDatasourceImpl(
-      Get.find<HtmlTransform>(),
-      Get.find<CacheExceptionThrower>(),
-    ), tag: composerId);
-    if (PlatformInfo.isMobile) {
-      Get.lazyPut(() => ComposerHiveCacheClient(), tag: composerId);
-      Get.lazyPut(() => ComposerPersistentCacheDatasourceImpl(
-        Get.find<ComposerHiveCacheClient>(tag: composerId),
-        Get.find<CacheExceptionThrower>(),
-      ), tag: composerId);
-    }
+    bindPlatformCacheDatasourceImpl();
   }
 
   @override
@@ -204,17 +207,7 @@ class ComposerBindings extends BaseBindings {
       () => Get.find<PrintFileDataSourceImpl>(tag: composerId),
       tag: composerId,
     );
-    if (PlatformInfo.isMobile) {
-      Get.lazyPut<ComposerCacheDatasource>(
-        () => Get.find<ComposerPersistentCacheDatasourceImpl>(tag: composerId),
-        tag: composerId,
-      );
-    } else {
-      Get.lazyPut<ComposerCacheDatasource>(
-        () => Get.find<ComposerSessionCacheDatasourceImpl>(tag: composerId),
-        tag: composerId,
-      );
-    }
+    bindPlatformComposerCacheDatasource();
   }
 
   @override
@@ -339,11 +332,7 @@ class ComposerBindings extends BaseBindings {
 
   @override
   void bindingsController() {
-    if (PlatformInfo.isWeb) {
-      Get.lazyPut(() => RichTextWebController(), tag: composerId);
-    } else {
-      Get.lazyPut(() => RichTextMobileTabletController(), tag: composerId);
-    }
+    bindPlatformRichTextController();
     Get.lazyPut(
       () => UploadController(Get.find<UploadAttachmentInteractor>(tag: composerId)),
       tag: composerId,
@@ -365,16 +354,13 @@ class ComposerBindings extends BaseBindings {
       Get.find<ComposerRepository>(tag: composerId),
       Get.find<SaveTemplateEmailInteractor>(tag: composerId),
       composerId: composerId,
+      autoSaveComposerId: _autoSaveComposerId,
       composerArgs: composerArguments,
     ), tag: composerId);
   }
 
   void dispose() {
-    if (PlatformInfo.isWeb) {
-      Get.delete<RichTextWebController>(tag: composerId);
-    } else {
-      Get.delete<RichTextMobileTabletController>(tag: composerId);
-    }
+    disposePlatformRichTextController();
     Get.delete<UploadController>(tag: composerId);
     Get.delete<ComposerController>(tag: composerId);
 
@@ -391,10 +377,7 @@ class ComposerBindings extends BaseBindings {
     Get.delete<EmailLocalStorageDataSourceImpl>(tag: composerId);
     Get.delete<EmailSessionStorageDatasourceImpl>(tag: composerId);
     Get.delete<ComposerSessionCacheDatasourceImpl>(tag: composerId);
-    if (PlatformInfo.isMobile) {
-      Get.delete<ComposerHiveCacheClient>(tag: composerId);
-      Get.delete<ComposerPersistentCacheDatasourceImpl>(tag: composerId);
-    }
+    disposePlatformCacheImpl();
 
     Get.delete<AttachmentUploadDataSource>(tag: composerId);
     Get.delete<ComposerDataSource>(tag: composerId);

--- a/lib/features/composer/presentation/composer_bindings.dart
+++ b/lib/features/composer/presentation/composer_bindings.dart
@@ -7,10 +7,12 @@ import 'package:tmail_ui_user/features/composer/data/datasource/composer_datasou
 import 'package:tmail_ui_user/features/composer/data/datasource/contact_datasource.dart';
 import 'package:tmail_ui_user/features/composer/data/datasource_impl/composer_datasource_impl.dart';
 import 'package:tmail_ui_user/features/composer/data/datasource_impl/contact_datasource_impl.dart';
+import 'package:tmail_ui_user/features/composer/data/adapter/html_email_transformer_adapter.dart';
 import 'package:tmail_ui_user/features/composer/data/repository/composer_repository_impl.dart';
 import 'package:tmail_ui_user/features/composer/data/repository/contact_repository_impl.dart';
 import 'package:tmail_ui_user/features/composer/domain/repository/composer_repository.dart';
 import 'package:tmail_ui_user/features/composer/domain/repository/contact_repository.dart';
+import 'package:tmail_ui_user/features/composer/domain/transformer/html_email_transformer.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/create_new_and_save_email_to_drafts_interactor.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/create_new_and_send_email_interactor.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/download_image_as_base64_interactor.dart';
@@ -312,7 +314,15 @@ abstract class ComposerBindings extends BaseBindings {
       Get.find<ComposerRepository>(tag: composerId),
     ), tag: composerId);
     Get.lazyPut(
-      () => RestoreEmailInlineImagesInteractor(Get.find<ComposerCacheRepository>(tag: composerId)),
+      () => HtmlEmailTransformerAdapter(Get.find<HtmlTransform>()),
+      tag: composerId,
+    );
+    Get.lazyPut<HtmlEmailTransformer>(
+      () => Get.find<HtmlEmailTransformerAdapter>(tag: composerId),
+      tag: composerId,
+    );
+    Get.lazyPut(
+      () => RestoreEmailInlineImagesInteractor(Get.find<HtmlEmailTransformer>(tag: composerId)),
       tag: composerId,
     );
     Get.lazyPut(
@@ -411,6 +421,8 @@ abstract class ComposerBindings extends BaseBindings {
     Get.delete<CreateNewAndSendEmailInteractor>(tag: composerId);
     Get.delete<CreateNewAndSaveEmailToDraftsInteractor>(tag: composerId);
     Get.delete<RestoreEmailInlineImagesInteractor>(tag: composerId);
+    Get.delete<HtmlEmailTransformer>(tag: composerId);
+    Get.delete<HtmlEmailTransformerAdapter>(tag: composerId);
     Get.delete<PrintEmailInteractor>(tag: composerId);
     Get.delete<SaveTemplateEmailInteractor>(tag: composerId);
 

--- a/lib/features/composer/presentation/composer_bindings.dart
+++ b/lib/features/composer/presentation/composer_bindings.dart
@@ -396,16 +396,22 @@ abstract class ComposerBindings extends BaseBindings {
     Get.delete<HtmlDataSource>(tag: composerId);
     Get.delete<StateDataSource>(tag: composerId);
     Get.delete<PrintFileDataSource>(tag: composerId);
-    Get.delete<ComposerCacheDatasource>(tag: composerId);
+    if (composerId != null) {
+      Get.delete<ComposerCacheDatasource>(tag: composerId);
+    }
 
     Get.delete<ComposerRepositoryImpl>(tag: composerId);
-    Get.delete<ComposerCacheRepositoryImpl>(tag: composerId);
+    if (composerId != null) {
+      Get.delete<ComposerCacheRepositoryImpl>(tag: composerId);
+    }
     Get.delete<ContactRepositoryImpl>(tag: composerId);
     Get.delete<MailboxRepositoryImpl>(tag: composerId);
     Get.delete<EmailRepositoryImpl>(tag: composerId);
 
     Get.delete<ComposerRepository>(tag: composerId);
-    Get.delete<ComposerCacheRepository>(tag: composerId);
+    if (composerId != null) {
+      Get.delete<ComposerCacheRepository>(tag: composerId);
+    }
     Get.delete<ContactRepository>(tag: composerId);
     Get.delete<MailboxRepository>(tag: composerId);
     Get.delete<EmailRepository>(tag: composerId);
@@ -414,7 +420,9 @@ abstract class ComposerBindings extends BaseBindings {
     Get.delete<LocalImagePickerInteractor>(tag: composerId);
     Get.delete<UploadAttachmentInteractor>(tag: composerId);
     Get.delete<GetEmailContentInteractor>(tag: composerId);
-    Get.delete<RemoveComposerCacheByIdInteractor>(tag: composerId);
+    if (composerId != null) {
+      Get.delete<RemoveComposerCacheByIdInteractor>(tag: composerId);
+    }
     Get.delete<SaveComposerCacheInteractor>(tag: composerId);
     Get.delete<DownloadImageAsBase64Interactor>(tag: composerId);
     Get.delete<TransformHtmlEmailContentInteractor>(tag: composerId);

--- a/lib/features/composer/presentation/composer_bindings.dart
+++ b/lib/features/composer/presentation/composer_bindings.dart
@@ -51,6 +51,8 @@ import 'package:tmail_ui_user/features/mailbox/data/repository/mailbox_repositor
 import 'package:tmail_ui_user/features/mailbox/domain/repository/mailbox_repository.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_session_cache_datasource_impl.dart';
+import 'package:tmail_ui_user/features/caching/clients/composer_hive_cache_client.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_persistent_cache_datasource_impl.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/repository/composer_cache_repository_impl.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/remove_composer_cache_by_id_interactor.dart';
@@ -77,10 +79,17 @@ import 'package:uuid/uuid.dart';
 
 class ComposerBindings extends BaseBindings {
 
-  final String? composerId;
+  final String? _composerId;
   final ComposerArguments? composerArguments;
 
-  ComposerBindings({this.composerId, this.composerArguments});
+  ComposerBindings({String? composerId, this.composerArguments})
+      : _composerId = composerId;
+
+  /// Returns the composerId passed at construction time, or falls back to the
+  /// one embedded in the route arguments (phone path where AppPages creates
+  /// ComposerBindings() without a composerId).
+  String? get composerId =>
+      _composerId ?? (Get.arguments as ComposerArguments?)?.composerId;
 
   @override
   void bindingsDataSourceImpl() {
@@ -152,6 +161,13 @@ class ComposerBindings extends BaseBindings {
       Get.find<HtmlTransform>(),
       Get.find<CacheExceptionThrower>(),
     ), tag: composerId);
+    if (PlatformInfo.isMobile) {
+      Get.lazyPut(() => ComposerHiveCacheClient(), tag: composerId);
+      Get.lazyPut(() => ComposerPersistentCacheDatasourceImpl(
+        Get.find<ComposerHiveCacheClient>(tag: composerId),
+        Get.find<CacheExceptionThrower>(),
+      ), tag: composerId);
+    }
   }
 
   @override
@@ -188,10 +204,17 @@ class ComposerBindings extends BaseBindings {
       () => Get.find<PrintFileDataSourceImpl>(tag: composerId),
       tag: composerId,
     );
-    Get.lazyPut<ComposerCacheDatasource>(
-      () => Get.find<ComposerSessionCacheDatasourceImpl>(tag: composerId),
-      tag: composerId,
-    );
+    if (PlatformInfo.isMobile) {
+      Get.lazyPut<ComposerCacheDatasource>(
+        () => Get.find<ComposerPersistentCacheDatasourceImpl>(tag: composerId),
+        tag: composerId,
+      );
+    } else {
+      Get.lazyPut<ComposerCacheDatasource>(
+        () => Get.find<ComposerSessionCacheDatasourceImpl>(tag: composerId),
+        tag: composerId,
+      );
+    }
   }
 
   @override
@@ -368,6 +391,10 @@ class ComposerBindings extends BaseBindings {
     Get.delete<EmailLocalStorageDataSourceImpl>(tag: composerId);
     Get.delete<EmailSessionStorageDatasourceImpl>(tag: composerId);
     Get.delete<ComposerSessionCacheDatasourceImpl>(tag: composerId);
+    if (PlatformInfo.isMobile) {
+      Get.delete<ComposerHiveCacheClient>(tag: composerId);
+      Get.delete<ComposerPersistentCacheDatasourceImpl>(tag: composerId);
+    }
 
     Get.delete<AttachmentUploadDataSource>(tag: composerId);
     Get.delete<ComposerDataSource>(tag: composerId);

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -271,8 +271,8 @@ class ComposerController extends BaseController
   SaveComposerCacheInteractor get saveComposerCacheInteractor =>
      _saveComposerCacheInteractor;
 
-  Future<CreateEmailRequest?> buildCreateEmailRequestForAutoSave() =>
-      _generateCreateEmailRequestToSaveAsCache();
+  Future<CreateEmailRequest?> buildCreateEmailRequestForAutoSave({String? htmlContent}) =>
+      _generateCreateEmailRequestToSaveAsCache(htmlContent: htmlContent);
 
   GetAllIdentitiesInteractor get getAllIdentitiesInteractor => _getAllIdentitiesInteractor;
 
@@ -526,7 +526,7 @@ class ComposerController extends BaseController
     }
   }
 
-  Future<CreateEmailRequest?> _generateCreateEmailRequestToSaveAsCache() async {
+  Future<CreateEmailRequest?> _generateCreateEmailRequestToSaveAsCache({String? htmlContent}) async {
     final arguments = composerArguments.value;
     final session = mailboxDashBoardController.sessionCurrent;
     final accountId = mailboxDashBoardController.accountId.value;
@@ -536,7 +536,7 @@ class ComposerController extends BaseController
       return null;
     }
     autoCreateEmailTag();
-    String emailContent = await getContentInEditor();
+    String emailContent = htmlContent ?? await getContentInEditor();
     if (currentEmailActionType == EmailActionType.compose) {
       emailContent = await _composerRepository.removeCollapsedExpandedSignatureEffect(
         emailContent: emailContent,
@@ -642,6 +642,7 @@ class ComposerController extends BaseController
     _isEmailBodyLoaded = true;
     await setupSelectedIdentity();
     _autoFocusFieldWhenLauncher();
+    if (PlatformInfo.isAndroid) unawaited(restoreIfEditorBlank());
   }
 
   void _injectBinding() {
@@ -1493,13 +1494,12 @@ class ComposerController extends BaseController
         richTextWebController!.isFormattingOptionsEnabled,
       );
     }
+    markCleanClose();
     mailboxDashBoardController.closeComposer(
       result: result,
       closeOverlays: closeOverlays,
       composerId: composerId,
     );
-
-    markCleanClose();
   }
 
   void displayScreenTypeComposerAction(ScreenDisplayMode displayMode) async {

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -310,10 +310,10 @@ class ComposerController extends BaseController
   @override
   void onInit() {
     super.onInit();
+    restoreEmailInlineImagesInteractor = getBinding<RestoreEmailInlineImagesInteractor>(tag: composerId);
     if (PlatformInfo.isWeb) {
       responsiveContainerKey = GlobalKey();
       richTextWebController = getBinding<RichTextWebController>(tag: composerId);
-      restoreEmailInlineImagesInteractor = getBinding<RestoreEmailInlineImagesInteractor>(tag: composerId);
       menuMoreOptionController = CustomPopupMenuController();
     } else {
       richTextMobileTabletController = getBinding<RichTextMobileTabletController>(tag: composerId);
@@ -363,6 +363,7 @@ class ComposerController extends BaseController
     subjectEmailInputFocusNode?.removeListener(_subjectEmailInputFocusListener);
     _composerCacheListener?.cancel();
     _beforeReconnectManager.removeListener(onBeforeReconnect);
+    restoreEmailInlineImagesInteractor = null;
     if (PlatformInfo.isWeb) {
       richTextWebController = null;
       responsiveContainerKey = null;

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -58,6 +58,7 @@ import 'package:tmail_ui_user/features/composer/domain/usecases/restore_email_in
 import 'package:tmail_ui_user/features/composer/domain/usecases/save_composer_cache_interactor.dart';
 import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_web_controller.dart';
+import 'package:tmail_ui_user/features/composer/presentation/extensions/handle_mobile_auto_save_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/attachment_detection_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/auto_create_tag_for_recipients_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/get_draft_mailbox_id_for_composer_extension.dart';
@@ -252,12 +253,25 @@ class ComposerController extends BaseController
   int minInputLengthAutocomplete = AppConfig.defaultMinInputLengthAutocomplete;
   EmailId? currentTemplateEmailId;
 
+  AppLifecycleListener? mobileAutoSaveLifecycleListener;
+  Timer? periodicSnapshotTimer;
+  Timer? inactiveGuardTimer;
+
   @visibleForTesting
   int? get savedEmailDraftHash => _savedEmailDraftHash;
 
   GetEmailContentInteractor get getEmailContentInteractor => _getEmailContentInteractor;
 
   GetServerSettingInteractor get getServerSettingInteractor => _getServerSettingInteractor;
+
+  CreateNewAndSaveEmailToDraftsInteractor get createNewAndSaveEmailToDraftsInteractor =>
+      _createNewAndSaveEmailToDraftsInteractor;
+
+  SaveComposerCacheInteractor get saveComposerCacheInteractor =>
+     _saveComposerCacheInteractor;
+
+  Future<CreateEmailRequest?> buildCreateEmailRequestForAutoSave() =>
+      _generateCreateEmailRequestToSaveAsCache();
 
   GetAllIdentitiesInteractor get getAllIdentitiesInteractor => _getAllIdentitiesInteractor;
 
@@ -308,6 +322,9 @@ class ComposerController extends BaseController
     _beforeReconnectManager.addListener(onBeforeReconnect);
     _injectBinding();
     onKeyboardShortcutInit();
+    if (PlatformInfo.isAndroid) {
+      initMobileAutoSave();
+    }
   }
 
   @override
@@ -352,6 +369,7 @@ class ComposerController extends BaseController
     } else {
       richTextMobileTabletController = null;
     }
+    if (PlatformInfo.isAndroid) tearDownMobileAutoSave();
     onKeyboardShortcutDispose();
     super.onClose();
   }
@@ -1479,6 +1497,8 @@ class ComposerController extends BaseController
       closeOverlays: closeOverlays,
       composerId: composerId,
     );
+
+    markCleanClose();
   }
 
   void displayScreenTypeComposerAction(ScreenDisplayMode displayMode) async {

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -178,6 +178,7 @@ class ComposerController extends BaseController
   final PrintEmailInteractor printEmailInteractor;
   final ComposerRepository _composerRepository;
   final String? composerId;
+  final String? autoSaveComposerId;
   final ComposerArguments? composerArgs;
   final SaveTemplateEmailInteractor _saveTemplateEmailInteractor;
 
@@ -301,6 +302,7 @@ class ComposerController extends BaseController
     this._saveTemplateEmailInteractor,
     {
       this.composerId,
+      this.autoSaveComposerId,
       this.composerArgs,
     }
   );
@@ -444,6 +446,7 @@ class ComposerController extends BaseController
 
   @override
   Future<void> onUnloadBrowserListener(html.Event event) async {
+    if (!PlatformInfo.isWeb) return;
     final username = mailboxDashBoardController.sessionCurrent?.username;
     final accountId = mailboxDashBoardController.accountId.value;
     if (composerId != null && username != null && accountId != null) {
@@ -507,8 +510,6 @@ class ComposerController extends BaseController
   }
 
   Future<void> _saveComposerSessionCache() async {
-    autoCreateEmailTag();
-
     final createEmailRequest = await _generateCreateEmailRequestToSaveAsCache();
     if (createEmailRequest == null) return;
 
@@ -533,7 +534,7 @@ class ComposerController extends BaseController
       log('ComposerController::_generateCreateEmailRequest: SESSION or ACCOUNT_ID or ARGUMENTS is NULL');
       return null;
     }
-    
+    autoCreateEmailTag();
     String emailContent = await getContentInEditor();
     if (currentEmailActionType == EmailActionType.compose) {
       emailContent = await _composerRepository.removeCollapsedExpandedSignatureEffect(
@@ -563,7 +564,6 @@ class ComposerController extends BaseController
       identity: identitySelected.value,
       attachments: uploadController.attachmentsUploaded,
       inlineAttachments: uploadController.mapInlineAttachments,
-      outboxMailboxId: getOutboxMailboxIdForComposer(),
       sentMailboxId: getSentMailboxIdForComposer(),
       draftsMailboxId: getDraftMailboxIdForComposer(),
       draftsEmailId: getDraftEmailId(),
@@ -2355,6 +2355,7 @@ class ComposerController extends BaseController
 
   @override
   Future<void> onBeforeReconnect() async {
+    if (!PlatformInfo.isWeb) return;
     if (mailboxDashBoardController.accountId.value != null &&
         mailboxDashBoardController.sessionCurrent?.username != null
     ) {

--- a/lib/features/composer/presentation/extensions/create_email_request_extension.dart
+++ b/lib/features/composer/presentation/extensions/create_email_request_extension.dart
@@ -17,6 +17,7 @@ import 'package:tmail_ui_user/features/composer/presentation/model/create_email_
 import 'package:tmail_ui_user/features/email/domain/extensions/list_attachments_extension.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/model/create_new_mailbox_request.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/extensions/sending_email_extension.dart';
 import 'package:tmail_ui_user/features/sending_queue/presentation/model/sending_email_arguments.dart';
 import 'package:tmail_ui_user/main/localizations/localization_service.dart';
@@ -236,7 +237,20 @@ extension CreateEmailRequestExtension on CreateEmailRequest {
 
   ComposerCache generateComposerCache({
     required Email emailCreated,
+    bool isPersistent = false,
   }) {
+    if (isPersistent) {
+      return ComposerPersistentCache(
+        email: emailCreated,
+        hasRequestReadReceipt: hasRequestReadReceipt,
+        isMarkAsImportant: isMarkAsImportant,
+        actionType: EmailActionType.restoreComposerFromPersistentCache,
+        draftEmailId: draftsEmailId,
+        composerId: composerId,
+        isCleanClose: false,
+        timestampMs: DateTime.now().millisecondsSinceEpoch,
+      );
+    }
     return ComposerCache(
       email: emailCreated,
       hasRequestReadReceipt: hasRequestReadReceipt,

--- a/lib/features/composer/presentation/extensions/email_action_type_extension.dart
+++ b/lib/features/composer/presentation/extensions/email_action_type_extension.dart
@@ -41,6 +41,7 @@ extension EmailActionTypeExtension on EmailActionType {
     EmailActionType.editDraft,
     EmailActionType.editSendingEmail,
     EmailActionType.reopenComposerBrowser,
+    EmailActionType.restoreComposerFromPersistentCache,
     EmailActionType.editAsNewEmail,
     EmailActionType.composeFromMailtoUri,
     EmailActionType.composeFromUnsubscribeMailtoLink,

--- a/lib/features/composer/presentation/extensions/handle_mobile_auto_save_extension.dart
+++ b/lib/features/composer/presentation/extensions/handle_mobile_auto_save_extension.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
+import 'package:core/presentation/utils/keyboard_utils.dart';
 import 'package:core/utils/app_logger.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:core/utils/sentry/sentry_manager.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter/widgets.dart';
@@ -42,13 +44,17 @@ extension HandleMobileAutoSaveExtension on ComposerController {
 
   // Only sets the flag in notifier state; the actual Hive clean-close write is
   // deferred to onClose so it runs after all timer/lifecycle teardown.
+  // No-op on non-Android: composerAutoSaveProvider is only initialised on
+  // Android, so reading it on other platforms would create an orphaned family
+  // entry that is never invalidated (memory leak).
   void markCleanClose() {
+    if (!PlatformInfo.isAndroid) return;
     _autoSaveNotifier()?.setCleanClose();
     log('HandleMobileAutoSaveExtension::markCleanClose: flagged');
   }
 
   ComposerAutoSaveNotifier? _autoSaveNotifier() {
-    final id = composerId;
+    final id = autoSaveComposerId;
     if (id == null) return null;
     return appProviderContainer.read(composerAutoSaveProvider(id).notifier);
   }
@@ -111,6 +117,9 @@ extension HandleMobileAutoSaveExtension on ComposerController {
       // Keep the fallback snapshot in sync: if the editor dies before the next
       // periodic tick, _saveSnapshotToCache will use this restored content.
       if (restoredHtml.isNotEmpty) _autoSaveNotifier()?.updateLastKnownContent(restoredHtml);
+      // Delete the stale snapshot now that its content is live in the editor.
+      // The periodic timer will write a fresh snapshot on the next 30 s tick.
+      unawaited(clearComposerMobileSnapshot());
     } catch (e) {
       log('HandleMobileAutoSaveExtension::_restoreIfEditorBlank: error=$e');
     }
@@ -128,7 +137,10 @@ extension HandleMobileAutoSaveExtension on ComposerController {
     try {
       await _refreshLastKnownContent(notifier);
 
+      KeyboardUtils.hideSystemKeyboardMobile();
+
       final createEmailRequest = await buildCreateEmailRequestForAutoSave();
+
       if (createEmailRequest == null) {
         log('HandleMobileAutoSaveExtension::_saveSnapshotToCache: no request, skip');
         return;
@@ -207,7 +219,7 @@ extension HandleMobileAutoSaveExtension on ComposerController {
   }
 
   void tearDownMobileAutoSave() {
-    final id = composerId;
+    final id = autoSaveComposerId;
     if (id != null) _persistCleanCloseIfNeeded(id);
     try {
       disposeMobileAutoSave();
@@ -217,7 +229,7 @@ extension HandleMobileAutoSaveExtension on ComposerController {
   }
 
   Future<void> clearComposerMobileSnapshot() {
-    if (composerId == null) return Future.value();
+    if (autoSaveComposerId == null) return Future.value();
     final accountId = mailboxDashBoardController.accountId.value;
     final userName = mailboxDashBoardController.sessionCurrent?.username;
     if (accountId == null || userName == null) return Future.value();

--- a/lib/features/composer/presentation/extensions/handle_mobile_auto_save_extension.dart
+++ b/lib/features/composer/presentation/extensions/handle_mobile_auto_save_extension.dart
@@ -5,11 +5,9 @@ import 'package:core/presentation/state/success.dart';
 import 'package:core/presentation/utils/keyboard_utils.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/platform_info.dart';
-import 'package:core/utils/sentry/sentry_manager.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter/widgets.dart';
 import 'package:model/model.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/save_email_as_drafts_state.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/update_email_drafts_state.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
@@ -26,6 +24,7 @@ extension HandleMobileAutoSaveExtension on ComposerController {
   static const _inactiveGuardDelay = Duration(milliseconds: 300);
 
   void initMobileAutoSave() {
+    if (autoSaveComposerId == null) return;
     mobileAutoSaveLifecycleListener ??= AppLifecycleListener(
       onStateChange: _onLifecycleStateChanged,
     );
@@ -42,15 +41,29 @@ extension HandleMobileAutoSaveExtension on ComposerController {
     mobileAutoSaveLifecycleListener = null;
   }
 
-  // Only sets the flag in notifier state; the actual Hive clean-close write is
-  // deferred to onClose so it runs after all timer/lifecycle teardown.
+  // Sets the in-memory clean-close flag and immediately fires the Hive write
+  // (unawaited). Writing eagerly — before navigation — is safer than deferring
+  // to onClose: the process is still foreground and the isCleanClose flag
+  // already blocks any further snapshot writes, so there is no race.
   // No-op on non-Android: composerAutoSaveProvider is only initialised on
   // Android, so reading it on other platforms would create an orphaned family
   // entry that is never invalidated (memory leak).
   void markCleanClose() {
     if (!PlatformInfo.isAndroid) return;
-    _autoSaveNotifier()?.setCleanClose();
-    log('HandleMobileAutoSaveExtension::markCleanClose: flagged');
+    final notifier = _autoSaveNotifier();
+    if (notifier == null) return;
+    notifier.setCleanClose();
+    _persistCleanCloseToCache();
+    log('HandleMobileAutoSaveExtension::markCleanClose: flagged and persisted');
+  }
+
+  void _persistCleanCloseToCache() {
+    final accountId = mailboxDashBoardController.accountId.value;
+    final userName = mailboxDashBoardController.sessionCurrent?.username;
+    if (accountId == null || userName == null) return;
+    unawaited(appProviderContainer
+        .read(markComposerLocalCacheCleanCloseProvider)
+        .execute(accountId, userName));
   }
 
   ComposerAutoSaveNotifier? _autoSaveNotifier() {
@@ -92,14 +105,14 @@ extension HandleMobileAutoSaveExtension on ComposerController {
       case AppLifecycleState.resumed:
         inactiveGuardTimer?.cancel();
         inactiveGuardTimer = null;
-        unawaited(_restoreIfEditorBlank());
+        unawaited(restoreIfEditorBlank());
         break;
       default:
         break;
     }
   }
 
-  Future<void> _restoreIfEditorBlank() async {
+  Future<void> restoreIfEditorBlank() async {
     try {
       final currentContent = await _fetchEditorContent();
       if (currentContent != null && currentContent.trim().isNotEmpty) return;
@@ -111,7 +124,7 @@ extension HandleMobileAutoSaveExtension on ComposerController {
       final cache = await _autoSaveNotifier()?.restore(accountId, userName);
       if (cache == null) return;
 
-      log('HandleMobileAutoSaveExtension::_restoreIfEditorBlank: restoring from cache');
+      log('HandleMobileAutoSaveExtension::restoreIfEditorBlank: restoring from cache');
       final restoredHtml = cache.email?.emailContentList.asHtmlString ?? '';
       await htmlEditorApi?.setText(restoredHtml);
       // Keep the fallback snapshot in sync: if the editor dies before the next
@@ -121,13 +134,36 @@ extension HandleMobileAutoSaveExtension on ComposerController {
       // The periodic timer will write a fresh snapshot on the next 30 s tick.
       unawaited(clearComposerMobileSnapshot());
     } catch (e) {
-      log('HandleMobileAutoSaveExtension::_restoreIfEditorBlank: error=$e');
+      log('HandleMobileAutoSaveExtension::restoreIfEditorBlank: error=$e');
     }
   }
 
-  Future<void> _refreshLastKnownContent(ComposerAutoSaveNotifier notifier) async {
-    final content = await _fetchEditorContent();
-    if (content != null && notifier.mounted) notifier.updateLastKnownContent(content);
+  // Picks the best available content and syncs it to the notifier.
+  // Fresh content from the editor takes priority; falls back to the last
+  // periodic snapshot (ADR-0086 Layer 1 fallback requirement).
+  String _resolveAndSyncContent(
+    String? freshContent,
+    ComposerAutoSaveNotifier notifier,
+  ) {
+    if (freshContent != null && freshContent.isNotEmpty) {
+      if (notifier.mounted) notifier.updateLastKnownContent(freshContent);
+      return freshContent;
+    }
+    return notifier.lastKnownHtmlContent;
+  }
+
+  Future<void> _executeCacheSave(
+    CreateEmailRequest createEmailRequest,
+    ComposerAutoSaveNotifier notifier,
+  ) async {
+    final saveResult = await saveComposerCacheInteractor.execute(
+      createEmailRequest: createEmailRequest,
+      isPersistent: true,
+    );
+    saveResult.fold(
+      (failure) => log('HandleMobileAutoSaveExtension::_saveSnapshotToCache: save failure=${failure.runtimeType}'),
+      (_) { if (notifier.mounted) notifier.onSnapshotSaved(); },
+    );
   }
 
   Future<void> _saveSnapshotToCache() async {
@@ -135,25 +171,20 @@ extension HandleMobileAutoSaveExtension on ComposerController {
     if (notifier == null || notifier.isCleanClose) return;
 
     try {
-      await _refreshLastKnownContent(notifier);
+      final freshContent = await _fetchEditorContent();
+      final effectiveContent = _resolveAndSyncContent(freshContent, notifier);
 
       KeyboardUtils.hideSystemKeyboardMobile();
 
-      final createEmailRequest = await buildCreateEmailRequestForAutoSave();
+      final createEmailRequest = await buildCreateEmailRequestForAutoSave(
+        htmlContent: effectiveContent,
+      );
 
       if (createEmailRequest == null) {
         log('HandleMobileAutoSaveExtension::_saveSnapshotToCache: no request, skip');
         return;
       }
-      final saveResult = await saveComposerCacheInteractor.execute(
-        createEmailRequest: createEmailRequest,
-        isPersistent: true,
-      );
-      saveResult.fold(
-        (failure) => log('HandleMobileAutoSaveExtension::_saveSnapshotToCache: save failure=${failure.runtimeType}'),
-        (_) { if (notifier.mounted) notifier.onSnapshotSaved(); },
-      );
-
+      await _executeCacheSave(createEmailRequest, notifier);
       unawaited(_saveToDraftSilently(createEmailRequest));
     } catch (e) {
       log('HandleMobileAutoSaveExtension::_saveSnapshotToCache: error=$e');
@@ -164,19 +195,19 @@ extension HandleMobileAutoSaveExtension on ComposerController {
     state.fold(
       (failure) {
         // Privacy: only the type is sent — no content, subject, or recipients.
-        SentryManager.instance.captureException(
-          'Layer2AutoSaveDraftFailure: ${failure.runtimeType}',
-          level: SentryLevel.warning,
-        );
-        log('HandleMobileAutoSaveExtension::_onDraftSaveState: failure=${failure.runtimeType}');
+        logError('HandleMobileAutoSaveExtension::_onDraftSaveState: failure=${failure.runtimeType}');
       },
       (success) {
-        if (success is SaveEmailAsDraftsSuccess || success is UpdateEmailDraftsSuccess) {
-          // Do NOT clear the Hive cache here: the periodic auto-save may have
-          // written a newer snapshot while this JMAP call was in flight (race
-          // condition on slow networks). Cleanup is handled by markCleanClose
-          // (intentional close) and the 24 h TTL on ComposerPersistentCache.
+        // Do NOT clear the Hive cache here: the periodic auto-save may have
+        // written a newer snapshot while this JMAP call was in flight (race
+        // condition on slow networks). Cleanup is handled by markCleanClose
+        // (intentional close) and the 24 h TTL on ComposerPersistentCache.
+        if (success is SaveEmailAsDraftsSuccess) {
+          emailIdEditing = success.emailId;
           log('HandleMobileAutoSaveExtension::_onDraftSaveState: saved to server draft');
+        } else if (success is UpdateEmailDraftsSuccess) {
+          emailIdEditing = success.emailId;
+          log('HandleMobileAutoSaveExtension::_onDraftSaveState: updated server draft');
         }
       },
     );
@@ -193,37 +224,23 @@ extension HandleMobileAutoSaveExtension on ComposerController {
       )) {
         _onDraftSaveState(state);
       }
-    } catch (e) {
+    } catch (e, st) {
       // Privacy: only the type is captured.
-      SentryManager.instance.captureException(
-        'Layer2AutoSaveDraftException: ${e.runtimeType}',
-        level: SentryLevel.warning,
+      logError(
+        'HandleMobileAutoSaveExtension::_saveToDraftSilently: error=${e.runtimeType}',
+        exception: e,
+        stackTrace: st,
       );
-      log('HandleMobileAutoSaveExtension::_saveToDraftSilently: error=${e.runtimeType}');
     } finally {
       if (notifier.mounted) notifier.endDraftSave();
     }
   }
 
-  void _persistCleanCloseIfNeeded(String id) {
-    final isCleanClose = appProviderContainer
-        .read(composerAutoSaveProvider(id).notifier)
-        .isCleanClose;
-    if (!isCleanClose) return;
-    final accountId = mailboxDashBoardController.accountId.value;
-    final userName = mailboxDashBoardController.sessionCurrent?.username;
-    if (accountId == null || userName == null) return;
-    unawaited(appProviderContainer
-        .read(markComposerLocalCacheCleanCloseProvider)
-        .execute(accountId, userName));
-  }
-
   void tearDownMobileAutoSave() {
-    final id = autoSaveComposerId;
-    if (id != null) _persistCleanCloseIfNeeded(id);
     try {
       disposeMobileAutoSave();
     } finally {
+      final id = autoSaveComposerId;
       if (id != null) appProviderContainer.invalidate(composerAutoSaveProvider(id));
     }
   }

--- a/lib/features/composer/presentation/extensions/handle_mobile_auto_save_extension.dart
+++ b/lib/features/composer/presentation/extensions/handle_mobile_auto_save_extension.dart
@@ -7,6 +7,7 @@ import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter/widgets.dart';
+import 'package:rich_text_composer/rich_text_composer.dart';
 import 'package:model/model.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/save_email_as_drafts_state.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/update_email_drafts_state.dart';
@@ -114,31 +115,36 @@ extension HandleMobileAutoSaveExtension on ComposerController {
 
   Future<void> restoreIfEditorBlank() async {
     try {
-      final currentContent = await _fetchEditorContent();
-      if (currentContent != null && currentContent.trim().isNotEmpty) return;
-
-      final accountId = mailboxDashBoardController.accountId.value;
-      final userName = mailboxDashBoardController.sessionCurrent?.username;
-      if (accountId == null || userName == null) return;
-
-      final cache = await _autoSaveNotifier()?.restore(accountId, userName);
-      if (cache == null) return;
-
-      final api = htmlEditorApi;
-      if (api == null) return;
-
+      final payload = await _resolveRestorePayload();
+      if (payload == null) return;
       log('HandleMobileAutoSaveExtension::restoreIfEditorBlank: restoring from cache');
-      final restoredHtml = cache.email?.emailContentList.asHtmlString ?? '';
-      await api.setText(restoredHtml);
+      await payload.api.setText(payload.html);
       // Keep the fallback snapshot in sync: if the editor dies before the next
       // periodic tick, _saveSnapshotToCache will use this restored content.
-      if (restoredHtml.isNotEmpty) _autoSaveNotifier()?.updateLastKnownContent(restoredHtml);
+      if (payload.html.isNotEmpty) _autoSaveNotifier()?.updateLastKnownContent(payload.html);
       // Delete the stale snapshot now that its content is live in the editor.
       // The periodic timer will write a fresh snapshot on the next 30 s tick.
       unawaited(clearComposerMobileSnapshot());
     } catch (e) {
       log('HandleMobileAutoSaveExtension::restoreIfEditorBlank: error=$e');
     }
+  }
+
+  Future<({HtmlEditorApi api, String html})?> _resolveRestorePayload() async {
+    final currentContent = await _fetchEditorContent();
+    if (currentContent != null && currentContent.trim().isNotEmpty) return null;
+
+    final accountId = mailboxDashBoardController.accountId.value;
+    final userName = mailboxDashBoardController.sessionCurrent?.username;
+    if (accountId == null || userName == null) return null;
+
+    final cache = await _autoSaveNotifier()?.restore(accountId, userName);
+    if (cache == null) return null;
+
+    final api = htmlEditorApi;
+    if (api == null) return null;
+
+    return (api: api, html: cache.email?.emailContentList.asHtmlString ?? '');
   }
 
   // Picks the best available content and syncs it to the notifier.

--- a/lib/features/composer/presentation/extensions/handle_mobile_auto_save_extension.dart
+++ b/lib/features/composer/presentation/extensions/handle_mobile_auto_save_extension.dart
@@ -124,9 +124,12 @@ extension HandleMobileAutoSaveExtension on ComposerController {
       final cache = await _autoSaveNotifier()?.restore(accountId, userName);
       if (cache == null) return;
 
+      final api = htmlEditorApi;
+      if (api == null) return;
+
       log('HandleMobileAutoSaveExtension::restoreIfEditorBlank: restoring from cache');
       final restoredHtml = cache.email?.emailContentList.asHtmlString ?? '';
-      await htmlEditorApi?.setText(restoredHtml);
+      await api.setText(restoredHtml);
       // Keep the fallback snapshot in sync: if the editor dies before the next
       // periodic tick, _saveSnapshotToCache will use this restored content.
       if (restoredHtml.isNotEmpty) _autoSaveNotifier()?.updateLastKnownContent(restoredHtml);

--- a/lib/features/composer/presentation/extensions/handle_mobile_auto_save_extension.dart
+++ b/lib/features/composer/presentation/extensions/handle_mobile_auto_save_extension.dart
@@ -114,6 +114,7 @@ extension HandleMobileAutoSaveExtension on ComposerController {
   }
 
   Future<void> restoreIfEditorBlank() async {
+    if (_autoSaveNotifier()?.isCleanClose == true) return;
     try {
       final payload = await _resolveRestorePayload();
       if (payload == null) return;

--- a/lib/features/composer/presentation/extensions/handle_mobile_auto_save_extension.dart
+++ b/lib/features/composer/presentation/extensions/handle_mobile_auto_save_extension.dart
@@ -1,0 +1,226 @@
+import 'dart:async';
+
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:core/utils/app_logger.dart';
+import 'package:core/utils/sentry/sentry_manager.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter/widgets.dart';
+import 'package:model/model.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:tmail_ui_user/features/composer/domain/state/save_email_as_drafts_state.dart';
+import 'package:tmail_ui_user/features/composer/domain/state/update_email_drafts_state.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
+import 'package:tmail_ui_user/features/composer/presentation/model/create_email_request.dart';
+import 'package:tmail_ui_user/features/composer/presentation/providers/composer_auto_save_notifier.dart';
+import 'package:tmail_ui_user/features/composer/presentation/providers/composer_cache_providers.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
+
+extension HandleMobileAutoSaveExtension on ComposerController {
+  static const _periodicSnapshotInterval = Duration(seconds: 30);
+  static const _getContentTimeout = Duration(seconds: 2);
+  // 300ms guard filters AppLifecycleState.inactive from system overlays
+  // (permission dialogs, incoming calls) that resolve quickly.
+  static const _inactiveGuardDelay = Duration(milliseconds: 300);
+
+  void initMobileAutoSave() {
+    mobileAutoSaveLifecycleListener ??= AppLifecycleListener(
+      onStateChange: _onLifecycleStateChanged,
+    );
+    _startPeriodicContentSnapshot();
+    log('HandleMobileAutoSaveExtension::initMobileAutoSave: initialized');
+  }
+
+  void disposeMobileAutoSave() {
+    inactiveGuardTimer?.cancel();
+    inactiveGuardTimer = null;
+    periodicSnapshotTimer?.cancel();
+    periodicSnapshotTimer = null;
+    mobileAutoSaveLifecycleListener?.dispose();
+    mobileAutoSaveLifecycleListener = null;
+  }
+
+  // Only sets the flag in notifier state; the actual Hive clean-close write is
+  // deferred to onClose so it runs after all timer/lifecycle teardown.
+  void markCleanClose() {
+    _autoSaveNotifier()?.setCleanClose();
+    log('HandleMobileAutoSaveExtension::markCleanClose: flagged');
+  }
+
+  ComposerAutoSaveNotifier? _autoSaveNotifier() {
+    final id = composerId;
+    if (id == null) return null;
+    return appProviderContainer.read(composerAutoSaveProvider(id).notifier);
+  }
+
+  Future<String?> _fetchEditorContent() async {
+    try {
+      return await htmlEditorApi?.getText().timeout(_getContentTimeout);
+    } catch (e) {
+      log('HandleMobileAutoSaveExtension::_fetchEditorContent: error=$e');
+      return null;
+    }
+  }
+
+  void _startPeriodicContentSnapshot() {
+    periodicSnapshotTimer?.cancel();
+    periodicSnapshotTimer = Timer.periodic(_periodicSnapshotInterval, (_) {
+      unawaited(_updateLastKnownContent());
+    });
+  }
+
+  Future<void> _updateLastKnownContent() async {
+    final content = await _fetchEditorContent();
+    if (content != null) _autoSaveNotifier()?.updateLastKnownContent(content);
+  }
+
+  void _onLifecycleStateChanged(AppLifecycleState state) {
+    log('HandleMobileAutoSaveExtension::_onLifecycleStateChanged: state=$state');
+    switch (state) {
+      case AppLifecycleState.inactive:
+        inactiveGuardTimer?.cancel();
+        inactiveGuardTimer = Timer(_inactiveGuardDelay, () {
+          unawaited(_saveSnapshotToCache());
+        });
+        break;
+      case AppLifecycleState.resumed:
+        inactiveGuardTimer?.cancel();
+        inactiveGuardTimer = null;
+        unawaited(_restoreIfEditorBlank());
+        break;
+      default:
+        break;
+    }
+  }
+
+  Future<void> _restoreIfEditorBlank() async {
+    try {
+      final currentContent = await _fetchEditorContent();
+      if (currentContent != null && currentContent.trim().isNotEmpty) return;
+
+      final accountId = mailboxDashBoardController.accountId.value;
+      final userName = mailboxDashBoardController.sessionCurrent?.username;
+      if (accountId == null || userName == null) return;
+
+      final cache = await _autoSaveNotifier()?.restore(accountId, userName);
+      if (cache == null) return;
+
+      log('HandleMobileAutoSaveExtension::_restoreIfEditorBlank: restoring from cache');
+      final restoredHtml = cache.email?.emailContentList.asHtmlString ?? '';
+      await htmlEditorApi?.setText(restoredHtml);
+      // Keep the fallback snapshot in sync: if the editor dies before the next
+      // periodic tick, _saveSnapshotToCache will use this restored content.
+      if (restoredHtml.isNotEmpty) _autoSaveNotifier()?.updateLastKnownContent(restoredHtml);
+    } catch (e) {
+      log('HandleMobileAutoSaveExtension::_restoreIfEditorBlank: error=$e');
+    }
+  }
+
+  Future<void> _refreshLastKnownContent(ComposerAutoSaveNotifier notifier) async {
+    final content = await _fetchEditorContent();
+    if (content != null && notifier.mounted) notifier.updateLastKnownContent(content);
+  }
+
+  Future<void> _saveSnapshotToCache() async {
+    final notifier = _autoSaveNotifier();
+    if (notifier == null || notifier.isCleanClose) return;
+
+    try {
+      await _refreshLastKnownContent(notifier);
+
+      final createEmailRequest = await buildCreateEmailRequestForAutoSave();
+      if (createEmailRequest == null) {
+        log('HandleMobileAutoSaveExtension::_saveSnapshotToCache: no request, skip');
+        return;
+      }
+      final saveResult = await saveComposerCacheInteractor.execute(
+        createEmailRequest: createEmailRequest,
+        isPersistent: true,
+      );
+      saveResult.fold(
+        (failure) => log('HandleMobileAutoSaveExtension::_saveSnapshotToCache: save failure=${failure.runtimeType}'),
+        (_) { if (notifier.mounted) notifier.onSnapshotSaved(); },
+      );
+
+      unawaited(_saveToDraftSilently(createEmailRequest));
+    } catch (e) {
+      log('HandleMobileAutoSaveExtension::_saveSnapshotToCache: error=$e');
+    }
+  }
+
+  void _onDraftSaveState(Either<Failure, Success> state) {
+    state.fold(
+      (failure) {
+        // Privacy: only the type is sent — no content, subject, or recipients.
+        SentryManager.instance.captureException(
+          'Layer2AutoSaveDraftFailure: ${failure.runtimeType}',
+          level: SentryLevel.warning,
+        );
+        log('HandleMobileAutoSaveExtension::_onDraftSaveState: failure=${failure.runtimeType}');
+      },
+      (success) {
+        if (success is SaveEmailAsDraftsSuccess || success is UpdateEmailDraftsSuccess) {
+          // Do NOT clear the Hive cache here: the periodic auto-save may have
+          // written a newer snapshot while this JMAP call was in flight (race
+          // condition on slow networks). Cleanup is handled by markCleanClose
+          // (intentional close) and the 24 h TTL on ComposerPersistentCache.
+          log('HandleMobileAutoSaveExtension::_onDraftSaveState: saved to server draft');
+        }
+      },
+    );
+  }
+
+  Future<void> _saveToDraftSilently(CreateEmailRequest createEmailRequest) async {
+    final notifier = _autoSaveNotifier();
+    if (notifier == null || notifier.isSavingToDraftInProgress) return;
+
+    notifier.beginDraftSave();
+    try {
+      await for (final state in createNewAndSaveEmailToDraftsInteractor.execute(
+        createEmailRequest: createEmailRequest,
+      )) {
+        _onDraftSaveState(state);
+      }
+    } catch (e) {
+      // Privacy: only the type is captured.
+      SentryManager.instance.captureException(
+        'Layer2AutoSaveDraftException: ${e.runtimeType}',
+        level: SentryLevel.warning,
+      );
+      log('HandleMobileAutoSaveExtension::_saveToDraftSilently: error=${e.runtimeType}');
+    } finally {
+      if (notifier.mounted) notifier.endDraftSave();
+    }
+  }
+
+  void _persistCleanCloseIfNeeded(String id) {
+    final isCleanClose = appProviderContainer
+        .read(composerAutoSaveProvider(id).notifier)
+        .isCleanClose;
+    if (!isCleanClose) return;
+    final accountId = mailboxDashBoardController.accountId.value;
+    final userName = mailboxDashBoardController.sessionCurrent?.username;
+    if (accountId == null || userName == null) return;
+    unawaited(appProviderContainer
+        .read(markComposerLocalCacheCleanCloseProvider)
+        .execute(accountId, userName));
+  }
+
+  void tearDownMobileAutoSave() {
+    final id = composerId;
+    if (id != null) _persistCleanCloseIfNeeded(id);
+    try {
+      disposeMobileAutoSave();
+    } finally {
+      if (id != null) appProviderContainer.invalidate(composerAutoSaveProvider(id));
+    }
+  }
+
+  Future<void> clearComposerMobileSnapshot() {
+    if (composerId == null) return Future.value();
+    final accountId = mailboxDashBoardController.accountId.value;
+    final userName = mailboxDashBoardController.sessionCurrent?.username;
+    if (accountId == null || userName == null) return Future.value();
+    return _autoSaveNotifier()?.clearCache(accountId, userName) ?? Future.value();
+  }
+}

--- a/lib/features/composer/presentation/extensions/setup_email_attachments_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_attachments_extension.dart
@@ -55,6 +55,7 @@ extension SetupEmailAttachmentsExtension on ComposerController {
     EmailActionType.replyAll,
     EmailActionType.forward,
     EmailActionType.reopenComposerBrowser,
+    EmailActionType.restoreComposerFromPersistentCache,
   }.contains(currentEmailActionType);
 
   void _uploadAttachmentFromFileShare(List<SharedMediaFile> listSharedMediaFile) {

--- a/lib/features/composer/presentation/extensions/setup_email_content_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_content_extension.dart
@@ -45,7 +45,7 @@ extension SetupEmailContentExtension on ComposerController {
     } else if (currentEmailActionType == EmailActionType.reopenComposerBrowser) {
       await _loadReopenBrowserEmailContent(arguments);
     } else if (currentEmailActionType == EmailActionType.restoreComposerFromPersistentCache) {
-      _setMobileRestoredEmailContent(arguments.emailContents ?? '');
+      await _loadMobileRestoredEmailContent(arguments);
     } else {
       emailContentsViewState.value = Right(LoadEmailContentCompleted());
     }
@@ -197,12 +197,21 @@ extension SetupEmailContentExtension on ComposerController {
     consumeState(Stream.value(Left(failure)));
   }
 
-  void _setMobileRestoredEmailContent(String content) {
+  Future<void> _loadMobileRestoredEmailContent(ComposerArguments arguments) async {
+    final content = arguments.emailContents ?? '';
+    final inlineImages = arguments.inlineImages ?? [];
+
     if (content.trim().isEmpty) {
       emailContentsViewState.value = Left(GetEmailContentFailure(EmptyEmailContentException()));
-    } else {
-      emailContentsViewState.value = Right(GetEmailContentSuccess(htmlEmailContent: content));
+      return;
     }
+
+    if (inlineImages.isEmpty) {
+      emailContentsViewState.value = Right(GetEmailContentSuccess(htmlEmailContent: content));
+      return;
+    }
+
+    await _restoreInlineImages(content, inlineImages);
   }
 
   Future<void> _getEmailContent(

--- a/lib/features/composer/presentation/extensions/setup_email_content_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_content_extension.dart
@@ -44,6 +44,8 @@ extension SetupEmailContentExtension on ComposerController {
       await _loadReplyForwardEmailContent(arguments);
     } else if (currentEmailActionType == EmailActionType.reopenComposerBrowser) {
       await _loadReopenBrowserEmailContent(arguments);
+    } else if (currentEmailActionType == EmailActionType.restoreComposerFromPersistentCache) {
+      _setMobileRestoredEmailContent(arguments.emailContents ?? '');
     } else {
       emailContentsViewState.value = Right(LoadEmailContentCompleted());
     }
@@ -193,6 +195,14 @@ extension SetupEmailContentExtension on ComposerController {
   void _setEmailContentFailure(GetEmailContentFailure failure) {
     emailContentsViewState.value = Left(failure);
     consumeState(Stream.value(Left(failure)));
+  }
+
+  void _setMobileRestoredEmailContent(String content) {
+    if (content.trim().isEmpty) {
+      emailContentsViewState.value = Left(GetEmailContentFailure(EmptyEmailContentException()));
+    } else {
+      emailContentsViewState.value = Right(GetEmailContentSuccess(htmlEmailContent: content));
+    }
   }
 
   Future<void> _getEmailContent(

--- a/lib/features/composer/presentation/extensions/setup_email_important_flag_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_important_flag_extension.dart
@@ -12,6 +12,7 @@ extension SetupEmailImportantFlagExtension on ComposerController {
         isMarkAsImportant.value = arguments.presentationEmail?.isMarkAsImportant ?? false;
         break;
       case EmailActionType.reopenComposerBrowser:
+      case EmailActionType.restoreComposerFromPersistentCache:
         isMarkAsImportant.value = arguments.isMarkAsImportant ?? false;
         break;
       case EmailActionType.editSendingEmail:

--- a/lib/features/composer/presentation/extensions/setup_email_recipients_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_recipients_extension.dart
@@ -36,6 +36,7 @@ extension SetupEmailRecipientsExtension on ComposerController {
     EmailActionType.editAsNewEmail,
     EmailActionType.editDraft,
     EmailActionType.reopenComposerBrowser,
+    EmailActionType.restoreComposerFromPersistentCache,
   }.contains(currentEmailActionType);
 
   bool get _isDirectToAddressAction => const {

--- a/lib/features/composer/presentation/extensions/setup_email_request_read_receipt_flag_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_request_read_receipt_flag_extension.dart
@@ -10,7 +10,8 @@ import 'package:tmail_ui_user/features/server_settings/domain/state/get_server_s
 extension SetupEmailRequestReadReceiptFlagExtension on ComposerController {
 
   void setupEmailRequestReadReceiptFlag(ComposerArguments arguments) {
-    if (currentEmailActionType == EmailActionType.reopenComposerBrowser) {
+    if (currentEmailActionType == EmailActionType.reopenComposerBrowser ||
+        currentEmailActionType == EmailActionType.restoreComposerFromPersistentCache) {
       hasRequestReadReceipt.value = arguments.hasRequestReadReceipt ?? false;
     } else if (currentEmailActionType == EmailActionType.editSendingEmail) {
       hasRequestReadReceipt.value = arguments.sendingEmail?.email.hasRequestReadReceipt ?? false;

--- a/lib/features/composer/presentation/mobile_composer_bindings.dart
+++ b/lib/features/composer/presentation/mobile_composer_bindings.dart
@@ -40,6 +40,7 @@ class MobileComposerBindings extends ComposerBindings {
 
   @override
   void disposePlatformCacheImpl() {
+    if (composerId == null) return;
     Get.delete<ComposerHiveCacheClient>(tag: composerId);
     Get.delete<ComposerPersistentCacheDatasourceImpl>(tag: composerId);
   }

--- a/lib/features/composer/presentation/mobile_composer_bindings.dart
+++ b/lib/features/composer/presentation/mobile_composer_bindings.dart
@@ -40,7 +40,6 @@ class MobileComposerBindings extends ComposerBindings {
 
   @override
   void disposePlatformCacheImpl() {
-    if (composerId == null) return;
     Get.delete<ComposerHiveCacheClient>(tag: composerId);
     Get.delete<ComposerPersistentCacheDatasourceImpl>(tag: composerId);
   }

--- a/lib/features/composer/presentation/mobile_composer_bindings.dart
+++ b/lib/features/composer/presentation/mobile_composer_bindings.dart
@@ -1,0 +1,46 @@
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/caching/clients/composer_hive_cache_client.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_bindings.dart';
+import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_persistent_cache_datasource_impl.dart';
+import 'package:tmail_ui_user/features/email/presentation/model/composer_arguments.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.dart';
+
+class MobileComposerBindings extends ComposerBindings {
+  MobileComposerBindings({String? composerId, ComposerArguments? composerArguments})
+      : super.base(composerId: composerId, composerArguments: composerArguments);
+
+  @override
+  void bindPlatformCacheDatasourceImpl() {
+    Get.lazyPut(() => ComposerHiveCacheClient(), tag: composerId);
+    Get.lazyPut(() => ComposerPersistentCacheDatasourceImpl(
+      Get.find<ComposerHiveCacheClient>(tag: composerId),
+      Get.find<CacheExceptionThrower>(),
+    ), tag: composerId);
+  }
+
+  @override
+  void bindPlatformComposerCacheDatasource() {
+    Get.lazyPut<ComposerCacheDatasource>(
+      () => Get.find<ComposerPersistentCacheDatasourceImpl>(tag: composerId),
+      tag: composerId,
+    );
+  }
+
+  @override
+  void bindPlatformRichTextController() {
+    Get.lazyPut(() => RichTextMobileTabletController(), tag: composerId);
+  }
+
+  @override
+  void disposePlatformRichTextController() {
+    Get.delete<RichTextMobileTabletController>(tag: composerId);
+  }
+
+  @override
+  void disposePlatformCacheImpl() {
+    Get.delete<ComposerHiveCacheClient>(tag: composerId);
+    Get.delete<ComposerPersistentCacheDatasourceImpl>(tag: composerId);
+  }
+}

--- a/lib/features/composer/presentation/providers/composer_auto_save_notifier.dart
+++ b/lib/features/composer/presentation/providers/composer_auto_save_notifier.dart
@@ -1,0 +1,127 @@
+import 'package:core/utils/app_logger.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:tmail_ui_user/features/composer/presentation/providers/composer_cache_providers.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/resolve_composer_cache_for_restore_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/remove_all_composer_cache_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor.dart';
+
+class ComposerAutoSaveState extends Equatable {
+  final bool hasRecoverableSnapshot;
+  final bool isCleanClose;
+  final bool isSavingToDraftInProgress;
+  final String lastKnownHtmlContent;
+
+  const ComposerAutoSaveState({
+    this.hasRecoverableSnapshot = false,
+    this.isCleanClose = false,
+    this.isSavingToDraftInProgress = false,
+    this.lastKnownHtmlContent = '',
+  });
+
+  ComposerAutoSaveState copyWith({
+    bool? hasRecoverableSnapshot,
+    bool? isCleanClose,
+    bool? isSavingToDraftInProgress,
+    String? lastKnownHtmlContent,
+  }) =>
+      ComposerAutoSaveState(
+        hasRecoverableSnapshot: hasRecoverableSnapshot ?? this.hasRecoverableSnapshot,
+        isCleanClose: isCleanClose ?? this.isCleanClose,
+        isSavingToDraftInProgress: isSavingToDraftInProgress ?? this.isSavingToDraftInProgress,
+        lastKnownHtmlContent: lastKnownHtmlContent ?? this.lastKnownHtmlContent,
+      );
+
+  @override
+  List<Object?> get props => [
+        hasRecoverableSnapshot,
+        isCleanClose,
+        isSavingToDraftInProgress,
+        lastKnownHtmlContent,
+      ];
+}
+
+/// Riverpod [StateNotifier] for Android composer auto-save (see ADR-0086).
+/// Keyed by composerId so each [ComposerController] gets an isolated instance.
+/// Must be invalidated from [ComposerController.onClose] to prevent unbounded
+/// family-instance growth in the global [ProviderContainer].
+class ComposerAutoSaveNotifier extends StateNotifier<ComposerAutoSaveState> {
+  final ResolveComposerCacheForRestoreInteractor _resolveInteractor;
+  final RemoveAllComposerCacheInteractor _removeInteractor;
+
+  ComposerAutoSaveNotifier(
+    this._resolveInteractor,
+    this._removeInteractor,
+  ) : super(const ComposerAutoSaveState());
+
+  bool get hasRecoverableSnapshot => state.hasRecoverableSnapshot;
+  bool get isCleanClose => state.isCleanClose;
+  bool get isSavingToDraftInProgress => state.isSavingToDraftInProgress;
+  String get lastKnownHtmlContent => state.lastKnownHtmlContent;
+
+  void onSnapshotSaved() {
+    state = state.copyWith(hasRecoverableSnapshot: true);
+    log('ComposerAutoSaveNotifier::onSnapshotSaved: snapshot recorded');
+  }
+
+  void setCleanClose() {
+    state = state.copyWith(isCleanClose: true);
+    log('ComposerAutoSaveNotifier::setCleanClose: flagged');
+  }
+
+  void updateLastKnownContent(String content) {
+    state = state.copyWith(lastKnownHtmlContent: content);
+  }
+
+  void beginDraftSave() {
+    state = state.copyWith(isSavingToDraftInProgress: true);
+  }
+
+  void endDraftSave() {
+    state = state.copyWith(isSavingToDraftInProgress: false);
+  }
+
+  Future<ComposerPersistentCache?> restore(
+    AccountId accountId,
+    UserName userName,
+  ) async {
+    final result = await _resolveInteractor.execute(accountId, userName);
+    return result.fold(
+      (failure) {
+        log('ComposerAutoSaveNotifier::restore: failure=${failure.runtimeType}');
+        return null;
+      },
+      (success) {
+        if (success is! ResolveComposerCacheForRestoreSuccess) return null;
+        final cache = success.cache;
+        if (cache != null) {
+          state = state.copyWith(hasRecoverableSnapshot: true);
+          log('ComposerAutoSaveNotifier::restore: found snapshot');
+        }
+        return cache;
+      },
+    );
+  }
+
+  Future<void> clearCache(AccountId accountId, UserName userName) async {
+    final result = await _removeInteractor.execute(accountId, userName);
+    result.fold(
+      (failure) => log('ComposerAutoSaveNotifier::clearCache: failure=${failure.runtimeType}'),
+      (_) {
+        state = state.copyWith(hasRecoverableSnapshot: false);
+        log('ComposerAutoSaveNotifier::clearCache: cleared');
+      },
+    );
+  }
+}
+
+final composerAutoSaveProvider = StateNotifierProvider.family<
+    ComposerAutoSaveNotifier, ComposerAutoSaveState, String>(
+  (ref, composerId) => ComposerAutoSaveNotifier(
+    ref.read(resolveComposerCacheForRestoreProvider),
+    ref.read(removeAllComposerCacheProvider),
+  ),
+);

--- a/lib/features/composer/presentation/providers/composer_cache_providers.dart
+++ b/lib/features/composer/presentation/providers/composer_cache_providers.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tmail_ui_user/features/caching/clients/composer_hive_cache_client.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_persistent_cache_datasource_impl.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/repository/composer_cache_repository_impl.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/mark_composer_cache_clean_close_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/remove_all_composer_cache_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.dart';
+
+final _composerHiveCacheClientProvider =
+    Provider<ComposerHiveCacheClient>((_) => ComposerHiveCacheClient());
+
+final _cacheExceptionThrowerProvider =
+    Provider<CacheExceptionThrower>((_) => CacheExceptionThrower());
+
+final _composerCacheDatasourceProvider = Provider<ComposerCacheDatasource>(
+  (ref) => ComposerPersistentCacheDatasourceImpl(
+    ref.read(_composerHiveCacheClientProvider),
+    ref.read(_cacheExceptionThrowerProvider),
+  ),
+);
+
+final composerCacheRepositoryProvider = Provider<ComposerCacheRepository>(
+  (ref) => ComposerCacheRepositoryImpl(ref.read(_composerCacheDatasourceProvider)),
+);
+
+final removeAllComposerCacheProvider = Provider<RemoveAllComposerCacheInteractor>(
+  (ref) => RemoveAllComposerCacheInteractor(ref.read(composerCacheRepositoryProvider)),
+);
+
+final markComposerLocalCacheCleanCloseProvider = Provider<MarkComposerCacheCleanCloseInteractor>(
+  (ref) => MarkComposerCacheCleanCloseInteractor(ref.read(composerCacheRepositoryProvider)),
+);
+
+final resolveComposerCacheForRestoreProvider = Provider<ResolveComposerCacheForRestoreInteractor>(
+  (ref) => ResolveComposerCacheForRestoreInteractor(ref.read(composerCacheRepositoryProvider)),
+);

--- a/lib/features/composer/presentation/view/mobile/mobile_editor_view.dart
+++ b/lib/features/composer/presentation/view/mobile/mobile_editor_view.dart
@@ -110,6 +110,7 @@ class MobileEditorView extends StatelessWidget with EditorViewMixin {
       EmailActionType.editSendingEmail,
       EmailActionType.composeFromContentShared,
       EmailActionType.reopenComposerBrowser,
+      EmailActionType.restoreComposerFromPersistentCache,
       EmailActionType.composeFromMailtoUri,
       EmailActionType.composeFromUnsubscribeMailtoLink,
       EmailActionType.editAsNewEmail,

--- a/lib/features/composer/presentation/web_composer_bindings.dart
+++ b/lib/features/composer/presentation/web_composer_bindings.dart
@@ -36,5 +36,7 @@ class WebComposerBindings extends ComposerBindings {
   }
 
   @override
-  void disposePlatformCacheImpl() {}
+  void disposePlatformCacheImpl() {
+    Get.delete<ComposerSessionCacheDatasourceImpl>(tag: composerId);
+  }
 }

--- a/lib/features/composer/presentation/web_composer_bindings.dart
+++ b/lib/features/composer/presentation/web_composer_bindings.dart
@@ -1,4 +1,3 @@
-import 'package:core/presentation/utils/html_transformer/html_transform.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_bindings.dart';
 import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_web_controller.dart';
@@ -14,7 +13,6 @@ class WebComposerBindings extends ComposerBindings {
   @override
   void bindPlatformCacheDatasourceImpl() {
     Get.lazyPut(() => ComposerSessionCacheDatasourceImpl(
-      Get.find<HtmlTransform>(),
       Get.find<CacheExceptionThrower>(),
     ), tag: composerId);
   }

--- a/lib/features/composer/presentation/web_composer_bindings.dart
+++ b/lib/features/composer/presentation/web_composer_bindings.dart
@@ -1,0 +1,42 @@
+import 'package:core/presentation/utils/html_transformer/html_transform.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_bindings.dart';
+import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_web_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_session_cache_datasource_impl.dart';
+import 'package:tmail_ui_user/features/email/presentation/model/composer_arguments.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.dart';
+
+class WebComposerBindings extends ComposerBindings {
+  WebComposerBindings({String? composerId, ComposerArguments? composerArguments})
+      : super.base(composerId: composerId, composerArguments: composerArguments);
+
+  @override
+  void bindPlatformCacheDatasourceImpl() {
+    Get.lazyPut(() => ComposerSessionCacheDatasourceImpl(
+      Get.find<HtmlTransform>(),
+      Get.find<CacheExceptionThrower>(),
+    ), tag: composerId);
+  }
+
+  @override
+  void bindPlatformComposerCacheDatasource() {
+    Get.lazyPut<ComposerCacheDatasource>(
+      () => Get.find<ComposerSessionCacheDatasourceImpl>(tag: composerId),
+      tag: composerId,
+    );
+  }
+
+  @override
+  void bindPlatformRichTextController() {
+    Get.lazyPut(() => RichTextWebController(), tag: composerId);
+  }
+
+  @override
+  void disposePlatformRichTextController() {
+    Get.delete<RichTextWebController>(tag: composerId);
+  }
+
+  @override
+  void disposePlatformCacheImpl() {}
+}

--- a/lib/features/email/presentation/model/composer_arguments.dart
+++ b/lib/features/email/presentation/model/composer_arguments.dart
@@ -7,6 +7,7 @@ import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 
 import 'package:tmail_ui_user/features/composer/presentation/model/screen_display_mode.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/model/sending_email.dart';
 import 'package:tmail_ui_user/features/sending_queue/presentation/model/sending_email_action_type.dart';
 import 'package:tmail_ui_user/main/routes/router_arguments.dart';
@@ -225,6 +226,23 @@ class ComposerArguments extends RouterArguments {
   SendingEmailActionType get sendingEmailActionType => sendingEmail != null
     ? SendingEmailActionType.edit
     : SendingEmailActionType.create;
+
+  factory ComposerArguments.fromComposerPersistentCache(ComposerPersistentCache cache) =>
+    ComposerArguments(
+      emailActionType: EmailActionType.restoreComposerFromPersistentCache,
+      presentationEmail: cache.email?.toPresentationEmail(),
+      emailContents: cache.email?.emailContentList.asHtmlString,
+      attachments: cache.email?.allAttachments.getListAttachmentsDisplayedOutside(
+        cache.email?.htmlBodyAttachments ?? [],
+      ),
+      selectedIdentityId: cache.email?.identityIdFromHeader,
+      inlineImages: cache.email?.allAttachments.listAttachmentsDisplayedInContent,
+      hasRequestReadReceipt: cache.hasRequestReadReceipt,
+      isMarkAsImportant: cache.isMarkAsImportant,
+      composerId: cache.composerId,
+      savedActionType: cache.actionType,
+      savedEmailDraftId: cache.draftEmailId,
+    );
 
   factory ComposerArguments.fromUnsubscribeMailtoLink({
     List<EmailAddress>? listEmailAddress,

--- a/lib/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart
+++ b/lib/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart
@@ -1,4 +1,3 @@
-import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
@@ -34,11 +33,4 @@ abstract class ComposerCacheDatasource {
       throw UnsupportedError(
           'removeComposerCacheById is not supported on this platform');
 
-  Future<String> restoreEmailInlineImages(
-    String htmlContent,
-    TransformConfiguration transformConfiguration,
-    Map<String, String> mapUrlDownloadCID,
-  ) =>
-      throw UnsupportedError(
-          'restoreEmailInlineImages is not supported on this platform');
 }

--- a/lib/features/mailbox_dashboard/data/datasource_impl/composer_persistent_cache_datasource_impl.dart
+++ b/lib/features/mailbox_dashboard/data/datasource_impl/composer_persistent_cache_datasource_impl.dart
@@ -1,0 +1,52 @@
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:tmail_ui_user/features/caching/clients/composer_hive_cache_client.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/exception_thrower.dart';
+
+class ComposerPersistentCacheDatasourceImpl extends ComposerCacheDatasource {
+  final ComposerHiveCacheClient _cacheClient;
+  final ExceptionThrower _exceptionThrower;
+
+  ComposerPersistentCacheDatasourceImpl(this._cacheClient, this._exceptionThrower);
+
+  @override
+  Future<void> saveComposerCache(
+    AccountId accountId,
+    UserName userName,
+    ComposerCache composerCache,
+  ) {
+    return Future.sync(
+      () => _cacheClient.saveCache(accountId, userName, composerCache),
+    ).catchError(_exceptionThrower.throwException);
+  }
+
+  @override
+  Future<List<ComposerCache>> getComposerCache(
+    AccountId accountId,
+    UserName userName,
+  ) {
+    return Future.sync(
+      () => _cacheClient.getCache(accountId, userName),
+    ).catchError(_exceptionThrower.throwException);
+  }
+
+  @override
+  Future<void> removeAllComposerCache(AccountId accountId, UserName userName) {
+    return Future.sync(
+      () => _cacheClient.deleteCache(accountId, userName),
+    ).catchError(_exceptionThrower.throwException);
+  }
+
+  @override
+  Future<void> removeComposerCacheById(
+    AccountId accountId,
+    UserName userName,
+    String composerId,
+  ) {
+    return Future.sync(
+      () => _cacheClient.deleteCacheById(accountId, userName, composerId),
+    ).catchError(_exceptionThrower.throwException);
+  }
+}

--- a/lib/features/mailbox_dashboard/data/datasource_impl/composer_session_cache_datasource_impl.dart
+++ b/lib/features/mailbox_dashboard/data/datasource_impl/composer_session_cache_datasource_impl.dart
@@ -1,7 +1,5 @@
 import 'dart:convert';
 import 'package:core/domain/exceptions/web_session_exception.dart';
-import 'package:core/presentation/utils/html_transformer/html_transform.dart';
-import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:model/email/email_action_type.dart';
@@ -13,13 +11,9 @@ import 'package:tmail_ui_user/main/exceptions/thrower/exception_thrower.dart';
 import 'package:universal_html/html.dart' as html;
 
 class ComposerSessionCacheDatasourceImpl extends ComposerCacheDatasource {
-  final HtmlTransform _htmlTransform;
   final ExceptionThrower _exceptionThrower;
 
-  ComposerSessionCacheDatasourceImpl(
-    this._htmlTransform,
-    this._exceptionThrower,
-  );
+  ComposerSessionCacheDatasourceImpl(this._exceptionThrower);
 
   @override
   Future<List<ComposerCache>> getComposerCache(
@@ -31,7 +25,7 @@ class ComposerSessionCacheDatasourceImpl extends ComposerCacheDatasource {
         EmailActionType.reopenComposerBrowser.name,
         accountId.asString,
         userName.value).toString();
-        
+
       final listEntries = html.window.sessionStorage.entries.where(
         (entry) => entry.key.startsWith(keyWithIdentity),
       );
@@ -60,19 +54,6 @@ class ComposerSessionCacheDatasourceImpl extends ComposerCacheDatasource {
         composerCache.composerId,
       ).toString();
       html.window.sessionStorage[composerCacheKey] = jsonEncode(composerCache.toJson());
-    }).catchError(_exceptionThrower.throwException);
-  }
-  
-  @override
-  Future<String> restoreEmailInlineImages(
-    String htmlContent,
-    TransformConfiguration transformConfiguration,
-    Map<String, String> mapUrlDownloadCID) {
-    return Future.sync(() async {
-      return await _htmlTransform.transformToHtml(
-        htmlContent: htmlContent,
-        transformConfiguration: transformConfiguration,
-        mapCidImageDownloadUrl: mapUrlDownloadCID);
     }).catchError(_exceptionThrower.throwException);
   }
 

--- a/lib/features/mailbox_dashboard/data/model/composer_persistent_cache.dart
+++ b/lib/features/mailbox_dashboard/data/model/composer_persistent_cache.dart
@@ -1,0 +1,108 @@
+import 'package:jmap_dart_client/http/converter/email_id_nullable_converter.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:model/email/email_action_type.dart';
+import 'package:tmail_ui_user/features/composer/presentation/model/screen_display_mode.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
+
+part 'composer_persistent_cache.g.dart';
+
+/// Extension of [ComposerCache] with draft-recovery metadata.
+///
+/// [isCleanClose] `null`/`false` means "restore on next open"; `true` means
+/// the composer was dismissed intentionally (send or explicit discard).
+/// [timestampMs] selects the most recent snapshot across concurrent sessions.
+@JsonSerializable(
+  explicitToJson: true,
+  includeIfNull: false,
+  converters: [
+    EmailIdNullableConverter(),
+  ],
+)
+class ComposerPersistentCache extends ComposerCache {
+  static const _expiryDuration = Duration(hours: 24);
+
+  final bool? isCleanClose;
+  final int? timestampMs;
+
+  ComposerPersistentCache({
+    super.email,
+    super.hasRequestReadReceipt,
+    super.isMarkAsImportant,
+    super.displayMode,
+    super.composerIndex,
+    super.composerId,
+    super.draftHash,
+    super.actionType,
+    super.draftEmailId,
+    super.templateEmailId,
+    this.isCleanClose,
+    this.timestampMs,
+  });
+
+  factory ComposerPersistentCache.fromJson(Map<String, dynamic> json) =>
+      _$ComposerPersistentCacheFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => {
+        ...super.toJson(),
+        ..._$ComposerPersistentCacheToJson(this),
+      };
+
+  bool get isRestorable => isCleanClose != true && !isExpired && !isEmpty;
+
+  bool get isExpired {
+    if (timestampMs == null) return false;
+    return DateTime.now().millisecondsSinceEpoch - timestampMs! >
+        _expiryDuration.inMilliseconds;
+  }
+
+  bool get isEmpty => email == null;
+
+  ComposerPersistentCache copyWith({
+    Email? email,
+    bool? hasRequestReadReceipt,
+    bool? isMarkAsImportant,
+    ScreenDisplayMode? displayMode,
+    int? composerIndex,
+    String? composerId,
+    int? draftHash,
+    EmailActionType? actionType,
+    EmailId? draftEmailId,
+    EmailId? templateEmailId,
+    bool? isCleanClose,
+    int? timestampMs,
+  }) =>
+      ComposerPersistentCache(
+        email: email ?? this.email,
+        hasRequestReadReceipt: hasRequestReadReceipt ?? this.hasRequestReadReceipt,
+        isMarkAsImportant: isMarkAsImportant ?? this.isMarkAsImportant,
+        displayMode: displayMode ?? this.displayMode,
+        composerIndex: composerIndex ?? this.composerIndex,
+        composerId: composerId ?? this.composerId,
+        draftHash: draftHash ?? this.draftHash,
+        actionType: actionType ?? this.actionType,
+        draftEmailId: draftEmailId ?? this.draftEmailId,
+        templateEmailId: templateEmailId ?? this.templateEmailId,
+        isCleanClose: isCleanClose ?? this.isCleanClose,
+        timestampMs: timestampMs ?? this.timestampMs,
+      );
+
+  @override
+  List<Object?> get props => [
+        ...super.props,
+        isCleanClose,
+        timestampMs,
+      ];
+}
+
+extension ComposerPersistentCacheListExtension on Iterable<ComposerCache> {
+  ComposerPersistentCache? get newestLocalCache =>
+      whereType<ComposerPersistentCache>()
+          .fold<ComposerPersistentCache?>(null, (newest, entry) {
+        if (newest == null) return entry;
+        return (entry.timestampMs ?? 0) > (newest.timestampMs ?? 0)
+            ? entry
+            : newest;
+      });
+}

--- a/lib/features/mailbox_dashboard/data/repository/composer_cache_repository_impl.dart
+++ b/lib/features/mailbox_dashboard/data/repository/composer_cache_repository_impl.dart
@@ -1,4 +1,3 @@
-import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart';
@@ -48,15 +47,4 @@ class ComposerCacheRepositoryImpl extends ComposerCacheRepository {
         composerId,
       );
 
-  @override
-  Future<String> restoreEmailInlineImages(
-    String htmlContent,
-    TransformConfiguration transformConfiguration,
-    Map<String, String> mapUrlDownloadCID,
-  ) =>
-      _composerCacheDatasource.restoreEmailInlineImages(
-        htmlContent,
-        transformConfiguration,
-        mapUrlDownloadCID,
-      );
 }

--- a/lib/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart
+++ b/lib/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart
@@ -1,4 +1,3 @@
-import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
@@ -24,11 +23,5 @@ abstract class ComposerCacheRepository {
     AccountId accountId,
     UserName userName,
     String composerId,
-  );
-
-  Future<String> restoreEmailInlineImages(
-    String htmlContent,
-    TransformConfiguration transformConfiguration,
-    Map<String, String> mapUrlDownloadCID,
   );
 }

--- a/lib/features/mailbox_dashboard/domain/state/mark_composer_cache_clean_close_state.dart
+++ b/lib/features/mailbox_dashboard/domain/state/mark_composer_cache_clean_close_state.dart
@@ -1,0 +1,8 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+
+class MarkComposerCacheCleanCloseSuccess extends UIState {}
+
+class MarkComposerCacheCleanCloseFailure extends FeatureFailure {
+  MarkComposerCacheCleanCloseFailure(Object? exception) : super(exception: exception);
+}

--- a/lib/features/mailbox_dashboard/domain/state/resolve_composer_cache_for_restore_state.dart
+++ b/lib/features/mailbox_dashboard/domain/state/resolve_composer_cache_for_restore_state.dart
@@ -1,0 +1,20 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+
+/// Emitted when the resolve logic completes, regardless of whether a
+/// restorable snapshot was found.  [cache] is null when no valid snapshot
+/// exists (expired, clean-close, or simply absent).
+class ResolveComposerCacheForRestoreSuccess extends UIState {
+  final ComposerPersistentCache? cache;
+
+  ResolveComposerCacheForRestoreSuccess(this.cache);
+
+  @override
+  List<Object?> get props => [cache, ...super.props];
+}
+
+class ResolveComposerCacheForRestoreFailure extends FeatureFailure {
+  ResolveComposerCacheForRestoreFailure(Object exception)
+      : super(exception: exception);
+}

--- a/lib/features/mailbox_dashboard/domain/usecases/mark_composer_cache_clean_close_interactor.dart
+++ b/lib/features/mailbox_dashboard/domain/usecases/mark_composer_cache_clean_close_interactor.dart
@@ -1,0 +1,48 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/mark_composer_cache_clean_close_state.dart';
+
+/// Two-step write (mark then remove) ensures the entry is not treated as a
+/// recoverable snapshot if removal is interrupted
+/// (see [ComposerPersistentCache.isRestorable]).
+class MarkComposerCacheCleanCloseInteractor {
+  final ComposerCacheRepository _repository;
+
+  MarkComposerCacheCleanCloseInteractor(this._repository);
+
+  Future<Either<Failure, Success>> execute(
+    AccountId accountId,
+    UserName userName,
+  ) async {
+    try {
+      final cache =
+          (await _repository.getComposerCache(accountId, userName)).newestLocalCache;
+      if (cache != null) await _tryMarkCleanClose(accountId, userName, cache);
+      await _repository.removeAllComposerCache(accountId, userName);
+      return Right(MarkComposerCacheCleanCloseSuccess());
+    } catch (exception) {
+      return Left(MarkComposerCacheCleanCloseFailure(exception));
+    }
+  }
+
+  Future<void> _tryMarkCleanClose(
+    AccountId accountId,
+    UserName userName,
+    ComposerPersistentCache cache,
+  ) async {
+    try {
+      await _repository.saveComposerCache(
+        accountId,
+        userName,
+        cache.copyWith(isCleanClose: true),
+      );
+    } catch (_) {
+      // Best-effort: mark failure must not prevent removal.
+    }
+  }
+}

--- a/lib/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor.dart
+++ b/lib/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor.dart
@@ -1,0 +1,42 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/resolve_composer_cache_for_restore_state.dart';
+
+/// Fetches, validates, and cleans up the composer cache in one pass.
+///
+/// Returns [ResolveComposerCacheForRestoreSuccess] with a non-null [cache]
+/// when a restorable snapshot exists.  Stale or clean-close entries are
+/// removed as a side-effect so Hive stays lean.
+class ResolveComposerCacheForRestoreInteractor {
+  final ComposerCacheRepository _repository;
+
+  ResolveComposerCacheForRestoreInteractor(this._repository);
+
+  Future<Either<Failure, Success>> execute(
+    AccountId accountId,
+    UserName userName,
+  ) async {
+    try {
+      final caches = await _repository.getComposerCache(accountId, userName);
+      final cache = caches.newestLocalCache;
+
+      if (cache == null) {
+        return Right(ResolveComposerCacheForRestoreSuccess(null));
+      }
+
+      if (!cache.isRestorable) {
+        await _repository.removeAllComposerCache(accountId, userName);
+        return Right(ResolveComposerCacheForRestoreSuccess(null));
+      }
+
+      return Right(ResolveComposerCacheForRestoreSuccess(cache));
+    } catch (exception) {
+      return Left(ResolveComposerCacheForRestoreFailure(exception));
+    }
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
@@ -1,9 +1,9 @@
 import 'package:core/data/model/source_type/data_source_type.dart';
 import 'package:core/data/network/download/download_manager.dart';
 import 'package:core/presentation/resources/image_paths.dart';
-import 'package:core/presentation/utils/html_transformer/html_transform.dart';
 import 'package:core/utils/config/app_config_loader.dart';
 import 'package:core/utils/file_utils.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:core/utils/preview_eml_file_utils.dart';
 import 'package:core/utils/print_utils.dart';
 import 'package:get/get.dart';
@@ -83,7 +83,6 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/hi
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/local_app_grid_datasource_impl.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/local_spam_report_datasource_impl.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/search_datasource_impl.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_session_cache_datasource_impl.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/local/local_sort_order_manager.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/network/linagora_ecosystem_api.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/repository/app_grid_repository_impl.dart';
@@ -113,6 +112,8 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/store_l
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/store_spam_report_state_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/bindings/email_action_interactor_bindings.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/bindings/linagora_ecosystem_interactor_bindings.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/bindings/mobile_mailbox_dashboard_bindings.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/bindings/web_mailbox_dashboard_bindings.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/app_grid_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
@@ -170,7 +171,19 @@ import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.da
 import 'package:tmail_ui_user/main/exceptions/thrower/remote_exception_thrower.dart';
 import 'package:tmail_ui_user/main/utils/ios_sharing_manager.dart';
 
-class MailboxDashBoardBindings extends BaseBindings {
+abstract class MailboxDashBoardBindings extends BaseBindings {
+
+  MailboxDashBoardBindings.base();
+
+  factory MailboxDashBoardBindings() {
+    if (PlatformInfo.isWeb) {
+      return WebMailboxDashboardBindings();
+    }
+    return MobileMailboxDashboardBindings();
+  }
+
+  void bindPlatformDatasourceImpl();
+  void bindPlatformDatasource();
 
   @override
   void dependencies() {
@@ -270,12 +283,12 @@ class MailboxDashBoardBindings extends BaseBindings {
     Get.lazyPut<StateDataSource>(() => Get.find<StateDataSourceImpl>());
     Get.lazyPut<PrintFileDataSource>(() => Get.find<PrintFileDataSourceImpl>());
     Get.lazyPut<MailboxDataSource>(() => Get.find<MailboxDataSourceImpl>());
-    Get.lazyPut<ComposerCacheDatasource>(() => Get.find<ComposerSessionCacheDatasourceImpl>());
     Get.lazyPut<MailboxCacheDataSourceImpl>(() => Get.find<MailboxCacheDataSourceImpl>());
     Get.lazyPut<ServerSettingsDataSource>(
       () => Get.find<RemoteServerSettingsDataSourceImpl>());
     Get.lazyPut<IdentityCreatorDataSource>(() => Get.find<LocalIdentityCreatorDataSourceImpl>());
     Get.lazyPut<AppGridDatasource>(() => Get.find<AppGridDatasourceImpl>());
+    bindPlatformDatasource();
   }
 
   @override
@@ -318,9 +331,6 @@ class MailboxDashBoardBindings extends BaseBindings {
     Get.lazyPut(() => MailboxCacheDataSourceImpl(
       Get.find<MailboxCacheManager>(),
       Get.find<CacheExceptionThrower>()));
-    Get.lazyPut(() => ComposerSessionCacheDatasourceImpl(
-      Get.find<HtmlTransform>(),
-      Get.find<CacheExceptionThrower>()));
     Get.lazyPut(() => LocalSpamReportDataSourceImpl(
       Get.find<PreferencesSettingManager>(),
       Get.find<CacheExceptionThrower>(),
@@ -359,6 +369,7 @@ class MailboxDashBoardBindings extends BaseBindings {
       Get.find<AppConfigLoader>(),
       Get.find<CacheExceptionThrower>(),
     ));
+    bindPlatformDatasourceImpl();
   }
 
   @override

--- a/lib/features/mailbox_dashboard/presentation/bindings/mobile_mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/mobile_mailbox_dashboard_bindings.dart
@@ -1,0 +1,28 @@
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/caching/clients/composer_hive_cache_client.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_persistent_cache_datasource_impl.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.dart';
+
+class MobileMailboxDashboardBindings extends MailboxDashBoardBindings {
+  MobileMailboxDashboardBindings() : super.base();
+
+  @override
+  void bindPlatformDatasourceImpl() {
+    Get.lazyPut(() => ComposerHiveCacheClient());
+    Get.lazyPut(
+      () => ComposerPersistentCacheDatasourceImpl(
+        Get.find<ComposerHiveCacheClient>(),
+        Get.find<CacheExceptionThrower>(),
+      ),
+    );
+  }
+
+  @override
+  void bindPlatformDatasource() {
+    Get.lazyPut<ComposerCacheDatasource>(
+      () => Get.find<ComposerPersistentCacheDatasourceImpl>(),
+    );
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/bindings/web_mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/web_mailbox_dashboard_bindings.dart
@@ -1,0 +1,28 @@
+import 'package:core/core.dart';
+import 'package:core/presentation/utils/html_transformer/html_transform.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_session_cache_datasource_impl.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.dart';
+
+class WebMailboxDashboardBindings extends MailboxDashBoardBindings {
+  WebMailboxDashboardBindings() : super.base();
+
+  @override
+  void bindPlatformDatasourceImpl() {
+    Get.lazyPut(
+      () => ComposerSessionCacheDatasourceImpl(
+        Get.find<HtmlTransform>(),
+        Get.find<CacheExceptionThrower>(),
+      ),
+    );
+  }
+
+  @override
+  void bindPlatformDatasource() {
+    Get.lazyPut<ComposerCacheDatasource>(
+      () => Get.find<ComposerSessionCacheDatasourceImpl>(),
+    );
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/bindings/web_mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/web_mailbox_dashboard_bindings.dart
@@ -1,5 +1,3 @@
-import 'package:core/core.dart';
-import 'package:core/presentation/utils/html_transformer/html_transform.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_session_cache_datasource_impl.dart';
@@ -13,7 +11,6 @@ class WebMailboxDashboardBindings extends MailboxDashBoardBindings {
   void bindPlatformDatasourceImpl() {
     Get.lazyPut(
       () => ComposerSessionCacheDatasourceImpl(
-        Get.find<HtmlTransform>(),
         Get.find<CacheExceptionThrower>(),
       ),
     );

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -146,6 +146,7 @@ import 'package:tmail_ui_user/features/mailbox/presentation/mixin/handle_team_ma
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/initialize_app_language.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/notify_thread_detail_setting_updated.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_composer_restore_on_mobile_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/open_and_close_composer_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/quick_search_emails_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/reopen_composer_cache_extension.dart';
@@ -904,6 +905,8 @@ class MailboxDashBoardController extends ReloadableController
     if (PlatformInfo.isWeb) {
       _handleComposerCache();
     }
+
+    unawaited(checkAndRestoreComposerOnMobile());
 
     if (PlatformInfo.isAndroid && !_notificationManager.isNotificationClickedOnTerminate) {
       _handleClickNotificationOnAndroidInTerminated();

--- a/lib/features/mailbox_dashboard/presentation/extensions/handle_composer_restore_on_mobile_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/handle_composer_restore_on_mobile_extension.dart
@@ -40,7 +40,13 @@ extension HandleComposerRestoreOnMobileExtension on MailboxDashBoardController {
         log('HandleComposerRestoreOnMobileExtension::_resolveRestorableCache: failure=${failure.runtimeType}');
         return null;
       },
-      (success) => (success as ResolveComposerCacheForRestoreSuccess).cache,
+      (success) {
+        if (success is ResolveComposerCacheForRestoreSuccess) {
+          return success.cache;
+        }
+        log('HandleComposerRestoreOnMobileExtension::_resolveRestorableCache: unexpected success type=${success.runtimeType}');
+        return null;
+      }
     );
   }
 }

--- a/lib/features/mailbox_dashboard/presentation/extensions/handle_composer_restore_on_mobile_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/handle_composer_restore_on_mobile_extension.dart
@@ -1,0 +1,46 @@
+import 'package:core/utils/app_logger.dart';
+import 'package:core/utils/platform_info.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:tmail_ui_user/features/composer/presentation/providers/composer_cache_providers.dart';
+import 'package:tmail_ui_user/features/email/presentation/model/composer_arguments.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/resolve_composer_cache_for_restore_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/open_and_close_composer_extension.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
+
+extension HandleComposerRestoreOnMobileExtension on MailboxDashBoardController {
+  Future<void> checkAndRestoreComposerOnMobile() async {
+    if (!PlatformInfo.isAndroid) return;
+
+    final currentAccountId = accountId.value;
+    final currentUserName = sessionCurrent?.username;
+    if (currentAccountId == null || currentUserName == null) return;
+
+    try {
+      final cache = await _resolveRestorableCache(currentAccountId, currentUserName);
+      if (cache == null) return;
+      log('HandleComposerRestoreOnMobileExtension::checkAndRestoreComposerOnMobile: reopening composer');
+      openComposer(ComposerArguments.fromComposerPersistentCache(cache));
+    } catch (e, stackTrace) {
+      logWarning('HandleComposerRestoreOnMobileExtension::checkAndRestoreComposerOnMobile: error=$e\n$stackTrace');
+    }
+  }
+
+  Future<ComposerPersistentCache?> _resolveRestorableCache(
+    AccountId accountId,
+    UserName userName,
+  ) async {
+    final result = await appProviderContainer
+        .read(resolveComposerCacheForRestoreProvider)
+        .execute(accountId, userName);
+    return result.fold(
+      (failure) {
+        log('HandleComposerRestoreOnMobileExtension::_resolveRestorableCache: failure=${failure.runtimeType}');
+        return null;
+      },
+      (success) => (success as ResolveComposerCacheForRestoreSuccess).cache,
+    );
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/extensions/open_and_close_composer_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/open_and_close_composer_extension.dart
@@ -57,6 +57,9 @@ extension OpenAndCloseComposerExtension on MailboxDashBoardController {
   Future<void> _openComposerOnMobile(ComposerArguments arguments) async {
     BackButtonInterceptor.removeByName(AppRoutes.dashboard);
 
+    final composerId = arguments.composerId ?? DateTime.now().millisecondsSinceEpoch.toString();
+    final argsWithId = arguments.copyWith(composerId: composerId);
+
     bool isTabletPlatform = currentContext != null
         && !responsiveUtils.isScreenWithShortestSide(currentContext!);
 
@@ -68,9 +71,9 @@ extension OpenAndCloseComposerExtension on MailboxDashBoardController {
 
       result = await Get.to(
         () => const ComposerView(),
-        binding: ComposerBindings(),
+        binding: ComposerBindings(composerId: composerId),
         opaque: false,
-        arguments: arguments,
+        arguments: argsWithId,
       );
 
       if (PlatformInfo.isIOS) {
@@ -80,7 +83,7 @@ extension OpenAndCloseComposerExtension on MailboxDashBoardController {
         );
       }
     } else {
-      result = await push(AppRoutes.composer, arguments: arguments);
+      result = await push(AppRoutes.composer, arguments: argsWithId);
     }
 
     BackButtonInterceptor.add(onBackButtonInterceptor, name: AppRoutes.dashboard);

--- a/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
+++ b/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
@@ -18,7 +18,11 @@ extension ThreadDetailOnSelectedEmailUpdated on ThreadDetailController {
     PresentationEmail? selectedEmail,
     BuildContext? context,
   ) {
-    if (selectedEmail?.id == null && mailboxDashBoardController.isEmailOpened) {
+    final selectedPresentationEmail = selectedEmail;
+    final selectedPresentationEmailId = selectedPresentationEmail?.id;
+    final selectedPresentationEmailThreadId = selectedPresentationEmail?.threadId;
+
+    if (selectedPresentationEmailId == null && mailboxDashBoardController.isEmailOpened) {
       closeThreadDetailAction();
       return;
     }
@@ -27,23 +31,23 @@ extension ThreadDetailOnSelectedEmailUpdated on ThreadDetailController {
     onKeyboardShortcutInit();
     scrollController ??= ScrollController();
 
-    if (currentExpandedEmailId.value == null) {
+    if (currentExpandedEmailId.value == null && selectedPresentationEmail != null) {
       loadThreadOnThreadChanged = isThreadDetailEnabled;
-      _preloadSelectedEmail(selectedEmail!);
+      _preloadSelectedEmail(selectedPresentationEmail);
       return;
     }
 
     // Thread setting updated, no need to dispose current single email controller
-    if (currentExpandedEmailId.value == selectedEmail!.id) {
-      _preloadSelectedEmail(selectedEmail);
+    if (currentExpandedEmailId.value == selectedPresentationEmailId && selectedPresentationEmail != null) {
+      _preloadSelectedEmail(selectedPresentationEmail);
 
-      if (isThreadDetailEnabled && selectedEmail.threadId != null) {
-        final mailboxContain = selectedEmail.findMailboxContain(
+      if (isThreadDetailEnabled && selectedPresentationEmailThreadId != null) {
+        final mailboxContain = selectedPresentationEmail.findMailboxContain(
           mailboxDashBoardController.mapMailboxById,
         );
         mailboxDashBoardController.dispatchThreadDetailUIAction(
           LoadThreadDetailAfterSelectedEmailAction(
-            selectedEmail.threadId!,
+            selectedPresentationEmailThreadId,
             isSentMailbox: mailboxContain?.isSent == true,
           )
         );
@@ -60,7 +64,10 @@ extension ThreadDetailOnSelectedEmailUpdated on ThreadDetailController {
     }
 
     loadThreadOnThreadChanged = isThreadDetailEnabled;
-    _preloadSelectedEmail(selectedEmail);
+
+    if (selectedPresentationEmail != null) {
+      _preloadSelectedEmail(selectedPresentationEmail);
+    }
   }
 
   void _preloadSelectedEmail(PresentationEmail selectedEmail) {

--- a/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
+++ b/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
@@ -31,7 +31,7 @@ extension ThreadDetailOnSelectedEmailUpdated on ThreadDetailController {
     onKeyboardShortcutInit();
     scrollController ??= ScrollController();
 
-    if (currentExpandedEmailId.value == null && selectedPresentationEmail != null) {
+    if (currentExpandedEmailId.value == null && selectedPresentationEmail != null && selectedPresentationEmailId != null) {
       loadThreadOnThreadChanged = isThreadDetailEnabled;
       _preloadSelectedEmail(selectedPresentationEmail);
       return;

--- a/model/lib/email/email_action_type.dart
+++ b/model/lib/email/email_action_type.dart
@@ -31,7 +31,8 @@ enum EmailActionType {
   composeFromUnsubscribeMailtoLink(),
   archiveMessage(3),
   printAll(4),
-  downloadMessageAsEML(4);
+  downloadMessageAsEML(4),
+  restoreComposerFromPersistentCache();
 
   /// Add category to group email action
   final int category;

--- a/test/features/composer/domain/usecases/restore_email_inline_images_interactor_test.dart
+++ b/test/features/composer/domain/usecases/restore_email_inline_images_interactor_test.dart
@@ -1,0 +1,61 @@
+import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/composer/domain/state/restore_email_inline_images_state.dart';
+import 'package:tmail_ui_user/features/composer/domain/transformer/html_email_transformer.dart';
+import 'package:tmail_ui_user/features/composer/domain/usecases/restore_email_inline_images_interactor.dart';
+
+import 'restore_email_inline_images_interactor_test.mocks.dart';
+
+@GenerateMocks([HtmlEmailTransformer])
+void main() {
+  late MockHtmlEmailTransformer mockTransformer;
+  late RestoreEmailInlineImagesInteractor interactor;
+
+  const htmlWithCid = '<img src="cid:abc123">';
+  const restoredHtml = '<img src="data:image/png;base64,abc==">';
+  final transformConfig = TransformConfiguration.forRestoreEmail();
+  final mapCid = {'abc123': 'https://example.com/download/abc'};
+
+  setUp(() {
+    mockTransformer = MockHtmlEmailTransformer();
+    interactor = RestoreEmailInlineImagesInteractor(mockTransformer);
+  });
+
+  group('execute', () {
+    test('emits RestoringEmailInlineImages then RestoreEmailInlineImagesSuccess on success', () async {
+      when(mockTransformer.transformToHtml(
+        htmlContent: htmlWithCid,
+        transformConfiguration: transformConfig,
+        mapCidImageDownloadUrl: mapCid,
+      )).thenAnswer((_) async => restoredHtml);
+
+      final states = await interactor.execute(
+        htmlContent: htmlWithCid,
+        transformConfiguration: transformConfig,
+        mapUrlDownloadCID: mapCid,
+      ).map((either) => either.fold((f) => f, (s) => s)).toList();
+
+      expect(states[0], isA<RestoringEmailInlineImages>());
+      expect(states[1], isA<RestoreEmailInlineImagesSuccess>());
+      expect((states[1] as RestoreEmailInlineImagesSuccess).emailContent, equals(restoredHtml));
+    });
+
+    test('emits RestoreEmailInlineImagesFailure when transformer throws', () async {
+      when(mockTransformer.transformToHtml(
+        htmlContent: anyNamed('htmlContent'),
+        transformConfiguration: anyNamed('transformConfiguration'),
+        mapCidImageDownloadUrl: anyNamed('mapCidImageDownloadUrl'),
+      )).thenThrow(Exception('network error'));
+
+      final states = await interactor.execute(
+        htmlContent: htmlWithCid,
+        transformConfiguration: transformConfig,
+        mapUrlDownloadCID: mapCid,
+      ).map((either) => either.fold((f) => f, (s) => s)).toList();
+
+      expect(states.last, isA<RestoreEmailInlineImagesFailure>());
+    });
+  });
+}

--- a/test/features/composer/domain/usecases/save_composer_cache_interactor_test.dart
+++ b/test/features/composer/domain/usecases/save_composer_cache_interactor_test.dart
@@ -1,0 +1,152 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/email/email_action_type.dart';
+import 'package:tmail_ui_user/features/composer/domain/repository/composer_repository.dart';
+import 'package:tmail_ui_user/features/composer/domain/usecases/save_composer_cache_interactor.dart';
+import 'package:tmail_ui_user/features/composer/presentation/model/create_email_request.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/save_composer_cache_state.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import '../../../../fixtures/session_fixtures.dart';
+import 'save_composer_cache_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<ComposerCacheRepository>(),
+  MockSpec<ComposerRepository>(),
+])
+void main() {
+  late MockComposerCacheRepository mockCacheRepository;
+  late MockComposerRepository mockComposerRepository;
+  late SaveComposerCacheInteractor interactor;
+
+  final session = SessionFixtures.aliceSession;
+  final accountId = AccountFixtures.aliceAccountId;
+
+  final baseRequest = CreateEmailRequest(
+    session: session,
+    accountId: accountId,
+    emailActionType: EmailActionType.compose,
+    ownEmailAddress: 'alice@domain.tld',
+    subject: 'Test subject',
+    emailContent: '<p>Hello</p>',
+    composerId: 'uuid-composer-123',
+  );
+
+  setUp(() {
+    mockCacheRepository = MockComposerCacheRepository();
+    mockComposerRepository = MockComposerRepository();
+    interactor = SaveComposerCacheInteractor(
+      mockCacheRepository,
+      mockComposerRepository,
+    );
+  });
+
+  void arrangeSuccess() {
+    when(mockComposerRepository.generateEmail(
+      any,
+      withIdentityHeader: anyNamed('withIdentityHeader'),
+      isDraft: anyNamed('isDraft'),
+    )).thenAnswer((_) async => Email());
+    when(mockCacheRepository.saveComposerCache(any, any, any))
+        .thenAnswer((_) async {});
+  }
+
+  void expectLeftWithSaveFailure(Either result, Exception exception) {
+    result.fold(
+      (f) {
+        expect(f, isA<SaveComposerCacheFailure>());
+        expect((f as SaveComposerCacheFailure).exception, exception);
+      },
+      (_) => fail('expected Left'),
+    );
+  }
+
+  Future<Object> captureAndGetSavedCache({required bool isPersistent}) async {
+    await interactor.execute(
+      createEmailRequest: baseRequest,
+      isPersistent: isPersistent,
+    );
+    return verify(
+      mockCacheRepository.saveComposerCache(any, any, captureAny),
+    ).captured.single;
+  }
+
+  group('SaveComposerCacheInteractor', () {
+    group('on success', () {
+      setUp(arrangeSuccess);
+
+      test('calls generateEmail with withIdentityHeader=true and isDraft=true', () async {
+        await interactor.execute(createEmailRequest: baseRequest);
+
+        verify(mockComposerRepository.generateEmail(
+          baseRequest,
+          withIdentityHeader: true,
+          isDraft: true,
+        )).called(1);
+      });
+
+      test('calls saveComposerCache with the correct accountId and userName', () async {
+        await interactor.execute(createEmailRequest: baseRequest);
+
+        verify(mockCacheRepository.saveComposerCache(
+          accountId,
+          session.username,
+          any,
+        )).called(1);
+      });
+
+      test('returns Right(SaveComposerCacheSuccess)', () async {
+        final result = await interactor.execute(createEmailRequest: baseRequest);
+
+        expect(result, Right(SaveComposerCacheSuccess()));
+      });
+
+      test('saves a ComposerPersistentCache when isPersistent is true', () async {
+        final captured = await captureAndGetSavedCache(isPersistent: true);
+
+        expect(captured, isA<ComposerPersistentCache>());
+      });
+
+      test('saves a plain ComposerCache when isPersistent is false', () async {
+        final captured = await captureAndGetSavedCache(isPersistent: false);
+
+        expect(captured, isNot(isA<ComposerPersistentCache>()));
+      });
+    });
+
+    group('error handling', () {
+      test('returns Left(SaveComposerCacheFailure) when generateEmail throws', () async {
+        final exception = Exception('generate failed');
+        when(mockComposerRepository.generateEmail(
+          any,
+          withIdentityHeader: anyNamed('withIdentityHeader'),
+          isDraft: anyNamed('isDraft'),
+        )).thenThrow(exception);
+
+        final result = await interactor.execute(createEmailRequest: baseRequest);
+
+        expectLeftWithSaveFailure(result, exception);
+      });
+
+      test('returns Left(SaveComposerCacheFailure) when saveComposerCache throws', () async {
+        when(mockComposerRepository.generateEmail(
+          any,
+          withIdentityHeader: anyNamed('withIdentityHeader'),
+          isDraft: anyNamed('isDraft'),
+        )).thenAnswer((_) async => Email());
+        final exception = Exception('save failed');
+        when(mockCacheRepository.saveComposerCache(any, any, any))
+            .thenThrow(exception);
+
+        final result = await interactor.execute(createEmailRequest: baseRequest);
+
+        expectLeftWithSaveFailure(result, exception);
+      });
+    });
+  });
+}

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -39,6 +39,7 @@ import 'package:tmail_ui_user/features/composer/presentation/composer_controller
 import 'package:tmail_ui_user/features/composer/presentation/composer_view_web.dart';
 import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_web_controller.dart';
+import 'package:tmail_ui_user/features/composer/presentation/extensions/handle_mobile_auto_save_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/setup_selected_identity_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/formatting_options_state.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/saved_composing_email.dart';
@@ -753,6 +754,54 @@ void main() {
             equals(savedEmailDraft.asString().hashCode),
           );
         });
+      });
+    });
+
+    group('markCleanClose - platform guard:', () {
+      // composerController has composerId = null in this test setup.
+      // _autoSaveNotifier() returns null for null composerId, so no provider
+      // entry is created regardless of platform. These tests verify that
+      // markCleanClose() does not throw and behaves safely on all platforms.
+
+      test(
+        'Should not throw on web\n'
+        'When composerId is null',
+      () {
+        PlatformInfo.isTestingForWeb = true;
+
+        expect(
+          () => composerController?.markCleanClose(),
+          returnsNormally,
+        );
+
+        PlatformInfo.isTestingForWeb = false;
+      });
+
+      test(
+        'Should not throw on non-web\n'
+        'When composerId is null',
+      () {
+        PlatformInfo.isTestingForWeb = false;
+
+        expect(
+          () => composerController?.markCleanClose(),
+          returnsNormally,
+        );
+      });
+    });
+
+    group('tearDownMobileAutoSave safety:', () {
+      // tearDownMobileAutoSave is only called on Android (onClose guard).
+      // With composerId = null, _persistCleanCloseIfNeeded is a no-op and
+      // disposeMobileAutoSave cancels any timers. Verify no exception is thrown.
+      test(
+        'Should not throw\n'
+        'When composerId is null and timers are not started',
+      () {
+        expect(
+          () => composerController?.tearDownMobileAutoSave(),
+          returnsNormally,
+        );
       });
     });
   });

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -6,6 +6,7 @@ import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:dartz/dartz.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
@@ -44,6 +45,7 @@ import 'package:tmail_ui_user/features/composer/presentation/extensions/setup_se
 import 'package:tmail_ui_user/features/composer/presentation/model/formatting_options_state.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/saved_composing_email.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/screen_display_mode.dart';
+import 'package:tmail_ui_user/features/composer/presentation/providers/composer_auto_save_notifier.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_email_content_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/print_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/save_template_email_interactor.dart';
@@ -68,6 +70,7 @@ import 'package:tmail_ui_user/features/upload/presentation/controller/upload_con
 import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_state.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
 import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/utils/app_config.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
@@ -758,6 +761,88 @@ void main() {
     });
 
     group('markCleanClose - platform guard:', () {
+      test(
+          'Should set isCleanClose flag in the notifier\n'
+          'When on Android with valid autoSaveComposerId', () {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        addTearDown(() {
+          debugDefaultTargetPlatformOverride = null;
+          appProviderContainer
+              .invalidate(composerAutoSaveProvider('mark-cc-android-test'));
+        });
+
+        final ctrl = ComposerController(
+          mockLocalFilePickerInteractor,
+          mockLocalImagePickerInteractor,
+          mockGetEmailContentInteractor,
+          mockGetAllIdentitiesInteractor,
+          mockUploadController,
+          mockRemoveComposerCacheByIdInteractor,
+          mockSaveComposerCacheInteractor,
+          mockDownloadImageAsBase64Interactor,
+          mockTransformHtmlEmailContentInteractor,
+          mockGetServerSettingInteractor,
+          mockCreateNewAndSendEmailInteractor,
+          mockCreateNewAndSaveEmailToDraftsInteractor,
+          mockPrintEmailInteractor,
+          mockComposerRepository,
+          mockSaveTemplateEmailInteractor,
+          autoSaveComposerId: 'mark-cc-android-test',
+        );
+
+        // act
+        ctrl.markCleanClose();
+
+        // assert
+        expect(
+          appProviderContainer
+              .read(composerAutoSaveProvider('mark-cc-android-test').notifier)
+              .isCleanClose,
+          isTrue,
+        );
+      });
+
+      test(
+          'Should be a no-op\n'
+          'When platform is not Android even with valid autoSaveComposerId',
+          () {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        addTearDown(() {
+          debugDefaultTargetPlatformOverride = null;
+          appProviderContainer
+              .invalidate(composerAutoSaveProvider('mark-cc-noop-test'));
+        });
+
+        final ctrl = ComposerController(
+          mockLocalFilePickerInteractor,
+          mockLocalImagePickerInteractor,
+          mockGetEmailContentInteractor,
+          mockGetAllIdentitiesInteractor,
+          mockUploadController,
+          mockRemoveComposerCacheByIdInteractor,
+          mockSaveComposerCacheInteractor,
+          mockDownloadImageAsBase64Interactor,
+          mockTransformHtmlEmailContentInteractor,
+          mockGetServerSettingInteractor,
+          mockCreateNewAndSendEmailInteractor,
+          mockCreateNewAndSaveEmailToDraftsInteractor,
+          mockPrintEmailInteractor,
+          mockComposerRepository,
+          mockSaveTemplateEmailInteractor,
+          autoSaveComposerId: 'mark-cc-noop-test',
+        );
+
+        // act
+        ctrl.markCleanClose();
+
+        // assert — notifier should remain at default (isCleanClose: false)
+        expect(
+          appProviderContainer
+              .read(composerAutoSaveProvider('mark-cc-noop-test').notifier)
+              .isCleanClose,
+          isFalse,
+        );
+      });
       // composerController has composerId = null in this test setup.
       // _autoSaveNotifier() returns null for null composerId, so no provider
       // entry is created regardless of platform. These tests verify that
@@ -790,6 +875,121 @@ void main() {
     });
 
     group('tearDownMobileAutoSave safety:', () {
+      test(
+          'periodicSnapshotTimer is active after initMobileAutoSave\n'
+          'When autoSaveComposerId is set', () {
+        final ctrl = ComposerController(
+          mockLocalFilePickerInteractor,
+          mockLocalImagePickerInteractor,
+          mockGetEmailContentInteractor,
+          mockGetAllIdentitiesInteractor,
+          mockUploadController,
+          mockRemoveComposerCacheByIdInteractor,
+          mockSaveComposerCacheInteractor,
+          mockDownloadImageAsBase64Interactor,
+          mockTransformHtmlEmailContentInteractor,
+          mockGetServerSettingInteractor,
+          mockCreateNewAndSendEmailInteractor,
+          mockCreateNewAndSaveEmailToDraftsInteractor,
+          mockPrintEmailInteractor,
+          mockComposerRepository,
+          mockSaveTemplateEmailInteractor,
+          autoSaveComposerId: 'timer-init-test',
+        );
+        addTearDown(() => ctrl.tearDownMobileAutoSave());
+
+        ctrl.initMobileAutoSave();
+
+        expect(ctrl.periodicSnapshotTimer?.isActive, isTrue);
+      });
+
+      test(
+          'periodicSnapshotTimer is null after tearDownMobileAutoSave\n'
+          'When timers were started', () {
+        final ctrl = ComposerController(
+          mockLocalFilePickerInteractor,
+          mockLocalImagePickerInteractor,
+          mockGetEmailContentInteractor,
+          mockGetAllIdentitiesInteractor,
+          mockUploadController,
+          mockRemoveComposerCacheByIdInteractor,
+          mockSaveComposerCacheInteractor,
+          mockDownloadImageAsBase64Interactor,
+          mockTransformHtmlEmailContentInteractor,
+          mockGetServerSettingInteractor,
+          mockCreateNewAndSendEmailInteractor,
+          mockCreateNewAndSaveEmailToDraftsInteractor,
+          mockPrintEmailInteractor,
+          mockComposerRepository,
+          mockSaveTemplateEmailInteractor,
+          autoSaveComposerId: 'timer-teardown-test',
+        );
+
+        ctrl.initMobileAutoSave();
+        ctrl.tearDownMobileAutoSave();
+
+        expect(ctrl.periodicSnapshotTimer, isNull);
+      });
+
+      test(
+          'mobileAutoSaveLifecycleListener is null after tearDownMobileAutoSave\n'
+          'When listener was started', () {
+        final ctrl = ComposerController(
+          mockLocalFilePickerInteractor,
+          mockLocalImagePickerInteractor,
+          mockGetEmailContentInteractor,
+          mockGetAllIdentitiesInteractor,
+          mockUploadController,
+          mockRemoveComposerCacheByIdInteractor,
+          mockSaveComposerCacheInteractor,
+          mockDownloadImageAsBase64Interactor,
+          mockTransformHtmlEmailContentInteractor,
+          mockGetServerSettingInteractor,
+          mockCreateNewAndSendEmailInteractor,
+          mockCreateNewAndSaveEmailToDraftsInteractor,
+          mockPrintEmailInteractor,
+          mockComposerRepository,
+          mockSaveTemplateEmailInteractor,
+          autoSaveComposerId: 'listener-teardown-test',
+        );
+
+        ctrl.initMobileAutoSave();
+        ctrl.tearDownMobileAutoSave();
+
+        expect(ctrl.mobileAutoSaveLifecycleListener, isNull);
+      });
+
+      test(
+          'Calling tearDownMobileAutoSave twice does not throw\n'
+          '— idempotent teardown', () {
+        final ctrl = ComposerController(
+          mockLocalFilePickerInteractor,
+          mockLocalImagePickerInteractor,
+          mockGetEmailContentInteractor,
+          mockGetAllIdentitiesInteractor,
+          mockUploadController,
+          mockRemoveComposerCacheByIdInteractor,
+          mockSaveComposerCacheInteractor,
+          mockDownloadImageAsBase64Interactor,
+          mockTransformHtmlEmailContentInteractor,
+          mockGetServerSettingInteractor,
+          mockCreateNewAndSendEmailInteractor,
+          mockCreateNewAndSaveEmailToDraftsInteractor,
+          mockPrintEmailInteractor,
+          mockComposerRepository,
+          mockSaveTemplateEmailInteractor,
+          autoSaveComposerId: 'idempotent-teardown-test',
+        );
+
+        ctrl.initMobileAutoSave();
+        ctrl.tearDownMobileAutoSave();
+
+        expect(
+          () => ctrl.tearDownMobileAutoSave(),
+          returnsNormally,
+        );
+      });
+
       // tearDownMobileAutoSave is only called on Android (onClose guard).
       // With composerId = null, disposeMobileAutoSave cancels any timers and
       // invalidate is skipped. Verify no exception is thrown.

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -768,13 +768,12 @@ void main() {
         'When composerId is null',
       () {
         PlatformInfo.isTestingForWeb = true;
+        addTearDown(() => PlatformInfo.isTestingForWeb = false);
 
         expect(
           () => composerController?.markCleanClose(),
           returnsNormally,
         );
-
-        PlatformInfo.isTestingForWeb = false;
       });
 
       test(
@@ -792,8 +791,8 @@ void main() {
 
     group('tearDownMobileAutoSave safety:', () {
       // tearDownMobileAutoSave is only called on Android (onClose guard).
-      // With composerId = null, _persistCleanCloseIfNeeded is a no-op and
-      // disposeMobileAutoSave cancels any timers. Verify no exception is thrown.
+      // With composerId = null, disposeMobileAutoSave cancels any timers and
+      // invalidate is skipped. Verify no exception is thrown.
       test(
         'Should not throw\n'
         'When composerId is null and timers are not started',
@@ -802,6 +801,79 @@ void main() {
           () => composerController?.tearDownMobileAutoSave(),
           returnsNormally,
         );
+      });
+    });
+
+    group('buildCreateEmailRequestForAutoSave htmlContent override:', () {
+      // ADR-0086 Layer 1: _saveSnapshotToCache always passes effectiveContent
+      // (fresh or lastKnownHtmlContent fallback) as htmlContent so getText()
+      // is never called a second time inside buildCreateEmailRequestForAutoSave.
+
+      const fallbackHtml = '<p>last known content</p>';
+      const editorHtml = '<p>live editor content</p>';
+
+      void arrangeComposerState() {
+        final args = ComposerArguments(
+          emailActionType: EmailActionType.compose,
+          displayMode: ScreenDisplayMode.normal,
+        );
+        composerController?.composerArguments.value = args;
+        composerController?.currentEmailActionType = EmailActionType.compose;
+        composerController?.richTextMobileTabletController =
+            mockRichTextMobileTabletController;
+        when(mockUploadController.attachmentsUploaded).thenReturn([]);
+        when(mockComposerRepository.removeCollapsedExpandedSignatureEffect(
+          emailContent: anyNamed('emailContent'),
+        )).thenAnswer((i) async =>
+            i.namedArguments[const Symbol('emailContent')] as String);
+      }
+
+      test(
+        'Should use provided htmlContent\n'
+        'When htmlContent is non-empty — getText() must not be called',
+      () async {
+        arrangeComposerState();
+        when(mockRichTextMobileTabletController.htmlEditorApi)
+            .thenReturn(mockHtmlEditorApi);
+        final request = await composerController
+            ?.buildCreateEmailRequestForAutoSave(htmlContent: fallbackHtml);
+
+        expect(request, isNotNull);
+        expect(request?.emailContent, equals(fallbackHtml));
+        verifyNever(mockHtmlEditorApi.getText());
+      });
+
+      test(
+        'Should call getContentInEditor\n'
+        'When htmlContent is null',
+      () async {
+        arrangeComposerState();
+        when(mockRichTextMobileTabletController.htmlEditorApi)
+            .thenReturn(mockHtmlEditorApi);
+        when(mockHtmlEditorApi.getText())
+            .thenAnswer((_) async => editorHtml);
+
+        final request = await composerController
+            ?.buildCreateEmailRequestForAutoSave();
+
+        expect(request, isNotNull);
+        verify(mockHtmlEditorApi.getText()).called(greaterThanOrEqualTo(1));
+      });
+
+      test(
+        'Should use empty string and not call getText()\n'
+        'When htmlContent is empty — ensures _saveSnapshotToCache never triggers a second getText() call',
+      () async {
+        arrangeComposerState();
+        when(mockRichTextMobileTabletController.htmlEditorApi)
+            .thenReturn(mockHtmlEditorApi);
+
+        final request = await composerController
+            ?.buildCreateEmailRequestForAutoSave(htmlContent: '');
+
+        expect(request, isNotNull);
+        expect(request?.emailContent, equals(''));
+        verifyNever(mockHtmlEditorApi.getText());
       });
     });
   });

--- a/test/features/composer/presentation/extensions/create_email_request_extension_test.dart
+++ b/test/features/composer/presentation/extensions/create_email_request_extension_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_body_part.dart';
 import 'package:jmap_dart_client/jmap/mail/email/individual_header_identifier.dart';
 import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
@@ -9,6 +10,9 @@ import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/model.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/create_email_request_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/create_email_request.dart';
+import 'package:tmail_ui_user/features/composer/presentation/model/screen_display_mode.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
 
 import '../../../../fixtures/account_fixtures.dart';
 import '../../../../fixtures/session_fixtures.dart';
@@ -264,6 +268,95 @@ void main() {
         KeyWordIdentifier.emailFlagged: true,
         KeyWordIdentifier.emailAnswered: true,
         KeyWordIdentifier.emailForwarded: true,
+      });
+    });
+  });
+
+  group('generateComposerCache', () {
+    CreateEmailRequest makeRequest({String? composerId}) => CreateEmailRequest(
+          session: SessionFixtures.aliceSession,
+          accountId: AccountFixtures.aliceAccountId,
+          emailActionType: EmailActionType.compose,
+          ownEmailAddress: 'alice@domain.tld',
+          subject: 'Test',
+          emailContent: '<p>Hello</p>',
+          composerId: composerId,
+        );
+
+    group('when isPersistent is true', () {
+      test('returns ComposerPersistentCache', () {
+        final cache = makeRequest().generateComposerCache(
+          emailCreated: Email(),
+          isPersistent: true,
+        );
+
+        expect(cache, isA<ComposerPersistentCache>());
+      });
+
+      test('sets actionType to restoreComposerFromPersistentCache', () {
+        final cache = makeRequest().generateComposerCache(
+          emailCreated: Email(),
+          isPersistent: true,
+        ) as ComposerPersistentCache;
+
+        expect(cache.actionType, EmailActionType.restoreComposerFromPersistentCache);
+      });
+
+      test('sets isCleanClose to false', () {
+        final cache = makeRequest().generateComposerCache(
+          emailCreated: Email(),
+          isPersistent: true,
+        ) as ComposerPersistentCache;
+
+        expect(cache.isCleanClose, isFalse);
+      });
+
+      test('sets timestampMs to a value within the current second', () {
+        final before = DateTime.now().millisecondsSinceEpoch;
+        final cache = makeRequest().generateComposerCache(
+          emailCreated: Email(),
+          isPersistent: true,
+        ) as ComposerPersistentCache;
+        final after = DateTime.now().millisecondsSinceEpoch;
+
+        expect(cache.timestampMs, isNotNull);
+        expect(cache.timestampMs, greaterThanOrEqualTo(before));
+        expect(cache.timestampMs, lessThanOrEqualTo(after));
+      });
+
+      test('includes the generated email', () {
+        final email = Email();
+        final cache = makeRequest().generateComposerCache(
+          emailCreated: email,
+          isPersistent: true,
+        );
+
+        expect(cache.email, same(email));
+      });
+
+      test('preserves composerId from the request', () {
+        const composerId = 'uuid-composer-abc';
+        final cache = makeRequest(composerId: composerId).generateComposerCache(
+          emailCreated: Email(),
+          isPersistent: true,
+        );
+
+        expect(cache.composerId, composerId);
+      });
+    });
+
+    group('when isPersistent is false (default)', () {
+      test('returns plain ComposerCache, not ComposerPersistentCache', () {
+        final cache = makeRequest().generateComposerCache(emailCreated: Email());
+
+        expect(cache, isA<ComposerCache>());
+        expect(cache, isNot(isA<ComposerPersistentCache>()));
+      });
+
+      test('preserves displayMode from the request', () {
+        final cache = makeRequest().generateComposerCache(emailCreated: Email());
+
+        expect(cache.displayMode, ScreenDisplayMode.normal);
       });
     });
   });

--- a/test/features/composer/presentation/providers/composer_auto_save_notifier_test.dart
+++ b/test/features/composer/presentation/providers/composer_auto_save_notifier_test.dart
@@ -183,5 +183,72 @@ void main() {
         expect(notifier.hasRecoverableSnapshot, isTrue);
       });
     });
+
+    group('restore → clearCache sequence (Layer 3 restore-and-clear pattern)', () {
+      test(
+        'hasRecoverableSnapshot transitions true→false after restore succeeds then cache is cleared',
+        () async {
+          final cache = makeCache(withEmail: true);
+          when(mockResolveInteractor.execute(any, any)).thenAnswer(
+            (_) async => Right(ResolveComposerCacheForRestoreSuccess(cache)),
+          );
+
+          await notifier.restore(testAccountId, testUserName);
+          expect(notifier.hasRecoverableSnapshot, isTrue);
+
+          await notifier.clearCache(testAccountId, testUserName);
+
+          expect(notifier.hasRecoverableSnapshot, isFalse);
+          verify(mockRemoveInteractor.execute(any, any)).called(1);
+        },
+      );
+
+      test('clearCache after failed restore does not call removeInteractor', () async {
+        when(mockResolveInteractor.execute(any, any)).thenAnswer(
+          (_) async => Left(ResolveComposerCacheForRestoreFailure(Exception('err'))),
+        );
+
+        await notifier.restore(testAccountId, testUserName);
+        expect(notifier.hasRecoverableSnapshot, isFalse);
+
+        await notifier.clearCache(testAccountId, testUserName);
+
+        // clearCache always calls removeInteractor regardless of prior restore result
+        verify(mockRemoveInteractor.execute(any, any)).called(1);
+        expect(notifier.hasRecoverableSnapshot, isFalse);
+      });
+    });
+
+    group('isCleanClose does not block clearCache', () {
+      test('clearCache executes even after setCleanClose is flagged', () async {
+        notifier.onSnapshotSaved();
+        notifier.setCleanClose();
+        expect(notifier.isCleanClose, isTrue);
+
+        await notifier.clearCache(testAccountId, testUserName);
+
+        verify(mockRemoveInteractor.execute(any, any)).called(1);
+        expect(notifier.hasRecoverableSnapshot, isFalse);
+      });
+    });
+
+    group('concurrent flag independence', () {
+      test('beginDraftSave and setCleanClose can coexist', () {
+        notifier.beginDraftSave();
+        notifier.setCleanClose();
+
+        expect(notifier.isSavingToDraftInProgress, isTrue);
+        expect(notifier.isCleanClose, isTrue);
+      });
+
+      test('endDraftSave clears only isSavingToDraftInProgress, not isCleanClose', () {
+        notifier.beginDraftSave();
+        notifier.setCleanClose();
+        notifier.endDraftSave();
+
+        expect(notifier.isSavingToDraftInProgress, isFalse);
+        expect(notifier.isCleanClose, isTrue);
+      });
+    });
   });
 }

--- a/test/features/composer/presentation/providers/composer_auto_save_notifier_test.dart
+++ b/test/features/composer/presentation/providers/composer_auto_save_notifier_test.dart
@@ -203,7 +203,7 @@ void main() {
         },
       );
 
-      test('clearCache after failed restore does not call removeInteractor', () async {
+      test('clearCache calls removeInteractor even after failed restore', () async {
         when(mockResolveInteractor.execute(any, any)).thenAnswer(
           (_) async => Left(ResolveComposerCacheForRestoreFailure(Exception('err'))),
         );

--- a/test/features/composer/presentation/providers/composer_auto_save_notifier_test.dart
+++ b/test/features/composer/presentation/providers/composer_auto_save_notifier_test.dart
@@ -1,0 +1,187 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/composer/presentation/providers/composer_auto_save_notifier.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/remove_all_composer_cache_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/resolve_composer_cache_for_restore_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/remove_all_composer_cache_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import '../../../../fixtures/session_fixtures.dart';
+import 'composer_auto_save_notifier_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<ResolveComposerCacheForRestoreInteractor>(),
+  MockSpec<RemoveAllComposerCacheInteractor>(),
+])
+void main() {
+  late MockResolveComposerCacheForRestoreInteractor mockResolveInteractor;
+  late MockRemoveAllComposerCacheInteractor mockRemoveInteractor;
+  late ComposerAutoSaveNotifier notifier;
+
+  final testAccountId = AccountFixtures.aliceAccountId;
+  final testUserName = SessionFixtures.aliceSession.username;
+
+  ComposerPersistentCache makeCache({
+    bool? isCleanClose,
+    int? timestampMs,
+    bool withEmail = false,
+  }) =>
+      ComposerPersistentCache(
+        isCleanClose: isCleanClose,
+        timestampMs: timestampMs ?? DateTime.now().millisecondsSinceEpoch,
+        email: withEmail ? Email() : null,
+      );
+
+  setUp(() {
+    mockResolveInteractor = MockResolveComposerCacheForRestoreInteractor();
+    mockRemoveInteractor = MockRemoveAllComposerCacheInteractor();
+    notifier = ComposerAutoSaveNotifier(mockResolveInteractor, mockRemoveInteractor);
+    when(mockRemoveInteractor.execute(any, any))
+        .thenAnswer((_) async => Right(RemoveAllComposerCacheSuccess()));
+  });
+
+  group('ComposerAutoSaveNotifier', () {
+    group('initial state', () {
+      test('all flags are false and content is empty', () {
+        expect(notifier.hasRecoverableSnapshot, isFalse);
+        expect(notifier.isCleanClose, isFalse);
+        expect(notifier.isSavingToDraftInProgress, isFalse);
+        expect(notifier.lastKnownHtmlContent, isEmpty);
+      });
+    });
+
+    group('onSnapshotSaved', () {
+      test('sets hasRecoverableSnapshot=true', () {
+        notifier.onSnapshotSaved();
+        expect(notifier.hasRecoverableSnapshot, isTrue);
+      });
+
+      test('is idempotent when called multiple times', () {
+        notifier.onSnapshotSaved();
+        notifier.onSnapshotSaved();
+        expect(notifier.hasRecoverableSnapshot, isTrue);
+      });
+    });
+
+    group('setCleanClose', () {
+      test('sets isCleanClose=true', () {
+        notifier.setCleanClose();
+        expect(notifier.isCleanClose, isTrue);
+      });
+
+      test('does not affect hasRecoverableSnapshot', () {
+        notifier.onSnapshotSaved();
+        notifier.setCleanClose();
+        expect(notifier.hasRecoverableSnapshot, isTrue);
+        expect(notifier.isCleanClose, isTrue);
+      });
+    });
+
+    group('updateLastKnownContent', () {
+      test('stores provided html content', () {
+        notifier.updateLastKnownContent('<p>hello</p>');
+        expect(notifier.lastKnownHtmlContent, '<p>hello</p>');
+      });
+
+      test('overwrites previous content on subsequent calls', () {
+        notifier.updateLastKnownContent('<p>first</p>');
+        notifier.updateLastKnownContent('<p>second</p>');
+        expect(notifier.lastKnownHtmlContent, '<p>second</p>');
+      });
+    });
+
+    group('beginDraftSave / endDraftSave', () {
+      test('beginDraftSave sets isSavingToDraftInProgress=true', () {
+        notifier.beginDraftSave();
+        expect(notifier.isSavingToDraftInProgress, isTrue);
+      });
+
+      test('endDraftSave clears isSavingToDraftInProgress', () {
+        notifier.beginDraftSave();
+        notifier.endDraftSave();
+        expect(notifier.isSavingToDraftInProgress, isFalse);
+      });
+    });
+
+    group('restore', () {
+      group('returns null and keeps hasRecoverableSnapshot=false', () {
+        final cases = [
+          (
+            'on interactor failure',
+            Left<Failure, Success>(
+              ResolveComposerCacheForRestoreFailure(Exception('storage error')),
+            ),
+          ),
+          (
+            'when no restorable snapshot found',
+            Right<Failure, Success>(ResolveComposerCacheForRestoreSuccess(null)),
+          ),
+        ];
+
+        for (final (description, response) in cases) {
+          test(description, () async {
+            when(mockResolveInteractor.execute(any, any))
+                .thenAnswer((_) async => response);
+
+            final result = await notifier.restore(testAccountId, testUserName);
+
+            expect(result, isNull);
+            expect(notifier.hasRecoverableSnapshot, isFalse);
+          });
+        }
+      });
+
+      test('returns cache and sets hasRecoverableSnapshot=true when snapshot found', () async {
+        final cache = makeCache(withEmail: true);
+        when(mockResolveInteractor.execute(any, any)).thenAnswer(
+          (_) async => Right(ResolveComposerCacheForRestoreSuccess(cache)),
+        );
+
+        final result = await notifier.restore(testAccountId, testUserName);
+
+        expect(result, cache);
+        expect(notifier.hasRecoverableSnapshot, isTrue);
+      });
+
+      test('does not call removeInteractor — cleanup is owned by the interactor', () async {
+        final cache = makeCache(withEmail: true);
+        when(mockResolveInteractor.execute(any, any)).thenAnswer(
+          (_) async => Right(ResolveComposerCacheForRestoreSuccess(cache)),
+        );
+
+        await notifier.restore(testAccountId, testUserName);
+
+        verifyNever(mockRemoveInteractor.execute(any, any));
+      });
+    });
+
+    group('clearCache', () {
+      test('calls removeInteractor and clears hasRecoverableSnapshot', () async {
+        notifier.onSnapshotSaved();
+
+        await notifier.clearCache(testAccountId, testUserName);
+
+        verify(mockRemoveInteractor.execute(any, any)).called(1);
+        expect(notifier.hasRecoverableSnapshot, isFalse);
+      });
+
+      test('keeps hasRecoverableSnapshot=true when remove fails', () async {
+        notifier.onSnapshotSaved();
+        when(mockRemoveInteractor.execute(any, any)).thenAnswer(
+          (_) async => Left(RemoveAllComposerCacheFailure(Exception('err'))),
+        );
+
+        await notifier.clearCache(testAccountId, testUserName);
+
+        expect(notifier.hasRecoverableSnapshot, isTrue);
+      });
+    });
+  });
+}

--- a/test/features/mailbox_dashboard/data/datasource_impl/composer_persistent_cache_datasource_impl_test.dart
+++ b/test/features/mailbox_dashboard/data/datasource_impl/composer_persistent_cache_datasource_impl_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:tmail_ui_user/features/caching/clients/composer_hive_cache_client.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_persistent_cache_datasource_impl.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/exception_thrower.dart';
+
+import 'composer_persistent_cache_datasource_impl_test.mocks.dart';
+
+@GenerateMocks([ComposerHiveCacheClient, ExceptionThrower])
+void main() {
+  late MockComposerHiveCacheClient mockCacheClient;
+  late MockExceptionThrower mockExceptionThrower;
+  late ComposerPersistentCacheDatasourceImpl datasource;
+
+  final accountId = AccountId(Id('account-1'));
+  final userName = UserName('user@example.com');
+
+  setUp(() {
+    mockCacheClient = MockComposerHiveCacheClient();
+    mockExceptionThrower = MockExceptionThrower();
+    datasource = ComposerPersistentCacheDatasourceImpl(
+      mockCacheClient,
+      mockExceptionThrower,
+    );
+  });
+
+  group('saveComposerCache', () {
+    test('delegates to cache client', () async {
+      final cache = ComposerCache(composerId: 'id-1');
+      when(mockCacheClient.saveCache(accountId, userName, cache))
+          .thenAnswer((_) async {});
+
+      await datasource.saveComposerCache(accountId, userName, cache);
+
+      verify(mockCacheClient.saveCache(accountId, userName, cache)).called(1);
+    });
+  });
+
+  group('getComposerCache', () {
+    test('delegates to cache client', () async {
+      when(mockCacheClient.getCache(accountId, userName))
+          .thenAnswer((_) async => []);
+
+      final result = await datasource.getComposerCache(accountId, userName);
+
+      expect(result, isEmpty);
+      verify(mockCacheClient.getCache(accountId, userName)).called(1);
+    });
+  });
+
+  group('removeAllComposerCache', () {
+    test('delegates to cache client', () async {
+      when(mockCacheClient.deleteCache(accountId, userName))
+          .thenAnswer((_) async {});
+
+      await datasource.removeAllComposerCache(accountId, userName);
+
+      verify(mockCacheClient.deleteCache(accountId, userName)).called(1);
+    });
+  });
+}

--- a/test/features/mailbox_dashboard/data/model/mobile_composer_cache_test.dart
+++ b/test/features/mailbox_dashboard/data/model/mobile_composer_cache_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
 
 void main() {
@@ -46,6 +47,26 @@ void main() {
     }
 
     group('isRestorable', () {
+      test('returns true when email is set, not expired, and not a clean close', () {
+        final cache = makeCache(
+          email: Email(),
+          isCleanClose: false,
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect(cache.isRestorable, isTrue);
+      });
+
+      test('returns true when isCleanClose is null (involuntary kill)', () {
+        final cache = makeCache(
+          email: Email(),
+          isCleanClose: null,
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect(cache.isRestorable, isTrue);
+      });
+
       test('returns false when isCleanClose is true', () {
         final cache = makeCache(
           isCleanClose: true,
@@ -62,6 +83,18 @@ void main() {
         );
 
         expect(cache.isEmpty, isTrue);
+        expect(cache.isRestorable, isFalse);
+      });
+
+      test('returns false when cache is expired', () {
+        final cache = makeCache(
+          email: Email(),
+          isCleanClose: false,
+          timestampMs: DateTime.now()
+              .subtract(const Duration(hours: 25))
+              .millisecondsSinceEpoch,
+        );
+
         expect(cache.isRestorable, isFalse);
       });
 
@@ -160,6 +193,57 @@ void main() {
           testCase.verify,
         );
       }
+    });
+
+    group('newestLocalCache extension', () {
+      test('returns null when iterable is empty', () {
+        expect(<ComposerPersistentCache>[].newestLocalCache, isNull);
+      });
+
+      test('returns the single entry when there is only one', () {
+        final cache = makeCache(
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect([cache].newestLocalCache, same(cache));
+      });
+
+      test('returns the entry with the highest timestampMs', () {
+        final older = makeCache(
+          timestampMs: DateTime.now()
+              .subtract(const Duration(hours: 2))
+              .millisecondsSinceEpoch,
+        );
+        final newer = makeCache(
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect([older, newer].newestLocalCache, same(newer));
+        expect([newer, older].newestLocalCache, same(newer));
+      });
+
+      test('ignores plain ComposerCache entries and picks the newest ComposerPersistentCache', () {
+        final plainCache = ComposerCache(email: Email());
+        final persistent = makeCache(
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect([plainCache, persistent].newestLocalCache, same(persistent));
+      });
+
+      test('returns null when iterable contains only plain ComposerCache entries', () {
+        final plain = ComposerCache(email: Email());
+        expect([plain].newestLocalCache, isNull);
+      });
+
+      test('treats null timestampMs as 0 when comparing', () {
+        final noTimestamp = makeCache(timestampMs: null);
+        final withTimestamp = makeCache(
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect([noTimestamp, withTimestamp].newestLocalCache, same(withTimestamp));
+      });
     });
 
     group('JSON serialisation', () {

--- a/test/features/mailbox_dashboard/data/model/mobile_composer_cache_test.dart
+++ b/test/features/mailbox_dashboard/data/model/mobile_composer_cache_test.dart
@@ -1,0 +1,221 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+
+void main() {
+  group('ComposerPersistentCache', () {
+    ComposerPersistentCache makeCache({
+      String composerId = 'session-uuid-123',
+      Email? email,
+      bool? isCleanClose,
+      int? timestampMs,
+    }) {
+      return ComposerPersistentCache(
+        composerId: composerId,
+        email: email,
+        isCleanClose: isCleanClose,
+        timestampMs: timestampMs,
+      );
+    }
+
+    ComposerPersistentCache makeSerializableCache() {
+      return ComposerPersistentCache(
+        composerId: 'uuid-test',
+        isCleanClose: true,
+        timestampMs: 1700000000000, // Fixed timestamp for determinism
+      );
+    }
+
+    void expectCacheEquals(
+      ComposerPersistentCache actual,
+      ComposerPersistentCache expected,
+    ) {
+      expect(actual.composerId, expected.composerId);
+      expect(actual.email, expected.email);
+      expect(actual.isCleanClose, expected.isCleanClose);
+      expect(actual.timestampMs, expected.timestampMs);
+    }
+
+    void expectCopyPreservesBaseFields(
+      ComposerPersistentCache copy,
+      ComposerPersistentCache original,
+    ) {
+      expect(copy.composerId, original.composerId);
+    }
+
+    group('isRestorable', () {
+      test('returns false when isCleanClose is true', () {
+        final cache = makeCache(
+          isCleanClose: true,
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect(cache.isRestorable, isFalse);
+      });
+
+      test('returns false when cache is empty', () {
+        final cache = makeCache(
+          isCleanClose: false,
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect(cache.isEmpty, isTrue);
+        expect(cache.isRestorable, isFalse);
+      });
+
+      test('evaluates guard conditions correctly', () {
+        final cache = makeCache(
+          isCleanClose: null,
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect(cache.isCleanClose, isNull);
+        expect(cache.isExpired, isFalse);
+        expect(cache.isEmpty, isTrue);
+        expect(cache.isRestorable, isFalse);
+      });
+    });
+
+    group('isExpired', () {
+      test('returns false when timestampMs is null', () {
+        expect(makeCache().isExpired, isFalse);
+      });
+
+      test('returns false when timestampMs is recent', () {
+        final cache = makeCache(
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect(cache.isExpired, isFalse);
+      });
+
+      test('returns true when timestampMs is older than 24 hours', () {
+        final cache = makeCache(
+          timestampMs: DateTime.now()
+              .subtract(const Duration(hours: 25))
+              .millisecondsSinceEpoch,
+        );
+
+        expect(cache.isExpired, isTrue);
+      });
+    });
+
+    group('isEmpty', () {
+      test('returns true when email is null', () {
+        expect(makeCache(email: null).isEmpty, isTrue);
+      });
+
+      test('returns false when email is not null', () {
+        expect(makeCache(email: Email()).isEmpty, isFalse);
+      });
+    });
+
+    group('copyWith', () {
+      final testCases = [
+        (
+          description: 'updates isCleanClose while preserving other fields',
+          verify: () {
+            final original = makeCache(
+              isCleanClose: false,
+              timestampMs: DateTime.now().millisecondsSinceEpoch,
+            );
+
+            final copy = original.copyWith(
+              isCleanClose: true,
+            );
+
+            expect(copy.isCleanClose, isTrue);
+            expect(copy.timestampMs, original.timestampMs);
+            expectCopyPreservesBaseFields(copy, original);
+          },
+        ),
+        (
+          description: 'updates timestampMs while preserving other fields',
+          verify: () {
+            final original = makeCache(
+              isCleanClose: false,
+            );
+
+            final newTimestamp = DateTime.now().millisecondsSinceEpoch;
+
+            final copy = original.copyWith(
+              timestampMs: newTimestamp,
+            );
+
+            expect(copy.timestampMs, newTimestamp);
+            expect(
+              copy.isCleanClose,
+              original.isCleanClose,
+            );
+            expectCopyPreservesBaseFields(copy, original);
+          },
+        ),
+      ];
+
+      for (final testCase in testCases) {
+        test(
+          testCase.description,
+          testCase.verify,
+        );
+      }
+    });
+
+    group('JSON serialisation', () {
+      test('toJson / fromJson round-trip preserves all fields', () {
+        final original = makeSerializableCache();
+
+        final restored = ComposerPersistentCache.fromJson(
+          original.toJson(),
+        );
+
+        expectCacheEquals(restored, original);
+      });
+
+      test('omits nullable fields when they are null', () {
+        final cache = ComposerPersistentCache(
+          composerId: 'uuid-xyz',
+        );
+
+        final json = cache.toJson();
+
+        expect(
+          json.containsKey('isCleanClose'),
+          isFalse,
+        );
+        expect(
+          json.containsKey('timestampMs'),
+          isFalse,
+        );
+      });
+
+      test('supports JSON string encode and decode', () {
+        final original = makeSerializableCache();
+
+        final jsonString = jsonEncode(
+          original.toJson(),
+        );
+
+        final decoded = ComposerPersistentCache.fromJson(
+          jsonDecode(jsonString) as Map<String, dynamic>,
+        );
+
+        expectCacheEquals(decoded, original);
+      });
+
+      test('toJson / fromJson round-trip preserves email field', () {
+        final original = ComposerPersistentCache(
+          composerId: 'uuid-email-test',
+          email: Email(),
+          isCleanClose: false,
+          timestampMs: 1700000000000,
+        );
+
+        final restored = ComposerPersistentCache.fromJson(original.toJson());
+
+        expect(restored.email, isNotNull);
+      });
+    });
+  });
+}

--- a/test/features/mailbox_dashboard/domain/usecases/get_composer_all_cache_interactor_test.dart
+++ b/test/features/mailbox_dashboard/domain/usecases/get_composer_all_cache_interactor_test.dart
@@ -1,0 +1,138 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/get_all_composer_cache_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/get_all_composer_cache_interactor.dart';
+
+import 'get_composer_local_cache_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<ComposerCacheRepository>()])
+void main() {
+  final accountId = AccountId(Id('account-1'));
+  final userName = UserName('user@example.com');
+
+  late MockComposerCacheRepository mockRepository;
+  late GetAllComposerCacheInteractor interactor;
+
+  setUp(() {
+    mockRepository = MockComposerCacheRepository();
+    interactor = GetAllComposerCacheInteractor(mockRepository);
+  });
+
+  ComposerPersistentCache makeLocalCache({
+    required int timestampMs,
+    bool withEmail = true,
+  }) =>
+      ComposerPersistentCache(
+        timestampMs: timestampMs,
+        email: withEmail ? Email() : null,
+      );
+
+  int msAgo(int hours) =>
+      DateTime.now().subtract(Duration(hours: hours)).millisecondsSinceEpoch;
+
+  void expectSuccessWithCache(
+    Either result,
+    ComposerPersistentCache expectedCache,
+  ) {
+    result.fold(
+      (_) => fail('expected Right'),
+      (s) => expect((s as GetAllComposerCacheSuccess).listComposerCache, equals([expectedCache])),
+    );
+  }
+
+  group('GetComposerLocalCacheInteractor', () {
+    group('when repository returns a single local cache', () {
+      test('returns success with that cache', () async {
+        final cache = makeLocalCache(timestampMs: msAgo(1));
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => [cache]);
+
+        final result = await interactor.execute(accountId, userName).last;
+
+        expectSuccessWithCache(result, cache);
+      });
+    });
+
+    group('when repository returns multiple local caches', () {
+      test('returns the most recent one by timestampMs', () async {
+        final older = makeLocalCache(timestampMs: msAgo(3));
+        final newer = makeLocalCache(timestampMs: msAgo(1));
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => [older, newer]);
+
+        final result = await interactor.execute(accountId, userName).last;
+
+        expectSuccessWithCache(result, newer);
+      });
+
+      test('ignores plain ComposerCache entries and picks newest ComposerPersistentCache', () async {
+        final plainCache = ComposerCache(email: Email());
+        final localCache = makeLocalCache(timestampMs: msAgo(1));
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => [plainCache, localCache]);
+
+        final result = await interactor.execute(accountId, userName).last;
+
+        expectSuccessWithCache(result, localCache);
+      });
+    });
+
+    group('when no usable cache exists', () {
+      test('returns NotFoundComposerLocalCacheException when list is empty', () async {
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => []);
+
+        final result = await interactor.execute(accountId, userName).last;
+
+        expect(
+          result.isLeft(),
+          isTrue,
+          reason: 'expected Left',
+        );
+        result.fold(
+          (f) => expect(f, isA<GetAllComposerCacheFailure>()),
+          (_) => fail('expected Left'),
+        );
+      });
+
+      test('returns NotFoundComposerLocalCacheException when list has only plain ComposerCache', () async {
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => [ComposerCache(email: Email())]);
+
+        final result = await interactor.execute(accountId, userName).last;
+
+        result.fold(
+          (f) => expect(f, isA<GetAllComposerCacheFailure>()),
+          (_) => fail('expected Left'),
+        );
+      });
+    });
+
+    group('error handling', () {
+      test('wraps repository exception in GetComposerLocalCacheFailure', () async {
+        final exception = Exception('db error');
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenThrow(exception);
+
+        final result = await interactor.execute(accountId, userName).last;
+
+        result.fold(
+          (f) {
+            expect(f, isA<GetAllComposerCacheFailure>());
+            expect((f as GetAllComposerCacheFailure).exception, exception);
+          },
+          (_) => fail('expected Left'),
+        );
+      });
+    });
+  });
+}

--- a/test/features/mailbox_dashboard/domain/usecases/get_composer_all_cache_interactor_test.dart
+++ b/test/features/mailbox_dashboard/domain/usecases/get_composer_all_cache_interactor_test.dart
@@ -50,7 +50,7 @@ void main() {
     );
   }
 
-  group('GetComposerLocalCacheInteractor', () {
+  group('GetAllComposerCacheInteractor', () {
     group('when repository returns a single local cache', () {
       test('returns success with that cache', () async {
         final cache = makeLocalCache(timestampMs: msAgo(1));
@@ -94,7 +94,7 @@ void main() {
           () async {
         final exception = Exception('db error');
         when(mockRepository.getComposerCache(accountId, userName))
-            .thenThrow(exception);
+            .thenAnswer((_) async => throw exception);
 
         final result = await interactor.execute(accountId, userName).last;
 

--- a/test/features/mailbox_dashboard/domain/usecases/get_composer_all_cache_interactor_test.dart
+++ b/test/features/mailbox_dashboard/domain/usecases/get_composer_all_cache_interactor_test.dart
@@ -12,7 +12,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/compo
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/get_all_composer_cache_state.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/get_all_composer_cache_interactor.dart';
 
-import 'get_composer_local_cache_interactor_test.mocks.dart';
+import 'get_composer_all_cache_interactor_test.mocks.dart';
 
 @GenerateNiceMocks([MockSpec<ComposerCacheRepository>()])
 void main() {

--- a/test/features/mailbox_dashboard/domain/usecases/get_composer_all_cache_interactor_test.dart
+++ b/test/features/mailbox_dashboard/domain/usecases/get_composer_all_cache_interactor_test.dart
@@ -45,7 +45,8 @@ void main() {
   ) {
     result.fold(
       (_) => fail('expected Right'),
-      (s) => expect((s as GetAllComposerCacheSuccess).listComposerCache, equals([expectedCache])),
+      (s) => expect((s as GetAllComposerCacheSuccess).listComposerCache,
+          contains(expectedCache)),
     );
   }
 
@@ -74,7 +75,9 @@ void main() {
         expectSuccessWithCache(result, newer);
       });
 
-      test('ignores plain ComposerCache entries and picks newest ComposerPersistentCache', () async {
+      test(
+          'ignores plain ComposerCache entries and picks newest ComposerPersistentCache',
+          () async {
         final plainCache = ComposerCache(email: Email());
         final localCache = makeLocalCache(timestampMs: msAgo(1));
         when(mockRepository.getComposerCache(accountId, userName))
@@ -86,39 +89,9 @@ void main() {
       });
     });
 
-    group('when no usable cache exists', () {
-      test('returns NotFoundComposerLocalCacheException when list is empty', () async {
-        when(mockRepository.getComposerCache(accountId, userName))
-            .thenAnswer((_) async => []);
-
-        final result = await interactor.execute(accountId, userName).last;
-
-        expect(
-          result.isLeft(),
-          isTrue,
-          reason: 'expected Left',
-        );
-        result.fold(
-          (f) => expect(f, isA<GetAllComposerCacheFailure>()),
-          (_) => fail('expected Left'),
-        );
-      });
-
-      test('returns NotFoundComposerLocalCacheException when list has only plain ComposerCache', () async {
-        when(mockRepository.getComposerCache(accountId, userName))
-            .thenAnswer((_) async => [ComposerCache(email: Email())]);
-
-        final result = await interactor.execute(accountId, userName).last;
-
-        result.fold(
-          (f) => expect(f, isA<GetAllComposerCacheFailure>()),
-          (_) => fail('expected Left'),
-        );
-      });
-    });
-
     group('error handling', () {
-      test('wraps repository exception in GetComposerLocalCacheFailure', () async {
+      test('wraps repository exception in GetComposerLocalCacheFailure',
+          () async {
         final exception = Exception('db error');
         when(mockRepository.getComposerCache(accountId, userName))
             .thenThrow(exception);

--- a/test/features/mailbox_dashboard/domain/usecases/mark_composer_cache_clean_close_interactor_test.dart
+++ b/test/features/mailbox_dashboard/domain/usecases/mark_composer_cache_clean_close_interactor_test.dart
@@ -35,60 +35,6 @@ void main() {
       );
 
   group('MarkComposerCacheCleanCloseInteractor', () {
-    group('normal flow', () {
-      test('marks newest cache with isCleanClose=true then removes all',
-          () async {
-        final cache = makeLocalCache(isCleanClose: false);
-        when(mockRepository.getComposerCache(accountId, userName))
-            .thenAnswer((_) async => [cache]);
-        when(mockRepository.saveComposerCache(
-          accountId,
-          userName,
-          anyNamed('composerCache'),
-        )).thenAnswer((_) async {});
-        when(mockRepository.removeAllComposerCache(accountId, userName))
-            .thenAnswer((_) async {});
-
-        final result = await interactor.execute(accountId, userName);
-
-        expect(result, Right(MarkComposerCacheCleanCloseSuccess()));
-
-        final captured = verify(mockRepository.saveComposerCache(
-          accountId,
-          userName,
-          captureAnyNamed('composerCache'),
-        )).captured.single as ComposerPersistentCache;
-        expect(captured.isCleanClose, isTrue);
-
-        verify(mockRepository.removeAllComposerCache(accountId, userName))
-            .called(1);
-      });
-
-      test('picks newest by timestampMs when multiple entries exist', () async {
-        final now = DateTime.now().millisecondsSinceEpoch;
-        final older = makeLocalCache(timestampMs: now - 5000);
-        final newer = makeLocalCache(timestampMs: now);
-        when(mockRepository.getComposerCache(accountId, userName))
-            .thenAnswer((_) async => [older, newer]);
-        when(mockRepository.saveComposerCache(
-          accountId,
-          userName,
-          anyNamed('composerCache'),
-        )).thenAnswer((_) async {});
-        when(mockRepository.removeAllComposerCache(accountId, userName))
-            .thenAnswer((_) async {});
-
-        await interactor.execute(accountId, userName);
-
-        final captured = verify(mockRepository.saveComposerCache(
-          accountId,
-          userName,
-          captureAnyNamed('composerCache'),
-        )).captured.single as ComposerPersistentCache;
-        expect(captured.timestampMs, newer.timestampMs);
-      });
-    });
-
     group('best-effort mark: save failure does not block removal', () {
       test('still removes all when mark write throws', () async {
         final cache = makeLocalCache();
@@ -97,7 +43,7 @@ void main() {
         when(mockRepository.saveComposerCache(
           accountId,
           userName,
-          anyNamed('composerCache'),
+          any,
         )).thenThrow(Exception('write failed'));
         when(mockRepository.removeAllComposerCache(accountId, userName))
             .thenAnswer((_) async {});
@@ -121,9 +67,9 @@ void main() {
 
         expect(result, Right(MarkComposerCacheCleanCloseSuccess()));
         verifyNever(mockRepository.saveComposerCache(
-          anyNamed('accountId'),
-          anyNamed('userName'),
-          anyNamed('composerCache'),
+          accountId,
+          userName,
+          any,
         ));
         verify(mockRepository.removeAllComposerCache(accountId, userName))
             .called(1);
@@ -155,7 +101,7 @@ void main() {
         when(mockRepository.saveComposerCache(
           accountId,
           userName,
-          anyNamed('composerCache'),
+          any,
         )).thenAnswer((_) async {});
         when(mockRepository.removeAllComposerCache(accountId, userName))
             .thenThrow(Exception('remove failed'));
@@ -165,7 +111,7 @@ void main() {
         verify(mockRepository.saveComposerCache(
           accountId,
           userName,
-          anyNamed('composerCache'),
+          any,
         )).called(1);
         result.fold(
           (f) {

--- a/test/features/mailbox_dashboard/domain/usecases/mark_composer_cache_clean_close_interactor_test.dart
+++ b/test/features/mailbox_dashboard/domain/usecases/mark_composer_cache_clean_close_interactor_test.dart
@@ -11,7 +11,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/compo
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/mark_composer_cache_clean_close_state.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/mark_composer_cache_clean_close_interactor.dart';
 
-import 'mark_composer_local_cache_clean_close_interactor_test.mocks.dart';
+import 'mark_composer_cache_clean_close_interactor_test.mocks.dart';
 
 @GenerateNiceMocks([MockSpec<ComposerCacheRepository>()])
 void main() {

--- a/test/features/mailbox_dashboard/domain/usecases/mark_composer_cache_clean_close_interactor_test.dart
+++ b/test/features/mailbox_dashboard/domain/usecases/mark_composer_cache_clean_close_interactor_test.dart
@@ -1,0 +1,181 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/mark_composer_cache_clean_close_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/mark_composer_cache_clean_close_interactor.dart';
+
+import 'mark_composer_local_cache_clean_close_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<ComposerCacheRepository>()])
+void main() {
+  final accountId = AccountId(Id('account-1'));
+  final userName = UserName('user@example.com');
+
+  late MockComposerCacheRepository mockRepository;
+  late MarkComposerCacheCleanCloseInteractor interactor;
+
+  setUp(() {
+    mockRepository = MockComposerCacheRepository();
+    interactor = MarkComposerCacheCleanCloseInteractor(mockRepository);
+  });
+
+  ComposerPersistentCache makeLocalCache(
+          {bool? isCleanClose, int? timestampMs}) =>
+      ComposerPersistentCache(
+        isCleanClose: isCleanClose,
+        timestampMs: timestampMs ?? DateTime.now().millisecondsSinceEpoch,
+        email: Email(),
+      );
+
+  group('MarkComposerCacheCleanCloseInteractor', () {
+    group('normal flow', () {
+      test('marks newest cache with isCleanClose=true then removes all',
+          () async {
+        final cache = makeLocalCache(isCleanClose: false);
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => [cache]);
+        when(mockRepository.saveComposerCache(
+          accountId,
+          userName,
+          anyNamed('composerCache'),
+        )).thenAnswer((_) async {});
+        when(mockRepository.removeAllComposerCache(accountId, userName))
+            .thenAnswer((_) async {});
+
+        final result = await interactor.execute(accountId, userName);
+
+        expect(result, Right(MarkComposerCacheCleanCloseSuccess()));
+
+        final captured = verify(mockRepository.saveComposerCache(
+          accountId,
+          userName,
+          captureAnyNamed('composerCache'),
+        )).captured.single as ComposerPersistentCache;
+        expect(captured.isCleanClose, isTrue);
+
+        verify(mockRepository.removeAllComposerCache(accountId, userName))
+            .called(1);
+      });
+
+      test('picks newest by timestampMs when multiple entries exist', () async {
+        final now = DateTime.now().millisecondsSinceEpoch;
+        final older = makeLocalCache(timestampMs: now - 5000);
+        final newer = makeLocalCache(timestampMs: now);
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => [older, newer]);
+        when(mockRepository.saveComposerCache(
+          accountId,
+          userName,
+          anyNamed('composerCache'),
+        )).thenAnswer((_) async {});
+        when(mockRepository.removeAllComposerCache(accountId, userName))
+            .thenAnswer((_) async {});
+
+        await interactor.execute(accountId, userName);
+
+        final captured = verify(mockRepository.saveComposerCache(
+          accountId,
+          userName,
+          captureAnyNamed('composerCache'),
+        )).captured.single as ComposerPersistentCache;
+        expect(captured.timestampMs, newer.timestampMs);
+      });
+    });
+
+    group('best-effort mark: save failure does not block removal', () {
+      test('still removes all when mark write throws', () async {
+        final cache = makeLocalCache();
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => [cache]);
+        when(mockRepository.saveComposerCache(
+          accountId,
+          userName,
+          anyNamed('composerCache'),
+        )).thenThrow(Exception('write failed'));
+        when(mockRepository.removeAllComposerCache(accountId, userName))
+            .thenAnswer((_) async {});
+
+        final result = await interactor.execute(accountId, userName);
+
+        expect(result, Right(MarkComposerCacheCleanCloseSuccess()));
+        verify(mockRepository.removeAllComposerCache(accountId, userName))
+            .called(1);
+      });
+    });
+
+    group('when no cache exists', () {
+      test('skips mark step and still removes all', () async {
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => []);
+        when(mockRepository.removeAllComposerCache(accountId, userName))
+            .thenAnswer((_) async {});
+
+        final result = await interactor.execute(accountId, userName);
+
+        expect(result, Right(MarkComposerCacheCleanCloseSuccess()));
+        verifyNever(mockRepository.saveComposerCache(
+          anyNamed('accountId'),
+          anyNamed('userName'),
+          anyNamed('composerCache'),
+        ));
+        verify(mockRepository.removeAllComposerCache(accountId, userName))
+            .called(1);
+      });
+    });
+
+    group('error handling', () {
+      test('returns failure when getComposerCache throws', () async {
+        final exception = Exception('db error');
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenThrow(exception);
+
+        final result = await interactor.execute(accountId, userName);
+
+        result.fold(
+          (f) {
+            expect(f, isA<MarkComposerCacheCleanCloseFailure>());
+            expect(
+                (f as MarkComposerCacheCleanCloseFailure).exception, exception);
+          },
+          (_) => fail('expected Left'),
+        );
+      });
+
+      test('returns failure when removeAllComposerCache throws', () async {
+        final cache = makeLocalCache();
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => [cache]);
+        when(mockRepository.saveComposerCache(
+          accountId,
+          userName,
+          anyNamed('composerCache'),
+        )).thenAnswer((_) async {});
+        when(mockRepository.removeAllComposerCache(accountId, userName))
+            .thenThrow(Exception('remove failed'));
+
+        final result = await interactor.execute(accountId, userName);
+
+        verify(mockRepository.saveComposerCache(
+          accountId,
+          userName,
+          anyNamed('composerCache'),
+        )).called(1);
+        result.fold(
+          (f) {
+            expect(f, isA<MarkComposerCacheCleanCloseFailure>());
+            expect((f as MarkComposerCacheCleanCloseFailure).exception,
+                isA<Exception>());
+          },
+          (_) => fail('expected Left'),
+        );
+      });
+    });
+  });
+}

--- a/test/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor_test.dart
+++ b/test/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor_test.dart
@@ -1,0 +1,178 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/resolve_composer_cache_for_restore_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor.dart';
+
+import 'resolve_composer_cache_for_restore_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<ComposerCacheRepository>()])
+void main() {
+  final accountId = AccountId(Id('account-1'));
+  final userName = UserName('user@example.com');
+
+  late MockComposerCacheRepository mockRepository;
+  late ResolveComposerCacheForRestoreInteractor interactor;
+
+  setUp(() {
+    mockRepository = MockComposerCacheRepository();
+    interactor = ResolveComposerCacheForRestoreInteractor(mockRepository);
+  });
+
+  ComposerPersistentCache makeCache({
+    bool? isCleanClose,
+    int? timestampMs,
+    bool withEmail = true,
+  }) =>
+      ComposerPersistentCache(
+        isCleanClose: isCleanClose,
+        timestampMs: timestampMs ?? DateTime.now().millisecondsSinceEpoch,
+        email: withEmail ? Email() : null,
+      );
+
+  void expectRightWithNullCache(Object result) {
+    (result as dynamic).fold(
+      (_) => fail('expected Right'),
+      (s) => expect((s as ResolveComposerCacheForRestoreSuccess).cache, isNull),
+    );
+  }
+
+  void expectRightWithoutRemoveAll(
+    Object result, {
+    ComposerPersistentCache? expectedCache,
+  }) {
+    verifyNever(mockRepository.removeAllComposerCache(any, any));
+    (result as dynamic).fold(
+      (_) => fail('expected Right'),
+      (s) {
+        expect(s, isA<ResolveComposerCacheForRestoreSuccess>());
+        expect(
+          (s as ResolveComposerCacheForRestoreSuccess).cache,
+          expectedCache == null ? isNull : same(expectedCache),
+        );
+      },
+    );
+  }
+
+  group('ResolveComposerCacheForRestoreInteractor', () {
+    group('when no cache entry exists', () {
+      test('returns Right with null cache and does not call removeAll', () async {
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => []);
+
+        final result = await interactor.execute(accountId, userName);
+
+        expectRightWithoutRemoveAll(result);
+      });
+    });
+
+    group('when cache is not restorable', () {
+      setUp(() {
+        when(mockRepository.removeAllComposerCache(accountId, userName))
+            .thenAnswer((_) async {});
+      });
+
+      final testCases = [
+        (
+          description: 'isCleanClose is true',
+          makeCache: () => ComposerPersistentCache(
+            isCleanClose: true,
+            timestampMs: DateTime.now().millisecondsSinceEpoch,
+            email: Email(),
+          ),
+        ),
+        (
+          description: 'cache is expired',
+          makeCache: () => ComposerPersistentCache(
+            timestampMs: DateTime.now()
+                .subtract(const Duration(hours: 25))
+                .millisecondsSinceEpoch,
+            email: Email(),
+          ),
+        ),
+        (
+          description: 'email is null (empty snapshot)',
+          makeCache: () => ComposerPersistentCache(
+            timestampMs: DateTime.now().millisecondsSinceEpoch,
+          ),
+        ),
+      ];
+
+      for (final tc in testCases) {
+        test('removes all and returns null when ${tc.description}', () async {
+          when(mockRepository.getComposerCache(accountId, userName))
+              .thenAnswer((_) async => [tc.makeCache()]);
+
+          final result = await interactor.execute(accountId, userName);
+
+          verify(mockRepository.removeAllComposerCache(accountId, userName)).called(1);
+          expectRightWithNullCache(result);
+        });
+      }
+    });
+
+    group('when cache is restorable', () {
+      test('returns the cache without calling removeAll', () async {
+        final cache = makeCache(isCleanClose: false);
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => [cache]);
+
+        final result = await interactor.execute(accountId, userName);
+
+        expectRightWithoutRemoveAll(result, expectedCache: cache);
+      });
+
+      test('returns the newest cache when multiple entries exist', () async {
+        final older = makeCache(
+          isCleanClose: false,
+          timestampMs: DateTime.now()
+              .subtract(const Duration(hours: 1))
+              .millisecondsSinceEpoch,
+        );
+        final newer = makeCache(
+          isCleanClose: false,
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => [older, newer]);
+
+        final result = await interactor.execute(accountId, userName);
+
+        result.fold(
+          (_) => fail('expected Right'),
+          (s) => expect(
+            (s as ResolveComposerCacheForRestoreSuccess).cache,
+            same(newer),
+          ),
+        );
+      });
+    });
+
+    group('error handling', () {
+      test('returns Left(ResolveComposerCacheForRestoreFailure) when repository throws', () async {
+        final exception = Exception('db error');
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenThrow(exception);
+
+        final result = await interactor.execute(accountId, userName);
+
+        result.fold(
+          (f) {
+            expect(f, isA<ResolveComposerCacheForRestoreFailure>());
+            expect(
+              (f as ResolveComposerCacheForRestoreFailure).exception,
+              exception,
+            );
+          },
+          (_) => fail('expected Left'),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Issue

#4473

Implement for ADR-0086 #4477

## Description

### Why
On Android, pressing Home may background the app and the system can kill the process. Since composer state is in-memory, unsaved drafts are lost. This PR implements ADR-0086 (4-layer auto-save) to guarantee recovery. Depends on refactor in #4485

### What
Add a Hive-backed persistent cache that auto-saves on every change and restores on next launch.


## Changes

### Persistent cache (Hive)
- `ComposerPersistentCache`: extends `ComposerCache` (`isCleanClose`, `timestampMs`)  
- `ComposerHiveCacheClient`: AES-256 encrypted Hive storage  
- `ComposerPersistentCacheDatasourceImpl`: read/write/delete  
- Extend `ComposerCacheDatasource` & `ComposerCacheRepository` for persistent support  

### Domain
- `ResolveComposerCacheForRestoreInteractor`: load latest, validate `isRestorable` (`!cleanClose && !expired && !empty`), remove stale  
- `MarkComposerCacheCleanCloseInteractor`: mark clean exit  
- `SaveComposerCacheInteractor`: persist snapshot  

### Auto-save (Riverpod)
- `ComposerAutoSaveNotifier`: auto-save + `restore()` / `clearCache()`  
- `composer_cache_providers.dart`: wire client → datasource → repository → interactors (DIP)  

### Extensions
- `HandleMobileAutoSaveExtension`: auto-save on content change, clean-close on exit  
- `HandleComposerRestoreOnMobileExtension`: restore draft on resume  

### UI
- `MobileEditorView`: integrate auto-save lifecycle  
- `ComposerArguments`: add `composerId` + restore fields  
- `EmailActionType`: add `restoreComposerFromPersistentCache`  


## Test
- `ComposerAutoSaveNotifier`: 15 cases (init, restore, clear)  
- `MarkComposerCacheCleanCloseInteractor`, `GetAllComposerCacheInteractor`: success/failure  
- `ComposerPersistentCache`: `isRestorable`, `isExpired`, `isEmpty`  
- Existing tests pass  



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Draft recovery on Android with periodic auto-save and restore on app reopen.
  * Reopen-composer flow for restored mobile drafts (preserves content, attachments, subject, recipients, and flags).
  * Clean-close marking to avoid unwanted restores after intentional sends/deletes.
* **Tests**
  * Added unit tests covering auto-save, restore, clean-close and mobile cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->