### PR TITLE
Fix prevent notification storm on burst FCM delivery on Android

### DIFF
--- a/lib/features/push_notification/data/repository/fcm_repository_impl.dart
+++ b/lib/features/push_notification/data/repository/fcm_repository_impl.dart
@@ -125,24 +125,32 @@ class FCMRepositoryImpl extends FCMRepository {
   }
 
   @override
-  Future<List<PresentationMailbox>> getMailboxesNotPutNotifications(Session session, AccountId accountId) async {
-    final mailboxesCache = await _mapMailboxDataSource[DataSourceType.local]!.getAllMailboxCache(accountId, session.username);
-    final mailboxesCacheNotPutNotifications = mailboxesCache
-      .map((mailbox) => mailbox.toPresentationMailbox())
-      .where((presentationMailbox) => presentationMailbox.pushNotificationDeactivated)
-      .toList();
-    log('FCMRepositoryImpl::getMailboxesNotPutNotifications():mailboxesCacheNotPutNotifications: $mailboxesCacheNotPutNotifications');
-    if (mailboxesCacheNotPutNotifications.isNotEmpty) {
-      return mailboxesCacheNotPutNotifications;
-    } else {
-      final mailboxResponse = await _mapMailboxDataSource[DataSourceType.network]!.getAllMailbox(session, accountId);
-      final mailboxesNotPutNotifications = mailboxResponse.mailboxes
-        .map((mailbox) => mailbox.toPresentationMailbox())
-        .where((presentationMailbox) => presentationMailbox.pushNotificationDeactivated)
-        .toList();
-      log('FCMRepositoryImpl::getMailboxesNotPutNotifications():mailboxesNotPutNotifications: $mailboxesNotPutNotifications');
-      return mailboxesNotPutNotifications;
+  Future<List<PresentationMailbox>> getMailboxesForNotification(
+    Session session,
+    AccountId accountId,
+  ) async {
+    final mailboxesCache = await _mapMailboxDataSource[DataSourceType.local]!
+        .getAllMailboxCache(accountId, session.username);
+
+    // Use inbox presence as a cache quality signal; if inbox is cached,
+    // the full mailbox structure is reliably available locally.
+    if (mailboxesCache.any((m) => m.isInbox)) {
+      final excluded = mailboxesCache
+          .map((m) => m.toPresentationMailbox())
+          .where((m) => m.pushNotificationDeactivated)
+          .toList();
+      log('FCMRepositoryImpl::getMailboxesForNotification(): cache hit — excluded=${excluded.length}');
+      return excluded;
     }
+
+    final mailboxResponse = await _mapMailboxDataSource[DataSourceType.network]!
+        .getAllMailbox(session, accountId);
+    final excluded = mailboxResponse.mailboxes
+        .map((m) => m.toPresentationMailbox())
+        .where((m) => m.pushNotificationDeactivated)
+        .toList();
+    log('FCMRepositoryImpl::getMailboxesForNotification(): network fetch — excluded=${excluded.length}');
+    return excluded;
   }
 
   @override

--- a/lib/features/push_notification/data/repository/fcm_repository_impl.dart
+++ b/lib/features/push_notification/data/repository/fcm_repository_impl.dart
@@ -125,7 +125,7 @@ class FCMRepositoryImpl extends FCMRepository {
   }
 
   @override
-  Future<List<PresentationMailbox>> getMailboxesForNotification(
+  Future<List<PresentationMailbox>> getExcludedMailboxesForNotification(
     Session session,
     AccountId accountId,
   ) async {
@@ -139,7 +139,7 @@ class FCMRepositoryImpl extends FCMRepository {
           .map((m) => m.toPresentationMailbox())
           .where((m) => m.pushNotificationDeactivated)
           .toList();
-      log('FCMRepositoryImpl::getMailboxesForNotification(): cache hit — excluded=${excluded.length}');
+      log('FCMRepositoryImpl::getExcludedMailboxesForNotification(): cache hit — excluded=${excluded.length}');
       return excluded;
     }
 
@@ -149,7 +149,7 @@ class FCMRepositoryImpl extends FCMRepository {
         .map((m) => m.toPresentationMailbox())
         .where((m) => m.pushNotificationDeactivated)
         .toList();
-    log('FCMRepositoryImpl::getMailboxesForNotification(): network fetch — excluded=${excluded.length}');
+    log('FCMRepositoryImpl::getExcludedMailboxesForNotification(): network fetch — excluded=${excluded.length}');
     return excluded;
   }
 

--- a/lib/features/push_notification/domain/repository/fcm_repository.dart
+++ b/lib/features/push_notification/domain/repository/fcm_repository.dart
@@ -44,7 +44,7 @@ abstract class FCMRepository {
 
   Future<void> updateFirebaseRegistrationToken(UpdateTokenExpiredTimeRequest expiredTimeRequest);
 
-  Future<List<PresentationMailbox>> getMailboxesForNotification(Session session, AccountId accountId);
+  Future<List<PresentationMailbox>> getExcludedMailboxesForNotification(Session session, AccountId accountId);
 
   Future<List<EmailId>> getEmailChangesToRemoveNotification(
     Session session,

--- a/lib/features/push_notification/domain/repository/fcm_repository.dart
+++ b/lib/features/push_notification/domain/repository/fcm_repository.dart
@@ -44,7 +44,7 @@ abstract class FCMRepository {
 
   Future<void> updateFirebaseRegistrationToken(UpdateTokenExpiredTimeRequest expiredTimeRequest);
 
-  Future<List<PresentationMailbox>> getMailboxesNotPutNotifications(Session session, AccountId accountId);
+  Future<List<PresentationMailbox>> getMailboxesForNotification(Session session, AccountId accountId);
 
   Future<List<EmailId>> getEmailChangesToRemoveNotification(
     Session session,

--- a/lib/features/push_notification/domain/usecases/get_mailboxes_not_put_notifications_interactor.dart
+++ b/lib/features/push_notification/domain/usecases/get_mailboxes_not_put_notifications_interactor.dart
@@ -14,7 +14,7 @@ class GetMailboxesNotPutNotificationsInteractor {
   Stream<Either<Failure, Success>> execute(Session session, AccountId accountId) async* {
     try {
       yield Right<Failure, Success>(GetMailboxesNotPutNotificationsLoading());
-      final mailboxes = await _fcmRepository.getMailboxesNotPutNotifications(session, accountId);
+      final mailboxes = await _fcmRepository.getMailboxesForNotification(session, accountId);
       yield Right<Failure, Success>(GetMailboxesNotPutNotificationsSuccess(mailboxes, session.username));
     } catch (e) {
       yield Left<Failure, Success>(GetMailboxesNotPutNotificationsFailure(e, session.username));

--- a/lib/features/push_notification/domain/usecases/get_mailboxes_not_put_notifications_interactor.dart
+++ b/lib/features/push_notification/domain/usecases/get_mailboxes_not_put_notifications_interactor.dart
@@ -14,7 +14,7 @@ class GetMailboxesNotPutNotificationsInteractor {
   Stream<Either<Failure, Success>> execute(Session session, AccountId accountId) async* {
     try {
       yield Right<Failure, Success>(GetMailboxesNotPutNotificationsLoading());
-      final mailboxes = await _fcmRepository.getMailboxesForNotification(session, accountId);
+      final mailboxes = await _fcmRepository.getExcludedMailboxesForNotification(session, accountId);
       yield Right<Failure, Success>(GetMailboxesNotPutNotificationsSuccess(mailboxes, session.username));
     } catch (e) {
       yield Left<Failure, Success>(GetMailboxesNotPutNotificationsFailure(e, session.username));

--- a/lib/features/push_notification/presentation/listener/email_change_listener.dart
+++ b/lib/features/push_notification/presentation/listener/email_change_listener.dart
@@ -302,7 +302,10 @@ class EmailChangeListener extends ChangeListener {
       return;
     }
 
-    for (var presentationEmail in emailList) {
+    final selectedEmails = emailList.selectEmailsForNotification();
+    log('EmailChangeListener::_handleLocalPushNotification(): SELECTED = ${selectedEmails.length}');
+
+    for (var presentationEmail in selectedEmails) {
       await _showLocalNotification(
         userName: userName,
         presentationEmail: presentationEmail,

--- a/lib/features/push_notification/presentation/listener/email_change_listener.dart
+++ b/lib/features/push_notification/presentation/listener/email_change_listener.dart
@@ -110,6 +110,14 @@ class EmailChangeListener extends ChangeListener {
     if (PlatformInfo.isMobile) {
       _getNewReceiveEmailFromNotificationAction(action.session, action.accountId, action.newState);
     }
+    if (PlatformInfo.isAndroid) {
+      // On Android, foreground sync must persist the new delivery state so the
+      // next background FCM push does not replay already-seen email changes.
+      final userName = action.session?.username;
+      if (userName != null) {
+        _storeEmailDeliveryStateAction(action.accountId, userName, action.newState);
+      }
+    }
   }
 
   void _onPushNotification(PushNotificationAction action) {

--- a/lib/features/push_notification/presentation/notification/local_notification_manager.dart
+++ b/lib/features/push_notification/presentation/notification/local_notification_manager.dart
@@ -159,7 +159,11 @@ class LocalNotificationManager {
   }
 
   Future<void> removeNotification(String id) async {
-    return _localNotificationsPlugin.cancel(id.hashCode);
+    try {
+      await _localNotificationsPlugin.cancel(id.hashCode);
+    } catch (e) {
+      logWarning('LocalNotificationManager::removeNotification(): id = $id | ERROR: $e');
+    }
   }
 
   Future<int> getCountActiveNotificationByGroupOnAndroid({required String groupId}) async {
@@ -207,7 +211,7 @@ class LocalNotificationManager {
     log('LocalNotificationManager::removeGroupPushNotification(): activeNotifications = ${activeNotifications.length} | listActiveNotificationByGroup = ${listActiveNotificationByGroup.length}');
     if (listActiveNotificationByGroup.length <= 1) {
       log('LocalNotificationManager::groupPushNotification():canceled');
-      await _localNotificationsPlugin.cancel(groupId.hashCode);
+      await removeNotification(groupId);
     }
   }
 

--- a/lib/features/push_notification/presentation/services/fcm_receiver.dart
+++ b/lib/features/push_notification/presentation/services/fcm_receiver.dart
@@ -63,7 +63,7 @@ class FcmReceiver {
       } catch (e, st) {
         if (attempt < MAX_COUNT_RETRY_TO_GET_FCM_TOKEN) {
           logWarning('FcmReceiver::_getInitialToken: attempt $attempt failed: $e');
-          await Future.delayed(Duration(seconds: attempt));
+          await Future.delayed(Duration(seconds: 1 << (attempt - 1)));
         } else {
           logError(
             'FcmReceiver::_getInitialToken: all $MAX_COUNT_RETRY_TO_GET_FCM_TOKEN attempts failed',

--- a/lib/features/push_notification/presentation/services/fcm_receiver.dart
+++ b/lib/features/push_notification/presentation/services/fcm_receiver.dart
@@ -55,18 +55,25 @@ class FcmReceiver {
   }
 
   Future<String?> _getInitialToken() async {
-    try {
-      final token = await FirebaseMessaging.instance.getToken();
-      log('FcmReceiver::_getInitialToken:token: $token');
-      return token;
-    } catch (e, st) {
-      logError(
-        'FcmReceiver::_getInitialToken:',
-        exception: e,
-        stackTrace: st,
-      );
-      return null;
+    for (var attempt = 1; attempt <= MAX_COUNT_RETRY_TO_GET_FCM_TOKEN; attempt++) {
+      try {
+        final token = await FirebaseMessaging.instance.getToken();
+        log('FcmReceiver::_getInitialToken:token: $token');
+        return token;
+      } catch (e, st) {
+        if (attempt < MAX_COUNT_RETRY_TO_GET_FCM_TOKEN) {
+          logWarning('FcmReceiver::_getInitialToken: attempt $attempt failed: $e');
+          await Future.delayed(Duration(seconds: attempt));
+        } else {
+          logError(
+            'FcmReceiver::_getInitialToken: all $MAX_COUNT_RETRY_TO_GET_FCM_TOKEN attempts failed',
+            exception: e,
+            stackTrace: st,
+          );
+        }
+      }
     }
+    return null;
   }
 
   Future _onHandleFcmToken() async {

--- a/model/lib/extensions/list_presentation_email_extension.dart
+++ b/model/lib/extensions/list_presentation_email_extension.dart
@@ -121,4 +121,16 @@ extension ListPresentationEmailExtension on List<PresentationEmail> {
       return where((email) => email.pushNotificationActivated).toList();
     }
   }
+
+  /// Selects at most [maxNotifications] emails for push notification display,
+  /// returning the newest emails first (sorted by receivedAt descending).
+  List<PresentationEmail> selectEmailsForNotification({
+    int maxNotifications = 20,
+  }) {
+    if (maxNotifications <= 0) return [];
+    final sorted = toList()
+      ..sort((a, b) => (b.receivedAt?.value ?? DateTime(0))
+          .compareTo(a.receivedAt?.value ?? DateTime(0)));
+    return sorted.take(maxNotifications).toList();
+  }
 }

--- a/model/lib/extensions/mailbox_extension.dart
+++ b/model/lib/extensions/mailbox_extension.dart
@@ -16,6 +16,8 @@ extension MailboxExtension on Mailbox {
 
   bool get isSent => role == PresentationMailbox.roleSent;
 
+  bool get isInbox => role == PresentationMailbox.roleInbox;
+
   bool get isOutbox => name?.name == PresentationMailbox.outboxRole || role == PresentationMailbox.roleOutbox;
 
   bool get pushNotificationDeactivated => isOutbox || isSent || isDrafts || isTrash || isSpam;

--- a/test/features/fcm/fcm_repository_test.dart
+++ b/test/features/fcm/fcm_repository_test.dart
@@ -4,7 +4,6 @@ import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
-import 'package:model/extensions/mailbox_extension.dart';
 import 'package:model/extensions/presentation_mailbox_extension.dart';
 import 'package:model/extensions/session_extension.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
@@ -40,7 +39,16 @@ void main() {
   final accountIdFixture = SessionFixtures.aliceSession.accountId;
   final userNameFixture = SessionFixtures.aliceSession.username;
 
-  group('getMailboxesNotPutNotifications_method::test', () {
+  final inboxMailbox = Mailbox(
+    id: MailboxId(Id('inbox-id')),
+    role: PresentationMailbox.roleInbox,
+  );
+  final spamMailbox = Mailbox(
+    id: MailboxId(Id('spam-id')),
+    role: PresentationMailbox.roleSpam,
+  );
+
+  group('getMailboxesForNotification:', () {
     setUp(() {
       fcmDatasource = MockFCMDatasource();
       cacheFCMDatasourceImpl = MockCacheFCMDatasourceImpl();
@@ -60,81 +68,77 @@ void main() {
       );
     });
 
-    test('should returns mailboxes with notifications deactivated from local cache', () async {
-      // Arrange
-      final Mailbox mailbox1 = Mailbox(
-        id: MailboxId(Id('spam-id')),
-        role: PresentationMailbox.roleSpam);
-      final Mailbox mailbox2 = Mailbox(
-        id: MailboxId(Id('inbox-id')),
-        role: PresentationMailbox.roleInbox);
+    test('returns excluded mailboxes from cache when inbox is present', () async {
       when(mailboxCacheDataSourceImpl.getAllMailboxCache(
         accountIdFixture,
-        userNameFixture
-      )).thenAnswer((_) async => [mailbox1, mailbox2]);
+        userNameFixture,
+      )).thenAnswer((_) async => [spamMailbox, inboxMailbox]);
 
-      // Act
-      final result = await fcmRepository.getMailboxesNotPutNotifications(
+      final result = await fcmRepository.getMailboxesForNotification(
         sessionFixture,
-        accountIdFixture);
+        accountIdFixture,
+      );
 
-      // Assert
-      expect(mailbox1.pushNotificationDeactivated, isTrue);
-      expect(mailbox2.pushNotificationDeactivated, isFalse);
       expect(result, hasLength(1));
       expect(result.first.pushNotificationDeactivated, isTrue);
+      verifyNever(mailboxDataSource.getAllMailbox(sessionFixture, accountIdFixture));
     });
 
-    test('should falls back to network source if local cache is empty', () async {
-      // Arrange
+    test('returns empty excluded list when cache has only inbox', () async {
       when(mailboxCacheDataSourceImpl.getAllMailboxCache(
         accountIdFixture,
-        userNameFixture
+        userNameFixture,
+      )).thenAnswer((_) async => [inboxMailbox]);
+
+      final result = await fcmRepository.getMailboxesForNotification(
+        sessionFixture,
+        accountIdFixture,
+      );
+
+      expect(result, isEmpty);
+      verifyNever(mailboxDataSource.getAllMailbox(sessionFixture, accountIdFixture));
+    });
+
+    test('falls back to network when inbox is not in cache', () async {
+      when(mailboxCacheDataSourceImpl.getAllMailboxCache(
+        accountIdFixture,
+        userNameFixture,
       )).thenAnswer((_) async => []);
 
-      final Mailbox mailbox1 = Mailbox(
-        id: MailboxId(Id('spam-id')),
-        role: PresentationMailbox.roleSpam);
-      final mailboxResponse = JmapMailboxResponse(mailboxes: [mailbox1]);
       when(mailboxDataSource.getAllMailbox(
         sessionFixture,
-        accountIdFixture
-      )).thenAnswer((_) async => mailboxResponse);
+        accountIdFixture,
+      )).thenAnswer((_) async => JmapMailboxResponse(mailboxes: [spamMailbox]));
 
-      // Act
-      final result = await fcmRepository.getMailboxesNotPutNotifications(
+      final result = await fcmRepository.getMailboxesForNotification(
         sessionFixture,
-        accountIdFixture);
+        accountIdFixture,
+      );
 
-      // Assert
-      expect(mailbox1.pushNotificationDeactivated, isTrue);
       expect(result, hasLength(1));
       expect(result.first.pushNotificationDeactivated, isTrue);
     });
 
-    test('should returns empty list if no mailboxes have notifications deactivated', () async {
-      // Arrange
-      final Mailbox mailbox1 = Mailbox(
-        id: MailboxId(Id('inbox-id')),
-        role: PresentationMailbox.roleInbox);
+    test('falls back to network and returns excluded mailboxes when cache has no inbox', () async {
       when(mailboxCacheDataSourceImpl.getAllMailboxCache(
         accountIdFixture,
-        userNameFixture
-      )).thenAnswer((_) async => [mailbox1]);
-      final mailboxResponse = JmapMailboxResponse(mailboxes: [mailbox1]);
+        userNameFixture,
+      )).thenAnswer((_) async => [spamMailbox]);
+
       when(mailboxDataSource.getAllMailbox(
         sessionFixture,
-        accountIdFixture
-      )).thenAnswer((_) async => mailboxResponse);
+        accountIdFixture,
+      )).thenAnswer((_) async => JmapMailboxResponse(
+        mailboxes: [spamMailbox, inboxMailbox],
+      ));
 
-      // Act
-      final result = await fcmRepository.getMailboxesNotPutNotifications(
+      final result = await fcmRepository.getMailboxesForNotification(
         sessionFixture,
-        accountIdFixture);
+        accountIdFixture,
+      );
 
-      // Assert
-      expect(mailbox1.pushNotificationDeactivated, isFalse);
-      expect(result, isEmpty);
+      expect(result, hasLength(1));
+      expect(result.first.pushNotificationDeactivated, isTrue);
     });
   });
 }

--- a/test/features/fcm/fcm_repository_test.dart
+++ b/test/features/fcm/fcm_repository_test.dart
@@ -48,7 +48,7 @@ void main() {
     role: PresentationMailbox.roleSpam,
   );
 
-  group('getMailboxesForNotification:', () {
+  group('getExcludedMailboxesForNotification:', () {
     setUp(() {
       fcmDatasource = MockFCMDatasource();
       cacheFCMDatasourceImpl = MockCacheFCMDatasourceImpl();
@@ -74,7 +74,7 @@ void main() {
         userNameFixture,
       )).thenAnswer((_) async => [spamMailbox, inboxMailbox]);
 
-      final result = await fcmRepository.getMailboxesForNotification(
+      final result = await fcmRepository.getExcludedMailboxesForNotification(
         sessionFixture,
         accountIdFixture,
       );
@@ -90,7 +90,7 @@ void main() {
         userNameFixture,
       )).thenAnswer((_) async => [inboxMailbox]);
 
-      final result = await fcmRepository.getMailboxesForNotification(
+      final result = await fcmRepository.getExcludedMailboxesForNotification(
         sessionFixture,
         accountIdFixture,
       );
@@ -110,13 +110,14 @@ void main() {
         accountIdFixture,
       )).thenAnswer((_) async => JmapMailboxResponse(mailboxes: [spamMailbox]));
 
-      final result = await fcmRepository.getMailboxesForNotification(
+      final result = await fcmRepository.getExcludedMailboxesForNotification(
         sessionFixture,
         accountIdFixture,
       );
 
       expect(result, hasLength(1));
       expect(result.first.pushNotificationDeactivated, isTrue);
+      verify(mailboxDataSource.getAllMailbox(sessionFixture, accountIdFixture)).called(1);
     });
 
     test('falls back to network and returns excluded mailboxes when cache has no inbox', () async {
@@ -132,13 +133,14 @@ void main() {
         mailboxes: [spamMailbox, inboxMailbox],
       ));
 
-      final result = await fcmRepository.getMailboxesForNotification(
+      final result = await fcmRepository.getExcludedMailboxesForNotification(
         sessionFixture,
         accountIdFixture,
       );
 
       expect(result, hasLength(1));
       expect(result.first.pushNotificationDeactivated, isTrue);
+      verify(mailboxDataSource.getAllMailbox(sessionFixture, accountIdFixture)).called(1);
     });
   });
 }

--- a/test/model/lib/extensions/list_presentation_email_extension_test.dart
+++ b/test/model/lib/extensions/list_presentation_email_extension_test.dart
@@ -66,5 +66,13 @@ void main() {
       final result = [older, middle, newer].selectEmailsForNotification();
       expect(result.map((e) => e.id?.id.value).toList(), ['newer', 'middle', 'older']);
     });
+
+    test('treats null receivedAt as oldest — excluded when cap is exceeded', () {
+      final withDate = _makeEmail(id: 'dated', receivedAt: DateTime(2024, 1, 2));
+      final withoutDate = _makeEmail(id: 'undated');
+      final result = [withoutDate, withDate].selectEmailsForNotification();
+      expect(result.first.id?.id.value, 'dated');
+      expect(result.last.id?.id.value, 'undated');
+    });
   });
 }

--- a/test/model/lib/extensions/list_presentation_email_extension_test.dart
+++ b/test/model/lib/extensions/list_presentation_email_extension_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/utc_date.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:model/email/presentation_email.dart';
+import 'package:model/extensions/list_presentation_email_extension.dart';
+
+PresentationEmail _makeEmail({
+  required String id,
+  DateTime? receivedAt,
+}) {
+  return PresentationEmail(
+    id: EmailId(Id(id)),
+    receivedAt: receivedAt != null ? UTCDate(receivedAt) : null,
+  );
+}
+
+/// Generates [count] emails ordered oldest-to-newest (1 hour apart each).
+List<PresentationEmail> _makeSequentialEmails(int count) {
+  return List.generate(
+    count,
+    (i) => _makeEmail(
+      id: 'e$i',
+      receivedAt: DateTime(2024, 1, 1).add(Duration(hours: i)),
+    ),
+  );
+}
+
+void main() {
+  group('selectEmailsForNotification:', () {
+    test('returns empty list when input is empty', () {
+      final result = <PresentationEmail>[].selectEmailsForNotification();
+      expect(result, isEmpty);
+    });
+
+    test('returns empty list when maxNotifications is 0', () {
+      final result = _makeSequentialEmails(5).selectEmailsForNotification(maxNotifications: 0);
+      expect(result, isEmpty);
+    });
+
+    test('returns all emails when count is below maxNotifications', () {
+      final result = _makeSequentialEmails(5).selectEmailsForNotification();
+      expect(result.length, 5);
+    });
+
+    test('caps at maxNotifications and selects the newest emails', () {
+      final emails = _makeSequentialEmails(50);
+      final result = emails.selectEmailsForNotification();
+      expect(result.length, 20);
+      // highest-index emails are newest (e49..e30)
+      final resultIds = result.map((e) => e.id?.id.value).toSet();
+      for (var i = 30; i < 50; i++) {
+        expect(resultIds, contains('e$i'));
+      }
+    });
+
+    test('respects custom maxNotifications', () {
+      final result = _makeSequentialEmails(30).selectEmailsForNotification(maxNotifications: 10);
+      expect(result.length, 10);
+    });
+
+    test('returns emails sorted newest first', () {
+      final older = _makeEmail(id: 'older', receivedAt: DateTime(2024, 1, 1));
+      final newer = _makeEmail(id: 'newer', receivedAt: DateTime(2024, 1, 3));
+      final middle = _makeEmail(id: 'middle', receivedAt: DateTime(2024, 1, 2));
+      final result = [older, middle, newer].selectEmailsForNotification();
+      expect(result.map((e) => e.id?.id.value).toList(), ['newer', 'middle', 'older']);
+    });
+  });
+}

--- a/test/model/lib/extensions/list_presentation_email_extension_test.dart
+++ b/test/model/lib/extensions/list_presentation_email_extension_test.dart
@@ -70,9 +70,9 @@ void main() {
     test('treats null receivedAt as oldest — excluded when cap is exceeded', () {
       final withDate = _makeEmail(id: 'dated', receivedAt: DateTime(2024, 1, 2));
       final withoutDate = _makeEmail(id: 'undated');
-      final result = [withoutDate, withDate].selectEmailsForNotification();
-      expect(result.first.id?.id.value, 'dated');
-      expect(result.last.id?.id.value, 'undated');
+      final result = [withoutDate, withDate]
+          .selectEmailsForNotification(maxNotifications: 1);
+      expect(result.map((e) => e.id?.id.value).toList(), ['dated']);
     });
   });
 }


### PR DESCRIPTION
## Context

Android users experienced notification storms after overnight device reconnection: the server
delivered a large burst of FCM events in a short window, causing hundreds of local notifications,
service overload, and device freezing.

This PR implements the client-side countermeasures from
[ADR-0073](https://github.com/linagora/tmail-flutter/blob/master/docs/adr/0073-prevent-notification-storm-android.md)
(MUST and SHOULD items), complementary to the server-side `collapse_key` mechanism
([tmail-backend#2301](https://github.com/linagora/tmail-backend/issues/2301)).

> The needs-action + Inbox heuristic (SHOULD — pending product validation) is intentionally
> excluded from this PR and will be introduced separately after product sign-off.

## Changes

### 1. Cap notifications at 20 per burst

Adds `selectEmailsForNotification` on `ListPresentationEmailExtension`.
On each FCM burst, at most 20 notifications are shown — always the **newest** emails sorted
by `receivedAt` descending. Emails with no date are treated as oldest and dropped first when
the burst exceeds the cap.

### 2. Keep FCM delivery state consistent during foreground sync

`EmailChangeListener` now stores the FCM delivery state after each foreground email sync on
Android. Previously this was skipped, causing the next background wake to re-process
already-seen emails and show stale notifications.

### 3. Unify mailbox cache lookup for notification exclusion

`getExcludedMailboxesForNotification` replaces the old `getMailboxesNotPutNotifications`.
It uses **inbox presence** as a cache quality signal: if the inbox is in the local cache the
full mailbox structure is considered reliable and no network call is made; otherwise it falls
back to the network. This avoids unnecessary network fetches while still filtering out
spam/trash/sent/drafts mailboxes.

### 4. Safe notification removal

`LocalNotificationManager.removeNotification()` now catches and logs `PlatformException`
(previously surfaced in Sentry as `PlatformException: Missing type parameter` from
`removeNotificationFromCache`) instead of propagating it and breaking the notification pipeline.

### 5. FCM token retry on SERVICE_NOT_AVAILABLE

`FcmReceiver._getInitialToken()` now retries up to `MAX_COUNT_RETRY_TO_GET_FCM_TOKEN` (3)
times with exponential backoff (`1 << (attempt - 1)` seconds: 1 s → 2 s) when token
retrieval fails. Transient Play Services failures are logged as `logWarning`; only a
definitive 3-attempt failure escalates to `logError`.

## Test coverage

- `selectEmailsForNotification`: cap at 20, newest-first ordering, `null receivedAt` treated
  as oldest, custom cap, empty input, zero cap.
- `getExcludedMailboxesForNotification`: cache hit (inbox present), cache miss (network
  fallback verified with `verify(...).called(1)`), empty cache, no-inbox cache.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local notification selection now limits and prioritizes emails (default cap 20) to reduce noise.

* **Improvements**
  * Mailbox selection for push favors local cache when inbox is present, otherwise falls back to network.
  * Foreground sync persists delivery state only when account identity is present.
  * Notification removal is more robust with error handling.
  * FCM token retrieval retries with exponential backoff.

* **Tests**
  * Updated tests covering mailbox selection, cache/network scenarios, and email-cap behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-flutter/pull/4537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->