### PR TITLE
TF-4529 Fix email subject not copyable on mobile

### DIFF
--- a/lib/features/email/presentation/widgets/email_subject_widget.dart
+++ b/lib/features/email/presentation/widgets/email_subject_widget.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:labels/model/label.dart';
@@ -129,7 +130,14 @@ class _EmailSubjectWidgetState extends State<EmailSubjectWidget> {
   }
 
   Widget _buildTitle() {
-    return Text(
+    if (PlatformInfo.isWeb) {
+      return Text(
+        _title,
+        style: EmailSubjectStyles.textStyle,
+        maxLines: EmailSubjectStyles.maxLines,
+      );
+    }
+    return SelectableText(
       _title,
       style: EmailSubjectStyles.textStyle,
       maxLines: EmailSubjectStyles.maxLines,

--- a/test/features/email/presentation/widgets/email_subject_widget_test.dart
+++ b/test/features/email/presentation/widgets/email_subject_widget_test.dart
@@ -1,0 +1,85 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/utils/platform_info.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/email_subject_widget.dart';
+
+import '../../../../fixtures/widget_fixtures.dart';
+
+void main() {
+  group('EmailSubjectWidget', () {
+    final imagePaths = ImagePaths();
+
+    Widget makeTestableWidget({
+      required String emailSubject,
+      bool isMobileResponsive = false,
+    }) {
+      return WidgetFixtures.makeTestableWidget(
+        child: EmailSubjectWidget(
+          emailSubject: emailSubject,
+          imagePaths: imagePaths,
+          isMobileResponsive: isMobileResponsive,
+        ),
+      );
+    }
+
+    testWidgets(
+      'should render nothing when subject is empty',
+      (tester) async {
+        await tester.pumpWidget(makeTestableWidget(emailSubject: ''));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(SelectableText), findsNothing);
+        expect(find.byType(Text), findsNothing);
+      },
+    );
+
+    group('when platform is mobile', () {
+      testWidgets(
+        'should render SelectableText when isMobileResponsive is false',
+        (tester) async {
+          const subject = 'Meeting tomorrow';
+
+          await tester.pumpWidget(makeTestableWidget(emailSubject: subject));
+          await tester.pumpAndSettle();
+
+          expect(find.byType(SelectableText), findsOneWidget);
+          expect(find.text(subject), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'should render SelectableText when isMobileResponsive is true',
+        (tester) async {
+          const subject = 'Important: Action required';
+
+          await tester.pumpWidget(
+            makeTestableWidget(emailSubject: subject, isMobileResponsive: true),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.byType(SelectableText), findsOneWidget);
+          expect(find.text(subject), findsOneWidget);
+        },
+      );
+    });
+
+    group('when platform is web', () {
+      setUp(() => PlatformInfo.isTestingForWeb = true);
+      tearDown(() => PlatformInfo.isTestingForWeb = false);
+
+      testWidgets(
+        'should render Text when subject is not empty',
+        (tester) async {
+          const subject = 'Meeting tomorrow';
+
+          await tester.pumpWidget(makeTestableWidget(emailSubject: subject));
+          await tester.pumpAndSettle();
+
+          expect(find.byType(SelectableText), findsNothing);
+          expect(find.text(subject), findsOneWidget);
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Issue

#4529

## Root cause

`EmailSubjectWidget._buildTitle()` used a plain `Text` widget unconditionally. On web, `SelectionArea` wraps the entire email body making all text selectable. On mobile, no such wrapper exists — `Text` is not selectable, so long-press copy was impossible.

## Solution

Use `SelectableText` on mobile so users can long-press to select and copy the subject. Web intentionally keeps `Text` to avoid creating an isolated selection boundary inside `SelectionArea`, which would break cross-widget drag selection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email subjects now render as selectable text on mobile platforms and standard text on web.

* **Tests**
  * Added comprehensive widget tests for email subject rendering across different platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-flutter/pull/4567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->