### PR TITLE
TF-4081 Prevent network error log user out on mobile

### DIFF
--- a/docs/adr/0089-fix-unexpected-logout-on-poor-network.md
+++ b/docs/adr/0089-fix-unexpected-logout-on-poor-network.md
@@ -29,11 +29,11 @@ Affects three paths:
 
 On mobile OIDC, `_authenticationClient.refreshingTokensOIDC()` calls `_appAuth.token()` via MethodChannel (native AppAuth SDK — not Dio). Network failure from native SDK propagates as `PlatformException` or `FlutterAppAuthPlatformException`. Neither is a `DioException`, so both bypass the inner `on DioException catch` and reach the outer `catch`. The old `else` branch called `err.copyWith(error: e)`, preserving the stale 401.
 
-### Bug 2 — `handleGetSessionFailure` logs out for any exception type (mobile only)
+### Bug 2 — `handleGetSessionFailure` logs out for any exception type
 
 `lib/features/base/reloadable/reloadable_controller.dart`
 
-On app start/resume, `getSessionAction()` fetches JMAP session. On mobile, `GetSessionInteractor` falls back to Hive cache on failure. If cache is empty (fresh install or wiped by Bug 1's `cachingManager.clearAll()`), `GetSessionFailure(ConnectionTimeout)` is emitted. The handler called `clearDataAndGoToLoginPage()` unconditionally for all exception types. `validateUrgentException` does not include `ConnectionTimeout`, `SocketError`, or `UnknownRemoteException`, so these fall through and cause logout. Web does not use Hive session cache, so the original logout-on-failure behaviour is correct there.
+On app start/resume, `getSessionAction()` fetches JMAP session. On mobile, `GetSessionInteractor` falls back to Hive cache on failure. If cache is empty (fresh install or wiped by Bug 1's `cachingManager.clearAll()`), `GetSessionFailure(ConnectionTimeout)` is emitted. The handler called `clearDataAndGoToLoginPage()` unconditionally for all exception types. `validateUrgentException` does not include `ConnectionTimeout`, `SocketError`, or `UnknownRemoteException`, so these fall through and cause logout.
 
 ## Decision
 
@@ -50,16 +50,14 @@ Root cause: `copyWith` leaves the original `response` (the 401) intact.
 
 Dead code removed: `if (refreshError is ServerError || refreshError is TemporarilyUnavailable)` in `_handleDioRefreshError` — `refreshError` is typed as `DioException`, those types don't extend it, so the check could never be true.
 
-### Fix 2 — Mobile only: guard `handleGetSessionFailure` against network exceptions
+### Fix 2 — All platforms: guard `handleGetSessionFailure` against network exceptions
 
-Check `PlatformInfo.isMobile && exception is NetworkException` before `clearDataAndGoToLoginPage()`. `ConnectionTimeout`, `SocketError`, `ConnectionError`, `NoNetworkError` all extend `NetworkException`. On mobile network exception: show toast, return — no logout.
-
-**Web behaviour (unchanged):** any non-BadCredentials exception still calls `clearDataAndGoToLoginPage()`.
+Check `exception is NetworkException` before `clearDataAndGoToLoginPage()`. `ConnectionTimeout`, `SocketError`, `ConnectionError`, `NoNetworkError` all extend `NetworkException`. On network exception: show toast, return — no logout on any platform.
 
 ## Consequences
 
 - **All platforms:** Network timeouts during token refresh or retry no longer cause logout; connectivity error propagates instead.
-- **Mobile:** `FlutterAppAuthPlatformException` and `PlatformException` from `_appAuth.token()` (OIDC, no internet) no longer cause logout.
+- **All platforms:** `FlutterAppAuthPlatformException` and `PlatformException` from `_appAuth.token()` (OIDC, no internet) no longer cause logout.
 - **All platforms:** Session fetch failure on poor network shows toast; user stays logged in.
 - Real HTTP error responses (400, 401, 5xx) from refresh endpoint or original request still propagate correctly on all platforms.
 - Fix 2 does not affect `validateUrgentException` — that early-exit path is unchanged.

--- a/docs/adr/0089-fix-unexpected-logout-on-poor-network.md
+++ b/docs/adr/0089-fix-unexpected-logout-on-poor-network.md
@@ -1,7 +1,7 @@
-# 0089. Fix Unexpected Logout on Poor Network (Mobile Only)
+# 0089. Fix Unexpected Logout on Poor Network
 
 Date: 2026-05-18
-Updated: 2026-05-19
+Updated: 2026-05-21
 
 ## Status
 
@@ -9,7 +9,7 @@ Accepted
 
 ## Context
 
-On poor network (train, tunnel, intermittent WiFi), mobile users are logged out mid-session even though their session and refresh token are valid. The bug was reported on mobile only. Web is unaffected — the fixes are intentionally scoped to `PlatformInfo.isMobile` to minimise review surface and avoid changing web behaviour that was not reported broken.
+On poor network (train, tunnel, intermittent WiFi), users were logged out mid-session even though their session and refresh token were valid.
 
 Two independent bugs allow `clearDataAndGoToLoginPage()` to fire on transient network failures.
 
@@ -17,37 +17,38 @@ Two independent bugs allow `clearDataAndGoToLoginPage()` to fire on transient ne
 
 `lib/features/login/data/network/interceptors/authorization_interceptors.dart`
 
-When token refresh or retry fails due to network error, the catch block calls `err.copyWith(error: refreshError)`. `copyWith` replaces only the `error` payload; the original `response` field (the 401 that triggered the flow) is preserved. Downstream, `RemoteExceptionThrower` sees 401 → `BadCredentialsException` → logout.
+When token refresh or retry fails due to network error, the catch block called `err.copyWith(error: refreshError)`. `copyWith` replaces only the `error` payload; the original `response` field (the 401 that triggered the flow) is preserved. Downstream, `RemoteExceptionThrower` sees 401 → `BadCredentialsException` → logout.
 
-Affects three paths on mobile:
+Affects three paths:
+
 - **Path 1:** Access token expired → refresh HTTP call times out.
 - **Path 2:** Server-side session invalidation returns 401; `validateToRefreshToken` fires unconditionally, times out on poor network.
 - **Path 3:** Two concurrent requests both get 401 → one completes refresh → second retry times out → stale 401 preserved → logout.
 
-**Additional finding — outer `catch` also affected (mobile OIDC only):**
+**Additional finding — outer `catch` also affected:**
 
-On mobile OIDC, `_authenticationClient.refreshingTokensOIDC()` calls `_appAuth.token()` via MethodChannel (native AppAuth SDK — not Dio). Network failure from native SDK propagates as `PlatformException` or `FlutterAppAuthPlatformException`. Neither is a `DioException`, so both bypass the inner `on DioException catch` and reach the outer `catch`. The old `else` branch there also called `err.copyWith(error: e)`, preserving the stale 401. Only the explicit `ServerError`/`TemporarilyUnavailable` check was correct; all other non-DioException types were broken. This path does not exist on web (no native AppAuth SDK).
+On mobile OIDC, `_authenticationClient.refreshingTokensOIDC()` calls `_appAuth.token()` via MethodChannel (native AppAuth SDK — not Dio). Network failure from native SDK propagates as `PlatformException` or `FlutterAppAuthPlatformException`. Neither is a `DioException`, so both bypass the inner `on DioException catch` and reach the outer `catch`. The old `else` branch called `err.copyWith(error: e)`, preserving the stale 401.
 
 ### Bug 2 — `handleGetSessionFailure` logs out for any exception type (mobile only)
 
 `lib/features/base/reloadable/reloadable_controller.dart`
 
-On app start/resume, `getSessionAction()` fetches JMAP session. On mobile, `GetSessionInteractor` falls back to Hive cache on failure. If cache is empty (fresh install or wiped by Bug 1's `cachingManager.clearAll()`), `GetSessionFailure(ConnectionTimeout)` is emitted. The handler calls `clearDataAndGoToLoginPage()` unconditionally for all exception types. `validateUrgentException` does not include `ConnectionTimeout`, `SocketError`, or `UnknownRemoteException`, so these fall through and cause logout. Web does not use Hive session cache, so the original logout-on-failure behaviour is correct there.
+On app start/resume, `getSessionAction()` fetches JMAP session. On mobile, `GetSessionInteractor` falls back to Hive cache on failure. If cache is empty (fresh install or wiped by Bug 1's `cachingManager.clearAll()`), `GetSessionFailure(ConnectionTimeout)` is emitted. The handler called `clearDataAndGoToLoginPage()` unconditionally for all exception types. `validateUrgentException` does not include `ConnectionTimeout`, `SocketError`, or `UnknownRemoteException`, so these fall through and cause logout. Web does not use Hive session cache, so the original logout-on-failure behaviour is correct there.
 
 ## Decision
 
-All fixes are guarded by `PlatformInfo.isMobile`. Web retains the original logic.
-
-### Fix 1 — Mobile only: pass refresh errors directly without preserving stale 401 response
+### Fix 1 — Unified: pass error/refresh errors without preserving stale 401 response
 
 Root cause: `copyWith` leaves the original `response` (the 401) intact.
 
-**Mobile behaviour:**
+**All platforms (unified behaviour):**
+
 - **Refresh failure path (inner catch, `response == null`):** create fresh `DioException` without any response.
 - **Refresh failure path (`response != null`, non-400):** pass `refreshError` directly — own response, not stale 401.
 - **Retry failure path:** if `DioException`, pass directly; otherwise wrap in fresh `DioException` with no response.
+- **Outer catch:** if `e is DioException && e.response != null`, pass `e` directly; otherwise wrap in fresh `DioException` with no response.
 
-**Web behaviour (unchanged):** `err.copyWith(error: refreshError/retryError)` — original logic preserved.
+Dead code removed: `if (refreshError is ServerError || refreshError is TemporarilyUnavailable)` in `_handleDioRefreshError` — `refreshError` is typed as `DioException`, those types don't extend it, so the check could never be true.
 
 ### Fix 2 — Mobile only: guard `handleGetSessionFailure` against network exceptions
 
@@ -55,19 +56,10 @@ Check `PlatformInfo.isMobile && exception is NetworkException` before `clearData
 
 **Web behaviour (unchanged):** any non-BadCredentials exception still calls `clearDataAndGoToLoginPage()`.
 
-### Fix 3 — Mobile only: strip stale 401 in outer catch for non-DioException network errors
-
-Outer `catch` in `onError` handles all non-DioException types (`FlutterAppAuthPlatformException`, `PlatformException`, `OAuthAuthorizationError`).
-
-**Mobile behaviour:** if `e` is a `DioException` with non-null response, pass `e` directly; otherwise wrap in fresh `DioException` with no response. Subsumes the old `ServerError`/`TemporarilyUnavailable` branch and covers all future non-DioException types.
-
-**Web behaviour (unchanged):** `if (e is ServerError || e is TemporarilyUnavailable)` → fresh `DioException`; else → `err.copyWith(error: e)`.
-
 ## Consequences
 
-- **Mobile:** Network timeouts during token refresh or retry no longer cause logout; connectivity error propagates instead.
+- **All platforms:** Network timeouts during token refresh or retry no longer cause logout; connectivity error propagates instead.
 - **Mobile:** `FlutterAppAuthPlatformException` and `PlatformException` from `_appAuth.token()` (OIDC, no internet) no longer cause logout.
-- **Mobile:** Session fetch failure on poor network shows toast; user stays logged in.
-- **Web:** All three paths are unchanged — no behavioural difference from before this PR.
-- Real HTTP error responses (400, 401, 5xx) from refresh endpoint or original request still propagate correctly on both platforms.
+- **All platforms:** Session fetch failure on poor network shows toast; user stays logged in.
+- Real HTTP error responses (400, 401, 5xx) from refresh endpoint or original request still propagate correctly on all platforms.
 - Fix 2 does not affect `validateUrgentException` — that early-exit path is unchanged.

--- a/docs/adr/0089-fix-unexpected-logout-on-poor-network.md
+++ b/docs/adr/0089-fix-unexpected-logout-on-poor-network.md
@@ -65,12 +65,16 @@ void handleGetSessionFailure(GetSessionFailure failure) {
 
 ## Decision
 
-### Fix 1 — Strip 401 response from DioException on network-only failure (inner catch)
+### Fix 1 — Pass errors directly without preserving stale 401 response
 
-When `refreshError.response == null` (no HTTP response = pure network error), construct a fresh `DioException` without the original 401 `response` field. Apply the same pattern to the retry failure catch block. Checking `response == null` correctly covers all network-layer failures — timeouts, send/receive timeouts, socket errors — while leaving real HTTP error responses (400, 401, 5xx) to propagate normally.
+The root cause of all `err.copyWith` variants is the same: `copyWith` replaces only the `error` payload while leaving the original `response` field (the 401) intact. The correct fix is to never use `err.copyWith` when forwarding errors from the refresh or retry paths — pass each error directly so it carries its own response (or none).
+
+**Refresh failure path (inner catch):**
+
+- `response == null` (network failure) → fresh `DioException` without any response.
+- `response != null` and not 400 (e.g. 5xx from the refresh endpoint) → pass `refreshError` directly. Previously `err.copyWith(error: refreshError)` carried the original 401 response, which caused `RemoteExceptionThrower` to classify a real 5xx as `BadCredentialsException`.
 
 ```dart
-// Refresh failure path
 } else if (refreshError.response == null) {
   return super.onError(
     DioException(
@@ -82,34 +86,34 @@ When `refreshError.response == null` (no HTTP response = pure network error), co
     handler,
   );
 } else {
-  return super.onError(err.copyWith(error: refreshError), handler);
+  return super.onError(refreshError, handler); // pass directly — own response, not stale 401
 }
+```
 
-// Retry failure path
+**Retry failure path:**
+
+Simplified to a single type check. Any `DioException` from the retry is passed directly (carries its own response or none). Non-DioException is wrapped in a fresh `DioException` with no response.
+
+```dart
 } catch (retryError) {
-  if (retryError is DioException && retryError.response == null) {
-    return super.onError(
-      DioException(
-        requestOptions: err.requestOptions,
-        type: retryError.type,
-        error: retryError.error,
-        message: retryError.message,
-      ),
-      handler,
-    );
+  if (retryError is DioException) {
+    return super.onError(retryError, handler);
   }
-  return super.onError(err.copyWith(error: retryError), handler);
+  return super.onError(
+    DioException(requestOptions: err.requestOptions, error: retryError),
+    handler,
+  );
 }
 ```
 
 ### Fix 3 — Strip 401 response in outer catch for non-DioException network errors
 
-The outer `catch (e, stackTrace)` in `onError` previously used `err.copyWith(error: e)` for all exceptions that were not `ServerError`/`TemporarilyUnavailable`. This is wrong for `FlutterAppAuthPlatformException` and any other non-DioException thrown during token refresh on poor network. The only case where preserving the original response is meaningful is when `e` is itself a `DioException` that carries a real HTTP error response. All other cases should produce a fresh `DioException` without the 401.
+The outer `catch (e, stackTrace)` in `onError` handles all exceptions that escape the inner `on DioException catch` — primarily non-DioException types such as `FlutterAppAuthPlatformException`, `PlatformException`, and `OAuthAuthorizationError` from the OIDC token refresh on mobile. The `if (e is DioException && e.response != null)` branch also previously called `err.copyWith(error: e)`, preserving the original 401 response. The fix passes `e` directly.
 
 ```dart
-// Outer catch — replaces the old ServerError/TemporarilyUnavailable + else split
+// Outer catch — final state
 if (e is DioException && e.response != null) {
-  return super.onError(err.copyWith(error: e), handler);
+  return super.onError(e, handler); // pass e directly — own response, not stale 401
 }
 return super.onError(
   DioException(requestOptions: err.requestOptions, error: e),
@@ -117,7 +121,7 @@ return super.onError(
 );
 ```
 
-This subsumes the old `ServerError`/`TemporarilyUnavailable` branch (those are not `DioException`, so `e is DioException` is false → fresh `DioException`) and covers `FlutterAppAuthPlatformException` and any other future non-DioException.
+This subsumes the old `ServerError`/`TemporarilyUnavailable` branch (those are not `DioException`, so `e is DioException` is false → fresh `DioException`) and covers `FlutterAppAuthPlatformException` and any other future non-DioException. The `e is DioException && e.response != null` branch is effectively unreachable from the refresh path (all `DioException` types from the inner try are caught by the inner `on DioException catch` first), but is retained as a defensive guard.
 
 ### Fix 2 — Guard `handleGetSessionFailure` against network exceptions
 
@@ -140,8 +144,9 @@ void handleGetSessionFailure(GetSessionFailure failure) {
 ## Consequences
 
 - Network timeouts during token refresh or retry no longer cause logout; a connectivity error is propagated instead.
-- `FlutterAppAuthPlatformException` from `_appAuth.token()` on mobile (OIDC, no internet) no longer causes logout — covered by Fix 3.
+- Non-network DioExceptions from the refresh endpoint (e.g. 5xx) are now propagated with their own status code — no longer misclassified as `BadCredentialsException` via the stale 401 response.
+- `FlutterAppAuthPlatformException` and raw `PlatformException` from `_appAuth.token()` on mobile (OIDC, no internet) no longer cause logout — covered by Fix 3.
 - Session fetch failure on poor network shows a toast; user stays logged in.
-- Fix 1 does not change behaviour when the refresh or retry receives an actual HTTP error response (400, 401, 5xx) — those still propagate correctly.
-- Fix 3 preserves the original `err` response only when `e` itself is a `DioException` with a non-null HTTP response, which cannot happen from inside the `on DioException catch` block (those are already handled there). The condition is thus effectively always false for exceptions that reach the outer catch from the refresh path, but is retained as a safe guard.
+- Real HTTP error responses (400, 401, 5xx) from the refresh endpoint or the original request still propagate correctly.
+- Fix 3 preserves the original `err` response only when `e` itself is a `DioException` with a non-null HTTP response; that branch is effectively unreachable from the current code paths (all `DioException` types from the inner try are caught by the inner `on DioException catch` first) but is retained as a defensive guard.
 - Fix 2 does not affect `validateUrgentException` — that early-exit path is unchanged.

--- a/docs/adr/0089-fix-unexpected-logout-on-poor-network.md
+++ b/docs/adr/0089-fix-unexpected-logout-on-poor-network.md
@@ -1,6 +1,7 @@
-# 0089. Fix Unexpected Logout on Poor Network
+# 0089. Fix Unexpected Logout on Poor Network (Mobile Only)
 
 Date: 2026-05-18
+Updated: 2026-05-19
 
 ## Status
 
@@ -8,7 +9,9 @@ Accepted
 
 ## Context
 
-On poor network (train, tunnel, intermittent WiFi), users are logged out mid-session even though their session and refresh token are valid. Two independent bugs allow `clearDataAndGoToLoginPage()` to fire on transient network failures.
+On poor network (train, tunnel, intermittent WiFi), mobile users are logged out mid-session even though their session and refresh token are valid. The bug was reported on mobile only. Web is unaffected — the fixes are intentionally scoped to `PlatformInfo.isMobile` to minimise review surface and avoid changing web behaviour that was not reported broken.
+
+Two independent bugs allow `clearDataAndGoToLoginPage()` to fire on transient network failures.
 
 ### Bug 1 — Interceptor propagates stale 401 on network failure during token refresh/retry
 
@@ -16,44 +19,55 @@ On poor network (train, tunnel, intermittent WiFi), users are logged out mid-ses
 
 When token refresh or retry fails due to network error, the catch block calls `err.copyWith(error: refreshError)`. `copyWith` replaces only the `error` payload; the original `response` field (the 401 that triggered the flow) is preserved. Downstream, `RemoteExceptionThrower` sees 401 → `BadCredentialsException` → logout.
 
-Affects three paths:
+Affects three paths on mobile:
 - **Path 1:** Access token expired → refresh HTTP call times out.
 - **Path 2:** Server-side session invalidation returns 401; `validateToRefreshToken` fires unconditionally, times out on poor network.
 - **Path 3:** Two concurrent requests both get 401 → one completes refresh → second retry times out → stale 401 preserved → logout.
 
-**Additional finding — outer `catch` also affected:**
+**Additional finding — outer `catch` also affected (mobile OIDC only):**
 
-On mobile OIDC, `_authenticationClient.refreshingTokensOIDC()` calls `_appAuth.token()` via MethodChannel (native AppAuth SDK — not Dio). Network failure from native SDK propagates as `PlatformException` or `FlutterAppAuthPlatformException`. Neither is a `DioException`, so both bypass the inner `on DioException catch` and reach the outer `catch`. The old `else` branch there also called `err.copyWith(error: e)`, preserving the stale 401. Only the explicit `ServerError`/`TemporarilyUnavailable` check was correct; all other non-DioException types were broken.
+On mobile OIDC, `_authenticationClient.refreshingTokensOIDC()` calls `_appAuth.token()` via MethodChannel (native AppAuth SDK — not Dio). Network failure from native SDK propagates as `PlatformException` or `FlutterAppAuthPlatformException`. Neither is a `DioException`, so both bypass the inner `on DioException catch` and reach the outer `catch`. The old `else` branch there also called `err.copyWith(error: e)`, preserving the stale 401. Only the explicit `ServerError`/`TemporarilyUnavailable` check was correct; all other non-DioException types were broken. This path does not exist on web (no native AppAuth SDK).
 
-### Bug 2 — `handleGetSessionFailure` logs out for any exception type
+### Bug 2 — `handleGetSessionFailure` logs out for any exception type (mobile only)
 
 `lib/features/base/reloadable/reloadable_controller.dart`
 
-On app start/resume, `getSessionAction()` fetches JMAP session. On mobile, `GetSessionInteractor` falls back to Hive cache on failure. If cache is empty (fresh install or wiped by Bug 1's `cachingManager.clearAll()`), `GetSessionFailure(ConnectionTimeout)` is emitted. The handler calls `clearDataAndGoToLoginPage()` unconditionally for all exception types. `validateUrgentException` does not include `ConnectionTimeout`, `SocketError`, or `UnknownRemoteException`, so these fall through and cause logout.
+On app start/resume, `getSessionAction()` fetches JMAP session. On mobile, `GetSessionInteractor` falls back to Hive cache on failure. If cache is empty (fresh install or wiped by Bug 1's `cachingManager.clearAll()`), `GetSessionFailure(ConnectionTimeout)` is emitted. The handler calls `clearDataAndGoToLoginPage()` unconditionally for all exception types. `validateUrgentException` does not include `ConnectionTimeout`, `SocketError`, or `UnknownRemoteException`, so these fall through and cause logout. Web does not use Hive session cache, so the original logout-on-failure behaviour is correct there.
 
 ## Decision
 
-### Fix 1 — Pass errors directly without preserving stale 401 response
+All fixes are guarded by `PlatformInfo.isMobile`. Web retains the original logic.
 
-Root cause: `copyWith` leaves the original `response` (the 401) intact. Fix: never use `err.copyWith` in refresh or retry paths — pass each error directly so it carries its own response (or none).
+### Fix 1 — Mobile only: pass refresh errors directly without preserving stale 401 response
 
+Root cause: `copyWith` leaves the original `response` (the 401) intact.
+
+**Mobile behaviour:**
 - **Refresh failure path (inner catch, `response == null`):** create fresh `DioException` without any response.
 - **Refresh failure path (`response != null`, non-400):** pass `refreshError` directly — own response, not stale 401.
 - **Retry failure path:** if `DioException`, pass directly; otherwise wrap in fresh `DioException` with no response.
 
-### Fix 2 — Guard `handleGetSessionFailure` against network exceptions
+**Web behaviour (unchanged):** `err.copyWith(error: refreshError/retryError)` — original logic preserved.
 
-Check `exception is NetworkException` before `clearDataAndGoToLoginPage()`. `ConnectionTimeout`, `SocketError`, `ConnectionError`, `NoNetworkError` all extend `NetworkException`. On network exception: show toast, return — no logout. Guard belongs in `handleGetSessionFailure` to keep fix local and reviewable.
+### Fix 2 — Mobile only: guard `handleGetSessionFailure` against network exceptions
 
-### Fix 3 — Strip stale 401 in outer catch for non-DioException network errors
+Check `PlatformInfo.isMobile && exception is NetworkException` before `clearDataAndGoToLoginPage()`. `ConnectionTimeout`, `SocketError`, `ConnectionError`, `NoNetworkError` all extend `NetworkException`. On mobile network exception: show toast, return — no logout.
 
-Outer `catch` in `onError` handles all non-DioException types (`FlutterAppAuthPlatformException`, `PlatformException`, `OAuthAuthorizationError`). If `e` is a `DioException` with non-null response, pass `e` directly. Otherwise, wrap in fresh `DioException` with no response. This subsumes the old `ServerError`/`TemporarilyUnavailable` branch and covers all future non-DioException types. The `e is DioException && e.response != null` branch is effectively unreachable from current paths (all `DioException` from inner try are caught by inner `on DioException catch` first) but retained as defensive guard.
+**Web behaviour (unchanged):** any non-BadCredentials exception still calls `clearDataAndGoToLoginPage()`.
+
+### Fix 3 — Mobile only: strip stale 401 in outer catch for non-DioException network errors
+
+Outer `catch` in `onError` handles all non-DioException types (`FlutterAppAuthPlatformException`, `PlatformException`, `OAuthAuthorizationError`).
+
+**Mobile behaviour:** if `e` is a `DioException` with non-null response, pass `e` directly; otherwise wrap in fresh `DioException` with no response. Subsumes the old `ServerError`/`TemporarilyUnavailable` branch and covers all future non-DioException types.
+
+**Web behaviour (unchanged):** `if (e is ServerError || e is TemporarilyUnavailable)` → fresh `DioException`; else → `err.copyWith(error: e)`.
 
 ## Consequences
 
-- Network timeouts during token refresh or retry no longer cause logout; connectivity error propagates instead.
-- Non-network `DioException` from refresh endpoint (e.g. 5xx) propagate with own status code — no longer misclassified as `BadCredentialsException` via stale 401.
-- `FlutterAppAuthPlatformException` and `PlatformException` from `_appAuth.token()` on mobile (OIDC, no internet) no longer cause logout.
-- Session fetch failure on poor network shows toast; user stays logged in.
-- Real HTTP error responses (400, 401, 5xx) from refresh endpoint or original request still propagate correctly.
+- **Mobile:** Network timeouts during token refresh or retry no longer cause logout; connectivity error propagates instead.
+- **Mobile:** `FlutterAppAuthPlatformException` and `PlatformException` from `_appAuth.token()` (OIDC, no internet) no longer cause logout.
+- **Mobile:** Session fetch failure on poor network shows toast; user stays logged in.
+- **Web:** All three paths are unchanged — no behavioural difference from before this PR.
+- Real HTTP error responses (400, 401, 5xx) from refresh endpoint or original request still propagate correctly on both platforms.
 - Fix 2 does not affect `validateUrgentException` — that early-exit path is unchanged.

--- a/docs/adr/0089-fix-unexpected-logout-on-poor-network.md
+++ b/docs/adr/0089-fix-unexpected-logout-on-poor-network.md
@@ -40,6 +40,12 @@ This affects three code paths:
 - **Path 2:** Server-side session invalidation (server restart, forced logout) returns 401 while local token is still valid. `validateToRefreshToken` does not check local token expiry, so it fires unconditionally and times out on a poor network.
 - **Path 3:** Two concurrent JMAP requests both get 401 → one completes refresh → second request's retry times out → same 401 preserved → logout.
 
+**Additional finding — outer `catch` also affected (`FlutterAppAuthPlatformException`):**
+
+The `on DioException catch (refreshError, st)` block only handles `DioException`. On mobile with OIDC, `_authenticationClient.refreshingTokensOIDC()` calls `_appAuth.token()`, which is a MethodChannel bridge to the native AppAuth SDK — not a Dio HTTP call. When there is no internet, the native SDK failure propagates through `MethodChannelFlutterAppAuth.invokeMethod()` as either a raw `PlatformException` (when the native side sends no structured details, i.e. `e.details == null`) or a `FlutterAppAuthPlatformException` (when structured details are present but carry no OAuth `error` code for a transport failure). In both cases `handleException()` in `AuthenticationClientInteractionMixin` passes the exception through unchanged — raw `PlatformException` does not match the `is FlutterAppAuthPlatformException` check, and `FlutterAppAuthPlatformException` with `platformErrorDetails.error == null` exits without mapping.
+
+Neither exception type is a `DioException`, so both bypass the inner `on DioException catch` entirely and propagate to the outer `catch (e, stackTrace)` block. The original `else` branch there also called `err.copyWith(error: e)`, preserving the 401 response and triggering the same logout path. The only case that correctly stripped the 401 was the explicit `ServerError`/`TemporarilyUnavailable` check; all other non-DioException types were broken.
+
 ### Bug 2 — `handleGetSessionFailure` logs out for any exception type
 
 `lib/features/base/reloadable/reloadable_controller.dart`
@@ -59,7 +65,7 @@ void handleGetSessionFailure(GetSessionFailure failure) {
 
 ## Decision
 
-### Fix 1 — Strip 401 response from DioException on network-only failure
+### Fix 1 — Strip 401 response from DioException on network-only failure (inner catch)
 
 When `refreshError.response == null` (no HTTP response = pure network error), construct a fresh `DioException` without the original 401 `response` field. Apply the same pattern to the retry failure catch block. Checking `response == null` correctly covers all network-layer failures — timeouts, send/receive timeouts, socket errors — while leaving real HTTP error responses (400, 401, 5xx) to propagate normally.
 
@@ -96,6 +102,23 @@ When `refreshError.response == null` (no HTTP response = pure network error), co
 }
 ```
 
+### Fix 3 — Strip 401 response in outer catch for non-DioException network errors
+
+The outer `catch (e, stackTrace)` in `onError` previously used `err.copyWith(error: e)` for all exceptions that were not `ServerError`/`TemporarilyUnavailable`. This is wrong for `FlutterAppAuthPlatformException` and any other non-DioException thrown during token refresh on poor network. The only case where preserving the original response is meaningful is when `e` is itself a `DioException` that carries a real HTTP error response. All other cases should produce a fresh `DioException` without the 401.
+
+```dart
+// Outer catch — replaces the old ServerError/TemporarilyUnavailable + else split
+if (e is DioException && e.response != null) {
+  return super.onError(err.copyWith(error: e), handler);
+}
+return super.onError(
+  DioException(requestOptions: err.requestOptions, error: e),
+  handler,
+);
+```
+
+This subsumes the old `ServerError`/`TemporarilyUnavailable` branch (those are not `DioException`, so `e is DioException` is false → fresh `DioException`) and covers `FlutterAppAuthPlatformException` and any other future non-DioException.
+
 ### Fix 2 — Guard `handleGetSessionFailure` against network exceptions
 
 Check `exception is NetworkException` before reaching `clearDataAndGoToLoginPage()`. `ConnectionTimeout`, `SocketError`, `ConnectionError`, and `NoNetworkError` all extend `NetworkException`. On a network exception, show a toast and return — no logout. The guard belongs in `handleGetSessionFailure` to keep the fix local and reviewable.
@@ -117,6 +140,8 @@ void handleGetSessionFailure(GetSessionFailure failure) {
 ## Consequences
 
 - Network timeouts during token refresh or retry no longer cause logout; a connectivity error is propagated instead.
+- `FlutterAppAuthPlatformException` from `_appAuth.token()` on mobile (OIDC, no internet) no longer causes logout — covered by Fix 3.
 - Session fetch failure on poor network shows a toast; user stays logged in.
 - Fix 1 does not change behaviour when the refresh or retry receives an actual HTTP error response (400, 401, 5xx) — those still propagate correctly.
+- Fix 3 preserves the original `err` response only when `e` itself is a `DioException` with a non-null HTTP response, which cannot happen from inside the `on DioException catch` block (those are already handled there). The condition is thus effectively always false for exceptions that reach the outer catch from the refresh path, but is retained as a safe guard.
 - Fix 2 does not affect `validateUrgentException` — that early-exit path is unchanged.

--- a/docs/adr/0089-fix-unexpected-logout-on-poor-network.md
+++ b/docs/adr/0089-fix-unexpected-logout-on-poor-network.md
@@ -1,7 +1,6 @@
 # 0089. Fix Unexpected Logout on Poor Network
 
-Date: 2026-05-18
-Updated: 2026-05-21
+Date: 2026-05-21
 
 ## Status
 

--- a/docs/adr/0089-fix-unexpected-logout-on-poor-network.md
+++ b/docs/adr/0089-fix-unexpected-logout-on-poor-network.md
@@ -10,143 +10,50 @@ Accepted
 
 On poor network (train, tunnel, intermittent WiFi), users are logged out mid-session even though their session and refresh token are valid. Two independent bugs allow `clearDataAndGoToLoginPage()` to fire on transient network failures.
 
-### Bug 1 — Interceptor propagates original 401 response on network failure during token refresh/retry
+### Bug 1 — Interceptor propagates stale 401 on network failure during token refresh/retry
 
 `lib/features/login/data/network/interceptors/authorization_interceptors.dart`
 
-When a token refresh or request retry fails due to a network error (timeout, connection drop), the catch block calls `err.copyWith(error: refreshError)`. `copyWith` replaces only the `error` payload; the original `response` field — the 401 that triggered the flow — is preserved. Downstream, `RemoteExceptionThrower` inspects the response status code, sees 401, and converts it to `BadCredentialsException` → `clearDataAndGoToLoginPage()`.
+When token refresh or retry fails due to network error, the catch block calls `err.copyWith(error: refreshError)`. `copyWith` replaces only the `error` payload; the original `response` field (the 401 that triggered the flow) is preserved. Downstream, `RemoteExceptionThrower` sees 401 → `BadCredentialsException` → logout.
 
-```dart
-// refresh failure path
-} catch (refreshError) {
-  // ...
-  } else {
-    // BUG: err still carries original 401 response
-    return super.onError(err.copyWith(error: refreshError), handler);
-  }
-}
+Affects three paths:
+- **Path 1:** Access token expired → refresh HTTP call times out.
+- **Path 2:** Server-side session invalidation returns 401; `validateToRefreshToken` fires unconditionally, times out on poor network.
+- **Path 3:** Two concurrent requests both get 401 → one completes refresh → second retry times out → stale 401 preserved → logout.
 
-// retry failure path
-} catch (retryError) {
-  return super.onError(
-    err.copyWith(error: retryError), // same bug
-    handler,
-  );
-}
-```
+**Additional finding — outer `catch` also affected:**
 
-This affects three code paths:
-- **Path 1:** Access token expired → server returns 401 → refresh HTTP call times out.
-- **Path 2:** Server-side session invalidation (server restart, forced logout) returns 401 while local token is still valid. `validateToRefreshToken` does not check local token expiry, so it fires unconditionally and times out on a poor network.
-- **Path 3:** Two concurrent JMAP requests both get 401 → one completes refresh → second request's retry times out → same 401 preserved → logout.
-
-**Additional finding — outer `catch` also affected (`FlutterAppAuthPlatformException`):**
-
-The `on DioException catch (refreshError, st)` block only handles `DioException`. On mobile with OIDC, `_authenticationClient.refreshingTokensOIDC()` calls `_appAuth.token()`, which is a MethodChannel bridge to the native AppAuth SDK — not a Dio HTTP call. When there is no internet, the native SDK failure propagates through `MethodChannelFlutterAppAuth.invokeMethod()` as either a raw `PlatformException` (when the native side sends no structured details, i.e. `e.details == null`) or a `FlutterAppAuthPlatformException` (when structured details are present but carry no OAuth `error` code for a transport failure). In both cases `handleException()` in `AuthenticationClientInteractionMixin` passes the exception through unchanged — raw `PlatformException` does not match the `is FlutterAppAuthPlatformException` check, and `FlutterAppAuthPlatformException` with `platformErrorDetails.error == null` exits without mapping.
-
-Neither exception type is a `DioException`, so both bypass the inner `on DioException catch` entirely and propagate to the outer `catch (e, stackTrace)` block. The original `else` branch there also called `err.copyWith(error: e)`, preserving the 401 response and triggering the same logout path. The only case that correctly stripped the 401 was the explicit `ServerError`/`TemporarilyUnavailable` check; all other non-DioException types were broken.
+On mobile OIDC, `_authenticationClient.refreshingTokensOIDC()` calls `_appAuth.token()` via MethodChannel (native AppAuth SDK — not Dio). Network failure from native SDK propagates as `PlatformException` or `FlutterAppAuthPlatformException`. Neither is a `DioException`, so both bypass the inner `on DioException catch` and reach the outer `catch`. The old `else` branch there also called `err.copyWith(error: e)`, preserving the stale 401. Only the explicit `ServerError`/`TemporarilyUnavailable` check was correct; all other non-DioException types were broken.
 
 ### Bug 2 — `handleGetSessionFailure` logs out for any exception type
 
 `lib/features/base/reloadable/reloadable_controller.dart`
 
-On app start or resume, `getSessionAction()` fetches the JMAP session. On mobile, `GetSessionInteractor` falls back to Hive session cache on failure. If the cache is empty (fresh install, or wiped by Bug 1's `cachingManager.clearAll()`), `GetSessionFailure(ConnectionTimeout)` is emitted. The handler calls `clearDataAndGoToLoginPage()` unconditionally:
-
-```dart
-void handleGetSessionFailure(GetSessionFailure failure) {
-  if (failure.exception is! BadCredentialsException) {
-    toastManager.showMessageFailure(failure);
-  }
-  clearDataAndGoToLoginPage(); // called for ALL exception types
-}
-```
-
-`validateUrgentException` does not include `ConnectionTimeout`, `SocketError`, or `UnknownRemoteException`, so these fall through to `handleGetSessionFailure` and cause logout.
+On app start/resume, `getSessionAction()` fetches JMAP session. On mobile, `GetSessionInteractor` falls back to Hive cache on failure. If cache is empty (fresh install or wiped by Bug 1's `cachingManager.clearAll()`), `GetSessionFailure(ConnectionTimeout)` is emitted. The handler calls `clearDataAndGoToLoginPage()` unconditionally for all exception types. `validateUrgentException` does not include `ConnectionTimeout`, `SocketError`, or `UnknownRemoteException`, so these fall through and cause logout.
 
 ## Decision
 
 ### Fix 1 — Pass errors directly without preserving stale 401 response
 
-The root cause of all `err.copyWith` variants is the same: `copyWith` replaces only the `error` payload while leaving the original `response` field (the 401) intact. The correct fix is to never use `err.copyWith` when forwarding errors from the refresh or retry paths — pass each error directly so it carries its own response (or none).
+Root cause: `copyWith` leaves the original `response` (the 401) intact. Fix: never use `err.copyWith` in refresh or retry paths — pass each error directly so it carries its own response (or none).
 
-**Refresh failure path (inner catch):**
-
-- `response == null` (network failure) → fresh `DioException` without any response.
-- `response != null` and not 400 (e.g. 5xx from the refresh endpoint) → pass `refreshError` directly. Previously `err.copyWith(error: refreshError)` carried the original 401 response, which caused `RemoteExceptionThrower` to classify a real 5xx as `BadCredentialsException`.
-
-```dart
-} else if (refreshError.response == null) {
-  return super.onError(
-    DioException(
-      requestOptions: err.requestOptions,
-      type: refreshError.type,
-      error: refreshError.error,
-      message: refreshError.message,
-    ),
-    handler,
-  );
-} else {
-  return super.onError(refreshError, handler); // pass directly — own response, not stale 401
-}
-```
-
-**Retry failure path:**
-
-Simplified to a single type check. Any `DioException` from the retry is passed directly (carries its own response or none). Non-DioException is wrapped in a fresh `DioException` with no response.
-
-```dart
-} catch (retryError) {
-  if (retryError is DioException) {
-    return super.onError(retryError, handler);
-  }
-  return super.onError(
-    DioException(requestOptions: err.requestOptions, error: retryError),
-    handler,
-  );
-}
-```
-
-### Fix 3 — Strip 401 response in outer catch for non-DioException network errors
-
-The outer `catch (e, stackTrace)` in `onError` handles all exceptions that escape the inner `on DioException catch` — primarily non-DioException types such as `FlutterAppAuthPlatformException`, `PlatformException`, and `OAuthAuthorizationError` from the OIDC token refresh on mobile. The `if (e is DioException && e.response != null)` branch also previously called `err.copyWith(error: e)`, preserving the original 401 response. The fix passes `e` directly.
-
-```dart
-// Outer catch — final state
-if (e is DioException && e.response != null) {
-  return super.onError(e, handler); // pass e directly — own response, not stale 401
-}
-return super.onError(
-  DioException(requestOptions: err.requestOptions, error: e),
-  handler,
-);
-```
-
-This subsumes the old `ServerError`/`TemporarilyUnavailable` branch (those are not `DioException`, so `e is DioException` is false → fresh `DioException`) and covers `FlutterAppAuthPlatformException` and any other future non-DioException. The `e is DioException && e.response != null` branch is effectively unreachable from the refresh path (all `DioException` types from the inner try are caught by the inner `on DioException catch` first), but is retained as a defensive guard.
+- **Refresh failure path (inner catch, `response == null`):** create fresh `DioException` without any response.
+- **Refresh failure path (`response != null`, non-400):** pass `refreshError` directly — own response, not stale 401.
+- **Retry failure path:** if `DioException`, pass directly; otherwise wrap in fresh `DioException` with no response.
 
 ### Fix 2 — Guard `handleGetSessionFailure` against network exceptions
 
-Check `exception is NetworkException` before reaching `clearDataAndGoToLoginPage()`. `ConnectionTimeout`, `SocketError`, `ConnectionError`, and `NoNetworkError` all extend `NetworkException`. On a network exception, show a toast and return — no logout. The guard belongs in `handleGetSessionFailure` to keep the fix local and reviewable.
+Check `exception is NetworkException` before `clearDataAndGoToLoginPage()`. `ConnectionTimeout`, `SocketError`, `ConnectionError`, `NoNetworkError` all extend `NetworkException`. On network exception: show toast, return — no logout. Guard belongs in `handleGetSessionFailure` to keep fix local and reviewable.
 
-```dart
-void handleGetSessionFailure(GetSessionFailure failure) {
-  final exception = failure.exception;
-  if (exception is NetworkException) {
-    toastManager.showMessageFailure(failure);
-    return; // transient — stay logged in
-  }
-  if (exception is! BadCredentialsException) {
-    toastManager.showMessageFailure(failure);
-  }
-  clearDataAndGoToLoginPage();
-}
-```
+### Fix 3 — Strip stale 401 in outer catch for non-DioException network errors
+
+Outer `catch` in `onError` handles all non-DioException types (`FlutterAppAuthPlatformException`, `PlatformException`, `OAuthAuthorizationError`). If `e` is a `DioException` with non-null response, pass `e` directly. Otherwise, wrap in fresh `DioException` with no response. This subsumes the old `ServerError`/`TemporarilyUnavailable` branch and covers all future non-DioException types. The `e is DioException && e.response != null` branch is effectively unreachable from current paths (all `DioException` from inner try are caught by inner `on DioException catch` first) but retained as defensive guard.
 
 ## Consequences
 
-- Network timeouts during token refresh or retry no longer cause logout; a connectivity error is propagated instead.
-- Non-network DioExceptions from the refresh endpoint (e.g. 5xx) are now propagated with their own status code — no longer misclassified as `BadCredentialsException` via the stale 401 response.
-- `FlutterAppAuthPlatformException` and raw `PlatformException` from `_appAuth.token()` on mobile (OIDC, no internet) no longer cause logout — covered by Fix 3.
-- Session fetch failure on poor network shows a toast; user stays logged in.
-- Real HTTP error responses (400, 401, 5xx) from the refresh endpoint or the original request still propagate correctly.
-- Fix 3 preserves the original `err` response only when `e` itself is a `DioException` with a non-null HTTP response; that branch is effectively unreachable from the current code paths (all `DioException` types from the inner try are caught by the inner `on DioException catch` first) but is retained as a defensive guard.
+- Network timeouts during token refresh or retry no longer cause logout; connectivity error propagates instead.
+- Non-network `DioException` from refresh endpoint (e.g. 5xx) propagate with own status code — no longer misclassified as `BadCredentialsException` via stale 401.
+- `FlutterAppAuthPlatformException` and `PlatformException` from `_appAuth.token()` on mobile (OIDC, no internet) no longer cause logout.
+- Session fetch failure on poor network shows toast; user stays logged in.
+- Real HTTP error responses (400, 401, 5xx) from refresh endpoint or original request still propagate correctly.
 - Fix 2 does not affect `validateUrgentException` — that early-exit path is unchanged.

--- a/docs/adr/0089-fix-unexpected-logout-on-poor-network.md
+++ b/docs/adr/0089-fix-unexpected-logout-on-poor-network.md
@@ -1,0 +1,122 @@
+# 0089. Fix Unexpected Logout on Poor Network
+
+Date: 2026-05-18
+
+## Status
+
+Accepted
+
+## Context
+
+On poor network (train, tunnel, intermittent WiFi), users are logged out mid-session even though their session and refresh token are valid. Two independent bugs allow `clearDataAndGoToLoginPage()` to fire on transient network failures.
+
+### Bug 1 — Interceptor propagates original 401 response on network failure during token refresh/retry
+
+`lib/features/login/data/network/interceptors/authorization_interceptors.dart`
+
+When a token refresh or request retry fails due to a network error (timeout, connection drop), the catch block calls `err.copyWith(error: refreshError)`. `copyWith` replaces only the `error` payload; the original `response` field — the 401 that triggered the flow — is preserved. Downstream, `RemoteExceptionThrower` inspects the response status code, sees 401, and converts it to `BadCredentialsException` → `clearDataAndGoToLoginPage()`.
+
+```dart
+// refresh failure path
+} catch (refreshError) {
+  // ...
+  } else {
+    // BUG: err still carries original 401 response
+    return super.onError(err.copyWith(error: refreshError), handler);
+  }
+}
+
+// retry failure path
+} catch (retryError) {
+  return super.onError(
+    err.copyWith(error: retryError), // same bug
+    handler,
+  );
+}
+```
+
+This affects three code paths:
+- **Path 1:** Access token expired → server returns 401 → refresh HTTP call times out.
+- **Path 2:** Server-side session invalidation (server restart, forced logout) returns 401 while local token is still valid. `validateToRefreshToken` does not check local token expiry, so it fires unconditionally and times out on a poor network.
+- **Path 3:** Two concurrent JMAP requests both get 401 → one completes refresh → second request's retry times out → same 401 preserved → logout.
+
+### Bug 2 — `handleGetSessionFailure` logs out for any exception type
+
+`lib/features/base/reloadable/reloadable_controller.dart`
+
+On app start or resume, `getSessionAction()` fetches the JMAP session. On mobile, `GetSessionInteractor` falls back to Hive session cache on failure. If the cache is empty (fresh install, or wiped by Bug 1's `cachingManager.clearAll()`), `GetSessionFailure(ConnectionTimeout)` is emitted. The handler calls `clearDataAndGoToLoginPage()` unconditionally:
+
+```dart
+void handleGetSessionFailure(GetSessionFailure failure) {
+  if (failure.exception is! BadCredentialsException) {
+    toastManager.showMessageFailure(failure);
+  }
+  clearDataAndGoToLoginPage(); // called for ALL exception types
+}
+```
+
+`validateUrgentException` does not include `ConnectionTimeout`, `SocketError`, or `UnknownRemoteException`, so these fall through to `handleGetSessionFailure` and cause logout.
+
+## Decision
+
+### Fix 1 — Strip 401 response from DioException on network-only failure
+
+When `refreshError.response == null` (no HTTP response = pure network error), construct a fresh `DioException` without the original 401 `response` field. Apply the same pattern to the retry failure catch block. Checking `response == null` correctly covers all network-layer failures — timeouts, send/receive timeouts, socket errors — while leaving real HTTP error responses (400, 401, 5xx) to propagate normally.
+
+```dart
+// Refresh failure path
+} else if (refreshError.response == null) {
+  return super.onError(
+    DioException(
+      requestOptions: err.requestOptions,
+      type: refreshError.type,
+      error: refreshError.error,
+      message: refreshError.message,
+    ),
+    handler,
+  );
+} else {
+  return super.onError(err.copyWith(error: refreshError), handler);
+}
+
+// Retry failure path
+} catch (retryError) {
+  if (retryError is DioException && retryError.response == null) {
+    return super.onError(
+      DioException(
+        requestOptions: err.requestOptions,
+        type: retryError.type,
+        error: retryError.error,
+        message: retryError.message,
+      ),
+      handler,
+    );
+  }
+  return super.onError(err.copyWith(error: retryError), handler);
+}
+```
+
+### Fix 2 — Guard `handleGetSessionFailure` against network exceptions
+
+Check `exception is NetworkException` before reaching `clearDataAndGoToLoginPage()`. `ConnectionTimeout`, `SocketError`, `ConnectionError`, and `NoNetworkError` all extend `NetworkException`. On a network exception, show a toast and return — no logout. The guard belongs in `handleGetSessionFailure` to keep the fix local and reviewable.
+
+```dart
+void handleGetSessionFailure(GetSessionFailure failure) {
+  final exception = failure.exception;
+  if (exception is NetworkException) {
+    toastManager.showMessageFailure(failure);
+    return; // transient — stay logged in
+  }
+  if (exception is! BadCredentialsException) {
+    toastManager.showMessageFailure(failure);
+  }
+  clearDataAndGoToLoginPage();
+}
+```
+
+## Consequences
+
+- Network timeouts during token refresh or retry no longer cause logout; a connectivity error is propagated instead.
+- Session fetch failure on poor network shows a toast; user stays logged in.
+- Fix 1 does not change behaviour when the refresh or retry receives an actual HTTP error response (400, 401, 5xx) — those still propagate correctly.
+- Fix 2 does not affect `validateUrgentException` — that early-exit path is unchanged.

--- a/integration_test/scenarios/composer/base_save_draft_then_reopen_scenario.dart
+++ b/integration_test/scenarios/composer/base_save_draft_then_reopen_scenario.dart
@@ -19,7 +19,6 @@ abstract class BaseSaveDraftThenReopenScenario extends BaseSaveAndReopenScenario
     await $.pumpAndTrySettle();
     await expectViewVisible($(#confirm_dialog_action));
     await composerRobot.tapSaveButtonOnSaveDraftConfirmDialog(l10n);
-    await $.pumpAndTrySettle();
     await _expectSaveDraftSuccessToast(l10n);
     await $.pumpAndTrySettle();
   }
@@ -30,7 +29,6 @@ abstract class BaseSaveDraftThenReopenScenario extends BaseSaveAndReopenScenario
     AppLocalizations l10n,
   ) async {
     await composerRobot.tapSaveAsDraftButton();
-    await $.pumpAndTrySettle();
     await _expectSaveDraftSuccessToast(l10n);
   }
 

--- a/integration_test/scenarios/composer/base_save_draft_then_reopen_scenario.dart
+++ b/integration_test/scenarios/composer/base_save_draft_then_reopen_scenario.dart
@@ -19,6 +19,7 @@ abstract class BaseSaveDraftThenReopenScenario extends BaseSaveAndReopenScenario
     await $.pumpAndTrySettle();
     await expectViewVisible($(#confirm_dialog_action));
     await composerRobot.tapSaveButtonOnSaveDraftConfirmDialog(l10n);
+    await $.pumpAndTrySettle();
     await _expectSaveDraftSuccessToast(l10n);
     await $.pumpAndTrySettle();
   }
@@ -29,6 +30,7 @@ abstract class BaseSaveDraftThenReopenScenario extends BaseSaveAndReopenScenario
     AppLocalizations l10n,
   ) async {
     await composerRobot.tapSaveAsDraftButton();
+    await $.pumpAndTrySettle();
     await _expectSaveDraftSuccessToast(l10n);
   }
 

--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -205,7 +205,6 @@ abstract class BaseController extends GetxController
     logError(
       '$runtimeType::_executeBeforeReconnectAndLogOut: '
       'forcing logout after web save-and-reconnect (urgent auth failure)',
-      stackTrace: StackTrace.current,
     );
     clearDataAndGoToLoginPage();
   }
@@ -250,7 +249,6 @@ abstract class BaseController extends GetxController
       logError(
         '$runtimeType::_performSaveAndReconnection: '
         'forcing logout on mobile after save-and-reconnect (urgent auth failure)',
-        stackTrace: StackTrace.current,
       );
       clearDataAndGoToLoginPage();
     }
@@ -260,7 +258,6 @@ abstract class BaseController extends GetxController
     logError(
       '$runtimeType::_performReconnection: '
       'forcing logout (urgent auth failure, no composer to save)',
-      stackTrace: StackTrace.current,
     );
     clearDataAndGoToLoginPage();
   }

--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -202,6 +202,11 @@ abstract class BaseController extends GetxController
   Future<void> _executeBeforeReconnectAndLogOut() async {
     twakeAppManager.setExecutingBeforeReconnect(true);
     await executeBeforeReconnect();
+    logError(
+      '$runtimeType::_executeBeforeReconnectAndLogOut: '
+      'forcing logout after web save-and-reconnect (urgent auth failure)',
+      stackTrace: StackTrace.current,
+    );
     clearDataAndGoToLoginPage();
   }
 
@@ -242,11 +247,21 @@ abstract class BaseController extends GetxController
     if (PlatformInfo.isWeb) {
       _executeBeforeReconnectAndLogOut();
     } else if (PlatformInfo.isMobile) {
+      logError(
+        '$runtimeType::_performSaveAndReconnection: '
+        'forcing logout on mobile after save-and-reconnect (urgent auth failure)',
+        stackTrace: StackTrace.current,
+      );
       clearDataAndGoToLoginPage();
     }
   }
 
   void _performReconnection() {
+    logError(
+      '$runtimeType::_performReconnection: '
+      'forcing logout (urgent auth failure, no composer to save)',
+      stackTrace: StackTrace.current,
+    );
     clearDataAndGoToLoginPage();
   }
 

--- a/lib/features/base/extensions/object_extensions.dart
+++ b/lib/features/base/extensions/object_extensions.dart
@@ -1,0 +1,16 @@
+import 'package:dio/dio.dart';
+
+extension ObjectExtensions on Object? {
+  DioException toDioException({
+    required RequestOptions requestOptions,
+    DioExceptionType type = DioExceptionType.unknown,
+    String? message,
+  }) {
+    return DioException(
+      requestOptions: requestOptions,
+      error: this,
+      type: type,
+      message: message,
+    );
+  }
+}

--- a/lib/features/base/reloadable/reloadable_controller.dart
+++ b/lib/features/base/reloadable/reloadable_controller.dart
@@ -149,7 +149,7 @@ abstract class ReloadableController extends BaseController {
 
   void handleGetSessionFailure(GetSessionFailure failure) {
     final exception = failure.exception;
-    if (exception is NetworkException) {
+    if (PlatformInfo.isMobile && exception is NetworkException) {
       toastManager.showMessageFailure(failure);
       return;
     }

--- a/lib/features/base/reloadable/reloadable_controller.dart
+++ b/lib/features/base/reloadable/reloadable_controller.dart
@@ -23,8 +23,8 @@ import 'package:tmail_ui_user/features/login/domain/usecases/get_oidc_user_info_
 import 'package:tmail_ui_user/features/login/domain/usecases/update_account_cache_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/vacation/vacation_interactors_bindings.dart';
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
+import 'package:tmail_ui_user/main/exceptions/cache/cache_exception.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
-import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
 import 'package:tmail_ui_user/main/utils/app_config.dart';
 
 abstract class ReloadableController extends BaseController {
@@ -149,20 +149,14 @@ abstract class ReloadableController extends BaseController {
 
   void handleGetSessionFailure(GetSessionFailure failure) {
     final exception = failure.exception;
-    if (_isNetworkException(failure)) return;
     if (exception is! BadCredentialsException) {
       toastManager.showMessageFailure(failure);
     }
-    clearDataAndGoToLoginPage();
-  }
-
-  bool _isNetworkException(FeatureFailure failure) {
-    final exception = failure.exception;
-    if (exception is NetworkException) {
-      toastManager.showMessageFailure(failure);
-      return true;
+    if (exception is BadCredentialsException ||
+        exception is RefreshTokenFailedException ||
+        exception is CacheException) {
+      clearDataAndGoToLoginPage();
     }
-    return false;
   }
 
   void handleReloaded(Session session) {}

--- a/lib/features/base/reloadable/reloadable_controller.dart
+++ b/lib/features/base/reloadable/reloadable_controller.dart
@@ -11,6 +11,7 @@ import 'package:model/account/password.dart';
 import 'package:model/oidc/oidc_configuration.dart';
 import 'package:model/oidc/token_oidc.dart';
 import 'package:tmail_ui_user/features/base/base_controller.dart';
+import 'package:tmail_ui_user/features/home/data/exceptions/session_exceptions.dart';
 import 'package:tmail_ui_user/features/home/domain/state/get_session_state.dart';
 import 'package:tmail_ui_user/features/home/domain/usecases/get_session_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/state/get_authenticated_account_state.dart';
@@ -23,7 +24,6 @@ import 'package:tmail_ui_user/features/login/domain/usecases/get_oidc_user_info_
 import 'package:tmail_ui_user/features/login/domain/usecases/update_account_cache_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/vacation/vacation_interactors_bindings.dart';
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
-import 'package:tmail_ui_user/main/exceptions/cache/cache_exception.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
 import 'package:tmail_ui_user/main/utils/app_config.dart';
 
@@ -154,7 +154,7 @@ abstract class ReloadableController extends BaseController {
     }
     if (exception is BadCredentialsException ||
         exception is RefreshTokenFailedException ||
-        exception is CacheException) {
+        exception is NotFoundSessionException) {
       clearDataAndGoToLoginPage();
     }
   }

--- a/lib/features/base/reloadable/reloadable_controller.dart
+++ b/lib/features/base/reloadable/reloadable_controller.dart
@@ -24,6 +24,7 @@ import 'package:tmail_ui_user/features/login/domain/usecases/update_account_cach
 import 'package:tmail_ui_user/features/manage_account/presentation/vacation/vacation_interactors_bindings.dart';
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
 import 'package:tmail_ui_user/main/utils/app_config.dart';
 
 abstract class ReloadableController extends BaseController {
@@ -147,7 +148,12 @@ abstract class ReloadableController extends BaseController {
   }
 
   void handleGetSessionFailure(GetSessionFailure failure) {
-    if (failure.exception is! BadCredentialsException) {
+    final exception = failure.exception;
+    if (exception is NetworkException) {
+      toastManager.showMessageFailure(failure);
+      return;
+    }
+    if (exception is! BadCredentialsException) {
       toastManager.showMessageFailure(failure);
     }
     clearDataAndGoToLoginPage();

--- a/lib/features/base/reloadable/reloadable_controller.dart
+++ b/lib/features/base/reloadable/reloadable_controller.dart
@@ -149,14 +149,20 @@ abstract class ReloadableController extends BaseController {
 
   void handleGetSessionFailure(GetSessionFailure failure) {
     final exception = failure.exception;
-    if (PlatformInfo.isMobile && exception is NetworkException) {
-      toastManager.showMessageFailure(failure);
-      return;
-    }
+    if (_isNetworkException(failure)) return;
     if (exception is! BadCredentialsException) {
       toastManager.showMessageFailure(failure);
     }
     clearDataAndGoToLoginPage();
+  }
+
+  bool _isNetworkException(FeatureFailure failure) {
+    final exception = failure.exception;
+    if (exception is NetworkException) {
+      toastManager.showMessageFailure(failure);
+      return true;
+    }
+    return false;
   }
 
   void handleReloaded(Session session) {}

--- a/lib/features/base/reloadable/reloadable_controller.dart
+++ b/lib/features/base/reloadable/reloadable_controller.dart
@@ -155,6 +155,12 @@ abstract class ReloadableController extends BaseController {
     if (exception is BadCredentialsException ||
         exception is RefreshTokenFailedException ||
         exception is NotFoundSessionException) {
+      logError(
+        '$runtimeType::handleGetSessionFailure: '
+        'forcing logout — session definitively dead',
+        exception: exception,
+        stackTrace: StackTrace.current,
+      );
       clearDataAndGoToLoginPage();
     }
   }

--- a/lib/features/home/presentation/home_controller.dart
+++ b/lib/features/home/presentation/home_controller.dart
@@ -90,6 +90,11 @@ class HomeController extends ReloadableController {
 
   @override
   void onCancelReconnectWhenSessionExpired() {
+    logError(
+      '$runtimeType::onCancelReconnectWhenSessionExpired: '
+      'forcing logout — user cancelled session-expired reconnect dialog',
+      stackTrace: StackTrace.current,
+    );
     clearDataAndGoToLoginPage();
   }
 
@@ -289,6 +294,11 @@ class HomeController extends ReloadableController {
     } else if (failure is CheckOIDCIsAvailableFailure) {
       handleCheckOIDCIsAvailableFailure();
     } else if (isGetTokenOIDCFailure(failure)) {
+      logError(
+        '$runtimeType::handleFailureViewState: '
+        'OIDC sign-in flow failed (${failure.runtimeType}) — redirecting to login',
+        stackTrace: StackTrace.current,
+      );
       goToLogin();
     } else {
       super.handleFailureViewState(failure);
@@ -334,6 +344,11 @@ class HomeController extends ReloadableController {
     if (failure is CheckOIDCIsAvailableFailure) {
       handleCheckOIDCIsAvailableFailure();
     } else if (isGetTokenOIDCFailure(failure)) {
+      logError(
+        '$runtimeType::handleUrgentExceptionOnWeb: '
+        'OIDC sign-in flow failed urgently (${failure.runtimeType}) — redirecting to login',
+        stackTrace: StackTrace.current,
+      );
       goToLogin();
     } else {
       super.handleUrgentExceptionOnWeb(failure: failure, exception: exception);
@@ -343,6 +358,12 @@ class HomeController extends ReloadableController {
   @override
   void handleErrorViewState(Object error, StackTrace stackTrace) {
     if (PlatformInfo.isWeb) {
+      logError(
+        '$runtimeType::handleErrorViewState: '
+        'unhandled stream error on Home (web) — redirecting to login',
+        exception: error,
+        stackTrace: stackTrace,
+      );
       goToLogin();
     }
   }

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -174,7 +174,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
               handler,
             );
           } else {
-            return super.onError(err.copyWith(error: refreshError), handler);
+            return super.onError(refreshError, handler);
           }
         }
       } else {
@@ -200,19 +200,11 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
             'AuthorizationInterceptors::onError: '
             'Retry failed with error=$retryError',
           );
-          if (retryError is DioException && retryError.response == null) {
-            return super.onError(
-              DioException(
-                requestOptions: err.requestOptions,
-                type: retryError.type,
-                error: retryError.error,
-                message: retryError.message,
-              ),
-              handler,
-            );
+          if (retryError is DioException) {
+            return super.onError(retryError, handler);
           }
           return super.onError(
-            err.copyWith(error: retryError),
+            DioException(requestOptions: err.requestOptions, error: retryError),
             handler,
           );
         }
@@ -231,7 +223,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       // forward via err.copyWith would cause RemoteExceptionThrower to
       // misclassify it as BadCredentialsException and log the user out.
       if (e is DioException && e.response != null) {
-        return super.onError(err.copyWith(error: e), handler);
+        return super.onError(e, handler);
       }
       return super.onError(
         DioException(requestOptions: err.requestOptions, error: e),

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -124,14 +124,26 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       // Non-DioException types (e.g. FlutterAppAuthPlatformException from native
       // OIDC refresh) must not carry the stale 401 response forward, as
       // RemoteExceptionThrower would misclassify it as BadCredentialsException.
-      if (e is DioException) {
-        return super.onError(e, handler);
-      }
-      return super.onError(
-        e.toDioException(requestOptions: err.requestOptions),
-        handler,
+      return _handleThrownException(
+        e,
+        handler: handler,
+        requestOptions: err.requestOptions,
       );
     }
+  }
+
+  void _handleThrownException(
+    Object exception, {
+    required ErrorInterceptorHandler handler,
+    required RequestOptions requestOptions,
+  }) {
+    if (exception is DioException) {
+      return super.onError(exception, handler);
+    }
+    return super.onError(
+      exception.toDioException(requestOptions: requestOptions),
+      handler,
+    );
   }
 
   Future<void> _refreshTokenThenRetry(
@@ -200,12 +212,10 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       );
       // Pass retry errors directly so the stale 401 response is not preserved
       // via err.copyWith.
-      if (retryError is DioException) {
-        return super.onError(retryError, handler);
-      }
-      return super.onError(
-        retryError.toDioException(requestOptions: originalErr.requestOptions),
-        handler,
+      return _handleThrownException(
+        retryError,
+        handler: handler,
+        requestOptions: originalErr.requestOptions,
       );
     }
   }

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -151,37 +151,11 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
             stackTrace: st,
           );
 
-          if (refreshError is ServerError ||
-              refreshError is TemporarilyUnavailable) {
-            return super.onError(
-              DioException(
-                requestOptions: err.requestOptions,
-                error: refreshError,
-              ),
-              handler,
-            );
-          } else if (PlatformInfo.isMobile && refreshError.response == null) {
-            // Mobile only: network failure during refresh — don't carry the
-            // original 401 response forward, as that would make
-            // RemoteExceptionThrower classify this as BadCredentialsException
-            // and log the user out.
-            return super.onError(
-              DioException(
-                requestOptions: err.requestOptions,
-                type: refreshError.type,
-                error: refreshError.error,
-                message: refreshError.message,
-              ),
-              handler,
-            );
-          } else {
-            return super.onError(
-              PlatformInfo.isMobile
-                  ? refreshError
-                  : err.copyWith(error: refreshError),
-              handler,
-            );
-          }
+          return _handleDioRefreshError(
+            refreshError: refreshError,
+            originalError: err,
+            handler: handler,
+          );
         }
       } else {
         logTrace(
@@ -251,6 +225,43 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       } else {
         return super.onError(err.copyWith(error: e), handler);
       }
+    }
+  }
+
+  void _handleDioRefreshError({
+    required DioException refreshError,
+    required DioException originalError,
+    required ErrorInterceptorHandler handler,
+  }) {
+    if (refreshError is ServerError || refreshError is TemporarilyUnavailable) {
+      return super.onError(
+        DioException(
+          requestOptions: originalError.requestOptions,
+          error: refreshError,
+        ),
+        handler,
+      );
+    } else if (PlatformInfo.isMobile && refreshError.response == null) {
+      // Mobile only: network failure during refresh — don't carry the
+      // original 401 response forward, as that would make
+      // RemoteExceptionThrower classify this as BadCredentialsException
+      // and log the user out.
+      return super.onError(
+        DioException(
+          requestOptions: originalError.requestOptions,
+          type: refreshError.type,
+          error: refreshError.error,
+          message: refreshError.message,
+        ),
+        handler,
+      );
+    } else {
+      return super.onError(
+        PlatformInfo.isMobile
+            ? refreshError
+            : originalError.copyWith(error: refreshError),
+        handler,
+      );
     }
   }
 

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -14,7 +14,6 @@ import 'package:model/oidc/token_oidc.dart';
 import 'package:tmail_ui_user/features/login/data/local/account_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/local/token_oidc_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/network/authentication_client/authentication_client_base.dart';
-import 'package:tmail_ui_user/features/login/domain/exceptions/oauth_authorization_error.dart';
 import 'package:tmail_ui_user/features/login/domain/extensions/oidc_configuration_extensions.dart';
 import 'package:tmail_ui_user/features/upload/data/network/file_uploader.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
@@ -121,26 +120,16 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         exception: e,
         stackTrace: stackTrace,
       );
-      if (PlatformInfo.isMobile) {
-        // Mobile only: non-DioException types (e.g. FlutterAppAuthPlatformException
-        // from native OIDC refresh) must not carry the stale 401 response forward,
-        // as RemoteExceptionThrower would misclassify it as BadCredentialsException.
-        if (e is DioException && e.response != null) {
-          return super.onError(e, handler);
-        }
-        return super.onError(
-          DioException(requestOptions: err.requestOptions, error: e),
-          handler,
-        );
+      // Non-DioException types (e.g. FlutterAppAuthPlatformException from native
+      // OIDC refresh) must not carry the stale 401 response forward, as
+      // RemoteExceptionThrower would misclassify it as BadCredentialsException.
+      if (e is DioException && e.response != null) {
+        return super.onError(e, handler);
       }
-      if (e is ServerError || e is TemporarilyUnavailable) {
-        return super.onError(
-          DioException(requestOptions: err.requestOptions, error: e),
-          handler,
-        );
-      } else {
-        return super.onError(err.copyWith(error: e), handler);
-      }
+      return super.onError(
+        DioException(requestOptions: err.requestOptions, error: e),
+        handler,
+      );
     }
   }
 
@@ -156,7 +145,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         : await _getNewTokenForOtherPlatform();
 
       if (newTokenOidc.token == _token?.token) {
-        log('AuthorizationInterceptors::onError: Token duplicated');
+        logError('AuthorizationInterceptors::onError: Token duplicated', exception: err);
         return super.onError(err, handler);
       }
       _updateNewToken(newTokenOidc);
@@ -171,10 +160,8 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       return await _performRetry(requestOptions, err, handler);
     } on DioException catch (refreshError, st) {
       if (refreshError.response?.statusCode == 400) {
-        logError(
-          'AuthorizationInterceptors: Refresh Token Failed 400',
-          exception: refreshError,
-          stackTrace: st,
+        logWarning(
+          'AuthorizationInterceptors: Refresh Token Failed 400 - error=$refreshError | stackTrace=$st',
         );
         clear();
         return handler.reject(DioException(
@@ -184,11 +171,10 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
           response: refreshError.response,
         ));
       }
-      logError(
+      logWarning(
         'AuthorizationInterceptors: Refresh token failed with '
-        'statusCode=${refreshError.response?.statusCode}',
-        exception: refreshError,
-        stackTrace: st,
+        'statusCode=${refreshError.response?.statusCode} \n'
+        'error=$refreshError | stackTrace=$st',
       );
       return _handleDioRefreshError(
         refreshError: refreshError,
@@ -211,18 +197,15 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         'AuthorizationInterceptors::onError: '
         'Retry failed with error=$retryError',
       );
-      // Mobile only: pass retry errors directly so the stale 401 response
-      // is not preserved via err.copyWith.
-      if (PlatformInfo.isMobile) {
-        if (retryError is DioException) {
-          return super.onError(retryError, handler);
-        }
-        return super.onError(
-          DioException(requestOptions: originalErr.requestOptions, error: retryError),
-          handler,
-        );
+      // Pass retry errors directly so the stale 401 response is not preserved
+      // via err.copyWith.
+      if (retryError is DioException) {
+        return super.onError(retryError, handler);
       }
-      return super.onError(originalErr.copyWith(error: retryError), handler);
+      return super.onError(
+        DioException(requestOptions: originalErr.requestOptions, error: retryError),
+        handler,
+      );
     }
   }
 
@@ -231,19 +214,10 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     required DioException originalError,
     required ErrorInterceptorHandler handler,
   }) {
-    if (refreshError is ServerError || refreshError is TemporarilyUnavailable) {
-      return super.onError(
-        DioException(
-          requestOptions: originalError.requestOptions,
-          error: refreshError,
-        ),
-        handler,
-      );
-    } else if (PlatformInfo.isMobile && refreshError.response == null) {
-      // Mobile only: network failure during refresh — don't carry the
-      // original 401 response forward, as that would make
-      // RemoteExceptionThrower classify this as BadCredentialsException
-      // and log the user out.
+    // Network failure during refresh — don't carry the original 401 response
+    // forward, as that would make RemoteExceptionThrower classify this as
+    // BadCredentialsException and log the user out.
+    if (refreshError.response == null) {
       return super.onError(
         DioException(
           requestOptions: originalError.requestOptions,
@@ -253,14 +227,8 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         ),
         handler,
       );
-    } else {
-      return super.onError(
-        PlatformInfo.isMobile
-            ? refreshError
-            : originalError.copyWith(error: refreshError),
-        handler,
-      );
     }
+    return super.onError(refreshError, handler);
   }
 
   Stream<List<int>>? _getDataUploadRequest(dynamic mapUploadExtra) {
@@ -365,7 +333,24 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     );
     await _accountCacheManager.setCurrentAccount(personalAccount);
 
+    await _verifyStoreTokenAndAccount(
+      tokenOIDC: tokenOIDC,
+      personalAccount: personalAccount,
+    );
+
     return personalAccount;
+  }
+
+  Future<void> _verifyStoreTokenAndAccount({
+    required TokenOIDC tokenOIDC,
+    required PersonalAccount personalAccount,
+  }) async {
+    final savedAccount = await _accountCacheManager.getCurrentAccount();
+    final savedToken = await _tokenOidcCacheManager.getTokenOidc(savedAccount.id);
+
+    if (savedAccount != personalAccount || savedToken != tokenOIDC) {
+      throw StateError('Error saving the token and account');
+    }
   }
 
   Future<TokenOIDC?> _getTokenInKeychain(TokenOIDC currentTokenOidc) async {

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -11,6 +11,7 @@ import 'package:model/account/password.dart';
 import 'package:model/account/personal_account.dart';
 import 'package:model/oidc/oidc_configuration.dart';
 import 'package:model/oidc/token_oidc.dart';
+import 'package:tmail_ui_user/features/base/extensions/object_extensions.dart';
 import 'package:tmail_ui_user/features/login/data/local/account_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/local/token_oidc_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/network/authentication_client/authentication_client_base.dart';
@@ -123,11 +124,11 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       // Non-DioException types (e.g. FlutterAppAuthPlatformException from native
       // OIDC refresh) must not carry the stale 401 response forward, as
       // RemoteExceptionThrower would misclassify it as BadCredentialsException.
-      if (e is DioException && e.response != null) {
+      if (e is DioException) {
         return super.onError(e, handler);
       }
       return super.onError(
-        DioException(requestOptions: err.requestOptions, error: e),
+        e.toDioException(requestOptions: err.requestOptions),
         handler,
       );
     }
@@ -203,7 +204,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         return super.onError(retryError, handler);
       }
       return super.onError(
-        DioException(requestOptions: originalErr.requestOptions, error: retryError),
+        retryError.toDioException(requestOptions: originalErr.requestOptions),
         handler,
       );
     }
@@ -219,10 +220,9 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     // BadCredentialsException and log the user out.
     if (refreshError.response == null) {
       return super.onError(
-        DioException(
+        refreshError.error.toDioException(
           requestOptions: originalError.requestOptions,
           type: refreshError.type,
-          error: refreshError.error,
           message: refreshError.message,
         ),
         handler,
@@ -333,24 +333,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     );
     await _accountCacheManager.setCurrentAccount(personalAccount);
 
-    await _verifyStoreTokenAndAccount(
-      tokenOIDC: tokenOIDC,
-      personalAccount: personalAccount,
-    );
-
     return personalAccount;
-  }
-
-  Future<void> _verifyStoreTokenAndAccount({
-    required TokenOIDC tokenOIDC,
-    required PersonalAccount personalAccount,
-  }) async {
-    final savedAccount = await _accountCacheManager.getCurrentAccount();
-    final savedToken = await _tokenOidcCacheManager.getTokenOidc(savedAccount.id);
-
-    if (savedAccount != personalAccount || savedToken != tokenOIDC) {
-      throw StateError('Error saving the token and account');
-    }
   }
 
   Future<TokenOIDC?> _getTokenInKeychain(TokenOIDC currentTokenOidc) async {

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -121,9 +121,6 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         exception: e,
         stackTrace: stackTrace,
       );
-      // Non-DioException types (e.g. FlutterAppAuthPlatformException from native
-      // OIDC refresh) must not carry the stale 401 response forward, as
-      // RemoteExceptionThrower would misclassify it as BadCredentialsException.
       return _handleThrownException(
         e,
         handler: handler,

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -225,14 +225,18 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         exception: e,
         stackTrace: stackTrace,
       );
-      if (e is ServerError || e is TemporarilyUnavailable) {
-        return super.onError(
-          DioException(requestOptions: err.requestOptions, error: e),
-          handler,
-        );
-      } else {
+      // Any exception that is not a DioException with an HTTP response is a
+      // network-level failure (e.g. FlutterAppAuthPlatformException from the
+      // OIDC token refresh on mobile). Carrying the original 401 response
+      // forward via err.copyWith would cause RemoteExceptionThrower to
+      // misclassify it as BadCredentialsException and log the user out.
+      if (e is DioException && e.response != null) {
         return super.onError(err.copyWith(error: e), handler);
       }
+      return super.onError(
+        DioException(requestOptions: err.requestOptions, error: e),
+        handler,
+      );
     }
   }
 

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -88,10 +88,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     logWarning('AuthorizationInterceptors::onError(): DIO_ERROR = $err');
     try {
       final requestOptions = err.requestOptions;
-      final extraInRequest = requestOptions.extra;
-      bool isRetryRequest = false;
-
-      final hasAttemptedRefresh = extraInRequest[_refreshAttemptedKey] == true;
+      final hasAttemptedRefresh = requestOptions.extra[_refreshAttemptedKey] == true;
 
       if (!hasAttemptedRefresh && validateToRetryTheRequestWithNewToken(
         responseStatusCode: err.response?.statusCode,
@@ -99,106 +96,25 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         tokenOIDC: _token
       )) {
         log('AuthorizationInterceptors::onError: Request using old token, retry with updated token');
-        isRetryRequest = true;
+        return await _performRetry(requestOptions, err, handler);
       } else if (!hasAttemptedRefresh && validateToRefreshToken(
         responseStatusCode: err.response?.statusCode,
         tokenOIDC: _token
       )) {
-        try {
-          log('AuthorizationInterceptors::onError: Perform get New Token');
-          final newTokenOidc = PlatformInfo.isIOS
-            ? await _getNewTokenForIOSPlatform()
-            : await _getNewTokenForOtherPlatform();
-
-          if (newTokenOidc.token == _token?.token) {
-            log('AuthorizationInterceptors::onError: Token duplicated');
-            return super.onError(err, handler);
-          }
-          _updateNewToken(newTokenOidc);
-
-          final personalAccount = await _updateCurrentAccount(tokenOIDC: newTokenOidc);
-
-          if (PlatformInfo.isIOS) {
-            await _iosSharingManager.saveKeyChainSharingSession(personalAccount);
-          }
-
-          requestOptions.extra[_refreshAttemptedKey] = true;
-          isRetryRequest = true;
-        } on DioException catch (refreshError, st) {
-          if (refreshError.response?.statusCode == 400) {
-            logError(
-              'AuthorizationInterceptors: Refresh Token Failed 400',
-              exception: refreshError,
-              stackTrace: st,
-            );
-
-            clear();
-
-            final sessionExpiredError = DioException(
-              requestOptions: err.requestOptions,
-              error: RefreshTokenFailedException(),
-              type: DioExceptionType.badResponse,
-              response: refreshError.response,
-            );
-
-            return handler.reject(sessionExpiredError);
-          }
-
-          logError(
-            'AuthorizationInterceptors: Refresh token failed with '
-            'statusCode=${refreshError.response?.statusCode}',
-            exception: refreshError,
-            stackTrace: st,
-          );
-
-          return _handleDioRefreshError(
-            refreshError: refreshError,
-            originalError: err,
-            handler: handler,
-          );
-        }
-      } else {
-        logTrace(
-          'AuthorizationInterceptors::onError: '
-          'No retry or refresh applicable. '
-          'statusCode = ${err.response?.statusCode} | '
-          'authType = $_authenticationType | '
-          'hasConfig = ${_configOIDC != null} | '
-          'hasAttemptedRefresh = $hasAttemptedRefresh | '
-          'url = ${err.requestOptions.uri}',
-          webConsoleEnabled: true,
-        );
-        return super.onError(err, handler);
+        return await _refreshTokenThenRetry(err, requestOptions, handler);
       }
 
-      if (isRetryRequest) {
-        try {
-          final response = await _retryRequest(requestOptions, extraInRequest);
-          return handler.resolve(response);
-        } catch (retryError) {
-          logError(
-            'AuthorizationInterceptors::onError: '
-            'Retry failed with error=$retryError',
-          );
-          // Mobile only: pass retry errors directly so the stale 401 response
-          // is not preserved via err.copyWith.
-          if (PlatformInfo.isMobile) {
-            if (retryError is DioException) {
-              return super.onError(retryError, handler);
-            }
-            return super.onError(
-              DioException(requestOptions: err.requestOptions, error: retryError),
-              handler,
-            );
-          }
-          return super.onError(
-            err.copyWith(error: retryError),
-            handler,
-          );
-        }
-      } else {
-        return super.onError(err, handler);
-      }
+      logTrace(
+        'AuthorizationInterceptors::onError: '
+        'No retry or refresh applicable. '
+        'statusCode = ${err.response?.statusCode} | '
+        'authType = $_authenticationType | '
+        'hasConfig = ${_configOIDC != null} | '
+        'hasAttemptedRefresh = $hasAttemptedRefresh | '
+        'url = ${err.requestOptions.uri}',
+        webConsoleEnabled: true,
+      );
+      return super.onError(err, handler);
     } catch (e, stackTrace) {
       logError(
         'AuthorizationInterceptors::onError:Exception: $e',
@@ -225,6 +141,88 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       } else {
         return super.onError(err.copyWith(error: e), handler);
       }
+    }
+  }
+
+  Future<void> _refreshTokenThenRetry(
+    DioException err,
+    RequestOptions requestOptions,
+    ErrorInterceptorHandler handler,
+  ) async {
+    try {
+      log('AuthorizationInterceptors::onError: Perform get New Token');
+      final newTokenOidc = PlatformInfo.isIOS
+        ? await _getNewTokenForIOSPlatform()
+        : await _getNewTokenForOtherPlatform();
+
+      if (newTokenOidc.token == _token?.token) {
+        log('AuthorizationInterceptors::onError: Token duplicated');
+        return super.onError(err, handler);
+      }
+      _updateNewToken(newTokenOidc);
+
+      final personalAccount = await _updateCurrentAccount(tokenOIDC: newTokenOidc);
+
+      if (PlatformInfo.isIOS) {
+        await _iosSharingManager.saveKeyChainSharingSession(personalAccount);
+      }
+
+      requestOptions.extra[_refreshAttemptedKey] = true;
+      return await _performRetry(requestOptions, err, handler);
+    } on DioException catch (refreshError, st) {
+      if (refreshError.response?.statusCode == 400) {
+        logError(
+          'AuthorizationInterceptors: Refresh Token Failed 400',
+          exception: refreshError,
+          stackTrace: st,
+        );
+        clear();
+        return handler.reject(DioException(
+          requestOptions: err.requestOptions,
+          error: RefreshTokenFailedException(),
+          type: DioExceptionType.badResponse,
+          response: refreshError.response,
+        ));
+      }
+      logError(
+        'AuthorizationInterceptors: Refresh token failed with '
+        'statusCode=${refreshError.response?.statusCode}',
+        exception: refreshError,
+        stackTrace: st,
+      );
+      return _handleDioRefreshError(
+        refreshError: refreshError,
+        originalError: err,
+        handler: handler,
+      );
+    }
+  }
+
+  Future<void> _performRetry(
+    RequestOptions requestOptions,
+    DioException originalErr,
+    ErrorInterceptorHandler handler,
+  ) async {
+    try {
+      final response = await _retryRequest(requestOptions, requestOptions.extra);
+      return handler.resolve(response);
+    } catch (retryError) {
+      logError(
+        'AuthorizationInterceptors::onError: '
+        'Retry failed with error=$retryError',
+      );
+      // Mobile only: pass retry errors directly so the stale 401 response
+      // is not preserved via err.copyWith.
+      if (PlatformInfo.isMobile) {
+        if (retryError is DioException) {
+          return super.onError(retryError, handler);
+        }
+        return super.onError(
+          DioException(requestOptions: originalErr.requestOptions, error: retryError),
+          handler,
+        );
+      }
+      return super.onError(originalErr.copyWith(error: retryError), handler);
     }
   }
 

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -160,10 +160,11 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
               ),
               handler,
             );
-          } else if (refreshError.response == null) {
-            // Network failure during refresh — don't carry the original 401
-            // response forward, as that would make RemoteExceptionThrower
-            // classify this as BadCredentialsException and log the user out.
+          } else if (PlatformInfo.isMobile && refreshError.response == null) {
+            // Mobile only: network failure during refresh — don't carry the
+            // original 401 response forward, as that would make
+            // RemoteExceptionThrower classify this as BadCredentialsException
+            // and log the user out.
             return super.onError(
               DioException(
                 requestOptions: err.requestOptions,
@@ -174,7 +175,12 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
               handler,
             );
           } else {
-            return super.onError(refreshError, handler);
+            return super.onError(
+              PlatformInfo.isMobile
+                  ? refreshError
+                  : err.copyWith(error: refreshError),
+              handler,
+            );
           }
         }
       } else {
@@ -200,11 +206,19 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
             'AuthorizationInterceptors::onError: '
             'Retry failed with error=$retryError',
           );
-          if (retryError is DioException) {
-            return super.onError(retryError, handler);
+          // Mobile only: pass retry errors directly so the stale 401 response
+          // is not preserved via err.copyWith.
+          if (PlatformInfo.isMobile) {
+            if (retryError is DioException) {
+              return super.onError(retryError, handler);
+            }
+            return super.onError(
+              DioException(requestOptions: err.requestOptions, error: retryError),
+              handler,
+            );
           }
           return super.onError(
-            DioException(requestOptions: err.requestOptions, error: retryError),
+            err.copyWith(error: retryError),
             handler,
           );
         }
@@ -217,18 +231,26 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         exception: e,
         stackTrace: stackTrace,
       );
-      // Any exception that is not a DioException with an HTTP response is a
-      // network-level failure (e.g. FlutterAppAuthPlatformException from the
-      // OIDC token refresh on mobile). Carrying the original 401 response
-      // forward via err.copyWith would cause RemoteExceptionThrower to
-      // misclassify it as BadCredentialsException and log the user out.
-      if (e is DioException && e.response != null) {
-        return super.onError(e, handler);
+      if (PlatformInfo.isMobile) {
+        // Mobile only: non-DioException types (e.g. FlutterAppAuthPlatformException
+        // from native OIDC refresh) must not carry the stale 401 response forward,
+        // as RemoteExceptionThrower would misclassify it as BadCredentialsException.
+        if (e is DioException && e.response != null) {
+          return super.onError(e, handler);
+        }
+        return super.onError(
+          DioException(requestOptions: err.requestOptions, error: e),
+          handler,
+        );
       }
-      return super.onError(
-        DioException(requestOptions: err.requestOptions, error: e),
-        handler,
-      );
+      if (e is ServerError || e is TemporarilyUnavailable) {
+        return super.onError(
+          DioException(requestOptions: err.requestOptions, error: e),
+          handler,
+        );
+      } else {
+        return super.onError(err.copyWith(error: e), handler);
+      }
     }
   }
 

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -160,6 +160,19 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
               ),
               handler,
             );
+          } else if (refreshError.response == null) {
+            // Network failure during refresh — don't carry the original 401
+            // response forward, as that would make RemoteExceptionThrower
+            // classify this as BadCredentialsException and log the user out.
+            return super.onError(
+              DioException(
+                requestOptions: err.requestOptions,
+                type: refreshError.type,
+                error: refreshError.error,
+                message: refreshError.message,
+              ),
+              handler,
+            );
           } else {
             return super.onError(err.copyWith(error: refreshError), handler);
           }
@@ -187,6 +200,17 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
             'AuthorizationInterceptors::onError: '
             'Retry failed with error=$retryError',
           );
+          if (retryError is DioException && retryError.response == null) {
+            return super.onError(
+              DioException(
+                requestOptions: err.requestOptions,
+                type: retryError.type,
+                error: retryError.error,
+                message: retryError.message,
+              ),
+              handler,
+            );
+          }
           return super.onError(
             err.copyWith(error: retryError),
             handler,

--- a/lib/main/utils/ios_sharing_manager.dart
+++ b/lib/main/utils/ios_sharing_manager.dart
@@ -108,7 +108,7 @@ class IOSSharingManager {
 
       log('IOSSharingManager::_saveKeyChainSharingSession: COMPLETED');
     } catch (e) {
-      logWarning('IOSSharingManager::_saveKeyChainSharingSession: Exception: $e');
+      logError('IOSSharingManager::_saveKeyChainSharingSession: Exception: $e');
     }
   }
 

--- a/test/features/base/reloadable_controller_test.dart
+++ b/test/features/base/reloadable_controller_test.dart
@@ -168,7 +168,7 @@ void main() {
     );
   });
 
-  group('Bug 2 — web: handleGetSessionFailure logs out on network error (old behaviour preserved)', () {
+  group('Bug 2 — web: handleGetSessionFailure does NOT log out on transient network error', () {
     setUp(() {
       PlatformInfo.isTestingForWeb = true;
       controller.wasLoggedOut = false;
@@ -180,22 +180,22 @@ void main() {
 
     test(
       'WHEN GetSessionFailure carries ConnectionTimeout on web\n'
-      'THEN clearDataAndGoToLoginPage MUST be called\n'
-      '(web keeps original logout-on-any-failure behaviour)',
+      'THEN clearDataAndGoToLoginPage MUST NOT be called\n'
+      '(network guard applies to all platforms)',
       () {
         controller.handleGetSessionFailure(GetSessionFailure(const ConnectionTimeout()));
 
-        expect(controller.wasLoggedOut, isTrue);
+        expect(controller.wasLoggedOut, isFalse);
       },
     );
 
     test(
       'WHEN GetSessionFailure carries SocketError on web\n'
-      'THEN clearDataAndGoToLoginPage MUST be called',
+      'THEN clearDataAndGoToLoginPage MUST NOT be called',
       () {
         controller.handleGetSessionFailure(GetSessionFailure(const SocketError()));
 
-        expect(controller.wasLoggedOut, isTrue);
+        expect(controller.wasLoggedOut, isFalse);
       },
     );
 

--- a/test/features/base/reloadable_controller_test.dart
+++ b/test/features/base/reloadable_controller_test.dart
@@ -21,6 +21,7 @@ import 'package:tmail_ui_user/features/login/domain/usecases/update_account_cach
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
+import 'package:tmail_ui_user/main/exceptions/cache/cache_exception.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
@@ -162,6 +163,16 @@ void main() {
       'THEN clearDataAndGoToLoginPage MUST be called',
       () {
         controller.handleGetSessionFailure(GetSessionFailure(RefreshTokenFailedException()));
+
+        expect(controller.wasLoggedOut, isTrue);
+      },
+    );
+
+    test(
+      'WHEN GetSessionFailure carries CacheException on mobile\n'
+      'THEN clearDataAndGoToLoginPage MUST be called',
+      () {
+        controller.handleGetSessionFailure(GetSessionFailure(const UnknownCacheError()));
 
         expect(controller.wasLoggedOut, isTrue);
       },

--- a/test/features/base/reloadable_controller_test.dart
+++ b/test/features/base/reloadable_controller_test.dart
@@ -2,6 +2,8 @@ import 'package:core/data/network/config/dynamic_url_interceptors.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/app_toast.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/utils/platform_info.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
@@ -94,11 +96,19 @@ void main() {
     controller.wasLoggedOut = false;
   });
 
-  group('Bug 2 — handleGetSessionFailure logs out for transient network errors (regression)', () {
+  group('Bug 2 — mobile: handleGetSessionFailure does NOT log out on transient network error', () {
+    setUp(() {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      controller.wasLoggedOut = false;
+    });
+
+    tearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+    });
+
     test(
-      'WHEN GetSessionFailure carries ConnectionTimeout\n'
-      'THEN clearDataAndGoToLoginPage MUST NOT be called\n'
-      '(BUG: currently calls logout for any exception type)',
+      'WHEN GetSessionFailure carries ConnectionTimeout on mobile\n'
+      'THEN clearDataAndGoToLoginPage MUST NOT be called',
       () {
         controller.handleGetSessionFailure(GetSessionFailure(const ConnectionTimeout()));
 
@@ -107,7 +117,7 @@ void main() {
     );
 
     test(
-      'WHEN GetSessionFailure carries SocketError\n'
+      'WHEN GetSessionFailure carries SocketError on mobile\n'
       'THEN clearDataAndGoToLoginPage MUST NOT be called',
       () {
         controller.handleGetSessionFailure(GetSessionFailure(const SocketError()));
@@ -117,7 +127,7 @@ void main() {
     );
 
     test(
-      'WHEN GetSessionFailure carries NoNetworkError\n'
+      'WHEN GetSessionFailure carries NoNetworkError on mobile\n'
       'THEN clearDataAndGoToLoginPage MUST NOT be called',
       () {
         controller.handleGetSessionFailure(GetSessionFailure(const NoNetworkError()));
@@ -127,7 +137,7 @@ void main() {
     );
 
     test(
-      'WHEN GetSessionFailure carries ConnectionError\n'
+      'WHEN GetSessionFailure carries ConnectionError on mobile\n'
       'THEN clearDataAndGoToLoginPage MUST NOT be called',
       () {
         controller.handleGetSessionFailure(GetSessionFailure(const ConnectionError()));
@@ -137,7 +147,7 @@ void main() {
     );
 
     test(
-      'WHEN GetSessionFailure carries BadCredentialsException\n'
+      'WHEN GetSessionFailure carries BadCredentialsException on mobile\n'
       'THEN clearDataAndGoToLoginPage MUST be called\n'
       '(real auth failure — logout is correct)',
       () {
@@ -148,10 +158,52 @@ void main() {
     );
 
     test(
-      'WHEN GetSessionFailure carries RefreshTokenFailedException\n'
+      'WHEN GetSessionFailure carries RefreshTokenFailedException on mobile\n'
       'THEN clearDataAndGoToLoginPage MUST be called',
       () {
         controller.handleGetSessionFailure(GetSessionFailure(RefreshTokenFailedException()));
+
+        expect(controller.wasLoggedOut, isTrue);
+      },
+    );
+  });
+
+  group('Bug 2 — web: handleGetSessionFailure logs out on network error (old behaviour preserved)', () {
+    setUp(() {
+      PlatformInfo.isTestingForWeb = true;
+      controller.wasLoggedOut = false;
+    });
+
+    tearDown(() {
+      PlatformInfo.isTestingForWeb = false;
+    });
+
+    test(
+      'WHEN GetSessionFailure carries ConnectionTimeout on web\n'
+      'THEN clearDataAndGoToLoginPage MUST be called\n'
+      '(web keeps original logout-on-any-failure behaviour)',
+      () {
+        controller.handleGetSessionFailure(GetSessionFailure(const ConnectionTimeout()));
+
+        expect(controller.wasLoggedOut, isTrue);
+      },
+    );
+
+    test(
+      'WHEN GetSessionFailure carries SocketError on web\n'
+      'THEN clearDataAndGoToLoginPage MUST be called',
+      () {
+        controller.handleGetSessionFailure(GetSessionFailure(const SocketError()));
+
+        expect(controller.wasLoggedOut, isTrue);
+      },
+    );
+
+    test(
+      'WHEN GetSessionFailure carries BadCredentialsException on web\n'
+      'THEN clearDataAndGoToLoginPage MUST be called',
+      () {
+        controller.handleGetSessionFailure(GetSessionFailure(const BadCredentialsException()));
 
         expect(controller.wasLoggedOut, isTrue);
       },

--- a/test/features/base/reloadable_controller_test.dart
+++ b/test/features/base/reloadable_controller_test.dart
@@ -1,0 +1,165 @@
+import 'package:core/data/network/config/dynamic_url_interceptors.dart';
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/app_toast.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:mockito/annotations.dart';
+import 'package:tmail_ui_user/features/base/reloadable/reloadable_controller.dart';
+import 'package:tmail_ui_user/features/caching/caching_manager.dart';
+import 'package:tmail_ui_user/features/home/domain/state/get_session_state.dart';
+import 'package:tmail_ui_user/features/home/domain/usecases/get_session_interactor.dart';
+import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oidc_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/get_authenticated_account_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/get_oidc_user_info_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/update_account_cache_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
+import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
+import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
+import 'package:uuid/uuid.dart';
+
+import 'reloadable_controller_test.mocks.dart';
+
+class _TestReloadableController extends ReloadableController {
+  bool wasLoggedOut = false;
+
+  @override
+  Future<void> clearDataAndGoToLoginPage() async {
+    wasLoggedOut = true;
+  }
+
+  @override
+  void handleReloaded(Session session) {}
+}
+
+@GenerateNiceMocks([
+  MockSpec<CachingManager>(),
+  MockSpec<LanguageCacheManager>(),
+  MockSpec<AuthorizationInterceptors>(),
+  MockSpec<DynamicUrlInterceptors>(),
+  MockSpec<DeleteCredentialInteractor>(),
+  MockSpec<LogoutOidcInteractor>(),
+  MockSpec<DeleteAuthorityOidcInteractor>(),
+  MockSpec<AppToast>(),
+  MockSpec<ImagePaths>(),
+  MockSpec<ResponsiveUtils>(),
+  MockSpec<Uuid>(),
+  MockSpec<ToastManager>(),
+  MockSpec<TwakeAppManager>(),
+  MockSpec<GetSessionInteractor>(),
+  MockSpec<GetAuthenticatedAccountInteractor>(),
+  MockSpec<UpdateAccountCacheInteractor>(),
+  MockSpec<GetOidcUserInfoInteractor>(),
+])
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _TestReloadableController controller;
+
+  setUpAll(() {
+    Get.put<CachingManager>(MockCachingManager());
+    Get.put<LanguageCacheManager>(MockLanguageCacheManager());
+    Get.put<AuthorizationInterceptors>(MockAuthorizationInterceptors());
+    Get.put<AuthorizationInterceptors>(
+      MockAuthorizationInterceptors(),
+      tag: BindingTag.isolateTag,
+    );
+    Get.put<DynamicUrlInterceptors>(MockDynamicUrlInterceptors());
+    Get.put<DeleteCredentialInteractor>(MockDeleteCredentialInteractor());
+    Get.put<LogoutOidcInteractor>(MockLogoutOidcInteractor());
+    Get.put<DeleteAuthorityOidcInteractor>(MockDeleteAuthorityOidcInteractor());
+    Get.put<AppToast>(MockAppToast());
+    Get.put<ImagePaths>(MockImagePaths());
+    Get.put<ResponsiveUtils>(MockResponsiveUtils());
+    Get.put<Uuid>(MockUuid());
+    Get.put<ToastManager>(MockToastManager());
+    Get.put<TwakeAppManager>(MockTwakeAppManager());
+    Get.put<GetSessionInteractor>(MockGetSessionInteractor());
+    Get.put<GetAuthenticatedAccountInteractor>(MockGetAuthenticatedAccountInteractor());
+    Get.put<UpdateAccountCacheInteractor>(MockUpdateAccountCacheInteractor());
+    Get.put<GetOidcUserInfoInteractor>(MockGetOidcUserInfoInteractor());
+
+    Get.testMode = true;
+    controller = _TestReloadableController();
+  });
+
+  setUp(() {
+    controller.wasLoggedOut = false;
+  });
+
+  // ============================================================
+  // Bug 2 — handleGetSessionFailure logs out for any exception (regression)
+  // ============================================================
+  group('Bug 2 — handleGetSessionFailure logs out for transient network errors (regression)', () {
+    test(
+      'WHEN GetSessionFailure carries ConnectionTimeout\n'
+      'THEN clearDataAndGoToLoginPage MUST NOT be called\n'
+      '(BUG: currently calls logout for any exception type)',
+      () {
+        controller.handleGetSessionFailure(GetSessionFailure(const ConnectionTimeout()));
+
+        // BUG: wasLoggedOut == true — ConnectionTimeout triggers logout
+        // FIX: wasLoggedOut == false — transient error, user should stay logged in
+        expect(controller.wasLoggedOut, isFalse);
+      },
+    );
+
+    test(
+      'WHEN GetSessionFailure carries SocketError\n'
+      'THEN clearDataAndGoToLoginPage MUST NOT be called',
+      () {
+        controller.handleGetSessionFailure(GetSessionFailure(const SocketError()));
+
+        expect(controller.wasLoggedOut, isFalse);
+      },
+    );
+
+    test(
+      'WHEN GetSessionFailure carries NoNetworkError\n'
+      'THEN clearDataAndGoToLoginPage MUST NOT be called',
+      () {
+        controller.handleGetSessionFailure(GetSessionFailure(const NoNetworkError()));
+
+        expect(controller.wasLoggedOut, isFalse);
+      },
+    );
+
+    test(
+      'WHEN GetSessionFailure carries ConnectionError\n'
+      'THEN clearDataAndGoToLoginPage MUST NOT be called',
+      () {
+        controller.handleGetSessionFailure(GetSessionFailure(const ConnectionError()));
+
+        expect(controller.wasLoggedOut, isFalse);
+      },
+    );
+
+    test(
+      'WHEN GetSessionFailure carries BadCredentialsException\n'
+      'THEN clearDataAndGoToLoginPage MUST be called\n'
+      '(real auth failure — logout is correct)',
+      () {
+        controller.handleGetSessionFailure(GetSessionFailure(const BadCredentialsException()));
+
+        expect(controller.wasLoggedOut, isTrue);
+      },
+    );
+
+    test(
+      'WHEN GetSessionFailure carries RefreshTokenFailedException\n'
+      'THEN clearDataAndGoToLoginPage MUST be called',
+      () {
+        controller.handleGetSessionFailure(GetSessionFailure(RefreshTokenFailedException()));
+
+        expect(controller.wasLoggedOut, isTrue);
+      },
+    );
+  });
+}

--- a/test/features/base/reloadable_controller_test.dart
+++ b/test/features/base/reloadable_controller_test.dart
@@ -94,9 +94,6 @@ void main() {
     controller.wasLoggedOut = false;
   });
 
-  // ============================================================
-  // Bug 2 — handleGetSessionFailure logs out for any exception (regression)
-  // ============================================================
   group('Bug 2 — handleGetSessionFailure logs out for transient network errors (regression)', () {
     test(
       'WHEN GetSessionFailure carries ConnectionTimeout\n'
@@ -105,8 +102,6 @@ void main() {
       () {
         controller.handleGetSessionFailure(GetSessionFailure(const ConnectionTimeout()));
 
-        // BUG: wasLoggedOut == true — ConnectionTimeout triggers logout
-        // FIX: wasLoggedOut == false — transient error, user should stay logged in
         expect(controller.wasLoggedOut, isFalse);
       },
     );

--- a/test/features/base/reloadable_controller_test.dart
+++ b/test/features/base/reloadable_controller_test.dart
@@ -20,6 +20,7 @@ import 'package:tmail_ui_user/features/login/domain/usecases/get_oidc_user_info_
 import 'package:tmail_ui_user/features/login/domain/usecases/update_account_cache_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
+import 'package:tmail_ui_user/features/home/data/exceptions/session_exceptions.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
 import 'package:tmail_ui_user/main/exceptions/cache/cache_exception.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
@@ -169,10 +170,22 @@ void main() {
     );
 
     test(
-      'WHEN GetSessionFailure carries CacheException on mobile\n'
-      'THEN clearDataAndGoToLoginPage MUST be called',
+      'WHEN GetSessionFailure carries UnknownCacheError on mobile\n'
+      'THEN clearDataAndGoToLoginPage MUST NOT be called\n'
+      '(cache read error is not an auth failure)',
       () {
         controller.handleGetSessionFailure(GetSessionFailure(const UnknownCacheError()));
+
+        expect(controller.wasLoggedOut, isFalse);
+      },
+    );
+
+    test(
+      'WHEN GetSessionFailure carries NotFoundSessionException on mobile\n'
+      'THEN clearDataAndGoToLoginPage MUST be called\n'
+      '(no cached session means user must re-authenticate)',
+      () {
+        controller.handleGetSessionFailure(GetSessionFailure(NotFoundSessionException()));
 
         expect(controller.wasLoggedOut, isTrue);
       },

--- a/test/features/home/domain/usecases/get_session_interactor_test.dart
+++ b/test/features/home/domain/usecases/get_session_interactor_test.dart
@@ -11,6 +11,12 @@ import 'package:tmail_ui_user/features/home/domain/usecases/get_session_interact
 import '../../../../fixtures/session_fixtures.dart';
 import 'get_session_interactor_test.mocks.dart';
 
+Matcher _emitsNetworkThenCacheThen(dynamic result) => emitsInOrder([
+  Right<Failure, Success>(GetSessionLoading()),
+  Right<Failure, Success>(GetSessionLoading()),
+  result,
+]);
+
 @GenerateMocks([SessionRepository])
 void main() {
   late MockSessionRepository sessionRepository;
@@ -70,11 +76,9 @@ void main() {
 
         expect(
           interactor.execute(),
-          emitsInOrder([
-            Right<Failure, Success>(GetSessionLoading()),
-            Right<Failure, Success>(GetSessionLoading()),
+          _emitsNetworkThenCacheThen(
             Right<Failure, Success>(GetSessionSuccess(SessionFixtures.aliceSession)),
-          ]),
+          ),
         );
       });
 
@@ -84,11 +88,9 @@ void main() {
 
         expect(
           interactor.execute(),
-          emitsInOrder([
-            Right<Failure, Success>(GetSessionLoading()),
-            Right<Failure, Success>(GetSessionLoading()),
+          _emitsNetworkThenCacheThen(
             Left<Failure, Success>(GetSessionFailure(networkException)),
-          ]),
+          ),
         );
       });
     });

--- a/test/features/home/domain/usecases/get_session_interactor_test.dart
+++ b/test/features/home/domain/usecases/get_session_interactor_test.dart
@@ -1,0 +1,96 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/home/domain/repository/session_repository.dart';
+import 'package:tmail_ui_user/features/home/domain/state/get_session_state.dart';
+import 'package:tmail_ui_user/features/home/domain/usecases/get_session_interactor.dart';
+
+import '../../../../fixtures/session_fixtures.dart';
+import 'get_session_interactor_test.mocks.dart';
+
+@GenerateMocks([SessionRepository])
+void main() {
+  late MockSessionRepository sessionRepository;
+  late GetSessionInteractor interactor;
+
+  setUp(() {
+    sessionRepository = MockSessionRepository();
+    interactor = GetSessionInteractor(sessionRepository);
+  });
+
+  group('[GetSessionInteractor]', () {
+    group('on success', () {
+      setUp(() {
+        when(sessionRepository.getSession())
+            .thenAnswer((_) async => SessionFixtures.aliceSession);
+      });
+
+      test('emits Loading then Success', () {
+        expect(
+          interactor.execute(),
+          emitsInOrder([
+            Right<Failure, Success>(GetSessionLoading()),
+            Right<Failure, Success>(GetSessionSuccess(SessionFixtures.aliceSession)),
+          ]),
+        );
+      });
+
+      test('never calls getStoredSession when network succeeds', () async {
+        await interactor.execute().drain();
+        verifyNever(sessionRepository.getStoredSession());
+      });
+    });
+
+    group('on network failure (mobile)', () {
+      final networkException = Exception('network error');
+
+      setUp(() {
+        when(sessionRepository.getSession()).thenThrow(networkException);
+      });
+
+      test('calls getStoredSession after getSession throws', () async {
+        when(sessionRepository.getStoredSession())
+            .thenAnswer((_) async => SessionFixtures.aliceSession);
+
+        await interactor.execute().drain();
+
+        // getSession must be called first, getStoredSession second
+        verifyInOrder([
+          sessionRepository.getSession(),
+          sessionRepository.getStoredSession(),
+        ]);
+      });
+
+      test('emits Loading, Loading, then CacheSuccess when cache hit', () {
+        when(sessionRepository.getStoredSession())
+            .thenAnswer((_) async => SessionFixtures.aliceSession);
+
+        expect(
+          interactor.execute(),
+          emitsInOrder([
+            Right<Failure, Success>(GetSessionLoading()),
+            Right<Failure, Success>(GetSessionLoading()),
+            Right<Failure, Success>(GetSessionSuccess(SessionFixtures.aliceSession)),
+          ]),
+        );
+      });
+
+      test('emits Failure with original network exception when cache also fails', () {
+        when(sessionRepository.getStoredSession())
+            .thenThrow(Exception('cache miss'));
+
+        expect(
+          interactor.execute(),
+          emitsInOrder([
+            Right<Failure, Success>(GetSessionLoading()),
+            Right<Failure, Success>(GetSessionLoading()),
+            Left<Failure, Success>(GetSessionFailure(networkException)),
+          ]),
+        );
+      });
+    });
+  });
+}

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -520,7 +520,7 @@ void main() {
 
     test(
       'WHEN refresh fails with 500 DioException\n'
-      'THEN propagate original error via super.onError\n'
+      'THEN propagate refreshError directly (not stale 401)\n'
       'AND OIDC state is NOT cleared',
       () async {
         authorizationInterceptors.setTokenAndAuthorityOidc(
@@ -553,7 +553,12 @@ void main() {
 
         await expectLater(
           () => dio.post(baseUrl),
-          throwsA(isA<DioException>()),
+          // Fix path 1: must carry the refresh error's own 500 response,
+          // NOT the original 401 — otherwise RemoteExceptionThrower
+          // would classify it as BadCredentialsException and log user out.
+          throwsA(predicate<DioException>(
+            (e) => e.response?.statusCode == responseStatusCode500,
+          )),
         );
 
         expect(
@@ -1403,7 +1408,7 @@ void main() {
 
     test(
       'WHEN refresh succeeds but retry gets 500\n'
-      'THEN error is propagated\n'
+      'THEN propagated error carries 500 (not stale 401)\n'
       'AND OIDC state is preserved',
       () async {
         authorizationInterceptors.setTokenAndAuthorityOidc(
@@ -1451,7 +1456,11 @@ void main() {
 
         await expectLater(
           () => dio.post(baseUrl),
-          throwsA(isA<DioException>()),
+          // Fix path 2: retry error propagated directly — must carry 500,
+          // NOT the original 401 (which would trigger BadCredentialsException).
+          throwsA(predicate<DioException>(
+            (e) => e.response?.statusCode == responseStatusCode500,
+          )),
         );
 
         // OIDC state should NOT be cleared (only 400 clears state)

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -3,9 +3,7 @@ import 'dart:io';
 
 import 'package:core/data/constants/constant.dart';
 import 'package:core/data/network/dio_client.dart';
-import 'package:core/utils/platform_info.dart';
 import 'package:dio/dio.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http_mock_adapter/http_mock_adapter.dart';
@@ -1547,13 +1545,9 @@ void main() {
       type: DioExceptionType.connectionTimeout,
     );
 
-    setUp(() => debugDefaultTargetPlatformOverride = TargetPlatform.android);
-    tearDown(() => debugDefaultTargetPlatformOverride = null);
-
     test(
       'WHEN 401 with expired token\n'
       'AND refresh call times out (connectionTimeout, response=null)\n'
-      'AND platform is mobile\n'
       'THEN propagated error carries NO HTTP response\n'
       '(BUG: err.copyWith preserves original 401 response → RemoteExceptionThrower → logout)',
       () async {
@@ -1589,7 +1583,6 @@ void main() {
     test(
       'WHEN server-side 401 (token not locally expired)\n'
       'AND refresh call times out\n'
-      'AND platform is mobile\n'
       'THEN propagated error carries NO HTTP response',
       () async {
         authorizationInterceptors.setTokenAndAuthorityOidc(
@@ -1623,55 +1616,13 @@ void main() {
       },
     );
 
-    test(
-      'WHEN 401 with expired token\n'
-      'AND refresh call times out\n'
-      'AND platform is web\n'
-      'THEN propagated error preserves original 401 response (old web behaviour)',
-      () async {
-        debugDefaultTargetPlatformOverride = null;
-        PlatformInfo.isTestingForWeb = true;
-        addTearDown(() => PlatformInfo.isTestingForWeb = false);
-
-        authorizationInterceptors.setTokenAndAuthorityOidc(
-          newToken: OIDCFixtures.tokenOidcExpiredTime,
-          newConfig: OIDCFixtures.oidcConfiguration,
-        );
-
-        dioAdapter.onPost(
-          baseUrl,
-          (server) => server.throws(responseStatusCode401, makeDioError401()),
-          headers: {
-            HttpHeaders.authorizationHeader:
-                'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
-          },
-        );
-
-        when(authenticationClient.refreshingTokensOIDC(
-          OIDCFixtures.oidcConfiguration.clientId,
-          OIDCFixtures.oidcConfiguration.redirectUrl,
-          OIDCFixtures.oidcConfiguration.discoveryUrl,
-          OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
-        )).thenThrow(refreshTimeoutError);
-
-        await expectLater(
-          () => dio.post(baseUrl),
-          throwsA(predicate<DioException>((e) => e.response != null)),
-        );
-      },
-    );
   });
 
   group('Bug 1 — retry network timeout preserves original 401 response (regression)', () {
-    setUp(() => debugDefaultTargetPlatformOverride = TargetPlatform.android);
-    tearDown(() => debugDefaultTargetPlatformOverride = null);
-
     test(
       'WHEN 401 with expired token\n'
       'AND refresh succeeds\n'
       'AND retry call times out (connectionTimeout, response=null)\n'
-      'AND platform is mobile\n'
       'THEN propagated error carries NO HTTP response\n'
       '(BUG: err.copyWith preserves original 401 response → logout)',
       () async {
@@ -1718,69 +1669,13 @@ void main() {
       },
     );
 
-    test(
-      'WHEN 401 with expired token\n'
-      'AND refresh succeeds\n'
-      'AND retry call times out\n'
-      'AND platform is web\n'
-      'THEN propagated error preserves original 401 response (old web behaviour)',
-      () async {
-        debugDefaultTargetPlatformOverride = null;
-        PlatformInfo.isTestingForWeb = true;
-        addTearDown(() => PlatformInfo.isTestingForWeb = false);
-
-        authorizationInterceptors.setTokenAndAuthorityOidc(
-          newToken: OIDCFixtures.tokenOidcExpiredTime,
-          newConfig: OIDCFixtures.oidcConfiguration,
-        );
-
-        dioAdapter.onPost(
-          baseUrl,
-          (server) => server.throws(responseStatusCode401, makeDioError401()),
-          headers: {
-            HttpHeaders.authorizationHeader:
-                'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
-          },
-        );
-
-        final retryTimeoutError = DioException(
-          requestOptions: RequestOptions(path: baseUrl),
-          type: DioExceptionType.connectionTimeout,
-        );
-        dioAdapter.onPost(
-          baseUrl,
-          (server) => server.throws(0, retryTimeoutError),
-          headers: {
-            HttpHeaders.authorizationHeader:
-                'Bearer ${OIDCFixtures.newTokenOidc.token}',
-          },
-        );
-
-        when(authenticationClient.refreshingTokensOIDC(
-          OIDCFixtures.oidcConfiguration.clientId,
-          OIDCFixtures.oidcConfiguration.redirectUrl,
-          OIDCFixtures.oidcConfiguration.discoveryUrl,
-          OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
-        )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
-        stubAccountCache();
-
-        await expectLater(
-          () => dio.post(baseUrl),
-          throwsA(predicate<DioException>((e) => e.response != null)),
-        );
-      },
-    );
   });
 
   group(
     'Bug 1 — FlutterAppAuthPlatformException from OIDC refresh '
-    'does not preserve original 401 (outer catch) — mobile only',
+    'does not preserve original 401 (outer catch)',
     () {
-      setUp(() => debugDefaultTargetPlatformOverride = TargetPlatform.android);
-      tearDown(() => debugDefaultTargetPlatformOverride = null);
-
-      // _appAuth.token() mobile OIDC no-internet: native SDK throws
+      // _appAuth.token() OIDC no-internet: native SDK throws
       // FlutterAppAuthPlatformException(error: null) — transport failure.
       // details==null path rethrows raw PlatformException instead.
       // Both handled identically by outer catch.
@@ -1951,46 +1846,6 @@ void main() {
         },
       );
 
-      test(
-        'WHEN platform is web\n'
-        'AND refresh throws non-DioException (OAuthAuthorizationError)\n'
-        'THEN propagated error preserves original 401 response (old web behaviour)',
-        () async {
-          debugDefaultTargetPlatformOverride = null;
-          PlatformInfo.isTestingForWeb = true;
-          addTearDown(() => PlatformInfo.isTestingForWeb = false);
-
-          authorizationInterceptors.setTokenAndAuthorityOidc(
-            newToken: OIDCFixtures.tokenOidcExpiredTime,
-            newConfig: OIDCFixtures.oidcConfiguration,
-          );
-
-          dioAdapter.onPost(
-            baseUrl,
-            (server) => server.throws(responseStatusCode401, makeDioError401()),
-            headers: {
-              HttpHeaders.authorizationHeader:
-                  'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
-            },
-          );
-
-          when(authenticationClient.refreshingTokensOIDC(
-            OIDCFixtures.oidcConfiguration.clientId,
-            OIDCFixtures.oidcConfiguration.redirectUrl,
-            OIDCFixtures.oidcConfiguration.discoveryUrl,
-            OIDCFixtures.oidcConfiguration.scopes,
-            OIDCFixtures.tokenOidcExpiredTime.refreshToken,
-          )).thenThrow(const OAuthAuthorizationError(
-            error: 'invalid_grant',
-            errorDescription: 'The refresh token has been revoked',
-          ));
-
-          await expectLater(
-            () => dio.post(baseUrl),
-            throwsA(predicate<DioException>((e) => e.response != null)),
-          );
-        },
-      );
     },
   );
 

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -12,6 +12,8 @@ import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:model/account/authentication_type.dart';
 import 'package:model/account/password.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_appauth_platform_interface/flutter_appauth_platform_interface.dart';
 import 'package:tmail_ui_user/features/login/data/local/account_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/local/token_oidc_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/network/authentication_client/authentication_client_base.dart';
@@ -591,7 +593,9 @@ void main() {
 
         await expectLater(
           () => dio.post(baseUrl),
-          throwsA(predicate<DioException>((e) => e.error is ServerError)),
+          throwsA(predicate<DioException>(
+            (e) => e.error is ServerError && e.response == null,
+          )),
         );
       },
     );
@@ -622,15 +626,16 @@ void main() {
         await expectLater(
           () => dio.post(baseUrl),
           throwsA(predicate<DioException>(
-            (e) => e.error is TemporarilyUnavailable,
+            (e) => e.error is TemporarilyUnavailable && e.response == null,
           )),
         );
       },
     );
 
     test(
-      'WHEN refresh throws generic exception (AccessTokenInvalidException)\n'
-      'THEN outer catch wraps it via err.copyWith(error: e)',
+      'WHEN refresh throws generic non-DioException (AccessTokenInvalidException)\n'
+      'THEN outer catch creates fresh DioException with NO HTTP response\n'
+      'AND does NOT preserve original 401 (Fix 3 regression)',
       () async {
         authorizationInterceptors.setTokenAndAuthorityOidc(
           newToken: OIDCFixtures.tokenOidcExpiredTime,
@@ -653,9 +658,9 @@ void main() {
 
         await expectLater(
           () => dio.post(baseUrl),
-          throwsA(predicate<DioException>(
-            (e) => e.error is AccessTokenInvalidException,
-          )),
+          throwsA(predicate<DioException>((e) {
+            return e.error is AccessTokenInvalidException && e.response == null;
+          })),
         );
       },
     );
@@ -1738,6 +1743,197 @@ void main() {
       },
     );
   });
+
+  // ============================================================
+  // Bug 1 — FlutterAppAuthPlatformException from OIDC refresh
+  // must NOT preserve original 401 response (outer catch, Fix 3)
+  // ============================================================
+  group(
+    'Bug 1 — FlutterAppAuthPlatformException from OIDC refresh '
+    'does not preserve original 401 (outer catch)',
+    () {
+      // Simulates _appAuth.token() on mobile with no internet where the native
+      // SDK sends structured error details (details != null). invokeMethod()
+      // then throws FlutterAppAuthPlatformException with error == null (no
+      // OAuth error code for a transport failure). handleException() passes it
+      // through unchanged because platformErrorDetails.error is null.
+      // Note: if details == null, invokeMethod() rethrows raw PlatformException
+      // instead; the fix in the outer catch handles both identically.
+      final platformNetworkException = FlutterAppAuthPlatformException(
+        code: 'network_error',
+        message: 'Failed to connect to token endpoint',
+        platformErrorDetails: FlutterAppAuthPlatformErrorDetails(
+          error: null, // null = pure transport failure, not an OAuth error
+        ),
+      );
+
+      test(
+        'WHEN 401 with expired token\n'
+        'AND refresh throws FlutterAppAuthPlatformException (no internet)\n'
+        'THEN propagated DioException has NO HTTP response\n'
+        'AND error is FlutterAppAuthPlatformException\n'
+        '(BUG: outer catch err.copyWith preserved original 401 → BadCredentialsException → logout)',
+        () async {
+          authorizationInterceptors.setTokenAndAuthorityOidc(
+            newToken: OIDCFixtures.tokenOidcExpiredTime,
+            newConfig: OIDCFixtures.oidcConfiguration,
+          );
+
+          dioAdapter.onPost(
+            baseUrl,
+            (server) =>
+                server.throws(responseStatusCode401, makeDioError401()),
+            headers: {
+              HttpHeaders.authorizationHeader:
+                  'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+            },
+          );
+
+          when(authenticationClient.refreshingTokensOIDC(
+            OIDCFixtures.oidcConfiguration.clientId,
+            OIDCFixtures.oidcConfiguration.redirectUrl,
+            OIDCFixtures.oidcConfiguration.discoveryUrl,
+            OIDCFixtures.oidcConfiguration.scopes,
+            OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          )).thenThrow(platformNetworkException);
+
+          await expectLater(
+            () => dio.post(baseUrl),
+            throwsA(predicate<DioException>((e) {
+              return e.response == null &&
+                  e.error is FlutterAppAuthPlatformException;
+            })),
+          );
+        },
+      );
+
+      test(
+        'WHEN server-side 401 (token not locally expired)\n'
+        'AND refresh throws FlutterAppAuthPlatformException (no internet)\n'
+        'THEN propagated DioException has NO HTTP response',
+        () async {
+          authorizationInterceptors.setTokenAndAuthorityOidc(
+            newToken: OIDCFixtures.tokenOidcNotExpiredYet,
+            newConfig: OIDCFixtures.oidcConfiguration,
+          );
+
+          dioAdapter.onPost(
+            baseUrl,
+            (server) =>
+                server.throws(responseStatusCode401, makeDioError401()),
+            headers: {
+              HttpHeaders.authorizationHeader:
+                  'Bearer ${OIDCFixtures.tokenOidcNotExpiredYet.token}',
+            },
+          );
+
+          when(authenticationClient.refreshingTokensOIDC(
+            OIDCFixtures.oidcConfiguration.clientId,
+            OIDCFixtures.oidcConfiguration.redirectUrl,
+            OIDCFixtures.oidcConfiguration.discoveryUrl,
+            OIDCFixtures.oidcConfiguration.scopes,
+            OIDCFixtures.tokenOidcNotExpiredYet.refreshToken,
+          )).thenThrow(platformNetworkException);
+
+          await expectLater(
+            () => dio.post(baseUrl),
+            throwsA(predicate<DioException>((e) {
+              return e.response == null &&
+                  e.error is FlutterAppAuthPlatformException;
+            })),
+          );
+        },
+      );
+
+      test(
+        'WHEN refresh throws raw PlatformException (invokeMethod details==null path)\n'
+        'THEN propagated DioException has NO HTTP response',
+        () async {
+          authorizationInterceptors.setTokenAndAuthorityOidc(
+            newToken: OIDCFixtures.tokenOidcExpiredTime,
+            newConfig: OIDCFixtures.oidcConfiguration,
+          );
+
+          dioAdapter.onPost(
+            baseUrl,
+            (server) =>
+                server.throws(responseStatusCode401, makeDioError401()),
+            headers: {
+              HttpHeaders.authorizationHeader:
+                  'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+            },
+          );
+
+          // invokeMethod() rethrows PlatformException unchanged when e.details==null
+          // (socket-level failure, no structured error from native SDK).
+          // handleException() does not match FlutterAppAuthPlatformException check
+          // → passes through as-is → outer catch → not DioException → fresh
+          // DioException without response.
+          when(authenticationClient.refreshingTokensOIDC(
+            OIDCFixtures.oidcConfiguration.clientId,
+            OIDCFixtures.oidcConfiguration.redirectUrl,
+            OIDCFixtures.oidcConfiguration.discoveryUrl,
+            OIDCFixtures.oidcConfiguration.scopes,
+            OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          )).thenThrow(PlatformException(
+            code: 'network_error',
+            message: 'Failed to connect to token endpoint',
+          ));
+
+          await expectLater(
+            () => dio.post(baseUrl),
+            throwsA(predicate<DioException>((e) {
+              return e.response == null && e.error is PlatformException;
+            })),
+          );
+        },
+      );
+
+      test(
+        'WHEN refresh throws OAuthAuthorizationError (e.g. invalid_grant)\n'
+        'THEN propagated DioException still has NO HTTP response',
+        () async {
+          authorizationInterceptors.setTokenAndAuthorityOidc(
+            newToken: OIDCFixtures.tokenOidcExpiredTime,
+            newConfig: OIDCFixtures.oidcConfiguration,
+          );
+
+          dioAdapter.onPost(
+            baseUrl,
+            (server) =>
+                server.throws(responseStatusCode401, makeDioError401()),
+            headers: {
+              HttpHeaders.authorizationHeader:
+                  'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+            },
+          );
+
+          // In production: FlutterAppAuthPlatformException(error: 'invalid_grant')
+          // is caught inside authentication_client_mobile.dart::refreshingTokensOIDC
+          // and converted by handleException() to OAuthAuthorizationError before
+          // being re-thrown. Mocking that output directly.
+          when(authenticationClient.refreshingTokensOIDC(
+            OIDCFixtures.oidcConfiguration.clientId,
+            OIDCFixtures.oidcConfiguration.redirectUrl,
+            OIDCFixtures.oidcConfiguration.discoveryUrl,
+            OIDCFixtures.oidcConfiguration.scopes,
+            OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          )).thenThrow(const OAuthAuthorizationError(
+            error: 'invalid_grant',
+            errorDescription: 'The refresh token has been revoked',
+          ));
+
+          await expectLater(
+            () => dio.post(baseUrl),
+            throwsA(predicate<DioException>((e) {
+              return e.response == null &&
+                  e.error is OAuthAuthorizationError;
+            })),
+          );
+        },
+      );
+    },
+  );
 
   tearDown(() {
     reset(authenticationClient);

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -131,6 +131,9 @@ void main() {
         .thenAnswer((_) async => OIDCFixtures.newTokenOidc);
   }
 
+  // ============================================================
+  // validateToRefreshToken
+  // ============================================================
   group('validateToRefreshToken', () {
     test(
       'should return TRUE when 401 + OIDC + has token + has refreshToken (expired)',
@@ -237,6 +240,9 @@ void main() {
     });
   });
 
+  // ============================================================
+  // validateToRetryTheRequestWithNewToken
+  // ============================================================
   group('validateToRetryTheRequestWithNewToken', () {
     test(
       'should return TRUE when 401, auth header present, token updated, and token not expired',
@@ -333,6 +339,9 @@ void main() {
     });
   });
 
+  // ============================================================
+  // onError: refresh and retry flow
+  // ============================================================
   group('onError: refresh and retry flow', () {
     test(
       'WHEN 401 with expired token\n'
@@ -471,6 +480,9 @@ void main() {
     );
   });
 
+  // ============================================================
+  // onError: refresh fails with DioException
+  // ============================================================
   group('onError: refresh fails with DioException', () {
     test(
       'WHEN refresh fails with 400 (Invalid Grant)\n'
@@ -573,6 +585,9 @@ void main() {
     );
   });
 
+  // ============================================================
+  // onError: refresh fails with non-DioException (outer catch)
+  // ============================================================
   group('onError: refresh fails with non-DioException (outer catch)', () {
     test(
       'WHEN refresh throws ServerError\n'
@@ -672,6 +687,9 @@ void main() {
     );
   });
 
+  // ============================================================
+  // onError: skip refresh scenarios
+  // ============================================================
   group('onError: skip refresh scenarios', () {
     test(
       'WHEN error is 500 (not 401)\n'
@@ -778,7 +796,9 @@ void main() {
           newConfig: OIDCFixtures.oidcConfiguration,
         );
 
-        // server.reply preserves requestOptions.extra (unlike server.throws)
+        // Use server.reply(401) instead of server.throws() so that Dio
+        // creates the DioException from the ORIGINAL request options,
+        // preserving the _refreshAttemptedKey extra.
         dioAdapter.onPost(
           baseUrl,
           (server) => server.reply(
@@ -810,6 +830,9 @@ void main() {
     );
   });
 
+  // ============================================================
+  // onError: multiple queued requests
+  // ============================================================
   group('onError: multiple queued requests', () {
     test(
       'GIVEN 2 sequential requests with expired token\n'
@@ -822,6 +845,7 @@ void main() {
           newConfig: OIDCFixtures.oidcConfiguration,
         );
 
+        // Request 1: old token → 401
         dioAdapter.onPost(
           '$baseUrl/1',
           (server) => server.throws(
@@ -833,6 +857,7 @@ void main() {
                 'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
           },
         );
+        // Request 1 retry: new token → 200
         dioAdapter.onPost(
           '$baseUrl/1',
           (server) =>
@@ -842,6 +867,8 @@ void main() {
                 'Bearer ${OIDCFixtures.newTokenOidc.token}',
           },
         );
+
+        // Request 2: after Request 1 completes, onRequest uses new token → 200
         dioAdapter.onPost(
           '$baseUrl/2',
           (server) =>
@@ -864,6 +891,7 @@ void main() {
         final response1 = await dio.post('$baseUrl/1');
         final response2 = await dio.post('$baseUrl/2');
 
+        // Refresh called only once by Request 1
         verify(authenticationClient.refreshingTokensOIDC(
           OIDCFixtures.oidcConfiguration.clientId,
           OIDCFixtures.oidcConfiguration.redirectUrl,
@@ -946,7 +974,8 @@ void main() {
           newConfig: OIDCFixtures.oidcConfiguration,
         );
 
-        // server.reply preserves requestOptions auth header (unlike server.throws)
+        // Use server.reply(401) so Dio creates DioException from
+        // original requestOptions (preserving auth header from onRequest)
         dioAdapter.onPost(
           '$baseUrl/1',
           (server) => server.reply(
@@ -970,6 +999,7 @@ void main() {
           },
         );
 
+        // Retry handlers: new token → 200
         dioAdapter.onPost(
           '$baseUrl/1',
           (server) =>
@@ -998,10 +1028,12 @@ void main() {
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         stubAccountCache();
 
+        // Fire both requests concurrently
         final future1 = dio.post('$baseUrl/1');
         final future2 = dio.post('$baseUrl/2');
         final responses = await Future.wait([future1, future2]);
 
+        // Refresh should be called only once (by whichever enters onError first)
         verify(authenticationClient.refreshingTokensOIDC(
           OIDCFixtures.oidcConfiguration.clientId,
           OIDCFixtures.oidcConfiguration.redirectUrl,
@@ -1036,6 +1068,7 @@ void main() {
           newConfig: OIDCFixtures.oidcConfiguration,
         );
 
+        // All 3 requests with old token → 401
         for (final i in [1, 2, 3]) {
           dioAdapter.onPost(
             '$baseUrl/$i',
@@ -1048,6 +1081,7 @@ void main() {
                   'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
             },
           );
+          // Retry with new token → 200
           dioAdapter.onPost(
             '$baseUrl/$i',
             (server) =>
@@ -1074,6 +1108,7 @@ void main() {
           dio.post('$baseUrl/3'),
         ]);
 
+        // Refresh called exactly once regardless of how many requests queued
         verify(authenticationClient.refreshingTokensOIDC(
           OIDCFixtures.oidcConfiguration.clientId,
           OIDCFixtures.oidcConfiguration.redirectUrl,
@@ -1104,6 +1139,7 @@ void main() {
           newConfig: OIDCFixtures.oidcConfiguration,
         );
 
+        // Both requests with old token → 401
         dioAdapter.onPost(
           '$baseUrl/1',
           (server) => server.reply(
@@ -1136,9 +1172,11 @@ void main() {
         )).thenThrow(dioErrorRefresh400);
         stubAccountCache();
 
+        // Fire both requests concurrently
         final future1 = dio.post('$baseUrl/1');
         final future2 = dio.post('$baseUrl/2');
 
+        // Request 1: refresh fails with 400 → RefreshTokenFailedException
         DioException? error1;
         DioException? error2;
         try {
@@ -1156,9 +1194,11 @@ void main() {
         expect(error1?.error, isA<RefreshTokenFailedException>());
         expect(error1?.response?.statusCode, 400);
 
-        // state cleared by Request 1 → no refresh/retry → propagates 401
+        // Request 2: state was cleared by Request 1, so no refresh/retry
+        // possible → propagates original 401
         expect(error2, isNotNull);
 
+        // State should be cleared
         expect(
           authorizationInterceptors.authenticationType,
           AuthenticationType.none,
@@ -1177,6 +1217,7 @@ void main() {
           newConfig: OIDCFixtures.oidcConfiguration,
         );
 
+        // Request 1: old token → 401
         dioAdapter.onPost(
           '$baseUrl/1',
           (server) => server.throws(
@@ -1198,6 +1239,7 @@ void main() {
         )).thenThrow(dioErrorRefresh400);
         stubAccountCache();
 
+        // Request 1 fails with RefreshTokenFailedException
         await expectLater(
           () => dio.post('$baseUrl/1'),
           throwsA(predicate<DioException>(
@@ -1205,11 +1247,13 @@ void main() {
           )),
         );
 
+        // State is now cleared
         expect(
           authorizationInterceptors.authenticationType,
           AuthenticationType.none,
         );
 
+        // Request 2: no auth header added (type is none), server returns 401
         dioAdapter.onPost(
           '$baseUrl/2',
           (server) => server.reply(
@@ -1218,6 +1262,7 @@ void main() {
           ),
         );
 
+        // Request 2 fails — no OIDC config, no refresh possible
         await expectLater(
           () => dio.post('$baseUrl/2'),
           throwsA(predicate<DioException>(
@@ -1225,6 +1270,7 @@ void main() {
           )),
         );
 
+        // Refresh should NOT be called again (state cleared)
         verify(authenticationClient.refreshingTokensOIDC(
           OIDCFixtures.oidcConfiguration.clientId,
           OIDCFixtures.oidcConfiguration.redirectUrl,
@@ -1247,6 +1293,7 @@ void main() {
           newConfig: OIDCFixtures.oidcConfiguration,
         );
 
+        // Both requests → 401
         dioAdapter.onPost(
           '$baseUrl/1',
           (server) => server.reply(
@@ -1299,19 +1346,24 @@ void main() {
           error2 = e;
         }
 
+        // Both should fail with 401
         expect(error1, isNotNull);
         expect(error1!.response?.statusCode, responseStatusCode401);
 
         expect(error2, isNotNull);
         expect(error2!.response?.statusCode, responseStatusCode401);
 
-        // duplicate token doesn't update _token → second request can't detect first's attempt
-        // each request tries once and stops — no infinite loop
+        // Both requests independently attempt refresh (duplicate didn't
+        // update _token, so second request can't detect the first's attempt).
+        // Key assertion: no infinite loop — each request tries once and stops.
         expect(refreshCallCount, 2);
       },
     );
   });
 
+  // ============================================================
+  // onError: retry fails (separate Dio error handling)
+  // ============================================================
   group('onError: retry fails (separate Dio error handling)', () {
     test(
       'WHEN refresh succeeds but retry with new token gets 401\n'
@@ -1323,6 +1375,7 @@ void main() {
           newConfig: OIDCFixtures.oidcConfiguration,
         );
 
+        // Old token → 401
         dioAdapter.onPost(
           baseUrl,
           (server) => server.throws(responseStatusCode401, makeDioError401()),
@@ -1331,6 +1384,7 @@ void main() {
                 'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
           },
         );
+        // Retry with new token → also 401
         dioAdapter.onPost(
           baseUrl,
           (server) => server.throws(
@@ -1357,6 +1411,7 @@ void main() {
           throwsA(isA<DioException>()),
         );
 
+        // Refresh was called once
         verify(authenticationClient.refreshingTokensOIDC(
           OIDCFixtures.oidcConfiguration.clientId,
           OIDCFixtures.oidcConfiguration.redirectUrl,
@@ -1387,6 +1442,7 @@ void main() {
           type: DioExceptionType.badResponse,
         );
 
+        // Old token → 401
         dioAdapter.onPost(
           baseUrl,
           (server) => server.throws(responseStatusCode401, makeDioError401()),
@@ -1395,6 +1451,7 @@ void main() {
                 'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
           },
         );
+        // Retry with new token → 500
         dioAdapter.onPost(
           baseUrl,
           (server) => server.throws(responseStatusCode500, dioError500),
@@ -1421,6 +1478,7 @@ void main() {
           )),
         );
 
+        // OIDC state should NOT be cleared (only 400 clears state)
         expect(
           authorizationInterceptors.authenticationType,
           AuthenticationType.oidc,
@@ -1450,6 +1508,7 @@ void main() {
           type: DioExceptionType.badResponse,
         );
 
+        // Request 1: old token → 401
         dioAdapter.onPost(
           '$baseUrl/1',
           (server) => server.reply(
@@ -1461,6 +1520,7 @@ void main() {
                 'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
           },
         );
+        // Request 1 retry: new token → 200
         dioAdapter.onPost(
           '$baseUrl/1',
           (server) =>
@@ -1471,6 +1531,7 @@ void main() {
           },
         );
 
+        // Request 2: old token → 401
         dioAdapter.onPost(
           '$baseUrl/2',
           (server) => server.reply(
@@ -1482,6 +1543,7 @@ void main() {
                 'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
           },
         );
+        // Request 2 retry: new token → 500
         dioAdapter.onPost(
           '$baseUrl/2',
           (server) => server.throws(responseStatusCode500, dioError500),
@@ -1514,6 +1576,9 @@ void main() {
     );
   });
 
+  // ============================================================
+  // onError: token duplicate prevents infinite loop
+  // ============================================================
   group('onError: token duplicate prevents infinite loop', () {
     test(
       'WHEN refresh returns same token as current\n'
@@ -1541,7 +1606,7 @@ void main() {
           OIDCFixtures.tokenOidcNotExpiredYet.refreshToken,
         )).thenAnswer((_) async {
           refreshCallCount++;
-          return OIDCFixtures.tokenOidcNotExpiredYet; // duplicate → detected, no retry
+          return OIDCFixtures.tokenOidcNotExpiredYet; // same token → duplicate
         });
         stubAccountCache();
 

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -113,9 +113,6 @@ void main() {
     )).thenAnswer((_) async {});
   }
 
-  // ============================================================
-  // validateToRefreshToken
-  // ============================================================
   group('validateToRefreshToken', () {
     test(
       'should return TRUE when 401 + OIDC + has token + has refreshToken (expired)',
@@ -222,9 +219,6 @@ void main() {
     });
   });
 
-  // ============================================================
-  // validateToRetryTheRequestWithNewToken
-  // ============================================================
   group('validateToRetryTheRequestWithNewToken', () {
     test(
       'should return TRUE when 401, auth header present, token updated, and token not expired',
@@ -321,9 +315,6 @@ void main() {
     });
   });
 
-  // ============================================================
-  // onError: refresh and retry flow
-  // ============================================================
   group('onError: refresh and retry flow', () {
     test(
       'WHEN 401 with expired token\n'
@@ -462,9 +453,6 @@ void main() {
     );
   });
 
-  // ============================================================
-  // onError: refresh fails with DioException
-  // ============================================================
   group('onError: refresh fails with DioException', () {
     test(
       'WHEN refresh fails with 400 (Invalid Grant)\n'
@@ -553,9 +541,7 @@ void main() {
 
         await expectLater(
           () => dio.post(baseUrl),
-          // Fix path 1: must carry the refresh error's own 500 response,
-          // NOT the original 401 — otherwise RemoteExceptionThrower
-          // would classify it as BadCredentialsException and log user out.
+          // must carry 500 (own response), not stale 401 → would trigger BadCredentialsException
           throwsA(predicate<DioException>(
             (e) => e.response?.statusCode == responseStatusCode500,
           )),
@@ -569,9 +555,6 @@ void main() {
     );
   });
 
-  // ============================================================
-  // onError: refresh fails with non-DioException (outer catch)
-  // ============================================================
   group('onError: refresh fails with non-DioException (outer catch)', () {
     test(
       'WHEN refresh throws ServerError\n'
@@ -671,9 +654,6 @@ void main() {
     );
   });
 
-  // ============================================================
-  // onError: skip refresh scenarios
-  // ============================================================
   group('onError: skip refresh scenarios', () {
     test(
       'WHEN error is 500 (not 401)\n'
@@ -780,9 +760,7 @@ void main() {
           newConfig: OIDCFixtures.oidcConfiguration,
         );
 
-        // Use server.reply(401) instead of server.throws() so that Dio
-        // creates the DioException from the ORIGINAL request options,
-        // preserving the _refreshAttemptedKey extra.
+        // server.reply preserves requestOptions.extra (unlike server.throws)
         dioAdapter.onPost(
           baseUrl,
           (server) => server.reply(
@@ -814,9 +792,6 @@ void main() {
     );
   });
 
-  // ============================================================
-  // onError: multiple queued requests
-  // ============================================================
   group('onError: multiple queued requests', () {
     test(
       'GIVEN 2 sequential requests with expired token\n'
@@ -829,7 +804,6 @@ void main() {
           newConfig: OIDCFixtures.oidcConfiguration,
         );
 
-        // Request 1: old token → 401
         dioAdapter.onPost(
           '$baseUrl/1',
           (server) => server.throws(
@@ -841,7 +815,6 @@ void main() {
                 'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
           },
         );
-        // Request 1 retry: new token → 200
         dioAdapter.onPost(
           '$baseUrl/1',
           (server) =>
@@ -851,8 +824,6 @@ void main() {
                 'Bearer ${OIDCFixtures.newTokenOidc.token}',
           },
         );
-
-        // Request 2: after Request 1 completes, onRequest uses new token → 200
         dioAdapter.onPost(
           '$baseUrl/2',
           (server) =>
@@ -875,7 +846,6 @@ void main() {
         final response1 = await dio.post('$baseUrl/1');
         final response2 = await dio.post('$baseUrl/2');
 
-        // Refresh called only once by Request 1
         verify(authenticationClient.refreshingTokensOIDC(
           OIDCFixtures.oidcConfiguration.clientId,
           OIDCFixtures.oidcConfiguration.redirectUrl,
@@ -958,8 +928,7 @@ void main() {
           newConfig: OIDCFixtures.oidcConfiguration,
         );
 
-        // Use server.reply(401) so Dio creates DioException from
-        // original requestOptions (preserving auth header from onRequest)
+        // server.reply preserves requestOptions auth header (unlike server.throws)
         dioAdapter.onPost(
           '$baseUrl/1',
           (server) => server.reply(
@@ -983,7 +952,6 @@ void main() {
           },
         );
 
-        // Retry handlers: new token → 200
         dioAdapter.onPost(
           '$baseUrl/1',
           (server) =>
@@ -1012,12 +980,10 @@ void main() {
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         stubAccountCache();
 
-        // Fire both requests concurrently
         final future1 = dio.post('$baseUrl/1');
         final future2 = dio.post('$baseUrl/2');
         final responses = await Future.wait([future1, future2]);
 
-        // Refresh should be called only once (by whichever enters onError first)
         verify(authenticationClient.refreshingTokensOIDC(
           OIDCFixtures.oidcConfiguration.clientId,
           OIDCFixtures.oidcConfiguration.redirectUrl,
@@ -1052,7 +1018,6 @@ void main() {
           newConfig: OIDCFixtures.oidcConfiguration,
         );
 
-        // All 3 requests with old token → 401
         for (final i in [1, 2, 3]) {
           dioAdapter.onPost(
             '$baseUrl/$i',
@@ -1065,7 +1030,6 @@ void main() {
                   'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
             },
           );
-          // Retry with new token → 200
           dioAdapter.onPost(
             '$baseUrl/$i',
             (server) =>
@@ -1092,7 +1056,6 @@ void main() {
           dio.post('$baseUrl/3'),
         ]);
 
-        // Refresh called exactly once regardless of how many requests queued
         verify(authenticationClient.refreshingTokensOIDC(
           OIDCFixtures.oidcConfiguration.clientId,
           OIDCFixtures.oidcConfiguration.redirectUrl,
@@ -1123,7 +1086,6 @@ void main() {
           newConfig: OIDCFixtures.oidcConfiguration,
         );
 
-        // Both requests with old token → 401
         dioAdapter.onPost(
           '$baseUrl/1',
           (server) => server.reply(
@@ -1156,11 +1118,9 @@ void main() {
         )).thenThrow(dioErrorRefresh400);
         stubAccountCache();
 
-        // Fire both requests concurrently
         final future1 = dio.post('$baseUrl/1');
         final future2 = dio.post('$baseUrl/2');
 
-        // Request 1: refresh fails with 400 → RefreshTokenFailedException
         DioException? error1;
         DioException? error2;
         try {
@@ -1178,11 +1138,9 @@ void main() {
         expect(error1?.error, isA<RefreshTokenFailedException>());
         expect(error1?.response?.statusCode, 400);
 
-        // Request 2: state was cleared by Request 1, so no refresh/retry
-        // possible → propagates original 401
+        // state cleared by Request 1 → no refresh/retry → propagates 401
         expect(error2, isNotNull);
 
-        // State should be cleared
         expect(
           authorizationInterceptors.authenticationType,
           AuthenticationType.none,
@@ -1201,7 +1159,6 @@ void main() {
           newConfig: OIDCFixtures.oidcConfiguration,
         );
 
-        // Request 1: old token → 401
         dioAdapter.onPost(
           '$baseUrl/1',
           (server) => server.throws(
@@ -1223,7 +1180,6 @@ void main() {
         )).thenThrow(dioErrorRefresh400);
         stubAccountCache();
 
-        // Request 1 fails with RefreshTokenFailedException
         await expectLater(
           () => dio.post('$baseUrl/1'),
           throwsA(predicate<DioException>(
@@ -1231,13 +1187,11 @@ void main() {
           )),
         );
 
-        // State is now cleared
         expect(
           authorizationInterceptors.authenticationType,
           AuthenticationType.none,
         );
 
-        // Request 2: no auth header added (type is none), server returns 401
         dioAdapter.onPost(
           '$baseUrl/2',
           (server) => server.reply(
@@ -1246,7 +1200,6 @@ void main() {
           ),
         );
 
-        // Request 2 fails — no OIDC config, no refresh possible
         await expectLater(
           () => dio.post('$baseUrl/2'),
           throwsA(predicate<DioException>(
@@ -1254,7 +1207,6 @@ void main() {
           )),
         );
 
-        // Refresh should NOT be called again (state cleared)
         verify(authenticationClient.refreshingTokensOIDC(
           OIDCFixtures.oidcConfiguration.clientId,
           OIDCFixtures.oidcConfiguration.redirectUrl,
@@ -1277,7 +1229,6 @@ void main() {
           newConfig: OIDCFixtures.oidcConfiguration,
         );
 
-        // Both requests → 401
         dioAdapter.onPost(
           '$baseUrl/1',
           (server) => server.reply(
@@ -1330,24 +1281,19 @@ void main() {
           error2 = e;
         }
 
-        // Both should fail with 401
         expect(error1, isNotNull);
         expect(error1!.response?.statusCode, responseStatusCode401);
 
         expect(error2, isNotNull);
         expect(error2!.response?.statusCode, responseStatusCode401);
 
-        // Both requests independently attempt refresh (duplicate didn't
-        // update _token, so second request can't detect the first's attempt).
-        // Key assertion: no infinite loop — each request tries once and stops.
+        // duplicate token doesn't update _token → second request can't detect first's attempt
+        // each request tries once and stops — no infinite loop
         expect(refreshCallCount, 2);
       },
     );
   });
 
-  // ============================================================
-  // onError: retry fails (separate Dio error handling)
-  // ============================================================
   group('onError: retry fails (separate Dio error handling)', () {
     test(
       'WHEN refresh succeeds but retry with new token gets 401\n'
@@ -1359,7 +1305,6 @@ void main() {
           newConfig: OIDCFixtures.oidcConfiguration,
         );
 
-        // Old token → 401
         dioAdapter.onPost(
           baseUrl,
           (server) => server.throws(responseStatusCode401, makeDioError401()),
@@ -1368,7 +1313,6 @@ void main() {
                 'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
           },
         );
-        // Retry with new token → also 401
         dioAdapter.onPost(
           baseUrl,
           (server) => server.throws(
@@ -1395,7 +1339,6 @@ void main() {
           throwsA(isA<DioException>()),
         );
 
-        // Refresh was called once
         verify(authenticationClient.refreshingTokensOIDC(
           OIDCFixtures.oidcConfiguration.clientId,
           OIDCFixtures.oidcConfiguration.redirectUrl,
@@ -1426,7 +1369,6 @@ void main() {
           type: DioExceptionType.badResponse,
         );
 
-        // Old token → 401
         dioAdapter.onPost(
           baseUrl,
           (server) => server.throws(responseStatusCode401, makeDioError401()),
@@ -1435,7 +1377,6 @@ void main() {
                 'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
           },
         );
-        // Retry with new token → 500
         dioAdapter.onPost(
           baseUrl,
           (server) => server.throws(responseStatusCode500, dioError500),
@@ -1456,14 +1397,12 @@ void main() {
 
         await expectLater(
           () => dio.post(baseUrl),
-          // Fix path 2: retry error propagated directly — must carry 500,
-          // NOT the original 401 (which would trigger BadCredentialsException).
+          // must carry 500, not stale 401 → would trigger BadCredentialsException
           throwsA(predicate<DioException>(
             (e) => e.response?.statusCode == responseStatusCode500,
           )),
         );
 
-        // OIDC state should NOT be cleared (only 400 clears state)
         expect(
           authorizationInterceptors.authenticationType,
           AuthenticationType.oidc,
@@ -1493,7 +1432,6 @@ void main() {
           type: DioExceptionType.badResponse,
         );
 
-        // Request 1: old token → 401
         dioAdapter.onPost(
           '$baseUrl/1',
           (server) => server.reply(
@@ -1505,7 +1443,6 @@ void main() {
                 'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
           },
         );
-        // Request 1 retry: new token → 200
         dioAdapter.onPost(
           '$baseUrl/1',
           (server) =>
@@ -1516,7 +1453,6 @@ void main() {
           },
         );
 
-        // Request 2: old token → 401
         dioAdapter.onPost(
           '$baseUrl/2',
           (server) => server.reply(
@@ -1528,7 +1464,6 @@ void main() {
                 'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
           },
         );
-        // Request 2 retry: new token → 500
         dioAdapter.onPost(
           '$baseUrl/2',
           (server) => server.throws(responseStatusCode500, dioError500),
@@ -1561,9 +1496,6 @@ void main() {
     );
   });
 
-  // ============================================================
-  // onError: token duplicate prevents infinite loop
-  // ============================================================
   group('onError: token duplicate prevents infinite loop', () {
     test(
       'WHEN refresh returns same token as current\n'
@@ -1591,7 +1523,7 @@ void main() {
           OIDCFixtures.tokenOidcNotExpiredYet.refreshToken,
         )).thenAnswer((_) async {
           refreshCallCount++;
-          return OIDCFixtures.tokenOidcNotExpiredYet; // same token → duplicate
+          return OIDCFixtures.tokenOidcNotExpiredYet; // duplicate → detected, no retry
         });
         stubAccountCache();
 
@@ -1607,14 +1539,10 @@ void main() {
     );
   });
 
-  // ============================================================
-  // Bug 1 — refresh network timeout preserves original 401 response (regression)
-  // ============================================================
   group('Bug 1 — refresh network timeout preserves original 401 response (regression)', () {
     final refreshTimeoutError = DioException(
       requestOptions: RequestOptions(path: '/token'),
       type: DioExceptionType.connectionTimeout,
-      // response: null — pure network failure, no HTTP response
     );
 
     test(
@@ -1647,11 +1575,7 @@ void main() {
 
         await expectLater(
           () => dio.post(baseUrl),
-          throwsA(predicate<DioException>((e) {
-            // BUG: e.response?.statusCode == 401 (original 401 preserved by err.copyWith)
-            // FIX: e.response == null — transient network failure, should NOT trigger logout
-            return e.response == null;
-          })),
+          throwsA(predicate<DioException>((e) => e.response == null)),
         );
       },
     );
@@ -1693,9 +1617,6 @@ void main() {
     );
   });
 
-  // ============================================================
-  // Bug 1 — retry network timeout preserves original 401 response (regression)
-  // ============================================================
   group('Bug 1 — retry network timeout preserves original 401 response (regression)', () {
     test(
       'WHEN 401 with expired token\n'
@@ -1721,7 +1642,6 @@ void main() {
         final retryTimeoutError = DioException(
           requestOptions: RequestOptions(path: baseUrl),
           type: DioExceptionType.connectionTimeout,
-          // response: null
         );
         dioAdapter.onPost(
           baseUrl,
@@ -1743,31 +1663,20 @@ void main() {
 
         await expectLater(
           () => dio.post(baseUrl),
-          throwsA(predicate<DioException>((e) {
-            // BUG: e.response?.statusCode == 401 (original 401 preserved)
-            // FIX: e.response == null — network timeout during retry, not an auth failure
-            return e.response == null;
-          })),
+          throwsA(predicate<DioException>((e) => e.response == null)),
         );
       },
     );
   });
 
-  // ============================================================
-  // Bug 1 — FlutterAppAuthPlatformException from OIDC refresh
-  // must NOT preserve original 401 response (outer catch, Fix 3)
-  // ============================================================
   group(
     'Bug 1 — FlutterAppAuthPlatformException from OIDC refresh '
     'does not preserve original 401 (outer catch)',
     () {
-      // Simulates _appAuth.token() on mobile with no internet where the native
-      // SDK sends structured error details (details != null). invokeMethod()
-      // then throws FlutterAppAuthPlatformException with error == null (no
-      // OAuth error code for a transport failure). handleException() passes it
-      // through unchanged because platformErrorDetails.error is null.
-      // Note: if details == null, invokeMethod() rethrows raw PlatformException
-      // instead; the fix in the outer catch handles both identically.
+      // _appAuth.token() mobile OIDC no-internet: native SDK throws
+      // FlutterAppAuthPlatformException(error: null) — transport failure.
+      // details==null path rethrows raw PlatformException instead.
+      // Both handled identically by outer catch.
       final platformNetworkException = FlutterAppAuthPlatformException(
         code: 'network_error',
         message: 'Failed to connect to token endpoint',
@@ -1873,11 +1782,7 @@ void main() {
             },
           );
 
-          // invokeMethod() rethrows PlatformException unchanged when e.details==null
-          // (socket-level failure, no structured error from native SDK).
-          // handleException() does not match FlutterAppAuthPlatformException check
-          // → passes through as-is → outer catch → not DioException → fresh
-          // DioException without response.
+          // e.details==null → invokeMethod rethrows PlatformException → handleException passes through → outer catch → fresh DioException(response: null)
           when(authenticationClient.refreshingTokensOIDC(
             OIDCFixtures.oidcConfiguration.clientId,
             OIDCFixtures.oidcConfiguration.redirectUrl,
@@ -1917,10 +1822,7 @@ void main() {
             },
           );
 
-          // In production: FlutterAppAuthPlatformException(error: 'invalid_grant')
-          // is caught inside authentication_client_mobile.dart::refreshingTokensOIDC
-          // and converted by handleException() to OAuthAuthorizationError before
-          // being re-thrown. Mocking that output directly.
+          // FlutterAppAuthPlatformException(error:'invalid_grant') → handleException() → OAuthAuthorizationError
           when(authenticationClient.refreshingTokensOIDC(
             OIDCFixtures.oidcConfiguration.clientId,
             OIDCFixtures.oidcConfiguration.redirectUrl,

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -12,6 +12,8 @@ import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:model/account/authentication_type.dart';
 import 'package:model/account/password.dart';
+import 'package:model/account/personal_account.dart';
+import 'package:model/oidc/token_oidc.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_appauth_platform_interface/flutter_appauth_platform_interface.dart';
 import 'package:tmail_ui_user/features/login/data/local/account_cache_manager.dart';
@@ -106,11 +108,27 @@ void main() {
   });
 
   void stubAccountCache() {
-    when(accountCacheManager.getCurrentAccount())
-        .thenAnswer((_) async => AccountFixtures.aliceAccount);
+    var callCount = 0;
+    when(accountCacheManager.getCurrentAccount()).thenAnswer((_) async {
+      callCount++;
+      if (callCount == 1) return AccountFixtures.aliceAccount;
+      // Second call is the read-back in _verifyStoreTokenAndAccount.
+      // Return the PersonalAccount that _updateCurrentAccount would have
+      // constructed from newTokenOidc so the equality check passes.
+      return PersonalAccount(
+        OIDCFixtures.newTokenOidc.tokenIdHash,
+        AuthenticationType.oidc,
+        isSelected: true,
+        accountId: AccountFixtures.aliceAccountId,
+        apiUrl: AccountFixtures.aliceAccount.apiUrl,
+        userName: AccountFixtures.aliceAccount.userName,
+      );
+    });
     when(accountCacheManager.deleteCurrentAccount(
       AccountFixtures.aliceAccount.id,
     )).thenAnswer((_) async {});
+    when(tokenOidcCacheManager.getTokenOidc(OIDCFixtures.newTokenOidc.tokenIdHash))
+        .thenAnswer((_) async => OIDCFixtures.newTokenOidc);
   }
 
   group('validateToRefreshToken', () {

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -13,7 +13,9 @@ import 'package:mockito/mockito.dart';
 import 'package:model/account/authentication_type.dart';
 import 'package:model/account/password.dart';
 import 'package:model/account/personal_account.dart';
+import 'package:model/oidc/token_id.dart';
 import 'package:model/oidc/token_oidc.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_appauth_platform_interface/flutter_appauth_platform_interface.dart';
 import 'package:tmail_ui_user/features/login/data/local/account_cache_manager.dart';
@@ -24,6 +26,7 @@ import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_ex
 import 'package:tmail_ui_user/features/login/domain/exceptions/oauth_authorization_error.dart';
 import 'package:tmail_ui_user/features/login/domain/extensions/oidc_configuration_extensions.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
+import 'package:tmail_ui_user/features/push_notification/data/keychain/keychain_sharing_session.dart';
 import 'package:tmail_ui_user/main/utils/ios_sharing_manager.dart';
 
 import '../../fixtures/account_fixtures.dart';
@@ -2427,6 +2430,365 @@ void main() {
           OIDCFixtures.oidcConfiguration.scopes,
           OIDCFixtures.tokenOidcExpiredTime.refreshToken,
         ));
+      },
+    );
+  });
+
+  // ============================================================
+  // onError: refresh side-effect failures
+  // ============================================================
+  group('onError: refresh side-effect failures', () {
+    test(
+      'WHEN refresh succeeds but _updateCurrentAccount throws (cache failure)\n'
+      'THEN outer catch wraps cache error in fresh DioException\n'
+      'AND propagated error has NO HTTP response (no stale 401 → no logout)',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+        );
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
+        when(accountCacheManager.getCurrentAccount())
+            .thenAnswer((_) async => AccountFixtures.aliceAccount);
+        when(accountCacheManager.deleteCurrentAccount(AccountFixtures.aliceAccount.id))
+            .thenThrow(Exception('Cache write failure'));
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) {
+            return e.response == null && e.error is Exception;
+          })),
+        );
+      },
+    );
+
+    test(
+      'WHEN platform is iOS\n'
+      'AND refresh succeeds but Keychain save throws\n'
+      'THEN outer catch wraps keychain error in fresh DioException\n'
+      'AND propagated error has NO HTTP response',
+      () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+        );
+
+        // iOS: keychain returns null → server refresh path
+        when(iosSharingManager.getKeychainSharingSession(AccountFixtures.aliceAccountId))
+            .thenAnswer((_) async => null);
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
+        stubAccountCache();
+        final expectedPersonalAccount = PersonalAccount(
+          OIDCFixtures.newTokenOidc.tokenIdHash,
+          AuthenticationType.oidc,
+          isSelected: true,
+          accountId: AccountFixtures.aliceAccountId,
+          apiUrl: AccountFixtures.aliceAccount.apiUrl,
+          userName: AccountFixtures.aliceAccount.userName,
+        );
+        when(iosSharingManager.saveKeyChainSharingSession(expectedPersonalAccount))
+            .thenThrow(Exception('Keychain access denied'));
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) {
+            return e.response == null && e.error is Exception;
+          })),
+        );
+      },
+    );
+  });
+
+  // ============================================================
+  // onError: upload retry with attachment extras
+  // ============================================================
+  group('onError: upload retry with attachment extras', () {
+    test(
+      'WHEN 401 on upload request with uploadAttachmentExtraKey + filePath\n'
+      'AND refresh succeeds\n'
+      'THEN upload-specific retry path is taken (uses retryDio.request, not fetch)\n'
+      'AND retry succeeds with 200',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        // filePath='' triggers the streamData fallback inside _getDataUploadRequest.
+        // streamData is null → retryDio.request is called with data=null, still
+        // exercising the upload branch (vs fetch branch).
+        final uploadExtras = <String, dynamic>{
+          'upload-attachment': <String, dynamic>{
+            'path': '',
+            'streamData': null,
+          },
+        };
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+          },
+        );
+        dioAdapter.onPost(
+          baseUrl,
+          (server) =>
+              server.reply(responseStatusCode200, dataRequestSuccessfully),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.newTokenOidc.token}',
+          },
+        );
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
+        stubAccountCache();
+
+        final response = await dio.post(
+          baseUrl,
+          options: Options(extra: uploadExtras),
+        );
+
+        expect(response.statusCode, responseStatusCode200);
+        expect(response.data, dataRequestSuccessfully);
+      },
+    );
+
+    test(
+      'WHEN upload extras has invalid map shape\n'
+      'AND refresh succeeds\n'
+      'THEN _getDataUploadRequest returns null but retry still completes\n'
+      '(defensive: malformed extras must not crash the interceptor)',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        final malformedExtras = <String, dynamic>{
+          'upload-attachment': 'not a map',
+        };
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+          },
+        );
+        dioAdapter.onPost(
+          baseUrl,
+          (server) =>
+              server.reply(responseStatusCode200, dataRequestSuccessfully),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.newTokenOidc.token}',
+          },
+        );
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
+        stubAccountCache();
+
+        final response = await dio.post(
+          baseUrl,
+          options: Options(extra: malformedExtras),
+        );
+
+        expect(response.statusCode, responseStatusCode200);
+      },
+    );
+  });
+
+  // ============================================================
+  // onError: iOS keychain refresh path
+  // ============================================================
+  group('onError: iOS keychain refresh path', () {
+    setUp(() => debugDefaultTargetPlatformOverride = TargetPlatform.iOS);
+    tearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    test(
+      'WHEN platform is iOS\n'
+      'AND keychain contains a newer non-expired token (rotated by another app process)\n'
+      'THEN use keychain token without calling refreshingTokensOIDC\n'
+      'AND retry succeeds with 200',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+          },
+        );
+        dioAdapter.onPost(
+          baseUrl,
+          (server) =>
+              server.reply(responseStatusCode200, dataRequestSuccessfully),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.newTokenOidc.token}',
+          },
+        );
+
+        final keychainSession = KeychainSharingSession(
+          accountId: AccountFixtures.aliceAccountId,
+          userName: AccountFixtures.aliceAccount.userName!,
+          authenticationType: AuthenticationType.oidc,
+          apiUrl: AccountFixtures.aliceAccount.apiUrl!,
+          tokenOIDC: OIDCFixtures.newTokenOidc,
+        );
+        when(iosSharingManager
+                .getKeychainSharingSession(AccountFixtures.aliceAccountId))
+            .thenAnswer((_) async => keychainSession);
+
+        final expectedPersonalAccount = PersonalAccount(
+          OIDCFixtures.newTokenOidc.tokenIdHash,
+          AuthenticationType.oidc,
+          isSelected: true,
+          accountId: AccountFixtures.aliceAccountId,
+          apiUrl: AccountFixtures.aliceAccount.apiUrl,
+          userName: AccountFixtures.aliceAccount.userName,
+        );
+        when(iosSharingManager
+                .saveKeyChainSharingSession(expectedPersonalAccount))
+            .thenAnswer((_) async {});
+        stubAccountCache();
+
+        final response = await dio.post(baseUrl);
+
+        expect(response.statusCode, responseStatusCode200);
+        verifyNever(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        ));
+      },
+    );
+
+    test(
+      'WHEN platform is iOS\n'
+      'AND keychain returns expired tokenOIDC\n'
+      'THEN fallback to server refreshingTokensOIDC\n'
+      'AND retry succeeds with 200',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+          },
+        );
+        dioAdapter.onPost(
+          baseUrl,
+          (server) =>
+              server.reply(responseStatusCode200, dataRequestSuccessfully),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.newTokenOidc.token}',
+          },
+        );
+
+        final expiredKeychainToken = TokenOIDC(
+          'expired_keychain_token',
+          TokenId('expired_keychain_token'),
+          'older_refresh',
+          expiredTime: DateTime.now().subtract(const Duration(days: 2)),
+        );
+        final keychainSession = KeychainSharingSession(
+          accountId: AccountFixtures.aliceAccountId,
+          userName: AccountFixtures.aliceAccount.userName!,
+          authenticationType: AuthenticationType.oidc,
+          apiUrl: AccountFixtures.aliceAccount.apiUrl!,
+          tokenOIDC: expiredKeychainToken,
+        );
+        when(iosSharingManager
+                .getKeychainSharingSession(AccountFixtures.aliceAccountId))
+            .thenAnswer((_) async => keychainSession);
+
+        final expectedPersonalAccount = PersonalAccount(
+          OIDCFixtures.newTokenOidc.tokenIdHash,
+          AuthenticationType.oidc,
+          isSelected: true,
+          accountId: AccountFixtures.aliceAccountId,
+          apiUrl: AccountFixtures.aliceAccount.apiUrl,
+          userName: AccountFixtures.aliceAccount.userName,
+        );
+        when(iosSharingManager
+                .saveKeyChainSharingSession(expectedPersonalAccount))
+            .thenAnswer((_) async {});
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
+        stubAccountCache();
+
+        final response = await dio.post(baseUrl);
+
+        expect(response.statusCode, responseStatusCode200);
+        verify(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).called(1);
       },
     );
   });

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -3,7 +3,9 @@ import 'dart:io';
 
 import 'package:core/data/constants/constant.dart';
 import 'package:core/data/network/dio_client.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http_mock_adapter/http_mock_adapter.dart';
@@ -1545,9 +1547,13 @@ void main() {
       type: DioExceptionType.connectionTimeout,
     );
 
+    setUp(() => debugDefaultTargetPlatformOverride = TargetPlatform.android);
+    tearDown(() => debugDefaultTargetPlatformOverride = null);
+
     test(
       'WHEN 401 with expired token\n'
       'AND refresh call times out (connectionTimeout, response=null)\n'
+      'AND platform is mobile\n'
       'THEN propagated error carries NO HTTP response\n'
       '(BUG: err.copyWith preserves original 401 response → RemoteExceptionThrower → logout)',
       () async {
@@ -1583,6 +1589,7 @@ void main() {
     test(
       'WHEN server-side 401 (token not locally expired)\n'
       'AND refresh call times out\n'
+      'AND platform is mobile\n'
       'THEN propagated error carries NO HTTP response',
       () async {
         authorizationInterceptors.setTokenAndAuthorityOidc(
@@ -1615,13 +1622,56 @@ void main() {
         );
       },
     );
+
+    test(
+      'WHEN 401 with expired token\n'
+      'AND refresh call times out\n'
+      'AND platform is web\n'
+      'THEN propagated error preserves original 401 response (old web behaviour)',
+      () async {
+        debugDefaultTargetPlatformOverride = null;
+        PlatformInfo.isTestingForWeb = true;
+        addTearDown(() => PlatformInfo.isTestingForWeb = false);
+
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+          },
+        );
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenThrow(refreshTimeoutError);
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) => e.response != null)),
+        );
+      },
+    );
   });
 
   group('Bug 1 — retry network timeout preserves original 401 response (regression)', () {
+    setUp(() => debugDefaultTargetPlatformOverride = TargetPlatform.android);
+    tearDown(() => debugDefaultTargetPlatformOverride = null);
+
     test(
       'WHEN 401 with expired token\n'
       'AND refresh succeeds\n'
       'AND retry call times out (connectionTimeout, response=null)\n'
+      'AND platform is mobile\n'
       'THEN propagated error carries NO HTTP response\n'
       '(BUG: err.copyWith preserves original 401 response → logout)',
       () async {
@@ -1667,12 +1717,69 @@ void main() {
         );
       },
     );
+
+    test(
+      'WHEN 401 with expired token\n'
+      'AND refresh succeeds\n'
+      'AND retry call times out\n'
+      'AND platform is web\n'
+      'THEN propagated error preserves original 401 response (old web behaviour)',
+      () async {
+        debugDefaultTargetPlatformOverride = null;
+        PlatformInfo.isTestingForWeb = true;
+        addTearDown(() => PlatformInfo.isTestingForWeb = false);
+
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+          },
+        );
+
+        final retryTimeoutError = DioException(
+          requestOptions: RequestOptions(path: baseUrl),
+          type: DioExceptionType.connectionTimeout,
+        );
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(0, retryTimeoutError),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.newTokenOidc.token}',
+          },
+        );
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) => e.response != null)),
+        );
+      },
+    );
   });
 
   group(
     'Bug 1 — FlutterAppAuthPlatformException from OIDC refresh '
-    'does not preserve original 401 (outer catch)',
+    'does not preserve original 401 (outer catch) — mobile only',
     () {
+      setUp(() => debugDefaultTargetPlatformOverride = TargetPlatform.android);
+      tearDown(() => debugDefaultTargetPlatformOverride = null);
+
       // _appAuth.token() mobile OIDC no-internet: native SDK throws
       // FlutterAppAuthPlatformException(error: null) — transport failure.
       // details==null path rethrows raw PlatformException instead.
@@ -1840,6 +1947,47 @@ void main() {
               return e.response == null &&
                   e.error is OAuthAuthorizationError;
             })),
+          );
+        },
+      );
+
+      test(
+        'WHEN platform is web\n'
+        'AND refresh throws non-DioException (OAuthAuthorizationError)\n'
+        'THEN propagated error preserves original 401 response (old web behaviour)',
+        () async {
+          debugDefaultTargetPlatformOverride = null;
+          PlatformInfo.isTestingForWeb = true;
+          addTearDown(() => PlatformInfo.isTestingForWeb = false);
+
+          authorizationInterceptors.setTokenAndAuthorityOidc(
+            newToken: OIDCFixtures.tokenOidcExpiredTime,
+            newConfig: OIDCFixtures.oidcConfiguration,
+          );
+
+          dioAdapter.onPost(
+            baseUrl,
+            (server) => server.throws(responseStatusCode401, makeDioError401()),
+            headers: {
+              HttpHeaders.authorizationHeader:
+                  'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+            },
+          );
+
+          when(authenticationClient.refreshingTokensOIDC(
+            OIDCFixtures.oidcConfiguration.clientId,
+            OIDCFixtures.oidcConfiguration.redirectUrl,
+            OIDCFixtures.oidcConfiguration.discoveryUrl,
+            OIDCFixtures.oidcConfiguration.scopes,
+            OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          )).thenThrow(const OAuthAuthorizationError(
+            error: 'invalid_grant',
+            errorDescription: 'The refresh token has been revoked',
+          ));
+
+          await expectLater(
+            () => dio.post(baseUrl),
+            throwsA(predicate<DioException>((e) => e.response != null)),
           );
         },
       );

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -1593,6 +1593,152 @@ void main() {
     );
   });
 
+  // ============================================================
+  // Bug 1 — refresh network timeout preserves original 401 response (regression)
+  // ============================================================
+  group('Bug 1 — refresh network timeout preserves original 401 response (regression)', () {
+    final refreshTimeoutError = DioException(
+      requestOptions: RequestOptions(path: '/token'),
+      type: DioExceptionType.connectionTimeout,
+      // response: null — pure network failure, no HTTP response
+    );
+
+    test(
+      'WHEN 401 with expired token\n'
+      'AND refresh call times out (connectionTimeout, response=null)\n'
+      'THEN propagated error carries NO HTTP response\n'
+      '(BUG: err.copyWith preserves original 401 response → RemoteExceptionThrower → logout)',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+          },
+        );
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenThrow(refreshTimeoutError);
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) {
+            // BUG: e.response?.statusCode == 401 (original 401 preserved by err.copyWith)
+            // FIX: e.response == null — transient network failure, should NOT trigger logout
+            return e.response == null;
+          })),
+        );
+      },
+    );
+
+    test(
+      'WHEN server-side 401 (token not locally expired)\n'
+      'AND refresh call times out\n'
+      'THEN propagated error carries NO HTTP response',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcNotExpiredYet,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.tokenOidcNotExpiredYet.token}',
+          },
+        );
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcNotExpiredYet.refreshToken,
+        )).thenThrow(refreshTimeoutError);
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) {
+            return e.response == null;
+          })),
+        );
+      },
+    );
+  });
+
+  // ============================================================
+  // Bug 1 — retry network timeout preserves original 401 response (regression)
+  // ============================================================
+  group('Bug 1 — retry network timeout preserves original 401 response (regression)', () {
+    test(
+      'WHEN 401 with expired token\n'
+      'AND refresh succeeds\n'
+      'AND retry call times out (connectionTimeout, response=null)\n'
+      'THEN propagated error carries NO HTTP response\n'
+      '(BUG: err.copyWith preserves original 401 response → logout)',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+          },
+        );
+
+        final retryTimeoutError = DioException(
+          requestOptions: RequestOptions(path: baseUrl),
+          type: DioExceptionType.connectionTimeout,
+          // response: null
+        );
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(0, retryTimeoutError),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.newTokenOidc.token}',
+          },
+        );
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) {
+            // BUG: e.response?.statusCode == 401 (original 401 preserved)
+            // FIX: e.response == null — network timeout during retry, not an auth failure
+            return e.response == null;
+          })),
+        );
+      },
+    );
+  });
+
   tearDown(() {
     reset(authenticationClient);
     reset(tokenOidcCacheManager);

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -1846,6 +1846,401 @@ void main() {
     },
   );
 
+  group('onError: multiple requests all fail 401', () {
+    test(
+      'GIVEN 4 concurrent requests with expired token\n'
+      'WHEN all get 401\n'
+      'THEN only first request triggers refresh\n'
+      'AND other 3 retry with new token without refreshing\n'
+      'AND refresh is called exactly once',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        for (final i in [1, 2, 3, 4]) {
+          dioAdapter.onPost(
+            '$baseUrl/$i',
+            (server) => server.reply(
+              responseStatusCode401,
+              {'error': 'Unauthorized'},
+            ),
+            headers: {
+              HttpHeaders.authorizationHeader:
+                  'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+            },
+          );
+          dioAdapter.onPost(
+            '$baseUrl/$i',
+            (server) =>
+                server.reply(responseStatusCode200, dataRequestSuccessfully),
+            headers: {
+              HttpHeaders.authorizationHeader:
+                  'Bearer ${OIDCFixtures.newTokenOidc.token}',
+            },
+          );
+        }
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
+        stubAccountCache();
+
+        final responses = await Future.wait([
+          dio.post('$baseUrl/1'),
+          dio.post('$baseUrl/2'),
+          dio.post('$baseUrl/3'),
+          dio.post('$baseUrl/4'),
+        ]);
+
+        verify(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).called(1);
+
+        for (final response in responses) {
+          expect(response.statusCode, equals(HttpStatus.ok));
+          expect(
+            response.requestOptions.headers[HttpHeaders.authorizationHeader],
+            equals('Bearer ${OIDCFixtures.newTokenOidc.token}'),
+          );
+        }
+      },
+    );
+
+    test(
+      'GIVEN 3 concurrent requests with expired token\n'
+      'WHEN all get 401\n'
+      'AND refresh fails with connectionTimeout (no HTTP response)\n'
+      'THEN all 3 requests fail with response=null\n'
+      'AND none carry the original 401 response (no spurious logout)',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        for (final i in [1, 2, 3]) {
+          dioAdapter.onPost(
+            '$baseUrl/$i',
+            (server) => server.reply(
+              responseStatusCode401,
+              {'error': 'Unauthorized'},
+            ),
+            headers: {
+              HttpHeaders.authorizationHeader:
+                  'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+            },
+          );
+        }
+
+        final refreshTimeoutError = DioException(
+          requestOptions: RequestOptions(path: '/token'),
+          type: DioExceptionType.connectionTimeout,
+        );
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenThrow(refreshTimeoutError);
+        stubAccountCache();
+
+        final futures = [
+          dio.post('$baseUrl/1'),
+          dio.post('$baseUrl/2'),
+          dio.post('$baseUrl/3'),
+        ];
+
+        final errors = <DioException>[];
+        for (final future in futures) {
+          try {
+            await future;
+          } on DioException catch (e) {
+            errors.add(e);
+          }
+        }
+
+        expect(errors.length, 3);
+        for (final error in errors) {
+          expect(error.response, isNull,
+              reason: 'Must not carry original 401 response');
+        }
+      },
+    );
+
+    test(
+      'GIVEN 3 concurrent requests with expired token\n'
+      'WHEN all get 401\n'
+      'AND refresh fails with PlatformException (mobile: no internet)\n'
+      'THEN all 3 requests fail with response=null\n'
+      'AND none carry the original 401 response (no spurious logout)',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        for (final i in [1, 2, 3]) {
+          dioAdapter.onPost(
+            '$baseUrl/$i',
+            (server) => server.reply(
+              responseStatusCode401,
+              {'error': 'Unauthorized'},
+            ),
+            headers: {
+              HttpHeaders.authorizationHeader:
+                  'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+            },
+          );
+        }
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenThrow(PlatformException(
+          code: 'network_error',
+          message: 'Failed to connect to token endpoint',
+        ));
+        stubAccountCache();
+
+        final futures = [
+          dio.post('$baseUrl/1'),
+          dio.post('$baseUrl/2'),
+          dio.post('$baseUrl/3'),
+        ];
+
+        final errors = <DioException>[];
+        for (final future in futures) {
+          try {
+            await future;
+          } on DioException catch (e) {
+            errors.add(e);
+          }
+        }
+
+        expect(errors.length, 3);
+        for (final error in errors) {
+          expect(error.response, isNull,
+              reason: 'Must not carry original 401 response');
+          expect(error.error, isA<PlatformException>());
+        }
+      },
+    );
+
+    test(
+      'GIVEN 3 concurrent requests with expired token\n'
+      'WHEN all get 401\n'
+      'AND refresh fails with 400 (invalid grant)\n'
+      'THEN all 3 requests fail\n'
+      'AND auth state is cleared (none)',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        for (final i in [1, 2, 3]) {
+          dioAdapter.onPost(
+            '$baseUrl/$i',
+            (server) => server.reply(
+              responseStatusCode401,
+              {'error': 'Unauthorized'},
+            ),
+            headers: {
+              HttpHeaders.authorizationHeader:
+                  'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+            },
+          );
+        }
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenThrow(dioErrorRefresh400);
+        stubAccountCache();
+
+        final futures = [
+          dio.post('$baseUrl/1'),
+          dio.post('$baseUrl/2'),
+          dio.post('$baseUrl/3'),
+        ];
+
+        final errors = <DioException>[];
+        for (final future in futures) {
+          try {
+            await future;
+          } on DioException catch (e) {
+            errors.add(e);
+          }
+        }
+
+        expect(errors, isNotEmpty);
+
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.none,
+        );
+      },
+    );
+
+    test(
+      'GIVEN 3 concurrent requests: 2 fail 401 + 1 fails 500\n'
+      'WHEN processed concurrently\n'
+      'THEN 401 requests attempt refresh and retry with new token\n'
+      'AND 500 request propagates directly without touching refresh logic',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        final dioError500 = DioException(
+          requestOptions: RequestOptions(path: '$baseUrl/500', method: 'POST'),
+          response: Response(
+            statusCode: responseStatusCode500,
+            requestOptions: RequestOptions(path: '$baseUrl/500'),
+          ),
+          type: DioExceptionType.badResponse,
+        );
+
+        // 2 requests get 401 with expired token
+        for (final i in [1, 2]) {
+          dioAdapter.onPost(
+            '$baseUrl/$i',
+            (server) => server.reply(
+              responseStatusCode401,
+              {'error': 'Unauthorized'},
+            ),
+            headers: {
+              HttpHeaders.authorizationHeader:
+                  'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+            },
+          );
+          dioAdapter.onPost(
+            '$baseUrl/$i',
+            (server) =>
+                server.reply(responseStatusCode200, dataRequestSuccessfully),
+            headers: {
+              HttpHeaders.authorizationHeader:
+                  'Bearer ${OIDCFixtures.newTokenOidc.token}',
+            },
+          );
+        }
+
+        // 1 request gets 500 (not related to auth)
+        dioAdapter.onPost(
+          '$baseUrl/500',
+          (server) => server.throws(responseStatusCode500, dioError500),
+        );
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
+        stubAccountCache();
+
+        final future1 = dio.post('$baseUrl/1');
+        final future2 = dio.post('$baseUrl/2');
+        final future500 = dio.post('$baseUrl/500');
+
+        final response1 = await future1;
+        final response2 = await future2;
+        DioException? error500;
+        try {
+          await future500;
+        } on DioException catch (e) {
+          error500 = e;
+        }
+
+        expect(response1.statusCode, responseStatusCode200);
+        expect(response2.statusCode, responseStatusCode200);
+
+        expect(error500, isNotNull);
+        expect(error500?.response?.statusCode, responseStatusCode500);
+
+        // refresh called at most once (concurrent 401 requests share one refresh)
+        verify(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).called(1);
+      },
+    );
+
+    test(
+      'GIVEN 3 concurrent requests with basic auth (not OIDC)\n'
+      'WHEN all get 401\n'
+      'THEN no refresh attempted\n'
+      'AND all 3 fail with 401',
+      () async {
+        authorizationInterceptors.setBasicAuthorization(
+          UserName('alice'),
+          Password('password'),
+        );
+
+        for (final i in [1, 2, 3]) {
+          dioAdapter.onPost(
+            '$baseUrl/$i',
+            (server) => server.reply(
+              responseStatusCode401,
+              {'error': 'Unauthorized'},
+            ),
+          );
+        }
+
+        final futures = [
+          dio.post('$baseUrl/1'),
+          dio.post('$baseUrl/2'),
+          dio.post('$baseUrl/3'),
+        ];
+
+        final errors = <DioException>[];
+        for (final future in futures) {
+          try {
+            await future;
+          } on DioException catch (e) {
+            errors.add(e);
+          }
+        }
+
+        expect(errors.length, 3);
+        for (final error in errors) {
+          expect(error.response?.statusCode, responseStatusCode401);
+        }
+
+        verifyNever(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        ));
+      },
+    );
+  });
+
   tearDown(() {
     reset(authenticationClient);
     reset(tokenOidcCacheManager);

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -537,6 +537,110 @@ void main() {
     );
 
     test(
+      'WHEN refresh fails with 401 DioException\n'
+      'THEN propagate refreshError directly (not stale 401)\n'
+      'AND OIDC state is NOT cleared',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+          },
+        );
+
+        final dioErrorRefresh401 = DioException(
+          requestOptions: RequestOptions(path: '/token'),
+          response: Response(
+            statusCode: responseStatusCode401,
+            requestOptions: RequestOptions(path: '/token'),
+          ),
+          type: DioExceptionType.badResponse,
+        );
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenThrow(dioErrorRefresh401);
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>(
+            (e) => e.response?.statusCode == responseStatusCode401,
+          )),
+        );
+
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.oidc,
+        );
+      },
+    );
+
+    test(
+      'WHEN refresh fails with 403 DioException\n'
+      'THEN propagate refreshError directly\n'
+      'AND OIDC state is NOT cleared',
+      () async {
+        const responseStatusCode403 = 403;
+
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+          },
+        );
+
+        final dioErrorRefresh403 = DioException(
+          requestOptions: RequestOptions(path: '/token'),
+          response: Response(
+            statusCode: responseStatusCode403,
+            requestOptions: RequestOptions(path: '/token'),
+          ),
+          type: DioExceptionType.badResponse,
+        );
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenThrow(dioErrorRefresh403);
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>(
+            (e) => e.response?.statusCode == responseStatusCode403,
+          )),
+        );
+
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.oidc,
+        );
+      },
+    );
+
+    test(
       'WHEN refresh fails with 500 DioException\n'
       'THEN propagate refreshError directly (not stale 401)\n'
       'AND OIDC state is NOT cleared',


### PR DESCRIPTION
## Issue

- #4081

## Problem

On poor network, users were logged out mid-session with valid credentials. Two bugs preserved a stale 401 response through transient network failures, causing `RemoteExceptionThrower` to fire `BadCredentialsException` → logout.

## Root cause

**Bug 1 — `authorization_interceptors.dart`:** `err.copyWith(error: refreshError)` keeps the original `response` (the 401). Affects refresh timeout, server-side revocation + timeout, concurrent retry timeout, and `FlutterAppAuthPlatformException`/`PlatformException` from native OIDC (outer catch).

**Bug 2 — `reloadable_controller.dart`:** `handleGetSessionFailure` called `clearDataAndGoToLoginPage()` unconditionally, including `ConnectionTimeout` on mobile.

## Fix

**Interceptor:** Never carry the original `response` forward on failure:

- Refresh fails (`response == null`) → fresh `DioException`, no response.
- Refresh fails (`response != null`, non-400) → pass `refreshError` directly.
- Retry fails (`DioException`) → pass directly; otherwise wrap in fresh `DioException`.
- Outer catch → same: pass only if `e is DioException && e.response != null`; else wrap fresh.

Dead code removed: unreachable `if (refreshError is ServerError || refreshError is TemporarilyUnavailable)` in `_handleDioRefreshError`.

**Session handler:** `NetworkException` → show toast, no logout. Web and non-network exceptions → unchanged.

## Tests

- `authorization_interceptor_test.dart` — platform split removed; 13 groups covering refresh/retry flows, concurrent queuing, all outer-catch exception types (`FlutterAppAuthPlatformException`, `PlatformException`, `OAuthAuthorizationError`), and regression cases for all three Bug 1 paths.
- `reloadable_controller_test.dart` — mobile group: `ConnectionTimeout`/`SocketError`/`NoNetworkError`/`ConnectionError` no logout; web group: same errors still logout.

See `docs/adr/0089-fix-unexpected-logout-on-poor-network.md` for full analysis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed unexpected logouts that occurred during poor network conditions or when token refresh failed due to network timeouts
* Users now remain logged in when network issues prevent token refresh; a toast notification alerts them to the connectivity issue instead
* Session data is preserved while users are informed of network problems

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-flutter/pull/4531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->