### PR TITLE
Fix inline image

### DIFF
--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -10,7 +10,6 @@ import 'js_interop_stub.dart' if (dart.library.html) 'dart:js_interop';
 import 'dart:typed_data';
 
 import 'package:core/data/constants/constant.dart';
-import 'package:core/presentation/extensions/html_extension.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:flutter/material.dart';
 import 'package:universal_html/html.dart' as html;
@@ -329,12 +328,14 @@ class HtmlUtils {
 
   static String convertBase64ToImageResourceData({
     required String base64Data,
-    required String mimeType
+    required String mimeType,
   }) {
-    if (!base64Data.endsWith('==')) {
-      base64Data.append('==');
+    try {
+      return 'data:$mimeType;base64,${base64.normalize(base64Data)}';
+    } catch (e) {
+      logWarning('HtmlUtils::convertBase64ToImageResourceData: $e');
+      return 'data:$mimeType;base64,$base64Data';
     }
-    return 'data:$mimeType;base64,$base64Data';
   }
 
   static String generateHtmlDocument({

--- a/core/test/utils/html_utils_test.dart
+++ b/core/test/utils/html_utils_test.dart
@@ -1113,4 +1113,22 @@ void main() {
       );
     });
   });
+
+  group('HtmlUtils::convertBase64ToImageResourceData::', () {
+    test(
+      'When base64 data needs == padding (length % 4 == 2),\n'
+      'should return a data URI with properly padded base64',
+    () {
+      // "YQ" is "a" encoded in base64 without padding — needs "==" appended
+      const unpaddedBase64 = 'YQ';
+
+      final result = HtmlUtils.convertBase64ToImageResourceData(
+        base64Data: unpaddedBase64,
+        mimeType: 'image/png',
+      );
+
+      // The returned URI must have properly padded base64 so it can be decoded
+      expect(result, 'data:image/png;base64,YQ==');
+    });
+  });
 }

--- a/core/test/utils/html_utils_test.dart
+++ b/core/test/utils/html_utils_test.dart
@@ -1127,8 +1127,51 @@ void main() {
         mimeType: 'image/png',
       );
 
-      // The returned URI must have properly padded base64 so it can be decoded
       expect(result, 'data:image/png;base64,YQ==');
+    });
+
+    test(
+      'When base64 data needs = padding (length % 4 == 3),\n'
+      'should return a data URI with one = appended',
+    () {
+      // "YWI" is "ab" encoded in base64 without padding — needs "=" appended
+      const unpaddedBase64 = 'YWI';
+
+      final result = HtmlUtils.convertBase64ToImageResourceData(
+        base64Data: unpaddedBase64,
+        mimeType: 'image/png',
+      );
+
+      expect(result, 'data:image/png;base64,YWI=');
+    });
+
+    test(
+      'When base64 data is already aligned (length % 4 == 0),\n'
+      'should return a data URI with no padding added',
+    () {
+      // "YWJj" is "abc" encoded in base64 — already 4-byte aligned
+      const paddedBase64 = 'YWJj';
+
+      final result = HtmlUtils.convertBase64ToImageResourceData(
+        base64Data: paddedBase64,
+        mimeType: 'image/png',
+      );
+
+      expect(result, 'data:image/png;base64,YWJj');
+    });
+
+    test(
+      'When base64 data is invalid (contains illegal characters),\n'
+      'should fall back to raw data URI without crashing',
+    () {
+      const invalidBase64 = '!!!not-valid-base64!!!';
+
+      final result = HtmlUtils.convertBase64ToImageResourceData(
+        base64Data: invalidBase64,
+        mimeType: 'image/png',
+      );
+
+      expect(result, 'data:image/png;base64,$invalidBase64');
     });
   });
 }

--- a/docs/adr/0038-logic-for-displaying-attachment-types-in-emails.md
+++ b/docs/adr/0038-logic-for-displaying-attachment-types-in-emails.md
@@ -1,6 +1,7 @@
 # 38. Logic for displaying `attachment` types in emails
 
 Date: 2024-02-20
+Updated: 2026-05-12
 
 ## Status
 
@@ -8,12 +9,11 @@ Accepted
 
 ## Context
 
-- The logic for displaying `attachments` while reading emails is complex
-- Avoid unwanted loss of `attachments` with each new version release
+The logic for displaying attachments while reading emails is complex. Changes must be tracked here to avoid regressions across releases.
+
+An **orphaned inline attachment** has `Content-Disposition: inline` + `Content-ID` but no matching `<img src="cid:...">` in the HTML body (common with Outlook/Word copy-paste). This caused orphans to be invisible to the reader and silently re-attached on every reply/forward.
 
 ## Decision
-
-Brief the logic flows to make it easier to track changes during `attachment` display in emails:
 
 1. External attachments: Displayed as files outside the email content
 
@@ -21,14 +21,15 @@ Brief the logic flows to make it easier to track changes during `attachment` dis
   - `cid is NULL` AND `not in htmlBody` AND `does not satisfy this condition mimeType = 'application/rtf' && disposition = 'inline'`
   - `disposition != 'inline'` AND `not in htmlBody` AND `does not satisfy this condition mimeType='application/rtf' && disposition = 'inline'`
 
-2. Inline attachments: Displayed within the email body
+2. **Inline attachments** — displayed within the email body when:
+   - `cid is not NULL` AND `disposition = 'inline' || disposition = NULL`
 
-- Display is only allowed when the following conditions are met:
-  - `cid is not NULL` AND `disposition = 'inline' || disposition = NULL`
+3. **Orphaned inlines** — inline attachments whose CID has no matching `<img src="cid:...">` in the body are **promoted to the attachment panel** (viewer) and **dropped on reply/forward** (composer), consistent with Thunderbird and Outlook behavior.
 
 ## Consequences
 
-- Any changes to attachment display while reading emails should be updated in this ADR.
+- Any changes to attachment display must be updated in this ADR.
+- Orphaned inline attachments are visible in the attachment panel.
 
 ## References
 - [rfc2392](https://datatracker.ietf.org/doc/html/rfc2392)

--- a/integration_test/scenarios/search_email_with_sort_order_scenario.dart
+++ b/integration_test/scenarios/search_email_with_sort_order_scenario.dart
@@ -1,4 +1,5 @@
 
+import 'package:collection/collection.dart';
 import 'package:core/domain/extensions/list_datetime_extension.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
@@ -55,42 +56,34 @@ class SearchEmailWithSortOrderScenario extends BaseTestScenario {
     await _expectSearchResultEmailListVisible();
     await _expectEmailListDisplayedCorrectly(listUsername: listUsername);
 
-    await _validateSortOrder(sortOrderType);
-  }
-
-  Future<void> _validateSortOrder(EmailSortOrderType sortOrderType) async {
-    final validators = <EmailSortOrderType, Future<void> Function()>{
-      EmailSortOrderType.mostRecent: _expectEmailListSortedCorrectByMostRecent,
-      EmailSortOrderType.oldest: _expectEmailListSortedCorrectByOldest,
-      EmailSortOrderType.senderAscending: () => _expectEmailListSortedByStringProperty(
-        listUsername: listUsername,
-        ascending: true,
-        getValue: (tile) => tile.presentationEmail.firstEmailAddressInFrom,
-        buildExpected: (username) => '${username.toLowerCase()}@example.com',
-      ),
-      EmailSortOrderType.senderDescending: () => _expectEmailListSortedByStringProperty(
-        listUsername: listUsername,
-        ascending: false,
-        getValue: (tile) => tile.presentationEmail.firstEmailAddressInFrom,
-        buildExpected: (username) => '${username.toLowerCase()}@example.com',
-      ),
-      EmailSortOrderType.subjectAscending: () => _expectEmailListSortedByStringProperty(
-        listUsername: listUsername,
-        ascending: true,
-        getValue: (tile) => tile.presentationEmail.subject,
-        buildExpected: (username) => '$username send Bob',
-      ),
-      EmailSortOrderType.subjectDescending: () => _expectEmailListSortedByStringProperty(
-        listUsername: listUsername,
-        ascending: false,
-        getValue: (tile) => tile.presentationEmail.subject,
-        buildExpected: (username) => '$username send Bob',
-      ),
-      EmailSortOrderType.sizeAscending: () => _expectEmailListSortedBySize(ascending: true),
-      EmailSortOrderType.sizeDescending: () => _expectEmailListSortedBySize(ascending: false),
-    };
-    final validator = validators[sortOrderType];
-    if (validator != null) await validator();
+    switch (sortOrderType) {
+      case EmailSortOrderType.mostRecent:
+        await _expectEmailListSortedCorrectByMostRecent();
+        break;
+      case EmailSortOrderType.oldest:
+        await _expectEmailListSortedCorrectByOldest();
+        break;
+      case EmailSortOrderType.senderAscending:
+        await _expectEmailListSortedCorrectBySenderAscending(listUsername: listUsername);
+        break;
+      case EmailSortOrderType.senderDescending:
+        await _expectEmailListSortedCorrectBySenderDescending(listUsername: listUsername);
+        break;
+      case EmailSortOrderType.subjectAscending:
+        await _expectEmailListSortedCorrectBySubjectAscending(listUsername: listUsername);
+        break;
+      case EmailSortOrderType.subjectDescending:
+        await _expectEmailListSortedCorrectBySubjectDescending(listUsername: listUsername);
+        break;
+      case EmailSortOrderType.relevance:
+        break;
+      case EmailSortOrderType.sizeAscending:
+        await _expectEmailListSortedCorrectBySizeAscending(listUsername: listUsername);
+        break;
+      case EmailSortOrderType.sizeDescending:
+        await _expectEmailListSortedCorrectBySizeDescending(listUsername: listUsername);
+        break;
+    }
   }
 
   Future<void> _expectSearchViewVisible() async {
@@ -119,18 +112,59 @@ class SearchEmailWithSortOrderScenario extends BaseTestScenario {
     expect(find.byType(EmailTileBuilder), findsNWidgets(listUsername.length));
   }
 
-  Future<void> _expectEmailListSortedByStringProperty({
+  Future<void> _expectEmailListSortedCorrectBySenderAscending({
     required List<String> listUsername,
-    required bool ascending,
-    required String? Function(EmailTileBuilder) getValue,
-    required String Function(String) buildExpected,
   }) async {
     final listEmailTile = $.tester
       .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
-    final orderedList = ascending ? listUsername : listUsername.reversed.toList();
-    for (int i = 0; i < orderedList.length; i++) {
-      final emailTile = listEmailTile.elementAt(i);
-      expect(getValue(emailTile), equals(buildExpected(orderedList[i])));
+
+    for (int i = 0; i < listUsername.length; i++) {
+      EmailTileBuilder emailTile = listEmailTile.elementAt(i);
+      final senderName = emailTile.presentationEmail.firstEmailAddressInFrom;
+      expect(senderName, equals('${listUsername[i].toLowerCase()}@example.com'));
+    }
+  }
+
+  Future<void> _expectEmailListSortedCorrectBySenderDescending({
+    required List<String> listUsername,
+  }) async {
+    final listEmailTile = $.tester
+      .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
+
+    final reversedListUsername = listUsername.reversed.toList();
+
+    for (int i = 0; i < reversedListUsername.length; i++) {
+      EmailTileBuilder emailTile = listEmailTile.elementAt(i);
+      final senderName = emailTile.presentationEmail.firstEmailAddressInFrom;
+      expect(senderName, equals('${reversedListUsername[i].toLowerCase()}@example.com'));
+    }
+  }
+
+  Future<void> _expectEmailListSortedCorrectBySubjectAscending({
+    required List<String> listUsername,
+  }) async {
+    final listEmailTile = $.tester
+      .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
+
+    for (int i = 0; i < listUsername.length; i++) {
+      EmailTileBuilder emailTile = listEmailTile.elementAt(i);
+      final subject = emailTile.presentationEmail.subject;
+      expect(subject, equals('${listUsername[i]} send Bob'));
+    }
+  }
+
+  Future<void> _expectEmailListSortedCorrectBySubjectDescending({
+    required List<String> listUsername,
+  }) async {
+    final listEmailTile = $.tester
+      .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
+
+    final reversedListUsername = listUsername.reversed.toList();
+
+    for (int i = 0; i < reversedListUsername.length; i++) {
+      EmailTileBuilder emailTile = listEmailTile.elementAt(i);
+      final subject = emailTile.presentationEmail.subject;
+      expect(subject, equals('${reversedListUsername[i]} send Bob'));
     }
   }
 
@@ -158,13 +192,32 @@ class SearchEmailWithSortOrderScenario extends BaseTestScenario {
     expect(listReceiveAtTime.isSortedByOldestFirst(), isTrue);
   }
 
-  Future<void> _expectEmailListSortedBySize({required bool ascending}) async {
-    final sizeList = $.tester
-      .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder))
-      .map((emailTile) => emailTile.presentationEmail.size)
+  Future<void> _expectEmailListSortedCorrectBySizeAscending({
+    required List<String> listUsername,
+  }) async {
+    final listEmailTile = $.tester
+        .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
+
+    List<UnsignedInt> sizeList = listEmailTile
+      .mapIndexed((index, emailTile) => listEmailTile.elementAt(index).presentationEmail.size)
       .nonNulls
       .toList();
-    expect(_isSortedAscending(sizeList), equals(ascending));
+
+    expect(_isSortedAscending(sizeList), isTrue);
+  }
+
+  Future<void> _expectEmailListSortedCorrectBySizeDescending({
+    required List<String> listUsername,
+  }) async {
+    final listEmailTile = $.tester
+        .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
+
+    List<UnsignedInt> sizeList = listEmailTile
+      .mapIndexed((index, emailTile) => listEmailTile.elementAt(index).presentationEmail.size)
+      .nonNulls
+      .toList();
+
+    expect(_isSortedAscending(sizeList), isFalse);
   }
 
   bool _isSortedAscending(List<UnsignedInt> list) {

--- a/integration_test/scenarios/search_email_with_sort_order_scenario.dart
+++ b/integration_test/scenarios/search_email_with_sort_order_scenario.dart
@@ -1,5 +1,4 @@
 
-import 'package:collection/collection.dart';
 import 'package:core/domain/extensions/list_datetime_extension.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
@@ -56,34 +55,42 @@ class SearchEmailWithSortOrderScenario extends BaseTestScenario {
     await _expectSearchResultEmailListVisible();
     await _expectEmailListDisplayedCorrectly(listUsername: listUsername);
 
-    switch (sortOrderType) {
-      case EmailSortOrderType.mostRecent:
-        await _expectEmailListSortedCorrectByMostRecent();
-        break;
-      case EmailSortOrderType.oldest:
-        await _expectEmailListSortedCorrectByOldest();
-        break;
-      case EmailSortOrderType.senderAscending:
-        await _expectEmailListSortedCorrectBySenderAscending(listUsername: listUsername);
-        break;
-      case EmailSortOrderType.senderDescending:
-        await _expectEmailListSortedCorrectBySenderDescending(listUsername: listUsername);
-        break;
-      case EmailSortOrderType.subjectAscending:
-        await _expectEmailListSortedCorrectBySubjectAscending(listUsername: listUsername);
-        break;
-      case EmailSortOrderType.subjectDescending:
-        await _expectEmailListSortedCorrectBySubjectDescending(listUsername: listUsername);
-        break;
-      case EmailSortOrderType.relevance:
-        break;
-      case EmailSortOrderType.sizeAscending:
-        await _expectEmailListSortedCorrectBySizeAscending(listUsername: listUsername);
-        break;
-      case EmailSortOrderType.sizeDescending:
-        await _expectEmailListSortedCorrectBySizeDescending(listUsername: listUsername);
-        break;
-    }
+    await _validateSortOrder(sortOrderType);
+  }
+
+  Future<void> _validateSortOrder(EmailSortOrderType sortOrderType) async {
+    final validators = <EmailSortOrderType, Future<void> Function()>{
+      EmailSortOrderType.mostRecent: _expectEmailListSortedCorrectByMostRecent,
+      EmailSortOrderType.oldest: _expectEmailListSortedCorrectByOldest,
+      EmailSortOrderType.senderAscending: () => _expectEmailListSortedByStringProperty(
+        listUsername: listUsername,
+        ascending: true,
+        getValue: (tile) => tile.presentationEmail.firstEmailAddressInFrom,
+        buildExpected: (username) => '${username.toLowerCase()}@example.com',
+      ),
+      EmailSortOrderType.senderDescending: () => _expectEmailListSortedByStringProperty(
+        listUsername: listUsername,
+        ascending: false,
+        getValue: (tile) => tile.presentationEmail.firstEmailAddressInFrom,
+        buildExpected: (username) => '${username.toLowerCase()}@example.com',
+      ),
+      EmailSortOrderType.subjectAscending: () => _expectEmailListSortedByStringProperty(
+        listUsername: listUsername,
+        ascending: true,
+        getValue: (tile) => tile.presentationEmail.subject,
+        buildExpected: (username) => '$username send Bob',
+      ),
+      EmailSortOrderType.subjectDescending: () => _expectEmailListSortedByStringProperty(
+        listUsername: listUsername,
+        ascending: false,
+        getValue: (tile) => tile.presentationEmail.subject,
+        buildExpected: (username) => '$username send Bob',
+      ),
+      EmailSortOrderType.sizeAscending: () => _expectEmailListSortedBySize(ascending: true),
+      EmailSortOrderType.sizeDescending: () => _expectEmailListSortedBySize(ascending: false),
+    };
+    final validator = validators[sortOrderType];
+    if (validator != null) await validator();
   }
 
   Future<void> _expectSearchViewVisible() async {
@@ -112,59 +119,18 @@ class SearchEmailWithSortOrderScenario extends BaseTestScenario {
     expect(find.byType(EmailTileBuilder), findsNWidgets(listUsername.length));
   }
 
-  Future<void> _expectEmailListSortedCorrectBySenderAscending({
+  Future<void> _expectEmailListSortedByStringProperty({
     required List<String> listUsername,
+    required bool ascending,
+    required String? Function(EmailTileBuilder) getValue,
+    required String Function(String) buildExpected,
   }) async {
     final listEmailTile = $.tester
       .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
-
-    for (int i = 0; i < listUsername.length; i++) {
-      EmailTileBuilder emailTile = listEmailTile.elementAt(i);
-      final senderName = emailTile.presentationEmail.firstEmailAddressInFrom;
-      expect(senderName, equals('${listUsername[i].toLowerCase()}@example.com'));
-    }
-  }
-
-  Future<void> _expectEmailListSortedCorrectBySenderDescending({
-    required List<String> listUsername,
-  }) async {
-    final listEmailTile = $.tester
-      .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
-
-    final reversedListUsername = listUsername.reversed.toList();
-
-    for (int i = 0; i < reversedListUsername.length; i++) {
-      EmailTileBuilder emailTile = listEmailTile.elementAt(i);
-      final senderName = emailTile.presentationEmail.firstEmailAddressInFrom;
-      expect(senderName, equals('${reversedListUsername[i].toLowerCase()}@example.com'));
-    }
-  }
-
-  Future<void> _expectEmailListSortedCorrectBySubjectAscending({
-    required List<String> listUsername,
-  }) async {
-    final listEmailTile = $.tester
-      .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
-
-    for (int i = 0; i < listUsername.length; i++) {
-      EmailTileBuilder emailTile = listEmailTile.elementAt(i);
-      final subject = emailTile.presentationEmail.subject;
-      expect(subject, equals('${listUsername[i]} send Bob'));
-    }
-  }
-
-  Future<void> _expectEmailListSortedCorrectBySubjectDescending({
-    required List<String> listUsername,
-  }) async {
-    final listEmailTile = $.tester
-      .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
-
-    final reversedListUsername = listUsername.reversed.toList();
-
-    for (int i = 0; i < reversedListUsername.length; i++) {
-      EmailTileBuilder emailTile = listEmailTile.elementAt(i);
-      final subject = emailTile.presentationEmail.subject;
-      expect(subject, equals('${reversedListUsername[i]} send Bob'));
+    final orderedList = ascending ? listUsername : listUsername.reversed.toList();
+    for (int i = 0; i < orderedList.length; i++) {
+      final emailTile = listEmailTile.elementAt(i);
+      expect(getValue(emailTile), equals(buildExpected(orderedList[i])));
     }
   }
 
@@ -192,32 +158,13 @@ class SearchEmailWithSortOrderScenario extends BaseTestScenario {
     expect(listReceiveAtTime.isSortedByOldestFirst(), isTrue);
   }
 
-  Future<void> _expectEmailListSortedCorrectBySizeAscending({
-    required List<String> listUsername,
-  }) async {
-    final listEmailTile = $.tester
-        .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
-
-    List<UnsignedInt> sizeList = listEmailTile
-      .mapIndexed((index, emailTile) => listEmailTile.elementAt(index).presentationEmail.size)
+  Future<void> _expectEmailListSortedBySize({required bool ascending}) async {
+    final sizeList = $.tester
+      .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder))
+      .map((emailTile) => emailTile.presentationEmail.size)
       .nonNulls
       .toList();
-
-    expect(_isSortedAscending(sizeList), isTrue);
-  }
-
-  Future<void> _expectEmailListSortedCorrectBySizeDescending({
-    required List<String> listUsername,
-  }) async {
-    final listEmailTile = $.tester
-        .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
-
-    List<UnsignedInt> sizeList = listEmailTile
-      .mapIndexed((index, emailTile) => listEmailTile.elementAt(index).presentationEmail.size)
-      .nonNulls
-      .toList();
-
-    expect(_isSortedAscending(sizeList), isFalse);
+    expect(_isSortedAscending(sizeList), equals(ascending));
   }
 
   bool _isSortedAscending(List<UnsignedInt> list) {

--- a/lib/features/base/upgradeable/upgrade_hive_database_steps_v22.dart
+++ b/lib/features/base/upgradeable/upgrade_hive_database_steps_v22.dart
@@ -1,0 +1,22 @@
+import 'package:core/utils/platform_info.dart';
+import 'package:tmail_ui_user/features/base/upgradeable/upgrade_database_steps.dart';
+import 'package:tmail_ui_user/features/caching/caching_manager.dart';
+
+class UpgradeHiveDatabaseStepsV22 extends UpgradeDatabaseSteps {
+  final CachingManager _cachingManager;
+
+  UpgradeHiveDatabaseStepsV22(this._cachingManager);
+
+  @override
+  Future<void> onUpgrade(int oldVersion, int newVersion) async {
+    if (_shouldUpgrade(oldVersion, newVersion)) {
+      await _cachingManager.clearDetailedEmailCache();
+    }
+  }
+
+  bool _shouldUpgrade(int oldVersion, int newVersion) =>
+    oldVersion > 0 &&
+    oldVersion < newVersion &&
+    newVersion == 22 &&
+    PlatformInfo.isMobile;
+}

--- a/lib/features/caching/config/cache_version.dart
+++ b/lib/features/caching/config/cache_version.dart
@@ -1,4 +1,4 @@
 
 class CacheVersion {
-  static const int hiveDBVersion = 21;
+  static const int hiveDBVersion = 22;
 }

--- a/lib/features/caching/config/hive_cache_config.dart
+++ b/lib/features/caching/config/hive_cache_config.dart
@@ -18,6 +18,7 @@ import 'package:tmail_ui_user/features/base/upgradeable/upgrade_hive_database_st
 import 'package:tmail_ui_user/features/base/upgradeable/upgrade_hive_database_steps_v19.dart';
 import 'package:tmail_ui_user/features/base/upgradeable/upgrade_hive_database_steps_v20.dart';
 import 'package:tmail_ui_user/features/base/upgradeable/upgrade_hive_database_steps_v21.dart';
+import 'package:tmail_ui_user/features/base/upgradeable/upgrade_hive_database_steps_v22.dart';
 import 'package:tmail_ui_user/features/base/upgradeable/upgrade_hive_database_steps_v7.dart';
 import 'package:tmail_ui_user/features/caching/caching_manager.dart';
 import 'package:tmail_ui_user/features/caching/config/cache_version.dart';
@@ -101,6 +102,7 @@ class HiveCacheConfig {
     await UpgradeHiveDatabaseStepsV19(cachingManager).onUpgrade(oldVersion, newVersion);
     await UpgradeHiveDatabaseStepsV20(cachingManager).onUpgrade(oldVersion, newVersion);
     await UpgradeHiveDatabaseStepsV21(cachingManager).onUpgrade(oldVersion, newVersion);
+    await UpgradeHiveDatabaseStepsV22(cachingManager).onUpgrade(oldVersion, newVersion);
 
     if (oldVersion != newVersion) {
       await cachingManager.storeCacheVersion(newVersion);

--- a/lib/features/composer/presentation/extensions/setup_email_attachments_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_attachments_extension.dart
@@ -32,7 +32,7 @@ extension SetupEmailAttachmentsExtension on ComposerController {
     if (currentEmailActionType == EmailActionType.editSendingEmail) {
       final email = arguments.sendingEmail?.email;
       if (email == null) return (attachments: null, inlineImages: null);
-      final classified = email.classifyAttachments();
+      final classified = email.toPresentationAttachments();
       return (
         attachments: classified.attachments,
         inlineImages: classified.inlineImages,

--- a/lib/features/composer/presentation/extensions/setup_email_attachments_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_attachments_extension.dart
@@ -2,10 +2,9 @@
 import 'package:core/utils/list_utils.dart';
 import 'package:model/email/attachment.dart';
 import 'package:model/email/email_action_type.dart';
-import 'package:model/extensions/email_extension.dart';
-import 'package:model/extensions/list_attachment_extension.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
+import 'package:tmail_ui_user/features/email/domain/extensions/email_attachment_classifier_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/list_shared_media_file_extension.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/composer_arguments.dart';
 import 'package:tmail_ui_user/features/upload/domain/extensions/list_file_info_extension.dart';
@@ -21,32 +20,31 @@ extension SetupEmailAttachmentsExtension on ComposerController {
       return;
     }
 
+    final resolved = _resolveAttachmentsFromArguments(arguments);
     initAttachmentsAndInlineImages(
-      attachments: _getAttachmentsFromArguments(arguments),
-      inlineImages: _getInlineImagesFromArguments(arguments),
+      attachments: resolved.attachments,
+      inlineImages: resolved.inlineImages,
     );
   }
 
-  List<Attachment>? _getAttachmentsFromArguments(ComposerArguments arguments) {
+  ({List<Attachment>? attachments, List<Attachment>? inlineImages})
+      _resolveAttachmentsFromArguments(ComposerArguments arguments) {
     if (currentEmailActionType == EmailActionType.editSendingEmail) {
-      final sendingEmail = arguments.sendingEmail;
-      if (sendingEmail == null) return null;
-      return sendingEmail.email.allAttachments.getListAttachmentsDisplayedOutside(
-        sendingEmail.email.htmlBodyAttachments,
+      final email = arguments.sendingEmail?.email;
+      if (email == null) return (attachments: null, inlineImages: null);
+      final classified = email.classifyAttachments();
+      return (
+        attachments: classified.attachments,
+        inlineImages: classified.inlineImages,
       );
     }
-    if (_shouldPreserveAttachments) return arguments.attachments;
-    return null;
-  }
-
-  List<Attachment>? _getInlineImagesFromArguments(ComposerArguments arguments) {
-    if (currentEmailActionType == EmailActionType.editSendingEmail) {
-      final sendingEmail = arguments.sendingEmail;
-      if (sendingEmail == null) return null;
-      return sendingEmail.email.allAttachments.listAttachmentsDisplayedInContent;
+    if (_shouldPreserveAttachments) {
+      return (
+        attachments: arguments.attachments,
+        inlineImages: arguments.inlineImages,
+      );
     }
-    if (_shouldPreserveAttachments) return arguments.inlineImages;
-    return null;
+    return (attachments: null, inlineImages: null);
   }
 
   bool get _shouldPreserveAttachments => const {

--- a/lib/features/composer/presentation/extensions/setup_email_attachments_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_attachments_extension.dart
@@ -32,10 +32,10 @@ extension SetupEmailAttachmentsExtension on ComposerController {
     if (currentEmailActionType == EmailActionType.editSendingEmail) {
       final email = arguments.sendingEmail?.email;
       if (email == null) return (attachments: null, inlineImages: null);
-      final classified = email.toPresentationAttachments();
+      final presentationAttachments = email.toPresentationAttachments();
       return (
-        attachments: classified.attachments,
-        inlineImages: classified.inlineImages,
+        attachments: presentationAttachments.attachments,
+        inlineImages: presentationAttachments.inlineImages,
       );
     }
     if (_shouldPreserveAttachments) {

--- a/lib/features/email/data/datasource_impl/email_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_datasource_impl.dart
@@ -403,9 +403,9 @@ class EmailDataSourceImpl extends EmailDataSource {
       final appLocalizations = previewEmailEMLRequest.appLocalizations;
       final locale = previewEmailEMLRequest.locale.toLanguageTag();
 
-      final classified = email.toPresentationAttachments();
-      final listAttachments = classified.attachments;
-      final listInlineImages = classified.inlineImages;
+      final presentationAttachments = email.toPresentationAttachments();
+      final listAttachments = presentationAttachments.attachments;
+      final listInlineImages = presentationAttachments.inlineImages;
 
       final mapCidImageDownloadUrl = listInlineImages.toMapCidImageDownloadUrl(
         accountId: previewEmailEMLRequest.accountId,

--- a/lib/features/email/data/datasource_impl/email_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_datasource_impl.dart
@@ -28,6 +28,7 @@ import 'package:tmail_ui_user/features/composer/domain/model/email_request.dart'
 import 'package:tmail_ui_user/features/email/data/datasource/email_datasource.dart';
 import 'package:tmail_ui_user/features/email/data/local/html_analyzer.dart';
 import 'package:tmail_ui_user/features/email/data/network/email_api.dart';
+import 'package:tmail_ui_user/features/email/domain/extensions/email_attachment_classifier_extension.dart';
 import 'package:tmail_ui_user/features/email/domain/model/detailed_email.dart';
 import 'package:tmail_ui_user/features/email/domain/model/move_to_mailbox_request.dart';
 import 'package:tmail_ui_user/features/email/domain/model/preview_email_eml_request.dart';
@@ -402,13 +403,9 @@ class EmailDataSourceImpl extends EmailDataSource {
       final appLocalizations = previewEmailEMLRequest.appLocalizations;
       final locale = previewEmailEMLRequest.locale.toLanguageTag();
 
-      final listAttachments = email
-        .allAttachments
-        .getListAttachmentsDisplayedOutside(email.htmlBodyAttachments);
-
-      final listInlineImages = email
-        .allAttachments
-        .listAttachmentsDisplayedInContent;
+      final classified = email.classifyAttachments();
+      final listAttachments = classified.attachments;
+      final listInlineImages = classified.inlineImages;
 
       final mapCidImageDownloadUrl = listInlineImages.toMapCidImageDownloadUrl(
         accountId: previewEmailEMLRequest.accountId,

--- a/lib/features/email/data/datasource_impl/email_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_datasource_impl.dart
@@ -403,7 +403,7 @@ class EmailDataSourceImpl extends EmailDataSource {
       final appLocalizations = previewEmailEMLRequest.appLocalizations;
       final locale = previewEmailEMLRequest.locale.toLanguageTag();
 
-      final classified = email.classifyAttachments();
+      final classified = email.toPresentationAttachments();
       final listAttachments = classified.attachments;
       final listInlineImages = classified.inlineImages;
 

--- a/lib/features/email/data/local/html_analyzer.dart
+++ b/lib/features/email/data/local/html_analyzer.dart
@@ -9,6 +9,7 @@ import 'package:core/presentation/utils/html_transformer/transform_configuration
 import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/string_convert.dart';
 import 'package:dartz/dartz.dart';
+import 'package:html/dom.dart';
 import 'package:html/parser.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_body_part.dart';
 import 'package:model/email/attachment.dart';
@@ -62,52 +63,40 @@ class HtmlAnalyzer {
   Future<List<EventAction>> getListEventAction(String emailContents) async {
     try {
       final document = parse(emailContents);
-
-      final openPaasLinkElements = document.querySelectorAll('a.part-button');
-      if (openPaasLinkElements.isNotEmpty) {
-        final listEventAction = openPaasLinkElements
-          .mapIndexed((index, element) {
-            final hrefLink = element.attributes['href'] ?? '';
-            if (hrefLink.isNotEmpty) {
-              if (index == 0) {
-                return EventAction(EventActionType.yes, hrefLink);
-              } else if (index == 1) {
-                return EventAction(EventActionType.maybe, hrefLink);
-              } else if (index == 2) {
-                return EventAction(EventActionType.no, hrefLink);
-              }
-            }
-            return null;
-          })
-          .nonNulls
-          .toList();
-        log('HtmlAnalyzer::getListEventAction:OPEN_PAAS::listEventAction: $listEventAction');
-        return listEventAction;
-      } else {
-        final googleLinkElements = document.querySelectorAll('a.grey-button-text');
-        final listEventAction = googleLinkElements
-          .mapIndexed((index, element) {
-            final hrefLink = element.attributes['href'] ?? '';
-            if (hrefLink.isNotEmpty) {
-              if (index == 0) {
-                return EventAction(EventActionType.yes, hrefLink);
-              } else if (index == 1) {
-                return EventAction(EventActionType.no, hrefLink);
-              } else if (index == 2) {
-                return EventAction(EventActionType.maybe, hrefLink);
-              }
-            }
-            return null;
-          })
-          .nonNulls
-          .toList();
-        log('HtmlAnalyzer::getListEventAction:GOOGLE::listEventAction: $listEventAction');
-        return listEventAction;
+      final openPaasElements = document.querySelectorAll('a.part-button');
+      if (openPaasElements.isNotEmpty) {
+        final result = _extractEventActions(
+          openPaasElements,
+          [EventActionType.yes, EventActionType.maybe, EventActionType.no],
+        );
+        log('HtmlAnalyzer::getListEventAction:OPEN_PAAS::listEventAction: $result');
+        return result;
       }
+      final googleElements = document.querySelectorAll('a.grey-button-text');
+      final result = _extractEventActions(
+        googleElements,
+        [EventActionType.yes, EventActionType.no, EventActionType.maybe],
+      );
+      log('HtmlAnalyzer::getListEventAction:GOOGLE::listEventAction: $result');
+      return result;
     } catch(e) {
       logWarning('HtmlAnalyzer::getListEventAction:Exception: $e');
       return [];
     }
+  }
+
+  List<EventAction> _extractEventActions(
+    List<Element> elements,
+    List<EventActionType> typeOrder,
+  ) {
+    return elements
+      .mapIndexed((index, element) {
+        final hrefLink = element.attributes['href'] ?? '';
+        if (hrefLink.isEmpty || index >= typeOrder.length) return null;
+        return EventAction(typeOrder[index], hrefLink);
+      })
+      .nonNulls
+      .toList();
   }
 
   Future<String> transformHtmlEmailContent(
@@ -128,90 +117,97 @@ class HtmlAnalyzer {
   }) async {
     final document = parse(emailContent);
     final listImgTag = document.querySelectorAll('img[src^="data:image/"]');
+    final cidImgTags = document.querySelectorAll('img[src^="$cidPrefixKey"]');
 
     log('HtmlAnalyzer::replaceImageBase64ToImageCID:listImgTagLength = ${listImgTag.length} | inlineAttachments = ${inlineAttachments.length}');
 
-    if (listImgTag.isEmpty) {
-      if (inlineAttachments.isEmpty) return Tuple2(emailContent, {});
-
-      // Only include attachments that are actually referenced by a cid: img tag in the body.
-      // Orphaned inline attachments (CID present in metadata but no body reference) must not
-      // be re-forwarded, as this produces sent emails with unreferenced attachments.
-      final cidImgTags = document.querySelectorAll('img[src^="$cidPrefixKey"]');
-      if (cidImgTags.isEmpty) return Tuple2(emailContent, {});
-
-      final referencedCids = cidImgTags
-        .map((img) => img.attributes['src']!.substring(cidPrefixKey.length).trim())
-        .toSet();
-
-      final referencedAttachments = inlineAttachments.entries
-        .where((entry) => referencedCids.contains(entry.key))
-        .map((entry) => entry.value.toEmailBodyPart(charset: Constant.base64Charset))
-        .toSet();
-
-      return Tuple2(emailContent, referencedAttachments);
+    if (listImgTag.isEmpty && (inlineAttachments.isEmpty || cidImgTags.isEmpty)) {
+      return Tuple2(emailContent, {});
     }
 
     final Set<EmailBodyPart> inlineAttachmentsSet = {};
 
     for (final imgTag in listImgTag) {
-      final attributes = imgTag.attributes;
-      final imageSrc = attributes['src'];
+      final imageSrc = imgTag.attributes['src'];
       if (imageSrc?.isEmpty ?? true) continue;
-
-      final idImg = attributes['id'];
-      if (idImg?.startsWith(cidPrefixKey) == true) {
-        final cid = idImg!.substring(cidPrefixKey.length).trim();
-        final attachment = inlineAttachments[cid];
-
-        if (attachment != null) {
-          attributes['src'] = '$cidPrefixKey$cid';
-          attributes.remove('id');
-          inlineAttachmentsSet.add(attachment.toEmailBodyPart(charset: Constant.base64Charset));
-          continue;
-        }
-      }
-
-      if (uploadUri == null) continue;
-
-      final taskId = idImg?.startsWith(cidPrefixKey) == true
-        ? idImg!.substring(cidPrefixKey.length)
-        : _uuid.v1();
-
-      final attachmentRecord = await _retrieveAttachmentFromUpload(
-        taskId: taskId,
+      final bodyPart = await _processBase64ImageTag(
+        attributes: imgTag.attributes,
+        inlineAttachments: inlineAttachments,
         uploadUri: uploadUri,
-        base64ImageTag: imageSrc!,
+        imageSrc: imageSrc!,
       );
-
-      if (attachmentRecord == null) continue;
-
-      final newInlineAttachment = attachmentRecord.$1.toAttachmentWithDisposition(
-        disposition: ContentDisposition.inline,
-        cid: attachmentRecord.$2,
-      );
-
-      final newCid = newInlineAttachment.cid!;
-      inlineAttachments[newCid] = newInlineAttachment;
-      attributes['src'] = '$cidPrefixKey$newCid';
-      attributes.remove('id');
-
-      inlineAttachmentsSet.add(newInlineAttachment.toEmailBodyPart(charset: Constant.base64Charset));
+      if (bodyPart != null) inlineAttachmentsSet.add(bodyPart);
     }
 
-    // Include attachments for cid: images that were never converted to base64
-    // (e.g. download failed during view). These are not in listImgTag but still
-    // need their attachment included so the recipient can load them.
-    final remainingCidImgs = document.querySelectorAll('img[src^="$cidPrefixKey"]');
-    for (final img in remainingCidImgs) {
-      final cid = img.attributes['src']!.substring(cidPrefixKey.length).trim();
+    // Include attachments for cid: images whose download failed during view (never converted to base64).
+    _includeCidImageAttachments(
+      cidImgTags: cidImgTags,
+      inlineAttachments: inlineAttachments,
+      inlineAttachmentsSet: inlineAttachmentsSet,
+    );
+
+    return Tuple2(document.body?.innerHtml ?? emailContent, inlineAttachmentsSet);
+  }
+
+  Future<EmailBodyPart?> _processBase64ImageTag({
+    required Map<Object, String> attributes,
+    required Map<String, Attachment> inlineAttachments,
+    required Uri? uploadUri,
+    required String imageSrc,
+  }) async {
+    final idImg = attributes['id'];
+
+    if (idImg?.startsWith(cidPrefixKey) == true) {
+      final cid = idImg!.substring(cidPrefixKey.length).trim();
+      final attachment = inlineAttachments[cid];
+      if (attachment != null) {
+        attributes['src'] = '$cidPrefixKey$cid';
+        attributes.remove('id');
+        return attachment.toEmailBodyPart(charset: Constant.base64Charset);
+      }
+    }
+
+    if (uploadUri == null) return null;
+
+    final taskId = idImg?.startsWith(cidPrefixKey) == true
+      ? idImg!.substring(cidPrefixKey.length)
+      : _uuid.v1();
+
+    final attachmentRecord = await _retrieveAttachmentFromUpload(
+      taskId: taskId,
+      uploadUri: uploadUri,
+      base64ImageTag: imageSrc,
+    );
+
+    if (attachmentRecord == null) return null;
+
+    final newInlineAttachment = attachmentRecord.$1.toAttachmentWithDisposition(
+      disposition: ContentDisposition.inline,
+      cid: attachmentRecord.$2,
+    );
+
+    final newCid = newInlineAttachment.cid!;
+    inlineAttachments[newCid] = newInlineAttachment;
+    attributes['src'] = '$cidPrefixKey$newCid';
+    attributes.remove('id');
+
+    return newInlineAttachment.toEmailBodyPart(charset: Constant.base64Charset);
+  }
+
+  void _includeCidImageAttachments({
+    required List<Element> cidImgTags,
+    required Map<String, Attachment> inlineAttachments,
+    required Set<EmailBodyPart> inlineAttachmentsSet,
+  }) {
+    for (final img in cidImgTags) {
+      final src = img.attributes['src'];
+      if (src == null) continue;
+      final cid = src.substring(cidPrefixKey.length).trim();
       final attachment = inlineAttachments[cid];
       if (attachment != null) {
         inlineAttachmentsSet.add(attachment.toEmailBodyPart(charset: Constant.base64Charset));
       }
     }
-
-    return Tuple2(document.body?.innerHtml ?? emailContent, inlineAttachmentsSet);
   }
 
   Future<String> removeCollapsedExpandedSignatureEffect({required String emailContent}) async {

--- a/lib/features/email/data/local/html_analyzer.dart
+++ b/lib/features/email/data/local/html_analyzer.dart
@@ -1,5 +1,4 @@
 
-import 'package:collection/collection.dart';
 import 'package:core/data/constants/constant.dart';
 import 'package:core/presentation/utils/html_transformer/html_transform.dart';
 import 'package:core/presentation/utils/html_transformer/text/persist_preformatted_text_transformer.dart';
@@ -17,7 +16,6 @@ import 'package:model/email/email_content.dart';
 import 'package:model/email/email_content_type.dart';
 import 'package:model/extensions/attachment_extension.dart';
 import 'package:model/upload/file_info.dart';
-import 'package:tmail_ui_user/features/email/domain/model/event_action.dart';
 import 'package:tmail_ui_user/features/upload/data/network/file_uploader.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
 import 'package:uuid/uuid.dart';
@@ -59,46 +57,6 @@ class HtmlAnalyzer {
         return emailContent;
     }
   }
-
-  Future<List<EventAction>> getListEventAction(String emailContents) async {
-    try {
-      final document = parse(emailContents);
-      final openPaasElements = document.querySelectorAll('a.part-button');
-      if (openPaasElements.isNotEmpty) {
-        final result = _extractEventActions(
-          openPaasElements,
-          [EventActionType.yes, EventActionType.maybe, EventActionType.no],
-        );
-        log('HtmlAnalyzer::getListEventAction:OPEN_PAAS::listEventAction: $result');
-        return result;
-      }
-      final googleElements = document.querySelectorAll('a.grey-button-text');
-      final result = _extractEventActions(
-        googleElements,
-        [EventActionType.yes, EventActionType.no, EventActionType.maybe],
-      );
-      log('HtmlAnalyzer::getListEventAction:GOOGLE::listEventAction: $result');
-      return result;
-    } catch(e) {
-      logWarning('HtmlAnalyzer::getListEventAction:Exception: $e');
-      return [];
-    }
-  }
-
-  List<EventAction> _extractEventActions(
-    List<Element> elements,
-    List<EventActionType> typeOrder,
-  ) {
-    return elements
-      .mapIndexed((index, element) {
-        final hrefLink = element.attributes['href'] ?? '';
-        if (hrefLink.isEmpty || index >= typeOrder.length) return null;
-        return EventAction(typeOrder[index], hrefLink);
-      })
-      .nonNulls
-      .toList();
-  }
-
   Future<String> transformHtmlEmailContent(
     String htmlContent,
     TransformConfiguration configuration

--- a/lib/features/email/data/local/html_analyzer.dart
+++ b/lib/features/email/data/local/html_analyzer.dart
@@ -16,7 +16,6 @@ import 'package:model/email/email_content.dart';
 import 'package:model/email/email_content_type.dart';
 import 'package:model/extensions/attachment_extension.dart';
 import 'package:model/upload/file_info.dart';
-import 'package:tmail_ui_user/features/email/domain/extensions/list_attachments_extension.dart';
 import 'package:tmail_ui_user/features/email/domain/model/event_action.dart';
 import 'package:tmail_ui_user/features/upload/data/network/file_uploader.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
@@ -133,12 +132,24 @@ class HtmlAnalyzer {
     log('HtmlAnalyzer::replaceImageBase64ToImageCID:listImgTagLength = ${listImgTag.length} | inlineAttachments = ${inlineAttachments.length}');
 
     if (listImgTag.isEmpty) {
-      return Tuple2(
-        emailContent,
-        inlineAttachments.isNotEmpty
-          ? inlineAttachments.values.toList().toEmailBodyPart(charset: Constant.base64Charset)
-          : {},
-      );
+      if (inlineAttachments.isEmpty) return Tuple2(emailContent, {});
+
+      // Only include attachments that are actually referenced by a cid: img tag in the body.
+      // Orphaned inline attachments (CID present in metadata but no body reference) must not
+      // be re-forwarded, as this produces sent emails with unreferenced attachments.
+      final cidImgTags = document.querySelectorAll('img[src^="$cidPrefixKey"]');
+      if (cidImgTags.isEmpty) return Tuple2(emailContent, {});
+
+      final referencedCids = cidImgTags
+        .map((img) => img.attributes['src']!.substring(cidPrefixKey.length).trim())
+        .toSet();
+
+      final referencedAttachments = inlineAttachments.entries
+        .where((entry) => referencedCids.contains(entry.key))
+        .map((entry) => entry.value.toEmailBodyPart(charset: Constant.base64Charset))
+        .toSet();
+
+      return Tuple2(emailContent, referencedAttachments);
     }
 
     final Set<EmailBodyPart> inlineAttachmentsSet = {};
@@ -186,6 +197,18 @@ class HtmlAnalyzer {
       attributes.remove('id');
 
       inlineAttachmentsSet.add(newInlineAttachment.toEmailBodyPart(charset: Constant.base64Charset));
+    }
+
+    // Include attachments for cid: images that were never converted to base64
+    // (e.g. download failed during view). These are not in listImgTag but still
+    // need their attachment included so the recipient can load them.
+    final remainingCidImgs = document.querySelectorAll('img[src^="$cidPrefixKey"]');
+    for (final img in remainingCidImgs) {
+      final cid = img.attributes['src']!.substring(cidPrefixKey.length).trim();
+      final attachment = inlineAttachments[cid];
+      if (attachment != null) {
+        inlineAttachmentsSet.add(attachment.toEmailBodyPart(charset: Constant.base64Charset));
+      }
     }
 
     return Tuple2(document.body?.innerHtml ?? emailContent, inlineAttachmentsSet);

--- a/lib/features/email/domain/extensions/email_attachment_classifier_extension.dart
+++ b/lib/features/email/domain/extensions/email_attachment_classifier_extension.dart
@@ -1,0 +1,55 @@
+import 'package:html/parser.dart' show parse;
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:model/email/attachment.dart';
+import 'package:model/extensions/email_extension.dart';
+import 'package:model/extensions/list_attachment_extension.dart';
+import 'package:model/extensions/list_email_content_extension.dart';
+
+class PresentationAttachments {
+  final List<Attachment> attachments;
+  final List<Attachment> inlineImages;
+
+  const PresentationAttachments({
+    required this.attachments,
+    required this.inlineImages,
+  });
+}
+
+extension EmailAttachmentClassifierExtension on Email {
+  PresentationAttachments classifyAttachments() {
+    // Cache: allAttachments getter re-allocates on each call.
+    final allAttachmentsSnapshot = allAttachments;
+    final outsideAttachments = allAttachmentsSnapshot.getListAttachmentsDisplayedOutside(htmlBodyAttachments);
+    final allInlineImages = allAttachmentsSnapshot.listAttachmentsDisplayedInContent;
+    final referencedCids = _extractReferencedCids(emailContentList.asHtmlString);
+    final inlineImages = <Attachment>[];
+    final orphanedInlineImages = <Attachment>[];
+    for (final a in allInlineImages) {
+      (referencedCids.contains(a.cid) ? inlineImages : orphanedInlineImages).add(a);
+    }
+    // Dedupe: undefined-disposition + cid attachments satisfy both
+    // isOutsideAttachment and listAttachmentsDisplayedInContent predicates.
+    // Without this filter the same blob would render twice in the panel.
+    final orphanBlobIds = orphanedInlineImages.map((a) => a.blobId).toSet();
+    final outsideOnly = outsideAttachments
+      .where((a) => !orphanBlobIds.contains(a.blobId))
+      .toList();
+    return PresentationAttachments(
+      attachments: [...outsideOnly, ...orphanedInlineImages],
+      inlineImages: inlineImages,
+    );
+  }
+}
+
+Set<String> _extractReferencedCids(String htmlContent) {
+  if (htmlContent.isEmpty) return {};
+  try {
+    return parse(htmlContent)
+      .querySelectorAll('img[src^="cid:"]')
+      .map((img) => img.attributes['src']?.substring('cid:'.length).trim())
+      .nonNulls
+      .toSet();
+  } catch (_) {
+    return {};
+  }
+}

--- a/lib/features/email/domain/extensions/email_attachment_classifier_extension.dart
+++ b/lib/features/email/domain/extensions/email_attachment_classifier_extension.dart
@@ -16,7 +16,7 @@ class PresentationAttachments {
 }
 
 extension EmailAttachmentClassifierExtension on Email {
-  PresentationAttachments classifyAttachments() {
+  PresentationAttachments toPresentationAttachments() {
     // Cache: allAttachments getter re-allocates on each call.
     final allAttachmentsSnapshot = allAttachments;
     final outsideAttachments = allAttachmentsSnapshot.getListAttachmentsDisplayedOutside(htmlBodyAttachments);

--- a/lib/features/email/domain/extensions/email_attachment_classifier_extension.dart
+++ b/lib/features/email/domain/extensions/email_attachment_classifier_extension.dart
@@ -30,9 +30,11 @@ extension EmailAttachmentClassifierExtension on Email {
     // Dedupe: undefined-disposition + cid attachments satisfy both
     // isOutsideAttachment and listAttachmentsDisplayedInContent predicates.
     // Without this filter the same blob would render twice in the panel.
-    final orphanBlobIds = orphanedInlineImages.map((a) => a.blobId).toSet();
+    // nonNulls: a null blobId in the orphan set would otherwise falsely match
+    // any outside attachment with a null blobId (Set<Id?> collapses all nulls).
+    final orphanBlobIds = orphanedInlineImages.map((a) => a.blobId).nonNulls.toSet();
     final outsideOnly = outsideAttachments
-      .where((a) => !orphanBlobIds.contains(a.blobId))
+      .where((a) => a.blobId == null || !orphanBlobIds.contains(a.blobId))
       .toList();
     return PresentationAttachments(
       attachments: [...outsideOnly, ...orphanedInlineImages],

--- a/lib/features/email/domain/extensions/email_extension.dart
+++ b/lib/features/email/domain/extensions/email_extension.dart
@@ -5,7 +5,7 @@ import 'package:tmail_ui_user/features/email/domain/model/detailed_email.dart';
 
 extension EmailExtension on Email {
   DetailedEmail toDetailedEmail({String? htmlEmailContent}) {
-    final classified = classifyAttachments();
+    final classified = toPresentationAttachments();
     return DetailedEmail(
       emailId: id!,
       createdTime: receivedAt?.value ?? DateTime.now(),

--- a/lib/features/email/domain/extensions/email_extension.dart
+++ b/lib/features/email/domain/extensions/email_extension.dart
@@ -1,21 +1,21 @@
 
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
-import 'package:model/extensions/email_extension.dart';
-import 'package:model/extensions/list_attachment_extension.dart';
+import 'package:tmail_ui_user/features/email/domain/extensions/email_attachment_classifier_extension.dart';
 import 'package:tmail_ui_user/features/email/domain/model/detailed_email.dart';
 
 extension EmailExtension on Email {
   DetailedEmail toDetailedEmail({String? htmlEmailContent}) {
+    final classified = classifyAttachments();
     return DetailedEmail(
       emailId: id!,
       createdTime: receivedAt?.value ?? DateTime.now(),
-      attachments: allAttachments.getListAttachmentsDisplayedOutside(htmlBodyAttachments),
+      attachments: classified.attachments,
       headers: headers,
       keywords: keywords,
       htmlEmailContent: htmlEmailContent,
       messageId: messageId,
       references: references,
-      inlineImages: allAttachments.listAttachmentsDisplayedInContent,
+      inlineImages: classified.inlineImages,
       sMimeStatusHeader: sMimeStatusHeader,
       identityHeader: identityHeader,
     );

--- a/lib/features/email/domain/usecases/get_email_content_interactor.dart
+++ b/lib/features/email/domain/usecases/get_email_content_interactor.dart
@@ -78,7 +78,7 @@ class GetEmailContentInteractor {
         accountId,
         emailId,
         additionalProperties: additionalProperties);
-      final classified = email.classifyAttachments();
+      final classified = email.toPresentationAttachments();
       final listAttachments = classified.attachments;
       final listInlineImages = classified.inlineImages;
       log('GetEmailContentInteractor::_getContentEmailFromServer: listAttachments = ${listAttachments.length} | listInlineImages = ${listInlineImages.length}');

--- a/lib/features/email/domain/usecases/get_email_content_interactor.dart
+++ b/lib/features/email/domain/usecases/get_email_content_interactor.dart
@@ -10,6 +10,7 @@ import 'package:jmap_dart_client/jmap/core/properties/properties.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:model/model.dart';
+import 'package:tmail_ui_user/features/email/domain/extensions/email_attachment_classifier_extension.dart';
 import 'package:tmail_ui_user/features/email/domain/model/detailed_email.dart';
 import 'package:tmail_ui_user/features/email/domain/repository/email_repository.dart';
 import 'package:tmail_ui_user/features/email/domain/state/get_email_content_state.dart';
@@ -77,8 +78,9 @@ class GetEmailContentInteractor {
         accountId,
         emailId,
         additionalProperties: additionalProperties);
-      final listAttachments = email.allAttachments.getListAttachmentsDisplayedOutside(email.htmlBodyAttachments);
-      final listInlineImages = email.allAttachments.listAttachmentsDisplayedInContent;
+      final classified = email.classifyAttachments();
+      final listAttachments = classified.attachments;
+      final listInlineImages = classified.inlineImages;
       log('GetEmailContentInteractor::_getContentEmailFromServer: listAttachments = ${listAttachments.length} | listInlineImages = ${listInlineImages.length}');
       if (email.emailContentList.isNotEmpty) {
         final mapCidImageDownloadUrl = listInlineImages.toMapCidImageDownloadUrl(

--- a/lib/features/email/presentation/model/composer_arguments.dart
+++ b/lib/features/email/presentation/model/composer_arguments.dart
@@ -132,7 +132,7 @@ class ComposerArguments extends RouterArguments {
   );
 
   factory ComposerArguments.fromSessionStorageBrowser(ComposerCache composerCache) {
-    final classified = composerCache.email?.classifyAttachments();
+    final classified = composerCache.email?.toPresentationAttachments();
     return ComposerArguments(
       emailActionType: EmailActionType.reopenComposerBrowser,
       presentationEmail: composerCache.email?.toPresentationEmail(),
@@ -231,7 +231,7 @@ class ComposerArguments extends RouterArguments {
     : SendingEmailActionType.create;
 
   factory ComposerArguments.fromComposerPersistentCache(ComposerPersistentCache cache) {
-    final classified = cache.email?.classifyAttachments();
+    final classified = cache.email?.toPresentationAttachments();
     return ComposerArguments(
       emailActionType: EmailActionType.restoreComposerFromPersistentCache,
       presentationEmail: cache.email?.toPresentationEmail(),

--- a/lib/features/email/presentation/model/composer_arguments.dart
+++ b/lib/features/email/presentation/model/composer_arguments.dart
@@ -9,6 +9,7 @@ import 'package:tmail_ui_user/features/composer/presentation/model/screen_displa
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_cache.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/data/model/composer_persistent_cache.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/model/sending_email.dart';
+import 'package:tmail_ui_user/features/email/domain/extensions/email_attachment_classifier_extension.dart';
 import 'package:tmail_ui_user/features/sending_queue/presentation/model/sending_email_action_type.dart';
 import 'package:tmail_ui_user/main/routes/router_arguments.dart';
 
@@ -130,14 +131,15 @@ class ComposerArguments extends RouterArguments {
     savedEmailTemplateId: savedEmailTemplateId,
   );
 
-  factory ComposerArguments.fromSessionStorageBrowser(ComposerCache composerCache) =>
-    ComposerArguments(
+  factory ComposerArguments.fromSessionStorageBrowser(ComposerCache composerCache) {
+    final classified = composerCache.email?.classifyAttachments();
+    return ComposerArguments(
       emailActionType: EmailActionType.reopenComposerBrowser,
       presentationEmail: composerCache.email?.toPresentationEmail(),
       emailContents: composerCache.email?.emailContentList.asHtmlString,
-      attachments: composerCache.email?.allAttachments.getListAttachmentsDisplayedOutside(composerCache.email?.htmlBodyAttachments ?? []),
+      attachments: classified?.attachments,
       selectedIdentityId: composerCache.email?.identityIdFromHeader,
-      inlineImages: composerCache.email?.allAttachments.listAttachmentsDisplayedInContent,
+      inlineImages: classified?.inlineImages,
       hasRequestReadReceipt: composerCache.hasRequestReadReceipt,
       displayMode: composerCache.displayMode,
       isMarkAsImportant: composerCache.isMarkAsImportant,
@@ -147,6 +149,7 @@ class ComposerArguments extends RouterArguments {
       savedEmailDraftId: composerCache.draftEmailId,
       savedEmailTemplateId: composerCache.templateEmailId,
     );
+  }
 
   factory ComposerArguments.replyEmail({
     required PresentationEmail presentationEmail,
@@ -227,16 +230,15 @@ class ComposerArguments extends RouterArguments {
     ? SendingEmailActionType.edit
     : SendingEmailActionType.create;
 
-  factory ComposerArguments.fromComposerPersistentCache(ComposerPersistentCache cache) =>
-    ComposerArguments(
+  factory ComposerArguments.fromComposerPersistentCache(ComposerPersistentCache cache) {
+    final classified = cache.email?.classifyAttachments();
+    return ComposerArguments(
       emailActionType: EmailActionType.restoreComposerFromPersistentCache,
       presentationEmail: cache.email?.toPresentationEmail(),
       emailContents: cache.email?.emailContentList.asHtmlString,
-      attachments: cache.email?.allAttachments.getListAttachmentsDisplayedOutside(
-        cache.email?.htmlBodyAttachments ?? [],
-      ),
+      attachments: classified?.attachments,
       selectedIdentityId: cache.email?.identityIdFromHeader,
-      inlineImages: cache.email?.allAttachments.listAttachmentsDisplayedInContent,
+      inlineImages: classified?.inlineImages,
       hasRequestReadReceipt: cache.hasRequestReadReceipt,
       isMarkAsImportant: cache.isMarkAsImportant,
       composerId: cache.composerId,
@@ -246,6 +248,7 @@ class ComposerArguments extends RouterArguments {
       savedEmailDraftId: cache.draftEmailId,
       savedEmailTemplateId: cache.templateEmailId,
     );
+  }
 
   factory ComposerArguments.fromUnsubscribeMailtoLink({
     List<EmailAddress>? listEmailAddress,

--- a/test/features/composer/data/html_analyzer_test.dart
+++ b/test/features/composer/data/html_analyzer_test.dart
@@ -356,5 +356,135 @@ void main() {
       verify(mockUuid.v1()).called(1);
       verify(mockFileUploader.uploadAttachment(any, any, any)).called(1);
     });
+
+    test(
+      'When HTML has both a base64 image (CID found) and a cid: image (download failed),\n'
+      'should include attachments for both images in result',
+    () async {
+      // img1: converted to base64 with id="cid:img1" (normal flow)
+      // img2: download failed, stayed as <img src="cid:img2"> (not in listImgTag)
+      const htmlContent = '<img src="data:image/png;base64,iVBORw0KGgo=" id="cid:img1"> '
+          '<img src="cid:img2">';
+      final inlineAttachments = {
+        'img1': Attachment(
+          blobId: Id('blob1'),
+          type: MediaType('image', 'png'),
+          disposition: ContentDisposition.inline,
+          cid: 'img1',
+        ),
+        'img2': Attachment(
+          blobId: Id('blob2'),
+          type: MediaType('image', 'png'),
+          disposition: ContentDisposition.inline,
+          cid: 'img2',
+        ),
+      };
+      final uploadUri = Uri.parse('https://example.com/upload');
+
+      final result = await htmlAnalyzer.replaceImageBase64ToImageCID(
+        emailContent: htmlContent,
+        inlineAttachments: inlineAttachments,
+        uploadUri: uploadUri,
+      );
+
+      // Both attachments must be present so recipient can load both images
+      expect(result.value2.length, 2);
+      expect(result.value2.any((p) => p.cid == 'img1'), isTrue);
+      expect(result.value2.any((p) => p.cid == 'img2'), isTrue);
+    });
+  });
+
+  group('HtmlAnalyzer::replaceImageBase64ToImageCID - orphaned inline attachments::', () {
+    late HtmlAnalyzer htmlAnalyzer;
+    late MockHtmlTransform mockHtmlTransform;
+    late MockFileUploader mockFileUploader;
+    late MockUuid mockUuid;
+
+    setUp(() {
+      mockHtmlTransform = MockHtmlTransform();
+      mockFileUploader = MockFileUploader();
+      mockUuid = MockUuid();
+      htmlAnalyzer = HtmlAnalyzer(mockHtmlTransform, mockFileUploader, mockUuid);
+    });
+
+    test(
+      'When inlineAttachments has entries but HTML body has no cid: img reference,\n'
+      'should return empty attachments (orphaned inline attachment must not be re-forwarded)',
+    () async {
+      // Simulates replying to a malformed Outlook email: the image is listed in
+      // JMAP attachment metadata (inline + CID) but the HTML body never references it.
+      const htmlContent = '<div>Hello World</div>';
+      final inlineAttachments = {
+        'orphan-cid': Attachment(
+          blobId: Id('blob-orphan'),
+          type: MediaType('image', 'png'),
+          disposition: ContentDisposition.inline,
+          cid: 'orphan-cid',
+        ),
+      };
+      final uploadUri = Uri.parse('https://example.com/upload');
+
+      final result = await htmlAnalyzer.replaceImageBase64ToImageCID(
+        emailContent: htmlContent,
+        inlineAttachments: inlineAttachments,
+        uploadUri: uploadUri,
+      );
+
+      expect(result.value1, htmlContent);
+      expect(result.value2, isEmpty);
+      verifyNever(mockFileUploader.uploadAttachment(any, any, any));
+    });
+
+    test(
+      'When inlineAttachments has entries and HTML has a matching cid: img reference,\n'
+      'should return only the referenced attachment',
+    () async {
+      // img1 is referenced in the body (download failed, stays as cid:)
+      // img2 is orphaned (not referenced in the body)
+      const htmlContent = '<img src="cid:img1"><div>text</div>';
+      final inlineAttachments = {
+        'img1': Attachment(
+          blobId: Id('blob1'),
+          type: MediaType('image', 'png'),
+          disposition: ContentDisposition.inline,
+          cid: 'img1',
+        ),
+        'img2': Attachment(
+          blobId: Id('blob2'),
+          type: MediaType('image', 'png'),
+          disposition: ContentDisposition.inline,
+          cid: 'img2',
+        ),
+      };
+      final uploadUri = Uri.parse('https://example.com/upload');
+
+      final result = await htmlAnalyzer.replaceImageBase64ToImageCID(
+        emailContent: htmlContent,
+        inlineAttachments: inlineAttachments,
+        uploadUri: uploadUri,
+      );
+
+      expect(result.value2.length, 1);
+      expect(result.value2.any((p) => p.cid == 'img1'), isTrue);
+      expect(result.value2.any((p) => p.cid == 'img2'), isFalse);
+    });
+
+    test(
+      'When inlineAttachments is empty and HTML has no base64 images,\n'
+      'should return empty attachments',
+    () async {
+      const htmlContent = '<div>Plain text, no images</div>';
+      final inlineAttachments = <String, Attachment>{};
+      final uploadUri = Uri.parse('https://example.com/upload');
+
+      final result = await htmlAnalyzer.replaceImageBase64ToImageCID(
+        emailContent: htmlContent,
+        inlineAttachments: inlineAttachments,
+        uploadUri: uploadUri,
+      );
+
+      expect(result.value1, htmlContent);
+      expect(result.value2, isEmpty);
+    });
   });
 }

--- a/test/features/email/domain/extensions/email_attachment_classifier_extension_test.dart
+++ b/test/features/email/domain/extensions/email_attachment_classifier_extension_test.dart
@@ -44,7 +44,7 @@ void main() {
   group('EmailAttachmentClassifierExtension::classifyAttachments::', () {
     test('no attachments returns empty lists', () {
       expectPartition(
-        buildEmail().classifyAttachments(),
+        buildEmail().toPresentationAttachments(),
         attachmentBlobIds: {},
         inlineCids: {},
       );
@@ -53,7 +53,7 @@ void main() {
     test('external attachment goes to attachments only', () {
       final email = buildEmail(attachments: {externalPart(blobIdValue: 'b', name: 'doc.pdf')});
       expectPartition(
-        email.classifyAttachments(),
+        email.toPresentationAttachments(),
         attachmentBlobIds: {'b'},
         inlineCids: {},
       );
@@ -90,7 +90,7 @@ void main() {
           htmlContent: tc.body,
         );
         expectPartition(
-          email.classifyAttachments(),
+          email.toPresentationAttachments(),
           attachmentBlobIds: tc.expectedAttachmentBlobs,
           inlineCids: tc.expectedInlineCids,
         );
@@ -107,7 +107,7 @@ void main() {
         htmlContent: '<img src="cid:ref@x">',
       );
       expectPartition(
-        email.classifyAttachments(),
+        email.toPresentationAttachments(),
         attachmentBlobIds: {'ext', 'orphan'},
         inlineCids: {'ref@x'},
       );
@@ -117,7 +117,7 @@ void main() {
       // No htmlBody/bodyValues → emailContentList is empty → asHtmlString = ''
       final email = buildEmail(attachments: {inlinePart(blobIdValue: 'b', cid: 'c@x')});
       expectPartition(
-        email.classifyAttachments(),
+        email.toPresentationAttachments(),
         attachmentBlobIds: {'b'},
         inlineCids: {},
       );
@@ -130,7 +130,7 @@ void main() {
         attachments: {inlinePart(blobIdValue: 'b', cid: 'c@x')},
         htmlContent: '<<<>>>not html<<<',
       );
-      expect(() => email.classifyAttachments(), returnsNormally);
+      expect(() => email.toPresentationAttachments(), returnsNormally);
     });
 
     test('inline disposition without cid is excluded from inline list', () {
@@ -141,7 +141,7 @@ void main() {
         htmlContent: '<p>text</p>',
       );
       expectPartition(
-        email.classifyAttachments(),
+        email.toPresentationAttachments(),
         attachmentBlobIds: {'b'},
         inlineCids: {},
       );
@@ -155,7 +155,7 @@ void main() {
         htmlContent: '<p>no cid ref</p>',
       );
       expectPartition(
-        email.classifyAttachments(),
+        email.toPresentationAttachments(),
         attachmentBlobIds: {'b'},
         inlineCids: {},
       );

--- a/test/features/email/domain/extensions/email_attachment_classifier_extension_test.dart
+++ b/test/features/email/domain/extensions/email_attachment_classifier_extension_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http_parser/http_parser.dart' show MediaType;
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email_body_part.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email_body_value.dart';
+import 'package:tmail_ui_user/features/email/domain/extensions/email_attachment_classifier_extension.dart';
+
+void main() {
+  EmailBodyPart externalPart({required String blobIdValue, String? name}) =>
+      EmailBodyPart(blobId: Id(blobIdValue), disposition: 'attachment', name: name);
+
+  EmailBodyPart inlinePart({
+    required String blobIdValue,
+    required String cid,
+    String? disposition = 'inline',
+  }) =>
+      EmailBodyPart(blobId: Id(blobIdValue), cid: cid, disposition: disposition);
+
+  Email buildEmail({Set<EmailBodyPart>? attachments, String htmlContent = ''}) {
+    if (htmlContent.isEmpty) {
+      return Email(id: EmailId(Id('e')), attachments: attachments);
+    }
+    return Email(
+      id: EmailId(Id('e')),
+      attachments: attachments,
+      htmlBody: {EmailBodyPart(partId: PartId('1'), type: MediaType('text', 'html'))},
+      bodyValues: {
+        PartId('1'): EmailBodyValue(value: htmlContent, isEncodingProblem: false, isTruncated: false),
+      },
+    );
+  }
+
+  // Asserts the partition by extracting blobIds for attachments and cids for inlines.
+  void expectPartition(
+    PresentationAttachments result, {
+    required Set<String> attachmentBlobIds,
+    required Set<String> inlineCids,
+  }) {
+    expect(result.attachments.map((a) => a.blobId?.value).toSet(), attachmentBlobIds);
+    expect(result.inlineImages.map((a) => a.cid).toSet(), inlineCids);
+  }
+
+  group('EmailAttachmentClassifierExtension::classifyAttachments::', () {
+    test('no attachments returns empty lists', () {
+      expectPartition(
+        buildEmail().classifyAttachments(),
+        attachmentBlobIds: {},
+        inlineCids: {},
+      );
+    });
+
+    test('external attachment goes to attachments only', () {
+      final email = buildEmail(attachments: {externalPart(blobIdValue: 'b', name: 'doc.pdf')});
+      expectPartition(
+        email.classifyAttachments(),
+        attachmentBlobIds: {'b'},
+        inlineCids: {},
+      );
+    });
+
+    // Single-inline cases: each row is one Email with one inline attachment;
+    // the body either references its cid (→ inlineImages) or doesn't (→ attachments).
+    for (final tc in [
+      (
+        name: 'referenced (cid present in body) goes to inlineImages',
+        cid: 'ref@x',
+        body: '<img src="cid:ref@x">',
+        expectedAttachmentBlobs: <String>{},
+        expectedInlineCids: {'ref@x'},
+      ),
+      (
+        name: 'orphaned (cid not in body) is promoted to attachments',
+        cid: 'orphan@x',
+        body: '<p>no images here</p>',
+        expectedAttachmentBlobs: {'b'},
+        expectedInlineCids: <String>{},
+      ),
+      (
+        name: 'cid: src with whitespace is trimmed before matching',
+        cid: 'ref@x',
+        body: '<img src="cid:  ref@x  ">',
+        expectedAttachmentBlobs: <String>{},
+        expectedInlineCids: {'ref@x'},
+      ),
+    ]) {
+      test(tc.name, () {
+        final email = buildEmail(
+          attachments: {inlinePart(blobIdValue: 'b', cid: tc.cid)},
+          htmlContent: tc.body,
+        );
+        expectPartition(
+          email.classifyAttachments(),
+          attachmentBlobIds: tc.expectedAttachmentBlobs,
+          inlineCids: tc.expectedInlineCids,
+        );
+      });
+    }
+
+    test('mixed: external + referenced + orphaned partition correctly', () {
+      final email = buildEmail(
+        attachments: {
+          externalPart(blobIdValue: 'ext', name: 'doc.pdf'),
+          inlinePart(blobIdValue: 'ref', cid: 'ref@x'),
+          inlinePart(blobIdValue: 'orphan', cid: 'orphan@x'),
+        },
+        htmlContent: '<img src="cid:ref@x">',
+      );
+      expectPartition(
+        email.classifyAttachments(),
+        attachmentBlobIds: {'ext', 'orphan'},
+        inlineCids: {'ref@x'},
+      );
+    });
+
+    test('empty body: all inlines treated as orphaned', () {
+      // No htmlBody/bodyValues → emailContentList is empty → asHtmlString = ''
+      final email = buildEmail(attachments: {inlinePart(blobIdValue: 'b', cid: 'c@x')});
+      expectPartition(
+        email.classifyAttachments(),
+        attachmentBlobIds: {'b'},
+        inlineCids: {},
+      );
+    });
+
+    test('malformed HTML: classifier must not crash', () {
+      // The html package is lenient; this test pins down the catch branch
+      // so future parser swaps don't propagate exceptions to callers.
+      final email = buildEmail(
+        attachments: {inlinePart(blobIdValue: 'b', cid: 'c@x')},
+        htmlContent: '<<<>>>not html<<<',
+      );
+      expect(() => email.classifyAttachments(), returnsNormally);
+    });
+
+    test('inline disposition without cid is excluded from inline list', () {
+      // hasCid() filter in listAttachmentsDisplayedInContent skips this entry;
+      // it falls through to outside (noCid() → isOutsideAttachment).
+      final email = buildEmail(
+        attachments: {EmailBodyPart(blobId: Id('b'), disposition: 'inline')},
+        htmlContent: '<p>text</p>',
+      );
+      expectPartition(
+        email.classifyAttachments(),
+        attachmentBlobIds: {'b'},
+        inlineCids: {},
+      );
+    });
+
+    test('undefined disposition + cid (orphan) appears once, not duplicated', () {
+      // Regression guard: undefined+cid satisfies BOTH isOutsideAttachment and
+      // listAttachmentsDisplayedInContent predicates. Must dedupe by blobId.
+      final email = buildEmail(
+        attachments: {inlinePart(blobIdValue: 'b', cid: 'c@x', disposition: null)},
+        htmlContent: '<p>no cid ref</p>',
+      );
+      expectPartition(
+        email.classifyAttachments(),
+        attachmentBlobIds: {'b'},
+        inlineCids: {},
+      );
+    });
+  });
+}

--- a/test/features/email/domain/extensions/email_attachment_classifier_extension_test.dart
+++ b/test/features/email/domain/extensions/email_attachment_classifier_extension_test.dart
@@ -41,7 +41,7 @@ void main() {
     expect(result.inlineImages.map((a) => a.cid).toSet(), inlineCids);
   }
 
-  group('EmailAttachmentClassifierExtension::classifyAttachments::', () {
+  group('EmailAttachmentClassifierExtension::toPresentationAttachments::', () {
     test('no attachments returns empty lists', () {
       expectPartition(
         buildEmail().toPresentationAttachments(),

--- a/test/features/email/domain/usecases/get_email_content_interactor_test.dart
+++ b/test/features/email/domain/usecases/get_email_content_interactor_test.dart
@@ -1,0 +1,195 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http_parser/http_parser.dart' show MediaType;
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email_body_part.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email_body_value.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/email/domain/repository/email_repository.dart';
+import 'package:tmail_ui_user/features/email/domain/state/get_email_content_state.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/get_email_content_interactor.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import '../../../../fixtures/session_fixtures.dart';
+
+import 'get_email_content_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<EmailRepository>()])
+void main() {
+  late MockEmailRepository mockEmailRepository;
+  late GetEmailContentInteractor interactor;
+
+  final session = SessionFixtures.aliceSession;
+  final accountId = AccountFixtures.aliceAccountId;
+  final emailId = EmailId(Id('test-email-id'));
+  const baseDownloadUrl = 'https://download.example.com/';
+  final transformConfig = TransformConfiguration.forPreviewEmailOnWeb();
+
+  setUp(() {
+    mockEmailRepository = MockEmailRepository();
+    interactor = GetEmailContentInteractor(mockEmailRepository);
+  });
+
+  // Helper: build EmailBodyPart for a regular (external) attachment
+  EmailBodyPart makeExternalAttachment({required String blobIdValue, String? name}) =>
+      EmailBodyPart(blobId: Id(blobIdValue), disposition: 'attachment', name: name);
+
+  // Helper: build EmailBodyPart for an inline attachment with a cid
+  EmailBodyPart makeInlineAttachment({required String blobIdValue, required String cid}) =>
+      EmailBodyPart(blobId: Id(blobIdValue), cid: cid, disposition: 'inline');
+
+  // Helper: build an Email with given attachments and an optional HTML body string
+  Email makeEmail({Set<EmailBodyPart>? attachments, String htmlContent = ''}) {
+    if (htmlContent.isEmpty) {
+      return Email(id: emailId, attachments: attachments);
+    }
+    return Email(
+      id: emailId,
+      attachments: attachments,
+      htmlBody: {
+        EmailBodyPart(partId: PartId('1'), type: MediaType('text', 'html')),
+      },
+      bodyValues: {
+        PartId('1'): EmailBodyValue(
+          value: htmlContent,
+          isEncodingProblem: false,
+          isTruncated: false,
+        ),
+      },
+    );
+  }
+
+  // Helper: stub transformEmailContent so the stream can proceed past email content processing
+  void stubTransform() {
+    when(mockEmailRepository.transformEmailContent(any, any, any))
+        .thenAnswer((_) async => []);
+  }
+
+  // Helper: extract GetEmailContentSuccess from stream results
+  Future<GetEmailContentSuccess> runAndGetSuccess() async {
+    final results = await interactor
+        .execute(session, accountId, emailId, baseDownloadUrl, transformConfig)
+        .toList();
+    return results
+        .whereType<Right<Failure, Success>>()
+        .map((r) => r.value)
+        .whereType<GetEmailContentSuccess>()
+        .first;
+  }
+
+  // Helper: stub + run a single inline-attachment scenario and return the success state
+  Future<GetEmailContentSuccess> runWithInlinePart({
+    required String cid,
+    required String blobIdValue,
+    required String htmlContent,
+  }) async {
+    final inlinePart = makeInlineAttachment(blobIdValue: blobIdValue, cid: cid);
+    when(mockEmailRepository.getEmailContent(session, accountId, emailId))
+        .thenAnswer((_) async => makeEmail(attachments: {inlinePart}, htmlContent: htmlContent));
+    stubTransform();
+    return runAndGetSuccess();
+  }
+
+  group('GetEmailContentInteractor::classifyAttachments::', () {
+    test('no attachments: both lists are empty', () async {
+      final email = makeEmail();
+      when(mockEmailRepository.getEmailContent(session, accountId, emailId))
+          .thenAnswer((_) async => email);
+      stubTransform();
+
+      final success = await runAndGetSuccess();
+
+      expect(success.attachments, isEmpty);
+      expect(success.inlineImages, isEmpty);
+    });
+
+    test('external attachment only: appears in attachments, not inlineImages', () async {
+      final extPart = makeExternalAttachment(blobIdValue: 'blob-ext', name: 'doc.pdf');
+      when(mockEmailRepository.getEmailContent(session, accountId, emailId))
+          .thenAnswer((_) async => makeEmail(attachments: {extPart}));
+      stubTransform();
+
+      final success = await runAndGetSuccess();
+
+      expect(success.attachments, hasLength(1));
+      expect(success.attachments!.first.blobId, equals(Id('blob-ext')));
+      expect(success.inlineImages, isEmpty);
+    });
+
+    for (final tc in [
+      (
+        description: 'referenced inline image: appears in inlineImages, not attachments',
+        cid: 'referenced-cid@domain',
+        blobId: 'blob-inline',
+        expectInline: true,
+      ),
+      (
+        description: 'orphaned inline image: promoted to attachments, not inlineImages',
+        cid: 'orphan-cid@domain',
+        blobId: 'blob-orphan',
+        expectInline: false,
+      ),
+    ]) {
+      final htmlContent = tc.expectInline
+          ? '<img src="cid:${tc.cid}">'
+          : '<p>No cid reference here</p>';
+
+      test(tc.description, () async {
+        final success = await runWithInlinePart(
+          cid: tc.cid,
+          blobIdValue: tc.blobId,
+          htmlContent: htmlContent,
+        );
+        final populated = tc.expectInline ? success.inlineImages : success.attachments;
+        final empty = tc.expectInline ? success.attachments : success.inlineImages;
+        expect(populated, hasLength(1));
+        expect(populated!.first.cid, equals(tc.cid));
+        expect(empty, isEmpty);
+      });
+    }
+
+    test('empty html body: inline image with cid treated as orphaned', () async {
+      const cid = 'some-cid@domain';
+      final inlinePart = makeInlineAttachment(blobIdValue: 'blob-inline', cid: cid);
+      // No htmlContent → emailContentList is empty → _extractReferencedCids returns {}
+      when(mockEmailRepository.getEmailContent(session, accountId, emailId))
+          .thenAnswer((_) async => makeEmail(attachments: {inlinePart}));
+      stubTransform();
+
+      final success = await runAndGetSuccess();
+
+      expect(success.attachments, hasLength(1));
+      expect(success.inlineImages, isEmpty);
+    });
+
+    test('mixed: external + referenced + orphaned are correctly partitioned', () async {
+      const referencedCid = 'referenced@domain';
+      const orphanedCid = 'orphan@domain';
+      final extPart = makeExternalAttachment(blobIdValue: 'blob-ext', name: 'report.pdf');
+      final referencedPart = makeInlineAttachment(blobIdValue: 'blob-ref', cid: referencedCid);
+      final orphanedPart = makeInlineAttachment(blobIdValue: 'blob-orphan', cid: orphanedCid);
+      when(mockEmailRepository.getEmailContent(session, accountId, emailId))
+          .thenAnswer((_) async => makeEmail(
+            attachments: {extPart, referencedPart, orphanedPart},
+            htmlContent: '<img src="cid:$referencedCid">',
+          ));
+      stubTransform();
+
+      final success = await runAndGetSuccess();
+
+      // attachments = external + orphaned (2 items)
+      expect(success.attachments, hasLength(2));
+      final attachmentBlobIds = success.attachments!.map((a) => a.blobId).toSet();
+      expect(attachmentBlobIds, containsAll([Id('blob-ext'), Id('blob-orphan')]));
+
+      // inlineImages = referenced only (1 item)
+      expect(success.inlineImages, hasLength(1));
+      expect(success.inlineImages!.first.cid, equals(referencedCid));
+    });
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Orphaned inline images are now shown in the attachment panel and not silently re-attached.
  * Improved attachment classification for consistent presentation of inline vs outside attachments.

* **Bug Fixes**
  * Base64 image handling normalized for reliable rendering; invalid base64 inputs are handled safely without crashes.
  * CID-referenced images preserved in email display/attachments.

* **Chores**
  * Cache version bumped; mobile upgrade clears detailed email cache.

* **Tests**
  * Added tests for base64 handling, CID images, orphaned inlines, and attachment classification.

* **Documentation**
  * ADR updated to document orphaned inline attachment behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-flutter/pull/4503)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->