### PR TITLE
TF-4593 Add log to tracing [Sentry] Mobile - Refresh token failed in some cases

### DIFF
--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -209,12 +209,13 @@ abstract class BaseController extends GetxController
     }
   }
 
-  Future<void> _executeBeforeReconnectAndLogOut() async {
+  Future<void> _executeBeforeReconnectAndLogOut({required String reason}) async {
     twakeAppManager.setExecutingBeforeReconnect(true);
     await executeBeforeReconnect();
     logError(
       '$runtimeType::_executeBeforeReconnectAndLogOut: '
-      'forcing logout after web save-and-reconnect (urgent auth failure)',
+      'forcing logout after web save-and-reconnect | reason=$reason',
+      extras: {'auth_error_type': reason},
       webConsoleEnabled: true,
     );
     clearDataAndGoToLoginPage();
@@ -250,32 +251,34 @@ abstract class BaseController extends GetxController
       webConsoleEnabled: true,
     );
     if (twakeAppManager.hasComposer) {
-      _performSaveAndReconnection();
+      _performSaveAndReconnection(reason: 'bad_credentials_401');
     } else {
-      _performReconnection();
+      _performReconnection(reason: 'bad_credentials_401');
     }
   }
 
-  void _performSaveAndReconnection() {
+  void _performSaveAndReconnection({required String reason}) {
     if (PlatformInfo.isWeb) {
       log(
         '$runtimeType::_performSaveAndReconnection: web save-and-reconnect path',
         webConsoleEnabled: true,
       );
-      _executeBeforeReconnectAndLogOut();
+      _executeBeforeReconnectAndLogOut(reason: reason);
     } else if (PlatformInfo.isMobile) {
       logError(
         '$runtimeType::_performSaveAndReconnection: '
-        'forcing logout on mobile after save-and-reconnect (urgent auth failure)',
+        'forcing logout on mobile after save-and-reconnect | reason=$reason',
+        extras: {'auth_error_type': reason},
       );
       clearDataAndGoToLoginPage();
     }
   }
 
-  void _performReconnection() {
+  void _performReconnection({required String reason}) {
     logError(
       '$runtimeType::_performReconnection: '
-      'forcing logout (urgent auth failure, no composer to save)',
+      'forcing logout | reason=$reason',
+      extras: {'auth_error_type': reason},
       webConsoleEnabled: true,
     );
     clearDataAndGoToLoginPage();
@@ -287,9 +290,9 @@ abstract class BaseController extends GetxController
       webConsoleEnabled: true,
     );
     if (twakeAppManager.hasComposer) {
-      _performSaveAndReconnection();
+      _performSaveAndReconnection(reason: 'refresh_token_400');
     } else {
-      _performReconnection();
+      _performReconnection(reason: 'refresh_token_400');
     }
   }
 

--- a/lib/features/base/reloadable/reloadable_controller.dart
+++ b/lib/features/base/reloadable/reloadable_controller.dart
@@ -155,12 +155,14 @@ abstract class ReloadableController extends BaseController {
     if (exception is BadCredentialsException ||
         exception is RefreshTokenFailedException ||
         exception is NotFoundSessionException) {
+      final authErrorType = _sessionLogoutAuthErrorType(exception);
       logError(
         '$runtimeType::handleGetSessionFailure: '
-        'forcing logout — session definitively dead — '
-        'exception=${exception.runtimeType}',
+        'auth_error_type=$authErrorType | will_logout=true — '
+        'session definitively dead — exception=${exception.runtimeType}',
         exception: exception,
         stackTrace: StackTrace.current,
+        extras: {'auth_error_type': authErrorType},
         webConsoleEnabled: true,
       );
       clearDataAndGoToLoginPage();
@@ -172,6 +174,18 @@ abstract class ReloadableController extends BaseController {
         webConsoleEnabled: true,
       );
     }
+  }
+
+  /// Tags the forced-logout cause from a definitively-dead session so every
+  /// logout is queryable in Sentry by a single `auth_error_type` field.
+  String _sessionLogoutAuthErrorType(Object? exception) {
+    if (exception is RefreshTokenFailedException) {
+      return 'forced_logout_session_refresh_token_failed';
+    }
+    if (exception is NotFoundSessionException) {
+      return 'forced_logout_session_not_found';
+    }
+    return 'forced_logout_session_bad_credentials';
   }
 
   void handleReloaded(Session session) {}

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:core/utils/app_logger.dart';
+import 'package:flutter/services.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:dio/dio.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
@@ -279,6 +280,25 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         refreshError: refreshError,
         originalError: err,
         handler: handler,
+      );
+    } on PlatformException catch (e, st) {
+      // flutter_appauth throws PlatformException when the native token request
+      // fails at the OS level (e.g. DNS resolution failure, no network to SSO).
+      // This is a connectivity failure, NOT a server rejection — keep the
+      // session alive and surface a connection-error toast instead of logging out.
+      logError(
+        'AuthorizationInterceptors: auth_error_type=token_refresh_platform_network_failure | '
+        'platformCode=${e.code} | '
+        'will_logout=false — error=$e',
+        stackTrace: st,
+      );
+      return super.onError(
+        DioException(
+          requestOptions: err.requestOptions,
+          error: e,
+          type: DioExceptionType.connectionError,
+        ),
+        handler,
       );
     }
   }

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -5,7 +5,6 @@ import 'dart:io';
 import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:dio/dio.dart';
-import 'package:flutter_appauth_platform_interface/flutter_appauth_platform_interface.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:model/account/authentication_type.dart';
 import 'package:model/account/password.dart';
@@ -20,7 +19,6 @@ import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_ex
 import 'package:tmail_ui_user/features/login/domain/extensions/oidc_configuration_extensions.dart';
 import 'package:tmail_ui_user/features/upload/data/network/file_uploader.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
-import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
 import 'package:tmail_ui_user/main/utils/ios_sharing_manager.dart';
 
 class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
@@ -191,38 +189,10 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     if (error is DioException) {
       return super.onError(error, handler);
     }
-    if (_isMobileNetworkRefreshError(error)) {
-      logWarning(
-        'AuthorizationInterceptors::_handleRefreshErrorOnMobile: '
-        'network failure during token refresh, keeping session — error=$error',
-      );
-      return super.onError(
-        error.toDioException(
-          requestOptions: originalError.requestOptions,
-          type: DioExceptionType.connectionError,
-        ),
-        handler,
-      );
-    }
     return super.onError(
       error.toDioException(requestOptions: originalError.requestOptions),
       handler,
     );
-  }
-
-  /// Returns true for network/DNS failures during mobile token refresh.
-  ///
-  /// Two sources:
-  /// - [ConnectionError]: produced by [handleException] when [FlutterAppAuthPlatformException]
-  ///   has a null OAuth error code (i.e. a transport failure, not a grant rejection).
-  /// - [FlutterAppAuthPlatformException] with null error code: same condition, reached
-  ///   directly when the caller bypasses [handleException] (e.g. in tests).
-  bool _isMobileNetworkRefreshError(Object error) {
-    if (error is ConnectionError) return true;
-    if (error is FlutterAppAuthPlatformException) {
-      return error.platformErrorDetails.error == null;
-    }
-    return false;
   }
 
   /// A retry that comes back 401 then surfaces downstream as
@@ -286,9 +256,10 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       // Mobile: 400 → session dead (RefreshTokenFailedException); other
       // statuses / no-response → network-tolerant via _handleDioRefreshError.
       if (refreshError.response?.statusCode == 400) {
-        logWarning(
+        logError(
           'AuthorizationInterceptors: auth_error_type=token_endpoint_400 | '
-          'will_logout=true — error=$refreshError | stackTrace=$st',
+          'will_logout=true — error=$refreshError',
+          stackTrace: st,
         );
         clear();
         return handler.reject(DioException(
@@ -298,10 +269,11 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
           response: refreshError.response,
         ));
       }
-      logWarning(
+      logError(
         'AuthorizationInterceptors: auth_error_type=token_endpoint_other | '
         'statusCode=${refreshError.response?.statusCode} | '
-        'will_logout=false — error=$refreshError | stackTrace=$st',
+        'will_logout=false — error=$refreshError',
+        stackTrace: st,
       );
       return _handleDioRefreshError(
         refreshError: refreshError,

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:dio/dio.dart';
+import 'package:flutter_appauth_platform_interface/flutter_appauth_platform_interface.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:model/account/authentication_type.dart';
 import 'package:model/account/password.dart';
@@ -19,6 +20,7 @@ import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_ex
 import 'package:tmail_ui_user/features/login/domain/extensions/oidc_configuration_extensions.dart';
 import 'package:tmail_ui_user/features/upload/data/network/file_uploader.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
 import 'package:tmail_ui_user/main/utils/ios_sharing_manager.dart';
 
 class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
@@ -189,10 +191,38 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     if (error is DioException) {
       return super.onError(error, handler);
     }
+    if (_isMobileNetworkRefreshError(error)) {
+      logWarning(
+        'AuthorizationInterceptors::_handleRefreshErrorOnMobile: '
+        'network failure during token refresh, keeping session — error=$error',
+      );
+      return super.onError(
+        error.toDioException(
+          requestOptions: originalError.requestOptions,
+          type: DioExceptionType.connectionError,
+        ),
+        handler,
+      );
+    }
     return super.onError(
       error.toDioException(requestOptions: originalError.requestOptions),
       handler,
     );
+  }
+
+  /// Returns true for network/DNS failures during mobile token refresh.
+  ///
+  /// Two sources:
+  /// - [ConnectionError]: produced by [handleException] when [FlutterAppAuthPlatformException]
+  ///   has a null OAuth error code (i.e. a transport failure, not a grant rejection).
+  /// - [FlutterAppAuthPlatformException] with null error code: same condition, reached
+  ///   directly when the caller bypasses [handleException] (e.g. in tests).
+  bool _isMobileNetworkRefreshError(Object error) {
+    if (error is ConnectionError) return true;
+    if (error is FlutterAppAuthPlatformException) {
+      return error.platformErrorDetails.error == null;
+    }
+    return false;
   }
 
   /// A retry that comes back 401 then surfaces downstream as
@@ -257,7 +287,8 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       // statuses / no-response → network-tolerant via _handleDioRefreshError.
       if (refreshError.response?.statusCode == 400) {
         logWarning(
-          'AuthorizationInterceptors: Refresh Token Failed 400 - error=$refreshError | stackTrace=$st',
+          'AuthorizationInterceptors: auth_error_type=token_endpoint_400 | '
+          'will_logout=true — error=$refreshError | stackTrace=$st',
         );
         clear();
         return handler.reject(DioException(
@@ -268,9 +299,9 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         ));
       }
       logWarning(
-        'AuthorizationInterceptors: Refresh token failed with '
-        'statusCode=${refreshError.response?.statusCode} \n'
-        'error=$refreshError | stackTrace=$st',
+        'AuthorizationInterceptors: auth_error_type=token_endpoint_other | '
+        'statusCode=${refreshError.response?.statusCode} | '
+        'will_logout=false — error=$refreshError | stackTrace=$st',
       );
       return _handleDioRefreshError(
         refreshError: refreshError,

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -120,16 +120,24 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         return await _refreshTokenThenRetry(err, requestOptions, handler);
       }
 
-      logTrace(
-        'AuthorizationInterceptors::onError: '
-        'No retry or refresh applicable. '
-        'statusCode = ${err.response?.statusCode} | '
-        'authType = $_authenticationType | '
-        'hasConfig = ${_configOIDC != null} | '
-        'hasAttemptedRefresh = $hasAttemptedRefresh | '
-        'url = ${err.requestOptions.uri}',
-        webConsoleEnabled: true,
-      );
+      if (err.response?.statusCode == 401) {
+        _logForcedLogoutFor401(
+          authErrorType: _classifySkippedRefresh401(hasAttemptedRefresh),
+          err: err,
+          hasAttemptedRefresh: hasAttemptedRefresh,
+        );
+      } else {
+        logTrace(
+          'AuthorizationInterceptors::onError: '
+          'No retry or refresh applicable. '
+          'statusCode = ${err.response?.statusCode} | '
+          'authType = $_authenticationType | '
+          'hasConfig = ${_configOIDC != null} | '
+          'hasAttemptedRefresh = $hasAttemptedRefresh | '
+          'url = ${err.requestOptions.uri}',
+          webConsoleEnabled: true,
+        );
+      }
       return super.onError(err, handler);
     } catch (e, stackTrace) {
       logError(
@@ -140,6 +148,36 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       );
       return _handleRefreshError(e, err, handler);
     }
+  }
+
+  String _classifySkippedRefresh401(bool hasAttemptedRefresh) {
+    if (hasAttemptedRefresh) {
+      return 'forced_logout_401_after_refresh_attempted';
+    }
+    if (_authenticationType != AuthenticationType.oidc) {
+      return 'forced_logout_401_non_oidc_session';
+    }
+    if (_configOIDC == null) {
+      return 'forced_logout_401_oidc_config_missing';
+    }
+    return 'forced_logout_401_refresh_preconditions_unmet';
+  }
+
+  void _logForcedLogoutFor401({
+    required String authErrorType,
+    required DioException err,
+    required bool hasAttemptedRefresh,
+  }) {
+    logError(
+      'AuthorizationInterceptors: auth_error_type=$authErrorType | will_logout=true | '
+      'authType=$_authenticationType | hasConfig=${_configOIDC != null} | '
+      'hasToken=${_isTokenNotEmpty(_token)} | hasRefreshToken=${_isRefreshTokenNotEmpty(_token)} | '
+      'tokenExpired=${_isTokenExpired(_token)} | hasAttemptedRefresh=$hasAttemptedRefresh | '
+      'statusCode=${err.response?.statusCode} | url=${err.requestOptions.uri}',
+      exception: err,
+      stackTrace: err.stackTrace,
+      webConsoleEnabled: true,
+    );
   }
 
   /// A failure with NO server response (network/transport drop, timeout) keeps
@@ -210,6 +248,15 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       webConsoleEnabled: true,
     );
     if (retryError is DioException) {
+      if (retryError.response?.statusCode == 401) {
+        // Retried with a fresh/updated token and STILL got 401 → server rejects
+        // the new token. Genuine auth failure heading to logout; tag it.
+        _logForcedLogoutFor401(
+          authErrorType: 'forced_logout_401_retry_rejected',
+          err: retryError,
+          hasAttemptedRefresh: requestOptions.extra[_refreshAttemptedKey] == true,
+        );
+      }
       return super.onError(retryError, handler);
     }
     return super.onError(
@@ -233,7 +280,13 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         : await _getNewTokenForOtherPlatform();
 
       if (newTokenOidc.token == _token?.token) {
-        logError('AuthorizationInterceptors::onError: Token duplicated', exception: err);
+        // Refresh returned the SAME token — retrying cannot clear the 401, so it
+        // propagates to logout. Real auth death, but tag it for forensics.
+        _logForcedLogoutFor401(
+          authErrorType: 'forced_logout_401_refreshed_token_duplicated',
+          err: err,
+          hasAttemptedRefresh: true,
+        );
         return super.onError(err, handler);
       }
       _updateNewToken(newTokenOidc);
@@ -260,6 +313,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         logError(
           'AuthorizationInterceptors: auth_error_type=token_endpoint_400 | '
           'will_logout=true — error=$refreshError',
+          exception: refreshError,
           stackTrace: st,
         );
         clear();
@@ -274,6 +328,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         'AuthorizationInterceptors: auth_error_type=token_endpoint_other | '
         'statusCode=${refreshError.response?.statusCode} | '
         'will_logout=false — error=$refreshError',
+        exception: refreshError,
         stackTrace: st,
       );
       return _handleDioRefreshError(
@@ -290,6 +345,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         'AuthorizationInterceptors: auth_error_type=token_refresh_platform_network_failure | '
         'platformCode=${e.code} | '
         'will_logout=false — error=$e',
+        exception: e,
         stackTrace: st,
       );
       return super.onError(

--- a/lib/main/exceptions/thrower/dio_no_response_error_handler.dart
+++ b/lib/main/exceptions/thrower/dio_no_response_error_handler.dart
@@ -35,6 +35,14 @@ class DioNoResponseErrorHandler {
       );
       throw ConnectionError(message: underlyingError.message);
     }
+    if (underlyingError is HttpException) {
+      logError(
+        'RemoteExceptionThrower: HTTP connection abort — will_logout=false | ${underlyingError.message}',
+        exception: underlyingError,
+        stackTrace: stackTrace,
+      );
+      throw ConnectionError(message: underlyingError.message);
+    }
     if (underlyingError is OAuthAuthorizationError) {
       throw underlyingError;
     }

--- a/lib/main/exceptions/thrower/dio_no_response_error_handler.dart
+++ b/lib/main/exceptions/thrower/dio_no_response_error_handler.dart
@@ -27,6 +27,14 @@ class DioNoResponseErrorHandler {
       logWarning('RemoteExceptionThrower: socket error');
       throw const SocketError();
     }
+    if (underlyingError is HandshakeException) {
+      logError(
+        'RemoteExceptionThrower: TLS handshake error — will_logout=false | ${underlyingError.message}',
+        exception: underlyingError,
+        stackTrace: stackTrace,
+      );
+      throw ConnectionError(message: underlyingError.message);
+    }
     if (underlyingError is OAuthAuthorizationError) {
       throw underlyingError;
     }

--- a/lib/main/exceptions/thrower/dio_no_response_error_handler.dart
+++ b/lib/main/exceptions/thrower/dio_no_response_error_handler.dart
@@ -27,26 +27,35 @@ class DioNoResponseErrorHandler {
       logWarning('RemoteExceptionThrower: socket error');
       throw const SocketError();
     }
-    if (underlyingError is HandshakeException) {
-      logError(
-        'RemoteExceptionThrower: TLS handshake error — will_logout=false | ${underlyingError.message}',
-        exception: underlyingError,
-        stackTrace: stackTrace,
-      );
-      throw ConnectionError(message: underlyingError.message);
-    }
-    if (underlyingError is HttpException) {
-      logError(
-        'RemoteExceptionThrower: HTTP connection abort — will_logout=false | ${underlyingError.message}',
-        exception: underlyingError,
-        stackTrace: stackTrace,
-      );
-      throw ConnectionError(message: underlyingError.message);
-    }
     if (underlyingError is OAuthAuthorizationError) {
       throw underlyingError;
     }
+    final ioConnectionError = _asIoConnectionError(underlyingError, stackTrace);
+    if (ioConnectionError != null) throw ioConnectionError;
     _throwUnknownRemoteException(underlyingError, stackTrace);
+  }
+
+  /// Maps dart:io transport errors that are connectivity failures (not server
+  /// rejections) to [ConnectionError], so the session is kept and a toast is
+  /// shown instead of logging the user out.
+  ConnectionError? _asIoConnectionError(dynamic error, StackTrace? stackTrace) {
+    if (error is HandshakeException) {
+      logError(
+        'RemoteExceptionThrower: TLS handshake error — will_logout=false | ${error.message}',
+        exception: error,
+        stackTrace: stackTrace,
+      );
+      return ConnectionError(message: error.message);
+    }
+    if (error is HttpException) {
+      logError(
+        'RemoteExceptionThrower: HTTP connection abort — will_logout=false | ${error.message}',
+        exception: error,
+        stackTrace: stackTrace,
+      );
+      return ConnectionError(message: error.message);
+    }
+    return null;
   }
 
   void _throwUnknownRemoteException(dynamic underlyingError, [StackTrace? stackTrace]) {

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -812,6 +812,58 @@ void main() {
   });
 
   // ============================================================
+  // onError: refresh fails with PlatformException (network failure)
+  // ============================================================
+  group('onError: refresh fails with PlatformException (network failure)', () {
+    test(
+      'WHEN refresh throws PlatformException(token_failed) due to network error\n'
+      'THEN propagates as DioException with type=connectionError (no response)\n'
+      'AND OIDC state is NOT cleared',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+          },
+        );
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenThrow(PlatformException(
+          code: 'token_failed',
+          message: 'Failed to get token: [error: null, description: Network error]',
+          details: 'Unable to resolve host "sso.linagora.com": No address associated with hostname',
+        ));
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) {
+            return e.type == DioExceptionType.connectionError &&
+                e.error is PlatformException &&
+                e.response == null;
+          })),
+        );
+
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.oidc,
+        );
+      },
+    );
+  });
+
+  // ============================================================
   // onError: skip refresh scenarios
   // ============================================================
   group('onError: skip refresh scenarios', () {

--- a/test/main/exceptions/thrower/dio_no_response_error_handler_test.dart
+++ b/test/main/exceptions/thrower/dio_no_response_error_handler_test.dart
@@ -86,5 +86,32 @@ void main() {
         );
       },
     );
+
+    test(
+      'WHEN DioException type=unknown with HttpException (connection abort)\n'
+      'THEN throws ConnectionError (not logout)\n'
+      'AND OIDC session is preserved (no forced logout path)',
+      () {
+        final error = DioException(
+          requestOptions: RequestOptions(path: '/jmap'),
+          type: DioExceptionType.unknown,
+          error: const HttpException(
+            'Software caused connection abort',
+            uri: null,
+          ),
+        );
+
+        expect(
+          () => handler.handle(error),
+          throwsA(
+            isA<ConnectionError>().having(
+              (e) => e.message,
+              'message',
+              contains('Software caused connection abort'),
+            ),
+          ),
+        );
+      },
+    );
   });
 }

--- a/test/main/exceptions/thrower/dio_no_response_error_handler_test.dart
+++ b/test/main/exceptions/thrower/dio_no_response_error_handler_test.dart
@@ -1,0 +1,90 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/dio_no_response_error_handler.dart';
+
+void main() {
+  late DioNoResponseErrorHandler handler;
+
+  setUp(() {
+    handler = DioNoResponseErrorHandler();
+  });
+
+  group('DioNoResponseErrorHandler', () {
+    test(
+      'WHEN DioException type=connectionError\n'
+      'THEN throws ConnectionError',
+      () {
+        final error = DioException(
+          requestOptions: RequestOptions(path: '/jmap'),
+          type: DioExceptionType.connectionError,
+          message: 'Connection refused',
+        );
+
+        expect(
+          () => handler.handle(error),
+          throwsA(isA<ConnectionError>()),
+        );
+      },
+    );
+
+    test(
+      'WHEN DioException type=connectionTimeout\n'
+      'THEN throws ConnectionTimeout',
+      () {
+        final error = DioException(
+          requestOptions: RequestOptions(path: '/jmap'),
+          type: DioExceptionType.connectionTimeout,
+        );
+
+        expect(
+          () => handler.handle(error),
+          throwsA(isA<ConnectionTimeout>()),
+        );
+      },
+    );
+
+    test(
+      'WHEN DioException type=unknown with SocketException\n'
+      'THEN throws SocketError',
+      () {
+        final error = DioException(
+          requestOptions: RequestOptions(path: '/jmap'),
+          type: DioExceptionType.unknown,
+          error: const SocketException('Connection refused'),
+        );
+
+        expect(
+          () => handler.handle(error),
+          throwsA(isA<SocketError>()),
+        );
+      },
+    );
+
+    test(
+      'WHEN DioException type=unknown with HandshakeException\n'
+      'THEN throws ConnectionError (not logout, not Sentry error)\n'
+      'AND OIDC session is preserved (no forced logout path)',
+      () {
+        final error = DioException(
+          requestOptions: RequestOptions(path: '/jmap'),
+          type: DioExceptionType.unknown,
+          error: const HandshakeException('Connection terminated during handshake'),
+        );
+
+        expect(
+          () => handler.handle(error),
+          throwsA(
+            isA<ConnectionError>().having(
+              (e) => e.message,
+              'message',
+              contains('Connection terminated during handshake'),
+            ),
+          ),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Issue

#4593

## Fixed

| # | Root Cause | Old Behavior | Fix |
|---|---|---|---|
| 1 | `PlatformException(token_failed)` from `flutter_appauth` when SSO host is unreachable (DNS/no-network) | Exception bubbled unhandled → clear OIDC state → forced logout | Caught in `AuthorizationInterceptors`, re-wrapped as `DioExceptionType.connectionError` → session preserved, toast shown |
| 2 | `HandshakeException` (TLS failure) in `DioNoResponseErrorHandler` | Fell through to `_throwUnknownRemoteException` → wrong error path / Sentry noise | Mapped to `ConnectionError` → correct error surface, no logout |
| 3 | `HttpException` (connection abort) in `DioNoResponseErrorHandler` | Same as 2 | Mapped to `ConnectionError` |
| 4 | Refresh token failure logs were `logWarning` | 400 and non-400 token endpoint errors silent in Sentry | Promoted to `logError` with structured `auth_error_type` + `will_logout` fields |
| 5 | Forced-logout Sentry events lacked discriminator | All forced logouts looked identical in Sentry | Added `auth_error_type` extra (`bad_credentials_401` / `refresh_token_400`) to all logout paths in `BaseController` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More precise classification and structured logging of authentication failures to improve logout/reconnect behavior.
  * Refined token refresh handling to distinguish connectivity vs auth errors and avoid unintended logouts.
  * Improved mapping of low-level connection issues into clearer connectivity errors for better recovery.

* **Tests**
  * Added tests covering token-refresh network failures and connection-error mapping scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->