### PR TITLE
 fix: bound Email/changes pagination to stop self-inflicted request storm

### DIFF
--- a/lib/features/push_notification/data/repository/fcm_repository_impl.dart
+++ b/lib/features/push_notification/data/repository/fcm_repository_impl.dart
@@ -26,7 +26,6 @@ import 'package:tmail_ui_user/features/push_notification/domain/model/update_tok
 import 'package:tmail_ui_user/features/push_notification/domain/repository/fcm_repository.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/utils/fcm_constants.dart';
 import 'package:tmail_ui_user/features/thread/data/datasource/thread_datasource.dart';
-import 'package:tmail_ui_user/features/thread/data/model/email_change_response.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/email_response.dart';
 
 class FCMRepositoryImpl extends FCMRepository {
@@ -51,28 +50,13 @@ class FCMRepositoryImpl extends FCMRepository {
       Properties? propertiesUpdated
     }
   ) async {
-    EmailChangeResponse? emailChangeResponse;
-    bool hasMoreChanges = true;
-    jmap.State? sinceState = currentState;
-
-    while (hasMoreChanges && sinceState != null) {
-      final changesResponse = await _threadDataSource.getChanges(
-        session,
-        accountId,
-        sinceState,
-        propertiesCreated: propertiesCreated,
-        propertiesUpdated: propertiesUpdated
-      );
-
-      hasMoreChanges = changesResponse.hasMoreChanges;
-      sinceState = changesResponse.newStateChanges;
-
-      if (emailChangeResponse != null) {
-        emailChangeResponse.union(changesResponse);
-      } else {
-        emailChangeResponse = changesResponse;
-      }
-    }
+    final emailChangeResponse = await _threadDataSource.getAllEmailChanges(
+      session,
+      accountId,
+      currentState,
+      propertiesCreated: propertiesCreated,
+      propertiesUpdated: propertiesUpdated
+    );
 
     final listEmails = emailChangeResponse?.created ?? [];
     listEmails.sortBy(EmailComparator(EmailComparatorProperty.receivedAt)..setIsAscending(true));
@@ -163,28 +147,13 @@ class FCMRepositoryImpl extends FCMRepository {
       Properties? propertiesUpdated
     }
   ) async {
-    EmailChangeResponse? emailChangeResponse;
-    bool hasMoreChanges = true;
-    jmap.State? sinceState = currentState;
-
-    while (hasMoreChanges && sinceState != null) {
-      final changesResponse = await _threadDataSource.getChanges(
-        session,
-        accountId,
-        sinceState,
-        propertiesCreated: propertiesCreated,
-        propertiesUpdated: propertiesUpdated
-      );
-
-      hasMoreChanges = changesResponse.hasMoreChanges;
-      sinceState = changesResponse.newStateChanges;
-
-      if (emailChangeResponse != null) {
-        emailChangeResponse.union(changesResponse);
-      } else {
-        emailChangeResponse = changesResponse;
-      }
-    }
+    final emailChangeResponse = await _threadDataSource.getAllEmailChanges(
+      session,
+      accountId,
+      currentState,
+      propertiesCreated: propertiesCreated,
+      propertiesUpdated: propertiesUpdated
+    );
 
     if (emailChangeResponse != null) {
       final listEmailIdMarkAsRead = emailChangeResponse.updated

--- a/lib/features/thread/data/datasource/thread_datasource.dart
+++ b/lib/features/thread/data/datasource/thread_datasource.dart
@@ -56,6 +56,22 @@ abstract class ThreadDataSource {
     }
   );
 
+  /// Drains every page of `Email/changes` starting from [sinceState] and
+  /// returns the accumulated result (or `null` when there were no changes).
+  ///
+  /// Pagination is bounded: it stops as soon as the server stops advancing the
+  /// state cursor or a hard iteration cap is reached, so a stale/looping state
+  /// can no longer fan out into hundreds of back-to-back requests.
+  Future<EmailChangeResponse?> getAllEmailChanges(
+    Session session,
+    AccountId accountId,
+    State sinceState,
+    {
+      Properties? propertiesCreated,
+      Properties? propertiesUpdated
+    }
+  );
+
   Future<List<Email>> getAllEmailCache(
     AccountId accountId,
     UserName userName,

--- a/lib/features/thread/data/datasource_impl/local_thread_datasource_impl.dart
+++ b/lib/features/thread/data/datasource_impl/local_thread_datasource_impl.dart
@@ -81,6 +81,19 @@ class LocalThreadDataSourceImpl extends ThreadDataSource {
   }
 
   @override
+  Future<EmailChangeResponse?> getAllEmailChanges(
+    Session session,
+    AccountId accountId,
+    State sinceState,
+    {
+      Properties? propertiesCreated,
+      Properties? propertiesUpdated
+    }
+  ) {
+    throw UnimplementedError();
+  }
+
+  @override
   Future<List<Email>> getAllEmailCache(
     AccountId accountId,
     UserName userName, {

--- a/lib/features/thread/data/datasource_impl/thread_datasource_impl.dart
+++ b/lib/features/thread/data/datasource_impl/thread_datasource_impl.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
+import 'package:core/utils/app_logger.dart';
 import 'package:dartz/dartz.dart' as dartz;
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/filter/filter.dart';
@@ -105,6 +106,68 @@ class ThreadDataSourceImpl extends ThreadDataSource {
         sinceState,
         propertiesCreated: propertiesCreated,
         propertiesUpdated: propertiesUpdated);
+    }).catchError(_exceptionThrower.throwException);
+  }
+
+  /// Upper bound on `Email/changes` pages drained in a single sync. With a page
+  /// size of 128 this caps one sync at ~12.8k changes; beyond that the local
+  /// state is hopelessly stale and a full reload is cheaper than paginating.
+  static const int _maxGetAllEmailChangesIterations = 100;
+
+  @override
+  Future<EmailChangeResponse?> getAllEmailChanges(
+    Session session,
+    AccountId accountId,
+    State sinceState,
+    {
+      Properties? propertiesCreated,
+      Properties? propertiesUpdated
+    }
+  ) {
+    return Future.sync(() async {
+      EmailChangeResponse? emailChangeResponse;
+      bool hasMoreChanges = true;
+      State? currentSinceState = sinceState;
+      int iterationCount = 0;
+
+      while (hasMoreChanges && currentSinceState != null) {
+        final State previousSinceState = currentSinceState;
+
+        final changesResponse = await threadAPI.getChanges(
+          session,
+          accountId,
+          currentSinceState,
+          propertiesCreated: propertiesCreated,
+          propertiesUpdated: propertiesUpdated);
+
+        emailChangeResponse = emailChangeResponse == null
+          ? changesResponse
+          : emailChangeResponse.union(changesResponse);
+
+        hasMoreChanges = changesResponse.hasMoreChanges;
+        currentSinceState = changesResponse.newStateChanges;
+
+        // Progress guard: the server claims more changes but the state cursor
+        // did not advance. Continuing would re-request the same page forever
+        // (self-inflicted DDoS), so stop here.
+        if (hasMoreChanges &&
+            (currentSinceState == null || currentSinceState == previousSinceState)) {
+          logWarning(
+            'ThreadDataSourceImpl::getAllEmailChanges(): state did not advance '
+            '($previousSinceState) while hasMoreChanges=true. Aborting pagination.');
+          break;
+        }
+
+        iterationCount++;
+        if (iterationCount >= _maxGetAllEmailChangesIterations) {
+          logWarning(
+            'ThreadDataSourceImpl::getAllEmailChanges(): reached max iterations '
+            '($_maxGetAllEmailChangesIterations) from $sinceState. Aborting pagination.');
+          break;
+        }
+      }
+
+      return emailChangeResponse;
     }).catchError(_exceptionThrower.throwException);
   }
 

--- a/lib/features/thread/data/repository/thread_repository_impl.dart
+++ b/lib/features/thread/data/repository/thread_repository_impl.dart
@@ -541,28 +541,12 @@ class ThreadRepositoryImpl extends ThreadRepository {
   ) async {
     final localEmailList = await mapDataSource[DataSourceType.local]!.getAllEmailCache(accountId, session.username);
 
-    EmailChangeResponse? emailChangeResponse;
-    bool hasMoreChanges = true;
-    jmap.State? sinceState = currentState;
-
-    while(hasMoreChanges && sinceState != null) {
-      log('ThreadRepositoryImpl::_synchronizeCacheWithChanges(): sinceState = $sinceState');
-      final changesResponse = await mapDataSource[DataSourceType.network]!.getChanges(
-        session,
-        accountId,
-        sinceState,
-        propertiesCreated: propertiesCreated,
-        propertiesUpdated: propertiesUpdated);
-
-      hasMoreChanges = changesResponse.hasMoreChanges;
-      sinceState = changesResponse.newStateChanges;
-
-      if (emailChangeResponse != null) {
-        emailChangeResponse.union(changesResponse);
-      } else {
-        emailChangeResponse = changesResponse;
-      }
-    }
+    final emailChangeResponse = await mapDataSource[DataSourceType.network]!.getAllEmailChanges(
+      session,
+      accountId,
+      currentState,
+      propertiesCreated: propertiesCreated,
+      propertiesUpdated: propertiesUpdated);
 
     if (emailChangeResponse != null) {
       final newEmailUpdated = await _combineEmailCache(

--- a/test/features/thread/data/datasource_impl/thread_datasource_impl_test.dart
+++ b/test/features/thread/data/datasource_impl/thread_datasource_impl_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/thread/data/datasource_impl/thread_datasource_impl.dart';
+import 'package:tmail_ui_user/features/thread/data/model/email_change_response.dart';
+import 'package:tmail_ui_user/features/thread/data/network/thread_api.dart';
+import 'package:tmail_ui_user/features/thread/data/network/thread_isolate_worker.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/exception_thrower.dart';
+
+import 'thread_datasource_impl_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<ThreadAPI>(),
+  MockSpec<ThreadIsolateWorker>(),
+  MockSpec<ExceptionThrower>(),
+  MockSpec<Session>(),
+  MockSpec<AccountId>(),
+])
+void main() {
+  // Mirrors the hard iteration cap declared in ThreadDataSourceImpl. Kept in
+  // sync manually since the production constant is private.
+  const int maxIterations = 100;
+
+  late MockThreadAPI threadAPI;
+  late MockExceptionThrower exceptionThrower;
+  late ThreadDataSourceImpl dataSource;
+  final session = MockSession();
+  final accountId = MockAccountId();
+
+  List<Email> emails(String prefix, int count) =>
+      List.generate(count, (i) => Email(id: EmailId(Id('${prefix}_$i'))));
+
+  // Shared matcher for threadAPI.getChanges, reused by both stubbing and
+  // verification so the long named-argument signature lives in one place.
+  void stubGetChanges(Future<EmailChangeResponse> Function(Invocation) answer) {
+    when(threadAPI.getChanges(any, any, any,
+            propertiesCreated: anyNamed('propertiesCreated'),
+            propertiesUpdated: anyNamed('propertiesUpdated')))
+        .thenAnswer(answer);
+  }
+
+  VerificationResult verifyGetChanges() => verify(threadAPI.getChanges(any, any,
+      any,
+      propertiesCreated: anyNamed('propertiesCreated'),
+      propertiesUpdated: anyNamed('propertiesUpdated')));
+
+  Future<EmailChangeResponse?> drain() =>
+      dataSource.getAllEmailChanges(session, accountId, State('initial'));
+
+  // A page that claims more changes; [nextState] drives the progress guard
+  // (a repeated value or null is what makes the drain stop).
+  EmailChangeResponse moreChangesPage({State? nextState}) => EmailChangeResponse(
+        hasMoreChanges: true,
+        created: emails('p', 1),
+        newStateChanges: nextState,
+      );
+
+  setUp(() {
+    threadAPI = MockThreadAPI();
+    exceptionThrower = MockExceptionThrower();
+    dataSource = ThreadDataSourceImpl(
+      threadAPI,
+      MockThreadIsolateWorker(),
+      exceptionThrower,
+    );
+  });
+
+  group('ThreadDataSourceImpl::getAllEmailChanges bound logic:', () {
+    test('drains a single page when the server reports no more changes',
+        () async {
+      stubGetChanges((_) async => EmailChangeResponse(
+            hasMoreChanges: false,
+            created: emails('single', 3),
+            newStateChanges: State('s1'),
+          ));
+
+      final result = await drain();
+
+      expect(result?.created?.length, 3);
+      verifyGetChanges().called(1);
+    });
+
+    test('drains every page and unions results while the state advances',
+        () async {
+      var call = 0;
+      stubGetChanges((_) async {
+        call++;
+        return EmailChangeResponse(
+          hasMoreChanges: call < 3,
+          created: emails('p$call', 2),
+          newStateChanges: State('s$call'),
+          newStateEmail: State('email_s$call'),
+        );
+      });
+
+      final result = await drain();
+
+      // 3 pages × 2 created = 6, and the last page's state wins.
+      expect(result?.created?.length, 6);
+      expect(result?.newStateChanges, State('s3'));
+      expect(result?.newStateEmail, State('email_s3'));
+      verifyGetChanges().called(3);
+    });
+
+    test('aborts when the state cursor stops advancing (repeats a value)',
+        () async {
+      // Advance once, then keep returning the same state with more=true.
+      stubGetChanges((_) async => moreChangesPage(nextState: State('stuck')));
+
+      final result = await drain();
+
+      expect(result, isNotNull);
+      // 1st call advances initial -> stuck; 2nd call returns stuck again
+      // (== previous) so the progress guard breaks. No request storm.
+      verifyGetChanges().called(2);
+    });
+
+    test('aborts when more changes are claimed but the next state is null',
+        () async {
+      stubGetChanges((_) async => moreChangesPage());
+
+      final result = await drain();
+
+      expect(result, isNotNull);
+      verifyGetChanges().called(1);
+    });
+
+    test('stops at the hard iteration cap even when the state keeps advancing',
+        () async {
+      var call = 0;
+      // Always advancing AND always more changes: the only thing that can stop
+      // this is the hard cap.
+      stubGetChanges((_) async {
+        call++;
+        return EmailChangeResponse(
+          hasMoreChanges: true,
+          created: emails('p$call', 1),
+          newStateChanges: State('s$call'),
+        );
+      });
+
+      await drain();
+
+      verifyGetChanges().called(maxIterations);
+    });
+
+    test('routes API errors through the exception thrower', () async {
+      final error = Exception('boom');
+      when(threadAPI.getChanges(any, any, any,
+              propertiesCreated: anyNamed('propertiesCreated'),
+              propertiesUpdated: anyNamed('propertiesUpdated')))
+          .thenThrow(error);
+
+      await drain();
+
+      verify(exceptionThrower.throwException(error, any)).called(1);
+    });
+  });
+}

--- a/test/features/thread/data/repository/thread_repository_impl_test.dart
+++ b/test/features/thread/data/repository/thread_repository_impl_test.dart
@@ -46,9 +46,6 @@ void main() {
     reset(stateDataSource);
   });
 
-  // ---- Shared arrange/act/verify for the getLatestChanges sync tests ----
-  // The mockito matcher signatures are long; keeping them in one place avoids
-  // copy-pasting the same stub/verify blocks across every sync test.
   void stubLocalEmailCache(List<Email> emails) {
     when(threadDataSource.getAllEmailCache(
       any,
@@ -58,6 +55,8 @@ void main() {
       limit: anyNamed('limit'),
       sort: anyNamed('sort'),
     )).thenAnswer((_) => Future.value(emails));
+    when(threadDataSource.getAllEmailCache(any, any))
+        .thenAnswer((_) => Future.value(emails));
   }
 
   void stubLocalState([String value = 'local_state']) {
@@ -93,7 +92,7 @@ void main() {
       )
       .toList();
 
-  VerificationResult verifyGetAllEmailChanges() => verify(
+  void verifyGetAllEmailChanges() => verify(
         threadDataSource.getAllEmailChanges(
           any,
           any,
@@ -101,7 +100,7 @@ void main() {
           propertiesCreated: anyNamed('propertiesCreated'),
           propertiesUpdated: anyNamed('propertiesUpdated'),
         ),
-      );
+      ).called(1);
 
   group('getAllEmail:', () {
     test('when local cache is empty should fetch from network', () async {
@@ -450,7 +449,7 @@ void main() {
 
       // Assert
       expect(responses.length, 2);
-      verifyGetAllEmailChanges().called(1);
+      verifyGetAllEmailChanges();
       verify(threadDataSource.update(
         any,
         any,
@@ -776,7 +775,7 @@ void main() {
 
       // Assert
       expect(responses.length, 2);
-      verifyGetAllEmailChanges().called(1);
+      verifyGetAllEmailChanges();
       verify(threadDataSource.update(
         any,
         any,

--- a/test/features/thread/data/repository/thread_repository_impl_test.dart
+++ b/test/features/thread/data/repository/thread_repository_impl_test.dart
@@ -46,6 +46,63 @@ void main() {
     reset(stateDataSource);
   });
 
+  // ---- Shared arrange/act/verify for the getLatestChanges sync tests ----
+  // The mockito matcher signatures are long; keeping them in one place avoids
+  // copy-pasting the same stub/verify blocks across every sync test.
+  void stubLocalEmailCache(List<Email> emails) {
+    when(threadDataSource.getAllEmailCache(
+      any,
+      any,
+      filterOption: anyNamed('filterOption'),
+      inMailboxId: anyNamed('inMailboxId'),
+      limit: anyNamed('limit'),
+      sort: anyNamed('sort'),
+    )).thenAnswer((_) => Future.value(emails));
+  }
+
+  void stubLocalState([String value = 'local_state']) {
+    when(stateDataSource.getState(any, any, any))
+        .thenAnswer((_) => Future.value(State(value)));
+  }
+
+  void stubGetAllEmailChanges(EmailChangeResponse response) {
+    when(threadDataSource.getAllEmailChanges(
+      any,
+      any,
+      any,
+      propertiesCreated: anyNamed('propertiesCreated'),
+      propertiesUpdated: anyNamed('propertiesUpdated'),
+    )).thenAnswer((_) => Future.value(response));
+  }
+
+  void stubGetAllEmailChangesError(Object error) {
+    when(threadDataSource.getAllEmailChanges(
+      any,
+      any,
+      any,
+      propertiesCreated: anyNamed('propertiesCreated'),
+      propertiesUpdated: anyNamed('propertiesUpdated'),
+    )).thenThrow(error);
+  }
+
+  Future<List<EmailsResponse>> getAllEmailWithLatestChanges() => threadRepository
+      .getAllEmail(
+        SessionFixtures.aliceSession,
+        AccountFixtures.aliceAccountId,
+        getLatestChanges: true,
+      )
+      .toList();
+
+  VerificationResult verifyGetAllEmailChanges() => verify(
+        threadDataSource.getAllEmailChanges(
+          any,
+          any,
+          any,
+          propertiesCreated: anyNamed('propertiesCreated'),
+          propertiesUpdated: anyNamed('propertiesUpdated'),
+        ),
+      );
+
   group('getAllEmail:', () {
     test('when local cache is empty should fetch from network', () async {
       // Arrange
@@ -345,50 +402,23 @@ void main() {
       final localEmails = List.generate(
         ThreadConstants.defaultLimit.value as int,
         (index) => Email(id: EmailId(Id('local_$index'))));
-      when(threadDataSource.getAllEmailCache(
-        any,
-        any,
-        filterOption: anyNamed('filterOption'),
-        inMailboxId: anyNamed('inMailboxId'),
-        limit: anyNamed('limit'),
-        sort: anyNamed('sort'),
-      )).thenAnswer((_) => Future.value(localEmails));
-
-      when(stateDataSource.getState(any, any, any))
-          .thenAnswer((_) => Future.value(State('local_state')));
-
       final changedEmails =
           List.generate(5, (index) => Email(id: EmailId(Id('changed_$index'))));
-      when(threadDataSource.getChanges(
-        any,
-        any,
-        any,
-        propertiesCreated: anyNamed('propertiesCreated'),
-        propertiesUpdated: anyNamed('propertiesUpdated'),
-      )).thenAnswer((_) => Future.value(EmailChangeResponse(
-          hasMoreChanges: false,
-          created: changedEmails,
-          newStateEmail: State('new_state'))));
+      stubLocalEmailCache(localEmails);
+      stubLocalState();
+      stubGetAllEmailChanges(EmailChangeResponse(
+        hasMoreChanges: false,
+        created: changedEmails,
+        newStateEmail: State('new_state'),
+      ));
 
       // Act
-      final responses = await threadRepository
-          .getAllEmail(
-            SessionFixtures.aliceSession,
-            AccountFixtures.aliceAccountId,
-            getLatestChanges: true,
-          )
-          .toList();
+      final responses = await getAllEmailWithLatestChanges();
 
       // Assert
       expect(responses.length, 2);
       verifyNever(threadDataSource.getAllEmail(any, any));
-      verify(threadDataSource.getChanges(
-        any,
-        any,
-        any,
-        propertiesCreated: anyNamed('propertiesCreated'),
-        propertiesUpdated: anyNamed('propertiesUpdated'),
-      ));
+      verifyGetAllEmailChanges();
       verify(threadDataSource.update(
         any,
         any,
@@ -402,67 +432,25 @@ void main() {
       final localEmails = List.generate(
           ThreadConstants.defaultLimit.value as int,
           (index) => Email(id: EmailId(Id('local_$index'))));
-      when(threadDataSource.getAllEmailCache(
-        any,
-        any,
-        filterOption: anyNamed('filterOption'),
-        inMailboxId: anyNamed('inMailboxId'),
-        limit: anyNamed('limit'),
-        sort: anyNamed('sort'),
-      )).thenAnswer((_) => Future.value(localEmails));
-
-      when(stateDataSource.getState(any, any, any))
-          .thenAnswer((_) => Future.value(State('local_state')));
-
       final firstChanges = List.generate(
           5, (index) => Email(id: EmailId(Id('change1_$index'))));
       final secondChanges = List.generate(
           5, (index) => Email(id: EmailId(Id('change2_$index'))));
-
-      var callCount = 0;
-      when(threadDataSource.getChanges(
-        any,
-        any,
-        any,
-        propertiesCreated: anyNamed('propertiesCreated'),
-        propertiesUpdated: anyNamed('propertiesUpdated'),
-      )).thenAnswer((_) {
-        callCount++;
-        if (callCount == 1) {
-          return Future.value(EmailChangeResponse(
-            hasMoreChanges: true,
-            created: firstChanges,
-            newStateChanges: State('intermediate_state'),
-            newStateEmail: State('intermediate_state_email'),
-          ));
-        } else {
-          return Future.value(EmailChangeResponse(
-            hasMoreChanges: false,
-            created: secondChanges,
-            newStateChanges: State('final_state'),
-            newStateEmail: State('final_state_email'),
-          ));
-        }
-      });
+      stubLocalEmailCache(localEmails);
+      stubLocalState();
+      stubGetAllEmailChanges(EmailChangeResponse(
+        hasMoreChanges: false,
+        created: [...firstChanges, ...secondChanges],
+        newStateChanges: State('final_state'),
+        newStateEmail: State('final_state_email'),
+      ));
 
       // Act
-      final responses = await threadRepository
-          .getAllEmail(
-            SessionFixtures.aliceSession,
-            AccountFixtures.aliceAccountId,
-            getLatestChanges: true,
-          )
-          .toList();
+      final responses = await getAllEmailWithLatestChanges();
 
       // Assert
       expect(responses.length, 2);
-      verify(threadDataSource.getChanges(
-        any,
-        any,
-        any,
-        propertiesCreated: anyNamed('propertiesCreated'),
-        propertiesUpdated: anyNamed('propertiesUpdated'),
-      )).called(2);
+      verifyGetAllEmailChanges().called(1);
       verify(threadDataSource.update(
         any,
         any,
@@ -691,58 +679,30 @@ void main() {
         ThreadConstants.defaultLimit.value.toInt(),
         (index) => Email(id: EmailId(Id('local_$index'))),
       );
-      when(threadDataSource.getAllEmailCache(
-        any,
-        any,
-        filterOption: anyNamed('filterOption'),
-        inMailboxId: anyNamed('inMailboxId'),
-        limit: anyNamed('limit'),
-        sort: anyNamed('sort'),
-      )).thenAnswer((_) => Future.value(localEmails));
-
-      when(stateDataSource.getState(any, any, any))
-          .thenAnswer((_) => Future.value(State('local_state')));
-
       final changedEmails = List.generate(
         5,
         (index) => Email(id: EmailId(Id('changed_$index'))),
       );
-
       final destroyedEmailIds = List.generate(
         5,
         (index) => EmailId(Id('destroyed_mail_$index')),
       );
-      when(threadDataSource.getChanges(
-        any,
-        any,
-        any,
-        propertiesCreated: anyNamed('propertiesCreated'),
-        propertiesUpdated: anyNamed('propertiesUpdated'),
-      )).thenAnswer((_) => Future.value(EmailChangeResponse(
-          hasMoreChanges: false,
-          created: changedEmails,
-          destroyed: destroyedEmailIds,
-          newStateEmail: State('new_state'))));
+      stubLocalEmailCache(localEmails);
+      stubLocalState();
+      stubGetAllEmailChanges(EmailChangeResponse(
+        hasMoreChanges: false,
+        created: changedEmails,
+        destroyed: destroyedEmailIds,
+        newStateEmail: State('new_state'),
+      ));
 
       // Act
-      final responses = await threadRepository
-          .getAllEmail(
-            SessionFixtures.aliceSession,
-            AccountFixtures.aliceAccountId,
-            getLatestChanges: true,
-          )
-          .toList();
+      final responses = await getAllEmailWithLatestChanges();
 
       // Assert
       expect(responses.length, 2);
       verifyNever(threadDataSource.getAllEmail(any, any));
-      verify(threadDataSource.getChanges(
-        any,
-        any,
-        any,
-        propertiesCreated: anyNamed('propertiesCreated'),
-        propertiesUpdated: anyNamed('propertiesUpdated'),
-      ));
+      verifyGetAllEmailChanges();
       verify(threadDataSource.update(
         any,
         any,
@@ -761,35 +721,13 @@ void main() {
         ThreadConstants.defaultLimit.value.toInt(),
         (index) => Email(id: EmailId(Id('local_$index'))),
       );
-      when(threadDataSource.getAllEmailCache(
-        any,
-        any,
-        filterOption: anyNamed('filterOption'),
-        inMailboxId: anyNamed('inMailboxId'),
-        limit: anyNamed('limit'),
-        sort: anyNamed('sort'),
-      )).thenAnswer((_) => Future.value(localEmails));
-
-      when(stateDataSource.getState(any, any, any))
-          .thenAnswer((_) => Future.value(State('local_state')));
-
-      when(threadDataSource.getChanges(
-        any,
-        any,
-        any,
-        propertiesCreated: anyNamed('propertiesCreated'),
-        propertiesUpdated: anyNamed('propertiesUpdated'),
-      )).thenThrow(Exception('Too many items in get method'));
+      stubLocalEmailCache(localEmails);
+      stubLocalState();
+      stubGetAllEmailChangesError(Exception('Too many items in get method'));
 
       // Assert
       expectLater(
-        () => threadRepository
-            .getAllEmail(
-              SessionFixtures.aliceSession,
-              AccountFixtures.aliceAccountId,
-              getLatestChanges: true,
-            )
-            .toList(),
+        () => getAllEmailWithLatestChanges(),
         throwsA(isA<Exception>().having((e) => e.toString(), 'description', contains('Too many items in get method'))),
       );
       verifyNever(threadDataSource.update(
@@ -811,18 +749,6 @@ void main() {
         ThreadConstants.defaultLimit.value.toInt(),
         (index) => Email(id: EmailId(Id('local_$index'))),
       );
-      when(threadDataSource.getAllEmailCache(
-        any,
-        any,
-        filterOption: anyNamed('filterOption'),
-        inMailboxId: anyNamed('inMailboxId'),
-        limit: anyNamed('limit'),
-        sort: anyNamed('sort'),
-      )).thenAnswer((_) => Future.value(localEmails));
-
-      when(stateDataSource.getState(any, any, any))
-          .thenAnswer((_) => Future.value(State('local_state')));
-
       final firstChanges = List.generate(
         5,
         (index) => Email(id: EmailId(Id('change1_$index'))),
@@ -831,58 +757,26 @@ void main() {
         5,
         (index) => Email(id: EmailId(Id('change2_$index'))),
       );
-
-      var callCount = 0;
-
       final firstDestroyedEmailIds = List.generate(
         5,
         (index) => EmailId(Id('destroyed_mail_$index')),
       );
-
-      when(threadDataSource.getChanges(
-        any,
-        any,
-        any,
-        propertiesCreated: anyNamed('propertiesCreated'),
-        propertiesUpdated: anyNamed('propertiesUpdated'),
-      )).thenAnswer((_) {
-        callCount++;
-        if (callCount == 1) {
-          return Future.value(EmailChangeResponse(
-            hasMoreChanges: true,
-            created: firstChanges,
-            destroyed: firstDestroyedEmailIds,
-            newStateChanges: State('intermediate_state'),
-            newStateEmail: State('intermediate_state_email'),
-          ));
-        } else {
-          return Future.value(EmailChangeResponse(
-            hasMoreChanges: false,
-            created: secondChanges,
-            newStateChanges: State('final_state'),
-            newStateEmail: State('final_state_email'),
-          ));
-        }
-      });
+      stubLocalEmailCache(localEmails);
+      stubLocalState();
+      stubGetAllEmailChanges(EmailChangeResponse(
+        hasMoreChanges: false,
+        created: [...firstChanges, ...secondChanges],
+        destroyed: firstDestroyedEmailIds,
+        newStateChanges: State('final_state'),
+        newStateEmail: State('final_state_email'),
+      ));
 
       // Act
-      final responses = await threadRepository
-          .getAllEmail(
-            SessionFixtures.aliceSession,
-            AccountFixtures.aliceAccountId,
-            getLatestChanges: true,
-          )
-          .toList();
+      final responses = await getAllEmailWithLatestChanges();
 
       // Assert
       expect(responses.length, 2);
-      verify(threadDataSource.getChanges(
-        any,
-        any,
-        any,
-        propertiesCreated: anyNamed('propertiesCreated'),
-        propertiesUpdated: anyNamed('propertiesUpdated'),
-      )).called(2);
+      verifyGetAllEmailChanges().called(1);
       verify(threadDataSource.update(
         any,
         any,
@@ -1172,7 +1066,7 @@ void main() {
         when(refreshChangesStateDataSource.getState(any, any, any))
             .thenAnswer((_) async => State('cache_state'));
 
-        when(networkDataSource.getChanges(
+        when(networkDataSource.getAllEmailChanges(
           any,
           any,
           any,
@@ -1237,7 +1131,7 @@ void main() {
         when(refreshChangesStateDataSource.getState(any, any, any))
             .thenAnswer((_) async => State('cache_state'));
 
-        when(networkDataSource.getChanges(
+        when(networkDataSource.getAllEmailChanges(
           any,
           any,
           any,
@@ -1300,7 +1194,7 @@ void main() {
         when(refreshChangesStateDataSource.getState(any, any, any))
             .thenAnswer((_) async => State('cache_state'));
 
-        when(networkDataSource.getChanges(
+        when(networkDataSource.getAllEmailChanges(
           any,
           any,
           any,
@@ -1352,31 +1246,20 @@ void main() {
         when(refreshChangesStateDataSource.getState(any, any, any))
             .thenAnswer((_) async => State('cache_state'));
 
-        int callCount = 0;
-
-        when(networkDataSource.getChanges(
+        when(networkDataSource.getAllEmailChanges(
           any,
           any,
           any,
           propertiesCreated: anyNamed('propertiesCreated'),
           propertiesUpdated: anyNamed('propertiesUpdated'),
-        )).thenAnswer((_) async {
-          callCount++;
-
-          if (callCount == 1) {
-            return EmailChangeResponse(
-              hasMoreChanges: true,
-              created: [Email(id: EmailId(Id('created1')))],
-              newStateChanges: State('mid'),
-            );
-          }
-
-          return EmailChangeResponse(
-            hasMoreChanges: false,
-            created: [Email(id: EmailId(Id('created2')))],
-            newStateChanges: State('final'),
-          );
-        });
+        )).thenAnswer((_) async => EmailChangeResponse(
+              hasMoreChanges: false,
+              created: [
+                Email(id: EmailId(Id('created1'))),
+                Email(id: EmailId(Id('created2'))),
+              ],
+              newStateChanges: State('final'),
+            ));
 
         final result = await refreshChangesThreadRepository
             .refreshChanges(
@@ -1386,13 +1269,13 @@ void main() {
             )
             .first;
 
-        verify(networkDataSource.getChanges(
+        verify(networkDataSource.getAllEmailChanges(
           any,
           any,
           any,
           propertiesCreated: anyNamed('propertiesCreated'),
           propertiesUpdated: anyNamed('propertiesUpdated'),
-        )).called(2);
+        )).called(1);
 
         expect(result.emailChangeResponse, isNotNull);
         expect(
@@ -1431,7 +1314,7 @@ void main() {
         when(refreshChangesStateDataSource.getState(any, any, any))
             .thenAnswer((_) async => State('cache_state'));
 
-        when(networkDataSource.getChanges(
+        when(networkDataSource.getAllEmailChanges(
           any,
           any,
           any,
@@ -1485,7 +1368,7 @@ void main() {
         when(refreshChangesStateDataSource.getState(any, any, any))
             .thenAnswer((_) async => State('cache_state'));
 
-        when(networkDataSource.getChanges(
+        when(networkDataSource.getAllEmailChanges(
           any,
           any,
           any,
@@ -1553,7 +1436,7 @@ void main() {
         when(refreshChangesStateDataSource.getState(any, any, any))
             .thenAnswer((_) async => State('cache_state'));
 
-        when(networkDataSource.getChanges(
+        when(networkDataSource.getAllEmailChanges(
           any,
           any,
           any,


### PR DESCRIPTION
Continue of https://github.com/linagora/tmail-flutter/pull/4580

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified and consolidated email-change retrieval for more efficient syncs
  * Added safeguards to prevent stuck or infinite synchronization loops
  * More robust merging of remote changes into the local email cache
* **Tests**
  * Expanded coverage for multi-page draining, edge cases, iteration limits, and error routing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->