### PR TITLE
Patrol Web Enable reset server

### DIFF
--- a/integration_test/utils/backend_reset_client.dart
+++ b/integration_test/utils/backend_reset_client.dart
@@ -1,16 +1,12 @@
-import 'dart:io';
-
 import 'package:core/utils/app_logger.dart';
+import 'package:dio/dio.dart';
 
 /// Calls the backend reset server running on the CI host.
 ///
-/// The Android emulator reaches the host at 10.0.2.2. The reset server
-/// (scripts/backend-reset-server.py) stops the running tmail-backend
-/// container and starts a fresh one from the provisioned snapshot, then
-/// returns 200 once James reports "server started".
-///
 /// Only active when RESET_SERVER_URL is provided via --dart-define,
 /// so local runs without the reset server are unaffected.
+///
+/// Uses Dio instead of dart:io so it works on all platforms including web.
 class BackendResetClient {
   static const String _resetUrl = String.fromEnvironment(
     'RESET_SERVER_URL',
@@ -26,19 +22,23 @@ class BackendResetClient {
   }) async {
     if (!isEnabled) return;
 
-    final uri = Uri.parse('$_resetUrl/reset');
-    final client = HttpClient()..connectionTimeout = timeout;
+    final dio = Dio(
+      BaseOptions(
+        connectTimeout: timeout,
+        receiveTimeout: timeout,
+        sendTimeout: timeout,
+      ),
+    );
 
     try {
-      final request = await client.postUrl(uri);
-      final response = await request.close().timeout(timeout);
+      final response = await dio.post('$_resetUrl/reset');
       if (response.statusCode != 200) {
         throw Exception('Backend reset failed with status ${response.statusCode}');
       }
     } catch (e) {
       logWarning('Backend reset failed: $e');
     } finally {
-      client.close();
+      dio.close();
     }
   }
 }

--- a/scripts/backend-reset-server.py
+++ b/scripts/backend-reset-server.py
@@ -28,7 +28,7 @@ import os
 import subprocess
 import sys
 import time
-from typing import Optional
+from typing import List, Optional
 
 RESET_PORT    = int(os.environ.get("RESET_PORT", "9999"))
 WEBADMIN_PORT = int(os.environ.get("WEBADMIN_PORT", "8000"))
@@ -49,11 +49,11 @@ _TEST_DOMAIN = "example.com"
 _BOB_USER = "bob@example.com"
 
 
-def _run(cmd: list[str], check: bool = False) -> subprocess.CompletedProcess:
+def _run(cmd: List[str], check: bool = False) -> subprocess.CompletedProcess:
     return subprocess.run(cmd, check=check, capture_output=True, text=True)
 
 
-def _webadmin(method: str, path: str, data: str | None = None) -> dict:
+def _webadmin(method: str, path: str, data: Optional[str] = None) -> dict:
     """Call the James WebAdmin API inside the container via docker exec curl."""
     cmd = [
         "curl", "-s", "-X", method,
@@ -158,20 +158,33 @@ def reset_backend() -> None:
 
 
 class ResetHandler(http.server.BaseHTTPRequestHandler):
+    def _send_cors_headers(self):
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "content-type")
+
+    def do_OPTIONS(self):
+        self.send_response(204)
+        self._send_cors_headers()
+        self.end_headers()
+
     def do_POST(self):
         if self.path != "/reset":
             self.send_response(404)
+            self._send_cors_headers()
             self.end_headers()
             return
 
         try:
             reset_backend()
             self.send_response(200)
+            self._send_cors_headers()
             self.end_headers()
             self.wfile.write(b"ok")
         except Exception as exc:
             print(f"[reset-server] ERROR: {exc}", file=sys.stderr, flush=True)
             self.send_response(500)
+            self._send_cors_headers()
             self.end_headers()
             self.wfile.write(str(exc).encode())
 

--- a/scripts/patrol-web-integration-test-with-docker.sh
+++ b/scripts/patrol-web-integration-test-with-docker.sh
@@ -41,6 +41,22 @@ docker exec tmail-backend ./root/conf/integration_test/provisioning.sh
 
 cd ..
 
+export RESET_PORT=9999
+
+RESET_SERVER_LOG="/tmp/backend-reset-server.log"
+echo "Starting backend reset server on port $RESET_PORT (logs: $RESET_SERVER_LOG)..."
+RESET_PORT="$RESET_PORT" python3 scripts/backend-reset-server.py > "$RESET_SERVER_LOG" 2>&1 &
+RESET_SERVER_PID=$!
+
+cleanup() {
+    echo "Cleaning up test environment..."
+    kill "$RESET_SERVER_PID" 2>/dev/null || true
+    cd backend-docker || exit 0
+    docker compose down
+    cd ..
+}
+trap cleanup EXIT
+
 echo "Copying integration_test/integration_test_env.file to env.file..."
 cp integration_test/integration_test_env.file env.file
 
@@ -55,13 +71,8 @@ patrol test -v \
     --dart-define=PASSWORD="$BOB" \
     --dart-define=ADDITIONAL_MAIL_RECIPIENT="$ALICE@$DOMAIN" \
     --dart-define=BASIC_AUTH_EMAIL="$BOB@$DOMAIN" \
-    --dart-define=BASIC_AUTH_URL="$BASIC_AUTH_URL"
+    --dart-define=BASIC_AUTH_URL="$BASIC_AUTH_URL" \
+    --dart-define=RESET_SERVER_URL="http://localhost:$RESET_PORT"
 TEST_EXIT_CODE=$?
-
-# Clean up (runs regardless of test result)
-echo "Cleaning up test environment..."
-cd backend-docker
-docker compose down
-cd ..
 
 exit $TEST_EXIT_CODE

--- a/scripts/patrol-web-local-integration-test-with-docker.sh
+++ b/scripts/patrol-web-local-integration-test-with-docker.sh
@@ -39,6 +39,22 @@ docker exec tmail-backend ./root/conf/integration_test/provisioning.sh
 
 cd ..
 
+export RESET_PORT=9999
+
+RESET_SERVER_LOG="/tmp/backend-reset-server.log"
+echo "Starting backend reset server on port $RESET_PORT (logs: $RESET_SERVER_LOG)..."
+RESET_PORT="$RESET_PORT" python3 scripts/backend-reset-server.py > "$RESET_SERVER_LOG" 2>&1 &
+RESET_SERVER_PID=$!
+
+cleanup() {
+    echo "Cleaning up test environment..."
+    kill "$RESET_SERVER_PID" 2>/dev/null || true
+    cd backend-docker || exit 0
+    docker compose down
+    cd ..
+}
+trap cleanup EXIT
+
 echo "Copying integration_test/integration_test_env.file to env.file..."
 cp integration_test/integration_test_env.file env.file
 
@@ -52,10 +68,5 @@ patrol test -v \
     --dart-define=PASSWORD="$BOB" \
     --dart-define=ADDITIONAL_MAIL_RECIPIENT="$ALICE@$DOMAIN" \
     --dart-define=BASIC_AUTH_EMAIL="$BOB@$DOMAIN" \
-    --dart-define=BASIC_AUTH_URL="$BASIC_AUTH_URL"
-
-# Clean up
-echo "Cleaning up test environment..."
-cd backend-docker
-docker compose down
-cd ..
+    --dart-define=BASIC_AUTH_URL="$BASIC_AUTH_URL" \
+    --dart-define=RESET_SERVER_URL="http://localhost:$RESET_PORT"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error responses from the backend reset endpoint for clearer failure diagnostics.

* **Chores**
  * Added CORS support to the backend reset service.
  * Start a local backend reset server before web integration tests and ensure it is cleaned up on exit.
  * Pass the reset server endpoint into the test run environment.
  * Switched to a more robust HTTP client for reset requests, with improved timeout handling and resource cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-flutter/pull/4557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->