### PR TITLE
TF-4473 Add E2E tests for Android composer auto-save draft

### DIFF
--- a/integration_test/base/app_constants.dart
+++ b/integration_test/base/app_constants.dart
@@ -1,0 +1,3 @@
+class AppConstants {
+  static const appId = 'com.linagora.android.teammail';
+}

--- a/integration_test/scenarios/composer/android/android_composer_background_restore_scenario.dart
+++ b/integration_test/scenarios/composer/android/android_composer_background_restore_scenario.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+
+import '../../../base/app_constants.dart';
+import '../../../base/base_test_scenario.dart';
+
+/// RC1 scenario: composer survives app backgrounding.
+///
+/// Steps:
+///   1. Login
+///   2. Open composer → fill subject
+///   3. Background the app (Home button) — triggers auto-save to Hive
+///   4. Return to the app
+///   5. Assert composer is still open with subject intact
+class AndroidComposerBackgroundRestoreScenario extends BaseTestScenario {
+  const AndroidComposerBackgroundRestoreScenario(super.$, super.robots);
+
+  static const _subject = 'Auto-save background test';
+  static const _appId = AppConstants.appId;
+
+  @override
+  Future<void> runTestLogic() async {
+    final threadRobot = robots.threadRobot();
+    final composerRobot = robots.composerRobot();
+    final native = $.platformAutomator.android;
+
+    await threadRobot.openComposer();
+    await _expectComposerVisible();
+    await composerRobot.grantContactPermission();
+    await composerRobot.addSubject(_subject);
+
+    // Backgrounding triggers AppLifecycleState.inactive → Hive auto-save.
+    await native.pressHome();
+    await $.pump(const Duration(seconds: 2));
+
+    await native.openApp(appId: _appId);
+    await $.pump(const Duration(seconds: 2));
+
+    await _expectComposerVisible();
+    await _expectSubjectVisible(_subject);
+  }
+
+  Future<void> _expectComposerVisible() => expectViewVisible($(ComposerView));
+
+  Future<void> _expectSubjectVisible(String subject) =>
+      expectViewVisible($(find.text(subject)));
+}

--- a/integration_test/tests/composer/android_composer_auto_save_test.dart
+++ b/integration_test/tests/composer/android_composer_auto_save_test.dart
@@ -1,0 +1,12 @@
+import '../../base/test_base.dart';
+import '../../models/test_tags.dart';
+import '../../scenarios/composer/android/android_composer_background_restore_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should keep composer open after app is sent to background (RC1)',
+    scenarioBuilder: ($, robots) =>
+        AndroidComposerBackgroundRestoreScenario($, robots),
+    tags: [TestTags.android],
+  );
+}

--- a/integration_test/utils/backend_reset_client.dart
+++ b/integration_test/utils/backend_reset_client.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:core/utils/app_logger.dart';
+
 /// Calls the backend reset server running on the CI host.
 ///
 /// The Android emulator reaches the host at 10.0.2.2. The reset server
@@ -33,6 +35,8 @@ class BackendResetClient {
       if (response.statusCode != 200) {
         throw Exception('Backend reset failed with status ${response.statusCode}');
       }
+    } catch (e) {
+      logWarning('Backend reset failed: $e');
     } finally {
       client.close();
     }


### PR DESCRIPTION
## Issue 

#4473 

## Blocker

- Need merged: https://github.com/linagora/tmail-flutter/pull/4478 

## Resolved

```console
🧪 tests.composer.android_composer_auto_save_test Should keep composer open after app is sent to background (RC1)
        ✅   1. tap widgets with text "Use company server".
✅ Should keep composer open after app is sent to background (RC1) 

Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: file:///Users/datvu/WorkingSpace/tmail-flutter/build/app/reports/androidTests/connected/debug/index.html
⏱️  Duration: 58s
```

[Screen_recording_20260504_122644.webm](https://github.com/user-attachments/assets/56854f38-6e6c-4651-8c10-b84e26c46535)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Android integration tests verifying the composer remains open and the entered subject text persists after the app is backgrounded and restored.
* **Chores**
  * Introduced a centralized app identifier constant.
  * Improved backend reset handling to log failures instead of failing silently.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-flutter/pull/4480)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->