### PR TITLE
Fix auto-load-more infinite loop / over-trigger on Android 10 Pro XL

### DIFF
--- a/docs/adr/0091-fix-auto-load-more-infinite-loop-large-screen.md
+++ b/docs/adr/0091-fix-auto-load-more-infinite-loop-large-screen.md
@@ -21,11 +21,15 @@ Root cause: the condition `maxScrollExtent <= viewportDimension` is equivalent t
 
 **Non-web:** Change auto-load threshold from `maxScrollExtent <= viewportDimension` to `maxScrollExtent <= 0` — trigger only when content has not yet filled the viewport.
 
-**Web:** Change estimated-height check from `totalHeight <= viewport` to `totalHeight < viewport` (strict) to avoid an extra load at the exact boundary.
+**Web:** Change estimated-height check from `totalHeightListEmails > 0 && totalHeightListEmails <= browserInnerHeight` to strict `totalHeight > 0 && totalHeight < viewportHeight` to avoid a spurious load when estimated height equals viewport height exactly.
 
-**Pagination:** Replace `canLoadMore = emailList.isNotEmpty` with `canLoadMore = emailList.length >= maxCountEmails`. A partial-page response means no more pages exist — no need to show Load More or make an empty request.
+**Pagination — initial load:** Replace `canLoadMore = emailList.isNotEmpty` with `canLoadMore = emailList.length >= maxCountEmails`. A partial-page response signals the last page — no further requests needed.
 
-Both detection methods extracted into `AutoLoadMorePolicy` for testability.
+**Pagination — load more:** Replace `canLoadMore = emailList.isNotEmpty` with `canLoadMore = serverEmailCount >= maxCountEmails`. For load-more, the repository removes the pagination-cursor email (last email of the previous page) from the response before returning, so `emailList.length` is always `maxCountEmails - 1` for a full page and would never satisfy `>= maxCountEmails`. `serverEmailCount` is captured before that removal and correctly reflects the server's actual response size.
+
+In both pagination paths, `canLoadMore` is now set unconditionally before the auto-load decision — not only in the `else` branch — ensuring the flag is always accurate regardless of whether auto-load fires.
+
+The two scroll-detection methods are extracted into `AutoLoadMorePolicy` for testability.
 
 ## Consequences
 

--- a/docs/adr/0091-fix-auto-load-more-infinite-loop-large-screen.md
+++ b/docs/adr/0091-fix-auto-load-more-infinite-loop-large-screen.md
@@ -1,0 +1,34 @@
+# 91. Fix auto-load-more infinite loop on large-screen devices
+
+Date: 2026-05-22
+
+## Status
+
+Accepted
+
+## Context
+
+On Android 10 Pro XL, opening a mailbox triggered an infinite chain of load-more requests. Log confirmed:
+
+```text
+ThreadController::_isNonWebAutoLoadMore():
+  maxScroll = 785.04, viewport = 816.33, isAutoLoadMore = true
+```
+
+Root cause: the condition `maxScrollExtent <= viewportDimension` is equivalent to *content height ≤ 2× viewport*, so on a large screen where 20 emails fill ~1.9× the viewport, auto-load kept firing after every page until the server ran out of emails. Smaller phones were unaffected because their content overflows 2× viewport after the first page.
+
+## Decision
+
+**Non-web:** Change auto-load threshold from `maxScrollExtent <= viewportDimension` to `maxScrollExtent <= 0` — trigger only when content has not yet filled the viewport.
+
+**Web:** Change estimated-height check from `totalHeight <= viewport` to `totalHeight < viewport` (strict) to avoid an extra load at the exact boundary.
+
+**Pagination:** Replace `canLoadMore = emailList.isNotEmpty` with `canLoadMore = emailList.length >= maxCountEmails`. A partial-page response means no more pages exist — no need to show Load More or make an empty request.
+
+Both detection methods extracted into `AutoLoadMorePolicy` for testability.
+
+## Consequences
+
+- Infinite loop fixed on large-screen Android. Normal phones unaffected — the new condition only changes behaviour when content fits within the viewport, which doesn't occur on smaller screens after the first page.
+- Load More button hidden correctly when mailbox has fewer emails than one page.
+- Unit tests and widget tests added for all three logic changes.

--- a/lib/features/thread/data/repository/thread_repository_impl.dart
+++ b/lib/features/thread/data/repository/thread_repository_impl.dart
@@ -465,11 +465,13 @@ class ThreadRepositoryImpl extends ThreadRepository {
           properties: emailRequest.properties)
         .then((response) {
           final listEmails = response.emailList;
+          final serverEmailCount = listEmails?.length ?? 0;
           if (emailRequest.lastEmailId != null && listEmails?.isNotEmpty == true) {
             listEmails?.removeWhere((email) => email.id == emailRequest.lastEmailId);
           }
           return EmailsResponse(
             emailList: listEmails,
+            serverEmailCount: serverEmailCount,
             state: response.state,
             notFoundEmailIds: response.notFoundEmailIds,
           );

--- a/lib/features/thread/domain/model/email_response.dart
+++ b/lib/features/thread/domain/model/email_response.dart
@@ -9,12 +9,14 @@ class EmailsResponse with EquatableMixin {
   final List<EmailId>? notFoundEmailIds;
   final State? state;
   final EmailChangeResponse? emailChangeResponse;
+  final int? serverEmailCount;
 
   const EmailsResponse({
     this.emailList,
     this.notFoundEmailIds,
     this.state,
     this.emailChangeResponse,
+    this.serverEmailCount,
   });
 
   bool hasEmails() => emailList != null && emailList!.isNotEmpty;
@@ -29,6 +31,7 @@ class EmailsResponse with EquatableMixin {
     notFoundEmailIds,
     state,
     emailChangeResponse,
+    serverEmailCount,
   ];
 
   EmailsResponse copyWith({
@@ -36,12 +39,14 @@ class EmailsResponse with EquatableMixin {
     List<EmailId>? notFoundEmailIds,
     State? state,
     EmailChangeResponse? emailChangeResponse,
+    int? serverEmailCount,
   }) {
     return EmailsResponse(
       emailList: emailList ?? this.emailList,
       notFoundEmailIds: notFoundEmailIds ?? this.notFoundEmailIds,
       state: state ?? this.state,
       emailChangeResponse: emailChangeResponse ?? this.emailChangeResponse,
+      serverEmailCount: serverEmailCount ?? this.serverEmailCount,
     );
   }
 }

--- a/lib/features/thread/domain/state/load_more_emails_state.dart
+++ b/lib/features/thread/domain/state/load_more_emails_state.dart
@@ -6,11 +6,12 @@ class LoadingMoreEmails extends LoadingState {}
 
 class LoadMoreEmailsSuccess extends UIState {
   final List<PresentationEmail> emailList;
+  final int serverEmailCount;
 
-  LoadMoreEmailsSuccess(this.emailList);
+  LoadMoreEmailsSuccess(this.emailList, {required this.serverEmailCount});
 
   @override
-  List<Object?> get props => [emailList];
+  List<Object?> get props => [emailList, serverEmailCount];
 }
 
 class LoadMoreEmailsFailure extends FeatureFailure {

--- a/lib/features/thread/domain/usecases/load_more_emails_in_mailbox_interactor.dart
+++ b/lib/features/thread/domain/usecases/load_more_emails_in_mailbox_interactor.dart
@@ -25,6 +25,9 @@ class LoadMoreEmailsInMailboxInteractor {
     final presentationEmailList = emailResponse.emailList
       ?.map((email) => email.toPresentationEmail()).toList() ?? List.empty();
 
-    return Right<Failure, Success>(LoadMoreEmailsSuccess(presentationEmailList));
+    return Right<Failure, Success>(LoadMoreEmailsSuccess(
+      presentationEmailList,
+      serverEmailCount: emailResponse.serverEmailCount ?? presentationEmailList.length,
+    ));
   }
 }

--- a/lib/features/thread/presentation/model/auto_load_more_policy.dart
+++ b/lib/features/thread/presentation/model/auto_load_more_policy.dart
@@ -1,0 +1,16 @@
+class AutoLoadMorePolicy {
+  AutoLoadMorePolicy._();
+
+  // <= 0 (not <= viewport) prevents loop on large screens where the first page
+  // fills 1×–2× the viewport, leaving maxScrollExtent in range (0, viewport].
+  static bool shouldAutoLoadMoreByScrollExtent(double maxScrollExtent) =>
+      maxScrollExtent <= 0;
+
+  // Strict < avoids a spurious load when estimated height equals viewport —
+  // actual rendered height is usually larger than the 40 px/item estimate.
+  static bool shouldAutoLoadMoreByEstimatedHeight(
+    int totalHeight,
+    int viewportHeight,
+  ) =>
+      totalHeight > 0 && totalHeight < viewportHeight;
+}

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -523,8 +523,10 @@ class ThreadController extends BaseController with EmailActionController {
         ? 0
         : currentListEmails.length *
             ThreadConstants.defaultMaxHeightEmailItemOnBrowser;
-    final isAutoLoadMore = totalHeightListEmails > 0 &&
-        totalHeightListEmails <= browserInnerHeight;
+    final isAutoLoadMore = shouldAutoLoadMoreByEstimatedHeight(
+      totalHeightListEmails,
+      browserInnerHeight,
+    );
     logTrace(
       'ThreadController::_isAutoLoadMore():'
       'BrowserInnerHeight = $browserInnerHeight, '
@@ -536,6 +538,17 @@ class ThreadController extends BaseController with EmailActionController {
     );
     return isAutoLoadMore;
   }
+
+  // Returns true only when the estimated list height has not yet filled the
+  // viewport (strictly less-than), so the list needs more items to fill the screen.
+  // Uses strict < to avoid triggering an extra load when estimated height equals
+  // the viewport — the actual rendered height is likely already overflowing.
+  @visibleForTesting
+  static bool shouldAutoLoadMoreByEstimatedHeight(
+    int totalHeight,
+    int viewportHeight,
+  ) =>
+      totalHeight > 0 && totalHeight < viewportHeight;
 
   bool get _isNonWebAutoLoadMore {
     if (!listEmailController.hasClients) {

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -648,7 +648,10 @@ class ThreadController extends BaseController with EmailActionController {
     log('ThreadController::_handleOnDoneGetAllEmailSuccess: EmailCount = ${emailList.length}');
     final hasMore = emailList.length >= ThreadConstants.maxCountEmails;
     canLoadMore = hasMore;
-    if (_isAutoLoadMore && hasMore) {
+    if (_isAutoLoadMore && emailList.isNotEmpty) {
+      // collapseThreads can return < limit; re-enable so _loadMoreEmails guard passes.
+      // _loadMoreEmailsSuccess will reset canLoadMore from serverEmailCount afterward.
+      canLoadMore = true;
       _performAutomaticallyLoadMoreEmails();
     }
   }

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -73,6 +73,7 @@ import 'package:tmail_ui_user/features/thread/presentation/extensions/handle_key
 import 'package:tmail_ui_user/features/thread/presentation/extensions/list_presentation_email_extensions.dart';
 import 'package:tmail_ui_user/features/thread/presentation/extensions/refresh_thread_detail_extension.dart';
 import 'package:tmail_ui_user/features/thread/presentation/mixin/email_action_controller.dart';
+import 'package:tmail_ui_user/features/thread/presentation/model/auto_load_more_policy.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/delete_action_type.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/loading_more_status.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/mail_list_shortcut_action_view_event.dart';
@@ -523,7 +524,7 @@ class ThreadController extends BaseController with EmailActionController {
         ? 0
         : currentListEmails.length *
             ThreadConstants.defaultMaxHeightEmailItemOnBrowser;
-    final isAutoLoadMore = shouldAutoLoadMoreByEstimatedHeight(
+    final isAutoLoadMore = AutoLoadMorePolicy.shouldAutoLoadMoreByEstimatedHeight(
       totalHeightListEmails,
       browserInnerHeight,
     );
@@ -539,17 +540,6 @@ class ThreadController extends BaseController with EmailActionController {
     return isAutoLoadMore;
   }
 
-  // Returns true only when the estimated list height has not yet filled the
-  // viewport (strictly less-than), so the list needs more items to fill the screen.
-  // Uses strict < to avoid triggering an extra load when estimated height equals
-  // the viewport — the actual rendered height is likely already overflowing.
-  @visibleForTesting
-  static bool shouldAutoLoadMoreByEstimatedHeight(
-    int totalHeight,
-    int viewportHeight,
-  ) =>
-      totalHeight > 0 && totalHeight < viewportHeight;
-
   bool get _isNonWebAutoLoadMore {
     if (!listEmailController.hasClients) {
       logTrace(
@@ -560,7 +550,7 @@ class ThreadController extends BaseController with EmailActionController {
 
     final maxScroll = listEmailController.position.maxScrollExtent;
     final viewport = listEmailController.position.viewportDimension;
-    final isAutoLoadMore = shouldAutoLoadMoreByScrollExtent(maxScroll);
+    final isAutoLoadMore = AutoLoadMorePolicy.shouldAutoLoadMoreByScrollExtent(maxScroll);
 
     logTrace(
       'ThreadController::_isNonWebAutoLoadMore():'
@@ -572,12 +562,6 @@ class ThreadController extends BaseController with EmailActionController {
 
     return isAutoLoadMore;
   }
-
-  // Returns true only when the content does not yet fill the viewport
-  // (maxScrollExtent == 0), so the list needs more items to fill the screen.
-  @visibleForTesting
-  static bool shouldAutoLoadMoreByScrollExtent(double maxScrollExtent) =>
-      maxScrollExtent <= 0;
 
   void _performAutomaticallyLoadMoreEmails() {
     log('ThreadController::_performAutomaticallyLoadMoreEmails:');

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -1014,7 +1014,7 @@ class ThreadController extends BaseController with EmailActionController {
       mailboxDashBoardController.emailsInCurrentMailbox.addAll(appendableList);
     }
 
-    canLoadMore = emailList.length >= ThreadConstants.maxCountEmails;
+    canLoadMore = success.serverEmailCount >= ThreadConstants.maxCountEmails;
     if (_isAutoLoadMore && canLoadMore) {
       _performAutomaticallyLoadMoreEmails();
     } else {

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -547,7 +547,7 @@ class ThreadController extends BaseController with EmailActionController {
 
     final maxScroll = listEmailController.position.maxScrollExtent;
     final viewport = listEmailController.position.viewportDimension;
-    final isAutoLoadMore = maxScroll <= viewport;
+    final isAutoLoadMore = shouldAutoLoadMoreByScrollExtent(maxScroll);
 
     logTrace(
       'ThreadController::_isNonWebAutoLoadMore():'
@@ -559,6 +559,12 @@ class ThreadController extends BaseController with EmailActionController {
 
     return isAutoLoadMore;
   }
+
+  // Returns true only when the content does not yet fill the viewport
+  // (maxScrollExtent == 0), so the list needs more items to fill the screen.
+  @visibleForTesting
+  static bool shouldAutoLoadMoreByScrollExtent(double maxScrollExtent) =>
+      maxScrollExtent <= 0;
 
   void _performAutomaticallyLoadMoreEmails() {
     log('ThreadController::_performAutomaticallyLoadMoreEmails:');
@@ -643,10 +649,10 @@ class ThreadController extends BaseController with EmailActionController {
     }
     final emailList = success.emailList;
     log('ThreadController::_handleOnDoneGetAllEmailSuccess: EmailCount = ${emailList.length}');
-    if (_isAutoLoadMore && emailList.isNotEmpty) {
+    final hasMore = emailList.length >= ThreadConstants.maxCountEmails;
+    canLoadMore = hasMore;
+    if (_isAutoLoadMore && hasMore) {
       _performAutomaticallyLoadMoreEmails();
-    } else {
-      canLoadMore = emailList.isNotEmpty;
     }
   }
 
@@ -1011,10 +1017,10 @@ class ThreadController extends BaseController with EmailActionController {
       mailboxDashBoardController.emailsInCurrentMailbox.addAll(appendableList);
     }
 
-    if (_isAutoLoadMore && emailList.isNotEmpty) {
+    canLoadMore = emailList.length >= ThreadConstants.maxCountEmails;
+    if (_isAutoLoadMore && canLoadMore) {
       _performAutomaticallyLoadMoreEmails();
     } else {
-      canLoadMore = emailList.isNotEmpty;
       loadingMoreStatus.value = LoadingMoreStatus.completed;
     }
   }

--- a/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
+++ b/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
@@ -109,6 +109,7 @@ import 'package:tmail_ui_user/features/thread/domain/usecases/refresh_changes_em
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_more_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
+import 'package:tmail_ui_user/features/thread/domain/constants/thread_constants.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_view.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
@@ -656,7 +657,7 @@ void main() {
 
       testWidgets(
         'LoadMoreButton SHOULD be displayed\n'
-        'WHEN the load more action returns a non-empty list',
+        'WHEN the load more action returns a full page',
       (tester) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
         final dpi = tester.view.devicePixelRatio;
@@ -684,21 +685,16 @@ void main() {
         mailboxDashboardController.setSelectedMailbox(MailboxFixtures.inboxMailbox.toPresentationMailbox());
         mailboxDashboardController.updateEmailList(listEmailsOfInbox);
 
-        // Perform load more action
-        final emailList = <PresentationEmail>[
-          PresentationEmail(
-            id: EmailId(Id('id_4')),
+        // A full page response signals more emails may exist on the server
+        final emailList = List.generate(
+          ThreadConstants.maxCountEmails,
+          (index) => PresentationEmail(
+            id: EmailId(Id('load_more_$index')),
             mailboxIds: {
               MailboxFixtures.inboxMailbox.id!: true
             }
           ),
-          PresentationEmail(
-            id: EmailId(Id('id_5')),
-            mailboxIds: {
-              MailboxFixtures.inboxMailbox.id!: true
-            }
-          ),
-        ];
+        );
         threadController.consumeState(Stream.value(Right(LoadMoreEmailsSuccess(emailList))));
 
         await tester.pump();

--- a/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
+++ b/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
@@ -695,7 +695,10 @@ void main() {
             }
           ),
         );
-        threadController.consumeState(Stream.value(Right(LoadMoreEmailsSuccess(emailList))));
+        threadController.consumeState(Stream.value(Right(LoadMoreEmailsSuccess(
+          emailList,
+          serverEmailCount: emailList.length,
+        ))));
 
         await tester.pump();
 
@@ -740,7 +743,10 @@ void main() {
 
         // Perform load more action
         final emailList = <PresentationEmail>[];
-        threadController.consumeState(Stream.value(Right(LoadMoreEmailsSuccess(emailList))));
+        threadController.consumeState(Stream.value(Right(LoadMoreEmailsSuccess(
+          emailList,
+          serverEmailCount: emailList.length,
+        ))));
 
         await tester.pump();
 

--- a/test/features/thread/data/repository/thread_repository_impl_test.dart
+++ b/test/features/thread/data/repository/thread_repository_impl_test.dart
@@ -1057,6 +1057,84 @@ void main() {
         destroyed: anyNamed('created'),
       ));
     });
+
+    test(
+      'GIVEN server returns a full page and one email matches lastEmailId '
+      'WHEN loadMoreEmails strips the anchor '
+      'THEN serverEmailCount SHOULD equal the server count before stripping',
+    () async {
+      final anchorId = EmailId(Id('anchor'));
+      final serverEmails = [
+        Email(id: anchorId),
+        ...List.generate(
+          ThreadConstants.defaultLimit.value.toInt() - 1,
+          (i) => Email(id: EmailId(Id('email_$i'))),
+        ),
+      ];
+      // Capture before the call — removeWhere modifies serverEmails in-place
+      final expectedServerCount = serverEmails.length;
+
+      when(threadDataSource.getAllEmail(
+        any,
+        any,
+        position: anyNamed('position'),
+        filter: anyNamed('filter'),
+        limit: anyNamed('limit'),
+        sort: anyNamed('sort'),
+        properties: anyNamed('properties'),
+      )).thenAnswer((_) => Future.value(EmailsResponse(
+        emailList: serverEmails,
+        state: State('s1'),
+      )));
+
+      final responses = await threadRepository
+          .loadMoreEmails(GetEmailRequest(
+            SessionFixtures.aliceSession,
+            AccountFixtures.aliceAccountId,
+            lastEmailId: anchorId,
+          ))
+          .toList();
+
+      expect(responses.length, 1);
+      expect(responses[0].serverEmailCount, expectedServerCount);
+      expect(responses[0].emailList?.length, expectedServerCount - 1);
+    });
+
+    test(
+      'GIVEN server returns a full page and lastEmailId is absent from the response '
+      'WHEN loadMoreEmails finds nothing to strip '
+      'THEN serverEmailCount SHOULD equal emailList length',
+    () async {
+      final serverEmails = List.generate(
+        ThreadConstants.defaultLimit.value.toInt(),
+        (i) => Email(id: EmailId(Id('email_$i'))),
+      );
+
+      when(threadDataSource.getAllEmail(
+        any,
+        any,
+        position: anyNamed('position'),
+        filter: anyNamed('filter'),
+        limit: anyNamed('limit'),
+        sort: anyNamed('sort'),
+        properties: anyNamed('properties'),
+      )).thenAnswer((_) => Future.value(EmailsResponse(
+        emailList: serverEmails,
+        state: State('s1'),
+      )));
+
+      final responses = await threadRepository
+          .loadMoreEmails(GetEmailRequest(
+            SessionFixtures.aliceSession,
+            AccountFixtures.aliceAccountId,
+            lastEmailId: EmailId(Id('not_in_response')),
+          ))
+          .toList();
+
+      expect(responses.length, 1);
+      expect(responses[0].serverEmailCount, serverEmails.length);
+      expect(responses[0].emailList?.length, serverEmails.length);
+    });
   });
 
   group('ThreadRepositoryImpl::refreshChanges', () {

--- a/test/features/thread/domain/usecases/load_more_emails_in_mailbox_interactor_test.dart
+++ b/test/features/thread/domain/usecases/load_more_emails_in_mailbox_interactor_test.dart
@@ -1,0 +1,120 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/thread/domain/constants/thread_constants.dart';
+import 'package:tmail_ui_user/features/thread/domain/model/email_response.dart';
+import 'package:tmail_ui_user/features/thread/domain/model/get_email_request.dart';
+import 'package:tmail_ui_user/features/thread/domain/repository/thread_repository.dart';
+import 'package:tmail_ui_user/features/thread/domain/state/load_more_emails_state.dart';
+import 'package:tmail_ui_user/features/thread/domain/usecases/load_more_emails_in_mailbox_interactor.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import '../../../../fixtures/session_fixtures.dart';
+
+import 'load_more_emails_in_mailbox_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<ThreadRepository>(),
+])
+void main() {
+  late MockThreadRepository mockThreadRepository;
+  late LoadMoreEmailsInMailboxInteractor interactor;
+
+  setUp(() {
+    mockThreadRepository = MockThreadRepository();
+    interactor = LoadMoreEmailsInMailboxInteractor(mockThreadRepository);
+  });
+
+  final request = GetEmailRequest(
+    SessionFixtures.aliceSession,
+    AccountFixtures.aliceAccountId,
+  );
+
+  group('LoadMoreEmailsInMailboxInteractor serverEmailCount:', () {
+    test(
+      'GIVEN repo returns EmailsResponse with serverEmailCount set '
+      'WHEN interactor maps to LoadMoreEmailsSuccess '
+      'THEN serverEmailCount SHOULD equal the repo value',
+    () async {
+      final serverEmails = List.generate(
+        ThreadConstants.maxCountEmails,
+        (i) => Email(id: EmailId(Id('e$i'))),
+      );
+
+      when(mockThreadRepository.loadMoreEmails(request))
+          .thenAnswer((_) => Stream.value(EmailsResponse(
+            emailList: serverEmails,
+            serverEmailCount: ThreadConstants.maxCountEmails,
+          )));
+
+      final states = await interactor.execute(request).toList();
+
+      final success = states
+          .whereType<Right>()
+          .map((r) => r.value)
+          .whereType<LoadMoreEmailsSuccess>()
+          .first;
+
+      expect(success.serverEmailCount, ThreadConstants.maxCountEmails);
+      expect(success.emailList.length, ThreadConstants.maxCountEmails);
+    });
+
+    test(
+      'GIVEN repo returns EmailsResponse with serverEmailCount > emailList.length '
+      '(anchor was stripped) '
+      'WHEN interactor maps to LoadMoreEmailsSuccess '
+      'THEN serverEmailCount SHOULD reflect the pre-strip count, not the stripped count',
+    () async {
+      final strippedEmails = List.generate(
+        ThreadConstants.maxCountEmails - 1,
+        (i) => Email(id: EmailId(Id('e$i'))),
+      );
+
+      when(mockThreadRepository.loadMoreEmails(request))
+          .thenAnswer((_) => Stream.value(EmailsResponse(
+            emailList: strippedEmails,
+            serverEmailCount: ThreadConstants.maxCountEmails,
+          )));
+
+      final states = await interactor.execute(request).toList();
+
+      final success = states
+          .whereType<Right>()
+          .map((r) => r.value)
+          .whereType<LoadMoreEmailsSuccess>()
+          .first;
+
+      expect(success.serverEmailCount, ThreadConstants.maxCountEmails);
+      expect(success.emailList.length, ThreadConstants.maxCountEmails - 1);
+    });
+
+    test(
+      'GIVEN repo returns EmailsResponse with serverEmailCount null '
+      'WHEN interactor maps to LoadMoreEmailsSuccess '
+      'THEN serverEmailCount SHOULD fall back to emailList.length',
+    () async {
+      final emails = List.generate(
+        5,
+        (i) => Email(id: EmailId(Id('e$i'))),
+      );
+
+      when(mockThreadRepository.loadMoreEmails(request))
+          .thenAnswer((_) => Stream.value(EmailsResponse(
+            emailList: emails,
+          )));
+
+      final states = await interactor.execute(request).toList();
+
+      final success = states
+          .whereType<Right>()
+          .map((r) => r.value)
+          .whereType<LoadMoreEmailsSuccess>()
+          .first;
+
+      expect(success.serverEmailCount, emails.length);
+    });
+  });
+}

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -46,6 +46,7 @@ import 'package:tmail_ui_user/features/thread/domain/usecases/load_more_emails_i
 import 'package:tmail_ui_user/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_more_email_interactor.dart';
+import 'package:tmail_ui_user/features/thread/presentation/model/auto_load_more_policy.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/search_state.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/search_status.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
@@ -671,7 +672,7 @@ void main() {
         'WHEN content exactly fills the viewport '
         'THEN SHOULD return true',
       () {
-        expect(ThreadController.shouldAutoLoadMoreByScrollExtent(0), isTrue);
+        expect(AutoLoadMorePolicy.shouldAutoLoadMoreByScrollExtent(0), isTrue);
       });
 
       test(
@@ -679,7 +680,7 @@ void main() {
         'WHEN content overflows the viewport '
         'THEN SHOULD return false',
       () {
-        expect(ThreadController.shouldAutoLoadMoreByScrollExtent(1), isFalse);
+        expect(AutoLoadMorePolicy.shouldAutoLoadMoreByScrollExtent(1), isFalse);
       });
 
       test(
@@ -688,7 +689,7 @@ void main() {
         'THEN SHOULD return false to prevent infinite load-more loop',
       () {
         expect(
-          ThreadController.shouldAutoLoadMoreByScrollExtent(785.0459770114941),
+          AutoLoadMorePolicy.shouldAutoLoadMoreByScrollExtent(785.0459770114941),
           isFalse,
         );
       });
@@ -716,7 +717,7 @@ void main() {
         final maxScroll = scrollController.position.maxScrollExtent;
         expect(maxScroll, greaterThan(0));
         expect(
-          ThreadController.shouldAutoLoadMoreByScrollExtent(maxScroll),
+          AutoLoadMorePolicy.shouldAutoLoadMoreByScrollExtent(maxScroll),
           isFalse,
         );
       });
@@ -742,7 +743,7 @@ void main() {
         final maxScroll = scrollController.position.maxScrollExtent;
         expect(maxScroll, 0.0);
         expect(
-          ThreadController.shouldAutoLoadMoreByScrollExtent(maxScroll),
+          AutoLoadMorePolicy.shouldAutoLoadMoreByScrollExtent(maxScroll),
           isTrue,
         );
       });
@@ -871,7 +872,7 @@ void main() {
         'THEN SHOULD return false — nothing to trigger load from',
       () {
         expect(
-          ThreadController.shouldAutoLoadMoreByEstimatedHeight(0, 816),
+          AutoLoadMorePolicy.shouldAutoLoadMoreByEstimatedHeight(0, 816),
           isFalse,
         );
       });
@@ -882,7 +883,7 @@ void main() {
         'THEN SHOULD return true',
       () {
         expect(
-          ThreadController.shouldAutoLoadMoreByEstimatedHeight(800, 816),
+          AutoLoadMorePolicy.shouldAutoLoadMoreByEstimatedHeight(800, 816),
           isTrue,
         );
       });
@@ -893,7 +894,7 @@ void main() {
         'THEN SHOULD return false — actual rendered height likely already overflows',
       () {
         expect(
-          ThreadController.shouldAutoLoadMoreByEstimatedHeight(816, 816),
+          AutoLoadMorePolicy.shouldAutoLoadMoreByEstimatedHeight(816, 816),
           isFalse,
         );
       });
@@ -904,7 +905,7 @@ void main() {
         'THEN SHOULD return false',
       () {
         expect(
-          ThreadController.shouldAutoLoadMoreByEstimatedHeight(1200, 816),
+          AutoLoadMorePolicy.shouldAutoLoadMoreByEstimatedHeight(1200, 816),
           isFalse,
         );
       });
@@ -917,7 +918,7 @@ void main() {
         const estimatedHeight =
             20 * ThreadConstants.defaultMaxHeightEmailItemOnBrowser;
         expect(
-          ThreadController.shouldAutoLoadMoreByEstimatedHeight(estimatedHeight, 816),
+          AutoLoadMorePolicy.shouldAutoLoadMoreByEstimatedHeight(estimatedHeight, 816),
           isTrue,
         );
       });
@@ -930,7 +931,7 @@ void main() {
         const estimatedHeight =
             21 * ThreadConstants.defaultMaxHeightEmailItemOnBrowser;
         expect(
-          ThreadController.shouldAutoLoadMoreByEstimatedHeight(estimatedHeight, 816),
+          AutoLoadMorePolicy.shouldAutoLoadMoreByEstimatedHeight(estimatedHeight, 816),
           isFalse,
         );
       });

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -863,5 +863,77 @@ void main() {
         expect(threadController.canLoadMore, isFalse);
       });
     });
+
+    group('shouldAutoLoadMoreByEstimatedHeight unit test:', () {
+      test(
+        'GIVEN totalHeight is 0 (empty list) '
+        'WHEN no emails are loaded '
+        'THEN SHOULD return false — nothing to trigger load from',
+      () {
+        expect(
+          ThreadController.shouldAutoLoadMoreByEstimatedHeight(0, 816),
+          isFalse,
+        );
+      });
+
+      test(
+        'GIVEN totalHeight is less than viewportHeight '
+        'WHEN content does not fill the viewport '
+        'THEN SHOULD return true',
+      () {
+        expect(
+          ThreadController.shouldAutoLoadMoreByEstimatedHeight(800, 816),
+          isTrue,
+        );
+      });
+
+      test(
+        'GIVEN totalHeight equals viewportHeight '
+        'WHEN estimated height exactly fills the viewport '
+        'THEN SHOULD return false — actual rendered height likely already overflows',
+      () {
+        expect(
+          ThreadController.shouldAutoLoadMoreByEstimatedHeight(816, 816),
+          isFalse,
+        );
+      });
+
+      test(
+        'GIVEN totalHeight exceeds viewportHeight '
+        'WHEN content overflows the viewport '
+        'THEN SHOULD return false',
+      () {
+        expect(
+          ThreadController.shouldAutoLoadMoreByEstimatedHeight(1200, 816),
+          isFalse,
+        );
+      });
+
+      test(
+        'GIVEN 20 emails × 40px estimate = 800px with viewport 816px '
+        'WHEN actual rendered height is likely larger (e.g. 70px/email = 1400px) '
+        'THEN SHOULD return true — one extra load may occur but no infinite loop',
+      () {
+        const estimatedHeight =
+            20 * ThreadConstants.defaultMaxHeightEmailItemOnBrowser;
+        expect(
+          ThreadController.shouldAutoLoadMoreByEstimatedHeight(estimatedHeight, 816),
+          isTrue,
+        );
+      });
+
+      test(
+        'GIVEN 21 emails × 40px estimate = 840px with viewport 816px '
+        'WHEN estimated height exceeds viewport on large-screen browser '
+        'THEN SHOULD return false to prevent infinite load-more loop',
+      () {
+        const estimatedHeight =
+            21 * ThreadConstants.defaultMaxHeightEmailItemOnBrowser;
+        expect(
+          ThreadController.shouldAutoLoadMoreByEstimatedHeight(estimatedHeight, 816),
+          isFalse,
+        );
+      });
+    });
   });
 }

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -798,6 +798,36 @@ void main() {
 
         expect(threadController.canLoadMore, isTrue);
       });
+
+      test(
+        'GIVEN server returns an empty list '
+        'WHEN getAllEmail stream completes (empty mailbox) '
+        'THEN canLoadMore SHOULD be false',
+      () {
+        setupMocksForOnDone();
+        threadController.viewState.value = Right(
+          GetAllEmailSuccess(emailList: makeEmails(0), currentMailboxId: mailboxId),
+        );
+
+        threadController.onDone();
+
+        expect(threadController.canLoadMore, isFalse);
+      });
+
+      test(
+        'GIVEN getAllEmail fails and auto-load is not active '
+        'WHEN the stream completes with GetAllEmailFailure '
+        'THEN canLoadMore SHOULD be false',
+      () {
+        setupMocksForOnDone();
+        threadController.canLoadMore = true;
+        threadController.viewState.value =
+            Left(GetAllEmailFailure(Exception('boom')));
+
+        threadController.onDone();
+
+        expect(threadController.canLoadMore, isFalse);
+      });
     });
 
     group('canLoadMore after loadMoreEmails completes test:', () {
@@ -834,7 +864,10 @@ void main() {
         setupMocksForLoadMore();
         final emails = makeEmails(5);
 
-        threadController.handleSuccessViewState(LoadMoreEmailsSuccess(emails));
+        threadController.handleSuccessViewState(LoadMoreEmailsSuccess(
+          emails,
+          serverEmailCount: emails.length,
+        ));
 
         expect(threadController.canLoadMore, isFalse);
       });
@@ -847,7 +880,10 @@ void main() {
         setupMocksForLoadMore();
         final emails = makeEmails(ThreadConstants.maxCountEmails);
 
-        threadController.handleSuccessViewState(LoadMoreEmailsSuccess(emails));
+        threadController.handleSuccessViewState(LoadMoreEmailsSuccess(
+          emails,
+          serverEmailCount: emails.length,
+        ));
 
         expect(threadController.canLoadMore, isTrue);
       });
@@ -859,9 +895,94 @@ void main() {
       () {
         setupMocksForLoadMore();
 
-        threadController.handleSuccessViewState(LoadMoreEmailsSuccess([]));
+        threadController.handleSuccessViewState(LoadMoreEmailsSuccess(
+          [],
+          serverEmailCount: 0,
+        ));
 
         expect(threadController.canLoadMore, isFalse);
+      });
+
+      test(
+        'REGRESSION GIVEN a full server page whose anchor was stripped by the repo '
+        '(arrives here as limit-1 = 19 all-new emails) '
+        'WHEN more pages still exist on the server '
+        'THEN canLoadMore SHOULD be true — a 19-item page must NOT be read as end-of-list',
+      () {
+        setupMocksForLoadMore();
+        final emails = makeEmails(ThreadConstants.maxCountEmails - 1);
+
+        threadController.handleSuccessViewState(LoadMoreEmailsSuccess(
+          emails,
+          serverEmailCount: ThreadConstants.maxCountEmails,
+        ));
+
+        expect(threadController.canLoadMore, isTrue);
+      });
+    });
+
+    group('canLoadMore lifecycle & guard regression:', () {
+      test(
+        'GIVEN canLoadMore was exhausted (false) '
+        'WHEN resetToOriginalValue runs (e.g. switching mailbox) '
+        'THEN canLoadMore SHOULD be re-enabled so the new mailbox can paginate',
+      () {
+        when(mockMailboxDashBoardController.emailsInCurrentMailbox)
+            .thenReturn(RxList([]));
+        when(mockMailboxDashBoardController.listEmailSelected)
+            .thenReturn(RxList([]));
+        when(mockMailboxDashBoardController.currentSelectMode)
+            .thenReturn(Rx(SelectMode.INACTIVE));
+        threadController.canLoadMore = false;
+
+        threadController.resetToOriginalValue();
+
+        expect(threadController.canLoadMore, isTrue);
+      });
+
+      test(
+        'GIVEN a load-more request failed '
+        'WHEN handleFailureViewState receives LoadMoreEmailsFailure '
+        'THEN canLoadMore SHOULD be true so the user can retry',
+      () {
+        threadController.canLoadMore = false;
+
+        threadController.handleFailureViewState(
+          LoadMoreEmailsFailure(Exception('network')),
+        );
+
+        expect(threadController.canLoadMore, isTrue);
+      });
+
+      test(
+        'GIVEN canLoadMore is false and search is not active '
+        'WHEN handleLoadMoreEmailsRequest is invoked '
+        'THEN the load-more interactor SHOULD NOT be called — the guard blocks it',
+      () {
+        when(mockMailboxDashBoardController.searchController)
+            .thenReturn(mockSearchController);
+        when(mockSearchController.isSearchEmailRunning).thenReturn(false);
+        threadController.canLoadMore = false;
+
+        threadController.handleLoadMoreEmailsRequest();
+
+        verifyNever(mockLoadMoreEmailsInMailboxInteractor.execute(any));
+      });
+
+      test(
+        'GIVEN search is active '
+        'WHEN handleLoadMoreEmailsRequest is invoked '
+        'THEN it routes to search-more, NOT load-more (canLoadMore is not consulted)',
+      () {
+        when(mockMailboxDashBoardController.searchController)
+            .thenReturn(mockSearchController);
+        when(mockSearchController.isSearchEmailRunning).thenReturn(true);
+        threadController.canSearchMore = false;
+        threadController.canLoadMore = true;
+
+        threadController.handleLoadMoreEmailsRequest();
+
+        verifyNever(mockLoadMoreEmailsInMailboxInteractor.execute(any));
       });
     });
 

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -5,6 +5,7 @@ import 'package:core/presentation/utils/app_toast.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:dartz/dartz.dart' hide State;
+import 'package:flutter/material.dart' hide SearchController, State;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
@@ -39,6 +40,8 @@ import 'package:tmail_ui_user/features/thread/domain/state/search_email_state.da
 import 'package:tmail_ui_user/features/thread/domain/usecases/clean_and_get_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/get_email_by_id_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/get_emails_in_mailbox_interactor.dart';
+import 'package:tmail_ui_user/features/thread/domain/state/get_all_email_state.dart';
+import 'package:tmail_ui_user/features/thread/domain/state/load_more_emails_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/load_more_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_email_interactor.dart';
@@ -659,6 +662,205 @@ void main() {
 
         // Assert - peak should be 15, not stale 40
         expect(limitEmailFetchedController.limitEmailFetched, UnsignedInt(15));
+      });
+    });
+
+    group('shouldAutoLoadMoreByScrollExtent unit test:', () {
+      test(
+        'GIVEN maxScrollExtent is 0 '
+        'WHEN content exactly fills the viewport '
+        'THEN SHOULD return true',
+      () {
+        expect(ThreadController.shouldAutoLoadMoreByScrollExtent(0), isTrue);
+      });
+
+      test(
+        'GIVEN maxScrollExtent is positive '
+        'WHEN content overflows the viewport '
+        'THEN SHOULD return false',
+      () {
+        expect(ThreadController.shouldAutoLoadMoreByScrollExtent(1), isFalse);
+      });
+
+      test(
+        'GIVEN maxScrollExtent is 785 with viewport 816 '
+        'WHEN content fills between 1× and 2× the viewport (large-screen device) '
+        'THEN SHOULD return false to prevent infinite load-more loop',
+      () {
+        expect(
+          ThreadController.shouldAutoLoadMoreByScrollExtent(785.0459770114941),
+          isFalse,
+        );
+      });
+    });
+
+    group('shouldAutoLoadMoreByScrollExtent widget test:', () {
+      testWidgets(
+        'GIVEN a ListView whose content overflows the viewport '
+        'THEN maxScrollExtent > 0 and SHOULD return false',
+      (tester) async {
+        final scrollController = ScrollController();
+        addTearDown(scrollController.dispose);
+
+        await tester.pumpWidget(MaterialApp(
+          home: SizedBox(
+            height: 500,
+            child: ListView.builder(
+              controller: scrollController,
+              itemCount: 20,
+              itemBuilder: (_, __) => const SizedBox(height: 80),
+            ),
+          ),
+        ));
+
+        final maxScroll = scrollController.position.maxScrollExtent;
+        expect(maxScroll, greaterThan(0));
+        expect(
+          ThreadController.shouldAutoLoadMoreByScrollExtent(maxScroll),
+          isFalse,
+        );
+      });
+
+      testWidgets(
+        'GIVEN a ListView whose content does not fill the viewport '
+        'THEN maxScrollExtent == 0 and SHOULD return true',
+      (tester) async {
+        final scrollController = ScrollController();
+        addTearDown(scrollController.dispose);
+
+        await tester.pumpWidget(MaterialApp(
+          home: SizedBox(
+            height: 500,
+            child: ListView.builder(
+              controller: scrollController,
+              itemCount: 3,
+              itemBuilder: (_, __) => const SizedBox(height: 80),
+            ),
+          ),
+        ));
+
+        final maxScroll = scrollController.position.maxScrollExtent;
+        expect(maxScroll, 0.0);
+        expect(
+          ThreadController.shouldAutoLoadMoreByScrollExtent(maxScroll),
+          isTrue,
+        );
+      });
+    });
+
+    group('canLoadMore after getAllEmail completes test:', () {
+      final mailboxId = MailboxId(Id('inbox'));
+
+      List<PresentationEmail> makeEmails(int count) => List.generate(
+        count,
+        (i) => PresentationEmail(
+          id: EmailId(Id('e$i')),
+          mailboxIds: {mailboxId: true},
+        ),
+      );
+
+      void setupMocksForOnDone() {
+        PlatformInfo.isTestingForWeb = false;
+        when(mockMailboxDashBoardController.isEmailListDisplayed).thenReturn(false);
+      }
+
+      tearDown(() => PlatformInfo.isTestingForWeb = false);
+
+      test(
+        'GIVEN server returns fewer than limit emails '
+        'WHEN getAllEmail stream completes (e.g. mailbox with 3 emails) '
+        'THEN canLoadMore SHOULD be false — no Load More button',
+      () {
+        setupMocksForOnDone();
+        final emails = makeEmails(3);
+        threadController.viewState.value = Right(
+          GetAllEmailSuccess(emailList: emails, currentMailboxId: mailboxId),
+        );
+
+        threadController.onDone();
+
+        expect(threadController.canLoadMore, isFalse);
+      });
+
+      test(
+        'GIVEN server returns exactly limit emails '
+        'WHEN getAllEmail stream completes '
+        'THEN canLoadMore SHOULD be true — more may exist',
+      () {
+        setupMocksForOnDone();
+        final emails = makeEmails(ThreadConstants.maxCountEmails);
+        threadController.viewState.value = Right(
+          GetAllEmailSuccess(emailList: emails, currentMailboxId: mailboxId),
+        );
+
+        threadController.onDone();
+
+        expect(threadController.canLoadMore, isTrue);
+      });
+    });
+
+    group('canLoadMore after loadMoreEmails completes test:', () {
+      final mailboxId = MailboxId(Id('inbox'));
+
+      List<PresentationEmail> makeEmails(int count) => List.generate(
+        count,
+        (i) => PresentationEmail(
+          id: EmailId(Id('lm$i')),
+          mailboxIds: {mailboxId: true},
+        ),
+      );
+
+      void setupMocksForLoadMore() {
+        PlatformInfo.isTestingForWeb = false;
+        when(mockMailboxDashBoardController.selectedMailbox)
+            .thenReturn(Rxn(PresentationMailbox(mailboxId)));
+        when(mockMailboxDashBoardController.mapMailboxById).thenReturn({});
+        when(mockMailboxDashBoardController.emailsInCurrentMailbox)
+            .thenReturn(RxList([]));
+        when(mockMailboxDashBoardController.searchController)
+            .thenReturn(mockSearchController);
+        when(mockSearchController.searchQuery).thenReturn(SearchQuery(''));
+        when(mockSearchController.isSearchEmailRunning).thenReturn(false);
+      }
+
+      tearDown(() => PlatformInfo.isTestingForWeb = false);
+
+      test(
+        'GIVEN server returns fewer than limit emails in load-more response '
+        'WHEN the last page has fewer items (e.g. 5 remaining) '
+        'THEN canLoadMore SHOULD be false immediately — no extra empty request needed',
+      () {
+        setupMocksForLoadMore();
+        final emails = makeEmails(5);
+
+        threadController.handleSuccessViewState(LoadMoreEmailsSuccess(emails));
+
+        expect(threadController.canLoadMore, isFalse);
+      });
+
+      test(
+        'GIVEN server returns exactly limit emails in load-more response '
+        'WHEN more pages may exist '
+        'THEN canLoadMore SHOULD be true',
+      () {
+        setupMocksForLoadMore();
+        final emails = makeEmails(ThreadConstants.maxCountEmails);
+
+        threadController.handleSuccessViewState(LoadMoreEmailsSuccess(emails));
+
+        expect(threadController.canLoadMore, isTrue);
+      });
+
+      test(
+        'GIVEN server returns 0 emails in load-more response '
+        'WHEN all emails have been loaded '
+        'THEN canLoadMore SHOULD be false',
+      () {
+        setupMocksForLoadMore();
+
+        threadController.handleSuccessViewState(LoadMoreEmailsSuccess([]));
+
+        expect(threadController.canLoadMore, isFalse);
       });
     });
   });

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -986,6 +986,120 @@ void main() {
       });
     });
 
+    group('auto-load-more collapseThreads partial-page edge case test:', () {
+      final mailboxId = MailboxId(Id('inbox'));
+
+      List<PresentationEmail> makeEmails(int count) => List.generate(
+        count,
+        (i) => PresentationEmail(
+          id: EmailId(Id('ct$i')),
+          mailboxIds: {mailboxId: true},
+        ),
+      );
+
+      late ThreadController collapseController;
+
+      setUp(() {
+        collapseController = ThreadController(
+          mockGetEmailsInMailboxInteractor,
+          mockRefreshChangesEmailsInMailboxInteractor,
+          mockLoadMoreEmailsInMailboxInteractor,
+          mockSearchEmailInteractor,
+          mockSearchMoreEmailInteractor,
+          mockGetEmailByIdInteractor,
+          mockCleanAndGetEmailsInMailboxInteractor,
+        );
+      });
+
+      tearDown(() {
+        PlatformInfo.isTestingForWeb = false;
+        collapseController.onClose();
+      });
+
+      testWidgets(
+        'GIVEN collapseThreads returns a partial page (< maxCountEmails threads) '
+        'AND the list content does not fill the viewport (maxScrollExtent = 0) '
+        'WHEN getAllEmail stream completes '
+        'THEN auto-load-more IS triggered to fill the viewport '
+        'AND canLoadMore reflects the subsequent load-more server response',
+      (tester) async {
+        PlatformInfo.isTestingForWeb = false;
+
+        final partialEmails = makeEmails(15); // fewer than maxCountEmails = 20
+
+        when(mockMailboxDashBoardController.isEmailListDisplayed).thenReturn(false);
+        when(mockMailboxDashBoardController.sessionCurrent)
+            .thenReturn(SessionFixtures.aliceSession);
+        when(mockMailboxDashBoardController.accountId)
+            .thenReturn(Rxn(AccountFixtures.aliceAccountId));
+        when(mockMailboxDashBoardController.selectedMailbox)
+            .thenReturn(Rxn(PresentationMailbox(mailboxId)));
+        when(mockMailboxDashBoardController.mapMailboxById).thenReturn({});
+        when(mockMailboxDashBoardController.emailsInCurrentMailbox)
+            .thenReturn(RxList(partialEmails));
+        when(mockMailboxDashBoardController.filterMessageOption)
+            .thenReturn(Rx(FilterMessageOption.all));
+        when(mockMailboxDashBoardController.searchController)
+            .thenReturn(mockSearchController);
+        when(mockSearchController.isSearchEmailRunning).thenReturn(false);
+        when(mockSearchController.searchQuery).thenReturn(SearchQuery(''));
+        when(mockLoadMoreEmailsInMailboxInteractor.execute(any))
+            .thenAnswer((_) => Stream.value(
+              Right(LoadMoreEmailsSuccess([], serverEmailCount: 0)),
+            ));
+
+        // Mount an empty ListView so listEmailController.hasClients = true
+        // and maxScrollExtent = 0 (content does not fill viewport).
+        await tester.pumpWidget(MaterialApp(
+          home: SizedBox(
+            height: 600,
+            child: ListView(controller: collapseController.listEmailController),
+          ),
+        ));
+
+        expect(
+          collapseController.listEmailController.position.maxScrollExtent,
+          0.0,
+        );
+
+        collapseController.viewState.value = Right(
+          GetAllEmailSuccess(emailList: partialEmails, currentMailboxId: mailboxId),
+        );
+
+        collapseController.onDone();
+        await tester.pumpAndSettle();
+
+        // Load-more interactor MUST be called to attempt filling the viewport.
+        verify(mockLoadMoreEmailsInMailboxInteractor.execute(any)).called(1);
+
+        // After the empty load-more response (serverEmailCount = 0 < maxCountEmails),
+        // canLoadMore is set to false by _loadMoreEmailsSuccess.
+        expect(collapseController.canLoadMore, isFalse);
+      });
+
+      test(
+        'GIVEN collapseThreads returns a partial page (< maxCountEmails threads) '
+        'AND canLoadMore is initially true before the call '
+        'WHEN viewport is already full (_isAutoLoadMore = false) '
+        'THEN canLoadMore SHOULD be false — no spurious Load More button',
+      () {
+        PlatformInfo.isTestingForWeb = false;
+        // No scroll controller client → _isAutoLoadMore = false
+        when(mockMailboxDashBoardController.isEmailListDisplayed).thenReturn(false);
+
+        final partialEmails = makeEmails(15);
+        threadController.canLoadMore = true;
+        threadController.viewState.value = Right(
+          GetAllEmailSuccess(emailList: partialEmails, currentMailboxId: mailboxId),
+        );
+
+        threadController.onDone();
+
+        expect(threadController.canLoadMore, isFalse);
+        verifyNever(mockLoadMoreEmailsInMailboxInteractor.execute(any));
+      });
+    });
+
     group('shouldAutoLoadMoreByEstimatedHeight unit test:', () {
       test(
         'GIVEN totalHeight is 0 (empty list) '


### PR DESCRIPTION
## Why?

**Non-web — infinite load-more loop**  
On Android 10 Pro XL, opening a mailbox triggered an infinite chain of load-more requests. Logs confirmed:

```
ThreadController::_isNonWebAutoLoadMore():
  maxScroll = 785.04, viewport = 816.33, isAutoLoadMore = true
```

`maxScrollExtent <= viewportDimension` is equivalent to *content height ≤ 2× viewport*. On a large screen where 20 emails fill ~1.9× the viewport, `maxScrollExtent` (~785 px) stays below `viewportDimension` (816 px) after every page, so auto-load never stops. Smaller phones are unaffected because their content overflows 2× viewport after the first page.

**Web — extra load at estimated-height boundary**  
The estimated-height guard used `<=` instead of `<`, firing one extra load when the estimate happened to equal the browser height exactly. Since `defaultMaxHeightEmailItemOnBrowser = 40 px` is a conservative underestimate, the actual rendered height already overflows at that boundary.

**Both platforms — Load More button on partial page**  
`canLoadMore = emailList.isNotEmpty` showed the Load More button even when the server returned a partial page (e.g. a 3-email mailbox), causing a wasted empty round-trip.

## Solution

- **Non-web:** `maxScrollExtent <= 0` — triggers only when the list hasn't yet filled the viewport.
- **Web:** Strict `<` on the estimated-height check.
- **Both platforms:** `canLoadMore = emailList.length >= maxCountEmails` — hides Load More when the server returns a partial page.

Both threshold conditions extracted into `AutoLoadMorePolicy` for independent testability. Unit tests and widget tests added for all three cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved infinite auto "load more" loops on large screens by tightening auto-load thresholds for web and non-web, and by ensuring pagination eligibility uses full-page counts rather than presence of items.
  * Preserved server-reported page counts when items are anchored/stripped so subsequent load decisions are accurate.

* **Tests**
  * Added unit and widget tests covering auto-load triggers, viewport/size boundaries, pagination lifecycle and regressions.

* **Documentation**
  * Added an ADR describing the issue and chosen decisions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-flutter/pull/4545?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->