### PR TITLE
Hotfix: Double-slash path normalization for JMAP session endpoints    

### DIFF
--- a/core/lib/presentation/extensions/uri_extension.dart
+++ b/core/lib/presentation/extensions/uri_extension.dart
@@ -37,4 +37,6 @@ extension URIExtension on Uri {
     }
     return replace(scheme: 'wss');
   }
+
+  Uri normalizePathSlashes() => Uri.parse(toString().normalizePathSlashes());
 }

--- a/core/lib/presentation/extensions/uri_extension.dart
+++ b/core/lib/presentation/extensions/uri_extension.dart
@@ -38,5 +38,5 @@ extension URIExtension on Uri {
     return replace(scheme: 'wss');
   }
 
-  Uri normalizePathSlashes() => Uri.parse(toString().normalizePathSlashes());
+  Uri normalizePathSlashes() => replace(path: path.normalizePathSlashes());
 }

--- a/core/lib/presentation/extensions/url_extension.dart
+++ b/core/lib/presentation/extensions/url_extension.dart
@@ -4,6 +4,9 @@ extension URLExtension on String {
   static const String prefixUrlHttps = 'https://';
   static const String prefixUrlHttp = 'http://';
 
+  // Negative lookbehind (?<!:) preserves :// so the scheme is never collapsed.
+  static final _multipleSlashRegExp = RegExp(r'(?<!:)/{2,}');
+
   String formatURLValid() {
     if (isNotEmpty) {
       if (startsWith(prefixUrlHttps)) {
@@ -46,4 +49,6 @@ extension URLExtension on String {
       return '/$this';
     }
   }
+
+  String normalizePathSlashes() => replaceAll(_multipleSlashRegExp, '/');
 }

--- a/core/test/presentation/extensions/uri_extension_test.dart
+++ b/core/test/presentation/extensions/uri_extension_test.dart
@@ -147,4 +147,63 @@ void main() {
       expect(uri.ensureWebSocketUri().toString(), 'wss://example.com/socket');
     });
   });
+
+  group('URIExtension.normalizePathSlashes', () {
+    test('should collapse leading double slash in path', () {
+      final uri = Uri.parse('http://localhost//upload/abc123');
+      expect(uri.normalizePathSlashes().toString(), 'http://localhost/upload/abc123');
+    });
+
+    test('should collapse triple slash in path', () {
+      final uri = Uri.parse('http://localhost///jmap');
+      expect(uri.normalizePathSlashes().toString(), 'http://localhost/jmap');
+    });
+
+    test('should not alter a path with single slashes', () {
+      final uri = Uri.parse('http://localhost/upload/abc123');
+      expect(uri.normalizePathSlashes().toString(), 'http://localhost/upload/abc123');
+    });
+
+    test('should preserve scheme, authority, and query string', () {
+      final uri = Uri.parse('http://example.com//download/acc/blob?type=plain&name=file');
+      final result = uri.normalizePathSlashes();
+      expect(result.scheme, 'http');
+      expect(result.host, 'example.com');
+      expect(result.path, '/download/acc/blob');
+      expect(result.query, 'type=plain&name=file');
+    });
+
+    test('should handle websocket URI with double slash', () {
+      final uri = Uri.parse('ws://localhost//jmap/ws');
+      expect(uri.normalizePathSlashes().toString(), 'ws://localhost/jmap/ws');
+    });
+
+    test('should normalize wss URI with double slash', () {
+      final uri = Uri.parse('wss://example.com//jmap/ws');
+      expect(uri.normalizePathSlashes().toString(), 'wss://example.com/jmap/ws');
+    });
+
+    test('should preserve port number while normalizing path', () {
+      final uri = Uri.parse('http://localhost:8080//upload/abc');
+      expect(uri.normalizePathSlashes().toString(), 'http://localhost:8080/upload/abc');
+    });
+
+    test('should collapse double slash in the middle of path', () {
+      final uri = Uri.parse('http://example.com/a//b/c');
+      expect(uri.normalizePathSlashes().toString(), 'http://example.com/a/b/c');
+    });
+
+    test('should collapse trailing double slash in path', () {
+      final uri = Uri.parse('http://example.com/api//');
+      expect(uri.normalizePathSlashes().toString(), 'http://example.com/api/');
+    });
+
+    test('should preserve query string while normalizing https URI', () {
+      final uri = Uri.parse('https://example.com//api?key=value');
+      final result = uri.normalizePathSlashes();
+      expect(result.path, '/api');
+      expect(result.query, 'key=value');
+      expect(result.toString(), 'https://example.com/api?key=value');
+    });
+  });
 }

--- a/core/test/presentation/extensions/url_extension_test.dart
+++ b/core/test/presentation/extensions/url_extension_test.dart
@@ -1,0 +1,85 @@
+import 'package:core/presentation/extensions/url_extension.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('URLExtension.normalizePathSlashes', () {
+    test('should collapse double slash in path', () {
+      expect(
+        'http://localhost//download/{accountId}/{blobId}'.normalizePathSlashes(),
+        'http://localhost/download/{accountId}/{blobId}',
+      );
+    });
+
+    test('should collapse triple slash in path', () {
+      expect(
+        'http://localhost///jmap'.normalizePathSlashes(),
+        'http://localhost/jmap',
+      );
+    });
+
+    test('should not alter a path with single slashes', () {
+      expect(
+        'http://localhost/upload/{accountId}'.normalizePathSlashes(),
+        'http://localhost/upload/{accountId}',
+      );
+    });
+
+    test('should preserve :// in the scheme', () {
+      expect(
+        'http://localhost//path'.normalizePathSlashes(),
+        'http://localhost/path',
+      );
+    });
+
+    test('should preserve URI template variables', () {
+      const url = 'http://localhost//downloadAll/{accountId}/{emailId}?name={name}';
+      expect(
+        url.normalizePathSlashes(),
+        'http://localhost/downloadAll/{accountId}/{emailId}?name={name}',
+      );
+    });
+
+    test('should handle websocket URL with double slash', () {
+      expect(
+        'ws://localhost//jmap/ws'.normalizePathSlashes(),
+        'ws://localhost/jmap/ws',
+      );
+    });
+
+    test('should return empty string unchanged', () {
+      expect(''.normalizePathSlashes(), '');
+    });
+
+    test('should collapse trailing double slash', () {
+      expect(
+        'http://localhost/path//'.normalizePathSlashes(),
+        'http://localhost/path/',
+      );
+    });
+
+    test('should collapse four or more consecutive slashes', () {
+      expect(
+        'http://localhost////path'.normalizePathSlashes(),
+        'http://localhost/path',
+      );
+    });
+
+    test('should preserve https:// scheme while normalizing path', () {
+      expect(
+        'https://localhost//path'.normalizePathSlashes(),
+        'https://localhost/path',
+      );
+    });
+
+    test('should preserve port number while normalizing path', () {
+      expect(
+        'http://localhost:8080//path'.normalizePathSlashes(),
+        'http://localhost:8080/path',
+      );
+    });
+
+    test('should collapse standalone double slash to single slash', () {
+      expect('//'.normalizePathSlashes(), '/');
+    });
+  });
+}

--- a/docs/adr/0087-fix-double-slash-path-normalization-jmap-endpoints.md
+++ b/docs/adr/0087-fix-double-slash-path-normalization-jmap-endpoints.md
@@ -8,36 +8,28 @@ Proposed
 
 ## Context
 
-The issue was surfaced during end-to-end (Patrol integration) tests: upload, download, WebSocket ticket, and download-all capability requests were returning 404 on certain server instances.
+Some JMAP servers return session capability URLs with consecutive slashes (e.g. `http://host//upload/{accountId}`). RFC 3986 treats `//path` and `/path` as distinct, so the extra slash is forwarded verbatim, causing 404s on upload, download, WebSocket ticket, and download-all requests.
 
-Root cause: some JMAP servers return session capability URLs with consecutive slashes in the path component (e.g. `http://host//upload/{accountId}`, `wss://host//event/{sessionState}`). RFC 3986 treats `//path` and `/path` as distinct URIs, so the extra slash is forwarded verbatim to the server, which rejects the request with 404.
-
-The project also had two independent implementations of the same normalization logic:
-
-- `Uri.normalizePathSlashes()` in `core/lib/presentation/extensions/uri_extension.dart`
-- `String.normalizePathSlashes()` in `core/lib/presentation/extensions/url_extension.dart`
-
-The `RegExp` for multi-slash detection was also instantiated on every call, causing unnecessary recompilation.
+The project also had two independent regex-based implementations of the same normalization, with the `RegExp` re-instantiated on every call.
 
 ## Decision
 
-1. **Single canonical implementation** — keep the regex in `String.normalizePathSlashes()` (`url_extension.dart`) and make `Uri.normalizePathSlashes()` delegate to it:
+1. **Single canonical implementation** — keep the regex in `String.normalizePathSlashes()` (`url_extension.dart`) and delegate from `Uri.normalizePathSlashes()`:
    ```dart
-   Uri normalizePathSlashes() => Uri.parse(toString().normalizePathSlashes());
+   Uri normalizePathSlashes() => replace(path: path.normalizePathSlashes());
    ```
 
-2. **Compile the regex once** — promote `RegExp(r'(?<!:)/{2,}')` to a `static final` field in `URLExtension`. The negative lookbehind `(?<!:)` ensures the `://` scheme separator is never collapsed.
+2. **Compile the regex once** — promote `RegExp(r'(?<!:)/{2,}')` to a `static final` field in `URLExtension`. The negative lookbehind `(?<!:)` ensures `://` is never collapsed.
 
-3. **Apply normalization at endpoint resolution** — call `normalizePathSlashes()` in four places where session URLs are turned into concrete HTTP/WebSocket requests:
-   - `SessionExtension.getUploadUri` (upload endpoint)
-   - `SessionExtension.getSafetyDownloadUrl` (download endpoint)
-   - `WebSocketTicketCapabilityExtension` (WebSocket ticket endpoint)
-   - `DownloadAllCapability.normalizedEndpoint` (download-all capability endpoint)
+3. **Apply normalization at endpoint resolution** — call `normalizePathSlashes()` in four places:
+   - `SessionExtension.getUploadUri`
+   - `SessionExtension.getSafetyDownloadUrl`
+   - `WebSocketTicketCapabilityExtension.normalizedGenerationEndpoint`
+   - `DownloadAllCapability.normalizedEndpoint`
 
 ## Consequences
 
-- ✅ Fixes 404 errors on servers that emit double-slash session URLs
-- ✅ Eliminates duplicated regex logic — single source of truth in `url_extension.dart`
-- ✅ Regex compiled once per app lifetime instead of once per call
-- ✅ No behaviour change for well-formed URLs (idempotent operation)
-- ✅ Full unit-test coverage added for the normalization chain: `url_extension`, `uri_extension`, `session_extension`, `download_all_capability`, and `web_socket_ticket_capability_extension`
+- Fixes 404 errors caused by double-slash session URLs
+- Single normalization source of truth; regex compiled once per app lifetime
+- No behaviour change for well-formed URLs (idempotent)
+- Full unit-test coverage for the normalization chain

--- a/docs/adr/0087-fix-double-slash-path-normalization-jmap-endpoints.md
+++ b/docs/adr/0087-fix-double-slash-path-normalization-jmap-endpoints.md
@@ -1,0 +1,43 @@
+# 0087 - Fix Double-Slash Path Normalization for JMAP Session Endpoints
+
+Date: 2026-05-12
+
+## Status
+
+Proposed
+
+## Context
+
+The issue was surfaced during end-to-end (Patrol integration) tests: upload, download, WebSocket ticket, and download-all capability requests were returning 404 on certain server instances.
+
+Root cause: some JMAP servers return session capability URLs with consecutive slashes in the path component (e.g. `http://host//upload/{accountId}`, `wss://host//event/{sessionState}`). RFC 3986 treats `//path` and `/path` as distinct URIs, so the extra slash is forwarded verbatim to the server, which rejects the request with 404.
+
+The project also had two independent implementations of the same normalization logic:
+
+- `Uri.normalizePathSlashes()` in `core/lib/presentation/extensions/uri_extension.dart`
+- `String.normalizePathSlashes()` in `core/lib/presentation/extensions/url_extension.dart`
+
+The `RegExp` for multi-slash detection was also instantiated on every call, causing unnecessary recompilation.
+
+## Decision
+
+1. **Single canonical implementation** — keep the regex in `String.normalizePathSlashes()` (`url_extension.dart`) and make `Uri.normalizePathSlashes()` delegate to it:
+   ```dart
+   Uri normalizePathSlashes() => Uri.parse(toString().normalizePathSlashes());
+   ```
+
+2. **Compile the regex once** — promote `RegExp(r'(?<!:)/{2,}')` to a `static final` field in `URLExtension`. The negative lookbehind `(?<!:)` ensures the `://` scheme separator is never collapsed.
+
+3. **Apply normalization at endpoint resolution** — call `normalizePathSlashes()` in four places where session URLs are turned into concrete HTTP/WebSocket requests:
+   - `SessionExtension.getUploadUri` (upload endpoint)
+   - `SessionExtension.getSafetyDownloadUrl` (download endpoint)
+   - `WebSocketTicketCapabilityExtension` (WebSocket ticket endpoint)
+   - `DownloadAllCapability.normalizedEndpoint` (download-all capability endpoint)
+
+## Consequences
+
+- ✅ Fixes 404 errors on servers that emit double-slash session URLs
+- ✅ Eliminates duplicated regex logic — single source of truth in `url_extension.dart`
+- ✅ Regex compiled once per app lifetime instead of once per call
+- ✅ No behaviour change for well-formed URLs (idempotent operation)
+- ✅ Full unit-test coverage added for the normalization chain: `url_extension`, `uri_extension`, `session_extension`, `download_all_capability`, and `web_socket_ticket_capability_extension`

--- a/lib/features/download/presentation/extensions/download_attachment_download_controller_extension.dart
+++ b/lib/features/download/presentation/extensions/download_attachment_download_controller_extension.dart
@@ -434,7 +434,7 @@ extension DownloadAttachmentDownloadControllerExtension on DownloadController {
     }
 
     final baseDownloadAllUrl =
-        session.getDownloadAllCapability(accountId)!.endpoint!;
+        session.getDownloadAllCapability(accountId)!.normalizedEndpoint!;
 
     consumeState(
       exportAllAttachmentsInteractor.execute(
@@ -504,7 +504,7 @@ extension DownloadAttachmentDownloadControllerExtension on DownloadController {
     }
 
     final baseDownloadAllUrl =
-        session.getDownloadAllCapability(accountId)!.endpoint!;
+        session.getDownloadAllCapability(accountId)!.normalizedEndpoint!;
 
     final downloadAttachment = Attachment(
       name: outputFileName,

--- a/lib/features/push_notification/data/extensions/web_socket_ticket_capability_extension.dart
+++ b/lib/features/push_notification/data/extensions/web_socket_ticket_capability_extension.dart
@@ -1,0 +1,10 @@
+import 'package:core/presentation/extensions/uri_extension.dart';
+import 'package:jmap_dart_client/jmap/core/capability/web_socket_ticket_capability.dart';
+
+extension WebSocketTicketCapabilityExtension on WebSocketTicketCapability {
+  Uri? get normalizedGenerationEndpoint =>
+      generationEndpoint?.normalizePathSlashes();
+
+  Uri? get normalizedRevocationEndpoint =>
+      revocationEndpoint?.normalizePathSlashes();
+}

--- a/lib/features/push_notification/data/extensions/web_socket_ticket_capability_extension.dart
+++ b/lib/features/push_notification/data/extensions/web_socket_ticket_capability_extension.dart
@@ -4,7 +4,4 @@ import 'package:jmap_dart_client/jmap/core/capability/web_socket_ticket_capabili
 extension WebSocketTicketCapabilityExtension on WebSocketTicketCapability {
   Uri? get normalizedGenerationEndpoint =>
       generationEndpoint?.normalizePathSlashes();
-
-  Uri? get normalizedRevocationEndpoint =>
-      revocationEndpoint?.normalizePathSlashes();
 }

--- a/lib/features/push_notification/data/network/web_socket_api.dart
+++ b/lib/features/push_notification/data/network/web_socket_api.dart
@@ -5,6 +5,7 @@ import 'package:jmap_dart_client/jmap/core/capability/capability_identifier.dart
 import 'package:jmap_dart_client/jmap/core/capability/web_socket_ticket_capability.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:model/extensions/session_extension.dart';
+import 'package:tmail_ui_user/features/push_notification/data/extensions/web_socket_ticket_capability_extension.dart';
 import 'package:tmail_ui_user/features/push_notification/data/model/web_socket_ticket.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/exceptions/web_socket_exceptions.dart';
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
@@ -26,7 +27,7 @@ class WebSocketApi {
       accountId,
       CapabilityIdentifier.jmapWebSocketTicket);
     
-    final webSocketTicketGenerationUrl = webSocketTicketCapability?.generationEndpoint;
+    final webSocketTicketGenerationUrl = webSocketTicketCapability?.normalizedGenerationEndpoint;
     if (webSocketTicketGenerationUrl == null) {
       throw WebSocketTicketUnavailableException();
     }

--- a/model/lib/download_all/download_all_capability.dart
+++ b/model/lib/download_all/download_all_capability.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/extensions/url_extension.dart';
 import 'package:jmap_dart_client/jmap/core/capability/capability_properties.dart';
 import 'package:json_annotation/json_annotation.dart';
 
@@ -8,6 +9,8 @@ class DownloadAllCapability extends CapabilityProperties {
   DownloadAllCapability({this.endpoint});
 
   final String? endpoint;
+
+  String? get normalizedEndpoint => endpoint?.normalizePathSlashes();
 
   factory DownloadAllCapability.fromJson(Map<String, dynamic> json) => _$DownloadAllCapabilityFromJson(json);
 

--- a/model/lib/extensions/session_extension.dart
+++ b/model/lib/extensions/session_extension.dart
@@ -33,7 +33,8 @@ extension SessionExtension on Session {
       throw const UnknownUriException();
     }
 
-    var baseUrl = '${downloadUrlValid.origin}${downloadUrlValid.path}?${downloadUrlValid.query}';
+    final normalizedUrl = downloadUrlValid.normalizePathSlashes();
+    var baseUrl = '${normalizedUrl.origin}${normalizedUrl.path}?${normalizedUrl.query}';
     if (baseUrl.endsWith('/')) {
       baseUrl = baseUrl.substring(0, baseUrl.length - 1);
     }
@@ -59,7 +60,8 @@ extension SessionExtension on Session {
       throw const UnknownUriException();
     }
 
-    final baseUrl = '${uploadUrlValid.origin}${uploadUrlValid.path}';
+    final normalizedUrl = uploadUrlValid.normalizePathSlashes();
+    final baseUrl = '${normalizedUrl.origin}${normalizedUrl.path}';
     final uploadUriTemplate = UriTemplate(Uri.decodeFull(baseUrl));
     final uploadUri = uploadUriTemplate.expand({
       'accountId' : accountId.id.value

--- a/model/test/download_all/download_all_capability_test.dart
+++ b/model/test/download_all/download_all_capability_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/download_all/download_all_capability.dart';
+
+void main() {
+  group('DownloadAllCapability.normalizedEndpoint', () {
+    test('should normalize double slashes from server-returned endpoint', () {
+      final capability = DownloadAllCapability(
+        endpoint: 'http://localhost//downloadAll/{accountId}/{emailId}?name={name}',
+      );
+
+      expect(
+        capability.normalizedEndpoint,
+        'http://localhost/downloadAll/{accountId}/{emailId}?name={name}',
+      );
+    });
+
+    test('should leave endpoint unchanged when path has single slash', () {
+      final capability = DownloadAllCapability(
+        endpoint: 'http://localhost/downloadAll/{accountId}/{emailId}?name={name}',
+      );
+
+      expect(
+        capability.normalizedEndpoint,
+        'http://localhost/downloadAll/{accountId}/{emailId}?name={name}',
+      );
+    });
+
+    test('should return null when endpoint is null', () {
+      final capability = DownloadAllCapability(endpoint: null);
+
+      expect(capability.normalizedEndpoint, isNull);
+    });
+
+    test('should preserve URI template variables after normalization', () {
+      final capability = DownloadAllCapability(
+        endpoint: 'https://example.com//api/{accountId}/{emailId}?name={name}',
+      );
+
+      expect(capability.normalizedEndpoint, contains('{accountId}'));
+      expect(capability.normalizedEndpoint, contains('{emailId}'));
+      expect(capability.normalizedEndpoint, contains('{name}'));
+    });
+
+    test('should collapse triple slashes to single slash', () {
+      final capability = DownloadAllCapability(
+        endpoint: 'http://localhost///downloadAll/{accountId}/{emailId}',
+      );
+
+      expect(
+        capability.normalizedEndpoint,
+        'http://localhost/downloadAll/{accountId}/{emailId}',
+      );
+    });
+
+    test('should collapse trailing double slash', () {
+      final capability = DownloadAllCapability(
+        endpoint: 'http://localhost/downloadAll//',
+      );
+
+      expect(capability.normalizedEndpoint, 'http://localhost/downloadAll/');
+    });
+
+    test('should return empty string when endpoint is empty', () {
+      final capability = DownloadAllCapability(endpoint: '');
+
+      expect(capability.normalizedEndpoint, '');
+    });
+
+    test('should normalize https endpoint with double slash', () {
+      final capability = DownloadAllCapability(
+        endpoint: 'https://example.com//api/{accountId}/{emailId}',
+      );
+
+      expect(
+        capability.normalizedEndpoint,
+        'https://example.com/api/{accountId}/{emailId}',
+      );
+    });
+  });
+}

--- a/model/test/extensions/session_extension_test.dart
+++ b/model/test/extensions/session_extension_test.dart
@@ -12,11 +12,129 @@ import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:model/error_type_handler/unknown_address_exception.dart';
+import 'package:model/error_type_handler/unknown_uri_exception.dart';
 import 'package:model/extensions/session_extension.dart';
 import 'package:model/principals/capability_principals.dart';
 
 void main() {
   final accountId = AccountId(Id('123abc'));
+
+  Session makeSession({
+    Uri? apiUrl,
+    Uri? downloadUrl,
+    Uri? uploadUrl,
+  }) =>
+      Session(
+        {},
+        {accountId: Account(AccountName('name'), true, true, {})},
+        {},
+        UserName('user@example.com'),
+        apiUrl ?? Uri.parse('http://localhost/jmap'),
+        downloadUrl ?? Uri.parse('http://localhost/download/{accountId}/{blobId}?type={type}&name={name}'),
+        uploadUrl ?? Uri.parse('http://localhost/upload/{accountId}'),
+        Uri.parse('http://localhost/eventSource'),
+        State(''),
+      );
+
+  group('getUploadUri', () {
+    test('should normalize double slashes when server returns path with //', () {
+      final session = makeSession(uploadUrl: Uri.parse('http://localhost//upload/{accountId}'));
+      expect(session.getUploadUri(accountId).toString(), 'http://localhost/upload/123abc');
+    });
+
+    test('should produce correct upload URI when path has single slash', () {
+      expect(makeSession().getUploadUri(accountId).toString(), 'http://localhost/upload/123abc');
+    });
+
+    test('should resolve relative uploadUrl using jmapUrl', () {
+      final session = makeSession(
+        apiUrl: Uri.parse('http://example.com/jmap'),
+        uploadUrl: Uri.parse('/upload/{accountId}'),
+      );
+      expect(
+        session.getUploadUri(accountId, jmapUrl: 'http://example.com').toString(),
+        'http://example.com/upload/123abc',
+      );
+    });
+
+    test('should throw UnknownUriException when uploadUrl has no origin and jmapUrl is not provided', () {
+      final session = makeSession(uploadUrl: Uri.parse('/upload/{accountId}'));
+      expect(
+        () => session.getUploadUri(accountId),
+        throwsA(isA<UnknownUriException>()),
+      );
+    });
+  });
+
+  group('getDownloadUrl', () {
+    test('should normalize double slashes when server returns path with //', () {
+      final session = makeSession(
+        downloadUrl: Uri.parse('http://localhost//download/{accountId}/{blobId}?type={type}&name={name}'),
+      );
+      expect(
+        session.getDownloadUrl(),
+        'http://localhost/download/{accountId}/{blobId}?type={type}&name={name}',
+      );
+    });
+
+    test('should produce correct download URL when path has single slash', () {
+      expect(
+        makeSession().getDownloadUrl(),
+        'http://localhost/download/{accountId}/{blobId}?type={type}&name={name}',
+      );
+    });
+
+    test('should resolve relative downloadUrl using jmapUrl', () {
+      final session = makeSession(
+        apiUrl: Uri.parse('http://example.com/jmap'),
+        downloadUrl: Uri.parse('/download/{accountId}/{blobId}?type={type}&name={name}'),
+      );
+      expect(
+        session.getDownloadUrl(jmapUrl: 'http://example.com'),
+        'http://example.com/download/{accountId}/{blobId}?type={type}&name={name}',
+      );
+    });
+
+    test('should throw UnknownUriException when downloadUrl has no origin and jmapUrl is not provided', () {
+      final session = makeSession(
+        downloadUrl: Uri.parse('/download/{accountId}/{blobId}?type={type}&name={name}'),
+      );
+      expect(
+        () => session.getDownloadUrl(),
+        throwsA(isA<UnknownUriException>()),
+      );
+    });
+
+    test('should preserve port number while normalizing download URL', () {
+      final session = makeSession(
+        apiUrl: Uri.parse('http://localhost:9000/jmap'),
+        downloadUrl: Uri.parse('http://localhost:9000//download/{accountId}/{blobId}?type={type}&name={name}'),
+      );
+      expect(
+        session.getDownloadUrl(),
+        'http://localhost:9000/download/{accountId}/{blobId}?type={type}&name={name}',
+      );
+    });
+  });
+
+  group('getSafetyDownloadUrl', () {
+    test('should return empty string when downloadUrl has no origin and jmapUrl is not provided', () {
+      final session = makeSession(
+        downloadUrl: Uri.parse('/download/{accountId}/{blobId}?type={type}&name={name}'),
+      );
+      expect(session.getSafetyDownloadUrl(), '');
+    });
+
+    test('should return normalized URL when downloadUrl is valid', () {
+      final session = makeSession(
+        downloadUrl: Uri.parse('http://localhost//download/{accountId}/{blobId}?type={type}&name={name}'),
+      );
+      expect(
+        session.getSafetyDownloadUrl(),
+        'http://localhost/download/{accountId}/{blobId}?type={type}&name={name}',
+      );
+    });
+  });
 
   group('validate calendar event capability test:', () {
     final account = Account(AccountName('name'), true, true, {});

--- a/test/features/push_notification/data/extensions/web_socket_ticket_capability_extension_test.dart
+++ b/test/features/push_notification/data/extensions/web_socket_ticket_capability_extension_test.dart
@@ -2,8 +2,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/core/capability/web_socket_ticket_capability.dart';
 import 'package:tmail_ui_user/features/push_notification/data/extensions/web_socket_ticket_capability_extension.dart';
 
-WebSocketTicketCapability _makeCapability({Uri? gen, Uri? rev}) =>
-    WebSocketTicketCapability(generationEndpoint: gen, revocationEndpoint: rev);
+WebSocketTicketCapability _makeCapability({Uri? gen}) =>
+    WebSocketTicketCapability(generationEndpoint: gen, revocationEndpoint: null);
 
 void main() {
   group('WebSocketTicketCapabilityExtension', () {
@@ -11,9 +11,7 @@ void main() {
       test('should normalize double slashes from server-returned endpoint', () {
         final endpoint = Uri.parse('http://localhost//jmap/ws/ticket');
         expect(
-          _makeCapability(gen: endpoint, rev: endpoint)
-              .normalizedGenerationEndpoint
-              .toString(),
+          _makeCapability(gen: endpoint).normalizedGenerationEndpoint.toString(),
           'http://localhost/jmap/ws/ticket',
         );
       });
@@ -21,9 +19,7 @@ void main() {
       test('should leave endpoint unchanged when path has single slash', () {
         final endpoint = Uri.parse('http://localhost/jmap/ws/ticket');
         expect(
-          _makeCapability(gen: endpoint, rev: endpoint)
-              .normalizedGenerationEndpoint
-              .toString(),
+          _makeCapability(gen: endpoint).normalizedGenerationEndpoint.toString(),
           'http://localhost/jmap/ws/ticket',
         );
       });
@@ -31,62 +27,13 @@ void main() {
       test('should return null when generationEndpoint is null', () {
         expect(_makeCapability().normalizedGenerationEndpoint, isNull);
       });
-    });
 
-    group('normalizedRevocationEndpoint', () {
-      test('should normalize double slashes from server-returned endpoint', () {
-        final endpoint = Uri.parse('http://localhost//jmap/ws/ticket');
+      test('should preserve port number after normalization', () {
+        final endpoint = Uri.parse('http://localhost:8080//jmap/ws/gen');
         expect(
-          _makeCapability(gen: endpoint, rev: endpoint)
-              .normalizedRevocationEndpoint
-              .toString(),
-          'http://localhost/jmap/ws/ticket',
+          _makeCapability(gen: endpoint).normalizedGenerationEndpoint.toString(),
+          'http://localhost:8080/jmap/ws/gen',
         );
-      });
-
-      test('should leave endpoint unchanged when path has single slash', () {
-        final endpoint = Uri.parse('http://localhost/jmap/ws/ticket');
-        expect(
-          _makeCapability(gen: endpoint, rev: endpoint)
-              .normalizedRevocationEndpoint
-              .toString(),
-          'http://localhost/jmap/ws/ticket',
-        );
-      });
-
-      test('should return null when revocationEndpoint is null', () {
-        expect(_makeCapability().normalizedRevocationEndpoint, isNull);
-      });
-
-      test('should collapse triple slashes', () {
-        final capability = _makeCapability(
-          gen: Uri.parse('http://localhost/jmap/ws/ticket'),
-          rev: Uri.parse('http://localhost///jmap/ws/ticket'),
-        );
-        expect(
-          capability.normalizedRevocationEndpoint.toString(),
-          'http://localhost/jmap/ws/ticket',
-        );
-      });
-    });
-
-    group('independent normalization', () {
-      test('should normalize both endpoints independently when they have different slash patterns', () {
-        final capability = _makeCapability(
-          gen: Uri.parse('http://localhost//gen/ticket'),
-          rev: Uri.parse('http://localhost///rev/ticket'),
-        );
-        expect(capability.normalizedGenerationEndpoint.toString(), 'http://localhost/gen/ticket');
-        expect(capability.normalizedRevocationEndpoint.toString(), 'http://localhost/rev/ticket');
-      });
-
-      test('should preserve port number in both endpoints', () {
-        final capability = _makeCapability(
-          gen: Uri.parse('http://localhost:8080//jmap/ws/gen'),
-          rev: Uri.parse('http://localhost:8080//jmap/ws/rev'),
-        );
-        expect(capability.normalizedGenerationEndpoint.toString(), 'http://localhost:8080/jmap/ws/gen');
-        expect(capability.normalizedRevocationEndpoint.toString(), 'http://localhost:8080/jmap/ws/rev');
       });
     });
   });

--- a/test/features/push_notification/data/extensions/web_socket_ticket_capability_extension_test.dart
+++ b/test/features/push_notification/data/extensions/web_socket_ticket_capability_extension_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/capability/web_socket_ticket_capability.dart';
+import 'package:tmail_ui_user/features/push_notification/data/extensions/web_socket_ticket_capability_extension.dart';
+
+WebSocketTicketCapability _makeCapability({Uri? gen, Uri? rev}) =>
+    WebSocketTicketCapability(generationEndpoint: gen, revocationEndpoint: rev);
+
+void main() {
+  group('WebSocketTicketCapabilityExtension', () {
+    group('normalizedGenerationEndpoint', () {
+      test('should normalize double slashes from server-returned endpoint', () {
+        final endpoint = Uri.parse('http://localhost//jmap/ws/ticket');
+        expect(
+          _makeCapability(gen: endpoint, rev: endpoint)
+              .normalizedGenerationEndpoint
+              .toString(),
+          'http://localhost/jmap/ws/ticket',
+        );
+      });
+
+      test('should leave endpoint unchanged when path has single slash', () {
+        final endpoint = Uri.parse('http://localhost/jmap/ws/ticket');
+        expect(
+          _makeCapability(gen: endpoint, rev: endpoint)
+              .normalizedGenerationEndpoint
+              .toString(),
+          'http://localhost/jmap/ws/ticket',
+        );
+      });
+
+      test('should return null when generationEndpoint is null', () {
+        expect(_makeCapability().normalizedGenerationEndpoint, isNull);
+      });
+    });
+
+    group('normalizedRevocationEndpoint', () {
+      test('should normalize double slashes from server-returned endpoint', () {
+        final endpoint = Uri.parse('http://localhost//jmap/ws/ticket');
+        expect(
+          _makeCapability(gen: endpoint, rev: endpoint)
+              .normalizedRevocationEndpoint
+              .toString(),
+          'http://localhost/jmap/ws/ticket',
+        );
+      });
+
+      test('should leave endpoint unchanged when path has single slash', () {
+        final endpoint = Uri.parse('http://localhost/jmap/ws/ticket');
+        expect(
+          _makeCapability(gen: endpoint, rev: endpoint)
+              .normalizedRevocationEndpoint
+              .toString(),
+          'http://localhost/jmap/ws/ticket',
+        );
+      });
+
+      test('should return null when revocationEndpoint is null', () {
+        expect(_makeCapability().normalizedRevocationEndpoint, isNull);
+      });
+
+      test('should collapse triple slashes', () {
+        final capability = _makeCapability(
+          gen: Uri.parse('http://localhost/jmap/ws/ticket'),
+          rev: Uri.parse('http://localhost///jmap/ws/ticket'),
+        );
+        expect(
+          capability.normalizedRevocationEndpoint.toString(),
+          'http://localhost/jmap/ws/ticket',
+        );
+      });
+    });
+
+    group('independent normalization', () {
+      test('should normalize both endpoints independently when they have different slash patterns', () {
+        final capability = _makeCapability(
+          gen: Uri.parse('http://localhost//gen/ticket'),
+          rev: Uri.parse('http://localhost///rev/ticket'),
+        );
+        expect(capability.normalizedGenerationEndpoint.toString(), 'http://localhost/gen/ticket');
+        expect(capability.normalizedRevocationEndpoint.toString(), 'http://localhost/rev/ticket');
+      });
+
+      test('should preserve port number in both endpoints', () {
+        final capability = _makeCapability(
+          gen: Uri.parse('http://localhost:8080//jmap/ws/gen'),
+          rev: Uri.parse('http://localhost:8080//jmap/ws/rev'),
+        );
+        expect(capability.normalizedGenerationEndpoint.toString(), 'http://localhost:8080/jmap/ws/gen');
+        expect(capability.normalizedRevocationEndpoint.toString(), 'http://localhost:8080/jmap/ws/rev');
+      });
+    });
+  });
+}


### PR DESCRIPTION

## Issue

Some JMAP server instances return capability URLs with consecutive slashes in the path (e.g. `http://host//upload/{accountId}`), causing `404` errors on:

- Upload
- Download
- WebSocket ticket
- Download-all

This issue was discovered during Patrol E2E testing.

## Root cause

According to RFC 3986, `//path` and `/path` are treated as distinct URIs, so the duplicated slash was forwarded unchanged to the server.

## Solution

- Added `String.normalizePathSlashes()` in `URLExtension`
- Used shared regex:

```dart
  (?<!:)/{2,}
```

- Updated `Uri.normalizePathSlashes()` to reuse the `String` implementation
- Applied normalization for 4 endpoints: upload, download, WebSocket ticket, and download-all


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed 404s and broken downloads caused by consecutive slashes by normalizing path slashes for upload, download, WebSocket and "download all" endpoints.

* **New Features**
  * Provide normalized endpoint access so callers receive cleaned URLs transparently.

* **Tests**
  * Added comprehensive unit tests covering slash-normalization across URL/URI flows and session resolution.

* **Documentation**
  * Added ADR describing the normalization approach and expected outcomes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-flutter/pull/4511)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->