### PR TITLE
Handle refreshToken failed for web

### DIFF
--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -187,7 +187,11 @@ abstract class BaseController extends GetxController
   }
 
   void handleUrgentExceptionOnWeb({Failure? failure, Exception? exception}) {
-    logWarning('$runtimeType::handleUrgentExceptionOnWeb():Failure: $failure | Exception: $exception');
+    logWarning(
+      '$runtimeType::handleUrgentExceptionOnWeb(): exception=${exception.runtimeType} | '
+      'failure=${failure.runtimeType}',
+      webConsoleEnabled: true,
+    );
     if (exception is NoNetworkError) {
       _handleNotNetworkErrorException();
     } else if (exception is ConnectionError) {
@@ -196,6 +200,12 @@ abstract class BaseController extends GetxController
       handleBadCredentialsException();
     } else if (exception is RefreshTokenFailedException) {
       handleRefreshTokenFailedException();
+    } else {
+      logWarning(
+        '$runtimeType::handleUrgentExceptionOnWeb(): NO branch matched — '
+        'will NOT navigate to login. exception=${exception.runtimeType}',
+        webConsoleEnabled: true,
+      );
     }
   }
 
@@ -205,6 +215,7 @@ abstract class BaseController extends GetxController
     logError(
       '$runtimeType::_executeBeforeReconnectAndLogOut: '
       'forcing logout after web save-and-reconnect (urgent auth failure)',
+      webConsoleEnabled: true,
     );
     clearDataAndGoToLoginPage();
   }
@@ -234,7 +245,10 @@ abstract class BaseController extends GetxController
   }
 
   void handleBadCredentialsException() {
-    log('$runtimeType::handleBadCredentialsException:');
+    log(
+      '$runtimeType::handleBadCredentialsException: hasComposer=${twakeAppManager.hasComposer}',
+      webConsoleEnabled: true,
+    );
     if (twakeAppManager.hasComposer) {
       _performSaveAndReconnection();
     } else {
@@ -244,6 +258,10 @@ abstract class BaseController extends GetxController
 
   void _performSaveAndReconnection() {
     if (PlatformInfo.isWeb) {
+      logWarning(
+        '$runtimeType::_performSaveAndReconnection: web save-and-reconnect path',
+        webConsoleEnabled: true,
+      );
       _executeBeforeReconnectAndLogOut();
     } else if (PlatformInfo.isMobile) {
       logError(
@@ -258,12 +276,16 @@ abstract class BaseController extends GetxController
     logError(
       '$runtimeType::_performReconnection: '
       'forcing logout (urgent auth failure, no composer to save)',
+      webConsoleEnabled: true,
     );
     clearDataAndGoToLoginPage();
   }
 
   void handleRefreshTokenFailedException() {
-    log('$runtimeType::handleRefreshTokenFailedException:');
+    log(
+      '$runtimeType::handleRefreshTokenFailedException: hasComposer=${twakeAppManager.hasComposer}',
+      webConsoleEnabled: true,
+    );
     if (twakeAppManager.hasComposer) {
       _performSaveAndReconnection();
     } else {
@@ -455,8 +477,17 @@ abstract class BaseController extends GetxController
 
   void navigateToLoginPage() {
     if (Get.currentRoute == AppRoutes.login) {
+      logWarning(
+        '$runtimeType::navigateToLoginPage: SKIPPED — already on login route',
+        webConsoleEnabled: true,
+      );
       return;
     }
+    logWarning(
+      '$runtimeType::navigateToLoginPage: navigating to login from '
+      'currentRoute=${Get.currentRoute}',
+      webConsoleEnabled: true,
+    );
     pushAndPopAll(
       AppRoutes.login,
       arguments: LoginArguments(LoginFormType.none));
@@ -590,9 +621,16 @@ abstract class BaseController extends GetxController
   }
 
   Future<void> clearDataAndGoToLoginPage() async {
-    log('$runtimeType::clearDataAndGoToLoginPage:');
+    log(
+      '$runtimeType::clearDataAndGoToLoginPage: clearing data then routing to login',
+      webConsoleEnabled: true,
+    );
     SentryManager.instance.clearUser();
     await clearAllData();
+    logWarning(
+      '$runtimeType::clearDataAndGoToLoginPage: data cleared, calling removeAllPageAndGoToLogin',
+      webConsoleEnabled: true,
+    );
     removeAllPageAndGoToLogin();
   }
 

--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -258,7 +258,7 @@ abstract class BaseController extends GetxController
 
   void _performSaveAndReconnection() {
     if (PlatformInfo.isWeb) {
-      logWarning(
+      log(
         '$runtimeType::_performSaveAndReconnection: web save-and-reconnect path',
         webConsoleEnabled: true,
       );
@@ -477,13 +477,13 @@ abstract class BaseController extends GetxController
 
   void navigateToLoginPage() {
     if (Get.currentRoute == AppRoutes.login) {
-      logWarning(
+      log(
         '$runtimeType::navigateToLoginPage: SKIPPED — already on login route',
         webConsoleEnabled: true,
       );
       return;
     }
-    logWarning(
+    log(
       '$runtimeType::navigateToLoginPage: navigating to login from '
       'currentRoute=${Get.currentRoute}',
       webConsoleEnabled: true,
@@ -627,7 +627,7 @@ abstract class BaseController extends GetxController
     );
     SentryManager.instance.clearUser();
     await clearAllData();
-    logWarning(
+    log(
       '$runtimeType::clearDataAndGoToLoginPage: data cleared, calling removeAllPageAndGoToLogin',
       webConsoleEnabled: true,
     );

--- a/lib/features/base/mixin/batch_set_email_processing_mixin.dart
+++ b/lib/features/base/mixin/batch_set_email_processing_mixin.dart
@@ -18,6 +18,7 @@ import 'package:tmail_ui_user/features/base/mixin/handle_error_mixin.dart';
 import 'package:tmail_ui_user/features/base/mixin/mail_api_mixin.dart';
 import 'package:tmail_ui_user/features/base/mixin/session_mixin.dart';
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
 
 typedef OnGeneratePatchObjectUpdates = Map<Id, PatchObject> Function(
   List<EmailId> batchIds,
@@ -71,11 +72,12 @@ mixin BatchSetEmailProcessingMixin
         } else {
           throw Exception('SetEmailResponse is null');
         }
-      } catch (e) {
-        logWarning(
-          'BatchSetEmailProcessingMixin::$debugLabel: Error processing batch ${start + 1}-$end: $e',
+      } catch (e, stackTrace) {
+        _handleBatchSetEmailErrors(
+          e,
+          stackTrace,
+          '$debugLabel: batch ${start + 1}-$end',
         );
-        if (e is DioException && e.response?.statusCode == 401) rethrow;
       }
     }
 
@@ -85,6 +87,31 @@ mixin BatchSetEmailProcessingMixin
     }
 
     return (emailIdsSuccess: updatedEmailIds, mapErrors: finalMapErrors);
+  }
+
+  bool _isSessionTerminatedError(Object error) {
+    return error is DioException &&
+        (error.response?.statusCode == 401 ||
+            error.error is RefreshTokenFailedException);
+  }
+
+  void _handleBatchSetEmailErrors(
+    Object error,
+    StackTrace stackTrace,
+    String batchContext,
+  ) {
+    if (_isSessionTerminatedError(error)) {
+      logError(
+        'BatchSetEmailProcessingMixin::$batchContext: session terminated: $error',
+        exception: error,
+        stackTrace: stackTrace,
+      );
+      throw error;
+    } else {
+      logWarning(
+        'BatchSetEmailProcessingMixin::$batchContext: Error processing batch: $error',
+      );
+    }
   }
 
   Future<SetEmailResponse?> _executeSetEmailBatch({

--- a/lib/features/base/mixin/batch_set_email_processing_mixin.dart
+++ b/lib/features/base/mixin/batch_set_email_processing_mixin.dart
@@ -1,6 +1,7 @@
 import 'dart:math' hide log;
 
 import 'package:core/utils/app_logger.dart';
+import 'package:dio/dio.dart';
 import 'package:jmap_dart_client/http/http_client.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/error/set_error.dart';
@@ -74,6 +75,7 @@ mixin BatchSetEmailProcessingMixin
         logWarning(
           'BatchSetEmailProcessingMixin::$debugLabel: Error processing batch ${start + 1}-$end: $e',
         );
+        if (e is DioException && e.response?.statusCode == 401) rethrow;
       }
     }
 

--- a/lib/features/base/reloadable/reloadable_controller.dart
+++ b/lib/features/base/reloadable/reloadable_controller.dart
@@ -157,11 +157,20 @@ abstract class ReloadableController extends BaseController {
         exception is NotFoundSessionException) {
       logError(
         '$runtimeType::handleGetSessionFailure: '
-        'forcing logout — session definitively dead',
+        'forcing logout — session definitively dead — '
+        'exception=${exception.runtimeType}',
         exception: exception,
         stackTrace: StackTrace.current,
+        webConsoleEnabled: true,
       );
       clearDataAndGoToLoginPage();
+    } else {
+      logWarning(
+        '$runtimeType::handleGetSessionFailure: NOT logging out — '
+        'exception=${exception.runtimeType} not in {BadCredentials, '
+        'RefreshTokenFailed, NotFoundSession}',
+        webConsoleEnabled: true,
+      );
     }
   }
 

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -93,7 +93,11 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
 
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) async {
-    logWarning('AuthorizationInterceptors::onError(): DIO_ERROR = $err');
+    logWarning(
+      'AuthorizationInterceptors::onError(): DIO_ERROR = $err | '
+      'statusCode=${err.response?.statusCode} | authType=$_authenticationType',
+      webConsoleEnabled: true,
+    );
     try {
       final requestOptions = err.requestOptions;
       final hasAttemptedRefresh = requestOptions.extra[_refreshAttemptedKey] == true;
@@ -103,7 +107,10 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         authHeader: requestOptions.headers[HttpHeaders.authorizationHeader],
         tokenOIDC: _token
       )) {
-        log('AuthorizationInterceptors::onError: Request using old token, retry with updated token');
+        log(
+          'AuthorizationInterceptors::onError: Request using old token, retry with updated token',
+          webConsoleEnabled: true,
+        );
         return await _performRetry(requestOptions, err, handler);
       } else if (!hasAttemptedRefresh && validateToRefreshToken(
         responseStatusCode: err.response?.statusCode,
@@ -128,6 +135,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         'AuthorizationInterceptors::onError:Exception: $e',
         exception: e,
         stackTrace: stackTrace,
+        webConsoleEnabled: true,
       );
       return _propagateRefreshError(e, err, handler);
     }
@@ -200,7 +208,10 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     ErrorInterceptorHandler handler,
   ) async {
     try {
-      log('AuthorizationInterceptors::onError: Perform get New Token');
+      log(
+        'AuthorizationInterceptors::onError: Perform get New Token',
+        webConsoleEnabled: true,
+      );
       final newTokenOidc = PlatformInfo.isIOS
         ? await _getNewTokenForIOSPlatform()
         : await _getNewTokenForOtherPlatform();

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -39,8 +39,8 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     Object error,
     DioException originalError,
     ErrorInterceptorHandler handler,
-  ) _propagateRefreshError =
-      PlatformInfo.isWeb ? _propagateRefreshErrorOnWeb : _propagateRefreshErrorOnMobile;
+  ) _handleRefreshError =
+      PlatformInfo.isWeb ? _handleRefreshErrorOnWeb : _handleRefreshErrorOnMobile;
 
   AuthorizationInterceptors(
     this._dio,
@@ -137,58 +137,50 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         stackTrace: stackTrace,
         webConsoleEnabled: true,
       );
-      return _propagateRefreshError(e, err, handler);
+      return _handleRefreshError(e, err, handler);
     }
   }
 
-  /// Web: end the session ONLY when the auth server actually responded (the
-  /// grant was rejected or the returned token was invalid) — the original 401
-  /// is preserved so [RemoteExceptionThrower] classifies it as
-  /// [BadCredentialsException] → logout.
-  ///
   /// A failure with NO server response (network/transport drop, timeout) keeps
   /// the session and is propagated WITHOUT the stale 401 — same as mobile — so
   /// a flaky connection does not log the web user out.
-  void _propagateRefreshErrorOnWeb(
+  void _handleRefreshErrorOnWeb(
     Object error,
     DioException originalError,
     ErrorInterceptorHandler handler,
   ) {
     if (_isWebRefreshRejectedByServer(error)) {
       logWarning(
-        'AuthorizationInterceptors::_propagateRefreshErrorOnWeb: '
+        'AuthorizationInterceptors::_handleRefreshErrorOnWeb: '
         'web refresh rejected by server, ending session — error=$error',
         webConsoleEnabled: true,
       );
       return super.onError(originalError.copyWith(error: error), handler);
     }
     logWarning(
-      'AuthorizationInterceptors::_propagateRefreshErrorOnWeb: '
+      'AuthorizationInterceptors::_handleRefreshErrorOnWeb: '
       'web refresh network/transient failure, keeping session — error=$error',
       webConsoleEnabled: true,
     );
-    return _propagateRefreshErrorOnMobile(error, originalError, handler);
+    return _handleRefreshErrorOnMobile(error, originalError, handler);
   }
 
-  /// Whether a web refresh/retry failure came WITH a server response (grant
-  /// rejected or token invalid) as opposed to a network/transport failure.
+  /// Whether a web REFRESH failure came WITH a server response (grant rejected
+  /// or token invalid) as opposed to a network/transport failure.
   ///
   /// flutter_appauth_web throws [ArgumentError] only after parsing a non-200
   /// token response, and [AccessTokenInvalidException] after a 200 that yields
-  /// an invalid token — both mean the server responded. A Dio retry that came
-  /// back with an HTTP status likewise responded. Everything else (no
+  /// an invalid token — both mean the server responded. Everything else (no
   /// response: timeouts, transport errors, ServerError/TemporarilyUnavailable)
   /// is treated as a network failure → session kept.
   bool _isWebRefreshRejectedByServer(Object error) {
     return error is ArgumentError ||
         error is AccessTokenInvalidException ||
+        error is UnsupportedError || 
         (error is DioException && error.response != null);
   }
 
-  /// Mobile: never carry the stale 401 forward — propagate the real
-  /// error without a response so a network failure is not misread as bad
-  /// credentials and the user is kept signed in.
-  void _propagateRefreshErrorOnMobile(
+  void _handleRefreshErrorOnMobile(
     Object error,
     DioException originalError,
     ErrorInterceptorHandler handler,
@@ -198,6 +190,28 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     }
     return super.onError(
       error.toDioException(requestOptions: originalError.requestOptions),
+      handler,
+    );
+  }
+
+  /// A retry that comes back 401 then surfaces downstream as
+  /// [BadCredentialsException]; a 5xx/network retry failure is propagated
+  /// without forcing a logout.
+  void _handleRetryError(
+    Object retryError,
+    RequestOptions requestOptions,
+    ErrorInterceptorHandler handler,
+  ) {
+    logWarning(
+      'AuthorizationInterceptors::_handleRetryError: '
+      'retry with new token failed — error=$retryError',
+      webConsoleEnabled: true,
+    );
+    if (retryError is DioException) {
+      return super.onError(retryError, handler);
+    }
+    return super.onError(
+      retryError.toDioException(requestOptions: requestOptions),
       handler,
     );
   }
@@ -231,11 +245,15 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       requestOptions.extra[_refreshAttemptedKey] = true;
       return await _performRetry(requestOptions, err, handler);
     } on DioException catch (refreshError, st) {
-      // Mobile-only in practice: native AppAuth surfaces token-endpoint
-      // failures as DioException. On web, flutter_appauth_web flattens every
-      // non-200 to a non-Dio ArgumentError, so web never reaches this block —
-      // it falls to the outer catch → _propagateRefreshErrorOnWeb (logout).
-      // If web ever gains a Dio-based refresh, add a web guard here too.
+      // Web routes ALL refresh failures (Dio or non-Dio) through the single
+      // web handler, so the session decision is uniform regardless of how the
+      // failure surfaced. (In practice flutter_appauth_web throws a non-Dio
+      // ArgumentError, but a Dio-based refresh must behave identically.)
+      if (PlatformInfo.isWeb) {
+        return _handleRefreshError(refreshError, err, handler);
+      }
+      // Mobile: 400 → session dead (RefreshTokenFailedException); other
+      // statuses / no-response → network-tolerant via _handleDioRefreshError.
       if (refreshError.response?.statusCode == 400) {
         logWarning(
           'AuthorizationInterceptors: Refresh Token Failed 400 - error=$refreshError | stackTrace=$st',
@@ -270,11 +288,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       final response = await _retryRequest(requestOptions, requestOptions.extra);
       return handler.resolve(response);
     } catch (retryError) {
-      logError(
-        'AuthorizationInterceptors::onError: '
-        'Retry failed with error=$retryError',
-      );
-      return _propagateRefreshError(retryError, originalErr, handler);
+      return _handleRetryError(retryError, originalErr.requestOptions, handler);
     }
   }
 

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -15,6 +15,7 @@ import 'package:tmail_ui_user/features/base/extensions/object_extensions.dart';
 import 'package:tmail_ui_user/features/login/data/local/account_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/local/token_oidc_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/network/authentication_client/authentication_client_base.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/oauth_authorization_error.dart';
 import 'package:tmail_ui_user/features/login/domain/extensions/oidc_configuration_extensions.dart';
 import 'package:tmail_ui_user/features/upload/data/network/file_uploader.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
@@ -33,6 +34,13 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
   OIDCConfiguration? _configOIDC;
   TokenOIDC? _token;
   String? _authorization;
+
+  late final void Function(
+    Object error,
+    DioException originalError,
+    ErrorInterceptorHandler handler,
+  ) _propagateRefreshError =
+      PlatformInfo.isWeb ? _propagateRefreshErrorOnWeb : _propagateRefreshErrorOnMobile;
 
   AuthorizationInterceptors(
     this._dio,
@@ -121,24 +129,45 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         exception: e,
         stackTrace: stackTrace,
       );
-      return _handleThrownException(
-        e,
-        handler: handler,
-        requestOptions: err.requestOptions,
-      );
+      return _propagateRefreshError(e, err, handler);
     }
   }
 
-  void _handleThrownException(
-    Object exception, {
-    required ErrorInterceptorHandler handler,
-    required RequestOptions requestOptions,
-  }) {
-    if (exception is DioException) {
-      return super.onError(exception, handler);
+  /// Web: preserve the original 401 response so
+  /// [RemoteExceptionThrower] classifies it as [BadCredentialsException] and
+  /// the user is logged out to login. Any refresh/retry failure ends the
+  /// session.
+  void _propagateRefreshErrorOnWeb(
+    Object error,
+    DioException originalError,
+    ErrorInterceptorHandler handler,
+  ) {
+    logWarning(
+      'AuthorizationInterceptors::_propagateRefreshErrorOnWeb: '
+      'web refresh/retry failed, ending session — error=$error',
+    );
+    if (error is ServerError || error is TemporarilyUnavailable) {
+      return super.onError(
+        DioException(requestOptions: originalError.requestOptions, error: error),
+        handler,
+      );
+    }
+    return super.onError(originalError.copyWith(error: error), handler);
+  }
+
+  /// Mobile: never carry the stale 401 forward — propagate the real
+  /// error without a response so a network failure is not misread as bad
+  /// credentials and the user is kept signed in.
+  void _propagateRefreshErrorOnMobile(
+    Object error,
+    DioException originalError,
+    ErrorInterceptorHandler handler,
+  ) {
+    if (error is DioException) {
+      return super.onError(error, handler);
     }
     return super.onError(
-      exception.toDioException(requestOptions: requestOptions),
+      error.toDioException(requestOptions: originalError.requestOptions),
       handler,
     );
   }
@@ -169,6 +198,11 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       requestOptions.extra[_refreshAttemptedKey] = true;
       return await _performRetry(requestOptions, err, handler);
     } on DioException catch (refreshError, st) {
+      // Mobile-only in practice: native AppAuth surfaces token-endpoint
+      // failures as DioException. On web, flutter_appauth_web flattens every
+      // non-200 to a non-Dio ArgumentError, so web never reaches this block —
+      // it falls to the outer catch → _propagateRefreshErrorOnWeb (logout).
+      // If web ever gains a Dio-based refresh, add a web guard here too.
       if (refreshError.response?.statusCode == 400) {
         logWarning(
           'AuthorizationInterceptors: Refresh Token Failed 400 - error=$refreshError | stackTrace=$st',
@@ -207,13 +241,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         'AuthorizationInterceptors::onError: '
         'Retry failed with error=$retryError',
       );
-      // Pass retry errors directly so the stale 401 response is not preserved
-      // via err.copyWith.
-      return _handleThrownException(
-        retryError,
-        handler: handler,
-        requestOptions: originalErr.requestOptions,
-      );
+      return _propagateRefreshError(retryError, originalErr, handler);
     }
   }
 

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -15,7 +15,7 @@ import 'package:tmail_ui_user/features/base/extensions/object_extensions.dart';
 import 'package:tmail_ui_user/features/login/data/local/account_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/local/token_oidc_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/network/authentication_client/authentication_client_base.dart';
-import 'package:tmail_ui_user/features/login/domain/exceptions/oauth_authorization_error.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_exception.dart' show AccessTokenInvalidException;
 import 'package:tmail_ui_user/features/login/domain/extensions/oidc_configuration_extensions.dart';
 import 'package:tmail_ui_user/features/upload/data/network/file_uploader.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
@@ -133,26 +133,48 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     }
   }
 
-  /// Web: preserve the original 401 response so
-  /// [RemoteExceptionThrower] classifies it as [BadCredentialsException] and
-  /// the user is logged out to login. Any refresh/retry failure ends the
-  /// session.
+  /// Web: end the session ONLY when the auth server actually responded (the
+  /// grant was rejected or the returned token was invalid) — the original 401
+  /// is preserved so [RemoteExceptionThrower] classifies it as
+  /// [BadCredentialsException] → logout.
+  ///
+  /// A failure with NO server response (network/transport drop, timeout) keeps
+  /// the session and is propagated WITHOUT the stale 401 — same as mobile — so
+  /// a flaky connection does not log the web user out.
   void _propagateRefreshErrorOnWeb(
     Object error,
     DioException originalError,
     ErrorInterceptorHandler handler,
   ) {
+    if (_isWebRefreshRejectedByServer(error)) {
+      logWarning(
+        'AuthorizationInterceptors::_propagateRefreshErrorOnWeb: '
+        'web refresh rejected by server, ending session — error=$error',
+        webConsoleEnabled: true,
+      );
+      return super.onError(originalError.copyWith(error: error), handler);
+    }
     logWarning(
       'AuthorizationInterceptors::_propagateRefreshErrorOnWeb: '
-      'web refresh/retry failed, ending session — error=$error',
+      'web refresh network/transient failure, keeping session — error=$error',
+      webConsoleEnabled: true,
     );
-    if (error is ServerError || error is TemporarilyUnavailable) {
-      return super.onError(
-        DioException(requestOptions: originalError.requestOptions, error: error),
-        handler,
-      );
-    }
-    return super.onError(originalError.copyWith(error: error), handler);
+    return _propagateRefreshErrorOnMobile(error, originalError, handler);
+  }
+
+  /// Whether a web refresh/retry failure came WITH a server response (grant
+  /// rejected or token invalid) as opposed to a network/transport failure.
+  ///
+  /// flutter_appauth_web throws [ArgumentError] only after parsing a non-200
+  /// token response, and [AccessTokenInvalidException] after a 200 that yields
+  /// an invalid token — both mean the server responded. A Dio retry that came
+  /// back with an HTTP status likewise responded. Everything else (no
+  /// response: timeouts, transport errors, ServerError/TemporarilyUnavailable)
+  /// is treated as a network failure → session kept.
+  bool _isWebRefreshRejectedByServer(Object error) {
+    return error is ArgumentError ||
+        error is AccessTokenInvalidException ||
+        (error is DioException && error.response != null);
   }
 
   /// Mobile: never carry the stale 401 forward — propagate the real

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -155,6 +155,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         'web refresh rejected by server, ending session — error=$error',
         webConsoleEnabled: true,
       );
+      clear();
       return super.onError(originalError.copyWith(error: error), handler);
     }
     logWarning(

--- a/test/features/base/mixin/batch_set_email_processing_mixin_test.dart
+++ b/test/features/base/mixin/batch_set_email_processing_mixin_test.dart
@@ -336,6 +336,202 @@ void main() {
     });
 
     test(
+      'executeBatchSetEmail SHOULD rethrow DioException with 401 status — '
+      'stops processing and propagates for upstream auth handling',
+      () async {
+        const maxObjects = 10;
+        final session =
+            SessionFixtures.getAliceSessionWithMaxObjectsInSet(maxObjects);
+        final List<EmailId> emailIds = List<EmailId>.generate(
+            10, (index) => EmailId(Id('email_$index')));
+
+        httpClient.setError(
+          0,
+          DioException(
+            requestOptions: RequestOptions(path: ''),
+            response: Response(
+              statusCode: 401,
+              requestOptions: RequestOptions(path: ''),
+            ),
+            type: DioExceptionType.badResponse,
+          ),
+        );
+
+        expect(
+          () => testMixin.executeBatchSetEmail(
+            session: session,
+            accountId: AccountFixtures.aliceAccountId,
+            emailIds: emailIds,
+            httpClient: httpClient,
+            onGenerateUpdates: (batchIds) =>
+                {for (final id in batchIds) id.id: PatchObject({})},
+          ),
+          throwsA(isA<DioException>().having(
+            (e) => e.response?.statusCode,
+            'statusCode',
+            401,
+          )),
+        );
+      },
+    );
+
+    test(
+      'executeBatchSetEmail SHOULD rethrow DioException with 401 in a later batch — '
+      'does not return partial results',
+      () async {
+        const maxObjects = 10;
+        final session =
+            SessionFixtures.getAliceSessionWithMaxObjectsInSet(maxObjects);
+        final List<EmailId> emailIds = List<EmailId>.generate(
+            20, (index) => EmailId(Id('email_$index')));
+
+        // Batch 1: Success
+        httpClient.setResponse(0, {
+          'sessionState': 'session_state',
+          'methodResponses': [
+            [
+              'Email/set',
+              {
+                'accountId': AccountFixtures.aliceAccountId.id.value,
+                'updated': {for (var i = 0; i < 10; i++) 'email_$i': null},
+              },
+              'c0',
+            ]
+          ]
+        });
+
+        // Batch 2: 401
+        httpClient.setError(
+          1,
+          DioException(
+            requestOptions: RequestOptions(path: ''),
+            response: Response(
+              statusCode: 401,
+              requestOptions: RequestOptions(path: ''),
+            ),
+            type: DioExceptionType.badResponse,
+          ),
+        );
+
+        expect(
+          () => testMixin.executeBatchSetEmail(
+            session: session,
+            accountId: AccountFixtures.aliceAccountId,
+            emailIds: emailIds,
+            httpClient: httpClient,
+            onGenerateUpdates: (batchIds) =>
+                {for (final id in batchIds) id.id: PatchObject({})},
+          ),
+          throwsA(isA<DioException>().having(
+            (e) => e.response?.statusCode,
+            'statusCode',
+            401,
+          )),
+        );
+      },
+    );
+
+    test(
+      'executeBatchSetEmail should NOT rethrow DioException with non-401 status — '
+      'continues processing remaining batches',
+      () async {
+        const maxObjects = 10;
+        final session =
+            SessionFixtures.getAliceSessionWithMaxObjectsInSet(maxObjects);
+        final List<EmailId> emailIds = List<EmailId>.generate(
+            20, (index) => EmailId(Id('email_$index')));
+
+        // Batch 1: 500 error — should be swallowed
+        httpClient.setError(
+          0,
+          DioException(
+            requestOptions: RequestOptions(path: ''),
+            response: Response(
+              statusCode: 500,
+              requestOptions: RequestOptions(path: ''),
+            ),
+            type: DioExceptionType.badResponse,
+          ),
+        );
+
+        // Batch 2: Success
+        httpClient.setResponse(1, {
+          'sessionState': 'session_state',
+          'methodResponses': [
+            [
+              'Email/set',
+              {
+                'accountId': AccountFixtures.aliceAccountId.id.value,
+                'updated': {for (var i = 10; i < 20; i++) 'email_$i': null},
+              },
+              'c0',
+            ]
+          ]
+        });
+
+        final result = await testMixin.executeBatchSetEmail(
+          session: session,
+          accountId: AccountFixtures.aliceAccountId,
+          emailIds: emailIds,
+          httpClient: httpClient,
+          onGenerateUpdates: (batchIds) =>
+              {for (final id in batchIds) id.id: PatchObject({})},
+        );
+
+        expect(result.emailIdsSuccess.length, 10);
+        expect(httpClient.postCallCount, 2);
+      },
+    );
+
+    test(
+      'executeBatchSetEmail should NOT rethrow DioException with no response (network error) — '
+      'continues processing remaining batches',
+      () async {
+        const maxObjects = 10;
+        final session =
+            SessionFixtures.getAliceSessionWithMaxObjectsInSet(maxObjects);
+        final List<EmailId> emailIds = List<EmailId>.generate(
+            20, (index) => EmailId(Id('email_$index')));
+
+        // Batch 1: Network error (no response) — should be swallowed
+        httpClient.setError(
+          0,
+          DioException(
+            requestOptions: RequestOptions(path: ''),
+            type: DioExceptionType.connectionTimeout,
+          ),
+        );
+
+        // Batch 2: Success
+        httpClient.setResponse(1, {
+          'sessionState': 'session_state',
+          'methodResponses': [
+            [
+              'Email/set',
+              {
+                'accountId': AccountFixtures.aliceAccountId.id.value,
+                'updated': {for (var i = 10; i < 20; i++) 'email_$i': null},
+              },
+              'c0',
+            ]
+          ]
+        });
+
+        final result = await testMixin.executeBatchSetEmail(
+          session: session,
+          accountId: AccountFixtures.aliceAccountId,
+          emailIds: emailIds,
+          httpClient: httpClient,
+          onGenerateUpdates: (batchIds) =>
+              {for (final id in batchIds) id.id: PatchObject({})},
+        );
+
+        expect(result.emailIdsSuccess.length, 10);
+        expect(httpClient.postCallCount, 2);
+      },
+    );
+
+    test(
       'executeBatchSetEmail should continue processing subsequent batches even when one batch throws an exception',
       () async {
         // Setup: 3 batches of 10 emails each (Total 30)

--- a/test/features/base/mixin/batch_set_email_processing_mixin_test.dart
+++ b/test/features/base/mixin/batch_set_email_processing_mixin_test.dart
@@ -8,6 +8,7 @@ import 'package:tmail_ui_user/features/base/mixin/batch_set_email_processing_mix
 import 'package:tmail_ui_user/features/base/mixin/handle_error_mixin.dart';
 import 'package:tmail_ui_user/features/base/mixin/mail_api_mixin.dart';
 import 'package:tmail_ui_user/features/base/mixin/session_mixin.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
 
 import '../../../fixtures/account_fixtures.dart';
 import '../../../fixtures/session_fixtures.dart';
@@ -428,6 +429,140 @@ void main() {
             401,
           )),
         );
+      },
+    );
+
+    test(
+      'executeBatchSetEmail SHOULD rethrow DioException wrapping RefreshTokenFailedException — '
+      'treated as session terminated even without a 401 status',
+      () async {
+        const maxObjects = 10;
+        final session =
+            SessionFixtures.getAliceSessionWithMaxObjectsInSet(maxObjects);
+        final List<EmailId> emailIds = List<EmailId>.generate(
+            10, (index) => EmailId(Id('email_$index')));
+
+        // Batch 1: DioException carrying a RefreshTokenFailedException.
+        // Note: status code is NOT 401 — the refresh-token branch must trigger.
+        httpClient.setError(
+          0,
+          DioException(
+            requestOptions: RequestOptions(path: ''),
+            error: RefreshTokenFailedException(),
+            type: DioExceptionType.unknown,
+          ),
+        );
+
+        expect(
+          () => testMixin.executeBatchSetEmail(
+            session: session,
+            accountId: AccountFixtures.aliceAccountId,
+            emailIds: emailIds,
+            httpClient: httpClient,
+            onGenerateUpdates: (batchIds) =>
+                {for (final id in batchIds) id.id: PatchObject({})},
+          ),
+          throwsA(isA<DioException>().having(
+            (e) => e.error,
+            'error',
+            isA<RefreshTokenFailedException>(),
+          )),
+        );
+      },
+    );
+
+    test(
+      'executeBatchSetEmail SHOULD rethrow DioException wrapping RefreshTokenFailedException in a later batch — '
+      'does not return partial results',
+      () async {
+        const maxObjects = 10;
+        final session =
+            SessionFixtures.getAliceSessionWithMaxObjectsInSet(maxObjects);
+        final List<EmailId> emailIds = List<EmailId>.generate(
+            20, (index) => EmailId(Id('email_$index')));
+
+        // Batch 1: Success
+        httpClient.setResponse(0, {
+          'sessionState': 'session_state',
+          'methodResponses': [
+            [
+              'Email/set',
+              {
+                'accountId': AccountFixtures.aliceAccountId.id.value,
+                'updated': {for (var i = 0; i < 10; i++) 'email_$i': null},
+              },
+              'c0',
+            ]
+          ]
+        });
+
+        // Batch 2: refresh token failed
+        httpClient.setError(
+          1,
+          DioException(
+            requestOptions: RequestOptions(path: ''),
+            error: RefreshTokenFailedException(),
+            type: DioExceptionType.unknown,
+          ),
+        );
+
+        expect(
+          () => testMixin.executeBatchSetEmail(
+            session: session,
+            accountId: AccountFixtures.aliceAccountId,
+            emailIds: emailIds,
+            httpClient: httpClient,
+            onGenerateUpdates: (batchIds) =>
+                {for (final id in batchIds) id.id: PatchObject({})},
+          ),
+          throwsA(isA<DioException>().having(
+            (e) => e.error,
+            'error',
+            isA<RefreshTokenFailedException>(),
+          )),
+        );
+      },
+    );
+
+    test(
+      'executeBatchSetEmail should NOT rethrow a bare RefreshTokenFailedException '
+      '(not wrapped in DioException) — session-terminated detection requires a DioException',
+      () async {
+        const maxObjects = 10;
+        final session =
+            SessionFixtures.getAliceSessionWithMaxObjectsInSet(maxObjects);
+        final List<EmailId> emailIds = List<EmailId>.generate(
+            20, (index) => EmailId(Id('email_$index')));
+
+        // Batch 1: bare exception (not a DioException) — should be swallowed
+        httpClient.setError(0, RefreshTokenFailedException());
+
+        // Batch 2: Success
+        httpClient.setResponse(1, {
+          'sessionState': 'session_state',
+          'methodResponses': [
+            [
+              'Email/set',
+              {
+                'accountId': AccountFixtures.aliceAccountId.id.value,
+                'updated': {for (var i = 10; i < 20; i++) 'email_$i': null},
+              },
+              'c0',
+            ]
+          ]
+        });
+
+        final result = await testMixin.executeBatchSetEmail(
+          session: session,
+          accountId: AccountFixtures.aliceAccountId,
+          emailIds: emailIds,
+          httpClient: httpClient,
+          onGenerateUpdates: (batchIds) =>
+              {for (final id in batchIds) id.id: PatchObject({})},
+        );
+
+        expect(result.emailIdsSuccess.length, 10);
+        expect(httpClient.postCallCount, 2);
       },
     );
 

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -135,6 +135,22 @@ void main() {
         .thenAnswer((_) async => OIDCFixtures.newTokenOidc);
   }
 
+  void stubWebRefresh401ThenThrow(Object error) {
+    authorizationInterceptors.setTokenAndAuthorityOidc(
+      newToken: OIDCFixtures.tokenOidcExpiredTime,
+      newConfig: OIDCFixtures.oidcConfiguration,
+    );
+    dioAdapter.onPost(baseUrl,
+      (server) => server.throws(responseStatusCode401, makeDioError401()));
+    when(authenticationClient.refreshingTokensOIDC(
+      OIDCFixtures.oidcConfiguration.clientId,
+      OIDCFixtures.oidcConfiguration.redirectUrl,
+      OIDCFixtures.oidcConfiguration.discoveryUrl,
+      OIDCFixtures.oidcConfiguration.scopes,
+      OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+    )).thenThrow(error);
+  }
+
   // ============================================================
   // validateToRefreshToken
   // ============================================================
@@ -762,9 +778,9 @@ void main() {
     );
 
     test(
-      'WHEN refresh throws generic non-DioException (AccessTokenInvalidException)\n'
-      'THEN outer catch creates fresh DioException with NO HTTP response\n'
-      'AND does NOT preserve original 401 (Fix 3 regression)',
+      'WHEN refresh throws non-DioException (AccessTokenInvalidException) [mobile]\n'
+      'THEN outer catch wraps it in fresh DioException with NO HTTP response\n'
+      'AND original 401 is NOT preserved — mobile keeps session; web would logout',
       () async {
         authorizationInterceptors.setTokenAndAuthorityOidc(
           newToken: OIDCFixtures.tokenOidcExpiredTime,
@@ -1730,7 +1746,7 @@ void main() {
     );
   });
 
-  group('Bug 1 — refresh network timeout preserves original 401 response (regression)', () {
+  group('onError [mobile]: refresh network timeout does NOT carry stale 401', () {
     final refreshTimeoutError = DioException(
       requestOptions: RequestOptions(path: '/token'),
       type: DioExceptionType.connectionTimeout,
@@ -1740,7 +1756,7 @@ void main() {
       'WHEN 401 with expired token\n'
       'AND refresh call times out (connectionTimeout, response=null)\n'
       'THEN propagated error carries NO HTTP response\n'
-      '(BUG: err.copyWith preserves original 401 response → RemoteExceptionThrower → logout)',
+      '(regression: stale 401 must NOT reach RemoteExceptionThrower → would logout)',
       () async {
         authorizationInterceptors.setTokenAndAuthorityOidc(
           newToken: OIDCFixtures.tokenOidcExpiredTime,
@@ -1809,13 +1825,13 @@ void main() {
 
   });
 
-  group('Bug 1 — retry network timeout preserves original 401 response (regression)', () {
+  group('onError [mobile/web]: retry network timeout does NOT carry stale 401', () {
     test(
       'WHEN 401 with expired token\n'
       'AND refresh succeeds\n'
       'AND retry call times out (connectionTimeout, response=null)\n'
       'THEN propagated error carries NO HTTP response\n'
-      '(BUG: err.copyWith preserves original 401 response → logout)',
+      '(regression: stale 401 must NOT reach RemoteExceptionThrower → would logout)',
       () async {
         authorizationInterceptors.setTokenAndAuthorityOidc(
           newToken: OIDCFixtures.tokenOidcExpiredTime,
@@ -1863,8 +1879,8 @@ void main() {
   });
 
   group(
-    'Bug 1 — FlutterAppAuthPlatformException from OIDC refresh '
-    'does not preserve original 401 (outer catch)',
+    'onError [mobile]: FlutterAppAuthPlatformException from OIDC refresh '
+    'does not preserve original 401',
     () {
       // _appAuth.token() OIDC no-internet: native SDK throws
       // FlutterAppAuthPlatformException(error: null) — transport failure.
@@ -1883,7 +1899,7 @@ void main() {
         'AND refresh throws FlutterAppAuthPlatformException (no internet)\n'
         'THEN propagated DioException has NO HTTP response\n'
         'AND error is FlutterAppAuthPlatformException\n'
-        '(BUG: outer catch err.copyWith preserved original 401 → BadCredentialsException → logout)',
+        '(regression: stale 401 must NOT reach RemoteExceptionThrower → would logout)',
         () async {
           authorizationInterceptors.setTokenAndAuthorityOidc(
             newToken: OIDCFixtures.tokenOidcExpiredTime,
@@ -2810,23 +2826,7 @@ void main() {
       'THEN original 401 response is preserved (→ BadCredentialsException → logout)\n'
       'AND error carries the ArgumentError',
       () async {
-        authorizationInterceptors.setTokenAndAuthorityOidc(
-          newToken: OIDCFixtures.tokenOidcExpiredTime,
-          newConfig: OIDCFixtures.oidcConfiguration,
-        );
-
-        dioAdapter.onPost(
-          baseUrl,
-          (server) => server.throws(responseStatusCode401, makeDioError401()),
-        );
-
-        when(authenticationClient.refreshingTokensOIDC(
-          OIDCFixtures.oidcConfiguration.clientId,
-          OIDCFixtures.oidcConfiguration.redirectUrl,
-          OIDCFixtures.oidcConfiguration.discoveryUrl,
-          OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
-        )).thenThrow(ArgumentError(
+        stubWebRefresh401ThenThrow(ArgumentError(
           'Failed to get token: [error: token_failed, description: invalid_grant]',
         ));
         stubAccountCache();
@@ -2845,23 +2845,7 @@ void main() {
       'WHEN refresh throws AccessTokenInvalidException\n'
       'THEN original 401 response is preserved (→ logout)',
       () async {
-        authorizationInterceptors.setTokenAndAuthorityOidc(
-          newToken: OIDCFixtures.tokenOidcExpiredTime,
-          newConfig: OIDCFixtures.oidcConfiguration,
-        );
-
-        dioAdapter.onPost(
-          baseUrl,
-          (server) => server.throws(responseStatusCode401, makeDioError401()),
-        );
-
-        when(authenticationClient.refreshingTokensOIDC(
-          OIDCFixtures.oidcConfiguration.clientId,
-          OIDCFixtures.oidcConfiguration.redirectUrl,
-          OIDCFixtures.oidcConfiguration.discoveryUrl,
-          OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
-        )).thenThrow(AccessTokenInvalidException());
+        stubWebRefresh401ThenThrow(AccessTokenInvalidException());
         stubAccountCache();
 
         await expectLater(
@@ -2880,25 +2864,9 @@ void main() {
     ]) {
       test(
         'WHEN refresh throws ${transientError.runtimeType}\n'
-        'THEN error is propagated WITHOUT an HTTP response (legacy carve-out)',
+        'THEN error is propagated WITHOUT an HTTP response — session kept',
         () async {
-          authorizationInterceptors.setTokenAndAuthorityOidc(
-            newToken: OIDCFixtures.tokenOidcExpiredTime,
-            newConfig: OIDCFixtures.oidcConfiguration,
-          );
-
-          dioAdapter.onPost(
-            baseUrl,
-            (server) => server.throws(responseStatusCode401, makeDioError401()),
-          );
-
-          when(authenticationClient.refreshingTokensOIDC(
-            OIDCFixtures.oidcConfiguration.clientId,
-            OIDCFixtures.oidcConfiguration.redirectUrl,
-            OIDCFixtures.oidcConfiguration.discoveryUrl,
-            OIDCFixtures.oidcConfiguration.scopes,
-            OIDCFixtures.tokenOidcExpiredTime.refreshToken,
-          )).thenThrow(transientError);
+          stubWebRefresh401ThenThrow(transientError);
           stubAccountCache();
 
           await expectLater(
@@ -2913,8 +2881,50 @@ void main() {
     }
 
     test(
-      'WHEN refresh succeeds but retry with new token fails\n'
-      'THEN original 401 response is preserved (→ logout)',
+      'WHEN refresh throws DioException WITH response (e.g. 503) on web\n'
+      'THEN treated as server rejection → original 401 preserved (→ logout)',
+      () async {
+        final refreshDioError = DioException(
+          requestOptions: RequestOptions(path: '/token'),
+          response: Response(
+            statusCode: 503,
+            requestOptions: RequestOptions(path: '/token'),
+          ),
+          type: DioExceptionType.badResponse,
+        );
+        stubWebRefresh401ThenThrow(refreshDioError);
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) =>
+            e.response?.statusCode == responseStatusCode401 &&
+            e.error is DioException)),
+        );
+      },
+    );
+
+    test(
+      'INVARIANT: flutter_appauth_web throws ArgumentError for non-200 token response\n'
+      'IF THIS TEST FAILS, update _isWebRefreshRejectedByServer',
+      () async {
+        // Arrange
+        stubWebRefresh401ThenThrow(ArgumentError('Failed to get token: [error: invalid_grant]'));
+        stubAccountCache();
+
+        // Act & Assert: ArgumentError → logout path (response preserved)
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) =>
+            e.response?.statusCode == 401 && e.error is ArgumentError)),
+        );
+      },
+    );
+
+    test(
+      'WHEN refresh succeeds but retry with new token also returns 401\n'
+      'THEN the retry RESPONSE (401) is propagated as-is (→ BadCredentials → logout)\n'
+      '— retry handling is separate from refresh handling',
       () async {
         authorizationInterceptors.setTokenAndAuthorityOidc(
           newToken: OIDCFixtures.tokenOidcExpiredTime,
@@ -2951,11 +2961,65 @@ void main() {
 
         await expectLater(
           () => dio.post(baseUrl),
-          throwsA(predicate<DioException>((e) {
-            // Original 401 preserved; the retry error is carried as `.error`.
-            return e.response?.statusCode == responseStatusCode401 &&
-                e.error is DioException;
-          })),
+          throwsA(predicate<DioException>(
+            (e) => e.response?.statusCode == responseStatusCode401,
+          )),
+        );
+      },
+    );
+
+    test(
+      'WHEN refresh succeeds but retry with new token returns 5xx\n'
+      'THEN the retry RESPONSE (500) is propagated — NOT forced logout via the\n'
+      'original 401 (retry handling is request-level, not a session verdict)',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        final retryError500 = DioException(
+          requestOptions: RequestOptions(path: baseUrl, method: 'POST'),
+          response: Response(
+            statusCode: responseStatusCode500,
+            requestOptions: RequestOptions(path: baseUrl),
+          ),
+          type: DioExceptionType.badResponse,
+        );
+
+        // Old token → 401
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+          },
+        );
+        // Retry with new token → 500
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode500, retryError500),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.newTokenOidc.token}',
+          },
+        );
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>(
+            (e) => e.response?.statusCode == responseStatusCode500,
+          )),
         );
       },
     );
@@ -2965,27 +3029,12 @@ void main() {
       'THEN session is KEPT — propagated error has NO HTTP response (no logout)\n'
       'AND OIDC state is NOT cleared (carve-out vs bad network)',
       () async {
-        authorizationInterceptors.setTokenAndAuthorityOidc(
-          newToken: OIDCFixtures.tokenOidcExpiredTime,
-          newConfig: OIDCFixtures.oidcConfiguration,
-        );
-
-        dioAdapter.onPost(
-          baseUrl,
-          (server) => server.throws(responseStatusCode401, makeDioError401()),
-        );
-
         final refreshNetworkError = DioException(
           requestOptions: RequestOptions(path: '/token'),
           type: DioExceptionType.connectionError,
         );
-        when(authenticationClient.refreshingTokensOIDC(
-          OIDCFixtures.oidcConfiguration.clientId,
-          OIDCFixtures.oidcConfiguration.redirectUrl,
-          OIDCFixtures.oidcConfiguration.discoveryUrl,
-          OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
-        )).thenThrow(refreshNetworkError);
+
+        stubWebRefresh401ThenThrow(refreshNetworkError);
         stubAccountCache();
 
         await expectLater(
@@ -3004,25 +3053,9 @@ void main() {
       'WHEN refresh fails with a non-Dio transport error (e.g. ClientException) on web\n'
       'THEN session is KEPT — propagated error has NO HTTP response (no logout)',
       () async {
-        authorizationInterceptors.setTokenAndAuthorityOidc(
-          newToken: OIDCFixtures.tokenOidcExpiredTime,
-          newConfig: OIDCFixtures.oidcConfiguration,
-        );
-
-        dioAdapter.onPost(
-          baseUrl,
-          (server) => server.throws(responseStatusCode401, makeDioError401()),
-        );
-
         // Simulates package:http throwing on a browser network drop (no
         // server response was ever received).
-        when(authenticationClient.refreshingTokensOIDC(
-          OIDCFixtures.oidcConfiguration.clientId,
-          OIDCFixtures.oidcConfiguration.redirectUrl,
-          OIDCFixtures.oidcConfiguration.discoveryUrl,
-          OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
-        )).thenThrow(Exception('XMLHttpRequest error'));
+        stubWebRefresh401ThenThrow(Exception('XMLHttpRequest error'));
         stubAccountCache();
 
         await expectLater(

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -2795,11 +2795,13 @@ void main() {
   });
 
   // ============================================================
-  // onError: WEB refresh failures (legacy pre-TF-4081 behaviour)
-  // Web logs out on ANY refresh/retry failure by preserving the original
-  // 401 response → BadCredentialsException downstream → login.
+  // onError: WEB refresh failures
+  // Server rejection (got a response: ArgumentError / AccessTokenInvalid /
+  // Dio retry with response) → preserve original 401 → logout.
+  // Network/transport failure (no response) → keep session (carve-out),
+  // so a flaky connection does NOT log the web user out.
   // ============================================================
-  group('onError: web refresh failure forces logout (legacy)', () {
+  group('onError: web refresh failure handling', () {
     setUp(() => PlatformInfo.isTestingForWeb = true);
     tearDown(() => PlatformInfo.isTestingForWeb = false);
 
@@ -2954,6 +2956,85 @@ void main() {
             return e.response?.statusCode == responseStatusCode401 &&
                 e.error is DioException;
           })),
+        );
+      },
+    );
+
+    test(
+      'WHEN refresh fails with a network DioException (no response) on web\n'
+      'THEN session is KEPT — propagated error has NO HTTP response (no logout)\n'
+      'AND OIDC state is NOT cleared (carve-out vs bad network)',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+        );
+
+        final refreshNetworkError = DioException(
+          requestOptions: RequestOptions(path: '/token'),
+          type: DioExceptionType.connectionError,
+        );
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenThrow(refreshNetworkError);
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) => e.response == null)),
+        );
+
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.oidc,
+        );
+      },
+    );
+
+    test(
+      'WHEN refresh fails with a non-Dio transport error (e.g. ClientException) on web\n'
+      'THEN session is KEPT — propagated error has NO HTTP response (no logout)',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+        );
+
+        // Simulates package:http throwing on a browser network drop (no
+        // server response was ever received).
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenThrow(Exception('XMLHttpRequest error'));
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) {
+            return e.response == null && e.error is Exception;
+          })),
+        );
+
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.oidc,
         );
       },
     );

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:core/data/constants/constant.dart';
 import 'package:core/data/network/dio_client.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -2789,6 +2790,228 @@ void main() {
           OIDCFixtures.oidcConfiguration.scopes,
           OIDCFixtures.tokenOidcExpiredTime.refreshToken,
         )).called(1);
+      },
+    );
+  });
+
+  // ============================================================
+  // onError: WEB refresh failures (legacy pre-TF-4081 behaviour)
+  // Web logs out on ANY refresh/retry failure by preserving the original
+  // 401 response → BadCredentialsException downstream → login.
+  // ============================================================
+  group('onError: web refresh failure forces logout (legacy)', () {
+    setUp(() => PlatformInfo.isTestingForWeb = true);
+    tearDown(() => PlatformInfo.isTestingForWeb = false);
+
+    test(
+      'WHEN refresh throws ArgumentError (flutter_appauth_web non-200, e.g. 400)\n'
+      'THEN original 401 response is preserved (→ BadCredentialsException → logout)\n'
+      'AND error carries the ArgumentError',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+        );
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenThrow(ArgumentError(
+          'Failed to get token: [error: token_failed, description: invalid_grant]',
+        ));
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) {
+            return e.response?.statusCode == responseStatusCode401 &&
+                e.error is ArgumentError;
+          })),
+        );
+      },
+    );
+
+    test(
+      'WHEN refresh throws AccessTokenInvalidException\n'
+      'THEN original 401 response is preserved (→ logout)',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+        );
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenThrow(AccessTokenInvalidException());
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) {
+            return e.response?.statusCode == responseStatusCode401 &&
+                e.error is AccessTokenInvalidException;
+          })),
+        );
+      },
+    );
+
+    for (final transientError in const <OAuthAuthorizationError>[
+      ServerError(),
+      TemporarilyUnavailable(),
+    ]) {
+      test(
+        'WHEN refresh throws ${transientError.runtimeType}\n'
+        'THEN error is propagated WITHOUT an HTTP response (legacy carve-out)',
+        () async {
+          authorizationInterceptors.setTokenAndAuthorityOidc(
+            newToken: OIDCFixtures.tokenOidcExpiredTime,
+            newConfig: OIDCFixtures.oidcConfiguration,
+          );
+
+          dioAdapter.onPost(
+            baseUrl,
+            (server) => server.throws(responseStatusCode401, makeDioError401()),
+          );
+
+          when(authenticationClient.refreshingTokensOIDC(
+            OIDCFixtures.oidcConfiguration.clientId,
+            OIDCFixtures.oidcConfiguration.redirectUrl,
+            OIDCFixtures.oidcConfiguration.discoveryUrl,
+            OIDCFixtures.oidcConfiguration.scopes,
+            OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          )).thenThrow(transientError);
+          stubAccountCache();
+
+          await expectLater(
+            () => dio.post(baseUrl),
+            throwsA(predicate<DioException>((e) {
+              return e.response == null &&
+                  e.error.runtimeType == transientError.runtimeType;
+            })),
+          );
+        },
+      );
+    }
+
+    test(
+      'WHEN refresh succeeds but retry with new token fails\n'
+      'THEN original 401 response is preserved (→ logout)',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        // Old token → 401
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+          },
+        );
+        // Retry with new token → also 401
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.newTokenOidc.token}',
+          },
+        );
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) {
+            // Original 401 preserved; the retry error is carried as `.error`.
+            return e.response?.statusCode == responseStatusCode401 &&
+                e.error is DioException;
+          })),
+        );
+      },
+    );
+  });
+
+  // ============================================================
+  // onError: WEB refresh SUCCESS path (platform split must not disturb it)
+  // ============================================================
+  group('onError: web refresh success path', () {
+    setUp(() => PlatformInfo.isTestingForWeb = true);
+    tearDown(() => PlatformInfo.isTestingForWeb = false);
+
+    test(
+      'WHEN 401 with expired token on web\n'
+      'AND refresh returns a new token\n'
+      'THEN retry succeeds with 200 (success flow unaffected by platform split)',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+          },
+        );
+        dioAdapter.onPost(
+          baseUrl,
+          (server) =>
+              server.reply(responseStatusCode200, dataRequestSuccessfully),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.newTokenOidc.token}',
+          },
+        );
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
+        stubAccountCache();
+
+        final response = await dio.post(baseUrl);
+
+        expect(response.statusCode, responseStatusCode200);
+        expect(response.data, dataRequestSuccessfully);
+        // Session preserved on a successful refresh.
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.oidc,
+        );
       },
     );
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Platform-aware token refresh and retry handling so web vs mobile failures surface appropriate errors and drive correct logout/reconnect behavior; improved status and auth-type logging during auth flows.

* **Tests**
  * Added comprehensive web-focused tests covering refresh failures, retry outcomes, transport errors, and successful refresh+retry scenarios.

* **Documentation**
  * Enhanced logging guidance and clarified expected error shapes for web vs mobile refresh failure behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-flutter/pull/4559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->