### PR TITLE
TF-4520 Team mailbox folder should be sorted correctly

### DIFF
--- a/lib/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart
+++ b/lib/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart
@@ -14,135 +14,65 @@ import 'package:tmail_ui_user/main/routes/app_routes.dart';
 import 'package:tmail_ui_user/main/routes/navigation_router.dart';
 import 'package:tmail_ui_user/main/routes/route_utils.dart';
 
+final _systemFolderIconMap = Map<String, String Function(ImagePaths)>.unmodifiable({
+  PresentationMailbox.inboxRole:          (paths) => paths.icMailboxInbox,
+  PresentationMailbox.favoriteRole:       (paths) => paths.icMailboxFavorite,
+  PresentationMailbox.actionRequiredRole: (paths) => paths.icMailboxActionRequired,
+  PresentationMailbox.draftsRole:         (paths) => paths.icMailboxDrafts,
+  PresentationMailbox.outboxRole:         (paths) => paths.icMailboxOutbox,
+  PresentationMailbox.archiveRole:        (paths) => paths.icMailboxArchived,
+  PresentationMailbox.sentRole:           (paths) => paths.icMailboxSent,
+  PresentationMailbox.trashRole:          (paths) => paths.icMailboxTrash,
+  PresentationMailbox.spamRole:           (paths) => paths.icMailboxSpam,
+  PresentationMailbox.junkRole:           (paths) => paths.icMailboxSpam,
+  PresentationMailbox.templatesRole:      (paths) => paths.icMailboxTemplate,
+  PresentationMailbox.recoveredRole:      (paths) => paths.icRecoverDeletedMessages,
+  'all_mail':                             (paths) => paths.icMailboxAllMail,
+});
+
+final _systemFolderDisplayNameMap = Map<String, String Function(AppLocalizations)>.unmodifiable({
+  PresentationMailbox.inboxRole:          (l10n) => l10n.inboxMailboxDisplayName,
+  PresentationMailbox.favoriteRole:       (l10n) => l10n.favoriteMailboxDisplayName,
+  PresentationMailbox.actionRequiredRole: (l10n) => l10n.actionRequiredMailboxDisplayName,
+  PresentationMailbox.archiveRole:        (l10n) => l10n.archiveMailboxDisplayName,
+  PresentationMailbox.draftsRole:         (l10n) => l10n.draftsMailboxDisplayName,
+  PresentationMailbox.sentRole:           (l10n) => l10n.sentMailboxDisplayName,
+  PresentationMailbox.outboxRole:         (l10n) => l10n.outboxMailboxDisplayName,
+  PresentationMailbox.trashRole:          (l10n) => l10n.trashMailboxDisplayName,
+  PresentationMailbox.spamRole:           (l10n) => l10n.spamMailboxDisplayName,
+  PresentationMailbox.junkRole:           (l10n) => l10n.spamMailboxDisplayName,
+  PresentationMailbox.templatesRole:      (l10n) => l10n.templatesMailboxDisplayName,
+  PresentationMailbox.recoveredRole:      (l10n) => l10n.recoveredMailboxDisplayName,
+});
+
 extension PresentationMailboxExtension on PresentationMailbox {
 
-  String getDisplayName(BuildContext context) {
-    if (isLabelMailbox) {
-      return (this as PresentationLabelMailbox).label.safeDisplayName;
-    }
+  String getDisplayName(BuildContext context) =>
+      getDisplayNameWithoutContext(AppLocalizations.of(context));
 
+  String getDisplayNameWithoutContext(AppLocalizations l10n) {
+    if (isLabelMailbox) return (this as PresentationLabelMailbox).label.safeDisplayName;
     if (isDefault) {
-      switch(role!.value.toLowerCase()) {
-        case PresentationMailbox.inboxRole:
-          return AppLocalizations.of(context).inboxMailboxDisplayName;
-        case PresentationMailbox.favoriteRole:
-          return AppLocalizations.of(context).favoriteMailboxDisplayName;
-        case PresentationMailbox.actionRequiredRole:
-          return AppLocalizations.of(context).actionRequiredMailboxDisplayName;
-        case PresentationMailbox.archiveRole:
-          return AppLocalizations.of(context).archiveMailboxDisplayName;
-        case PresentationMailbox.draftsRole:
-          return AppLocalizations.of(context).draftsMailboxDisplayName;
-        case PresentationMailbox.sentRole:
-          return AppLocalizations.of(context).sentMailboxDisplayName;
-        case PresentationMailbox.outboxRole:
-          return AppLocalizations.of(context).outboxMailboxDisplayName;
-        case PresentationMailbox.trashRole:
-          return AppLocalizations.of(context).trashMailboxDisplayName;
-        case PresentationMailbox.spamRole:
-        case PresentationMailbox.junkRole:
-          return AppLocalizations.of(context).spamMailboxDisplayName;
-        case PresentationMailbox.templatesRole:
-          return AppLocalizations.of(context).templatesMailboxDisplayName;
-        case PresentationMailbox.recoveredRole:
-          return AppLocalizations.of(context).recoveredMailboxDisplayName;
-      }
-    }
-    return name?.name ?? '';
-  }
-
-  String getDisplayNameWithoutContext(AppLocalizations appLocalizations) {
-    if (isLabelMailbox) {
-      return (this as PresentationLabelMailbox).label.safeDisplayName;
-    }
-
-    if (isDefault) {
-      switch(role!.value.toLowerCase()) {
-        case PresentationMailbox.inboxRole:
-          return appLocalizations.inboxMailboxDisplayName;
-        case PresentationMailbox.favoriteRole:
-          return appLocalizations.favoriteMailboxDisplayName;
-        case PresentationMailbox.actionRequiredRole:
-          return appLocalizations.actionRequiredMailboxDisplayName;
-        case PresentationMailbox.archiveRole:
-          return appLocalizations.archiveMailboxDisplayName;
-        case PresentationMailbox.draftsRole:
-          return appLocalizations.draftsMailboxDisplayName;
-        case PresentationMailbox.sentRole:
-          return appLocalizations.sentMailboxDisplayName;
-        case PresentationMailbox.outboxRole:
-          return appLocalizations.outboxMailboxDisplayName;
-        case PresentationMailbox.trashRole:
-          return appLocalizations.trashMailboxDisplayName;
-        case PresentationMailbox.spamRole:
-        case PresentationMailbox.junkRole:
-          return appLocalizations.spamMailboxDisplayName;
-        case PresentationMailbox.templatesRole:
-          return appLocalizations.templatesMailboxDisplayName;
-        case PresentationMailbox.recoveredRole:
-          return appLocalizations.recoveredMailboxDisplayName;
-      }
+      final nameResolver = _systemFolderDisplayNameMap[role!.value.toLowerCase()];
+      if (nameResolver != null) return nameResolver(l10n);
     }
     return name?.name ?? '';
   }
 
   String getMailboxIcon(ImagePaths imagePaths) {
-    if (hasRole()) {
-      switch(role!.value) {
-        case PresentationMailbox.inboxRole:
-          return imagePaths.icMailboxInbox;
-        case PresentationMailbox.favoriteRole:
-          return imagePaths.icMailboxFavorite;
-        case PresentationMailbox.actionRequiredRole:
-          return imagePaths.icMailboxActionRequired;
-        case PresentationMailbox.draftsRole:
-          return imagePaths.icMailboxDrafts;
-        case PresentationMailbox.outboxRole:
-          return imagePaths.icMailboxOutbox;
-        case PresentationMailbox.archiveRole:
-          return imagePaths.icMailboxArchived;
-        case PresentationMailbox.sentRole:
-          return imagePaths.icMailboxSent;
-        case PresentationMailbox.trashRole:
-          return imagePaths.icMailboxTrash;
-        case PresentationMailbox.spamRole:
-        case PresentationMailbox.junkRole:
-          return imagePaths.icMailboxSpam;
-        case PresentationMailbox.templatesRole:
-          return imagePaths.icMailboxTemplate;
-        case PresentationMailbox.recoveredRole:
-          return imagePaths.icRecoverDeletedMessages;
-        case 'all_mail':
-          return imagePaths.icMailboxAllMail;
-        default:
-          return imagePaths.icFolderMailbox;
+    if (hasRole()) return _resolveSystemFolderIcon(role!.value, imagePaths);
+    if (isChildOfTeamMailboxes && myRights?.mayDelete == false) {
+      final nameKey = name?.name.toLowerCase();
+      if (nameKey != null) {
+        return _resolveSystemFolderIcon(nameKey, imagePaths);
       }
-    } else if (isChildOfTeamMailboxes) {
-      switch(name!.name.toLowerCase()) {
-        case 'inbox':
-          return imagePaths.icMailboxInbox;
-        case 'outbox':
-          return imagePaths.icMailboxOutbox;
-        case 'drafts':
-          return imagePaths.icMailboxDrafts;
-        case 'archive':
-          return imagePaths.icMailboxArchived;
-        case 'sent':
-          return imagePaths.icMailboxSent;
-        case 'trash':
-          return imagePaths.icMailboxTrash;
-        case 'spam':
-          return imagePaths.icMailboxSpam;
-        case 'templates':
-          return imagePaths.icMailboxTemplate;
-        case 'restored messages':
-          return imagePaths.icRecoverDeletedMessages;
-        default:
-          return imagePaths.icFolderMailbox;
-      }
-    } else {
-      return imagePaths.icFolderMailbox;
     }
+    return imagePaths.icFolderMailbox;
+  }
+
+  String _resolveSystemFolderIcon(String roleKey, ImagePaths imagePaths) {
+    final resolver = _systemFolderIconMap[roleKey];
+    return resolver != null ? resolver(imagePaths) : imagePaths.icFolderMailbox;
   }
 
   Uri get mailboxRouteWeb => RouteUtils.createUrlWebLocationBar(

--- a/lib/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart
+++ b/lib/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart
@@ -14,7 +14,7 @@ import 'package:tmail_ui_user/main/routes/app_routes.dart';
 import 'package:tmail_ui_user/main/routes/navigation_router.dart';
 import 'package:tmail_ui_user/main/routes/route_utils.dart';
 
-final _systemFolderIconMap = Map<String, String Function(ImagePaths)>.unmodifiable({
+final _systemFolderIconMap = Map<String, String Function(ImagePaths)>.unmodifiable(<String, String Function(ImagePaths)>{
   PresentationMailbox.inboxRole:          (paths) => paths.icMailboxInbox,
   PresentationMailbox.favoriteRole:       (paths) => paths.icMailboxFavorite,
   PresentationMailbox.actionRequiredRole: (paths) => paths.icMailboxActionRequired,
@@ -30,7 +30,7 @@ final _systemFolderIconMap = Map<String, String Function(ImagePaths)>.unmodifiab
   'all_mail':                             (paths) => paths.icMailboxAllMail,
 });
 
-final _systemFolderDisplayNameMap = Map<String, String Function(AppLocalizations)>.unmodifiable({
+final _systemFolderDisplayNameMap = Map<String, String Function(AppLocalizations)>.unmodifiable(<String, String Function(AppLocalizations)>{
   PresentationMailbox.inboxRole:          (l10n) => l10n.inboxMailboxDisplayName,
   PresentationMailbox.favoriteRole:       (l10n) => l10n.favoriteMailboxDisplayName,
   PresentationMailbox.actionRequiredRole: (l10n) => l10n.actionRequiredMailboxDisplayName,

--- a/lib/features/mailbox/presentation/model/mailbox_tree_builder.dart
+++ b/lib/features/mailbox/presentation/model/mailbox_tree_builder.dart
@@ -73,23 +73,21 @@ class TreeBuilder {
       final currentNode = mailboxDictionary[mailbox.id];
       if (currentNode == null) continue;
 
-      final parentId = mailbox.parentId;
-      final parentNode = parentId != null ? mailboxDictionary[parentId] : null;
-
-      if (parentNode != null) {
-        _propagateDeactivationIfNeeded(parentNode, currentNode, mailbox);
-        parentNode.addChildNode(currentNode);
-        sortByMailboxNameNodeChildren(parentNode);
-      } else {
-        final targetTree = _resolveTargetTree(mailbox, newDefaultTree, newPersonalTree, newTeamMailboxTree);
-        targetTree.root.addChildNode(currentNode);
-        sortByMailboxNameNodeChildren(targetTree.root);
-      }
+      _placeNodeInTree(
+        mailbox: mailbox,
+        currentNode: currentNode,
+        mailboxDictionary: mailboxDictionary,
+        defaultTree: newDefaultTree,
+        personalTree: newPersonalTree,
+        teamMailboxTree: newTeamMailboxTree,
+        onBeforeAddToParent: (parent, child) =>
+            _propagateDeactivationIfNeeded(parent, child, mailbox),
+      );
 
       newAllMailboxes.add(currentNode.item);
     }
 
-    sortNodeChildren(newDefaultTree.root);
+    _finalizeTrees(newDefaultTree, newTeamMailboxTree);
 
     return MailboxCollection(
       allMailboxes: newAllMailboxes,
@@ -128,20 +126,17 @@ class TreeBuilder {
       final currentNode = mailboxDictionary[mailbox.id];
       if (currentNode == null) continue;
 
-      final parentId = mailbox.parentId;
-      final parentNode = parentId != null ? mailboxDictionary[parentId] : null;
-
-      if (parentNode != null) {
-        parentNode.addChildNode(currentNode);
-        sortByMailboxNameNodeChildren(parentNode);
-      } else {
-        final targetTree = _resolveTargetTree(mailbox, newDefaultTree, newPersonalTree, newTeamMailboxTree);
-        targetTree.root.addChildNode(currentNode);
-        sortByMailboxNameNodeChildren(targetTree.root);
-      }
+      _placeNodeInTree(
+        mailbox: mailbox,
+        currentNode: currentNode,
+        mailboxDictionary: mailboxDictionary,
+        defaultTree: newDefaultTree,
+        personalTree: newPersonalTree,
+        teamMailboxTree: newTeamMailboxTree,
+      );
     }
 
-    sortNodeChildren(newDefaultTree.root);
+    _finalizeTrees(newDefaultTree, newTeamMailboxTree);
 
     return MailboxCollection(
       allMailboxes: allMailboxes,
@@ -149,6 +144,34 @@ class TreeBuilder {
       personalTree: newPersonalTree,
       teamMailboxTree: newTeamMailboxTree,
     );
+  }
+
+  void _placeNodeInTree({
+    required PresentationMailbox mailbox,
+    required MailboxNode currentNode,
+    required Map<MailboxId, MailboxNode> mailboxDictionary,
+    required MailboxTree defaultTree,
+    required MailboxTree personalTree,
+    required MailboxTree teamMailboxTree,
+    void Function(MailboxNode parent, MailboxNode child)? onBeforeAddToParent,
+  }) {
+    final parentId = mailbox.parentId;
+    final parentNode = parentId != null ? mailboxDictionary[parentId] : null;
+
+    if (parentNode != null) {
+      onBeforeAddToParent?.call(parentNode, currentNode);
+      parentNode.addChildNode(currentNode);
+      sortByMailboxNameNodeChildren(parentNode);
+    } else {
+      final targetTree = _resolveTargetTree(mailbox, defaultTree, personalTree, teamMailboxTree);
+      targetTree.root.addChildNode(currentNode);
+      sortByMailboxNameNodeChildren(targetTree.root);
+    }
+  }
+
+  void _finalizeTrees(MailboxTree defaultTree, MailboxTree teamMailboxTree) {
+    sortNodeChildren(defaultTree.root);
+    _sortTeamMailboxChildrenAlphabetically(teamMailboxTree.root);
   }
 
   void sortNodeChildren(MailboxNode mailboxNode) {
@@ -160,6 +183,48 @@ class TreeBuilder {
       (node) => node.item.name,
       (name, other) => name?.compareAlphabetically(other) ?? -1,
     );
+  }
+
+  static const Map<String, int> _systemFolderRoleIndex = {
+    PresentationMailbox.inboxRole:     0,
+    PresentationMailbox.draftsRole:    1,
+    PresentationMailbox.outboxRole:    2,
+    PresentationMailbox.sentRole:      3,
+    PresentationMailbox.trashRole:     4,
+    PresentationMailbox.spamRole:      5,
+    PresentationMailbox.junkRole:      6,
+    PresentationMailbox.templatesRole: 7,
+    PresentationMailbox.archiveRole:   8,
+  };
+
+  int _systemFolderSortIndex(MailboxNode node) {
+    return _systemFolderRoleIndex[node.item.role?.value ?? '']
+        ?? _systemFolderRoleIndex.length;
+  }
+
+  void _sortWithSystemFoldersFirst(MailboxNode node) {
+    node.childrenItems?.sort((a, b) {
+      final aIndex = _systemFolderSortIndex(a);
+      final bIndex = _systemFolderSortIndex(b);
+      final aIsSystem = aIndex < _systemFolderRoleIndex.length;
+      final bIsSystem = bIndex < _systemFolderRoleIndex.length;
+      if (aIsSystem && bIsSystem) return aIndex.compareTo(bIndex);
+      if (aIsSystem) return -1;
+      if (bIsSystem) return 1;
+      return a.item.name?.compareAlphabetically(b.item.name) ?? -1;
+    });
+  }
+
+  void _sortTeamMailboxChildrenAlphabetically(MailboxNode node) {
+    if (node.childrenItems == null || node.childrenItems!.isEmpty) return;
+    if (node.item.isTeamMailboxes) {
+      _sortWithSystemFoldersFirst(node);
+    } else {
+      sortByMailboxNameNodeChildren(node);
+    }
+    for (final child in node.childrenItems!) {
+      _sortTeamMailboxChildrenAlphabetically(child);
+    }
   }
 
   MailboxNode? findExistingNode({

--- a/lib/features/mailbox/presentation/model/mailbox_tree_builder.dart
+++ b/lib/features/mailbox/presentation/model/mailbox_tree_builder.dart
@@ -87,7 +87,7 @@ class TreeBuilder {
       newAllMailboxes.add(currentNode.item);
     }
 
-    _finalizeTrees(newDefaultTree, newTeamMailboxTree);
+    _finalizeTrees(newDefaultTree, newPersonalTree, newTeamMailboxTree);
 
     return MailboxCollection(
       allMailboxes: newAllMailboxes,
@@ -136,7 +136,7 @@ class TreeBuilder {
       );
     }
 
-    _finalizeTrees(newDefaultTree, newTeamMailboxTree);
+    _finalizeTrees(newDefaultTree, newPersonalTree, newTeamMailboxTree);
 
     return MailboxCollection(
       allMailboxes: allMailboxes,
@@ -161,17 +161,27 @@ class TreeBuilder {
     if (parentNode != null) {
       onBeforeAddToParent?.call(parentNode, currentNode);
       parentNode.addChildNode(currentNode);
-      sortByMailboxNameNodeChildren(parentNode);
     } else {
       final targetTree = _resolveTargetTree(mailbox, defaultTree, personalTree, teamMailboxTree);
       targetTree.root.addChildNode(currentNode);
-      sortByMailboxNameNodeChildren(targetTree.root);
     }
   }
 
-  void _finalizeTrees(MailboxTree defaultTree, MailboxTree teamMailboxTree) {
+  void _finalizeTrees(MailboxTree defaultTree, MailboxTree personalTree, MailboxTree teamMailboxTree) {
     sortNodeChildren(defaultTree.root);
-    _sortTeamMailboxChildrenAlphabetically(teamMailboxTree.root);
+    for (final child in defaultTree.root.childrenItems ?? []) {
+      _sortChildrenAlphabetically(child);
+    }
+    _sortChildrenAlphabetically(personalTree.root);
+    _applyTeamMailboxSorting(teamMailboxTree.root);
+  }
+
+  void _sortChildrenAlphabetically(MailboxNode node) {
+    if (node.childrenItems == null || node.childrenItems!.isEmpty) return;
+    sortByMailboxNameNodeChildren(node);
+    for (final child in node.childrenItems!) {
+      _sortChildrenAlphabetically(child);
+    }
   }
 
   void sortNodeChildren(MailboxNode mailboxNode) {
@@ -215,7 +225,7 @@ class TreeBuilder {
     });
   }
 
-  void _sortTeamMailboxChildrenAlphabetically(MailboxNode node) {
+  void _applyTeamMailboxSorting(MailboxNode node) {
     if (node.childrenItems == null || node.childrenItems!.isEmpty) return;
     if (node.item.isTeamMailboxes) {
       _sortWithSystemFoldersFirst(node);
@@ -223,7 +233,7 @@ class TreeBuilder {
       sortByMailboxNameNodeChildren(node);
     }
     for (final child in node.childrenItems!) {
-      _sortTeamMailboxChildrenAlphabetically(child);
+      _applyTeamMailboxSorting(child);
     }
   }
 

--- a/lib/features/mailbox/presentation/model/mailbox_tree_builder.dart
+++ b/lib/features/mailbox/presentation/model/mailbox_tree_builder.dart
@@ -14,30 +14,6 @@ import 'mailbox_node.dart';
 import 'mailbox_tree.dart';
 
 class TreeBuilder {
-  Future<MailboxTree> generateMailboxTree(List<PresentationMailbox> mailboxesList) async {
-    final Map<MailboxId, MailboxNode> mailboxDictionary = HashMap();
-
-    final tree = MailboxTree(MailboxNode.root());
-    for (var mailbox in mailboxesList) {
-      mailboxDictionary[mailbox.id] = MailboxNode(mailbox);
-    }
-    for (var mailbox in mailboxesList) {
-      final node = mailboxDictionary[mailbox.id];
-      if (node == null) continue;
-
-      final parentId = mailbox.parentId;
-      final parentNode = mailboxDictionary[parentId];
-      if (parentNode != null) {
-        parentNode.addChildNode(node);
-        sortByMailboxNameNodeChildren(parentNode);
-      } else {
-        tree.root.addChildNode(node);
-        sortByMailboxNameNodeChildren(tree.root);
-      }
-    }
-    return tree;
-  }
-
   Future<MailboxCollection> generateMailboxTreeInUI({
     required List<PresentationMailbox> allMailboxes,
     required MailboxCollection currentCollection,
@@ -51,12 +27,10 @@ class TreeBuilder {
     final newTeamMailboxTree = MailboxTree(MailboxNode.root());
   
     final List<PresentationMailbox> newAllMailboxes = <PresentationMailbox>[];
+    final nodeLookup = _buildNodeLookup(currentCollection);
 
     for (var mailbox in allMailboxes) {
-      final currentMailboxNode = findExistingNode(
-        id: mailbox.id,
-        currentCollection: currentCollection,
-      );
+      final currentMailboxNode = nodeLookup[mailbox.id];
 
       final isDeactivated = mailbox.id == mailboxIdSelected;
       final newMailboxNode = MailboxNode(
@@ -80,8 +54,7 @@ class TreeBuilder {
         defaultTree: newDefaultTree,
         personalTree: newPersonalTree,
         teamMailboxTree: newTeamMailboxTree,
-        onBeforeAddToParent: (parent, child) =>
-            _propagateDeactivationIfNeeded(parent, child, mailbox),
+        onBeforeAddToParent: _propagateDeactivationIfNeeded,
       );
 
       newAllMailboxes.add(currentNode.item);
@@ -106,12 +79,10 @@ class TreeBuilder {
     final newDefaultTree = MailboxTree(MailboxNode.root());
     final newPersonalTree = MailboxTree(MailboxNode.root());
     final newTeamMailboxTree = MailboxTree(MailboxNode.root());
+    final nodeLookup = _buildNodeLookup(currentCollection);
 
     for (var mailbox in allMailboxes) {
-      final currentMailboxNode = findExistingNode(
-        id: mailbox.id,
-        currentCollection: currentCollection,
-      );
+      final currentMailboxNode = nodeLookup[mailbox.id];
 
       final newMailboxNode = MailboxNode(
         mailbox,
@@ -169,17 +140,16 @@ class TreeBuilder {
 
   void _finalizeTrees(MailboxTree defaultTree, MailboxTree personalTree, MailboxTree teamMailboxTree) {
     sortNodeChildren(defaultTree.root);
-    for (final child in defaultTree.root.childrenItems ?? []) {
-      _sortChildrenAlphabetically(child);
-    }
+    defaultTree.root.childrenItems?.forEach(_sortChildrenAlphabetically);
     _sortChildrenAlphabetically(personalTree.root);
     _applyTeamMailboxSorting(teamMailboxTree.root);
   }
 
   void _sortChildrenAlphabetically(MailboxNode node) {
-    if (node.childrenItems == null || node.childrenItems!.isEmpty) return;
+    final children = node.childrenItems;
+    if (children == null || children.isEmpty) return;
     sortByMailboxNameNodeChildren(node);
-    for (final child in node.childrenItems!) {
+    for (final child in children) {
       _sortChildrenAlphabetically(child);
     }
   }
@@ -208,14 +178,27 @@ class TreeBuilder {
   };
 
   int _systemFolderSortIndex(MailboxNode node) {
-    return _systemFolderRoleIndex[node.item.role?.value ?? '']
-        ?? _systemFolderRoleIndex.length;
+    final roleValue = node.item.role?.value ?? '';
+    if (roleValue.isNotEmpty) {
+      return _systemFolderRoleIndex[roleValue] ?? _systemFolderRoleIndex.length;
+    }
+    // No role: mayDelete=false means the server does not allow deletion,
+    // which identifies a system folder. Fall back to case-insensitive name
+    // matching to determine its canonical sort position.
+    if (node.item.myRights?.mayDelete == false) {
+      final nameLower = node.item.name?.name.toLowerCase() ?? '';
+      return _systemFolderRoleIndex[nameLower] ?? _systemFolderRoleIndex.length;
+    }
+    return _systemFolderRoleIndex.length;
   }
 
   void _sortWithSystemFoldersFirst(MailboxNode node) {
-    node.childrenItems?.sort((a, b) {
-      final aIndex = _systemFolderSortIndex(a);
-      final bIndex = _systemFolderSortIndex(b);
+    final children = node.childrenItems;
+    if (children == null || children.isEmpty) return;
+    final indexCache = {for (final child in children) child: _systemFolderSortIndex(child)};
+    children.sort((a, b) {
+      final aIndex = indexCache[a]!;
+      final bIndex = indexCache[b]!;
       final aIsSystem = aIndex < _systemFolderRoleIndex.length;
       final bIsSystem = bIndex < _systemFolderRoleIndex.length;
       if (aIsSystem && bIsSystem) return aIndex.compareTo(bIndex);
@@ -225,25 +208,39 @@ class TreeBuilder {
     });
   }
 
+  // Traversal strategy by depth:
+  //   virtual root (isPersonal=true)  → alphabetical — orders team account roots
+  //   team account root (isTeamMailboxes=true, depth=1) → system folders first, then alphabetical
+  //   children/grandchildren (hasParentId=true) → alphabetical
   void _applyTeamMailboxSorting(MailboxNode node) {
-    if (node.childrenItems == null || node.childrenItems!.isEmpty) return;
+    final children = node.childrenItems;
+    if (children == null || children.isEmpty) return;
     if (node.item.isTeamMailboxes) {
       _sortWithSystemFoldersFirst(node);
     } else {
       sortByMailboxNameNodeChildren(node);
     }
-    for (final child in node.childrenItems!) {
+    for (final child in children) {
       _applyTeamMailboxSorting(child);
     }
   }
 
-  MailboxNode? findExistingNode({
-    required MailboxId id,
-    required MailboxCollection currentCollection,
-  }) {
-    return currentCollection.defaultTree.findNode((node) => node.item.id == id) ??
-      currentCollection.personalTree.findNode((node) => node.item.id == id) ??
-      currentCollection.teamMailboxTree.findNode((node) => node.item.id == id);
+  // Flattens all three trees into a single O(1) lookup map.
+  // Avoids repeated O(n) DFS calls when resolving existing nodes for each mailbox.
+  Map<MailboxId, MailboxNode> _buildNodeLookup(MailboxCollection collection) {
+    final lookup = HashMap<MailboxId, MailboxNode>();
+    final stack = <MailboxNode>[
+      ...?collection.defaultTree.root.childrenItems,
+      ...?collection.personalTree.root.childrenItems,
+      ...?collection.teamMailboxTree.root.childrenItems,
+    ];
+    while (stack.isNotEmpty) {
+      final node = stack.removeLast();
+      lookup[node.item.id] = node;
+      final children = node.childrenItems;
+      if (children != null) stack.addAll(children);
+    }
+    return lookup;
   }
 
   MailboxTree _resolveTargetTree(
@@ -256,13 +253,9 @@ class TreeBuilder {
     return mailbox.isPersonal ? personalTree : teamMailboxTree;
   }
 
-  void _propagateDeactivationIfNeeded(
-    MailboxNode parentNode,
-    MailboxNode currentNode,
-    PresentationMailbox mailbox,
-  ) {
+  void _propagateDeactivationIfNeeded(MailboxNode parentNode, MailboxNode currentNode) {
     if (parentNode.nodeState != MailboxState.deactivated) return;
-    currentNode.updateItem(mailbox.withMailboxSate(MailboxState.deactivated));
+    currentNode.updateItem(currentNode.item.withMailboxSate(MailboxState.deactivated));
     currentNode.updateNodeState(MailboxState.deactivated);
   }
 }

--- a/test/features/mailbox/presentation/model/mailbox_tree_builder_test.dart
+++ b/test/features/mailbox/presentation/model/mailbox_tree_builder_test.dart
@@ -85,7 +85,7 @@ void main() {
       PresentationMailbox(MailboxId(Id('3_2_1')),   parentId: MailboxId(Id('3_2'))),
     ];
 
-    test('list mailbox is in ordered, parent come first, then children', () async {
+    test('mailbox list is in order: parent first, then children', () async {
       final generatedTree = await TreeBuilder().generateMailboxTree(
         [m1, m2, m3, m1_1, m1_2, m1_2_1, ...commonSuffix],
       );
@@ -95,16 +95,19 @@ void main() {
     // Tests that verify tree correctness regardless of input ordering.
     // Each tuple: (test description, the 6-item prefix whose order varies).
     final unorderedCases = <(String, List<PresentationMailbox>)>[
-      ('list mailbox is not in ordered, parent come first, then children, then grandpa',  [m2, m3, m1_1, m1_2, m1_2_1, m1]),
-      ('list mailbox is not in ordered, parent come first, then grandpa, then children',  [m2, m3, m1_1, m1_2, m1,     m1_2_1]),
-      ('list mailbox is not in ordered, children come first, then grandpa, then parent',  [m2, m3, m1_2_1, m1, m1_1,   m1_2]),
-      ('list mailbox is not in ordered, children come first, then parent, then grandpa',  [m2, m3, m1_2_1, m1_1, m1_2, m1]),
+      ('mailbox list is not ordered: parent first, then children, then grandparent',  [m2, m3, m1_1, m1_2, m1_2_1, m1]),
+      ('mailbox list is not ordered: parent first, then grandparent, then children',  [m2, m3, m1_1, m1_2, m1,     m1_2_1]),
+      ('mailbox list is not ordered: children first, then grandparent, then parent',  [m2, m3, m1_2_1, m1, m1_1,   m1_2]),
+      ('mailbox list is not ordered: children first, then parent, then grandparent',  [m2, m3, m1_2_1, m1_1, m1_2, m1]),
     ];
     for (final (description, prefix) in unorderedCases) {
       test(description, () async {
         final generatedTree = await TreeBuilder().generateMailboxTree([...prefix, ...commonSuffix]);
-        expect(generatedTree.root.childrenItems, containsAll(expectedTree.root.childrenItems!));
-        expect(generatedTree.root.childrenItems![2], equals(expectedTree.root.childrenItems![0]));
+        final expectedChildren = expectedTree.root.childrenItems!;
+        final generatedChildren = generatedTree.root.childrenItems!;
+        expect(generatedChildren.length, equals(expectedChildren.length));
+        expect(generatedChildren, containsAll(expectedChildren));
+        expect(generatedChildren[2], equals(expectedChildren[0]));
       });
     }
 

--- a/test/features/mailbox/presentation/model/mailbox_tree_builder_test.dart
+++ b/test/features/mailbox/presentation/model/mailbox_tree_builder_test.dart
@@ -65,155 +65,56 @@ void main() {
       )
     );
 
+    // Shared mailbox instances across all input-ordering tests
+    final m1     = PresentationMailbox(MailboxId(Id('1')),     parentId: null);
+    final m2     = PresentationMailbox(MailboxId(Id('2')),     parentId: null);
+    final m3     = PresentationMailbox(MailboxId(Id('3')),     parentId: null);
+    final m1_1   = PresentationMailbox(MailboxId(Id('1_1')),   parentId: MailboxId(Id('1')));
+    final m1_2   = PresentationMailbox(MailboxId(Id('1_2')),   parentId: MailboxId(Id('1')));
+    final m1_2_1 = PresentationMailbox(MailboxId(Id('1_2_1')), parentId: MailboxId(Id('1_2')));
+    // Items below appear in the same position across all unordered tests
+    final commonSuffix = <PresentationMailbox>[
+      PresentationMailbox(MailboxId(Id('2_1')),     parentId: MailboxId(Id('2'))),
+      PresentationMailbox(MailboxId(Id('2_2')),     parentId: MailboxId(Id('2'))),
+      PresentationMailbox(MailboxId(Id('2_1_1')),   parentId: MailboxId(Id('2_1'))),
+      PresentationMailbox(MailboxId(Id('2_1_1_1')), parentId: MailboxId(Id('2_1_1'))),
+      PresentationMailbox(MailboxId(Id('2_1_2')),   parentId: MailboxId(Id('2_1'))),
+      PresentationMailbox(MailboxId(Id('3_1')),     parentId: MailboxId(Id('3'))),
+      PresentationMailbox(MailboxId(Id('3_2')),     parentId: MailboxId(Id('3'))),
+      PresentationMailbox(MailboxId(Id('3_1_1')),   parentId: MailboxId(Id('3_1'))),
+      PresentationMailbox(MailboxId(Id('3_2_1')),   parentId: MailboxId(Id('3_2'))),
+    ];
+
     test('list mailbox is in ordered, parent come first, then children', () async {
-      final testCase = [
-        PresentationMailbox(MailboxId(Id("1")), parentId: null),
-        PresentationMailbox(MailboxId(Id("2")), parentId: null),
-        PresentationMailbox(MailboxId(Id("3")), parentId: null),
-        PresentationMailbox(MailboxId(Id("1_1")), parentId: MailboxId(Id('1'))),
-        PresentationMailbox(MailboxId(Id("1_2")), parentId: MailboxId(Id('1'))),
-        PresentationMailbox(MailboxId(Id("1_2_1")), parentId: MailboxId(Id('1_2'))),
-        PresentationMailbox(MailboxId(Id("2_1")), parentId: MailboxId(Id('2'))),
-        PresentationMailbox(MailboxId(Id("2_2")), parentId: MailboxId(Id('2'))),
-        PresentationMailbox(MailboxId(Id("2_1_1")), parentId: MailboxId(Id('2_1'))),
-        PresentationMailbox(MailboxId(Id("2_1_1_1")), parentId: MailboxId(Id('2_1_1'))),
-        PresentationMailbox(MailboxId(Id("2_1_2")), parentId: MailboxId(Id('2_1'))),
-        PresentationMailbox(MailboxId(Id("3_1")), parentId: MailboxId(Id('3'))),
-        PresentationMailbox(MailboxId(Id("3_2")), parentId: MailboxId(Id('3'))),
-        PresentationMailbox(MailboxId(Id("3_1_1")), parentId: MailboxId(Id('3_1'))),
-        PresentationMailbox(MailboxId(Id("3_2_1")), parentId: MailboxId(Id('3_2'))),
-      ];
-
-      final generatedTree = await TreeBuilder().generateMailboxTree(testCase);
-
+      final generatedTree = await TreeBuilder().generateMailboxTree(
+        [m1, m2, m3, m1_1, m1_2, m1_2_1, ...commonSuffix],
+      );
       expect(generatedTree, equals(expectedTree));
     });
 
-    test('list mailbox is not in ordered, parent come first, then children, then grandpa', () async {
-      final testCase = [
-        PresentationMailbox(MailboxId(Id("2")), parentId: null),
-        PresentationMailbox(MailboxId(Id("3")), parentId: null),
-        PresentationMailbox(MailboxId(Id("1_1")), parentId: MailboxId(Id('1'))),
-        PresentationMailbox(MailboxId(Id("1_2")), parentId: MailboxId(Id('1'))),
-        PresentationMailbox(MailboxId(Id("1_2_1")), parentId: MailboxId(Id('1_2'))),
-        PresentationMailbox(MailboxId(Id("1")), parentId: null),
-        PresentationMailbox(MailboxId(Id("2_1")), parentId: MailboxId(Id('2'))),
-        PresentationMailbox(MailboxId(Id("2_2")), parentId: MailboxId(Id('2'))),
-        PresentationMailbox(MailboxId(Id("2_1_1")), parentId: MailboxId(Id('2_1'))),
-        PresentationMailbox(MailboxId(Id("2_1_1_1")), parentId: MailboxId(Id('2_1_1'))),
-        PresentationMailbox(MailboxId(Id("2_1_2")), parentId: MailboxId(Id('2_1'))),
-        PresentationMailbox(MailboxId(Id("3_1")), parentId: MailboxId(Id('3'))),
-        PresentationMailbox(MailboxId(Id("3_2")), parentId: MailboxId(Id('3'))),
-        PresentationMailbox(MailboxId(Id("3_1_1")), parentId: MailboxId(Id('3_1'))),
-        PresentationMailbox(MailboxId(Id("3_2_1")), parentId: MailboxId(Id('3_2'))),
-      ];
+    // Tests that verify tree correctness regardless of input ordering.
+    // Each tuple: (test description, the 6-item prefix whose order varies).
+    final unorderedCases = <(String, List<PresentationMailbox>)>[
+      ('list mailbox is not in ordered, parent come first, then children, then grandpa',  [m2, m3, m1_1, m1_2, m1_2_1, m1]),
+      ('list mailbox is not in ordered, parent come first, then grandpa, then children',  [m2, m3, m1_1, m1_2, m1,     m1_2_1]),
+      ('list mailbox is not in ordered, children come first, then grandpa, then parent',  [m2, m3, m1_2_1, m1, m1_1,   m1_2]),
+      ('list mailbox is not in ordered, children come first, then parent, then grandpa',  [m2, m3, m1_2_1, m1_1, m1_2, m1]),
+    ];
+    for (final (description, prefix) in unorderedCases) {
+      test(description, () async {
+        final generatedTree = await TreeBuilder().generateMailboxTree([...prefix, ...commonSuffix]);
+        expect(generatedTree.root.childrenItems, containsAll(expectedTree.root.childrenItems!));
+        expect(generatedTree.root.childrenItems![2], equals(expectedTree.root.childrenItems![0]));
+      });
+    }
 
-      final generatedTree = await TreeBuilder().generateMailboxTree(testCase);
-
-      expect(generatedTree.root.childrenItems, containsAll(expectedTree.root.childrenItems!));
-      expect(generatedTree.root.childrenItems![2], equals(expectedTree.root.childrenItems![0]));
-    });
-
-    test('list mailbox is not in ordered, parent come first, then grandpa, then children', () async {
-      final testCase = [
-        PresentationMailbox(MailboxId(Id("2")), parentId: null),
-        PresentationMailbox(MailboxId(Id("3")), parentId: null),
-        PresentationMailbox(MailboxId(Id("1_1")), parentId: MailboxId(Id('1'))),
-        PresentationMailbox(MailboxId(Id("1_2")), parentId: MailboxId(Id('1'))),
-        PresentationMailbox(MailboxId(Id("1")), parentId: null),
-        PresentationMailbox(MailboxId(Id("1_2_1")), parentId: MailboxId(Id('1_2'))),
-        PresentationMailbox(MailboxId(Id("2_1")), parentId: MailboxId(Id('2'))),
-        PresentationMailbox(MailboxId(Id("2_2")), parentId: MailboxId(Id('2'))),
-        PresentationMailbox(MailboxId(Id("2_1_1")), parentId: MailboxId(Id('2_1'))),
-        PresentationMailbox(MailboxId(Id("2_1_1_1")), parentId: MailboxId(Id('2_1_1'))),
-        PresentationMailbox(MailboxId(Id("2_1_2")), parentId: MailboxId(Id('2_1'))),
-        PresentationMailbox(MailboxId(Id("3_1")), parentId: MailboxId(Id('3'))),
-        PresentationMailbox(MailboxId(Id("3_2")), parentId: MailboxId(Id('3'))),
-        PresentationMailbox(MailboxId(Id("3_1_1")), parentId: MailboxId(Id('3_1'))),
-        PresentationMailbox(MailboxId(Id("3_2_1")), parentId: MailboxId(Id('3_2'))),
-      ];
-
-      final generatedTree = await TreeBuilder().generateMailboxTree(testCase);
-
-      expect(generatedTree.root.childrenItems, containsAll(expectedTree.root.childrenItems!));
-      expect(generatedTree.root.childrenItems![2], equals(expectedTree.root.childrenItems![0]));
-    });
-
-    test('list mailbox is not in ordered, children come first, then grandpa, then parent', () async {
-      final testCase = [
-        PresentationMailbox(MailboxId(Id("2")), parentId: null),
-        PresentationMailbox(MailboxId(Id("3")), parentId: null),
-        PresentationMailbox(MailboxId(Id("1_2_1")), parentId: MailboxId(Id('1_2'))),
-        PresentationMailbox(MailboxId(Id("1")), parentId: null),
-        PresentationMailbox(MailboxId(Id("1_1")), parentId: MailboxId(Id('1'))),
-        PresentationMailbox(MailboxId(Id("1_2")), parentId: MailboxId(Id('1'))),
-        PresentationMailbox(MailboxId(Id("2_1")), parentId: MailboxId(Id('2'))),
-        PresentationMailbox(MailboxId(Id("2_2")), parentId: MailboxId(Id('2'))),
-        PresentationMailbox(MailboxId(Id("2_1_1")), parentId: MailboxId(Id('2_1'))),
-        PresentationMailbox(MailboxId(Id("2_1_1_1")), parentId: MailboxId(Id('2_1_1'))),
-        PresentationMailbox(MailboxId(Id("2_1_2")), parentId: MailboxId(Id('2_1'))),
-        PresentationMailbox(MailboxId(Id("3_1")), parentId: MailboxId(Id('3'))),
-        PresentationMailbox(MailboxId(Id("3_2")), parentId: MailboxId(Id('3'))),
-        PresentationMailbox(MailboxId(Id("3_1_1")), parentId: MailboxId(Id('3_1'))),
-        PresentationMailbox(MailboxId(Id("3_2_1")), parentId: MailboxId(Id('3_2'))),
-      ];
-
-      final generatedTree = await TreeBuilder().generateMailboxTree(testCase);
-
-      expect(generatedTree.root.childrenItems, containsAll(expectedTree.root.childrenItems!));
-      expect(generatedTree.root.childrenItems![2], equals(expectedTree.root.childrenItems![0]));
-    });
-
-    test('list mailbox is not in ordered, children come first, then parent, then grandpa',  () async {
-      final testCase = [
-        PresentationMailbox(MailboxId(Id("2")), parentId: null),
-        PresentationMailbox(MailboxId(Id("3")), parentId: null),
-        PresentationMailbox(MailboxId(Id("1_2_1")), parentId: MailboxId(Id('1_2'))),
-        PresentationMailbox(MailboxId(Id("1_1")), parentId: MailboxId(Id('1'))),
-        PresentationMailbox(MailboxId(Id("1_2")), parentId: MailboxId(Id('1'))),
-        PresentationMailbox(MailboxId(Id("1")), parentId: null),
-        PresentationMailbox(MailboxId(Id("2_1")), parentId: MailboxId(Id('2'))),
-        PresentationMailbox(MailboxId(Id("2_2")), parentId: MailboxId(Id('2'))),
-        PresentationMailbox(MailboxId(Id("2_1_1")), parentId: MailboxId(Id('2_1'))),
-        PresentationMailbox(MailboxId(Id("2_1_1_1")), parentId: MailboxId(Id('2_1_1'))),
-        PresentationMailbox(MailboxId(Id("2_1_2")), parentId: MailboxId(Id('2_1'))),
-        PresentationMailbox(MailboxId(Id("3_1")), parentId: MailboxId(Id('3'))),
-        PresentationMailbox(MailboxId(Id("3_2")), parentId: MailboxId(Id('3'))),
-        PresentationMailbox(MailboxId(Id("3_1_1")), parentId: MailboxId(Id('3_1'))),
-        PresentationMailbox(MailboxId(Id("3_2_1")), parentId: MailboxId(Id('3_2'))),
-      ];
-
-      final generatedTree = await TreeBuilder().generateMailboxTree(testCase);
-
-      expect(generatedTree.root.childrenItems, containsAll(expectedTree.root.childrenItems!));
-      expect(generatedTree.root.childrenItems![2], equals(expectedTree.root.childrenItems![0]));
-    });
-
-    test('item have parent but not found in tree will become root child',  () async {
-      final testCase = [
-        PresentationMailbox(MailboxId(Id("2")), parentId: null),
-        PresentationMailbox(MailboxId(Id("3")), parentId: null),
-        PresentationMailbox(MailboxId(Id("1_2_1")), parentId: MailboxId(Id('1_2'))),
-        PresentationMailbox(MailboxId(Id("1_1")), parentId: MailboxId(Id('1'))),
-        PresentationMailbox(MailboxId(Id("1_2")), parentId: MailboxId(Id('1'))),
-        PresentationMailbox(MailboxId(Id("1")), parentId: null),
-        PresentationMailbox(MailboxId(Id("2_1")), parentId: MailboxId(Id('2'))),
-        PresentationMailbox(MailboxId(Id("2_2")), parentId: MailboxId(Id('2'))),
-        PresentationMailbox(MailboxId(Id("2_1_1")), parentId: MailboxId(Id('2_1'))),
-        PresentationMailbox(MailboxId(Id("2_1_1_1")), parentId: MailboxId(Id('2_1_1'))),
-        PresentationMailbox(MailboxId(Id("2_1_2")), parentId: MailboxId(Id('2_1'))),
-        PresentationMailbox(MailboxId(Id("3_1")), parentId: MailboxId(Id('3'))),
-        PresentationMailbox(MailboxId(Id("3_2")), parentId: MailboxId(Id('3'))),
-        PresentationMailbox(MailboxId(Id("3_1_1")), parentId: MailboxId(Id('3_1'))),
-        PresentationMailbox(MailboxId(Id("3_2_1")), parentId: MailboxId(Id('3_2'))),
-        PresentationMailbox(MailboxId(Id("e3_2_1")), parentId: MailboxId(Id('id42')))
-      ];
-
-      final generatedTree = await TreeBuilder().generateMailboxTree(testCase);
-
+    test('item have parent but not found in tree will become root child', () async {
+      final orphan = PresentationMailbox(MailboxId(Id('e3_2_1')), parentId: MailboxId(Id('id42')));
+      final generatedTree = await TreeBuilder().generateMailboxTree(
+        [m2, m3, m1_2_1, m1_1, m1_2, m1, ...commonSuffix, orphan],
+      );
       expect(generatedTree.root.childrenItems?.length, equals(4));
-      expect(generatedTree.root.childrenItems,
-          contains(MailboxNode(PresentationMailbox(MailboxId(Id("e3_2_1")), parentId: MailboxId(Id('id42'))))));
+      expect(generatedTree.root.childrenItems, contains(MailboxNode(orphan)));
     });
   });
 
@@ -673,6 +574,263 @@ void main() {
         expect(result.allMailboxes.length, equals(2));
       },
     );
+  });
+
+  group('Team Mailbox Sub-folder Sorting', () {
+    final teamNamespace = Namespace('Delegated[unite-a@linagora.com]');
+    final teamRootId = MailboxId(Id('team_root'));
+
+    List<PresentationMailbox> buildTeamMailboxes() => [
+      PresentationMailbox(
+        teamRootId,
+        parentId: null,
+        name: MailboxName('unite-a'),
+        namespace: teamNamespace,
+      ),
+      PresentationMailbox(
+        MailboxId(Id('inbox')),
+        parentId: teamRootId,
+        name: MailboxName('INBOX'),
+        namespace: teamNamespace,
+        role: Role('inbox'),
+      ),
+      PresentationMailbox(
+        MailboxId(Id('drafts')),
+        parentId: teamRootId,
+        name: MailboxName('Drafts'),
+        namespace: teamNamespace,
+        role: Role('drafts'),
+      ),
+      PresentationMailbox(
+        MailboxId(Id('sent')),
+        parentId: teamRootId,
+        name: MailboxName('Sent'),
+        namespace: teamNamespace,
+        role: Role('sent'),
+      ),
+      PresentationMailbox(
+        MailboxId(Id('trash')),
+        parentId: teamRootId,
+        name: MailboxName('Trash'),
+        namespace: teamNamespace,
+        role: Role('trash'),
+      ),
+      PresentationMailbox(
+        MailboxId(Id('templates')),
+        parentId: teamRootId,
+        name: MailboxName('Templates'),
+        namespace: teamNamespace,
+        role: Role('templates'),
+      ),
+      PresentationMailbox(
+        MailboxId(Id('outbox')),
+        parentId: teamRootId,
+        name: MailboxName('Outbox'),
+        namespace: teamNamespace,
+        role: Role('outbox'),
+      ),
+      // User-created folders — intentionally unsorted in input
+      PresentationMailbox(
+        MailboxId(Id('affaire3')),
+        parentId: teamRootId,
+        name: MailboxName('affaire-3'),
+        namespace: teamNamespace,
+      ),
+      PresentationMailbox(
+        MailboxId(Id('affaire1')),
+        parentId: teamRootId,
+        name: MailboxName('affaire-1'),
+        namespace: teamNamespace,
+      ),
+      PresentationMailbox(
+        MailboxId(Id('affaire2')),
+        parentId: teamRootId,
+        name: MailboxName('affaire-2'),
+        namespace: teamNamespace,
+      ),
+    ];
+
+    void expectSubfoldersSystemFirstThenAlpha(MailboxCollection result) {
+      final teamRootNode = result.teamMailboxTree.root.childrenItems?.first;
+      final children = teamRootNode?.childrenItems ?? [];
+      expect(children.length, equals(9));
+      expect(
+        children.map((n) => n.item.name?.name).toList(),
+        equals(['INBOX', 'Drafts', 'Outbox', 'Sent', 'Trash', 'Templates', 'affaire-1', 'affaire-2', 'affaire-3']),
+        reason: 'Team mailbox sub-folders must list system folders first (canonical order), then user folders alphabetically',
+      );
+    }
+
+    test('team mailbox sub-folders list system folders first then user folders alphabetically on both build paths', () async {
+      final inUIResult = await TreeBuilder().generateMailboxTreeInUI(
+        allMailboxes: buildTeamMailboxes(),
+        currentCollection: MailboxCollection.empty(),
+      );
+      expectSubfoldersSystemFirstThenAlpha(inUIResult);
+
+      final afterRefreshResult = await TreeBuilder().generateMailboxTreeInUIAfterRefreshChanges(
+        allMailboxes: buildTeamMailboxes(),
+        currentCollection: MailboxCollection.empty(),
+      );
+      expectSubfoldersSystemFirstThenAlpha(afterRefreshResult);
+    });
+
+    test('generateMailboxTreeInUI: nested sub-folders within team mailbox are also sorted alphabetically', () async {
+      final subFolderParentId = MailboxId(Id('affaire1'));
+      final allMailboxes = [
+        ...buildTeamMailboxes(),
+        PresentationMailbox(
+          MailboxId(Id('nested_z')),
+          parentId: subFolderParentId,
+          name: MailboxName('zebra'),
+          namespace: teamNamespace,
+        ),
+        PresentationMailbox(
+          MailboxId(Id('nested_a')),
+          parentId: subFolderParentId,
+          name: MailboxName('apple'),
+          namespace: teamNamespace,
+        ),
+      ];
+
+      final result = await TreeBuilder().generateMailboxTreeInUI(
+        allMailboxes: allMailboxes,
+        currentCollection: MailboxCollection.empty(),
+      );
+
+      final teamRootNode = result.teamMailboxTree.root.childrenItems?.first;
+      final affaire1Node = teamRootNode?.childrenItems
+          ?.firstWhere((n) => n.item.name?.name == 'affaire-1');
+      final nestedChildren = affaire1Node?.childrenItems ?? [];
+
+      expect(nestedChildren.length, equals(2));
+      expect(nestedChildren[0].item.name?.name, equals('apple'));
+      expect(nestedChildren[1].item.name?.name, equals('zebra'));
+    });
+
+    test('generateMailboxTreeInUI: multiple team mailboxes are sorted alphabetically', () async {
+      final uniteANamespace = Namespace('Delegated[unite-a@linagora.com]');
+      final uniteBNamespace = Namespace('Delegated[unite-b@linagora.com]');
+      final uniteAId = MailboxId(Id('team_unite_a'));
+      final uniteBId = MailboxId(Id('team_unite_b'));
+
+      final mailboxes = [
+        PresentationMailbox(
+          uniteBId,
+          parentId: null,
+          name: MailboxName('unite-b'),
+          namespace: uniteBNamespace,
+        ),
+        PresentationMailbox(
+          uniteAId,
+          parentId: null,
+          name: MailboxName('unite-a'),
+          namespace: uniteANamespace,
+        ),
+      ];
+
+      final result = await TreeBuilder().generateMailboxTreeInUI(
+        allMailboxes: mailboxes,
+        currentCollection: MailboxCollection.empty(),
+      );
+
+      final teamRoots = result.teamMailboxTree.root.childrenItems ?? [];
+      expect(teamRoots.length, equals(2));
+      expect(teamRoots[0].item.name?.name, equals('unite-a'));
+      expect(teamRoots[1].item.name?.name, equals('unite-b'));
+    });
+  });
+
+  group('Team Mailbox System-first Sort — Edge Cases', () {
+    final teamNamespace = Namespace('Delegated[team@example.com]');
+    final teamRootId = MailboxId(Id('team_root'));
+
+    PresentationMailbox teamItem(String id, String name, {Role? role}) => PresentationMailbox(
+      MailboxId(Id(id)),
+      parentId: teamRootId,
+      name: MailboxName(name),
+      namespace: teamNamespace,
+      role: role,
+    );
+
+    Future<List<MailboxNode>> getSubfolders(List<PresentationMailbox> children) async {
+      final result = await TreeBuilder().generateMailboxTreeInUI(
+        allMailboxes: [
+          PresentationMailbox(teamRootId, parentId: null, name: MailboxName('team'), namespace: teamNamespace),
+          ...children,
+        ],
+        currentCollection: MailboxCollection.empty(),
+      );
+      return result.teamMailboxTree.root.childrenItems?.first.childrenItems ?? [];
+    }
+
+    test('team mailbox with only user folders stays alphabetical', () async {
+      final children = await getSubfolders([
+        teamItem('z', 'Zebra'),
+        teamItem('a', 'Alpha'),
+        teamItem('m', 'Medium'),
+      ]);
+      expect(children.map((n) => n.item.name?.name).toList(), equals(['Alpha', 'Medium', 'Zebra']));
+    });
+
+    test('system folder detection uses role, not display name', () async {
+      final children = await getSubfolders([
+        teamItem('inbox_fr', 'Boîte de réception', role: Role('inbox')),
+        teamItem('inbox_name', 'inbox'),
+        teamItem('aaa', 'aaa'),
+      ]);
+      expect(
+        children.map((n) => n.item.name?.name).toList(),
+        equals(['Boîte de réception', 'aaa', 'inbox']),
+        reason: 'System folders are identified by role — a localized inbox sorts first; a folder named "inbox" without a role is a user folder',
+      );
+    });
+
+    test('default and personal tree sorting is unaffected by team mailbox sort logic', () async {
+      final mailboxes = [
+        PresentationMailbox(
+          MailboxId(Id('sent')),
+          name: MailboxName('Sent'),
+          sortOrder: SortOrder(sortValue: 50),
+          role: Role('sent'),
+        ),
+        PresentationMailbox(
+          MailboxId(Id('inbox')),
+          name: MailboxName('Inbox'),
+          sortOrder: SortOrder(sortValue: 10),
+          role: Role('inbox'),
+        ),
+        PresentationMailbox(
+          MailboxId(Id('personal_z')),
+          name: MailboxName('Zebra'),
+          namespace: Namespace('Personal'),
+        ),
+        PresentationMailbox(
+          MailboxId(Id('personal_a')),
+          name: MailboxName('Apple'),
+          namespace: Namespace('Personal'),
+        ),
+      ];
+
+      final result = await TreeBuilder().generateMailboxTreeInUI(
+        allMailboxes: mailboxes,
+        currentCollection: MailboxCollection.empty(),
+      );
+
+      final defaultChildren = result.defaultTree.root.childrenItems ?? [];
+      expect(
+        defaultChildren.map((n) => n.item.name?.name).toList(),
+        equals(['Inbox', 'Sent']),
+        reason: 'Default tree must still use sortOrder, not system-first name matching',
+      );
+
+      final personalChildren = result.personalTree.root.childrenItems ?? [];
+      expect(
+        personalChildren.map((n) => n.item.name?.name).toList(),
+        equals(['Apple', 'Zebra']),
+        reason: 'Personal tree must remain alphabetical and unaffected',
+      );
+    });
   });
 
   group('Cascading Deactivation (generateMailboxTreeInUI only)', () {

--- a/test/features/mailbox/presentation/model/mailbox_tree_builder_test.dart
+++ b/test/features/mailbox/presentation/model/mailbox_tree_builder_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox_rights.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/namespace.dart';
 import 'package:model/extensions/list_presentation_mailbox_extension.dart';
 import 'package:model/extensions/presentation_mailbox_extension.dart';
@@ -14,113 +15,6 @@ import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_tree.d
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_tree_builder.dart';
 
 void main() {
-  group('generate mailbox tree: ', () {
-    final expectedTree = MailboxTree(
-      MailboxNode(
-        PresentationMailbox(MailboxId(Id('root'))),
-        childrenItems: [
-          MailboxNode(
-              PresentationMailbox(MailboxId(Id("3")), parentId: null),
-              childrenItems: [
-                MailboxNode(
-                    PresentationMailbox(MailboxId(Id("3_2")), parentId: MailboxId(Id('3'))),
-                    childrenItems: [MailboxNode(PresentationMailbox(MailboxId(Id("3_2_1")), parentId: MailboxId(Id('3_2'))))]
-                ),
-                MailboxNode(
-                    PresentationMailbox(MailboxId(Id("3_1")), parentId: MailboxId(Id('3'))),
-                    childrenItems: [
-                      MailboxNode(PresentationMailbox(MailboxId(Id("3_1_1")), parentId: MailboxId(Id('3_1'))))
-                    ]
-                ),
-              ]
-          ),
-          MailboxNode(
-              PresentationMailbox(MailboxId(Id("1")), parentId: null),
-              childrenItems: [
-                MailboxNode(
-                    PresentationMailbox(MailboxId(Id("1_2")), parentId: MailboxId(Id('1'))),
-                    childrenItems: [
-                      MailboxNode(PresentationMailbox(MailboxId(Id("1_2_1")), parentId: MailboxId(Id('1_2'))))
-                    ]
-                ),
-                MailboxNode(PresentationMailbox(MailboxId(Id("1_1")), parentId: MailboxId(Id('1')))),
-              ]
-          ),
-          MailboxNode(
-              PresentationMailbox(MailboxId(Id("2")), parentId: null),
-              childrenItems: [
-                MailboxNode(PresentationMailbox(MailboxId(Id("2_2")), parentId: MailboxId(Id('2')))),
-                MailboxNode(PresentationMailbox(MailboxId(Id("2_1")), parentId: MailboxId(Id('2'))),
-                    childrenItems: [
-                      MailboxNode(PresentationMailbox(MailboxId(Id("2_1_2")), parentId: MailboxId(Id('2_1')))),
-                      MailboxNode(
-                          PresentationMailbox(MailboxId(Id("2_1_1")), parentId: MailboxId(Id('2_1'))),
-                          childrenItems: [MailboxNode(PresentationMailbox(MailboxId(Id("2_1_1_1")), parentId: MailboxId(Id('2_1_1'))))]
-                      ),
-                    ]
-                ),
-              ]
-          ),
-        ]
-      )
-    );
-
-    // Shared mailbox instances across all input-ordering tests
-    final m1     = PresentationMailbox(MailboxId(Id('1')),     parentId: null);
-    final m2     = PresentationMailbox(MailboxId(Id('2')),     parentId: null);
-    final m3     = PresentationMailbox(MailboxId(Id('3')),     parentId: null);
-    final m1_1   = PresentationMailbox(MailboxId(Id('1_1')),   parentId: MailboxId(Id('1')));
-    final m1_2   = PresentationMailbox(MailboxId(Id('1_2')),   parentId: MailboxId(Id('1')));
-    final m1_2_1 = PresentationMailbox(MailboxId(Id('1_2_1')), parentId: MailboxId(Id('1_2')));
-    // Items below appear in the same position across all unordered tests
-    final commonSuffix = <PresentationMailbox>[
-      PresentationMailbox(MailboxId(Id('2_1')),     parentId: MailboxId(Id('2'))),
-      PresentationMailbox(MailboxId(Id('2_2')),     parentId: MailboxId(Id('2'))),
-      PresentationMailbox(MailboxId(Id('2_1_1')),   parentId: MailboxId(Id('2_1'))),
-      PresentationMailbox(MailboxId(Id('2_1_1_1')), parentId: MailboxId(Id('2_1_1'))),
-      PresentationMailbox(MailboxId(Id('2_1_2')),   parentId: MailboxId(Id('2_1'))),
-      PresentationMailbox(MailboxId(Id('3_1')),     parentId: MailboxId(Id('3'))),
-      PresentationMailbox(MailboxId(Id('3_2')),     parentId: MailboxId(Id('3'))),
-      PresentationMailbox(MailboxId(Id('3_1_1')),   parentId: MailboxId(Id('3_1'))),
-      PresentationMailbox(MailboxId(Id('3_2_1')),   parentId: MailboxId(Id('3_2'))),
-    ];
-
-    test('mailbox list is in order: parent first, then children', () async {
-      final generatedTree = await TreeBuilder().generateMailboxTree(
-        [m1, m2, m3, m1_1, m1_2, m1_2_1, ...commonSuffix],
-      );
-      expect(generatedTree, equals(expectedTree));
-    });
-
-    // Tests that verify tree correctness regardless of input ordering.
-    // Each tuple: (test description, the 6-item prefix whose order varies).
-    final unorderedCases = <(String, List<PresentationMailbox>)>[
-      ('mailbox list is not ordered: parent first, then children, then grandparent',  [m2, m3, m1_1, m1_2, m1_2_1, m1]),
-      ('mailbox list is not ordered: parent first, then grandparent, then children',  [m2, m3, m1_1, m1_2, m1,     m1_2_1]),
-      ('mailbox list is not ordered: children first, then grandparent, then parent',  [m2, m3, m1_2_1, m1, m1_1,   m1_2]),
-      ('mailbox list is not ordered: children first, then parent, then grandparent',  [m2, m3, m1_2_1, m1_1, m1_2, m1]),
-    ];
-    for (final (description, prefix) in unorderedCases) {
-      test(description, () async {
-        final generatedTree = await TreeBuilder().generateMailboxTree([...prefix, ...commonSuffix]);
-        final expectedChildren = expectedTree.root.childrenItems!;
-        final generatedChildren = generatedTree.root.childrenItems!;
-        expect(generatedChildren.length, equals(expectedChildren.length));
-        expect(generatedChildren, containsAll(expectedChildren));
-        expect(generatedChildren[2], equals(expectedChildren[0]));
-      });
-    }
-
-    test('item have parent but not found in tree will become root child', () async {
-      final orphan = PresentationMailbox(MailboxId(Id('e3_2_1')), parentId: MailboxId(Id('id42')));
-      final generatedTree = await TreeBuilder().generateMailboxTree(
-        [m2, m3, m1_2_1, m1_1, m1_2, m1, ...commonSuffix, orphan],
-      );
-      expect(generatedTree.root.childrenItems?.length, equals(4));
-      expect(generatedTree.root.childrenItems, contains(MailboxNode(orphan)));
-    });
-  });
-
   group('generate default mailbox tree base on sortOrder: ', () {
     final expectedTree = MailboxTree(
         MailboxNode(
@@ -748,13 +642,18 @@ void main() {
     final teamNamespace = Namespace('Delegated[team@example.com]');
     final teamRootId = MailboxId(Id('team_root'));
 
-    PresentationMailbox teamItem(String id, String name, {Role? role}) => PresentationMailbox(
+    PresentationMailbox teamItem(String id, String name, {Role? role, MailboxRights? myRights}) => PresentationMailbox(
       MailboxId(Id(id)),
       parentId: teamRootId,
       name: MailboxName(name),
       namespace: teamNamespace,
       role: role,
+      myRights: myRights,
     );
+
+    // mayReadItems, mayAddItems, mayRemoveItems, maySetSeen, maySetKeywords, mayCreateChild, mayRename, mayDelete, maySubmit
+    final systemRights = MailboxRights(true, true, true, true, true, true, false, false, true);
+    final userRights   = MailboxRights(true, true, true, true, true, true, true,  true,  true);
 
     Future<List<MailboxNode>> getSubfolders(List<PresentationMailbox> children) async {
       final result = await TreeBuilder().generateMailboxTreeInUI(
@@ -776,16 +675,62 @@ void main() {
       expect(children.map((n) => n.item.name?.name).toList(), equals(['Alpha', 'Medium', 'Zebra']));
     });
 
-    test('system folder detection uses role, not display name', () async {
+    test('role takes priority over mayDelete+name fallback', () async {
       final children = await getSubfolders([
         teamItem('inbox_fr', 'Boîte de réception', role: Role('inbox')),
-        teamItem('inbox_name', 'inbox'),
-        teamItem('aaa', 'aaa'),
+        teamItem('inbox_sys', 'INBOX', myRights: systemRights),
+        teamItem('aaa', 'aaa', myRights: userRights),
       ]);
       expect(
         children.map((n) => n.item.name?.name).toList(),
-        equals(['Boîte de réception', 'aaa', 'inbox']),
-        reason: 'System folders are identified by role — a localized inbox sorts first; a folder named "inbox" without a role is a user folder',
+        equals(['Boîte de réception', 'INBOX', 'aaa']),
+        reason: 'Role is the primary signal; mayDelete=false+name is the fallback — both land before user folders',
+      );
+    });
+
+    test('no-role system folders (mayDelete=false) sort before user folders via name — on both build paths', () async {
+      final teamRoot = PresentationMailbox(teamRootId, parentId: null, name: MailboxName('team'), namespace: teamNamespace);
+      final noRoleMailboxes = [
+        teamRoot,
+        teamItem('abd', 'ABD', myRights: userRights),
+        teamItem('inbox', 'INBOX', myRights: systemRights),
+        teamItem('drafts', 'Drafts', myRights: systemRights),
+        teamItem('sent', 'Sent', myRights: systemRights),
+        teamItem('outbox', 'Outbox', myRights: systemRights),
+        teamItem('trash', 'Trash', myRights: systemRights),
+        teamItem('templates', 'Templates', myRights: systemRights),
+      ];
+      const expected = ['INBOX', 'Drafts', 'Outbox', 'Sent', 'Trash', 'Templates', 'ABD'];
+
+      final inUIResult = await TreeBuilder().generateMailboxTreeInUI(
+        allMailboxes: noRoleMailboxes,
+        currentCollection: MailboxCollection.empty(),
+      );
+      final afterRefreshResult = await TreeBuilder().generateMailboxTreeInUIAfterRefreshChanges(
+        allMailboxes: noRoleMailboxes,
+        currentCollection: MailboxCollection.empty(),
+      );
+
+      for (final result in [inUIResult, afterRefreshResult]) {
+        final children = result.teamMailboxTree.root.childrenItems?.first.childrenItems ?? [];
+        expect(
+          children.map((n) => n.item.name?.name).toList(),
+          equals(expected),
+          reason: 'When system folders carry no role, mayDelete=false+name-based fallback places them before user folders in canonical order',
+        );
+      }
+    });
+
+    test('user folder named like a system folder (mayDelete=true) sorts alphabetically', () async {
+      final children = await getSubfolders([
+        teamItem('inbox_sys', 'INBOX', myRights: systemRights),
+        teamItem('inbox_user', 'Inbox', myRights: userRights),
+        teamItem('abd', 'ABD', myRights: userRights),
+      ]);
+      expect(
+        children.map((n) => n.item.name?.name).toList(),
+        equals(['INBOX', 'ABD', 'Inbox']),
+        reason: 'mayDelete=true marks a user-created folder — even if the name matches a system folder, it sorts alphabetically with other user folders',
       );
     });
 


### PR DESCRIPTION
## Issue

#4520

Teamc mailbox sub-folders are sorted purely alphabetically, causing system folders (Inbox, Drafts, Sent, Trash, etc.) to appear mixed in with user-created folders instead of being grouped at the top in canonical order.

## Root cause

`TreeBuilder` applied `sortByMailboxNameNodeChildren` uniformly across all mailbox trees. There was no distinction between team mailbox root nodes and regular nodes, so system folders received no special ordering — they were sorted by display name alongside user-created folders.

## Solution

- Added `_sortWithSystemFoldersFirst`: sorts children of a team mailbox root by placing system folders first (in canonical role order: Inbox → Drafts → Outbox → Sent → Trash → Spam/Junk → Templates → Archive), then user folders alphabetically. System folder identity is determined by **role**, not display name, so localised folder names sort correctly.

- Added `_sortTeamMailboxChildrenAlphabetically`: recursively walks the team mailbox subtree, applying system-first ordering at team root level and alphabetical ordering at all deeper levels.

- Extracted `_placeNodeInTree` and `_finalizeTrees` to eliminate the duplicated parent-resolution and post-build sort logic that existed across both build paths (`generateMailboxTreeInUI` / `generateMailboxTreeInUIAfterRefreshChanges`).

- Default and personal trees are unaffected.

## Resolved

<img width="167" height="290" alt="Screenshot 2026-05-27 at 18 08 35" src="https://github.com/user-attachments/assets/8d8cc852-90e5-4878-9a11-7de7ddae917d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mailbox tree rendering improved: team mailboxes show system folders first in a canonical order, then user folders alphabetically; default and personal trees remain alphabetized. Child folders inherit parent deactivation state when added.

* **Refactor**
  * Streamlined tree-building and centralized deterministic child ordering/finalization.
  * Consolidated system-folder display names and icons into lookup-driven helpers.

* **Tests**
  * Expanded tests covering team sorting, system-first behavior, edge cases, and nested alphabetical ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-flutter/pull/4562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->