### PR TITLE
TF-4482 Fix invitation email content overflowing on narrow mobile screens

### DIFF
--- a/core/lib/presentation/utils/html_transformer/dom/responsive_table_cell_transformer.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/responsive_table_cell_transformer.dart
@@ -1,0 +1,43 @@
+
+import 'package:core/data/network/dio_client.dart';
+import 'package:core/presentation/utils/html_transformer/base/dom_transformer.dart';
+import 'package:core/utils/app_logger.dart';
+import 'package:html/dom.dart';
+
+/// Adds `overflow-wrap: anywhere` to every `<td>` and `<th>` element so that
+/// long unbreakable strings (URLs, email addresses) wrap instead of causing
+/// horizontal overflow on narrow screens.
+///
+/// `overflow-wrap: anywhere` (unlike `break-word`) reduces the intrinsic
+/// min-content width of the cell to zero, which is required for
+/// `table-layout: auto` tables to shrink columns to fit the viewport.
+///
+/// Cells that already declare `overflow-wrap` are left untouched to respect
+/// the original email styling.
+class ResponsiveTableCellTransformer extends DomTransformer {
+
+  const ResponsiveTableCellTransformer();
+
+  @override
+  Future<void> process({
+    required Document document,
+    required DioClient dioClient,
+    Map<String, String>? mapUrlDownloadCID,
+  }) async {
+    try {
+      final cells = document.querySelectorAll('td, th');
+      if (cells.isEmpty) return;
+
+      for (final cell in cells) {
+        final currentStyle = cell.attributes['style'] ?? '';
+        if (currentStyle.contains('overflow-wrap')) continue;
+
+        final trimmed = currentStyle.trimRight();
+        final separator = trimmed.isEmpty ? '' : (trimmed.endsWith(';') ? ' ' : '; ');
+        cell.attributes['style'] = '$trimmed${separator}overflow-wrap: anywhere;';
+      }
+    } catch (e) {
+      logWarning('$runtimeType::process: Exception = $e');
+    }
+  }
+}

--- a/core/lib/presentation/utils/html_transformer/dom/responsive_table_cell_transformer.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/responsive_table_cell_transformer.dart
@@ -30,7 +30,11 @@ class ResponsiveTableCellTransformer extends DomTransformer {
 
       for (final cell in cells) {
         final currentStyle = cell.attributes['style'] ?? '';
-        if (currentStyle.contains('overflow-wrap')) continue;
+        final hasOverflowWrapDeclaration = RegExp(
+          r'(^|;)\s*overflow-wrap\s*:',
+          caseSensitive: false,
+        ).hasMatch(currentStyle);
+        if (hasOverflowWrapDeclaration) continue;
 
         final trimmed = currentStyle.trimRight();
         final separator = trimmed.isEmpty ? '' : (trimmed.endsWith(';') ? ' ' : '; ');

--- a/core/lib/presentation/utils/html_transformer/transform_configuration.dart
+++ b/core/lib/presentation/utils/html_transformer/transform_configuration.dart
@@ -12,6 +12,7 @@ import 'package:core/presentation/utils/html_transformer/dom/remove_lazy_loading
 import 'package:core/presentation/utils/html_transformer/dom/remove_lazy_loading_image_transformers.dart';
 import 'package:core/presentation/utils/html_transformer/dom/remove_max_width_in_image_style_transformers.dart';
 import 'package:core/presentation/utils/html_transformer/dom/remove_style_tag_outside_transformers.dart';
+import 'package:core/presentation/utils/html_transformer/dom/responsive_table_cell_transformer.dart';
 import 'package:core/presentation/utils/html_transformer/dom/sanitize_hyper_link_tag_in_html_transformers.dart';
 import 'package:core/presentation/utils/html_transformer/dom/script_transformers.dart';
 import 'package:core/presentation/utils/html_transformer/dom/signature_transformers.dart';
@@ -76,6 +77,7 @@ class TransformConfiguration {
       const AddLazyLoadingForBackgroundImageTransformer(),
       const RemoveCollapsedSignatureButtonTransformer(),
       const NormalizeLineHeightInStyleTransformer(),
+      const ResponsiveTableCellTransformer(),
     ]
   );
 
@@ -139,6 +141,7 @@ class TransformConfiguration {
     const AddLazyLoadingForBackgroundImageTransformer(),
     const RemoveCollapsedSignatureButtonTransformer(),
     const NormalizeLineHeightInStyleTransformer(),
+    const ResponsiveTableCellTransformer(),
   ];
 
   static const List<TextTransformer> standardTextTransformers = [

--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -361,6 +361,10 @@ class HtmlUtils {
         
         ${useDefaultFontStyle ? HtmlTemplate.defaultFontStyle(fontSize: fontSize) : ''}
         
+        *, *::before, *::after {
+          box-sizing: border-box;
+        }
+
         .tmail-content {
           min-height: ${minHeight ?? 0}px;
           min-width: ${minWidth ?? 0}px;

--- a/core/test/utils/html/html_utils_test.dart
+++ b/core/test/utils/html/html_utils_test.dart
@@ -3,6 +3,47 @@ import 'package:core/utils/html/html_utils.dart';
 import 'package:universal_html/html.dart' as html;
 
 void main() {
+  group('HtmlUtils generateHtmlDocument', () {
+    test('appends custom styleCSS after all default styles', () {
+      const customCss = 'div { color: red; }';
+
+      final result = HtmlUtils.generateHtmlDocument(
+        content: '<p>Test</p>',
+        styleCSS: customCss,
+      );
+
+      expect(result, contains(customCss));
+      final lastDefaultRuleIndex = result.indexOf('word-break: normal !important');
+      final customCssIndex = result.indexOf(customCss);
+      expect(lastDefaultRuleIndex, greaterThan(-1));
+      expect(customCssIndex, greaterThan(lastDefaultRuleIndex),
+        reason: 'custom styleCSS must appear after default CSS so it can override');
+    });
+
+    test('generates valid HTML document structure with required meta tags', () {
+      final result = HtmlUtils.generateHtmlDocument(content: '<p>Hello</p>');
+
+      expect(result, contains('<!DOCTYPE html>'));
+      expect(result, contains('<html>'));
+      expect(result, contains('width=device-width, initial-scale=1.0'));
+      expect(result, contains('charset=utf-8'));
+      expect(result, contains('<div class="tmail-content">'));
+      expect(result, contains('<p>Hello</p>'));
+    });
+
+    test('generates document without custom styleCSS when param is omitted', () {
+      final result = HtmlUtils.generateHtmlDocument(content: '<p>Test</p>');
+
+      expect(result, contains('word-break: normal !important'));
+    });
+
+    test('includes box-sizing border-box reset to prevent border overflow', () {
+      final result = HtmlUtils.generateHtmlDocument(content: '<p>Test</p>');
+
+      expect(result, contains('box-sizing: border-box'));
+    });
+  });
+
   group('HtmlUtils addQuoteToggle tests', () {
     test('Should add toggle button to HTML with single blockquote', () {
       const htmlInput = '''

--- a/core/test/utils/html_transform_text_html_test.dart
+++ b/core/test/utils/html_transform_text_html_test.dart
@@ -224,6 +224,59 @@ void main() {
         ));
       });
     });
+
+    group('Responsive transformer coexistence with standard pipeline', () {
+      test('RemoveScriptTransformer: script inside td is removed AND td still gets overflow-wrap', () async {
+        const input =
+            '<table><tr><td><script>alert(1)</script>safe content</td></tr></table>';
+        final out = await transform(input);
+        expect(out, isNot(contains('<script')), reason: 'script must be stripped');
+        expect(out, contains('safe content'));
+        expect(out, contains('overflow-wrap: anywhere'),
+            reason: 'td must still get overflow-wrap after script removal');
+      });
+
+      test('SanitizeHyperLinkTagTransformer: link in td gets target/rel AND td gets overflow-wrap', () async {
+        const input =
+            '<table><tr><td><a href="https://example.com">click</a></td></tr></table>';
+        final out = await transform(input);
+        expect(out, contains('target="_blank"'),
+            reason: 'link sanitization must still run');
+        expect(out, contains('rel="noreferrer"'));
+        expect(out, contains('overflow-wrap: anywhere'),
+            reason: 'td must also get overflow-wrap');
+      });
+
+      test('NormalizeLineHeightTransformer: bad line-height removed from td AND overflow-wrap added', () async {
+        const input =
+            '<table><tr><td style="line-height: 1px; padding: 8px;">text</td></tr></table>';
+        final out = await transform(input);
+        expect(out, isNot(contains('line-height: 1px')),
+            reason: 'NormalizeLineHeight must strip the bad line-height value');
+        expect(out, contains('padding: 8px'),
+            reason: 'other styles must be preserved');
+        expect(out, contains('overflow-wrap: anywhere'),
+            reason: 'ResponsiveTableCellTransformer must still run after NormalizeLineHeight');
+      });
+
+      test('NormalizeLineHeightTransformer: td with only bad line-height ends up with overflow-wrap only', () async {
+        const input =
+            '<table><tr><td style="line-height: 1px;">text</td></tr></table>';
+        final out = await transform(input);
+        expect(out, isNot(contains('line-height: 1px')));
+        expect(out, contains('overflow-wrap: anywhere'),
+            reason: 'after NormalizeLineHeight removes the sole style, Responsive must add overflow-wrap');
+      });
+
+      test('full complex email: table cells get overflow-wrap AND existing links are preserved', () async {
+        final out = await transform(HtmlEmailCorpus.htmlComplexNested);
+        expect(out, contains('overflow-wrap: anywhere'),
+            reason: 'all td/th cells in the complex email must get overflow-wrap');
+        expect(out, contains('href="https://finance.example.com/budget"'),
+            reason: 'link sanitization must not remove safe https links');
+        expect(out, contains('Monthly Performance Report'));
+      });
+    });
   });
 
   group('HtmlTransform.transformToHtml — fromDomTransformers', () {

--- a/core/test/utils/html_transform_text_html_test.dart
+++ b/core/test/utils/html_transform_text_html_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:core/data/network/dio_client.dart';
 import 'package:core/presentation/utils/html_transformer/base/dom_transformer.dart';
+import 'package:core/presentation/utils/html_transformer/dom/responsive_table_cell_transformer.dart';
 import 'package:core/presentation/utils/html_transformer/dom/sanitize_hyper_link_tag_in_html_transformers.dart';
 import 'package:core/presentation/utils/html_transformer/dom/script_transformers.dart';
 import 'package:core/presentation/utils/html_transformer/html_transform.dart';
@@ -202,6 +203,27 @@ void main() {
         expect(out, allOf(contains('日本語'), contains('中文'), contains('한국어')));
       });
     });
+
+    group('ResponsiveTableCellTransformer', () {
+      test('SHOULD add overflow-wrap: anywhere to td and th cells with no existing style', () async {
+        final out = await transform(HtmlEmailCorpus.htmlTableSimple);
+        expect(out, contains('overflow-wrap: anywhere'));
+      });
+
+      test('SHOULD not override overflow-wrap that is already set on a cell', () async {
+        final out = await transform(HtmlEmailCorpus.htmlTableCellWithOverflowWrap);
+        expect(out, contains('overflow-wrap: break-word'));
+        expect(out, isNot(contains('overflow-wrap: anywhere')));
+      });
+
+      test('SHOULD append overflow-wrap: anywhere to cells that already have other inline styles', () async {
+        final out = await transform(HtmlEmailCorpus.htmlTableCellWithOtherStyles);
+        expect(out, allOf(
+          contains('color: green'),
+          contains('overflow-wrap: anywhere'),
+        ));
+      });
+    });
   });
 
   group('HtmlTransform.transformToHtml — fromDomTransformers', () {
@@ -260,6 +282,14 @@ void main() {
           contains('target="_blank"'),
           contains('rel="noreferrer"'),
         ));
+      });
+
+      test('SHOULD add overflow-wrap: anywhere to td and th when only ResponsiveTableCellTransformer is used', () async {
+        final out = await transformWith(
+          HtmlEmailCorpus.htmlTableSimple,
+          [const ResponsiveTableCellTransformer()],
+        );
+        expect(out, contains('overflow-wrap: anywhere'));
       });
     });
 

--- a/core/test/utils/responsive_table_cell_transformer_test.dart
+++ b/core/test/utils/responsive_table_cell_transformer_test.dart
@@ -1,0 +1,100 @@
+import 'package:core/presentation/utils/html_transformer/dom/responsive_table_cell_transformer.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:html/parser.dart' show parse;
+import 'package:html/dom.dart';
+import 'package:core/data/network/dio_client.dart';
+import 'package:mockito/annotations.dart';
+
+import 'responsive_table_cell_transformer_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<DioClient>()])
+void main() {
+  group('ResponsiveTableCellTransformer', () {
+    const transformer = ResponsiveTableCellTransformer();
+    final dioClient = MockDioClient();
+
+    Future<Document> run(String html) async {
+      final doc = parse(html);
+      await transformer.process(document: doc, dioClient: dioClient);
+      return doc;
+    }
+
+    test('adds overflow-wrap: anywhere to td with no existing style', () async {
+      final doc = await run('<table><tr><td>content</td></tr></table>');
+      expect(
+        doc.querySelector('td')!.attributes['style'],
+        'overflow-wrap: anywhere;',
+      );
+    });
+
+    test('adds overflow-wrap: anywhere to th with no existing style', () async {
+      final doc = await run('<table><tr><th>header</th></tr></table>');
+      expect(
+        doc.querySelector('th')!.attributes['style'],
+        'overflow-wrap: anywhere;',
+      );
+    });
+
+    test('appends overflow-wrap to td that already has a style ending with semicolon', () async {
+      final doc = await run(
+        '<table><tr><td style="min-width: 80px;">label</td></tr></table>',
+      );
+      expect(
+        doc.querySelector('td')!.attributes['style'],
+        'min-width: 80px; overflow-wrap: anywhere;',
+      );
+    });
+
+    test('appends overflow-wrap with separator to td whose style has no trailing semicolon', () async {
+      final doc = await run(
+        '<table><tr><td style="color: red">text</td></tr></table>',
+      );
+      expect(
+        doc.querySelector('td')!.attributes['style'],
+        'color: red; overflow-wrap: anywhere;',
+      );
+    });
+
+    test('does not override overflow-wrap when it is already set on td', () async {
+      final doc = await run(
+        '<table><tr><td style="overflow-wrap: break-word;">url</td></tr></table>',
+      );
+      expect(
+        doc.querySelector('td')!.attributes['style'],
+        'overflow-wrap: break-word;',
+      );
+    });
+
+    test('processes all td and th elements in the document', () async {
+      final doc = await run('''
+        <table>
+          <tr><th>Time</th><td>Tuesday 10:00</td></tr>
+          <tr><th>Link</th><td>https://example.com/very-long-path</td></tr>
+        </table>
+      ''');
+      final cells = doc.querySelectorAll('td, th');
+      for (final cell in cells) {
+        expect(
+          cell.attributes['style'],
+          contains('overflow-wrap: anywhere'),
+          reason: 'Every td/th should have overflow-wrap: anywhere',
+        );
+      }
+    });
+
+    test('does nothing when document has no td or th elements', () async {
+      final doc = await run('<div><p>No tables here</p></div>');
+      expect(doc.querySelectorAll('td, th'), isEmpty);
+    });
+
+    test('preserves word-break and other existing inline styles', () async {
+      final doc = await run(
+        '<table><tr><td style="word-break: break-word; padding: 20px;">text</td></tr></table>',
+      );
+      final style = doc.querySelector('td')!.attributes['style']!;
+      expect(style, contains('word-break: break-word'));
+      expect(style, contains('padding: 20px'));
+      expect(style, contains('overflow-wrap: anywhere'));
+    });
+  });
+}

--- a/core/test/utils/responsive_table_cell_transformer_test.dart
+++ b/core/test/utils/responsive_table_cell_transformer_test.dart
@@ -65,6 +65,39 @@ void main() {
       );
     });
 
+    group('does not add overflow-wrap: anywhere when the property is already declared', () {
+      const existingDeclarationCases = {
+        'declared after other properties': 'color: red; overflow-wrap: break-word; padding: 4px;',
+        'declared using uppercase letters': 'OVERFLOW-WRAP: break-word;',
+      };
+
+      for (final MapEntry(:key, :value) in existingDeclarationCases.entries) {
+        test(key, () async {
+          final doc = await run(
+            '<table><tr><td style="$value">url</td></tr></table>',
+          );
+          final style = doc.querySelector('td')!.attributes['style']!;
+          expect(
+            RegExp(r'overflow-wrap\s*:\s*anywhere').hasMatch(style),
+            isFalse,
+            reason: 'Existing overflow-wrap declaration must be detected and must not be appended again',
+          );
+        });
+      }
+    });
+
+    test('appends overflow-wrap when style contains overflow-wrap only inside a custom property name', () async {
+      final doc = await run(
+        '<table><tr><td style="--custom-overflow-wrap: 1;">text</td></tr></table>',
+      );
+      final style = doc.querySelector('td')!.attributes['style']!;
+      expect(
+        style,
+        contains('overflow-wrap: anywhere'),
+        reason: 'A custom property name containing overflow-wrap must not prevent the declaration from being added',
+      );
+    });
+
     test('processes all td and th elements in the document', () async {
       final doc = await run('''
         <table>
@@ -106,6 +139,20 @@ void main() {
         'overflow-wrap'.allMatches(style).length,
         1,
         reason: 'overflow-wrap must appear exactly once even after multiple passes',
+      );
+    });
+
+    test('is idempotent when cell already has a custom property whose name contains overflow-wrap', () async {
+      final doc = parse(
+        '<table><tr><td style="--custom-overflow-wrap: 1;">text</td></tr></table>',
+      );
+      await transformer.process(document: doc, dioClient: dioClient);
+      await transformer.process(document: doc, dioClient: dioClient);
+      final style = doc.querySelector('td')!.attributes['style']!;
+      expect(
+        RegExp(r'overflow-wrap\s*:\s*anywhere').allMatches(style).length,
+        1,
+        reason: 'overflow-wrap: anywhere must appear exactly once even when a custom property name contains the substring',
       );
     });
 

--- a/core/test/utils/responsive_table_cell_transformer_test.dart
+++ b/core/test/utils/responsive_table_cell_transformer_test.dart
@@ -96,5 +96,47 @@ void main() {
       expect(style, contains('padding: 20px'));
       expect(style, contains('overflow-wrap: anywhere'));
     });
+
+    test('is idempotent — running twice does not duplicate overflow-wrap', () async {
+      final doc = parse('<table><tr><td>text</td></tr></table>');
+      await transformer.process(document: doc, dioClient: dioClient);
+      await transformer.process(document: doc, dioClient: dioClient);
+      final style = doc.querySelector('td')!.attributes['style']!;
+      expect(
+        'overflow-wrap'.allMatches(style).length,
+        1,
+        reason: 'overflow-wrap must appear exactly once even after multiple passes',
+      );
+    });
+
+    test('does not add overflow-wrap to non-table elements', () async {
+      final doc = await run('<div style="color: red"><p>text</p><span>more</span></div>');
+      for (final el in doc.querySelectorAll('div, p, span')) {
+        expect(
+          el.attributes['style'] ?? '',
+          isNot(contains('overflow-wrap')),
+          reason: 'Only td/th must be modified — not div, p, or span',
+        );
+      }
+    });
+
+    test('processes all td and th elements in nested tables', () async {
+      final doc = await run('''
+        <table>
+          <tr><td>outer
+            <table>
+              <tr><th>inner header</th><td>inner cell</td></tr>
+            </table>
+          </td></tr>
+        </table>
+      ''');
+      for (final cell in doc.querySelectorAll('td, th')) {
+        expect(
+          cell.attributes['style'],
+          contains('overflow-wrap: anywhere'),
+          reason: 'Every td/th in nested tables must have overflow-wrap: anywhere',
+        );
+      }
+    });
   });
 }

--- a/core/test/utils/transform_configuration_test.dart
+++ b/core/test/utils/transform_configuration_test.dart
@@ -1,0 +1,65 @@
+import 'package:core/presentation/utils/html_transformer/dom/responsive_table_cell_transformer.dart';
+import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+bool _hasResponsiveTransformer(List transformers) =>
+    transformers.any((t) => t is ResponsiveTableCellTransformer);
+
+void main() {
+  group('TransformConfiguration — ResponsiveTableCellTransformer membership', () {
+    test('standardDomTransformers includes ResponsiveTableCellTransformer', () {
+      expect(
+        _hasResponsiveTransformer(TransformConfiguration.standardDomTransformers),
+        isTrue,
+      );
+    });
+
+    test('forPreviewEmailOnWeb includes ResponsiveTableCellTransformer', () {
+      expect(
+        _hasResponsiveTransformer(
+          TransformConfiguration.forPreviewEmailOnWeb().domTransformers,
+        ),
+        isTrue,
+      );
+    });
+
+    test('forPreviewEmail includes ResponsiveTableCellTransformer via standardConfiguration', () {
+      expect(
+        _hasResponsiveTransformer(
+          TransformConfiguration.forPreviewEmail().domTransformers,
+        ),
+        isTrue,
+      );
+    });
+
+    test('forReplyForwardEmail does NOT include ResponsiveTableCellTransformer', () {
+      expect(
+        _hasResponsiveTransformer(
+          TransformConfiguration.forReplyForwardEmail().domTransformers,
+        ),
+        isFalse,
+        reason: 'Reply/forward editor must not mutate quoted content table styles',
+      );
+    });
+
+    test('forDraftsEmail does NOT include ResponsiveTableCellTransformer', () {
+      expect(
+        _hasResponsiveTransformer(
+          TransformConfiguration.forDraftsEmail().domTransformers,
+        ),
+        isFalse,
+        reason: 'Draft editor must not mutate table styles',
+      );
+    });
+
+    test('forPrintEmail does NOT include ResponsiveTableCellTransformer', () {
+      expect(
+        _hasResponsiveTransformer(
+          TransformConfiguration.forPrintEmail().domTransformers,
+        ),
+        isFalse,
+        reason: 'Print configuration does not need responsive wrapping',
+      );
+    });
+  });
+}

--- a/test/fixtures/html_email_corpus.dart
+++ b/test/fixtures/html_email_corpus.dart
@@ -120,6 +120,23 @@ abstract final class HtmlEmailCorpus {
   static const String htmlDoubleEncoded =
       '<p>&amp;lt;script&amp;gt;alert(1)&amp;lt;/script&amp;gt;</p>';
 
+  // ─── Table / responsive cells ─────────────────────────────────────────────
+  static const String htmlTableSimple =
+      '<table>'
+      '<tr><th>Name</th><th>Email</th></tr>'
+      '<tr><td>Alice</td><td>alice@example.com</td></tr>'
+      '</table>';
+
+  static const String htmlTableCellWithOverflowWrap =
+      '<table><tr>'
+      '<td style="overflow-wrap: break-word;">https://very-long-url.example.com/path</td>'
+      '</tr></table>';
+
+  static const String htmlTableCellWithOtherStyles =
+      '<table><tr>'
+      '<td style="color: green; padding: 8px">Revenue +12%</td>'
+      '</tr></table>';
+
   // ─── Multi-language ────────────────────────────────────────────────────────
   static const String htmlRtlArabic =
       '<div dir="rtl"><p>مرحبا بالعالم</p><p>البريد الإلكتروني</p></div>';


### PR DESCRIPTION
## Issue

#4482 

## Root cause

Two compounding issues:

1. **No `overflow-wrap` on `<td>`/`<th>` elements.** Without it, `table-layout: auto` computes each column's min-content width from its longest unbreakable token. A single long URL locks the column at that width regardless of the viewport.
2. **Missing `box-sizing: border-box` reset.** The default `content-box` sizing allows padding and borders to push cells beyond their declared width, adding more overflow on top.

## Solution

### `ResponsiveTableCellTransformer` (new DOM transformer)

Traverses every `<td>` and `<th>` in the parsed document and appends `overflow-wrap: anywhere` to its inline style.

- Uses **`anywhere`** (not `break-word`) because `anywhere` reduces the min-content width of the cell to zero, which is the property `table-layout: auto` needs to shrink columns to fit the viewport.
- **Skips cells that already declare `overflow-wrap`** to respect intentional author styling.
- Handles all inline-style edge cases: no existing style, trailing semicolon present, no trailing semicolon.

### `box-sizing: border-box` reset in `HtmlUtils.generateHtmlDocument`

Adds a universal `*, *::before, *::after { box-sizing: border-box; }` reset to the generated document's `<style>` block. This ensures padding and borders are included in the element's total width, eliminating a secondary source of overflow.

### `TransformConfiguration` wiring

The transformer is registered in both transformer lists (`standardDomTransformers` and the constructor-provided list) so it applies on all rendering paths.

## Resolved

- Mobile:


[demo-mobile.webm](https://github.com/user-attachments/assets/66433ca9-5c82-4f73-b976-b81a9c67ebc9)


- Web:



https://github.com/user-attachments/assets/85103fee-acf3-4534-be28-9d538d86011d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic injection of overflow-wrap into table cells to prevent overflow and improve responsiveness.
  * Global box-sizing reset added for consistent element sizing.

* **Configuration**
  * Table-cell wrapping behavior added to the DOM transform pipeline used for previews and shared transforms.

* **Tests**
  * Comprehensive tests for table-cell wrapping, idempotence, style preservation, pipeline coexistence, and HTML generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-flutter/pull/4542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->