### PR TITLE
change sortOrder to Most Recent by default

### DIFF
--- a/integration_test/robots/abstract/abstract_search_input_robot.dart
+++ b/integration_test/robots/abstract/abstract_search_input_robot.dart
@@ -1,0 +1,7 @@
+abstract class AbstractSearchInputRobot {
+  Future<void> enterKeyword(String keyword);
+  Future<void> verifySearchSuggestionHighlights(String keyword);
+  Future<void> tapOnShowAllResultsText();
+  Future<void> expectSuggestionListVisible();
+  Future<void> scrollToEndListSearchFilter();
+}

--- a/integration_test/robots/abstract/abstract_search_result_robot.dart
+++ b/integration_test/robots/abstract/abstract_search_result_robot.dart
@@ -1,0 +1,12 @@
+abstract class AbstractSearchResultRobot {
+  Future<void> expectSearchResultEmailListVisible();
+  Future<void> expectEmailListCount(int count);
+  Future<void> expectEmailListSortedBySenderAscending(List<String> listUsername);
+  Future<void> expectEmailListSortedBySenderDescending(List<String> listUsername);
+  Future<void> expectEmailListSortedBySubjectAscending(List<String> listUsername);
+  Future<void> expectEmailListSortedBySubjectDescending(List<String> listUsername);
+  Future<void> expectEmailListSortedByMostRecent();
+  Future<void> expectEmailListSortedByOldest();
+  Future<void> expectEmailListSortedBySizeAscending();
+  Future<void> expectEmailListSortedBySizeDescending();
+}

--- a/integration_test/robots/abstract/abstract_search_robot.dart
+++ b/integration_test/robots/abstract/abstract_search_robot.dart
@@ -1,11 +1,14 @@
-abstract class AbstractSearchRobot {
-  Future<void> enterKeyword(String keyword);
-  Future<void> verifySearchSuggestionHighlights(String keyword);
-  Future<void> tapOnShowAllResultsText();
-  Future<void> scrollToEndListSearchFilter();
-  Future<void> expectSuggestionListVisible();
-  Future<void> openSortOrderMenu();
-  Future<void> expectSortOrderMenuVisible();
-  Future<void> selectSortOrder(String sortOrderName);
-  Future<void> expectSearchResultEmailListVisible();
-}
+import 'abstract_search_input_robot.dart';
+import 'abstract_search_result_robot.dart';
+import 'abstract_search_sort_robot.dart';
+
+// Composite interface — keeps the factory signature stable (robots.searchRobot()
+// returns AbstractSearchRobot) while the real contracts live in focused interfaces.
+//
+// Adding methods to any sub-interface keeps each contract small and leaves
+// unrelated robots unaffected.
+abstract class AbstractSearchRobot
+    implements
+        AbstractSearchInputRobot,
+        AbstractSearchSortRobot,
+        AbstractSearchResultRobot {}

--- a/integration_test/robots/abstract/abstract_search_robot.dart
+++ b/integration_test/robots/abstract/abstract_search_robot.dart
@@ -1,4 +1,6 @@
 abstract class AbstractSearchRobot {
   Future<void> enterKeyword(String keyword);
   Future<void> verifySearchSuggestionHighlights(String keyword);
+  Future<void> tapOnShowAllResultsText();
+  Future<void> scrollToEndListSearchFilter();
 }

--- a/integration_test/robots/abstract/abstract_search_robot.dart
+++ b/integration_test/robots/abstract/abstract_search_robot.dart
@@ -3,4 +3,9 @@ abstract class AbstractSearchRobot {
   Future<void> verifySearchSuggestionHighlights(String keyword);
   Future<void> tapOnShowAllResultsText();
   Future<void> scrollToEndListSearchFilter();
+  Future<void> expectSuggestionListVisible();
+  Future<void> openSortOrderMenu();
+  Future<void> expectSortOrderMenuVisible();
+  Future<void> selectSortOrder(String sortOrderName);
+  Future<void> expectSearchResultEmailListVisible();
 }

--- a/integration_test/robots/abstract/abstract_search_sort_robot.dart
+++ b/integration_test/robots/abstract/abstract_search_sort_robot.dart
@@ -1,0 +1,5 @@
+abstract class AbstractSearchSortRobot {
+  Future<void> openSortOrderMenu();
+  Future<void> expectSortOrderMenuVisible();
+  Future<void> selectSortOrder(String sortOrderName);
+}

--- a/integration_test/robots/mobile/mobile_search_robot.dart
+++ b/integration_test/robots/mobile/mobile_search_robot.dart
@@ -1,4 +1,5 @@
 import 'package:patrol/patrol.dart';
+import 'package:flutter/material.dart';
 import 'package:core/presentation/views/text/rich_text_builder.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -7,6 +8,16 @@ import '../search_robot.dart';
 
 class MobileSearchRobot extends SearchRobot implements AbstractSearchRobot {
   MobileSearchRobot(PatrolIntegrationTester $) : super($);
+
+  @override
+  Future<void> scrollToEndListSearchFilter() async {
+    await $.scrollUntilVisible(
+      finder: $(#mobile_sortBy_search_filter_button),
+      view: $(#search_filter_list_view),
+      scrollDirection: AxisDirection.right,
+      delta: 300,
+    );
+  }
 
   @override
   Future<void> verifySearchSuggestionHighlights(String keyword) async {

--- a/integration_test/robots/mobile/mobile_search_robot.dart
+++ b/integration_test/robots/mobile/mobile_search_robot.dart
@@ -2,6 +2,7 @@ import 'package:patrol/patrol.dart';
 import 'package:flutter/material.dart';
 import 'package:core/presentation/views/text/rich_text_builder.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';
 
 import '../abstract/abstract_search_robot.dart';
 import '../search_robot.dart';
@@ -24,5 +25,10 @@ class MobileSearchRobot extends SearchRobot implements AbstractSearchRobot {
     // Mobile: SearchEmailView renders suggestions directly in its widget tree
     await $.waitUntilVisible($(RichTextBuilder));
     expect($(RichTextBuilder).$(keyword.split(' ').first).evaluate().length, 10);
+  }
+
+  @override
+  Future<void> expectSearchResultEmailListVisible() async {
+    await $.waitUntilVisible($(EmailTileBuilder));
   }
 }

--- a/integration_test/robots/search_robot.dart
+++ b/integration_test/robots/search_robot.dart
@@ -1,8 +1,17 @@
+import 'package:collection/collection.dart';
+import 'package:core/domain/extensions/list_datetime_extension.dart';
 import 'package:core/presentation/views/text/text_field_builder.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_view.dart';
-import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';
+// Conditional import resolves to the correct runtime EmailTileBuilder type:
+//   mobile → email_tile_builder.dart (StatelessWidget)
+//   web    → email_tile_web_builder.dart (StatefulWidget)
+// This matches thread_view.dart's own conditional import so find.byType works
+// on both platforms without any platform check in callers.
+import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart'
+  if (dart.library.html) 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_web_builder.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../base/core_robot.dart';
@@ -64,7 +73,7 @@ class SearchRobot extends CoreRobot {
     }
     await finder.enterTextWithoutTapAction(keyword);
   }
-  
+
   Future<void> tapOnShowAllResultsText() async {
     await $.waitUntilVisible($(AppLocalizations().showingResultsFor));
     await $(AppLocalizations().showingResultsFor).tap();
@@ -112,5 +121,89 @@ class SearchRobot extends CoreRobot {
 
   Future<void> openLabelListModal() async {
     await $(#mobile_labels_search_filter_button).tap();
+  }
+
+  // ─── Email list assertions ────────────────────────────────────────────────
+  // The conditional import above ensures EmailTileBuilder resolves to the correct
+  // runtime type on each platform, so find.byType and widgetList work correctly
+  // on both mobile and web without any override in the platform subclasses.
+
+  Future<void> expectEmailListCount(int count) async {
+    expect(find.byType(EmailTileBuilder), findsNWidgets(count));
+  }
+
+  Future<void> expectEmailListSortedBySenderAscending(List<String> listUsername) async {
+    final tiles = $.tester.widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
+    for (int i = 0; i < listUsername.length; i++) {
+      final sender = tiles.elementAt(i).presentationEmail.firstEmailAddressInFrom;
+      expect(sender, equals('${listUsername[i].toLowerCase()}@example.com'));
+    }
+  }
+
+  Future<void> expectEmailListSortedBySenderDescending(List<String> listUsername) async {
+    final tiles = $.tester.widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
+    final reversed = listUsername.reversed.toList();
+    for (int i = 0; i < reversed.length; i++) {
+      final sender = tiles.elementAt(i).presentationEmail.firstEmailAddressInFrom;
+      expect(sender, equals('${reversed[i].toLowerCase()}@example.com'));
+    }
+  }
+
+  Future<void> expectEmailListSortedBySubjectAscending(List<String> listUsername) async {
+    final tiles = $.tester.widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
+    for (int i = 0; i < listUsername.length; i++) {
+      expect(tiles.elementAt(i).presentationEmail.subject, equals('${listUsername[i]} send Bob'));
+    }
+  }
+
+  Future<void> expectEmailListSortedBySubjectDescending(List<String> listUsername) async {
+    final tiles = $.tester.widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
+    final reversed = listUsername.reversed.toList();
+    for (int i = 0; i < reversed.length; i++) {
+      expect(tiles.elementAt(i).presentationEmail.subject, equals('${reversed[i]} send Bob'));
+    }
+  }
+
+  Future<void> expectEmailListSortedByMostRecent() async {
+    final tiles = $.tester.widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
+    final dates = tiles
+      .map((t) => t.presentationEmail.receivedAt?.value)
+      .nonNulls
+      .toList();
+    expect(dates.isSortedByMostRecent(), isTrue);
+  }
+
+  Future<void> expectEmailListSortedByOldest() async {
+    final tiles = $.tester.widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
+    final dates = tiles
+      .map((t) => t.presentationEmail.receivedAt?.value)
+      .nonNulls
+      .toList();
+    expect(dates.isSortedByOldestFirst(), isTrue);
+  }
+
+  Future<void> expectEmailListSortedBySizeAscending() async {
+    final sizes = _collectSizes();
+    expect(_isSortedAscending(sizes), isTrue);
+  }
+
+  Future<void> expectEmailListSortedBySizeDescending() async {
+    final sizes = _collectSizes();
+    expect(_isSortedAscending(sizes), isFalse);
+  }
+
+  List<UnsignedInt> _collectSizes() {
+    final tiles = $.tester.widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
+    return tiles
+      .mapIndexed((i, _) => tiles.elementAt(i).presentationEmail.size)
+      .nonNulls
+      .toList();
+  }
+
+  bool _isSortedAscending(List<UnsignedInt> list) {
+    for (int i = 0; i < list.length - 1; i++) {
+      if (list[i].value > list[i + 1].value) return false;
+    }
+    return true;
   }
 }

--- a/integration_test/robots/search_robot.dart
+++ b/integration_test/robots/search_robot.dart
@@ -31,13 +31,27 @@ class SearchRobot extends CoreRobot {
     );
   }
 
-  Future<void> openSortOrderBottomDialog() async {
+  Future<void> openSortOrderBottomDialog() => openSortOrderMenu();
+
+  Future<void> openSortOrderMenu() async {
     await $(#mobile_sortBy_search_filter_button).tap();
   }
 
   Future<void> selectSortOrder(String sortOrderName) async {
     await $(find.text(sortOrderName)).tap();
     await $.pump(const Duration(seconds: 2));
+  }
+
+  // Mobile: in-page suggestion ListView carries the #suggestion_search_list_view key.
+  // Web overrides this — suggestions live in a PointerInterceptor overlay with no key.
+  Future<void> expectSuggestionListVisible() async {
+    await $.waitUntilVisible($(#suggestion_search_list_view));
+  }
+
+  // Mobile: sortBy opens a bottom sheet keyed #sort_filter_context_menu.
+  // Web overrides this — sortBy opens a showMenu popup that has no container key.
+  Future<void> expectSortOrderMenuVisible() async {
+    await $.waitUntilVisible($(#sort_filter_context_menu));
   }
 
   Future<void> enterKeyword(String keyword) async {

--- a/integration_test/robots/web/web_search_robot.dart
+++ b/integration_test/robots/web/web_search_robot.dart
@@ -2,10 +2,13 @@ import 'package:core/presentation/views/text/rich_text_builder.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
+import 'package:tmail_ui_user/features/base/widget/popup_menu/popup_menu_item_action_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/quick_search/email_quick_search_item_tile_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart';
+import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_web_builder.dart';
 
 import '../../extensions/patrol_finder_extension.dart';
+import '../../utils/wait_for_condition.dart';
 import '../abstract/abstract_search_robot.dart';
 import '../search_robot.dart';
 
@@ -34,6 +37,27 @@ class WebSearchRobot extends SearchRobot implements AbstractSearchRobot {
   }
 
   @override
+  Future<void> expectSuggestionListVisible() async {
+    // Web: suggestions render inside an OverlayEntry wrapped by PointerInterceptor,
+    // making them unreliable to assert. Skip on web — the search is still committed
+    // via tapOnShowAllResultsText() and validated against the result list.
+  }
+
+  @override
+  Future<void> openSortOrderMenu() async {
+    // Web desktop closes SearchEmailView and renders search + filters inside the
+    // dashboard, whose sortBy button key has no `mobile_` prefix.
+    await $(#sortBy_search_filter_button).tap();
+  }
+
+  @override
+  Future<void> expectSortOrderMenuVisible() async {
+    // Web: sortBy opens a showMenu popup (no container key). Assert the popup is
+    // open via its rendered sort-order menu items instead.
+    await $.waitUntilVisible($(PopupMenuItemActionWidget));
+  }
+
+  @override
   Future<void> verifySearchSuggestionHighlights(String keyword) async {
     // Web: suggestions render inside an OverlayEntry wrapped by PointerInterceptor,
     // so they are not hit-testable. Use waitUntilExists instead of waitUntilVisible.
@@ -41,6 +65,22 @@ class WebSearchRobot extends SearchRobot implements AbstractSearchRobot {
     expect(
       $(EmailQuickSearchItemTileWidget).$(RichTextBuilder).evaluate().isNotEmpty,
       isTrue,
+    );
+  }
+
+  @override
+  Future<void> expectSearchResultEmailListVisible() async {
+    // Web: results render in ThreadView (not SearchEmailView, which self-closes).
+    // EmailTileBuilder (web = StatefulWidget from email_tile_web_builder.dart) is
+    // not hit-testable, so waitUntilVisible fails. waitUntilExists also fails because
+    // Patrol's loop calls tester.pump() one frame at a time — it does NOT yield to
+    // the browser event loop, so JMAP XHR callbacks never fire.
+    //
+    // waitForCondition uses Future.delayed between retries, which DOES yield to the
+    // browser event loop, allowing JMAP responses to arrive.
+    //
+    await waitForCondition(
+      () async => $(EmailTileBuilder).evaluate().isNotEmpty,
     );
   }
 }

--- a/integration_test/robots/web/web_search_robot.dart
+++ b/integration_test/robots/web/web_search_robot.dart
@@ -20,6 +20,20 @@ class WebSearchRobot extends SearchRobot implements AbstractSearchRobot {
   }
 
   @override
+  Future<void> scrollToEndListSearchFilter() async {
+    // Web: sortBy button is always visible in the top bar outside the
+    // horizontal filter list, so no scrolling is needed.
+  }
+
+  @override
+  Future<void> tapOnShowAllResultsText() async {
+    // Web: "showing results for" button is inside a PointerInterceptor overlay
+    // and not reliably hit-testable. Pressing Enter on the search field triggers
+    // the same onSubmitted → searchEmailByQueryString action.
+    await $.platformAutomator.web.pressKeyCombo(keys: ['Enter']);
+  }
+
+  @override
   Future<void> verifySearchSuggestionHighlights(String keyword) async {
     // Web: suggestions render inside an OverlayEntry wrapped by PointerInterceptor,
     // so they are not hit-testable. Use waitUntilExists instead of waitUntilVisible.

--- a/integration_test/scenarios/search/search_email_with_sort_order_most_recent_by_default_scenario.dart
+++ b/integration_test/scenarios/search/search_email_with_sort_order_most_recent_by_default_scenario.dart
@@ -33,14 +33,10 @@ class SearchEmailWithSortOrderMostRecentByDefaultScenario
 
     await searchRobot.enterKeyword(queryString);
     await searchRobot.tapOnShowAllResultsText();
-    await _expectSearchResultEmailListVisible();
+    await searchRobot.expectSearchResultEmailListVisible();
 
     await searchRobot.scrollToEndListSearchFilter();
     await _expectMostRecentSortOrderButtonVisible();
-  }
-
-  Future<void> _expectSearchResultEmailListVisible() async {
-    await expectViewVisible($(#search_email_list_notification_listener));
   }
 
   Future<void> _expectMostRecentSortOrderButtonVisible() async {

--- a/integration_test/scenarios/search/search_email_with_sort_order_most_recent_by_default_scenario.dart
+++ b/integration_test/scenarios/search/search_email_with_sort_order_most_recent_by_default_scenario.dart
@@ -1,22 +1,23 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_filters/search_filter_button.dart';
-import 'package:tmail_ui_user/features/search/email/presentation/search_email_view.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../../base/base_test_scenario.dart';
 import '../../models/provisioning_email.dart';
-import '../../robots/search_robot.dart';
-import '../../robots/thread_robot.dart';
 
-class SearchEmailWithSortOrderRelevanceByDefaultScenario
+class SearchEmailWithSortOrderMostRecentByDefaultScenario
     extends BaseTestScenario {
-  const SearchEmailWithSortOrderRelevanceByDefaultScenario(super.$, super.robots);
+  const SearchEmailWithSortOrderMostRecentByDefaultScenario(super.$, super.robots);
 
-  static const queryString = 'Relevance by default';
+  static const queryString = 'Most recent by default';
   static const listUsername = ['Alice', 'Brian', 'Charlotte', 'David', 'Emma'];
 
   @override
   Future<void> runTestLogic() async {
+    final commonRobot = robots.commonRobot();
+    final threadRobot = robots.threadRobot();
+    final searchRobot = robots.searchRobot();
+
     final listProvisioningEmail = listUsername
         .map((username) => ProvisioningEmail(
               toEmail: '${username.toLowerCase()}@example.com',
@@ -25,33 +26,26 @@ class SearchEmailWithSortOrderRelevanceByDefaultScenario
             ))
         .toList();
 
-    await provisionEmail(listProvisioningEmail);
+    await commonRobot.provisionEmail(listProvisioningEmail);
     await $.pumpAndSettle();
 
-    final threadRobot = ThreadRobot($);
-    await threadRobot.openSearchView();
-    await _expectSearchViewVisible();
+    await threadRobot.tapOnSearchField();
 
-    final searchRobot = SearchRobot($);
-    await searchRobot.enterQueryString(queryString);
+    await searchRobot.enterKeyword(queryString);
     await searchRobot.tapOnShowAllResultsText();
     await _expectSearchResultEmailListVisible();
 
     await searchRobot.scrollToEndListSearchFilter();
-    await _expectRelevanceSortOrderButtonVisible();
-  }
-
-  Future<void> _expectSearchViewVisible() async {
-    await expectViewVisible($(SearchEmailView));
+    await _expectMostRecentSortOrderButtonVisible();
   }
 
   Future<void> _expectSearchResultEmailListVisible() async {
     await expectViewVisible($(#search_email_list_notification_listener));
   }
 
-  Future<void> _expectRelevanceSortOrderButtonVisible() async {
+  Future<void> _expectMostRecentSortOrderButtonVisible() async {
     await expectViewVisible(
-      $(SearchFilterButton).$(AppLocalizations().relevance),
+      $(SearchFilterButton).$(AppLocalizations().mostRecent),
     );
   }
 }

--- a/integration_test/scenarios/search_email_with_sort_order_scenario.dart
+++ b/integration_test/scenarios/search_email_with_sort_order_scenario.dart
@@ -1,11 +1,4 @@
-
-import 'package:collection/collection.dart';
-import 'package:core/domain/extensions/list_datetime_extension.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
-import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart'
-  if (dart.library.html) 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_web_builder.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../base/base_test_scenario.dart';
@@ -51,165 +44,41 @@ class SearchEmailWithSortOrderScenario extends BaseTestScenario {
 
     await searchRobot.openSortOrderMenu();
     await searchRobot.expectSortOrderMenuVisible();
-
     await searchRobot.selectSortOrder(sortOrderType.getTitleByAppLocalizations(appLocalizations));
 
     // Relevance ordering is non-deterministic; verify only that the tap succeeded.
     if (sortOrderType == EmailSortOrderType.relevance) return;
 
     await searchRobot.expectSearchResultEmailListVisible();
-    await _expectEmailListDisplayedCorrectly(listUsername: listUsername);
+    await searchRobot.expectEmailListCount(listUsername.length);
 
     switch (sortOrderType) {
       case EmailSortOrderType.mostRecent:
-        await _expectEmailListSortedCorrectByMostRecent();
+        await searchRobot.expectEmailListSortedByMostRecent();
         break;
       case EmailSortOrderType.oldest:
-        await _expectEmailListSortedCorrectByOldest();
+        await searchRobot.expectEmailListSortedByOldest();
         break;
       case EmailSortOrderType.senderAscending:
-        await _expectEmailListSortedCorrectBySenderAscending(listUsername: listUsername);
+        await searchRobot.expectEmailListSortedBySenderAscending(listUsername);
         break;
       case EmailSortOrderType.senderDescending:
-        await _expectEmailListSortedCorrectBySenderDescending(listUsername: listUsername);
+        await searchRobot.expectEmailListSortedBySenderDescending(listUsername);
         break;
       case EmailSortOrderType.subjectAscending:
-        await _expectEmailListSortedCorrectBySubjectAscending(listUsername: listUsername);
+        await searchRobot.expectEmailListSortedBySubjectAscending(listUsername);
         break;
       case EmailSortOrderType.subjectDescending:
-        await _expectEmailListSortedCorrectBySubjectDescending(listUsername: listUsername);
+        await searchRobot.expectEmailListSortedBySubjectDescending(listUsername);
         break;
       case EmailSortOrderType.relevance:
         break;
       case EmailSortOrderType.sizeAscending:
-        await _expectEmailListSortedCorrectBySizeAscending(listUsername: listUsername);
+        await searchRobot.expectEmailListSortedBySizeAscending();
         break;
       case EmailSortOrderType.sizeDescending:
-        await _expectEmailListSortedCorrectBySizeDescending(listUsername: listUsername);
+        await searchRobot.expectEmailListSortedBySizeDescending();
         break;
     }
-  }
-
-  Future<void> _expectEmailListDisplayedCorrectly({
-    required List<String> listUsername,
-  }) async {
-    expect(find.byType(EmailTileBuilder), findsNWidgets(listUsername.length));
-  }
-
-  Future<void> _expectEmailListSortedCorrectBySenderAscending({
-    required List<String> listUsername,
-  }) async {
-    final listEmailTile = $.tester
-      .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
-
-    for (int i = 0; i < listUsername.length; i++) {
-      EmailTileBuilder emailTile = listEmailTile.elementAt(i);
-      final senderName = emailTile.presentationEmail.firstEmailAddressInFrom;
-      expect(senderName, equals('${listUsername[i].toLowerCase()}@example.com'));
-    }
-  }
-
-  Future<void> _expectEmailListSortedCorrectBySenderDescending({
-    required List<String> listUsername,
-  }) async {
-    final listEmailTile = $.tester
-      .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
-
-    final reversedListUsername = listUsername.reversed.toList();
-
-    for (int i = 0; i < reversedListUsername.length; i++) {
-      EmailTileBuilder emailTile = listEmailTile.elementAt(i);
-      final senderName = emailTile.presentationEmail.firstEmailAddressInFrom;
-      expect(senderName, equals('${reversedListUsername[i].toLowerCase()}@example.com'));
-    }
-  }
-
-  Future<void> _expectEmailListSortedCorrectBySubjectAscending({
-    required List<String> listUsername,
-  }) async {
-    final listEmailTile = $.tester
-      .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
-
-    for (int i = 0; i < listUsername.length; i++) {
-      EmailTileBuilder emailTile = listEmailTile.elementAt(i);
-      final subject = emailTile.presentationEmail.subject;
-      expect(subject, equals('${listUsername[i]} send Bob'));
-    }
-  }
-
-  Future<void> _expectEmailListSortedCorrectBySubjectDescending({
-    required List<String> listUsername,
-  }) async {
-    final listEmailTile = $.tester
-      .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
-
-    final reversedListUsername = listUsername.reversed.toList();
-
-    for (int i = 0; i < reversedListUsername.length; i++) {
-      EmailTileBuilder emailTile = listEmailTile.elementAt(i);
-      final subject = emailTile.presentationEmail.subject;
-      expect(subject, equals('${reversedListUsername[i]} send Bob'));
-    }
-  }
-
-  Future<void> _expectEmailListSortedCorrectByMostRecent() async {
-    final listEmailTile = $.tester
-      .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
-
-    final listReceiveAtTime = listEmailTile
-      .map((emailTile) => emailTile.presentationEmail.receivedAt?.value)
-      .nonNulls
-      .toList();
-
-    expect(listReceiveAtTime.isSortedByMostRecent(), isTrue);
-  }
-
-  Future<void> _expectEmailListSortedCorrectByOldest() async {
-    final listEmailTile = $.tester
-      .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
-
-    final listReceiveAtTime = listEmailTile
-      .map((emailTile) => emailTile.presentationEmail.receivedAt?.value)
-      .nonNulls
-      .toList();
-
-    expect(listReceiveAtTime.isSortedByOldestFirst(), isTrue);
-  }
-
-  Future<void> _expectEmailListSortedCorrectBySizeAscending({
-    required List<String> listUsername,
-  }) async {
-    final listEmailTile = $.tester
-        .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
-
-    List<UnsignedInt> sizeList = listEmailTile
-      .mapIndexed((index, emailTile) => listEmailTile.elementAt(index).presentationEmail.size)
-      .nonNulls
-      .toList();
-
-    expect(_isSortedAscending(sizeList), isTrue);
-  }
-
-  Future<void> _expectEmailListSortedCorrectBySizeDescending({
-    required List<String> listUsername,
-  }) async {
-    final listEmailTile = $.tester
-        .widgetList<EmailTileBuilder>(find.byType(EmailTileBuilder));
-
-    List<UnsignedInt> sizeList = listEmailTile
-      .mapIndexed((index, emailTile) => listEmailTile.elementAt(index).presentationEmail.size)
-      .nonNulls
-      .toList();
-
-    expect(_isSortedAscending(sizeList), isFalse);
-  }
-
-  bool _isSortedAscending(List<UnsignedInt> list) {
-    for (int i = 0; i < list.length - 1; i++) {
-      if (list[i].value > list[i + 1].value) {
-        return false;
-      }
-    }
-    return true;
   }
 }

--- a/integration_test/scenarios/search_email_with_sort_order_scenario.dart
+++ b/integration_test/scenarios/search_email_with_sort_order_scenario.dart
@@ -4,13 +4,12 @@ import 'package:core/domain/extensions/list_datetime_extension.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
-import 'package:tmail_ui_user/features/search/email/presentation/search_email_view.dart';
-import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';
+import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart'
+  if (dart.library.html) 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_web_builder.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../base/base_test_scenario.dart';
-import '../robots/search_robot.dart';
-import '../robots/thread_robot.dart';
+import '../robots/abstract/abstract_search_robot.dart';
 
 class SearchEmailWithSortOrderScenario extends BaseTestScenario {
   const SearchEmailWithSortOrderScenario(super.$, super.robots);
@@ -20,16 +19,17 @@ class SearchEmailWithSortOrderScenario extends BaseTestScenario {
 
   @override
   Future<void> runTestLogic() async {
-    final threadRobot = ThreadRobot($);
-    await threadRobot.openSearchView();
-    await _expectSearchViewVisible();
+    final threadRobot = robots.threadRobot();
+    final searchRobot = robots.searchRobot();
 
-    final searchRobot = SearchRobot($);
-    await searchRobot.enterQueryString(queryString);
-    await _expectSuggestionSearchListViewVisible();
+    await threadRobot.tapOnSearchField();
+    await searchRobot.enterKeyword(queryString);
+    await searchRobot.expectSuggestionListVisible();
+
+    await searchRobot.tapOnShowAllResultsText();
+    await searchRobot.expectSearchResultEmailListVisible();
 
     await searchRobot.scrollToEndListSearchFilter();
-    await _expectSortBySearchFilterButtonVisible();
 
     final appLocalizations = AppLocalizations();
 
@@ -43,17 +43,21 @@ class SearchEmailWithSortOrderScenario extends BaseTestScenario {
   }
 
   Future<void> _performSelectSortOrderAndValidateSearchResult({
-    required SearchRobot searchRobot,
+    required AbstractSearchRobot searchRobot,
     required EmailSortOrderType sortOrderType,
     required AppLocalizations appLocalizations,
   }) async {
     await Future.delayed(const Duration(seconds: 2));
 
-    await searchRobot.openSortOrderBottomDialog();
-    await _expectSortFilterContextMenuVisible();
+    await searchRobot.openSortOrderMenu();
+    await searchRobot.expectSortOrderMenuVisible();
 
     await searchRobot.selectSortOrder(sortOrderType.getTitleByAppLocalizations(appLocalizations));
-    await _expectSearchResultEmailListVisible();
+
+    // Relevance ordering is non-deterministic; verify only that the tap succeeded.
+    if (sortOrderType == EmailSortOrderType.relevance) return;
+
+    await searchRobot.expectSearchResultEmailListVisible();
     await _expectEmailListDisplayedCorrectly(listUsername: listUsername);
 
     switch (sortOrderType) {
@@ -84,26 +88,6 @@ class SearchEmailWithSortOrderScenario extends BaseTestScenario {
         await _expectEmailListSortedCorrectBySizeDescending(listUsername: listUsername);
         break;
     }
-  }
-
-  Future<void> _expectSearchViewVisible() async {
-    await expectViewVisible($(SearchEmailView));
-  }
-
-  Future<void> _expectSuggestionSearchListViewVisible() async {
-    await expectViewVisible($(#suggestion_search_list_view));
-  }
-
-  Future<void> _expectSortBySearchFilterButtonVisible() async {
-    await expectViewVisible($(#mobile_sortBy_search_filter_button));
-  }
-  
-  Future<void> _expectSortFilterContextMenuVisible() async {
-    await expectViewVisible($(#sort_filter_context_menu));
-  }
-  
-  Future<void> _expectSearchResultEmailListVisible() async {
-    await expectViewVisible($(#search_email_list_notification_listener));
   }
 
   Future<void> _expectEmailListDisplayedCorrectly({

--- a/integration_test/tests/search/search_email_with_sort_order_most_recent_by_default_test.dart
+++ b/integration_test/tests/search/search_email_with_sort_order_most_recent_by_default_test.dart
@@ -1,0 +1,11 @@
+import '../../base/test_base.dart';
+import '../../models/test_tags.dart';
+import '../../scenarios/search/search_email_with_sort_order_most_recent_by_default_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should see list email displayed by sort order `Most Recent` by default when search email successfully',
+    scenarioBuilder: ($, robots) => SearchEmailWithSortOrderMostRecentByDefaultScenario($, robots),
+    tags: [TestTags.android, TestTags.ios, TestTags.web],
+  );
+}

--- a/integration_test/tests/search/search_email_with_sort_order_relevance_by_default_test.dart
+++ b/integration_test/tests/search/search_email_with_sort_order_relevance_by_default_test.dart
@@ -1,9 +1,0 @@
-import '../../base/test_base.dart';
-import '../../scenarios/search/search_email_with_sort_order_relevance_by_default_scenario.dart';
-
-void main() {
-  TestBase().runPatrolTest(
-    description: 'Should see list email displayed by sort order `Relevance` by default when search email successfully',
-    scenarioBuilder: ($, robots) => SearchEmailWithSortOrderRelevanceByDefaultScenario($, robots),
-  );
-}

--- a/integration_test/tests/search/search_email_with_sort_order_test.dart
+++ b/integration_test/tests/search/search_email_with_sort_order_test.dart
@@ -1,9 +1,11 @@
 import '../../base/test_base.dart';
+import '../../models/test_tags.dart';
 import '../../scenarios/search_email_with_sort_order_scenario.dart';
 
 void main() {
   TestBase().runPatrolTest(
     description: 'Should see list email displayed by sort order selected when search email successfully',
+    tags: [TestTags.android, TestTags.ios, TestTags.web],
     scenarioBuilder: ($, robots) => SearchEmailWithSortOrderScenario($, robots),
   );
 }

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -2358,7 +2358,12 @@ class MailboxDashBoardController extends ReloadableController
 
   void selectSortOrderQuickSearchFilter(EmailSortOrderType sortOrder) {
     log('MailboxDashBoardController::selectSortOrderQuickSearchFilter():sortOrder: $sortOrder');
-    searchController.updateFilterEmail(sortOrderTypeOption: Some(sortOrder));
+    searchController.updateFilterEmail(
+      sortOrderTypeOption: Some(sortOrder),
+      beforeOption: const None(),
+      startDateOption: const None(),
+      positionOption: const None(),
+    );
     storeEmailSortOrder(sortOrder);
     dispatchAction(StartSearchEmailAction());
   }

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -2358,10 +2358,20 @@ class MailboxDashBoardController extends ReloadableController
 
   void selectSortOrderQuickSearchFilter(EmailSortOrderType sortOrder) {
     log('MailboxDashBoardController::selectSortOrderQuickSearchFilter():sortOrder: $sortOrder');
+    // Clear pagination cursors accumulated by the previous sort's load-more so
+    // the new search doesn't inherit a stale cursor (e.g. `after: lastEmail.receivedAt`
+    // set by `oldest` load-more) that would return 0 results.
+    //
+    // startDate/endDate are only cleared when no user date-range filter is active.
+    // If the user picked a range (e.g. "Last 7 days"), those values belong to the
+    // filter — clearing them would silently drop it while the UI chip stays selected.
+    final isDateFilterActive =
+        searchController.receiveTimeFiltered != EmailReceiveTimeType.allTime;
     searchController.updateFilterEmail(
       sortOrderTypeOption: Some(sortOrder),
       beforeOption: const None(),
-      startDateOption: const None(),
+      startDateOption: isDateFilterActive ? null : const None(),
+      endDateOption: isDateFilterActive ? null : const None(),
       positionOption: const None(),
     );
     storeEmailSortOrder(sortOrder);

--- a/lib/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart
+++ b/lib/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart
@@ -22,7 +22,7 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 class SearchEmailFilter with EquatableMixin, OptionParamMixin {
 
-  static const EmailSortOrderType defaultSortOrder = EmailSortOrderType.relevance;
+  static const EmailSortOrderType defaultSortOrder = EmailSortOrderType.mostRecent;
 
   final Set<String> from;
   final Set<String> to;

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -552,8 +552,11 @@ void main() {
         forceEmailQuery: anyNamed('forceEmailQuery'),
         collapseThreads: anyNamed('collapseThreads'),
       ));
-      expect(searchController.sortOrderFiltered, SearchEmailFilter.defaultSortOrder);
-      expect(searchController.searchEmailFilter.value, SearchEmailFilter.initial());
+      // Reset clears all filters but preserves the selected sort order
+      expect(searchController.sortOrderFiltered, EmailSortOrderType.relevance);
+      expect(
+        searchController.searchEmailFilter.value,
+        SearchEmailFilter.withSortOrder(EmailSortOrderType.relevance));
       verify(getEmailsInMailboxInteractor.execute(
         testSession, testAccountId,
         limit: ThreadConstants.defaultLimit,
@@ -598,7 +601,6 @@ void main() {
         text: SearchQuery(queryString),
         emailReceiveTimeType: EmailReceiveTimeType.last30Days,
         hasAttachment: true,
-        position: 0,
       )
     );
   });

--- a/test/features/mailbox_dashboard/presentation/extensions/quick_search_emails_extension_test.dart
+++ b/test/features/mailbox_dashboard/presentation/extensions/quick_search_emails_extension_test.dart
@@ -67,7 +67,7 @@ void main() {
           session,
           accountId,
           limit: anyNamed('limit'),
-          sort: sortOrderType?.getSortOrder().toNullable(),
+          sort: SearchEmailFilter(sortOrderType: sortOrderType).sortOrderType.getSortOrder().toNullable(),
           filter: anyNamed('filter'),
           properties: anyNamed('properties'),
         )).called(1);


### PR DESCRIPTION
### Desc:

https://github.com/linagora/tmail-flutter/issues/4515

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refactored search test helpers into input/sort/result abstractions and added platform-specific behaviors for mobile/web (scroll, show-all, Enter key) plus richer list/sort assertions.
* **Bug Fixes**
  * Default email search sort changed from "Relevance" to "Most Recent".
  * Selecting a sort order now clears pagination/position and preserves date-range appropriately.
* **Tests**
  * Integration tests updated/added for sort-default and UI flows; one obsolete relevance-default test removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->