### PR TITLE
TF-4426 Add warning when detect reject rule filter

### DIFF
--- a/integration_test/factories/mobile_robot_factory.dart
+++ b/integration_test/factories/mobile_robot_factory.dart
@@ -2,13 +2,17 @@ import 'package:patrol/patrol.dart';
 
 import '../robots/abstract/abstract_app_grid_robot.dart';
 import '../robots/abstract/abstract_composer_robot.dart';
+import '../robots/abstract/abstract_email_rules_setting_robot.dart';
 import '../robots/abstract/abstract_login_robot.dart';
 import '../robots/abstract/abstract_mailbox_menu_robot.dart';
+import '../robots/abstract/abstract_rules_filter_creator_robot.dart';
 import '../robots/abstract/abstract_thread_robot.dart';
-import '../robots/mailbox_menu_robot.dart';
 import '../robots/mobile/mobile_app_grid_robot.dart';
 import '../robots/mobile/mobile_composer_robot.dart';
+import '../robots/mobile/mobile_email_rules_setting_robot.dart';
 import '../robots/mobile/mobile_login_robot.dart';
+import '../robots/mobile/mobile_mailbox_menu_robot.dart';
+import '../robots/mobile/mobile_rules_filter_creator_robot.dart';
 import '../robots/mobile/mobile_thread_robot.dart';
 import 'robot_factory.dart';
 
@@ -30,5 +34,11 @@ class MobileRobotFactory implements RobotFactory {
   AbstractAppGridRobot appGridRobot() => MobileAppGridRobot($);
 
   @override
-  AbstractMailboxMenuRobot mailboxMenuRobot() => MailboxMenuRobot($);
+  AbstractMailboxMenuRobot mailboxMenuRobot() => MobileMailboxMenuRobot($);
+
+  @override
+  AbstractRulesFilterCreatorRobot rulesFilterCreatorRobot() => MobileRulesFilterCreatorRobot($);
+
+  @override
+  AbstractEmailRulesSettingRobot emailRulesSettingRobot() => MobileEmailRulesSettingRobot($);
 }

--- a/integration_test/factories/robot_factory.dart
+++ b/integration_test/factories/robot_factory.dart
@@ -1,7 +1,9 @@
 import '../robots/abstract/abstract_app_grid_robot.dart';
 import '../robots/abstract/abstract_composer_robot.dart';
+import '../robots/abstract/abstract_email_rules_setting_robot.dart';
 import '../robots/abstract/abstract_login_robot.dart';
 import '../robots/abstract/abstract_mailbox_menu_robot.dart';
+import '../robots/abstract/abstract_rules_filter_creator_robot.dart';
 import '../robots/abstract/abstract_thread_robot.dart';
 
 abstract class RobotFactory {
@@ -10,4 +12,6 @@ abstract class RobotFactory {
   AbstractComposerRobot composerRobot();
   AbstractAppGridRobot appGridRobot();
   AbstractMailboxMenuRobot mailboxMenuRobot();
+  AbstractRulesFilterCreatorRobot rulesFilterCreatorRobot();
+  AbstractEmailRulesSettingRobot emailRulesSettingRobot();
 }

--- a/integration_test/factories/web_robot_factory.dart
+++ b/integration_test/factories/web_robot_factory.dart
@@ -2,13 +2,17 @@ import 'package:patrol/patrol.dart';
 
 import '../robots/abstract/abstract_app_grid_robot.dart';
 import '../robots/abstract/abstract_composer_robot.dart';
+import '../robots/abstract/abstract_email_rules_setting_robot.dart';
 import '../robots/abstract/abstract_login_robot.dart';
 import '../robots/abstract/abstract_mailbox_menu_robot.dart';
+import '../robots/abstract/abstract_rules_filter_creator_robot.dart';
 import '../robots/abstract/abstract_thread_robot.dart';
-import '../robots/mailbox_menu_robot.dart';
 import '../robots/web/web_app_grid_robot.dart';
 import '../robots/web/web_composer_robot.dart';
+import '../robots/web/web_email_rules_setting_robot.dart';
 import '../robots/web/web_login_robot.dart';
+import '../robots/web/web_mailbox_menu_robot.dart';
+import '../robots/web/web_rules_filter_creator_robot.dart';
 import '../robots/web/web_thread_robot.dart';
 import 'robot_factory.dart';
 
@@ -30,5 +34,11 @@ class WebRobotFactory implements RobotFactory {
   AbstractAppGridRobot appGridRobot() => WebAppGridRobot($);
 
   @override
-  AbstractMailboxMenuRobot mailboxMenuRobot() => MailboxMenuRobot($);
+  AbstractMailboxMenuRobot mailboxMenuRobot() => WebMailboxMenuRobot($);
+
+  @override
+  AbstractRulesFilterCreatorRobot rulesFilterCreatorRobot() => WebRulesFilterCreatorRobot($);
+
+  @override
+  AbstractEmailRulesSettingRobot emailRulesSettingRobot() => WebEmailRulesSettingRobot($);
 }

--- a/integration_test/mixin/scenario_utils_mixin.dart
+++ b/integration_test/mixin/scenario_utils_mixin.dart
@@ -53,7 +53,13 @@ mixin ScenarioUtilsMixin {
     ComposerBindings().dependencies();
 
     await waitForCondition(
-      () => getBinding<MailboxDashBoardController>() != null,
+      () {
+        final controller = getBinding<MailboxDashBoardController>();
+        if (controller == null) return false;
+        return controller.sessionCurrent != null &&
+            controller.accountId.value != null &&
+            controller.outboxMailbox != null;
+      },
     );
     final mailboxDashBoardController = Get.find<MailboxDashBoardController>();
     final createNewAndSendEmailInteractor =

--- a/integration_test/mixin/scenario_utils_mixin.dart
+++ b/integration_test/mixin/scenario_utils_mixin.dart
@@ -58,7 +58,7 @@ mixin ScenarioUtilsMixin {
         if (controller == null) return false;
         return controller.sessionCurrent != null &&
             controller.accountId.value != null &&
-            controller.outboxMailbox != null;
+            controller.selectedMailbox.value != null;
       },
     );
     final mailboxDashBoardController = Get.find<MailboxDashBoardController>();

--- a/integration_test/mixin/scenario_utils_mixin.dart
+++ b/integration_test/mixin/scenario_utils_mixin.dart
@@ -53,13 +53,7 @@ mixin ScenarioUtilsMixin {
     ComposerBindings().dependencies();
 
     await waitForCondition(
-      () {
-        final controller = getBinding<MailboxDashBoardController>();
-        if (controller == null) return false;
-        return controller.sessionCurrent != null &&
-            controller.accountId.value != null &&
-            controller.selectedMailbox.value != null;
-      },
+      () => _isMailboxReady(getBinding<MailboxDashBoardController>()),
     );
     final mailboxDashBoardController = Get.find<MailboxDashBoardController>();
     final createNewAndSendEmailInteractor =
@@ -108,6 +102,13 @@ mixin ScenarioUtilsMixin {
     }
 
     ComposerBindings().dispose();
+  }
+
+  bool _isMailboxReady(MailboxDashBoardController? mailboxDashBoardController) {
+    return mailboxDashBoardController != null &&
+        mailboxDashBoardController.sessionCurrent != null &&
+        mailboxDashBoardController.accountId.value != null &&
+        mailboxDashBoardController.selectedMailbox.value != null;
   }
 
   Future<void> simulateUpdateFlagsOfEmailsWithSubjectsFromOutsideCurrentClient({

--- a/integration_test/robots/abstract/abstract_email_rules_setting_robot.dart
+++ b/integration_test/robots/abstract/abstract_email_rules_setting_robot.dart
@@ -1,0 +1,11 @@
+import '../../base/core_robot.dart';
+
+abstract class AbstractEmailRulesSettingRobot extends CoreRobot {
+  AbstractEmailRulesSettingRobot(super.$);
+
+  Future<void> expectRuleVisible(String ruleName);
+
+  /// On desktop: taps the edit icon button directly.
+  /// On mobile: taps the more button then selects [editRuleLabel] from bottom sheet.
+  Future<void> tapEditRule(String ruleName, String editRuleLabel);
+}

--- a/integration_test/robots/abstract/abstract_mailbox_menu_robot.dart
+++ b/integration_test/robots/abstract/abstract_mailbox_menu_robot.dart
@@ -1,4 +1,5 @@
 abstract class AbstractMailboxMenuRobot {
   Future<void> openFolderByName(String name);
   Future<void> pullToRefresh();
+  Future<void> openSetting();
 }

--- a/integration_test/robots/abstract/abstract_rules_filter_creator_robot.dart
+++ b/integration_test/robots/abstract/abstract_rules_filter_creator_robot.dart
@@ -1,0 +1,21 @@
+import '../../base/core_robot.dart';
+
+abstract class AbstractRulesFilterCreatorRobot extends CoreRobot {
+  AbstractRulesFilterCreatorRobot(super.$);
+
+  Future<void> expectCreatorViewVisible();
+
+  Future<void> enterRuleName(String name);
+
+  Future<void> selectEmptyActionSlot(String actionName, String selectActionHint);
+
+  Future<void> tapAddActionButton();
+
+  Future<void> tapCreateRuleButton();
+
+  Future<void> expectWarningTextVisible(String warningText);
+
+  Future<void> confirmWarningDialog(String confirmLabel);
+
+  Future<void> expectCreatorViewClosed();
+}

--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -5,6 +5,7 @@ import 'package:core/presentation/views/text/text_field_builder.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/label_mailbox_item_widget.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/mailbox_item_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/presentation/mailbox_creator_view.dart';
@@ -32,7 +33,7 @@ class MailboxMenuRobot extends CoreRobot implements AbstractMailboxMenuRobot {
 
   @override
   Future<void> openSetting() async {
-    await $(#user_avatar).tap();
+    await $(const ValueKey(UiKeys.userAvatar)).tap();
   }
 
   Future<void> longPressMailboxWithName(String name) async {

--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -30,6 +30,7 @@ class MailboxMenuRobot extends CoreRobot implements AbstractMailboxMenuRobot {
     await mailboxItem.tap();
   }
 
+  @override
   Future<void> openSetting() async {
     await $(#user_avatar).tap();
   }

--- a/integration_test/robots/mobile/mobile_email_rules_setting_robot.dart
+++ b/integration_test/robots/mobile/mobile_email_rules_setting_robot.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
+
+import '../abstract/abstract_email_rules_setting_robot.dart';
+
+class MobileEmailRulesSettingRobot extends AbstractEmailRulesSettingRobot {
+  MobileEmailRulesSettingRobot(super.$);
+
+  @override
+  Future<void> expectRuleVisible(String ruleName) async {
+    await $.waitUntilVisible($(find.text(ruleName)));
+  }
+
+  @override
+  Future<void> tapEditRule(String ruleName, String editRuleLabel) async {
+    await $(ValueKey('${UiKeys.moreEmailRuleButton}_$ruleName')).tap();
+    await $.pumpAndTrySettle();
+    await $(find.text(editRuleLabel)).tap();
+  }
+}

--- a/integration_test/robots/mobile/mobile_mailbox_menu_robot.dart
+++ b/integration_test/robots/mobile/mobile_mailbox_menu_robot.dart
@@ -1,3 +1,6 @@
+import 'package:flutter/foundation.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
+
 import '../abstract/abstract_mailbox_menu_robot.dart';
 import '../mailbox_menu_robot.dart';
 
@@ -6,7 +9,7 @@ class MobileMailboxMenuRobot extends MailboxMenuRobot implements AbstractMailbox
 
   @override
   Future<void> openSetting() async {
-    await $(#mobile_mailbox_menu_button).tap();
+    await $(const ValueKey(UiKeys.mobileMailboxMenuButton)).tap();
     await super.openSetting();
   }
 }

--- a/integration_test/robots/mobile/mobile_mailbox_menu_robot.dart
+++ b/integration_test/robots/mobile/mobile_mailbox_menu_robot.dart
@@ -1,0 +1,12 @@
+import '../abstract/abstract_mailbox_menu_robot.dart';
+import '../mailbox_menu_robot.dart';
+
+class MobileMailboxMenuRobot extends MailboxMenuRobot implements AbstractMailboxMenuRobot {
+  MobileMailboxMenuRobot(super.$);
+
+  @override
+  Future<void> openSetting() async {
+    await $(#mobile_mailbox_menu_button).tap();
+    await super.openSetting();
+  }
+}

--- a/integration_test/robots/mobile/mobile_rules_filter_creator_robot.dart
+++ b/integration_test/robots/mobile/mobile_rules_filter_creator_robot.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
+import 'package:tmail_ui_user/features/rules_filter_creator/presentation/rules_filter_creator_view.dart';
+
+import '../abstract/abstract_rules_filter_creator_robot.dart';
+
+class MobileRulesFilterCreatorRobot extends AbstractRulesFilterCreatorRobot {
+  MobileRulesFilterCreatorRobot(super.$);
+
+  @override
+  Future<void> expectCreatorViewVisible() =>
+      $.waitUntilVisible($(RuleFilterCreatorView));
+
+  @override
+  Future<void> enterRuleName(String name) async {
+    await $(RuleFilterCreatorView).$(TextField).enterText(name);
+  }
+
+  @override
+  Future<void> selectEmptyActionSlot(
+    String actionName,
+    String selectActionHint,
+  ) async {
+    await $(find.text(selectActionHint)).tap();
+    await $.pumpAndTrySettle();
+    await $(find.text(actionName)).tap();
+  }
+
+  @override
+  Future<void> tapAddActionButton() async {
+    await $(const ValueKey(UiKeys.addActionButton)).scrollTo();
+    await $(const ValueKey(UiKeys.addActionButton)).tap();
+  }
+
+  @override
+  Future<void> tapCreateRuleButton() async {
+    await $(const ValueKey(UiKeys.createRuleButton)).tap();
+  }
+
+  @override
+  Future<void> expectWarningTextVisible(String warningText) async {
+    await $.waitUntilVisible($(warningText));
+  }
+
+  @override
+  Future<void> confirmWarningDialog(String confirmLabel) async {
+    await $(find.text(confirmLabel)).tap();
+  }
+
+  @override
+  Future<void> expectCreatorViewClosed() async {
+    expect($(RuleFilterCreatorView), findsNothing);
+  }
+}

--- a/integration_test/robots/mobile/mobile_rules_filter_creator_robot.dart
+++ b/integration_test/robots/mobile/mobile_rules_filter_creator_robot.dart
@@ -29,8 +29,9 @@ class MobileRulesFilterCreatorRobot extends AbstractRulesFilterCreatorRobot {
 
   @override
   Future<void> tapAddActionButton() async {
-    await $(const ValueKey(UiKeys.addActionButton)).scrollTo();
-    await $(const ValueKey(UiKeys.addActionButton)).tap();
+    const addActionButtonKey = ValueKey(UiKeys.addActionButton);
+    await $(addActionButtonKey).scrollTo();
+    await $(addActionButtonKey).tap();
   }
 
   @override

--- a/integration_test/robots/setting_robot.dart
+++ b/integration_test/robots/setting_robot.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../base/core_robot.dart';
@@ -34,5 +35,9 @@ class SettingRobot extends CoreRobot {
 
   Future<void> closeSettings() async {
     await $(#settings_close_button).tap();
+  }
+
+  Future<void> openEmailRulesMenuItem() async {
+    await $(const ValueKey(UiKeys.emailRulesSettingMenuItem)).tap();
   }
 }

--- a/integration_test/robots/thread_robot.dart
+++ b/integration_test/robots/thread_robot.dart
@@ -47,7 +47,7 @@ class ThreadRobot extends CoreRobot {
   }
 
   Future<void> openMailbox() async {
-    await $(#mobile_mailbox_menu_button).tap();
+    await $(const ValueKey(UiKeys.mobileMailboxMenuButton)).tap();
   }
 
   Future<void> tapEmptyTrashBanner() => $(' ${AppLocalizations().empty_trash_now}').tap();

--- a/integration_test/robots/web/web_email_rules_setting_robot.dart
+++ b/integration_test/robots/web/web_email_rules_setting_robot.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
+
+import '../abstract/abstract_email_rules_setting_robot.dart';
+
+class WebEmailRulesSettingRobot extends AbstractEmailRulesSettingRobot {
+  WebEmailRulesSettingRobot(super.$);
+
+  @override
+  Future<void> expectRuleVisible(String ruleName) async {
+    await $.waitUntilVisible($(find.text(ruleName)));
+  }
+
+  @override
+  Future<void> tapEditRule(String ruleName, String editRuleLabel) async {
+    await $(ValueKey('${UiKeys.editEmailRuleButton}_$ruleName')).tap();
+  }
+}

--- a/integration_test/robots/web/web_mailbox_menu_robot.dart
+++ b/integration_test/robots/web/web_mailbox_menu_robot.dart
@@ -1,4 +1,6 @@
-import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:flutter/foundation.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/profile_setting/profile_setting_action_type.dart';
 
 import '../mobile/mobile_mailbox_menu_robot.dart';
 
@@ -7,7 +9,7 @@ class WebMailboxMenuRobot extends MobileMailboxMenuRobot {
 
   @override
   Future<void> openSetting() async {
-    await $(#user_avatar).tap();
-    await $(AppLocalizations().manage_account).tap();
+    await $(const ValueKey(UiKeys.userAvatar)).tap();
+    await $(ValueKey(ProfileSettingActionType.manageAccount.name)).tap();
   }
 }

--- a/integration_test/robots/web/web_mailbox_menu_robot.dart
+++ b/integration_test/robots/web/web_mailbox_menu_robot.dart
@@ -1,0 +1,13 @@
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../mobile/mobile_mailbox_menu_robot.dart';
+
+class WebMailboxMenuRobot extends MobileMailboxMenuRobot {
+  WebMailboxMenuRobot(super.$);
+
+  @override
+  Future<void> openSetting() async {
+    await $(#user_avatar).tap();
+    await $(AppLocalizations().manage_account).tap();
+  }
+}

--- a/integration_test/robots/web/web_rules_filter_creator_robot.dart
+++ b/integration_test/robots/web/web_rules_filter_creator_robot.dart
@@ -1,0 +1,5 @@
+import '../mobile/mobile_rules_filter_creator_robot.dart';
+
+class WebRulesFilterCreatorRobot extends MobileRulesFilterCreatorRobot {
+  WebRulesFilterCreatorRobot(super.$);
+}

--- a/integration_test/scenarios/email_rules/create_edit_rule_with_reject_scenario.dart
+++ b/integration_test/scenarios/email_rules/create_edit_rule_with_reject_scenario.dart
@@ -1,0 +1,108 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../robots/email_address_dialog_robot.dart';
+import '../../robots/email_robot.dart';
+import '../../robots/setting_robot.dart';
+
+class CreateEditRuleWithRejectScenario extends BaseTestScenario {
+  const CreateEditRuleWithRejectScenario(super.$, super.robots);
+
+  static const _subject = 'Create edit rule with reject action';
+  static const _ruleName = 'Reject rule';
+
+  @override
+  Future<void> runTestLogic() async {
+    const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    final appLocalizations = AppLocalizations();
+
+    final threadRobot = robots.threadRobot();
+    final emailRobot = EmailRobot($);
+    final emailAddressDialogRobot = EmailAddressDialogRobot($);
+    final mailboxMenuRobot = robots.mailboxMenuRobot();
+    final settingRobot = SettingRobot($);
+    final rulesFilterCreatorRobot = robots.rulesFilterCreatorRobot();
+    final emailRulesSettingRobot = robots.emailRulesSettingRobot();
+
+    await provisionEmail(
+      [
+        ProvisioningEmail(
+          toEmail: emailUser,
+          subject: _subject,
+          content: _subject,
+        ),
+      ],
+      requestReadReceipt: false,
+    );
+
+    await threadRobot.openEmailWithSubject(_subject);
+
+    await emailRobot.tapSenderEmailAddress(emailUser);
+
+    await emailAddressDialogRobot
+        .tapCreateRuleWithThisEmailAddressButton(appLocalizations);
+
+    await rulesFilterCreatorRobot.expectCreatorViewVisible();
+
+    await rulesFilterCreatorRobot.enterRuleName(_ruleName);
+
+    await rulesFilterCreatorRobot.selectEmptyActionSlot(
+      appLocalizations.rejectIt,
+      appLocalizations.selectAction,
+    );
+
+    await rulesFilterCreatorRobot.tapCreateRuleButton();
+
+    await rulesFilterCreatorRobot.expectWarningTextVisible(
+      appLocalizations.messageConfirmationRuleWithRejectAction,
+    );
+
+    await rulesFilterCreatorRobot.confirmWarningDialog(
+      appLocalizations.confirm,
+    );
+
+    await emailRobot.onTapBackButton();
+
+    await mailboxMenuRobot.openSetting();
+
+    await settingRobot.openEmailRulesMenuItem();
+
+    await emailRulesSettingRobot.expectRuleVisible(_ruleName);
+
+    await emailRulesSettingRobot.tapEditRule(
+      _ruleName,
+      appLocalizations.editRule,
+    );
+
+    await rulesFilterCreatorRobot.expectCreatorViewVisible();
+
+    await rulesFilterCreatorRobot.tapAddActionButton();
+
+    await rulesFilterCreatorRobot.selectEmptyActionSlot(
+      appLocalizations.maskAsSeen,
+      appLocalizations.selectAction,
+    );
+
+    await rulesFilterCreatorRobot.tapAddActionButton();
+
+    await rulesFilterCreatorRobot.selectEmptyActionSlot(
+      appLocalizations.starIt,
+      appLocalizations.selectAction,
+    );
+
+    await rulesFilterCreatorRobot.tapCreateRuleButton();
+
+    await rulesFilterCreatorRobot.expectWarningTextVisible(
+      appLocalizations.messageConfirmationRuleWithRejectAction,
+    );
+
+    await rulesFilterCreatorRobot
+        .confirmWarningDialog(appLocalizations.confirm);
+
+    await rulesFilterCreatorRobot.expectCreatorViewClosed();
+
+    await emailRulesSettingRobot.expectRuleVisible(_ruleName);
+  }
+}

--- a/integration_test/scenarios/setting/identity/create_new_identity_scenario.dart
+++ b/integration_test/scenarios/setting/identity/create_new_identity_scenario.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/identity_creator/presentation/identity_creator_view.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
@@ -54,7 +56,8 @@ class CreateNewIdentityScenario extends BaseTestScenario {
     }
   }
 
-  Future<void> _expectUserAvatarVisible() => expectViewVisible($(#user_avatar));
+  Future<void> _expectUserAvatarVisible() =>
+      expectViewVisible($(const ValueKey(UiKeys.userAvatar)));
 
   Future<void> _expectSettingViewVisible(AppLocalizations appLocalizations) =>
       expectViewVisible($(find.text(appLocalizations.settings)));

--- a/integration_test/scenarios/setting/language/change_language_scenario.dart
+++ b/integration_test/scenarios/setting/language/change_language_scenario.dart
@@ -1,6 +1,7 @@
 import 'package:duration/duration.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../../../base/base_test_scenario.dart';
@@ -44,7 +45,8 @@ class ChangeLanguageScenario extends BaseTestScenario {
     await _expectLanguageViewWithVietnameseTitleVisible();
   }
 
-  Future<void> _expectUserAvatarVisible() => expectViewVisible($(#user_avatar));
+  Future<void> _expectUserAvatarVisible() =>
+      expectViewVisible($(const ValueKey(UiKeys.userAvatar)));
 
   Future<void> _expectSettingViewVisible(AppLocalizations appLocalizations) =>
       expectViewVisible($(find.text(appLocalizations.settings)));

--- a/integration_test/tests/email_rules/create_edit_rule_with_reject_test.dart
+++ b/integration_test/tests/email_rules/create_edit_rule_with_reject_test.dart
@@ -1,0 +1,11 @@
+import '../../base/test_base.dart';
+import '../../models/test_tags.dart';
+import '../../scenarios/email_rules/create_edit_rule_with_reject_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see warning dialog when create or edit rule with reject action',
+    tags: [TestTags.android, TestTags.ios, TestTags.web],
+    scenarioBuilder: ($, robots) => CreateEditRuleWithRejectScenario($, robots),
+  );
+}

--- a/lib/features/base/model/ui_keys.dart
+++ b/lib/features/base/model/ui_keys.dart
@@ -18,4 +18,6 @@ class UiKeys {
   static const String editEmailRuleButton = 'editEmailRuleButton';
   static const String moreEmailRuleButton = 'moreEmailRuleButton';
   static const String addActionButton = 'addActionButton';
+  static const String mobileMailboxMenuButton = 'mobileMailboxMenuButton';
+  static const String userAvatar = 'userAvatar';
 }

--- a/lib/features/base/model/ui_keys.dart
+++ b/lib/features/base/model/ui_keys.dart
@@ -11,4 +11,11 @@ class UiKeys {
   // Keep snake_case values — existing widgets and tests already reference these key names.
   static const String composerMoreButton = 'composer_more_button';
   static const String saveDraftPopupItem = 'save_as_draft_popup_item';
+
+  // Email rules / rules filter creator
+  static const String createRuleButton = 'createRuleButton';
+  static const String emailRulesSettingMenuItem = 'setting_email_rules';
+  static const String editEmailRuleButton = 'editEmailRuleButton';
+  static const String moreEmailRuleButton = 'moreEmailRuleButton';
+  static const String addActionButton = 'addActionButton';
 }

--- a/lib/features/base/widget/popup_menu/popup_menu_item_action_widget.dart
+++ b/lib/features/base/widget/popup_menu/popup_menu_item_action_widget.dart
@@ -207,6 +207,9 @@ class _PopupMenuItemActionWidgetState extends State<PopupMenuItemActionWidget> {
       child: Material(
         type: MaterialType.transparency,
         child: InkWell(
+          key: widget.menuAction.key != null
+              ? ValueKey(widget.menuAction.key!)
+              : null,
           onTap: () => widget.menuAction.onClick(widget.menuActionClick),
           hoverColor: AppColor.popupMenuItemHovered,
           onHover: (_) {

--- a/lib/features/mailbox/presentation/widgets/mailbox_app_bar.dart
+++ b/lib/features/mailbox/presentation/widgets/mailbox_app_bar.dart
@@ -51,7 +51,7 @@ class MailboxAppBar extends StatelessWidget {
               onTapAction: openAppGridAction!,
             ),
           UserAvatarBuilder(
-            key: const Key('user_avatar'),
+            key: const ValueKey(UiKeys.userAvatar),
             username: username.firstLetterToUpperCase,
             padding: const EdgeInsetsDirectional.only(start: 4),
             onTapAction: openSettingsAction,

--- a/lib/features/mailbox_dashboard/presentation/model/profile_setting/popup_menu_item_profile_setting_type_action.dart
+++ b/lib/features/mailbox_dashboard/presentation/model/profile_setting/popup_menu_item_profile_setting_type_action.dart
@@ -14,7 +14,7 @@ class PopupMenuItemProfileSettingTypeAction
     super.action,
     this.appLocalizations,
     this.imagePaths,
-  );
+  ) : super(key: action.getKey());
 
   @override
   String get actionIcon => action.getIcon(imagePaths);

--- a/lib/features/mailbox_dashboard/presentation/model/profile_setting/profile_setting_action_type.dart
+++ b/lib/features/mailbox_dashboard/presentation/model/profile_setting/profile_setting_action_type.dart
@@ -23,4 +23,11 @@ enum ProfileSettingActionType {
         return imagePaths.icLogout;
     }
   }
+
+  String? getKey() {
+    return switch (this) {
+      ProfileSettingActionType.manageAccount => name,
+      _ => null,
+    };
+  }
 }

--- a/lib/features/mailbox_dashboard/presentation/widgets/navigation_bar/navigation_bar_widget.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/navigation_bar/navigation_bar_widget.dart
@@ -98,7 +98,7 @@ class NavigationBarWidget extends StatelessWidget {
                   }),
                 const SizedBox(width: 16),
                 ProfileSettingIcon(
-                  key: const ValueKey('user_avatar'),
+                  key: const ValueKey(UiKeys.userAvatar),
                   ownEmailAddress: ownEmailAddress,
                   settingActionTypes: settingActionTypes,
                   onProfileSettingActionTypeClick: onProfileSettingActionTypeClick,

--- a/lib/features/mailbox_dashboard/presentation/widgets/navigation_bar/navigation_bar_widget.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/navigation_bar/navigation_bar_widget.dart
@@ -98,6 +98,7 @@ class NavigationBarWidget extends StatelessWidget {
                   }),
                 const SizedBox(width: 16),
                 ProfileSettingIcon(
+                  key: const ValueKey('user_avatar'),
                   ownEmailAddress: ownEmailAddress,
                   settingActionTypes: settingActionTypes,
                   onProfileSettingActionTypeClick: onProfileSettingActionTypeClick,

--- a/lib/features/manage_account/presentation/email_rules/widgets/email_rule_item_widget.dart
+++ b/lib/features/manage_account/presentation/email_rules/widgets/email_rule_item_widget.dart
@@ -6,6 +6,7 @@ import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:rule_filter/rule_filter/tmail_rule.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/extensions/tmail_rule_extension.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
@@ -90,6 +91,7 @@ class EmailRulesItemWidget extends StatelessWidget {
               ),
             ),
             TMailButtonWidget.fromIcon(
+              key: ValueKey('${UiKeys.editEmailRuleButton}_${rule.name}'),
               icon: imagePaths.icEdit,
               iconSize: 20,
               iconColor: AppColor.steelGrayA540,
@@ -116,6 +118,7 @@ class EmailRulesItemWidget extends StatelessWidget {
               ),
             ),
             TMailButtonWidget.fromIcon(
+              key: ValueKey('${UiKeys.moreEmailRuleButton}_${rule.name}'),
               icon: imagePaths.icMoreVertical,
               iconSize: 20,
               iconColor: AppColor.steelGrayA540,

--- a/lib/features/manage_account/presentation/menu/manage_account_menu_view.dart
+++ b/lib/features/manage_account/presentation/menu/manage_account_menu_view.dart
@@ -85,6 +85,7 @@ class ManageAccountMenuView extends GetWidget<ManageAccountMenuController> {
                      itemBuilder: (context, index) => Obx(() {
                        final menuItem = controller.listAccountMenuItem[index];
                        return AccountMenuItemTileBuilder(
+                         key: menuItem.uiKey,
                          imagePaths: controller.imagePaths,
                          responsiveUtils: controller.responsiveUtils,
                          menuItem: menuItem,

--- a/lib/features/manage_account/presentation/menu/settings/settings_first_level_view.dart
+++ b/lib/features/manage_account/presentation/menu/settings/settings_first_level_view.dart
@@ -3,6 +3,7 @@ import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:model/extensions/session_extension.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/home/domain/extensions/session_extensions.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/user_information_widget.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/menu/settings/setting_user_info_widget.dart';
@@ -90,6 +91,7 @@ class SettingsFirstLevelView extends GetWidget<SettingsController> {
           if (controller.manageAccountDashboardController.isRuleFilterCapabilitySupported) {
             return Column(children: [
               _buildSettingItem(
+                key: const ValueKey(UiKeys.emailRulesSettingMenuItem),
                 context: context,
                 menuItem: AccountMenuItem.emailRules,
                 appLocalizations: appLocalizations,

--- a/lib/features/manage_account/presentation/model/account_menu_item.dart
+++ b/lib/features/manage_account/presentation/model/account_menu_item.dart
@@ -1,5 +1,7 @@
 
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:flutter/foundation.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 enum AccountMenuItem {
@@ -134,4 +136,9 @@ enum AccountMenuItem {
         return 'profiles';
     }
   }
+
+  Key? get uiKey => switch (this) {
+    AccountMenuItem.emailRules => const ValueKey(UiKeys.emailRulesSettingMenuItem),
+    _ => null
+  };
 }

--- a/lib/features/rules_filter_creator/presentation/rules_filter_creator_controller.dart
+++ b/lib/features/rules_filter_creator/presentation/rules_filter_creator_controller.dart
@@ -548,19 +548,7 @@ class RulesFilterCreatorController extends BaseMailboxController {
       }
     }
 
-    final hasRejectAction = listEmailRuleFilterActionSelected
-        .any((action) => action is RejectItActionArguments);
-
-    if (hasRejectAction && context.mounted) {
-      await MessageDialogActionManager().showConfirmDialogAction(
-        context,
-        appLocalizations.messageConfirmationRuleWithRejectAction,
-        appLocalizations.confirm,
-        title: appLocalizations.titleConfirmRuleWithRejectAction,
-        cancelTitle: appLocalizations.cancel,
-        alignCenter: true,
-        onConfirmAction: _buildAndSubmitRuleFilter,
-      );
+    if (await _submitRuleWithRejectAction(context)) {
       return;
     }
 
@@ -635,6 +623,27 @@ class RulesFilterCreatorController extends BaseMailboxController {
       ruleFilterRequest = EditEmailRuleFilterRequest(_listEmailRule?.withIds ?? [], newTMailRule);
     }
     popBack(result: ruleFilterRequest);
+  }
+
+  Future<bool> _submitRuleWithRejectAction(BuildContext context) async {
+    final appLocalizations = AppLocalizations.of(context);
+    final hasRejectAction = listEmailRuleFilterActionSelected
+        .any((action) => action is RejectItActionArguments);
+
+    if (hasRejectAction && context.mounted) {
+      await MessageDialogActionManager().showConfirmDialogAction(
+        context,
+        appLocalizations.messageConfirmationRuleWithRejectAction,
+        appLocalizations.confirm,
+        title: appLocalizations.titleConfirmRuleWithRejectAction,
+        cancelTitle: appLocalizations.cancel,
+        alignCenter: true,
+        onConfirmAction: _buildAndSubmitRuleFilter,
+      );
+      return true;
+    }
+
+    return false;
   }
 
   void closeView(BuildContext context) {

--- a/lib/features/rules_filter_creator/presentation/rules_filter_creator_controller.dart
+++ b/lib/features/rules_filter_creator/presentation/rules_filter_creator_controller.dart
@@ -17,6 +17,7 @@ import 'package:rule_filter/rule_filter/rule_condition.dart';
 import 'package:rule_filter/rule_filter/rule_condition_group.dart';
 import 'package:rule_filter/rule_filter/tmail_rule.dart';
 import 'package:tmail_ui_user/features/base/base_mailbox_controller.dart';
+import 'package:tmail_ui_user/features/base/mixin/message_dialog_action_manager.dart';
 import 'package:tmail_ui_user/features/destination_picker/presentation/model/destination_picker_arguments.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/state/get_all_mailboxes_state.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/usecases/get_all_mailbox_interactor.dart';
@@ -456,7 +457,7 @@ class RulesFilterCreatorController extends BaseMailboxController {
     }
   }
 
-  void createNewRuleFilter(BuildContext context) {
+  Future<void> createNewRuleFilter(BuildContext context) async {
     final appLocalizations = AppLocalizations.of(context);
     final errorName = _getErrorStringByInputValue(
       appLocalizations,
@@ -547,6 +548,26 @@ class RulesFilterCreatorController extends BaseMailboxController {
       }
     }
 
+    final hasRejectAction = listEmailRuleFilterActionSelected
+        .any((action) => action is RejectItActionArguments);
+
+    if (hasRejectAction && context.mounted) {
+      await MessageDialogActionManager().showConfirmDialogAction(
+        context,
+        appLocalizations.messageConfirmationRuleWithRejectAction,
+        appLocalizations.confirm,
+        title: appLocalizations.titleConfirmRuleWithRejectAction,
+        cancelTitle: appLocalizations.cancel,
+        alignCenter: true,
+        onConfirmAction: _buildAndSubmitRuleFilter,
+      );
+      return;
+    }
+
+    _buildAndSubmitRuleFilter();
+  }
+
+  void _buildAndSubmitRuleFilter() {
     late EquatableMixin ruleFilterRequest;
 
     List<MailboxId> mailboxIds = [];

--- a/lib/features/rules_filter_creator/presentation/rules_filter_creator_view.dart
+++ b/lib/features/rules_filter_creator/presentation/rules_filter_creator_view.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:core/core.dart';
 import 'package:core/presentation/views/dialog/confirm_dialog_button.dart';
 import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/widget/label_input_field_builder.dart';
 import 'package:tmail_ui_user/features/base/widget/pop_back_barrier_widget.dart';
@@ -400,6 +401,7 @@ class RuleFilterCreatorView extends GetWidget<RulesFilterCreatorController> {
                         height: 36,
                         margin: const EdgeInsetsDirectional.only(top: 4),
                         child: ConfirmDialogButton(
+                          key: const ValueKey(UiKeys.addActionButton),
                           label: AppLocalizations.of(context).addAnAction,
                           backgroundColor: Colors.white,
                           textColor: AppColor.primaryMain,

--- a/lib/features/rules_filter_creator/presentation/widgets/rule_filter_list_action_widget.dart
+++ b/lib/features/rules_filter_creator/presentation/widgets/rule_filter_list_action_widget.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/views/dialog/confirm_dialog_button.dart';
 import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 
 class RuleFilterListActionWidget extends StatelessWidget {
   final String positiveLabel;
@@ -33,6 +34,7 @@ class RuleFilterListActionWidget extends StatelessWidget {
       constraints: const BoxConstraints(minWidth: 143),
       height: 48,
       child: ConfirmDialogButton(
+        key: const ValueKey(UiKeys.createRuleButton),
         label: positiveLabel,
         backgroundColor: AppColor.primaryMain,
         textColor: Colors.white,

--- a/lib/features/thread/presentation/widgets/app_bar/default_mobile_app_bar_thread_widget.dart
+++ b/lib/features/thread/presentation/widgets/app_bar/default_mobile_app_bar_thread_widget.dart
@@ -4,6 +4,7 @@ import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
 import 'package:tmail_ui_user/features/thread/presentation/styles/app_bar/mobile_app_bar_thread_widget_style.dart';
@@ -43,7 +44,7 @@ class DefaultMobileAppBarThreadWidget extends StatelessWidget {
       child: Row(
         children: [
           TMailButtonWidget.fromIcon(
-            key: const Key('mobile_mailbox_menu_button'),
+            key: const ValueKey(UiKeys.mobileMailboxMenuButton),
             icon: imagePaths.icMenuDrawer,
             backgroundColor: Colors.transparent,
             padding: MobileAppBarThreadWidgetStyle.mailboxMenuPadding,

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1322,6 +1322,12 @@
     "placeholders_order": [],
     "placeholders": {}
   },
+  "confirm": "Confirm",
+  "@confirm": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
   "you_have_created_a_new_identity": "You have created a new identity",
   "@you_have_created_a_new_identity": {
     "type": "text",
@@ -2156,6 +2162,18 @@
   },
   "emailRuleSettingExplanation": "Creating rules to handle incoming messages. You choose both the condition that triggers a rule and the actions the rule will take.",
   "@emailRuleSettingExplanation": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "titleConfirmRuleWithRejectAction": "Reject all emails matching this condition?",
+  "@titleConfirmRuleWithRejectAction": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "messageConfirmationRuleWithRejectAction": "This action is irreversible. Are you sure you want to proceed?",
+  "@messageConfirmationRuleWithRejectAction": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -1338,6 +1338,13 @@ class AppLocalizations {
         name: 'create');
   }
 
+  String get confirm {
+    return Intl.message(
+      'Confirm',
+      name: 'confirm',
+    );
+  }
+
   String get you_have_created_a_new_identity {
     return Intl.message(
         'You have created a new identity',
@@ -2197,6 +2204,20 @@ class AppLocalizations {
     return Intl.message(
       'Creating rules to handle incoming messages. You choose both the condition that triggers a rule and the actions the rule will take.',
       name: 'emailRuleSettingExplanation');
+  }
+
+  String get titleConfirmRuleWithRejectAction {
+    return Intl.message(
+      'Reject all emails matching this condition?',
+      name: 'titleConfirmRuleWithRejectAction',
+    );
+  }
+
+  String get messageConfirmationRuleWithRejectAction {
+    return Intl.message(
+      'This action is irreversible. Are you sure you want to proceed?',
+      name: 'messageConfirmationRuleWithRejectAction',
+    );
   }
 
   String messageConfirmationDialogDeleteEmailRule(String ruleName) {


### PR DESCRIPTION
## Issue
- #4426 

## Integration test results
### Web
```console
✅ Should see warning dialog when create or edit rule with reject action (/tests/email_rules/create_edit_rule_with_reject_test.dart) (18s)

Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: .../tmail-flutter/playwright-report
⏱️  Duration: 32s
```
### Mobile
```console
✅ Should see warning dialog when create or edit rule with reject action (/tests/email_rules/create_edit_rule_with_reject_test.dart) (50s)

Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: .../tmail-flutter/build/app/reports/androidTests/connected/debug/index.html
⏱️  Duration: 1m 27s
```

## Resolved
### Web

https://github.com/user-attachments/assets/bc36c00e-1f87-4a3d-aea5-2c8ca7f36cfa

### Mobile

https://github.com/user-attachments/assets/6f8bfa3d-2818-429f-863c-9b4f345b7476



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Confirmation prompt when creating an email rule that includes a reject action, with localized title, message and confirm button.
* **UI Improvements**
  * More stable widget keys for avatar, menu items, mailbox controls and email-rule action buttons for consistent navigation and editing.
* **Tests**
  * New end-to-end integration tests, scenarios and UI robots covering create/edit rule flows including reject-action confirmation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-flutter/pull/4536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->