### PR TITLE
HOTFIX Sentry disable default replay

### DIFF
--- a/core/lib/utils/sentry/sentry_config.dart
+++ b/core/lib/utils/sentry/sentry_config.dart
@@ -40,10 +40,10 @@ class SentryConfig {
   final String? dist;
 
   // Release Health: The sampling rate for sessions (0.0 to 1.0). Defines the percentage of sessions to send.
-  final double sessionSampleRate;
+  final double? sessionSampleRate;
 
   // Error tracking: The sampling rate for errors (0.0 to 1.0). If set to 0.1, only 10% of errors are sent.
-  final double onErrorSampleRate;
+  final double? onErrorSampleRate;
 
   // Performance: Tracks UI rendering performance (slow and frozen frames).
   final bool enableFramesTracking;
@@ -54,8 +54,8 @@ class SentryConfig {
     required this.release,
     this.tracesSampleRate = 0.1,
     this.profilesSampleRate = 0.1,
-    this.sessionSampleRate = 1.0,
-    this.onErrorSampleRate = 1.0,
+    this.sessionSampleRate,
+    this.onErrorSampleRate,
     this.enableLogs = true,
     this.enableFramesTracking = true,
     this.isDebug = BuildUtils.isDebugMode,

--- a/lib/features/caching/entries/sentry_configuration_cache.dart
+++ b/lib/features/caching/entries/sentry_configuration_cache.dart
@@ -34,10 +34,10 @@ class SentryConfigurationCache extends HiveObject with EquatableMixin {
   final bool isAvailable;
 
   @HiveField(9)
-  final double sessionSampleRate;
+  final double? sessionSampleRate;
 
   @HiveField(10)
-  final double onErrorSampleRate;
+  final double? onErrorSampleRate;
 
   @HiveField(11)
   final bool enableFramesTracking;


### PR DESCRIPTION
## Description
Disable Sentry replay record by default. Config can still turn it back on if needed.

## Demo
### Before
<img width="1552" height="1012" alt="Screenshot 2026-05-07 at 12 01 58 PM" src="https://github.com/user-attachments/assets/a4a44140-4bb4-4b64-9ed7-2a9dfc775552" />

### After
<img width="1552" height="1012" alt="after" src="https://github.com/user-attachments/assets/798dda66-051e-4a7e-8a86-10ba59043107" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error and session sampling rates in Sentry configuration are now optional, providing greater flexibility in error tracking setup without requiring predefined default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->