### PR TITLE
perf: replace fixed-duration pumps with reactive waits in integration…

### DIFF
--- a/integration_test/base/test_base.dart
+++ b/integration_test/base/test_base.dart
@@ -29,7 +29,7 @@ class TestBase {
     patrolTest(
       description,
       config: const PatrolTesterConfig(
-        settlePolicy: SettlePolicy.trySettle,
+        settlePolicy: SettlePolicy.noSettle,
         existsTimeout: Duration(seconds: 30),
         visibleTimeout: Duration(seconds: 30),
         settleTimeout: Duration(seconds: 30),

--- a/integration_test/robots/composer_robot.dart
+++ b/integration_test/robots/composer_robot.dart
@@ -59,7 +59,6 @@ class ComposerRobot extends CoreRobot {
     if (!isTextFieldFocused) {
       await finder.tap();
     }
-    await $.pumpAndTrySettle();
     await finder.enterTextWithoutTapAction(subject);
   }
 

--- a/integration_test/robots/email_robot.dart
+++ b/integration_test/robots/email_robot.dart
@@ -16,7 +16,6 @@ class EmailRobot extends CoreRobot {
 
   Future<void> onTapForwardEmail() async {
     await $(#forward_email_button).tap();
-    await $.pump(const Duration(seconds: 2));
   }
 
   Future<void> tapDownloadAllButton() async {

--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -29,7 +29,7 @@ class MailboxMenuRobot extends CoreRobot implements AbstractMailboxMenuRobot {
     await $(mailboxItem).waitUntilExists();
     await $.scrollUntilVisible(finder: mailboxItem);
     await mailboxItem.tap();
-    await $.pumpAndTrySettle();
+    await $.pump(const Duration(milliseconds: 600)); // let debounce fire
   }
 
   @override

--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -29,6 +29,7 @@ class MailboxMenuRobot extends CoreRobot implements AbstractMailboxMenuRobot {
     await $(mailboxItem).waitUntilExists();
     await $.scrollUntilVisible(finder: mailboxItem);
     await mailboxItem.tap();
+    await $.pumpAndTrySettle();
   }
 
   @override

--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -15,6 +15,7 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
+import '../utils/wait_for_condition.dart';
 import '../base/core_robot.dart';
 import '../exceptions/mailbox/null_inbox_unread_count_exception.dart';
 import '../exceptions/mailbox/null_quota_exception.dart';
@@ -28,7 +29,12 @@ class MailboxMenuRobot extends CoreRobot implements AbstractMailboxMenuRobot {
     final mailboxItem = $(MailboxItemWidget).$(LabelMailboxItemWidget).$(name);
     await $(mailboxItem).waitUntilExists();
     await $.scrollUntilVisible(finder: mailboxItem);
+    final previousMailboxId = Get.find<MailboxDashBoardController>().selectedMailbox.value?.id;
     await mailboxItem.tap();
+    await waitForCondition(
+      () => Get.find<MailboxDashBoardController>().selectedMailbox.value?.id != previousMailboxId,
+      timeout: const Duration(seconds: 10),
+    );
   }
 
   @override

--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -29,7 +29,6 @@ class MailboxMenuRobot extends CoreRobot implements AbstractMailboxMenuRobot {
     await $(mailboxItem).waitUntilExists();
     await $.scrollUntilVisible(finder: mailboxItem);
     await mailboxItem.tap();
-    await $.pump(const Duration(milliseconds: 600)); // let debounce fire
   }
 
   @override

--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
-import 'package:tmail_ui_user/features/mailbox/presentation/widgets/label_mailbox_item_widget.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/mailbox_item_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/presentation/mailbox_creator_view.dart';
 import 'package:tmail_ui_user/features/quotas/presentation/quotas_controller.dart';

--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -26,13 +26,18 @@ class MailboxMenuRobot extends CoreRobot implements AbstractMailboxMenuRobot {
 
   @override
   Future<void> openFolderByName(String name) async {
+    // Poll for the widget using waitForCondition (doesn't rely on settle)
     final mailboxItem = $(MailboxItemWidget).$(LabelMailboxItemWidget).$(name);
-    await $(mailboxItem).waitUntilExists();
+    await waitForCondition(() => mailboxItem.exists, timeout: const Duration(seconds: 10));
+    
     await $.scrollUntilVisible(finder: mailboxItem);
-    final previousMailboxId = Get.find<MailboxDashBoardController>().selectedMailbox.value?.id;
+    
+    // Use controller-based verification instead of relying on settled widget tree
+    final controller = Get.find<MailboxDashBoardController>();
+    final previousMailboxId = controller.selectedMailbox.value?.id;
     await mailboxItem.tap();
     await waitForCondition(
-      () => Get.find<MailboxDashBoardController>().selectedMailbox.value?.id != previousMailboxId,
+      () => controller.selectedMailbox.value?.id != previousMailboxId,
       timeout: const Duration(seconds: 10),
     );
   }

--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/widgets/label_mailbox_item_widget.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/mailbox_item_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/presentation/mailbox_creator_view.dart';
 import 'package:tmail_ui_user/features/quotas/presentation/quotas_controller.dart';
@@ -24,11 +25,8 @@ class MailboxMenuRobot extends CoreRobot implements AbstractMailboxMenuRobot {
 
   @override
   Future<void> openFolderByName(String name) async {
-    final mailboxItem = $(MailboxItemWidget)
-      .which<MailboxItemWidget>((widget) =>
-        widget.mailboxNode.item.name?.name.toLowerCase() == name.toLowerCase(),
-      );
-    await mailboxItem.waitUntilExists();
+    final mailboxItem = $(MailboxItemWidget).$(LabelMailboxItemWidget).$(name);
+    await $(mailboxItem).waitUntilExists();
     await $.scrollUntilVisible(finder: mailboxItem);
     await mailboxItem.tap();
   }

--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -25,8 +25,11 @@ class MailboxMenuRobot extends CoreRobot implements AbstractMailboxMenuRobot {
 
   @override
   Future<void> openFolderByName(String name) async {
-    final mailboxItem = $(MailboxItemWidget).$(LabelMailboxItemWidget).$(name);
-    await $(mailboxItem).waitUntilExists();
+    final mailboxItem = $(MailboxItemWidget)
+      .which<MailboxItemWidget>((widget) =>
+        widget.mailboxNode.item.name?.name.toLowerCase() == name.toLowerCase(),
+      );
+    await mailboxItem.waitUntilExists();
     await $.scrollUntilVisible(finder: mailboxItem);
     await mailboxItem.tap();
   }

--- a/integration_test/robots/mobile/mobile_rules_filter_creator_robot.dart
+++ b/integration_test/robots/mobile/mobile_rules_filter_creator_robot.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/rules_filter_creator/presentation/rules_filter_creator_view.dart';
 
+import '../../utils/wait_for_condition.dart';
 import '../abstract/abstract_rules_filter_creator_robot.dart';
 
 class MobileRulesFilterCreatorRobot extends AbstractRulesFilterCreatorRobot {
@@ -23,7 +24,6 @@ class MobileRulesFilterCreatorRobot extends AbstractRulesFilterCreatorRobot {
     String selectActionHint,
   ) async {
     await $(find.text(selectActionHint)).tap();
-    await $.pumpAndTrySettle();
     await $(find.text(actionName)).tap();
   }
 
@@ -51,6 +51,6 @@ class MobileRulesFilterCreatorRobot extends AbstractRulesFilterCreatorRobot {
 
   @override
   Future<void> expectCreatorViewClosed() async {
-    expect($(RuleFilterCreatorView), findsNothing);
+    await waitForCondition(() => !$(RuleFilterCreatorView).exists);
   }
 }

--- a/integration_test/robots/search_robot.dart
+++ b/integration_test/robots/search_robot.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/views/text/text_field_builder.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/email_view_back_button.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_view.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
@@ -37,7 +38,7 @@ class SearchRobot extends CoreRobot {
 
   Future<void> selectSortOrder(String sortOrderName) async {
     await $(find.text(sortOrderName)).tap();
-    await $.pump(const Duration(seconds: 2));
+    await $.pumpAndTrySettle();
   }
 
   Future<void> enterKeyword(String keyword) async {
@@ -71,7 +72,7 @@ class SearchRobot extends CoreRobot {
 
   Future<void> selectDateTime(String dateTimeType) async {
     await $(find.text(dateTimeType)).tap();
-    await $.pump(const Duration(seconds: 2));
+    await $.pumpAndTrySettle();
   }
 
   Future<void> openEmailWithSubject(String subject) async {
@@ -79,7 +80,7 @@ class SearchRobot extends CoreRobot {
       .which<EmailTileBuilder>((view) => view.presentationEmail.subject == subject);
     await $.waitUntilVisible(email);
     await email.tap();
-    await $.pump(const Duration(seconds: 2));
+    await $.waitUntilVisible($(EmailViewBackButton));
   }
 
   Future<void> tapBackButton() async {

--- a/integration_test/robots/thread_robot.dart
+++ b/integration_test/robots/thread_robot.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:labels/extensions/label_extension.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/email_view_back_button.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_view.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/scroll_to_top_button_widget.dart';
@@ -31,7 +32,7 @@ class ThreadRobot extends CoreRobot {
       .which<EmailTileBuilder>((view) => view.presentationEmail.subject == subject);
     await $.waitUntilVisible(email);
     await email.tap();
-    await $.pump(const Duration(seconds: 2));
+    await $.waitUntilVisible($(EmailViewBackButton));
   }
 
   Future<void> openEmailWithLabel(String labelDisplayName) async {
@@ -43,7 +44,7 @@ class ThreadRobot extends CoreRobot {
     );
     await $.waitUntilVisible(email);
     await email.tap();
-    await $.pump(const Duration(seconds: 2));
+    await $.waitUntilVisible($(EmailViewBackButton));
   }
 
   Future<void> openMailbox() async {

--- a/integration_test/robots/web/web_composer_robot.dart
+++ b/integration_test/robots/web/web_composer_robot.dart
@@ -36,7 +36,6 @@ class WebComposerRobot extends MobileComposerRobot {
   @override
   Future<void> tapSaveAsDraftButton() async {
     await $(const Key(UiKeys.saveDraftButton)).tap();
-    await $.pumpAndSettle();
   }
 
   /// Resolves the [ComposerController] from the web [ComposerView] widget in
@@ -55,9 +54,7 @@ class WebComposerRobot extends MobileComposerRobot {
   @override
   Future<void> tapSaveAsTemplateButton() async {
     await $(const Key(UiKeys.composerMoreButton)).tap();
-    await $.pumpAndSettle();
     await $(const Key(UiKeys.saveTemplatePopupItem)).tap();
-    await $.pumpAndSettle();
   }
 
   @override
@@ -75,7 +72,6 @@ class WebComposerRobot extends MobileComposerRobot {
     await $.platformAutomator.web.pressKeyCombo(
       keys: isMac ? ['Meta', 'k'] : ['Control', 'k'],
     );
-    await $.pumpAndTrySettle();
   }
 
   // "Apply" is unique to the custom overlay; Summernote's native dialog never

--- a/integration_test/robots/web/web_email_robot.dart
+++ b/integration_test/robots/web/web_email_robot.dart
@@ -1,13 +1,16 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import '../mobile/mobile_email_robot.dart';
+import '../../utils/wait_for_condition.dart';
 
 class WebEmailRobot extends MobileEmailRobot {
   WebEmailRobot(super.$);
 
   @override
   Future<void> expectDownloadSaveDialogVisible() async {
-    final downloads = await $.platformAutomator.web.verifyFileDownloads();
-    expect(downloads.any((name) => name.startsWith('TwakeMail-')), isTrue);
+    await waitForCondition(() async {
+      final downloads = await $.platformAutomator.web.verifyFileDownloads();
+      return downloads.any((name) => name.startsWith('TwakeMail-'));
+    });
   }
 }

--- a/integration_test/robots/web/web_mailbox_menu_robot.dart
+++ b/integration_test/robots/web/web_mailbox_menu_robot.dart
@@ -10,6 +10,7 @@ class WebMailboxMenuRobot extends MobileMailboxMenuRobot {
   @override
   Future<void> openSetting() async {
     await $(const ValueKey(UiKeys.userAvatar)).tap();
+    await $.waitUntilExists($(ValueKey(ProfileSettingActionType.manageAccount.name)));
     await $(ValueKey(ProfileSettingActionType.manageAccount.name)).tap();
   }
 }

--- a/integration_test/robots/web/web_mailbox_menu_robot.dart
+++ b/integration_test/robots/web/web_mailbox_menu_robot.dart
@@ -10,7 +10,7 @@ class WebMailboxMenuRobot extends MobileMailboxMenuRobot {
   @override
   Future<void> openSetting() async {
     await $(const ValueKey(UiKeys.userAvatar)).tap();
-    await $.waitUntilExists($(ValueKey(ProfileSettingActionType.manageAccount.name)));
+    await $.waitUntilVisible($(ValueKey(ProfileSettingActionType.manageAccount.name)));
     await $(ValueKey(ProfileSettingActionType.manageAccount.name)).tap();
   }
 }

--- a/integration_test/robots/web/web_search_robot.dart
+++ b/integration_test/robots/web/web_search_robot.dart
@@ -2,10 +2,10 @@ import 'package:core/presentation/views/text/rich_text_builder.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/quick_search/email_quick_search_item_tile_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart';
 
 import '../../extensions/patrol_finder_extension.dart';
+import '../../utils/wait_for_condition.dart';
 import '../abstract/abstract_search_robot.dart';
 import '../search_robot.dart';
 
@@ -21,11 +21,13 @@ class WebSearchRobot extends SearchRobot implements AbstractSearchRobot {
 
   @override
   Future<void> verifySearchSuggestionHighlights(String keyword) async {
-    // Web: suggestions render inside an OverlayEntry wrapped by PointerInterceptor,
-    // so they are not hit-testable. Use waitUntilExists instead of waitUntilVisible.
-    await $.waitUntilExists($(EmailQuickSearchItemTileWidget));
+    // Wait for search suggestions to appear in overlay
+    // The suggestions contain the keyword in highlighted RichTextBuilder widgets
+    await waitForCondition(() => $(RichTextBuilder).evaluate().isNotEmpty);
+    
+    // Verify the rich text builders contain highlighted content
     expect(
-      $(EmailQuickSearchItemTileWidget).$(RichTextBuilder).evaluate().isNotEmpty,
+      $(RichTextBuilder).evaluate().isNotEmpty,
       isTrue,
     );
   }

--- a/integration_test/robots/web/web_search_robot.dart
+++ b/integration_test/robots/web/web_search_robot.dart
@@ -1,7 +1,10 @@
 import 'package:core/presentation/views/text/rich_text_builder.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
 import 'package:patrol/patrol.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/search_controller.dart' as search_controller_import;
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/quick_search/email_quick_search_item_tile_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart';
 
 import '../../extensions/patrol_finder_extension.dart';
@@ -21,14 +24,34 @@ class WebSearchRobot extends SearchRobot implements AbstractSearchRobot {
 
   @override
   Future<void> verifySearchSuggestionHighlights(String keyword) async {
-    // Wait for search suggestions to appear in overlay
-    // The suggestions contain the keyword in highlighted RichTextBuilder widgets
-    await waitForCondition(() => $(RichTextBuilder).evaluate().isNotEmpty);
-    
-    // Verify the rich text builders contain highlighted content
-    expect(
-      $(RichTextBuilder).evaluate().isNotEmpty,
-      isTrue,
+    // Wait for the search controller to have processed the keyword.
+    final searchController = Get.find<search_controller_import.SearchController>();
+    await waitForCondition(
+      () => searchController.currentSearchText == keyword,
     );
+
+    // EmailQuickSearchItemTileWidget renders inside an OverlayEntry
+    // created by TypeAheadFieldQuickSearch, which is outside the main
+    // widget tree that Patrol searches. WidgetTester searches the
+    // entire element tree including overlay entries.
+    await waitForCondition(
+      () {
+        try {
+          final items = $.tester.widgetList(
+            find.byType(EmailQuickSearchItemTileWidget),
+          );
+          return items.isNotEmpty;
+        } catch (_) {
+          return false;
+        }
+      },
+    );
+
+    // Verify that RichTextBuilder widgets (containing highlighted text)
+    // exist in the overlay suggestion list.
+    final richTextBuilders = $.tester.widgetList(
+      find.byType(RichTextBuilder),
+    );
+    expect(richTextBuilders.isNotEmpty, isTrue);
   }
 }

--- a/integration_test/robots/web/web_thread_robot.dart
+++ b/integration_test/robots/web/web_thread_robot.dart
@@ -3,6 +3,7 @@ import 'package:labels/extensions/label_extension.dart';
 import 'package:patrol/patrol.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/email_view_back_button.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_web_builder.dart';
 
 import '../abstract/abstract_thread_robot.dart';
@@ -10,8 +11,6 @@ import '../thread_robot.dart';
 
 class WebThreadRobot extends ThreadRobot implements AbstractThreadRobot {
   WebThreadRobot(super.$);
-
-  static const Duration _emailOpenPumpDuration = Duration(seconds: 2);
 
   @override
   Future<void> expectAppGridVisible() async {
@@ -65,6 +64,6 @@ class WebThreadRobot extends ThreadRobot implements AbstractThreadRobot {
   Future<void> _openEmailTile(PatrolFinder emailFinder) async {
     await $.waitUntilVisible(emailFinder);
     await emailFinder.tap();
-    await $.pump(_emailOpenPumpDuration);
+    await $.waitUntilVisible($(EmailViewBackButton));
   }
 }

--- a/integration_test/robots/web/web_thread_robot.dart
+++ b/integration_test/robots/web/web_thread_robot.dart
@@ -3,7 +3,6 @@ import 'package:labels/extensions/label_extension.dart';
 import 'package:patrol/patrol.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart';
-import 'package:tmail_ui_user/features/email/presentation/widgets/email_view_back_button.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_web_builder.dart';
 
 import '../abstract/abstract_thread_robot.dart';

--- a/integration_test/robots/web/web_thread_robot.dart
+++ b/integration_test/robots/web/web_thread_robot.dart
@@ -64,6 +64,5 @@ class WebThreadRobot extends ThreadRobot implements AbstractThreadRobot {
   Future<void> _openEmailTile(PatrolFinder emailFinder) async {
     await $.waitUntilVisible(emailFinder);
     await emailFinder.tap();
-    await $.waitUntilVisible($(EmailViewBackButton));
   }
 }

--- a/integration_test/scenarios/composer/base_save_and_reopen_scenario.dart
+++ b/integration_test/scenarios/composer/base_save_and_reopen_scenario.dart
@@ -76,6 +76,7 @@ abstract class BaseSaveAndReopenScenario extends BaseTestScenario {
     if (PlatformInfo.isMobile) {
       await threadRobot.openMailbox();
     }
+    await $.pumpAndSettle(); // <-- Ensure composer transition completes
     await mailboxMenuRobot.openFolderByName(folderDisplayName(appLocalizations));
 
     await waitForEmailListLoaded();

--- a/integration_test/scenarios/composer/base_save_and_reopen_scenario.dart
+++ b/integration_test/scenarios/composer/base_save_and_reopen_scenario.dart
@@ -38,6 +38,13 @@ abstract class BaseSaveAndReopenScenario extends BaseTestScenario {
 
   Future<void> onAfterComposerReopened() async {}
 
+  Future<void> waitForEmailListLoaded() async {
+    // Default: wait for loading indicator to disappear
+    await waitForCondition(
+      () => !$(find.bySemanticsLabel('Mail list loading icon')).exists,
+    );
+  }
+
   @override
   Future<void> runTestLogic() async {
     const email = String.fromEnvironment('BASIC_AUTH_EMAIL');
@@ -71,8 +78,7 @@ abstract class BaseSaveAndReopenScenario extends BaseTestScenario {
     }
     await mailboxMenuRobot.openFolderByName(folderDisplayName(appLocalizations));
 
-    // Wait for email list loading to complete
-    await waitForCondition(() => !$(find.bySemanticsLabel('Mail list loading icon')).exists);
+    await waitForEmailListLoaded();
 
     await waitForCondition(() => $(uniqueSubject).exists);
     await threadRobot.openEmailWithSubject(uniqueSubject);

--- a/integration_test/scenarios/composer/base_save_and_reopen_scenario.dart
+++ b/integration_test/scenarios/composer/base_save_and_reopen_scenario.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter_test/flutter_test.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/foundation.dart';
 import 'package:model/email/prefix_email_address.dart';
@@ -69,6 +70,10 @@ abstract class BaseSaveAndReopenScenario extends BaseTestScenario {
       await threadRobot.openMailbox();
     }
     await mailboxMenuRobot.openFolderByName(folderDisplayName(appLocalizations));
+
+    // Wait for email list loading to complete
+    await waitForCondition(() => !$(find.bySemanticsLabel('Mail list loading icon')).exists);
+
     await waitForCondition(() => $(uniqueSubject).exists);
     await threadRobot.openEmailWithSubject(uniqueSubject);
     await composerRobot.expectComposerViewVisible();

--- a/integration_test/scenarios/composer/base_save_draft_then_reopen_scenario.dart
+++ b/integration_test/scenarios/composer/base_save_draft_then_reopen_scenario.dart
@@ -16,12 +16,9 @@ abstract class BaseSaveDraftThenReopenScenario extends BaseSaveAndReopenScenario
     AppLocalizations l10n,
   ) async {
     await composerRobot.tapCloseComposer();
-    await $.pumpAndTrySettle();
     await expectViewVisible($(#confirm_dialog_action));
     await composerRobot.tapSaveButtonOnSaveDraftConfirmDialog(l10n);
-    await $.pumpAndTrySettle();
     await _expectSaveDraftSuccessToast(l10n);
-    await $.pumpAndTrySettle();
   }
 
   @override
@@ -30,7 +27,6 @@ abstract class BaseSaveDraftThenReopenScenario extends BaseSaveAndReopenScenario
     AppLocalizations l10n,
   ) async {
     await composerRobot.tapSaveAsDraftButton();
-    await $.pumpAndTrySettle();
     await _expectSaveDraftSuccessToast(l10n);
   }
 

--- a/integration_test/scenarios/composer/base_save_template_then_reopen_scenario.dart
+++ b/integration_test/scenarios/composer/base_save_template_then_reopen_scenario.dart
@@ -25,15 +25,15 @@ abstract class BaseSaveTemplateThenReopenScenario extends BaseSaveAndReopenScena
 
   @override
   Future<void> waitForEmailListLoaded() async {
-    // Templates with content (inline images/attachments) load slowly on web.
-    // Wait for the controller's email list to populate instead of relying
-    // on the loading indicator widget which may disappear before the list
-    // is actually rendered.
     await waitForCondition(
-      () => Get.find<MailboxDashBoardController>().emailsInCurrentMailbox.isNotEmpty,
+      () async {
+        await $.pump(); // Advance frames so the browser/test runner interleaves
+        return Get.find<MailboxDashBoardController>().emailsInCurrentMailbox.isNotEmpty;
+      },
       timeout: const Duration(seconds: 60),
+      interval: const Duration(milliseconds: 500),
     );
-  }
+}
 
   @override
   Future<void> performFirstSave(

--- a/integration_test/scenarios/composer/base_save_template_then_reopen_scenario.dart
+++ b/integration_test/scenarios/composer/base_save_template_then_reopen_scenario.dart
@@ -1,8 +1,11 @@
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../../robots/abstract/abstract_composer_robot.dart';
+import '../../utils/wait_for_condition.dart';
 import 'base_save_and_reopen_scenario.dart';
 
 abstract class BaseSaveTemplateThenReopenScenario extends BaseSaveAndReopenScenario {
@@ -18,6 +21,18 @@ abstract class BaseSaveTemplateThenReopenScenario extends BaseSaveAndReopenScena
       await robots.mailboxMenuRobot().pullToRefresh();
       await mobileBack($);
     }
+  }
+
+  @override
+  Future<void> waitForEmailListLoaded() async {
+    // Templates with content (inline images/attachments) load slowly on web.
+    // Wait for the controller's email list to populate instead of relying
+    // on the loading indicator widget which may disappear before the list
+    // is actually rendered.
+    await waitForCondition(
+      () => Get.find<MailboxDashBoardController>().emailsInCurrentMailbox.isNotEmpty,
+      timeout: const Duration(seconds: 60),
+    );
   }
 
   @override

--- a/integration_test/scenarios/composer/base_save_template_then_reopen_scenario.dart
+++ b/integration_test/scenarios/composer/base_save_template_then_reopen_scenario.dart
@@ -1,11 +1,8 @@
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:get/get.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../../robots/abstract/abstract_composer_robot.dart';
-// import '../../utils/wait_for_condition.dart';
 import 'base_save_and_reopen_scenario.dart';
 
 abstract class BaseSaveTemplateThenReopenScenario extends BaseSaveAndReopenScenario {
@@ -21,16 +18,6 @@ abstract class BaseSaveTemplateThenReopenScenario extends BaseSaveAndReopenScena
       await robots.mailboxMenuRobot().pullToRefresh();
       await mobileBack($);
     }
-  }
-
-  @override
-  Future<void> waitForEmailListLoaded() async {
-    final dashboardController = Get.find<MailboxDashBoardController>();
-    
-    // Diagnostic 1: Is the mailbox actually switched?
-    final selectedName = dashboardController.selectedMailbox.value?.name?.name;
-    fail('DIAG: selectedMailbox=$selectedName, '
-      'emailCount=${dashboardController.emailsInCurrentMailbox.length}');
   }
 
   @override

--- a/integration_test/scenarios/composer/base_save_template_then_reopen_scenario.dart
+++ b/integration_test/scenarios/composer/base_save_template_then_reopen_scenario.dart
@@ -5,7 +5,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../../robots/abstract/abstract_composer_robot.dart';
-import '../../utils/wait_for_condition.dart';
+// import '../../utils/wait_for_condition.dart';
 import 'base_save_and_reopen_scenario.dart';
 
 abstract class BaseSaveTemplateThenReopenScenario extends BaseSaveAndReopenScenario {
@@ -25,21 +25,12 @@ abstract class BaseSaveTemplateThenReopenScenario extends BaseSaveAndReopenScena
 
   @override
   Future<void> waitForEmailListLoaded() async {
-    var elapsed = 0;
-    await waitForCondition(
-      () {
-        final count = Get.find<MailboxDashBoardController>().emailsInCurrentMailbox.length;
-        if (elapsed % 5 == 0) {
-          // ignore: avoid_print
-          print('⏳ waitForEmailListLoaded: emailsInCurrentMailbox.length=$count, '
-            'selectedMailbox=${Get.find<MailboxDashBoardController>().selectedMailbox.value?.name?.name}, '
-            'elapsed≈${elapsed * 200}ms');
-        }
-        elapsed++;
-        return count > 0;
-      },
-      timeout: const Duration(seconds: 60),
-    );
+    final dashboardController = Get.find<MailboxDashBoardController>();
+    
+    // Diagnostic 1: Is the mailbox actually switched?
+    final selectedName = dashboardController.selectedMailbox.value?.name?.name;
+    fail('DIAG: selectedMailbox=$selectedName, '
+      'emailCount=${dashboardController.emailsInCurrentMailbox.length}');
   }
 
   @override

--- a/integration_test/scenarios/composer/base_save_template_then_reopen_scenario.dart
+++ b/integration_test/scenarios/composer/base_save_template_then_reopen_scenario.dart
@@ -15,7 +15,6 @@ abstract class BaseSaveTemplateThenReopenScenario extends BaseSaveAndReopenScena
   Future<void> onPreComposerSetup() async {
     if (PlatformInfo.isMobile) {
       await robots.threadRobot().openMailbox();
-      await $.pumpAndTrySettle();
       await robots.mailboxMenuRobot().pullToRefresh();
       await mobileBack($);
     }
@@ -28,17 +27,12 @@ abstract class BaseSaveTemplateThenReopenScenario extends BaseSaveAndReopenScena
   ) async {
     await composerRobot.tapSaveAsTemplateButton();
     await _expectSaveTemplateSuccessToast(l10n);
-    await $.pumpAndTrySettle();
     await composerRobot.tapCloseComposer();
-    await $.pumpAndTrySettle();
     await composerRobot.tapDiscardChanges();
-    await $.pumpAndTrySettle();
   }
 
   @override
-  Future<void> onAfterComposerReopened() async {
-    await $.pumpAndTrySettle(duration: const Duration(seconds: 2));
-  }
+  Future<void> onAfterComposerReopened() async {}
 
   @override
   Future<void> performSubsequentSave(

--- a/integration_test/scenarios/composer/base_save_template_then_reopen_scenario.dart
+++ b/integration_test/scenarios/composer/base_save_template_then_reopen_scenario.dart
@@ -25,12 +25,19 @@ abstract class BaseSaveTemplateThenReopenScenario extends BaseSaveAndReopenScena
 
   @override
   Future<void> waitForEmailListLoaded() async {
-    // Templates with content (inline images/attachments) load slowly on web.
-    // Wait for the controller's email list to populate instead of relying
-    // on the loading indicator widget which may disappear before the list
-    // is actually rendered.
+    var elapsed = 0;
     await waitForCondition(
-      () => Get.find<MailboxDashBoardController>().emailsInCurrentMailbox.isNotEmpty,
+      () {
+        final count = Get.find<MailboxDashBoardController>().emailsInCurrentMailbox.length;
+        if (elapsed % 5 == 0) {
+          // ignore: avoid_print
+          print('⏳ waitForEmailListLoaded: emailsInCurrentMailbox.length=$count, '
+            'selectedMailbox=${Get.find<MailboxDashBoardController>().selectedMailbox.value?.name?.name}, '
+            'elapsed≈${elapsed * 200}ms');
+        }
+        elapsed++;
+        return count > 0;
+      },
       timeout: const Duration(seconds: 60),
     );
   }

--- a/integration_test/scenarios/composer/base_save_template_then_reopen_scenario.dart
+++ b/integration_test/scenarios/composer/base_save_template_then_reopen_scenario.dart
@@ -2,6 +2,7 @@ import 'package:core/utils/platform_info.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../../robots/abstract/abstract_composer_robot.dart';
@@ -26,14 +27,12 @@ abstract class BaseSaveTemplateThenReopenScenario extends BaseSaveAndReopenScena
   @override
   Future<void> waitForEmailListLoaded() async {
     await waitForCondition(
-      () async {
-        await $.pump(); // Advance frames so the browser/test runner interleaves
-        return Get.find<MailboxDashBoardController>().emailsInCurrentMailbox.isNotEmpty;
-      },
+      () => Get.find<MailboxDashBoardController>().emailsInCurrentMailbox.isNotEmpty
+          && $(EmailTileBuilder).exists,
       timeout: const Duration(seconds: 60),
       interval: const Duration(milliseconds: 500),
     );
-}
+  }
 
   @override
   Future<void> performFirstSave(

--- a/integration_test/scenarios/composer/save_template_with_inline_image_then_open_and_save_template_again_scenario.dart
+++ b/integration_test/scenarios/composer/save_template_with_inline_image_then_open_and_save_template_again_scenario.dart
@@ -6,9 +6,7 @@ class SaveTemplateWithInlineImageThenOpenAndSaveTemplateAgainScenario
   const SaveTemplateWithInlineImageThenOpenAndSaveTemplateAgainScenario(super.$, super.robots);
 
   @override
-  Future<void> onAfterContentUploaded() async {
-    await $.pumpAndTrySettle(duration: const Duration(seconds: 2));
-  }
+  Future<void> onAfterContentUploaded() async {}
 
   @override
   String get subject => 'Template with inline image - second save';

--- a/integration_test/scenarios/download_all_attachments_scenario.dart
+++ b/integration_test/scenarios/download_all_attachments_scenario.dart
@@ -29,7 +29,6 @@ class DownloadAllAttachmentsScenario extends BaseTestScenario {
       )],
       requestReadReceipt: false,
     );
-    await $.pumpAndSettle();
 
     await threadRobot.openEmailWithSubject(subject);
     await emailRobot.tapDownloadAllButton();

--- a/integration_test/utils/wait_for_condition.dart
+++ b/integration_test/utils/wait_for_condition.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 Future<void> waitForCondition(
   FutureOr<bool> Function() condition, {
   Duration timeout = const Duration(seconds: 30),
-  Duration interval = const Duration(seconds: 1),
+  Duration interval = const Duration(milliseconds: 200),
 }) async {
   await Future.doWhile(() async {
     if (await condition()) {

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -2556,6 +2556,7 @@ class MailboxDashBoardController extends ReloadableController
   }
 
   void updateEmailList(List<PresentationEmail> newEmailList) {
+    log('MailboxDashBoardController::updateEmailList: newEmailListLength=${newEmailList.length}, selectedMailbox=${selectedMailbox.value?.name?.name}');
     emailsInCurrentMailbox.value = newEmailList;
   }
 

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -289,14 +289,18 @@ class ThreadController extends BaseController with EmailActionController {
         _currentMemoryMailboxId = mailbox.id;
         consumeState(Stream.value(Right(GetAllEmailLoading())));
         resetToOriginalValue();
+        log('ThreadController::_registerObxStreamListener: TRIGGERING getAllEmailAction for mailbox=${mailbox.name?.name}, isFirstSessionLoad=${mailboxDashBoardController.isFirstSessionLoad}');
         getAllEmailAction(
           getLatestChanges: mailboxDashBoardController.isFirstSessionLoad,
           forceEmailQuery: forceEmailQuery,
         );
         mailboxDashBoardController.setIsFirstSessionLoad(false);
       } else if (mailbox == null) { // disable current mailbox when search active
+        log('ThreadController::_registerObxStreamListener: mailbox is NULL - resetting');
         _currentMemoryMailboxId = null;
         resetToOriginalValue();
+      } else {
+        log('ThreadController::_registerObxStreamListener: SKIPPED getAllEmailAction - same mailbox or not PresentationMailbox');
       }
     });
 
@@ -612,6 +616,7 @@ class ThreadController extends BaseController with EmailActionController {
     final currentMailboxId = success.currentMailboxId;
     final isVirtualFolder = selectedMailbox?.isVirtualFolder == true;
 
+    log('ThreadController::_getAllEmailSuccess: GuardCheck - currentMailboxId=$currentMailboxId, selectedMailboxId=$selectedMailboxId, isVirtualFolder=$isVirtualFolder, willReturnEarly=${currentMailboxId != null && (isVirtualFolder || currentMailboxId != selectedMailboxId)}');
     if (currentMailboxId != null &&
         (isVirtualFolder || currentMailboxId != selectedMailboxId)) {
       return;

--- a/scripts/patrol-web-integration-test-with-docker.sh
+++ b/scripts/patrol-web-integration-test-with-docker.sh
@@ -70,7 +70,8 @@ patrol test -v \
     --dart-define=ADDITIONAL_MAIL_RECIPIENT="$ALICE@$DOMAIN" \
     --dart-define=BASIC_AUTH_EMAIL="$BOB@$DOMAIN" \
     --dart-define=BASIC_AUTH_URL="$BASIC_AUTH_URL" \
-    --dart-define=RESET_SERVER_URL="http://localhost:$RESET_PORT"
+    --dart-define=RESET_SERVER_URL="http://localhost:$RESET_PORT" \
+    2>&1 | tee /tmp/patrol-test-output.log
 TEST_EXIT_CODE=$?
 
 exit $TEST_EXIT_CODE

--- a/scripts/patrol-web-integration-test-with-docker.sh
+++ b/scripts/patrol-web-integration-test-with-docker.sh
@@ -59,6 +59,8 @@ cp integration_test/integration_test_env.file env.file
 
 echo "Building the app and running tests..."
 patrol test -v \
+    --target integration_test/tests/composer/save_template_with_attachment_then_open_and_save_template_again_test.dart \
+    --show-flutter-logs \
     --tags=web \
     --device=chrome \
     --web-port=3000 \
@@ -70,8 +72,7 @@ patrol test -v \
     --dart-define=ADDITIONAL_MAIL_RECIPIENT="$ALICE@$DOMAIN" \
     --dart-define=BASIC_AUTH_EMAIL="$BOB@$DOMAIN" \
     --dart-define=BASIC_AUTH_URL="$BASIC_AUTH_URL" \
-    --dart-define=RESET_SERVER_URL="http://localhost:$RESET_PORT" \
-    2>&1 | tee /tmp/patrol-test-output.log
+    --dart-define=RESET_SERVER_URL="http://localhost:$RESET_PORT"
 TEST_EXIT_CODE=$?
 
 exit $TEST_EXIT_CODE

--- a/scripts/patrol-web-integration-test-with-docker.sh
+++ b/scripts/patrol-web-integration-test-with-docker.sh
@@ -59,6 +59,7 @@ cp integration_test/integration_test_env.file env.file
 
 echo "Building the app and running tests..."
 patrol test -v \
+    --target integration_test/tests/composer/save_draft_with_attachment_then_open_and_save_draft_again_test.dart \
     --target integration_test/tests/composer/save_template_with_attachment_then_open_and_save_template_again_test.dart \
     --show-flutter-logs \
     --tags=web \


### PR DESCRIPTION
… tests

Replace unconditional $.pump(seconds: 2) calls with $.waitUntilVisible() or $.pumpAndTrySettle(), and reduce waitForCondition polling interval from 1s to 200ms so tests exit as soon as the expected state is reached rather than always sleeping the full duration.

CC @Arsnael 