### PR TITLE
TF-4535 Enable label Classification in Preferences

### DIFF
--- a/lib/features/mailbox_dashboard/presentation/extensions/ai_scribe/setup_ai_needs_action_setting_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/ai_scribe/setup_ai_needs_action_setting_extension.dart
@@ -7,7 +7,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 extension SetupAiNeedsActionSettingExtension on MailboxDashBoardController {
   void setupAINeedsActionSetting({TMailServerSettingOptions? options}) {
     if (options != null) {
-      isAINeedsActionSettingEnabled.value = options.isAINeedsActionEnabled;
+      isAINeedsActionSettingEnabled.value = options.isAILabelCategorizationEnabled;
     } else {
       isAINeedsActionSettingEnabled.value = false;
     }

--- a/lib/features/manage_account/presentation/model/preferences_option_type.dart
+++ b/lib/features/manage_account/presentation/model/preferences_option_type.dart
@@ -30,7 +30,7 @@ enum PreferencesOptionType {
       case PreferencesOptionType.aiScribe:
         return appLocalizations.aiScribe;
       case PreferencesOptionType.aiNeedsAction:
-        return appLocalizations.aiNeedsAction;
+        return appLocalizations.aiLabelCategorization;
       case PreferencesOptionType.label:
         return appLocalizations.labelVisibility;
     }
@@ -49,7 +49,7 @@ enum PreferencesOptionType {
       case PreferencesOptionType.aiScribe:
         return appLocalizations.aiScribeSettingExplanation;
       case PreferencesOptionType.aiNeedsAction:
-        return appLocalizations.aiNeedsActionSettingExplanation;
+        return appLocalizations.aiLabelCategorizationSettingExplanation;
       case PreferencesOptionType.label:
         return appLocalizations.labelVisibilitySettingExplanation;
     }
@@ -68,7 +68,7 @@ enum PreferencesOptionType {
       case PreferencesOptionType.aiScribe:
         return appLocalizations.aiScribeToggleDescription;
       case PreferencesOptionType.aiNeedsAction:
-        return appLocalizations.aiNeedsActionToggleDescription;
+        return appLocalizations.aiLabelCategorizationToggleDescription;
       case PreferencesOptionType.label:
         return appLocalizations.labelVisibilityToggleDescription;
     }

--- a/lib/features/manage_account/presentation/model/preferences_option_type.dart
+++ b/lib/features/manage_account/presentation/model/preferences_option_type.dart
@@ -10,7 +10,7 @@ enum PreferencesOptionType {
   thread(isLocal: true),
   spamReport(isLocal: true),
   aiScribe(isLocal: true),
-  aiNeedsAction(isLocal: false),
+  aiLabelCategorization(isLocal: false),
   label(isLocal: true);
 
   final bool isLocal;
@@ -29,7 +29,7 @@ enum PreferencesOptionType {
         return appLocalizations.spamReports;
       case PreferencesOptionType.aiScribe:
         return appLocalizations.aiScribe;
-      case PreferencesOptionType.aiNeedsAction:
+      case PreferencesOptionType.aiLabelCategorization:
         return appLocalizations.aiLabelCategorization;
       case PreferencesOptionType.label:
         return appLocalizations.labelVisibility;
@@ -48,7 +48,7 @@ enum PreferencesOptionType {
         return appLocalizations.spamReportsSettingExplanation;
       case PreferencesOptionType.aiScribe:
         return appLocalizations.aiScribeSettingExplanation;
-      case PreferencesOptionType.aiNeedsAction:
+      case PreferencesOptionType.aiLabelCategorization:
         return appLocalizations.aiLabelCategorizationSettingExplanation;
       case PreferencesOptionType.label:
         return appLocalizations.labelVisibilitySettingExplanation;
@@ -67,7 +67,7 @@ enum PreferencesOptionType {
         return appLocalizations.spamReportToggleDescription;
       case PreferencesOptionType.aiScribe:
         return appLocalizations.aiScribeToggleDescription;
-      case PreferencesOptionType.aiNeedsAction:
+      case PreferencesOptionType.aiLabelCategorization:
         return appLocalizations.aiLabelCategorizationToggleDescription;
       case PreferencesOptionType.label:
         return appLocalizations.labelVisibilityToggleDescription;
@@ -89,8 +89,8 @@ enum PreferencesOptionType {
         return preferencesSetting.spamReportConfig.isEnabled;
       case PreferencesOptionType.aiScribe:
         return preferencesSetting.aiScribeConfig.isEnabled;
-      case PreferencesOptionType.aiNeedsAction:
-        return settingOption?.isAINeedsActionEnabled ?? false;
+      case PreferencesOptionType.aiLabelCategorization:
+        return settingOption?.isAILabelCategorizationEnabled ?? false;
       case PreferencesOptionType.label:
         return preferencesSetting.labelConfig.isEnabled;
     }

--- a/lib/features/manage_account/presentation/preferences/preferences_controller.dart
+++ b/lib/features/manage_account/presentation/preferences/preferences_controller.dart
@@ -198,7 +198,7 @@ class PreferencesController extends BaseController {
         break;
       case PreferencesOptionType.aiNeedsAction:
         newSettingOption = settingOption.value?.copyWith(
-          aiLabelCategorizationEnabled: !isEnabled,
+          aiNeedsActionEnabled: !isEnabled,
         );
         break;
       default:

--- a/lib/features/manage_account/presentation/preferences/preferences_controller.dart
+++ b/lib/features/manage_account/presentation/preferences/preferences_controller.dart
@@ -196,9 +196,9 @@ class PreferencesController extends BaseController {
           displaySenderPriority: !isEnabled,
         );
         break;
-      case PreferencesOptionType.aiNeedsAction:
+      case PreferencesOptionType.aiLabelCategorization:
         newSettingOption = settingOption.value?.copyWith(
-          aiNeedsActionEnabled: !isEnabled,
+          aiLabelCategorizationEnabled: !isEnabled,
         );
         break;
       default:

--- a/lib/features/manage_account/presentation/preferences/preferences_controller.dart
+++ b/lib/features/manage_account/presentation/preferences/preferences_controller.dart
@@ -198,7 +198,7 @@ class PreferencesController extends BaseController {
         break;
       case PreferencesOptionType.aiNeedsAction:
         newSettingOption = settingOption.value?.copyWith(
-          aiNeedsActionEnabled: !isEnabled,
+          aiLabelCategorizationEnabled: !isEnabled,
         );
         break;
       default:

--- a/lib/features/manage_account/presentation/preferences/preferences_view.dart
+++ b/lib/features/manage_account/presentation/preferences/preferences_view.dart
@@ -72,7 +72,7 @@ class PreferencesView extends GetWidget<PreferencesController> with AppLoaderMix
                         ...PreferencesOptionType.values.where(
                           (type) =>
                               !type.isLocal &&
-                              type != PreferencesOptionType.aiNeedsAction,
+                              type != PreferencesOptionType.aiLabelCategorization,
                         ),
                       if (localSettingOption.configs.isNotEmpty)
                         ...PreferencesOptionType.values.where(
@@ -84,7 +84,7 @@ class PreferencesView extends GetWidget<PreferencesController> with AppLoaderMix
                         ),
                       if (settingOption != null &&
                           controller.isAICapabilitySupported)
-                        PreferencesOptionType.aiNeedsAction,
+                        PreferencesOptionType.aiLabelCategorization,
                       if (isLabelVisibility.isTrue)
                         PreferencesOptionType.label,
                     ];

--- a/lib/features/server_settings/domain/extensions/tmail_server_settings_extension.dart
+++ b/lib/features/server_settings/domain/extensions/tmail_server_settings_extension.dart
@@ -11,7 +11,7 @@ extension TmailServerSettingsExtension on TMailServerSettings {
         settings: TMailServerSettingOptions(
           alwaysReadReceipts: settings?.alwaysReadReceipts,
           displaySenderPriority: settings?.displaySenderPriority,
-          aiNeedsActionEnabled: settings?.aiNeedsActionEnabled,
+          aiLabelCategorizationEnabled: settings?.aiLabelCategorizationEnabled,
         ),
       );
     }

--- a/lib/features/server_settings/domain/extensions/tmail_server_settings_extension.dart
+++ b/lib/features/server_settings/domain/extensions/tmail_server_settings_extension.dart
@@ -12,6 +12,7 @@ extension TmailServerSettingsExtension on TMailServerSettings {
           alwaysReadReceipts: settings?.alwaysReadReceipts,
           displaySenderPriority: settings?.displaySenderPriority,
           aiNeedsActionEnabled: settings?.aiNeedsActionEnabled,
+          aiLabelCategorizationEnabled: settings?.aiLabelCategorizationEnabled,
         ),
       );
     }

--- a/lib/features/server_settings/domain/extensions/tmail_server_settings_extension.dart
+++ b/lib/features/server_settings/domain/extensions/tmail_server_settings_extension.dart
@@ -12,7 +12,6 @@ extension TmailServerSettingsExtension on TMailServerSettings {
           alwaysReadReceipts: settings?.alwaysReadReceipts,
           displaySenderPriority: settings?.displaySenderPriority,
           aiNeedsActionEnabled: settings?.aiNeedsActionEnabled,
-          aiLabelCategorizationEnabled: settings?.aiLabelCategorizationEnabled,
         ),
       );
     }

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2026-04-17T18:25:40.778609",
+  "@@last_modified": "2026-05-26T13:37:50.997089",
   "initializing_data": "Initializing data...",
   "@initializing_data": {
     "type": "text",
@@ -5184,24 +5184,6 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "aiNeedsAction": "AI needs-action",
-  "@aiNeedsAction": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "aiNeedsActionToggleDescription": "Enable AI needs-action",
-  "@aiNeedsActionToggleDescription": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "aiNeedsActionSettingExplanation": "Detect emails that need your attention using AI. When turned off, AI will not process any emails.",
-  "@aiNeedsActionSettingExplanation": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
   "labels": "Labels",
   "@labels": {
     "type": "text",
@@ -5546,6 +5528,24 @@
   },
   "createALabel": "Create a label",
   "@createALabel": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "aiLabelCategorization": "Label categorisation",
+  "@aiLabelCategorization": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "aiLabelCategorizationToggleDescription": "Enable label categorisation",
+  "@aiLabelCategorizationToggleDescription": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "aiLabelCategorizationSettingExplanation": "Apply my labels on incoming emails using their description",
+  "@aiLabelCategorizationSettingExplanation": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -5500,27 +5500,6 @@ class AppLocalizations {
     );
   }
 
-  String get aiNeedsAction {
-    return Intl.message(
-      'AI needs-action',
-      name: 'aiNeedsAction',
-    );
-  }
-
-  String get aiNeedsActionToggleDescription {
-    return Intl.message(
-      'Enable AI needs-action',
-      name: 'aiNeedsActionToggleDescription',
-    );
-  }
-
-  String get aiNeedsActionSettingExplanation {
-    return Intl.message(
-      'Detect emails that need your attention using AI. When turned off, AI will not process any emails.',
-      name: 'aiNeedsActionSettingExplanation',
-    );
-  }
-
   String get labels {
     return Intl.message(
       'Labels',
@@ -5879,6 +5858,27 @@ class AppLocalizations {
     return Intl.message(
       'Create a label',
       name: 'createALabel',
+    );
+  }
+
+  String get aiLabelCategorization {
+    return Intl.message(
+      'Label categorisation',
+      name: 'aiLabelCategorization',
+    );
+  }
+
+  String get aiLabelCategorizationToggleDescription {
+    return Intl.message(
+      'Enable label categorisation',
+      name: 'aiLabelCategorizationToggleDescription',
+    );
+  }
+
+  String get aiLabelCategorizationSettingExplanation {
+    return Intl.message(
+      'Apply my labels on incoming emails using their description',
+      name: 'aiLabelCategorizationSettingExplanation',
     );
   }
 }

--- a/server_settings/lib/server_settings/tmail_server_settings.dart
+++ b/server_settings/lib/server_settings/tmail_server_settings.dart
@@ -40,7 +40,7 @@ class TMailServerSettingOptions with EquatableMixin {
   @JsonKey(name: 'language')
   final String? language;
 
-  @JsonKey(name: 'ai.needs-action.enabled')
+  @JsonKey(name: 'ai.label-categorization.enabled')
   final bool? aiNeedsActionEnabled;
 
   TMailServerSettingOptions({

--- a/server_settings/lib/server_settings/tmail_server_settings.dart
+++ b/server_settings/lib/server_settings/tmail_server_settings.dart
@@ -41,13 +41,13 @@ class TMailServerSettingOptions with EquatableMixin {
   final String? language;
 
   @JsonKey(name: 'ai.label-categorization.enabled')
-  final bool? aiNeedsActionEnabled;
+  final bool? aiLabelCategorizationEnabled;
 
   TMailServerSettingOptions({
     this.alwaysReadReceipts,
     this.displaySenderPriority,
     this.language,
-    this.aiNeedsActionEnabled,
+    this.aiLabelCategorizationEnabled,
   });
 
   factory TMailServerSettingOptions.fromJson(Map<String, dynamic> json) =>
@@ -59,13 +59,13 @@ class TMailServerSettingOptions with EquatableMixin {
     bool? alwaysReadReceipts,
     bool? displaySenderPriority,
     String? language,
-    bool? aiNeedsActionEnabled,
+    bool? aiLabelCategorizationEnabled,
   }) {
     return TMailServerSettingOptions(
       alwaysReadReceipts: alwaysReadReceipts ?? this.alwaysReadReceipts,
       displaySenderPriority: displaySenderPriority ?? this.displaySenderPriority,
       language: language ?? this.language,
-      aiNeedsActionEnabled: aiNeedsActionEnabled ?? this.aiNeedsActionEnabled,
+      aiLabelCategorizationEnabled: aiLabelCategorizationEnabled ?? this.aiLabelCategorizationEnabled,
     );
   }
 
@@ -74,6 +74,6 @@ class TMailServerSettingOptions with EquatableMixin {
     alwaysReadReceipts,
     displaySenderPriority,
     language,
-    aiNeedsActionEnabled,
+    aiLabelCategorizationEnabled,
   ];
 }

--- a/server_settings/lib/server_settings/tmail_server_settings.dart
+++ b/server_settings/lib/server_settings/tmail_server_settings.dart
@@ -8,8 +8,8 @@ import 'package:server_settings/server_settings/server_settings_id.dart';
 part 'tmail_server_settings.g.dart';
 
 @JsonSerializable(
-  explicitToJson: true, 
-  includeIfNull: false, 
+  explicitToJson: true,
+  includeIfNull: false,
   converters: [ServerSettingsIdNullableConverter()])
 class TMailServerSettings extends ServerSettings {
   final ServerSettingsId? id;
@@ -26,7 +26,7 @@ class TMailServerSettings extends ServerSettings {
 }
 
 @JsonSerializable(
-  explicitToJson: true, 
+  explicitToJson: true,
   includeIfNull: false,
   converters: [BooleanNullableConverter()]
 )
@@ -40,19 +40,14 @@ class TMailServerSettingOptions with EquatableMixin {
   @JsonKey(name: 'language')
   final String? language;
 
-  // Legacy key from older BE versions — read-only, never written back to server
-  @JsonKey(name: 'ai.needs-action.enabled', includeToJson: false)
-  final bool? aiNeedsActionEnabled;
-
   @JsonKey(name: 'ai.label-categorization.enabled')
-  final bool? aiLabelCategorizationEnabled;
+  final bool? aiNeedsActionEnabled;
 
   TMailServerSettingOptions({
     this.alwaysReadReceipts,
     this.displaySenderPriority,
     this.language,
     this.aiNeedsActionEnabled,
-    this.aiLabelCategorizationEnabled,
   });
 
   factory TMailServerSettingOptions.fromJson(Map<String, dynamic> json) =>
@@ -64,14 +59,13 @@ class TMailServerSettingOptions with EquatableMixin {
     bool? alwaysReadReceipts,
     bool? displaySenderPriority,
     String? language,
-    bool? aiLabelCategorizationEnabled,
+    bool? aiNeedsActionEnabled,
   }) {
     return TMailServerSettingOptions(
       alwaysReadReceipts: alwaysReadReceipts ?? this.alwaysReadReceipts,
       displaySenderPriority: displaySenderPriority ?? this.displaySenderPriority,
       language: language ?? this.language,
-      aiNeedsActionEnabled: aiNeedsActionEnabled,
-      aiLabelCategorizationEnabled: aiLabelCategorizationEnabled ?? this.aiLabelCategorizationEnabled,
+      aiNeedsActionEnabled: aiNeedsActionEnabled ?? this.aiNeedsActionEnabled,
     );
   }
 
@@ -81,6 +75,5 @@ class TMailServerSettingOptions with EquatableMixin {
     displaySenderPriority,
     language,
     aiNeedsActionEnabled,
-    aiLabelCategorizationEnabled,
   ];
 }

--- a/server_settings/lib/server_settings/tmail_server_settings.dart
+++ b/server_settings/lib/server_settings/tmail_server_settings.dart
@@ -40,14 +40,19 @@ class TMailServerSettingOptions with EquatableMixin {
   @JsonKey(name: 'language')
   final String? language;
 
-  @JsonKey(name: 'ai.label-categorization.enabled')
+  // Legacy key from older BE versions — read-only, never written back to server
+  @JsonKey(name: 'ai.needs-action.enabled', includeToJson: false)
   final bool? aiNeedsActionEnabled;
+
+  @JsonKey(name: 'ai.label-categorization.enabled')
+  final bool? aiLabelCategorizationEnabled;
 
   TMailServerSettingOptions({
     this.alwaysReadReceipts,
     this.displaySenderPriority,
     this.language,
     this.aiNeedsActionEnabled,
+    this.aiLabelCategorizationEnabled,
   });
 
   factory TMailServerSettingOptions.fromJson(Map<String, dynamic> json) =>
@@ -59,13 +64,14 @@ class TMailServerSettingOptions with EquatableMixin {
     bool? alwaysReadReceipts,
     bool? displaySenderPriority,
     String? language,
-    bool? aiNeedsActionEnabled,
+    bool? aiLabelCategorizationEnabled,
   }) {
     return TMailServerSettingOptions(
       alwaysReadReceipts: alwaysReadReceipts ?? this.alwaysReadReceipts,
       displaySenderPriority: displaySenderPriority ?? this.displaySenderPriority,
       language: language ?? this.language,
-      aiNeedsActionEnabled: aiNeedsActionEnabled ?? this.aiNeedsActionEnabled,
+      aiNeedsActionEnabled: aiNeedsActionEnabled,
+      aiLabelCategorizationEnabled: aiLabelCategorizationEnabled ?? this.aiLabelCategorizationEnabled,
     );
   }
 
@@ -75,5 +81,6 @@ class TMailServerSettingOptions with EquatableMixin {
     displaySenderPriority,
     language,
     aiNeedsActionEnabled,
+    aiLabelCategorizationEnabled,
   ];
 }

--- a/server_settings/lib/server_settings/tmail_server_settings_extension.dart
+++ b/server_settings/lib/server_settings/tmail_server_settings_extension.dart
@@ -6,6 +6,5 @@ extension TmailServerSettingsExtension on TMailServerSettingOptions {
 
   bool get isAlwaysReadReceipts => alwaysReadReceipts ?? false;
 
-  // Prefer new key; fall back to legacy for older BE versions
-  bool get isAINeedsActionEnabled => aiLabelCategorizationEnabled ?? aiNeedsActionEnabled ?? false;
+  bool get isAINeedsActionEnabled => aiNeedsActionEnabled ?? false;
 }

--- a/server_settings/lib/server_settings/tmail_server_settings_extension.dart
+++ b/server_settings/lib/server_settings/tmail_server_settings_extension.dart
@@ -6,5 +6,5 @@ extension TmailServerSettingsExtension on TMailServerSettingOptions {
 
   bool get isAlwaysReadReceipts => alwaysReadReceipts ?? false;
 
-  bool get isAINeedsActionEnabled => aiNeedsActionEnabled ?? false;
+  bool get isAILabelCategorizationEnabled => aiLabelCategorizationEnabled ?? false;
 }

--- a/server_settings/lib/server_settings/tmail_server_settings_extension.dart
+++ b/server_settings/lib/server_settings/tmail_server_settings_extension.dart
@@ -6,5 +6,6 @@ extension TmailServerSettingsExtension on TMailServerSettingOptions {
 
   bool get isAlwaysReadReceipts => alwaysReadReceipts ?? false;
 
-  bool get isAINeedsActionEnabled => aiNeedsActionEnabled ?? false;
+  // Prefer new key; fall back to legacy for older BE versions
+  bool get isAINeedsActionEnabled => aiLabelCategorizationEnabled ?? aiNeedsActionEnabled ?? false;
 }

--- a/server_settings/test/server_settings/tmail_server_setting_options_test.dart
+++ b/server_settings/test/server_settings/tmail_server_setting_options_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_settings/server_settings/tmail_server_settings.dart';
+import 'package:server_settings/server_settings/tmail_server_settings_extension.dart';
+
+void main() {
+  group('TMailServerSettingOptions', () {
+    group('fromJson', () {
+      test('parses ai.label-categorization.enabled as true', () {
+        final options = TMailServerSettingOptions.fromJson({
+          'ai.label-categorization.enabled': 'true',
+        });
+        expect(options.aiNeedsActionEnabled, isTrue);
+      });
+
+      test('parses ai.label-categorization.enabled as false', () {
+        final options = TMailServerSettingOptions.fromJson({
+          'ai.label-categorization.enabled': 'false',
+        });
+        expect(options.aiNeedsActionEnabled, isFalse);
+      });
+
+      test('leaves aiNeedsActionEnabled null when key is absent', () {
+        final options = TMailServerSettingOptions.fromJson({});
+        expect(options.aiNeedsActionEnabled, isNull);
+      });
+
+      test('does not read from legacy ai.needs-action.enabled key', () {
+        final options = TMailServerSettingOptions.fromJson({
+          'ai.needs-action.enabled': 'true',
+        });
+        expect(options.aiNeedsActionEnabled, isNull);
+      });
+    });
+
+    group('toJson', () {
+      test('serializes ai.label-categorization.enabled when set to true', () {
+        final options = TMailServerSettingOptions(aiNeedsActionEnabled: true);
+        final json = options.toJson();
+        expect(json['ai.label-categorization.enabled'], isNotNull);
+      });
+
+      test('omits ai.label-categorization.enabled when null', () {
+        final options = TMailServerSettingOptions();
+        final json = options.toJson();
+        expect(json.containsKey('ai.label-categorization.enabled'), isFalse);
+      });
+
+      test('does not include ai.needs-action.enabled key', () {
+        final options = TMailServerSettingOptions(aiNeedsActionEnabled: true);
+        final json = options.toJson();
+        expect(json.containsKey('ai.needs-action.enabled'), isFalse);
+      });
+    });
+
+    group('copyWith', () {
+      test('overrides aiNeedsActionEnabled', () {
+        final original = TMailServerSettingOptions(aiNeedsActionEnabled: false);
+        final copy = original.copyWith(aiNeedsActionEnabled: true);
+        expect(copy.aiNeedsActionEnabled, isTrue);
+      });
+
+      test('preserves aiNeedsActionEnabled when not supplied', () {
+        final original = TMailServerSettingOptions(aiNeedsActionEnabled: true);
+        final copy = original.copyWith(alwaysReadReceipts: false);
+        expect(copy.aiNeedsActionEnabled, isTrue);
+      });
+    });
+  });
+
+  group('TmailServerSettingsExtension', () {
+    test('isAINeedsActionEnabled returns true when field is true', () {
+      final options = TMailServerSettingOptions(aiNeedsActionEnabled: true);
+      expect(options.isAINeedsActionEnabled, isTrue);
+    });
+
+    test('isAINeedsActionEnabled returns false when field is false', () {
+      final options = TMailServerSettingOptions(aiNeedsActionEnabled: false);
+      expect(options.isAINeedsActionEnabled, isFalse);
+    });
+
+    test('isAINeedsActionEnabled defaults to false when field is null', () {
+      final options = TMailServerSettingOptions();
+      expect(options.isAINeedsActionEnabled, isFalse);
+    });
+  });
+}

--- a/server_settings/test/server_settings/tmail_server_setting_options_test.dart
+++ b/server_settings/test/server_settings/tmail_server_setting_options_test.dart
@@ -54,7 +54,7 @@ void main() {
     group('copyWith', () {
       test('overrides aiLabelCategorizationEnabled', () {
         final original = TMailServerSettingOptions(aiLabelCategorizationEnabled: false);
-        final copy = original.copyWith(aiNeedsActionEnabled: true);
+        final copy = original.copyWith(aiLabelCategorizationEnabled: true);
         expect(copy.aiLabelCategorizationEnabled, isTrue);
       });
 

--- a/server_settings/test/server_settings/tmail_server_setting_options_test.dart
+++ b/server_settings/test/server_settings/tmail_server_setting_options_test.dart
@@ -9,32 +9,49 @@ void main() {
         final options = TMailServerSettingOptions.fromJson({
           'ai.label-categorization.enabled': 'true',
         });
-        expect(options.aiNeedsActionEnabled, isTrue);
+        expect(options.aiLabelCategorizationEnabled, isTrue);
       });
 
       test('parses ai.label-categorization.enabled as false', () {
         final options = TMailServerSettingOptions.fromJson({
           'ai.label-categorization.enabled': 'false',
         });
-        expect(options.aiNeedsActionEnabled, isFalse);
+        expect(options.aiLabelCategorizationEnabled, isFalse);
       });
 
-      test('leaves aiNeedsActionEnabled null when key is absent', () {
-        final options = TMailServerSettingOptions.fromJson({});
-        expect(options.aiNeedsActionEnabled, isNull);
-      });
-
-      test('does not read from legacy ai.needs-action.enabled key', () {
+      test('parses legacy ai.needs-action.enabled as true', () {
         final options = TMailServerSettingOptions.fromJson({
           'ai.needs-action.enabled': 'true',
         });
+        expect(options.aiNeedsActionEnabled, isTrue);
+      });
+
+      test('parses legacy ai.needs-action.enabled as false', () {
+        final options = TMailServerSettingOptions.fromJson({
+          'ai.needs-action.enabled': 'false',
+        });
+        expect(options.aiNeedsActionEnabled, isFalse);
+      });
+
+      test('parses both keys independently when both present', () {
+        final options = TMailServerSettingOptions.fromJson({
+          'ai.needs-action.enabled': 'false',
+          'ai.label-categorization.enabled': 'true',
+        });
+        expect(options.aiNeedsActionEnabled, isFalse);
+        expect(options.aiLabelCategorizationEnabled, isTrue);
+      });
+
+      test('leaves both fields null when neither key present', () {
+        final options = TMailServerSettingOptions.fromJson({});
         expect(options.aiNeedsActionEnabled, isNull);
+        expect(options.aiLabelCategorizationEnabled, isNull);
       });
     });
 
     group('toJson', () {
       test('serializes ai.label-categorization.enabled when set to true', () {
-        final options = TMailServerSettingOptions(aiNeedsActionEnabled: true);
+        final options = TMailServerSettingOptions(aiLabelCategorizationEnabled: true);
         final json = options.toJson();
         expect(json['ai.label-categorization.enabled'], isNotNull);
       });
@@ -45,7 +62,7 @@ void main() {
         expect(json.containsKey('ai.label-categorization.enabled'), isFalse);
       });
 
-      test('does not include ai.needs-action.enabled key', () {
+      test('never includes legacy ai.needs-action.enabled key', () {
         final options = TMailServerSettingOptions(aiNeedsActionEnabled: true);
         final json = options.toJson();
         expect(json.containsKey('ai.needs-action.enabled'), isFalse);
@@ -53,13 +70,19 @@ void main() {
     });
 
     group('copyWith', () {
-      test('overrides aiNeedsActionEnabled', () {
-        final original = TMailServerSettingOptions(aiNeedsActionEnabled: false);
-        final copy = original.copyWith(aiNeedsActionEnabled: true);
-        expect(copy.aiNeedsActionEnabled, isTrue);
+      test('overrides aiLabelCategorizationEnabled', () {
+        final original = TMailServerSettingOptions(aiLabelCategorizationEnabled: false);
+        final copy = original.copyWith(aiLabelCategorizationEnabled: true);
+        expect(copy.aiLabelCategorizationEnabled, isTrue);
       });
 
-      test('preserves aiNeedsActionEnabled when not supplied', () {
+      test('preserves aiLabelCategorizationEnabled when not supplied', () {
+        final original = TMailServerSettingOptions(aiLabelCategorizationEnabled: true);
+        final copy = original.copyWith(alwaysReadReceipts: false);
+        expect(copy.aiLabelCategorizationEnabled, isTrue);
+      });
+
+      test('carries through legacy aiNeedsActionEnabled unchanged', () {
         final original = TMailServerSettingOptions(aiNeedsActionEnabled: true);
         final copy = original.copyWith(alwaysReadReceipts: false);
         expect(copy.aiNeedsActionEnabled, isTrue);
@@ -68,17 +91,30 @@ void main() {
   });
 
   group('TmailServerSettingsExtension', () {
-    test('isAINeedsActionEnabled returns true when field is true', () {
+    test('isAINeedsActionEnabled returns true from new key', () {
+      final options = TMailServerSettingOptions(aiLabelCategorizationEnabled: true);
+      expect(options.isAINeedsActionEnabled, isTrue);
+    });
+
+    test('isAINeedsActionEnabled returns false from new key', () {
+      final options = TMailServerSettingOptions(aiLabelCategorizationEnabled: false);
+      expect(options.isAINeedsActionEnabled, isFalse);
+    });
+
+    test('isAINeedsActionEnabled falls back to legacy key when new key absent', () {
       final options = TMailServerSettingOptions(aiNeedsActionEnabled: true);
       expect(options.isAINeedsActionEnabled, isTrue);
     });
 
-    test('isAINeedsActionEnabled returns false when field is false', () {
-      final options = TMailServerSettingOptions(aiNeedsActionEnabled: false);
-      expect(options.isAINeedsActionEnabled, isFalse);
+    test('isAINeedsActionEnabled new key takes precedence over legacy key', () {
+      final options = TMailServerSettingOptions(
+        aiNeedsActionEnabled: false,
+        aiLabelCategorizationEnabled: true,
+      );
+      expect(options.isAINeedsActionEnabled, isTrue);
     });
 
-    test('isAINeedsActionEnabled defaults to false when field is null', () {
+    test('isAINeedsActionEnabled defaults to false when both fields null', () {
       final options = TMailServerSettingOptions();
       expect(options.isAINeedsActionEnabled, isFalse);
     });

--- a/server_settings/test/server_settings/tmail_server_setting_options_test.dart
+++ b/server_settings/test/server_settings/tmail_server_setting_options_test.dart
@@ -9,49 +9,31 @@ void main() {
         final options = TMailServerSettingOptions.fromJson({
           'ai.label-categorization.enabled': 'true',
         });
-        expect(options.aiLabelCategorizationEnabled, isTrue);
+        expect(options.aiNeedsActionEnabled, isTrue);
       });
 
       test('parses ai.label-categorization.enabled as false', () {
         final options = TMailServerSettingOptions.fromJson({
           'ai.label-categorization.enabled': 'false',
         });
-        expect(options.aiLabelCategorizationEnabled, isFalse);
-      });
-
-      test('parses legacy ai.needs-action.enabled as true', () {
-        final options = TMailServerSettingOptions.fromJson({
-          'ai.needs-action.enabled': 'true',
-        });
-        expect(options.aiNeedsActionEnabled, isTrue);
-      });
-
-      test('parses legacy ai.needs-action.enabled as false', () {
-        final options = TMailServerSettingOptions.fromJson({
-          'ai.needs-action.enabled': 'false',
-        });
         expect(options.aiNeedsActionEnabled, isFalse);
       });
 
-      test('parses both keys independently when both present', () {
-        final options = TMailServerSettingOptions.fromJson({
-          'ai.needs-action.enabled': 'false',
-          'ai.label-categorization.enabled': 'true',
-        });
-        expect(options.aiNeedsActionEnabled, isFalse);
-        expect(options.aiLabelCategorizationEnabled, isTrue);
-      });
-
-      test('leaves both fields null when neither key present', () {
+      test('leaves aiNeedsActionEnabled null when key absent', () {
         final options = TMailServerSettingOptions.fromJson({});
         expect(options.aiNeedsActionEnabled, isNull);
-        expect(options.aiLabelCategorizationEnabled, isNull);
       });
     });
 
     group('toJson', () {
       test('serializes ai.label-categorization.enabled when set to true', () {
-        final options = TMailServerSettingOptions(aiLabelCategorizationEnabled: true);
+        final options = TMailServerSettingOptions(aiNeedsActionEnabled: true);
+        final json = options.toJson();
+        expect(json['ai.label-categorization.enabled'], isNotNull);
+      });
+
+      test('serializes ai.label-categorization.enabled when set to false', () {
+        final options = TMailServerSettingOptions(aiNeedsActionEnabled: false);
         final json = options.toJson();
         expect(json['ai.label-categorization.enabled'], isNotNull);
       });
@@ -62,7 +44,7 @@ void main() {
         expect(json.containsKey('ai.label-categorization.enabled'), isFalse);
       });
 
-      test('never includes legacy ai.needs-action.enabled key', () {
+      test('does not include legacy ai.needs-action.enabled key', () {
         final options = TMailServerSettingOptions(aiNeedsActionEnabled: true);
         final json = options.toJson();
         expect(json.containsKey('ai.needs-action.enabled'), isFalse);
@@ -70,51 +52,38 @@ void main() {
     });
 
     group('copyWith', () {
-      test('overrides aiLabelCategorizationEnabled', () {
-        final original = TMailServerSettingOptions(aiLabelCategorizationEnabled: false);
-        final copy = original.copyWith(aiLabelCategorizationEnabled: true);
-        expect(copy.aiLabelCategorizationEnabled, isTrue);
+      test('overrides aiNeedsActionEnabled', () {
+        final original = TMailServerSettingOptions(aiNeedsActionEnabled: false);
+        final copy = original.copyWith(aiNeedsActionEnabled: true);
+        expect(copy.aiNeedsActionEnabled, isTrue);
       });
 
-      test('preserves aiLabelCategorizationEnabled when not supplied', () {
-        final original = TMailServerSettingOptions(aiLabelCategorizationEnabled: true);
-        final copy = original.copyWith(alwaysReadReceipts: false);
-        expect(copy.aiLabelCategorizationEnabled, isTrue);
-      });
-
-      test('carries through legacy aiNeedsActionEnabled unchanged', () {
+      test('preserves aiNeedsActionEnabled when not supplied', () {
         final original = TMailServerSettingOptions(aiNeedsActionEnabled: true);
         final copy = original.copyWith(alwaysReadReceipts: false);
         expect(copy.aiNeedsActionEnabled, isTrue);
+      });
+
+      test('preserves aiNeedsActionEnabled as null when not supplied', () {
+        final original = TMailServerSettingOptions();
+        final copy = original.copyWith(alwaysReadReceipts: false);
+        expect(copy.aiNeedsActionEnabled, isNull);
       });
     });
   });
 
   group('TmailServerSettingsExtension', () {
-    test('isAINeedsActionEnabled returns true from new key', () {
-      final options = TMailServerSettingOptions(aiLabelCategorizationEnabled: true);
-      expect(options.isAINeedsActionEnabled, isTrue);
-    });
-
-    test('isAINeedsActionEnabled returns false from new key', () {
-      final options = TMailServerSettingOptions(aiLabelCategorizationEnabled: false);
-      expect(options.isAINeedsActionEnabled, isFalse);
-    });
-
-    test('isAINeedsActionEnabled falls back to legacy key when new key absent', () {
+    test('isAINeedsActionEnabled returns true when aiNeedsActionEnabled is true', () {
       final options = TMailServerSettingOptions(aiNeedsActionEnabled: true);
       expect(options.isAINeedsActionEnabled, isTrue);
     });
 
-    test('isAINeedsActionEnabled new key takes precedence over legacy key', () {
-      final options = TMailServerSettingOptions(
-        aiNeedsActionEnabled: false,
-        aiLabelCategorizationEnabled: true,
-      );
-      expect(options.isAINeedsActionEnabled, isTrue);
+    test('isAINeedsActionEnabled returns false when aiNeedsActionEnabled is false', () {
+      final options = TMailServerSettingOptions(aiNeedsActionEnabled: false);
+      expect(options.isAINeedsActionEnabled, isFalse);
     });
 
-    test('isAINeedsActionEnabled defaults to false when both fields null', () {
+    test('isAINeedsActionEnabled defaults to false when aiNeedsActionEnabled is null', () {
       final options = TMailServerSettingOptions();
       expect(options.isAINeedsActionEnabled, isFalse);
     });

--- a/server_settings/test/server_settings/tmail_server_setting_options_test.dart
+++ b/server_settings/test/server_settings/tmail_server_setting_options_test.dart
@@ -9,31 +9,31 @@ void main() {
         final options = TMailServerSettingOptions.fromJson({
           'ai.label-categorization.enabled': 'true',
         });
-        expect(options.aiNeedsActionEnabled, isTrue);
+        expect(options.aiLabelCategorizationEnabled, isTrue);
       });
 
       test('parses ai.label-categorization.enabled as false', () {
         final options = TMailServerSettingOptions.fromJson({
           'ai.label-categorization.enabled': 'false',
         });
-        expect(options.aiNeedsActionEnabled, isFalse);
+        expect(options.aiLabelCategorizationEnabled, isFalse);
       });
 
       test('leaves aiNeedsActionEnabled null when key absent', () {
         final options = TMailServerSettingOptions.fromJson({});
-        expect(options.aiNeedsActionEnabled, isNull);
+        expect(options.aiLabelCategorizationEnabled, isNull);
       });
     });
 
     group('toJson', () {
       test('serializes ai.label-categorization.enabled when set to true', () {
-        final options = TMailServerSettingOptions(aiNeedsActionEnabled: true);
+        final options = TMailServerSettingOptions(aiLabelCategorizationEnabled: true);
         final json = options.toJson();
         expect(json['ai.label-categorization.enabled'], isNotNull);
       });
 
       test('serializes ai.label-categorization.enabled when set to false', () {
-        final options = TMailServerSettingOptions(aiNeedsActionEnabled: false);
+        final options = TMailServerSettingOptions(aiLabelCategorizationEnabled: false);
         final json = options.toJson();
         expect(json['ai.label-categorization.enabled'], isNotNull);
       });
@@ -45,47 +45,47 @@ void main() {
       });
 
       test('does not include legacy ai.needs-action.enabled key', () {
-        final options = TMailServerSettingOptions(aiNeedsActionEnabled: true);
+        final options = TMailServerSettingOptions(aiLabelCategorizationEnabled: true);
         final json = options.toJson();
         expect(json.containsKey('ai.needs-action.enabled'), isFalse);
       });
     });
 
     group('copyWith', () {
-      test('overrides aiNeedsActionEnabled', () {
-        final original = TMailServerSettingOptions(aiNeedsActionEnabled: false);
+      test('overrides aiLabelCategorizationEnabled', () {
+        final original = TMailServerSettingOptions(aiLabelCategorizationEnabled: false);
         final copy = original.copyWith(aiNeedsActionEnabled: true);
-        expect(copy.aiNeedsActionEnabled, isTrue);
+        expect(copy.aiLabelCategorizationEnabled, isTrue);
       });
 
-      test('preserves aiNeedsActionEnabled when not supplied', () {
-        final original = TMailServerSettingOptions(aiNeedsActionEnabled: true);
+      test('preserves aiLabelCategorizationEnabled when not supplied', () {
+        final original = TMailServerSettingOptions(aiLabelCategorizationEnabled: true);
         final copy = original.copyWith(alwaysReadReceipts: false);
-        expect(copy.aiNeedsActionEnabled, isTrue);
+        expect(copy.aiLabelCategorizationEnabled, isTrue);
       });
 
-      test('preserves aiNeedsActionEnabled as null when not supplied', () {
+      test('preserves aiLabelCategorizationEnabled as null when not supplied', () {
         final original = TMailServerSettingOptions();
         final copy = original.copyWith(alwaysReadReceipts: false);
-        expect(copy.aiNeedsActionEnabled, isNull);
+        expect(copy.aiLabelCategorizationEnabled, isNull);
       });
     });
   });
 
   group('TmailServerSettingsExtension', () {
-    test('isAINeedsActionEnabled returns true when aiNeedsActionEnabled is true', () {
-      final options = TMailServerSettingOptions(aiNeedsActionEnabled: true);
-      expect(options.isAINeedsActionEnabled, isTrue);
+    test('isAILabelCategorizationEnabled returns true when aiLabelCategorizationEnabled is true', () {
+      final options = TMailServerSettingOptions(aiLabelCategorizationEnabled: true);
+      expect(options.isAILabelCategorizationEnabled, isTrue);
     });
 
-    test('isAINeedsActionEnabled returns false when aiNeedsActionEnabled is false', () {
-      final options = TMailServerSettingOptions(aiNeedsActionEnabled: false);
-      expect(options.isAINeedsActionEnabled, isFalse);
+    test('isAILabelCategorizationEnabled returns false when aiLabelCategorizationEnabled is false', () {
+      final options = TMailServerSettingOptions(aiLabelCategorizationEnabled: false);
+      expect(options.isAILabelCategorizationEnabled, isFalse);
     });
 
-    test('isAINeedsActionEnabled defaults to false when aiNeedsActionEnabled is null', () {
+    test('isAILabelCategorizationEnabled defaults to false when aiLabelCategorizationEnabled is null', () {
       final options = TMailServerSettingOptions();
-      expect(options.isAINeedsActionEnabled, isFalse);
+      expect(options.isAILabelCategorizationEnabled, isFalse);
     });
   });
 }


### PR DESCRIPTION
## Issue

#4535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the AI preference from "AI needs action" to "AI label categorization" across the app: updated labels, toggle descriptions, settings UI, server setting key, and dashboard behavior so the new wording and setting are used consistently.

* **Tests**
  * Added tests for AI label categorization covering serialization, parsing, toggling, defaults, and configuration behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-flutter/pull/4561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->