### PR TITLE
[Part 2] TF-4551: feat: add experimental mode with 7-tap secret activation

### DIFF
--- a/lib/features/manage_account/data/datasource/manage_account_datasource.dart
+++ b/lib/features/manage_account/data/datasource/manage_account_datasource.dart
@@ -14,4 +14,8 @@ abstract class ManageAccountDataSource {
   Future<AIScribeConfig> getAiScribeConfigLocalSettings();
 
   Future<bool> getLabelSettingState();
+
+  Future<bool> getExperimentalModeEnabled();
+
+  Future<void> enableExperimentalMode();
 }

--- a/lib/features/manage_account/data/datasource_impl/manage_account_datasource_impl.dart
+++ b/lib/features/manage_account/data/datasource_impl/manage_account_datasource_impl.dart
@@ -56,4 +56,16 @@ class ManageAccountDataSourceImpl extends ManageAccountDataSource {
       return labelConfig.isEnabled;
     }).catchError(_exceptionThrower.throwException);
   }
+
+  @override
+  Future<bool> getExperimentalModeEnabled() {
+    return Future.sync(() => _preferencesSettingManager.getExperimentalModeEnabled())
+        .catchError(_exceptionThrower.throwException);
+  }
+
+  @override
+  Future<void> enableExperimentalMode() {
+    return Future.sync(() => _preferencesSettingManager.enableExperimentalMode())
+        .catchError(_exceptionThrower.throwException);
+  }
 }

--- a/lib/features/manage_account/data/local/preferences_setting_manager.dart
+++ b/lib/features/manage_account/data/local/preferences_setting_manager.dart
@@ -120,7 +120,7 @@ class PreferencesSettingManager {
       );
 
   Future<bool> getExperimentalModeEnabled() async {
-    // Write-once flag — no reload needed.
+    await _sharedPreferences.reload();
     return _sharedPreferences.getBool(_experimentalModeKey) ?? false;
   }
 

--- a/lib/features/manage_account/data/local/preferences_setting_manager.dart
+++ b/lib/features/manage_account/data/local/preferences_setting_manager.dart
@@ -13,6 +13,7 @@ import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/t
 
 class PreferencesSettingManager {
   static const _storagePrefix = 'PREFERENCES_SETTING';
+  static const _experimentalModeKey = 'EXPERIMENTAL_MODE_ENABLED';
 
   static String _storageKey(String suffix) => '${_storagePrefix}_$suffix';
 
@@ -117,6 +118,14 @@ class PreferencesSettingManager {
         defaultFactory: LabelConfig.initial,
         fromJson: LabelConfig.fromJson,
       );
+
+  Future<bool> getExperimentalModeEnabled() async {
+    // Write-once flag — no reload needed.
+    return _sharedPreferences.getBool(_experimentalModeKey) ?? false;
+  }
+
+  Future<void> enableExperimentalMode() =>
+      _sharedPreferences.setBool(_experimentalModeKey, true);
 
   Future<T> _readConfig<T extends PreferencesConfig>({
     required String key,

--- a/lib/features/manage_account/data/repository/manage_account_repository_impl.dart
+++ b/lib/features/manage_account/data/repository/manage_account_repository_impl.dart
@@ -36,4 +36,14 @@ class ManageAccountRepositoryImpl extends ManageAccountRepository {
   Future<bool> getLabelSettingState() {
     return dataSource.getLabelSettingState();
   }
+
+  @override
+  Future<bool> getExperimentalModeEnabled() {
+    return dataSource.getExperimentalModeEnabled();
+  }
+
+  @override
+  Future<void> enableExperimentalMode() {
+    return dataSource.enableExperimentalMode();
+  }
 }

--- a/lib/features/manage_account/domain/repository/manage_account_repository.dart
+++ b/lib/features/manage_account/domain/repository/manage_account_repository.dart
@@ -14,4 +14,8 @@ abstract class ManageAccountRepository {
   Future<AIScribeConfig> getAiScribeConfigLocalSettings();
 
   Future<bool> getLabelSettingState();
+
+  Future<bool> getExperimentalModeEnabled();
+
+  Future<void> enableExperimentalMode();
 }

--- a/lib/features/manage_account/domain/state/experimental_mode_state.dart
+++ b/lib/features/manage_account/domain/state/experimental_mode_state.dart
@@ -1,0 +1,24 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+
+class GetExperimentalModeEnabledSuccess extends UIState {
+  final bool isEnabled;
+
+  GetExperimentalModeEnabledSuccess(this.isEnabled);
+
+  @override
+  List<Object> get props => [isEnabled];
+}
+
+class GetExperimentalModeEnabledFailure extends FeatureFailure {
+  GetExperimentalModeEnabledFailure(dynamic exception) : super(exception: exception);
+}
+
+class EnableExperimentalModeSuccess extends UIState {
+  @override
+  List<Object> get props => [];
+}
+
+class EnableExperimentalModeFailure extends FeatureFailure {
+  EnableExperimentalModeFailure(dynamic exception) : super(exception: exception);
+}

--- a/lib/features/manage_account/domain/usecases/enable_experimental_mode_interactor.dart
+++ b/lib/features/manage_account/domain/usecases/enable_experimental_mode_interactor.dart
@@ -1,0 +1,20 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/repository/manage_account_repository.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/state/experimental_mode_state.dart';
+
+class EnableExperimentalModeInteractor {
+  const EnableExperimentalModeInteractor(this._repository);
+
+  final ManageAccountRepository _repository;
+
+  Future<Either<Failure, Success>> execute() async {
+    try {
+      await _repository.enableExperimentalMode();
+      return Right(EnableExperimentalModeSuccess());
+    } catch (e) {
+      return Left(EnableExperimentalModeFailure(e));
+    }
+  }
+}

--- a/lib/features/manage_account/domain/usecases/get_experimental_mode_enabled_interactor.dart
+++ b/lib/features/manage_account/domain/usecases/get_experimental_mode_enabled_interactor.dart
@@ -1,0 +1,20 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/repository/manage_account_repository.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/state/experimental_mode_state.dart';
+
+class GetExperimentalModeEnabledInteractor {
+  const GetExperimentalModeEnabledInteractor(this._repository);
+
+  final ManageAccountRepository _repository;
+
+  Future<Either<Failure, Success>> execute() async {
+    try {
+      final isEnabled = await _repository.getExperimentalModeEnabled();
+      return Right(GetExperimentalModeEnabledSuccess(isEnabled));
+    } catch (e) {
+      return Left(GetExperimentalModeEnabledFailure(e));
+    }
+  }
+}

--- a/lib/features/manage_account/presentation/menu/settings/setting_app_bar.dart
+++ b/lib/features/manage_account/presentation/menu/settings/setting_app_bar.dart
@@ -14,6 +14,7 @@ class SettingAppBar extends StatelessWidget {
   final VoidCallback onBackAction;
   final VoidCallback? onExportTraceLogAction;
   final VoidCallback? onMultiClickAction;
+  final int? multiClickCount;
 
   const SettingAppBar({
     super.key,
@@ -24,6 +25,7 @@ class SettingAppBar extends StatelessWidget {
     required this.onBackAction,
     this.onExportTraceLogAction,
     this.onMultiClickAction,
+    this.multiClickCount,
   });
 
   @override
@@ -42,6 +44,7 @@ class SettingAppBar extends StatelessWidget {
         responsiveUtils: responsiveUtils,
         onBackAction: onBackAction,
         onMultiClickAction: onMultiClickAction,
+        multiClickCount: multiClickCount,
       );
     }
   }

--- a/lib/features/manage_account/presentation/menu/settings/setting_first_level_app_bar.dart
+++ b/lib/features/manage_account/presentation/menu/settings/setting_first_level_app_bar.dart
@@ -5,6 +5,7 @@ import 'package:core/presentation/views/button/multi_click_widget.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/providers/experimental_mode_notifier.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 class SettingFirstLevelAppBar extends StatelessWidget {
@@ -13,6 +14,7 @@ class SettingFirstLevelAppBar extends StatelessWidget {
   final ResponsiveUtils responsiveUtils;
   final VoidCallback onBackAction;
   final VoidCallback? onMultiClickAction;
+  final int? multiClickCount;
 
   const SettingFirstLevelAppBar({
     super.key,
@@ -21,6 +23,7 @@ class SettingFirstLevelAppBar extends StatelessWidget {
     required this.responsiveUtils,
     required this.onBackAction,
     this.onMultiClickAction,
+    this.multiClickCount,
   });
 
   @override
@@ -37,6 +40,7 @@ class SettingFirstLevelAppBar extends StatelessWidget {
     if (onMultiClickAction != null) {
       titleWidget = MultiClickWidget(
         onMultiTap: onMultiClickAction!,
+        requiredClicks: multiClickCount ?? ExperimentalModeNotifier.activationTapCount,
         child: titleWidget,
       );
     }

--- a/lib/features/manage_account/presentation/menu/settings/settings_controller.dart
+++ b/lib/features/manage_account/presentation/menu/settings/settings_controller.dart
@@ -10,11 +10,13 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/prof
 import 'package:tmail_ui_user/features/manage_account/presentation/extensions/export_trace_log_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/extensions/handle_profile_setting_action_type_click_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/manage_account_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/mixin/enable_experimental_mode_mixin.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/settings_page_level.dart';
 import 'package:tmail_ui_user/main/utils/app_utils.dart';
 
-class SettingsController extends GetxController with ContactSupportMixin {
+class SettingsController extends GetxController
+    with ContactSupportMixin, EnableExperimentalModeMixin {
   final manageAccountDashboardController = Get.find<ManageAccountDashBoardController>();
   final responsiveUtils = Get.find<ResponsiveUtils>();
   final imagePaths = Get.find<ImagePaths>();
@@ -44,6 +46,8 @@ class SettingsController extends GetxController with ContactSupportMixin {
   void showExportTraceLogConfirmDialog(BuildContext context) {
     manageAccountDashboardController.showExportTraceLogConfirmDialog(context);
   }
+
+  void onMultiClickPreferencesTitle() => enableExperimentalMode();
 
   void goToCommonSetting(OidcUserInfo oidcUserInfo) {
     final commonSettingUrl = WebLinkGenerator.safeGenerateWebLink(

--- a/lib/features/manage_account/presentation/menu/settings/settings_view.dart
+++ b/lib/features/manage_account/presentation/menu/settings/settings_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/email_rules/email_rules_view.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/extensions/vacation_response_extension.dart';
@@ -14,6 +15,7 @@ import 'package:tmail_ui_user/features/manage_account/presentation/menu/settings
 import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/settings_page_level.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/notification/notification_view.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/providers/experimental_mode_notifier.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/preferences/preferences_view.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/storage/storage_view.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/vacation/vacation_view.dart';
@@ -28,23 +30,7 @@ class SettingsView extends GetWidget<SettingsController> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Obx(() {
-          return SettingAppBar(
-            pageLevel: controller
-                .manageAccountDashboardController
-                .settingsPageLevel
-                .value,
-            accountMenuItem: controller
-                .manageAccountDashboardController
-                .accountMenuItemSelected
-                .value,
-            imagePaths: controller.imagePaths,
-            responsiveUtils: controller.responsiveUtils,
-            onBackAction: () => controller.onBackSettingAction(context),
-            onExportTraceLogAction: () =>
-                controller.showExportTraceLogConfirmDialog(context),
-          );
-        }),
+        _buildAppBar(context),
         Obx(() {
           final dashboard = controller.manageAccountDashboardController;
           final vacation = dashboard.vacationResponse.value;
@@ -88,8 +74,8 @@ class SettingsView extends GetWidget<SettingsController> {
             return const SizedBox.shrink();
           }
         }),
-        Expanded(child: _bodySettingsScreen())
-      ]
+        Expanded(child: _bodySettingsScreen()),
+      ],
     );
   }
 
@@ -157,5 +143,39 @@ class SettingsView extends GetWidget<SettingsController> {
           return const SizedBox.shrink();
       }
     });
+  }
+
+  Widget _buildAppBar(BuildContext context) {
+    return Consumer(
+      builder: (context, ref, _) {
+        final isExperimentalEnabled = ref.watch(experimentalModeNotifierProvider);
+        return Obx(() {
+          final selectedMenuItem = controller
+              .manageAccountDashboardController
+              .accountMenuItemSelected
+              .value;
+
+          final pageLevel = controller
+            .manageAccountDashboardController
+            .settingsPageLevel
+            .value;
+
+          return SettingAppBar(
+            pageLevel: pageLevel,
+            accountMenuItem: selectedMenuItem,
+            imagePaths: controller.imagePaths,
+            responsiveUtils: controller.responsiveUtils,
+            onBackAction: () => controller.onBackSettingAction(context),
+            onExportTraceLogAction: () =>
+                controller.showExportTraceLogConfirmDialog(context),
+            onMultiClickAction: selectedMenuItem == AccountMenuItem.preferences &&
+                    !isExperimentalEnabled
+                ? controller.onMultiClickPreferencesTitle
+                : null,
+            multiClickCount: ExperimentalModeNotifier.activationTapCount,
+          );
+        });
+      },
+    );
   }
 }

--- a/lib/features/manage_account/presentation/mixin/enable_experimental_mode_mixin.dart
+++ b/lib/features/manage_account/presentation/mixin/enable_experimental_mode_mixin.dart
@@ -1,0 +1,26 @@
+import 'dart:async';
+
+import 'package:core/presentation/utils/app_toast.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/providers/experimental_mode_notifier.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+
+mixin EnableExperimentalModeMixin {
+  void enableExperimentalMode() {
+    unawaited(
+      appProviderContainer
+          .read(experimentalModeNotifierProvider.notifier)
+          .enable()
+          .then((_) {
+        final isEnabled = appProviderContainer.read(experimentalModeNotifierProvider);
+        if (!isEnabled) return;
+        if (currentOverlayContext == null || currentContext == null) return;
+        getBinding<AppToast>()?.showToastSuccessMessage(
+          currentOverlayContext!,
+          AppLocalizations.of(currentContext!).experimentalFeaturesEnabled,
+        );
+      }),
+    );
+  }
+}

--- a/lib/features/manage_account/presentation/providers/experimental_mode_notifier.dart
+++ b/lib/features/manage_account/presentation/providers/experimental_mode_notifier.dart
@@ -1,0 +1,49 @@
+import 'package:core/utils/app_logger.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/state/experimental_mode_state.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/enable_experimental_mode_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_experimental_mode_enabled_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/providers/manage_account_local_providers.dart';
+
+class ExperimentalModeNotifier extends StateNotifier<bool> {
+  static const int activationTapCount = 7;
+
+  final GetExperimentalModeEnabledInteractor _getInteractor;
+  final EnableExperimentalModeInteractor _enableInteractor;
+
+  // Resolves when the initial load from storage completes.
+  late final Future<void> ensureLoaded;
+
+  ExperimentalModeNotifier(this._getInteractor, this._enableInteractor) : super(false) {
+    ensureLoaded = _load().onError((e, _) {
+      logError('ExperimentalModeNotifier: failed to load initial state: $e');
+    });
+  }
+
+  Future<void> _load() async {
+    final result = await _getInteractor.execute();
+    result.fold(
+      (_) {},
+      (success) {
+        if (success is GetExperimentalModeEnabledSuccess) state = success.isEnabled;
+      },
+    );
+  }
+
+  Future<void> enable() async {
+    if (state) return;
+    final result = await _enableInteractor.execute();
+    result.fold(
+      (_) {},
+      (_) => state = true,
+    );
+  }
+}
+
+final experimentalModeNotifierProvider =
+    StateNotifierProvider<ExperimentalModeNotifier, bool>(
+  (ref) => ExperimentalModeNotifier(
+    ref.read(getExperimentalModeEnabledProvider),
+    ref.read(enableExperimentalModeProvider),
+  ),
+);

--- a/lib/features/manage_account/presentation/providers/experimental_mode_notifier.dart
+++ b/lib/features/manage_account/presentation/providers/experimental_mode_notifier.dart
@@ -35,7 +35,9 @@ class ExperimentalModeNotifier extends StateNotifier<bool> {
     final result = await _enableInteractor.execute();
     result.fold(
       (_) {},
-      (_) => state = true,
+      (success) {
+        if (success is EnableExperimentalModeSuccess) state = true;
+      },
     );
   }
 }

--- a/lib/features/manage_account/presentation/providers/manage_account_local_providers.dart
+++ b/lib/features/manage_account/presentation/providers/manage_account_local_providers.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tmail_ui_user/features/manage_account/data/datasource/manage_account_datasource.dart';
+import 'package:tmail_ui_user/features/manage_account/data/datasource_impl/manage_account_datasource_impl.dart';
+import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
+import 'package:tmail_ui_user/features/manage_account/data/local/preferences_setting_manager.dart';
+import 'package:tmail_ui_user/features/manage_account/data/repository/manage_account_repository_impl.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/repository/manage_account_repository.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/enable_experimental_mode_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_experimental_mode_enabled_interactor.dart';
+import 'package:tmail_ui_user/main/providers/cache_exception_thrower_provider.dart';
+import 'package:tmail_ui_user/main/providers/shared_preferences_provider.dart';
+
+final _languageCacheManagerProvider = Provider<LanguageCacheManager>(
+  (ref) => LanguageCacheManager(ref.read(sharedPreferencesProvider)),
+);
+
+final _preferencesSettingManagerProvider = Provider<PreferencesSettingManager>(
+  (ref) => PreferencesSettingManager(ref.read(sharedPreferencesProvider)),
+);
+
+final _manageAccountLocalDataSourceProvider = Provider<ManageAccountDataSource>(
+  (ref) => ManageAccountDataSourceImpl(
+    ref.read(_languageCacheManagerProvider),
+    ref.read(_preferencesSettingManagerProvider),
+    ref.read(cacheExceptionThrowerProvider),
+  ),
+);
+
+final _manageAccountLocalRepositoryProvider = Provider<ManageAccountRepository>(
+  (ref) => ManageAccountRepositoryImpl(ref.read(_manageAccountLocalDataSourceProvider)),
+);
+
+final getExperimentalModeEnabledProvider = Provider<GetExperimentalModeEnabledInteractor>(
+  (ref) => GetExperimentalModeEnabledInteractor(ref.read(_manageAccountLocalRepositoryProvider)),
+);
+
+final enableExperimentalModeProvider = Provider<EnableExperimentalModeInteractor>(
+  (ref) => EnableExperimentalModeInteractor(ref.read(_manageAccountLocalRepositoryProvider)),
+);

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2026-04-17T18:25:40.778609",
+  "@@last_modified": "2026-05-25T10:48:23.465659",
   "initializing_data": "Initializing data...",
   "@initializing_data": {
     "type": "text",
@@ -4894,6 +4894,12 @@
   },
   "aiScribeToggleDescription": "Enable AI Scribe",
   "@aiScribeToggleDescription": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "experimentalFeaturesEnabled": "Experimental features enabled",
+  "@experimentalFeaturesEnabled": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,9 @@ import 'package:scribe/scribe/ai/localizations/scribe_localizations.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations_delegate.dart';
 import 'package:tmail_ui_user/main/localizations/localization_service.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tmail_ui_user/main/main_entry.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/runner/app_runner_mobile.dart'
     if (dart.library.html) 'package:tmail_ui_user/main/runner/app_runner_web.dart';
 import 'package:tmail_ui_user/main/pages/app_pages.dart';
@@ -41,40 +43,43 @@ class _TMailAppState extends State<TMailApp> {
 
   @override
   Widget build(BuildContext context) {
-    return GetMaterialApp(
-      debugShowCheckedModeBanner: false,
-      theme: ThemeUtils.buildAppTheme(context),
-      supportedLocales: LocalizationService.supportedLocales,
-      localizationsDelegates: const [
-        AppLocalizationsDelegate(),
-        ScribeLocalizations.delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-      ],
-      localeResolutionCallback: (deviceLocale, supportedLocales) {
-        for (var locale in supportedLocales) {
-          if (locale.languageCode == deviceLocale?.languageCode) {
-            return deviceLocale;
+    return UncontrolledProviderScope(
+      container: appProviderContainer,
+      child: GetMaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: ThemeUtils.buildAppTheme(context),
+        supportedLocales: LocalizationService.supportedLocales,
+        localizationsDelegates: const [
+          AppLocalizationsDelegate(),
+          ScribeLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        localeResolutionCallback: (deviceLocale, supportedLocales) {
+          for (var locale in supportedLocales) {
+            if (locale.languageCode == deviceLocale?.languageCode) {
+              return deviceLocale;
+            }
           }
-        }
-        return supportedLocales.first;
-      },
-      locale: LocalizationService.getInitialLocale(),
-      fallbackLocale: LocalizationService.fallbackLocale,
-      translations: LocalizationService(),
-      onGenerateTitle: (context) {
-        if (Get.currentRoute == AppRoutes.unknownRoutePage) {
-          return AppLocalizations.of(context).page404;
-        } else {
-          return AppLocalizations.of(context).page_name;
-        }
-      },
-      unknownRoute: AppPages.unknownRoutePage,
-      defaultTransition: Transition.noTransition,
-      initialRoute: AppRoutes.home,
-      getPages: AppPages.pages,
-      builder: FlutterSmartDialog.init(),
+          return supportedLocales.first;
+        },
+        locale: LocalizationService.getInitialLocale(),
+        fallbackLocale: LocalizationService.fallbackLocale,
+        translations: LocalizationService(),
+        onGenerateTitle: (context) {
+          if (Get.currentRoute == AppRoutes.unknownRoutePage) {
+            return AppLocalizations.of(context).page404;
+          } else {
+            return AppLocalizations.of(context).page_name;
+          }
+        },
+        unknownRoute: AppPages.unknownRoutePage,
+        defaultTransition: Transition.noTransition,
+        initialRoute: AppRoutes.home,
+        getPages: AppPages.pages,
+        builder: FlutterSmartDialog.init(),
+      ),
     );
   }
 

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -5181,6 +5181,13 @@ class AppLocalizations {
     );
   }
 
+  String get experimentalFeaturesEnabled {
+    return Intl.message(
+      'Experimental features enabled',
+      name: 'experimentalFeaturesEnabled',
+    );
+  }
+
   String showMoreAttachmentButton(int count) {
     return Intl.message(
       'Show +$count more',

--- a/lib/main/main_entry.dart
+++ b/lib/main/main_entry.dart
@@ -2,9 +2,11 @@ import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/utils/build_utils.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/widgets.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tmail_ui_user/features/caching/config/hive_cache_config.dart';
 import 'package:tmail_ui_user/main.dart';
 import 'package:tmail_ui_user/main/bindings/main_bindings.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/utils/asset_preloader.dart';
 import 'package:tmail_ui_user/main/utils/cozy_integration.dart';
 import 'package:url_strategy/url_strategy.dart';
@@ -23,6 +25,11 @@ Future<void> runTmailPreload() async {
     HiveCacheConfig.instance.setUp(),
     if (PlatformInfo.isWeb) AssetPreloader.preloadHtmlEditorAssets(),
   ], eagerError: false);
+
+  // SharedPreferences was initialized inside MainBindings; getInstance() returns
+  // the cached instance here. We wire it into Riverpod so no provider needs GetX.
+  final prefs = await SharedPreferences.getInstance();
+  initAppProviderContainer(prefs);
 
   if (PlatformInfo.isMobile) {
     await workerManager.init(dynamicSpawning: true);

--- a/lib/main/providers/app_provider_container.dart
+++ b/lib/main/providers/app_provider_container.dart
@@ -1,5 +1,26 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tmail_ui_user/main/providers/shared_preferences_provider.dart';
 
 /// Singleton [ProviderContainer] shared between the [ProviderScope] and
 /// non-widget code (e.g. GetX controllers / services).
-final appProviderContainer = ProviderContainer();
+///
+/// Must be initialized via [initAppProviderContainer] before any access.
+/// The app entry point (main_entry.dart) guarantees this before any widget renders.
+ProviderContainer? _appProviderContainer;
+
+ProviderContainer get appProviderContainer {
+  assert(
+    _appProviderContainer != null,
+    'appProviderContainer accessed before initAppProviderContainer()',
+  );
+  return _appProviderContainer!;
+}
+
+void initAppProviderContainer(SharedPreferences prefs) {
+  _appProviderContainer = ProviderContainer(
+    overrides: [
+      sharedPreferencesProvider.overrideWithValue(prefs),
+    ],
+  );
+}

--- a/lib/main/providers/app_provider_container.dart
+++ b/lib/main/providers/app_provider_container.dart
@@ -18,6 +18,7 @@ ProviderContainer get appProviderContainer {
 }
 
 void initAppProviderContainer(SharedPreferences prefs) {
+  if (_appProviderContainer != null) return;
   _appProviderContainer = ProviderContainer(
     overrides: [
       sharedPreferencesProvider.overrideWithValue(prefs),

--- a/lib/main/providers/cache_exception_thrower_provider.dart
+++ b/lib/main/providers/cache_exception_thrower_provider.dart
@@ -1,0 +1,6 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.dart';
+
+final cacheExceptionThrowerProvider = Provider<CacheExceptionThrower>(
+  (_) => CacheExceptionThrower(),
+);

--- a/lib/main/providers/shared_preferences_provider.dart
+++ b/lib/main/providers/shared_preferences_provider.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+final sharedPreferencesProvider = Provider<SharedPreferences>(
+  (ref) => throw UnimplementedError(
+    'sharedPreferencesProvider must be overridden via initAppProviderContainer()',
+  ),
+);

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -1,4 +1,6 @@
 import 'package:core/data/network/config/dynamic_url_interceptors.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:core/presentation/utils/app_toast.dart';
@@ -72,7 +74,6 @@ import 'package:tmail_ui_user/features/upload/presentation/controller/upload_con
 import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_state.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
 import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.dart';
-import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/utils/app_config.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
@@ -763,6 +764,11 @@ void main() {
     });
 
     group('markCleanClose - platform guard:', () {
+      setUp(() async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        initAppProviderContainer(prefs);
+      });
       test(
           'Should set isCleanClose flag in the notifier\n'
           'When on Android with valid autoSaveComposerId', () {

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -1,4 +1,6 @@
 import 'package:core/data/network/config/dynamic_url_interceptors.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/app_toast.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
@@ -318,6 +320,11 @@ void main() {
       Session({}, {}, {}, UserName('data'), google, google, google, google, State('1'));
   final testMailboxId = MailboxId(Id('1'));
   final testAccountId = AccountId(Id('123'));
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    initAppProviderContainer(await SharedPreferences.getInstance());
+  });
 
   setUp(() {
     Get.put<RemoveEmailDraftsInteractor>(removeEmailDraftsInteractor);

--- a/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
+++ b/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
@@ -1,4 +1,6 @@
 import 'package:core/data/network/config/dynamic_url_interceptors.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/app_toast.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
@@ -324,6 +326,11 @@ void main() {
   }
 
   group('MailboxDashboardView', () {
+    setUpAll(() async {
+      SharedPreferences.setMockInitialValues({});
+      initAppProviderContainer(await SharedPreferences.getInstance());
+    });
+
     setUp(() {
       Get.testMode = true;
 

--- a/test/features/manage_account/domain/usecases/enable_experimental_mode_interactor_test.dart
+++ b/test/features/manage_account/domain/usecases/enable_experimental_mode_interactor_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/repository/manage_account_repository.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/state/experimental_mode_state.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/enable_experimental_mode_interactor.dart';
+
+import 'enable_experimental_mode_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<ManageAccountRepository>()])
+void main() {
+  late MockManageAccountRepository mockRepo;
+  late EnableExperimentalModeInteractor interactor;
+
+  setUp(() {
+    mockRepo = MockManageAccountRepository();
+    interactor = EnableExperimentalModeInteractor(mockRepo);
+  });
+
+  group('EnableExperimentalModeInteractor', () {
+    test('returns Right(EnableExperimentalModeSuccess) when repo completes', () async {
+      when(mockRepo.enableExperimentalMode()).thenAnswer((_) async {});
+
+      final result = await interactor.execute();
+
+      expect(result.isRight(), isTrue);
+      result.fold(
+        (_) => fail('expected Right'),
+        (success) => expect(success, isA<EnableExperimentalModeSuccess>()),
+      );
+    });
+
+    test('returns Left(EnableExperimentalModeFailure) when repo throws', () async {
+      when(mockRepo.enableExperimentalMode()).thenThrow(Exception('disk error'));
+
+      final result = await interactor.execute();
+
+      expect(result.isLeft(), isTrue);
+      result.fold(
+        (failure) => expect(failure, isA<EnableExperimentalModeFailure>()),
+        (_) => fail('expected Left'),
+      );
+    });
+  });
+}

--- a/test/features/manage_account/domain/usecases/get_experimental_mode_enabled_interactor_test.dart
+++ b/test/features/manage_account/domain/usecases/get_experimental_mode_enabled_interactor_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/repository/manage_account_repository.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/state/experimental_mode_state.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_experimental_mode_enabled_interactor.dart';
+
+import 'get_experimental_mode_enabled_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<ManageAccountRepository>()])
+void main() {
+  late MockManageAccountRepository mockRepo;
+  late GetExperimentalModeEnabledInteractor interactor;
+
+  setUp(() {
+    mockRepo = MockManageAccountRepository();
+    interactor = GetExperimentalModeEnabledInteractor(mockRepo);
+  });
+
+  group('GetExperimentalModeEnabledInteractor', () {
+    test('returns Right with isEnabled=true when repo returns true', () async {
+      when(mockRepo.getExperimentalModeEnabled()).thenAnswer((_) async => true);
+
+      final result = await interactor.execute();
+
+      result.fold(
+        (_) => fail('expected Right'),
+        (success) {
+          expect(success, isA<GetExperimentalModeEnabledSuccess>());
+          expect((success as GetExperimentalModeEnabledSuccess).isEnabled, isTrue);
+        },
+      );
+    });
+
+    test('returns Right with isEnabled=false when repo returns false', () async {
+      when(mockRepo.getExperimentalModeEnabled()).thenAnswer((_) async => false);
+
+      final result = await interactor.execute();
+
+      result.fold(
+        (_) => fail('expected Right'),
+        (success) {
+          expect(success, isA<GetExperimentalModeEnabledSuccess>());
+          expect((success as GetExperimentalModeEnabledSuccess).isEnabled, isFalse);
+        },
+      );
+    });
+
+    test('returns Left(GetExperimentalModeEnabledFailure) when repo throws', () async {
+      when(mockRepo.getExperimentalModeEnabled()).thenThrow(Exception('storage error'));
+
+      final result = await interactor.execute();
+
+      expect(result.isLeft(), isTrue);
+      result.fold(
+        (failure) => expect(failure, isA<GetExperimentalModeEnabledFailure>()),
+        (_) => fail('expected Left'),
+      );
+    });
+  });
+}

--- a/test/features/manage_account/presentation/providers/experimental_mode_notifier_test.dart
+++ b/test/features/manage_account/presentation/providers/experimental_mode_notifier_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/providers/experimental_mode_notifier.dart';
+import 'package:tmail_ui_user/main/providers/shared_preferences_provider.dart';
+
+void main() {
+  group('ExperimentalModeNotifier', () {
+    late SharedPreferences prefs;
+    late ProviderContainer container;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      prefs = await SharedPreferences.getInstance();
+      container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+        ],
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('initial state is false', () async {
+      await container.read(experimentalModeNotifierProvider.notifier).ensureLoaded;
+      expect(container.read(experimentalModeNotifierProvider), isFalse);
+    });
+
+    test('enable sets state to true', () async {
+      await container.read(experimentalModeNotifierProvider.notifier).enable();
+      expect(container.read(experimentalModeNotifierProvider), isTrue);
+    });
+
+    test('enable is idempotent — second call has no effect', () async {
+      await container.read(experimentalModeNotifierProvider.notifier).enable();
+      await container.read(experimentalModeNotifierProvider.notifier).enable();
+      expect(container.read(experimentalModeNotifierProvider), isTrue);
+    });
+
+    test('state persists across notifier restarts', () async {
+      await container.read(experimentalModeNotifierProvider.notifier).enable();
+
+      final container2 = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+        ],
+      );
+      addTearDown(container2.dispose);
+
+      await container2.read(experimentalModeNotifierProvider.notifier).ensureLoaded;
+      expect(container2.read(experimentalModeNotifierProvider), isTrue);
+    });
+
+    test('activationTapCount is 7', () {
+      expect(ExperimentalModeNotifier.activationTapCount, 7);
+    });
+  });
+}

--- a/test/features/search/verify_before_time_in_search_email_filter_test.dart
+++ b/test/features/search/verify_before_time_in_search_email_filter_test.dart
@@ -1,6 +1,8 @@
 import 'dart:math' as math;
 
 import 'package:core/data/network/config/dynamic_url_interceptors.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/app_toast.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
@@ -270,7 +272,9 @@ void main() {
   late MockToastManager mockToastManager;
   late MockTwakeAppManager mockTwakeAppManager;
 
-  setUpAll(() {
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    initAppProviderContainer(await SharedPreferences.getInstance());
     Get.testMode = true;
     // Mock base controller
     mockCachingManager = MockCachingManager();

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -1,4 +1,6 @@
 import 'package:core/data/network/config/dynamic_url_interceptors.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:core/presentation/utils/app_toast.dart';
@@ -119,7 +121,9 @@ void main() {
   late MockToastManager mockToastManager;
   late MockTwakeAppManager mockTwakeAppManager;
 
-  setUpAll(() {
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    initAppProviderContainer(await SharedPreferences.getInstance());
     Get.testMode = true;
     // Mock base controller
     mockCachingManager = MockCachingManager();


### PR DESCRIPTION
### What
An opt-in "experimental mode" persisted in `SharedPreferences`. Once enabled it
stays on permanently (no disable path by design). Activation: tap the **Preferences**
section title 7 times — the counter resets if experimental mode is already on.

### Architecture

**Riverpod setup** (required to share state between widget tree and GetX controllers):
- `SharedPreferencesProvider` — overridden at startup with the cached instance
- `CacheExceptionThrowerProvider`
- `appProviderContainer` changed from eager `ProviderContainer()` to `late final` initialized in `main_entry.dart` before any widget renders
- `UncontrolledProviderScope` wraps `GetMaterialApp` in `main.dart`

**Domain/data:**
- `ExperimentalModeState` — `GetExperimentalModeEnabledSuccess`, `EnableExperimentalModeSuccess` + failure variants
- `GetExperimentalModeEnabledInteractor` / `EnableExperimentalModeInteractor`
- `PreferencesSettingManager`: stores flag under key `EXPERIMENTAL_MODE_ENABLED` (outside the `PREFERENCES_SETTING_*` namespace)
- `ManageAccountLocalProviders`: Riverpod wiring for the data layer (datasource → repository → interactors)

**Presentation:**
- `ExperimentalModeNotifier` (`StateNotifier<bool>`) — loads flag on startup via `ensureLoaded`
- `EnableExperimentalModeMixin` — wraps `enable()` call; shows success toast only if state actually flipped to `true`
- `SettingsController` + `SettingsView`: passes `onMultiClickAction` to `SettingAppBar` only when experimental mode is off and the selected menu item is Preferences

### Test
`ExperimentalModeNotifier` unit tests: initial load, enable, idempotent double-enable, storage failure handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental mode that users can enable through a multi-click action on the settings page.
  * Shows a success notification when experimental features are enabled.

* **Infrastructure**
  * Refactored app initialization to integrate state management with local storage for better feature management.

* **Tests**
  * Added comprehensive test coverage for the new experimental mode feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-flutter/pull/4553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->