### PR TITLE
Hotfix: Prevent `sentry_flutter` from loading Sentry bundle from CDN  

### DIFF
--- a/docs/adr/0087-block-sentry-cdn-on-web.md
+++ b/docs/adr/0087-block-sentry-cdn-on-web.md
@@ -1,0 +1,96 @@
+# 0087. Block Sentry CDN Loading on Web
+
+Date: 2026-05-12
+
+## Status
+
+Accepted
+
+## Context
+
+`sentry_flutter` on web initializes the Sentry JS SDK by dynamically injecting a `<script>` tag pointing to `https://browser.sentry-cdn.com/<version>/bundle.tracing.min.js`. This creates an external network dependency that:
+
+- Violates Content Security Policy in environments that restrict third-party scripts.
+- Introduces a CDN availability risk — if `browser.sentry-cdn.com` is unreachable, Sentry initialization fails silently.
+- May be blocked by corporate proxies or privacy-focused browser extensions.
+
+The goal is to serve the Sentry JS bundle from the same origin as the app while reliably preventing the package from loading it from CDN at runtime.
+
+## Investigation
+
+### Why `document.createElement` patching does not work
+
+The first fix attempt intercepted CDN loading by overriding `document.createElement('script')`. This approach failed because `sentry_flutter`'s `web_script_dom_api.dart` creates script elements via:
+
+```dart
+final script = HTMLScriptElement()  // Dart package:web interop
+```
+
+`HTMLScriptElement()` is a native DOM constructor called through Dart's JS interop (`package:web`). It does **not** go through `document.createElement`, so the patch was never triggered and the CDN request was never blocked.
+
+### Why SRI caused a silent outage
+
+The first fix also added `integrity="sha384-..."` and `crossorigin="anonymous"` attributes to the self-hosted scripts. When the deployed file content on the server differed from the hash in `index.html` (deployment drift), the browser blocked both scripts via SRI failure. With neither the self-hosted SDK nor the interceptor loaded, the CDN request went through unblocked — the security mechanism was silently disabled.
+
+For same-origin scripts, SRI provides marginal security value:
+- Full-compromise scenario: an attacker who can tamper the JS file can also update the hash in `index.html`.
+- MITM scenario: HTTPS already covers this for same-origin resources.
+
+The operational risk (hash staleness disables the entire protection silently) outweighs the security benefit.
+
+## Decision
+
+### 1. Self-host the Sentry JS bundle
+
+Place `bundle.tracing.min.js` (renamed to `sentry-tracing.min.js`) under `web/js/` and load it via a `<script>` tag in `index.html` **before** the Flutter app boots. This pre-populates `window.Sentry` so the Dart SDK can use it without fetching from CDN.
+
+### 2. Patch `HTMLScriptElement.prototype.src` to block CDN injection
+
+Since `sentry_flutter` creates `HTMLScriptElement` instances via the native constructor (bypassing `document.createElement`), the interceptor must patch the **prototype-level `src` setter**. This intercepts `src` assignments on all script elements universally, regardless of how they were created.
+
+```javascript
+const nativeSrcDescriptor = Object.getOwnPropertyDescriptor(HTMLScriptElement.prototype, 'src');
+Object.defineProperty(HTMLScriptElement.prototype, 'src', {
+  configurable: true,
+  enumerable: true,
+  get: function() { return nativeSrcDescriptor.get.call(this); },
+  set: function(val) {
+    if (shouldBlockSentryUrl(String(val))) {
+      // dispatch synthetic 'load' so the SDK's internal Promise resolves cleanly
+      setTimeout(() => this.dispatchEvent(new Event('load')), 10);
+      return;
+    }
+    nativeSrcDescriptor.set.call(this, val);
+  },
+});
+```
+
+`Element.prototype.setAttribute` is also patched as defense-in-depth for the `setAttribute('src', ...)` path.
+
+### 3. Omit SRI for self-hosted scripts
+
+`integrity` and `crossorigin` attributes are intentionally omitted from the two self-hosted `<script>` tags. The rationale:
+
+- SRI for same-origin resources does not protect against the scenarios it is designed for (cross-origin supply-chain attacks, CDN compromise).
+- Hash staleness from any deployment drift would silently disable the interceptor — the opposite of the intended behavior.
+- HTTPS protects same-origin transport. The server itself is the trust boundary.
+
+If a stronger integrity posture is required in the future, a `Content-Security-Policy: script-src 'self'` header at the server/nginx level is the correct solution — it enforces origin restriction without the fragility of per-file hashes.
+
+### 4. Load order
+
+```html
+<!-- index.html -->
+<script src="js/sentry-tracing.min.js?v=1.0.0"></script>   <!-- SDK bundle, populates window.Sentry -->
+<script src="js/sentry-interceptor.js?v=1.0.1"></script>   <!-- patches prototype, blocks CDN injection -->
+<!-- Flutter bootstrap follows -->
+```
+
+The interceptor must activate after the SDK bundle so `window.Sentry` is already populated when `SentryFlutter.init()` runs.
+
+## Consequences
+
+- `browser.sentry-cdn.com` is never contacted at runtime — CDN dependency is eliminated.
+- Sentry initialization is resilient to CDN availability issues and third-party blockers.
+- Updating the Sentry JS bundle version requires replacing `web/js/sentry-tracing.min.js` and bumping the `?v=` query parameter in `index.html`.
+- The interceptor is version-independent: it blocks any URL matching `*.sentry-cdn.com/*/bundle.tracing.min.js`, so it does not need to be updated when the SDK version changes.

--- a/test/features/caching/email_cache_client_test.dart
+++ b/test/features/caching/email_cache_client_test.dart
@@ -13,8 +13,8 @@ void main() {
 
   late EmailCacheClient emailCacheClient;
 
-  setUpAll(() {
-    HiveCacheConfig.instance.setUp(cachePath: Directory.current.path);
+  setUpAll(() async {
+    await HiveCacheConfig.instance.setUp(cachePath: Directory.current.path);
   });
 
   setUp(() {

--- a/web/index.html
+++ b/web/index.html
@@ -41,10 +41,11 @@
   <script src="worker_service/worker_service.js"></script>
   <script src="i18n/translater.js"></script>
   <script src="https://unpkg.com/@dotlottie/player-component@2.7.12/dist/dotlottie-player.mjs" type="module"></script>
-  <!-- Load Sentry SDK first (self-hosted bundle), then interceptor to block any subsequent CDN injection.
-       Order matters: the interceptor must activate after the SDK is ready so it can patch document.createElement. -->
-  <script src="js/sentry-tracing.min.js?v=1.0.0" integrity="sha384-SFODEb3T2QkMjTr3S1it5zIK0cIW7jsComFUkmJ9nU9uaWs3AzA6cubt8xn0zW7A" crossorigin="anonymous"></script>
-  <script src="js/sentry-interceptor.js?v=1.0.0" integrity="sha384-uThyomTT1K0+gzqsKuq4UoZXu3SABtbtP7Y3NXFyvabuIQPGYszSO41UBrcs5czI" crossorigin="anonymous"></script>
+  <!-- Load self-hosted Sentry SDK first, then the interceptor that blocks any subsequent
+       CDN injection attempted by sentry_flutter at runtime. Order matters: interceptor
+       must activate after the SDK bundle so window.Sentry is already populated. -->
+  <script src="js/sentry-tracing.min.js?v=1.0.0"></script>
+  <script src="js/sentry-interceptor.js?v=1.0.1"></script>
 </head>
 <body>
 

--- a/web/js/sentry-interceptor.js
+++ b/web/js/sentry-interceptor.js
@@ -1,4 +1,10 @@
 (function() {
+  // Guard against double-execution (e.g. duplicate script tag, hot-reload).
+  // On a second load, nativeSrcDescriptor would resolve to our already-patched
+  // setter instead of the native one, causing infinite recursion.
+  if (window.__sentryInterceptorActive) return;
+  window.__sentryInterceptorActive = true;
+
   const BLOCKED_PATHNAME = '/bundle.tracing.min.js';
 
   function isSentryCdnHostname(hostname) {
@@ -20,7 +26,7 @@
     console.log('[Sentry Interceptor] 🛑 Blocked CDN request (' + channel + '):', urlString);
     // Dispatch a synthetic 'load' event so the Sentry SDK's internal Promise
     // resolves cleanly instead of hanging indefinitely.
-    setTimeout(() => element.dispatchEvent(new Event('load')), 10);
+    Promise.resolve().then(() => element.dispatchEvent(new Event('load')));
   }
 
   // sentry_flutter's web_script_dom_api.dart creates script elements via
@@ -59,14 +65,25 @@
   }
 
   // Defense-in-depth: also intercept setAttribute('src', ...) as a fallback.
+  // Patched on HTMLScriptElement.prototype only (not Element) to avoid
+  // intercepting setAttribute on every element in the DOM.
   const originalSetAttribute = Element.prototype.setAttribute;
-  Element.prototype.setAttribute = function(name, value) {
-    const urlString = value ? String(value) : '';
-    const isScriptSrc = this instanceof HTMLScriptElement && String(name).toLowerCase() === 'src';
-    if (isScriptSrc && shouldBlockSentryUrl(urlString)) {
-      blockAndNotify(this, 'setAttribute', urlString);
-      return;
-    }
-    originalSetAttribute.call(this, name, value);
-  };
+  try {
+    Object.defineProperty(HTMLScriptElement.prototype, 'setAttribute', {
+      configurable: true,
+      writable: true,
+      value: function(name, value) {
+        if (String(name).toLowerCase() === 'src') {
+          const urlString = String(value || '');
+          if (shouldBlockSentryUrl(urlString)) {
+            blockAndNotify(this, 'setAttribute', urlString);
+            return;
+          }
+        }
+        originalSetAttribute.call(this, name, value);
+      },
+    });
+  } catch (e) {
+    console.warn('[Sentry Interceptor] Failed to patch HTMLScriptElement.setAttribute:', e);
+  }
 })();

--- a/web/js/sentry-interceptor.js
+++ b/web/js/sentry-interceptor.js
@@ -1,8 +1,4 @@
 (function() {
-  const originalCreateElement = document.createElement;
-
-  // Only block the specific tracing bundle we self-host. Narrowing to this pathname
-  // prevents silently swallowing future CDN assets that have no local replacement.
   const BLOCKED_PATHNAME = '/bundle.tracing.min.js';
 
   function isSentryCdnHostname(hostname) {
@@ -13,71 +9,50 @@
     if (!urlString) return false;
     try {
       const parsed = new URL(urlString, document.baseURI);
-      const hostname = parsed.hostname.toLowerCase();
-      const pathname = parsed.pathname.toLowerCase();
-      return isSentryCdnHostname(hostname) && pathname.endsWith(BLOCKED_PATHNAME);
+      return isSentryCdnHostname(parsed.hostname.toLowerCase()) &&
+             parsed.pathname.toLowerCase().endsWith(BLOCKED_PATHNAME);
     } catch (e) {
-      // Fallback for non-parseable URLs: check if it looks like a plain hostname
-      // (no whitespace, no path/query/fragment separators).
-      const str = String(urlString).trim().toLowerCase();
-      const isHostLike = str.length > 0 && !/[\s/?#]/.test(str);
-      return isHostLike && isSentryCdnHostname(str);
+      return false;
     }
   }
 
   function blockAndNotify(element, channel, urlString) {
     console.log('[Sentry Interceptor] 🛑 Blocked CDN request (' + channel + '):', urlString);
-    // Fire a synthetic 'load' event so the Sentry SDK's internal Promise resolves
-    // cleanly instead of hanging indefinitely waiting for a CDN script we blocked.
+    // Dispatch a synthetic 'load' event so the Sentry SDK's internal Promise
+    // resolves cleanly instead of hanging indefinitely.
     setTimeout(() => element.dispatchEvent(new Event('load')), 10);
   }
 
-  function makeSrcSetter(nativeSrcDescriptor) {
-    return function(val) {
+  // sentry_flutter's web_script_dom_api.dart creates script elements via
+  // `new HTMLScriptElement()` (Dart package:web interop), which bypasses
+  // document.createElement entirely. We must patch the prototype-level src
+  // setter to intercept ALL HTMLScriptElement src assignments universally.
+  const nativeSrcDescriptor = Object.getOwnPropertyDescriptor(HTMLScriptElement.prototype, 'src');
+  Object.defineProperty(HTMLScriptElement.prototype, 'src', {
+    configurable: true,
+    enumerable: true,
+    get: function() {
+      return nativeSrcDescriptor.get.call(this);
+    },
+    set: function(val) {
       const urlString = val ? String(val) : '';
       if (shouldBlockSentryUrl(urlString)) {
-        blockAndNotify(this, 'Property', urlString);
-      } else {
-        nativeSrcDescriptor?.set?.call(this, val);
-      }
-    };
-  }
-
-  function makeSrcGetter(nativeSrcDescriptor) {
-    return function() {
-      return nativeSrcDescriptor?.get?.call(this) ?? '';
-    };
-  }
-
-  function makeSetAttribute(originalSetAttribute) {
-    return function(name, value) {
-      const urlString = value ? String(value) : '';
-      if (String(name).toLowerCase() === 'src' && shouldBlockSentryUrl(urlString)) {
-        blockAndNotify(this, 'Attribute', urlString);
+        blockAndNotify(this, 'HTMLScriptElement.src', urlString);
         return;
       }
-      originalSetAttribute.call(this, name, value);
-    };
-  }
+      nativeSrcDescriptor.set.call(this, val);
+    },
+  });
 
-  function patchScriptElement(element) {
-    const nativeSrcDescriptor = Object.getOwnPropertyDescriptor(HTMLScriptElement.prototype, 'src');
-    Object.defineProperty(element, 'src', {
-      configurable: true,
-      set: makeSrcSetter(nativeSrcDescriptor),
-      get: makeSrcGetter(nativeSrcDescriptor),
-    });
-    element.setAttribute = makeSetAttribute(element.setAttribute);
-  }
-
-  // Load order: sentry-tracing.min.js (self-hosted SDK) must run before this interceptor.
-  // This interceptor patches document.createElement to block any subsequent CDN injection
-  // the SDK may attempt at runtime.
-  document.createElement = function(tagName, options) {
-    const element = originalCreateElement.call(document, tagName, options);
-    if (String(tagName).toLowerCase() === 'script') {
-      patchScriptElement(element);
+  // Defense-in-depth: also intercept setAttribute('src', ...) as a fallback.
+  const originalSetAttribute = Element.prototype.setAttribute;
+  Element.prototype.setAttribute = function(name, value) {
+    const urlString = value ? String(value) : '';
+    const isScriptSrc = this instanceof HTMLScriptElement && String(name).toLowerCase() === 'src';
+    if (isScriptSrc && shouldBlockSentryUrl(urlString)) {
+      blockAndNotify(this, 'setAttribute', urlString);
+      return;
     }
-    return element;
+    originalSetAttribute.call(this, name, value);
   };
 })();

--- a/web/js/sentry-interceptor.js
+++ b/web/js/sentry-interceptor.js
@@ -28,21 +28,35 @@
   // document.createElement entirely. We must patch the prototype-level src
   // setter to intercept ALL HTMLScriptElement src assignments universally.
   const nativeSrcDescriptor = Object.getOwnPropertyDescriptor(HTMLScriptElement.prototype, 'src');
-  Object.defineProperty(HTMLScriptElement.prototype, 'src', {
-    configurable: true,
-    enumerable: true,
-    get: function() {
-      return nativeSrcDescriptor.get.call(this);
-    },
-    set: function(val) {
-      const urlString = val ? String(val) : '';
-      if (shouldBlockSentryUrl(urlString)) {
-        blockAndNotify(this, 'HTMLScriptElement.src', urlString);
-        return;
-      }
-      nativeSrcDescriptor.set.call(this, val);
-    },
-  });
+  const canPatchSrc =
+    nativeSrcDescriptor &&
+    typeof nativeSrcDescriptor.get === 'function' &&
+    typeof nativeSrcDescriptor.set === 'function' &&
+    nativeSrcDescriptor.configurable === true;
+
+  if (canPatchSrc) {
+    try {
+      Object.defineProperty(HTMLScriptElement.prototype, 'src', {
+        configurable: true,
+        enumerable: nativeSrcDescriptor.enumerable,
+        get: function() {
+          return nativeSrcDescriptor.get.call(this);
+        },
+        set: function(val) {
+          const urlString = val ? String(val) : '';
+          if (shouldBlockSentryUrl(urlString)) {
+            blockAndNotify(this, 'HTMLScriptElement.src', urlString);
+            return;
+          }
+          nativeSrcDescriptor.set.call(this, val);
+        },
+      });
+    } catch (e) {
+      console.warn('[Sentry Interceptor] Failed to patch HTMLScriptElement.src:', e);
+    }
+  } else {
+    console.warn('[Sentry Interceptor] HTMLScriptElement.src patch unavailable; using setAttribute fallback only.');
+  }
 
   // Defense-in-depth: also intercept setAttribute('src', ...) as a fallback.
   const originalSetAttribute = Element.prototype.setAttribute;


### PR DESCRIPTION
## Issue

After deploying #4343 (self-hosted Sentry bundle), `bundle.tracing.min.js` was still being loaded from `browser.sentry-cdn.com` instead of the self-hosted server.

<img width="969" height="523" alt="Screenshot 2026-05-12 at 10 36 42" src="https://github.com/user-attachments/assets/9867fe23-df23-4e74-9ba5-aad728c76c15" />


## Root Cause

### 1. Wrong interception hook

`sentry-interceptor.js` patched `document.createElement('script')`, but `sentry_flutter`'s `web_script_dom_api.dart` creates script elements via `new HTMLScriptElement()` (Dart `package:web` interop), which bypasses `document.createElement`.  As a result, the interceptor was never triggered.

### 2. SRI blocked script loading

The `integrity="sha384-..."` attributes in `index.html` caused SRI validation failures because the deployed file content differed from the local hash.

This prevented both self-hosted scripts from loading:

- `sentry-tracing.min.js`
- `sentry-interceptor.js`

Because the interceptor failed to load, requests to `browser.sentry-cdn.com` were not blocked.

## Solution

### Update `sentry-interceptor.js`

Replace `document.createElement` interception with `HTMLScriptElement.prototype.src` descriptor patching.

This ensures all script `src` assignments are intercepted, regardless of whether the script element is created via:

- `document.createElement(...)`
- `new HTMLScriptElement()`

### Update `index.html`

Remove `integrity` and `crossorigin` attributes from the self-hosted Sentry scripts.

For same-origin resources, SRI provides limited security value but increases deployment risk because stale hashes can silently break script loading.

Also update interceptor version:

- `sentry-interceptor.js?v=1.0.1`

to force browser cache refresh.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched to a self‑hosted Sentry SDK, added a startup interceptor to block runtime CDN requests, preloaded the SDK before app boot, and updated script version query params while removing subresource integrity attributes.

* **Bug Fixes**
  * Prevents CDN loads at runtime and dispatches synthetic load events so initialization proceeds reliably even when external requests are blocked.

* **Documentation**
  * Added an ADR describing the approved approach and deployment considerations.

* **Tests**
  * Updated test setup to asynchronously initialize cache configuration before running tests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-flutter/pull/4509)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->