### PR TITLE
[Part 1][Collapse Thread Preference] refactor: make PreferencesOptionType and PreferencesSettingManager extensible

### DIFF
--- a/lib/features/manage_account/data/datasource_impl/manage_account_datasource_impl.dart
+++ b/lib/features/manage_account/data/datasource_impl/manage_account_datasource_impl.dart
@@ -4,12 +4,8 @@ import 'package:tmail_ui_user/features/manage_account/data/datasource/manage_acc
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/preferences_setting_manager.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/ai_scribe_config.dart';
-import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/label_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
-import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/spam_report_config.dart';
-import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/text_formatting_menu_config.dart';
-import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/thread_detail_config.dart';
 import 'package:tmail_ui_user/main/exceptions/thrower/exception_thrower.dart';
 
 class ManageAccountDataSourceImpl extends ManageAccountDataSource {
@@ -34,31 +30,7 @@ class ManageAccountDataSourceImpl extends ManageAccountDataSource {
   @override
   Future<PreferencesSetting> toggleLocalSettingsState(PreferencesConfig preferencesConfig) {
     return Future.sync(() async {
-      if (preferencesConfig is ThreadDetailConfig) {
-        await _preferencesSettingManager.updateThread(
-          preferencesConfig.isEnabled,
-        );
-      } else if (preferencesConfig is SpamReportConfig) {
-        await _preferencesSettingManager.updateSpamReport(
-          isEnabled: preferencesConfig.isEnabled,
-        );
-      } else if (preferencesConfig is TextFormattingMenuConfig) {
-        await _preferencesSettingManager.updateTextFormattingMenu(
-          isDisplayed: preferencesConfig.isDisplayed,
-        );
-      } else if (preferencesConfig is AIScribeConfig) {
-        await _preferencesSettingManager.updateAIScribe(
-          preferencesConfig.isEnabled,
-        );
-      } else if (preferencesConfig is LabelConfig) {
-        await _preferencesSettingManager.updateLabel(
-          preferencesConfig.isEnabled,
-        );
-      } else {
-        await _preferencesSettingManager.savePreferences(
-          preferencesConfig,
-        );
-      }
+      await _preferencesSettingManager.savePreferences(preferencesConfig);
       return await _preferencesSettingManager.loadPreferences();
     }).catchError(_exceptionThrower.throwException);
   }

--- a/lib/features/manage_account/data/local/preferences_setting_manager.dart
+++ b/lib/features/manage_account/data/local/preferences_setting_manager.dart
@@ -12,17 +12,19 @@ import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/t
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/thread_detail_config.dart';
 
 class PreferencesSettingManager {
-  static const String _preferencesSettingKey = 'PREFERENCES_SETTING';
-  static const String _preferencesSettingThreadKey =
-      '${_preferencesSettingKey}_THREAD';
-  static const String _preferencesSettingSpamReportKey =
-      '${_preferencesSettingKey}_SPAM_REPORT';
-  static const String _preferencesSettingTextFormattingMenuKey =
-      '${_preferencesSettingKey}_TEXT_FORMATTING_MENU';
-  static const String _preferencesSettingAIScribeKey =
-      '${_preferencesSettingKey}_AI_SCRIBE';
-  static const String _preferencesSettingLabelKey =
-      '${_preferencesSettingKey}_LABEL';
+  static const _storagePrefix = 'PREFERENCES_SETTING';
+
+  static String _storageKey(String suffix) => '${_storagePrefix}_$suffix';
+
+  // Add one entry here when introducing a new PreferencesConfig subclass.
+  static final Map<String, PreferencesConfig Function(Map<String, dynamic>)>
+      _configFactories = Map.unmodifiable({
+    _storageKey(ThreadDetailConfig.keySuffix): ThreadDetailConfig.fromJson,
+    _storageKey(SpamReportConfig.keySuffix): SpamReportConfig.fromJson,
+    _storageKey(TextFormattingMenuConfig.keySuffix): TextFormattingMenuConfig.fromJson,
+    _storageKey(AIScribeConfig.keySuffix): AIScribeConfig.fromJson,
+    _storageKey(LabelConfig.keySuffix): LabelConfig.fromJson,
+  });
 
   const PreferencesSettingManager(this._sharedPreferences);
 
@@ -31,32 +33,17 @@ class PreferencesSettingManager {
   Future<PreferencesSetting> loadPreferences() async {
     await _sharedPreferences.reload();
 
-    final keys = _sharedPreferences.getKeys();
-    final preferencesKeys =
-        keys.where((key) => key.startsWith(_preferencesSettingKey)).toList();
-
-    final listConfigs = preferencesKeys.map((key) {
-      final jsonString = _sharedPreferences.getString(key);
-      if (jsonString != null) {
-        final jsonDecoded = jsonDecode(jsonString);
-
-        switch (key) {
-          case _preferencesSettingThreadKey:
-            return ThreadDetailConfig.fromJson(jsonDecoded);
-          case _preferencesSettingSpamReportKey:
-            return SpamReportConfig.fromJson(jsonDecoded);
-          case _preferencesSettingTextFormattingMenuKey:
-            return TextFormattingMenuConfig.fromJson(jsonDecoded);
-          case _preferencesSettingAIScribeKey:
-            return AIScribeConfig.fromJson(jsonDecoded);
-          case _preferencesSettingLabelKey:
-            return LabelConfig.fromJson(jsonDecoded);
-          default:
-            return DefaultPreferencesConfig.fromJson(jsonDecoded);
-        }
-      }
-      return EmptyPreferencesConfig();
-    }).toList();
+    final listConfigs = _sharedPreferences
+        .getKeys()
+        .where((key) => key.startsWith(_storagePrefix))
+        .map((key) {
+          final jsonString = _sharedPreferences.getString(key);
+          if (jsonString == null) return EmptyPreferencesConfig();
+          final json = jsonDecode(jsonString) as Map<String, dynamic>;
+          final factory = _configFactories[key];
+          return factory != null ? factory(json) : DefaultPreferencesConfig.fromJson(json);
+        })
+        .toList();
 
     if (listConfigs.isEmpty) {
       return PreferencesSetting.initial();
@@ -65,122 +52,77 @@ class PreferencesSettingManager {
     return PreferencesSetting(listConfigs);
   }
 
-  String _getPreferencesConfigKey(PreferencesConfig config) {
-    if (config is ThreadDetailConfig) {
-      return _preferencesSettingThreadKey;
-    } else if (config is SpamReportConfig) {
-      return _preferencesSettingSpamReportKey;
-    } else if (config is TextFormattingMenuConfig) {
-      return _preferencesSettingTextFormattingMenuKey;
-    } else if (config is AIScribeConfig) {
-      return _preferencesSettingAIScribeKey;
-    } else if (config is LabelConfig) {
-      return _preferencesSettingLabelKey;
-    } else {
-      return _preferencesSettingKey;
-    }
-  }
-
+  // SpamReportConfig is read-merge-written to preserve lastTimeDismissedMilliseconds.
   Future<void> savePreferences(PreferencesConfig config) async {
+    if (config is SpamReportConfig) {
+      await updateSpamReport(isEnabled: config.isEnabled);
+      return;
+    }
     await _sharedPreferences.setString(
-      _getPreferencesConfigKey(config),
+      _storageKey(config.configKey),
       jsonEncode(config.toJson()),
     );
   }
 
-  Future<void> updateThread(bool isEnabled) async {
-    final currentConfig = await getThreadConfig();
-    final updatedConfig = currentConfig.copyWith(isEnabled: isEnabled);
-    await savePreferences(updatedConfig);
-  }
+  Future<SpamReportConfig> getSpamReportConfig() => _readConfig(
+        key: _storageKey(SpamReportConfig.keySuffix),
+        defaultFactory: SpamReportConfig.initial,
+        fromJson: SpamReportConfig.fromJson,
+      );
 
+  // Used by spam-report logic that runs outside the preferences toggle flow.
   Future<void> updateSpamReport({
     bool? isEnabled,
     int? lastTimeDismissedMilliseconds,
   }) async {
-    final currentConfig = await getSpamReportConfig();
-    final updatedConfig = currentConfig.copyWith(
-      isEnabled: isEnabled,
-      lastTimeDismissedMilliseconds: lastTimeDismissedMilliseconds,
+    final current = await getSpamReportConfig();
+    await _sharedPreferences.setString(
+      _storageKey(SpamReportConfig.keySuffix),
+      jsonEncode(current.copyWith(
+        isEnabled: isEnabled,
+        lastTimeDismissedMilliseconds: lastTimeDismissedMilliseconds,
+      ).toJson()),
     );
-    await savePreferences(updatedConfig);
   }
 
-  Future<SpamReportConfig> getSpamReportConfig() async {
-    await _sharedPreferences.reload();
+  Future<ThreadDetailConfig> getThreadConfig() => _readConfig(
+        key: _storageKey(ThreadDetailConfig.keySuffix),
+        defaultFactory: ThreadDetailConfig.initial,
+        fromJson: ThreadDetailConfig.fromJson,
+      );
 
-    final jsonString = _sharedPreferences.getString(
-      _preferencesSettingSpamReportKey,
-    );
-
-    return jsonString == null
-        ? SpamReportConfig.initial()
-        : SpamReportConfig.fromJson(jsonDecode(jsonString));
-  }
-
-  Future<ThreadDetailConfig> getThreadConfig() async {
-    await _sharedPreferences.reload();
-
-    final jsonString = _sharedPreferences.getString(
-      _preferencesSettingThreadKey,
-    );
-
-    return jsonString == null
-        ? ThreadDetailConfig.initial()
-        : ThreadDetailConfig.fromJson(jsonDecode(jsonString));
-  }
-
-  Future<TextFormattingMenuConfig> getTextFormattingMenuConfig() async {
-    await _sharedPreferences.reload();
-
-    final jsonString = _sharedPreferences.getString(
-      _preferencesSettingTextFormattingMenuKey,
-    );
-
-    return jsonString == null
-        ? TextFormattingMenuConfig.initial()
-        : TextFormattingMenuConfig.fromJson(jsonDecode(jsonString));
-  }
+  Future<TextFormattingMenuConfig> getTextFormattingMenuConfig() => _readConfig(
+        key: _storageKey(TextFormattingMenuConfig.keySuffix),
+        defaultFactory: TextFormattingMenuConfig.initial,
+        fromJson: TextFormattingMenuConfig.fromJson,
+      );
 
   Future<void> updateTextFormattingMenu({required bool isDisplayed}) async {
-    final currentConfig = await getTextFormattingMenuConfig();
-    final updatedConfig = currentConfig.copyWith(isDisplayed: isDisplayed);
-    await savePreferences(updatedConfig);
+    final current = await getTextFormattingMenuConfig();
+    await savePreferences(current.copyWith(isDisplayed: isDisplayed));
   }
 
-  Future<AIScribeConfig> getAIScribeConfig() async {
+  Future<AIScribeConfig> getAIScribeConfig() => _readConfig(
+        key: _storageKey(AIScribeConfig.keySuffix),
+        defaultFactory: AIScribeConfig.initial,
+        fromJson: AIScribeConfig.fromJson,
+      );
+
+  Future<LabelConfig> getLabelConfig() => _readConfig(
+        key: _storageKey(LabelConfig.keySuffix),
+        defaultFactory: LabelConfig.initial,
+        fromJson: LabelConfig.fromJson,
+      );
+
+  Future<T> _readConfig<T extends PreferencesConfig>({
+    required String key,
+    required T Function() defaultFactory,
+    required T Function(Map<String, dynamic>) fromJson,
+  }) async {
     await _sharedPreferences.reload();
-
-    final jsonString = _sharedPreferences.getString(
-      _preferencesSettingAIScribeKey,
-    );
-
+    final jsonString = _sharedPreferences.getString(key);
     return jsonString == null
-        ? AIScribeConfig.initial()
-        : AIScribeConfig.fromJson(jsonDecode(jsonString));
-  }
-
-  Future<void> updateAIScribe(bool isEnabled) async {
-    final currentConfig = await getAIScribeConfig();
-    final updatedConfig = currentConfig.copyWith(isEnabled: isEnabled);
-    await savePreferences(updatedConfig);
-  }
-
-  Future<LabelConfig> getLabelConfig() async {
-    await _sharedPreferences.reload();
-
-    final jsonString = _sharedPreferences.getString(
-      _preferencesSettingLabelKey,
-    );
-
-    return jsonString == null
-        ? LabelConfig.initial()
-        : LabelConfig.fromJson(jsonDecode(jsonString));
-  }
-
-  Future<void> updateLabel(bool isEnabled) async {
-    final currentConfig = await getLabelConfig();
-    final updatedConfig = currentConfig.copyWith(isEnabled: isEnabled);
-    await savePreferences(updatedConfig);
+        ? defaultFactory()
+        : fromJson(jsonDecode(jsonString) as Map<String, dynamic>);
   }
 }

--- a/lib/features/manage_account/domain/model/preferences/ai_scribe_config.dart
+++ b/lib/features/manage_account/domain/model/preferences/ai_scribe_config.dart
@@ -5,11 +5,16 @@ part 'ai_scribe_config.g.dart';
 
 @JsonSerializable()
 class AIScribeConfig extends PreferencesConfig {
+  static const keySuffix = 'AI_SCRIBE';
+
   final bool isEnabled;
 
   AIScribeConfig({
     this.isEnabled = true,
   });
+
+  @override
+  String get configKey => keySuffix;
 
   factory AIScribeConfig.initial() => AIScribeConfig();
 

--- a/lib/features/manage_account/domain/model/preferences/default_preferences_config.dart
+++ b/lib/features/manage_account/domain/model/preferences/default_preferences_config.dart
@@ -6,6 +6,9 @@ class DefaultPreferencesConfig extends PreferencesConfig {
 
   DefaultPreferencesConfig(this.data);
 
+  @override
+  String get configKey => '';
+
   factory DefaultPreferencesConfig.fromJson(Map<String, dynamic> json) =>
       const DefaultPreferencesConfigConverter().fromJson(json);
 

--- a/lib/features/manage_account/domain/model/preferences/empty_preferences_config.dart
+++ b/lib/features/manage_account/domain/model/preferences/empty_preferences_config.dart
@@ -2,6 +2,9 @@ import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/p
 
 class EmptyPreferencesConfig extends PreferencesConfig {
   @override
+  String get configKey => '';
+
+  @override
   List<Object?> get props => [];
 
   @override

--- a/lib/features/manage_account/domain/model/preferences/label_config.dart
+++ b/lib/features/manage_account/domain/model/preferences/label_config.dart
@@ -5,9 +5,14 @@ part 'label_config.g.dart';
 
 @JsonSerializable()
 class LabelConfig extends PreferencesConfig {
+  static const keySuffix = 'LABEL';
+
   final bool isEnabled;
 
   LabelConfig({this.isEnabled = true});
+
+  @override
+  String get configKey => keySuffix;
 
   factory LabelConfig.initial() => LabelConfig();
 

--- a/lib/features/manage_account/domain/model/preferences/preferences_config.dart
+++ b/lib/features/manage_account/domain/model/preferences/preferences_config.dart
@@ -1,6 +1,7 @@
 import 'package:equatable/equatable.dart';
 
 abstract class PreferencesConfig with EquatableMixin {
+  String get configKey;
 
   Map<String, dynamic> toJson();
 

--- a/lib/features/manage_account/domain/model/preferences/preferences_setting.dart
+++ b/lib/features/manage_account/domain/model/preferences/preferences_setting.dart
@@ -1,4 +1,3 @@
-import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/ai_scribe_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/label_config.dart';
@@ -18,58 +17,27 @@ class PreferencesSetting with EquatableMixin {
       SpamReportConfig.initial(),
       TextFormattingMenuConfig.initial(),
       AIScribeConfig.initial(),
+      LabelConfig.initial(),
     ]);
   }
 
-  ThreadDetailConfig get threadConfig {
-    final threadConfig =
-        configs.firstWhereOrNull((config) => config is ThreadDetailConfig);
-    if (threadConfig != null) {
-      return threadConfig as ThreadDetailConfig;
-    } else {
-      return ThreadDetailConfig.initial();
-    }
-  }
+  T getConfigOrDefault<T extends PreferencesConfig>(T defaultValue) =>
+      configs.whereType<T>().firstOrNull ?? defaultValue;
 
-  SpamReportConfig get spamReportConfig {
-    final spamConfig =
-        configs.firstWhereOrNull((config) => config is SpamReportConfig);
-    if (spamConfig != null) {
-      return spamConfig as SpamReportConfig;
-    } else {
-      return SpamReportConfig.initial();
-    }
-  }
+  ThreadDetailConfig get threadConfig =>
+      getConfigOrDefault(ThreadDetailConfig.initial());
 
-  TextFormattingMenuConfig get textFormattingMenuConfig {
-    final formatConfig = configs
-        .firstWhereOrNull((config) => config is TextFormattingMenuConfig);
-    if (formatConfig != null) {
-      return formatConfig as TextFormattingMenuConfig;
-    } else {
-      return TextFormattingMenuConfig.initial();
-    }
-  }
+  SpamReportConfig get spamReportConfig =>
+      getConfigOrDefault(SpamReportConfig.initial());
 
-  AIScribeConfig get aiScribeConfig {
-    final aiConfig =
-        configs.firstWhereOrNull((config) => config is AIScribeConfig);
-    if (aiConfig != null) {
-      return aiConfig as AIScribeConfig;
-    } else {
-      return AIScribeConfig.initial();
-    }
-  }
+  TextFormattingMenuConfig get textFormattingMenuConfig =>
+      getConfigOrDefault(TextFormattingMenuConfig.initial());
 
-  LabelConfig get labelConfig {
-    final labelConfig =
-        configs.firstWhereOrNull((config) => config is LabelConfig);
-    if (labelConfig != null) {
-      return labelConfig as LabelConfig;
-    } else {
-      return LabelConfig.initial();
-    }
-  }
+  AIScribeConfig get aiScribeConfig =>
+      getConfigOrDefault(AIScribeConfig.initial());
+
+  LabelConfig get labelConfig =>
+      getConfigOrDefault(LabelConfig.initial());
 
   @override
   List<Object?> get props => [configs];

--- a/lib/features/manage_account/domain/model/preferences/spam_report_config.dart
+++ b/lib/features/manage_account/domain/model/preferences/spam_report_config.dart
@@ -6,6 +6,8 @@ part 'spam_report_config.g.dart';
 
 @JsonSerializable()
 class SpamReportConfig extends PreferencesConfig {
+  static const keySuffix = 'SPAM_REPORT';
+
   final bool isEnabled;
   final int lastTimeDismissedMilliseconds;
 
@@ -13,6 +15,9 @@ class SpamReportConfig extends PreferencesConfig {
     this.isEnabled = true,
     this.lastTimeDismissedMilliseconds = 0,
   });
+
+  @override
+  String get configKey => keySuffix;
 
   factory SpamReportConfig.initial() => SpamReportConfig();
 

--- a/lib/features/manage_account/domain/model/preferences/text_formatting_menu_config.dart
+++ b/lib/features/manage_account/domain/model/preferences/text_formatting_menu_config.dart
@@ -5,9 +5,14 @@ part 'text_formatting_menu_config.g.dart';
 
 @JsonSerializable()
 class TextFormattingMenuConfig extends PreferencesConfig {
+  static const keySuffix = 'TEXT_FORMATTING_MENU';
+
   final bool isDisplayed;
 
   TextFormattingMenuConfig({this.isDisplayed = false});
+
+  @override
+  String get configKey => keySuffix;
 
   factory TextFormattingMenuConfig.initial() => TextFormattingMenuConfig();
 

--- a/lib/features/manage_account/domain/model/preferences/thread_detail_config.dart
+++ b/lib/features/manage_account/domain/model/preferences/thread_detail_config.dart
@@ -5,9 +5,14 @@ part 'thread_detail_config.g.dart';
 
 @JsonSerializable()
 class ThreadDetailConfig extends PreferencesConfig {
+  static const keySuffix = 'THREAD';
+
   final bool isEnabled;
 
   ThreadDetailConfig({this.isEnabled = false});
+
+  @override
+  String get configKey => keySuffix;
 
   factory ThreadDetailConfig.initial() => ThreadDetailConfig();
 

--- a/lib/features/manage_account/presentation/model/preferences_option_type.dart
+++ b/lib/features/manage_account/presentation/model/preferences_option_type.dart
@@ -1,8 +1,13 @@
-
 import 'package:server_settings/server_settings/tmail_server_settings.dart';
 import 'package:server_settings/server_settings/tmail_server_settings_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+typedef _OptionStrings = ({
+  String title,
+  String explanation,
+  String toggleDescription,
+});
 
 enum PreferencesOptionType {
   readReceipt(isLocal: false),
@@ -17,82 +22,69 @@ enum PreferencesOptionType {
 
   const PreferencesOptionType({required this.isLocal});
 
-  String getTitle(AppLocalizations appLocalizations) {
-    switch(this) {
-      case PreferencesOptionType.readReceipt:
-        return appLocalizations.emailReadReceipts;
-      case PreferencesOptionType.senderPriority:
-        return appLocalizations.senderSetImportantFlag;
-      case PreferencesOptionType.thread:
-        return appLocalizations.thread;
-      case PreferencesOptionType.spamReport:
-        return appLocalizations.spamReports;
-      case PreferencesOptionType.aiScribe:
-        return appLocalizations.aiScribe;
-      case PreferencesOptionType.aiNeedsAction:
-        return appLocalizations.aiNeedsAction;
-      case PreferencesOptionType.label:
-        return appLocalizations.labelVisibility;
-    }
-  }
+  static final _stringBuilders =
+      <PreferencesOptionType, _OptionStrings Function(AppLocalizations)>{
+        readReceipt: (l) => (
+          title: l.emailReadReceipts,
+          explanation: l.emailReadReceiptsSettingExplanation,
+          toggleDescription: l.emailReadReceiptsToggleDescription,
+        ),
+        senderPriority: (l) => (
+          title: l.senderSetImportantFlag,
+          explanation: l.senderImportantSettingExplanation,
+          toggleDescription: l.senderImportantSettingToggleDescription,
+        ),
+        thread: (l) => (
+          title: l.thread,
+          explanation: l.threadSettingExplanation,
+          toggleDescription: l.threadToggleDescription,
+        ),
+        spamReport: (l) => (
+          title: l.spamReports,
+          explanation: l.spamReportsSettingExplanation,
+          toggleDescription: l.spamReportToggleDescription,
+        ),
+        aiScribe: (l) => (
+          title: l.aiScribe,
+          explanation: l.aiScribeSettingExplanation,
+          toggleDescription: l.aiScribeToggleDescription,
+        ),
+        aiNeedsAction: (l) => (
+          title: l.aiNeedsAction,
+          explanation: l.aiNeedsActionSettingExplanation,
+          toggleDescription: l.aiNeedsActionToggleDescription,
+        ),
+        label: (l) => (
+          title: l.labelVisibility,
+          explanation: l.labelVisibilitySettingExplanation,
+          toggleDescription: l.labelVisibilityToggleDescription,
+        ),
+      };
 
-  String getExplanation(AppLocalizations appLocalizations) {
-    switch(this) {
-      case PreferencesOptionType.readReceipt:
-        return appLocalizations.emailReadReceiptsSettingExplanation;
-      case PreferencesOptionType.senderPriority:
-        return appLocalizations.senderImportantSettingExplanation;
-      case PreferencesOptionType.thread:
-        return appLocalizations.threadSettingExplanation;
-      case PreferencesOptionType.spamReport:
-        return appLocalizations.spamReportsSettingExplanation;
-      case PreferencesOptionType.aiScribe:
-        return appLocalizations.aiScribeSettingExplanation;
-      case PreferencesOptionType.aiNeedsAction:
-        return appLocalizations.aiNeedsActionSettingExplanation;
-      case PreferencesOptionType.label:
-        return appLocalizations.labelVisibilitySettingExplanation;
-    }
-  }
+  String getTitle(AppLocalizations l) => _stringBuilders[this]!(l).title;
 
-  String getToggleDescription(AppLocalizations appLocalizations) {
-    switch(this) {
-      case PreferencesOptionType.readReceipt:
-        return appLocalizations.emailReadReceiptsToggleDescription;
-      case PreferencesOptionType.senderPriority:
-        return appLocalizations.senderImportantSettingToggleDescription;
-      case PreferencesOptionType.thread:
-        return appLocalizations.threadToggleDescription;
-      case PreferencesOptionType.spamReport:
-        return appLocalizations.spamReportToggleDescription;
-      case PreferencesOptionType.aiScribe:
-        return appLocalizations.aiScribeToggleDescription;
-      case PreferencesOptionType.aiNeedsAction:
-        return appLocalizations.aiNeedsActionToggleDescription;
-      case PreferencesOptionType.label:
-        return appLocalizations.labelVisibilityToggleDescription;
-    }
-  }
+  String getExplanation(AppLocalizations l) =>
+      _stringBuilders[this]!(l).explanation;
+
+  String getToggleDescription(AppLocalizations l) =>
+      _stringBuilders[this]!(l).toggleDescription;
+
+  static final _enabledResolvers =
+      <
+        PreferencesOptionType,
+        bool Function(TMailServerSettingOptions?, PreferencesSetting)
+      >{
+        readReceipt: (s, _) => s?.isAlwaysReadReceipts ?? false,
+        senderPriority: (s, _) => s?.isDisplaySenderPriority ?? false,
+        thread: (_, p) => p.threadConfig.isEnabled,
+        spamReport: (_, p) => p.spamReportConfig.isEnabled,
+        aiScribe: (_, p) => p.aiScribeConfig.isEnabled,
+        aiNeedsAction: (s, _) => s?.isAINeedsActionEnabled ?? false,
+        label: (_, p) => p.labelConfig.isEnabled,
+      };
 
   bool isEnabled(
     TMailServerSettingOptions? settingOption,
     PreferencesSetting preferencesSetting,
-  ) {
-    switch(this) {
-      case PreferencesOptionType.readReceipt:
-        return settingOption?.isAlwaysReadReceipts ?? false;
-      case PreferencesOptionType.senderPriority:
-        return settingOption?.isDisplaySenderPriority ?? false;
-      case PreferencesOptionType.thread:
-        return preferencesSetting.threadConfig.isEnabled;
-      case PreferencesOptionType.spamReport:
-        return preferencesSetting.spamReportConfig.isEnabled;
-      case PreferencesOptionType.aiScribe:
-        return preferencesSetting.aiScribeConfig.isEnabled;
-      case PreferencesOptionType.aiNeedsAction:
-        return settingOption?.isAINeedsActionEnabled ?? false;
-      case PreferencesOptionType.label:
-        return preferencesSetting.labelConfig.isEnabled;
-    }
-  }
+  ) => _enabledResolvers[this]!(settingOption, preferencesSetting);
 }


### PR DESCRIPTION
### Problem
Adding a new preference option required touching many files:
- A new hardcoded key constant in `PreferencesSettingManager`
- A new `case` in `_getPreferencesConfigKey` and `loadPreferences` switch
- A new `case` in each of `getTitle`, `getExplanation`, `getToggleDescription`, `isEnabled`

### Changes
- `PreferencesConfig`: add abstract `configKey` getter; all subclasses implement it with a `static const keySuffix`
- `PreferencesSettingManager`: replace per-type key constants + switch with a single `_configFactories` map and `_storageKey(suffix)` helper — **adding a future config = one line in the map**
- `PreferencesSetting`: replace five copy-paste `firstWhereOrNull` getters with `getConfigOrDefault<T>()`; add `LabelConfig` to `initial()` (was missing)
- `PreferencesOptionType`: replace four switch statements with static dispatch maps (`_stringBuilders`, `_enabledResolvers`)

### No behavior change
All existing preferences (thread, spam, AI scribe, label, text formatting) work identically. No new UI or storage keys.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the internal preference configuration management system to use a unified storage approach with configuration-specific key identifiers, improving code consistency and maintainability across all preference types.
  * Optimized preference option type resolution and localized text generation using lookup tables, streamlining the overall preference handling logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-flutter/pull/4550?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->