### PR TITLE
[Part 3] TF-4551  feat: add collapseThread preference gated behind experimental mode

### DIFF
--- a/lib/features/composer/presentation/providers/composer_cache_providers.dart
+++ b/lib/features/composer/presentation/providers/composer_cache_providers.dart
@@ -7,18 +7,15 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/domain/repository/compo
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/mark_composer_cache_clean_close_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/remove_all_composer_cache_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/resolve_composer_cache_for_restore_interactor.dart';
-import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.dart';
+import 'package:tmail_ui_user/main/providers/cache_exception_thrower_provider.dart';
 
 final _composerHiveCacheClientProvider =
     Provider<ComposerHiveCacheClient>((_) => ComposerHiveCacheClient());
 
-final _cacheExceptionThrowerProvider =
-    Provider<CacheExceptionThrower>((_) => CacheExceptionThrower());
-
 final _composerCacheDatasourceProvider = Provider<ComposerCacheDatasource>(
   (ref) => ComposerPersistentCacheDatasourceImpl(
     ref.read(_composerHiveCacheClientProvider),
-    ref.read(_cacheExceptionThrowerProvider),
+    ref.read(cacheExceptionThrowerProvider),
   ),
 );
 

--- a/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
@@ -127,6 +127,9 @@ import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_all_id
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_local_settings_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/bindings/setting_interactor_bindings.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_service.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_reader.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/riverpod_local_settings_reader.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/identities/identity_interactors_bindings.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/identities/utils/identity_utils.dart';
 import 'package:tmail_ui_user/features/offline_mode/manager/new_email_cache_manager.dart';
@@ -203,6 +206,7 @@ abstract class MailboxDashBoardBindings extends BaseBindings {
     // Must be registered first so [localSettingsNotifierProvider] is populated
     // before any controller reads local settings.
     Get.put(LocalSettingsService(Get.find<GetLocalSettingsInteractor>()));
+    Get.put<ILocalSettingsReader>(RiverpodLocalSettingsReader(appProviderContainer));
 
     Get.put(AppGridDashboardController(
       Get.find<GetAppDashboardConfigurationInteractor>(),

--- a/lib/features/manage_account/data/local/preferences_setting_manager.dart
+++ b/lib/features/manage_account/data/local/preferences_setting_manager.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/ai_scribe_config.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/collapse_thread_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/default_preferences_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/empty_preferences_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/label_config.dart';
@@ -21,6 +22,7 @@ class PreferencesSettingManager {
   static final Map<String, PreferencesConfig Function(Map<String, dynamic>)>
       _configFactories = Map.unmodifiable({
     _storageKey(ThreadDetailConfig.keySuffix): ThreadDetailConfig.fromJson,
+    _storageKey(CollapseThreadConfig.keySuffix): CollapseThreadConfig.fromJson,
     _storageKey(SpamReportConfig.keySuffix): SpamReportConfig.fromJson,
     _storageKey(TextFormattingMenuConfig.keySuffix): TextFormattingMenuConfig.fromJson,
     _storageKey(AIScribeConfig.keySuffix): AIScribeConfig.fromJson,

--- a/lib/features/manage_account/domain/model/preferences/collapse_thread_config.dart
+++ b/lib/features/manage_account/domain/model/preferences/collapse_thread_config.dart
@@ -1,0 +1,35 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_config.dart';
+
+part 'collapse_thread_config.g.dart';
+
+@JsonSerializable()
+class CollapseThreadConfig extends PreferencesConfig {
+  static const keySuffix = 'COLLAPSE_THREAD';
+
+  final bool isEnabled;
+
+  CollapseThreadConfig({this.isEnabled = false});
+
+  @override
+  String get configKey => keySuffix;
+
+  factory CollapseThreadConfig.initial() => CollapseThreadConfig();
+
+  factory CollapseThreadConfig.fromJson(Map<String, dynamic> json) =>
+      _$CollapseThreadConfigFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$CollapseThreadConfigToJson(this);
+
+  @override
+  List<Object> get props => [isEnabled];
+}
+
+extension CollapseThreadConfigExtension on CollapseThreadConfig {
+  CollapseThreadConfig copyWith({bool? isEnabled}) {
+    return CollapseThreadConfig(
+      isEnabled: isEnabled ?? this.isEnabled,
+    );
+  }
+}

--- a/lib/features/manage_account/domain/model/preferences/preferences_setting.dart
+++ b/lib/features/manage_account/domain/model/preferences/preferences_setting.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/ai_scribe_config.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/collapse_thread_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/label_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/spam_report_config.dart';
@@ -14,6 +15,7 @@ class PreferencesSetting with EquatableMixin {
   factory PreferencesSetting.initial() {
     return PreferencesSetting([
       ThreadDetailConfig.initial(),
+      CollapseThreadConfig.initial(),
       SpamReportConfig.initial(),
       TextFormattingMenuConfig.initial(),
       AIScribeConfig.initial(),
@@ -27,6 +29,9 @@ class PreferencesSetting with EquatableMixin {
   ThreadDetailConfig get threadConfig =>
       getConfigOrDefault(ThreadDetailConfig.initial());
 
+  CollapseThreadConfig get collapseThreadConfig =>
+      getConfigOrDefault(CollapseThreadConfig.initial());
+
   SpamReportConfig get spamReportConfig =>
       getConfigOrDefault(SpamReportConfig.initial());
 
@@ -38,6 +43,9 @@ class PreferencesSetting with EquatableMixin {
 
   LabelConfig get labelConfig =>
       getConfigOrDefault(LabelConfig.initial());
+
+  bool get isCollapseThreadsEnabled =>
+      threadConfig.isEnabled && collapseThreadConfig.isEnabled;
 
   @override
   List<Object?> get props => [configs];

--- a/lib/features/manage_account/presentation/model/preferences_option_type.dart
+++ b/lib/features/manage_account/presentation/model/preferences_option_type.dart
@@ -1,7 +1,15 @@
 import 'package:server_settings/server_settings/tmail_server_settings.dart';
 import 'package:server_settings/server_settings/tmail_server_settings_extension.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/ai_scribe_config.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/collapse_thread_config.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/label_config.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/spam_report_config.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/thread_detail_config.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+enum PreferencesOptionCategory { standard, experimental }
 
 typedef _OptionStrings = ({
   String title,
@@ -9,18 +17,45 @@ typedef _OptionStrings = ({
   String toggleDescription,
 });
 
+typedef PreferencesVisibilityContext = ({
+  TMailServerSettingOptions? settingOption,
+  PreferencesSetting localSettings,
+  bool isExperimentalEnabled,
+  bool isAIScribeAvailable,
+  bool isAICapabilitySupported,
+  bool isLabelVisibility,
+});
+
 enum PreferencesOptionType {
   readReceipt(isLocal: false),
   senderPriority(isLocal: false),
   thread(isLocal: true),
+  collapseThread(
+    isLocal: true,
+    category: PreferencesOptionCategory.experimental,
+  ),
   spamReport(isLocal: true),
   aiScribe(isLocal: true),
   aiNeedsAction(isLocal: false),
   label(isLocal: true);
 
   final bool isLocal;
+  final PreferencesOptionCategory category;
 
-  const PreferencesOptionType({required this.isLocal});
+  const PreferencesOptionType({
+    required this.isLocal,
+    this.category = PreferencesOptionCategory.standard,
+  });
+
+  bool get isExperimental => category == PreferencesOptionCategory.experimental;
+
+  static final _parentTypes = <PreferencesOptionType, PreferencesOptionType>{
+    PreferencesOptionType.collapseThread: PreferencesOptionType.thread,
+  };
+
+  PreferencesOptionType? get parentType => _parentTypes[this];
+
+  bool get isChildOption => parentType != null;
 
   static final _stringBuilders =
       <PreferencesOptionType, _OptionStrings Function(AppLocalizations)>{
@@ -38,6 +73,11 @@ enum PreferencesOptionType {
           title: l.thread,
           explanation: l.threadSettingExplanation,
           toggleDescription: l.threadToggleDescription,
+        ),
+        collapseThread: (l) => (
+          title: l.collapseThread,
+          explanation: l.collapseThreadSettingExplanation,
+          toggleDescription: l.collapseThreadToggleDescription,
         ),
         spamReport: (l) => (
           title: l.spamReports,
@@ -85,6 +125,7 @@ enum PreferencesOptionType {
         readReceipt: (s, _) => s?.isAlwaysReadReceipts ?? false,
         senderPriority: (s, _) => s?.isDisplaySenderPriority ?? false,
         thread: (_, p) => p.threadConfig.isEnabled,
+        collapseThread: (_, p) => p.collapseThreadConfig.isEnabled,
         spamReport: (_, p) => p.spamReportConfig.isEnabled,
         aiScribe: (_, p) => p.aiScribeConfig.isEnabled,
         aiNeedsAction: (s, _) => s?.isAINeedsActionEnabled ?? false,
@@ -95,11 +136,58 @@ enum PreferencesOptionType {
   bool isEnabled(
     TMailServerSettingOptions? settingOption,
     PreferencesSetting preferencesSetting,
-  ) {
+) {
     final fn = _enabledResolvers[this];
     if (fn == null) {
       throw StateError('PreferencesOptionType.$name missing from _enabledResolvers');
     }
     return fn(settingOption, preferencesSetting);
+  }
+
+  // Returns null for server-side options; they are handled via a separate path.
+  static final _toggledConfigBuilders =
+      <
+        PreferencesOptionType,
+        PreferencesConfig Function(PreferencesSetting, bool)
+      >{
+        thread: (s, e) => s.threadConfig.copyWith(isEnabled: !e),
+        collapseThread: (s, e) =>
+            s.collapseThreadConfig.copyWith(isEnabled: !e),
+        spamReport: (s, e) => s.spamReportConfig.copyWith(isEnabled: !e),
+        aiScribe: (s, e) => s.aiScribeConfig.copyWith(isEnabled: !e),
+        label: (s, e) => s.labelConfig.copyWith(isEnabled: !e),
+      };
+
+  PreferencesConfig? createToggledConfig(
+    PreferencesSetting currentSettings,
+    bool currentIsEnabled,
+  ) => _toggledConfigBuilders[this]?.call(currentSettings, currentIsEnabled);
+
+  // CHECKLIST: when adding a new PreferencesOptionType value, add an entry here.
+  static final _visibilityChecks =
+      <PreferencesOptionType, bool Function(PreferencesVisibilityContext)>{
+        readReceipt: (ctx) => ctx.settingOption != null,
+        senderPriority: (ctx) => ctx.settingOption != null,
+        thread: (ctx) => ctx.localSettings.configs.isNotEmpty,
+        collapseThread: (ctx) =>
+            ctx.isExperimentalEnabled &&
+            ctx.localSettings.configs.isNotEmpty &&
+            PreferencesOptionType.thread.isEnabled(
+              ctx.settingOption,
+              ctx.localSettings,
+            ),
+        spamReport: (ctx) => ctx.localSettings.configs.isNotEmpty,
+        aiScribe: (ctx) =>
+            ctx.localSettings.configs.isNotEmpty && ctx.isAIScribeAvailable,
+        aiNeedsAction: (ctx) =>
+            ctx.settingOption != null && ctx.isAICapabilitySupported,
+        label: (ctx) => ctx.isLabelVisibility,
+      };
+
+  // CHECKLIST: when adding a new PreferencesOptionType value, add an entry here.
+  bool isVisible(PreferencesVisibilityContext ctx) {
+    final fn = _visibilityChecks[this];
+    assert(fn != null, 'PreferencesOptionType.$name missing from _visibilityChecks');
+    return fn!(ctx);
   }
 }

--- a/lib/features/manage_account/presentation/preferences/preferences_controller.dart
+++ b/lib/features/manage_account/presentation/preferences/preferences_controller.dart
@@ -7,28 +7,24 @@ import 'package:server_settings/server_settings/tmail_server_settings.dart';
 import 'package:tmail_ui_user/features/base/base_controller.dart';
 import 'package:tmail_ui_user/features/home/data/exceptions/session_exceptions.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/loader_status.dart';
-import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/ai_scribe_config.dart';
-import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/label_config.dart';
-import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
-import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/spam_report_config.dart';
-import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/thread_detail_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/state/get_local_settings_state.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/state/update_local_settings_state.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_local_settings_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/update_local_settings_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/manage_account_dashboard_controller.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/providers/local_settings_notifier.dart';
-import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/preferences_option_type.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/mixin/enable_experimental_mode_mixin.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/providers/local_settings_notifier.dart';
 import 'package:tmail_ui_user/features/server_settings/domain/state/get_server_setting_state.dart';
 import 'package:tmail_ui_user/features/server_settings/domain/state/update_server_setting_state.dart';
 import 'package:tmail_ui_user/features/server_settings/domain/usecases/get_server_setting_interactor.dart';
 import 'package:tmail_ui_user/features/server_settings/domain/usecases/update_server_setting_interactor.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
-class PreferencesController extends BaseController {
+class PreferencesController extends BaseController with EnableExperimentalModeMixin {
   PreferencesController(
     this._getServerSettingInteractor,
     this._updateServerSettingInteractor,
@@ -157,24 +153,7 @@ class PreferencesController extends BaseController {
     PreferencesOptionType optionType,
     bool isEnabled,
   ) {
-    PreferencesConfig? config;
-    switch(optionType) {
-      case PreferencesOptionType.thread:
-        config = ThreadDetailConfig(isEnabled: !isEnabled);
-        break;
-      case PreferencesOptionType.spamReport:
-        config = SpamReportConfig(isEnabled: !isEnabled);
-        break;
-      case PreferencesOptionType.aiScribe:
-        config = AIScribeConfig(isEnabled: !isEnabled);
-        break;
-      case PreferencesOptionType.label:
-        config = LabelConfig(isEnabled: !isEnabled);
-        break;
-      default:
-        break;
-    }
-
+    final config = optionType.createToggledConfig(localSettings.value, isEnabled);
     if (config != null) {
       consumeState(_updateLocalSettingsInteractor.execute(config));
     }

--- a/lib/features/manage_account/presentation/preferences/preferences_view.dart
+++ b/lib/features/manage_account/presentation/preferences/preferences_view.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get/get.dart';
+import 'package:server_settings/server_settings/tmail_server_settings.dart';
 import 'package:tmail_ui_user/features/base/mixin/app_loader_mixin.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/base/setting_detail_view_builder.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/menu/settings_utils.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/preferences_option_type.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/preferences/preferences_controller.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/preferences/widgets/preferences_option_item.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/providers/experimental_mode_notifier.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/widgets/setting_header_widget.dart';
 
 class PreferencesView extends GetWidget<PreferencesController> with AppLoaderMixin {
@@ -47,70 +51,114 @@ class PreferencesView extends GetWidget<PreferencesController> with AppLoaderMix
               padding: controller.responsiveUtils.isDesktop(context)
                 ? const EdgeInsets.symmetric(vertical: 30, horizontal: 22)
                 : null,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  if (controller.responsiveUtils.isWebDesktop(context))
-                    const SettingHeaderWidget(
-                      menuItem: AccountMenuItem.preferences,
-                      padding: EdgeInsets.only(bottom: 21),
-                    ),
-                  Obx(() {
-                    final settingOption = controller.settingOption.value;
-                    final localSettingOption = controller.localSettings.value;
-                    final isLabelVisibility = controller
-                        .accountDashboardController
-                        .isLabelVisibilityEnabled;
-
-                    if (settingOption == null &&
-                        localSettingOption.configs.isEmpty) {
-                      return const SizedBox.shrink();
-                    }
-
-                    final availableSettingOptions = [
-                      if (settingOption != null)
-                        ...PreferencesOptionType.values.where(
-                          (type) =>
-                              !type.isLocal &&
-                              type != PreferencesOptionType.aiNeedsAction,
-                        ),
-                      if (localSettingOption.configs.isNotEmpty)
-                        ...PreferencesOptionType.values.where(
-                          (type) =>
-                              type.isLocal &&
-                              type != PreferencesOptionType.label &&
-                              (type != PreferencesOptionType.aiScribe ||
-                                  controller.isAIScribeCapabilityAvailable),
-                        ),
-                      if (settingOption != null &&
-                          controller.isAICapabilitySupported)
-                        PreferencesOptionType.aiNeedsAction,
-                      if (isLabelVisibility.isTrue)
-                        PreferencesOptionType.label,
-                    ];
-
-                    return Expanded(
-                      child: ListView.separated(
-                        itemCount: availableSettingOptions.length,
-                        itemBuilder: (context, index) {
-                          return PreferencesOptionItem(
-                            imagePaths: controller.imagePaths,
-                            settingOption: settingOption,
-                            preferencesSetting: localSettingOption,
-                            optionType: availableSettingOptions[index],
-                            onTapPreferencesOptionAction: controller.updateStateSettingOption,
-                          );
-                        },
-                        separatorBuilder: (_, __) => const SizedBox(height: 49),
-                      ),
-                    );
-                  }),
-                ],
-              ),
+              child: _PreferencesBody(controller: controller),
             ),
           ),
         ),
       ],
+    );
+  }
+}
+
+class _PreferencesBody extends ConsumerWidget {
+  const _PreferencesBody({required this.controller});
+
+  final PreferencesController controller;
+
+  static const _childOptionBorderColor = Color(0xFFE0E0E0);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isExperimentalEnabled = ref.watch(experimentalModeNotifierProvider);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (controller.responsiveUtils.isWebDesktop(context))
+          SettingHeaderWidget(
+            menuItem: AccountMenuItem.preferences,
+            padding: const EdgeInsets.only(bottom: 21),
+            onMultiClickAction: isExperimentalEnabled
+                ? null
+                : controller.enableExperimentalMode,
+            multiClickCount: ExperimentalModeNotifier.activationTapCount,
+          ),
+        Obx(() {
+          final settingOption = controller.settingOption.value;
+          final localSettingOption = controller.localSettings.value;
+          final isLabelVisibility = controller
+              .accountDashboardController
+              .isLabelVisibilityEnabled;
+
+          if (settingOption == null &&
+              localSettingOption.configs.isEmpty) {
+            return const SizedBox.shrink();
+          }
+
+          final ctx = (
+            settingOption: settingOption,
+            localSettings: localSettingOption,
+            isExperimentalEnabled: isExperimentalEnabled,
+            isAIScribeAvailable: controller.isAIScribeCapabilityAvailable,
+            isAICapabilitySupported: controller.isAICapabilitySupported,
+            isLabelVisibility: isLabelVisibility.isTrue,
+          );
+          final availableSettingOptions = _buildAvailableOptions(ctx);
+
+          return Expanded(
+            child: ListView.separated(
+              itemCount: availableSettingOptions.length,
+              itemBuilder: (context, index) {
+                final optionType = availableSettingOptions[index];
+                return _buildOptionItem(
+                  optionType: optionType,
+                  settingOption: settingOption,
+                  localSettingOption: localSettingOption,
+                );
+              },
+              separatorBuilder: (_, __) => const SizedBox(height: 49),
+            ),
+          );
+        }),
+      ],
+    );
+  }
+
+  List<PreferencesOptionType> _buildAvailableOptions(
+    PreferencesVisibilityContext ctx,
+  ) {
+    return PreferencesOptionType.values
+        .where((type) => type.isVisible(ctx))
+        .toList();
+  }
+
+  Widget _buildOptionItem({
+    required PreferencesOptionType optionType,
+    required TMailServerSettingOptions? settingOption,
+    required PreferencesSetting localSettingOption,
+  }) {
+    final item = PreferencesOptionItem(
+      imagePaths: controller.imagePaths,
+      settingOption: settingOption,
+      preferencesSetting: localSettingOption,
+      optionType: optionType,
+      onTapPreferencesOptionAction: controller.updateStateSettingOption,
+    );
+
+    if (!optionType.isChildOption) return item;
+
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(start: 24),
+      child: DecoratedBox(
+        decoration: const BoxDecoration(
+          border: BorderDirectional(
+            start: BorderSide(color: _childOptionBorderColor, width: 2),
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsetsDirectional.only(start: 16),
+          child: item,
+        ),
+      ),
     );
   }
 }

--- a/lib/features/manage_account/presentation/services/local_settings_reader.dart
+++ b/lib/features/manage_account/presentation/services/local_settings_reader.dart
@@ -1,0 +1,11 @@
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
+
+abstract interface class ILocalSettingsReader {
+  bool get isCollapseThreadsEnabled;
+
+  PreferencesSetting get currentSettings;
+
+  /// Registers [onChange] to be called whenever [PreferencesSetting] changes.
+  /// Returns a cancel callback; the caller must invoke it in [onClose].
+  void Function() listen(void Function(PreferencesSetting) onChange);
+}

--- a/lib/features/manage_account/presentation/services/riverpod_local_settings_reader.dart
+++ b/lib/features/manage_account/presentation/services/riverpod_local_settings_reader.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/providers/local_settings_notifier.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_reader.dart';
+
+class RiverpodLocalSettingsReader implements ILocalSettingsReader {
+  final ProviderContainer _container;
+
+  const RiverpodLocalSettingsReader(this._container);
+
+  @override
+  PreferencesSetting get currentSettings =>
+      _container.read(localSettingsNotifierProvider);
+
+  @override
+  bool get isCollapseThreadsEnabled => currentSettings.isCollapseThreadsEnabled;
+
+  @override
+  void Function() listen(void Function(PreferencesSetting) onChange) {
+    final sub = _container.listen(
+      localSettingsNotifierProvider,
+      (_, next) => onChange(next),
+      fireImmediately: false,
+    );
+    return sub.close;
+  }
+}

--- a/lib/features/manage_account/presentation/widgets/setting_header_widget.dart
+++ b/lib/features/manage_account/presentation/widgets/setting_header_widget.dart
@@ -3,6 +3,7 @@ import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/multi_click_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/providers/experimental_mode_notifier.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 class SettingHeaderWidget extends StatelessWidget {
@@ -10,6 +11,7 @@ class SettingHeaderWidget extends StatelessWidget {
   final EdgeInsetsGeometry? padding;
   final TextStyle? textStyle;
   final VoidCallback? onMultiClickAction;
+  final int? multiClickCount;
 
   const SettingHeaderWidget({
     Key? key,
@@ -17,6 +19,7 @@ class SettingHeaderWidget extends StatelessWidget {
     this.padding,
     this.textStyle,
     this.onMultiClickAction,
+    this.multiClickCount,
   }) : super(key: key);
 
   @override
@@ -35,6 +38,7 @@ class SettingHeaderWidget extends StatelessWidget {
     if (onMultiClickAction != null) {
       titleWidget = MultiClickWidget(
         onMultiTap: onMultiClickAction!,
+        requiredClicks: multiClickCount ?? ExperimentalModeNotifier.activationTapCount,
         child: titleWidget,
       );
     }

--- a/lib/features/search/email/presentation/search_email_bindings.dart
+++ b/lib/features/search/email/presentation/search_email_bindings.dart
@@ -1,6 +1,7 @@
 
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/base_bindings.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_reader.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/get_all_recent_search_latest_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/quick_search_email_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/save_recent_search_interactor.dart';
@@ -20,6 +21,7 @@ class SearchEmailBindings extends BaseBindings {
       Get.find<SearchEmailInteractor>(),
       Get.find<SearchMoreEmailInteractor>(),
       Get.find<RefreshChangesSearchEmailInteractor>(),
+      Get.find<ILocalSettingsReader>(),
     ));
   }
 

--- a/lib/features/search/email/presentation/search_email_controller.dart
+++ b/lib/features/search/email/presentation/search_email_controller.dart
@@ -52,8 +52,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/quick_s
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/save_recent_search_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/action/dashboard_action.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_store_email_sort_order_extension.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/providers/local_settings_notifier.dart';
-import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_reader.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/update_emails_with_new_mailbox_id_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
@@ -106,6 +105,7 @@ class SearchEmailController extends BaseController
   final SearchEmailInteractor _searchEmailInteractor;
   final SearchMoreEmailInteractor _searchMoreEmailInteractor;
   final RefreshChangesSearchEmailInteractor _refreshChangesSearchEmailInteractor;
+  final ILocalSettingsReader _localSettingsReader;
 
   final textInputSearchController = TextEditingController();
   final resultSearchScrollController = ScrollController();
@@ -162,8 +162,7 @@ class SearchEmailController extends BaseController
 
   Set<String> get listHasKeywordFiltered => searchEmailFilter.value.hasKeyword;
 
-  bool get _isCollapseThreadsEnabled =>
-      appProviderContainer.read(localSettingsNotifierProvider).threadConfig.isEnabled;
+  bool get _isCollapseThreadsEnabled => _localSettingsReader.isCollapseThreadsEnabled;
 
   SearchEmailController(
       this._quickSearchEmailInteractor,
@@ -172,6 +171,7 @@ class SearchEmailController extends BaseController
       this._searchEmailInteractor,
       this._searchMoreEmailInteractor,
       this._refreshChangesSearchEmailInteractor,
+      this._localSettingsReader,
   );
 
   @override

--- a/lib/features/thread/presentation/thread_bindings.dart
+++ b/lib/features/thread/presentation/thread_bindings.dart
@@ -21,6 +21,7 @@ import 'package:tmail_ui_user/features/thread/domain/usecases/load_more_emails_i
 import 'package:tmail_ui_user/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_more_email_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_reader.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
 import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.dart';
 import 'package:tmail_ui_user/main/exceptions/thrower/remote_exception_thrower.dart';
@@ -38,6 +39,7 @@ class ThreadBindings extends BaseBindings {
       Get.find<SearchMoreEmailInteractor>(),
       Get.find<GetEmailByIdInteractor>(),
       Get.find<CleanAndGetEmailsInMailboxInteractor>(),
+      Get.find<ILocalSettingsReader>(),
     ));
   }
 

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -41,11 +41,9 @@ import 'package:tmail_ui_user/features/push_notification/presentation/websocket/
 import 'package:tmail_ui_user/features/push_notification/presentation/websocket/web_socket_queue_handler.dart';
 import 'package:tmail_ui_user/features/labels/presentation/delegates/add_list_label_to_list_emails_delegate.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/providers/local_settings_notifier.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_reader.dart';
 import 'package:tmail_ui_user/features/thread/data/model/email_change_response.dart';
-import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_bindings.dart';
 import 'package:tmail_ui_user/features/thread/data/extensions/email_change_response_extension.dart';
 import 'package:tmail_ui_user/features/thread/domain/constants/thread_constants.dart';
@@ -99,6 +97,7 @@ class ThreadController extends BaseController with EmailActionController {
   final SearchMoreEmailInteractor _searchMoreEmailInteractor;
   final GetEmailByIdInteractor _getEmailByIdInteractor;
   final CleanAndGetEmailsInMailboxInteractor cleanAndGetEmailsInMailboxInteractor;
+  final ILocalSettingsReader _localSettingsReader;
 
   final listEmailDrag = <PresentationEmail>[].obs;
   bool rangeSelectionMode = false;
@@ -119,7 +118,8 @@ class ThreadController extends BaseController with EmailActionController {
   StreamSubscription<MailListShortcutActionViewEvent>? shortcutActionEventSubscription;
 
   StreamSubscription<html.Event>? _resizeBrowserStreamSubscription;
-  ProviderSubscription<PreferencesSetting>? _localSettingsSubscription;
+  void Function()? _cancelLocalSettings;
+  PreferencesSetting? _previousSettings;
 
   AccountId? get _accountId => mailboxDashBoardController.accountId.value;
 
@@ -133,8 +133,7 @@ class ThreadController extends BaseController with EmailActionController {
 
   SearchEmailFilter get _searchEmailFilter => searchController.searchEmailFilter.value;
 
-  bool get _isCollapseThreadsEnabled =>
-      appProviderContainer.read(localSettingsNotifierProvider).threadConfig.isEnabled;
+  bool get _isCollapseThreadsEnabled => _localSettingsReader.isCollapseThreadsEnabled;
 
   bool get _shouldCollapseThreads => forceEmailQuery && _isCollapseThreadsEnabled;
 
@@ -148,11 +147,13 @@ class ThreadController extends BaseController with EmailActionController {
     this._searchMoreEmailInteractor,
     this._getEmailByIdInteractor,
     this.cleanAndGetEmailsInMailboxInteractor,
+    this._localSettingsReader,
   );
 
   @override
   void onInit() {
     _registerObxStreamListener();
+    _registerLocalSettingsListener();
     if (PlatformInfo.isWeb) {
       _registerBrowserResizeListener();
       onKeyboardShortcutInit();
@@ -170,13 +171,14 @@ class ThreadController extends BaseController with EmailActionController {
   @override
   void onClose() {
     _currentMemoryMailboxId = null;
+    _previousSettings = null;
+    _cancelLocalSettings?.call();
     listEmailController.dispose();
     if (PlatformInfo.isWeb) {
       _resizeBrowserStreamSubscription?.cancel();
       onKeyboardShortcutDispose();
     }
     _webSocketQueueHandler?.dispose();
-    _localSettingsSubscription?.close();
     super.onClose();
   }
 
@@ -438,26 +440,34 @@ class ThreadController extends BaseController with EmailActionController {
         _peakEmailCount = countEmails;
       }
     });
-
-    _registerLocalSettingsListener();
   }
 
   void _registerLocalSettingsListener() {
-    if (_localSettingsSubscription != null) return;
-    _localSettingsSubscription = appProviderContainer.listen(
-      localSettingsNotifierProvider,
-      (previous, next) {
-        if (previous?.threadConfig == next.threadConfig) return;
-        if (searchController.isSearchEmailRunning) {
-          _searchEmail(limit: limitEmailFetched);
-        } else if (forceEmailQuery) {
-          getAllEmailAction(
-            forceEmailQuery: forceEmailQuery,
-          );
-        }
-      },
-      fireImmediately: false,
-    );
+    _previousSettings = _localSettingsReader.currentSettings;
+    _cancelLocalSettings = _localSettingsReader.listen(_onLocalSettingsChanged);
+  }
+
+  void _onLocalSettingsChanged(PreferencesSetting next) {
+    final previous = _previousSettings;
+    _previousSettings = next;
+    _onCollapseThreadSettingChanged(previous, next);
+  }
+
+  void _onCollapseThreadSettingChanged(
+    PreferencesSetting? previous,
+    PreferencesSetting next,
+  ) {
+    // Both threadConfig and collapseThreadConfig affect the collapseThreads query
+    // parameter — refresh whenever either changes.
+    if (previous?.threadConfig == next.threadConfig &&
+        previous?.collapseThreadConfig == next.collapseThreadConfig) {
+      return;
+    }
+    if (searchController.isSearchEmailRunning) {
+      _searchEmail(limit: limitEmailFetched);
+    } else if (forceEmailQuery) {
+      getAllEmailAction(forceEmailQuery: forceEmailQuery);
+    }
   }
 
   void _handleMarkEmailsAsReadByMailboxId(MailboxId mailboxId) {

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -4472,6 +4472,30 @@
     "placeholders_order": [],
     "placeholders": {}
   },
+  "collapseThread": "Collapse thread",
+  "@collapseThread": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "collapseThreadSettingExplanation": "Show only the latest email per thread in your inbox",
+  "@collapseThreadSettingExplanation": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "collapseThreadToggleDescription": "Enable collapse thread",
+  "@collapseThreadToggleDescription": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "experimentalFeaturesEnabled": "Experimental features enabled",
+  "@experimentalFeaturesEnabled": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
   "exportTraceLogFailed": "Export trace log failed",
   "@exportTraceLogFailed": {
     "type": "text",

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2026-05-25T10:48:23.465659",
+  "@@last_modified": "2026-05-25T14:24:28.291963",
   "initializing_data": "Initializing data...",
   "@initializing_data": {
     "type": "text",
@@ -4918,12 +4918,6 @@
   },
   "aiScribeToggleDescription": "Enable AI Scribe",
   "@aiScribeToggleDescription": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "experimentalFeaturesEnabled": "Experimental features enabled",
-  "@experimentalFeaturesEnabled": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -4706,6 +4706,34 @@ class AppLocalizations {
     );
   }
 
+  String get collapseThread {
+    return Intl.message(
+      'Collapse thread',
+      name: 'collapseThread',
+    );
+  }
+
+  String get collapseThreadSettingExplanation {
+    return Intl.message(
+      'Show only the latest email per thread in your inbox',
+      name: 'collapseThreadSettingExplanation',
+    );
+  }
+
+  String get collapseThreadToggleDescription {
+    return Intl.message(
+      'Enable collapse thread',
+      name: 'collapseThreadToggleDescription',
+    );
+  }
+
+  String get experimentalFeaturesEnabled {
+    return Intl.message(
+      'Experimental features enabled',
+      name: 'experimentalFeaturesEnabled',
+    );
+  }
+
   String get exportTraceLogFailed {
     return Intl.message(
       'Export trace log failed',

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -5209,13 +5209,6 @@ class AppLocalizations {
     );
   }
 
-  String get experimentalFeaturesEnabled {
-    return Intl.message(
-      'Experimental features enabled',
-      name: 'experimentalFeaturesEnabled',
-    );
-  }
-
   String showMoreAttachmentButton(int count) {
     return Intl.message(
       'Show +$count more',

--- a/scribe/lib/scribe/ai/l10n/intl_messages.arb
+++ b/scribe/lib/scribe/ai/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2026-03-02T09:20:40.561113",
+  "@@last_modified": "2026-05-22T20:01:32.339386",
   "categoryCorrectGrammar": "Correct",
   "@categoryCorrectGrammar": {
     "type": "text",

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -74,6 +74,8 @@ import 'package:tmail_ui_user/features/upload/presentation/controller/upload_con
 import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_state.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
 import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/utils/app_config.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
@@ -219,6 +221,16 @@ class MockMailboxDashBoardController extends Mock implements MailboxDashBoardCon
 ])
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    initAppProviderContainer(prefs);
+  });
+
+  tearDownAll(() {
+    appProviderContainer.dispose();
+  });
 
   // Declaration base controller
   late MockCachingManager mockCachingManager;

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -74,8 +74,6 @@ import 'package:tmail_ui_user/features/upload/presentation/controller/upload_con
 import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_state.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
 import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/utils/app_config.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -106,6 +106,7 @@ import 'package:tmail_ui_user/features/thread/domain/usecases/refresh_changes_em
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_more_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/presentation/extensions/handle_email_filter_extension.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_reader.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
 import 'package:tmail_ui_user/main/utils/email_receive_manager.dart';
@@ -199,12 +200,15 @@ const fallbackGenerators = {
   MockSpec<GetIdentityCacheOnWebInteractor>(),
   MockSpec<ComposerManager>(fallbackGenerators: fallbackGenerators),
   MockSpec<CleanAndGetEmailsInMailboxInteractor>(),
+  MockSpec<ILocalSettingsReader>(),
   MockSpec<ClearMailboxInteractor>(),
   MockSpec<GetAuthenticationInfoInteractor>(),
   MockSpec<GetStoredOidcConfigurationInteractor>(),
   MockSpec<GetTokenOIDCInteractor>(),
 ])
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   // mock mailbox dashboard controller direct dependencies
   final moveToMailboxInteractor = MockMoveToMailboxInteractor();
   final deleteEmailPermanentlyInteractor =
@@ -310,6 +314,7 @@ void main() {
   final searchEmailInteractor = MockSearchEmailInteractor();
   final searchMoreEmailInteractor = MockSearchMoreEmailInteractor();
   late ThreadController threadController;
+  late MockILocalSettingsReader mockLocalSettingsReader;
 
   late AdvancedFilterController advancedFilterController;
 
@@ -408,6 +413,8 @@ void main() {
   group('search/sort/filter feature:', () {
     setUp(() {
       getEmailsInMailboxInteractor = MockGetEmailsInMailboxInteractor();
+      mockLocalSettingsReader = MockILocalSettingsReader();
+      when(mockLocalSettingsReader.isCollapseThreadsEnabled).thenReturn(false);
 
       when(emailReceiveManager.pendingSharedFileInfo).thenAnswer((_) => BehaviorSubject.seeded([]));
       when(downloadController.downloadUIAction).thenAnswer((_) => Rxn(DownloadUIAction.idle));
@@ -440,7 +447,9 @@ void main() {
         searchEmailInteractor,
         searchMoreEmailInteractor,
         getEmailByIdInteractor,
-        cleanAndGetEmailsInMailboxInteractor);
+        cleanAndGetEmailsInMailboxInteractor,
+        mockLocalSettingsReader,
+      );
       Get.put(threadController);
 
       advancedFilterController = AdvancedFilterController();
@@ -684,6 +693,9 @@ void main() {
           refreshAllMailboxInteractor);
       mailboxController.onReady();
 
+      mockLocalSettingsReader = MockILocalSettingsReader();
+      when(mockLocalSettingsReader.isCollapseThreadsEnabled).thenReturn(false);
+
       threadController = ThreadController(
           getEmailsInMailboxInteractor,
           refreshChangesEmailsInMailboxInteractor,
@@ -692,6 +704,7 @@ void main() {
           searchMoreEmailInteractor,
           getEmailByIdInteractor,
           cleanAndGetEmailsInMailboxInteractor,
+          mockLocalSettingsReader,
       );
       Get.put(threadController);
 

--- a/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
+++ b/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
@@ -110,6 +110,7 @@ import 'package:tmail_ui_user/features/thread/domain/usecases/move_multiple_emai
 import 'package:tmail_ui_user/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_more_email_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_reader.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_view.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
@@ -211,6 +212,7 @@ const fallbackGenerators = {
   MockSpec<GetIdentityCacheOnWebInteractor>(),
   MockSpec<ComposerManager>(fallbackGenerators: fallbackGenerators),
   MockSpec<CleanAndGetEmailsInMailboxInteractor>(),
+  MockSpec<ILocalSettingsReader>(),
   MockSpec<ClearMailboxInteractor>(),
   MockSpec<GetAuthenticationInfoInteractor>(),
   MockSpec<GetStoredOidcConfigurationInteractor>(),
@@ -325,6 +327,70 @@ void main() {
     );
   }
 
+  MailboxDashBoardController createMailboxDashboardController() =>
+      MailboxDashBoardController(
+        moveToMailboxInteractor,
+        deleteEmailPermanentlyInteractor,
+        markAsMailboxReadInteractor,
+        getAllComposerCacheInteractor,
+        getIdentityCacheOnWebInteractor,
+        markAsEmailReadInteractor,
+        markAsStarEmailInteractor,
+        markAsMultipleEmailReadInteractor,
+        markAsStarMultipleEmailInteractor,
+        moveMultipleEmailToMailboxInteractor,
+        emptyTrashFolderInteractor,
+        deleteMultipleEmailsPermanentlyInteractor,
+        getEmailByIdInteractor,
+        sendEmailInteractor,
+        storeSendingEmailInteractor,
+        updateSendingEmailInteractor,
+        getAllSendingEmailInteractor,
+        storeSessionInteractor,
+        emptySpamFolderInteractor,
+        deleteSendingEmailInteractor,
+        unsubscribeEmailInteractor,
+        restoreDeletedMessageInteractor,
+        getRestoredDeletedMessageInteractor,
+        removeAllComposerCacheInteractor,
+        removeComposerCacheByIdInteractor,
+        getAllIdentitiesInteractor,
+        clearMailboxInteractor,
+        storeEmailSortOrderInteractor,
+        getStoredEmailSortOrderInteractor,
+      );
+
+  MailboxController createMailboxController() => MailboxController(
+        createNewMailboxInteractor,
+        deleteMultipleMailboxInteractor,
+        renameMailboxInteractor,
+        moveMailboxInteractor,
+        subscribeMailboxInteractor,
+        subscribeMultipleMailboxInteractor,
+        subaddressingInteractor,
+        createDefaultMailboxInteractor,
+        moveFolderContentInteractor,
+        treeBuilder,
+        verifyNameInteractor,
+        getAllMailboxInteractor,
+        refreshAllMailboxInteractor,
+      );
+
+  ThreadController createThreadController() {
+    final mockLocalSettingsReader = MockILocalSettingsReader();
+    when(mockLocalSettingsReader.isCollapseThreadsEnabled).thenReturn(false);
+    return ThreadController(
+      getEmailsInMailboxInteractor,
+      refreshChangesEmailsInMailboxInteractor,
+      loadMoreEmailsInMailboxInteractor,
+      searchEmailInteractor,
+      searchMoreEmailInteractor,
+      getEmailByIdInteractor,
+      cleanAndGetEmailsInMailboxInteractor,
+      mockLocalSettingsReader,
+    );
+  }
+
   group('MailboxDashboardView', () {
     setUpAll(() async {
       SharedPreferences.setMockInitialValues({});
@@ -373,77 +439,23 @@ void main() {
 
       when(emailReceiveManager.pendingSharedFileInfo).thenAnswer((_) => BehaviorSubject.seeded([]));
       when(downloadController.downloadUIAction).thenAnswer((_) => Rxn(DownloadUIAction.idle));
-      final isLabelSettingEnabled = RxBool(false);
-      when(labelController.isLabelSettingEnabled).thenReturn(isLabelSettingEnabled);
+      when(labelController.isLabelSettingEnabled).thenReturn(RxBool(false));
 
       searchController = SearchController(
         quickSearchEmailInteractor,
         saveRecentSearchInteractor,
-        getAllRecentSearchLatestInteractor
+        getAllRecentSearchLatestInteractor,
       );
       Get.put(searchController);
 
-      mailboxDashboardController = MailboxDashBoardController(
-        moveToMailboxInteractor,
-        deleteEmailPermanentlyInteractor,
-        markAsMailboxReadInteractor,
-        getAllComposerCacheInteractor,
-        getIdentityCacheOnWebInteractor,
-        markAsEmailReadInteractor,
-        markAsStarEmailInteractor,
-        markAsMultipleEmailReadInteractor,
-        markAsStarMultipleEmailInteractor,
-        moveMultipleEmailToMailboxInteractor,
-        emptyTrashFolderInteractor,
-        deleteMultipleEmailsPermanentlyInteractor,
-        getEmailByIdInteractor,
-        sendEmailInteractor,
-        storeSendingEmailInteractor,
-        updateSendingEmailInteractor,
-        getAllSendingEmailInteractor,
-        storeSessionInteractor,
-        emptySpamFolderInteractor,
-        deleteSendingEmailInteractor,
-        unsubscribeEmailInteractor,
-        restoreDeletedMessageInteractor,
-        getRestoredDeletedMessageInteractor,
-        removeAllComposerCacheInteractor,
-        removeComposerCacheByIdInteractor,
-        getAllIdentitiesInteractor,
-        clearMailboxInteractor,
-        storeEmailSortOrderInteractor,
-        getStoredEmailSortOrderInteractor,
-      );
+      mailboxDashboardController = createMailboxDashboardController();
       Get.put(mailboxDashboardController);
       mailboxDashboardController.onReady();
 
-      mailboxController = MailboxController(
-        createNewMailboxInteractor,
-        deleteMultipleMailboxInteractor,
-        renameMailboxInteractor,
-        moveMailboxInteractor,
-        subscribeMailboxInteractor,
-        subscribeMultipleMailboxInteractor,
-        subaddressingInteractor,
-        createDefaultMailboxInteractor,
-        moveFolderContentInteractor,
-        treeBuilder,
-        verifyNameInteractor,
-        getAllMailboxInteractor,
-        refreshAllMailboxInteractor
-      );
+      mailboxController = createMailboxController();
       Get.put(mailboxController);
-      // mailboxController.onReady();
 
-      threadController = ThreadController(
-        getEmailsInMailboxInteractor,
-        refreshChangesEmailsInMailboxInteractor,
-        loadMoreEmailsInMailboxInteractor,
-        searchEmailInteractor,
-        searchMoreEmailInteractor,
-        getEmailByIdInteractor,
-        cleanAndGetEmailsInMailboxInteractor,
-      );
+      threadController = createThreadController();
       Get.put(threadController);
 
       quotasController = QuotasController(getQuotasInteractor);

--- a/test/features/manage_account/data/local/preferences_setting_manager_test.dart
+++ b/test/features/manage_account/data/local/preferences_setting_manager_test.dart
@@ -1,0 +1,129 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tmail_ui_user/features/manage_account/data/local/preferences_setting_manager.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/collapse_thread_config.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/spam_report_config.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/thread_detail_config.dart';
+
+const _threadKey = 'PREFERENCES_SETTING_THREAD';
+const _collapseThreadKey = 'PREFERENCES_SETTING_COLLAPSE_THREAD';
+const _spamReportKey = 'PREFERENCES_SETTING_SPAM_REPORT';
+
+PreferencesSettingManager _makeManager(SharedPreferences prefs) =>
+    PreferencesSettingManager(prefs);
+
+void main() {
+  group('PreferencesSettingManager', () {
+    late SharedPreferences prefs;
+    late PreferencesSettingManager manager;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      prefs = await SharedPreferences.getInstance();
+      manager = _makeManager(prefs);
+    });
+
+    group('loadPreferences', () {
+      test('returns initial when no keys present', () async {
+        final setting = await manager.loadPreferences();
+        expect(setting.threadConfig, isA<ThreadDetailConfig>());
+        expect(setting.threadConfig.isEnabled, isFalse);
+      });
+
+      test('parses ThreadDetailConfig from stored key', () async {
+        await prefs.setString(
+          _threadKey,
+          jsonEncode(ThreadDetailConfig(isEnabled: true).toJson()),
+        );
+        final setting = await manager.loadPreferences();
+        expect(setting.threadConfig.isEnabled, isTrue);
+      });
+
+      test('parses CollapseThreadConfig from stored key', () async {
+        await prefs.setString(
+          _collapseThreadKey,
+          jsonEncode(CollapseThreadConfig(isEnabled: true).toJson()),
+        );
+        final setting = await manager.loadPreferences();
+        expect(setting.collapseThreadConfig.isEnabled, isTrue);
+      });
+
+      test('ignores unknown PREFERENCES_SETTING_* keys gracefully', () async {
+        await prefs.setString('PREFERENCES_SETTING_UNKNOWN', '{"x":1}');
+        final setting = await manager.loadPreferences();
+        expect(setting.configs.isEmpty, isFalse);
+      });
+    });
+
+    group('savePreferences', () {
+      test('writes CollapseThreadConfig to correct key', () async {
+        await manager.savePreferences(CollapseThreadConfig(isEnabled: true));
+        expect(prefs.containsKey(_collapseThreadKey), isTrue);
+        final stored = CollapseThreadConfig.fromJson(
+          jsonDecode(prefs.getString(_collapseThreadKey)!) as Map<String, dynamic>,
+        );
+        expect(stored.isEnabled, isTrue);
+      });
+
+      test('SpamReportConfig goes through read-merge-write path', () async {
+        await prefs.setString(
+          _spamReportKey,
+          jsonEncode(SpamReportConfig(
+            isEnabled: true,
+            lastTimeDismissedMilliseconds: 9999,
+          ).toJson()),
+        );
+
+        await manager.savePreferences(SpamReportConfig(isEnabled: false));
+
+        final stored = SpamReportConfig.fromJson(
+          jsonDecode(prefs.getString(_spamReportKey)!) as Map<String, dynamic>,
+        );
+        expect(stored.isEnabled, isFalse);
+        expect(stored.lastTimeDismissedMilliseconds, 9999);
+      });
+    });
+
+    group('updateTextFormattingMenu', () {
+      test('writes isDisplayed=true and round-trips', () async {
+        await manager.updateTextFormattingMenu(isDisplayed: true);
+        final config = await manager.getTextFormattingMenuConfig();
+        expect(config.isDisplayed, isTrue);
+      });
+    });
+
+    group('_readConfig (via getThreadConfig)', () {
+      test('returns defaultFactory when key absent', () async {
+        final config = await manager.getThreadConfig();
+        expect(config, equals(ThreadDetailConfig.initial()));
+      });
+
+      test('returns stored value when key present', () async {
+        await prefs.setString(
+          _threadKey,
+          jsonEncode(ThreadDetailConfig(isEnabled: true).toJson()),
+        );
+        final config = await manager.getThreadConfig();
+        expect(config.isEnabled, isTrue);
+      });
+    });
+
+    group('experimental mode', () {
+      test('getExperimentalModeEnabled returns false when not set', () async {
+        expect(await manager.getExperimentalModeEnabled(), isFalse);
+      });
+
+      test('enableExperimentalMode persists true', () async {
+        await manager.enableExperimentalMode();
+        expect(await manager.getExperimentalModeEnabled(), isTrue);
+      });
+
+      test('getExperimentalModeEnabled reads from SharedPreferences directly', () async {
+        await prefs.setBool('EXPERIMENTAL_MODE_ENABLED', true);
+        expect(await manager.getExperimentalModeEnabled(), isTrue);
+      });
+    });
+  });
+}

--- a/test/features/manage_account/data/local/preferences_setting_manager_test.dart
+++ b/test/features/manage_account/data/local/preferences_setting_manager_test.dart
@@ -55,6 +55,19 @@ void main() {
         final setting = await manager.loadPreferences();
         expect(setting.configs.isEmpty, isFalse);
       });
+
+      test('skips corrupt JSON entries and returns remaining configs', () async {
+        await prefs.setString(
+          _threadKey,
+          jsonEncode(ThreadDetailConfig(isEnabled: true).toJson()),
+        );
+        await prefs.setString(_collapseThreadKey, 'not-valid-json{{{');
+
+        final setting = await manager.loadPreferences();
+
+        expect(setting.threadConfig.isEnabled, isTrue);
+        expect(setting.collapseThreadConfig.isEnabled, isFalse);
+      });
     });
 
     group('savePreferences', () {

--- a/test/features/manage_account/domain/model/preferences/collapse_thread_config_test.dart
+++ b/test/features/manage_account/domain/model/preferences/collapse_thread_config_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/collapse_thread_config.dart';
+
+void main() {
+  group('CollapseThreadConfig', () {
+    test('initial defaults to disabled', () {
+      final config = CollapseThreadConfig.initial();
+      expect(config.isEnabled, isFalse);
+    });
+
+    test('copyWith returns new instance with updated value', () {
+      final original = CollapseThreadConfig(isEnabled: false);
+      final updated = original.copyWith(isEnabled: true);
+
+      expect(updated.isEnabled, isTrue);
+      expect(original.isEnabled, isFalse);
+    });
+
+    test('copyWith preserves existing value when no argument is passed', () {
+      final config = CollapseThreadConfig(isEnabled: true);
+      final copy = config.copyWith();
+
+      expect(copy.isEnabled, isTrue);
+    });
+
+    test('fromJson round-trips through toJson', () {
+      final config = CollapseThreadConfig(isEnabled: true);
+      final json = config.toJson();
+      final restored = CollapseThreadConfig.fromJson(json);
+
+      expect(restored, config);
+    });
+
+    test('equality is value-based', () {
+      expect(
+        CollapseThreadConfig(isEnabled: true),
+        equals(CollapseThreadConfig(isEnabled: true)),
+      );
+      expect(
+        CollapseThreadConfig(isEnabled: true),
+        isNot(equals(CollapseThreadConfig(isEnabled: false))),
+      );
+    });
+  });
+}

--- a/test/features/manage_account/domain/model/preferences/preferences_setting_collapse_thread_test.dart
+++ b/test/features/manage_account/domain/model/preferences/preferences_setting_collapse_thread_test.dart
@@ -4,6 +4,40 @@ import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/p
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/thread_detail_config.dart';
 
 void main() {
+  group('PreferencesSetting.isCollapseThreadsEnabled', () {
+    test('true when both thread and collapse are enabled', () {
+      final s = PreferencesSetting([
+        ThreadDetailConfig(isEnabled: true),
+        CollapseThreadConfig(isEnabled: true),
+      ]);
+      expect(s.isCollapseThreadsEnabled, isTrue);
+    });
+
+    test('false when thread is disabled', () {
+      final s = PreferencesSetting([
+        ThreadDetailConfig(isEnabled: false),
+        CollapseThreadConfig(isEnabled: true),
+      ]);
+      expect(s.isCollapseThreadsEnabled, isFalse);
+    });
+
+    test('false when collapse is disabled', () {
+      final s = PreferencesSetting([
+        ThreadDetailConfig(isEnabled: true),
+        CollapseThreadConfig(isEnabled: false),
+      ]);
+      expect(s.isCollapseThreadsEnabled, isFalse);
+    });
+
+    test('false when both are disabled', () {
+      final s = PreferencesSetting([
+        ThreadDetailConfig(isEnabled: false),
+        CollapseThreadConfig(isEnabled: false),
+      ]);
+      expect(s.isCollapseThreadsEnabled, isFalse);
+    });
+  });
+
   group('PreferencesSetting.collapseThreadConfig', () {
     test('returns CollapseThreadConfig when present in configs', () {
       final config = CollapseThreadConfig(isEnabled: true);

--- a/test/features/manage_account/domain/model/preferences/preferences_setting_collapse_thread_test.dart
+++ b/test/features/manage_account/domain/model/preferences/preferences_setting_collapse_thread_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/collapse_thread_config.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/thread_detail_config.dart';
+
+void main() {
+  group('PreferencesSetting.collapseThreadConfig', () {
+    test('returns CollapseThreadConfig when present in configs', () {
+      final config = CollapseThreadConfig(isEnabled: true);
+      final setting = PreferencesSetting([config]);
+
+      expect(setting.collapseThreadConfig.isEnabled, isTrue);
+    });
+
+    test('returns initial (disabled) when CollapseThreadConfig is absent', () {
+      final setting = PreferencesSetting([ThreadDetailConfig(isEnabled: true)]);
+
+      expect(setting.collapseThreadConfig.isEnabled, isFalse);
+    });
+
+    test('initial() includes CollapseThreadConfig defaulting to disabled', () {
+      final setting = PreferencesSetting.initial();
+
+      expect(setting.collapseThreadConfig, isA<CollapseThreadConfig>());
+      expect(setting.collapseThreadConfig.isEnabled, isFalse);
+    });
+  });
+}

--- a/test/features/manage_account/presentation/model/preferences_option_type_experimental_test.dart
+++ b/test/features/manage_account/presentation/model/preferences_option_type_experimental_test.dart
@@ -4,6 +4,13 @@ import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/c
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/thread_detail_config.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/preferences_option_type.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+// Returns empty strings for all localization getters — used by smoke tests only.
+class _FakeL10n implements AppLocalizations {
+  @override
+  dynamic noSuchMethod(Invocation _) => '';
+}
 
 // All options that are standard (not experimental) and top-level (no parent).
 // collapseThread is the only exception: experimental + child.
@@ -36,7 +43,43 @@ PreferencesVisibilityContext _serverCtx({
   isLabelVisibility: false,
 );
 
+final _fakeL10n = _FakeL10n();
+
+final _smokeCtx = _ctx(
+  isExperimentalEnabled: true,
+  isAIScribeAvailable: true,
+  isLabelVisibility: true,
+  localSettings: PreferencesSetting.initial(),
+);
+
 void main() {
+  group('smoke: all enum values covered by maps', () {
+    for (final type in PreferencesOptionType.values) {
+      test('${type.name}: getTitle does not throw', () {
+        expect(() => type.getTitle(_fakeL10n), returnsNormally);
+      });
+
+      test('${type.name}: getExplanation does not throw', () {
+        expect(() => type.getExplanation(_fakeL10n), returnsNormally);
+      });
+
+      test('${type.name}: getToggleDescription does not throw', () {
+        expect(() => type.getToggleDescription(_fakeL10n), returnsNormally);
+      });
+
+      test('${type.name}: isEnabled does not throw', () {
+        expect(
+          () => type.isEnabled(null, PreferencesSetting.initial()),
+          returnsNormally,
+        );
+      });
+
+      test('${type.name}: isVisible does not throw', () {
+        expect(() => type.isVisible(_smokeCtx), returnsNormally);
+      });
+    }
+  });
+
   group('collapseThread is experimental and a child of thread', () {
     test('isExperimental is true', () {
       expect(PreferencesOptionType.collapseThread.isExperimental, isTrue);

--- a/test/features/manage_account/presentation/model/preferences_option_type_experimental_test.dart
+++ b/test/features/manage_account/presentation/model/preferences_option_type_experimental_test.dart
@@ -1,0 +1,175 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_settings/server_settings/tmail_server_settings.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/collapse_thread_config.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/thread_detail_config.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/model/preferences_option_type.dart';
+
+// All options that are standard (not experimental) and top-level (no parent).
+// collapseThread is the only exception: experimental + child.
+final _standardTopLevelOptions = PreferencesOptionType.values
+    .where((t) => t != PreferencesOptionType.collapseThread)
+    .toList();
+
+PreferencesVisibilityContext _ctx({
+  bool isExperimentalEnabled = false,
+  bool isAIScribeAvailable = false,
+  bool isLabelVisibility = false,
+  PreferencesSetting? localSettings,
+}) => (
+  settingOption: null,
+  localSettings: localSettings ?? PreferencesSetting.initial(),
+  isExperimentalEnabled: isExperimentalEnabled,
+  isAIScribeAvailable: isAIScribeAvailable,
+  isAICapabilitySupported: false,
+  isLabelVisibility: isLabelVisibility,
+);
+
+PreferencesVisibilityContext _serverCtx({
+  bool isAICapabilitySupported = false,
+}) => (
+  settingOption: TMailServerSettingOptions(),
+  localSettings: PreferencesSetting.initial(),
+  isExperimentalEnabled: false,
+  isAIScribeAvailable: false,
+  isAICapabilitySupported: isAICapabilitySupported,
+  isLabelVisibility: false,
+);
+
+void main() {
+  group('collapseThread is experimental and a child of thread', () {
+    test('isExperimental is true', () {
+      expect(PreferencesOptionType.collapseThread.isExperimental, isTrue);
+    });
+
+    test('parentType is thread', () {
+      expect(
+        PreferencesOptionType.collapseThread.parentType,
+        PreferencesOptionType.thread,
+      );
+    });
+
+    test('isChildOption is true', () {
+      expect(PreferencesOptionType.collapseThread.isChildOption, isTrue);
+    });
+  });
+
+  group('all other options: standard, no parent', () {
+    for (final option in _standardTopLevelOptions) {
+      test('${option.name}: not experimental, no parent, not child', () {
+        expect(option.isExperimental, isFalse);
+        expect(option.parentType, isNull);
+        expect(option.isChildOption, isFalse);
+      });
+    }
+  });
+
+  group('PreferencesOptionType.isEnabled for collapseThread', () {
+    for (final isEnabled in [true, false]) {
+      test('returns $isEnabled when collapseThreadConfig.isEnabled is $isEnabled', () {
+        final setting = PreferencesSetting([
+          ThreadDetailConfig(isEnabled: true),
+          CollapseThreadConfig(isEnabled: isEnabled),
+        ]);
+        expect(
+          PreferencesOptionType.collapseThread.isEnabled(null, setting),
+          isEnabled ? isTrue : isFalse,
+        );
+      });
+    }
+  });
+
+  group('PreferencesOptionType.createToggledConfig', () {
+    test('collapseThread toggles from false to true', () {
+      final settings = PreferencesSetting([CollapseThreadConfig(isEnabled: false)]);
+      final result =
+          PreferencesOptionType.collapseThread.createToggledConfig(settings, false);
+      expect((result as CollapseThreadConfig).isEnabled, isTrue);
+    });
+
+    test('thread toggles from true to false', () {
+      final settings = PreferencesSetting([ThreadDetailConfig(isEnabled: true)]);
+      final result =
+          PreferencesOptionType.thread.createToggledConfig(settings, true);
+      expect((result as ThreadDetailConfig).isEnabled, isFalse);
+    });
+
+    test('returns null for non-local options', () {
+      final settings = PreferencesSetting.initial();
+      expect(
+        PreferencesOptionType.readReceipt.createToggledConfig(settings, true),
+        isNull,
+      );
+      expect(
+        PreferencesOptionType.aiNeedsAction.createToggledConfig(settings, false),
+        isNull,
+      );
+    });
+  });
+
+  group('PreferencesOptionType.isVisible', () {
+    test('readReceipt visible only when settingOption is present', () {
+      expect(PreferencesOptionType.readReceipt.isVisible(_ctx()), isFalse);
+      expect(PreferencesOptionType.readReceipt.isVisible(_serverCtx()), isTrue);
+    });
+
+    test('thread visible only when local configs are loaded', () {
+      expect(
+        PreferencesOptionType.thread.isVisible(_ctx(localSettings: PreferencesSetting([]))),
+        isFalse,
+      );
+      expect(PreferencesOptionType.thread.isVisible(_ctx()), isTrue);
+    });
+
+    test('collapseThread hidden when experimental mode is off', () {
+      expect(PreferencesOptionType.collapseThread.isVisible(_ctx()), isFalse);
+    });
+
+    test('collapseThread hidden when thread is disabled even if experimental on', () {
+      final settings = PreferencesSetting([ThreadDetailConfig(isEnabled: false)]);
+      expect(
+        PreferencesOptionType.collapseThread.isVisible(
+          _ctx(isExperimentalEnabled: true, localSettings: settings),
+        ),
+        isFalse,
+      );
+    });
+
+    test('collapseThread visible when experimental on and thread enabled', () {
+      final settings = PreferencesSetting([ThreadDetailConfig(isEnabled: true)]);
+      expect(
+        PreferencesOptionType.collapseThread.isVisible(
+          _ctx(isExperimentalEnabled: true, localSettings: settings),
+        ),
+        isTrue,
+      );
+    });
+
+    test('aiScribe hidden when capability not available', () {
+      expect(PreferencesOptionType.aiScribe.isVisible(_ctx()), isFalse);
+      expect(
+        PreferencesOptionType.aiScribe.isVisible(_ctx(isAIScribeAvailable: true)),
+        isTrue,
+      );
+    });
+
+    test('aiNeedsAction requires server settings and AI capability', () {
+      expect(PreferencesOptionType.aiNeedsAction.isVisible(_ctx()), isFalse);
+      expect(
+        PreferencesOptionType.aiNeedsAction.isVisible(_serverCtx()),
+        isFalse,
+      );
+      expect(
+        PreferencesOptionType.aiNeedsAction.isVisible(
+          _serverCtx(isAICapabilitySupported: true),
+        ),
+        isTrue,
+      );
+    });
+
+    test('label visible only when label visibility is enabled', () {
+      expect(PreferencesOptionType.label.isVisible(_ctx()), isFalse);
+      expect(PreferencesOptionType.label.isVisible(_ctx(isLabelVisibility: true)), isTrue);
+    });
+  });
+}

--- a/test/features/manage_account/presentation/services/riverpod_local_settings_reader_test.dart
+++ b/test/features/manage_account/presentation/services/riverpod_local_settings_reader_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/collapse_thread_config.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/thread_detail_config.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/providers/local_settings_notifier.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/riverpod_local_settings_reader.dart';
+
+ProviderContainer _makeContainer() => ProviderContainer();
+
+void main() {
+  group('RiverpodLocalSettingsReader', () {
+    late ProviderContainer container;
+    late RiverpodLocalSettingsReader reader;
+
+    setUp(() {
+      container = _makeContainer();
+      reader = RiverpodLocalSettingsReader(container);
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('currentSettings returns initial PreferencesSetting', () {
+      expect(reader.currentSettings, equals(PreferencesSetting.initial()));
+    });
+
+    test('listen notifies onChange when provider changes', () {
+      PreferencesSetting? received;
+      reader.listen((next) => received = next);
+
+      final updated = PreferencesSetting([
+        ThreadDetailConfig(isEnabled: true),
+        CollapseThreadConfig(isEnabled: true),
+      ]);
+      container.read(localSettingsNotifierProvider.notifier).update(updated);
+
+      expect(received, equals(updated));
+    });
+
+    test('cancel stops future notifications', () {
+      PreferencesSetting? received;
+      final cancel = reader.listen((next) => received = next);
+
+      cancel();
+
+      container.read(localSettingsNotifierProvider.notifier).update(
+        PreferencesSetting([ThreadDetailConfig(isEnabled: true)]),
+      );
+
+      expect(received, isNull);
+    });
+
+    test('isCollapseThreadsEnabled is true when thread and collapse both enabled', () {
+      container.read(localSettingsNotifierProvider.notifier).update(
+        PreferencesSetting([
+          ThreadDetailConfig(isEnabled: true),
+          CollapseThreadConfig(isEnabled: true),
+        ]),
+      );
+
+      expect(reader.isCollapseThreadsEnabled, isTrue);
+    });
+
+    test('isCollapseThreadsEnabled is false when thread is disabled', () {
+      container.read(localSettingsNotifierProvider.notifier).update(
+        PreferencesSetting([
+          ThreadDetailConfig(isEnabled: false),
+          CollapseThreadConfig(isEnabled: true),
+        ]),
+      );
+
+      expect(reader.isCollapseThreadsEnabled, isFalse);
+    });
+
+    test('isCollapseThreadsEnabled is false when collapse is disabled', () {
+      container.read(localSettingsNotifierProvider.notifier).update(
+        PreferencesSetting([
+          ThreadDetailConfig(isEnabled: true),
+          CollapseThreadConfig(isEnabled: false),
+        ]),
+      );
+
+      expect(reader.isCollapseThreadsEnabled, isFalse);
+    });
+  });
+}

--- a/test/features/search/verify_before_time_in_search_email_filter_test.dart
+++ b/test/features/search/verify_before_time_in_search_email_filter_test.dart
@@ -89,6 +89,7 @@ import 'package:tmail_ui_user/features/thread/domain/usecases/refresh_changes_em
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_more_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/presentation/extensions/handle_email_filter_extension.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_reader.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
 import 'package:tmail_ui_user/main/utils/email_receive_manager.dart';
@@ -170,6 +171,7 @@ const fallbackGenerators = {
   MockSpec<GetAllIdentitiesInteractor>(),
   MockSpec<ComposerManager>(fallbackGenerators: fallbackGenerators),
   MockSpec<CleanAndGetEmailsInMailboxInteractor>(),
+  MockSpec<ILocalSettingsReader>(),
   MockSpec<ClearMailboxInteractor>(),
   MockSpec<GetAuthenticationInfoInteractor>(),
   MockSpec<GetStoredOidcConfigurationInteractor>(),
@@ -418,6 +420,9 @@ void main() {
 
     Get.put<MailboxDashBoardController>(mailboxDashboardController);
 
+    final mockLocalSettingsReader = MockILocalSettingsReader();
+    when(mockLocalSettingsReader.isCollapseThreadsEnabled).thenReturn(false);
+
     threadController = ThreadController(
       mockGetEmailsInMailboxInteractor,
       mockRefreshChangesEmailsInMailboxInteractor,
@@ -426,6 +431,7 @@ void main() {
       mockSearchMoreEmailInteractor,
       mockGetEmailByIdInteractor,
       mockCleanAndGetEmailsInMailboxInteractor,
+      mockLocalSettingsReader,
     );
     threadController.onInit();
 

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -49,6 +49,10 @@ import 'package:tmail_ui_user/features/thread/presentation/model/search_state.da
 import 'package:tmail_ui_user/features/thread/presentation/model/search_status.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/collapse_thread_config.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/thread_detail_config.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/services/local_settings_reader.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
 import 'package:uuid/uuid.dart';
@@ -89,6 +93,7 @@ const fallbackGenerators = {
   MockSpec<SearchMoreEmailInteractor>(),
   MockSpec<GetEmailByIdInteractor>(),
   MockSpec<CleanAndGetEmailsInMailboxInteractor>(),
+  MockSpec<ILocalSettingsReader>(),
 ])
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -105,6 +110,7 @@ void main() {
   late MockSearchMoreEmailInteractor mockSearchMoreEmailInteractor;
   late MockGetEmailByIdInteractor mockGetEmailByIdInteractor;
   late MockCleanAndGetEmailsInMailboxInteractor mockCleanAndGetEmailsInMailboxInteractor;
+  late MockILocalSettingsReader mockLocalSettingsReader;
 
   // Declaration base controller
   late MockCachingManager mockCachingManager;
@@ -169,6 +175,8 @@ void main() {
     mockSearchMoreEmailInteractor = MockSearchMoreEmailInteractor();
     mockGetEmailByIdInteractor = MockGetEmailByIdInteractor();
     mockCleanAndGetEmailsInMailboxInteractor = MockCleanAndGetEmailsInMailboxInteractor();
+    mockLocalSettingsReader = MockILocalSettingsReader();
+    when(mockLocalSettingsReader.isCollapseThreadsEnabled).thenReturn(false);
 
     Get.put<NetworkConnectionController>(mockNetworkConnectionController);
     Get.put<SearchController>(mockSearchController);
@@ -182,6 +190,7 @@ void main() {
       mockSearchMoreEmailInteractor,
       mockGetEmailByIdInteractor,
       mockCleanAndGetEmailsInMailboxInteractor,
+      mockLocalSettingsReader,
     );
   });
 
@@ -281,6 +290,7 @@ void main() {
           mockSearchMoreEmailInteractor,
           mockGetEmailByIdInteractor,
           mockCleanAndGetEmailsInMailboxInteractor,
+          mockLocalSettingsReader,
         );
       });
 
@@ -480,6 +490,7 @@ void main() {
           mockSearchMoreEmailInteractor,
           mockGetEmailByIdInteractor,
           mockCleanAndGetEmailsInMailboxInteractor,
+          mockLocalSettingsReader,
         );
       });
 
@@ -557,6 +568,7 @@ void main() {
           mockSearchMoreEmailInteractor,
           mockGetEmailByIdInteractor,
           mockCleanAndGetEmailsInMailboxInteractor,
+          mockLocalSettingsReader,
         );
 
         when(mockMailboxDashBoardController.selectedMailbox).thenReturn(Rxn(null));
@@ -664,6 +676,25 @@ void main() {
         // Assert - peak should be 15, not stale 40
         expect(limitEmailFetchedController.limitEmailFetched, UnsignedInt(15));
       });
+    });
+
+    group('PreferencesSetting.isCollapseThreadsEnabled semantics', () {
+      final cases = [
+        (thread: true,  collapse: true,  active: true,  label: 'thread=true, collapse=true → collapse is active'),
+        (thread: true,  collapse: false, active: false, label: 'thread=true, collapse=false → collapse is inactive'),
+        (thread: false, collapse: true,  active: false, label: 'thread=false, collapse=true → collapse is inactive'),
+        (thread: false, collapse: false, active: false, label: 'both false → collapse is inactive'),
+      ];
+
+      for (final c in cases) {
+        test(c.label, () {
+          final settings = PreferencesSetting([
+            ThreadDetailConfig(isEnabled: c.thread),
+            CollapseThreadConfig(isEnabled: c.collapse),
+          ]);
+          expect(settings.isCollapseThreadsEnabled, equals(c.active));
+        });
+      }
     });
   });
 }


### PR DESCRIPTION

### What
Adds a **Collapse Thread** toggle in the Preferences screen. Only visible when:
1. Experimental mode is enabled
2. Thread view is enabled

When active, emails in a thread are rendered collapsed by default.

### Changes

**Model:**
- `CollapseThreadConfig` — stored under `PREFERENCES_SETTING_COLLAPSE_THREAD`
- `PreferencesSetting.isCollapseThreadsEnabled` = `threadConfig.isEnabled && collapseThreadConfig.isEnabled`
- `PreferencesSettingManager._configFactories`: one new entry

**PreferencesOptionType extensions** (infrastructure usable by all future options):
- `createToggledConfig(settings, isEnabled)` — returns the flipped config; callers no longer need a switch
- `isVisible(PreferencesVisibilityContext)` — centralizes per-option visibility logic
- `PreferencesOptionCategory` enum (`standard` / `experimental`) — `collapseThread` is the first experimental entry
- `_parentTypes` map — `collapseThread` is a child of `thread`

**Integration:**
- `ILocalSettingsReader` interface + `RiverpodLocalSettingsReader` — decouples `ThreadController` and `SearchEmailController` from direct `appProviderContainer` reads
- `ThreadController` / `SearchEmailController`: use `ILocalSettingsReader.isCollapseThreadsEnabled`; listen for live changes and re-fetch on toggle
- `PreferencesController`: uses `createToggledConfig` — the toggle handler is now a single generic call with no switch
- `PreferencesView`: renders options via `isVisible(ctx)` — no manual visibility conditionals

### l10n
New keys: `collapseThread`, `collapseThreadSettingExplanation`, `collapseThreadToggleDescription`, `experimentalFeaturesEnabled`.

### Tests
`CollapseThreadConfig`, `PreferencesSetting` (collapse logic), `PreferencesOptionType` (experimental visibility), `PreferencesSettingManager` (registry round-trip), `ThreadController`, search filter, mailbox dashboard, composer cache.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental "Collapse Thread" preference option to manage thread display behavior. This setting works in conjunction with the existing thread setting and is available under experimental features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-flutter/pull/4554?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->