### PR TITLE
ADR-0092 Upgrade flutter_riverpod to 3.x

### DIFF
--- a/docs/adr/0092-upgrade-flutter-riverpod-3.md
+++ b/docs/adr/0092-upgrade-flutter-riverpod-3.md
@@ -4,80 +4,68 @@ Date: 2026-05-28
 
 ## Status
 
-Proposed
+Accepted
 
 ## Related ADRs
 
-- [ADR-0085](./0085-riverpod-state-management-for-local-settings.md) — introduced `localSettingsNotifierProvider`
+- [ADR-0085](./0085-riverpod-state-management-for-local-settings.md) — introduced `localSettingsProvider`
 - [ADR-0086](./0086-android-composer-draft-loss-on-background.md) — introduced `ComposerAutoSaveNotifier`
 
 ## Context
 
 The project uses `flutter_riverpod: ^2.6.1`. Riverpod 3.0 was already stable (released Sep 2025) when `^2.6.1` was introduced in April 2026 — the choice was deliberate, for three reasons:
 
-1. **No UI involvement.** Both pilot features (ADR-0085, ADR-0086) use Riverpod purely for state sharing between GetX controllers via `appProviderContainer.read()/.listen()`. No `ConsumerWidget` or widget-level `ref.watch` was needed. This kept logic changes minimal and avoided restructuring the widget layer alongside the controller layer.
+1. **No UI involvement.** Both pilot features (ADR-0085, ADR-0086) use Riverpod purely for state sharing between GetX controllers via `appProviderContainer.read()/.listen()`. No `ConsumerWidget` or widget-level `ref.watch` was needed.
 
-2. **Narrow pilot scope.** ADR-0085's goal was to validate one question: *does GetX + Riverpod coexistence work?* Using the established `StateNotifier` API (well-documented, familiar) kept the pilot's variable count to one. Starting with Riverpod 3.0's `Notifier` API — different lifecycle semantics, `build()` method, `ref` inside the notifier — would have introduced a second unknown simultaneously.
+2. **Narrow pilot scope.** ADR-0085's goal was to validate one question: *does GetX + Riverpod coexistence work?* Using the established `StateNotifier` API kept the pilot's variable count to one.
 
-3. **Ecosystem dependency conflicts.** Riverpod 3.0 brings pressure to adopt its tooling (`riverpod_lint`, `riverpod_generator`). Both conflict with this project's `analyzer: ">=12.0.0 <13.0.0"` pin (required by `dart_style` and `json_serializable`). Staying on 2.6.1 avoided forcing a resolution of those conflicts before the pattern was proven.
+3. **Ecosystem dependency conflicts.** Riverpod 3.0 brings pressure to adopt its tooling (`riverpod_lint`, `riverpod_generator`). Both conflict with this project's `analyzer: ">=12.0.0 <13.0.0"` pin. Staying on 2.6.1 avoided forcing a resolution before the pattern was proven.
 
 ### Breaking changes in 3.x that affect this codebase
 
 **1. `StateNotifier` / `StateNotifierProvider` moved to `legacy.dart`**
 
-No longer exported from `flutter_riverpod/flutter_riverpod.dart`. Two files extend `StateNotifier` and declare `StateNotifierProvider`; both become compile errors without migration.
+No longer exported from `flutter_riverpod/flutter_riverpod.dart`. Two files extend `StateNotifier`; both become compile errors without migration.
 
 **2. `ref.read` inside `Provider` bodies is a lint error**
 
-Riverpod 3.0 enforces `ref.watch` for dependency tracking inside provider factory bodies. `composer_cache_providers.dart` has 6 such call sites.
-
-### Breaking changes in 3.x that do NOT affect this codebase
-
-| Change | Why no impact |
-|---|---|
-| Automatic retry on async providers | No `FutureProvider` or `StreamProvider` in use |
-| Provider pausing when widget goes off-screen | No `ConsumerWidget`; all access is imperative via `appProviderContainer` |
-| `ProviderObserver` interface updated | No `ProviderObserver` registered |
-| `AutoDispose` type aliases removed | Not used; providers are non-autoDispose or manually invalidated |
-| `AsyncValue.value` returns null on error | No `AsyncValue` consumed in current Riverpod code |
-| `ProviderException` wraps rethrown errors | No try-catch on provider reads |
+Riverpod 3.0 enforces `ref.watch` for dependency tracking inside provider factory bodies.
 
 ### Anti-patterns identified in current usage
 
 **A. Global `ProviderContainer` without `UncontrolledProviderScope`**
 
-`appProviderContainer = ProviderContainer()` is a global singleton with no connection to the Flutter widget tree. The official Riverpod documentation states:
-
-> "If you are using Flutter, you do not need to care about ProviderContainer outside of testing, as it is implicitly created for you by ProviderScope."
-
-This was acknowledged in ADR-0085 as a known limitation. The correct long-term fix is to eliminate `appProviderContainer` entirely and use plain `ProviderScope` at the root. However, this cannot be done in a single step — see *"Why not ProviderScope directly"* below.
+`appProviderContainer = ProviderContainer()` is a global singleton with no connection to the Flutter widget tree. The correct fix is to eliminate it entirely and use plain `ProviderScope`. This cannot be done in one step — see *"Why not ProviderScope directly"* below.
 
 **B. `ref.read()` inside `Provider()` factory bodies**
 
-6 call sites in `composer_cache_providers.dart` use `ref.read()` to resolve dependencies inside `Provider(...)` factory bodies. In Riverpod 3.x this is a lint error: `Provider` factories should use `ref.watch()` to correctly track dependency rebuilds.
-
-### Why not `@riverpod` codegen
-
-`riverpod_generator` requires `analyzer <10.0.0`. This project pins `analyzer: ">=12.0.0 <13.0.0"` via `dependency_overrides` for `dart_style` and `json_serializable`. No version overlap exists — codegen remains blocked until upstream resolves the constraint.
+6 call sites in `composer_cache_providers.dart` used `ref.read()` to resolve dependencies inside `Provider(...)` factory bodies.
 
 ## Decision
 
-Upgrade to `flutter_riverpod: ^3.0.0`. This constraint resolves to the latest 3.x stable (currently **3.3.1**) and tracks all future 3.x patch and minor releases automatically. No new packages are added.
+Upgrade to `flutter_riverpod: ^3.3.1` and adopt `@riverpod` codegen across the entire composer cache provider chain.
 
 ### Dependency changes
 
-| Package | Current | Target | Notes |
-|---|---|---|---|
-| `flutter_riverpod` | `^2.6.1` | `^3.0.0` | Resolves to 3.3.1 (latest 3.x) |
-| `riverpod` | transitive | transitive | Resolved automatically |
-| `riverpod_lint` | — | — | Not used; can be enabled in a follow-up ADR once tooling conflict resolves |
-| `riverpod_generator` | — | — | Blocked by `analyzer` constraint — see above |
+| Package | Previous | Resolved | Type | Notes |
+|---|---|---|---|---|
+| `flutter_riverpod` | `^2.6.1` | `3.3.1` | direct | Tracks all future 3.x patch/minor |
+| `riverpod` | transitive | `3.3.1` | transitive | Resolved automatically |
+| `riverpod_annotation` | — | `4.0.2` | direct (runtime) | Annotation types only |
+| `riverpod_generator` | — | `4.0.4-dev.3` | dev | Build-time only; prerelease with `analyzer ^12.0.0` support |
+| `freezed_annotation` | transitive `^2.4.4` | `3.1.0` | override | `riverpod_generator` requires `^3.0.0`; `super_dns_client` pins `^2.4.4`; annotation-only so overriding is safe |
 
-### Changes required
+### `keepAlive: true` rule
 
-#### 1. `main.dart` — add `UncontrolledProviderScope`
+Riverpod 3.x defaults to `autoDispose: true` — providers are disposed when they have no active listeners. All providers in this codebase use `@Riverpod(keepAlive: true)` because every access is imperative (`appProviderContainer.read()/.listen()`) from GetX controllers with no persistent `ref.watch()` listener. Without `keepAlive`, a `.read()` call with no watcher causes the provider to be disposed immediately, destroying state and recreating instances on every call.
 
-Addresses anti-pattern A. Wraps `GetMaterialApp` so the widget tree has access to `appProviderContainer`. GetX controllers continue to use `appProviderContainer.read()/.listen()` unchanged; this addition enables future `ConsumerWidget` migration without a separate architectural step.
+This rule applies until the corresponding GetX controller is migrated to `ConsumerWidget`. Once a provider has a persistent `ref.watch()` from the widget tree, `keepAlive` can be dropped on a case-by-case basis.
+
+## Changes made in this ADR
+
+### 1. `main.dart` — add `UncontrolledProviderScope`
+
+Wraps `GetMaterialApp` so the widget tree shares `appProviderContainer`. GetX controllers continue to use `appProviderContainer.read()/.listen()` unchanged; this enables future `ConsumerWidget` migration without a separate architectural step.
 
 ```dart
 // Before
@@ -92,53 +80,42 @@ return UncontrolledProviderScope(
 
 **Why `UncontrolledProviderScope` and not plain `ProviderScope`?**
 
-`ProviderScope` creates its own internal `ProviderContainer` that is inaccessible outside the widget tree. The six existing `appProviderContainer` call sites are all **GetX controllers/services** — they have no `BuildContext` or `WidgetRef` and cannot use the widget-tree API:
+`ProviderScope` creates its own internal `ProviderContainer` that is inaccessible outside the widget tree. The six existing `appProviderContainer` call sites are all GetX controllers/services with no `BuildContext` or `WidgetRef`. Using plain `ProviderScope` would create **two isolated containers** — one for the widget tree (unused) and `appProviderContainer` still required by all six controllers. Both would hold separate instances of the same providers with no shared state.
 
-| File | Operation |
-|---|---|
-| `LocalSettingsService` | `.read(localSettingsNotifierProvider.notifier).update()` |
-| `PreferencesController` | `.read(localSettingsNotifierProvider.notifier).update()` |
-| `ThreadController` | `.read(localSettingsNotifierProvider)` + `.listen(...)` |
-| `SearchEmailController` | `.read(localSettingsNotifierProvider)` |
-| `HandleMobileAutoSaveExtension` | `.read(composerAutoSaveProvider)` + `.invalidate(...)` |
-| `HandleComposerRestoreOnMobileExtension` | `.read(resolveComposerCacheForRestoreProvider)` |
+`UncontrolledProviderScope(container: appProviderContainer)` exposes the **same container** to both the widget tree and the imperative GetX layer, enabling incremental `ConsumerWidget` migration.
 
-If we used plain `ProviderScope`, the result would be **two isolated containers** — one for the widget tree (unused, no `ConsumerWidget` yet) and `appProviderContainer` still required by all six controllers. Both containers would hold separate instances of the same providers with no shared state, which is strictly worse than the current situation.
-
-`UncontrolledProviderScope(container: appProviderContainer)` exposes the **same container** to both the widget tree and the imperative GetX layer — enabling `ConsumerWidget` migration incrementally without a big-bang refactor.
-
-**Eliminating `appProviderContainer` entirely** requires converting each of the six access points from GetX to Riverpod-native code. That is the scope of the GetX → Riverpod migration roadmap (ADR-0077), not this ADR.
-
-**Rule introduced by this ADR: `appProviderContainer` is frozen.** No new `appProviderContainer.read()` / `.listen()` / `.invalidate()` calls may be added. New features that need Riverpod state must use `ConsumerWidget` + `ref.watch/read`. Each ADR-0075 controller migration eliminates one existing call. When all six are gone, `UncontrolledProviderScope` is replaced by plain `ProviderScope` and `appProviderContainer` is deleted.
-
-#### 2. `LocalSettingsNotifier` — `StateNotifier` → `Notifier`
-
-`StateNotifierProvider` → `NotifierProvider`. The `build()` method replaces `super(initialState)`. All call sites (`ref.read`, `.listen`, `.notifier`) are unchanged.
+### 2. `LocalSettingsNotifier` — `StateNotifier` → `@riverpod Notifier`
 
 ```dart
 // Before
 class LocalSettingsNotifier extends StateNotifier<PreferencesSetting> {
   LocalSettingsNotifier() : super(PreferencesSetting.initial());
+  void update(PreferencesSetting settings) => state = settings;
 }
-final localSettingsNotifierProvider =
+final localSettingsProvider =
     StateNotifierProvider<LocalSettingsNotifier, PreferencesSetting>(
       (ref) => LocalSettingsNotifier());
 
-// After
-class LocalSettingsNotifier extends Notifier<PreferencesSetting> {
+// After — local_settings_notifier.dart
+part 'local_settings_notifier.g.dart';
+
+@Riverpod(keepAlive: true)
+class LocalSettingsNotifier extends _$LocalSettingsNotifier {
   @override
   PreferencesSetting build() => PreferencesSetting.initial();
+
+  void update(PreferencesSetting settings) => state = settings;
 }
-final localSettingsNotifierProvider =
-    NotifierProvider<LocalSettingsNotifier, PreferencesSetting>(
-      LocalSettingsNotifier.new);
+// localSettingsProvider generated by build_runner
 ```
 
-#### 3. `ComposerAutoSaveNotifier` — `StateNotifierProvider.family` → `NotifierProvider.family`
+Call sites (`LocalSettingsService`, `PreferencesController`, `ThreadController`, `SearchEmailController`) are unchanged — the generated provider name is identical.
 
-In Riverpod 3.0, `NotifierProvider.family` passes the family argument through the constructor; `build()` takes no parameters. `StateNotifier.mounted` does not exist on `Notifier` — replaced by a `_mounted` flag via `ref.onDispose`.
+### 3. `ComposerAutoSaveNotifier` — `StateNotifierProvider.family` → `@riverpod Notifier` family
 
-Interactors are resolved eagerly in `build()` and stored as `late final` fields. This preserves the existing safety guarantee — async methods (`restore`, `clearCache`) hold plain Dart object references that remain valid even if the provider is disposed mid-flight, avoiding the `StateError` that `ref.read()` inside async methods would throw post-disposal.
+With `@riverpod` codegen, the family argument becomes a parameter of `build()` directly. `StateNotifier.mounted` does not exist on `Notifier` — replaced by a `_mounted` flag via `ref.onDispose`.
+
+Interactors are resolved eagerly in `build()` via `ref.read()` and stored as `late final` fields. This preserves the safety guarantee — async methods hold plain Dart object references that remain valid even if the provider is disposed mid-flight.
 
 ```dart
 // Before
@@ -156,17 +133,17 @@ final composerAutoSaveProvider = StateNotifierProvider.family<
     ref.read(removeAllComposerCacheProvider),
   ));
 
-// After
-class ComposerAutoSaveNotifier extends Notifier<ComposerAutoSaveState> {
-  final String composerId;
+// After — composer_auto_save_notifier.dart
+part 'composer_auto_save_notifier.g.dart';
+
+@Riverpod(keepAlive: true)
+class ComposerAutoSaveNotifier extends _$ComposerAutoSaveNotifier {
+  bool _mounted = true;
   late final ResolveComposerCacheForRestoreInteractor _resolveInteractor;
   late final RemoveAllComposerCacheInteractor _removeInteractor;
-  bool _mounted = true;
-
-  ComposerAutoSaveNotifier(this.composerId);
 
   @override
-  ComposerAutoSaveState build() {
+  ComposerAutoSaveState build(String composerId) {
     _resolveInteractor = ref.read(resolveComposerCacheForRestoreProvider);
     _removeInteractor = ref.read(removeAllComposerCacheProvider);
     ref.onDispose(() => _mounted = false);
@@ -175,16 +152,30 @@ class ComposerAutoSaveNotifier extends Notifier<ComposerAutoSaveState> {
 
   bool get mounted => _mounted;
 }
-final composerAutoSaveProvider = NotifierProvider.family<
-    ComposerAutoSaveNotifier, ComposerAutoSaveState, String>(
-  (id) => ComposerAutoSaveNotifier(id));
+// composerAutoSaveProvider(String composerId) generated by build_runner — name unchanged
 ```
 
-#### 4. `composer_cache_providers.dart` — `ref.read` → `ref.watch` inside `Provider` bodies
+`ComposerAutoSaveNotifier` is a family provider: each `composerId` creates a separate instance. Instances must be explicitly cleaned up when the composer closes to prevent unbounded growth. Call sites in `handle_mobile_auto_save_extension.dart` require no change.
 
-Addresses anti-pattern B. All 6 `ref.read(...)` calls inside `Provider(...)` factory bodies become `ref.watch(...)`. These providers are non-autoDispose singletons; `watch` adds correct dependency tracking with no behavioral difference at runtime.
+### 4. `composer_cache_providers.dart` — deleted; providers moved inline with `@riverpod` codegen
 
-#### 5. Unit tests for `ComposerAutoSaveNotifier`
+The file contained 6 `Provider(ref => ...)` factories using `ref.read()`. Rather than patching `ref.read` → `ref.watch` in-place, each provider was relocated to the file that owns the class, adopting `@riverpod` codegen throughout.
+
+The full provider chain after migration:
+
+| File | Provider | Depends on |
+|---|---|---|
+| `composer_hive_cache_client.dart` | `composerHiveCacheClientProvider` | — |
+| `cache_exception_thrower.dart` | `cacheExceptionThrowerProvider` | — |
+| `composer_persistent_cache_datasource_impl.dart` | `composerCacheDatasourceProvider` | `composerHiveCacheClientProvider`, `cacheExceptionThrowerProvider` |
+| `composer_cache_repository_impl.dart` | `composerCacheRepositoryProvider` | `composerCacheDatasourceProvider` |
+| `resolve_composer_cache_for_restore_interactor.dart` | `resolveComposerCacheForRestoreProvider` | `composerCacheRepositoryProvider` |
+| `remove_all_composer_cache_interactor.dart` | `removeAllComposerCacheProvider` | `composerCacheRepositoryProvider` |
+| `mark_composer_cache_clean_close_interactor.dart` | `markComposerLocalCacheCleanCloseProvider` | `composerCacheRepositoryProvider` |
+
+All dependencies use `ref.watch()` — correct dependency tracking with no behavioral difference at runtime since all providers are `keepAlive` singletons.
+
+### 5. Unit tests for `ComposerAutoSaveNotifier`
 
 Interactors are no longer injected via constructor — they are resolved in `build()` through `ref`. Tests switch from direct instantiation to `ProviderContainer` with overrides.
 
@@ -200,15 +191,39 @@ container = ProviderContainer(overrides: [
 notifier = container.read(composerAutoSaveProvider('test-id').notifier);
 ```
 
+## What remains
+
+### Frozen rule: no new `appProviderContainer` call sites
+
+`appProviderContainer` is frozen. No new `.read()` / `.listen()` / `.invalidate()` calls may be added to it. New features that need Riverpod state must use `ConsumerWidget` + `ref.watch/read` against the widget tree scope.
+
+### Six existing call sites to migrate
+
+| File | Operation | Migration target |
+|---|---|---|
+| `LocalSettingsService` | `.read(localSettingsProvider.notifier).update()` | Inject via `ConsumerWidget` or `ref` in a Riverpod-native service |
+| `PreferencesController` | `.read(localSettingsProvider.notifier).update()` | Migrate controller to `Notifier` or `ConsumerWidget` |
+| `ThreadController` | `.read(localSettingsProvider)` + `.listen(...)` | Migrate to `ConsumerWidget` + `ref.watch` |
+| `SearchEmailController` | `.read(localSettingsProvider)` | Migrate to `ConsumerWidget` + `ref.watch` |
+| `HandleMobileAutoSaveExtension` | `.read(composerAutoSaveProvider(id).notifier)` + `.invalidate(...)` | Migrate composer to `ConsumerStatefulWidget` |
+| `HandleComposerRestoreOnMobileExtension` | `.read(resolveComposerCacheForRestoreProvider)` | Migrate to `ref.read` within a `ConsumerWidget` |
+
+Each migration will be covered by a dedicated ADR and eliminates one `appProviderContainer` call site. When all six are gone:
+
+1. Replace `UncontrolledProviderScope` with plain `ProviderScope` in `main.dart`
+2. Delete `appProviderContainer` from `app_provider_container.dart`
+3. Enable `riverpod_lint` (follow-up ADR)
+
 ## Consequences
 
 **Positive**
 - Eliminates all `StateNotifier` / `StateNotifierProvider` usage; no deprecated API warnings
-- `UncontrolledProviderScope` at the root enables future `ConsumerWidget` migration without a separate architectural step
-- `riverpod_lint` can be enabled at full strength in a follow-up once the `analyzer` constraint conflict is resolved upstream
-- No new runtime dependencies — a version bump and internal code changes only
-- Unblocks a future `@riverpod` codegen ADR once `riverpod_generator` supports `analyzer >=12.0.0`
+- `@riverpod` codegen adopted across the entire composer cache stack — provider boilerplate is generated, not hand-written
+- `UncontrolledProviderScope` at root enables future `ConsumerWidget` migration without a separate architectural step
+- Provider dependency chain uses `ref.watch()` — correct rebuild semantics
+- `riverpod_lint` can be enabled in a follow-up ADR once `appProviderContainer` is removed
 
 **Negative**
-- `ComposerAutoSaveNotifier` owns Android draft-loss prevention (ADR-0086) — manual testing on Android required after migration
-- `_mounted` via `ref.onDispose` fires when the provider element is torn down (on `invalidate`), not synchronously — verify stale-write guards in `handle_mobile_auto_save_extension.dart` still hold
+- All providers use `keepAlive: true` — they live for the entire app lifetime, no automatic cleanup. This is intentional and matches the current GetX singleton pattern, but becomes unnecessary once controllers are fully migrated to `ConsumerWidget`
+- `ComposerAutoSaveNotifier` (family) requires explicit `invalidate()` on composer close to prevent unbounded instance accumulation — missing invalidation is a silent memory leak
+- `ComposerAutoSaveNotifier` owns Android draft-loss prevention (ADR-0086) — manual testing on Android required after this migration

--- a/docs/adr/0092-upgrade-flutter-riverpod-3.md
+++ b/docs/adr/0092-upgrade-flutter-riverpod-3.md
@@ -13,17 +13,48 @@ Proposed
 
 ## Context
 
-The project uses `flutter_riverpod: ^2.6.1`. Riverpod 3.0 ships two categories of breaking changes that affect this codebase:
+The project uses `flutter_riverpod: ^2.6.1`. Riverpod 3.0 was already stable (released Sep 2025) when `^2.6.1` was introduced in April 2026 — the choice was deliberate, for three reasons:
+
+1. **No UI involvement.** Both pilot features (ADR-0085, ADR-0086) use Riverpod purely for state sharing between GetX controllers via `appProviderContainer.read()/.listen()`. No `ConsumerWidget` or widget-level `ref.watch` was needed. This kept logic changes minimal and avoided restructuring the widget layer alongside the controller layer.
+
+2. **Narrow pilot scope.** ADR-0085's goal was to validate one question: *does GetX + Riverpod coexistence work?* Using the established `StateNotifier` API (well-documented, familiar) kept the pilot's variable count to one. Starting with Riverpod 3.0's `Notifier` API — different lifecycle semantics, `build()` method, `ref` inside the notifier — would have introduced a second unknown simultaneously.
+
+3. **Ecosystem dependency conflicts.** Riverpod 3.0 brings pressure to adopt its tooling (`riverpod_lint`, `riverpod_generator`). Both conflict with this project's `analyzer: ">=12.0.0 <13.0.0"` pin (required by `dart_style` and `json_serializable`). Staying on 2.6.1 avoided forcing a resolution of those conflicts before the pattern was proven.
+
+### Breaking changes in 3.x that affect this codebase
 
 **1. `StateNotifier` / `StateNotifierProvider` moved to `legacy.dart`**
 
-They are no longer exported from `flutter_riverpod/flutter_riverpod.dart`. Two files extend `StateNotifier` and declare `StateNotifierProvider`; both become compile errors unless migrated or the import is switched to `flutter_riverpod/legacy.dart`.
+No longer exported from `flutter_riverpod/flutter_riverpod.dart`. Two files extend `StateNotifier` and declare `StateNotifierProvider`; both become compile errors without migration.
 
 **2. `ref.read` inside `Provider` bodies is a lint error**
 
 Riverpod 3.0 enforces `ref.watch` for dependency tracking inside provider factory bodies. `composer_cache_providers.dart` has 6 such call sites.
 
-Other 3.0 changes (automatic retry, `==` update filtering, `AutoDispose` type aliases) do not require code changes in this codebase.
+### Breaking changes in 3.x that do NOT affect this codebase
+
+| Change | Why no impact |
+|---|---|
+| Automatic retry on async providers | No `FutureProvider` or `StreamProvider` in use |
+| Provider pausing when widget goes off-screen | No `ConsumerWidget`; all access is imperative via `appProviderContainer` |
+| `ProviderObserver` interface updated | No `ProviderObserver` registered |
+| `AutoDispose` type aliases removed | Not used; providers are non-autoDispose or manually invalidated |
+| `AsyncValue.value` returns null on error | No `AsyncValue` consumed in current Riverpod code |
+| `ProviderException` wraps rethrown errors | No try-catch on provider reads |
+
+### Anti-patterns identified in current usage
+
+**A. Global `ProviderContainer` without `UncontrolledProviderScope`**
+
+`appProviderContainer = ProviderContainer()` is a global singleton with no connection to the Flutter widget tree. The official Riverpod documentation states:
+
+> "If you are using Flutter, you do not need to care about ProviderContainer outside of testing, as it is implicitly created for you by ProviderScope."
+
+This was acknowledged in ADR-0085 as a known limitation. The correct long-term fix is to eliminate `appProviderContainer` entirely and use plain `ProviderScope` at the root. However, this cannot be done in a single step — see *"Why not ProviderScope directly"* below.
+
+**B. `ref.read()` inside `Provider()` factory bodies**
+
+6 call sites in `composer_cache_providers.dart` use `ref.read()` to resolve dependencies inside `Provider(...)` factory bodies. In Riverpod 3.x this is a lint error: `Provider` factories should use `ref.watch()` to correctly track dependency rebuilds.
 
 ### Why not `@riverpod` codegen
 
@@ -31,21 +62,56 @@ Other 3.0 changes (automatic retry, `==` update filtering, `AutoDispose` type al
 
 ## Decision
 
-Upgrade to `flutter_riverpod: ^3.0.0` (latest stable: **3.3.1**) using the manual `Notifier` API. No new packages are added.
+Upgrade to `flutter_riverpod: ^3.0.0`. This constraint resolves to the latest 3.x stable (currently **3.3.1**) and tracks all future 3.x patch and minor releases automatically. No new packages are added.
 
 ### Dependency changes
 
 | Package | Current | Target | Notes |
 |---|---|---|---|
-| `flutter_riverpod` | `^2.6.1` | `^3.0.0` | Direct dep in root `pubspec.yaml` |
+| `flutter_riverpod` | `^2.6.1` | `^3.0.0` | Resolves to 3.3.1 (latest 3.x) |
 | `riverpod` | transitive | transitive | Resolved automatically |
-| `riverpod_lint` | — | — | Not used; can be added in a follow-up ADR |
+| `riverpod_lint` | — | — | Not used; can be enabled in a follow-up ADR once tooling conflict resolves |
 | `riverpod_generator` | — | — | Blocked by `analyzer` constraint — see above |
-| `riverpod_annotation` | — | — | Only needed with codegen |
 
-### Logic changes required
+### Changes required
 
-#### 1. `LocalSettingsNotifier` — `StateNotifier` → `Notifier`
+#### 1. `main.dart` — add `UncontrolledProviderScope`
+
+Addresses anti-pattern A. Wraps `GetMaterialApp` so the widget tree has access to `appProviderContainer`. GetX controllers continue to use `appProviderContainer.read()/.listen()` unchanged; this addition enables future `ConsumerWidget` migration without a separate architectural step.
+
+```dart
+// Before
+return GetMaterialApp(...);
+
+// After
+return UncontrolledProviderScope(
+  container: appProviderContainer,
+  child: GetMaterialApp(...),
+);
+```
+
+**Why `UncontrolledProviderScope` and not plain `ProviderScope`?**
+
+`ProviderScope` creates its own internal `ProviderContainer` that is inaccessible outside the widget tree. The six existing `appProviderContainer` call sites are all **GetX controllers/services** — they have no `BuildContext` or `WidgetRef` and cannot use the widget-tree API:
+
+| File | Operation |
+|---|---|
+| `LocalSettingsService` | `.read(localSettingsNotifierProvider.notifier).update()` |
+| `PreferencesController` | `.read(localSettingsNotifierProvider.notifier).update()` |
+| `ThreadController` | `.read(localSettingsNotifierProvider)` + `.listen(...)` |
+| `SearchEmailController` | `.read(localSettingsNotifierProvider)` |
+| `HandleMobileAutoSaveExtension` | `.read(composerAutoSaveProvider)` + `.invalidate(...)` |
+| `HandleComposerRestoreOnMobileExtension` | `.read(resolveComposerCacheForRestoreProvider)` |
+
+If we used plain `ProviderScope`, the result would be **two isolated containers** — one for the widget tree (unused, no `ConsumerWidget` yet) and `appProviderContainer` still required by all six controllers. Both containers would hold separate instances of the same providers with no shared state, which is strictly worse than the current situation.
+
+`UncontrolledProviderScope(container: appProviderContainer)` exposes the **same container** to both the widget tree and the imperative GetX layer — enabling `ConsumerWidget` migration incrementally without a big-bang refactor.
+
+**Eliminating `appProviderContainer` entirely** requires converting each of the six access points from GetX to Riverpod-native code. That is the scope of the GetX → Riverpod migration roadmap (ADR-0077), not this ADR.
+
+**Rule introduced by this ADR: `appProviderContainer` is frozen.** No new `appProviderContainer.read()` / `.listen()` / `.invalidate()` calls may be added. New features that need Riverpod state must use `ConsumerWidget` + `ref.watch/read`. Each ADR-0075 controller migration eliminates one existing call. When all six are gone, `UncontrolledProviderScope` is replaced by plain `ProviderScope` and `appProviderContainer` is deleted.
+
+#### 2. `LocalSettingsNotifier` — `StateNotifier` → `Notifier`
 
 `StateNotifierProvider` → `NotifierProvider`. The `build()` method replaces `super(initialState)`. All call sites (`ref.read`, `.listen`, `.notifier`) are unchanged.
 
@@ -68,13 +134,18 @@ final localSettingsNotifierProvider =
       LocalSettingsNotifier.new);
 ```
 
-#### 2. `ComposerAutoSaveNotifier` — `StateNotifierProvider.family` → `NotifierProvider.family`
+#### 3. `ComposerAutoSaveNotifier` — `StateNotifierProvider.family` → `NotifierProvider.family`
 
-In Riverpod 3.0, `NotifierProvider.family` passes the family argument through the constructor; `build()` takes no parameters. `StateNotifier.mounted` does not exist on `Notifier` — it is replaced by a `_mounted` flag managed via `ref.onDispose`.
+In Riverpod 3.0, `NotifierProvider.family` passes the family argument through the constructor; `build()` takes no parameters. `StateNotifier.mounted` does not exist on `Notifier` — replaced by a `_mounted` flag via `ref.onDispose`.
+
+Interactors are resolved eagerly in `build()` and stored as `late final` fields. This preserves the existing safety guarantee — async methods (`restore`, `clearCache`) hold plain Dart object references that remain valid even if the provider is disposed mid-flight, avoiding the `StateError` that `ref.read()` inside async methods would throw post-disposal.
 
 ```dart
 // Before
 class ComposerAutoSaveNotifier extends StateNotifier<ComposerAutoSaveState> {
+  final ResolveComposerCacheForRestoreInteractor _resolveInteractor;
+  final RemoveAllComposerCacheInteractor _removeInteractor;
+
   ComposerAutoSaveNotifier(this._resolveInteractor, this._removeInteractor)
       : super(const ComposerAutoSaveState());
 }
@@ -88,31 +159,34 @@ final composerAutoSaveProvider = StateNotifierProvider.family<
 // After
 class ComposerAutoSaveNotifier extends Notifier<ComposerAutoSaveState> {
   final String composerId;
+  late final ResolveComposerCacheForRestoreInteractor _resolveInteractor;
+  late final RemoveAllComposerCacheInteractor _removeInteractor;
   bool _mounted = true;
 
   ComposerAutoSaveNotifier(this.composerId);
 
   @override
   ComposerAutoSaveState build() {
+    _resolveInteractor = ref.read(resolveComposerCacheForRestoreProvider);
+    _removeInteractor = ref.read(removeAllComposerCacheProvider);
     ref.onDispose(() => _mounted = false);
     return const ComposerAutoSaveState();
   }
 
   bool get mounted => _mounted;
-  // methods call ref.read(resolveComposerCacheForRestoreProvider), etc.
 }
 final composerAutoSaveProvider = NotifierProvider.family<
     ComposerAutoSaveNotifier, ComposerAutoSaveState, String>(
   (id) => ComposerAutoSaveNotifier(id));
 ```
 
-#### 3. `composer_cache_providers.dart` — `ref.read` → `ref.watch` inside `Provider` bodies
+#### 4. `composer_cache_providers.dart` — `ref.read` → `ref.watch` inside `Provider` bodies
 
-All 6 `ref.read(...)` calls inside `Provider(...)` factory bodies become `ref.watch(...)`. These providers are non-autoDispose singletons; `watch` adds proper dependency tracking with no behavioral difference.
+Addresses anti-pattern B. All 6 `ref.read(...)` calls inside `Provider(...)` factory bodies become `ref.watch(...)`. These providers are non-autoDispose singletons; `watch` adds correct dependency tracking with no behavioral difference at runtime.
 
-#### 4. Unit tests for `ComposerAutoSaveNotifier`
+#### 5. Unit tests for `ComposerAutoSaveNotifier`
 
-Interactors are no longer injected via constructor — they are resolved through `ref`. Tests must switch from direct instantiation to `ProviderContainer` with overrides.
+Interactors are no longer injected via constructor — they are resolved in `build()` through `ref`. Tests switch from direct instantiation to `ProviderContainer` with overrides.
 
 ```dart
 // Before
@@ -130,11 +204,11 @@ notifier = container.read(composerAutoSaveProvider('test-id').notifier);
 
 **Positive**
 - Eliminates all `StateNotifier` / `StateNotifierProvider` usage; no deprecated API warnings
-- `riverpod_lint` can be enabled at full strength in a follow-up
+- `UncontrolledProviderScope` at the root enables future `ConsumerWidget` migration without a separate architectural step
+- `riverpod_lint` can be enabled at full strength in a follow-up once the `analyzer` constraint conflict is resolved upstream
 - No new runtime dependencies — a version bump and internal code changes only
 - Unblocks a future `@riverpod` codegen ADR once `riverpod_generator` supports `analyzer >=12.0.0`
 
 **Negative**
 - `ComposerAutoSaveNotifier` owns Android draft-loss prevention (ADR-0086) — manual testing on Android required after migration
 - `_mounted` via `ref.onDispose` fires when the provider element is torn down (on `invalidate`), not synchronously — verify stale-write guards in `handle_mobile_auto_save_extension.dart` still hold
-- `ComposerAutoSaveNotifier` test setup is less direct: `ProviderContainer` with overrides replaces a plain constructor call

--- a/docs/adr/0092-upgrade-flutter-riverpod-3.md
+++ b/docs/adr/0092-upgrade-flutter-riverpod-3.md
@@ -1,0 +1,140 @@
+# 92. Upgrade flutter_riverpod to 3.x
+
+Date: 2026-05-28
+
+## Status
+
+Proposed
+
+## Related ADRs
+
+- [ADR-0085](./0085-riverpod-state-management-for-local-settings.md) — introduced `localSettingsNotifierProvider`
+- [ADR-0086](./0086-android-composer-draft-loss-on-background.md) — introduced `ComposerAutoSaveNotifier`
+
+## Context
+
+The project uses `flutter_riverpod: ^2.6.1`. Riverpod 3.0 ships two categories of breaking changes that affect this codebase:
+
+**1. `StateNotifier` / `StateNotifierProvider` moved to `legacy.dart`**
+
+They are no longer exported from `flutter_riverpod/flutter_riverpod.dart`. Two files extend `StateNotifier` and declare `StateNotifierProvider`; both become compile errors unless migrated or the import is switched to `flutter_riverpod/legacy.dart`.
+
+**2. `ref.read` inside `Provider` bodies is a lint error**
+
+Riverpod 3.0 enforces `ref.watch` for dependency tracking inside provider factory bodies. `composer_cache_providers.dart` has 6 such call sites.
+
+Other 3.0 changes (automatic retry, `==` update filtering, `AutoDispose` type aliases) do not require code changes in this codebase.
+
+### Why not `@riverpod` codegen
+
+`riverpod_generator` requires `analyzer <10.0.0`. This project pins `analyzer: ">=12.0.0 <13.0.0"` via `dependency_overrides` for `dart_style` and `json_serializable`. No version overlap exists — codegen remains blocked until upstream resolves the constraint.
+
+## Decision
+
+Upgrade to `flutter_riverpod: ^3.0.0` (latest stable: **3.3.1**) using the manual `Notifier` API. No new packages are added.
+
+### Dependency changes
+
+| Package | Current | Target | Notes |
+|---|---|---|---|
+| `flutter_riverpod` | `^2.6.1` | `^3.0.0` | Direct dep in root `pubspec.yaml` |
+| `riverpod` | transitive | transitive | Resolved automatically |
+| `riverpod_lint` | — | — | Not used; can be added in a follow-up ADR |
+| `riverpod_generator` | — | — | Blocked by `analyzer` constraint — see above |
+| `riverpod_annotation` | — | — | Only needed with codegen |
+
+### Logic changes required
+
+#### 1. `LocalSettingsNotifier` — `StateNotifier` → `Notifier`
+
+`StateNotifierProvider` → `NotifierProvider`. The `build()` method replaces `super(initialState)`. All call sites (`ref.read`, `.listen`, `.notifier`) are unchanged.
+
+```dart
+// Before
+class LocalSettingsNotifier extends StateNotifier<PreferencesSetting> {
+  LocalSettingsNotifier() : super(PreferencesSetting.initial());
+}
+final localSettingsNotifierProvider =
+    StateNotifierProvider<LocalSettingsNotifier, PreferencesSetting>(
+      (ref) => LocalSettingsNotifier());
+
+// After
+class LocalSettingsNotifier extends Notifier<PreferencesSetting> {
+  @override
+  PreferencesSetting build() => PreferencesSetting.initial();
+}
+final localSettingsNotifierProvider =
+    NotifierProvider<LocalSettingsNotifier, PreferencesSetting>(
+      LocalSettingsNotifier.new);
+```
+
+#### 2. `ComposerAutoSaveNotifier` — `StateNotifierProvider.family` → `NotifierProvider.family`
+
+In Riverpod 3.0, `NotifierProvider.family` passes the family argument through the constructor; `build()` takes no parameters. `StateNotifier.mounted` does not exist on `Notifier` — it is replaced by a `_mounted` flag managed via `ref.onDispose`.
+
+```dart
+// Before
+class ComposerAutoSaveNotifier extends StateNotifier<ComposerAutoSaveState> {
+  ComposerAutoSaveNotifier(this._resolveInteractor, this._removeInteractor)
+      : super(const ComposerAutoSaveState());
+}
+final composerAutoSaveProvider = StateNotifierProvider.family<
+    ComposerAutoSaveNotifier, ComposerAutoSaveState, String>(
+  (ref, id) => ComposerAutoSaveNotifier(
+    ref.read(resolveComposerCacheForRestoreProvider),
+    ref.read(removeAllComposerCacheProvider),
+  ));
+
+// After
+class ComposerAutoSaveNotifier extends Notifier<ComposerAutoSaveState> {
+  final String composerId;
+  bool _mounted = true;
+
+  ComposerAutoSaveNotifier(this.composerId);
+
+  @override
+  ComposerAutoSaveState build() {
+    ref.onDispose(() => _mounted = false);
+    return const ComposerAutoSaveState();
+  }
+
+  bool get mounted => _mounted;
+  // methods call ref.read(resolveComposerCacheForRestoreProvider), etc.
+}
+final composerAutoSaveProvider = NotifierProvider.family<
+    ComposerAutoSaveNotifier, ComposerAutoSaveState, String>(
+  (id) => ComposerAutoSaveNotifier(id));
+```
+
+#### 3. `composer_cache_providers.dart` — `ref.read` → `ref.watch` inside `Provider` bodies
+
+All 6 `ref.read(...)` calls inside `Provider(...)` factory bodies become `ref.watch(...)`. These providers are non-autoDispose singletons; `watch` adds proper dependency tracking with no behavioral difference.
+
+#### 4. Unit tests for `ComposerAutoSaveNotifier`
+
+Interactors are no longer injected via constructor — they are resolved through `ref`. Tests must switch from direct instantiation to `ProviderContainer` with overrides.
+
+```dart
+// Before
+notifier = ComposerAutoSaveNotifier(mockResolveInteractor, mockRemoveInteractor);
+
+// After
+container = ProviderContainer(overrides: [
+  resolveComposerCacheForRestoreProvider.overrideWithValue(mockResolveInteractor),
+  removeAllComposerCacheProvider.overrideWithValue(mockRemoveInteractor),
+]);
+notifier = container.read(composerAutoSaveProvider('test-id').notifier);
+```
+
+## Consequences
+
+**Positive**
+- Eliminates all `StateNotifier` / `StateNotifierProvider` usage; no deprecated API warnings
+- `riverpod_lint` can be enabled at full strength in a follow-up
+- No new runtime dependencies — a version bump and internal code changes only
+- Unblocks a future `@riverpod` codegen ADR once `riverpod_generator` supports `analyzer >=12.0.0`
+
+**Negative**
+- `ComposerAutoSaveNotifier` owns Android draft-loss prevention (ADR-0086) — manual testing on Android required after migration
+- `_mounted` via `ref.onDispose` fires when the provider element is torn down (on `invalidate`), not synchronously — verify stale-write guards in `handle_mobile_auto_save_extension.dart` still hold
+- `ComposerAutoSaveNotifier` test setup is less direct: `ProviderContainer` with overrides replaces a plain constructor call


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an Architecture Decision Record for upgrading to Riverpod v3, including migration guidance, testing strategy updates, and runtime considerations.
  * Documents migration constraints, required verification steps (including Android), updated unit-test approaches, and follow-up items for linters/codegen and remaining call sites to address in future ADRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->