### PR TITLE
TF-4540 Fix left margin of email truncated on email view

### DIFF
--- a/core/lib/presentation/utils/html_transformer/dom/remove_negative_margin_float_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/remove_negative_margin_float_transformers.dart
@@ -1,0 +1,123 @@
+import 'package:core/data/network/dio_client.dart';
+import 'package:core/presentation/utils/html_transformer/base/dom_transformer.dart';
+import 'package:core/utils/app_logger.dart';
+import 'package:flutter/widgets.dart' show visibleForTesting;
+import 'package:html/dom.dart';
+
+/// Removes inline CSS patterns that clip the left edge of email content
+/// rendered in a body with `overflow-x: hidden`.
+///
+/// **Case 1 — float + same-side negative margin**
+/// GitLab heading anchors carry `float: left; margin-left: -20px` for gutter
+/// deep-links. `overflow-x: hidden` creates a BFC (Block Formatting Context)
+/// whose scroll extent expands leftward to contain the float; because scrolling
+/// is suppressed, the first N px of content are clipped.
+///
+/// **Case 2 — aria-hidden anchor with negative margin (post-sanitisation)**
+/// The CSS sanitiser strips `float` (not in `allowedCssProperties`), turning
+/// the anchor into an inline element whose `margin-left: -Npx` shifts sibling
+/// heading text into the clipped zone. `aria-hidden="true"` anchors are purely
+/// decorative, so removing their negative margin has no visual impact.
+class RemoveNegativeMarginFloatTransformer extends DomTransformer {
+  const RemoveNegativeMarginFloatTransformer();
+
+  // \s* around `:` tolerates irregular spacing (e.g. `float : left ;`).
+  static final _floatLeftPattern = RegExp(
+    r'float\s*:\s*left\s*;?',
+    caseSensitive: false,
+  );
+  static final _floatRightPattern = RegExp(
+    r'float\s*:\s*right\s*;?',
+    caseSensitive: false,
+  );
+
+  // [^;]+ captures the value and unit without crossing a property boundary;
+  // `;?` handles the last property, which may omit the trailing semicolon.
+  static final _negativeMarginLeftPattern = RegExp(
+    r'margin-left\s*:\s*-[^;]+;?',
+    caseSensitive: false,
+  );
+  static final _negativeMarginRightPattern = RegExp(
+    r'margin-right\s*:\s*-[^;]+;?',
+    caseSensitive: false,
+  );
+
+  static final _multipleSpacesPattern = RegExp(r' {2,}');
+
+  @visibleForTesting
+  static RegExp get floatLeftPattern => _floatLeftPattern;
+
+  @visibleForTesting
+  static RegExp get floatRightPattern => _floatRightPattern;
+
+  @visibleForTesting
+  static RegExp get negativeMarginLeftPattern => _negativeMarginLeftPattern;
+
+  @visibleForTesting
+  static RegExp get negativeMarginRightPattern => _negativeMarginRightPattern;
+
+  @override
+  Future<void> process({
+    required Document document,
+    required DioClient dioClient,
+    Map<String, String>? mapUrlDownloadCID,
+  }) async {
+    try {
+      // Narrow selector: only float-bearing elements and aria-hidden anchors
+      // are candidates — avoids scanning every styled element in the document.
+      final elements = document.querySelectorAll(
+        '[style*="float"], a[aria-hidden="true"][style]',
+      );
+      for (final element in elements) {
+        final style = element.attributes['style'];
+        if (style == null) continue;
+
+        var updatedStyle = style;
+
+        // Case 1: float + same-side negative margin.
+        // In production, the CSS sanitiser strips float before DOM transformers
+        // run (Case 2 handles that path). This is a defensive guard for raw
+        // HTML and any future allowedCssProperties changes that re-allow float.
+        if (_floatLeftPattern.hasMatch(style) && _negativeMarginLeftPattern.hasMatch(style)) {
+          updatedStyle = updatedStyle
+              .replaceAll(_floatLeftPattern, '')
+              .replaceAll(_negativeMarginLeftPattern, '');
+        }
+        if (_floatRightPattern.hasMatch(style) && _negativeMarginRightPattern.hasMatch(style)) {
+          updatedStyle = updatedStyle
+              .replaceAll(_floatRightPattern, '')
+              .replaceAll(_negativeMarginRightPattern, '');
+        }
+
+        // Case 2: aria-hidden anchor with negative margin (the common path).
+        // The sanitiser strips float but preserves margin-left, so the anchor
+        // becomes inline with a negative margin that shifts heading text into
+        // the clipped zone. Operate on updatedStyle so Case 1 removals are reflected.
+        final isAriaHiddenAnchor = element.localName == 'a' &&
+            element.attributes['aria-hidden'] == 'true';
+        if (isAriaHiddenAnchor) {
+          if (_negativeMarginLeftPattern.hasMatch(updatedStyle)) {
+            updatedStyle = updatedStyle.replaceAll(_negativeMarginLeftPattern, '');
+          }
+          if (_negativeMarginRightPattern.hasMatch(updatedStyle)) {
+            updatedStyle = updatedStyle.replaceAll(_negativeMarginRightPattern, '');
+          }
+        }
+
+        if (updatedStyle == style) continue;
+
+        updatedStyle = updatedStyle
+            .replaceAll(_multipleSpacesPattern, ' ')
+            .trim();
+
+        if (updatedStyle.isEmpty) {
+          element.attributes.remove('style');
+        } else {
+          element.attributes['style'] = updatedStyle;
+        }
+      }
+    } catch (e) {
+      logWarning('$runtimeType::process: Exception = $e');
+    }
+  }
+}

--- a/core/lib/presentation/utils/html_transformer/transform_configuration.dart
+++ b/core/lib/presentation/utils/html_transformer/transform_configuration.dart
@@ -11,6 +11,7 @@ import 'package:core/presentation/utils/html_transformer/dom/remove_collapsed_si
 import 'package:core/presentation/utils/html_transformer/dom/remove_lazy_loading_for_background_image_transformers.dart';
 import 'package:core/presentation/utils/html_transformer/dom/remove_lazy_loading_image_transformers.dart';
 import 'package:core/presentation/utils/html_transformer/dom/remove_max_width_in_image_style_transformers.dart';
+import 'package:core/presentation/utils/html_transformer/dom/remove_negative_margin_float_transformers.dart';
 import 'package:core/presentation/utils/html_transformer/dom/autolink_text_node_transformer.dart';
 import 'package:core/presentation/utils/html_transformer/dom/remove_style_tag_outside_transformers.dart';
 import 'package:core/presentation/utils/html_transformer/dom/responsive_table_cell_transformer.dart';
@@ -80,6 +81,7 @@ class TransformConfiguration {
       const RemoveCollapsedSignatureButtonTransformer(),
       const NormalizeLineHeightInStyleTransformer(),
       const ResponsiveTableCellTransformer(),
+      const RemoveNegativeMarginFloatTransformer(),
     ]
   );
 
@@ -155,6 +157,7 @@ class TransformConfiguration {
     const RemoveCollapsedSignatureButtonTransformer(),
     const NormalizeLineHeightInStyleTransformer(),
     const ResponsiveTableCellTransformer(),
+    const RemoveNegativeMarginFloatTransformer(),
   ];
 
   static const List<TextTransformer> standardTextTransformers = [

--- a/core/test/utils/autolink_text_node_transformer_test.dart
+++ b/core/test/utils/autolink_text_node_transformer_test.dart
@@ -270,7 +270,7 @@ void main() {
       });
 
       test('SHOULD preserve all HTML structure around a deeply nested URL', () async {
-        final html = '<table><tr><td><p><span>https://deep.example.com</span></p></td></tr></table>';
+        const html = '<table><tr><td><p><span>https://deep.example.com</span></p></td></tr></table>';
         final result = await transform(html);
         expect(result, allOf(
           contains('href="https://deep.example.com"'),

--- a/core/test/utils/html_transform_text_html_test.dart
+++ b/core/test/utils/html_transform_text_html_test.dart
@@ -277,6 +277,68 @@ void main() {
         expect(out, contains('Monthly Performance Report'));
       });
     });
+
+    group(
+        'RemoveNegativeMarginFloatTransformer coexistence with standard pipeline', () {
+      test(
+        'SHOULD remove float:left + negative margin-left from GitLab heading anchors'
+            ' AND preserve heading text',
+            () async {
+          final out = await transform(HtmlEmailCorpus.htmlGitLabHeadingAnchors);
+          expect(out, isNot(contains('float: left')),
+              reason: 'float:left on anchor elements must be stripped');
+          expect(out, isNot(contains('margin-left: -20px')),
+              reason: 'negative margin-left must be stripped');
+          expect(out,
+              allOf(contains('Optimize fetch strategy'), contains('Summary')),
+              reason: 'heading text content must be preserved');
+          expect(out, contains('Body text here'),
+              reason: 'paragraph body must be preserved');
+        },
+      );
+
+      test(
+        'SHOULD preserve positive margin-left on non-aria-hidden element',
+            () async {
+          // The CSS sanitizer strips `float` from all inline styles (not in
+          // allowedCssProperties). The transformer must not touch margin-left
+          // when the element is not an aria-hidden anchor.
+          final out = await transform(
+              HtmlEmailCorpus.htmlWithFloatLeftPositiveMargin);
+          expect(out, contains('margin-left: 10px'),
+              reason: 'positive margin-left on a non-aria-hidden element must not be altered');
+        },
+      );
+
+      test(
+        'SHOULD strip anchor float styles AND still add target/rel to other links'
+            ' in the same email',
+            () async {
+          const input = '${HtmlEmailCorpus
+              .htmlGitLabHeadingAnchors}<p>See <a href="https://example.com">the docs</a>.</p>';
+          final out = await transform(input);
+          expect(out, isNot(contains('float: left')),
+              reason: 'float:left on anchor elements must be stripped');
+          expect(out, contains('target="_blank"'),
+              reason: 'SanitizeHyperLinkTagTransformer must still run');
+          expect(out, contains('rel="noreferrer"'));
+        },
+      );
+
+      test(
+        'SHOULD strip anchor float styles AND still add overflow-wrap to table cells'
+            ' in the same email',
+            () async {
+          const input = HtmlEmailCorpus.htmlGitLabHeadingAnchors +
+              HtmlEmailCorpus.htmlTableSimple;
+          final out = await transform(input);
+          expect(out, isNot(contains('float: left')),
+              reason: 'float:left on anchor elements must be stripped');
+          expect(out, contains('overflow-wrap: anywhere'),
+              reason: 'ResponsiveTableCellTransformer must still run');
+        },
+      );
+    });
   });
 
   group('HtmlTransform.transformToHtml — fromDomTransformers', () {

--- a/core/test/utils/remove_negative_margin_float_transformer_test.dart
+++ b/core/test/utils/remove_negative_margin_float_transformer_test.dart
@@ -1,0 +1,286 @@
+import 'package:core/data/network/dio_client.dart';
+import 'package:core/presentation/utils/html_transformer/dom/remove_negative_margin_float_transformers.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:html/dom.dart';
+import 'package:html/parser.dart' show parse;
+import 'package:mockito/annotations.dart';
+
+import 'remove_negative_margin_float_transformer_test.mocks.dart';
+
+void _verifyFloatPattern(RegExp pattern, String direction, String opposite) {
+  expect(pattern.hasMatch('float: $direction;'), isTrue);
+  expect(pattern.hasMatch('float:$direction'), isTrue);
+  expect(pattern.hasMatch('float: $opposite;'), isFalse);
+}
+
+void _verifyNegativeMarginPattern(RegExp pattern, String side) {
+  expect(pattern.hasMatch('margin-$side: -20px;'), isTrue);
+  expect(pattern.hasMatch('margin-$side: -1em;'), isTrue);
+  expect(pattern.hasMatch('margin-$side: 20px;'), isFalse);
+  expect(pattern.hasMatch('margin-$side: 0px;'), isFalse);
+}
+
+@GenerateNiceMocks([MockSpec<DioClient>()])
+void main() {
+  group('RemoveNegativeMarginFloatTransformer', () {
+    const transformer = RemoveNegativeMarginFloatTransformer();
+    late MockDioClient dioClient;
+
+    setUp(() {
+      dioClient = MockDioClient();
+    });
+
+    Future<Document> run(String html) async {
+      final doc = parse(html);
+      await transformer.process(document: doc, dioClient: dioClient);
+      return doc;
+    }
+
+    group('GitLab heading anchor pattern', () {
+      test(
+        'SHOULD remove float:left and negative margin-left from anchor element',
+        () async {
+          final doc = await run(
+            '<h2>'
+            '<a class="anchor" aria-hidden="true"'
+            ' style="margin-top: 0; float: left; margin-left: -20px;'
+            ' text-decoration: none;"></a>'
+            'Heading text'
+            '</h2>',
+          );
+          final anchor = doc.querySelector('a.anchor')!;
+          final style = anchor.attributes['style'] ?? '';
+          expect(style, isNot(contains('float')));
+          expect(style, isNot(contains('margin-left: -20px')));
+          expect(style, contains('margin-top: 0'));
+          expect(style, contains('text-decoration: none'));
+        },
+      );
+
+      test(
+        'SHOULD remove float:right and negative margin-right from element',
+        () async {
+          final doc = await run(
+            '<span style="float: right; margin-right: -15px; color: red;">x</span>',
+          );
+          final span = doc.querySelector('span')!;
+          final style = span.attributes['style'] ?? '';
+          expect(style, isNot(contains('float')));
+          expect(style, isNot(contains('margin-right: -15px')));
+          expect(style, contains('color: red'));
+        },
+      );
+
+      test(
+        'SHOULD remove style attribute entirely when only the problematic properties remain',
+        () async {
+          final doc = await run(
+            '<a style="float: left; margin-left: -20px;"></a>',
+          );
+          final anchor = doc.querySelector('a')!;
+          expect(anchor.attributes.containsKey('style'), isFalse);
+        },
+      );
+    });
+
+    group('Should NOT modify when pattern is not problematic', () {
+      test('SHOULD keep float:left when margin-left is positive', () async {
+        final doc = await run(
+          '<img style="float: left; margin-left: 10px;" src="img.png">',
+        );
+        final img = doc.querySelector('img')!;
+        final style = img.attributes['style'] ?? '';
+        expect(style, contains('float: left'));
+        expect(style, contains('margin-left: 10px'));
+      });
+
+      test('SHOULD keep float:left when margin-left is zero', () async {
+        final doc = await run(
+          '<img style="float: left; margin-left: 0px;" src="img.png">',
+        );
+        final img = doc.querySelector('img')!;
+        final style = img.attributes['style'] ?? '';
+        expect(style, contains('float: left'));
+        expect(style, contains('margin-left: 0px'));
+      });
+
+      test('SHOULD keep negative margin-left when there is no float', () async {
+        final doc = await run(
+          '<p style="margin-left: -5px; color: blue;">text</p>',
+        );
+        final p = doc.querySelector('p')!;
+        final style = p.attributes['style'] ?? '';
+        expect(style, contains('margin-left: -5px'));
+        expect(style, contains('color: blue'));
+      });
+
+      test(
+        'SHOULD NOT remove float:left when negative margin is on opposite side (margin-right)',
+        () async {
+          final doc = await run(
+            '<div style="float: left; margin-right: -10px;"></div>',
+          );
+          final div = doc.querySelector('div')!;
+          final style = div.attributes['style'] ?? '';
+          expect(style, contains('float: left'));
+          expect(style, contains('margin-right: -10px'));
+        },
+      );
+
+      test('SHOULD keep elements without style attribute unchanged', () async {
+        final doc = await run('<p>No style here</p>');
+        final p = doc.querySelector('p')!;
+        expect(p.attributes.containsKey('style'), isFalse);
+      });
+    });
+
+    group('Style cleanup', () {
+      test('SHOULD collapse extra spaces after property removal', () async {
+        final doc = await run(
+          '<a style="color: red;  float: left;  margin-left: -20px;  font-size: 14px;"></a>',
+        );
+        final anchor = doc.querySelector('a')!;
+        final style = anchor.attributes['style'] ?? '';
+        expect(style, isNot(contains('  ')));
+        expect(style, contains('color: red'));
+        expect(style, contains('font-size: 14px'));
+      });
+
+      test('SHOULD handle irregular spacing in property values', () async {
+        final doc = await run(
+          '<a style="float :  left ; margin-left :  -20px ;"></a>',
+        );
+        final anchor = doc.querySelector('a')!;
+        expect(anchor.attributes.containsKey('style'), isFalse);
+      });
+    });
+
+    group('Multiple elements in document', () {
+      test(
+        'SHOULD fix all affected anchors in a multi-heading document',
+        () async {
+          const html = '''
+<div>
+  <h2><a class="anchor" style="float: left; margin-left: -20px;"></a>H2</h2>
+  <h3><a class="anchor" style="float: left; margin-left: -20px;"></a>H3</h3>
+  <p style="float: left; margin-left: 5px;">Normal float para</p>
+</div>
+''';
+          final doc = await run(html);
+          final anchors = doc.querySelectorAll('a.anchor');
+          for (final anchor in anchors) {
+            expect(anchor.attributes.containsKey('style'), isFalse);
+          }
+          final para = doc.querySelector('p')!;
+          expect(para.attributes['style'], contains('float: left'));
+          expect(para.attributes['style'], contains('margin-left: 5px'));
+        },
+      );
+    });
+
+    group('Case 2 — aria-hidden anchor with negative margin (post-sanitisation)', () {
+      test(
+        'SHOULD remove negative margin-left from aria-hidden anchor'
+        ' even without float (post-sanitisation state)',
+        () async {
+          // Simulates what the element looks like after the CSS sanitiser
+          // strips float:left — only the negative margin-left remains.
+          final doc = await run(
+            '<h2>'
+            '<a aria-hidden="true" class="anchor"'
+            ' style="margin-top: 0; margin-left: -20px; text-decoration: none;"></a>'
+            'Heading text'
+            '</h2>',
+          );
+          final anchor = doc.querySelector('a.anchor')!;
+          final style = anchor.attributes['style'] ?? '';
+          expect(style, isNot(contains('margin-left: -20px')),
+              reason: 'negative margin-left must be removed from aria-hidden anchor');
+          expect(style, contains('margin-top: 0'),
+              reason: 'other style properties must be preserved');
+          expect(style, contains('text-decoration: none'));
+        },
+      );
+
+      test(
+        'SHOULD remove negative margin-right from aria-hidden anchor',
+        () async {
+          final doc = await run(
+            '<h3>'
+            '<a aria-hidden="true"'
+            ' style="margin-right: -20px; text-decoration: none;"></a>'
+            'Heading 3'
+            '</h3>',
+          );
+          final anchor = doc.querySelector('a')!;
+          final style = anchor.attributes['style'] ?? '';
+          expect(style, isNot(contains('margin-right: -20px')));
+          expect(style, contains('text-decoration: none'));
+        },
+      );
+
+      test(
+        'SHOULD NOT remove negative margin-left from a regular (non-aria-hidden) anchor',
+        () async {
+          final doc = await run(
+            '<a href="#section" style="margin-left: -5px; color: blue;">Back</a>',
+          );
+          final anchor = doc.querySelector('a')!;
+          final style = anchor.attributes['style'] ?? '';
+          expect(style, contains('margin-left: -5px'),
+              reason: 'non-aria-hidden anchors must not be touched');
+          expect(style, contains('color: blue'));
+        },
+      );
+
+      test(
+        'SHOULD fix all aria-hidden anchors across multiple headings',
+        () async {
+          final doc = await run(
+            '<h2><a aria-hidden="true" style="margin-top: 0; margin-left: -20px;"></a>H2</h2>'
+            '<h3><a aria-hidden="true" style="margin-top: 0; margin-left: -20px;"></a>H3</h3>'
+            '<p><a href="#link" style="margin-left: -5px;">normal link</a></p>',
+          );
+          final headingAnchors = doc.querySelectorAll('a[aria-hidden="true"]');
+          for (final anchor in headingAnchors) {
+            final style = anchor.attributes['style'] ?? '';
+            expect(style, isNot(contains('margin-left: -20px')));
+          }
+          final normalAnchor = doc.querySelector('a[href="#link"]')!;
+          expect(normalAnchor.attributes['style'], contains('margin-left: -5px'),
+              reason: 'non-aria-hidden anchor must not be modified');
+        },
+      );
+    });
+
+    group('Regex pattern verification', () {
+      test('floatLeftPattern matches float:left variants', () {
+        _verifyFloatPattern(
+          RemoveNegativeMarginFloatTransformer.floatLeftPattern,
+          'left', 'right',
+        );
+      });
+
+      test('floatRightPattern matches float:right variants', () {
+        _verifyFloatPattern(
+          RemoveNegativeMarginFloatTransformer.floatRightPattern,
+          'right', 'left',
+        );
+      });
+
+      test('negativeMarginLeftPattern matches negative values only', () {
+        _verifyNegativeMarginPattern(
+          RemoveNegativeMarginFloatTransformer.negativeMarginLeftPattern,
+          'left',
+        );
+      });
+
+      test('negativeMarginRightPattern matches negative values only', () {
+        _verifyNegativeMarginPattern(
+          RemoveNegativeMarginFloatTransformer.negativeMarginRightPattern,
+          'right',
+        );
+      });
+    });
+  });
+}

--- a/core/test/utils/transform_configuration_test.dart
+++ b/core/test/utils/transform_configuration_test.dart
@@ -1,9 +1,13 @@
+import 'package:core/presentation/utils/html_transformer/dom/remove_negative_margin_float_transformers.dart';
 import 'package:core/presentation/utils/html_transformer/dom/responsive_table_cell_transformer.dart';
 import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 bool _hasResponsiveTransformer(List transformers) =>
     transformers.any((t) => t is ResponsiveTableCellTransformer);
+
+bool _hasNegativeMarginFloatTransformer(List transformers) =>
+    transformers.any((t) => t is RemoveNegativeMarginFloatTransformer);
 
 void main() {
   group('TransformConfiguration — ResponsiveTableCellTransformer membership', () {
@@ -59,6 +63,63 @@ void main() {
         ),
         isFalse,
         reason: 'Print configuration does not need responsive wrapping',
+      );
+    });
+  });
+
+  group('TransformConfiguration — RemoveNegativeMarginFloatTransformer membership', () {
+    test('standardDomTransformers includes RemoveNegativeMarginFloatTransformer', () {
+      expect(
+        _hasNegativeMarginFloatTransformer(TransformConfiguration.standardDomTransformers),
+        isTrue,
+      );
+    });
+
+    test('forPreviewEmail includes RemoveNegativeMarginFloatTransformer via standardConfiguration', () {
+      expect(
+        _hasNegativeMarginFloatTransformer(
+          TransformConfiguration.forPreviewEmail().domTransformers,
+        ),
+        isTrue,
+      );
+    });
+
+    test('forPreviewEmailOnWeb includes RemoveNegativeMarginFloatTransformer', () {
+      expect(
+        _hasNegativeMarginFloatTransformer(
+          TransformConfiguration.forPreviewEmailOnWeb().domTransformers,
+        ),
+        isTrue,
+      );
+    });
+
+    test('forReplyForwardEmail does NOT include RemoveNegativeMarginFloatTransformer', () {
+      expect(
+        _hasNegativeMarginFloatTransformer(
+          TransformConfiguration.forReplyForwardEmail().domTransformers,
+        ),
+        isFalse,
+        reason: 'Reply/forward editor operates on draft content, not received email rendering',
+      );
+    });
+
+    test('forDraftsEmail does NOT include RemoveNegativeMarginFloatTransformer', () {
+      expect(
+        _hasNegativeMarginFloatTransformer(
+          TransformConfiguration.forDraftsEmail().domTransformers,
+        ),
+        isFalse,
+        reason: 'Draft editor operates on composed content, not received email rendering',
+      );
+    });
+
+    test('forPrintEmail does NOT include RemoveNegativeMarginFloatTransformer', () {
+      expect(
+        _hasNegativeMarginFloatTransformer(
+          TransformConfiguration.forPrintEmail().domTransformers,
+        ),
+        isFalse,
+        reason: 'Print pipeline renders the original email faithfully without layout adjustments',
       );
     });
   });

--- a/test/fixtures/html_email_corpus.dart
+++ b/test/fixtures/html_email_corpus.dart
@@ -137,6 +137,36 @@ abstract final class HtmlEmailCorpus {
       '<td style="color: green; padding: 8px">Revenue +12%</td>'
       '</tr></table>';
 
+  // ─── Negative-margin float (GitLab-style heading anchors) ────────────────
+  /// Mirrors the exact pattern emitted by GitLab's markdown renderer:
+  /// empty anchor tags with `float: left; margin-left: -20px` are injected
+  /// before every heading for gutter deep-link navigation.
+  static const String htmlGitLabHeadingAnchors =
+      '<div class="md">'
+      '<h2>'
+      '<a aria-hidden="true" class="anchor"'
+      ' style="margin-top: 0; float: left; margin-left: -20px;'
+      ' text-decoration: none; outline: none;"></a>'
+      'Optimize fetch strategy'
+      '</h2>'
+      '<h3>'
+      '<a aria-hidden="true" class="anchor"'
+      ' style="margin-top: 0; float: left; margin-left: -20px;'
+      ' text-decoration: none; outline: none;"></a>'
+      'Summary'
+      '</h3>'
+      '<p>Body text here.</p>'
+      '</div>';
+
+  /// Floated image with a *positive* margin — must be left untouched by the
+  /// negative-margin-float transformer.
+  static const String htmlWithFloatLeftPositiveMargin =
+      '<p>'
+      '<img src="logo.png"'
+      ' style="float: left; margin-left: 10px; margin-right: 8px;">'
+      'Company logo beside this text.'
+      '</p>';
+
   // ─── Multi-language ────────────────────────────────────────────────────────
   static const String htmlRtlArabic =
       '<div dir="rtl"><p>مرحبا بالعالم</p><p>البريد الإلكتروني</p></div>';


### PR DESCRIPTION
## Issue 

#4540

## Root cause

`HtmlUtils.generateHtmlDocument()` wraps email content in a `<body style="overflow-x: hidden; ...">`. This creates a **BFC (Block Formatting Context)** on the body element.

GitLab's markdown renderer injects empty `<a aria-hidden="true" class="anchor" style="float: left; margin-left: -20px; ...">` elements before every heading for gutter deep-links. Inside a BFC, the browser expands the scroll origin leftward to contain the floated anchor's negative margin. Because `overflow-x: hidden` suppresses scrolling, the leftmost 20 px of content become permanently hidden.

The CSS sanitiser (`StandardizeHtmlSanitizingTransformers`) strips `float` from inline styles before DOM transformers run, but preserves `margin-left`. This turns the anchor into an inline element whose `margin-left: -20px` shifts sibling heading text left — straight into the clipped zone.

## Solution

Add `RemoveNegativeMarginFloatTransformer` as the last step in `standardDomTransformers` and `forPreviewEmailOnWeb()`. It handles two cases:

**Case 1 — float + same-side negative margin** (defensive guard for unsanitised HTML)
Removes both `float` and the negative margin when they appear together on the same element.

**Case 2 — `aria-hidden="true"` anchor with negative margin** (the production path)
After sanitisation, these anchors have no `float` but retain their negative margin. Since `aria-hidden="true"` anchors are purely decorative, their negative margins are safe to remove without visual impact.

The selector is narrowed to `[style*="float"], a[aria-hidden="true"][style]` to avoid iterating every styled element in the document.

## Resolved


<img width="270" height="611" alt="Screenshot 2026-06-05 at 18 12 28" src="https://github.com/user-attachments/assets/b73509a8-71a9-4367-830f-6de1d4e30394" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering issues in HTML emails by removing problematic float and negative margin CSS properties from heading anchors that could cause content clipping under overflow constraints. Improvements apply to web and email preview modes.

* **Tests**
  * Added comprehensive test coverage for CSS property sanitization and HTML transformation pipeline integration, including edge cases and multi-element scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->