### PR TITLE
TF-4491 Fix reversed semantic in label action toast messages

### DIFF
--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -5654,7 +5654,7 @@
       "labelName": {}
     }
   },
-  "addLabelToEmailSuccessfullyMessage": "E-mail ajouté au libellé \"{labelName}\"",
+  "addLabelToEmailSuccessfullyMessage": "Libellé \"{labelName}\" ajouté à l'e-mail",
   "@addLabelToEmailSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5664,7 +5664,7 @@
       "labelName": {}
     }
   },
-  "addLabelToEmailFailureMessage": "Impossible d'ajouter l'e-mail au libellé \"{labelName}\"",
+  "addLabelToEmailFailureMessage": "Impossible d'ajouter le libellé \"{labelName}\" à l'e-mail",
   "@addLabelToEmailFailureMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5674,7 +5674,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromEmailSuccessfullyMessage": "E-mail retiré du libellé \"{labelName}\"",
+  "removeLabelFromEmailSuccessfullyMessage": "Libellé \"{labelName}\" retiré de l'e-mail",
   "@removeLabelFromEmailSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5684,7 +5684,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromEmailFailureMessage": "Impossible de retirer l'e-mail du libellé \"{labelName}\"",
+  "removeLabelFromEmailFailureMessage": "Impossible de retirer le libellé \"{labelName}\" de l'e-mail",
   "@removeLabelFromEmailFailureMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5694,7 +5694,7 @@
       "labelName": {}
     }
   },
-  "addLabelToThreadSuccessfullyMessage": "Tous les e-mails du fil ont été ajoutés au libellé \"{labelName}\"",
+  "addLabelToThreadSuccessfullyMessage": "Libellé \"{labelName}\" ajouté à tous les e-mails du fil",
   "@addLabelToThreadSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5704,7 +5704,7 @@
       "labelName": {}
     }
   },
-  "addLabelToThreadFailureMessage": "Impossible d'ajouter tous les e-mails du fil au libellé \"{labelName}\"",
+  "addLabelToThreadFailureMessage": "Impossible d'ajouter le libellé \"{labelName}\" à tous les e-mails du fil",
   "@addLabelToThreadFailureMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5714,7 +5714,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromThreadSuccessfullyMessage": "Tous les e-mails du fil ont été retirés du libellé \"{labelName}\"",
+  "removeLabelFromThreadSuccessfullyMessage": "Libellé \"{labelName}\" retiré de tous les e-mails du fil",
   "@removeLabelFromThreadSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5724,7 +5724,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromThreadFailureMessage": "Impossible de retirer tous les e-mails du fil du libellé \"{labelName}\"",
+  "removeLabelFromThreadFailureMessage": "Impossible de retirer le libellé \"{labelName}\" de tous les e-mails du fil",
   "@removeLabelFromThreadFailureMessage": {
     "type": "text",
     "placeholders_order": [

--- a/lib/l10n/intl_ga.arb
+++ b/lib/l10n/intl_ga.arb
@@ -5411,7 +5411,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "addLabelToEmailSuccessfullyMessage": "Seoladh ríomhphoist curtha leis an lipéad \"{labelName}\"",
+  "addLabelToEmailSuccessfullyMessage": "Cuireadh an lipéad \"{labelName}\" leis an ríomhphost",
   "@addLabelToEmailSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5421,7 +5421,7 @@
       "labelName": {}
     }
   },
-  "addLabelToEmailFailureMessage": "Ní féidir ríomhphost a chur leis an lipéad \"{labelName}\"",
+  "addLabelToEmailFailureMessage": "Ní féidir an lipéad \"{labelName}\" a chur leis an ríomhphost",
   "@addLabelToEmailFailureMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5437,7 +5437,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "addLabelToThreadSuccessfullyMessage": "Cuireadh gach ríomhphost sa snáithe leis an lipéad \"{labelName}\"",
+  "addLabelToThreadSuccessfullyMessage": "Cuireadh an lipéad \"{labelName}\" le gach ríomhphost sa snáithe",
   "@addLabelToThreadSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5447,7 +5447,7 @@
       "labelName": {}
     }
   },
-  "addLabelToThreadFailureMessage": "Ní féidir gach ríomhphost sa snáithe a chur leis an lipéad \"{labelName}\"",
+  "addLabelToThreadFailureMessage": "Ní féidir an lipéad \"{labelName}\" a chur le gach ríomhphost sa snáithe",
   "@addLabelToThreadFailureMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5497,7 +5497,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "removeLabelFromEmailSuccessfullyMessage": "Baineadh an ríomhphost ón lipéad \"{labelName}\"",
+  "removeLabelFromEmailSuccessfullyMessage": "Baineadh an lipéad \"{labelName}\" den ríomhphost",
   "@removeLabelFromEmailSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5507,7 +5507,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromEmailFailureMessage": "Ní féidir ríomhphost a bhaint den lipéad \"{labelName}\"",
+  "removeLabelFromEmailFailureMessage": "Ní féidir an lipéad \"{labelName}\" a bhaint den ríomhphost",
   "@removeLabelFromEmailFailureMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5517,7 +5517,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromThreadSuccessfullyMessage": "Baineadh gach ríomhphost sa snáithe den lipéad \"{labelName}\"",
+  "removeLabelFromThreadSuccessfullyMessage": "Baineadh an lipéad \"{labelName}\" de gach ríomhphost sa snáithe",
   "@removeLabelFromThreadSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5527,7 +5527,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromThreadFailureMessage": "Ní féidir gach ríomhphost sa snáithe a bhaint den lipéad \"{labelName}\"",
+  "removeLabelFromThreadFailureMessage": "Ní féidir an lipéad \"{labelName}\" a bhaint de gach ríomhphost sa snáithe",
   "@removeLabelFromThreadFailureMessage": {
     "type": "text",
     "placeholders_order": [

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2026-05-26T13:37:50.997089",
+  "@@last_modified": "2026-05-28T18:17:44.649881",
   "initializing_data": "Initializing data...",
   "@initializing_data": {
     "type": "text",
@@ -5290,7 +5290,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "addLabelToEmailSuccessfullyMessage": "Email added to the \"{labelName}\" label",
+  "addLabelToEmailSuccessfullyMessage": "Label \"{labelName}\" added to email",
   "@addLabelToEmailSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5300,7 +5300,7 @@
       "labelName": {}
     }
   },
-  "addLabelToEmailFailureMessage": "Cannot add email to the \"{labelName}\" label",
+  "addLabelToEmailFailureMessage": "Cannot add label \"{labelName}\" to email",
   "@addLabelToEmailFailureMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5316,7 +5316,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "addLabelToThreadSuccessfullyMessage": "All emails in thread added to the \"{labelName}\" label",
+  "addLabelToThreadSuccessfullyMessage": "Label \"{labelName}\" added to all emails in thread",
   "@addLabelToThreadSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5326,7 +5326,7 @@
       "labelName": {}
     }
   },
-  "addLabelToThreadFailureMessage": "Cannot add all emails in thread to the \"{labelName}\" label",
+  "addLabelToThreadFailureMessage": "Cannot add label \"{labelName}\" to all emails in thread",
   "@addLabelToThreadFailureMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5376,7 +5376,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "removeLabelFromEmailSuccessfullyMessage": "Email removed from the \"{labelName}\" label",
+  "removeLabelFromEmailSuccessfullyMessage": "Label \"{labelName}\" removed from email",
   "@removeLabelFromEmailSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5386,7 +5386,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromEmailFailureMessage": "Cannot remove email from the \"{labelName}\" label",
+  "removeLabelFromEmailFailureMessage": "Cannot remove label \"{labelName}\" from email",
   "@removeLabelFromEmailFailureMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5396,7 +5396,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromThreadSuccessfullyMessage": "All emails in thread removed from the \"{labelName}\" label",
+  "removeLabelFromThreadSuccessfullyMessage": "Label \"{labelName}\" removed from all emails in thread",
   "@removeLabelFromThreadSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5406,7 +5406,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromThreadFailureMessage": "Cannot remove all emails in thread from the \"{labelName}\" label",
+  "removeLabelFromThreadFailureMessage": "Cannot remove label \"{labelName}\" from all emails in thread",
   "@removeLabelFromThreadFailureMessage": {
     "type": "text",
     "placeholders_order": [

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -5672,7 +5672,7 @@
       "labelName": {}
     }
   },
-  "addLabelToEmailSuccessfullyMessage": "Письмо добавлено в метку \"{labelName}\"",
+  "addLabelToEmailSuccessfullyMessage": "Метка \"{labelName}\" добавлена к письму",
   "@addLabelToEmailSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5682,7 +5682,7 @@
       "labelName": {}
     }
   },
-  "addLabelToEmailFailureMessage": "Не удалось добавить письмо в метку \"{labelName}\"",
+  "addLabelToEmailFailureMessage": "Не удалось добавить метку \"{labelName}\" к письму",
   "@addLabelToEmailFailureMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5692,7 +5692,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromEmailSuccessfullyMessage": "Письмо удалено из метки \"{labelName}\"",
+  "removeLabelFromEmailSuccessfullyMessage": "Метка \"{labelName}\" удалена с письма",
   "@removeLabelFromEmailSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5702,7 +5702,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromEmailFailureMessage": "Не удалось удалить письмо из метки \"{labelName}\"",
+  "removeLabelFromEmailFailureMessage": "Не удалось удалить метку \"{labelName}\" с письма",
   "@removeLabelFromEmailFailureMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5712,7 +5712,7 @@
       "labelName": {}
     }
   },
-  "addLabelToThreadSuccessfullyMessage": "Все письма в цепочке добавлены в метку \"{labelName}\"",
+  "addLabelToThreadSuccessfullyMessage": "Метка \"{labelName}\" добавлена ко всем письмам в цепочке",
   "@addLabelToThreadSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5722,7 +5722,7 @@
       "labelName": {}
     }
   },
-  "addLabelToThreadFailureMessage": "Не удалось добавить все письма в цепочке в метку \"{labelName}\"",
+  "addLabelToThreadFailureMessage": "Не удалось добавить метку \"{labelName}\" ко всем письмам в цепочке",
   "@addLabelToThreadFailureMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5732,7 +5732,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromThreadSuccessfullyMessage": "Все письма в цепочке удалены из метки \"{labelName}\"",
+  "removeLabelFromThreadSuccessfullyMessage": "Метка \"{labelName}\" удалена со всех писем в цепочке",
   "@removeLabelFromThreadSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5742,7 +5742,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromThreadFailureMessage": "Не удалось удалить все письма в цепочке из метки \"{labelName}\"",
+  "removeLabelFromThreadFailureMessage": "Не удалось удалить метку \"{labelName}\" со всех писем в цепочке",
   "@removeLabelFromThreadFailureMessage": {
     "type": "text",
     "placeholders_order": [

--- a/lib/l10n/intl_vi.arb
+++ b/lib/l10n/intl_vi.arb
@@ -5660,7 +5660,7 @@
       "labelName": {}
     }
   },
-  "addLabelToEmailSuccessfullyMessage": "Đã thêm email vào nhãn \"{labelName}\"",
+  "addLabelToEmailSuccessfullyMessage": "Nhãn \"{labelName}\" đã được thêm vào email",
   "@addLabelToEmailSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5670,7 +5670,7 @@
       "labelName": {}
     }
   },
-  "addLabelToEmailFailureMessage": "Không thể thêm email vào nhãn \"{labelName}\"",
+  "addLabelToEmailFailureMessage": "Không thể thêm nhãn \"{labelName}\" vào email",
   "@addLabelToEmailFailureMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5680,7 +5680,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromEmailSuccessfullyMessage": "Đã gỡ email khỏi nhãn \"{labelName}\"",
+  "removeLabelFromEmailSuccessfullyMessage": "Nhãn \"{labelName}\" đã được gỡ khỏi email",
   "@removeLabelFromEmailSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5690,7 +5690,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromEmailFailureMessage": "Không thể gỡ email khỏi nhãn \"{labelName}\"",
+  "removeLabelFromEmailFailureMessage": "Không thể gỡ nhãn \"{labelName}\" khỏi email",
   "@removeLabelFromEmailFailureMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5700,7 +5700,7 @@
       "labelName": {}
     }
   },
-  "addLabelToThreadSuccessfullyMessage": "Tất cả email trong chuỗi đã được thêm vào nhãn \"{labelName}\"",
+  "addLabelToThreadSuccessfullyMessage": "Nhãn \"{labelName}\" đã được thêm vào tất cả email trong chuỗi",
   "@addLabelToThreadSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5710,7 +5710,7 @@
       "labelName": {}
     }
   },
-  "addLabelToThreadFailureMessage": "Không thể thêm tất cả email trong chuỗi vào nhãn \"{labelName}\"",
+  "addLabelToThreadFailureMessage": "Không thể thêm nhãn \"{labelName}\" vào tất cả email trong chuỗi",
   "@addLabelToThreadFailureMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5720,7 +5720,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromThreadSuccessfullyMessage": "Tất cả email trong chuỗi đã được gỡ khỏi nhãn \"{labelName}\"",
+  "removeLabelFromThreadSuccessfullyMessage": "Nhãn \"{labelName}\" đã được gỡ khỏi tất cả email trong chuỗi",
   "@removeLabelFromThreadSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5730,7 +5730,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromThreadFailureMessage": "Không thể gỡ tất cả email trong chuỗi khỏi nhãn \"{labelName}\"",
+  "removeLabelFromThreadFailureMessage": "Không thể gỡ nhãn \"{labelName}\" khỏi tất cả email trong chuỗi",
   "@removeLabelFromThreadFailureMessage": {
     "type": "text",
     "placeholders_order": [

--- a/lib/l10n/intl_zh_Hans.arb
+++ b/lib/l10n/intl_zh_Hans.arb
@@ -5405,7 +5405,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "addLabelToEmailSuccessfullyMessage": "邮件已添加至“{labelName}”标签",
+  “addLabelToEmailSuccessfullyMessage”: “标签”{labelName}”已添加至邮件”,
   "@addLabelToEmailSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5415,7 +5415,7 @@
       "labelName": {}
     }
   },
-  "addLabelToEmailFailureMessage": "无法将邮件添加至“{labelName}”标签",
+  “addLabelToEmailFailureMessage”: “无法将标签”{labelName}”添加至邮件”,
   "@addLabelToEmailFailureMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5431,7 +5431,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "addLabelToThreadSuccessfullyMessage": "线程中的所有邮件已添加至“{labelName}”标签",
+  “addLabelToThreadSuccessfullyMessage”: “标签”{labelName}”已添加至线程中的所有邮件”,
   "@addLabelToThreadSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5441,7 +5441,7 @@
       "labelName": {}
     }
   },
-  "addLabelToThreadFailureMessage": "无法将线程中的所有邮件添加至“{labelName}”标签",
+  “addLabelToThreadFailureMessage”: “无法将标签”{labelName}”添加至线程中的所有邮件”,
   "@addLabelToThreadFailureMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5491,7 +5491,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "removeLabelFromEmailSuccessfullyMessage": "邮件已从“{labelName}”标签移除",
+  “removeLabelFromEmailSuccessfullyMessage”: “标签”{labelName}”已从邮件移除”,
   "@removeLabelFromEmailSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5501,7 +5501,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromEmailFailureMessage": "无法从“{labelName}”标签移除邮件",
+  “removeLabelFromEmailFailureMessage”: “无法从邮件移除标签”{labelName}””,
   "@removeLabelFromEmailFailureMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5511,7 +5511,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromThreadSuccessfullyMessage": "线程中的所有邮件已从“{labelName}”标签移除",
+  “removeLabelFromThreadSuccessfullyMessage”: “标签”{labelName}”已从线程中的所有邮件移除”,
   "@removeLabelFromThreadSuccessfullyMessage": {
     "type": "text",
     "placeholders_order": [
@@ -5521,7 +5521,7 @@
       "labelName": {}
     }
   },
-  "removeLabelFromThreadFailureMessage": "无法从“{labelName}”标签移除线程中的所有邮件",
+  “removeLabelFromThreadFailureMessage”: “无法从线程中的所有邮件移除标签”{labelName}””,
   "@removeLabelFromThreadFailureMessage": {
     "type": "text",
     "placeholders_order": [

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -5622,7 +5622,7 @@ class AppLocalizations {
 
   String addLabelToEmailSuccessfullyMessage(String labelName) {
     return Intl.message(
-      'Email added to the "$labelName" label',
+      'Label "$labelName" added to email',
       name: 'addLabelToEmailSuccessfullyMessage',
       args: [labelName],
     );
@@ -5630,7 +5630,7 @@ class AppLocalizations {
 
   String addLabelToEmailFailureMessage(String labelName) {
     return Intl.message(
-      'Cannot add email to the "$labelName" label',
+      'Cannot add label "$labelName" to email',
       name: 'addLabelToEmailFailureMessage',
       args: [labelName],
     );
@@ -5645,7 +5645,7 @@ class AppLocalizations {
 
   String addLabelToThreadSuccessfullyMessage(String labelName) {
     return Intl.message(
-      'All emails in thread added to the "$labelName" label',
+      'Label "$labelName" added to all emails in thread',
       name: 'addLabelToThreadSuccessfullyMessage',
       args: [labelName],
     );
@@ -5653,7 +5653,7 @@ class AppLocalizations {
 
   String addLabelToThreadFailureMessage(String labelName) {
     return Intl.message(
-      'Cannot add all emails in thread to the "$labelName" label',
+      'Cannot add label "$labelName" to all emails in thread',
       name: 'addLabelToThreadFailureMessage',
       args: [labelName],
     );
@@ -5704,7 +5704,7 @@ class AppLocalizations {
   }
   String removeLabelFromEmailSuccessfullyMessage(String labelName) {
     return Intl.message(
-      'Email removed from the "$labelName" label',
+      'Label "$labelName" removed from email',
       name: 'removeLabelFromEmailSuccessfullyMessage',
       args: [labelName],
     );
@@ -5712,7 +5712,7 @@ class AppLocalizations {
 
   String removeLabelFromEmailFailureMessage(String labelName) {
     return Intl.message(
-      'Cannot remove email from the "$labelName" label',
+      'Cannot remove label "$labelName" from email',
       name: 'removeLabelFromEmailFailureMessage',
       args: [labelName],
     );
@@ -5720,7 +5720,7 @@ class AppLocalizations {
 
   String removeLabelFromThreadSuccessfullyMessage(String labelName) {
     return Intl.message(
-      'All emails in thread removed from the "$labelName" label',
+      'Label "$labelName" removed from all emails in thread',
       name: 'removeLabelFromThreadSuccessfullyMessage',
       args: [labelName],
     );
@@ -5728,7 +5728,7 @@ class AppLocalizations {
 
   String removeLabelFromThreadFailureMessage(String labelName) {
     return Intl.message(
-      'Cannot remove all emails in thread from the "$labelName" label',
+      'Cannot remove label "$labelName" from all emails in thread',
       name: 'removeLabelFromThreadFailureMessage',
       args: [labelName],
     );


### PR DESCRIPTION
## Issue

#4491


## Affected messages (8 keys)

| Key | Before | After |
|-----|--------|-------|
| `addLabelToEmailSuccessfullyMessage` | Email added to the "{name}" label | Label "{name}" added to email |
| `addLabelToEmailFailureMessage` | Cannot add email to the "{name}" label | Cannot add label "{name}" to email |
| `addLabelToThreadSuccessfullyMessage` | All emails in thread added to the "{name}" label | Label "{name}" added to all emails in thread |
| `addLabelToThreadFailureMessage` | Cannot add all emails in thread to the "{name}" label | Cannot add label "{name}" to all emails in thread |
| `removeLabelFromEmailSuccessfullyMessage` | Email removed from the "{name}" label | Label "{name}" removed from email |
| `removeLabelFromEmailFailureMessage` | Cannot remove email from the "{name}" label | Cannot remove label "{name}" from email |
| `removeLabelFromThreadSuccessfullyMessage` | All emails in thread removed from the "{name}" label | Label "{name}" removed from all emails in thread |
| `removeLabelFromThreadFailureMessage` | Cannot remove all emails in thread from the "{name}" label | Cannot remove label "{name}" from all emails in thread |

## Files changed

- `lib/main/localizations/app_localizations.dart` — source strings
- `lib/l10n/intl_messages.arb` — English base (regenerated by prebuild)
- `lib/l10n/intl_vi.arb` — Vietnamese
- `lib/l10n/intl_fr.arb` — French
- `lib/l10n/intl_ru.arb` — Russian
- `lib/l10n/intl_zh_Hans.arb` — Chinese Simplified
- `lib/l10n/intl_ga.arb` — Irish Gaelic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated user-facing messages across multiple languages (French, Irish, Russian, Vietnamese, and Chinese Simplified) for label operations. Label management notifications when adding or removing labels from individual emails and email threads have been refined for improved clarity and consistency, with explicit references to label names in success and failure messages throughout the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/tmail-flutter/pull/4568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->