### PR TITLE
[Part 2][TF-4479] Add integration tests for clear trash subfolders

### DIFF
--- a/integration_test/mixin/scenario_utils_mixin.dart
+++ b/integration_test/mixin/scenario_utils_mixin.dart
@@ -8,13 +8,17 @@ import 'package:core/utils/platform_info.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/http/http_client.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/capability/capability_identifier.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/identities/identity.dart';
 import 'package:jmap_dart_client/jmap/jmap_request.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
 import 'package:jmap_dart_client/jmap/mail/email/set/set_email_method.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/set/set_mailbox_method.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/set/set_mailbox_response.dart';
 import 'package:labels/extensions/list_label_extension.dart';
 import 'package:model/model.dart';
 import 'package:path_provider/path_provider.dart';
@@ -287,6 +291,55 @@ mixin ScenarioUtilsMixin {
     }
 
     IdentityInteractorsBindings().dispose();
+  }
+
+  Future<void> provisionTrashSubfolder(String subfolderName) async {
+    await waitForCondition(
+      () => getBinding<MailboxDashBoardController>().isReady,
+    );
+    final dashboardController = Get.find<MailboxDashBoardController>();
+    final session = dashboardController.sessionCurrent
+        ?? (throw StateError('provisionTrashSubfolder: session is null'));
+    final accountId = dashboardController.accountId.value
+        ?? (throw StateError('provisionTrashSubfolder: accountId is null'));
+    final trashMailboxId =
+        dashboardController.mapDefaultMailboxIdByRole[PresentationMailbox.roleTrash]
+        ?? (throw StateError('provisionTrashSubfolder: trashMailboxId is null'));
+
+    await _jmapCreateSubfolder(session, accountId, trashMailboxId, subfolderName);
+  }
+
+  Future<void> _jmapCreateSubfolder(
+    Session session,
+    AccountId accountId,
+    MailboxId parentId,
+    String name,
+  ) async {
+    final requestBuilder = JmapRequestBuilder(
+      Get.find<HttpClient>(),
+      ProcessingInvocation(),
+    );
+    final setMailboxMethod = SetMailboxMethod(accountId)
+      ..addCreate(
+        Id(const Uuid().v1()),
+        Mailbox(
+          name: MailboxName(name),
+          parentId: parentId,
+          isSubscribed: IsSubscribed(true),
+        ),
+      );
+    final invocation = requestBuilder.invocation(setMailboxMethod);
+    final response = await (requestBuilder
+          ..usings(setMailboxMethod.requiredCapabilities
+              .toCapabilitiesSupportTeamMailboxes(session, accountId)))
+        .build()
+        .execute();
+    final created = response
+        .parse<SetMailboxResponse>(invocation.methodCallId, SetMailboxResponse.deserialize)
+        ?.created;
+    if (created == null || created.isEmpty) {
+      throw StateError('provisionTrashSubfolder: mailbox creation failed for "$name"');
+    }
   }
 
   void hideKeyboard() {

--- a/integration_test/robots/abstract/abstract_mailbox_assertion_robot.dart
+++ b/integration_test/robots/abstract/abstract_mailbox_assertion_robot.dart
@@ -1,3 +1,6 @@
+import 'package:patrol/patrol.dart';
+
 abstract class AbstractMailboxAssertionRobot {
-  Future<void> expectMailboxWithNameVisible(String name);
+  Future<void> expectMailboxVisible(PatrolFinder finder);
+  Future<void> expectSubfolderNotExist(PatrolFinder finder);
 }

--- a/integration_test/robots/abstract/abstract_mailbox_empty_trash_robot.dart
+++ b/integration_test/robots/abstract/abstract_mailbox_empty_trash_robot.dart
@@ -1,0 +1,4 @@
+abstract class AbstractMailboxEmptyTrashRobot {
+  Future<void> tapEmptyTrash();
+  Future<void> confirmEmptyTrash();
+}

--- a/integration_test/robots/abstract/abstract_mailbox_folder_robot.dart
+++ b/integration_test/robots/abstract/abstract_mailbox_folder_robot.dart
@@ -1,0 +1,16 @@
+import 'package:patrol/patrol.dart';
+
+abstract class AbstractMailboxFolderRobot {
+  Future<void> tapAddNewFolderButton();
+  Future<void> tapCreateNewSubFolder();
+  Future<void> enterNewFolderName(String name);
+  Future<void> confirmCreateNewFolder();
+  Future<void> tapRenameMailbox();
+  Future<void> enterRenameSubFolderName(String name);
+  Future<void> confirmRenameSubFolder();
+  Future<void> tapMoveMailbox();
+  Future<void> tapDeleteMailbox();
+  Future<void> confirmDeleteMailbox();
+  Future<void> tapHideMailbox();
+  Future<void> tapMoveFolderContentAction(PatrolFinder targetMailbox);
+}

--- a/integration_test/robots/abstract/abstract_mailbox_menu_folder_robot.dart
+++ b/integration_test/robots/abstract/abstract_mailbox_menu_folder_robot.dart
@@ -1,5 +1,0 @@
-abstract class AbstractMailboxMenuFolderRobot {
-  Future<void> tapAddNewFolderButton();
-  Future<void> enterNewFolderName(String name);
-  Future<void> confirmCreateNewFolder();
-}

--- a/integration_test/robots/abstract/abstract_mailbox_menu_robot.dart
+++ b/integration_test/robots/abstract/abstract_mailbox_menu_robot.dart
@@ -1,9 +1,18 @@
-import 'abstract_mailbox_assertion_robot.dart';
-import 'abstract_mailbox_menu_folder_robot.dart';
+import 'package:patrol/patrol.dart';
 
-abstract class AbstractMailboxMenuRobot
-    implements AbstractMailboxMenuFolderRobot, AbstractMailboxAssertionRobot {
-  Future<void> openFolderByName(String name);
+import 'abstract_mailbox_assertion_robot.dart';
+import 'abstract_mailbox_empty_trash_robot.dart';
+import 'abstract_mailbox_folder_robot.dart';
+import 'abstract_mailbox_navigation_robot.dart';
+
+abstract class AbstractMailboxMenuRobot {
+  PatrolFinder mailboxItemByName(String name);
+  PatrolFinder mailboxItemByExactName(String name);
   Future<void> pullToRefresh();
   Future<void> openSetting();
+
+  AbstractMailboxNavigationRobot get navigation;
+  AbstractMailboxFolderRobot get folder;
+  AbstractMailboxEmptyTrashRobot get emptyTrash;
+  AbstractMailboxAssertionRobot get assertion;
 }

--- a/integration_test/robots/abstract/abstract_mailbox_navigation_robot.dart
+++ b/integration_test/robots/abstract/abstract_mailbox_navigation_robot.dart
@@ -1,0 +1,8 @@
+import 'package:patrol/patrol.dart';
+
+abstract class AbstractMailboxNavigationRobot {
+  Future<void> openFolder(PatrolFinder finder);
+  Future<void> longPressMailbox(PatrolFinder finder);
+  Future<void> expandMailbox(PatrolFinder finder);
+  Future<void> tapMailbox(PatrolFinder finder);
+}

--- a/integration_test/robots/abstract/abstract_thread_assertion_robot.dart
+++ b/integration_test/robots/abstract/abstract_thread_assertion_robot.dart
@@ -1,0 +1,6 @@
+abstract class AbstractThreadAssertionRobot {
+  Future<void> expectAppGridButtonVisible();
+  Future<void> expectTrashBannerVisible();
+  Future<void> expectTrashBannerInvisible();
+  Future<void> expectEmptyTrashThreadView();
+}

--- a/integration_test/robots/abstract/abstract_thread_empty_trash_robot.dart
+++ b/integration_test/robots/abstract/abstract_thread_empty_trash_robot.dart
@@ -1,0 +1,4 @@
+abstract class AbstractThreadEmptyTrashRobot {
+  Future<void> tapEmptyTrashBanner();
+  Future<void> confirmEmptyTrash();
+}

--- a/integration_test/robots/abstract/abstract_thread_robot.dart
+++ b/integration_test/robots/abstract/abstract_thread_robot.dart
@@ -1,6 +1,11 @@
+import 'abstract_thread_assertion_robot.dart';
+import 'abstract_thread_empty_trash_robot.dart';
+
 abstract class AbstractThreadRobot {
+  AbstractThreadAssertionRobot get assertion;
+  AbstractThreadEmptyTrashRobot get emptyTrash;
+
   Future<void> openComposer();
-  Future<void> expectAppGridVisible();
   Future<void> openAppGrid();
   Future<void> openMailbox();
   Future<void> openEmailWithSubject(String subject);

--- a/integration_test/robots/mailbox_assertion_robot.dart
+++ b/integration_test/robots/mailbox_assertion_robot.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/patrol.dart';
+
+import '../base/core_robot.dart';
+import '../utils/wait_for_condition.dart';
+import 'abstract/abstract_mailbox_assertion_robot.dart';
+
+class MailboxAssertionRobot extends CoreRobot implements AbstractMailboxAssertionRobot {
+  MailboxAssertionRobot(super.$);
+
+  @override
+  Future<void> expectMailboxVisible(PatrolFinder finder) async {
+    await waitForCondition(() async => finder.evaluate().isNotEmpty);
+    expect(finder, findsWidgets);
+  }
+
+  @override
+  Future<void> expectSubfolderNotExist(PatrolFinder finder) async {
+    await waitForCondition(() => !finder.exists);
+  }
+}

--- a/integration_test/robots/mailbox_empty_trash_robot.dart
+++ b/integration_test/robots/mailbox_empty_trash_robot.dart
@@ -1,0 +1,17 @@
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../base/core_robot.dart';
+import 'abstract/abstract_mailbox_empty_trash_robot.dart';
+
+class MailboxEmptyTrashRobot extends CoreRobot
+    implements AbstractMailboxEmptyTrashRobot {
+  final _l10n = AppLocalizations();
+
+  MailboxEmptyTrashRobot(super.$);
+
+  @override
+  Future<void> tapEmptyTrash() async => $(_l10n.emptyTrash).tap();
+
+  @override
+  Future<void> confirmEmptyTrash() async => $(_l10n.delete).tap();
+}

--- a/integration_test/robots/mailbox_folder_robot.dart
+++ b/integration_test/robots/mailbox_folder_robot.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:patrol/patrol.dart';
+import 'package:tmail_ui_user/features/mailbox_creator/presentation/mailbox_creator_view.dart';
+import 'package:core/presentation/views/text/text_field_builder.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../base/core_robot.dart';
+import 'abstract/abstract_mailbox_folder_robot.dart';
+
+class MailboxFolderRobot extends CoreRobot implements AbstractMailboxFolderRobot {
+  final _l10n = AppLocalizations();
+
+  MailboxFolderRobot(super.$);
+
+  @override
+  Future<void> tapAddNewFolderButton() async {
+    await $(#add_new_folder_button).tap();
+  }
+
+  @override
+  Future<void> tapCreateNewSubFolder() async {
+    await $(_l10n.newSubfolder).tap();
+  }
+
+  @override
+  Future<void> enterNewFolderName(String name) async {
+    await $(MailboxCreatorView)
+        .$(TextFieldBuilder)
+        .enterText(name);
+  }
+
+  @override
+  Future<void> confirmCreateNewFolder() async {
+    await $(MailboxCreatorView)
+        .$(_l10n.createFolder)
+        .tap();
+  }
+
+  @override
+  Future<void> tapRenameMailbox() async {
+    await $(_l10n.renameFolder).tap();
+  }
+
+  @override
+  Future<void> enterRenameSubFolderName(String name) async {
+    await $(#rename_mailbox_dialog)
+        .$(TextField)
+        .enterText(name);
+    await $.pumpAndSettle(duration: const Duration(seconds: 1));
+  }
+
+  @override
+  Future<void> confirmRenameSubFolder() async {
+    await $(#rename_mailbox_dialog)
+        .$(_l10n.rename.toUpperCase())
+        .tap();
+  }
+
+  @override
+  Future<void> tapMoveMailbox() async {
+    await $(_l10n.moveFolder).tap();
+  }
+
+  @override
+  Future<void> tapDeleteMailbox() async {
+    await $(_l10n.deleteFolder).tap();
+  }
+
+  @override
+  Future<void> confirmDeleteMailbox() async {
+    await $(_l10n.delete).tap();
+    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+  }
+
+  @override
+  Future<void> tapHideMailbox() async {
+    await $(_l10n.hideFolder).tap();
+  }
+
+  @override
+  Future<void> tapMoveFolderContentAction(PatrolFinder targetMailbox) async {
+    await $(_l10n.moveFolderContent).tap();
+    await $.pumpAndTrySettle();
+    await targetMailbox.tap();
+    await $.pumpAndTrySettle();
+  }
+}

--- a/integration_test/robots/mailbox_menu_robot.dart
+++ b/integration_test/robots/mailbox_menu_robot.dart
@@ -1,16 +1,14 @@
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
-
-import 'package:core/presentation/views/text/text_field_builder.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
+import 'package:patrol/patrol.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/label_mailbox_item_widget.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/mailbox_item_widget.dart';
-import 'package:tmail_ui_user/features/mailbox_creator/presentation/mailbox_creator_view.dart';
 import 'package:tmail_ui_user/features/quotas/presentation/quotas_controller.dart';
 import 'package:tmail_ui_user/features/search/mailbox/presentation/search_mailbox_view.dart';
+import 'package:core/presentation/views/text/text_field_builder.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
@@ -18,56 +16,53 @@ import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import '../base/core_robot.dart';
 import '../exceptions/mailbox/null_inbox_unread_count_exception.dart';
 import '../exceptions/mailbox/null_quota_exception.dart';
-import '../utils/wait_for_condition.dart';
+import 'abstract/abstract_mailbox_assertion_robot.dart';
+import 'abstract/abstract_mailbox_empty_trash_robot.dart';
+import 'abstract/abstract_mailbox_folder_robot.dart';
 import 'abstract/abstract_mailbox_menu_robot.dart';
+import 'abstract/abstract_mailbox_navigation_robot.dart';
+import 'mailbox_assertion_robot.dart';
+import 'mailbox_empty_trash_robot.dart';
+import 'mailbox_folder_robot.dart';
+import 'mailbox_navigation_robot.dart';
 
 class MailboxMenuRobot extends CoreRobot implements AbstractMailboxMenuRobot {
-  MailboxMenuRobot(super.$);
+  @override
+  final AbstractMailboxNavigationRobot navigation;
 
   @override
-  Future<void> openFolderByName(String name) async {
-    final mailboxItem = $(MailboxItemWidget).$(LabelMailboxItemWidget).$(name);
-    await $(mailboxItem).waitUntilExists();
-    await $.scrollUntilVisible(finder: mailboxItem);
-    await mailboxItem.tap();
-  }
+  final AbstractMailboxFolderRobot folder;
+
+  @override
+  final AbstractMailboxEmptyTrashRobot emptyTrash;
+
+  @override
+  final AbstractMailboxAssertionRobot assertion;
+
+  MailboxMenuRobot(
+    PatrolIntegrationTester $, {
+    AbstractMailboxNavigationRobot? navigationRobot,
+  })  : navigation = navigationRobot ?? MailboxNavigationRobot($),
+        folder = MailboxFolderRobot($),
+        emptyTrash = MailboxEmptyTrashRobot($),
+        assertion = MailboxAssertionRobot($),
+        super($);
+
+  final _l10n = AppLocalizations();
+
+  //// Finds a mailbox item containing the given display name text.
+  @override
+  PatrolFinder mailboxItemByName(String name) =>
+      $(MailboxItemWidget).$(LabelMailboxItemWidget).$(name);
+
+  /// Finds a mailbox item whose name exactly matches the given value.
+  @override
+  PatrolFinder mailboxItemByExactName(String name) =>
+      $(MailboxItemWidget).which<MailboxItemWidget>((w) => w.mailboxNode.item.name?.name.toLowerCase() == name.toLowerCase());
 
   @override
   Future<void> openSetting() async {
     await $(const ValueKey(UiKeys.userAvatar)).tap();
-  }
-
-  Future<void> longPressMailboxWithName(String name) async {
-    await $(name).longPress();
-    await $.pumpAndSettle();
-  }
-
-  Future<void> tapCreateNewSubFolder() async {
-    await $(AppLocalizations().newSubfolder).tap();
-  }
-
-  @override
-  Future<void> enterNewFolderName(String name) async {
-    await $(MailboxCreatorView)
-        .$(TextFieldBuilder)
-        .enterText(name);
-  }
-
-  @override
-  Future<void> confirmCreateNewFolder() async {
-    await $(MailboxCreatorView)
-        .$(AppLocalizations().createFolder)
-        .tap();
-  }
-
-  Future<void> expandMailboxWithName(String name) async {
-    await $(MailboxItemWidget)
-        .which<MailboxItemWidget>((widget) {
-          return widget.mailboxNode.item.name?.name.toLowerCase() ==
-              name.toLowerCase();
-        })
-        .$(#expand_mailbox_button)
-        .tap();
   }
 
   Future<void> openMailboxSearch() async {
@@ -81,10 +76,6 @@ class MailboxMenuRobot extends CoreRobot implements AbstractMailboxMenuRobot {
   Future<void> searchMailbox(String query) async {
     await $(SearchMailboxView).$(TextFieldBuilder).enterText(query);
     await $.pumpAndSettle();
-  }
-
-  Future<void> tapHideMailbox() async {
-    await $(AppLocalizations().hideFolder).tap();
   }
 
   Future<void> closeMenu() async {
@@ -108,12 +99,12 @@ class MailboxMenuRobot extends CoreRobot implements AbstractMailboxMenuRobot {
   }
 
   Future<void> tapSignOut() async {
-    await $.scrollUntilVisible(finder: $(AppLocalizations().sign_out));
-    await $(AppLocalizations().sign_out).tap();
+    await $.scrollUntilVisible(finder: $(_l10n.sign_out));
+    await $(_l10n.sign_out).tap();
   }
 
   Future<void> confirmSignOut() async {
-    await $(AppLocalizations().yesLogout).tap();
+    await $(_l10n.yesLogout).tap();
   }
 
   int getUsedQuota() {
@@ -130,75 +121,20 @@ class MailboxMenuRobot extends CoreRobot implements AbstractMailboxMenuRobot {
   }
 
   Future<void> tapRecoverDeletedMessages() async {
-    await $(AppLocalizations().recoverDeletedMessages).tap();
+    await $(_l10n.recoverDeletedMessages).tap();
   }
 
   Future<void> tapConfirmRecoverDeletedMessages() async {
     if (await native.isPermissionDialogVisible(timeout: const Duration(seconds: 2))) {
       await native.grantPermissionWhenInUse();
     }
-    await $(AppLocalizations().restore).tap();
+    await $(_l10n.restore).tap();
     await $.pumpAndSettle();
-  }
-
-  Future<void> tapRenameMailbox() async {
-    await $(AppLocalizations().renameFolder).tap();
-  }
-
-  Future<void> enterRenameSubFolderName(String name) async {
-    await $(#rename_mailbox_dialog)
-        .$(TextField)
-        .enterText(name);
-    await $.pumpAndSettle(duration: const Duration(seconds: 1));
-  }
-
-  Future<void> confirmRenameSubFolder() async {
-    await $(#rename_mailbox_dialog)
-        .$(AppLocalizations().rename.toUpperCase())
-        .tap();
-  }
-
-  Future<void> tapMoveMailbox() async {
-    await $(AppLocalizations().moveFolder).tap();
-  }
-
-  Future<void> tapMailboxWithName(String name) async {
-    await $(name).tap();
-    await $.pumpAndSettle(duration: const Duration(seconds: 2));
-  }
-
-  Future<void> tapDeleteMailbox() async {
-    await $(AppLocalizations().deleteFolder).tap();
-  }
-
-  Future<void> confirmDeleteMailbox() async {
-    await $(AppLocalizations().delete).tap();
-    await $.pumpAndSettle(duration: const Duration(seconds: 2));
-  }
-
-  @override
-  Future<void> tapAddNewFolderButton() async {
-    await $(#add_new_folder_button).tap();
-  }
-
-  @override
-  Future<void> expectMailboxWithNameVisible(String name) async {
-    final mailboxItem = $(MailboxItemWidget).$(LabelMailboxItemWidget).$(name);
-    await waitForCondition(() async => mailboxItem.evaluate().isNotEmpty);
-    expect(mailboxItem, findsWidgets);
   }
 
   Future<void> tapMarkAsRead() async {
-    await $(AppLocalizations().mark_as_read).tap();
+    await $(_l10n.mark_as_read).tap();
     await $.pumpAndSettle();
-  }
-
-  Future<void> tapMoveFolderContentAction(String mailboxName) async {
-    await $(AppLocalizations().moveFolderContent).tap();
-    await $.pumpAndTrySettle();
-
-    await $(mailboxName).tap();
-    await $.pumpAndTrySettle();
   }
 
   @override

--- a/integration_test/robots/mailbox_navigation_robot.dart
+++ b/integration_test/robots/mailbox_navigation_robot.dart
@@ -1,0 +1,41 @@
+import 'package:patrol/patrol.dart';
+
+import '../base/core_robot.dart';
+import 'abstract/abstract_mailbox_navigation_robot.dart';
+
+class MailboxNavigationRobot extends CoreRobot implements AbstractMailboxNavigationRobot {
+  MailboxNavigationRobot(super.$);
+
+  Future<void> _ensureReady(PatrolFinder finder) async {
+    await finder.waitUntilExists();
+    await $.scrollUntilVisible(finder: finder);
+  }
+
+  @override
+  Future<void> openFolder(PatrolFinder finder) async {
+    await _ensureReady(finder);
+    await finder.tap();
+  }
+
+  @override
+  Future<void> longPressMailbox(PatrolFinder finder) async {
+    await _ensureReady(finder);
+    await finder.longPress();
+    await $.pumpAndSettle();
+  }
+
+  @override
+  Future<void> expandMailbox(PatrolFinder finder) async {
+    await _ensureReady(finder);
+    final expandButton = finder.$(#expand_mailbox_button);
+    await expandButton.waitUntilExists();
+    await expandButton.tap();
+  }
+
+  @override
+  Future<void> tapMailbox(PatrolFinder finder) async {
+    await _ensureReady(finder);
+    await finder.tap();
+    await $.pumpAndSettle(duration: const Duration(seconds: 2));
+  }
+}

--- a/integration_test/robots/mobile/mobile_mailbox_menu_robot.dart
+++ b/integration_test/robots/mobile/mobile_mailbox_menu_robot.dart
@@ -1,11 +1,16 @@
 import 'package:flutter/foundation.dart';
+import 'package:patrol/patrol.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 
 import '../abstract/abstract_mailbox_menu_robot.dart';
+import '../abstract/abstract_mailbox_navigation_robot.dart';
 import '../mailbox_menu_robot.dart';
 
 class MobileMailboxMenuRobot extends MailboxMenuRobot implements AbstractMailboxMenuRobot {
-  MobileMailboxMenuRobot(super.$);
+  MobileMailboxMenuRobot(
+    PatrolIntegrationTester $, {
+    AbstractMailboxNavigationRobot? navigationRobot,
+  }) : super($, navigationRobot: navigationRobot);
 
   @override
   Future<void> openSetting() async {

--- a/integration_test/robots/mobile/mobile_thread_robot.dart
+++ b/integration_test/robots/mobile/mobile_thread_robot.dart
@@ -9,12 +9,6 @@ class MobileThreadRobot extends ThreadRobot implements AbstractThreadRobot {
   MobileThreadRobot(PatrolIntegrationTester $) : super($);
 
   @override
-  Future<void> expectAppGridVisible() async {
-    await openMailbox();
-    await $(const ValueKey(UiKeys.toggleAppGridButton)).waitUntilVisible();
-  }
-
-  @override
   Future<void> openAppGrid() async {
     await $(const ValueKey(UiKeys.toggleAppGridButton)).tap();
   }

--- a/integration_test/robots/thread_assertion_robot.dart
+++ b/integration_test/robots/thread_assertion_robot.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
+import 'package:tmail_ui_user/features/base/widget/clean_messages_banner.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../base/core_robot.dart';
+import '../utils/wait_for_condition.dart';
+import 'abstract/abstract_thread_assertion_robot.dart';
+
+class ThreadAssertionRobot extends CoreRobot implements AbstractThreadAssertionRobot {
+  ThreadAssertionRobot(super.$);
+
+  @override
+  Future<void> expectAppGridButtonVisible() async {
+    await $(const ValueKey(UiKeys.toggleAppGridButton)).waitUntilVisible();
+  }
+
+  @override
+  Future<void> expectTrashBannerVisible() async {
+    await $(find.textContaining(AppLocalizations().empty_trash_now)).waitUntilVisible();
+  }
+
+  @override
+  Future<void> expectTrashBannerInvisible() async {
+    await $(const Key(UiKeys.cleanMessageBannerNotVisible)).waitUntilExists();
+    await waitForCondition(() => !$(CleanMessagesBanner).visible);
+  }
+
+  @override
+  Future<void> expectEmptyTrashThreadView() async {
+    await $(const Key(UiKeys.emptyThreadView)).waitUntilVisible();
+  }
+}

--- a/integration_test/robots/thread_empty_trash_robot.dart
+++ b/integration_test/robots/thread_empty_trash_robot.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../base/core_robot.dart';
+import 'abstract/abstract_thread_empty_trash_robot.dart';
+
+class ThreadEmptyTrashRobot extends CoreRobot implements AbstractThreadEmptyTrashRobot {
+  ThreadEmptyTrashRobot(super.$);
+
+  @override
+  Future<void> tapEmptyTrashBanner() async =>
+      $(find.textContaining(AppLocalizations().empty_trash_now)).tap();
+
+  @override
+  Future<void> confirmEmptyTrash() async =>
+      $(AppLocalizations().delete).tap();
+}

--- a/integration_test/robots/thread_robot.dart
+++ b/integration_test/robots/thread_robot.dart
@@ -2,6 +2,7 @@ import 'package:core/presentation/views/search/search_bar_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:labels/extensions/label_extension.dart';
+import 'package:patrol/patrol.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_view.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';
@@ -10,9 +11,21 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../base/core_robot.dart';
 import '../utils/wait_for_condition.dart';
+import 'abstract/abstract_thread_assertion_robot.dart';
+import 'abstract/abstract_thread_empty_trash_robot.dart';
+import 'thread_assertion_robot.dart';
+import 'thread_empty_trash_robot.dart';
 
 class ThreadRobot extends CoreRobot {
-  ThreadRobot(super.$);
+  final AbstractThreadAssertionRobot assertion;
+  final AbstractThreadEmptyTrashRobot emptyTrash;
+
+  ThreadRobot(
+    PatrolIntegrationTester $, {
+    AbstractThreadEmptyTrashRobot? emptyTrashRobot,
+  })  : assertion = ThreadAssertionRobot($),
+        emptyTrash = emptyTrashRobot ?? ThreadEmptyTrashRobot($),
+        super($);
 
   Future<void> openComposer() async {
     await $(const ValueKey(UiKeys.composeEmailButton)).$(InkWell).tap();
@@ -49,8 +62,6 @@ class ThreadRobot extends CoreRobot {
   Future<void> openMailbox() async {
     await $(const ValueKey(UiKeys.mobileMailboxMenuButton)).tap();
   }
-
-  Future<void> tapEmptyTrashBanner() => $(' ${AppLocalizations().empty_trash_now}').tap();
 
   Future<void> tapDeleteAllButtonOnEmptyTrashConfirmDialog(
     AppLocalizations appLocalizations,
@@ -95,10 +106,6 @@ class ThreadRobot extends CoreRobot {
   Future<void> tapOnMailboxWithName(String name) async {
     await $(name).tap();
     await $.pumpAndSettle();
-  }
-
-  Future<void> confirmEmptyTrash() async {
-    await $(AppLocalizations().delete_all).tap();
   }
 
   Future<void> tapEmptySpamBanner() async {

--- a/integration_test/robots/web/web_fire_on_tap.dart
+++ b/integration_test/robots/web/web_fire_on_tap.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Fires the [TapGestureRecognizer] for the [TextSpan] whose text matches
+/// [text] inside the first matching widget of [finder].
+///
+/// Required on web because [RichText] spans are not hit-testable via the
+/// standard [WidgetTester.tap] — only the recognizer fire path works.
+void webFireOnTap(Finder finder, String text) {
+  final elements = finder.evaluate().toList();
+  if (elements.isEmpty) {
+    throw StateError('No widget found for tappable text: $text');
+  }
+  for (final element in elements) {
+    final renderObject = element.renderObject;
+    if (renderObject is RenderParagraph &&
+        _tryFireTapInParagraph(renderObject, text)) {
+      return;
+    }
+  }
+  throw StateError('Tap target not found or not tappable: $text');
+}
+
+bool _tryFireTapInParagraph(RenderParagraph paragraph, String text) {
+  var fired = false;
+  paragraph.text.visitChildren((InlineSpan span) {
+    if (span is! TextSpan || span.text != text) return true;
+    final recognizer = span.recognizer;
+    if (recognizer is TapGestureRecognizer) {
+      recognizer.onTap?.call();
+      fired = true;
+      return false;
+    }
+    return true;
+  });
+  return fired;
+}

--- a/integration_test/robots/web/web_mailbox_menu_robot.dart
+++ b/integration_test/robots/web/web_mailbox_menu_robot.dart
@@ -1,11 +1,39 @@
-import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/patrol.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/profile_setting/profile_setting_action_type.dart';
 
+import '../mailbox_navigation_robot.dart';
 import '../mobile/mobile_mailbox_menu_robot.dart';
 
+/// Web-specific navigation robot that simulates "long-press" via mouse hover
+/// then tapping the more-action button, because mobile long-press gestures
+/// are not available in a web browser context.
+class WebMailboxNavigationRobot extends MailboxNavigationRobot {
+  WebMailboxNavigationRobot(super.$);
+
+  @override
+  Future<void> longPressMailbox(PatrolFinder finder) async {
+    await finder.waitUntilExists();
+
+    final gesture = await $.tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    try {
+      await gesture.moveTo($.tester.getCenter(finder));
+      await $.pump();
+
+      await finder.$(const ValueKey(UiKeys.mailboxMoreActionButton)).tap();
+      await $.pumpAndTrySettle();
+    } finally {
+      await gesture.removePointer();
+    }
+  }
+}
+
 class WebMailboxMenuRobot extends MobileMailboxMenuRobot {
-  WebMailboxMenuRobot(super.$);
+  WebMailboxMenuRobot(super.$) : super(navigationRobot: WebMailboxNavigationRobot($));
 
   @override
   Future<void> openSetting() async {

--- a/integration_test/robots/web/web_thread_robot.dart
+++ b/integration_test/robots/web/web_thread_robot.dart
@@ -1,22 +1,49 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:labels/extensions/label_extension.dart';
 import 'package:patrol/patrol.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_web_builder.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../abstract/abstract_thread_robot.dart';
+import '../thread_empty_trash_robot.dart';
 import '../thread_robot.dart';
+import 'web_fire_on_tap.dart';
 
-class WebThreadRobot extends ThreadRobot implements AbstractThreadRobot {
-  WebThreadRobot(super.$);
-
-  static const Duration _emailOpenPumpDuration = Duration(seconds: 2);
+/// Web-specific empty-trash robot: tapping the banner requires firing the
+/// [TapGestureRecognizer] of a [TextSpan] directly, because [RichText] spans
+/// are not hit-testable via the standard gesture dispatch on web.
+class WebThreadEmptyTrashRobot extends ThreadEmptyTrashRobot {
+  WebThreadEmptyTrashRobot(super.$);
 
   @override
-  Future<void> expectAppGridVisible() async {
-    await $(const ValueKey(UiKeys.toggleAppGridButton)).waitUntilVisible();
+  Future<void> tapEmptyTrashBanner() async {
+    final actionText = AppLocalizations().empty_trash_now;
+    final textFinder = find.textContaining(actionText);
+    await $.waitUntilVisible($(textFinder));
+
+    // Compact layout: positive action rendered as a hit-testable Text widget inside a button.
+    // $(text) only matches Text widgets, not RichText spans, so this is empty in desktop mode.
+    final compactButton = $(actionText);
+    if (compactButton.evaluate().isNotEmpty) {
+      await compactButton.tap();
+      return;
+    }
+
+    // Desktop layout: positive action is a TextSpan inside RichText — not hit-testable via tap.
+    webFireOnTap($(textFinder), actionText);
+    await $.pumpAndTrySettle();
   }
+}
+
+class WebThreadRobot extends ThreadRobot implements AbstractThreadRobot {
+  WebThreadRobot(PatrolIntegrationTester $)
+      : super($, emptyTrashRobot: WebThreadEmptyTrashRobot($));
+
+  static const Duration _emailOpenPumpDuration = Duration(seconds: 2);
 
   @override
   Future<void> openAppGrid() async {

--- a/integration_test/scenarios/app_grid_scenario.dart
+++ b/integration_test/scenarios/app_grid_scenario.dart
@@ -13,7 +13,8 @@ class AppGridScenario extends BaseTestScenario {
       final threadRobot = robots.threadRobot();
       final appGridRobot = robots.appGridRobot();
 
-      await threadRobot.expectAppGridVisible();
+      await threadRobot.openMailbox();
+      await threadRobot.assertion.expectAppGridButtonVisible();
       await threadRobot.openAppGrid();
 
       await appGridRobot.expectAppCountAndLabelsMatch();

--- a/integration_test/scenarios/composer/base_save_and_reopen_scenario.dart
+++ b/integration_test/scenarios/composer/base_save_and_reopen_scenario.dart
@@ -68,7 +68,7 @@ abstract class BaseSaveAndReopenScenario extends BaseTestScenario {
     if (PlatformInfo.isMobile) {
       await threadRobot.openMailbox();
     }
-    await mailboxMenuRobot.openFolderByName(folderDisplayName(appLocalizations));
+    await mailboxMenuRobot.navigation.openFolder(mailboxMenuRobot.mailboxItemByName(folderDisplayName(appLocalizations)));
     await waitForCondition(() => $(uniqueSubject).exists);
     await threadRobot.openEmailWithSubject(uniqueSubject);
     await composerRobot.expectComposerViewVisible();

--- a/integration_test/scenarios/composer/change_identity_in_draft_email_scenario.dart
+++ b/integration_test/scenarios/composer/change_identity_in_draft_email_scenario.dart
@@ -74,7 +74,7 @@ class ChangeIdentityInDraftEmailScenario extends BaseTestScenario {
 
     await threadRobot.openMailbox();
     await mailboxMenuRobot
-        .openFolderByName(appLocalizations.draftsMailboxDisplayName);
+        .navigation.openFolder(mailboxMenuRobot.mailboxItemByName(appLocalizations.draftsMailboxDisplayName));
 
     await threadRobot.openEmailWithSubject(subject);
     await _expectComposerViewVisible();

--- a/integration_test/scenarios/composer/update_draft_email_with_message_success_toast_scenario.dart
+++ b/integration_test/scenarios/composer/update_draft_email_with_message_success_toast_scenario.dart
@@ -45,8 +45,8 @@ class UpdateDraftEmailWithMessageSuccessToastScenario extends BaseTestScenario {
     await $.pumpAndSettle();
 
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.openFolderByName(
-      appLocalizations.draftsMailboxDisplayName,
+    await mailboxMenuRobot.navigation.openFolder(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.draftsMailboxDisplayName),
     );
     await threadRobot.openEmailWithSubject(subject);
     await _expectComposerViewVisible();

--- a/integration_test/scenarios/email/reply_to_own_sent_email_scenario.dart
+++ b/integration_test/scenarios/email/reply_to_own_sent_email_scenario.dart
@@ -27,8 +27,8 @@ class ReplyToOwnSentEmailScenario extends BaseTestScenario {
 
     await sendEmailScenario.runTestLogic();
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.openFolderByName(
-      appLocalizations.sentMailboxDisplayName,
+    await mailboxMenuRobot.navigation.openFolder(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.sentMailboxDisplayName),
     );
     await threadRobot.openEmailWithSubject(subject);
     await emailRobot.onTapReplyEmail();

--- a/integration_test/scenarios/email_detailed/archive_email_scenario.dart
+++ b/integration_test/scenarios/email_detailed/archive_email_scenario.dart
@@ -47,7 +47,7 @@ class ArchiveEmailScenario extends BaseTestScenario {
     await $.pumpAndSettle();
 
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.openFolderByName(appLocalizations.archiveMailboxDisplayName);
+    await mailboxMenuRobot.navigation.openFolder(mailboxMenuRobot.mailboxItemByName(appLocalizations.archiveMailboxDisplayName));
     await _expectEmailWithSubjectInArchiveFolderVisible(subject);
   }
 

--- a/integration_test/scenarios/email_detailed/delete_email_scenario.dart
+++ b/integration_test/scenarios/email_detailed/delete_email_scenario.dart
@@ -44,7 +44,7 @@ class DeleteEmailScenario extends BaseTestScenario {
     _expectEmailViewInvisible();
 
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.openFolderByName(appLocalizations.trashMailboxDisplayName);
+    await mailboxMenuRobot.navigation.openFolder(mailboxMenuRobot.mailboxItemByName(appLocalizations.trashMailboxDisplayName));
     await _expectEmailWithSubjectInTrashFolderVisible(subject);
   }
 

--- a/integration_test/scenarios/email_detailed/mark_as_spam_email_scenario.dart
+++ b/integration_test/scenarios/email_detailed/mark_as_spam_email_scenario.dart
@@ -46,7 +46,7 @@ class MarkAsSpamEmailScenario extends BaseTestScenario {
     _expectEmailViewInvisible();
 
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.openFolderByName(appLocalizations.spamMailboxDisplayName);
+    await mailboxMenuRobot.navigation.openFolder(mailboxMenuRobot.mailboxItemByName(appLocalizations.spamMailboxDisplayName));
     await _expectEmailWithSubjectInSpamFolderVisible(subject);
   }
 

--- a/integration_test/scenarios/email_detailed/move_email_to_folder_scenario.dart
+++ b/integration_test/scenarios/email_detailed/move_email_to_folder_scenario.dart
@@ -47,7 +47,7 @@ class MoveEmailToFolderScenario extends BaseTestScenario {
     _expectEmailWithSubjectInCurrentFolderInvisible(subject);
 
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.openFolderByName(appLocalizations.templatesMailboxDisplayName);
+    await mailboxMenuRobot.navigation.openFolder(mailboxMenuRobot.mailboxItemByName(appLocalizations.templatesMailboxDisplayName));
     await _expectEmailWithSubjectInDestinationFolderVisible(subject);
   }
 

--- a/integration_test/scenarios/mailbox/clear_trash_subfolders_via_banner_scenario.dart
+++ b/integration_test/scenarios/mailbox/clear_trash_subfolders_via_banner_scenario.dart
@@ -1,0 +1,41 @@
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+
+class ClearTrashSubfoldersViaBannerScenario extends BaseTestScenario {
+  const ClearTrashSubfoldersViaBannerScenario(super.$, super.robots);
+
+  static const _subfolderName = 'Trash subfolder banner test';
+
+  @override
+  Future<void> runTestLogic() async {
+    const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const subject = 'Empty trash';
+    final appLocalizations = AppLocalizations();
+    final mailboxMenuRobot = robots.mailboxMenuRobot();
+    final threadRobot = robots.threadRobot();
+
+    await provisionTrashSubfolder(_subfolderName);
+
+    await robots.commonRobot().provisionEmail([
+      ProvisioningEmail(toEmail: emailUser, subject: subject, content: subject),
+    ], folderLocationRole: PresentationMailbox.roleTrash);
+
+    final trashFolder = mailboxMenuRobot.mailboxItemByName(appLocalizations.trashMailboxDisplayName);
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.navigation.openFolder(trashFolder);
+    await threadRobot.assertion.expectTrashBannerVisible();
+
+    await threadRobot.emptyTrash.tapEmptyTrashBanner();
+    await threadRobot.emptyTrash.confirmEmptyTrash();
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.assertion.expectSubfolderNotExist(mailboxMenuRobot.mailboxItemByName(_subfolderName));
+
+    await mailboxMenuRobot.navigation.openFolder(trashFolder);
+    await threadRobot.assertion.expectEmptyTrashThreadView();
+    await threadRobot.assertion.expectTrashBannerInvisible();
+  }
+}

--- a/integration_test/scenarios/mailbox/clear_trash_subfolders_via_context_menu_scenario.dart
+++ b/integration_test/scenarios/mailbox/clear_trash_subfolders_via_context_menu_scenario.dart
@@ -1,0 +1,43 @@
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+
+class ClearTrashSubfoldersViaContextMenuScenario extends BaseTestScenario {
+  const ClearTrashSubfoldersViaContextMenuScenario(super.$, super.robots);
+
+  static const _subfolderName = 'Trash subfolder context menu test';
+
+  @override
+  Future<void> runTestLogic() async {
+    const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const subject = 'Empty trash';
+    final appLocalizations = AppLocalizations();
+    final mailboxMenuRobot = robots.mailboxMenuRobot();
+    final threadRobot = robots.threadRobot();
+
+    await provisionTrashSubfolder(_subfolderName);
+
+    await robots.commonRobot().provisionEmail([
+      ProvisioningEmail(toEmail: emailUser, subject: subject, content: subject),
+    ], folderLocationRole: PresentationMailbox.roleTrash);
+
+    final trashFolder = mailboxMenuRobot.mailboxItemByName(appLocalizations.trashMailboxDisplayName);
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.navigation.openFolder(trashFolder);
+    await threadRobot.assertion.expectTrashBannerVisible();
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.navigation.longPressMailbox(mailboxMenuRobot.mailboxItemByExactName(appLocalizations.trashMailboxDisplayName));
+    await mailboxMenuRobot.emptyTrash.tapEmptyTrash();
+    await mailboxMenuRobot.emptyTrash.confirmEmptyTrash();
+
+    await threadRobot.openMailbox();
+    await mailboxMenuRobot.assertion.expectSubfolderNotExist(mailboxMenuRobot.mailboxItemByName(_subfolderName));
+
+    await mailboxMenuRobot.navigation.openFolder(trashFolder);
+    await threadRobot.assertion.expectEmptyTrashThreadView();
+    await threadRobot.assertion.expectTrashBannerInvisible();
+  }
+}

--- a/integration_test/scenarios/mailbox/create_and_hide_sub_folder_scenario.dart
+++ b/integration_test/scenarios/mailbox/create_and_hide_sub_folder_scenario.dart
@@ -18,20 +18,20 @@ class CreateAndHideSubFolderScenario extends BaseTestScenario {
     final appLocalizations = AppLocalizations();
 
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.longPressMailboxWithName(
-      appLocalizations.inboxMailboxDisplayName,
+    await mailboxMenuRobot.navigation.longPressMailbox(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.inboxMailboxDisplayName),
     );
-    await mailboxMenuRobot.tapCreateNewSubFolder();
-    await mailboxMenuRobot.enterNewFolderName(subFolderName);
-    await mailboxMenuRobot.confirmCreateNewFolder();
+    await mailboxMenuRobot.folder.tapCreateNewSubFolder();
+    await mailboxMenuRobot.folder.enterNewFolderName(subFolderName);
+    await mailboxMenuRobot.folder.confirmCreateNewFolder();
     await _expectMailboxWithNameVisible(subFolderName);
 
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.expandMailboxWithName(
-      appLocalizations.inboxMailboxDisplayName
+    await mailboxMenuRobot.navigation.expandMailbox(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.inboxMailboxDisplayName),
     );
-    await mailboxMenuRobot.longPressMailboxWithName(subFolderName);
-    await mailboxMenuRobot.tapHideMailbox();
+    await mailboxMenuRobot.navigation.longPressMailbox(mailboxMenuRobot.mailboxItemByName(subFolderName));
+    await mailboxMenuRobot.folder.tapHideMailbox();
     await _expectMailboxWithNameHaveNoChildren(
       appLocalizations.inboxMailboxDisplayName
     );

--- a/integration_test/scenarios/mailbox/create_personal_folder_scenario.dart
+++ b/integration_test/scenarios/mailbox/create_personal_folder_scenario.dart
@@ -11,9 +11,9 @@ class CreatePersonalFolderScenario extends BaseTestScenario {
     final mailboxMenuRobot = robots.mailboxMenuRobot();
 
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.tapAddNewFolderButton();
-    await mailboxMenuRobot.enterNewFolderName(_folderName);
-    await mailboxMenuRobot.confirmCreateNewFolder();
-    await mailboxMenuRobot.expectMailboxWithNameVisible(_folderName);
+    await mailboxMenuRobot.folder.tapAddNewFolderButton();
+    await mailboxMenuRobot.folder.enterNewFolderName(_folderName);
+    await mailboxMenuRobot.folder.confirmCreateNewFolder();
+    await mailboxMenuRobot.assertion.expectMailboxVisible(mailboxMenuRobot.mailboxItemByName(_folderName));
   }
 }

--- a/integration_test/scenarios/mailbox/create_rename_move_and_delete_mailbox_scenario.dart
+++ b/integration_test/scenarios/mailbox/create_rename_move_and_delete_mailbox_scenario.dart
@@ -20,36 +20,36 @@ class CreateRenameMoveAndDeleteMailboxScenario extends BaseTestScenario {
 
     // Create sub folder
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.longPressMailboxWithName(
-      appLocalizations.inboxMailboxDisplayName,
+    await mailboxMenuRobot.navigation.longPressMailbox(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.inboxMailboxDisplayName),
     );
-    await mailboxMenuRobot.tapCreateNewSubFolder();
-    await mailboxMenuRobot.enterNewFolderName(subFolderName);
-    await mailboxMenuRobot.confirmCreateNewFolder();
+    await mailboxMenuRobot.folder.tapCreateNewSubFolder();
+    await mailboxMenuRobot.folder.enterNewFolderName(subFolderName);
+    await mailboxMenuRobot.folder.confirmCreateNewFolder();
     await _expectMailboxWithNameVisible(subFolderName);
 
     // Rename sub folder
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.expandMailboxWithName(
-      appLocalizations.inboxMailboxDisplayName
+    await mailboxMenuRobot.navigation.expandMailbox(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.inboxMailboxDisplayName),
     );
-    await mailboxMenuRobot.longPressMailboxWithName(subFolderName);
-    await mailboxMenuRobot.tapRenameMailbox();
-    await mailboxMenuRobot.enterRenameSubFolderName(subFolderRenamedName);
-    await mailboxMenuRobot.confirmRenameSubFolder();
+    await mailboxMenuRobot.navigation.longPressMailbox(mailboxMenuRobot.mailboxItemByName(subFolderName));
+    await mailboxMenuRobot.folder.tapRenameMailbox();
+    await mailboxMenuRobot.folder.enterRenameSubFolderName(subFolderRenamedName);
+    await mailboxMenuRobot.folder.confirmRenameSubFolder();
     await _expectMailboxWithNameVisible(subFolderRenamedName);
 
     // Move sub folder to archive mailbox
-    await mailboxMenuRobot.longPressMailboxWithName(subFolderRenamedName);
-    await mailboxMenuRobot.tapMoveMailbox();
-    await mailboxMenuRobot.tapMailboxWithName(appLocalizations.archiveMailboxDisplayName);
+    await mailboxMenuRobot.navigation.longPressMailbox(mailboxMenuRobot.mailboxItemByName(subFolderRenamedName));
+    await mailboxMenuRobot.folder.tapMoveMailbox();
+    await mailboxMenuRobot.navigation.tapMailbox(mailboxMenuRobot.mailboxItemByName(appLocalizations.archiveMailboxDisplayName));
     await _expectMailboxWithNameHaveSubFolder(appLocalizations.archiveMailboxDisplayName);
 
     // Delete sub folder
-    await mailboxMenuRobot.expandMailboxWithName(appLocalizations.archiveMailboxDisplayName);
-    await mailboxMenuRobot.longPressMailboxWithName(subFolderRenamedName);
-    await mailboxMenuRobot.tapDeleteMailbox();
-    await mailboxMenuRobot.confirmDeleteMailbox();
+    await mailboxMenuRobot.navigation.expandMailbox(mailboxMenuRobot.mailboxItemByName(appLocalizations.archiveMailboxDisplayName));
+    await mailboxMenuRobot.navigation.longPressMailbox(mailboxMenuRobot.mailboxItemByName(subFolderRenamedName));
+    await mailboxMenuRobot.folder.tapDeleteMailbox();
+    await mailboxMenuRobot.folder.confirmDeleteMailbox();
     await _expectMailboxWithNameNotHaveSubFolder(appLocalizations.archiveMailboxDisplayName);
   }
 

--- a/integration_test/scenarios/mailbox/display_empty_view_for_favorite_folder_scenario.dart
+++ b/integration_test/scenarios/mailbox/display_empty_view_for_favorite_folder_scenario.dart
@@ -21,8 +21,8 @@ class DisplayEmptyViewForFavoriteFolderScenario extends BaseTestScenario {
     await threadRobot.openMailbox();
     await _expectFolderVisible(appLocalizations.favoriteMailboxDisplayName);
 
-    await mailboxMenuRobot.openFolderByName(
-      appLocalizations.favoriteMailboxDisplayName,
+    await mailboxMenuRobot.navigation.openFolder(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.favoriteMailboxDisplayName),
     );
     await $.pumpAndTrySettle();
     await _expectEmptyViewVisible();

--- a/integration_test/scenarios/mailbox/empty_and_recover_spam_scenario.dart
+++ b/integration_test/scenarios/mailbox/empty_and_recover_spam_scenario.dart
@@ -30,22 +30,22 @@ class EmptyAndRecoverSpamScenario extends BaseTestScenario {
     );
 
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.openFolderByName(
-      appLocalizations.spamMailboxDisplayName,
+    await mailboxMenuRobot.navigation.openFolder(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.spamMailboxDisplayName),
     );
     await threadRobot.tapEmptySpamBanner();
     await threadRobot.confirmEmptySpam();
     await _expectSpamBannerInvisible();
 
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.longPressMailboxWithName(
-      appLocalizations.trashMailboxDisplayName,
+    await mailboxMenuRobot.navigation.longPressMailbox(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.trashMailboxDisplayName),
     );
     await mailboxMenuRobot.tapRecoverDeletedMessages();
     await mailboxMenuRobot.tapConfirmRecoverDeletedMessages();
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.openFolderByName(
-      appLocalizations.recoveredMailboxDisplayName,
+    await mailboxMenuRobot.navigation.openFolder(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.recoveredMailboxDisplayName),
     );
     await _expectEmailWithSubjectVisible(subject);
   }

--- a/integration_test/scenarios/mailbox/empty_and_recover_trash_scenario.dart
+++ b/integration_test/scenarios/mailbox/empty_and_recover_trash_scenario.dart
@@ -29,23 +29,20 @@ class EmptyAndRecoverTrashScenario extends BaseTestScenario {
       folderLocationRole: PresentationMailbox.roleTrash,
     );
 
+    final trashFolder = mailboxMenuRobot.mailboxItemByName(appLocalizations.trashMailboxDisplayName);
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.openFolderByName(
-      appLocalizations.trashMailboxDisplayName,
-    );
-    await threadRobot.tapEmptyTrashBanner();
-    await threadRobot.confirmEmptyTrash();
+    await mailboxMenuRobot.navigation.openFolder(trashFolder);
+    await threadRobot.emptyTrash.tapEmptyTrashBanner();
+    await threadRobot.emptyTrash.confirmEmptyTrash();
     await _expectTrashBannerInvisible();
 
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.longPressMailboxWithName(
-      appLocalizations.trashMailboxDisplayName,
-    );
+    await mailboxMenuRobot.navigation.longPressMailbox(trashFolder);
     await mailboxMenuRobot.tapRecoverDeletedMessages();
     await mailboxMenuRobot.tapConfirmRecoverDeletedMessages();
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.openFolderByName(
-      appLocalizations.recoveredMailboxDisplayName,
+    await mailboxMenuRobot.navigation.openFolder(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.recoveredMailboxDisplayName),
     );
     await _expectEmailWithSubjectVisible(subject);
   }

--- a/integration_test/scenarios/mailbox/empty_trash_scenario.dart
+++ b/integration_test/scenarios/mailbox/empty_trash_scenario.dart
@@ -42,13 +42,13 @@ class EmptyTrashScenario extends BaseTestScenario {
     await _expectMailboxViewVisible();
     await _expectFolderVisible(appLocalizations.trashMailboxDisplayName);
 
-    await mailboxMenuRobot.openFolderByName(
-      appLocalizations.trashMailboxDisplayName,
+    await mailboxMenuRobot.navigation.openFolder(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.trashMailboxDisplayName),
     );
     await _expectEmptyTrashBannerVisible();
     await _expectEmailWithSubjectVisible(subject);
 
-    await threadRobot.tapEmptyTrashBanner();
+    await threadRobot.emptyTrash.tapEmptyTrashBanner();
     await _expectEmptyTrashConfirmDialogVisible(appLocalizations);
     await threadRobot.tapDeleteAllButtonOnEmptyTrashConfirmDialog(
       appLocalizations,

--- a/integration_test/scenarios/mailbox/long_press_empty_and_recover_spam_scenario.dart
+++ b/integration_test/scenarios/mailbox/long_press_empty_and_recover_spam_scenario.dart
@@ -36,8 +36,8 @@ class LongPressEmptyAndRecoverSpamScenario extends BaseTestScenario {
     _expectSpamUnreadCountVisible(
       appLocalizations.spamMailboxDisplayName,
     );
-    await mailboxMenuRobot.longPressMailboxWithName(
-      appLocalizations.spamMailboxDisplayName,
+    await mailboxMenuRobot.navigation.longPressMailbox(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.spamMailboxDisplayName),
     );
     await threadRobot.tapEmptySpamAfterLongPress();
     await threadRobot.confirmEmptySpam();
@@ -46,20 +46,20 @@ class LongPressEmptyAndRecoverSpamScenario extends BaseTestScenario {
       appLocalizations.spamMailboxDisplayName,
     );
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.openFolderByName(
-      appLocalizations.spamMailboxDisplayName,
+    await mailboxMenuRobot.navigation.openFolder(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.spamMailboxDisplayName),
     );
     await _expectSpamBannerInvisible();
 
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.longPressMailboxWithName(
-      appLocalizations.trashMailboxDisplayName,
+    await mailboxMenuRobot.navigation.longPressMailbox(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.trashMailboxDisplayName),
     );
     await mailboxMenuRobot.tapRecoverDeletedMessages();
     await mailboxMenuRobot.tapConfirmRecoverDeletedMessages();
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.openFolderByName(
-      appLocalizations.recoveredMailboxDisplayName,
+    await mailboxMenuRobot.navigation.openFolder(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.recoveredMailboxDisplayName),
     );
     await _expectEmailWithSubjectVisible(subject);
   }

--- a/integration_test/scenarios/mailbox/long_press_empty_and_recover_trash_scenario.dart
+++ b/integration_test/scenarios/mailbox/long_press_empty_and_recover_trash_scenario.dart
@@ -36,28 +36,23 @@ class LongPressEmptyAndRecoverTrashScenario extends BaseTestScenario {
     _expectTrashUnreadCountVisible(
       appLocalizations.trashMailboxDisplayName,
     );
-    await mailboxMenuRobot.longPressMailboxWithName(
-      appLocalizations.trashMailboxDisplayName,
-    );
+    final trashFolder = mailboxMenuRobot.mailboxItemByName(appLocalizations.trashMailboxDisplayName);
+    await mailboxMenuRobot.navigation.longPressMailbox(trashFolder);
     await threadRobot.tapEmptyTrashAfterLongPress();
     await threadRobot.tapConfirmEmptyTrashAfterLongPress();
     _expectTrashUnreadCountInvisible(
       appLocalizations.trashMailboxDisplayName,
     );
-    await mailboxMenuRobot.openFolderByName(
-      appLocalizations.trashMailboxDisplayName,
-    );
+    await mailboxMenuRobot.navigation.openFolder(trashFolder);
     await _expectTrashBannerInvisible();
 
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.longPressMailboxWithName(
-      appLocalizations.trashMailboxDisplayName,
-    );
+    await mailboxMenuRobot.navigation.longPressMailbox(trashFolder);
     await mailboxMenuRobot.tapRecoverDeletedMessages();
     await mailboxMenuRobot.tapConfirmRecoverDeletedMessages();
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.openFolderByName(
-      appLocalizations.recoveredMailboxDisplayName,
+    await mailboxMenuRobot.navigation.openFolder(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.recoveredMailboxDisplayName),
     );
     await _expectEmailWithSubjectVisible(subject);
   }

--- a/integration_test/scenarios/mailbox/mailbox_move_email_scenario.dart
+++ b/integration_test/scenarios/mailbox/mailbox_move_email_scenario.dart
@@ -35,15 +35,15 @@ class MailboxMoveEmailScenario extends BaseTestScenario {
     await threadRobot.longPressEmailWithSubject(templatesSubject);
     await threadRobot.moveEmailToMailboxWithName(appLocalizations.templatesMailboxDisplayName);
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.openFolderByName(appLocalizations.templatesMailboxDisplayName);
+    await mailboxMenuRobot.navigation.openFolder(mailboxMenuRobot.mailboxItemByName(appLocalizations.templatesMailboxDisplayName));
     await _expectEmailWithSubjectVisible(templatesSubject);
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.openFolderByName(appLocalizations.inboxMailboxDisplayName);
+    await mailboxMenuRobot.navigation.openFolder(mailboxMenuRobot.mailboxItemByName(appLocalizations.inboxMailboxDisplayName));
 
     await threadRobot.longPressEmailWithSubject(trashSubject);
     await threadRobot.moveEmailToTrash();
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.openFolderByName(appLocalizations.trashMailboxDisplayName);
+    await mailboxMenuRobot.navigation.openFolder(mailboxMenuRobot.mailboxItemByName(appLocalizations.trashMailboxDisplayName));
     await _expectEmailWithSubjectVisible(trashSubject);
   }
 

--- a/integration_test/scenarios/mailbox/mark_mailbox_as_read_scenario.dart
+++ b/integration_test/scenarios/mailbox/mark_mailbox_as_read_scenario.dart
@@ -29,8 +29,8 @@ class MarkMailboxAsReadScenario extends BaseTestScenario {
     await $.pumpAndTrySettle();
     _expectInboxUnreadCountVisible();
 
-    await mailboxMenuRobot.longPressMailboxWithName(
-      AppLocalizations().inboxMailboxDisplayName,
+    await mailboxMenuRobot.navigation.longPressMailbox(
+      mailboxMenuRobot.mailboxItemByName(AppLocalizations().inboxMailboxDisplayName),
     );
     await mailboxMenuRobot.tapMarkAsRead();
     await threadRobot.openMailbox();

--- a/integration_test/scenarios/mailbox/mark_single_selected_email_as_spam_scenario.dart
+++ b/integration_test/scenarios/mailbox/mark_single_selected_email_as_spam_scenario.dart
@@ -25,8 +25,8 @@ class MarkSingleSelectedEmailAsSpamScenario extends BaseTestScenario {
     await threadRobot.longPressEmailWithSubject(spamSubject);
     await threadRobot.tapMarkAsSpamAction();
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.openFolderByName(
-      AppLocalizations().spamMailboxDisplayName,
+    await mailboxMenuRobot.navigation.openFolder(
+      mailboxMenuRobot.mailboxItemByName(AppLocalizations().spamMailboxDisplayName),
     );
     await _expectEmailWithSubjectExist(spamSubject);
   }

--- a/integration_test/scenarios/mailbox/move_folder_content_scenario.dart
+++ b/integration_test/scenarios/mailbox/move_folder_content_scenario.dart
@@ -36,26 +36,26 @@ class MoveFolderContentScenario extends BaseTestScenario {
     await threadRobot.openMailbox();
     await $.pumpAndTrySettle();
 
-    await mailboxMenuRobot.longPressMailboxWithName(
-      appLocalizations.inboxMailboxDisplayName,
+    await mailboxMenuRobot.navigation.longPressMailbox(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.inboxMailboxDisplayName),
     );
-    await mailboxMenuRobot.tapMoveFolderContentAction(
-      appLocalizations.templatesMailboxDisplayName,
+    await mailboxMenuRobot.folder.tapMoveFolderContentAction(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.templatesMailboxDisplayName),
     );
     await $.pumpAndTrySettle(duration: const Duration(seconds: 3));
 
     await threadRobot.openMailbox();
     await $.pumpAndTrySettle();
-    await mailboxMenuRobot.openFolderByName(
-      appLocalizations.templatesMailboxDisplayName,
+    await mailboxMenuRobot.navigation.openFolder(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.templatesMailboxDisplayName),
     );
     await $.pumpAndTrySettle();
     await _expectEmailWithSubjectVisible(emailSubject);
 
     await threadRobot.openMailbox();
     await $.pumpAndTrySettle();
-    await mailboxMenuRobot.openFolderByName(
-      appLocalizations.inboxMailboxDisplayName,
+    await mailboxMenuRobot.navigation.openFolder(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.inboxMailboxDisplayName),
     );
     await $.pumpAndTrySettle();
     await _expectEmailWithSubjectInVisible(emailSubject);

--- a/integration_test/scenarios/mailbox/team_mailbox_receive_email_scenario.dart
+++ b/integration_test/scenarios/mailbox/team_mailbox_receive_email_scenario.dart
@@ -43,8 +43,8 @@ class TeamMailboxReceiveEmailScenario extends BaseTestScenario {
     await $.pump(const Duration(seconds: 2));
 
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.expandMailboxWithName(teamMailboxName);
-    await mailboxMenuRobot.openFolderByName(appLocalizations.inboxMailboxDisplayName.toUpperCase());
+    await mailboxMenuRobot.navigation.expandMailbox(mailboxMenuRobot.mailboxItemByName(teamMailboxName));
+    await mailboxMenuRobot.navigation.openFolder(mailboxMenuRobot.mailboxItemByName(appLocalizations.inboxMailboxDisplayName.toUpperCase()));
     await _expectEmailWithSubjectVisible(subject);
   }
 

--- a/integration_test/scenarios/save_as_template_scenario.dart
+++ b/integration_test/scenarios/save_as_template_scenario.dart
@@ -19,8 +19,8 @@ class SaveAsTemplateScenario extends BaseTestScenario {
     final composerRobot = ComposerRobot($);
 
     await threadRobot.openMailbox();
-    await mailboxMenuRobot.openFolderByName(
-      appLocalizations.templatesMailboxDisplayName,
+    await mailboxMenuRobot.navigation.openFolder(
+      mailboxMenuRobot.mailboxItemByName(appLocalizations.templatesMailboxDisplayName),
     );
     
     await threadRobot.openComposer();

--- a/integration_test/scenarios/save_draft_then_close_composer_and_open_draft_scenario.dart
+++ b/integration_test/scenarios/save_draft_then_close_composer_and_open_draft_scenario.dart
@@ -54,7 +54,7 @@ class SaveDraftThenCloseComposerAndOpenDraftScenario extends BaseTestScenario {
     await _expectMailboxViewVisible();
     await _expectDraftFolderVisible(appLocalizations);
 
-    await mailboxMenuRobot.openFolderByName(appLocalizations.draftsMailboxDisplayName);
+    await mailboxMenuRobot.navigation.openFolder(mailboxMenuRobot.mailboxItemByName(appLocalizations.draftsMailboxDisplayName));
     await $.pump(const Duration(seconds: 2));
     await _expectDraftEmailWithSubjectVisible(subject);
 

--- a/integration_test/tests/mailbox/clear_trash_subfolders_via_banner_test.dart
+++ b/integration_test/tests/mailbox/clear_trash_subfolders_via_banner_test.dart
@@ -1,0 +1,11 @@
+import '../../base/test_base.dart';
+import '../../models/test_tags.dart';
+import '../../scenarios/mailbox/clear_trash_subfolders_via_banner_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should delete trash subfolders when emptying trash via banner',
+    tags: [TestTags.android, TestTags.ios, TestTags.web],
+    scenarioBuilder: ($, robots) => ClearTrashSubfoldersViaBannerScenario($, robots),
+  );
+}

--- a/integration_test/tests/mailbox/clear_trash_subfolders_via_context_menu_test.dart
+++ b/integration_test/tests/mailbox/clear_trash_subfolders_via_context_menu_test.dart
@@ -1,0 +1,11 @@
+import '../../base/test_base.dart';
+import '../../models/test_tags.dart';
+import '../../scenarios/mailbox/clear_trash_subfolders_via_context_menu_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should delete trash subfolders when emptying trash via context menu',
+    tags: [TestTags.android, TestTags.ios, TestTags.web],
+    scenarioBuilder: ($, robots) => ClearTrashSubfoldersViaContextMenuScenario($, robots),
+  );
+}

--- a/lib/features/base/model/ui_keys.dart
+++ b/lib/features/base/model/ui_keys.dart
@@ -28,4 +28,7 @@ class UiKeys {
   static const String openAdvancedSearchButton = 'open_advanced_search_button';
   static const String advancedSearchLabelDropDown = 'advanced_search_label_drop_down';
   static const String advancedSearchSearchButton = 'advanced_search_search_button';
+
+  static const String mailboxMoreActionButton = 'mailbox_more_action_button';
+  static const String cleanMessageBannerNotVisible = 'clean_message_banner_not_visible';
 }

--- a/lib/features/mailbox/presentation/widgets/label_mailbox_item_widget.dart
+++ b/lib/features/mailbox/presentation/widgets/label_mailbox_item_widget.dart
@@ -15,6 +15,7 @@ import 'package:tmail_ui_user/features/mailbox/presentation/styles/trailing_mail
 import 'package:tmail_ui_user/features/mailbox/presentation/utils/mailbox_method_action_define.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/empty_mailbox_popup_dialog_widget.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/mailbox_expand_button.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/trailing_mailbox_item_widget.dart';
 
 class LabelMailboxItemWidget extends StatefulWidget {
@@ -140,6 +141,7 @@ class _LabelMailboxItemWidgetState extends State<LabelMailboxItemWidget> {
           Offstage(
             offstage: !_shouldShowMorePopupMenu,
             child: TMailButtonWidget.fromIcon(
+              key: const ValueKey(UiKeys.mailboxMoreActionButton),
               margin: _responsiveUtils.isDesktop(context) &&
                       widget.mailboxNode.allowedHasEmptyAction
                   ? EdgeInsets.zero

--- a/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart
+++ b/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart
@@ -275,7 +275,7 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
                                     ),
                                   );
                                 } else {
-                                  return const SizedBox.shrink();
+                                  return const SizedBox.shrink(key: Key(UiKeys.cleanMessageBannerNotVisible));
                                 }
                               }),
                               _buildListButtonQuickSearchFilter(context),

--- a/lib/features/thread/presentation/thread_view.dart
+++ b/lib/features/thread/presentation/thread_view.dart
@@ -236,7 +236,7 @@ class ThreadView extends GetWidget<ThreadController>
                         );
                       } else {
                         return const SizedBox.shrink(
-                          key: Key('clean_message_banner_not_visible'),
+                          key: Key(UiKeys.cleanMessageBannerNotVisible),
                         );
                       }
                     }),


### PR DESCRIPTION
## Summary

- Add e2e scenarios for clearing trash subfolders via context menu and via empty-trash banner
- Extend robots (`MailboxMenuRobot`, `ThreadRobot`, web variants) with clear-trash actions
- Add scenario utils for trash subfolder setup

## Result

```console
✅ Should delete trash subfolders when emptying trash via banner (/tests/mailbox/clear_trash_subfolders_via_banner_test.dart) (9s)
✅ Should delete trash subfolders when emptying trash via context menu (/tests/mailbox/clear_trash_subfolders_via_context_menu_test.dart) (8s)

Test summary:
📝 Total: 2
✅ Successful: 2
❌ Failed: 0
⏩ Skipped: 0
📊 Report: /Users/datvu/WorkingSpace/tmail-flutter/playwright-report
⏱️  Duration: 39s

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Verified that emptying the Trash now removes any Trash subfolders (covered via both banner and context-menu flows).

* **Tests**
  * Added new integration test scenarios and entry points for clearing Trash subfolders.
  * Expanded and refactored mailbox/thread test automation to use more robust UI navigation and assertions.

* **Bug Fixes**
  * Stabilized UI element identity for the “clean message banner not visible” state and the mailbox “more” button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->