### PR TITLE
TF-4473 Implement ADR-0086 Android composer auto-save draft on background

### DIFF
--- a/docs/adr/0086-android-composer-draft-loss-on-background.md
+++ b/docs/adr/0086-android-composer-draft-loss-on-background.md
@@ -95,13 +95,13 @@ The `isCleanClose` flag, persisted alongside the cached content, is the discrimi
 
 #### Layer 1 — Proactive Local Cache at `AppLifecycleState.inactive`
 
-Add an `AppLifecycleListener` to `ComposerController` (mobile only). On `onInactive`, extract the current editor HTML, build a `CreateEmailRequest` from all composer fields (recipients, subject, identity, attachments), then call `SaveComposerCacheOnMobileInteractor` which generates the full `Email` object via `ComposerRepository.generateEmail()` and persists a `ComposerCache` entry to the Hive box (`composerMobileCache`) keyed by `_mobileSessionId`.
+Add an `AppLifecycleListener` to `ComposerController` (**Android only**). On `onInactive`, extract the current editor HTML, build a `CreateEmailRequest` from all composer fields (recipients, subject, identity, attachments), then call `SaveComposerCacheInteractor` (with `isPersistent: true`) which generates the full `Email` object via `ComposerRepository.generateEmail()` and persists a `ComposerPersistentCache` entry to the Hive box (`composer_hive_cache_box`) keyed by `autoSaveComposerId`.
 
-> **`composerId`** is a web-only concept managed by `ComposerManager` to support multiple simultaneous composer instances on desktop browsers. On mobile, `ComposerBindings` is always instantiated without a `composerId` (it is `null`). Therefore, the mobile cache uses a separate **`_mobileSessionId`**: a UUID generated inside `ComposerController.onInit()` on mobile only. Since mobile allows only one composer at a time (full-screen route), a single UUID per session is sufficient as the direct cache key. It is passed to the repository methods at every call site — no computed getter is needed. On mobile, `_mobileSessionId` is stored as the `composerId` field value inside `ComposerCache` (see "Reusing `ComposerCache` for mobile" below).
+> **`autoSaveComposerId`** is the composerId value from the current route arguments. On mobile, `ComposerBindings` receives a timestamp-based UUID generated when the composer route is opened. This UUID is stored as the `composerId` field inside `ComposerPersistentCache` (see "New `ComposerPersistentCache` subclass" below).
 
 This is the primary fix for both RC1 and RC2. It is fast, offline, and does not depend on network connectivity.
 
-**Fallback for `getText()` failure**: a periodic content snapshot (`Timer.periodic(30s)`) runs while the editor is loaded, storing the last known HTML in `_lastKnownContent`. At `inactive`, extraction uses `try/catch` around `getText().timeout(2s)`. On any exception — timeout, renderer crash, or empty result — the fallback is `_lastKnownContent`. This ensures Layer 1 persistence is never silently skipped.
+**Fallback for `getText()` failure**: a periodic content snapshot (`Timer.periodic(30s)`) runs while the editor is loaded, storing the last known HTML in `notifier.lastKnownHtmlContent`. At `inactive`, extraction calls `_fetchEditorContent()` which wraps `getText()` in a `try/catch` with a 2 s timeout. The timeout prevents an indefinite hang if the JS bridge freezes (distinct from a renderer crash, which throws immediately). If the result is `null` (renderer crash or timeout), the fallback is `notifier.lastKnownHtmlContent` from the last periodic tick. The resolved effective content — either fresh or fallback, even if empty — is always passed as `htmlContent` to `buildCreateEmailRequestForAutoSave(htmlContent: effectiveContent)`, so `getText()` is never called a second time inside that method.
 
 **System dialog false positive**: `AppLifecycleState.inactive` is also triggered by system overlays (permission dialogs, incoming calls, notification shade). To avoid unnecessary saves in these cases, the save is preceded by a short guard delay (~300 ms). If the state returns to `active` within that window, the save is cancelled. This prevents both the Layer 1 Hive write and the Layer 2 network call from triggering unnecessarily when the user never actually leaves the app.
 
@@ -121,44 +121,45 @@ This is **fire-and-forget** — failure is reported via `SentryManager.instance.
 
 **Deduplication guard**: a boolean `_isSavingToDraftInProgress` flag on `ComposerController` ensures only one server-side save runs at a time. If `onInactive` fires again (e.g., user rapidly switches apps back and forth) while a save is still in flight, the duplicate trigger is silently skipped. The flag is cleared on completion (success or failure). Note that Layer 1 (Hive write) is also protected by the 300 ms guard described above — the deduplication flag applies only to the Layer 2 network call.
 
-#### Layer 3 — Recovery at `AppLifecycleState.resumed` / `onReady` (RC1)
+#### Layer 3 — Recovery at `AppLifecycleState.resumed` (RC1)
 
-On `ComposerController.onReady()` (mobile only), check whether a non-clean-close cache entry exists for the current `_mobileSessionId`. If found, inject the cached HTML into the editor and restore all composer fields. Delete the cache entry after successful restoration.
+On `AppLifecycleState.resumed`, `_restoreIfEditorBlank()` checks if the editor content is empty (renderer was killed while the app stayed alive). If so, it calls `ResolveComposerCacheForRestoreInteractor` to fetch the newest restorable snapshot and reinjects the cached HTML into the editor via `htmlEditorApi.setText()`. The snapshot is then cleared so the periodic timer can write a fresh one.
 
-On `AppLifecycleState.resumed`, check if the editor is blank (renderer was killed while app stayed alive) and a non-clean cache entry exists. If so, reinject the cached content.
+**Layer 4 → Layer 3 bridge (RC2)**: when `MailboxDashBoardController` re-opens the composer with `EmailActionType.restoreComposerFromPersistentCache`, `setupEmailContent()` routes to `_loadMobileRestoredEmailContent()` which loads the cached HTML directly. No additional `onReady()` check is required in this path — the content is delivered via `ComposerArguments`.
 
-**Cache-cleared edge case**: if Layer 2 succeeded and cleared the local cache before the user returns, Layer 3 `onResumed` will find no cache entry and will not reinject. In this case the draft is safely persisted in the Drafts folder on the server; the user can open it from there. No data is lost.
+**Cache not cleared after Layer 2**: Layer 2 deliberately does NOT clear the Hive cache on server-save success (see Layer 2 note). If the cache happens to be absent when the user returns, Layer 3 `_restoreIfEditorBlank()` finds nothing and leaves the editor as-is. The draft is safely persisted in the Drafts folder; the user can open it from there. No data is lost.
 
 #### Layer 4 — Re-open Composer on App Restart (RC2)
 
 When Android kills the entire app process, `ComposerController` is destroyed along with the route stack. Any recovery logic inside `ComposerController` will never be called because the controller no longer exists.
 
-Recovery for RC2 must happen at a higher level — `MailboxDashBoardController.onReady()` — which always runs when the app restarts. On startup:
+Recovery for RC2 must happen at a higher level — `_handleSessionFromArguments()` inside `MailboxDashBoardController`, which always runs when the session is established on app restart. On startup:
 
-1. `MailboxDashBoardController` reads all valid entries (mobile only) via `appProviderContainer.read(composerAutoSaveProvider.notifier).restoreAll()` (filter: `isCleanClose = false`, age < 24 h). `MailboxDashBoardController` is a GetX controller and follows the same `appProviderContainer.read(...)` pattern as `ComposerController`.
-2. If one or more entries exist, the dashboard MUST select exactly one deterministically — the **newest by `timestampMs`** — and open the composer with that snapshot as `ComposerArguments`. Any older stale entries are cleared immediately.
-3. `ComposerController.onReady()` then proceeds with Layer 3 to inject the content into the editor.
-4. The restored cache entry is cleared after successful injection.
+1. `HandleComposerRestoreOnMobileExtension.checkAndRestoreComposerOnMobile()` calls `appProviderContainer.read(resolveComposerCacheForRestoreProvider).execute(accountId, userName)`. `ResolveComposerCacheForRestoreInteractor` fetches all cached entries, picks the **newest by `timestampMs`** via `newestLocalCache`, discards non-restorable entries, and returns the single best candidate (filter: `isRestorable == true`, age < 24 h).
+2. If a restorable entry is found, the dashboard opens the composer with `ComposerArguments.fromComposerPersistentCache(cache)` which sets `emailActionType = EmailActionType.restoreComposerFromPersistentCache`.
+3. `ComposerController.setupEmailContent()` detects `restoreComposerFromPersistentCache` and calls `_loadMobileRestoredEmailContent()` to inject the cached HTML. Inline images are restored via `_restoreInlineImages()`.
+4. Non-restorable entries (expired or `isCleanClose=true`) are removed as a side-effect of step 1.
 
 ```text
 App process restarted
         │
         ▼
-MailboxDashBoardController.onReady()  [mobile only]
+MailboxDashBoardController._handleSessionFromArguments()  [Android only]
         │
-        ├── appProviderContainer.read(composerAutoSaveProvider.notifier).restoreAll()
-        │                                          ← filter: !cleanClose, age < 24h
+        ├── checkAndRestoreComposerOnMobile()
+        │       └── resolveComposerCacheForRestoreProvider.execute(accountId, userName)
+        │               ← newestLocalCache: pick newest by timestampMs
+        │               ← non-restorable entries removed as side-effect
         │
-        ├── entries found?
-        │       ├── pick newest by timestampMs
-        │       ├── clear remaining stale entries
-        │       └── openComposer(ComposerArguments.fromSnapshot(snapshot))
+        ├── cache found?
+        │       └── openComposer(ComposerArguments.fromComposerPersistentCache(cache))
+        │               emailActionType = restoreComposerFromPersistentCache
         │                           │
         │                           ▼
-        │                   ComposerController.onReady()
-        │                           └── Layer 3: inject content into editor
+        │               ComposerController.setupEmailContent()
+        │                           └── _loadMobileRestoredEmailContent()
         │
-        └── no entries / all clean → normal startup flow
+        └── no restorable entry → normal startup flow
 ```
 
 This mirrors the existing web behaviour where `reopenComposerBrowser` (`EmailActionType`) restores a cached composer on page reload.
@@ -166,156 +167,166 @@ This mirrors the existing web behaviour where `reopenComposerBrowser` (`EmailAct
 ### Architecture
 
 ```text
-ComposerController (GetX)  [mobile only]
+ComposerController (GetX)  [Android only]
     │
     ├── AppLifecycleListener
-    │       ├── onInactive → _onAppInactive()
-    │       └── onResume   → _onAppResumed()
+    │       ├── onInactive → 300ms guard → _saveSnapshotToCache()
+    │       └── onResume   → _restoreIfEditorBlank()
     │
-    ├── _onAppInactive()
-    │       ├── [300ms guard — cancels if state → active]
-    │       ├── try { content = await getText().timeout(2s) }
-    │       │   catch (_) { content = _lastKnownContent }
-    │       ├── await Layer 1: appProviderContainer.read(composerAutoSaveProvider(_saveComposerCacheInteractor).notifier)
-    │       │                       .save(_mobileSessionId, ...)          ← Hive write
-    │       └── fire Layer 2: CreateNewAndSaveEmailToDraftsInteractor     ← unawaited
+    ├── _saveSnapshotToCache()
+    │       ├── freshContent = _fetchEditorContent()  ← getText().timeout(2s)
+    │       ├── effectiveContent = freshContent ?? notifier.lastKnownHtmlContent
+    │       ├── await Layer 1: saveComposerCacheInteractor.execute(
+    │       │                       createEmailRequest: ...(htmlContent: effectiveContent),
+    │       │                       isPersistent: true,
+    │       │                  )                                         ← Hive write
+    │       └── fire Layer 2: CreateNewAndSaveEmailToDraftsInteractor   ← unawaited
     │
-    ├── onReady() [RC1 Scenario A — fresh open after renderer kill]
-    │       └── _checkAndRestoreComposerCache(_mobileSessionId)
+    ├── _restoreIfEditorBlank()  [RC1 — user returns, editor blank]
+    │       └── editor blank + resolveComposerCacheForRestoreProvider returns cache?
+    │               └── htmlEditorApi.setText(cache.email.emailContentList.asHtmlString)
     │
-    ├── _onAppResumed() [RC1 Scenario B — user returns, editor blank]
-    │       └── editor blank + cache entry exists?
-    │               └── _checkAndRestoreComposerCache(_mobileSessionId)
+    ├── _closeComposerAction() [mark clean — Android only]
+    │       ├── markCleanClose()  ← notifier.setCleanClose() + MarkComposerCacheCleanCloseInteractor (unawaited)
+    │       └── closeComposer()   ← navigation (after clean-close is already persisting)
     │
-    ├── _closeComposerAction() [mark clean — mobile only]
-    │       └── appProviderContainer.read(composerAutoSaveProvider(_saveComposerCacheInteractor).notifier)
-    │                   .markCleanClose(_mobileSessionId)
-    │
-    └── onClose() [mobile only]
-            └── appProviderContainer.invalidate(composerAutoSaveProvider(_saveComposerCacheInteractor))
+    └── onClose() [Android only]
+            └── appProviderContainer.invalidate(composerAutoSaveProvider(autoSaveComposerId))
 ```
 
 ```text
 ComposerAutoSaveNotifier (Riverpod StateNotifier)
-    │   [family param: SaveComposerCacheOnMobileInteractor — constructed by ComposerController]
+    │   [family param: String — autoSaveComposerId]
     │
-    ├── save(sessionId, CreateEmailRequest)   → SaveComposerCacheOnMobileInteractor (family param)
-    │                                               └── ComposerRepository (GetX) + ComposerMobileCacheRepository
-    ├── restore(sessionId)                    → GetComposerCacheOnMobileInteractor
-    ├── restoreAll()                          → GetAllComposerCacheOnMobileInteractor  [Layer 4]
-    ├── markCleanClose(sessionId)             → SaveComposerCacheOnMobileInteractor (isCleanClose=true)
-    └── clearById(sessionId)                  → RemoveComposerCacheByIdOnMobileInteractor
+    ├── state fields: hasRecoverableSnapshot, isCleanClose,
+    │                 isSavingToDraftInProgress, lastKnownHtmlContent
+    │
+    ├── onSnapshotSaved()          — sets hasRecoverableSnapshot = true
+    ├── setCleanClose()            — sets isCleanClose = true (Hive write fired immediately in markCleanClose)
+    ├── updateLastKnownContent(s)  — stores periodic snapshot for fallback
+    ├── beginDraftSave() / endDraftSave()  — deduplication guard for Layer 2
+    ├── restore(accountId, userName)  → ResolveComposerCacheForRestoreInteractor
+    └── clearCache(accountId, userName) → RemoveAllComposerCacheInteractor
         │
-        └── Get/GetAll/RemoveById → ComposerMobileCacheRepository (domain interface — NEW)
-                                        └── ComposerMobileCacheRepositoryImpl (data — NEW)
-                                                └── ComposerMobileCacheClient (HiveCacheClient<String> — NEW)
+        └── Restore/Clear → ComposerCacheRepository (existing)
+                                └── ComposerHiveCacheClient (HiveCacheClient<String>, encryption=true)
+                                        └── box: composer_hive_cache_box
 ```
 
-### Reusing `ComposerCache` for mobile
+```text
+Riverpod providers  [composer_cache_providers.dart]
 
-Rather than introducing a new model, the existing `ComposerCache` (in `mailbox_dashboard/data/model/`) is reused for mobile persistence. `ComposerCache` already carries the full `Email` object — generated via `ComposerRepository.generateEmail()` the same way `SaveComposerCacheOnWebInteractor` does — including inline images as base64 attachments, regular attachments, recipients, subject, identity, action type, and draft ID.
+    _composerHiveCacheClientProvider  (private)
+    _composerCacheDatasourceProvider  (private)
+    composerCacheRepositoryProvider   (public)
+    removeAllComposerCacheProvider    (public)
+    markComposerLocalCacheCleanCloseProvider  (public)
+    resolveComposerCacheForRestoreProvider    (public)
 
-Two nullable fields are added to `ComposerCache` for mobile recovery logic:
+    composerAutoSaveProvider = StateNotifierProvider.family<
+        ComposerAutoSaveNotifier, ComposerAutoSaveState, String>
+```
+
+### New `ComposerPersistentCache` subclass
+
+A new subclass `ComposerPersistentCache extends ComposerCache` (in `mailbox_dashboard/data/model/`) is introduced for Android persistence. It extends `ComposerCache` — which already carries the full `Email` object generated via `ComposerRepository.generateEmail()`, including inline images as base64 attachments, regular attachments, recipients, subject, identity, action type, and draft ID — with two new nullable fields:
 
 ```dart
-// New mobile-only fields (null on all web entries — no impact on web serialisation)
 final bool? isCleanClose;   // null/false = involuntary kill → restore; true = deliberate discard → skip
 final int? timestampMs;     // snapshot time (ms); used for Layer 4 deterministic selection
 ```
 
-`@JsonSerializable(includeIfNull: false)` is already on `ComposerCache`, so these fields are omitted from web-generated JSON entirely — zero impact on web.
+`@JsonSerializable(includeIfNull: false)` ensures these fields are omitted from JSON when null, so existing `ComposerCache` entries (web) are unaffected.
 
-`composerId` field (already in `ComposerCache`) is reused as the mobile session key: on mobile, `composerId = _mobileSessionId` (UUID generated in `onInit()`).
+`composerId` (already in `ComposerCache`) is used as the cache key: on mobile, `composerId = autoSaveComposerId` (timestamp-based UUID generated when the composer route is opened).
 
-**Required enum change**: `EmailActionType.reopenComposerMobile` must be added to the existing `EmailActionType` enum (`model/` package). This is the action type used when restoring a cached mobile composer — analogous to the existing `reopenComposerBrowser` for web.
+`ComposerPersistentCache` also provides:
+- `isRestorable` — `true` iff `isCleanClose != true && !isExpired && !isEmpty`
+- `isExpired` — `true` when `timestampMs` is older than 24 hours
+- `newestLocalCache` extension on `Iterable<ComposerCache>` — picks the `ComposerPersistentCache` with the highest `timestampMs`
 
-**Inline images for `reopenComposerMobile`**: `setup_email_attachments_extension.dart` treats `EmailActionType.reopenComposerMobile` identically to `reopenComposerBrowser` — both restore `attachments` and `inlineImages` from `ComposerCache.email`. `SaveComposerCacheOnMobileInteractor` calls `ComposerRepository.generateEmail()` at snapshot time, which embeds inline images as base64 data URIs in the `Email` body and records them in the attachment list. On restore, they are available immediately without any network fetch.
+**Enum change**: `EmailActionType.restoreComposerFromPersistentCache` was added to `EmailActionType` (`model/` package). This is the action type used when restoring a cached Android composer — analogous to `reopenComposerBrowser` for web.
+
+**Inline images for `restoreComposerFromPersistentCache`**: `setup_email_attachments_extension.dart` treats `EmailActionType.restoreComposerFromPersistentCache` identically to `reopenComposerBrowser` — both restore `attachments` and `inlineImages` from `ComposerCache.email`. `SaveComposerCacheInteractor` calls `ComposerRepository.generateEmail()` at snapshot time, which embeds inline images as base64 data URIs in the `Email` body. On restore, they are available immediately without any network fetch.
 
 ### Riverpod pattern
 
-`ComposerAutoSaveNotifier` (Riverpod `StateNotifier`) receives mobile interactors as dependencies, mirroring the web pattern (`SaveComposerCacheOnWebInteractor`, `GetComposerCacheOnWebInteractor`, etc.). Riverpod is chosen to keep the auto-save concern isolated, independently testable, and aligned with the ADR-0075 migration roadmap. `ComposerController` (GetX) is a consumer only, via `appProviderContainer.read(...)`.
+`ComposerAutoSaveNotifier` (Riverpod `StateNotifier`) holds the in-flight auto-save state and delegates restore/clear operations to domain interactors. Riverpod is chosen to keep the auto-save concern isolated, independently testable, and aligned with the ADR-0075 migration roadmap. `ComposerController` (GetX) is a consumer only, via `appProviderContainer.read(...)`.
 
 The dependency chain is managed **purely by Riverpod** via `ref.read()` — no `Get.find<>()` inside any provider.
 
-`SaveComposerCacheOnMobileInteractor` requires `ComposerRepository` (GetX-managed). Rather than leaking `ComposerRepository` into the provider signature (ISP violation — the notifier doesn't use it directly), `ComposerController` constructs `SaveComposerCacheOnMobileInteractor` itself in `onInit()` using its own injected `_composerRepository`, then passes the ready interactor as the `family` parameter. The provider only sees interactors — its natural dependencies.
+`SaveComposerCacheInteractor` (which needs `ComposerRepository`, a GetX-managed dependency) is **not** a Riverpod provider. It is obtained via `Get.find<SaveComposerCacheInteractor>(tag: composerId)` in `ComposerController` and called directly from `HandleMobileAutoSaveExtension._saveSnapshotToCache()`, keeping GetX at the controller boundary (SOLID: ISP, SRP).
 
-**Memory management**: `StateNotifierProvider.family` on a global `appProviderContainer` caches one entry per unique parameter. `ComposerController.onClose()` calls `appProviderContainer.invalidate(...)` to remove the entry when the composer closes. Using `autoDispose + listen` was rejected: maintaining a keep-alive listener from a GetX controller is an anti-pattern that fights the framework and risks accidental early disposal.
+The `composerAutoSaveProvider` family is keyed by `String` (the `autoSaveComposerId`) rather than by the interactor, because the notifier itself does not call save — only the controller extension does. The notifier handles state tracking and restore/clear operations only.
 
-`composerMobileCacheRepositoryProvider` is intentionally public — `ComposerController` reads it to construct `SaveComposerCacheOnMobileInteractor`.
+**Memory management**: `StateNotifierProvider.family` on a global `appProviderContainer` caches one entry per unique parameter. `ComposerController.onClose()` calls `appProviderContainer.invalidate(composerAutoSaveProvider(autoSaveComposerId))` to remove the entry when the composer closes. Using `autoDispose + listen` was rejected: maintaining a keep-alive listener from a GetX controller is an anti-pattern that fights the framework and risks accidental early disposal.
 
 Follows [ADR-0085](./0085-riverpod-state-management-for-local-settings.md): providers are registered on the global `appProviderContainer`.
 
 ```dart
-// All providers co-located in composer_auto_save_notifier.dart — internal providers are private (_)
+// All providers co-located in composer_cache_providers.dart — internal providers are private (_)
 
-final _composerMobileCacheClientProvider = Provider<ComposerMobileCacheClient>(
-  (_) => ComposerMobileCacheClient(),
-);
+final _composerHiveCacheClientProvider =
+    Provider<ComposerHiveCacheClient>((_) => ComposerHiveCacheClient());
 
-// Public: ComposerController reads this to construct SaveComposerCacheOnMobileInteractor.
-final composerMobileCacheRepositoryProvider = Provider<ComposerMobileCacheRepository>(
-  (ref) => ComposerMobileCacheRepositoryImpl(
-    ref.read(_composerMobileCacheClientProvider),
+final _composerCacheDatasourceProvider = Provider<ComposerCacheDatasource>(
+  (ref) => ComposerPersistentCacheDatasourceImpl(
+    ref.read(_composerHiveCacheClientProvider),
+    ref.read(_cacheExceptionThrowerProvider),
   ),
 );
 
-final _getOnMobileProvider = Provider(
-  (ref) => GetComposerCacheOnMobileInteractor(
-    ref.read(composerMobileCacheRepositoryProvider),
-  ),
+final composerCacheRepositoryProvider = Provider<ComposerCacheRepository>(
+  (ref) => ComposerCacheRepositoryImpl(ref.read(_composerCacheDatasourceProvider)),
 );
 
-final _getAllOnMobileProvider = Provider(
-  (ref) => GetAllComposerCacheOnMobileInteractor(
-    ref.read(composerMobileCacheRepositoryProvider),
-  ),
+final removeAllComposerCacheProvider = Provider<RemoveAllComposerCacheInteractor>(
+  (ref) => RemoveAllComposerCacheInteractor(ref.read(composerCacheRepositoryProvider)),
 );
 
-final _removeByIdOnMobileProvider = Provider(
-  (ref) => RemoveComposerCacheByIdOnMobileInteractor(
-    ref.read(composerMobileCacheRepositoryProvider),
-  ),
+final markComposerLocalCacheCleanCloseProvider = Provider<MarkComposerCacheCleanCloseInteractor>(
+  (ref) => MarkComposerCacheCleanCloseInteractor(ref.read(composerCacheRepositoryProvider)),
 );
 
-// SaveComposerCacheOnMobileInteractor is NOT wired inside this file — it needs
-// ComposerRepository (GetX-managed). ComposerController constructs it and passes it as
-// the family parameter, keeping GetX at the controller boundary (SOLID: ISP, SRP).
+final resolveComposerCacheForRestoreProvider = Provider<ResolveComposerCacheForRestoreInteractor>(
+  (ref) => ResolveComposerCacheForRestoreInteractor(ref.read(composerCacheRepositoryProvider)),
+);
+
+// Keyed by String (autoSaveComposerId). The notifier handles restore/clear; save is
+// called directly by HandleMobileAutoSaveExtension via saveComposerCacheInteractor.
 final composerAutoSaveProvider = StateNotifierProvider
-    .family<ComposerAutoSaveNotifier, ComposerAutoSaveState, SaveComposerCacheOnMobileInteractor>(
-  (ref, saveInteractor) => ComposerAutoSaveNotifier(
-    saveInteractor,
-    ref.read(_getOnMobileProvider),
-    ref.read(_getAllOnMobileProvider),
-    ref.read(_removeByIdOnMobileProvider),
+    .family<ComposerAutoSaveNotifier, ComposerAutoSaveState, String>(
+  (ref, composerId) => ComposerAutoSaveNotifier(
+    ref.read(resolveComposerCacheForRestoreProvider),
+    ref.read(removeAllComposerCacheProvider),
   ),
 );
 ```
 
-`ComposerController` (mobile only):
+`ComposerController` (Android only):
 
 ```dart
-// onInit() — construct interactor using own GetX-injected repository
-_saveComposerCacheInteractor = SaveComposerCacheOnMobileInteractor(
-  appProviderContainer.read(composerMobileCacheRepositoryProvider),
-  _composerRepository,  // injected via ComposerBindings
+// _saveSnapshotToCache — calls save interactor directly (not through the notifier)
+final createEmailRequest = await buildCreateEmailRequestForAutoSave(
+  htmlContent: effectiveContent,  // always pass; never null to avoid a second getText() call
 );
-
-// usage
-appProviderContainer
-    .read(composerAutoSaveProvider(_saveComposerCacheInteractor).notifier)
-    .save(_mobileSessionId, ...);
+await saveComposerCacheInteractor.execute(
+  createEmailRequest: createEmailRequest,
+  isPersistent: true,
+);
+notifier.onSnapshotSaved();
 
 // onClose() — invalidate family entry to prevent memory leak on appProviderContainer
-appProviderContainer.invalidate(composerAutoSaveProvider(_saveComposerCacheInteractor));
+appProviderContainer.invalidate(composerAutoSaveProvider(autoSaveComposerId));
 ```
 
 ### Cache eviction
 
 - Entries older than 24 hours are ignored on restore (treated as expired).
 - Entries are deleted after successful restoration or after `markCleanClose`.
-- On successful server-side draft save (Layer 2), the local cache entry is also cleared.
+- On successful server-side draft save (Layer 2), the local cache entry is **not** cleared. Clearing on success introduces a race condition: the periodic 30 s timer may have written a newer snapshot while the JMAP call was in flight on a slow network, and clearing would discard it. Cleanup is handled exclusively by `markCleanClose` (intentional close) and the 24 h TTL.
 - If the close is **not** a clean close (system kill, swipe from Recents, or any scenario where `isCleanClose` is not explicitly set to `true`), the entry remains in cache indefinitely until it is either restored by Layer 3/4, replaced by a newer snapshot, or expires after 24 hours. This is intentional: every involuntary kill must result in a restore attempt.
-- `composerMobileCache` MUST use encrypted Hive storage (AES-256 cipher) with keys provided by `HiveCacheConfig`. Plaintext storage is not permitted for draft body content. The AES key is generated once by `HiveCacheConfig.initializeEncryptionKey()` on first launch and stored in device secure storage via `EncryptionKeyCacheManager` (backed by `flutter_secure_storage`). There is no scheduled key rotation — the key is stable for the lifetime of the app installation. If the key is missing after a backup/restore (Android backup does not include `flutter_secure_storage` data by default), the Hive box will fail to open; in that case the cache is treated as empty and the user must re-compose.
+- `composer_hive_cache_box` MUST use encrypted Hive storage (AES-256 cipher) with keys provided by `HiveCacheConfig`. Plaintext storage is not permitted for draft body content. The AES key is generated once by `HiveCacheConfig.initializeEncryptionKey()` on first launch and stored in device secure storage via `EncryptionKeyCacheManager` (backed by `flutter_secure_storage`). There is no scheduled key rotation — the key is stable for the lifetime of the app installation. If the key is missing after a backup/restore (Android backup does not include `flutter_secure_storage` data by default), the Hive box will fail to open; in that case the cache is treated as empty and the user must re-compose.
 
 ### What is NOT in scope
 
@@ -331,7 +342,7 @@ appProviderContainer.invalidate(composerAutoSaveProvider(_saveComposerCacheInter
 ### Positive
 
 - Draft content is preserved across Android background kills (both renderer-only and full process), without any user action required. On full process kill (RC2), the composer is automatically re-opened on next app launch.
-- Although the root cause (RC1 — WebView renderer kill) is Android-specific, Layers 1–4 run on iOS as well. iOS users benefit from the same protection if the app is terminated in the background, even though the WKWebView renderer is less aggressively killed on iOS than Android.
+- Layers 1–4 are **Android-only**. iOS has a less aggressive memory management policy (WKWebView renderer is not independently killable by the OS), so the feature is intentionally scoped to Android to limit complexity.
 - The fix is additive — no existing save/close/send logic is changed in behaviour.
 - Follows the established Riverpod coexistence pattern (ADR-0085) for the new state logic.
 - Layer 2 (silent server save) gives users a fallback in Drafts even if local cache is unavailable.
@@ -340,7 +351,7 @@ appProviderContainer.invalidate(composerAutoSaveProvider(_saveComposerCacheInter
 
 ### Negative
 
-- Two `AppLifecycleListener` instances will exist on mobile per open composer (one already exists in `WebSocketController`). This is acceptable; each is scoped to its owning controller's lifecycle.
+- Two `AppLifecycleListener` instances will exist on **Android** per open composer (one already exists in `WebSocketController`). This is acceptable; each is scoped to its owning controller's lifecycle.
 - The periodic snapshot timer (30 s) adds a minor recurring async cost while the composer is open. This is negligible compared to the existing WebView overhead.
 - The `isCleanClose` write path must be added to **all** explicit-discard code paths. Missing one would cause a phantom restore. This must be enforced via code review and covered by unit tests.
 - `enough_html_editor`'s `onRenderProcessGone` gap remains unaddressed. If the renderer is killed between the `inactive` snapshot and the user returning (rare), the snapshot may be stale by a few seconds.

--- a/lib/features/composer/presentation/composer_bindings.dart
+++ b/lib/features/composer/presentation/composer_bindings.dart
@@ -20,8 +20,8 @@ import 'package:tmail_ui_user/features/composer/domain/usecases/restore_email_in
 import 'package:tmail_ui_user/features/composer/domain/usecases/save_composer_cache_interactor.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/upload_attachment_interactor.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
-import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart';
-import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_web_controller.dart';
+import 'package:tmail_ui_user/features/composer/presentation/mobile_composer_bindings.dart';
+import 'package:tmail_ui_user/features/composer/presentation/web_composer_bindings.dart';
 import 'package:tmail_ui_user/features/email/data/datasource/email_datasource.dart';
 import 'package:tmail_ui_user/features/email/data/datasource/html_datasource.dart';
 import 'package:tmail_ui_user/features/email/data/datasource/print_file_datasource.dart';
@@ -52,7 +52,6 @@ import 'package:tmail_ui_user/features/mailbox/data/network/mailbox_isolate_work
 import 'package:tmail_ui_user/features/mailbox/data/repository/mailbox_repository_impl.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/repository/mailbox_repository.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_session_cache_datasource_impl.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/repository/composer_cache_repository_impl.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/remove_composer_cache_by_id_interactor.dart';
@@ -77,12 +76,40 @@ import 'package:tmail_ui_user/main/exceptions/thrower/remote_exception_thrower.d
 import 'package:tmail_ui_user/main/utils/ios_sharing_manager.dart';
 import 'package:uuid/uuid.dart';
 
-class ComposerBindings extends BaseBindings {
+abstract class ComposerBindings extends BaseBindings {
 
-  final String? composerId;
+  final String? _composerId;
   final ComposerArguments? composerArguments;
 
-  ComposerBindings({this.composerId, this.composerArguments});
+  ComposerBindings.base({String? composerId, this.composerArguments})
+      : _composerId = composerId;
+
+  factory ComposerBindings({String? composerId, ComposerArguments? composerArguments}) {
+    if (PlatformInfo.isWeb) {
+      return WebComposerBindings(composerId: composerId, composerArguments: composerArguments);
+    }
+    return MobileComposerBindings(composerId: composerId, composerArguments: composerArguments);
+  }
+
+  /// GetX registration tag. Null on the phone path (ComposerBindings() in
+  /// app_pages.dart has no explicit composerId), matching ComposerView's
+  /// GetWidget<ComposerController> default tag of null.
+  String? get composerId => _composerId;
+
+  /// composerId for the controller's auto-save feature.
+  /// Falls back to route arguments on the phone path so the controller
+  /// always receives a composerId for Riverpod provider keying.
+  String? get _autoSaveComposerId {
+    if (_composerId != null) return _composerId;
+    final args = Get.arguments;
+    return args is ComposerArguments ? args.composerId : null;
+  }
+
+  void bindPlatformCacheDatasourceImpl();
+  void bindPlatformComposerCacheDatasource();
+  void bindPlatformRichTextController();
+  void disposePlatformRichTextController();
+  void disposePlatformCacheImpl();
 
   @override
   void bindingsDataSourceImpl() {
@@ -146,13 +173,7 @@ class ComposerBindings extends BaseBindings {
       Get.find<SessionStorageManager>(),
       Get.find<CacheExceptionThrower>(),
     ), tag: composerId);
-    _bindComposerCacheDatasourceImpl();
-  }
-
-  void _bindComposerCacheDatasourceImpl() {
-    Get.lazyPut(() => ComposerSessionCacheDatasourceImpl(
-      Get.find<CacheExceptionThrower>(),
-    ), tag: composerId);
+    bindPlatformCacheDatasourceImpl();
   }
 
   @override
@@ -189,10 +210,7 @@ class ComposerBindings extends BaseBindings {
       () => Get.find<PrintFileDataSourceImpl>(tag: composerId),
       tag: composerId,
     );
-    Get.lazyPut<ComposerCacheDatasource>(
-      () => Get.find<ComposerSessionCacheDatasourceImpl>(tag: composerId),
-      tag: composerId,
-    );
+    bindPlatformComposerCacheDatasource();
   }
 
   @override
@@ -325,11 +343,7 @@ class ComposerBindings extends BaseBindings {
 
   @override
   void bindingsController() {
-    if (PlatformInfo.isWeb) {
-      Get.lazyPut(() => RichTextWebController(), tag: composerId);
-    } else {
-      Get.lazyPut(() => RichTextMobileTabletController(), tag: composerId);
-    }
+    bindPlatformRichTextController();
     Get.lazyPut(
       () => UploadController(Get.find<UploadAttachmentInteractor>(tag: composerId)),
       tag: composerId,
@@ -351,16 +365,13 @@ class ComposerBindings extends BaseBindings {
       Get.find<ComposerRepository>(tag: composerId),
       Get.find<SaveTemplateEmailInteractor>(tag: composerId),
       composerId: composerId,
+      autoSaveComposerId: _autoSaveComposerId,
       composerArgs: composerArguments,
     ), tag: composerId);
   }
 
   void dispose() {
-    if (PlatformInfo.isWeb) {
-      Get.delete<RichTextWebController>(tag: composerId);
-    } else {
-      Get.delete<RichTextMobileTabletController>(tag: composerId);
-    }
+    disposePlatformRichTextController();
     Get.delete<UploadController>(tag: composerId);
     Get.delete<ComposerController>(tag: composerId);
 
@@ -376,7 +387,7 @@ class ComposerBindings extends BaseBindings {
     Get.delete<EmailHiveCacheDataSourceImpl>(tag: composerId);
     Get.delete<EmailLocalStorageDataSourceImpl>(tag: composerId);
     Get.delete<EmailSessionStorageDatasourceImpl>(tag: composerId);
-    Get.delete<ComposerSessionCacheDatasourceImpl>(tag: composerId);
+    disposePlatformCacheImpl();
 
     Get.delete<AttachmentUploadDataSource>(tag: composerId);
     Get.delete<ComposerDataSource>(tag: composerId);

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -58,6 +58,7 @@ import 'package:tmail_ui_user/features/composer/domain/usecases/restore_email_in
 import 'package:tmail_ui_user/features/composer/domain/usecases/save_composer_cache_interactor.dart';
 import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_web_controller.dart';
+import 'package:tmail_ui_user/features/composer/presentation/extensions/handle_mobile_auto_save_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/attachment_detection_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/auto_create_tag_for_recipients_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/get_draft_mailbox_id_for_composer_extension.dart';
@@ -177,6 +178,7 @@ class ComposerController extends BaseController
   final PrintEmailInteractor printEmailInteractor;
   final ComposerRepository _composerRepository;
   final String? composerId;
+  final String? autoSaveComposerId;
   final ComposerArguments? composerArgs;
   final SaveTemplateEmailInteractor _saveTemplateEmailInteractor;
 
@@ -252,12 +254,25 @@ class ComposerController extends BaseController
   int minInputLengthAutocomplete = AppConfig.defaultMinInputLengthAutocomplete;
   EmailId? currentTemplateEmailId;
 
+  AppLifecycleListener? mobileAutoSaveLifecycleListener;
+  Timer? periodicSnapshotTimer;
+  Timer? inactiveGuardTimer;
+
   @visibleForTesting
   int? get savedEmailDraftHash => _savedEmailDraftHash;
 
   GetEmailContentInteractor get getEmailContentInteractor => _getEmailContentInteractor;
 
   GetServerSettingInteractor get getServerSettingInteractor => _getServerSettingInteractor;
+
+  CreateNewAndSaveEmailToDraftsInteractor get createNewAndSaveEmailToDraftsInteractor =>
+      _createNewAndSaveEmailToDraftsInteractor;
+
+  SaveComposerCacheInteractor get saveComposerCacheInteractor =>
+     _saveComposerCacheInteractor;
+
+  Future<CreateEmailRequest?> buildCreateEmailRequestForAutoSave({String? htmlContent}) =>
+      _generateCreateEmailRequestToSaveAsCache(htmlContent: htmlContent);
 
   GetAllIdentitiesInteractor get getAllIdentitiesInteractor => _getAllIdentitiesInteractor;
 
@@ -287,6 +302,7 @@ class ComposerController extends BaseController
     this._saveTemplateEmailInteractor,
     {
       this.composerId,
+      this.autoSaveComposerId,
       this.composerArgs,
     }
   );
@@ -294,10 +310,10 @@ class ComposerController extends BaseController
   @override
   void onInit() {
     super.onInit();
+    restoreEmailInlineImagesInteractor = getBinding<RestoreEmailInlineImagesInteractor>(tag: composerId);
     if (PlatformInfo.isWeb) {
       responsiveContainerKey = GlobalKey();
       richTextWebController = getBinding<RichTextWebController>(tag: composerId);
-      restoreEmailInlineImagesInteractor = getBinding<RestoreEmailInlineImagesInteractor>(tag: composerId);
       menuMoreOptionController = CustomPopupMenuController();
     } else {
       richTextMobileTabletController = getBinding<RichTextMobileTabletController>(tag: composerId);
@@ -308,6 +324,9 @@ class ComposerController extends BaseController
     _beforeReconnectManager.addListener(onBeforeReconnect);
     _injectBinding();
     onKeyboardShortcutInit();
+    if (PlatformInfo.isAndroid) {
+      initMobileAutoSave();
+    }
   }
 
   @override
@@ -344,6 +363,7 @@ class ComposerController extends BaseController
     subjectEmailInputFocusNode?.removeListener(_subjectEmailInputFocusListener);
     _composerCacheListener?.cancel();
     _beforeReconnectManager.removeListener(onBeforeReconnect);
+    restoreEmailInlineImagesInteractor = null;
     if (PlatformInfo.isWeb) {
       richTextWebController = null;
       responsiveContainerKey = null;
@@ -352,6 +372,7 @@ class ComposerController extends BaseController
     } else {
       richTextMobileTabletController = null;
     }
+    if (PlatformInfo.isAndroid) tearDownMobileAutoSave();
     onKeyboardShortcutDispose();
     super.onClose();
   }
@@ -426,6 +447,7 @@ class ComposerController extends BaseController
 
   @override
   Future<void> onUnloadBrowserListener(html.Event event) async {
+    if (!PlatformInfo.isWeb) return;
     final username = mailboxDashBoardController.sessionCurrent?.username;
     final accountId = mailboxDashBoardController.accountId.value;
     if (composerId != null && username != null && accountId != null) {
@@ -489,8 +511,6 @@ class ComposerController extends BaseController
   }
 
   Future<void> _saveComposerSessionCache() async {
-    autoCreateEmailTag();
-
     final createEmailRequest = await _generateCreateEmailRequestToSaveAsCache();
     if (createEmailRequest == null) return;
 
@@ -506,7 +526,7 @@ class ComposerController extends BaseController
     }
   }
 
-  Future<CreateEmailRequest?> _generateCreateEmailRequestToSaveAsCache() async {
+  Future<CreateEmailRequest?> _generateCreateEmailRequestToSaveAsCache({String? htmlContent}) async {
     final arguments = composerArguments.value;
     final session = mailboxDashBoardController.sessionCurrent;
     final accountId = mailboxDashBoardController.accountId.value;
@@ -515,8 +535,8 @@ class ComposerController extends BaseController
       log('ComposerController::_generateCreateEmailRequest: SESSION or ACCOUNT_ID or ARGUMENTS is NULL');
       return null;
     }
-    
-    String emailContent = await getContentInEditor();
+    autoCreateEmailTag();
+    String emailContent = htmlContent ?? await getContentInEditor();
     if (currentEmailActionType == EmailActionType.compose) {
       emailContent = await _composerRepository.removeCollapsedExpandedSignatureEffect(
         emailContent: emailContent,
@@ -545,7 +565,6 @@ class ComposerController extends BaseController
       identity: identitySelected.value,
       attachments: uploadController.attachmentsUploaded,
       inlineAttachments: uploadController.mapInlineAttachments,
-      outboxMailboxId: getOutboxMailboxIdForComposer(),
       sentMailboxId: getSentMailboxIdForComposer(),
       draftsMailboxId: getDraftMailboxIdForComposer(),
       draftsEmailId: getDraftEmailId(),
@@ -623,6 +642,7 @@ class ComposerController extends BaseController
     _isEmailBodyLoaded = true;
     await setupSelectedIdentity();
     _autoFocusFieldWhenLauncher();
+    if (PlatformInfo.isAndroid) unawaited(restoreIfEditorBlank());
   }
 
   void _injectBinding() {
@@ -1474,6 +1494,7 @@ class ComposerController extends BaseController
         richTextWebController!.isFormattingOptionsEnabled,
       );
     }
+    markCleanClose();
     mailboxDashBoardController.closeComposer(
       result: result,
       closeOverlays: closeOverlays,
@@ -2335,6 +2356,7 @@ class ComposerController extends BaseController
 
   @override
   Future<void> onBeforeReconnect() async {
+    if (!PlatformInfo.isWeb) return;
     if (mailboxDashBoardController.accountId.value != null &&
         mailboxDashBoardController.sessionCurrent?.username != null
     ) {

--- a/lib/features/composer/presentation/extensions/email_action_type_extension.dart
+++ b/lib/features/composer/presentation/extensions/email_action_type_extension.dart
@@ -41,6 +41,7 @@ extension EmailActionTypeExtension on EmailActionType {
     EmailActionType.editDraft,
     EmailActionType.editSendingEmail,
     EmailActionType.reopenComposerBrowser,
+    EmailActionType.restoreComposerFromPersistentCache,
     EmailActionType.editAsNewEmail,
     EmailActionType.composeFromMailtoUri,
     EmailActionType.composeFromUnsubscribeMailtoLink,

--- a/lib/features/composer/presentation/extensions/handle_mobile_auto_save_extension.dart
+++ b/lib/features/composer/presentation/extensions/handle_mobile_auto_save_extension.dart
@@ -1,0 +1,265 @@
+import 'dart:async';
+
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:core/presentation/utils/keyboard_utils.dart';
+import 'package:core/utils/app_logger.dart';
+import 'package:core/utils/platform_info.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter/widgets.dart';
+import 'package:rich_text_composer/rich_text_composer.dart';
+import 'package:model/model.dart';
+import 'package:tmail_ui_user/features/composer/domain/state/save_email_as_drafts_state.dart';
+import 'package:tmail_ui_user/features/composer/domain/state/update_email_drafts_state.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
+import 'package:tmail_ui_user/features/composer/presentation/model/create_email_request.dart';
+import 'package:tmail_ui_user/features/composer/presentation/providers/composer_auto_save_notifier.dart';
+import 'package:tmail_ui_user/features/composer/presentation/providers/composer_cache_providers.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
+
+extension HandleMobileAutoSaveExtension on ComposerController {
+  static const _periodicSnapshotInterval = Duration(seconds: 30);
+  static const _getContentTimeout = Duration(seconds: 2);
+  // 300ms guard filters AppLifecycleState.inactive from system overlays
+  // (permission dialogs, incoming calls) that resolve quickly.
+  static const _inactiveGuardDelay = Duration(milliseconds: 300);
+
+  void initMobileAutoSave() {
+    if (autoSaveComposerId == null) return;
+    mobileAutoSaveLifecycleListener ??= AppLifecycleListener(
+      onStateChange: _onLifecycleStateChanged,
+    );
+    _startPeriodicContentSnapshot();
+    log('HandleMobileAutoSaveExtension::initMobileAutoSave: initialized');
+  }
+
+  void disposeMobileAutoSave() {
+    inactiveGuardTimer?.cancel();
+    inactiveGuardTimer = null;
+    periodicSnapshotTimer?.cancel();
+    periodicSnapshotTimer = null;
+    mobileAutoSaveLifecycleListener?.dispose();
+    mobileAutoSaveLifecycleListener = null;
+  }
+
+  // Sets the in-memory clean-close flag and immediately fires the Hive write
+  // (unawaited). Writing eagerly — before navigation — is safer than deferring
+  // to onClose: the process is still foreground and the isCleanClose flag
+  // already blocks any further snapshot writes, so there is no race.
+  // No-op on non-Android: composerAutoSaveProvider is only initialised on
+  // Android, so reading it on other platforms would create an orphaned family
+  // entry that is never invalidated (memory leak).
+  void markCleanClose() {
+    if (!PlatformInfo.isAndroid) return;
+    final notifier = _autoSaveNotifier();
+    if (notifier == null) return;
+    notifier.setCleanClose();
+    _persistCleanCloseToCache();
+    log('HandleMobileAutoSaveExtension::markCleanClose: flagged and persisted');
+  }
+
+  void _persistCleanCloseToCache() {
+    final accountId = mailboxDashBoardController.accountId.value;
+    final userName = mailboxDashBoardController.sessionCurrent?.username;
+    if (accountId == null || userName == null) return;
+    unawaited(appProviderContainer
+        .read(markComposerLocalCacheCleanCloseProvider)
+        .execute(accountId, userName));
+  }
+
+  ComposerAutoSaveNotifier? _autoSaveNotifier() {
+    final id = autoSaveComposerId;
+    if (id == null) return null;
+    return appProviderContainer.read(composerAutoSaveProvider(id).notifier);
+  }
+
+  Future<String?> _fetchEditorContent() async {
+    try {
+      return await htmlEditorApi?.getText().timeout(_getContentTimeout);
+    } catch (e) {
+      log('HandleMobileAutoSaveExtension::_fetchEditorContent: error=$e');
+      return null;
+    }
+  }
+
+  void _startPeriodicContentSnapshot() {
+    periodicSnapshotTimer?.cancel();
+    periodicSnapshotTimer = Timer.periodic(_periodicSnapshotInterval, (_) {
+      unawaited(_updateLastKnownContent());
+    });
+  }
+
+  Future<void> _updateLastKnownContent() async {
+    final content = await _fetchEditorContent();
+    if (content != null) _autoSaveNotifier()?.updateLastKnownContent(content);
+  }
+
+  void _onLifecycleStateChanged(AppLifecycleState state) {
+    log('HandleMobileAutoSaveExtension::_onLifecycleStateChanged: state=$state');
+    switch (state) {
+      case AppLifecycleState.inactive:
+        inactiveGuardTimer?.cancel();
+        inactiveGuardTimer = Timer(_inactiveGuardDelay, () {
+          unawaited(_saveSnapshotToCache());
+        });
+        break;
+      case AppLifecycleState.resumed:
+        inactiveGuardTimer?.cancel();
+        inactiveGuardTimer = null;
+        unawaited(restoreIfEditorBlank());
+        break;
+      default:
+        break;
+    }
+  }
+
+  Future<void> restoreIfEditorBlank() async {
+    if (_autoSaveNotifier()?.isCleanClose == true) return;
+    try {
+      final payload = await _resolveRestorePayload();
+      if (payload == null) return;
+      log('HandleMobileAutoSaveExtension::restoreIfEditorBlank: restoring from cache');
+      await payload.api.setText(payload.html);
+      // Keep the fallback snapshot in sync: if the editor dies before the next
+      // periodic tick, _saveSnapshotToCache will use this restored content.
+      if (payload.html.isNotEmpty) _autoSaveNotifier()?.updateLastKnownContent(payload.html);
+      // Delete the stale snapshot now that its content is live in the editor.
+      // The periodic timer will write a fresh snapshot on the next 30 s tick.
+      unawaited(clearComposerMobileSnapshot());
+    } catch (e) {
+      log('HandleMobileAutoSaveExtension::restoreIfEditorBlank: error=$e');
+    }
+  }
+
+  Future<({HtmlEditorApi api, String html})?> _resolveRestorePayload() async {
+    final currentContent = await _fetchEditorContent();
+    if (currentContent != null && currentContent.trim().isNotEmpty) return null;
+
+    final accountId = mailboxDashBoardController.accountId.value;
+    final userName = mailboxDashBoardController.sessionCurrent?.username;
+    if (accountId == null || userName == null) return null;
+
+    final cache = await _autoSaveNotifier()?.restore(accountId, userName);
+    if (cache == null) return null;
+
+    final api = htmlEditorApi;
+    if (api == null) return null;
+
+    return (api: api, html: cache.email?.emailContentList.asHtmlString ?? '');
+  }
+
+  // Picks the best available content and syncs it to the notifier.
+  // Fresh content from the editor takes priority; falls back to the last
+  // periodic snapshot (ADR-0086 Layer 1 fallback requirement).
+  String _resolveAndSyncContent(
+    String? freshContent,
+    ComposerAutoSaveNotifier notifier,
+  ) {
+    if (freshContent != null && freshContent.isNotEmpty) {
+      if (notifier.mounted) notifier.updateLastKnownContent(freshContent);
+      return freshContent;
+    }
+    return notifier.lastKnownHtmlContent;
+  }
+
+  Future<void> _executeCacheSave(
+    CreateEmailRequest createEmailRequest,
+    ComposerAutoSaveNotifier notifier,
+  ) async {
+    final saveResult = await saveComposerCacheInteractor.execute(
+      createEmailRequest: createEmailRequest,
+      isPersistent: true,
+    );
+    saveResult.fold(
+      (failure) => log('HandleMobileAutoSaveExtension::_saveSnapshotToCache: save failure=${failure.runtimeType}'),
+      (_) { if (notifier.mounted) notifier.onSnapshotSaved(); },
+    );
+  }
+
+  Future<void> _saveSnapshotToCache() async {
+    final notifier = _autoSaveNotifier();
+    if (notifier == null || notifier.isCleanClose) return;
+
+    try {
+      final freshContent = await _fetchEditorContent();
+      final effectiveContent = _resolveAndSyncContent(freshContent, notifier);
+
+      KeyboardUtils.hideSystemKeyboardMobile();
+
+      final createEmailRequest = await buildCreateEmailRequestForAutoSave(
+        htmlContent: effectiveContent,
+      );
+
+      if (createEmailRequest == null) {
+        log('HandleMobileAutoSaveExtension::_saveSnapshotToCache: no request, skip');
+        return;
+      }
+      await _executeCacheSave(createEmailRequest, notifier);
+      unawaited(_saveToDraftSilently(createEmailRequest));
+    } catch (e) {
+      log('HandleMobileAutoSaveExtension::_saveSnapshotToCache: error=$e');
+    }
+  }
+
+  void _onDraftSaveState(Either<Failure, Success> state) {
+    state.fold(
+      (failure) {
+        // Privacy: only the type is sent — no content, subject, or recipients.
+        logError('HandleMobileAutoSaveExtension::_onDraftSaveState: failure=${failure.runtimeType}');
+      },
+      (success) {
+        // Do NOT clear the Hive cache here: the periodic auto-save may have
+        // written a newer snapshot while this JMAP call was in flight (race
+        // condition on slow networks). Cleanup is handled by markCleanClose
+        // (intentional close) and the 24 h TTL on ComposerPersistentCache.
+        if (success is SaveEmailAsDraftsSuccess) {
+          emailIdEditing = success.emailId;
+          log('HandleMobileAutoSaveExtension::_onDraftSaveState: saved to server draft');
+        } else if (success is UpdateEmailDraftsSuccess) {
+          emailIdEditing = success.emailId;
+          log('HandleMobileAutoSaveExtension::_onDraftSaveState: updated server draft');
+        }
+      },
+    );
+  }
+
+  Future<void> _saveToDraftSilently(CreateEmailRequest createEmailRequest) async {
+    final notifier = _autoSaveNotifier();
+    if (notifier == null || notifier.isSavingToDraftInProgress) return;
+
+    notifier.beginDraftSave();
+    try {
+      await for (final state in createNewAndSaveEmailToDraftsInteractor.execute(
+        createEmailRequest: createEmailRequest,
+      )) {
+        _onDraftSaveState(state);
+      }
+    } catch (e, st) {
+      // Privacy: only the type is captured.
+      logError(
+        'HandleMobileAutoSaveExtension::_saveToDraftSilently: error=${e.runtimeType}',
+        exception: e,
+        stackTrace: st,
+      );
+    } finally {
+      if (notifier.mounted) notifier.endDraftSave();
+    }
+  }
+
+  void tearDownMobileAutoSave() {
+    try {
+      disposeMobileAutoSave();
+    } finally {
+      final id = autoSaveComposerId;
+      if (id != null) appProviderContainer.invalidate(composerAutoSaveProvider(id));
+    }
+  }
+
+  Future<void> clearComposerMobileSnapshot() {
+    if (autoSaveComposerId == null) return Future.value();
+    final accountId = mailboxDashBoardController.accountId.value;
+    final userName = mailboxDashBoardController.sessionCurrent?.username;
+    if (accountId == null || userName == null) return Future.value();
+    return _autoSaveNotifier()?.clearCache(accountId, userName) ?? Future.value();
+  }
+}

--- a/lib/features/composer/presentation/extensions/setup_email_attachments_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_attachments_extension.dart
@@ -55,6 +55,7 @@ extension SetupEmailAttachmentsExtension on ComposerController {
     EmailActionType.replyAll,
     EmailActionType.forward,
     EmailActionType.reopenComposerBrowser,
+    EmailActionType.restoreComposerFromPersistentCache,
   }.contains(currentEmailActionType);
 
   void _uploadAttachmentFromFileShare(List<SharedMediaFile> listSharedMediaFile) {

--- a/lib/features/composer/presentation/extensions/setup_email_content_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_content_extension.dart
@@ -44,6 +44,8 @@ extension SetupEmailContentExtension on ComposerController {
       await _loadReplyForwardEmailContent(arguments);
     } else if (currentEmailActionType == EmailActionType.reopenComposerBrowser) {
       await _loadReopenBrowserEmailContent(arguments);
+    } else if (currentEmailActionType == EmailActionType.restoreComposerFromPersistentCache) {
+      await _loadMobileRestoredEmailContent(arguments);
     } else {
       emailContentsViewState.value = Right(LoadEmailContentCompleted());
     }
@@ -193,6 +195,23 @@ extension SetupEmailContentExtension on ComposerController {
   void _setEmailContentFailure(GetEmailContentFailure failure) {
     emailContentsViewState.value = Left(failure);
     consumeState(Stream.value(Left(failure)));
+  }
+
+  Future<void> _loadMobileRestoredEmailContent(ComposerArguments arguments) async {
+    final content = arguments.emailContents ?? '';
+    final inlineImages = arguments.inlineImages ?? [];
+
+    if (content.trim().isEmpty) {
+      emailContentsViewState.value = Left(GetEmailContentFailure(EmptyEmailContentException()));
+      return;
+    }
+
+    if (inlineImages.isEmpty) {
+      emailContentsViewState.value = Right(GetEmailContentSuccess(htmlEmailContent: content));
+      return;
+    }
+
+    await _restoreInlineImages(content, inlineImages);
   }
 
   Future<void> _getEmailContent(

--- a/lib/features/composer/presentation/extensions/setup_email_important_flag_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_important_flag_extension.dart
@@ -12,6 +12,7 @@ extension SetupEmailImportantFlagExtension on ComposerController {
         isMarkAsImportant.value = arguments.presentationEmail?.isMarkAsImportant ?? false;
         break;
       case EmailActionType.reopenComposerBrowser:
+      case EmailActionType.restoreComposerFromPersistentCache:
         isMarkAsImportant.value = arguments.isMarkAsImportant ?? false;
         break;
       case EmailActionType.editSendingEmail:

--- a/lib/features/composer/presentation/extensions/setup_email_recipients_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_recipients_extension.dart
@@ -36,6 +36,7 @@ extension SetupEmailRecipientsExtension on ComposerController {
     EmailActionType.editAsNewEmail,
     EmailActionType.editDraft,
     EmailActionType.reopenComposerBrowser,
+    EmailActionType.restoreComposerFromPersistentCache,
   }.contains(currentEmailActionType);
 
   bool get _isDirectToAddressAction => const {

--- a/lib/features/composer/presentation/extensions/setup_email_request_read_receipt_flag_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_request_read_receipt_flag_extension.dart
@@ -10,7 +10,8 @@ import 'package:tmail_ui_user/features/server_settings/domain/state/get_server_s
 extension SetupEmailRequestReadReceiptFlagExtension on ComposerController {
 
   void setupEmailRequestReadReceiptFlag(ComposerArguments arguments) {
-    if (currentEmailActionType == EmailActionType.reopenComposerBrowser) {
+    if (currentEmailActionType == EmailActionType.reopenComposerBrowser ||
+        currentEmailActionType == EmailActionType.restoreComposerFromPersistentCache) {
       hasRequestReadReceipt.value = arguments.hasRequestReadReceipt ?? false;
     } else if (currentEmailActionType == EmailActionType.editSendingEmail) {
       hasRequestReadReceipt.value = arguments.sendingEmail?.email.hasRequestReadReceipt ?? false;

--- a/lib/features/composer/presentation/mobile_composer_bindings.dart
+++ b/lib/features/composer/presentation/mobile_composer_bindings.dart
@@ -1,0 +1,46 @@
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/caching/clients/composer_hive_cache_client.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_bindings.dart';
+import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_persistent_cache_datasource_impl.dart';
+import 'package:tmail_ui_user/features/email/presentation/model/composer_arguments.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.dart';
+
+class MobileComposerBindings extends ComposerBindings {
+  MobileComposerBindings({String? composerId, ComposerArguments? composerArguments})
+      : super.base(composerId: composerId, composerArguments: composerArguments);
+
+  @override
+  void bindPlatformCacheDatasourceImpl() {
+    Get.lazyPut(() => ComposerHiveCacheClient(), tag: composerId);
+    Get.lazyPut(() => ComposerPersistentCacheDatasourceImpl(
+      Get.find<ComposerHiveCacheClient>(tag: composerId),
+      Get.find<CacheExceptionThrower>(),
+    ), tag: composerId);
+  }
+
+  @override
+  void bindPlatformComposerCacheDatasource() {
+    Get.lazyPut<ComposerCacheDatasource>(
+      () => Get.find<ComposerPersistentCacheDatasourceImpl>(tag: composerId),
+      tag: composerId,
+    );
+  }
+
+  @override
+  void bindPlatformRichTextController() {
+    Get.lazyPut(() => RichTextMobileTabletController(), tag: composerId);
+  }
+
+  @override
+  void disposePlatformRichTextController() {
+    Get.delete<RichTextMobileTabletController>(tag: composerId);
+  }
+
+  @override
+  void disposePlatformCacheImpl() {
+    Get.delete<ComposerHiveCacheClient>(tag: composerId);
+    Get.delete<ComposerPersistentCacheDatasourceImpl>(tag: composerId);
+  }
+}

--- a/lib/features/composer/presentation/providers/composer_auto_save_notifier.dart
+++ b/lib/features/composer/presentation/providers/composer_auto_save_notifier.dart
@@ -1,0 +1,127 @@
+import 'package:core/utils/app_logger.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:tmail_ui_user/features/composer/presentation/providers/composer_cache_providers.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/resolve_composer_cache_for_restore_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/remove_all_composer_cache_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor.dart';
+
+class ComposerAutoSaveState extends Equatable {
+  final bool hasRecoverableSnapshot;
+  final bool isCleanClose;
+  final bool isSavingToDraftInProgress;
+  final String lastKnownHtmlContent;
+
+  const ComposerAutoSaveState({
+    this.hasRecoverableSnapshot = false,
+    this.isCleanClose = false,
+    this.isSavingToDraftInProgress = false,
+    this.lastKnownHtmlContent = '',
+  });
+
+  ComposerAutoSaveState copyWith({
+    bool? hasRecoverableSnapshot,
+    bool? isCleanClose,
+    bool? isSavingToDraftInProgress,
+    String? lastKnownHtmlContent,
+  }) =>
+      ComposerAutoSaveState(
+        hasRecoverableSnapshot: hasRecoverableSnapshot ?? this.hasRecoverableSnapshot,
+        isCleanClose: isCleanClose ?? this.isCleanClose,
+        isSavingToDraftInProgress: isSavingToDraftInProgress ?? this.isSavingToDraftInProgress,
+        lastKnownHtmlContent: lastKnownHtmlContent ?? this.lastKnownHtmlContent,
+      );
+
+  @override
+  List<Object?> get props => [
+        hasRecoverableSnapshot,
+        isCleanClose,
+        isSavingToDraftInProgress,
+        lastKnownHtmlContent,
+      ];
+}
+
+/// Riverpod [StateNotifier] for Android composer auto-save (see ADR-0086).
+/// Keyed by composerId so each [ComposerController] gets an isolated instance.
+/// Must be invalidated from [ComposerController.onClose] to prevent unbounded
+/// family-instance growth in the global [ProviderContainer].
+class ComposerAutoSaveNotifier extends StateNotifier<ComposerAutoSaveState> {
+  final ResolveComposerCacheForRestoreInteractor _resolveInteractor;
+  final RemoveAllComposerCacheInteractor _removeInteractor;
+
+  ComposerAutoSaveNotifier(
+    this._resolveInteractor,
+    this._removeInteractor,
+  ) : super(const ComposerAutoSaveState());
+
+  bool get hasRecoverableSnapshot => state.hasRecoverableSnapshot;
+  bool get isCleanClose => state.isCleanClose;
+  bool get isSavingToDraftInProgress => state.isSavingToDraftInProgress;
+  String get lastKnownHtmlContent => state.lastKnownHtmlContent;
+
+  void onSnapshotSaved() {
+    state = state.copyWith(hasRecoverableSnapshot: true);
+    log('ComposerAutoSaveNotifier::onSnapshotSaved: snapshot recorded');
+  }
+
+  void setCleanClose() {
+    state = state.copyWith(isCleanClose: true);
+    log('ComposerAutoSaveNotifier::setCleanClose: flagged');
+  }
+
+  void updateLastKnownContent(String content) {
+    state = state.copyWith(lastKnownHtmlContent: content);
+  }
+
+  void beginDraftSave() {
+    state = state.copyWith(isSavingToDraftInProgress: true);
+  }
+
+  void endDraftSave() {
+    state = state.copyWith(isSavingToDraftInProgress: false);
+  }
+
+  Future<ComposerPersistentCache?> restore(
+    AccountId accountId,
+    UserName userName,
+  ) async {
+    final result = await _resolveInteractor.execute(accountId, userName);
+    return result.fold(
+      (failure) {
+        log('ComposerAutoSaveNotifier::restore: failure=${failure.runtimeType}');
+        return null;
+      },
+      (success) {
+        if (success is! ResolveComposerCacheForRestoreSuccess) return null;
+        final cache = success.cache;
+        if (cache != null) {
+          state = state.copyWith(hasRecoverableSnapshot: true);
+          log('ComposerAutoSaveNotifier::restore: found snapshot');
+        }
+        return cache;
+      },
+    );
+  }
+
+  Future<void> clearCache(AccountId accountId, UserName userName) async {
+    final result = await _removeInteractor.execute(accountId, userName);
+    result.fold(
+      (failure) => log('ComposerAutoSaveNotifier::clearCache: failure=${failure.runtimeType}'),
+      (_) {
+        state = state.copyWith(hasRecoverableSnapshot: false);
+        log('ComposerAutoSaveNotifier::clearCache: cleared');
+      },
+    );
+  }
+}
+
+final composerAutoSaveProvider = StateNotifierProvider.family<
+    ComposerAutoSaveNotifier, ComposerAutoSaveState, String>(
+  (ref, composerId) => ComposerAutoSaveNotifier(
+    ref.read(resolveComposerCacheForRestoreProvider),
+    ref.read(removeAllComposerCacheProvider),
+  ),
+);

--- a/lib/features/composer/presentation/providers/composer_cache_providers.dart
+++ b/lib/features/composer/presentation/providers/composer_cache_providers.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tmail_ui_user/features/caching/clients/composer_hive_cache_client.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_persistent_cache_datasource_impl.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/repository/composer_cache_repository_impl.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/composer_cache_repository.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/mark_composer_cache_clean_close_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/remove_all_composer_cache_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.dart';
+
+final _composerHiveCacheClientProvider =
+    Provider<ComposerHiveCacheClient>((_) => ComposerHiveCacheClient());
+
+final _cacheExceptionThrowerProvider =
+    Provider<CacheExceptionThrower>((_) => CacheExceptionThrower());
+
+final _composerCacheDatasourceProvider = Provider<ComposerCacheDatasource>(
+  (ref) => ComposerPersistentCacheDatasourceImpl(
+    ref.read(_composerHiveCacheClientProvider),
+    ref.read(_cacheExceptionThrowerProvider),
+  ),
+);
+
+final composerCacheRepositoryProvider = Provider<ComposerCacheRepository>(
+  (ref) => ComposerCacheRepositoryImpl(ref.read(_composerCacheDatasourceProvider)),
+);
+
+final removeAllComposerCacheProvider = Provider<RemoveAllComposerCacheInteractor>(
+  (ref) => RemoveAllComposerCacheInteractor(ref.read(composerCacheRepositoryProvider)),
+);
+
+final markComposerLocalCacheCleanCloseProvider = Provider<MarkComposerCacheCleanCloseInteractor>(
+  (ref) => MarkComposerCacheCleanCloseInteractor(ref.read(composerCacheRepositoryProvider)),
+);
+
+final resolveComposerCacheForRestoreProvider = Provider<ResolveComposerCacheForRestoreInteractor>(
+  (ref) => ResolveComposerCacheForRestoreInteractor(ref.read(composerCacheRepositoryProvider)),
+);

--- a/lib/features/composer/presentation/view/mobile/mobile_editor_view.dart
+++ b/lib/features/composer/presentation/view/mobile/mobile_editor_view.dart
@@ -110,6 +110,7 @@ class MobileEditorView extends StatelessWidget with EditorViewMixin {
       EmailActionType.editSendingEmail,
       EmailActionType.composeFromContentShared,
       EmailActionType.reopenComposerBrowser,
+      EmailActionType.restoreComposerFromPersistentCache,
       EmailActionType.composeFromMailtoUri,
       EmailActionType.composeFromUnsubscribeMailtoLink,
       EmailActionType.editAsNewEmail,

--- a/lib/features/composer/presentation/web_composer_bindings.dart
+++ b/lib/features/composer/presentation/web_composer_bindings.dart
@@ -1,0 +1,42 @@
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_bindings.dart';
+import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_web_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_session_cache_datasource_impl.dart';
+import 'package:tmail_ui_user/features/email/presentation/model/composer_arguments.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.dart';
+
+class WebComposerBindings extends ComposerBindings {
+  WebComposerBindings({String? composerId, ComposerArguments? composerArguments})
+      : super.base(composerId: composerId, composerArguments: composerArguments);
+
+  @override
+  void bindPlatformCacheDatasourceImpl() {
+    Get.lazyPut(() => ComposerSessionCacheDatasourceImpl(
+      Get.find<CacheExceptionThrower>(),
+    ), tag: composerId);
+  }
+
+  @override
+  void bindPlatformComposerCacheDatasource() {
+    Get.lazyPut<ComposerCacheDatasource>(
+      () => Get.find<ComposerSessionCacheDatasourceImpl>(tag: composerId),
+      tag: composerId,
+    );
+  }
+
+  @override
+  void bindPlatformRichTextController() {
+    Get.lazyPut(() => RichTextWebController(), tag: composerId);
+  }
+
+  @override
+  void disposePlatformRichTextController() {
+    Get.delete<RichTextWebController>(tag: composerId);
+  }
+
+  @override
+  void disposePlatformCacheImpl() {
+    Get.delete<ComposerSessionCacheDatasourceImpl>(tag: composerId);
+  }
+}

--- a/lib/features/email/presentation/model/composer_arguments.dart
+++ b/lib/features/email/presentation/model/composer_arguments.dart
@@ -7,6 +7,7 @@ import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 
 import 'package:tmail_ui_user/features/composer/presentation/model/screen_display_mode.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/model/sending_email.dart';
 import 'package:tmail_ui_user/features/sending_queue/presentation/model/sending_email_action_type.dart';
 import 'package:tmail_ui_user/main/routes/router_arguments.dart';
@@ -225,6 +226,23 @@ class ComposerArguments extends RouterArguments {
   SendingEmailActionType get sendingEmailActionType => sendingEmail != null
     ? SendingEmailActionType.edit
     : SendingEmailActionType.create;
+
+  factory ComposerArguments.fromComposerPersistentCache(ComposerPersistentCache cache) =>
+    ComposerArguments(
+      emailActionType: EmailActionType.restoreComposerFromPersistentCache,
+      presentationEmail: cache.email?.toPresentationEmail(),
+      emailContents: cache.email?.emailContentList.asHtmlString,
+      attachments: cache.email?.allAttachments.getListAttachmentsDisplayedOutside(
+        cache.email?.htmlBodyAttachments ?? [],
+      ),
+      selectedIdentityId: cache.email?.identityIdFromHeader,
+      inlineImages: cache.email?.allAttachments.listAttachmentsDisplayedInContent,
+      hasRequestReadReceipt: cache.hasRequestReadReceipt,
+      isMarkAsImportant: cache.isMarkAsImportant,
+      composerId: cache.composerId,
+      savedActionType: cache.actionType,
+      savedEmailDraftId: cache.draftEmailId,
+    );
 
   factory ComposerArguments.fromUnsubscribeMailtoLink({
     List<EmailAddress>? listEmailAddress,

--- a/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
@@ -3,6 +3,7 @@ import 'package:core/data/network/download/download_manager.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/utils/config/app_config_loader.dart';
 import 'package:core/utils/file_utils.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:core/utils/preview_eml_file_utils.dart';
 import 'package:core/utils/print_utils.dart';
 import 'package:get/get.dart';
@@ -82,7 +83,6 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/hi
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/local_app_grid_datasource_impl.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/local_spam_report_datasource_impl.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/search_datasource_impl.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_session_cache_datasource_impl.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/local/local_sort_order_manager.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/network/linagora_ecosystem_api.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/repository/app_grid_repository_impl.dart';
@@ -112,6 +112,8 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/store_l
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/store_spam_report_state_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/bindings/email_action_interactor_bindings.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/bindings/linagora_ecosystem_interactor_bindings.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/bindings/mobile_mailbox_dashboard_bindings.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/bindings/web_mailbox_dashboard_bindings.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/app_grid_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
@@ -169,7 +171,19 @@ import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.da
 import 'package:tmail_ui_user/main/exceptions/thrower/remote_exception_thrower.dart';
 import 'package:tmail_ui_user/main/utils/ios_sharing_manager.dart';
 
-class MailboxDashBoardBindings extends BaseBindings {
+abstract class MailboxDashBoardBindings extends BaseBindings {
+
+  MailboxDashBoardBindings.base();
+
+  factory MailboxDashBoardBindings() {
+    if (PlatformInfo.isWeb) {
+      return WebMailboxDashboardBindings();
+    }
+    return MobileMailboxDashboardBindings();
+  }
+
+  void bindPlatformDatasourceImpl();
+  void bindPlatformDatasource();
 
   @override
   void dependencies() {
@@ -269,12 +283,12 @@ class MailboxDashBoardBindings extends BaseBindings {
     Get.lazyPut<StateDataSource>(() => Get.find<StateDataSourceImpl>());
     Get.lazyPut<PrintFileDataSource>(() => Get.find<PrintFileDataSourceImpl>());
     Get.lazyPut<MailboxDataSource>(() => Get.find<MailboxDataSourceImpl>());
-    Get.lazyPut<ComposerCacheDatasource>(() => Get.find<ComposerSessionCacheDatasourceImpl>());
     Get.lazyPut<MailboxCacheDataSourceImpl>(() => Get.find<MailboxCacheDataSourceImpl>());
     Get.lazyPut<ServerSettingsDataSource>(
       () => Get.find<RemoteServerSettingsDataSourceImpl>());
     Get.lazyPut<IdentityCreatorDataSource>(() => Get.find<LocalIdentityCreatorDataSourceImpl>());
     Get.lazyPut<AppGridDatasource>(() => Get.find<AppGridDatasourceImpl>());
+    bindPlatformDatasource();
   }
 
   @override
@@ -317,8 +331,6 @@ class MailboxDashBoardBindings extends BaseBindings {
     Get.lazyPut(() => MailboxCacheDataSourceImpl(
       Get.find<MailboxCacheManager>(),
       Get.find<CacheExceptionThrower>()));
-    Get.lazyPut(() => ComposerSessionCacheDatasourceImpl(
-      Get.find<CacheExceptionThrower>()));
     Get.lazyPut(() => LocalSpamReportDataSourceImpl(
       Get.find<PreferencesSettingManager>(),
       Get.find<CacheExceptionThrower>(),
@@ -357,6 +369,7 @@ class MailboxDashBoardBindings extends BaseBindings {
       Get.find<AppConfigLoader>(),
       Get.find<CacheExceptionThrower>(),
     ));
+    bindPlatformDatasourceImpl();
   }
 
   @override

--- a/lib/features/mailbox_dashboard/presentation/bindings/mobile_mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/mobile_mailbox_dashboard_bindings.dart
@@ -1,0 +1,28 @@
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/caching/clients/composer_hive_cache_client.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_persistent_cache_datasource_impl.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.dart';
+
+class MobileMailboxDashboardBindings extends MailboxDashBoardBindings {
+  MobileMailboxDashboardBindings() : super.base();
+
+  @override
+  void bindPlatformDatasourceImpl() {
+    Get.lazyPut(() => ComposerHiveCacheClient());
+    Get.lazyPut(
+      () => ComposerPersistentCacheDatasourceImpl(
+        Get.find<ComposerHiveCacheClient>(),
+        Get.find<CacheExceptionThrower>(),
+      ),
+    );
+  }
+
+  @override
+  void bindPlatformDatasource() {
+    Get.lazyPut<ComposerCacheDatasource>(
+      () => Get.find<ComposerPersistentCacheDatasourceImpl>(),
+    );
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/bindings/web_mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/web_mailbox_dashboard_bindings.dart
@@ -1,0 +1,25 @@
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource/composer_cache_datasource.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/datasource_impl/composer_session_cache_datasource_impl.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.dart';
+
+class WebMailboxDashboardBindings extends MailboxDashBoardBindings {
+  WebMailboxDashboardBindings() : super.base();
+
+  @override
+  void bindPlatformDatasourceImpl() {
+    Get.lazyPut(
+      () => ComposerSessionCacheDatasourceImpl(
+        Get.find<CacheExceptionThrower>(),
+      ),
+    );
+  }
+
+  @override
+  void bindPlatformDatasource() {
+    Get.lazyPut<ComposerCacheDatasource>(
+      () => Get.find<ComposerSessionCacheDatasourceImpl>(),
+    );
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -146,6 +146,7 @@ import 'package:tmail_ui_user/features/mailbox/presentation/mixin/handle_team_ma
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/initialize_app_language.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/notify_thread_detail_setting_updated.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_composer_restore_on_mobile_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/open_and_close_composer_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/quick_search_emails_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/reopen_composer_cache_extension.dart';
@@ -904,6 +905,8 @@ class MailboxDashBoardController extends ReloadableController
     if (PlatformInfo.isWeb) {
       _handleComposerCache();
     }
+
+    unawaited(checkAndRestoreComposerOnMobile());
 
     if (PlatformInfo.isAndroid && !_notificationManager.isNotificationClickedOnTerminate) {
       _handleClickNotificationOnAndroidInTerminated();

--- a/lib/features/mailbox_dashboard/presentation/extensions/handle_composer_restore_on_mobile_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/handle_composer_restore_on_mobile_extension.dart
@@ -1,0 +1,52 @@
+import 'package:core/utils/app_logger.dart';
+import 'package:core/utils/platform_info.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:tmail_ui_user/features/composer/presentation/providers/composer_cache_providers.dart';
+import 'package:tmail_ui_user/features/email/presentation/model/composer_arguments.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/resolve_composer_cache_for_restore_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/open_and_close_composer_extension.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
+
+extension HandleComposerRestoreOnMobileExtension on MailboxDashBoardController {
+  Future<void> checkAndRestoreComposerOnMobile() async {
+    if (!PlatformInfo.isAndroid) return;
+
+    final currentAccountId = accountId.value;
+    final currentUserName = sessionCurrent?.username;
+    if (currentAccountId == null || currentUserName == null) return;
+
+    try {
+      final cache = await _resolveRestorableCache(currentAccountId, currentUserName);
+      if (cache == null) return;
+      log('HandleComposerRestoreOnMobileExtension::checkAndRestoreComposerOnMobile: reopening composer');
+      openComposer(ComposerArguments.fromComposerPersistentCache(cache));
+    } catch (e, stackTrace) {
+      logWarning('HandleComposerRestoreOnMobileExtension::checkAndRestoreComposerOnMobile: error=$e\n$stackTrace');
+    }
+  }
+
+  Future<ComposerPersistentCache?> _resolveRestorableCache(
+    AccountId accountId,
+    UserName userName,
+  ) async {
+    final result = await appProviderContainer
+        .read(resolveComposerCacheForRestoreProvider)
+        .execute(accountId, userName);
+    return result.fold(
+      (failure) {
+        log('HandleComposerRestoreOnMobileExtension::_resolveRestorableCache: failure=${failure.runtimeType}');
+        return null;
+      },
+      (success) {
+        if (success is ResolveComposerCacheForRestoreSuccess) {
+          return success.cache;
+        }
+        log('HandleComposerRestoreOnMobileExtension::_resolveRestorableCache: unexpected success type=${success.runtimeType}');
+        return null;
+      }
+    );
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/extensions/open_and_close_composer_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/open_and_close_composer_extension.dart
@@ -57,6 +57,9 @@ extension OpenAndCloseComposerExtension on MailboxDashBoardController {
   Future<void> _openComposerOnMobile(ComposerArguments arguments) async {
     BackButtonInterceptor.removeByName(AppRoutes.dashboard);
 
+    final composerId = arguments.composerId ?? DateTime.now().millisecondsSinceEpoch.toString();
+    final argsWithId = arguments.copyWith(composerId: composerId);
+
     bool isTabletPlatform = currentContext != null
         && !responsiveUtils.isScreenWithShortestSide(currentContext!);
 
@@ -68,9 +71,9 @@ extension OpenAndCloseComposerExtension on MailboxDashBoardController {
 
       result = await Get.to(
         () => const ComposerView(),
-        binding: ComposerBindings(),
+        binding: ComposerBindings(composerId: composerId),
         opaque: false,
-        arguments: arguments,
+        arguments: argsWithId,
       );
 
       if (PlatformInfo.isIOS) {
@@ -80,7 +83,7 @@ extension OpenAndCloseComposerExtension on MailboxDashBoardController {
         );
       }
     } else {
-      result = await push(AppRoutes.composer, arguments: arguments);
+      result = await push(AppRoutes.composer, arguments: argsWithId);
     }
 
     BackButtonInterceptor.add(onBackButtonInterceptor, name: AppRoutes.dashboard);

--- a/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
+++ b/lib/features/thread_detail/presentation/extension/thread_detail_on_selected_email_updated.dart
@@ -18,7 +18,11 @@ extension ThreadDetailOnSelectedEmailUpdated on ThreadDetailController {
     PresentationEmail? selectedEmail,
     BuildContext? context,
   ) {
-    if (selectedEmail?.id == null && mailboxDashBoardController.isEmailOpened) {
+    final selectedPresentationEmail = selectedEmail;
+    final selectedPresentationEmailId = selectedPresentationEmail?.id;
+    final selectedPresentationEmailThreadId = selectedPresentationEmail?.threadId;
+
+    if (selectedPresentationEmailId == null && mailboxDashBoardController.isEmailOpened) {
       closeThreadDetailAction();
       return;
     }
@@ -27,23 +31,23 @@ extension ThreadDetailOnSelectedEmailUpdated on ThreadDetailController {
     onKeyboardShortcutInit();
     scrollController ??= ScrollController();
 
-    if (currentExpandedEmailId.value == null) {
+    if (currentExpandedEmailId.value == null && selectedPresentationEmail != null && selectedPresentationEmailId != null) {
       loadThreadOnThreadChanged = isThreadDetailEnabled;
-      _preloadSelectedEmail(selectedEmail!);
+      _preloadSelectedEmail(selectedPresentationEmail);
       return;
     }
 
     // Thread setting updated, no need to dispose current single email controller
-    if (currentExpandedEmailId.value == selectedEmail!.id) {
-      _preloadSelectedEmail(selectedEmail);
+    if (currentExpandedEmailId.value == selectedPresentationEmailId && selectedPresentationEmail != null) {
+      _preloadSelectedEmail(selectedPresentationEmail);
 
-      if (isThreadDetailEnabled && selectedEmail.threadId != null) {
-        final mailboxContain = selectedEmail.findMailboxContain(
+      if (isThreadDetailEnabled && selectedPresentationEmailThreadId != null) {
+        final mailboxContain = selectedPresentationEmail.findMailboxContain(
           mailboxDashBoardController.mapMailboxById,
         );
         mailboxDashBoardController.dispatchThreadDetailUIAction(
           LoadThreadDetailAfterSelectedEmailAction(
-            selectedEmail.threadId!,
+            selectedPresentationEmailThreadId,
             isSentMailbox: mailboxContain?.isSent == true,
           )
         );
@@ -60,7 +64,10 @@ extension ThreadDetailOnSelectedEmailUpdated on ThreadDetailController {
     }
 
     loadThreadOnThreadChanged = isThreadDetailEnabled;
-    _preloadSelectedEmail(selectedEmail);
+
+    if (selectedPresentationEmail != null) {
+      _preloadSelectedEmail(selectedPresentationEmail);
+    }
   }
 
   void _preloadSelectedEmail(PresentationEmail selectedEmail) {

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -39,6 +39,7 @@ import 'package:tmail_ui_user/features/composer/presentation/composer_controller
 import 'package:tmail_ui_user/features/composer/presentation/composer_view_web.dart';
 import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_web_controller.dart';
+import 'package:tmail_ui_user/features/composer/presentation/extensions/handle_mobile_auto_save_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/setup_selected_identity_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/formatting_options_state.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/saved_composing_email.dart';
@@ -753,6 +754,126 @@ void main() {
             equals(savedEmailDraft.asString().hashCode),
           );
         });
+      });
+    });
+
+    group('markCleanClose - platform guard:', () {
+      // composerController has composerId = null in this test setup.
+      // _autoSaveNotifier() returns null for null composerId, so no provider
+      // entry is created regardless of platform. These tests verify that
+      // markCleanClose() does not throw and behaves safely on all platforms.
+
+      test(
+        'Should not throw on web\n'
+        'When composerId is null',
+      () {
+        PlatformInfo.isTestingForWeb = true;
+        addTearDown(() => PlatformInfo.isTestingForWeb = false);
+
+        expect(
+          () => composerController?.markCleanClose(),
+          returnsNormally,
+        );
+      });
+
+      test(
+        'Should not throw on non-web\n'
+        'When composerId is null',
+      () {
+        PlatformInfo.isTestingForWeb = false;
+
+        expect(
+          () => composerController?.markCleanClose(),
+          returnsNormally,
+        );
+      });
+    });
+
+    group('tearDownMobileAutoSave safety:', () {
+      // tearDownMobileAutoSave is only called on Android (onClose guard).
+      // With composerId = null, disposeMobileAutoSave cancels any timers and
+      // invalidate is skipped. Verify no exception is thrown.
+      test(
+        'Should not throw\n'
+        'When composerId is null and timers are not started',
+      () {
+        expect(
+          () => composerController?.tearDownMobileAutoSave(),
+          returnsNormally,
+        );
+      });
+    });
+
+    group('buildCreateEmailRequestForAutoSave htmlContent override:', () {
+      // ADR-0086 Layer 1: _saveSnapshotToCache always passes effectiveContent
+      // (fresh or lastKnownHtmlContent fallback) as htmlContent so getText()
+      // is never called a second time inside buildCreateEmailRequestForAutoSave.
+
+      const fallbackHtml = '<p>last known content</p>';
+      const editorHtml = '<p>live editor content</p>';
+
+      void arrangeComposerState() {
+        final args = ComposerArguments(
+          emailActionType: EmailActionType.compose,
+          displayMode: ScreenDisplayMode.normal,
+        );
+        composerController?.composerArguments.value = args;
+        composerController?.currentEmailActionType = EmailActionType.compose;
+        composerController?.richTextMobileTabletController =
+            mockRichTextMobileTabletController;
+        when(mockUploadController.attachmentsUploaded).thenReturn([]);
+        when(mockComposerRepository.removeCollapsedExpandedSignatureEffect(
+          emailContent: anyNamed('emailContent'),
+        )).thenAnswer((i) async =>
+            i.namedArguments[const Symbol('emailContent')] as String);
+      }
+
+      test(
+        'Should use provided htmlContent\n'
+        'When htmlContent is non-empty — getText() must not be called',
+      () async {
+        arrangeComposerState();
+        when(mockRichTextMobileTabletController.htmlEditorApi)
+            .thenReturn(mockHtmlEditorApi);
+        final request = await composerController
+            ?.buildCreateEmailRequestForAutoSave(htmlContent: fallbackHtml);
+
+        expect(request, isNotNull);
+        expect(request?.emailContent, equals(fallbackHtml));
+        verifyNever(mockHtmlEditorApi.getText());
+      });
+
+      test(
+        'Should call getContentInEditor\n'
+        'When htmlContent is null',
+      () async {
+        arrangeComposerState();
+        when(mockRichTextMobileTabletController.htmlEditorApi)
+            .thenReturn(mockHtmlEditorApi);
+        when(mockHtmlEditorApi.getText())
+            .thenAnswer((_) async => editorHtml);
+
+        final request = await composerController
+            ?.buildCreateEmailRequestForAutoSave();
+
+        expect(request, isNotNull);
+        verify(mockHtmlEditorApi.getText()).called(greaterThanOrEqualTo(1));
+      });
+
+      test(
+        'Should use empty string and not call getText()\n'
+        'When htmlContent is empty — ensures _saveSnapshotToCache never triggers a second getText() call',
+      () async {
+        arrangeComposerState();
+        when(mockRichTextMobileTabletController.htmlEditorApi)
+            .thenReturn(mockHtmlEditorApi);
+
+        final request = await composerController
+            ?.buildCreateEmailRequestForAutoSave(htmlContent: '');
+
+        expect(request, isNotNull);
+        expect(request?.emailContent, equals(''));
+        verifyNever(mockHtmlEditorApi.getText());
       });
     });
   });

--- a/test/features/composer/presentation/providers/composer_auto_save_notifier_test.dart
+++ b/test/features/composer/presentation/providers/composer_auto_save_notifier_test.dart
@@ -1,0 +1,254 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/composer/presentation/providers/composer_auto_save_notifier.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/remove_all_composer_cache_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/resolve_composer_cache_for_restore_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/remove_all_composer_cache_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import '../../../../fixtures/session_fixtures.dart';
+import 'composer_auto_save_notifier_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<ResolveComposerCacheForRestoreInteractor>(),
+  MockSpec<RemoveAllComposerCacheInteractor>(),
+])
+void main() {
+  late MockResolveComposerCacheForRestoreInteractor mockResolveInteractor;
+  late MockRemoveAllComposerCacheInteractor mockRemoveInteractor;
+  late ComposerAutoSaveNotifier notifier;
+
+  final testAccountId = AccountFixtures.aliceAccountId;
+  final testUserName = SessionFixtures.aliceSession.username;
+
+  ComposerPersistentCache makeCache({
+    bool? isCleanClose,
+    int? timestampMs,
+    bool withEmail = false,
+  }) =>
+      ComposerPersistentCache(
+        isCleanClose: isCleanClose,
+        timestampMs: timestampMs ?? DateTime.now().millisecondsSinceEpoch,
+        email: withEmail ? Email() : null,
+      );
+
+  setUp(() {
+    mockResolveInteractor = MockResolveComposerCacheForRestoreInteractor();
+    mockRemoveInteractor = MockRemoveAllComposerCacheInteractor();
+    notifier = ComposerAutoSaveNotifier(mockResolveInteractor, mockRemoveInteractor);
+    when(mockRemoveInteractor.execute(any, any))
+        .thenAnswer((_) async => Right(RemoveAllComposerCacheSuccess()));
+  });
+
+  group('ComposerAutoSaveNotifier', () {
+    group('initial state', () {
+      test('all flags are false and content is empty', () {
+        expect(notifier.hasRecoverableSnapshot, isFalse);
+        expect(notifier.isCleanClose, isFalse);
+        expect(notifier.isSavingToDraftInProgress, isFalse);
+        expect(notifier.lastKnownHtmlContent, isEmpty);
+      });
+    });
+
+    group('onSnapshotSaved', () {
+      test('sets hasRecoverableSnapshot=true', () {
+        notifier.onSnapshotSaved();
+        expect(notifier.hasRecoverableSnapshot, isTrue);
+      });
+
+      test('is idempotent when called multiple times', () {
+        notifier.onSnapshotSaved();
+        notifier.onSnapshotSaved();
+        expect(notifier.hasRecoverableSnapshot, isTrue);
+      });
+    });
+
+    group('setCleanClose', () {
+      test('sets isCleanClose=true', () {
+        notifier.setCleanClose();
+        expect(notifier.isCleanClose, isTrue);
+      });
+
+      test('does not affect hasRecoverableSnapshot', () {
+        notifier.onSnapshotSaved();
+        notifier.setCleanClose();
+        expect(notifier.hasRecoverableSnapshot, isTrue);
+        expect(notifier.isCleanClose, isTrue);
+      });
+    });
+
+    group('updateLastKnownContent', () {
+      test('stores provided html content', () {
+        notifier.updateLastKnownContent('<p>hello</p>');
+        expect(notifier.lastKnownHtmlContent, '<p>hello</p>');
+      });
+
+      test('overwrites previous content on subsequent calls', () {
+        notifier.updateLastKnownContent('<p>first</p>');
+        notifier.updateLastKnownContent('<p>second</p>');
+        expect(notifier.lastKnownHtmlContent, '<p>second</p>');
+      });
+    });
+
+    group('beginDraftSave / endDraftSave', () {
+      test('beginDraftSave sets isSavingToDraftInProgress=true', () {
+        notifier.beginDraftSave();
+        expect(notifier.isSavingToDraftInProgress, isTrue);
+      });
+
+      test('endDraftSave clears isSavingToDraftInProgress', () {
+        notifier.beginDraftSave();
+        notifier.endDraftSave();
+        expect(notifier.isSavingToDraftInProgress, isFalse);
+      });
+    });
+
+    group('restore', () {
+      group('returns null and keeps hasRecoverableSnapshot=false', () {
+        final cases = [
+          (
+            'on interactor failure',
+            Left<Failure, Success>(
+              ResolveComposerCacheForRestoreFailure(Exception('storage error')),
+            ),
+          ),
+          (
+            'when no restorable snapshot found',
+            Right<Failure, Success>(ResolveComposerCacheForRestoreSuccess(null)),
+          ),
+        ];
+
+        for (final (description, response) in cases) {
+          test(description, () async {
+            when(mockResolveInteractor.execute(any, any))
+                .thenAnswer((_) async => response);
+
+            final result = await notifier.restore(testAccountId, testUserName);
+
+            expect(result, isNull);
+            expect(notifier.hasRecoverableSnapshot, isFalse);
+          });
+        }
+      });
+
+      test('returns cache and sets hasRecoverableSnapshot=true when snapshot found', () async {
+        final cache = makeCache(withEmail: true);
+        when(mockResolveInteractor.execute(any, any)).thenAnswer(
+          (_) async => Right(ResolveComposerCacheForRestoreSuccess(cache)),
+        );
+
+        final result = await notifier.restore(testAccountId, testUserName);
+
+        expect(result, cache);
+        expect(notifier.hasRecoverableSnapshot, isTrue);
+      });
+
+      test('does not call removeInteractor — cleanup is owned by the interactor', () async {
+        final cache = makeCache(withEmail: true);
+        when(mockResolveInteractor.execute(any, any)).thenAnswer(
+          (_) async => Right(ResolveComposerCacheForRestoreSuccess(cache)),
+        );
+
+        await notifier.restore(testAccountId, testUserName);
+
+        verifyNever(mockRemoveInteractor.execute(any, any));
+      });
+    });
+
+    group('clearCache', () {
+      test('calls removeInteractor and clears hasRecoverableSnapshot', () async {
+        notifier.onSnapshotSaved();
+
+        await notifier.clearCache(testAccountId, testUserName);
+
+        verify(mockRemoveInteractor.execute(any, any)).called(1);
+        expect(notifier.hasRecoverableSnapshot, isFalse);
+      });
+
+      test('keeps hasRecoverableSnapshot=true when remove fails', () async {
+        notifier.onSnapshotSaved();
+        when(mockRemoveInteractor.execute(any, any)).thenAnswer(
+          (_) async => Left(RemoveAllComposerCacheFailure(Exception('err'))),
+        );
+
+        await notifier.clearCache(testAccountId, testUserName);
+
+        expect(notifier.hasRecoverableSnapshot, isTrue);
+      });
+    });
+
+    group('restore → clearCache sequence (Layer 3 restore-and-clear pattern)', () {
+      test(
+        'hasRecoverableSnapshot transitions true→false after restore succeeds then cache is cleared',
+        () async {
+          final cache = makeCache(withEmail: true);
+          when(mockResolveInteractor.execute(any, any)).thenAnswer(
+            (_) async => Right(ResolveComposerCacheForRestoreSuccess(cache)),
+          );
+
+          await notifier.restore(testAccountId, testUserName);
+          expect(notifier.hasRecoverableSnapshot, isTrue);
+
+          await notifier.clearCache(testAccountId, testUserName);
+
+          expect(notifier.hasRecoverableSnapshot, isFalse);
+          verify(mockRemoveInteractor.execute(any, any)).called(1);
+        },
+      );
+
+      test('clearCache calls removeInteractor even after failed restore', () async {
+        when(mockResolveInteractor.execute(any, any)).thenAnswer(
+          (_) async => Left(ResolveComposerCacheForRestoreFailure(Exception('err'))),
+        );
+
+        await notifier.restore(testAccountId, testUserName);
+        expect(notifier.hasRecoverableSnapshot, isFalse);
+
+        await notifier.clearCache(testAccountId, testUserName);
+
+        // clearCache always calls removeInteractor regardless of prior restore result
+        verify(mockRemoveInteractor.execute(any, any)).called(1);
+        expect(notifier.hasRecoverableSnapshot, isFalse);
+      });
+    });
+
+    group('isCleanClose does not block clearCache', () {
+      test('clearCache executes even after setCleanClose is flagged', () async {
+        notifier.onSnapshotSaved();
+        notifier.setCleanClose();
+        expect(notifier.isCleanClose, isTrue);
+
+        await notifier.clearCache(testAccountId, testUserName);
+
+        verify(mockRemoveInteractor.execute(any, any)).called(1);
+        expect(notifier.hasRecoverableSnapshot, isFalse);
+      });
+    });
+
+    group('concurrent flag independence', () {
+      test('beginDraftSave and setCleanClose can coexist', () {
+        notifier.beginDraftSave();
+        notifier.setCleanClose();
+
+        expect(notifier.isSavingToDraftInProgress, isTrue);
+        expect(notifier.isCleanClose, isTrue);
+      });
+
+      test('endDraftSave clears only isSavingToDraftInProgress, not isCleanClose', () {
+        notifier.beginDraftSave();
+        notifier.setCleanClose();
+        notifier.endDraftSave();
+
+        expect(notifier.isSavingToDraftInProgress, isFalse);
+        expect(notifier.isCleanClose, isTrue);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Dependencies

> **Merge order (sequential):**
> 1. [#4485 — TF-4473 Refactor reduce cyclomatic complexity in email setup extensions](https://github.com/linagora/tmail-flutter/pull/4485) ← **must be merged first**
> 2. PR1 — TF-4473 Add Android composer persistent cache — data and domain layer ← **must be merged second**
> 3. **This PR** ← merge last

This PR branches off the data/domain PR (PR1). It must not be merged until both #4485 and [PR1](https://github.com/linagora/tmail-flutter/pull/4492)  have landed.

---

## Summary

Wires up the [ADR-0086](docs/adr/0086-android-composer-draft-loss-on-background.md) feature end-to-end using the data/domain layer introduced in PR1. Implements two recovery paths:

- **Layer 1** — Periodic in-memory snapshot (30 s timer) as the last-resort content fallback when the editor cannot be queried at background time.
- **Layer 2** — Silent JMAP draft sync (`CreateEmailDraft` / `UpdateEmailDraft`) while the composer is in the foreground.

### Bindings — split web/mobile

`ComposerBindings` refactored to an abstract class with `MobileComposerBindings` / `WebComposerBindings` subclasses:
- **Mobile path** — registers the persistent Hive datasource (`ComposerPersistentCacheDatasourceImpl`).
- **Web path** — keeps the existing session datasource (`ComposerSessionCacheDatasourceImpl`).

Same split applied to `MailboxDashBoardBindings` → `MobileMailboxDashboardBindings` / `WebMailboxDashboardBindings`.

### Auto-save lifecycle (`HandleMobileAutoSaveExtension`)

- **`AppLifecycleListener`** — on `inactive`, starts a 300 ms guard timer then saves snapshot (guard filters transient overlays: permission dialogs, incoming calls); on `resumed`, attempts content restore.
- **30 s periodic timer** — keeps `lastKnownHtmlContent` in the notifier in sync as a Layer 1 fallback.
- **`markCleanClose()`** — called on intentional close (send / explicit discard) to prevent spurious restore on next open.
- **`restoreIfEditorBlank()`** — called both on `resumed` lifecycle and in `onLoadCompletedMobileEditorAction` to cover the initial-open crash-recovery case (not just background → foreground).

### State management (`ComposerAutoSaveNotifier`)

Riverpod `StateNotifier` keyed by `composerId`, tracking:
- `isCleanClose` — blocks snapshot writes after intentional close.
- `isSavingToDraftInProgress` — prevents concurrent JMAP calls.
- `lastKnownHtmlContent` — Layer 1 fallback content.
- `hasRecoverableSnapshot` — signals that a crash snapshot exists.

Invalidated in `ComposerController.onClose` to prevent unbounded provider family memory growth.

### Crash restore on app launch (`HandleComposerRestoreOnMobileExtension`)

`checkAndRestoreComposerOnMobile()` — called from `MailboxDashBoardController` after session is ready. Calls `ResolveComposerCacheForRestoreInteractor`, and if a restorable snapshot is found, reopens the composer via `ComposerArguments.fromComposerPersistentCache`.

### Other

- **`ComposerArguments`** — new `autoSaveComposerId` (Riverpod provider keying) and `savedEmailDraftId` (JMAP update-vs-create disambiguation) fields.
- **`create_email_request_extension`** and setup extensions — minor updates to pass auto-save metadata through `CreateEmailRequest`.
- **ADR-0086** — updated to reflect final implementation decisions.

### Tests

- `ComposerAutoSaveNotifier` — 254 lines
- `ComposerController` additions — 121 lines
- `CreateEmailRequestExtension` — 93 lines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * **Android Auto-Save**: Draft emails are now automatically saved when you switch away from the app or the app closes unexpectedly. Your draft will be recovered when you reopen the app.
  * Improved draft recovery: Unsaved composer content is intelligently restored on app restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->