### PR TITLE
TF-4479 Delete Trash subfolders when cleared

### DIFF
--- a/integration_test/mixin/scenario_utils_mixin.dart
+++ b/integration_test/mixin/scenario_utils_mixin.dart
@@ -15,6 +15,7 @@ import 'package:jmap_dart_client/jmap/jmap_request.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
 import 'package:jmap_dart_client/jmap/mail/email/set/set_email_method.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/set/set_mailbox_method.dart';
 import 'package:labels/extensions/list_label_extension.dart';
 import 'package:model/model.dart';
 import 'package:path_provider/path_provider.dart';
@@ -290,6 +291,42 @@ mixin ScenarioUtilsMixin {
     }
 
     IdentityInteractorsBindings().dispose();
+  }
+
+  Future<void> provisionTrashSubfolder(String subfolderName) async {
+    await waitForCondition(
+      () => _isMailboxReady(getBinding<MailboxDashBoardController>()),
+    );
+
+    final dashboardController = Get.find<MailboxDashBoardController>();
+    final session = dashboardController.sessionCurrent;
+    final accountId = dashboardController.accountId.value;
+    final trashMailboxId =
+        dashboardController.mapDefaultMailboxIdByRole[PresentationMailbox.roleTrash];
+
+    if (session == null || accountId == null || trashMailboxId == null) return;
+
+    final requestBuilder = JmapRequestBuilder(
+      Get.find<HttpClient>(),
+      ProcessingInvocation(),
+    );
+
+    final setMailboxMethod = SetMailboxMethod(accountId)
+      ..addCreate(
+        Id(const Uuid().v1()),
+        Mailbox(
+          name: MailboxName(subfolderName),
+          parentId: trashMailboxId,
+        ),
+      );
+
+    requestBuilder.invocation(setMailboxMethod);
+
+    await (requestBuilder
+          ..usings(setMailboxMethod.requiredCapabilities
+              .toCapabilitiesSupportTeamMailboxes(session, accountId)))
+        .build()
+        .execute();
   }
 
   void hideKeyboard() {

--- a/integration_test/robots/abstract/abstract_mailbox_menu_robot.dart
+++ b/integration_test/robots/abstract/abstract_mailbox_menu_robot.dart
@@ -2,4 +2,8 @@ abstract class AbstractMailboxMenuRobot {
   Future<void> openFolderByName(String name);
   Future<void> pullToRefresh();
   Future<void> openSetting();
+  Future<void> expectSubfolderNotExist(String subfolderName);
+  Future<void> tapEmptyTrashInContextMenu();
+  Future<void> confirmEmptyTrashInContextMenu();
+  Future<void> openTrashContextMenu(String trashFolderName);
 }

--- a/integration_test/robots/abstract/abstract_thread_robot.dart
+++ b/integration_test/robots/abstract/abstract_thread_robot.dart
@@ -4,4 +4,9 @@ abstract class AbstractThreadRobot {
   Future<void> openAppGrid();
   Future<void> openMailbox();
   Future<void> openEmailWithSubject(String subject);
+  Future<void> expectTrashBannerVisible();
+  Future<void> expectTrashBannerInvisible();
+  Future<void> expectEmptyTrashThreadView();
+  Future<void> confirmEmptyTrashViaBanner();
+  Future<void> tapEmptyTrashBanner();
 }

--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -18,6 +18,7 @@ import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import '../base/core_robot.dart';
 import '../exceptions/mailbox/null_inbox_unread_count_exception.dart';
 import '../exceptions/mailbox/null_quota_exception.dart';
+import '../utils/wait_for_condition.dart';
 import 'abstract/abstract_mailbox_menu_robot.dart';
 
 class MailboxMenuRobot extends CoreRobot implements AbstractMailboxMenuRobot {
@@ -193,5 +194,29 @@ class MailboxMenuRobot extends CoreRobot implements AbstractMailboxMenuRobot {
   @override
   Future<void> pullToRefresh() async {
     await $.platformAutomator.mobile.pullToRefresh();
+  }
+
+  @override
+  Future<void> expectSubfolderNotExist(String subfolderName) async {
+    await waitForCondition(
+      () => !$(
+        MailboxItemWidget,
+      ).$(LabelMailboxItemWidget).containing($(subfolderName)).exists,
+    );
+  }
+
+  @override
+  Future<void> tapEmptyTrashInContextMenu() async {
+    await $(AppLocalizations().emptyTrash).tap();
+  }
+
+  @override
+  Future<void> confirmEmptyTrashInContextMenu() async {
+    await $(AppLocalizations().delete).tap();
+  }
+
+  @override
+  Future<void> openTrashContextMenu(String trashFolderName) async {
+    await $(trashFolderName).longPress();
   }
 }

--- a/integration_test/robots/mobile/mobile_thread_robot.dart
+++ b/integration_test/robots/mobile/mobile_thread_robot.dart
@@ -1,7 +1,12 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
+import 'package:tmail_ui_user/features/base/widget/clean_messages_banner.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
+import '../../utils/wait_for_condition.dart';
 import '../abstract/abstract_thread_robot.dart';
 import '../thread_robot.dart';
 
@@ -17,5 +22,26 @@ class MobileThreadRobot extends ThreadRobot implements AbstractThreadRobot {
   @override
   Future<void> openAppGrid() async {
     await $(const ValueKey(UiKeys.toggleAppGridButton)).tap();
+  }
+
+  // AbstractTrashRobot
+
+  @override
+  Future<void> confirmEmptyTrashViaBanner() => confirmEmptyTrash();
+
+  @override
+  Future<void> expectEmptyTrashThreadView() async {
+    await $(const Key(UiKeys.emptyThreadView)).waitUntilVisible();
+  }
+
+  @override
+  Future<void> expectTrashBannerVisible() async {
+    await $(find.textContaining(AppLocalizations().empty_trash_now)).waitUntilVisible();
+  }
+
+  @override
+  Future<void> expectTrashBannerInvisible() async {
+    await $(const Key(UiKeys.cleanMessageBannerNotVisible)).waitUntilExists();
+    await waitForCondition(() => !$(CleanMessagesBanner).visible);
   }
 }

--- a/integration_test/robots/web/web_mailbox_menu_robot.dart
+++ b/integration_test/robots/web/web_mailbox_menu_robot.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/widgets/mailbox_item_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/profile_setting/profile_setting_action_type.dart';
 
 import '../mobile/mobile_mailbox_menu_robot.dart';
@@ -11,5 +14,23 @@ class WebMailboxMenuRobot extends MobileMailboxMenuRobot {
   Future<void> openSetting() async {
     await $(const ValueKey(UiKeys.userAvatar)).tap();
     await $(ValueKey(ProfileSettingActionType.manageAccount.name)).tap();
+  }
+
+  @override
+  Future<void> openTrashContextMenu(String trashFolderName) async {
+    final trashItemFinder = $(MailboxItemWidget).which<MailboxItemWidget>(
+      (w) => w.mailboxNode.item.name?.name.toLowerCase() ==
+          trashFolderName.toLowerCase(),
+    );
+    await trashItemFinder.waitUntilExists();
+
+    final gesture = await $.tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo($.tester.getCenter(trashItemFinder));
+    await $.pump();
+
+    await $(const ValueKey(UiKeys.mailboxMoreActionButton)).tap();
+    await $.pumpAndTrySettle();
   }
 }

--- a/integration_test/robots/web/web_thread_robot.dart
+++ b/integration_test/robots/web/web_thread_robot.dart
@@ -1,8 +1,12 @@
-import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:labels/extensions/label_extension.dart';
 import 'package:patrol/patrol.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_web_builder.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../mobile/mobile_thread_robot.dart';
 
@@ -41,5 +45,31 @@ class WebThreadRobot extends MobileThreadRobot {
     await $.waitUntilVisible(emailFinder);
     await emailFinder.tap();
     await $.pump(_emailOpenPumpDuration);
+  }
+
+  @override
+  Future<void> openMailbox() async {}
+
+    /// Runs the onTap handler for the [TextSpan] which matches the search-string.
+  void fireOnTap(Finder finder, String text) {
+    final Element element = finder.evaluate().single;
+    final RenderParagraph paragraph = element.renderObject as RenderParagraph;
+    // The children are the individual TextSpans which have GestureRecognizers
+    paragraph.text.visitChildren((dynamic span) {
+      if (span.text != text) return true; // continue iterating.
+
+      (span.recognizer as TapGestureRecognizer).onTap?.call();
+      return false; // stop iterating, we found the one.
+    });
+  }
+
+  @override
+  Future<void> tapEmptyTrashBanner() async {
+    final textContainEmptyTrash = find.textContaining(AppLocalizations().empty_trash_now);
+    await $.waitUntilVisible($(textContainEmptyTrash));
+    fireOnTap(
+      $(textContainEmptyTrash),
+      AppLocalizations().empty_trash_now,
+    );
   }
 }

--- a/integration_test/scenarios/mailbox/clear_trash_subfolders_via_banner_scenario.dart
+++ b/integration_test/scenarios/mailbox/clear_trash_subfolders_via_banner_scenario.dart
@@ -1,0 +1,51 @@
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+
+class ClearTrashSubfoldersViaBannerScenario extends BaseTestScenario {
+  const ClearTrashSubfoldersViaBannerScenario(super.$, super.robots);
+
+  static const _subfolderName = 'Trash subfolder banner test';
+
+  @override
+  Future<void> runTestLogic() async {
+    const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const subject = 'Empty trash';
+    final appLocalizations = AppLocalizations();
+    final mailboxMenuRobot = robots.mailboxMenuRobot();
+    final threadRobot = robots.threadRobot();
+
+    await provisionTrashSubfolder(_subfolderName);
+
+    await provisionEmail(
+      [
+        ProvisioningEmail(
+          toEmail: emailUser,
+          subject: subject,
+          content: subject,
+        ),
+      ],
+      folderLocationRole: PresentationMailbox.roleTrash,
+    );
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openFolderByName(
+      appLocalizations.trashMailboxDisplayName,
+    );
+    await threadRobot.expectTrashBannerVisible();
+
+    await threadRobot.tapEmptyTrashBanner();
+    await threadRobot.confirmEmptyTrashViaBanner();
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.expectSubfolderNotExist(_subfolderName);
+
+    await mailboxMenuRobot.openFolderByName(
+      appLocalizations.trashMailboxDisplayName,
+    );
+    await threadRobot.expectEmptyTrashThreadView();
+    await threadRobot.expectTrashBannerInvisible();
+  }
+}

--- a/integration_test/scenarios/mailbox/clear_trash_subfolders_via_context_menu_scenario.dart
+++ b/integration_test/scenarios/mailbox/clear_trash_subfolders_via_context_menu_scenario.dart
@@ -1,0 +1,54 @@
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+
+class ClearTrashSubfoldersViaContextMenuScenario extends BaseTestScenario {
+  const ClearTrashSubfoldersViaContextMenuScenario(super.$, super.robots);
+
+  static const _subfolderName = 'Trash subfolder context menu test';
+
+  @override
+  Future<void> runTestLogic() async {
+    const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const subject = 'Empty trash';
+    final appLocalizations = AppLocalizations();
+    final mailboxMenuRobot = robots.mailboxMenuRobot();
+    final threadRobot = robots.threadRobot();
+
+    await provisionTrashSubfolder(_subfolderName);
+
+    await provisionEmail(
+      [
+        ProvisioningEmail(
+          toEmail: emailUser,
+          subject: subject,
+          content: subject,
+        ),
+      ],
+      folderLocationRole: PresentationMailbox.roleTrash,
+    );
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openFolderByName(
+      appLocalizations.trashMailboxDisplayName,
+    );
+    await threadRobot.expectTrashBannerVisible();
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.openTrashContextMenu(
+      appLocalizations.trashMailboxDisplayName,
+    );
+    await mailboxMenuRobot.tapEmptyTrashInContextMenu();
+    await mailboxMenuRobot.confirmEmptyTrashInContextMenu();
+
+    await mailboxMenuRobot.expectSubfolderNotExist(_subfolderName);
+
+    await mailboxMenuRobot.openFolderByName(
+      appLocalizations.trashMailboxDisplayName,
+    );
+    await threadRobot.expectEmptyTrashThreadView();
+    await threadRobot.expectTrashBannerInvisible();
+  }
+}

--- a/integration_test/tests/mailbox/clear_trash_subfolders_via_banner_test.dart
+++ b/integration_test/tests/mailbox/clear_trash_subfolders_via_banner_test.dart
@@ -1,0 +1,11 @@
+import '../../base/test_base.dart';
+import '../../models/test_tags.dart';
+import '../../scenarios/mailbox/clear_trash_subfolders_via_banner_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should delete trash subfolders when emptying trash via banner',
+    tags: [TestTags.android, TestTags.ios, TestTags.web],
+    scenarioBuilder: ($, robots) => ClearTrashSubfoldersViaBannerScenario($, robots),
+  );
+}

--- a/integration_test/tests/mailbox/clear_trash_subfolders_via_context_menu_test.dart
+++ b/integration_test/tests/mailbox/clear_trash_subfolders_via_context_menu_test.dart
@@ -1,0 +1,11 @@
+import '../../base/test_base.dart';
+import '../../models/test_tags.dart';
+import '../../scenarios/mailbox/clear_trash_subfolders_via_context_menu_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should delete trash subfolders when emptying trash via context menu',
+    tags: [TestTags.android, TestTags.ios, TestTags.web],
+    scenarioBuilder: ($, robots) => ClearTrashSubfoldersViaContextMenuScenario($, robots),
+  );
+}

--- a/lib/features/base/model/ui_keys.dart
+++ b/lib/features/base/model/ui_keys.dart
@@ -20,4 +20,8 @@ class UiKeys {
   static const String addActionButton = 'addActionButton';
   static const String mobileMailboxMenuButton = 'mobileMailboxMenuButton';
   static const String userAvatar = 'userAvatar';
+
+  static const String mailboxMoreActionButton = 'mailbox_more_action_button';
+  static const String emptyThreadView = 'empty_thread_view';
+  static const String cleanMessageBannerNotVisible = 'clean_message_banner_not_visible';
 }

--- a/lib/features/mailbox/presentation/providers/delete_trash_subfolders_provider.dart
+++ b/lib/features/mailbox/presentation/providers/delete_trash_subfolders_provider.dart
@@ -1,0 +1,66 @@
+import 'package:core/utils/app_logger.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:get/get.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/state/delete_multiple_mailbox_state.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/usecases/delete_multiple_mailbox_interactor.dart';
+
+enum DeleteTrashSubfoldersStatus { idle, loading, success, partialSuccess, failed }
+
+class DeleteTrashSubfoldersNotifier extends StateNotifier<DeleteTrashSubfoldersStatus> {
+  final DeleteMultipleMailboxInteractor _interactor;
+
+  DeleteTrashSubfoldersNotifier(this._interactor) : super(DeleteTrashSubfoldersStatus.idle);
+
+  bool get isLoading => state == DeleteTrashSubfoldersStatus.loading;
+
+  Future<void> execute(
+    MailboxId trashMailboxId,
+    Map<MailboxId, PresentationMailbox> mailboxMap,
+    Session session,
+    AccountId accountId,
+  ) async {
+    if (isLoading) return;
+
+    final childIds = mailboxMap.values
+        .where((m) => m.parentId == trashMailboxId)
+        .map((m) => m.id)
+        .toList();
+
+    if (childIds.isEmpty) {
+      state = DeleteTrashSubfoldersStatus.idle;
+      return;
+    }
+
+    state = DeleteTrashSubfoldersStatus.loading;
+
+    try {
+      final result = await _interactor
+          .execute(session, accountId, childIds)
+          .last;
+
+      state = result.fold(
+        (_) => DeleteTrashSubfoldersStatus.failed,
+        (success) {
+          if (success is DeleteMultipleMailboxAllSuccess) {
+            return DeleteTrashSubfoldersStatus.success;
+          } else if (success is DeleteMultipleMailboxHasSomeSuccess) {
+            return DeleteTrashSubfoldersStatus.partialSuccess;
+          }
+          return DeleteTrashSubfoldersStatus.failed;
+        },
+      );
+    } catch (e) {
+      logError('DeleteTrashSubfoldersNotifier::execute: $e');
+      state = DeleteTrashSubfoldersStatus.failed;
+    }
+  }
+}
+
+final deleteTrashSubfoldersProvider =
+    StateNotifierProvider<DeleteTrashSubfoldersNotifier, DeleteTrashSubfoldersStatus>(
+  (ref) => DeleteTrashSubfoldersNotifier(Get.find<DeleteMultipleMailboxInteractor>()),
+);

--- a/lib/features/mailbox/presentation/widgets/label_mailbox_item_widget.dart
+++ b/lib/features/mailbox/presentation/widgets/label_mailbox_item_widget.dart
@@ -15,6 +15,7 @@ import 'package:tmail_ui_user/features/mailbox/presentation/styles/trailing_mail
 import 'package:tmail_ui_user/features/mailbox/presentation/utils/mailbox_method_action_define.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/empty_mailbox_popup_dialog_widget.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/mailbox_expand_button.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/trailing_mailbox_item_widget.dart';
 
 class LabelMailboxItemWidget extends StatefulWidget {
@@ -140,6 +141,7 @@ class _LabelMailboxItemWidgetState extends State<LabelMailboxItemWidget> {
           Offstage(
             offstage: !_shouldShowMorePopupMenu,
             child: TMailButtonWidget.fromIcon(
+              key: const ValueKey(UiKeys.mailboxMoreActionButton),
               margin: _responsiveUtils.isDesktop(context) &&
                       widget.mailboxNode.item.allowedHasEmptyAction
                   ? EdgeInsets.zero

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -108,6 +108,8 @@ import 'package:tmail_ui_user/features/mailbox/domain/usecases/mark_as_mailbox_r
 import 'package:tmail_ui_user/features/mailbox/presentation/action/mailbox_ui_action.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_actions.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/providers/delete_trash_subfolders_provider.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/exceptions/spam_report_exception.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/linagora_ecosystem/linagora_ecosystem.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/model/spam_report_state.dart';
@@ -443,6 +445,10 @@ class MailboxDashBoardController extends ReloadableController
     _handleArguments();
     _loadAppGrid();
     loadAIScribeConfig();
+    appProviderContainer.listen<DeleteTrashSubfoldersStatus>(
+      deleteTrashSubfoldersProvider,
+      (_, next) => _onDeleteTrashSubfoldersStateChanged(next),
+    );
     super.onReady();
   }
 
@@ -1879,6 +1885,8 @@ class MailboxDashBoardController extends ReloadableController
     Function? onCancelSelectionEmail,
     PresentationMailbox? trashMailbox,
   }) {
+    if (appProviderContainer.read(deleteTrashSubfoldersProvider) == DeleteTrashSubfoldersStatus.loading) return;
+
     onCancelSelectionEmail?.call();
 
     final trashFolder = trashMailbox
@@ -1931,6 +1939,52 @@ class MailboxDashBoardController extends ReloadableController
     );
 
     toastManager.showMessageSuccess(success);
+
+    triggerTrashSubfolderDeletion(success.mailboxId);
+  }
+
+  void triggerTrashSubfolderDeletion(MailboxId? trashId) {
+    final session = sessionCurrent;
+    final account = accountId.value;
+    if (trashId == null || session == null || account == null) return;
+    appProviderContainer
+        .read(deleteTrashSubfoldersProvider.notifier)
+        .execute(trashId, Map.unmodifiable(mapMailboxById), session, account);
+  }
+
+  void _onDeleteTrashSubfoldersStateChanged(DeleteTrashSubfoldersStatus status) {
+    switch (status) {
+      case DeleteTrashSubfoldersStatus.idle:
+      case DeleteTrashSubfoldersStatus.loading:
+        return;
+      case DeleteTrashSubfoldersStatus.success:
+      case DeleteTrashSubfoldersStatus.partialSuccess:
+        _showDeleteTrashSubfoldersToast(status);
+        _refreshMailboxTreeAfterSubfolderDeletion();
+      case DeleteTrashSubfoldersStatus.failed:
+        _showDeleteTrashSubfoldersToast(status);
+    }
+  }
+
+  void _showDeleteTrashSubfoldersToast(DeleteTrashSubfoldersStatus status) {
+    if (currentContext == null || currentOverlayContext == null) return;
+    final l10n = AppLocalizations.of(currentContext!);
+    switch (status) {
+      case DeleteTrashSubfoldersStatus.success:
+        appToast.showToastSuccessMessage(currentOverlayContext!, l10n.clearTrashSubfoldersSuccess);
+      case DeleteTrashSubfoldersStatus.partialSuccess:
+        appToast.showToastMessage(currentOverlayContext!, l10n.clearTrashSubfoldersPartialSuccess);
+      case DeleteTrashSubfoldersStatus.failed:
+        appToast.showToastErrorMessage(currentOverlayContext!, l10n.clearTrashSubfoldersFailed);
+      default:
+        return;
+    }
+  }
+
+  void _refreshMailboxTreeAfterSubfolderDeletion() {
+    dispatchMailboxUIAction(RefreshChangeMailboxAction(
+      newState: jmap.State('trash-subfolder-refresh-${DateTime.now().millisecondsSinceEpoch}'),
+    ));
   }
 
   void _deleteMultipleEmailsPermanently(List<PresentationEmail> listEmails, {Function? onCancelSelectionEmail}) {

--- a/lib/features/mailbox_dashboard/presentation/extensions/handle_clear_mailbox_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/handle_clear_mailbox_extension.dart
@@ -4,6 +4,7 @@ import 'package:dartz/dartz.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/state/clear_mailbox_state.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 
@@ -32,6 +33,10 @@ extension HandleClearMailboxExtension on MailboxDashBoardController {
 
     if (selectedMailbox.value?.id == success.mailboxId) {
       emailsInCurrentMailbox.clear();
+    }
+
+    if (success.mailboxRole == PresentationMailbox.roleTrash) {
+      triggerTrashSubfolderDeletion(success.mailboxId);
     }
   }
 

--- a/lib/features/thread/presentation/thread_view.dart
+++ b/lib/features/thread/presentation/thread_view.dart
@@ -253,7 +253,7 @@ class ThreadView extends GetWidget<ThreadController>
                         );
                       } else {
                         return const SizedBox.shrink(
-                          key: Key('clean_message_banner_not_visible'),
+                          key: Key(UiKeys.cleanMessageBannerNotVisible),
                         );
                       }
                     }),
@@ -799,7 +799,7 @@ class ThreadView extends GetWidget<ThreadController>
             deepRefreshText: AppLocalizations.of(context).deepRefresh,
             pullHarderForText: AppLocalizations.of(context).pullHarderFor,
             child: EmptyEmailsWidget(
-              key: const Key('empty_thread_view'),
+              key: const Key(UiKeys.emptyThreadView),
               isNetworkConnectionAvailable: controller.networkConnectionController.isNetworkConnectionAvailable(),
               isSearchActive: controller.isSearchActive,
               isFilterMessageActive: controller.mailboxDashBoardController.filterMessageOption.value != FilterMessageOption.all,

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -1135,6 +1135,15 @@ class AppLocalizations {
         name: 'toast_message_empty_trash_folder_success');
   }
 
+  String get clearTrashSubfoldersSuccess =>
+      Intl.message('Trash subfolders deleted', name: 'clearTrashSubfoldersSuccess');
+
+  String get clearTrashSubfoldersPartialSuccess =>
+      Intl.message('Some subfolders in Trash could not be deleted', name: 'clearTrashSubfoldersPartialSuccess');
+
+  String get clearTrashSubfoldersFailed =>
+      Intl.message('Failed to delete subfolders in Trash', name: 'clearTrashSubfoldersFailed');
+
   String get version {
     return Intl.message(
         'Version',


### PR DESCRIPTION
## Issue
- #4479 

## Test results
### Web
```console
✅ Should delete trash subfolders when emptying trash via banner (/tests/mailbox/clear_trash_subfolders_via_banner_test.dart) (8s)
✅ Should delete trash subfolders when emptying trash via context menu (/tests/mailbox/clear_trash_subfolders_via_context_menu_test.dart) (8s)

Test summary:
📝 Total: 2
✅ Successful: 2
❌ Failed: 0
⏩ Skipped: 0
📊 Report: .../tmail-worktree/playwright-report
⏱️  Duration: 36s
```
### Mobile
```console
✅ Should delete trash subfolders when emptying trash via banner (/tests/mailbox/clear_trash_subfolders_via_banner_test.dart) (9s)
✅ Should delete trash subfolders when emptying trash via context menu (/tests/mailbox/clear_trash_subfolders_via_context_menu_test.dart) (10s)

Test summary:
📝 Total: 2
✅ Successful: 2
❌ Failed: 0
⏩ Skipped: 0
📊 Report: .../tmail-worktree/build/app/reports/androidTests/connected/debug/index.html
⏱️  Duration: 37s
```

## Resolved
### Web

https://github.com/user-attachments/assets/84224844-c7e2-4646-b142-a86034a5e896

### Mobile

[empty-trash-mobile.webm](https://github.com/user-attachments/assets/dc589d41-575c-4f77-9ae5-f0202ba02b2f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clear trash subfolders via an "Empty trash" banner or the trash folder context menu.
  * Trash subfolders are automatically cleared when emptying the main trash folder.
  * Outcome notifications for trash subfolder deletion (success, partial success, failure).

* **UI & Localization**
  * Added UI keys for mailbox actions and empty-thread views.
  * Added localized messages for trash-subfolder deletion outcomes.

* **Tests**
  * New integration tests covering banner and context-menu clear flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-flutter/pull/4563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->