### PR TITLE
TF-4488 Fix Ctrl+K / Cmd+K opening wrong link dialog in composer

### DIFF
--- a/integration_test/robots/abstract/abstract_composer_robot.dart
+++ b/integration_test/robots/abstract/abstract_composer_robot.dart
@@ -25,6 +25,9 @@ abstract class AbstractComposerRobot {
   Future<void> tapDiscardChanges();
   /// Returns the active [ComposerController] for the currently visible composer.
   /// Platform implementations must resolve the correct GetX tag (web uses a
-  /// per-instance composerId; mobile uses the default null tag).
+  /// per-instance composerId tag; mobile uses the default null tag).
   ComposerController? findComposerController();
+  // Cmd+K on macOS, Ctrl+K elsewhere — mirrors the JS isMac heuristic in the editor.
+  Future<void> openInsertLinkDialogViaKeyboardShortcut();
+  Future<void> expectInsertLinkDialogVisible(AppLocalizations appLocalizations);
 }

--- a/integration_test/robots/mobile/mobile_composer_robot.dart
+++ b/integration_test/robots/mobile/mobile_composer_robot.dart
@@ -9,6 +9,7 @@ import 'package:patrol/patrol.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/download_image_as_base64_state.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../../mocks/fake_file_picker.dart';
 import '../abstract/abstract_composer_robot.dart';
@@ -136,4 +137,12 @@ class MobileComposerRobot extends ComposerRobot implements AbstractComposerRobot
       if (ready == true) return;
     }
   }
+
+  @override
+  Future<void> openInsertLinkDialogViaKeyboardShortcut() =>
+      throw UnsupportedError('Insert-link keyboard shortcut is web-only');
+
+  @override
+  Future<void> expectInsertLinkDialogVisible(AppLocalizations appLocalizations) =>
+      throw UnsupportedError('Insert-link keyboard shortcut is web-only');
 }

--- a/integration_test/robots/web/web_composer_robot.dart
+++ b/integration_test/robots/web/web_composer_robot.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show TargetPlatform, defaultTargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
@@ -5,6 +6,7 @@ import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_view_web.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/web/web_editor_widget.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../mobile/mobile_composer_robot.dart';
 
@@ -56,5 +58,30 @@ class WebComposerRobot extends MobileComposerRobot {
     await $.pumpAndSettle();
     await $(const Key(UiKeys.saveTemplatePopupItem)).tap();
     await $.pumpAndSettle();
+  }
+
+  @override
+  Future<void> openInsertLinkDialogViaKeyboardShortcut() async {
+    await $(WebEditorWidget).tap();
+    // enterText focuses div.note-editable inside the iframe and the element
+    // retains focus afterward, so pressKeyCombo lands in Summernote rather
+    // than the outer Flutter shell.
+    await $.platformAutomator.web.enterText(
+      WebSelector(cssOrXpath: 'div.note-editable'),
+      iframeSelector: WebSelector(cssOrXpath: 'iframe'),
+      text: ' ',
+    );
+    final isMac = defaultTargetPlatform == TargetPlatform.macOS;
+    await $.platformAutomator.web.pressKeyCombo(
+      keys: isMac ? ['Meta', 'k'] : ['Control', 'k'],
+    );
+    await $.pumpAndTrySettle();
+  }
+
+  // "Apply" is unique to the custom overlay; Summernote's native dialog never
+  // renders this Flutter widget, so its presence confirms the correct dialog.
+  @override
+  Future<void> expectInsertLinkDialogVisible(AppLocalizations appLocalizations) async {
+    await $.waitUntilVisible($(find.text(appLocalizations.apply)));
   }
 }

--- a/integration_test/scenarios/composer/open_insert_link_dialog_via_keyboard_shortcut_scenario.dart
+++ b/integration_test/scenarios/composer/open_insert_link_dialog_via_keyboard_shortcut_scenario.dart
@@ -1,0 +1,21 @@
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+
+class OpenInsertLinkDialogViaKeyboardShortcutScenario extends BaseTestScenario {
+  const OpenInsertLinkDialogViaKeyboardShortcutScenario(super.$, super.robots);
+
+  @override
+  Future<void> runTestLogic() async {
+    final composerRobot = robots.composerRobot();
+    final appLocalizations = AppLocalizations();
+
+    await robots.threadRobot().openComposer();
+    await composerRobot.expectComposerViewVisible();
+    await composerRobot.grantContactPermission();
+
+    await composerRobot.openInsertLinkDialogViaKeyboardShortcut();
+
+    await composerRobot.expectInsertLinkDialogVisible(appLocalizations);
+  }
+}

--- a/integration_test/tests/composer/open_insert_link_dialog_via_keyboard_shortcut_test.dart
+++ b/integration_test/tests/composer/open_insert_link_dialog_via_keyboard_shortcut_test.dart
@@ -1,0 +1,12 @@
+import '../../base/test_base.dart';
+import '../../models/test_tags.dart';
+import '../../scenarios/composer/open_insert_link_dialog_via_keyboard_shortcut_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should open custom insert-link dialog when pressing Ctrl+K / Cmd+K in the composer editor',
+    scenarioBuilder: ($, robots) =>
+        OpenInsertLinkDialogViaKeyboardShortcutScenario($, robots),
+    tags: [TestTags.web],
+  );
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1280,8 +1280,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: main
-      resolved-ref: "2e3d7a03403c6d1beedf6baae983615f593d9e59"
+      ref: "fix/tf-4488-fix-ctrl-k-opens-custom-link-dialog"
+      resolved-ref: "785f61ac4c5ed3c0c855be2b9a537f2ede971cca"
       url: "https://github.com/linagora/html-editor-enhanced.git"
     source: git
     version: "3.3.5"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1280,11 +1280,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "fix/tf-4488-fix-ctrl-k-opens-custom-link-dialog"
-      resolved-ref: "785f61ac4c5ed3c0c855be2b9a537f2ede971cca"
+      ref: main
+      resolved-ref: "388c756491955c77aee56f2153cd726eafe7a985"
       url: "https://github.com/linagora/html-editor-enhanced.git"
     source: git
-    version: "3.3.5"
+    version: "3.3.6"
   html_unescape:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,8 +69,7 @@ dependencies:
   html_editor_enhanced:
     git:
       url: https://github.com/linagora/html-editor-enhanced.git
-      # TODO(TF-4488): revert to ref: main once linagora/html-editor-enhanced#70 is merged
-      ref: fix/tf-4488-fix-ctrl-k-opens-custom-link-dialog
+      ref: main
 
   jmap_dart_client:
     git:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,6 +69,7 @@ dependencies:
   html_editor_enhanced:
     git:
       url: https://github.com/linagora/html-editor-enhanced.git
+      # TODO(TF-4488): revert to ref: main once linagora/html-editor-enhanced#70 is merged
       ref: fix/tf-4488-fix-ctrl-k-opens-custom-link-dialog
 
   jmap_dart_client:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,7 +69,7 @@ dependencies:
   html_editor_enhanced:
     git:
       url: https://github.com/linagora/html-editor-enhanced.git
-      ref: main
+      ref: fix/tf-4488-fix-ctrl-k-opens-custom-link-dialog
 
   jmap_dart_client:
     git:


### PR DESCRIPTION
## Issue

#4488 

## Root cause

Pressing `Ctrl+K` in the email composer opened Summernote's native link dialog instead of the custom `LinkEditDialogOverlay`. The native dialog cannot be focused or styled, making it unusable.

## Solution 

Handled in the `html_editor_enhanced` library (see linked PR).  This PR updates `pubspec.yaml` and `pubspec.lock` to point to the fix branch. Need merged: https://github.com/linagora/html-editor-enhanced/pull/70 

> **Depends on:** linagora/html-editor-enhanced — `fix/tf-4488-fix-ctrl-k-opens-custom-link-dialog`


## Resolved


https://github.com/user-attachments/assets/ecff81fc-42aa-48b6-bd7a-32fb724a3536

## E2E Test

```console
✅ Should open custom insert-link dialog when pressing Ctrl+K / Cmd+K in the composer editor (/tests/composer/open_insert_link_dialog_via_keyboard_shortcut_test.dart) (7s)

Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: /Users/datvu/WorkingSpace/tmail-flutter/playwright-report
⏱️  Duration: 21s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web: Press Cmd/Ctrl+K to open the insert-link dialog in the composer.
* **Bug Fixes**
  * Shortcut now reliably opens the correct insert-link dialog (mobile platforms do not support the keyboard shortcut).
* **Tests**
  * Added an automated test that verifies the insert-link dialog opens via the keyboard shortcut.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-flutter/pull/4539?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->