### PR TITLE
fix: Do not double escape text in Scribe

### DIFF
--- a/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
+++ b/lib/features/composer/presentation/extensions/ai_scribe/handle_ai_scribe_in_composer_extension.dart
@@ -42,8 +42,7 @@ extension HandleAiScribeInComposerExtension on ComposerController {
 
   Future<void> insertTextInEditor(String text) async {    
     try {
-      final escapedText = StringConvert.escapeTextContent(text);
-      final htmlContent = StringConvert.convertTextContentToHtmlContent(escapedText);
+      final htmlContent = StringConvert.convertTextContentToHtmlContent(text);
 
       if (PlatformInfo.isWeb) {
         await richTextWebController?.editorController.evaluateJavascriptWeb(
@@ -62,8 +61,7 @@ extension HandleAiScribeInComposerExtension on ComposerController {
 
   Future<void> setTextInEditor(String text) async {
     try {
-      final escapedText = StringConvert.escapeTextContent(text);
-      final htmlContent = StringConvert.convertTextContentToHtmlContent(escapedText);
+      final htmlContent = StringConvert.convertTextContentToHtmlContent(text);
       
       if (PlatformInfo.isWeb) {
         richTextWebController?.editorController.setText(htmlContent);


### PR DESCRIPTION
After merging our final PRs, we ended with double escape of text which led to some characters being replaced by their HTML code like ' was replaced by &#39;

See https://github.com/linagora/tmail-flutter/issues/4528

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified text processing in the AI Scribe composer for improved HTML conversion accuracy when inserting or updating text in the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->