### PR TITLE
TF-4473 Add Android composer persistent cache — data and domain layer

### DIFF
--- a/lib/features/caching/clients/composer_hive_cache_client.dart
+++ b/lib/features/caching/clients/composer_hive_cache_client.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+
+import 'package:core/core.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:model/extensions/account_id_extensions.dart';
+import 'package:tmail_ui_user/features/caching/config/hive_cache_client.dart';
+import 'package:tmail_ui_user/features/caching/utils/cache_utils.dart';
+import 'package:tmail_ui_user/features/caching/utils/caching_constants.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+
+class ComposerHiveCacheClient extends HiveCacheClient<String> {
+  @override
+  String get tableName => CachingConstants.composerHiveCacheBoxName;
+
+  @override
+  bool get encryption => true;
+
+  String _entryKey(AccountId accountId, UserName userName, String? composerId) =>
+      TupleKey(
+        composerId ?? CachingConstants.composerHiveCacheKeyName,
+        accountId.asString,
+        userName.value,
+      ).encodeKey;
+
+  String _accountKey(AccountId accountId, UserName userName) =>
+      TupleKey(accountId.asString, userName.value).encodeKey;
+
+  ComposerPersistentCache? _decodeEntry(String raw) {
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is Map<String, dynamic>) {
+        return ComposerPersistentCache.fromJson(decoded);
+      }
+    } catch (e) {
+      logWarning('ComposerHiveCacheClient::_decodeEntry: corrupted entry, skipping: $e');
+    }
+    return null;
+  }
+
+  Future<void> saveCache(
+    AccountId accountId,
+    UserName userName,
+    ComposerCache cache,
+  ) =>
+      insertItem(
+        _entryKey(accountId, userName, cache.composerId),
+        jsonEncode(cache.toJson()),
+      );
+
+  Future<List<ComposerCache>> getCache(
+    AccountId accountId,
+    UserName userName,
+  ) async {
+    final rawList = await getListByNestedKey(_accountKey(accountId, userName));
+    return rawList.map(_decodeEntry).nonNulls.toList();
+  }
+
+  Future<void> deleteCache(AccountId accountId, UserName userName) =>
+      clearAllDataContainKey(_accountKey(accountId, userName));
+
+  Future<void> deleteCacheById(
+    AccountId accountId,
+    UserName userName,
+    String composerId,
+  ) =>
+      deleteItem(_entryKey(accountId, userName, composerId));
+}

--- a/lib/features/caching/utils/caching_constants.dart
+++ b/lib/features/caching/utils/caching_constants.dart
@@ -32,10 +32,12 @@ class CachingConstants {
   static const String oidcConfigurationCacheBoxName = 'oidc_configuration_cache_box';
   static const String sentryConfigurationCacheBoxName = 'sentry_configuration_cache_box';
   static const String sentryUserCacheBoxName = 'sentry_user_cache_box';
+  static const String composerHiveCacheBoxName = 'composer_hive_cache_box';
 
   static const String oidcConfigurationCacheKeyName = 'oidc_configuration_cache_key';
   static const String sentryConfigurationCacheKeyName = 'sentry_configuration_cache_key';
   static const String sentryUserCacheKeyName = 'sentry_user_cache_key';
+  static const String composerHiveCacheKeyName = 'composer_hive_cache_key';
 
   static const String newEmailsContentFolderName = 'new_emails';
   static const String openedEmailContentFolderName = 'opened_email';

--- a/lib/features/composer/data/adapter/html_email_transformer_adapter.dart
+++ b/lib/features/composer/data/adapter/html_email_transformer_adapter.dart
@@ -1,0 +1,22 @@
+import 'package:core/presentation/utils/html_transformer/html_transform.dart';
+import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
+import 'package:tmail_ui_user/features/composer/domain/transformer/html_email_transformer.dart';
+
+class HtmlEmailTransformerAdapter implements HtmlEmailTransformer {
+  final HtmlTransform _htmlTransform;
+
+  HtmlEmailTransformerAdapter(this._htmlTransform);
+
+  @override
+  Future<String> transformToHtml({
+    required String htmlContent,
+    required TransformConfiguration transformConfiguration,
+    Map<String, String>? mapCidImageDownloadUrl,
+  }) {
+    return _htmlTransform.transformToHtml(
+      htmlContent: htmlContent,
+      transformConfiguration: transformConfiguration,
+      mapCidImageDownloadUrl: mapCidImageDownloadUrl,
+    );
+  }
+}

--- a/lib/features/composer/domain/transformer/html_email_transformer.dart
+++ b/lib/features/composer/domain/transformer/html_email_transformer.dart
@@ -1,0 +1,9 @@
+import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
+
+abstract class HtmlEmailTransformer {
+  Future<String> transformToHtml({
+    required String htmlContent,
+    required TransformConfiguration transformConfiguration,
+    Map<String, String>? mapCidImageDownloadUrl,
+  });
+}

--- a/lib/features/composer/domain/usecases/restore_email_inline_images_interactor.dart
+++ b/lib/features/composer/domain/usecases/restore_email_inline_images_interactor.dart
@@ -3,25 +3,26 @@ import 'package:core/presentation/state/success.dart';
 import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:dartz/dartz.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/restore_email_inline_images_state.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
+import 'package:tmail_ui_user/features/composer/domain/transformer/html_email_transformer.dart';
 
 class RestoreEmailInlineImagesInteractor {
-  RestoreEmailInlineImagesInteractor(this._composerCacheRepository);
+  final HtmlEmailTransformer _htmlEmailTransformer;
 
-  final ComposerCacheRepository _composerCacheRepository;
+  RestoreEmailInlineImagesInteractor(this._htmlEmailTransformer);
 
   Stream<Either<Failure, Success>> execute({
     required String htmlContent,
     required TransformConfiguration transformConfiguration,
-    required Map<String, String> mapUrlDownloadCID
+    required Map<String, String> mapUrlDownloadCID,
   }) async* {
     try {
       yield Right(RestoringEmailInlineImages());
-      
-      final emailContent = await _composerCacheRepository.restoreEmailInlineImages(
-        htmlContent,
-        transformConfiguration,
-        mapUrlDownloadCID);
+
+      final emailContent = await _htmlEmailTransformer.transformToHtml(
+        htmlContent: htmlContent,
+        transformConfiguration: transformConfiguration,
+        mapCidImageDownloadUrl: mapUrlDownloadCID,
+      );
       yield Right(RestoreEmailInlineImagesSuccess(emailContent));
     } catch (exception) {
       yield Left(RestoreEmailInlineImagesFailure(exception: exception));

--- a/lib/features/composer/domain/usecases/save_composer_cache_interactor.dart
+++ b/lib/features/composer/domain/usecases/save_composer_cache_interactor.dart
@@ -18,6 +18,7 @@ class SaveComposerCacheInteractor {
 
   Future<Either<Failure, Success>> execute({
     required CreateEmailRequest createEmailRequest,
+    bool isPersistent = false,
   }) async {
     try {
       final emailCreated = await _composerRepository.generateEmail(
@@ -29,6 +30,7 @@ class SaveComposerCacheInteractor {
       final userName = createEmailRequest.session.username;
       final composerCache = createEmailRequest.generateComposerCache(
         emailCreated: emailCreated,
+        isPersistent: isPersistent,
       );
       await _composerCacheRepository.saveComposerCache(
         accountId,

--- a/lib/features/composer/presentation/composer_bindings.dart
+++ b/lib/features/composer/presentation/composer_bindings.dart
@@ -411,6 +411,8 @@ class ComposerBindings extends BaseBindings {
     Get.delete<CreateNewAndSendEmailInteractor>(tag: composerId);
     Get.delete<CreateNewAndSaveEmailToDraftsInteractor>(tag: composerId);
     Get.delete<RestoreEmailInlineImagesInteractor>(tag: composerId);
+    Get.delete<HtmlEmailTransformerAdapter>(tag: composerId);
+    Get.delete<HtmlEmailTransformer>(tag: composerId);
     Get.delete<PrintEmailInteractor>(tag: composerId);
     Get.delete<SaveTemplateEmailInteractor>(tag: composerId);
 

--- a/lib/features/composer/presentation/composer_bindings.dart
+++ b/lib/features/composer/presentation/composer_bindings.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/base_bindings.dart';
 import 'package:tmail_ui_user/features/caching/utils/local_storage_manager.dart';
 import 'package:tmail_ui_user/features/caching/utils/session_storage_manager.dart';
+import 'package:tmail_ui_user/features/composer/data/adapter/html_email_transformer_adapter.dart';
 import 'package:tmail_ui_user/features/composer/data/datasource/composer_datasource.dart';
 import 'package:tmail_ui_user/features/composer/data/datasource/contact_datasource.dart';
 import 'package:tmail_ui_user/features/composer/data/datasource_impl/composer_datasource_impl.dart';
@@ -11,6 +12,7 @@ import 'package:tmail_ui_user/features/composer/data/repository/composer_reposit
 import 'package:tmail_ui_user/features/composer/data/repository/contact_repository_impl.dart';
 import 'package:tmail_ui_user/features/composer/domain/repository/composer_repository.dart';
 import 'package:tmail_ui_user/features/composer/domain/repository/contact_repository.dart';
+import 'package:tmail_ui_user/features/composer/domain/transformer/html_email_transformer.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/create_new_and_save_email_to_drafts_interactor.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/create_new_and_send_email_interactor.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/download_image_as_base64_interactor.dart';
@@ -149,7 +151,6 @@ class ComposerBindings extends BaseBindings {
 
   void _bindComposerCacheDatasourceImpl() {
     Get.lazyPut(() => ComposerSessionCacheDatasourceImpl(
-      Get.find<HtmlTransform>(),
       Get.find<CacheExceptionThrower>(),
     ), tag: composerId);
   }
@@ -297,7 +298,15 @@ class ComposerBindings extends BaseBindings {
       Get.find<ComposerRepository>(tag: composerId),
     ), tag: composerId);
     Get.lazyPut(
-      () => RestoreEmailInlineImagesInteractor(Get.find<ComposerCacheRepository>(tag: composerId)),
+      () => HtmlEmailTransformerAdapter(Get.find<HtmlTransform>()),
+      tag: composerId,
+    );
+    Get.lazyPut<HtmlEmailTransformer>(
+      () => Get.find<HtmlEmailTransformerAdapter>(tag: composerId),
+      tag: composerId,
+    );
+    Get.lazyPut(
+      () => RestoreEmailInlineImagesInteractor(Get.find<HtmlEmailTransformer>(tag: composerId)),
       tag: composerId,
     );
     Get.lazyPut(

--- a/lib/features/composer/presentation/extensions/create_email_request_extension.dart
+++ b/lib/features/composer/presentation/extensions/create_email_request_extension.dart
@@ -17,6 +17,7 @@ import 'package:tmail_ui_user/features/composer/presentation/model/create_email_
 import 'package:tmail_ui_user/features/email/domain/extensions/list_attachments_extension.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/model/create_new_mailbox_request.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/extensions/sending_email_extension.dart';
 import 'package:tmail_ui_user/features/sending_queue/presentation/model/sending_email_arguments.dart';
 import 'package:tmail_ui_user/main/localizations/localization_service.dart';
@@ -236,7 +237,20 @@ extension CreateEmailRequestExtension on CreateEmailRequest {
 
   ComposerCache generateComposerCache({
     required Email emailCreated,
+    bool isPersistent = false,
   }) {
+    if (isPersistent) {
+      return ComposerPersistentCache(
+        email: emailCreated,
+        hasRequestReadReceipt: hasRequestReadReceipt,
+        isMarkAsImportant: isMarkAsImportant,
+        actionType: EmailActionType.restoreComposerFromPersistentCache,
+        draftEmailId: draftsEmailId,
+        composerId: composerId,
+        isCleanClose: false,
+        timestampMs: DateTime.now().millisecondsSinceEpoch,
+      );
+    }
     return ComposerCache(
       email: emailCreated,
       hasRequestReadReceipt: hasRequestReadReceipt,

--- a/lib/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart
+++ b/lib/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart
@@ -1,4 +1,3 @@
-import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
@@ -34,11 +33,4 @@ abstract class ComposerCacheDatasource {
       throw UnsupportedError(
           'removeComposerCacheById is not supported on this platform');
 
-  Future<String> restoreEmailInlineImages(
-    String htmlContent,
-    TransformConfiguration transformConfiguration,
-    Map<String, String> mapUrlDownloadCID,
-  ) =>
-      throw UnsupportedError(
-          'restoreEmailInlineImages is not supported on this platform');
 }

--- a/lib/features/mailbox_dashboard/data/datasource_impl/composer_persistent_cache_datasource_impl.dart
+++ b/lib/features/mailbox_dashboard/data/datasource_impl/composer_persistent_cache_datasource_impl.dart
@@ -1,0 +1,52 @@
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:tmail_ui_user/features/caching/clients/composer_hive_cache_client.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/exception_thrower.dart';
+
+class ComposerPersistentCacheDatasourceImpl extends ComposerCacheDatasource {
+  final ComposerHiveCacheClient _cacheClient;
+  final ExceptionThrower _exceptionThrower;
+
+  ComposerPersistentCacheDatasourceImpl(this._cacheClient, this._exceptionThrower);
+
+  @override
+  Future<void> saveComposerCache(
+    AccountId accountId,
+    UserName userName,
+    ComposerCache composerCache,
+  ) {
+    return Future.sync(
+      () => _cacheClient.saveCache(accountId, userName, composerCache),
+    ).catchError(_exceptionThrower.throwException);
+  }
+
+  @override
+  Future<List<ComposerCache>> getComposerCache(
+    AccountId accountId,
+    UserName userName,
+  ) {
+    return Future.sync(
+      () => _cacheClient.getCache(accountId, userName),
+    ).catchError(_exceptionThrower.throwException);
+  }
+
+  @override
+  Future<void> removeAllComposerCache(AccountId accountId, UserName userName) {
+    return Future.sync(
+      () => _cacheClient.deleteCache(accountId, userName),
+    ).catchError(_exceptionThrower.throwException);
+  }
+
+  @override
+  Future<void> removeComposerCacheById(
+    AccountId accountId,
+    UserName userName,
+    String composerId,
+  ) {
+    return Future.sync(
+      () => _cacheClient.deleteCacheById(accountId, userName, composerId),
+    ).catchError(_exceptionThrower.throwException);
+  }
+}

--- a/lib/features/mailbox_dashboard/data/datasource_impl/composer_session_cache_datasource_impl.dart
+++ b/lib/features/mailbox_dashboard/data/datasource_impl/composer_session_cache_datasource_impl.dart
@@ -1,7 +1,5 @@
 import 'dart:convert';
 import 'package:core/domain/exceptions/web_session_exception.dart';
-import 'package:core/presentation/utils/html_transformer/html_transform.dart';
-import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:model/email/email_action_type.dart';
@@ -13,13 +11,9 @@ import 'package:tmail_ui_user/main/exceptions/thrower/exception_thrower.dart';
 import 'package:universal_html/html.dart' as html;
 
 class ComposerSessionCacheDatasourceImpl extends ComposerCacheDatasource {
-  final HtmlTransform _htmlTransform;
   final ExceptionThrower _exceptionThrower;
 
-  ComposerSessionCacheDatasourceImpl(
-    this._htmlTransform,
-    this._exceptionThrower,
-  );
+  ComposerSessionCacheDatasourceImpl(this._exceptionThrower);
 
   @override
   Future<List<ComposerCache>> getComposerCache(
@@ -31,7 +25,7 @@ class ComposerSessionCacheDatasourceImpl extends ComposerCacheDatasource {
         EmailActionType.reopenComposerBrowser.name,
         accountId.asString,
         userName.value).toString();
-        
+
       final listEntries = html.window.sessionStorage.entries.where(
         (entry) => entry.key.startsWith(keyWithIdentity),
       );
@@ -60,19 +54,6 @@ class ComposerSessionCacheDatasourceImpl extends ComposerCacheDatasource {
         composerCache.composerId,
       ).toString();
       html.window.sessionStorage[composerCacheKey] = jsonEncode(composerCache.toJson());
-    }).catchError(_exceptionThrower.throwException);
-  }
-  
-  @override
-  Future<String> restoreEmailInlineImages(
-    String htmlContent,
-    TransformConfiguration transformConfiguration,
-    Map<String, String> mapUrlDownloadCID) {
-    return Future.sync(() async {
-      return await _htmlTransform.transformToHtml(
-        htmlContent: htmlContent,
-        transformConfiguration: transformConfiguration,
-        mapCidImageDownloadUrl: mapUrlDownloadCID);
     }).catchError(_exceptionThrower.throwException);
   }
 

--- a/lib/features/mailbox_dashboard/data/model/composer_persistent_cache.dart
+++ b/lib/features/mailbox_dashboard/data/model/composer_persistent_cache.dart
@@ -1,0 +1,108 @@
+import 'package:jmap_dart_client/http/converter/email_id_nullable_converter.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:model/email/email_action_type.dart';
+import 'package:tmail_ui_user/features/composer/presentation/model/screen_display_mode.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
+
+part 'composer_persistent_cache.g.dart';
+
+/// Extension of [ComposerCache] with draft-recovery metadata.
+///
+/// [isCleanClose] `null`/`false` means "restore on next open"; `true` means
+/// the composer was dismissed intentionally (send or explicit discard).
+/// [timestampMs] selects the most recent snapshot across concurrent sessions.
+@JsonSerializable(
+  explicitToJson: true,
+  includeIfNull: false,
+  converters: [
+    EmailIdNullableConverter(),
+  ],
+)
+class ComposerPersistentCache extends ComposerCache {
+  static const _expiryDuration = Duration(hours: 24);
+
+  final bool? isCleanClose;
+  final int? timestampMs;
+
+  ComposerPersistentCache({
+    super.email,
+    super.hasRequestReadReceipt,
+    super.isMarkAsImportant,
+    super.displayMode,
+    super.composerIndex,
+    super.composerId,
+    super.draftHash,
+    super.actionType,
+    super.draftEmailId,
+    super.templateEmailId,
+    this.isCleanClose,
+    this.timestampMs,
+  });
+
+  factory ComposerPersistentCache.fromJson(Map<String, dynamic> json) =>
+      _$ComposerPersistentCacheFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => {
+        ...super.toJson(),
+        ..._$ComposerPersistentCacheToJson(this),
+      };
+
+  bool get isRestorable => isCleanClose != true && !isExpired && !isEmpty;
+
+  bool get isExpired {
+    if (timestampMs == null) return false;
+    return DateTime.now().millisecondsSinceEpoch - timestampMs! >
+        _expiryDuration.inMilliseconds;
+  }
+
+  bool get isEmpty => email == null;
+
+  ComposerPersistentCache copyWith({
+    Email? email,
+    bool? hasRequestReadReceipt,
+    bool? isMarkAsImportant,
+    ScreenDisplayMode? displayMode,
+    int? composerIndex,
+    String? composerId,
+    int? draftHash,
+    EmailActionType? actionType,
+    EmailId? draftEmailId,
+    EmailId? templateEmailId,
+    bool? isCleanClose,
+    int? timestampMs,
+  }) =>
+      ComposerPersistentCache(
+        email: email ?? this.email,
+        hasRequestReadReceipt: hasRequestReadReceipt ?? this.hasRequestReadReceipt,
+        isMarkAsImportant: isMarkAsImportant ?? this.isMarkAsImportant,
+        displayMode: displayMode ?? this.displayMode,
+        composerIndex: composerIndex ?? this.composerIndex,
+        composerId: composerId ?? this.composerId,
+        draftHash: draftHash ?? this.draftHash,
+        actionType: actionType ?? this.actionType,
+        draftEmailId: draftEmailId ?? this.draftEmailId,
+        templateEmailId: templateEmailId ?? this.templateEmailId,
+        isCleanClose: isCleanClose ?? this.isCleanClose,
+        timestampMs: timestampMs ?? this.timestampMs,
+      );
+
+  @override
+  List<Object?> get props => [
+        ...super.props,
+        isCleanClose,
+        timestampMs,
+      ];
+}
+
+extension ComposerPersistentCacheListExtension on Iterable<ComposerCache> {
+  ComposerPersistentCache? get newestLocalCache =>
+      whereType<ComposerPersistentCache>()
+          .fold<ComposerPersistentCache?>(null, (newest, entry) {
+        if (newest == null) return entry;
+        return (entry.timestampMs ?? 0) > (newest.timestampMs ?? 0)
+            ? entry
+            : newest;
+      });
+}

--- a/lib/features/mailbox_dashboard/data/repository/composer_cache_repository_impl.dart
+++ b/lib/features/mailbox_dashboard/data/repository/composer_cache_repository_impl.dart
@@ -1,4 +1,3 @@
-import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart';
@@ -48,15 +47,4 @@ class ComposerCacheRepositoryImpl extends ComposerCacheRepository {
         composerId,
       );
 
-  @override
-  Future<String> restoreEmailInlineImages(
-    String htmlContent,
-    TransformConfiguration transformConfiguration,
-    Map<String, String> mapUrlDownloadCID,
-  ) =>
-      _composerCacheDatasource.restoreEmailInlineImages(
-        htmlContent,
-        transformConfiguration,
-        mapUrlDownloadCID,
-      );
 }

--- a/lib/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart
+++ b/lib/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart
@@ -1,4 +1,3 @@
-import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
@@ -24,11 +23,5 @@ abstract class ComposerCacheRepository {
     AccountId accountId,
     UserName userName,
     String composerId,
-  );
-
-  Future<String> restoreEmailInlineImages(
-    String htmlContent,
-    TransformConfiguration transformConfiguration,
-    Map<String, String> mapUrlDownloadCID,
   );
 }

--- a/lib/features/mailbox_dashboard/domain/state/mark_composer_cache_clean_close_state.dart
+++ b/lib/features/mailbox_dashboard/domain/state/mark_composer_cache_clean_close_state.dart
@@ -1,0 +1,8 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+
+class MarkComposerCacheCleanCloseSuccess extends UIState {}
+
+class MarkComposerCacheCleanCloseFailure extends FeatureFailure {
+  MarkComposerCacheCleanCloseFailure(Object? exception) : super(exception: exception);
+}

--- a/lib/features/mailbox_dashboard/domain/state/mark_composer_cache_clean_close_state.dart
+++ b/lib/features/mailbox_dashboard/domain/state/mark_composer_cache_clean_close_state.dart
@@ -4,5 +4,5 @@ import 'package:core/presentation/state/success.dart';
 class MarkComposerCacheCleanCloseSuccess extends UIState {}
 
 class MarkComposerCacheCleanCloseFailure extends FeatureFailure {
-  MarkComposerCacheCleanCloseFailure(Object? exception) : super(exception: exception);
+  MarkComposerCacheCleanCloseFailure(dynamic exception) : super(exception: exception);
 }

--- a/lib/features/mailbox_dashboard/domain/state/resolve_composer_cache_for_restore_state.dart
+++ b/lib/features/mailbox_dashboard/domain/state/resolve_composer_cache_for_restore_state.dart
@@ -1,0 +1,20 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+
+/// Emitted when the resolve logic completes, regardless of whether a
+/// restorable snapshot was found.  [cache] is null when no valid snapshot
+/// exists (expired, clean-close, or simply absent).
+class ResolveComposerCacheForRestoreSuccess extends UIState {
+  final ComposerPersistentCache? cache;
+
+  ResolveComposerCacheForRestoreSuccess(this.cache);
+
+  @override
+  List<Object?> get props => [cache, ...super.props];
+}
+
+class ResolveComposerCacheForRestoreFailure extends FeatureFailure {
+  ResolveComposerCacheForRestoreFailure(Object exception)
+      : super(exception: exception);
+}

--- a/lib/features/mailbox_dashboard/domain/state/resolve_composer_cache_for_restore_state.dart
+++ b/lib/features/mailbox_dashboard/domain/state/resolve_composer_cache_for_restore_state.dart
@@ -15,6 +15,6 @@ class ResolveComposerCacheForRestoreSuccess extends UIState {
 }
 
 class ResolveComposerCacheForRestoreFailure extends FeatureFailure {
-  ResolveComposerCacheForRestoreFailure(Object exception)
+  ResolveComposerCacheForRestoreFailure(dynamic exception)
       : super(exception: exception);
 }

--- a/lib/features/mailbox_dashboard/domain/usecases/mark_composer_cache_clean_close_interactor.dart
+++ b/lib/features/mailbox_dashboard/domain/usecases/mark_composer_cache_clean_close_interactor.dart
@@ -1,0 +1,48 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/mark_composer_cache_clean_close_state.dart';
+
+/// Two-step write (mark then remove) ensures the entry is not treated as a
+/// recoverable snapshot if removal is interrupted
+/// (see [ComposerPersistentCache.isRestorable]).
+class MarkComposerCacheCleanCloseInteractor {
+  final ComposerCacheRepository _repository;
+
+  MarkComposerCacheCleanCloseInteractor(this._repository);
+
+  Future<Either<Failure, Success>> execute(
+    AccountId accountId,
+    UserName userName,
+  ) async {
+    try {
+      final cache =
+          (await _repository.getComposerCache(accountId, userName)).newestLocalCache;
+      if (cache != null) await _tryMarkCleanClose(accountId, userName, cache);
+      await _repository.removeAllComposerCache(accountId, userName);
+      return Right(MarkComposerCacheCleanCloseSuccess());
+    } catch (exception) {
+      return Left(MarkComposerCacheCleanCloseFailure(exception));
+    }
+  }
+
+  Future<void> _tryMarkCleanClose(
+    AccountId accountId,
+    UserName userName,
+    ComposerPersistentCache cache,
+  ) async {
+    try {
+      await _repository.saveComposerCache(
+        accountId,
+        userName,
+        cache.copyWith(isCleanClose: true),
+      );
+    } catch (_) {
+      // Best-effort: mark failure must not prevent removal.
+    }
+  }
+}

--- a/lib/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor.dart
+++ b/lib/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor.dart
@@ -7,11 +7,11 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_per
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/resolve_composer_cache_for_restore_state.dart';
 
-/// Fetches, validates, and cleans up the composer cache in one pass.
+/// Fetches and validates the newest composer cache entry.
 ///
 /// Returns [ResolveComposerCacheForRestoreSuccess] with a non-null [cache]
-/// when a restorable snapshot exists.  Stale or clean-close entries are
-/// removed as a side-effect so Hive stays lean.
+/// when a restorable snapshot exists.  All entries are removed when the
+/// newest cache is absent or not restorable.
 class ResolveComposerCacheForRestoreInteractor {
   final ComposerCacheRepository _repository;
 

--- a/lib/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor.dart
+++ b/lib/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor.dart
@@ -1,0 +1,42 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/resolve_composer_cache_for_restore_state.dart';
+
+/// Fetches, validates, and cleans up the composer cache in one pass.
+///
+/// Returns [ResolveComposerCacheForRestoreSuccess] with a non-null [cache]
+/// when a restorable snapshot exists.  Stale or clean-close entries are
+/// removed as a side-effect so Hive stays lean.
+class ResolveComposerCacheForRestoreInteractor {
+  final ComposerCacheRepository _repository;
+
+  ResolveComposerCacheForRestoreInteractor(this._repository);
+
+  Future<Either<Failure, Success>> execute(
+    AccountId accountId,
+    UserName userName,
+  ) async {
+    try {
+      final caches = await _repository.getComposerCache(accountId, userName);
+      final cache = caches.newestLocalCache;
+
+      if (cache == null) {
+        return Right(ResolveComposerCacheForRestoreSuccess(null));
+      }
+
+      if (!cache.isRestorable) {
+        await _repository.removeAllComposerCache(accountId, userName);
+        return Right(ResolveComposerCacheForRestoreSuccess(null));
+      }
+
+      return Right(ResolveComposerCacheForRestoreSuccess(cache));
+    } catch (exception) {
+      return Left(ResolveComposerCacheForRestoreFailure(exception));
+    }
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
@@ -1,7 +1,6 @@
 import 'package:core/data/model/source_type/data_source_type.dart';
 import 'package:core/data/network/download/download_manager.dart';
 import 'package:core/presentation/resources/image_paths.dart';
-import 'package:core/presentation/utils/html_transformer/html_transform.dart';
 import 'package:core/utils/config/app_config_loader.dart';
 import 'package:core/utils/file_utils.dart';
 import 'package:core/utils/preview_eml_file_utils.dart';
@@ -319,7 +318,6 @@ class MailboxDashBoardBindings extends BaseBindings {
       Get.find<MailboxCacheManager>(),
       Get.find<CacheExceptionThrower>()));
     Get.lazyPut(() => ComposerSessionCacheDatasourceImpl(
-      Get.find<HtmlTransform>(),
       Get.find<CacheExceptionThrower>()));
     Get.lazyPut(() => LocalSpamReportDataSourceImpl(
       Get.find<PreferencesSettingManager>(),

--- a/model/lib/email/email_action_type.dart
+++ b/model/lib/email/email_action_type.dart
@@ -31,7 +31,8 @@ enum EmailActionType {
   composeFromUnsubscribeMailtoLink(),
   archiveMessage(3),
   printAll(4),
-  downloadMessageAsEML(4);
+  downloadMessageAsEML(4),
+  restoreComposerFromPersistentCache();
 
   /// Add category to group email action
   final int category;

--- a/test/features/composer/domain/usecases/restore_email_inline_images_interactor_test.dart
+++ b/test/features/composer/domain/usecases/restore_email_inline_images_interactor_test.dart
@@ -1,0 +1,61 @@
+import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/composer/domain/state/restore_email_inline_images_state.dart';
+import 'package:tmail_ui_user/features/composer/domain/transformer/html_email_transformer.dart';
+import 'package:tmail_ui_user/features/composer/domain/usecases/restore_email_inline_images_interactor.dart';
+
+import 'restore_email_inline_images_interactor_test.mocks.dart';
+
+@GenerateMocks([HtmlEmailTransformer])
+void main() {
+  late MockHtmlEmailTransformer mockTransformer;
+  late RestoreEmailInlineImagesInteractor interactor;
+
+  const htmlWithCid = '<img src="cid:abc123">';
+  const restoredHtml = '<img src="data:image/png;base64,abc==">';
+  final transformConfig = TransformConfiguration.forRestoreEmail();
+  final mapCid = {'abc123': 'https://example.com/download/abc'};
+
+  setUp(() {
+    mockTransformer = MockHtmlEmailTransformer();
+    interactor = RestoreEmailInlineImagesInteractor(mockTransformer);
+  });
+
+  group('execute', () {
+    test('emits RestoringEmailInlineImages then RestoreEmailInlineImagesSuccess on success', () async {
+      when(mockTransformer.transformToHtml(
+        htmlContent: htmlWithCid,
+        transformConfiguration: transformConfig,
+        mapCidImageDownloadUrl: mapCid,
+      )).thenAnswer((_) async => restoredHtml);
+
+      final states = await interactor.execute(
+        htmlContent: htmlWithCid,
+        transformConfiguration: transformConfig,
+        mapUrlDownloadCID: mapCid,
+      ).map((either) => either.fold((f) => f, (s) => s)).toList();
+
+      expect(states[0], isA<RestoringEmailInlineImages>());
+      expect(states[1], isA<RestoreEmailInlineImagesSuccess>());
+      expect((states[1] as RestoreEmailInlineImagesSuccess).emailContent, equals(restoredHtml));
+    });
+
+    test('emits RestoreEmailInlineImagesFailure when transformer throws', () async {
+      when(mockTransformer.transformToHtml(
+        htmlContent: anyNamed('htmlContent'),
+        transformConfiguration: anyNamed('transformConfiguration'),
+        mapCidImageDownloadUrl: anyNamed('mapCidImageDownloadUrl'),
+      )).thenThrow(Exception('network error'));
+
+      final states = await interactor.execute(
+        htmlContent: htmlWithCid,
+        transformConfiguration: transformConfig,
+        mapUrlDownloadCID: mapCid,
+      ).map((either) => either.fold((f) => f, (s) => s)).toList();
+
+      expect(states.last, isA<RestoreEmailInlineImagesFailure>());
+    });
+  });
+}

--- a/test/features/composer/domain/usecases/restore_email_inline_images_interactor_test.dart
+++ b/test/features/composer/domain/usecases/restore_email_inline_images_interactor_test.dart
@@ -55,7 +55,9 @@ void main() {
         mapUrlDownloadCID: mapCid,
       ).map((either) => either.fold((f) => f, (s) => s)).toList();
 
-      expect(states.last, isA<RestoreEmailInlineImagesFailure>());
+       expect(states, hasLength(2));
+       expect(states[0], isA<RestoringEmailInlineImages>());
+       expect(states[1], isA<RestoreEmailInlineImagesFailure>());
     });
   });
 }

--- a/test/features/composer/domain/usecases/save_composer_cache_interactor_test.dart
+++ b/test/features/composer/domain/usecases/save_composer_cache_interactor_test.dart
@@ -1,0 +1,152 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/email/email_action_type.dart';
+import 'package:tmail_ui_user/features/composer/domain/repository/composer_repository.dart';
+import 'package:tmail_ui_user/features/composer/domain/usecases/save_composer_cache_interactor.dart';
+import 'package:tmail_ui_user/features/composer/presentation/model/create_email_request.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/save_composer_cache_state.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import '../../../../fixtures/session_fixtures.dart';
+import 'save_composer_cache_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<ComposerCacheRepository>(),
+  MockSpec<ComposerRepository>(),
+])
+void main() {
+  late MockComposerCacheRepository mockCacheRepository;
+  late MockComposerRepository mockComposerRepository;
+  late SaveComposerCacheInteractor interactor;
+
+  final session = SessionFixtures.aliceSession;
+  final accountId = AccountFixtures.aliceAccountId;
+
+  final baseRequest = CreateEmailRequest(
+    session: session,
+    accountId: accountId,
+    emailActionType: EmailActionType.compose,
+    ownEmailAddress: 'alice@domain.tld',
+    subject: 'Test subject',
+    emailContent: '<p>Hello</p>',
+    composerId: 'uuid-composer-123',
+  );
+
+  setUp(() {
+    mockCacheRepository = MockComposerCacheRepository();
+    mockComposerRepository = MockComposerRepository();
+    interactor = SaveComposerCacheInteractor(
+      mockCacheRepository,
+      mockComposerRepository,
+    );
+  });
+
+  void arrangeSuccess() {
+    when(mockComposerRepository.generateEmail(
+      any,
+      withIdentityHeader: anyNamed('withIdentityHeader'),
+      isDraft: anyNamed('isDraft'),
+    )).thenAnswer((_) async => Email());
+    when(mockCacheRepository.saveComposerCache(any, any, any))
+        .thenAnswer((_) async {});
+  }
+
+  void expectLeftWithSaveFailure(Either result, Exception exception) {
+    result.fold(
+      (f) {
+        expect(f, isA<SaveComposerCacheFailure>());
+        expect((f as SaveComposerCacheFailure).exception, exception);
+      },
+      (_) => fail('expected Left'),
+    );
+  }
+
+  Future<Object> captureAndGetSavedCache({required bool isPersistent}) async {
+    await interactor.execute(
+      createEmailRequest: baseRequest,
+      isPersistent: isPersistent,
+    );
+    return verify(
+      mockCacheRepository.saveComposerCache(any, any, captureAny),
+    ).captured.single;
+  }
+
+  group('SaveComposerCacheInteractor', () {
+    group('on success', () {
+      setUp(arrangeSuccess);
+
+      test('calls generateEmail with withIdentityHeader=true and isDraft=true', () async {
+        await interactor.execute(createEmailRequest: baseRequest);
+
+        verify(mockComposerRepository.generateEmail(
+          baseRequest,
+          withIdentityHeader: true,
+          isDraft: true,
+        )).called(1);
+      });
+
+      test('calls saveComposerCache with the correct accountId and userName', () async {
+        await interactor.execute(createEmailRequest: baseRequest);
+
+        verify(mockCacheRepository.saveComposerCache(
+          accountId,
+          session.username,
+          any,
+        )).called(1);
+      });
+
+      test('returns Right(SaveComposerCacheSuccess)', () async {
+        final result = await interactor.execute(createEmailRequest: baseRequest);
+
+        expect(result, Right(SaveComposerCacheSuccess()));
+      });
+
+      test('saves a ComposerPersistentCache when isPersistent is true', () async {
+        final captured = await captureAndGetSavedCache(isPersistent: true);
+
+        expect(captured, isA<ComposerPersistentCache>());
+      });
+
+      test('saves a plain ComposerCache when isPersistent is false', () async {
+        final captured = await captureAndGetSavedCache(isPersistent: false);
+
+        expect(captured, isNot(isA<ComposerPersistentCache>()));
+      });
+    });
+
+    group('error handling', () {
+      test('returns Left(SaveComposerCacheFailure) when generateEmail throws', () async {
+        final exception = Exception('generate failed');
+        when(mockComposerRepository.generateEmail(
+          any,
+          withIdentityHeader: anyNamed('withIdentityHeader'),
+          isDraft: anyNamed('isDraft'),
+        )).thenThrow(exception);
+
+        final result = await interactor.execute(createEmailRequest: baseRequest);
+
+        expectLeftWithSaveFailure(result, exception);
+      });
+
+      test('returns Left(SaveComposerCacheFailure) when saveComposerCache throws', () async {
+        when(mockComposerRepository.generateEmail(
+          any,
+          withIdentityHeader: anyNamed('withIdentityHeader'),
+          isDraft: anyNamed('isDraft'),
+        )).thenAnswer((_) async => Email());
+        final exception = Exception('save failed');
+        when(mockCacheRepository.saveComposerCache(any, any, any))
+            .thenThrow(exception);
+
+        final result = await interactor.execute(createEmailRequest: baseRequest);
+
+        expectLeftWithSaveFailure(result, exception);
+      });
+    });
+  });
+}

--- a/test/features/composer/presentation/extensions/create_email_request_extension_test.dart
+++ b/test/features/composer/presentation/extensions/create_email_request_extension_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_body_part.dart';
 import 'package:jmap_dart_client/jmap/mail/email/individual_header_identifier.dart';
 import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
@@ -9,6 +10,9 @@ import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/model.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/create_email_request_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/create_email_request.dart';
+import 'package:tmail_ui_user/features/composer/presentation/model/screen_display_mode.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
 
 import '../../../../fixtures/account_fixtures.dart';
 import '../../../../fixtures/session_fixtures.dart';
@@ -264,6 +268,98 @@ void main() {
         KeyWordIdentifier.emailFlagged: true,
         KeyWordIdentifier.emailAnswered: true,
         KeyWordIdentifier.emailForwarded: true,
+      });
+    });
+  });
+
+  group('generateComposerCache', () {
+    CreateEmailRequest makeRequest({String? composerId}) => CreateEmailRequest(
+          session: SessionFixtures.aliceSession,
+          accountId: AccountFixtures.aliceAccountId,
+          emailActionType: EmailActionType.compose,
+          ownEmailAddress: 'alice@domain.tld',
+          subject: 'Test',
+          emailContent: '<p>Hello</p>',
+          composerId: composerId,
+        );
+
+    group('when isPersistent is true', () {
+      test('returns ComposerPersistentCache', () {
+        final cache = makeRequest().generateComposerCache(
+          emailCreated: Email(),
+          isPersistent: true,
+        );
+
+        expect(cache, isA<ComposerPersistentCache>());
+      });
+
+      test('sets actionType to restoreComposerFromPersistentCache', () {
+        final cache = makeRequest().generateComposerCache(
+          emailCreated: Email(),
+          isPersistent: true,
+        ) as ComposerPersistentCache;
+
+        expect(cache.actionType,
+            EmailActionType.restoreComposerFromPersistentCache);
+      });
+
+      test('sets isCleanClose to false', () {
+        final cache = makeRequest().generateComposerCache(
+          emailCreated: Email(),
+          isPersistent: true,
+        ) as ComposerPersistentCache;
+
+        expect(cache.isCleanClose, isFalse);
+      });
+
+      test('sets timestampMs to a value within the current second', () {
+        final before = DateTime.now().millisecondsSinceEpoch;
+        final cache = makeRequest().generateComposerCache(
+          emailCreated: Email(),
+          isPersistent: true,
+        ) as ComposerPersistentCache;
+        final after = DateTime.now().millisecondsSinceEpoch;
+
+        expect(cache.timestampMs, isNotNull);
+        expect(cache.timestampMs, greaterThanOrEqualTo(before));
+        expect(cache.timestampMs, lessThanOrEqualTo(after));
+      });
+
+      test('includes the generated email', () {
+        final email = Email();
+        final cache = makeRequest().generateComposerCache(
+          emailCreated: email,
+          isPersistent: true,
+        );
+
+        expect(cache.email, same(email));
+      });
+
+      test('preserves composerId from the request', () {
+        const composerId = 'uuid-composer-abc';
+        final cache = makeRequest(composerId: composerId).generateComposerCache(
+          emailCreated: Email(),
+          isPersistent: true,
+        );
+
+        expect(cache.composerId, composerId);
+      });
+    });
+
+    group('when isPersistent is false (default)', () {
+      test('returns plain ComposerCache, not ComposerPersistentCache', () {
+        final cache =
+            makeRequest().generateComposerCache(emailCreated: Email());
+
+        expect(cache, isA<ComposerCache>());
+        expect(cache, isNot(isA<ComposerPersistentCache>()));
+      });
+
+      test('preserves displayMode from the request', () {
+        final cache =
+            makeRequest().generateComposerCache(emailCreated: Email());
+
+        expect(cache.displayMode, ScreenDisplayMode.normal);
       });
     });
   });

--- a/test/features/mailbox_dashboard/data/datasource_impl/composer_persistent_cache_datasource_impl_test.dart
+++ b/test/features/mailbox_dashboard/data/datasource_impl/composer_persistent_cache_datasource_impl_test.dart
@@ -63,4 +63,16 @@ void main() {
       verify(mockCacheClient.deleteCache(accountId, userName)).called(1);
     });
   });
+
+  group('removeComposerCacheById', () {
+    test('delegates to cache client', () async {
+      const composerId = 'composer-uuid-1';
+      when(mockCacheClient.deleteCacheById(accountId, userName, composerId))
+          .thenAnswer((_) async {});
+
+      await datasource.removeComposerCacheById(accountId, userName, composerId);
+
+      verify(mockCacheClient.deleteCacheById(accountId, userName, composerId)).called(1);
+    });
+  });
 }

--- a/test/features/mailbox_dashboard/data/datasource_impl/composer_persistent_cache_datasource_impl_test.dart
+++ b/test/features/mailbox_dashboard/data/datasource_impl/composer_persistent_cache_datasource_impl_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:tmail_ui_user/features/caching/clients/composer_hive_cache_client.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_persistent_cache_datasource_impl.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/exception_thrower.dart';
+
+import 'composer_persistent_cache_datasource_impl_test.mocks.dart';
+
+@GenerateMocks([ComposerHiveCacheClient, ExceptionThrower])
+void main() {
+  late MockComposerHiveCacheClient mockCacheClient;
+  late MockExceptionThrower mockExceptionThrower;
+  late ComposerPersistentCacheDatasourceImpl datasource;
+
+  final accountId = AccountId(Id('account-1'));
+  final userName = UserName('user@example.com');
+
+  setUp(() {
+    mockCacheClient = MockComposerHiveCacheClient();
+    mockExceptionThrower = MockExceptionThrower();
+    datasource = ComposerPersistentCacheDatasourceImpl(
+      mockCacheClient,
+      mockExceptionThrower,
+    );
+  });
+
+  group('saveComposerCache', () {
+    test('delegates to cache client', () async {
+      final cache = ComposerCache(composerId: 'id-1');
+      when(mockCacheClient.saveCache(accountId, userName, cache))
+          .thenAnswer((_) async {});
+
+      await datasource.saveComposerCache(accountId, userName, cache);
+
+      verify(mockCacheClient.saveCache(accountId, userName, cache)).called(1);
+    });
+  });
+
+  group('getComposerCache', () {
+    test('delegates to cache client', () async {
+      when(mockCacheClient.getCache(accountId, userName))
+          .thenAnswer((_) async => []);
+
+      final result = await datasource.getComposerCache(accountId, userName);
+
+      expect(result, isEmpty);
+      verify(mockCacheClient.getCache(accountId, userName)).called(1);
+    });
+  });
+
+  group('removeAllComposerCache', () {
+    test('delegates to cache client', () async {
+      when(mockCacheClient.deleteCache(accountId, userName))
+          .thenAnswer((_) async {});
+
+      await datasource.removeAllComposerCache(accountId, userName);
+
+      verify(mockCacheClient.deleteCache(accountId, userName)).called(1);
+    });
+  });
+}

--- a/test/features/mailbox_dashboard/data/model/mobile_composer_cache_test.dart
+++ b/test/features/mailbox_dashboard/data/model/mobile_composer_cache_test.dart
@@ -1,0 +1,305 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+
+void main() {
+  group('ComposerPersistentCache', () {
+    ComposerPersistentCache makeCache({
+      String composerId = 'session-uuid-123',
+      Email? email,
+      bool? isCleanClose,
+      int? timestampMs,
+    }) {
+      return ComposerPersistentCache(
+        composerId: composerId,
+        email: email,
+        isCleanClose: isCleanClose,
+        timestampMs: timestampMs,
+      );
+    }
+
+    ComposerPersistentCache makeSerializableCache() {
+      return ComposerPersistentCache(
+        composerId: 'uuid-test',
+        isCleanClose: true,
+        timestampMs: 1700000000000, // Fixed timestamp for determinism
+      );
+    }
+
+    void expectCacheEquals(
+      ComposerPersistentCache actual,
+      ComposerPersistentCache expected,
+    ) {
+      expect(actual.composerId, expected.composerId);
+      expect(actual.email, expected.email);
+      expect(actual.isCleanClose, expected.isCleanClose);
+      expect(actual.timestampMs, expected.timestampMs);
+    }
+
+    void expectCopyPreservesBaseFields(
+      ComposerPersistentCache copy,
+      ComposerPersistentCache original,
+    ) {
+      expect(copy.composerId, original.composerId);
+    }
+
+    group('isRestorable', () {
+      test('returns true when email is set, not expired, and not a clean close', () {
+        final cache = makeCache(
+          email: Email(),
+          isCleanClose: false,
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect(cache.isRestorable, isTrue);
+      });
+
+      test('returns true when isCleanClose is null (involuntary kill)', () {
+        final cache = makeCache(
+          email: Email(),
+          isCleanClose: null,
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect(cache.isRestorable, isTrue);
+      });
+
+      test('returns false when isCleanClose is true', () {
+        final cache = makeCache(
+          isCleanClose: true,
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect(cache.isRestorable, isFalse);
+      });
+
+      test('returns false when cache is empty', () {
+        final cache = makeCache(
+          isCleanClose: false,
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect(cache.isEmpty, isTrue);
+        expect(cache.isRestorable, isFalse);
+      });
+
+      test('returns false when cache is expired', () {
+        final cache = makeCache(
+          email: Email(),
+          isCleanClose: false,
+          timestampMs: DateTime.now()
+              .subtract(const Duration(hours: 25))
+              .millisecondsSinceEpoch,
+        );
+
+        expect(cache.isRestorable, isFalse);
+      });
+
+      test('evaluates guard conditions correctly', () {
+        final cache = makeCache(
+          isCleanClose: null,
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect(cache.isCleanClose, isNull);
+        expect(cache.isExpired, isFalse);
+        expect(cache.isEmpty, isTrue);
+        expect(cache.isRestorable, isFalse);
+      });
+    });
+
+    group('isExpired', () {
+      test('returns false when timestampMs is null', () {
+        expect(makeCache().isExpired, isFalse);
+      });
+
+      test('returns false when timestampMs is recent', () {
+        final cache = makeCache(
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect(cache.isExpired, isFalse);
+      });
+
+      test('returns true when timestampMs is older than 24 hours', () {
+        final cache = makeCache(
+          timestampMs: DateTime.now()
+              .subtract(const Duration(hours: 25))
+              .millisecondsSinceEpoch,
+        );
+
+        expect(cache.isExpired, isTrue);
+      });
+    });
+
+    group('isEmpty', () {
+      test('returns true when email is null', () {
+        expect(makeCache(email: null).isEmpty, isTrue);
+      });
+
+      test('returns false when email is not null', () {
+        expect(makeCache(email: Email()).isEmpty, isFalse);
+      });
+    });
+
+    group('copyWith', () {
+      final testCases = [
+        (
+          description: 'updates isCleanClose while preserving other fields',
+          verify: () {
+            final original = makeCache(
+              isCleanClose: false,
+              timestampMs: DateTime.now().millisecondsSinceEpoch,
+            );
+
+            final copy = original.copyWith(
+              isCleanClose: true,
+            );
+
+            expect(copy.isCleanClose, isTrue);
+            expect(copy.timestampMs, original.timestampMs);
+            expectCopyPreservesBaseFields(copy, original);
+          },
+        ),
+        (
+          description: 'updates timestampMs while preserving other fields',
+          verify: () {
+            final original = makeCache(
+              isCleanClose: false,
+            );
+
+            final newTimestamp = DateTime.now().millisecondsSinceEpoch;
+
+            final copy = original.copyWith(
+              timestampMs: newTimestamp,
+            );
+
+            expect(copy.timestampMs, newTimestamp);
+            expect(
+              copy.isCleanClose,
+              original.isCleanClose,
+            );
+            expectCopyPreservesBaseFields(copy, original);
+          },
+        ),
+      ];
+
+      for (final testCase in testCases) {
+        test(
+          testCase.description,
+          testCase.verify,
+        );
+      }
+    });
+
+    group('newestLocalCache extension', () {
+      test('returns null when iterable is empty', () {
+        expect(<ComposerPersistentCache>[].newestLocalCache, isNull);
+      });
+
+      test('returns the single entry when there is only one', () {
+        final cache = makeCache(
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect([cache].newestLocalCache, same(cache));
+      });
+
+      test('returns the entry with the highest timestampMs', () {
+        final older = makeCache(
+          timestampMs: DateTime.now()
+              .subtract(const Duration(hours: 2))
+              .millisecondsSinceEpoch,
+        );
+        final newer = makeCache(
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect([older, newer].newestLocalCache, same(newer));
+        expect([newer, older].newestLocalCache, same(newer));
+      });
+
+      test('ignores plain ComposerCache entries and picks the newest ComposerPersistentCache', () {
+        final plainCache = ComposerCache(email: Email());
+        final persistent = makeCache(
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect([plainCache, persistent].newestLocalCache, same(persistent));
+      });
+
+      test('returns null when iterable contains only plain ComposerCache entries', () {
+        final plain = ComposerCache(email: Email());
+        expect([plain].newestLocalCache, isNull);
+      });
+
+      test('treats null timestampMs as 0 when comparing', () {
+        final noTimestamp = makeCache(timestampMs: null);
+        final withTimestamp = makeCache(
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect([noTimestamp, withTimestamp].newestLocalCache, same(withTimestamp));
+      });
+    });
+
+    group('JSON serialisation', () {
+      test('toJson / fromJson round-trip preserves all fields', () {
+        final original = makeSerializableCache();
+
+        final restored = ComposerPersistentCache.fromJson(
+          original.toJson(),
+        );
+
+        expectCacheEquals(restored, original);
+      });
+
+      test('omits nullable fields when they are null', () {
+        final cache = ComposerPersistentCache(
+          composerId: 'uuid-xyz',
+        );
+
+        final json = cache.toJson();
+
+        expect(
+          json.containsKey('isCleanClose'),
+          isFalse,
+        );
+        expect(
+          json.containsKey('timestampMs'),
+          isFalse,
+        );
+      });
+
+      test('supports JSON string encode and decode', () {
+        final original = makeSerializableCache();
+
+        final jsonString = jsonEncode(
+          original.toJson(),
+        );
+
+        final decoded = ComposerPersistentCache.fromJson(
+          jsonDecode(jsonString) as Map<String, dynamic>,
+        );
+
+        expectCacheEquals(decoded, original);
+      });
+
+      test('toJson / fromJson round-trip preserves email field', () {
+        final original = ComposerPersistentCache(
+          composerId: 'uuid-email-test',
+          email: Email(),
+          isCleanClose: false,
+          timestampMs: 1700000000000,
+        );
+
+        final restored = ComposerPersistentCache.fromJson(original.toJson());
+
+        expect(restored.email, isNotNull);
+      });
+    });
+  });
+}

--- a/test/features/mailbox_dashboard/domain/usecases/get_composer_all_cache_interactor_test.dart
+++ b/test/features/mailbox_dashboard/domain/usecases/get_composer_all_cache_interactor_test.dart
@@ -1,0 +1,111 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/get_all_composer_cache_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/get_all_composer_cache_interactor.dart';
+
+import 'get_composer_all_cache_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<ComposerCacheRepository>()])
+void main() {
+  final accountId = AccountId(Id('account-1'));
+  final userName = UserName('user@example.com');
+
+  late MockComposerCacheRepository mockRepository;
+  late GetAllComposerCacheInteractor interactor;
+
+  setUp(() {
+    mockRepository = MockComposerCacheRepository();
+    interactor = GetAllComposerCacheInteractor(mockRepository);
+  });
+
+  ComposerPersistentCache makeLocalCache({
+    required int timestampMs,
+    bool withEmail = true,
+  }) =>
+      ComposerPersistentCache(
+        timestampMs: timestampMs,
+        email: withEmail ? Email() : null,
+      );
+
+  int msAgo(int hours) =>
+      DateTime.now().subtract(Duration(hours: hours)).millisecondsSinceEpoch;
+
+  void expectSuccessWithCache(
+    Either result,
+    ComposerPersistentCache expectedCache,
+  ) {
+    result.fold(
+      (_) => fail('expected Right'),
+      (s) => expect((s as GetAllComposerCacheSuccess).listComposerCache,
+          contains(expectedCache)),
+    );
+  }
+
+  group('GetAllComposerCacheInteractor', () {
+    group('when repository returns a single local cache', () {
+      test('returns success with that cache', () async {
+        final cache = makeLocalCache(timestampMs: msAgo(1));
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => [cache]);
+
+        final result = await interactor.execute(accountId, userName).last;
+
+        expectSuccessWithCache(result, cache);
+      });
+    });
+
+    group('when repository returns multiple local caches', () {
+      test('returns the most recent one by timestampMs', () async {
+        final older = makeLocalCache(timestampMs: msAgo(3));
+        final newer = makeLocalCache(timestampMs: msAgo(1));
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => [older, newer]);
+
+        final result = await interactor.execute(accountId, userName).last;
+
+        expectSuccessWithCache(result, newer);
+      });
+
+      test(
+          'ignores plain ComposerCache entries and picks newest ComposerPersistentCache',
+          () async {
+        final plainCache = ComposerCache(email: Email());
+        final localCache = makeLocalCache(timestampMs: msAgo(1));
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => [plainCache, localCache]);
+
+        final result = await interactor.execute(accountId, userName).last;
+
+        expectSuccessWithCache(result, localCache);
+      });
+    });
+
+    group('error handling', () {
+      test('wraps repository exception in GetComposerLocalCacheFailure',
+          () async {
+        final exception = Exception('db error');
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => throw exception);
+
+        final result = await interactor.execute(accountId, userName).last;
+
+        result.fold(
+          (f) {
+            expect(f, isA<GetAllComposerCacheFailure>());
+            expect((f as GetAllComposerCacheFailure).exception, exception);
+          },
+          (_) => fail('expected Left'),
+        );
+      });
+    });
+  });
+}

--- a/test/features/mailbox_dashboard/domain/usecases/mark_composer_cache_clean_close_interactor_test.dart
+++ b/test/features/mailbox_dashboard/domain/usecases/mark_composer_cache_clean_close_interactor_test.dart
@@ -1,0 +1,127 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/mark_composer_cache_clean_close_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/mark_composer_cache_clean_close_interactor.dart';
+
+import 'mark_composer_cache_clean_close_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<ComposerCacheRepository>()])
+void main() {
+  final accountId = AccountId(Id('account-1'));
+  final userName = UserName('user@example.com');
+
+  late MockComposerCacheRepository mockRepository;
+  late MarkComposerCacheCleanCloseInteractor interactor;
+
+  setUp(() {
+    mockRepository = MockComposerCacheRepository();
+    interactor = MarkComposerCacheCleanCloseInteractor(mockRepository);
+  });
+
+  ComposerPersistentCache makeLocalCache(
+          {bool? isCleanClose, int? timestampMs}) =>
+      ComposerPersistentCache(
+        isCleanClose: isCleanClose,
+        timestampMs: timestampMs ?? DateTime.now().millisecondsSinceEpoch,
+        email: Email(),
+      );
+
+  group('MarkComposerCacheCleanCloseInteractor', () {
+    group('best-effort mark: save failure does not block removal', () {
+      test('still removes all when mark write throws', () async {
+        final cache = makeLocalCache();
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => [cache]);
+        when(mockRepository.saveComposerCache(
+          accountId,
+          userName,
+          any,
+        )).thenThrow(Exception('write failed'));
+        when(mockRepository.removeAllComposerCache(accountId, userName))
+            .thenAnswer((_) async {});
+
+        final result = await interactor.execute(accountId, userName);
+
+        expect(result, Right(MarkComposerCacheCleanCloseSuccess()));
+        verify(mockRepository.removeAllComposerCache(accountId, userName))
+            .called(1);
+      });
+    });
+
+    group('when no cache exists', () {
+      test('skips mark step and still removes all', () async {
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => []);
+        when(mockRepository.removeAllComposerCache(accountId, userName))
+            .thenAnswer((_) async {});
+
+        final result = await interactor.execute(accountId, userName);
+
+        expect(result, Right(MarkComposerCacheCleanCloseSuccess()));
+        verifyNever(mockRepository.saveComposerCache(
+          accountId,
+          userName,
+          any,
+        ));
+        verify(mockRepository.removeAllComposerCache(accountId, userName))
+            .called(1);
+      });
+    });
+
+    group('error handling', () {
+      test('returns failure when getComposerCache throws', () async {
+        final exception = Exception('db error');
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenThrow(exception);
+
+        final result = await interactor.execute(accountId, userName);
+
+        result.fold(
+          (f) {
+            expect(f, isA<MarkComposerCacheCleanCloseFailure>());
+            expect(
+                (f as MarkComposerCacheCleanCloseFailure).exception, exception);
+          },
+          (_) => fail('expected Left'),
+        );
+      });
+
+      test('returns failure when removeAllComposerCache throws', () async {
+        final cache = makeLocalCache();
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => [cache]);
+        when(mockRepository.saveComposerCache(
+          accountId,
+          userName,
+          any,
+        )).thenAnswer((_) async {});
+        when(mockRepository.removeAllComposerCache(accountId, userName))
+            .thenThrow(Exception('remove failed'));
+
+        final result = await interactor.execute(accountId, userName);
+
+        verify(mockRepository.saveComposerCache(
+          accountId,
+          userName,
+          any,
+        )).called(1);
+        result.fold(
+          (f) {
+            expect(f, isA<MarkComposerCacheCleanCloseFailure>());
+            expect((f as MarkComposerCacheCleanCloseFailure).exception,
+                isA<Exception>());
+          },
+          (_) => fail('expected Left'),
+        );
+      });
+    });
+  });
+}

--- a/test/features/mailbox_dashboard/domain/usecases/mark_composer_cache_clean_close_interactor_test.dart
+++ b/test/features/mailbox_dashboard/domain/usecases/mark_composer_cache_clean_close_interactor_test.dart
@@ -103,8 +103,9 @@ void main() {
           userName,
           any,
         )).thenAnswer((_) async {});
+        final exception = Exception('remove failed');
         when(mockRepository.removeAllComposerCache(accountId, userName))
-            .thenThrow(Exception('remove failed'));
+            .thenThrow(exception);
 
         final result = await interactor.execute(accountId, userName);
 
@@ -116,8 +117,7 @@ void main() {
         result.fold(
           (f) {
             expect(f, isA<MarkComposerCacheCleanCloseFailure>());
-            expect((f as MarkComposerCacheCleanCloseFailure).exception,
-                isA<Exception>());
+            expect((f as MarkComposerCacheCleanCloseFailure).exception, exception);
           },
           (_) => fail('expected Left'),
         );

--- a/test/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor_test.dart
+++ b/test/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor_test.dart
@@ -1,0 +1,178 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/resolve_composer_cache_for_restore_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor.dart';
+
+import 'resolve_composer_cache_for_restore_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<ComposerCacheRepository>()])
+void main() {
+  final accountId = AccountId(Id('account-1'));
+  final userName = UserName('user@example.com');
+
+  late MockComposerCacheRepository mockRepository;
+  late ResolveComposerCacheForRestoreInteractor interactor;
+
+  setUp(() {
+    mockRepository = MockComposerCacheRepository();
+    interactor = ResolveComposerCacheForRestoreInteractor(mockRepository);
+  });
+
+  ComposerPersistentCache makeCache({
+    bool? isCleanClose,
+    int? timestampMs,
+    bool withEmail = true,
+  }) =>
+      ComposerPersistentCache(
+        isCleanClose: isCleanClose,
+        timestampMs: timestampMs ?? DateTime.now().millisecondsSinceEpoch,
+        email: withEmail ? Email() : null,
+      );
+
+  void expectRightWithNullCache(Object result) {
+    (result as dynamic).fold(
+      (_) => fail('expected Right'),
+      (s) => expect((s as ResolveComposerCacheForRestoreSuccess).cache, isNull),
+    );
+  }
+
+  void expectRightWithoutRemoveAll(
+    Object result, {
+    ComposerPersistentCache? expectedCache,
+  }) {
+    verifyNever(mockRepository.removeAllComposerCache(any, any));
+    (result as dynamic).fold(
+      (_) => fail('expected Right'),
+      (s) {
+        expect(s, isA<ResolveComposerCacheForRestoreSuccess>());
+        expect(
+          (s as ResolveComposerCacheForRestoreSuccess).cache,
+          expectedCache == null ? isNull : same(expectedCache),
+        );
+      },
+    );
+  }
+
+  group('ResolveComposerCacheForRestoreInteractor', () {
+    group('when no cache entry exists', () {
+      test('returns Right with null cache and does not call removeAll', () async {
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => []);
+
+        final result = await interactor.execute(accountId, userName);
+
+        expectRightWithoutRemoveAll(result);
+      });
+    });
+
+    group('when cache is not restorable', () {
+      setUp(() {
+        when(mockRepository.removeAllComposerCache(accountId, userName))
+            .thenAnswer((_) async {});
+      });
+
+      final testCases = [
+        (
+          description: 'isCleanClose is true',
+          makeCache: () => ComposerPersistentCache(
+            isCleanClose: true,
+            timestampMs: DateTime.now().millisecondsSinceEpoch,
+            email: Email(),
+          ),
+        ),
+        (
+          description: 'cache is expired',
+          makeCache: () => ComposerPersistentCache(
+            timestampMs: DateTime.now()
+                .subtract(const Duration(hours: 25))
+                .millisecondsSinceEpoch,
+            email: Email(),
+          ),
+        ),
+        (
+          description: 'email is null (empty snapshot)',
+          makeCache: () => ComposerPersistentCache(
+            timestampMs: DateTime.now().millisecondsSinceEpoch,
+          ),
+        ),
+      ];
+
+      for (final tc in testCases) {
+        test('removes all and returns null when ${tc.description}', () async {
+          when(mockRepository.getComposerCache(accountId, userName))
+              .thenAnswer((_) async => [tc.makeCache()]);
+
+          final result = await interactor.execute(accountId, userName);
+
+          verify(mockRepository.removeAllComposerCache(accountId, userName)).called(1);
+          expectRightWithNullCache(result);
+        });
+      }
+    });
+
+    group('when cache is restorable', () {
+      test('returns the cache without calling removeAll', () async {
+        final cache = makeCache(isCleanClose: false);
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => [cache]);
+
+        final result = await interactor.execute(accountId, userName);
+
+        expectRightWithoutRemoveAll(result, expectedCache: cache);
+      });
+
+      test('returns the newest cache when multiple entries exist', () async {
+        final older = makeCache(
+          isCleanClose: false,
+          timestampMs: DateTime.now()
+              .subtract(const Duration(hours: 1))
+              .millisecondsSinceEpoch,
+        );
+        final newer = makeCache(
+          isCleanClose: false,
+          timestampMs: DateTime.now().millisecondsSinceEpoch,
+        );
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenAnswer((_) async => [older, newer]);
+
+        final result = await interactor.execute(accountId, userName);
+
+        result.fold(
+          (_) => fail('expected Right'),
+          (s) => expect(
+            (s as ResolveComposerCacheForRestoreSuccess).cache,
+            same(newer),
+          ),
+        );
+      });
+    });
+
+    group('error handling', () {
+      test('returns Left(ResolveComposerCacheForRestoreFailure) when repository throws', () async {
+        final exception = Exception('db error');
+        when(mockRepository.getComposerCache(accountId, userName))
+            .thenThrow(exception);
+
+        final result = await interactor.execute(accountId, userName);
+
+        result.fold(
+          (f) {
+            expect(f, isA<ResolveComposerCacheForRestoreFailure>());
+            expect(
+              (f as ResolveComposerCacheForRestoreFailure).exception,
+              exception,
+            );
+          },
+          (_) => fail('expected Left'),
+        );
+      });
+    });
+  });
+}

--- a/test/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor_test.dart
+++ b/test/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor_test.dart
@@ -174,5 +174,15 @@ void main() {
         );
       });
     });
+
+    test('returns the cache when isCleanClose is null (crash snapshot)', () async {
+      final cache = makeCache(isCleanClose: null);  // null means clean-close was never written
+      when(mockRepository.getComposerCache(accountId, userName))
+          .thenAnswer((_) async => [cache]);
+
+      final result = await interactor.execute(accountId, userName);
+
+      expectRightWithoutRemoveAll(result, expectedCache: cache);
+    });
   });
 }


### PR DESCRIPTION
## Dependencies

> **Merge order (sequential):**
> 1. [#4485 — TF-4473 Refactor reduce cyclomatic complexity in email setup extensions](https://github.com/linagora/tmail-flutter/pull/4485) ← **must be merged first**
> 2. **This PR** ← merge second
> 3. PR2 (presentation layer) ← merge last

This PR branches off `bugfix/tf-4473-refactor-reduce-cyclomatic-complexity` (#4485). It must not be merged into `master` until #4485 has landed.

---

## Summary

Introduces the data and domain layer infrastructure required by [ADR-0086](docs/adr/0086-android-composer-draft-loss-on-background.md) (Android composer draft recovery on background/crash). This PR contains no UI or wiring changes and can be reviewed independently of the presentation layer.

### Data layer

- **`ComposerPersistentCache`** — extends `ComposerCache` with `isCleanClose` and `timestampMs` fields. Includes `isRestorable` check (24 h TTL + clean-close flag) and `newestLocalCache` selection across concurrent sessions.
- **`ComposerPersistentCacheDatasourceImpl`** — Hive-backed persistent datasource (survives process kill), keyed per user account.
- **`ComposerHiveCacheClient`** — Hive box lifecycle management with new type ID constants in `caching_constants.dart`.
- **`ComposerSessionCacheDatasourceImpl`** — refactored to implement the generalized `ComposerCacheDatasource` interface (was previously web-only).
- **`HtmlEmailTransformerAdapter`** + **`HtmlEmailTransformer`** — adapter layer for reconstructing inline images when restoring a draft from cache.
- **`ComposerCacheRepository` / `ComposerCacheRepositoryImpl`** — interface and impl updated to support persistent cache alongside session cache.

### Domain layer — 2 new interactors

- **`MarkComposerCacheCleanCloseInteractor`** — two-step write (mark `isCleanClose=true` → remove) so an interrupted close is never mistaken for a crash snapshot.
- **`ResolveComposerCacheForRestoreInteractor`** — validates and selects the newest restorable snapshot; removes stale or expired entries as a side-effect to keep Hive lean.

### Model

- **`EmailActionType`** — new `editDraft` value required for the restore-from-cache flow.

### Tests

7 new test files covering all new datasource, model, and interactor logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent composer drafts with encrypted local storage and per-account/user scoping.
  * Option to save drafts as persistent snapshots (with timestamps) and recover the latest restorable draft.
  * Mark drafts as "clean-closed" to prevent automatic restore.
  * Improved HTML inline-image restoration via a dedicated HTML transformer.
  * New compose/download actions: "compose from unsubscribe mailto link" and "download message as EML".

* **Tests**
  * Expanded test coverage for persistence, restore, cleanup, and inline-image restoration flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->