### PR TITLE
TF-4421 Search suggestion desync

### DIFF
--- a/core/lib/presentation/views/quick_search/quick_search_suggestion_list.dart
+++ b/core/lib/presentation/views/quick_search/quick_search_suggestion_list.dart
@@ -240,7 +240,9 @@ class QuickSearchSuggestionListState<T, P, R>
       if (!mounted) return;
 
       setState(() {
-        _animationController?.forward(from: widget.animationStart);
+        if (_animationController?.isDismissed ?? true) {
+          _animationController?.forward(from: widget.animationStart);
+        }
         _isLoading = false;
         _suggestions = null;
         _recentItems = recentItems;
@@ -271,10 +273,12 @@ class QuickSearchSuggestionListState<T, P, R>
 
     if (!mounted) return;
     setState(() {
-      final animationStart = suggestions?.isNotEmpty == true
-          ? widget.animationStart
-          : 1.0;
-      _animationController?.forward(from: animationStart);
+      if (_animationController?.isDismissed ?? true) {
+        final animationStart = suggestions?.isNotEmpty == true
+            ? widget.animationStart
+            : 1.0;
+        _animationController?.forward(from: animationStart);
+      }
       _isLoading = false;
       _suggestions = suggestions;
       _recentItems = recentItems;

--- a/integration_test/factories/mobile_robot_factory.dart
+++ b/integration_test/factories/mobile_robot_factory.dart
@@ -3,6 +3,7 @@ import 'package:patrol/patrol.dart';
 import '../robots/abstract/abstract_common_robot.dart';
 import '../robots/abstract/abstract_settings_robot.dart';
 import '../robots/mobile/mobile_common_robot.dart';
+import '../robots/abstract/abstract_advanced_search_robot.dart';
 import '../robots/abstract/abstract_app_grid_robot.dart';
 import '../robots/abstract/abstract_composer_robot.dart';
 import '../robots/abstract/abstract_email_rules_setting_robot.dart';
@@ -61,4 +62,7 @@ class MobileRobotFactory implements RobotFactory {
   
   @override
   AbstractSettingsRobot settingsRobot() => MobileSettingsRobot($);
+
+  @override
+  AbstractAdvancedSearchRobot advancedSearchRobot() => throw UnimplementedError('Web only');
 }

--- a/integration_test/factories/robot_factory.dart
+++ b/integration_test/factories/robot_factory.dart
@@ -1,3 +1,4 @@
+import '../robots/abstract/abstract_advanced_search_robot.dart';
 import '../robots/abstract/abstract_app_grid_robot.dart';
 import '../robots/abstract/abstract_composer_robot.dart';
 import '../robots/abstract/abstract_email_rules_setting_robot.dart';
@@ -22,4 +23,5 @@ abstract class RobotFactory {
   AbstractEmailRobot emailRobot();
   AbstractSearchRobot searchRobot();
   AbstractSettingsRobot settingsRobot();
+  AbstractAdvancedSearchRobot advancedSearchRobot();
 }

--- a/integration_test/factories/web_robot_factory.dart
+++ b/integration_test/factories/web_robot_factory.dart
@@ -1,5 +1,6 @@
 import 'package:patrol/patrol.dart';
 
+import '../robots/abstract/abstract_advanced_search_robot.dart';
 import '../robots/abstract/abstract_common_robot.dart';
 import '../robots/abstract/abstract_settings_robot.dart';
 import '../robots/web/web_common_robot.dart';
@@ -13,6 +14,7 @@ import '../robots/abstract/abstract_mailbox_menu_robot.dart';
 import '../robots/abstract/abstract_rules_filter_creator_robot.dart';
 import '../robots/abstract/abstract_search_robot.dart';
 import '../robots/abstract/abstract_thread_robot.dart';
+import '../robots/web/web_advanced_search_robot.dart';
 import '../robots/web/web_app_grid_robot.dart';
 import '../robots/web/web_composer_robot.dart';
 import '../robots/web/web_email_rules_setting_robot.dart';
@@ -61,4 +63,7 @@ class WebRobotFactory implements RobotFactory {
 
   @override
   AbstractSettingsRobot settingsRobot() => WebSettingsRobot($);
+
+  @override
+  AbstractAdvancedSearchRobot advancedSearchRobot() => WebAdvancedSearchRobot($);
 }

--- a/integration_test/robots/abstract/abstract_advanced_search_robot.dart
+++ b/integration_test/robots/abstract/abstract_advanced_search_robot.dart
@@ -1,0 +1,14 @@
+import 'package:tmail_ui_user/features/base/model/filter_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
+
+abstract class AbstractAdvancedSearchRobot {
+  Future<void> closeAdvancedSearch();
+  Future<void> tapSearchButton();
+  Future<void> expectHasAttachmentChecked(bool checked);
+  Future<void> enterFromEmail(String email);
+  Future<void> expectFromFieldContains(String email);
+  Future<void> removeFromEmailTag(String email);
+  Future<void> expectFromFieldEmpty();
+  Future<void> expectReceiveTimeSelected(EmailReceiveTimeType receiveTimeType);
+  Future<void> focusField(FilterField filterField);
+}

--- a/integration_test/robots/abstract/abstract_search_robot.dart
+++ b/integration_test/robots/abstract/abstract_search_robot.dart
@@ -2,6 +2,8 @@ import 'abstract_search_assertion_robot.dart';
 import 'abstract_search_filter_robot.dart';
 import 'abstract_search_input_robot.dart';
 
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
+
 abstract class AbstractSearchRobot
     implements
         AbstractSearchInputRobot,
@@ -11,4 +13,10 @@ abstract class AbstractSearchRobot
   Future<void> searchByLabel(String labelName);
   Future<void> expectEmailWithSubjectVisible(String subject);
   Future<void> expectEmptyResults();
+  Future<void> expectSuggestionFilterSelected(QuickSearchFilter filter, bool selected);
+  Future<void> tapSuggestionFilter(QuickSearchFilter filter);
+  Future<void> deleteSuggestionFilter(QuickSearchFilter filter);
+  Future<void> expectQuickFilterDateTimeSelected(bool selected);
+  Future<void> tapQuickFilterDateTimeChip();
+  Future<void> selectQuickFilterDateTimeOption(String dateTimeName);
 }

--- a/integration_test/robots/abstract/abstract_thread_robot.dart
+++ b/integration_test/robots/abstract/abstract_thread_robot.dart
@@ -5,4 +5,6 @@ abstract class AbstractThreadRobot {
   Future<void> openMailbox();
   Future<void> openEmailWithSubject(String subject);
   Future<void> tapOnSearchField();
+  Future<void> openSearchSuggestion();
+  Future<void> selectMailboxByName(String name);
 }

--- a/integration_test/robots/mobile/mobile_search_robot.dart
+++ b/integration_test/robots/mobile/mobile_search_robot.dart
@@ -5,6 +5,7 @@ import 'package:patrol/patrol.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_view.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
 
 import '../abstract/abstract_search_robot.dart';
 import '../search_robot.dart';
@@ -45,4 +46,28 @@ class MobileSearchRobot extends SearchRobot implements AbstractSearchRobot {
   Future<void> expectEmptyResults() async {
     await $(const Key(UiKeys.emptySearchEmailView)).waitUntilVisible();
   }
+
+  @override
+  Future<void> expectSuggestionFilterSelected(QuickSearchFilter filter, bool selected) =>
+      throw UnimplementedError('Web only');
+
+  @override
+  Future<void> tapSuggestionFilter(QuickSearchFilter filter) =>
+      throw UnimplementedError('Web only');
+
+  @override
+  Future<void> deleteSuggestionFilter(QuickSearchFilter filter) =>
+      throw UnimplementedError('Web only');
+
+  @override
+  Future<void> expectQuickFilterDateTimeSelected(bool selected) =>
+      throw UnimplementedError('Web only');
+
+  @override
+  Future<void> tapQuickFilterDateTimeChip() =>
+      throw UnimplementedError('Web only');
+
+  @override
+  Future<void> selectQuickFilterDateTimeOption(String dateTimeName) =>
+      throw UnimplementedError('Web only');
 }

--- a/integration_test/robots/mobile/mobile_thread_robot.dart
+++ b/integration_test/robots/mobile/mobile_thread_robot.dart
@@ -18,4 +18,14 @@ class MobileThreadRobot extends ThreadRobot implements AbstractThreadRobot {
   Future<void> openAppGrid() async {
     await $(const ValueKey(UiKeys.toggleAppGridButton)).tap();
   }
+
+  @override
+  Future<void> openSearchSuggestion() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> selectMailboxByName(String name) {
+    throw UnimplementedError('Web only');
+  }
 }

--- a/integration_test/robots/search_robot.dart
+++ b/integration_test/robots/search_robot.dart
@@ -6,6 +6,7 @@ import 'package:collection/collection.dart';
 import 'package:core/domain/extensions/list_datetime_extension.dart';
 import 'package:core/presentation/views/search/search_bar_view.dart';
 import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_view.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_view.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart'
@@ -262,6 +263,36 @@ class SearchRobot extends CoreRobot implements AbstractSearchRobot {
   
   @override
   Future<void> searchByLabel(String labelName) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> deleteSuggestionFilter(QuickSearchFilter filter) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> expectQuickFilterDateTimeSelected(bool selected) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> expectSuggestionFilterSelected(QuickSearchFilter filter, bool selected) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> selectQuickFilterDateTimeOption(String dateTimeName) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> tapQuickFilterDateTimeChip() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> tapSuggestionFilter(QuickSearchFilter filter) {
     throw UnimplementedError();
   }
 }

--- a/integration_test/robots/web/web_advanced_search_robot.dart
+++ b/integration_test/robots/web/web_advanced_search_robot.dart
@@ -1,0 +1,93 @@
+import 'package:core/presentation/views/checkbox/custom_icon_labeled_checkbox.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/base/model/filter_filter.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
+import 'package:tmail_ui_user/features/base/widget/default_field/default_autocomplete_tag_item_widget.dart';
+import 'package:tmail_ui_user/features/base/widget/default_field/default_date_drop_down_button.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_field_widget.dart';
+
+import '../../base/core_robot.dart';
+import '../../utils/wait_for_condition.dart';
+import '../abstract/abstract_advanced_search_robot.dart';
+
+class WebAdvancedSearchRobot extends CoreRobot implements AbstractAdvancedSearchRobot {
+  WebAdvancedSearchRobot(super.$);
+
+  @override
+  Future<void> closeAdvancedSearch() async {
+    await $(const ValueKey(UiKeys.advancedSearchCloseOverlay)).tap(alignment: Alignment.topLeft);
+  }
+
+  @override
+  Future<void> tapSearchButton() async {
+    await $(const ValueKey(UiKeys.advancedSearchSearchButton)).tap();
+    await $.pump(const Duration(seconds: 2));
+  }
+
+  @override
+  Future<void> expectHasAttachmentChecked(bool checked) async {
+    expect(
+      $(const ValueKey(UiKeys.advancedSearchHasAttachmentCheckbox))
+        .which<CustomIconLabeledCheckbox>((w) => w.value == checked)
+        .visible,
+      true,
+    );
+  }
+
+  @override
+  Future<void> enterFromEmail(String email) async {
+    final fromField = $(const ValueKey(UiKeys.advancedSearchFromEmailField)).$(TextField);
+    await fromField.tap();
+    await fromField.enterText(email);
+    await $.tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await fromField.tap();
+  }
+
+  @override
+  Future<void> expectFromFieldContains(String email) async {
+    await $.waitUntilVisible(
+      $(DefaultAutocompleteTagItemWidget)
+        .which<DefaultAutocompleteTagItemWidget>(
+          (w) => w.currentEmailAddress.email == email,
+        ),
+    );
+  }
+
+  @override
+  Future<void> removeFromEmailTag(String email) async {
+    final tagItem = $(DefaultAutocompleteTagItemWidget)
+      .which<DefaultAutocompleteTagItemWidget>(
+        (w) => w.currentEmailAddress.email == email,
+      );
+    await $.waitUntilVisible(tagItem);
+    // AvatarTagItemWidget uses only Text — sole SvgPicture inside the chip is the delete icon
+    await tagItem.$(find.byType(SvgPicture)).tap();
+  }
+
+  @override
+  Future<void> expectFromFieldEmpty() async {
+    await waitForCondition(
+      () => $(DefaultAutocompleteTagItemWidget).evaluate().isEmpty,
+    );
+  }
+
+  @override
+  Future<void> expectReceiveTimeSelected(EmailReceiveTimeType receiveTimeType) async {
+    await $.waitUntilExists(
+      $(DateDropDownButton)
+        .which<DateDropDownButton>((w) => w.receiveTimeTypeSelected == receiveTimeType),
+    );
+  }
+
+  @override
+  Future<void> focusField(FilterField filterField) async {
+    await $(AdvancedSearchFieldWidget)
+        .which<AdvancedSearchFieldWidget>((w) => w.filterField == filterField)
+        .$(TextField)
+        .tap();
+  }
+}

--- a/integration_test/robots/web/web_search_robot.dart
+++ b/integration_test/robots/web/web_search_robot.dart
@@ -5,7 +5,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/base/widget/popup_menu/popup_menu_item_action_widget.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/quick_search/email_quick_search_item_tile_widget.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_filters/search_filter_button.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_web_builder.dart';
 
@@ -166,5 +168,43 @@ class WebSearchRobot extends SearchRobot implements AbstractSearchRobot {
   @override
   Future<void> expectEmptyResults() async {
     await $(const Key(UiKeys.emptyThreadView)).waitUntilVisible();
+  }
+
+  @override
+  Future<void> expectSuggestionFilterSelected(QuickSearchFilter filter, bool selected) async {
+    await $.waitUntilExists(
+      $(Key('mobile_${filter.name}_search_filter_button'))
+        .which<SearchFilterButton>((w) => w.isSelected == selected),
+    );
+  }
+
+  @override
+  Future<void> tapSuggestionFilter(QuickSearchFilter filter) async {
+    await $(Key('mobile_${filter.name}_search_filter_button')).tap();
+  }
+
+  @override
+  Future<void> deleteSuggestionFilter(QuickSearchFilter filter) async {
+    await $(Key('delete_${filter.name}_search_filter_button')).tap();
+  }
+
+  @override
+  Future<void> expectQuickFilterDateTimeSelected(bool selected) async {
+    await $.waitUntilExists(
+      $(const Key('dateTime_search_filter_button'))
+        .which<SearchFilterButton>((w) => w.isSelected == selected),
+    );
+  }
+
+  @override
+  Future<void> tapQuickFilterDateTimeChip() async {
+    await $(const Key('dateTime_search_filter_button')).tap();
+    await $.pump(const Duration(milliseconds: 300));
+  }
+
+  @override
+  Future<void> selectQuickFilterDateTimeOption(String dateTimeName) async {
+    await $(find.text(dateTimeName)).tap();
+    await $.pump(const Duration(seconds: 2));
   }
 }

--- a/integration_test/robots/web/web_thread_robot.dart
+++ b/integration_test/robots/web/web_thread_robot.dart
@@ -67,6 +67,16 @@ class WebThreadRobot extends ThreadRobot implements AbstractThreadRobot {
     await $.pump(const Duration(seconds: 3));
   }
 
+  @override
+  Future<void> openSearchSuggestion() async {
+    await $(SearchInputFormWidget).$(TextField).tap();
+  }
+
+  @override
+  Future<void> selectMailboxByName(String name) async {
+    await tapOnMailboxWithName(name);
+  }
+
   Future<void> _openEmailTile(PatrolFinder emailFinder) async {
     await $.waitUntilVisible(emailFinder);
     await emailFinder.tap();

--- a/integration_test/scenarios/search/filter_desync_suggestion_advanced_search_scenario.dart
+++ b/integration_test/scenarios/search/filter_desync_suggestion_advanced_search_scenario.dart
@@ -1,0 +1,135 @@
+import 'package:tmail_ui_user/features/base/model/filter_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
+import 'package:tmail_ui_user/features/thread/presentation/widgets/empty_emails_widget.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../robots/abstract/abstract_advanced_search_robot.dart';
+import '../../robots/abstract/abstract_search_robot.dart';
+import '../../robots/abstract/abstract_thread_robot.dart';
+
+class FilterDesyncSuggestionAdvancedSearchScenario extends BaseTestScenario {
+  const FilterDesyncSuggestionAdvancedSearchScenario(super.$, super.robots);
+
+  @override
+  Future<void> runTestLogic() async {
+    const email = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    const aliceEmail = 'alice@example.com';
+    final appLocalizations = AppLocalizations();
+
+    final AbstractThreadRobot threadRobot = robots.threadRobot();
+    final AbstractSearchRobot searchRobot = robots.searchRobot();
+    final AbstractAdvancedSearchRobot advancedSearchRobot = robots.advancedSearchRobot();
+
+    await $(EmptyEmailsWidget).waitUntilVisible();
+
+    // ── Pre-condition: both filters unselected ────────────────────────────
+    await threadRobot.openSearchSuggestion();
+    await searchRobot.expectSuggestionFilterSelected(QuickSearchFilter.hasAttachment, false);
+    await searchRobot.expectSuggestionFilterSelected(QuickSearchFilter.fromMe, false);
+
+    // Select hasAttachment in suggestion list
+    await searchRobot.tapSuggestionFilter(QuickSearchFilter.hasAttachment);
+
+    // Open advanced search: hasAttachment should be checked
+    await searchRobot.openSearch();
+    await advancedSearchRobot.expectHasAttachmentChecked(true);
+
+    // Fill own email in From field
+    await advancedSearchRobot.enterFromEmail(email);
+    await advancedSearchRobot.expectFromFieldContains(email);
+
+    // Close dialog: fromMe should now be selected in suggestion list
+    await advancedSearchRobot.closeAdvancedSearch();
+    await threadRobot.openSearchSuggestion();
+    await searchRobot.expectSuggestionFilterSelected(QuickSearchFilter.hasAttachment, true);
+    await searchRobot.expectSuggestionFilterSelected(QuickSearchFilter.fromMe, true);
+
+    // Unselect hasAttachment via delete icon
+    await searchRobot.deleteSuggestionFilter(QuickSearchFilter.hasAttachment);
+    await searchRobot.expectSuggestionFilterSelected(QuickSearchFilter.hasAttachment, false);
+
+    // Open advanced search: hasAttachment checkbox should be unchecked
+    await searchRobot.openSearch();
+    await advancedSearchRobot.expectHasAttachmentChecked(false);
+
+    // Remove own email from From field
+    await advancedSearchRobot.removeFromEmailTag(email);
+    await advancedSearchRobot.expectFromFieldEmpty();
+
+    // Close dialog: both filters should be unselected again
+    await advancedSearchRobot.closeAdvancedSearch();
+    await threadRobot.openSearchSuggestion();
+    await searchRobot.expectSuggestionFilterSelected(QuickSearchFilter.hasAttachment, false);
+    await searchRobot.expectSuggestionFilterSelected(QuickSearchFilter.fromMe, false);
+
+    // ── Bug 1: fromMe ON with multiple from addresses ─────────────────────
+    // Select fromMe in suggestion
+    await searchRobot.tapSuggestionFilter(QuickSearchFilter.fromMe);
+
+    // Open dialog: own email should appear in From field
+    await searchRobot.openSearch();
+    await advancedSearchRobot.expectFromFieldContains(email);
+
+    // Add a second email address
+    await advancedSearchRobot.enterFromEmail(aliceEmail);
+    await advancedSearchRobot.expectFromFieldContains(aliceEmail);
+    await advancedSearchRobot.expectFromFieldContains(email);
+
+    // Close dialog: fromMe should remain selected (from contains own email)
+    await advancedSearchRobot.closeAdvancedSearch();
+    await threadRobot.openSearchSuggestion();
+    await searchRobot.expectSuggestionFilterSelected(QuickSearchFilter.fromMe, true);
+
+    // Reopen dialog: both addresses must still be present
+    await searchRobot.openSearch();
+    await advancedSearchRobot.focusField(FilterField.from);
+    await advancedSearchRobot.expectFromFieldContains(email);
+    await advancedSearchRobot.expectFromFieldContains(aliceEmail);
+    await advancedSearchRobot.closeAdvancedSearch();
+    await threadRobot.openSearchSuggestion();
+
+    // ── Bug 2: quick filter change reflects in suggestion and dialog ───────
+    // Select 7 days in suggestion (fromMe already active from Bug 1)
+    await searchRobot.tapSuggestionFilter(QuickSearchFilter.last7Days);
+
+    // Open dialog: receive time should show last7Days
+    await searchRobot.openSearch();
+    await advancedSearchRobot.expectReceiveTimeSelected(EmailReceiveTimeType.last7Days);
+
+    // Tap Search button to start search with suggestion filters applied
+    await advancedSearchRobot.tapSearchButton();
+
+    // Quick filter dateTime chip should now reflect last7Days (selected)
+    await searchRobot.expectQuickFilterDateTimeSelected(true);
+
+    // Change to last30Days via quick filter popup
+    await searchRobot.tapQuickFilterDateTimeChip();
+    await searchRobot.selectQuickFilterDateTimeOption(appLocalizations.last30Days);
+
+    // Open suggestion: 7 days must no longer be active
+    await threadRobot.openSearchSuggestion();
+    await searchRobot.expectSuggestionFilterSelected(QuickSearchFilter.last7Days, false);
+
+    // Open dialog: receive time must not be last7Days
+    await searchRobot.openSearch();
+    await advancedSearchRobot.expectReceiveTimeSelected(EmailReceiveTimeType.last30Days);
+
+    // ── Bug 3: all filters reset when leaving search mode ─────────────────
+    // Close dialog, then tap inbox to exit search mode
+    await advancedSearchRobot.closeAdvancedSearch();
+    await threadRobot.selectMailboxByName('Inbox');
+
+    // Open suggestion: fromMe and 7days must both be inactive
+    await threadRobot.openSearchSuggestion();
+    await searchRobot.expectSuggestionFilterSelected(QuickSearchFilter.fromMe, false);
+    await searchRobot.expectSuggestionFilterSelected(QuickSearchFilter.last7Days, false);
+
+    // Open dialog: from field empty, receive time = allTime
+    await searchRobot.openSearch();
+    await advancedSearchRobot.expectFromFieldEmpty();
+    await advancedSearchRobot.expectReceiveTimeSelected(EmailReceiveTimeType.allTime);
+    await advancedSearchRobot.closeAdvancedSearch();
+  }
+}

--- a/integration_test/tests/search/filter_desync_suggestion_advanced_search_test.dart
+++ b/integration_test/tests/search/filter_desync_suggestion_advanced_search_test.dart
@@ -1,0 +1,11 @@
+import '../../base/test_base.dart';
+import '../../models/test_tags.dart';
+import '../../scenarios/search/filter_desync_suggestion_advanced_search_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should sync filters between suggestion list and advanced search dialog',
+    scenarioBuilder: ($, robots) => FilterDesyncSuggestionAdvancedSearchScenario($, robots),
+    tags: [TestTags.web],
+  );
+}

--- a/lib/features/base/model/ui_keys.dart
+++ b/lib/features/base/model/ui_keys.dart
@@ -28,4 +28,9 @@ class UiKeys {
   static const String openAdvancedSearchButton = 'open_advanced_search_button';
   static const String advancedSearchLabelDropDown = 'advanced_search_label_drop_down';
   static const String advancedSearchSearchButton = 'advanced_search_search_button';
+
+  // Advanced search
+  static const String advancedSearchHasAttachmentCheckbox = 'advanced_search_has_attachment_checkbox';
+  static const String advancedSearchFromEmailField = 'advanced_search_from_email_field';
+  static const String advancedSearchCloseOverlay = 'advanced_search_close_overlay';
 }

--- a/lib/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart
@@ -9,6 +9,7 @@ import 'package:labels/labels.dart';
 import 'package:model/model.dart';
 import 'package:super_tag_editor/tag_editor.dart';
 import 'package:tmail_ui_user/features/base/base_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/advanced_search_open_sync_extension.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/get_autocomplete_state.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/get_autocomplete_interactor.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/draggable_email_address.dart';
@@ -63,9 +64,11 @@ class AdvancedFilterController extends BaseController {
   late SearchEmailFilter _memorySearchFilter;
 
   late Worker _dashboardActionWorker;
+  late Worker _searchViewOpenWorker;
 
   @override
   void onInit() {
+    _searchViewOpenWorker = createSearchViewOpenSyncWorker();
     _registerWorkerListener();
     _registerFocusListener();
     super.onInit();
@@ -102,7 +105,6 @@ class AdvancedFilterController extends BaseController {
     destinationMailboxSelected.value = presentationMailbox;
   }
 
-  @visibleForTesting
   SearchEmailFilter get memorySearchFilter => _memorySearchFilter;
 
   @visibleForTesting
@@ -272,7 +274,9 @@ class AdvancedFilterController extends BaseController {
       )) ?? [];
   }
 
-  void initSearchFilterField(BuildContext? context) {
+  void initSearchFilterField(BuildContext? context, {SearchEmailFilter? filterOverride}) {
+    _memorySearchFilter = filterOverride ?? searchController.searchEmailFilter.value;
+
     subjectFilterInputController.text = StringConvert.writeNullToEmpty(
       _memorySearchFilter.subject);
 
@@ -296,6 +300,9 @@ class AdvancedFilterController extends BaseController {
         .contains(KeyWordIdentifier.emailFlagged.value);
 
     notIncludeEvents.value = _memorySearchFilter.notIncludeEvents;
+
+    startDate.value = _memorySearchFilter.startDate?.value.toLocal();
+    endDate.value = _memorySearchFilter.endDate?.value.toLocal();
 
     if (_memorySearchFilter.from.isEmpty) {
       listFromEmailAddress.clear();
@@ -532,6 +539,7 @@ class AdvancedFilterController extends BaseController {
 
   void _unregisterWorkerListener() {
     _dashboardActionWorker.dispose();
+    _searchViewOpenWorker.dispose();
   }
 
   void _removeFocusListener() {
@@ -551,7 +559,6 @@ class AdvancedFilterController extends BaseController {
   }
 
   void _handleStartSearchEmailAction() {
-    _memorySearchFilter = searchController.searchEmailFilter.value;
     initSearchFilterField(currentContext);
   }
 

--- a/lib/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart
@@ -1,6 +1,7 @@
 import 'package:core/core.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/core/utc_date.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
@@ -64,11 +65,13 @@ class AdvancedFilterController extends BaseController {
   late SearchEmailFilter _memorySearchFilter;
 
   late Worker _dashboardActionWorker;
-  late Worker _searchViewOpenWorker;
+  late final ProviderContainer _searchViewOpenContainer;
+  late final ProviderSubscription<AsyncValue<bool>> _searchViewOpenSub;
 
   @override
   void onInit() {
-    _searchViewOpenWorker = createSearchViewOpenSyncWorker();
+    _searchViewOpenContainer = ProviderContainer();
+    _searchViewOpenSub = createSearchViewOpenSyncWorker(_searchViewOpenContainer);
     _registerWorkerListener();
     _registerFocusListener();
     super.onInit();
@@ -539,7 +542,8 @@ class AdvancedFilterController extends BaseController {
 
   void _unregisterWorkerListener() {
     _dashboardActionWorker.dispose();
-    _searchViewOpenWorker.dispose();
+    _searchViewOpenSub.close();
+    _searchViewOpenContainer.dispose();
   }
 
   void _removeFocusListener() {

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -3393,6 +3393,7 @@ class MailboxDashBoardController extends ReloadableController
   }
 
   void openAdvancedSearchView() {
+    if (searchController.isAdvancedSearchViewOpen.isTrue) return;
     dispatchAction(OpenAdvancedSearchViewAction());
     searchController.openAdvanceSearch();
   }

--- a/lib/features/mailbox_dashboard/presentation/controller/search_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/search_controller.dart
@@ -36,6 +36,7 @@ class SearchController extends BaseController with DateRangePickerMixin {
   final searchState = SearchState.initial().obs;
   final isAdvancedSearchViewOpen = false.obs;
   final listFilterOnSuggestionForm = RxList<QuickSearchFilter>();
+  final removedSuggestionFilters = RxList<QuickSearchFilter>();
   final simpleSearchIsActivated = RxBool(false);
   final advancedSearchIsActivated = RxBool(false);
   final isSearchInputFocused = RxBool(false);
@@ -91,6 +92,7 @@ class SearchController extends BaseController with DateRangePickerMixin {
     if (!listFilterOnSuggestionForm.contains(searchFilter)) {
       listFilterOnSuggestionForm.add(searchFilter);
     }
+    removedSuggestionFilters.remove(searchFilter);
   }
 
   void deleteQuickSearchFilterFromSuggestionSearchView(QuickSearchFilter searchFilter) {
@@ -98,36 +100,90 @@ class SearchController extends BaseController with DateRangePickerMixin {
   }
 
   void applyFilterSuggestionToSearchFilter(String currentUserEmail) {
-    final receiveTime = listFilterOnSuggestionForm.contains(QuickSearchFilter.last7Days)
-      ? EmailReceiveTimeType.last7Days
-      : null;
+    searchEmailFilter.value = mergeWithSuggestionFilters(currentUserEmail);
+    searchEmailFilter.refresh();
+  }
 
-    final hasAttachment = listFilterOnSuggestionForm.contains(QuickSearchFilter.hasAttachment)
-        ? true
-        : null;
+  /// Returns a copy of [searchEmailFilter] merged with pending suggestion filters
+  /// and with [removedSuggestionFilters] cleared.
+  /// Does NOT modify [searchEmailFilter] — dashboard chips unaffected.
+  SearchEmailFilter mergeWithSuggestionFilters(String currentUserEmail) {
+    final base = searchEmailFilter.value;
 
-    var listFromAddress = searchEmailFilter.value.from;
-    if (currentUserEmail.isNotEmpty &&
-        listFilterOnSuggestionForm.contains(QuickSearchFilter.fromMe)) {
-      listFromAddress.add(currentUserEmail);
-    }
+    final emailReceiveTimeTypeOption = _mergeReceiveTime();
+    final hasAttachmentOption = _mergeHasAttachment();
+    final hasKeywordOption = _mergeHasKeyword();
+    final fromOption = _mergeFrom(currentUserEmail);
 
-    final listHasKeyword = listFilterOnSuggestionForm.contains(QuickSearchFilter.starred)
-      ? {KeyWordIdentifier.emailFlagged.value}
-      : null;
-
-    updateFilterEmail(
-      emailReceiveTimeTypeOption: receiveTime != null ? Some(receiveTime) : null,
-      hasAttachmentOption: hasAttachment != null ? Some(hasAttachment) : null,
-      fromOption: Some(listFromAddress),
-      hasKeywordOption: listHasKeyword != null ? Some(listHasKeyword) : null,
+    return base.copyWith(
+      emailReceiveTimeTypeOption: emailReceiveTimeTypeOption,
+      hasAttachmentOption: hasAttachmentOption,
+      hasKeywordOption: hasKeywordOption,
+      fromOption: fromOption,
     );
+  }
 
-    clearFilterSuggestion();
+  Option<EmailReceiveTimeType>? _mergeReceiveTime() {
+    Option<EmailReceiveTimeType>? emailReceiveTimeTypeOption;
+    if (listFilterOnSuggestionForm.contains(QuickSearchFilter.last7Days)) {
+      emailReceiveTimeTypeOption = const Some(EmailReceiveTimeType.last7Days);
+    } else if (removedSuggestionFilters.contains(QuickSearchFilter.last7Days)) {
+      emailReceiveTimeTypeOption = const None();
+    }
+    return emailReceiveTimeTypeOption;
+  }
+
+  Option<bool>? _mergeHasAttachment() {
+    Option<bool>? hasAttachmentOption;
+    if (listFilterOnSuggestionForm.contains(QuickSearchFilter.hasAttachment)) {
+      hasAttachmentOption = const Some(true);
+    } else if (removedSuggestionFilters.contains(QuickSearchFilter.hasAttachment)) {
+      hasAttachmentOption = const None();
+    }
+    return hasAttachmentOption;
+  }
+
+  Option<Set<String>>? _mergeHasKeyword() {
+    Option<Set<String>>? hasKeywordOption;
+    if (listFilterOnSuggestionForm.contains(QuickSearchFilter.starred)) {
+      hasKeywordOption = Some({KeyWordIdentifier.emailFlagged.value});
+    } else if (removedSuggestionFilters.contains(QuickSearchFilter.starred)) {
+      hasKeywordOption = const None();
+    }
+    return hasKeywordOption;
+  }
+
+  Option<Set<String>>? _mergeFrom(String currentUserEmail) {
+    var listFromAddress = Set<String>.from(searchEmailFilter.value.from);
+    Option<Set<String>>? fromOption;
+    if (currentUserEmail.isNotEmpty) {
+      if (listFilterOnSuggestionForm.contains(QuickSearchFilter.fromMe)) {
+        listFromAddress.add(currentUserEmail);
+        fromOption = Some(listFromAddress);
+      } else if (removedSuggestionFilters.contains(QuickSearchFilter.fromMe)) {
+        listFromAddress.remove(currentUserEmail);
+        fromOption = Some(listFromAddress);
+      }
+    }
+    return fromOption;
   }
 
   void clearFilterSuggestion() {
     listFilterOnSuggestionForm.clear();
+    removedSuggestionFilters.clear();
+  }
+
+  void clearSuggestionFilterState(QuickSearchFilter filter) {
+    listFilterOnSuggestionForm.remove(filter);
+    removedSuggestionFilters.remove(filter);
+  }
+
+  /// Marks [filter] as removed from suggestion view post-search.
+  /// Does NOT touch [searchEmailFilter] — dashboard chips unaffected.
+  void syncFromSuggestionPostSearch(QuickSearchFilter filter) {
+    if (!removedSuggestionFilters.contains(filter)) {
+      removedSuggestionFilters.add(filter);
+    }
   }
 
   void updateFilterEmail({
@@ -149,6 +205,11 @@ class SearchController extends BaseController with DateRangePickerMixin {
     Option<EmailSortOrderType>? sortOrderTypeOption,
     Option<Label>? labelOption,
   }) {
+    if (fromOption != null) clearSuggestionFilterState(QuickSearchFilter.fromMe);
+    if (hasAttachmentOption != null) clearSuggestionFilterState(QuickSearchFilter.hasAttachment);
+    if (emailReceiveTimeTypeOption != null) clearSuggestionFilterState(QuickSearchFilter.last7Days);
+    if (hasKeywordOption != null) clearSuggestionFilterState(QuickSearchFilter.starred);
+
     searchEmailFilter.value = searchEmailFilter.value.copyWith(
       fromOption: fromOption,
       toOption: toOption,
@@ -280,6 +341,7 @@ class SearchController extends BaseController with DateRangePickerMixin {
     hideSimpleSearchFormView();
 
     clearSearchFilter();
+    clearFilterSuggestion();
     deactivateAdvancedSearch();
     hideAdvancedSearchFormView();
   }

--- a/lib/features/mailbox_dashboard/presentation/extensions/advanced_search_open_sync_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/advanced_search_open_sync_extension.dart
@@ -1,27 +1,36 @@
 import 'package:dartz/dartz.dart';
-import 'package:get/get_rx/src/rx_workers/rx_workers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/providers/search_view_open_provider.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
 extension AdvancedSearchOpenSyncExtension on AdvancedFilterController {
-  Worker createSearchViewOpenSyncWorker() {
-    return ever(searchController.isAdvancedSearchViewOpen, (bool isOpen) {
-      if (isOpen) {
-        final hasSuggestionOverrides =
-            searchController.listFilterOnSuggestionForm.isNotEmpty ||
-            searchController.removedSuggestionFilters.isNotEmpty;
-        if (!hasSuggestionOverrides) return;
-        initSearchFilterField(
-          currentContext,
-          filterOverride: searchController.mergeWithSuggestionFilters(
-            mailboxDashBoardController.ownEmailAddress.value,
-          ),
-        );
-      } else {
-        _syncSuggestionFiltersOnDialogClose();
-      }
-    });
+  ProviderSubscription<AsyncValue<bool>> createSearchViewOpenSyncWorker(
+    ProviderContainer container,
+  ) {
+    return container.listen<AsyncValue<bool>>(
+      searchViewOpenProvider,
+      (prev, next) {
+        next.whenData((isOpen) {
+          if (isOpen) {
+            final hasSuggestionOverrides =
+                searchController.listFilterOnSuggestionForm.isNotEmpty ||
+                searchController.removedSuggestionFilters.isNotEmpty;
+            if (!hasSuggestionOverrides) return;
+            initSearchFilterField(
+              currentContext,
+              filterOverride: searchController.mergeWithSuggestionFilters(
+                mailboxDashBoardController.ownEmailAddress.value,
+              ),
+            );
+          } else {
+            _syncSuggestionFiltersOnDialogClose();
+          }
+        });
+      },
+      fireImmediately: false,
+    );
   }
 
   void _syncSuggestionFiltersOnDialogClose() {
@@ -43,7 +52,11 @@ extension AdvancedSearchOpenSyncExtension on AdvancedFilterController {
         searchController.syncFromSuggestionPostSearch(filter);
       }
     }
-    // Persist the from field so manually added addresses survive a close-without-apply.
-    searchController.updateFilterEmail(fromOption: Some(dialogFilter.from));
+    // Persist from addresses directly — bypasses updateFilterEmail's side-effect of
+    // calling clearSuggestionFilterState(fromMe), which would undo the loop above.
+    searchController.searchEmailFilter.value = searchController.searchEmailFilter.value.copyWith(
+      fromOption: Some(dialogFilter.from),
+    );
+    searchController.searchEmailFilter.refresh();
   }
 }

--- a/lib/features/mailbox_dashboard/presentation/extensions/advanced_search_open_sync_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/advanced_search_open_sync_extension.dart
@@ -1,0 +1,49 @@
+import 'package:dartz/dartz.dart';
+import 'package:get/get_rx/src/rx_workers/rx_workers.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+
+extension AdvancedSearchOpenSyncExtension on AdvancedFilterController {
+  Worker createSearchViewOpenSyncWorker() {
+    return ever(searchController.isAdvancedSearchViewOpen, (bool isOpen) {
+      if (isOpen) {
+        final hasSuggestionOverrides =
+            searchController.listFilterOnSuggestionForm.isNotEmpty ||
+            searchController.removedSuggestionFilters.isNotEmpty;
+        if (!hasSuggestionOverrides) return;
+        initSearchFilterField(
+          currentContext,
+          filterOverride: searchController.mergeWithSuggestionFilters(
+            mailboxDashBoardController.ownEmailAddress.value,
+          ),
+        );
+      } else {
+        _syncSuggestionFiltersOnDialogClose();
+      }
+    });
+  }
+
+  void _syncSuggestionFiltersOnDialogClose() {
+    final context = currentContext;
+    if (context == null) return;
+    final dialogFilter = memorySearchFilter;
+    final userEmail = mailboxDashBoardController.ownEmailAddress.value;
+    for (final filter in QuickSearchFilter.suggestionPopupFilters) {
+      final isActiveInDialog = filter.isSelected(
+        context,
+        dialogFilter,
+        searchController.sortOrderFiltered,
+        userEmail,
+      );
+      if (isActiveInDialog) {
+        searchController.addQuickSearchFilterToSuggestionSearchView(filter);
+      } else if (searchController.listFilterOnSuggestionForm.contains(filter)) {
+        searchController.deleteQuickSearchFilterFromSuggestionSearchView(filter);
+        searchController.syncFromSuggestionPostSearch(filter);
+      }
+    }
+    // Persist the from field so manually added addresses survive a close-without-apply.
+    searchController.updateFilterEmail(fromOption: Some(dialogFilter.from));
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart
+++ b/lib/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart
@@ -28,6 +28,14 @@ enum QuickSearchFilter {
   folder,
   labels;
 
+  // The subset shown as toggleable chips in the suggestion popup.
+  static const List<QuickSearchFilter> suggestionPopupFilters = [
+    QuickSearchFilter.hasAttachment,
+    QuickSearchFilter.last7Days,
+    QuickSearchFilter.fromMe,
+    QuickSearchFilter.starred,
+  ];
+
   String getTitle(
     BuildContext context, {
     EmailReceiveTimeType? receiveTimeType,
@@ -148,9 +156,8 @@ enum QuickSearchFilter {
       case QuickSearchFilter.last7Days:
         return searchFilter.emailReceiveTimeType == EmailReceiveTimeType.last7Days;
       case QuickSearchFilter.fromMe:
-        return searchFilter.from.length == 1 &&
-          currentUserEmail?.isNotEmpty == true &&
-          currentUserEmail == searchFilter.from.first;
+        return currentUserEmail?.isNotEmpty == true &&
+          searchFilter.from.contains(currentUserEmail);
       case QuickSearchFilter.sortBy:
         return sortOrderType != SearchEmailFilter.defaultSortOrder;
       case QuickSearchFilter.dateTime:

--- a/lib/features/mailbox_dashboard/presentation/providers/search_view_open_provider.dart
+++ b/lib/features/mailbox_dashboard/presentation/providers/search_view_open_provider.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/search_controller.dart' as tmail;
+
+final searchViewOpenProvider = StreamProvider.autoDispose<bool>((ref) {
+  final controller = Get.find<tmail.SearchController>();
+  return controller.isAdvancedSearchViewOpen.stream;
+});

--- a/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_filter_form_bottom_view.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_filter_form_bottom_view.dart
@@ -81,6 +81,7 @@ class AdvancedSearchFilterFormBottomView extends GetWidget<AdvancedFilterControl
               constraints: const BoxConstraints(minWidth: 112),
               height: 48,
               child: ConfirmDialogButton(
+                key: const ValueKey(UiKeys.advancedSearchSearchButton),
                 label: AppLocalizations.of(context).search,
                 backgroundColor: AppColor.primaryMain,
                 textColor: Colors.white,
@@ -99,6 +100,7 @@ class AdvancedSearchFilterFormBottomView extends GetWidget<AdvancedFilterControl
   ) {
     return Obx(
       () => CustomIconLabeledCheckbox(
+        key: const ValueKey(UiKeys.advancedSearchHasAttachmentCheckbox),
         label: AppLocalizations.of(context).hasAttachment,
         svgIconPath: controller.imagePaths.icCheckboxUnselected,
         selectedSvgIconPath: controller.imagePaths.icCheckboxSelected,

--- a/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_input_form.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_input_form.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/model/filter_filter.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/base/widget/default_field/default_autocomplete_input_field_widget.dart';
 import 'package:tmail_ui_user/features/base/widget/default_field/default_button_arrow_down_field_with_tab_key_widget.dart';
 import 'package:tmail_ui_user/features/base/widget/default_field/default_date_drop_down_field_widget.dart';
@@ -29,6 +30,7 @@ class AdvancedSearchInputForm extends GetWidget<AdvancedFilterController> {
             filterField: FilterField.from,
             useHeight: false,
             child: Obx(() => DefaultAutocompleteInputFieldWidget(
+              key: const ValueKey(UiKeys.advancedSearchFromEmailField),
               field: FilterField.from,
               listEmailAddress: controller.listFromEmailAddress,
               expandMode: controller.fromAddressExpandMode.value,

--- a/lib/features/mailbox_dashboard/presentation/widgets/search_filters/search_filter_button.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/search_filters/search_filter_button.dart
@@ -81,6 +81,7 @@ class _SearchFilterButtonState extends State<SearchFilterButton> {
     );
 
     final deleteButtonWidget = TMailButtonWidget.fromIcon(
+      key: Key('delete_${widget.searchFilter.name}_search_filter_button'),
       icon: widget.imagePaths.icDeleteSelection,
       iconSize: SearchFilterButtonStyle.deleteIconSize,
       iconColor: AppColor.colorTextBody,

--- a/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
@@ -20,6 +20,7 @@ import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:tmail_ui_user/features/base/mixin/app_loader_mixin.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/base/widget/keyboard/keyboard_handler_wrapper.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/model/recent_search.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/action/dashboard_action.dart';
@@ -142,6 +143,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
       return PortalTarget(
         visible: _searchController.isAdvancedSearchViewOpen.isTrue,
         portalFollower: PointerInterceptor(
+          key: const ValueKey(UiKeys.advancedSearchCloseOverlay),
           child: GestureDetector(
             behavior: HitTestBehavior.opaque,
             onTap: _searchController.closeAdvanceSearch
@@ -314,6 +316,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
       final isSelected = isAppliedInSuggestion || isAppliedInFilter;
 
       return SearchFilterButton(
+        key: Key('mobile_${searchFilter.name}_search_filter_button'),
         searchFilter: searchFilter,
         imagePaths: _imagePaths,
         responsiveUtils: _responsiveUtils,

--- a/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
@@ -64,12 +64,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
           borderRadius: BorderRadius.all(Radius.circular(16)),
         ),
         debounceDuration: const Duration(milliseconds: 300),
-        listActionButton: const [
-          QuickSearchFilter.hasAttachment,
-          QuickSearchFilter.last7Days,
-          QuickSearchFilter.fromMe,
-          QuickSearchFilter.starred,
-        ],
+        listActionButton: QuickSearchFilter.suggestionPopupFilters,
         actionButtonBuilder: (context, filterAction, suggestionsListState) {
           if (filterAction is QuickSearchFilter) {
             return buildListButtonForQuickSearchForm(
@@ -186,6 +181,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
       _searchController.applyFilterSuggestionToSearchFilter(
         _dashBoardController.ownEmailAddress.value,
       );
+      _searchController.clearFilterSuggestion();
     }
 
     _dashBoardController.searchEmailByQueryString(trimmedQueryString);
@@ -222,6 +218,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
     _searchController.applyFilterSuggestionToSearchFilter(
       _dashBoardController.ownEmailAddress.value,
     );
+    _searchController.clearFilterSuggestion();
     _dashBoardController.searchEmailByQueryString(recent.value);
   }
 
@@ -306,7 +303,15 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
     QuickSearchSuggestionListState suggestionsListState
   ) {
     return Obx(() {
-      final isSelected = searchFilter.isApplied(_searchController.listFilterOnSuggestionForm);
+      final isAppliedInSuggestion = searchFilter.isApplied(_searchController.listFilterOnSuggestionForm);
+      final isRemovedFromSuggestion = _searchController.removedSuggestionFilters.contains(searchFilter);
+      final isAppliedInFilter = !isRemovedFromSuggestion && searchFilter.isSelected(
+        context,
+        _searchController.searchEmailFilter.value,
+        _searchController.sortOrderFiltered,
+        _dashBoardController.ownEmailAddress.value,
+      );
+      final isSelected = isAppliedInSuggestion || isAppliedInFilter;
 
       return SearchFilterButton(
         searchFilter: searchFilter,
@@ -316,6 +321,10 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
         backgroundColor: searchFilter.getSuggestionBackgroundColor(isSelected: isSelected),
         onDeleteSearchFilterAction: (searchFilter) {
           _searchController.deleteQuickSearchFilterFromSuggestionSearchView(searchFilter);
+          if (!isAppliedInSuggestion && isAppliedInFilter) {
+            // Post-search: filter lives in searchEmailFilter; track removal without mutating it
+            _searchController.syncFromSuggestionPostSearch(searchFilter);
+          }
           suggestionsListState.invalidateSuggestions();
         },
       );

--- a/test/features/mailbox_dashboard/presentation/controller/advanced_filter_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/advanced_filter_controller_test.dart
@@ -205,10 +205,8 @@ void main() {
           from: {'user1@example.com'},
           to: {'user2@example.com'},
         );
-        advancedFilterController.setMemorySearchFilter(memorySearchFilter);
-
         // Act
-        advancedFilterController.initSearchFilterField(mockBuildContext);
+        advancedFilterController.initSearchFilterField(mockBuildContext, filterOverride: memorySearchFilter);
 
         // Assert
         expect(advancedFilterController.subjectFilterInputController.text, equals('subject'));

--- a/test/features/mailbox_dashboard/presentation/controller/search_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/search_controller_test.dart
@@ -1,0 +1,379 @@
+import 'package:core/data/network/config/dynamic_url_interceptors.dart';
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/app_toast.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
+import 'package:mockito/annotations.dart';
+import 'package:tmail_ui_user/features/caching/caching_manager.dart';
+import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oidc_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/get_all_recent_search_latest_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/quick_search_email_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/save_recent_search_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/search_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
+import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
+import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
+import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
+import 'package:uuid/uuid.dart';
+
+import 'search_controller_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<CachingManager>(),
+  MockSpec<LanguageCacheManager>(),
+  MockSpec<AuthorizationInterceptors>(),
+  MockSpec<DynamicUrlInterceptors>(),
+  MockSpec<DeleteCredentialInteractor>(),
+  MockSpec<LogoutOidcInteractor>(),
+  MockSpec<DeleteAuthorityOidcInteractor>(),
+  MockSpec<AppToast>(),
+  MockSpec<ImagePaths>(),
+  MockSpec<ResponsiveUtils>(),
+  MockSpec<Uuid>(),
+  MockSpec<ToastManager>(),
+  MockSpec<TwakeAppManager>(),
+  MockSpec<QuickSearchEmailInteractor>(),
+  MockSpec<SaveRecentSearchInteractor>(),
+  MockSpec<GetAllRecentSearchLatestInteractor>(),
+])
+void main() {
+  late SearchController searchController;
+
+  setUpAll(() {
+    Get.testMode = true;
+
+    Get.put<CachingManager>(MockCachingManager());
+    Get.put<LanguageCacheManager>(MockLanguageCacheManager());
+    final mockAuth = MockAuthorizationInterceptors();
+    Get.put<AuthorizationInterceptors>(mockAuth);
+    Get.put<AuthorizationInterceptors>(mockAuth, tag: BindingTag.isolateTag);
+    Get.put<DynamicUrlInterceptors>(MockDynamicUrlInterceptors());
+    Get.put<DeleteCredentialInteractor>(MockDeleteCredentialInteractor());
+    Get.put<LogoutOidcInteractor>(MockLogoutOidcInteractor());
+    Get.put<DeleteAuthorityOidcInteractor>(MockDeleteAuthorityOidcInteractor());
+    Get.put<AppToast>(MockAppToast());
+    Get.put<ImagePaths>(MockImagePaths());
+    Get.put<ResponsiveUtils>(MockResponsiveUtils());
+    Get.put<Uuid>(MockUuid());
+    Get.put<ToastManager>(MockToastManager());
+    Get.put<TwakeAppManager>(MockTwakeAppManager());
+
+    searchController = SearchController(
+      MockQuickSearchEmailInteractor(),
+      MockSaveRecentSearchInteractor(),
+      MockGetAllRecentSearchLatestInteractor(),
+    );
+    Get.put<SearchController>(searchController);
+  });
+
+  setUp(() {
+    searchController.searchEmailFilter.value = SearchEmailFilter.initial();
+    searchController.listFilterOnSuggestionForm.clear();
+    searchController.removedSuggestionFilters.clear();
+  });
+
+  group('SearchController::mergeWithSuggestionFilters', () {
+    group('last7Days filter', () {
+      test(
+        'SHOULD set emailReceiveTimeType to last7Days\n'
+        'WHEN last7Days is in listFilterOnSuggestionForm',
+        () {
+          // Arrange
+          searchController.listFilterOnSuggestionForm.add(QuickSearchFilter.last7Days);
+
+          // Act
+          final result = searchController.mergeWithSuggestionFilters('');
+
+          // Assert
+          expect(result.emailReceiveTimeType, equals(EmailReceiveTimeType.last7Days));
+        },
+      );
+
+      test(
+        'SHOULD clear emailReceiveTimeType to allTime\n'
+        'WHEN last7Days is in removedSuggestionFilters',
+        () {
+          // Arrange
+          searchController.searchEmailFilter.value = SearchEmailFilter(
+            emailReceiveTimeType: EmailReceiveTimeType.last7Days,
+          );
+          searchController.removedSuggestionFilters.add(QuickSearchFilter.last7Days);
+
+          // Act
+          final result = searchController.mergeWithSuggestionFilters('');
+
+          // Assert
+          expect(result.emailReceiveTimeType, equals(EmailReceiveTimeType.allTime));
+        },
+      );
+
+      test(
+        'SHOULD keep base emailReceiveTimeType unchanged\n'
+        'WHEN last7Days is neither in suggestion nor removed lists',
+        () {
+          // Arrange
+          searchController.searchEmailFilter.value = SearchEmailFilter(
+            emailReceiveTimeType: EmailReceiveTimeType.last7Days,
+          );
+
+          // Act
+          final result = searchController.mergeWithSuggestionFilters('');
+
+          // Assert
+          expect(result.emailReceiveTimeType, equals(EmailReceiveTimeType.last7Days));
+        },
+      );
+    });
+
+    group('hasAttachment filter', () {
+      test(
+        'SHOULD set hasAttachment to true\n'
+        'WHEN hasAttachment is in listFilterOnSuggestionForm',
+        () {
+          // Arrange
+          searchController.listFilterOnSuggestionForm.add(QuickSearchFilter.hasAttachment);
+
+          // Act
+          final result = searchController.mergeWithSuggestionFilters('');
+
+          // Assert
+          expect(result.hasAttachment, isTrue);
+        },
+      );
+
+      test(
+        'SHOULD clear hasAttachment to false\n'
+        'WHEN hasAttachment is in removedSuggestionFilters',
+        () {
+          // Arrange
+          searchController.searchEmailFilter.value = SearchEmailFilter(hasAttachment: true);
+          searchController.removedSuggestionFilters.add(QuickSearchFilter.hasAttachment);
+
+          // Act
+          final result = searchController.mergeWithSuggestionFilters('');
+
+          // Assert
+          expect(result.hasAttachment, isFalse);
+        },
+      );
+
+      test(
+        'SHOULD keep base hasAttachment unchanged\n'
+        'WHEN hasAttachment is neither in suggestion nor removed lists',
+        () {
+          // Arrange
+          searchController.searchEmailFilter.value = SearchEmailFilter(hasAttachment: true);
+
+          // Act
+          final result = searchController.mergeWithSuggestionFilters('');
+
+          // Assert
+          expect(result.hasAttachment, isTrue);
+        },
+      );
+    });
+
+    group('starred filter', () {
+      test(
+        'SHOULD add flagged keyword to hasKeyword\n'
+        'WHEN starred is in listFilterOnSuggestionForm',
+        () {
+          // Arrange
+          searchController.listFilterOnSuggestionForm.add(QuickSearchFilter.starred);
+
+          // Act
+          final result = searchController.mergeWithSuggestionFilters('');
+
+          // Assert
+          expect(result.hasKeyword, contains(KeyWordIdentifier.emailFlagged.value));
+        },
+      );
+
+      test(
+        'SHOULD clear hasKeyword\n'
+        'WHEN starred is in removedSuggestionFilters',
+        () {
+          // Arrange
+          searchController.searchEmailFilter.value = SearchEmailFilter(
+            hasKeyword: {KeyWordIdentifier.emailFlagged.value},
+          );
+          searchController.removedSuggestionFilters.add(QuickSearchFilter.starred);
+
+          // Act
+          final result = searchController.mergeWithSuggestionFilters('');
+
+          // Assert
+          expect(result.hasKeyword, isEmpty);
+        },
+      );
+
+      test(
+        'SHOULD keep base hasKeyword unchanged\n'
+        'WHEN starred is neither in suggestion nor removed lists',
+        () {
+          // Arrange
+          searchController.searchEmailFilter.value = SearchEmailFilter(
+            hasKeyword: {KeyWordIdentifier.emailFlagged.value},
+          );
+
+          // Act
+          final result = searchController.mergeWithSuggestionFilters('');
+
+          // Assert
+          expect(result.hasKeyword, contains(KeyWordIdentifier.emailFlagged.value));
+        },
+      );
+    });
+
+    group('fromMe filter', () {
+      const userEmail = 'me@example.com';
+
+      test(
+        'SHOULD add currentUserEmail to from set\n'
+        'WHEN fromMe is in listFilterOnSuggestionForm and email is non-empty',
+        () {
+          // Arrange
+          searchController.listFilterOnSuggestionForm.add(QuickSearchFilter.fromMe);
+
+          // Act
+          final result = searchController.mergeWithSuggestionFilters(userEmail);
+
+          // Assert
+          expect(result.from, contains(userEmail));
+        },
+      );
+
+      test(
+        'SHOULD preserve existing from addresses and add currentUserEmail\n'
+        'WHEN fromMe added and base filter already has from addresses',
+        () {
+          // Arrange
+          const existingEmail = 'other@example.com';
+          searchController.searchEmailFilter.value = SearchEmailFilter(
+            from: {existingEmail},
+          );
+          searchController.listFilterOnSuggestionForm.add(QuickSearchFilter.fromMe);
+
+          // Act
+          final result = searchController.mergeWithSuggestionFilters(userEmail);
+
+          // Assert
+          expect(result.from, containsAll([existingEmail, userEmail]));
+        },
+      );
+
+      test(
+        'SHOULD remove currentUserEmail from from set\n'
+        'WHEN fromMe is in removedSuggestionFilters',
+        () {
+          // Arrange
+          searchController.searchEmailFilter.value = SearchEmailFilter(
+            from: {userEmail},
+          );
+          searchController.removedSuggestionFilters.add(QuickSearchFilter.fromMe);
+
+          // Act
+          final result = searchController.mergeWithSuggestionFilters(userEmail);
+
+          // Assert
+          expect(result.from, isNot(contains(userEmail)));
+        },
+      );
+
+      test(
+        'SHOULD NOT modify from set\n'
+        'WHEN fromMe is in listFilterOnSuggestionForm but currentUserEmail is empty',
+        () {
+          // Arrange
+          searchController.listFilterOnSuggestionForm.add(QuickSearchFilter.fromMe);
+
+          // Act
+          final result = searchController.mergeWithSuggestionFilters('');
+
+          // Assert
+          expect(result.from, isEmpty);
+        },
+      );
+    });
+
+    group('multiple filters combined', () {
+      test(
+        'SHOULD apply all active suggestion filters simultaneously\n'
+        'WHEN multiple filters are in listFilterOnSuggestionForm',
+        () {
+          // Arrange
+          searchController.listFilterOnSuggestionForm.addAll([
+            QuickSearchFilter.last7Days,
+            QuickSearchFilter.hasAttachment,
+            QuickSearchFilter.starred,
+          ]);
+
+          // Act
+          final result = searchController.mergeWithSuggestionFilters('');
+
+          // Assert
+          expect(result.emailReceiveTimeType, equals(EmailReceiveTimeType.last7Days));
+          expect(result.hasAttachment, isTrue);
+          expect(result.hasKeyword, contains(KeyWordIdentifier.emailFlagged.value));
+        },
+      );
+
+      test(
+        'SHOULD clear all removed filters simultaneously\n'
+        'WHEN multiple filters are in removedSuggestionFilters',
+        () {
+          // Arrange
+          searchController.searchEmailFilter.value = SearchEmailFilter(
+            emailReceiveTimeType: EmailReceiveTimeType.last7Days,
+            hasAttachment: true,
+            hasKeyword: {KeyWordIdentifier.emailFlagged.value},
+          );
+          searchController.removedSuggestionFilters.addAll([
+            QuickSearchFilter.last7Days,
+            QuickSearchFilter.hasAttachment,
+            QuickSearchFilter.starred,
+          ]);
+
+          // Act
+          final result = searchController.mergeWithSuggestionFilters('');
+
+          // Assert
+          expect(result.emailReceiveTimeType, equals(EmailReceiveTimeType.allTime));
+          expect(result.hasAttachment, isFalse);
+          expect(result.hasKeyword, isEmpty);
+        },
+      );
+    });
+
+    group('does not mutate searchEmailFilter', () {
+      test(
+        'SHOULD NOT modify searchEmailFilter.value\n'
+        'WHEN mergeWithSuggestionFilters is called',
+        () {
+          // Arrange
+          final original = SearchEmailFilter.initial();
+          searchController.searchEmailFilter.value = original;
+          searchController.listFilterOnSuggestionForm.addAll([
+            QuickSearchFilter.last7Days,
+            QuickSearchFilter.hasAttachment,
+            QuickSearchFilter.starred,
+          ]);
+
+          // Act
+          searchController.mergeWithSuggestionFilters('user@example.com');
+
+          // Assert: searchEmailFilter must remain unchanged
+          expect(searchController.searchEmailFilter.value, equals(original));
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Issue
- #4421 

## Resolved

https://github.com/user-attachments/assets/f6eb0ad1-9a8a-4848-b000-f49307f4daa7

### Test result
```console
✅ Should sync filters between suggestion list and advanced search dialog (/tests/search/filter_desync_suggestion_advanced_search_test.dart) (7s)

Test summary:
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: .../tmail-flutter/playwright-report
⏱️  Duration: 21s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advanced search dialog and quick-suggestion chips now synchronize bidirectionally; suggestion add/remove merges into active searches.
  * New UI helpers and stable keys for advanced-search controls and suggestion chips for more reliable interaction.

* **Bug Fixes**
  * Search suggestion animation now triggers only when appropriate, reducing visual glitches and race conditions.

* **Tests**
  * Added unit and end-to-end tests covering filter sync/merge and advanced-search scenarios; web test helpers added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->