### PR TITLE
fix: bound Email/changes pagination to stop self-inflicted request st…

### DIFF
--- a/lib/features/push_notification/data/repository/fcm_repository_impl.dart
+++ b/lib/features/push_notification/data/repository/fcm_repository_impl.dart
@@ -26,7 +26,6 @@ import 'package:tmail_ui_user/features/push_notification/domain/model/update_tok
 import 'package:tmail_ui_user/features/push_notification/domain/repository/fcm_repository.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/utils/fcm_constants.dart';
 import 'package:tmail_ui_user/features/thread/data/datasource/thread_datasource.dart';
-import 'package:tmail_ui_user/features/thread/data/model/email_change_response.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/email_response.dart';
 
 class FCMRepositoryImpl extends FCMRepository {
@@ -51,28 +50,13 @@ class FCMRepositoryImpl extends FCMRepository {
       Properties? propertiesUpdated
     }
   ) async {
-    EmailChangeResponse? emailChangeResponse;
-    bool hasMoreChanges = true;
-    jmap.State? sinceState = currentState;
-
-    while (hasMoreChanges && sinceState != null) {
-      final changesResponse = await _threadDataSource.getChanges(
-        session,
-        accountId,
-        sinceState,
-        propertiesCreated: propertiesCreated,
-        propertiesUpdated: propertiesUpdated
-      );
-
-      hasMoreChanges = changesResponse.hasMoreChanges;
-      sinceState = changesResponse.newStateChanges;
-
-      if (emailChangeResponse != null) {
-        emailChangeResponse.union(changesResponse);
-      } else {
-        emailChangeResponse = changesResponse;
-      }
-    }
+    final emailChangeResponse = await _threadDataSource.getAllEmailChanges(
+      session,
+      accountId,
+      currentState,
+      propertiesCreated: propertiesCreated,
+      propertiesUpdated: propertiesUpdated
+    );
 
     final listEmails = emailChangeResponse?.created ?? [];
     listEmails.sortBy(EmailComparator(EmailComparatorProperty.receivedAt)..setIsAscending(true));
@@ -163,28 +147,13 @@ class FCMRepositoryImpl extends FCMRepository {
       Properties? propertiesUpdated
     }
   ) async {
-    EmailChangeResponse? emailChangeResponse;
-    bool hasMoreChanges = true;
-    jmap.State? sinceState = currentState;
-
-    while (hasMoreChanges && sinceState != null) {
-      final changesResponse = await _threadDataSource.getChanges(
-        session,
-        accountId,
-        sinceState,
-        propertiesCreated: propertiesCreated,
-        propertiesUpdated: propertiesUpdated
-      );
-
-      hasMoreChanges = changesResponse.hasMoreChanges;
-      sinceState = changesResponse.newStateChanges;
-
-      if (emailChangeResponse != null) {
-        emailChangeResponse.union(changesResponse);
-      } else {
-        emailChangeResponse = changesResponse;
-      }
-    }
+    final emailChangeResponse = await _threadDataSource.getAllEmailChanges(
+      session,
+      accountId,
+      currentState,
+      propertiesCreated: propertiesCreated,
+      propertiesUpdated: propertiesUpdated
+    );
 
     if (emailChangeResponse != null) {
       final listEmailIdMarkAsRead = emailChangeResponse.updated

--- a/lib/features/thread/data/datasource/thread_datasource.dart
+++ b/lib/features/thread/data/datasource/thread_datasource.dart
@@ -56,6 +56,22 @@ abstract class ThreadDataSource {
     }
   );
 
+  /// Drains every page of `Email/changes` starting from [sinceState] and
+  /// returns the accumulated result (or `null` when there were no changes).
+  ///
+  /// Pagination is bounded: it stops as soon as the server stops advancing the
+  /// state cursor or a hard iteration cap is reached, so a stale/looping state
+  /// can no longer fan out into hundreds of back-to-back requests.
+  Future<EmailChangeResponse?> getAllEmailChanges(
+    Session session,
+    AccountId accountId,
+    State sinceState,
+    {
+      Properties? propertiesCreated,
+      Properties? propertiesUpdated
+    }
+  );
+
   Future<List<Email>> getAllEmailCache(
     AccountId accountId,
     UserName userName,

--- a/lib/features/thread/data/datasource_impl/local_thread_datasource_impl.dart
+++ b/lib/features/thread/data/datasource_impl/local_thread_datasource_impl.dart
@@ -81,6 +81,19 @@ class LocalThreadDataSourceImpl extends ThreadDataSource {
   }
 
   @override
+  Future<EmailChangeResponse?> getAllEmailChanges(
+    Session session,
+    AccountId accountId,
+    State sinceState,
+    {
+      Properties? propertiesCreated,
+      Properties? propertiesUpdated
+    }
+  ) {
+    throw UnimplementedError();
+  }
+
+  @override
   Future<List<Email>> getAllEmailCache(
     AccountId accountId,
     UserName userName, {

--- a/lib/features/thread/data/datasource_impl/thread_datasource_impl.dart
+++ b/lib/features/thread/data/datasource_impl/thread_datasource_impl.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
+import 'package:core/utils/app_logger.dart';
 import 'package:dartz/dartz.dart' as dartz;
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/filter/filter.dart';
@@ -105,6 +106,68 @@ class ThreadDataSourceImpl extends ThreadDataSource {
         sinceState,
         propertiesCreated: propertiesCreated,
         propertiesUpdated: propertiesUpdated);
+    }).catchError(_exceptionThrower.throwException);
+  }
+
+  /// Upper bound on `Email/changes` pages drained in a single sync. With a page
+  /// size of 128 this caps one sync at ~12.8k changes; beyond that the local
+  /// state is hopelessly stale and a full reload is cheaper than paginating.
+  static const int _maxGetAllEmailChangesIterations = 100;
+
+  @override
+  Future<EmailChangeResponse?> getAllEmailChanges(
+    Session session,
+    AccountId accountId,
+    State sinceState,
+    {
+      Properties? propertiesCreated,
+      Properties? propertiesUpdated
+    }
+  ) {
+    return Future.sync(() async {
+      EmailChangeResponse? emailChangeResponse;
+      bool hasMoreChanges = true;
+      State? currentSinceState = sinceState;
+      int iterationCount = 0;
+
+      while (hasMoreChanges && currentSinceState != null) {
+        final State previousSinceState = currentSinceState;
+
+        final changesResponse = await threadAPI.getChanges(
+          session,
+          accountId,
+          currentSinceState,
+          propertiesCreated: propertiesCreated,
+          propertiesUpdated: propertiesUpdated);
+
+        emailChangeResponse = emailChangeResponse == null
+          ? changesResponse
+          : emailChangeResponse.union(changesResponse);
+
+        hasMoreChanges = changesResponse.hasMoreChanges;
+        currentSinceState = changesResponse.newStateChanges;
+
+        // Progress guard: the server claims more changes but the state cursor
+        // did not advance. Continuing would re-request the same page forever
+        // (self-inflicted DDoS), so stop here.
+        if (hasMoreChanges &&
+            (currentSinceState == null || currentSinceState == previousSinceState)) {
+          logWarning(
+            'ThreadDataSourceImpl::getAllEmailChanges(): state did not advance '
+            '($previousSinceState) while hasMoreChanges=true. Aborting pagination.');
+          break;
+        }
+
+        iterationCount++;
+        if (iterationCount >= _maxGetAllEmailChangesIterations) {
+          logWarning(
+            'ThreadDataSourceImpl::getAllEmailChanges(): reached max iterations '
+            '($_maxGetAllEmailChangesIterations) from $sinceState. Aborting pagination.');
+          break;
+        }
+      }
+
+      return emailChangeResponse;
     }).catchError(_exceptionThrower.throwException);
   }
 

--- a/lib/features/thread/data/repository/thread_repository_impl.dart
+++ b/lib/features/thread/data/repository/thread_repository_impl.dart
@@ -541,28 +541,12 @@ class ThreadRepositoryImpl extends ThreadRepository {
   ) async {
     final localEmailList = await mapDataSource[DataSourceType.local]!.getAllEmailCache(accountId, session.username);
 
-    EmailChangeResponse? emailChangeResponse;
-    bool hasMoreChanges = true;
-    jmap.State? sinceState = currentState;
-
-    while(hasMoreChanges && sinceState != null) {
-      log('ThreadRepositoryImpl::_synchronizeCacheWithChanges(): sinceState = $sinceState');
-      final changesResponse = await mapDataSource[DataSourceType.network]!.getChanges(
-        session,
-        accountId,
-        sinceState,
-        propertiesCreated: propertiesCreated,
-        propertiesUpdated: propertiesUpdated);
-
-      hasMoreChanges = changesResponse.hasMoreChanges;
-      sinceState = changesResponse.newStateChanges;
-
-      if (emailChangeResponse != null) {
-        emailChangeResponse.union(changesResponse);
-      } else {
-        emailChangeResponse = changesResponse;
-      }
-    }
+    final emailChangeResponse = await mapDataSource[DataSourceType.network]!.getAllEmailChanges(
+      session,
+      accountId,
+      currentState,
+      propertiesCreated: propertiesCreated,
+      propertiesUpdated: propertiesUpdated);
 
     if (emailChangeResponse != null) {
       final newEmailUpdated = await _combineEmailCache(


### PR DESCRIPTION
…orms

A stale or non-advancing local email state could make the Email/changes pagination loop fire hundreds of back-to-back requests (observed ~475 in 20s for a single user), effectively DDoSing the JMAP backend.

- Add ThreadDataSource.getAllEmailChanges: a single guarded drain with a progress guard (stop when the state cursor no longer advances) and a hard iteration cap.
- Route the three duplicated while(hasMoreChanges) loops through it (thread sync, push-notification, remove-notification).
- Fix latent bug where EmailChangeResponse.union()'s return value was discarded, keeping only the first page of multi-page changes.