### PR TITLE
TF-4592 Fix EXC_BAD_ACCESS crash on iOS foreground data-only FCM push

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -48,6 +48,38 @@ import flutter_local_notifications
     override func applicationWillTerminate(_ application: UIApplication) {
         updateApplicationStateInUserDefaults(false)
     }
+
+    // FCM data-only pushes (aps present, aps.alert absent) delivered when the app is
+    // foreground/inactive trigger EXC_BAD_ACCESS in FLTFirebaseMessagingPlugin._channel
+    // (KERN_INVALID_ADDRESS at 0x80) because the plugin's FlutterMethodChannel becomes a
+    // dangling pointer after a scene disconnect tears down the Flutter engine.
+    //
+    // GULAppDelegateSwizzler holds the plugin via a weak reference; when the engine is
+    // released the channel object is freed, but the swizzler still dispatches the next
+    // notification to that stale pointer before the weak container is zeroed.
+    //
+    // Fix: intercept this exact combination (FCM, non-background, no alert) ourselves
+    // and relay Messaging#onMessage via the AppDelegate's own fcmMethodChannel, which
+    // is tied to the current engine. For background pushes we still delegate to super so
+    // the headless Dart isolate (Messaging#onBackgroundMessage) continues to work.
+    override func application(
+        _ application: UIApplication,
+        didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+        fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+    ) -> Bool {
+        if isForegroundFcmDataOnlyNotification(userInfo) {
+            fcmMethodChannel?.invokeMethod(CoreUtils.FCM_ON_MESSAGE_METHOD_NAME, arguments: userInfo)
+            completionHandler(.noData)
+            return true
+        }
+        return super.application(application, didReceiveRemoteNotification: userInfo, fetchCompletionHandler: completionHandler)
+    }
+
+    private func isForegroundFcmDataOnlyNotification(_ userInfo: [AnyHashable: Any]) -> Bool {
+        guard userInfo["gcm.message_id"] != nil else { return false }
+        guard let aps = userInfo["aps"] as? [String: Any], aps["alert"] == nil else { return false }
+        return UIApplication.shared.applicationState != .background
+    }
     
     override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         let sharingIntent = SwiftReceiveSharingIntentPlugin.instance


### PR DESCRIPTION
## Issue

#4592 

Fix a fatal crash (`EXC_BAD_ACCESS KERN_INVALID_ADDRESS at 0x80`) that occurs on iOS
when a JMAP data-only FCM push arrives while the app is in the foreground or inactive state.

Sentry issue: https://errors.cozycloud.cc/organizations/cozycloud/issues/387367

## Root Cause

Three components combine to produce the crash:

**1. `GULAppDelegateSwizzler` holds `FLTFirebaseMessagingPlugin` via a weak reference.**

Firebase swizzles `AppDelegate` to intercept `application:didReceiveRemoteNotification:fetchCompletionHandler:` and dispatches calls to all registered interceptors. Each interceptor is stored in a `GULZeroingWeakContainer` (`@property(nonatomic, weak) id object`), meaning the plugin's only strong references come from Flutter's plugin registrar.

**2. A scene disconnect releases the Flutter engine and the plugin's `FlutterMethodChannel`.**

With the `FlutterImplicitEngineDelegate` pattern, the Flutter engine is created lazily per scene. When a UIScene disconnects (user kills app from the switcher, memory pressure), Flutter's registrar drops its strong reference to `FLTFirebaseMessagingPlugin`. The plugin is deallocated; its `FlutterMethodChannel` (`_channel`) is freed. The `GULZeroingWeakContainer` zeroes its weak pointer asynchronously — but there is a short window before that zeroing completes.

**3. The crash branch is hit by every JMAP data-only push when the app is not in background.**

```objc
// FLTFirebaseMessagingPlugin.m:607-609
} else {  // applicationState != UIApplicationStateBackground
    if (userInfo[@"aps"] != nil && userInfo[@"aps"][@"alert"] == nil) {
        [_channel invokeMethod:@"Messaging#onMessage" arguments:notificationDict]; // CRASH
    }
}
```

JMAP pushes always have `aps.content-available = 1` and no `aps.alert`. When the push arrives during the deallocation window, `_channel` is a dangling pointer whose freed memory reads `0x80` at the isa position. `objc_msgSend` faults trying to look up `invokeMethod:arguments:` at address `0x80`.

## Solution

Override `application:didReceiveRemoteNotification:fetchCompletionHandler:` in `AppDelegate` to intercept the exact crash condition — FCM + data-only + non-background — and relay `Messaging#onMessage` directly via the AppDelegate's own `fcmMethodChannel`, which is always tied to the current live engine instance. `super` is not called for this case, bypassing the crashing plugin code path. Background pushes still delegate to `super` so the headless Dart isolate (`Messaging#onBackgroundMessage`) continues to work normally.


| App state | Push type | Before | After |
|---|---|---|---|
| Active / Inactive | JMAP data-only | **CRASH** | `fcmMethodChannel.invokeMethod` ✓ |
| Background | JMAP data-only | Background isolate via `super` ✓ | `super` still called ✓ |
| Active | Alert notification | `willPresent` → `fcmMethodChannel` ✓ | Unchanged ✓ |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handling Firebase Cloud Messaging data-only notifications when the app is in the foreground, enabling better notification delivery and processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->