### PR TITLE
Patrol Delete user data instead of restart docker

### DIFF
--- a/backend-docker/deletedMessageVault.properties
+++ b/backend-docker/deletedMessageVault.properties
@@ -5,4 +5,4 @@ restoreLocation=Restored-Messages
 
 # Retention period for your deleted messages into the vault, after which they expire and can be potentially cleaned up
 # Optional, default 1y
-# retentionPeriod=1y
+retentionPeriod=0s

--- a/backend-docker/docker-compose.yaml
+++ b/backend-docker/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   tmail-backend:
-    image: linagora/tmail-backend:memory-1.0.16-rc2
+    image: linagora/tmail-backend:memory-1.0.17
     container_name: tmail-backend
     volumes:
       - ./jwt_publickey:/root/conf/jwt_publickey

--- a/provisioning/integration_test/eml/reply_email_with_image_base64/0.eml
+++ b/provisioning/integration_test/eml/reply_email_with_image_base64/0.eml
@@ -2085,7 +2085,7 @@ etica, sans-serif; font-size: 10pt; outline: none !important;"><br></span><=
 ---=Part.1bd.4ef68904eeebae66.195606209ac.53698bc33f399720=---
 
 ---=Part.1be.1277f087a345ce6f.195606209ad.927f064d648ea859=-
-Content-Type: image/webp; name="=?US-ASCII?Q?xe2.webp?="; charset=base64
+Content-Type: image/webp; name="=?US-ASCII?Q?xe2.webp?="
 Content-Disposition: inline
 Content-Transfer-Encoding: base64
 Content-ID: fe053a60-f8d6-11ef-9b24-8d26b6f9ffbd

--- a/provisioning/integration_test/provisioning.sh
+++ b/provisioning/integration_test/provisioning.sh
@@ -4,6 +4,9 @@
 users=("alice" "bob" "brian" "charlotte" "david" "emma")
 bobFolders=("Search Emails" "Forward Emails" "Disposition" "MailBase64" "Calendar" "Reply Emails")
 
+# Add domain
+james-cli AddDomain "example.com" &
+
 # Add users in parallel
 for user in "${users[@]}"; do
   james-cli AddUser "$user@example.com" "$user" &

--- a/scripts/backend-reset-server.py
+++ b/scripts/backend-reset-server.py
@@ -5,57 +5,110 @@ HTTP server that resets tmail-backend to a clean provisioned state.
 The Android emulator reaches the host at 10.0.2.2, so Dart tests call:
   POST http://10.0.2.2:9999/reset
 
-On each reset the server restarts the container (wiping all in-memory
-James state) and re-runs provisioning.sh to restore users/mailboxes/emails.
-Returns 200 OK only once James reports "server started" and provisioning
-completes, so Dart tearDown blocks until the next test can safely start.
+Reset strategy: call the James WebAdmin `deleteData` action for every test
+user, which runs all DeleteUserDataTaskStep hooks (clearing mailboxes, emails,
+JMAP settings, and identities) without restarting the JVM. User accounts are
+preserved so provisioning.sh can re-import mailboxes/emails immediately.
+The AddUser calls in provisioning.sh print "already exists" errors but are
+harmless — everything else (CreateMailbox, ImportEml, team-mailboxes, quota)
+proceeds normally.
 
-Note: docker commit cannot capture JVM heap state, so the memory-based
-backend must always be restored by re-running provisioning after restart.
+Returns 200 OK only once all deleteData tasks complete and provisioning
+finishes, so Dart tearDown blocks until the next test can safely start.
 
 Environment variables:
-  RESET_PORT   Listening port (default: 9999)
-  WORK_DIR     Repo root, used to resolve the compose file (default: cwd)
+  RESET_PORT      Listening port (default: 9999)
+  WORK_DIR        Repo root, used to resolve the compose file (default: cwd)
+  WEBADMIN_PORT   James WebAdmin port inside the container (default: 8000)
 """
 
 import http.server
+import json
 import os
 import subprocess
 import sys
 import time
-from datetime import datetime, timezone
+from typing import Optional
 
-RESET_PORT = int(os.environ.get("RESET_PORT", "9999"))
-WORK_DIR   = os.environ.get("WORK_DIR", os.getcwd())
-COMPOSE    = os.path.join(WORK_DIR, "backend-docker", "docker-compose.yaml")
-PROVISION  = "/root/conf/integration_test/provisioning.sh"
+RESET_PORT    = int(os.environ.get("RESET_PORT", "9999"))
+WEBADMIN_PORT = int(os.environ.get("WEBADMIN_PORT", "8000"))
+PROVISION     = "/root/conf/integration_test/provisioning.sh"
+
+# Must match the users created by provisioning.sh
+_TEST_USERS = [
+    "alice@example.com",
+    "bob@example.com",
+    "brian@example.com",
+    "charlotte@example.com",
+    "david@example.com",
+    "emma@example.com",
+]
+
+_TEST_DOMAIN = "example.com"
 
 
 def _run(cmd: list[str], check: bool = False) -> subprocess.CompletedProcess:
     return subprocess.run(cmd, check=check, capture_output=True, text=True)
 
 
-def _backend_ready_since(since: str) -> bool:
-    # Only inspect logs produced after `since` to avoid matching the previous run's startup message.
-    result = _run(["docker", "logs", "--since", since, "tmail-backend"])
-    combined = result.stdout + result.stderr
-    return "JAMES server started" in combined
+def _webadmin(method: str, path: str) -> dict:
+    """Call the James WebAdmin API inside the container via docker exec curl."""
+    result = _run([
+        "docker", "exec", "tmail-backend",
+        "curl", "-s", "-X", method,
+        f"http://localhost:{WEBADMIN_PORT}{path}",
+    ])
+    if not result.stdout.strip():
+        return {}
+    return json.loads(result.stdout)
+
+
+def _delete_domain_data(domain: str) -> str:
+    """Submit a deleteData task for all users of a domain and return the task ID."""
+    resp = _webadmin("POST", f"/domains/{domain}?action=deleteData")
+    print(f"[reset-server] delete_domain_data response: {resp}", flush=True)
+    task_id = resp.get("taskId")
+    if not task_id:
+        raise RuntimeError(f"deleteData for domain {domain} returned no taskId: {resp}")
+    return task_id
+
+def _delete_user_vault() -> Optional[str]:
+    """Submit a vault deletion task for one user. Returns taskId or None if vault is empty."""
+    resp = _webadmin("DELETE", f"/deletedMessages?scope=expired")
+    print(f"[reset-server] delete_user_vault response: {resp}", flush=True)
+    return resp.get("taskId")
+
+
+def _wait_for_task(task_id: str, timeout: float = 30.0) -> None:
+    """Poll until the James task reaches completed or failed status."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        resp = _webadmin("GET", f"/tasks/{task_id}")
+        status = resp.get("status")
+        if status == "completed":
+            print(f"[reset-server] task completed with response: {resp}", flush=True)
+            return
+        if status == "failed":
+            raise RuntimeError(f"James task {task_id} failed: {resp}")
+        time.sleep(0.2)
+    raise TimeoutError(f"James task {task_id} did not complete within {timeout}s")
 
 
 def reset_backend() -> None:
-    print("[reset-server] Restarting tmail-backend...", flush=True)
-    restart_time = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    _run(["docker", "compose", "-f", COMPOSE, "restart", "tmail-backend"], check=True)
+    print("[reset-server] Deleting user data for all test users...", flush=True)
 
-    deadline = time.time() + 120
-    while time.time() < deadline:
-        if _backend_ready_since(restart_time):
-            break
-        time.sleep(2)
-    else:
-        raise TimeoutError("tmail-backend did not start within 120 seconds")
+    task_id = _delete_domain_data(_TEST_DOMAIN)
+    _wait_for_task(task_id)
+    print(f"[reset-server]   cleared {_TEST_DOMAIN}", flush=True)
+
+    # Clear deleted message vault for all test users.
+    print("[reset-server] Clearing deleted message vault for all test users...", flush=True)
+    task_id = _delete_user_vault()
+    _wait_for_task(task_id)
+    print(f"[reset-server]   cleared vault for {_TEST_DOMAIN}", flush=True)
 
     print("[reset-server] Re-running provisioning...", flush=True)
+    # AddUser calls will log "already exists" errors — expected and harmless.
     _run(["docker", "exec", "tmail-backend", PROVISION], check=True)
     print("[reset-server] Reset complete.", flush=True)
 

--- a/scripts/patrol-integration-test-with-docker.sh
+++ b/scripts/patrol-integration-test-with-docker.sh
@@ -46,7 +46,7 @@ export RESET_PORT=9999
 
 RESET_SERVER_LOG="/tmp/backend-reset-server.log"
 echo "Starting backend reset server on port $RESET_PORT (logs: $RESET_SERVER_LOG)..."
-WORK_DIR="$(pwd)" RESET_PORT="$RESET_PORT" python3 scripts/backend-reset-server.py > "$RESET_SERVER_LOG" 2>&1 &
+RESET_PORT="$RESET_PORT" python3 scripts/backend-reset-server.py > "$RESET_SERVER_LOG" 2>&1 &
 RESET_SERVER_PID=$!
 
 cleanup() {

--- a/scripts/patrol-local-integration-test-with-docker.sh
+++ b/scripts/patrol-local-integration-test-with-docker.sh
@@ -51,7 +51,7 @@ export RESET_PORT=9999
 
 RESET_SERVER_LOG="/tmp/backend-reset-server.log"
 echo "Starting backend reset server on port $RESET_PORT (logs: $RESET_SERVER_LOG)..."
-WORK_DIR="$(pwd)" RESET_PORT="$RESET_PORT" python3 scripts/backend-reset-server.py > "$RESET_SERVER_LOG" 2>&1 &
+RESET_PORT="$RESET_PORT" python3 scripts/backend-reset-server.py > "$RESET_SERVER_LOG" 2>&1 &
 RESET_SERVER_PID=$!
 
 cleanup() {


### PR DESCRIPTION
## Description

Restarting docker backend, although ensure test isolation, takes long time. New strategy is tried here:
```python
resp = _webadmin("POST", f"/users/{user}?action=deleteData")
...
resp = _webadmin("DELETE", f"/deletedMessages/users/{user}")
```

## Test result
```console
✓ Completed building apk with entrypoint test_bundle.dart (21.1s)
• Executing tests of apk with entrypoint test_bundle.dart on emulator-5554...
✅ Should display and navigate app grid correctly when clicked (/tests/app_grid/app_grid_test.dart) (40s)
✅ Should see save dialog when download all attachments successfully (/tests/attachments/download_all_attachments_test.dart) (30s)
✅ Should see base64 inline image when attachment has no disposition but has cid (/tests/attachments/no_disposition_inline_test.dart) (24s)
✅ Should see yes and mail to attendees buttons and should not see no and maybe buttons when user view calendar event counter email (/tests/calendar/calendar_event_counter_test.dart) (25s)
✅ Should fill subject with reply prefix when user taps mail to attendees button on calendar event email (/tests/calendar/mail_to_attendees_event_email_test.dart) (28s)
✅ Should not see attachment reminder when send email with attachment keyword in signature (/tests/composer/attachment_reminder_test.dart) (35s)
✅ Should see new identity in From field when select new identity and save as draft successfully (/tests/composer/change_identity_in_draft_email_test.dart) (34s)
✅ Should see attachment and inline image when upload success in composer (/tests/composer/composer_upload_attachment_and_inline_image_test.dart) (24s)
✅ Should see HTML content contain enough: Subject, From, To, Cc, Bcc, Reply to (/tests/composer/forward_email_test.dart) (28s)
✅ Should see inline image with cid when reply email with content contain image base64 data (/tests/composer/reply_email_with_content_contain_image_base64_data_test.dart) (44s)
✅ Should insert inline under signature and above reply body when user focused composer with signature (/tests/composer/reply_inline_focused_with_signature_test.dart) (26s)
✅ Should insert inline above reply body when user focused composer without signature (/tests/composer/reply_inline_focused_without_signature_test.dart) (30s)
✅ Should insert inline at first line when user never focused composer on reply (/tests/composer/reply_inline_no_focus_at_first_line_test.dart) (29s)
✅ Should all To recipients when reply to own sent email (/tests/composer/reply_to_own_sent_email_test.dart) (34s)
✅ Should save email as template successfully (/tests/composer/save_as_template_test.dart) (35s)
✅ Should not see email address in `Reply-To` field when save draft email without `Reply-To` then open draft email (/tests/composer/save_draft_then_close_composer_and_open_draft_test.dart) (39s)
✅ Should see success toast when send email successfully (/tests/composer/send_email_test.dart) (24s)
✅ Should see email item has important flag icon when send email with mark as important successfully (/tests/composer/send_email_with_mark_as_important_test.dart) (31s)
✅ Should see read receipt dialog when user toggle read receipt and open read receipt email (/tests/composer/send_email_with_read_receipt_enabled_test.dart) (46s)
✅ Should see all recipient fields when expand all recipients in composer (/tests/composer/show_full_recipient_fields_when_expand_all_test.dart) (24s)
✅ Should see message success toast when edit draft email and save draft successfully (/tests/composer/update_draft_email_with_messsage_success_toast_test.dart) (34s)
✅ Should see email in Archive folder when open detailed email and archive email successfully (/tests/email_detailed/archive_email_test.dart) (26s)
✅ Should see normalized inline image when open email with content contain inline image (/tests/email_detailed/deformed_inlined_image_test.dart) (28s)
✅ Should see email in Trash folder when open detailed email and delete email successfully (/tests/email_detailed/delete_email_test.dart) (25s)
✅ Should see toast message success when open detailed email and delete thread successfully (/tests/email_detailed/delete_thread_to_trash_test.dart) (23s)
✅ Should be visible and fully scrollable when opening a long email (/tests/email_detailed/display_and_scroll_email_with_long_content_test.dart) (48s)
✅ Should display full content when opening a short email (/tests/email_detailed/display_email_with_short_content_test.dart) (28s)
✅ Should not display alert dialog when opening an email containing content xss (/tests/email_detailed/display_email_with_xss_content_test.dart) (27s)
✅ Should open new composer with To field has email address when open detailed email and tap `Compose email` butt (/tests/email_detailed/email_address_dialog/compose_email_from_email_address_test.dart) (26s)
✅ Should see Clipboard SnackBar when open detailed email and tap `Copy email address` button in email address inf (/tests/email_detailed/email_address_dialog/copy_email_address_to_clipboard_test.dart) (23s)
✅ Should open new rule filter creator view with condition field has email address when open detailed email and tap (/tests/email_detailed/email_address_dialog/create_rule_with_email_address_test.dart) (23s)
✅ Should see email address info dialog when open detailed email and click email address if sender or recipient (/tests/email_detailed/email_address_dialog/display_email_address_info_dialog_test.dart) (26s)
✅ Should see Clipboard SnackBar when open detailed email and long press email address of sender or rec (/tests/email_detailed/email_address_dialog/long_press_copy_email_address_to_clipboard_test.dart) (23s)
✅ Should auto preview attachment when export attachment successfully (/tests/email_detailed/export_attachment_test.dart) (26s)
✅ The subject line of an email should not be changed when forwarding to an email that has already been forwarded to. (/tests/email_detailed/forward_email_forwarded_when_change_language_test.dart) (135s)
✅ The forward prefix should be displayed correctly when forwarding an email. (/tests/email_detailed/forward_email_when_change_language_test.dart) (138s)
✅ Should see attachment list in email view after forward email successfully (/tests/email_detailed/forwarding_email_lost_attachments_test.dart) (29s)
✅ Should see email in Spam folder when open detailed email and mark as spam email successfully (/tests/email_detailed/mark_as_spam_email_test.dart) (31s)
✅ Should see star and unStar icon when open detailed email and mark as star and unStar email successfully (/tests/email_detailed/mark_as_star_email_test.dart) (27s)
✅ Should see email item has unread icon when open detailed email and select mark as unread email successfully (/tests/email_detailed/mark_as_unread_email_test.dart) (28s)
✅ Should see email in destination folder when open detailed email and move email to destination folder successfully (/tests/email_detailed/move_email_to_folder_test.dart) (30s)
🧪 tests.email_detailed.reply_all_email_test SHOULD see the Subject contain the prefix `Re:`
✅ SHOULD see the Subject contain the prefix `Re:`
AND the To, Cc, Bcc field should display correctly (/tests/email_detailed/reply_all_email_test.dart) (29s)
✅ The subject line of an email should not be changed when replying to an email that has already been replied to. (/tests/email_detailed/reply_email_replied_when_change_language_test.dart) (122s)
🧪 tests.email_detailed.reply_email_when_change_language_test The reply prefix should be displayed correctly when replying to an email.
❌ The reply prefix should be displayed correctly when replying to an email. (/tests/email_detailed/reply_email_when_change_language_test.dart) (64s)
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞═════════════════
The following WaitUntilVisibleTimeoutException was thrown running
a test:
TimeoutException after 0:00:10.000000: Finder "Found 0 widgets
with key [<'reply_email_button'>]: []" did not find any visible
(i.e. hit-testable) widgets

When the exception was thrown, this was the stack:
#0      PatrolTester.waitUntilVisible.<anonymous closure>.<anonymous closure> (package:patrol_finders/src/custom_finders/patrol_tester.dart:575:15)
<asynchronous suspension>
#1      PatrolTester.wrapWithPatrolLog (package:patrol_finders/src/custom_finders/patrol_tester.dart:168:22)
<asynchronous suspension>
#2      TestAsyncUtils.guard.<anonymous closure> (package:flutter_test/src/test_async_utils.dart:130:27)
<asynchronous suspension>
#3      BaseScenario.expectViewVisible (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/base/base_scenario.dart:16:5)
<asynchronous suspension>
#4      ReplyEmailWhenChangeLanguageScenario._expectReplyEmailButtonVisible (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/scenarios/email_detailed/reply_email_when_change_language_scenario.dart:99:5)
<asynchronous suspension>
#5      ReplyEmailWhenChangeLanguageScenario._replyEmailBySubject (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/scenarios/email_detailed/reply_email_when_change_language_scenario.dart:80:5)
<asynchronous suspension>
#6      ReplyEmailWhenChangeLanguageScenario.runTestLogic (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/scenarios/email_detailed/reply_email_when_change_language_scenario.dart:52:7)
<asynchronous suspension>
#7      BaseTestScenario.execute (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/base/base_test_scenario.dart:19:5)
<asynchronous suspension>
#8      TestBase.runPatrolTest.<anonymous closure> (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/base/test_base.dart:45:9)
<asynchronous suspension>
#9      patrolTest.<anonymous closure> (package:patrol/src/common.dart:169:9)
<asynchronous suspension>
#10     testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:192:15)
<asynchronous suspension>
#11     PatrolBinding._wrapTestBodyWithExceptionGatherer (package:patrol/src/binding.dart:250:5)
<asynchronous suspension>
#12     TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:1059:5)
<asynchronous suspension>
#13     TestWidgetsFlutterBinding._createTestCompletionHandler.<anonymous closure> (package:flutter_test/src/binding.dart:814:12)
<asynchronous suspension>

The test description was:
  The reply prefix should be displayed correctly when replying to
  an email.
═════════════════════════════════════════════════════════════════

🧪 tests.email_detailed.reply_email_with_reply_to_test SHOULD see the Subject contain the prefix `Re:`
✅ SHOULD see the Subject contain the prefix `Re:`
AND the To field should contain the email's `Reply-To` address. (/tests/email_detailed/reply_email_with_reply_to_test.dart) (31s)
🧪 tests.email_detailed.reply_email_without_reply_to_test SHOULD see the Subject contain the prefix `Re:`
✅ SHOULD see the Subject contain the prefix `Re:`
AND the To field should contain the email's `From` address. (/tests/email_detailed/reply_email_without_reply_to_test.dart) (31s)
🧪 tests.email_detailed.reply_to_list_email_test SHOULD see the Subject contain the prefix `Re:`
✅ SHOULD see the Subject contain the prefix `Re:`
AND the To field should contain the email's `List-Post` address. (/tests/email_detailed/reply_to_list_email_test.dart) (32s)
✅ Should see inline image when open email with inline image (/tests/email_detailed/view_inline_image_test.dart) (34s)
✅ Should create a new label and add to email when select "Create a new Label" button in add label modal of detailed email view (/tests/labels/create_a_new_tag_from_an_email_test.dart) (24s)
✅ Should show "Create a label" button in Choose Label modal when labels exist, and create a new label successfully (/tests/labels/create_label_from_choose_label_modal_with_existing_labels_test.dart) (26s)
✅ Should create a label from NoLabelYetWidget and show it in the Choose Label modal list (/tests/labels/create_label_from_no_label_yet_widget_test.dart) (26s)
✅ Should show toast success when create new a label successfully (/tests/labels/create_new_a_tag_test.dart) (20s)
✅ Should delete label in label list when delete a label successfully (/tests/labels/delete_a_tag_test.dart) (23s)
✅ Should display empty view when open tag with no email (/tests/labels/display_empty_view_when_open_tag_test.dart) (33s)
✅ Should display folder info when open mail list from tag (/tests/labels/display_folder_info_when_open_mail_from_tag_test.dart) (30s)
✅ Should display NoLabelYetWidget when opening Choose Label modal with no labels (/tests/labels/display_no_label_yet_widget_when_open_choose_label_modal_test.dart) (23s)
✅ Should display view with all email with tag correctly when open label (/tests/labels/display_view_with_all_email_with_tag_test.dart) (32s)
✅ Should update label display name when edit a label successfully (/tests/labels/edit_a_label_test.dart) (24s)
✅ Should remove tag on email subject when clicking on the cross on a tag in the opened mail (/tests/labels/remove_a_label_from_email_test.dart) (28s)
✅ Should see thread view when login with basic auth successfully (/tests/login/login_with_basic_auth_test.dart) (16s)
✅ Should create and hide sub folder successfully (/tests/mailbox/create_and_hide_sub_folder_test.dart) (28s)
✅ Should create personal mailbox successfully (/tests/mailbox/create_personal_folder_test.dart) (21s)
✅ Should create, rename, move and delete mailbox successfully (/tests/mailbox/create_rename_move_and_delete_mailbox_test.dart) (33s)
✅ Should display empty view when no mail favorites (/tests/mailbox/display_empty_view_for_favorite_folder_test.dart) (19s)
🧪 tests.mailbox.empty_and_recover_spam_test Should empty and recover spam successfully
❌ Should empty and recover spam successfully (/tests/mailbox/empty_and_recover_spam_test.dart) (45s)
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞═════════════════
The following WaitUntilVisibleTimeoutException was thrown running
a test:
TimeoutException after 0:00:10.000000: Finder "Found 0 widgets
with text "spam and recover": []" did not find any visible (i.e.
hit-testable) widgets

When the exception was thrown, this was the stack:
#0      PatrolTester.waitUntilVisible.<anonymous closure>.<anonymous closure> (package:patrol_finders/src/custom_finders/patrol_tester.dart:575:15)
<asynchronous suspension>
#1      PatrolTester.wrapWithPatrolLog (package:patrol_finders/src/custom_finders/patrol_tester.dart:168:22)
<asynchronous suspension>
#2      TestAsyncUtils.guard.<anonymous closure> (package:flutter_test/src/test_async_utils.dart:130:27)
<asynchronous suspension>
#3      BaseScenario.expectViewVisible (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/base/base_scenario.dart:16:5)
<asynchronous suspension>
#4      EmptyAndRecoverSpamScenario._expectEmailWithSubjectVisible (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/scenarios/mailbox/empty_and_recover_spam_scenario.dart:59:5)
<asynchronous suspension>
#5      EmptyAndRecoverSpamScenario.runTestLogic (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/scenarios/mailbox/empty_and_recover_spam_scenario.dart:50:5)
<asynchronous suspension>
#6      BaseTestScenario.execute (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/base/base_test_scenario.dart:19:5)
<asynchronous suspension>
#7      TestBase.runPatrolTest.<anonymous closure> (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/base/test_base.dart:45:9)
<asynchronous suspension>
#8      patrolTest.<anonymous closure> (package:patrol/src/common.dart:169:9)
<asynchronous suspension>
#9      testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:192:15)
<asynchronous suspension>
#10     PatrolBinding._wrapTestBodyWithExceptionGatherer (package:patrol/src/binding.dart:250:5)
<asynchronous suspension>
#11     TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:1059:5)
<asynchronous suspension>
#12     TestWidgetsFlutterBinding._createTestCompletionHandler.<anonymous closure> (package:flutter_test/src/binding.dart:814:12)
<asynchronous suspension>

The test description was:
  Should empty and recover spam successfully
═════════════════════════════════════════════════════════════════

🧪 tests.mailbox.empty_and_recover_trash_test Should empty and recover trash successfully
❌ Should empty and recover trash successfully (/tests/mailbox/empty_and_recover_trash_test.dart) (42s)
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞═════════════════
The following WaitUntilVisibleTimeoutException was thrown running
a test:
TimeoutException after 0:00:10.000000: Finder "Found 0 widgets
with text "trash and recover": []" did not find any visible (i.e.
hit-testable) widgets

When the exception was thrown, this was the stack:
#0      PatrolTester.waitUntilVisible.<anonymous closure>.<anonymous closure> (package:patrol_finders/src/custom_finders/patrol_tester.dart:575:15)
<asynchronous suspension>
#1      PatrolTester.wrapWithPatrolLog (package:patrol_finders/src/custom_finders/patrol_tester.dart:168:22)
<asynchronous suspension>
#2      TestAsyncUtils.guard.<anonymous closure> (package:flutter_test/src/test_async_utils.dart:130:27)
<asynchronous suspension>
#3      BaseScenario.expectViewVisible (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/base/base_scenario.dart:16:5)
<asynchronous suspension>
#4      EmptyAndRecoverTrashScenario._expectEmailWithSubjectVisible (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/scenarios/mailbox/empty_and_recover_trash_scenario.dart:59:5)
<asynchronous suspension>
#5      EmptyAndRecoverTrashScenario.runTestLogic (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/scenarios/mailbox/empty_and_recover_trash_scenario.dart:50:5)
<asynchronous suspension>
#6      BaseTestScenario.execute (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/base/base_test_scenario.dart:19:5)
<asynchronous suspension>
#7      TestBase.runPatrolTest.<anonymous closure> (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/base/test_base.dart:45:9)
<asynchronous suspension>
#8      patrolTest.<anonymous closure> (package:patrol/src/common.dart:169:9)
<asynchronous suspension>
#9      testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:192:15)
<asynchronous suspension>
#10     PatrolBinding._wrapTestBodyWithExceptionGatherer (package:patrol/src/binding.dart:250:5)
<asynchronous suspension>
#11     TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:1059:5)
<asynchronous suspension>
#12     TestWidgetsFlutterBinding._createTestCompletionHandler.<anonymous closure> (package:flutter_test/src/binding.dart:814:12)
<asynchronous suspension>

The test description was:
  Should empty and recover trash successfully
═════════════════════════════════════════════════════════════════

✅ Should empty view and hide empty trash banner when empty trash successfully (/tests/mailbox/empty_trash_test.dart) (23s)
🧪 tests.mailbox.long_press_empty_and_recover_spam_test Should empty and recover spam by long press mailbox successfully
❌ Should empty and recover spam by long press mailbox successfully (/tests/mailbox/long_press_empty_and_recover_spam_test.dart) (45s)
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞═════════════════
The following WaitUntilVisibleTimeoutException was thrown running
a test:
TimeoutException after 0:00:05.000000: Finder "Found 0 widgets
with text "long press spam" (considering only hit-testable
widgets with a RenderBox): []" did not find any visible (i.e.
hit-testable) widgets

When the exception was thrown, this was the stack:
#0      PatrolTester.dragUntilVisible.<anonymous closure>.<anonymous closure> (package:patrol_finders/src/custom_finders/patrol_tester.dart:741:13)
<asynchronous suspension>
#1      TestAsyncUtils.guard.<anonymous closure> (package:flutter_test/src/test_async_utils.dart:130:27)
<asynchronous suspension>
#2      PatrolTester.scrollUntilVisible.<anonymous closure>.<anonymous closure> (package:patrol_finders/src/custom_finders/patrol_tester.dart:884:34)
<asynchronous suspension>
#3      TestAsyncUtils.guard.<anonymous closure> (package:flutter_test/src/test_async_utils.dart:130:27)
<asynchronous suspension>
#4      PatrolTester.wrapWithPatrolLog (package:patrol_finders/src/custom_finders/patrol_tester.dart:168:22)
<asynchronous suspension>
#5      LongPressEmptyAndRecoverSpamScenario._expectEmailWithSubjectVisible (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/scenarios/mailbox/long_press_empty_and_recover_spam_scenario.dart:73:5)
<asynchronous suspension>
#6      LongPressEmptyAndRecoverSpamScenario.runTestLogic (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/scenarios/mailbox/long_press_empty_and_recover_spam_scenario.dart:64:5)
<asynchronous suspension>
#7      BaseTestScenario.execute (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/base/base_test_scenario.dart:19:5)
<asynchronous suspension>
#8      TestBase.runPatrolTest.<anonymous closure> (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/base/test_base.dart:45:9)
<asynchronous suspension>
#9      patrolTest.<anonymous closure> (package:patrol/src/common.dart:169:9)
<asynchronous suspension>
#10     testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:192:15)
<asynchronous suspension>
#11     PatrolBinding._wrapTestBodyWithExceptionGatherer (package:patrol/src/binding.dart:250:5)
<asynchronous suspension>
#12     TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:1059:5)
<asynchronous suspension>
#13     TestWidgetsFlutterBinding._createTestCompletionHandler.<anonymous closure> (package:flutter_test/src/binding.dart:814:12)
<asynchronous suspension>

The test description was:
  Should empty and recover spam by long press mailbox
  successfully
═════════════════════════════════════════════════════════════════

🧪 tests.mailbox.long_press_empty_and_recover_trash_test Should empty and recover trash by long press mailbox successfully
❌ Should empty and recover trash by long press mailbox successfully (/tests/mailbox/long_press_empty_and_recover_trash_test.dart) (44s)
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞═════════════════
The following WaitUntilVisibleTimeoutException was thrown running
a test:
TimeoutException after 0:00:05.000000: Finder "Found 0 widgets
with text "long press trash" (considering only hit-testable
widgets with a RenderBox): []" did not find any visible (i.e.
hit-testable) widgets

When the exception was thrown, this was the stack:
#0      PatrolTester.dragUntilVisible.<anonymous closure>.<anonymous closure> (package:patrol_finders/src/custom_finders/patrol_tester.dart:741:13)
<asynchronous suspension>
#1      TestAsyncUtils.guard.<anonymous closure> (package:flutter_test/src/test_async_utils.dart:130:27)
<asynchronous suspension>
#2      PatrolTester.scrollUntilVisible.<anonymous closure>.<anonymous closure> (package:patrol_finders/src/custom_finders/patrol_tester.dart:884:34)
<asynchronous suspension>
#3      TestAsyncUtils.guard.<anonymous closure> (package:flutter_test/src/test_async_utils.dart:130:27)
<asynchronous suspension>
#4      PatrolTester.wrapWithPatrolLog (package:patrol_finders/src/custom_finders/patrol_tester.dart:168:22)
<asynchronous suspension>
#5      LongPressEmptyAndRecoverTrashScenario._expectEmailWithSubjectVisible (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/scenarios/mailbox/long_press_empty_and_recover_trash_scenario.dart:71:5)
<asynchronous suspension>
#6      LongPressEmptyAndRecoverTrashScenario.runTestLogic (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/scenarios/mailbox/long_press_empty_and_recover_trash_scenario.dart:62:5)
<asynchronous suspension>
#7      BaseTestScenario.execute (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/base/base_test_scenario.dart:19:5)
<asynchronous suspension>
#8      TestBase.runPatrolTest.<anonymous closure> (file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/integration_test/base/test_base.dart:45:9)
<asynchronous suspension>
#9      patrolTest.<anonymous closure> (package:patrol/src/common.dart:169:9)
<asynchronous suspension>
#10     testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:192:15)
<asynchronous suspension>
#11     PatrolBinding._wrapTestBodyWithExceptionGatherer (package:patrol/src/binding.dart:250:5)
<asynchronous suspension>
#12     TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:1059:5)
<asynchronous suspension>
#13     TestWidgetsFlutterBinding._createTestCompletionHandler.<anonymous closure> (package:flutter_test/src/binding.dart:814:12)
<asynchronous suspension>

The test description was:
  Should empty and recover trash by long press mailbox
  successfully
═════════════════════════════════════════════════════════════════

✅ Should see mailbox unread count update real time (/tests/mailbox/mailbox_count_real_time_update_test.dart) (28s)
✅ Should move email to mailbox successfully (/tests/mailbox/mailbox_move_email_test.dart) (68s)
✅ Should not see unread counter when mark mailbox as read (/tests/mailbox/mark_mailbox_as_read_test.dart) (23s)
✅ Should see selected email mark as read successfully (/tests/mailbox/mark_single_selected_email_as_read_test.dart) (21s)
✅ Should see selected email mark as spam successfully (/tests/mailbox/mark_single_selected_email_as_spam_test.dart) (24s)
✅ Should see selected email mark as star successfully (/tests/mailbox/mark_single_selected_email_as_star_test.dart) (21s)
✅ Should see all Inbox emails in the Templates folder when perform move folder content action successfully (/tests/mailbox/move_folder_content_test.dart) (32s)
✅ Should refresh email list when pull to refresh (/tests/mailbox/pull_to_refresh_test.dart) (20s)
✅ Should see email with expected condition when quick filter email changed (/tests/mailbox/quick_filter_test.dart) (52s)
✅ Should see quota increase when send email successfully (/tests/mailbox/quota_count_test.dart) (24s)
✅ Should see back to top button when scroll list email in mailbox to bottom and not see back to top button when scroll list emai (/tests/mailbox/scroll_list_email_in_mailbox_and_back_to_top_test.dart) (25s)
✅ Should see expected mailbox when searching mailboxes (/tests/mailbox/search_mailbox_inbox_test.dart) (19s)
✅ Should switch and see emails in mailboxes (/tests/mailbox/switch_mailbox_test.dart) (26s)
✅ Should see email in team mailbox INBOX after sending to team mailbox address (/tests/mailbox/team_mailbox_receive_email_test.dart) (28s)
✅ Should see Twake welcome screen when log out successfully (/tests/misc/log_out_test.dart) (22s)
✅ Should see the same email when selecting filter and changing search input text (/tests/search/persist_filter_when_change_search_input_text_test.dart) (23s)
✅ Should see list email displayed by date time `Last 7 days` and sort order `Relevance` when search email successfully (/tests/search/search_email_by_date_time_and_sort_order_relevance_test.dart) (31s)
✅ Should see list email displayed by sort order `Relevance` by default when search email successfully (/tests/search/search_email_with_sort_order_relevance_by_default_test.dart) (20s)
✅ Should see list email displayed by sort order selected when search email successfully (/tests/search/search_email_with_sort_order_test.dart) (65s)
✅ Should display email list correctly when search with tag (/tests/search/search_email_with_tag_test.dart) (35s)
✅ Should see highlighted keyword in search result (/tests/search/search_result_highlights_test.dart) (26s)
✅ Should see email with subject escaped when search email successfully (/tests/search/search_snippets_with_html_escape_test.dart) (21s)
✅ Should see highlighted keyword in search suggestion (/tests/search/search_suggestion_highlights_test.dart) (22s)
✅ Should see identity as default when select identity as default (/tests/setting/identity/select_identity_as_default_test.dart) (29s)
✅ Should see title in Setting change language when successfully selecting another language (/tests/setting/language/change_language_test.dart) (27s)
✅ Should see reply of thread detail (/tests/thread_detail/thread_detail_reply_real_time_update_test.dart) (31s)
✅ Should see thread view updated per web socket message (/tests/web_socket/web_socket_test.dart) (24s)

Test summary:
📝 Total: 96
✅ Successful: 91
❌ Failed: 5
  - The reply prefix should be displayed correctly when replying to an email. (/tests/email_detailed/reply_email_when_change_language_test.dart)
  - Should empty and recover spam successfully (/tests/mailbox/empty_and_recover_spam_test.dart)
  - Should empty and recover trash successfully (/tests/mailbox/empty_and_recover_trash_test.dart)
  - Should empty and recover spam by long press mailbox successfully (/tests/mailbox/long_press_empty_and_recover_spam_test.dart)
  - Should empty and recover trash by long press mailbox successfully (/tests/mailbox/long_press_empty_and_recover_trash_test.dart)
⏩ Skipped: 0
📊 Report: file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/build/app/reports/androidTests/connected/debug/index.html
⏱️  Duration: 1h 0m 58s
```

Ignore `The reply prefix should be displayed correctly when replying to an email. (/tests/email_detailed/reply_email_when_change_language_test.dart)`. That test is fixed in another branch.

## Problem
4 tests always fail using this method:
```console
- Should empty and recover spam successfully (/tests/mailbox/empty_and_recover_spam_test.dart)
- Should empty and recover trash successfully (/tests/mailbox/empty_and_recover_trash_test.dart)
- Should empty and recover spam by long press mailbox successfully (/tests/mailbox/long_press_empty_and_recover_spam_test.dart)
- Should empty and recover trash by long press mailbox successfully (/tests/mailbox/long_press_empty_and_recover_trash_test.dart)
```

## Analysis
- After a test finish, all of the user's emails are deleted through web admin.
- The above 4 tests always fail when looking for the recovered email in the "Recovered" mailbox
- The `EmailRecoveryAction/set-EmailRecoveryAction/get` method never returns the deleted email in any of those 4 tests

## Question
- Is there a limit on how many emails the backend can recover from `EmailRecoveryAction/set-EmailRecoveryAction/get`?
- How can I ensure the email I just deleted can be recovered? Is there any config for this?