### PR TITLE
TF-4598 Add log to tracing Sentry [Web] -  Refresh token invalid grant

### DIFF
--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -285,13 +285,9 @@ abstract class BaseController extends GetxController
   }
 
   void handleRefreshTokenFailedException() {
-    logError(
+    log(
       '$runtimeType::handleRefreshTokenFailedException: '
-      'auth_error_type=refresh_token_failed | will_logout=true | '
       'hasComposer=${twakeAppManager.hasComposer}',
-      exception: RefreshTokenFailedException(),
-      stackTrace: StackTrace.current,
-      extras: {'auth_error_type': 'refresh_token_failed'},
       webConsoleEnabled: true,
     );
     if (twakeAppManager.hasComposer) {

--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -201,9 +201,11 @@ abstract class BaseController extends GetxController
     } else if (exception is RefreshTokenFailedException) {
       handleRefreshTokenFailedException();
     } else {
-      logWarning(
+      logError(
         '$runtimeType::handleUrgentExceptionOnWeb(): NO branch matched — '
         'will NOT navigate to login. exception=${exception.runtimeType}',
+        exception: exception,
+        stackTrace: StackTrace.current,
         webConsoleEnabled: true,
       );
     }
@@ -285,8 +287,13 @@ abstract class BaseController extends GetxController
   }
 
   void handleRefreshTokenFailedException() {
-    log(
-      '$runtimeType::handleRefreshTokenFailedException: hasComposer=${twakeAppManager.hasComposer}',
+    logError(
+      '$runtimeType::handleRefreshTokenFailedException: '
+      'auth_error_type=refresh_token_failed | will_logout=true | '
+      'hasComposer=${twakeAppManager.hasComposer}',
+      exception: RefreshTokenFailedException(),
+      stackTrace: StackTrace.current,
+      extras: {'auth_error_type': 'refresh_token_failed'},
       webConsoleEnabled: true,
     );
     if (twakeAppManager.hasComposer) {

--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -201,11 +201,9 @@ abstract class BaseController extends GetxController
     } else if (exception is RefreshTokenFailedException) {
       handleRefreshTokenFailedException();
     } else {
-      logError(
+      logWarning(
         '$runtimeType::handleUrgentExceptionOnWeb(): NO branch matched — '
         'will NOT navigate to login. exception=${exception.runtimeType}',
-        exception: exception,
-        stackTrace: StackTrace.current,
         webConsoleEnabled: true,
       );
     }

--- a/lib/features/login/data/network/authentication_client/web_refresh_token_error_classifier.dart
+++ b/lib/features/login/data/network/authentication_client/web_refresh_token_error_classifier.dart
@@ -29,24 +29,28 @@ class WebRefreshTokenErrorClassifier {
   /// that maps to HTTP 400 or 401, making logout the correct response.
   bool isServerRejection(Object error) {
     if (error is AccessTokenInvalidException) return true;
-    if (error is ArgumentError) {
-      final code = _parseOAuthCode(error);
-      if (code != null && _badGrantCodes.contains(code)) return true;
-      // flutter_appauth_web always wraps non-200 token responses as
-      // [error: token_failed, description: <actual-rfc-6749-code>].
-      // When the code is 'token_failed', the real rejection signal lives in
-      // the description field.
-      if (code == 'token_failed') {
-        final desc = _parseOAuthDesc(error);
-        return desc != null && _badGrantCodes.contains(desc);
-      }
-      return false;
-    }
-    if (error is DioException) {
-      final statusCode = error.response?.statusCode;
-      return statusCode == 400 || statusCode == 401;
+    if (error is ArgumentError) return _isArgumentErrorRejection(error);
+    if (error is DioException) return _isDioRejection(error);
+    return false;
+  }
+
+  bool _isArgumentErrorRejection(ArgumentError error) {
+    final code = _parseOAuthCode(error);
+    if (code != null && _badGrantCodes.contains(code)) return true;
+    // flutter_appauth_web always wraps non-200 token responses as
+    // [error: token_failed, description: <actual-rfc-6749-code>].
+    // When the code is 'token_failed', the real rejection signal lives in
+    // the description field.
+    if (code == 'token_failed') {
+      final desc = _parseOAuthDesc(error);
+      return desc != null && _badGrantCodes.contains(desc);
     }
     return false;
+  }
+
+  bool _isDioRejection(DioException error) {
+    final statusCode = error.response?.statusCode;
+    return statusCode == 400 || statusCode == 401;
   }
 
   /// Builds structured Sentry extras for [error].

--- a/lib/features/login/data/network/authentication_client/web_refresh_token_error_classifier.dart
+++ b/lib/features/login/data/network/authentication_client/web_refresh_token_error_classifier.dart
@@ -17,11 +17,12 @@ class WebRefreshTokenErrorClassifier {
   /// Non-standard codes (e.g. "token_failed") are absent intentionally;
   /// they are logged to Sentry until their HTTP status is confirmed.
   static const _badGrantCodes = {
-    'invalid_grant',       // refresh token expired or revoked (400)
-    'invalid_client',      // client authentication failed (400 or 401)
-    'invalid_request',     // request was malformed (400)
-    'invalid_scope',       // requested scope exceeds original grant (400)
-    'unauthorized_client', // client not authorized for this grant type (400)
+    'invalid_grant',          // refresh token expired or revoked (400)
+    'invalid_client',         // client authentication failed (400 or 401)
+    'invalid_request',        // request was malformed (400)
+    'invalid_scope',          // requested scope exceeds original grant (400)
+    'unauthorized_client',    // client not authorized for this grant type (400)
+    'unsupported_grant_type', // grant type not supported by the server (400)
   };
 
   /// Returns `true` when [error] represents a confirmed server-side rejection

--- a/lib/features/login/data/network/authentication_client/web_refresh_token_error_classifier.dart
+++ b/lib/features/login/data/network/authentication_client/web_refresh_token_error_classifier.dart
@@ -31,7 +31,16 @@ class WebRefreshTokenErrorClassifier {
     if (error is AccessTokenInvalidException) return true;
     if (error is ArgumentError) {
       final code = _parseOAuthCode(error);
-      return code != null && _badGrantCodes.contains(code);
+      if (code != null && _badGrantCodes.contains(code)) return true;
+      // flutter_appauth_web always wraps non-200 token responses as
+      // [error: token_failed, description: <actual-rfc-6749-code>].
+      // When the code is 'token_failed', the real rejection signal lives in
+      // the description field.
+      if (code == 'token_failed') {
+        final desc = _parseOAuthDesc(error);
+        return desc != null && _badGrantCodes.contains(desc);
+      }
+      return false;
     }
     if (error is DioException) {
       final statusCode = error.response?.statusCode;

--- a/lib/features/login/data/network/authentication_client/web_refresh_token_error_classifier.dart
+++ b/lib/features/login/data/network/authentication_client/web_refresh_token_error_classifier.dart
@@ -1,0 +1,73 @@
+import 'package:dio/dio.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_exception.dart'
+    show AccessTokenInvalidException;
+
+/// Classifies web token-refresh errors according to RFC 6749 §5.2.
+/// https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+///
+/// Single responsibility: answer two questions —
+///   1. Is this error a definitive server rejection (400/401 equivalent)?
+///   2. What structured extras should go to Sentry for tracing?
+///
+/// Intentionally has NO dependency on Dio handler operations or interceptor
+/// state; callers act on the result (logout, keep session, log).
+class WebRefreshTokenErrorClassifier {
+  /// Standard RFC 6749 §5.2 token-endpoint error codes that map to a
+  /// definitive 400/401 rejection — logout is safe.
+  /// Non-standard codes (e.g. "token_failed") are absent intentionally;
+  /// they are logged to Sentry until their HTTP status is confirmed.
+  static const _badGrantCodes = {
+    'invalid_grant',       // refresh token expired or revoked (400)
+    'invalid_client',      // client authentication failed (400 or 401)
+    'invalid_request',     // request was malformed (400)
+    'invalid_scope',       // requested scope exceeds original grant (400)
+    'unauthorized_client', // client not authorized for this grant type (400)
+  };
+
+  /// Returns `true` when [error] represents a confirmed server-side rejection
+  /// that maps to HTTP 400 or 401, making logout the correct response.
+  bool isServerRejection(Object error) {
+    if (error is AccessTokenInvalidException) return true;
+    if (error is ArgumentError) {
+      final code = _parseOAuthCode(error);
+      return code != null && _badGrantCodes.contains(code);
+    }
+    if (error is DioException) {
+      final statusCode = error.response?.statusCode;
+      return statusCode == 400 || statusCode == 401;
+    }
+    return false;
+  }
+
+  /// Builds structured Sentry extras for [error].
+  ///
+  /// For [ArgumentError], includes [oauth_error_code] and
+  /// [oauth_error_description] parsed from the flutter_appauth_web message so
+  /// that non-standard codes (e.g. "token_failed") are fully visible in Sentry.
+  Map<String, dynamic> buildSentryExtras(Object error) {
+    final rejected = isServerRejection(error);
+    final extras = <String, dynamic>{
+      'auth_error_type': rejected
+          ? 'web_server_rejected_refresh'
+          : 'web_token_unknown_error',
+    };
+    if (error is ArgumentError) {
+      extras['oauth_error_code'] = _parseOAuthCode(error) ?? 'unknown';
+      extras['oauth_error_description'] = _parseOAuthDesc(error) ?? 'unknown';
+    }
+    return extras;
+  }
+
+  // Parses the OAuth2 `error` field from flutter_appauth_web's ArgumentError
+  // message format: "Failed to get token: [error: X, description: Y]"
+  String? _parseOAuthCode(ArgumentError error) => RegExp(r'\[error: ([^,\]]+)')
+      .firstMatch(error.message?.toString() ?? '')
+      ?.group(1)
+      ?.trim();
+
+  String? _parseOAuthDesc(ArgumentError error) =>
+      RegExp(r'description: ([^\]]+)\]')
+          .firstMatch(error.message?.toString() ?? '')
+          ?.group(1)
+          ?.trim();
+}

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -189,9 +189,12 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     ErrorInterceptorHandler handler,
   ) {
     if (_isWebRefreshRejectedByServer(error)) {
-      logWarning(
+      logError(
         'AuthorizationInterceptors::_handleRefreshErrorOnWeb: '
-        'web refresh rejected by server, ending session — error=$error',
+        'auth_error_type=web_server_rejected_refresh | will_logout=true — error=$error',
+        exception: error,
+        stackTrace: StackTrace.current,
+        extras: {'auth_error_type': 'web_server_rejected_refresh'},
         webConsoleEnabled: true,
       );
       clear();

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -36,7 +36,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
   TokenOIDC? _token;
   String? _authorization;
 
-  final _webErrorClassifier = WebRefreshTokenErrorClassifier();
+  final WebRefreshTokenErrorClassifier _webErrorClassifier;
 
   late final void Function(
     Object error,
@@ -51,8 +51,9 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     this._authenticationClient,
     this._tokenOidcCacheManager,
     this._accountCacheManager,
-    this._iosSharingManager,
-  );
+    this._iosSharingManager, {
+    WebRefreshTokenErrorClassifier? webErrorClassifier,
+  }) : _webErrorClassifier = webErrorClassifier ?? WebRefreshTokenErrorClassifier();
 
   void setBasicAuthorization(UserName userName, Password password) {
     _authorization = base64Encode(utf8.encode('${userName.value}:${password.value}'));
@@ -374,6 +375,15 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         ),
         handler,
       );
+    } catch (e, st) {
+      // On web, flutter_appauth_web throws ArgumentError (and similar non-Dio
+      // errors) for token-endpoint failures. Catching here routes them directly
+      // to _handleRefreshError — preventing the outer catch in onError() from
+      // firing and producing a duplicate Sentry event.
+      if (PlatformInfo.isWeb) {
+        return _handleRefreshError(e, st, err, handler);
+      }
+      rethrow;
     }
   }
 

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -40,6 +40,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
 
   late final void Function(
     Object error,
+    StackTrace stackTrace,
     DioException originalError,
     ErrorInterceptorHandler handler,
   ) _handleRefreshError =
@@ -148,7 +149,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         stackTrace: stackTrace,
         webConsoleEnabled: true,
       );
-      return _handleRefreshError(e, err, handler);
+      return _handleRefreshError(e, stackTrace, err, handler);
     }
   }
 
@@ -192,6 +193,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
   /// - Network/transport failure → keep session silently.
   void _handleRefreshErrorOnWeb(
     Object error,
+    StackTrace stackTrace,
     DioException originalError,
     ErrorInterceptorHandler handler,
   ) {
@@ -202,7 +204,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         'AuthorizationInterceptors::_handleRefreshErrorOnWeb: '
         'will_logout=true — error=$error',
         exception: error,
-        stackTrace: StackTrace.current,
+        stackTrace: stackTrace,
         extras: _webErrorClassifier.buildSentryExtras(error),
         webConsoleEnabled: true,
       );
@@ -220,11 +222,11 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         'AuthorizationInterceptors::_handleRefreshErrorOnWeb: '
         'will_logout=false — error=$error',
         exception: error,
-        stackTrace: StackTrace.current,
+        stackTrace: stackTrace,
         extras: _webErrorClassifier.buildSentryExtras(error),
         webConsoleEnabled: true,
       );
-      return _handleRefreshErrorOnMobile(error, originalError, handler);
+      return _handleRefreshErrorOnMobile(error, stackTrace, originalError, handler);
     }
 
     logWarning(
@@ -232,11 +234,12 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       'web refresh network/transient failure, keeping session — error=$error',
       webConsoleEnabled: true,
     );
-    return _handleRefreshErrorOnMobile(error, originalError, handler);
+    return _handleRefreshErrorOnMobile(error, stackTrace, originalError, handler);
   }
 
   void _handleRefreshErrorOnMobile(
     Object error,
+    StackTrace stackTrace,
     DioException originalError,
     ErrorInterceptorHandler handler,
   ) {
@@ -320,7 +323,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       // failure surfaced. (In practice flutter_appauth_web throws a non-Dio
       // ArgumentError, but a Dio-based refresh must behave identically.)
       if (PlatformInfo.isWeb) {
-        return _handleRefreshError(refreshError, err, handler);
+        return _handleRefreshError(refreshError, st, err, handler);
       }
       // Mobile: 400 → session dead (RefreshTokenFailedException); other
       // statuses / no-response → network-tolerant via _handleDioRefreshError.

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -16,7 +16,7 @@ import 'package:tmail_ui_user/features/base/extensions/object_extensions.dart';
 import 'package:tmail_ui_user/features/login/data/local/account_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/local/token_oidc_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/network/authentication_client/authentication_client_base.dart';
-import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_exception.dart' show AccessTokenInvalidException;
+import 'package:tmail_ui_user/features/login/data/network/authentication_client/web_refresh_token_error_classifier.dart';
 import 'package:tmail_ui_user/features/login/domain/extensions/oidc_configuration_extensions.dart';
 import 'package:tmail_ui_user/features/upload/data/network/file_uploader.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
@@ -35,6 +35,8 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
   OIDCConfiguration? _configOIDC;
   TokenOIDC? _token;
   String? _authorization;
+
+  final _webErrorClassifier = WebRefreshTokenErrorClassifier();
 
   late final void Function(
     Object error,
@@ -183,44 +185,54 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
   /// A failure with NO server response (network/transport drop, timeout) keeps
   /// the session and is propagated WITHOUT the stale 401 — same as mobile — so
   /// a flaky connection does not log the web user out.
+  ///
+  /// Error routing delegates RFC 6749 classification to [WebRefreshTokenErrorClassifier]:
+  /// - Server rejection (400/401 or RFC 6749 bad-grant code) → logout.
+  /// - [ArgumentError] with unknown OAuth2 code → Sentry trace, keep session.
+  /// - Network/transport failure → keep session silently.
   void _handleRefreshErrorOnWeb(
     Object error,
     DioException originalError,
     ErrorInterceptorHandler handler,
   ) {
-    if (_isWebRefreshRejectedByServer(error)) {
+    final isRejected = _webErrorClassifier.isServerRejection(error);
+
+    if (isRejected) {
       logError(
         'AuthorizationInterceptors::_handleRefreshErrorOnWeb: '
-        'auth_error_type=web_server_rejected_refresh | will_logout=true — error=$error',
+        'will_logout=true — error=$error',
         exception: error,
         stackTrace: StackTrace.current,
-        extras: {'auth_error_type': 'web_server_rejected_refresh'},
+        extras: _webErrorClassifier.buildSentryExtras(error),
         webConsoleEnabled: true,
       );
       clear();
-      return super.onError(originalError.copyWith(error: error), handler);
+      return handler.reject(DioException(
+        requestOptions: originalError.requestOptions,
+        error: RefreshTokenFailedException(),
+        type: DioExceptionType.badResponse,
+      ));
     }
+
+    if (error is ArgumentError) {
+      // Non-standard OAuth2 code — log to Sentry for investigation, keep session.
+      logError(
+        'AuthorizationInterceptors::_handleRefreshErrorOnWeb: '
+        'will_logout=false — error=$error',
+        exception: error,
+        stackTrace: StackTrace.current,
+        extras: _webErrorClassifier.buildSentryExtras(error),
+        webConsoleEnabled: true,
+      );
+      return _handleRefreshErrorOnMobile(error, originalError, handler);
+    }
+
     logWarning(
       'AuthorizationInterceptors::_handleRefreshErrorOnWeb: '
       'web refresh network/transient failure, keeping session — error=$error',
       webConsoleEnabled: true,
     );
     return _handleRefreshErrorOnMobile(error, originalError, handler);
-  }
-
-  /// Whether a web REFRESH failure came WITH a server response (grant rejected
-  /// or token invalid) as opposed to a network/transport failure.
-  ///
-  /// flutter_appauth_web throws [ArgumentError] only after parsing a non-200
-  /// token response, and [AccessTokenInvalidException] after a 200 that yields
-  /// an invalid token — both mean the server responded. Everything else (no
-  /// response: timeouts, transport errors, ServerError/TemporarilyUnavailable)
-  /// is treated as a network failure → session kept.
-  bool _isWebRefreshRejectedByServer(Object error) {
-    return error is ArgumentError ||
-        error is AccessTokenInvalidException ||
-        error is UnsupportedError || 
-        (error is DioException && error.response != null);
   }
 
   void _handleRefreshErrorOnMobile(
@@ -359,26 +371,6 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         ),
         handler,
       );
-    } on ArgumentError catch (e, st) {
-      // flutter_appauth_web throws ArgumentError when the token endpoint returns a
-      // non-200 response (e.g. 400 invalid_grant). This is always a server rejection
-      // (no-response network drops surface differently). Treat identically to mobile
-      // 400: session dead, force logout via RefreshTokenFailedException.
-      if (!PlatformInfo.isWeb) rethrow;
-      logError(
-        'AuthorizationInterceptors: auth_error_type=web_invalid_grant | '
-        'will_logout=true — ${e.message}',
-        exception: e,
-        stackTrace: st,
-        extras: {'auth_error_type': 'web_invalid_grant'},
-        webConsoleEnabled: true,
-      );
-      clear();
-      return handler.reject(DioException(
-        requestOptions: err.requestOptions,
-        error: RefreshTokenFailedException(),
-        type: DioExceptionType.badResponse,
-      ));
     }
   }
 

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -356,6 +356,26 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         ),
         handler,
       );
+    } on ArgumentError catch (e, st) {
+      // flutter_appauth_web throws ArgumentError when the token endpoint returns a
+      // non-200 response (e.g. 400 invalid_grant). This is always a server rejection
+      // (no-response network drops surface differently). Treat identically to mobile
+      // 400: session dead, force logout via RefreshTokenFailedException.
+      if (!PlatformInfo.isWeb) rethrow;
+      logError(
+        'AuthorizationInterceptors: auth_error_type=web_invalid_grant | '
+        'will_logout=true — ${e.message}',
+        exception: e,
+        stackTrace: st,
+        extras: {'auth_error_type': 'web_invalid_grant'},
+        webConsoleEnabled: true,
+      );
+      clear();
+      return handler.reject(DioException(
+        requestOptions: err.requestOptions,
+        error: RefreshTokenFailedException(),
+        type: DioExceptionType.badResponse,
+      ));
     }
   }
 

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -2923,13 +2923,14 @@ void main() {
       },
     );
 
-    // ---- Non-standard OAuth2 code → session kept, logged for investigation ----
+    // ---- flutter_appauth_web token_failed wrapper: RFC 6749 code in description → logout ----
+    // flutter_appauth_web always emits [error: token_failed, description: <actual-rfc-code>].
 
     test(
-      'WHEN refresh throws ArgumentError with non-standard "token_failed" code '
-      'and description invalid_request (Sentry issue)\n'
-      'THEN session is KEPT — error propagated with NO HTTP response\n'
-      'AND OIDC state is NOT cleared (HTTP status unknown, cannot confirm 400/401)',
+      'WHEN refresh throws ArgumentError with token_failed code '
+      'and description invalid_request (flutter_appauth_web format)\n'
+      'THEN rejected with RefreshTokenFailedException (→ forced logout)\n'
+      'AND OIDC state is cleared',
       () async {
         stubWebRefresh401ThenThrow(ArgumentError(
           'Failed to get token: [error: token_failed, description: invalid_request]',
@@ -2939,25 +2940,52 @@ void main() {
         await expectLater(
           () => dio.post(baseUrl),
           throwsA(predicate<DioException>((e) {
-            return e.response == null && e.error is ArgumentError;
+            return e.error is RefreshTokenFailedException;
           })),
         );
 
         expect(
           authorizationInterceptors.authenticationType,
-          AuthenticationType.oidc,
+          AuthenticationType.none,
         );
       },
     );
 
     test(
-      'WHEN refresh throws ArgumentError with non-standard "token_failed" code '
-      'and description invalid_grant (Sentry issue)\n'
-      'THEN session is KEPT — error propagated with NO HTTP response\n'
-      'AND OIDC state is NOT cleared',
+      'WHEN refresh throws ArgumentError with token_failed code '
+      'and description invalid_grant (flutter_appauth_web format)\n'
+      'THEN rejected with RefreshTokenFailedException (→ forced logout)\n'
+      'AND OIDC state is cleared',
       () async {
         stubWebRefresh401ThenThrow(ArgumentError(
           'Failed to get token: [error: token_failed, description: invalid_grant]',
+        ));
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) {
+            return e.error is RefreshTokenFailedException;
+          })),
+        );
+
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.none,
+        );
+      },
+    );
+
+    // ---- token_failed with non-RFC description → session kept ----
+
+    test(
+      'WHEN refresh throws ArgumentError with token_failed code '
+      'and non-RFC description (server_error)\n'
+      'THEN session is KEPT — HTTP status unknown\n'
+      'AND OIDC state is NOT cleared',
+      () async {
+        stubWebRefresh401ThenThrow(ArgumentError(
+          'Failed to get token: [error: token_failed, description: server_error]',
         ));
         stubAccountCache();
 

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -3131,7 +3131,7 @@ void main() {
 
     test(
       'INVARIANT: flutter_appauth_web throws ArgumentError for non-200 token response\n'
-      'Standard RFC 6749 codes (invalid_grant) are routed through _handleWebTokenArgumentError',
+      'Standard RFC 6749 codes (invalid_grant) are classified as server rejections and trigger logout',
       () async {
         stubWebRefresh401ThenThrow(ArgumentError('Failed to get token: [error: invalid_grant]'));
         stubAccountCache();

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -2874,9 +2874,9 @@ void main() {
     tearDown(() => PlatformInfo.isTestingForWeb = false);
 
     test(
-      'WHEN refresh throws ArgumentError (flutter_appauth_web non-200, e.g. 400)\n'
-      'THEN original 401 response is preserved (→ BadCredentialsException → logout)\n'
-      'AND error carries the ArgumentError',
+      'WHEN refresh throws ArgumentError (flutter_appauth_web invalid_grant/non-200)\n'
+      'THEN rejected with RefreshTokenFailedException (→ forced logout)\n'
+      'AND OIDC state is cleared',
       () async {
         stubWebRefresh401ThenThrow(ArgumentError(
           'Failed to get token: [error: token_failed, description: invalid_grant]',
@@ -2886,9 +2886,13 @@ void main() {
         await expectLater(
           () => dio.post(baseUrl),
           throwsA(predicate<DioException>((e) {
-            return e.response?.statusCode == responseStatusCode401 &&
-                e.error is ArgumentError;
+            return e.error is RefreshTokenFailedException;
           })),
+        );
+
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.none,
         );
       },
     );
@@ -2958,17 +2962,14 @@ void main() {
 
     test(
       'INVARIANT: flutter_appauth_web throws ArgumentError for non-200 token response\n'
-      'IF THIS TEST FAILS, update _isWebRefreshRejectedByServer',
+      'IF THIS TEST FAILS, update ArgumentError catch in _refreshTokenThenRetry',
       () async {
-        // Arrange
         stubWebRefresh401ThenThrow(ArgumentError('Failed to get token: [error: invalid_grant]'));
         stubAccountCache();
 
-        // Act & Assert: ArgumentError → logout path (response preserved)
         await expectLater(
           () => dio.post(baseUrl),
-          throwsA(predicate<DioException>((e) =>
-            e.response?.statusCode == 401 && e.error is ArgumentError)),
+          throwsA(predicate<DioException>((e) => e.error is RefreshTokenFailedException)),
         );
       },
     );

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -3,6 +3,10 @@ import 'dart:io';
 
 import 'package:core/data/constants/constant.dart';
 import 'package:core/data/network/dio_client.dart';
+import 'package:core/utils/logging/app_logger_registry.dart';
+import 'package:core/utils/logging/log_handler.dart';
+import 'package:core/utils/logging/log_level.dart';
+import 'package:core/utils/logging/log_record.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -3380,6 +3384,95 @@ void main() {
     );
   });
 
+  // ============================================================
+  // onError: WEB refresh failure emits EXACTLY ONE Sentry event
+  // Guards the dedup: the generic catch in _refreshTokenThenRetry routes the
+  // non-Dio ArgumentError straight to the web handler, so the outer catch in
+  // onError() never fires its own logError. Without that routing, one refresh
+  // failure would log twice (generic onError:Exception + the classified event).
+  // ============================================================
+  group('onError: web refresh failure emits a single Sentry event', () {
+    late _CapturingLogHandler logHandler;
+
+    setUp(() {
+      PlatformInfo.isTestingForWeb = true;
+      logHandler = _CapturingLogHandler();
+      AppLoggerRegistry.instance.registerHandler(logHandler);
+    });
+
+    tearDown(() {
+      AppLoggerRegistry.instance.resetForTesting();
+      PlatformInfo.isTestingForWeb = false;
+    });
+
+    test(
+      'WHEN web refresh throws ArgumentError classified as server rejection\n'
+      'THEN exactly ONE error-level event is emitted (will_logout=true)\n'
+      'AND the duplicate generic onError:Exception event is NOT logged',
+      () async {
+        stubWebRefresh401ThenThrow(ArgumentError(
+          'Failed to get token: [error: token_failed, description: invalid_request]',
+        ));
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>(
+            (e) => e.error is RefreshTokenFailedException,
+          )),
+        );
+
+        final errorRecords = logHandler.errorRecords;
+        expect(
+          errorRecords.length,
+          1,
+          reason: 'web refresh rejection must emit exactly one error event',
+        );
+        expect(errorRecords.single.rawMessage, contains('will_logout=true'));
+        expect(
+          errorRecords.single.rawMessage,
+          contains('_handleRefreshErrorOnWeb'),
+        );
+        expect(
+          errorRecords.any((r) => r.rawMessage.contains('onError:Exception')),
+          isFalse,
+          reason: 'the outer-catch duplicate event must not fire on web',
+        );
+      },
+    );
+
+    test(
+      'WHEN web refresh throws ArgumentError with an unknown OAuth code (session kept)\n'
+      'THEN exactly ONE error-level event is emitted (will_logout=false)\n'
+      'AND the duplicate generic onError:Exception event is NOT logged',
+      () async {
+        stubWebRefresh401ThenThrow(ArgumentError(
+          'Failed to get token: [error: token_failed, description: server_error]',
+        ));
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>(
+            (e) => e.response == null && e.error is ArgumentError,
+          )),
+        );
+
+        final errorRecords = logHandler.errorRecords;
+        expect(
+          errorRecords.length,
+          1,
+          reason: 'unknown-code web refresh must emit exactly one error event',
+        );
+        expect(errorRecords.single.rawMessage, contains('will_logout=false'));
+        expect(
+          errorRecords.any((r) => r.rawMessage.contains('onError:Exception')),
+          isFalse,
+        );
+      },
+    );
+  });
+
   tearDown(() {
     reset(authenticationClient);
     reset(tokenOidcCacheManager);
@@ -3391,4 +3484,14 @@ void main() {
     dioAdapter.close();
     dio.close();
   });
+}
+
+class _CapturingLogHandler extends LogHandler {
+  final List<LogRecord> records = [];
+
+  @override
+  void handle(LogRecord record) => records.add(record);
+
+  List<LogRecord> get errorRecords =>
+      records.where((r) => r.level == Level.error).toList();
 }

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -2873,13 +2873,15 @@ void main() {
     setUp(() => PlatformInfo.isTestingForWeb = true);
     tearDown(() => PlatformInfo.isTestingForWeb = false);
 
+    // ---- RFC 6749 standard error codes → logout ----
+
     test(
-      'WHEN refresh throws ArgumentError (flutter_appauth_web invalid_grant/non-200)\n'
+      'WHEN refresh throws ArgumentError with standard invalid_grant code\n'
       'THEN rejected with RefreshTokenFailedException (→ forced logout)\n'
       'AND OIDC state is cleared',
       () async {
         stubWebRefresh401ThenThrow(ArgumentError(
-          'Failed to get token: [error: token_failed, description: invalid_grant]',
+          'Failed to get token: [error: invalid_grant, description: Refresh token expired]',
         ));
         stubAccountCache();
 
@@ -2898,8 +2900,109 @@ void main() {
     );
 
     test(
+      'WHEN refresh throws ArgumentError with standard invalid_client code\n'
+      'THEN rejected with RefreshTokenFailedException (→ forced logout)\n'
+      'AND OIDC state is cleared',
+      () async {
+        stubWebRefresh401ThenThrow(ArgumentError(
+          'Failed to get token: [error: invalid_client, description: Client authentication failed]',
+        ));
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) {
+            return e.error is RefreshTokenFailedException;
+          })),
+        );
+
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.none,
+        );
+      },
+    );
+
+    // ---- Non-standard OAuth2 code → session kept, logged for investigation ----
+
+    test(
+      'WHEN refresh throws ArgumentError with non-standard "token_failed" code '
+      'and description invalid_request (Sentry issue)\n'
+      'THEN session is KEPT — error propagated with NO HTTP response\n'
+      'AND OIDC state is NOT cleared (HTTP status unknown, cannot confirm 400/401)',
+      () async {
+        stubWebRefresh401ThenThrow(ArgumentError(
+          'Failed to get token: [error: token_failed, description: invalid_request]',
+        ));
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) {
+            return e.response == null && e.error is ArgumentError;
+          })),
+        );
+
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.oidc,
+        );
+      },
+    );
+
+    test(
+      'WHEN refresh throws ArgumentError with non-standard "token_failed" code '
+      'and description invalid_grant (Sentry issue)\n'
+      'THEN session is KEPT — error propagated with NO HTTP response\n'
+      'AND OIDC state is NOT cleared',
+      () async {
+        stubWebRefresh401ThenThrow(ArgumentError(
+          'Failed to get token: [error: token_failed, description: invalid_grant]',
+        ));
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) {
+            return e.response == null && e.error is ArgumentError;
+          })),
+        );
+
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.oidc,
+        );
+      },
+    );
+
+    test(
+      'WHEN refresh throws ArgumentError "Invalid or corrupted pad block" (local crypto failure)\n'
+      'THEN session is KEPT — error propagated with NO HTTP response\n'
+      'AND OIDC state is NOT cleared',
+      () async {
+        stubWebRefresh401ThenThrow(
+          ArgumentError('Invalid or corrupted pad block'),
+        );
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) {
+            return e.response == null && e.error is ArgumentError;
+          })),
+        );
+
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.oidc,
+        );
+      },
+    );
+
+    test(
       'WHEN refresh throws AccessTokenInvalidException\n'
-      'THEN original 401 response is preserved (→ logout)',
+      'THEN rejected with RefreshTokenFailedException (→ forced logout)\n'
+      'AND OIDC state is cleared',
       () async {
         stubWebRefresh401ThenThrow(AccessTokenInvalidException());
         stubAccountCache();
@@ -2907,9 +3010,13 @@ void main() {
         await expectLater(
           () => dio.post(baseUrl),
           throwsA(predicate<DioException>((e) {
-            return e.response?.statusCode == responseStatusCode401 &&
-                e.error is AccessTokenInvalidException;
+            return e.error is RefreshTokenFailedException;
           })),
+        );
+
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.none,
         );
       },
     );
@@ -2936,11 +3043,70 @@ void main() {
       );
     }
 
+    // ---- DioException from token endpoint: only 400/401 → logout ----
+
     test(
-      'WHEN refresh throws DioException WITH response (e.g. 503) on web\n'
-      'THEN treated as server rejection → original 401 preserved (→ logout)',
+      'WHEN refresh throws DioException WITH 400 response on web\n'
+      'THEN rejected with RefreshTokenFailedException (→ forced logout)\n'
+      'AND OIDC state is cleared',
       () async {
-        final refreshDioError = DioException(
+        final refreshDioError400 = DioException(
+          requestOptions: RequestOptions(path: '/token'),
+          response: Response(
+            statusCode: 400,
+            requestOptions: RequestOptions(path: '/token'),
+          ),
+          type: DioExceptionType.badResponse,
+        );
+        stubWebRefresh401ThenThrow(refreshDioError400);
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) => e.error is RefreshTokenFailedException)),
+        );
+
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.none,
+        );
+      },
+    );
+
+    test(
+      'WHEN refresh throws DioException WITH 401 response on web\n'
+      'THEN rejected with RefreshTokenFailedException (→ forced logout)\n'
+      'AND OIDC state is cleared',
+      () async {
+        final refreshDioError401 = DioException(
+          requestOptions: RequestOptions(path: '/token'),
+          response: Response(
+            statusCode: responseStatusCode401,
+            requestOptions: RequestOptions(path: '/token'),
+          ),
+          type: DioExceptionType.badResponse,
+        );
+        stubWebRefresh401ThenThrow(refreshDioError401);
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) => e.error is RefreshTokenFailedException)),
+        );
+
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.none,
+        );
+      },
+    );
+
+    test(
+      'WHEN refresh throws DioException WITH 503 response on web\n'
+      'THEN session is KEPT — 503 is not a 400/401 rejection\n'
+      'AND OIDC state is NOT cleared',
+      () async {
+        final refreshDioError503 = DioException(
           requestOptions: RequestOptions(path: '/token'),
           response: Response(
             statusCode: 503,
@@ -2948,21 +3114,24 @@ void main() {
           ),
           type: DioExceptionType.badResponse,
         );
-        stubWebRefresh401ThenThrow(refreshDioError);
+        stubWebRefresh401ThenThrow(refreshDioError503);
         stubAccountCache();
 
         await expectLater(
           () => dio.post(baseUrl),
-          throwsA(predicate<DioException>((e) =>
-            e.response?.statusCode == responseStatusCode401 &&
-            e.error is DioException)),
+          throwsA(predicate<DioException>((e) => e.response?.statusCode == 503)),
+        );
+
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.oidc,
         );
       },
     );
 
     test(
       'INVARIANT: flutter_appauth_web throws ArgumentError for non-200 token response\n'
-      'IF THIS TEST FAILS, update ArgumentError catch in _refreshTokenThenRetry',
+      'Standard RFC 6749 codes (invalid_grant) are routed through _handleWebTokenArgumentError',
       () async {
         stubWebRefresh401ThenThrow(ArgumentError('Failed to get token: [error: invalid_grant]'));
         stubAccountCache();

--- a/test/features/login/data/network/authentication_client/web_refresh_token_error_classifier_test.dart
+++ b/test/features/login/data/network/authentication_client/web_refresh_token_error_classifier_test.dart
@@ -78,27 +78,50 @@ void main() {
       });
     });
 
-    group('ArgumentError — non-standard / unknown codes', () {
+    group('ArgumentError — token_failed (flutter_appauth_web wrapper code)', () {
+      // flutter_appauth_web always uses [error: token_failed, description: <actual-code>].
+      // The real RFC 6749 signal is in the description field.
       ArgumentError appAuthError(String code, {String desc = 'some description'}) =>
           ArgumentError('Invalid argument(s): Failed to get token: [error: $code, description: $desc]');
 
-      test('returns false for token_failed with invalid_grant in description', () {
-        // "token_failed" is not RFC 6749; unknown HTTP status — keep session
+      test('returns true for token_failed with invalid_grant in description', () {
         expect(
           classifier.isServerRejection(appAuthError('token_failed', desc: 'invalid_grant')),
-          isFalse,
+          isTrue,
         );
       });
 
-      test('returns false for token_failed with invalid_request in description', () {
+      test('returns true for token_failed with invalid_request in description', () {
         expect(
           classifier.isServerRejection(appAuthError('token_failed', desc: 'invalid_request')),
+          isTrue,
+        );
+      });
+
+      test('returns true for token_failed with invalid_client in description', () {
+        expect(
+          classifier.isServerRejection(appAuthError('token_failed', desc: 'invalid_client')),
+          isTrue,
+        );
+      });
+
+      test('returns false for token_failed with non-RFC-6749 description (server_error)', () {
+        // Non-standard description → HTTP status unknown → keep session
+        expect(
+          classifier.isServerRejection(appAuthError('token_failed', desc: 'server_error')),
           isFalse,
         );
       });
 
       test('returns false for token_failed with empty description', () {
         expect(classifier.isServerRejection(appAuthError('token_failed', desc: '')), isFalse);
+      });
+
+      test('returns false for token_failed with non-RFC description (plain text)', () {
+        expect(
+          classifier.isServerRejection(appAuthError('token_failed', desc: 'some description')),
+          isFalse,
+        );
       });
     });
 
@@ -163,12 +186,12 @@ void main() {
         expect(extras['oauth_error_description'], equals('Token has expired'));
       });
 
-      test('parses code and description for token_failed (unknown)', () {
+      test('parses code and description for token_failed with RFC 6749 desc (server rejection)', () {
         final error = ArgumentError(
           'Invalid argument(s): Failed to get token: [error: token_failed, description: invalid_request]',
         );
         final extras = classifier.buildSentryExtras(error);
-        expect(extras['auth_error_type'], equals('web_token_unknown_error'));
+        expect(extras['auth_error_type'], equals('web_server_rejected_refresh'));
         expect(extras['oauth_error_code'], equals('token_failed'));
         expect(extras['oauth_error_description'], equals('invalid_request'));
       });

--- a/test/features/login/data/network/authentication_client/web_refresh_token_error_classifier_test.dart
+++ b/test/features/login/data/network/authentication_client/web_refresh_token_error_classifier_test.dart
@@ -1,0 +1,187 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/login/data/network/authentication_client/web_refresh_token_error_classifier.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_exception.dart';
+
+void main() {
+  late WebRefreshTokenErrorClassifier classifier;
+
+  setUp(() {
+    classifier = WebRefreshTokenErrorClassifier();
+  });
+
+  group('WebRefreshTokenErrorClassifier::isServerRejection', () {
+    group('AccessTokenInvalidException', () {
+      test('returns true', () {
+        expect(classifier.isServerRejection(AccessTokenInvalidException()), isTrue);
+      });
+    });
+
+    group('DioException', () {
+      DioException dioBadResponse(int statusCode) => DioException(
+            requestOptions: RequestOptions(),
+            response: Response(requestOptions: RequestOptions(), statusCode: statusCode),
+            type: DioExceptionType.badResponse,
+          );
+
+      test('returns true for 400', () {
+        expect(classifier.isServerRejection(dioBadResponse(400)), isTrue);
+      });
+
+      test('returns true for 401', () {
+        expect(classifier.isServerRejection(dioBadResponse(401)), isTrue);
+      });
+
+      test('returns false for 500', () {
+        expect(classifier.isServerRejection(dioBadResponse(500)), isFalse);
+      });
+
+      test('returns false for 503', () {
+        expect(classifier.isServerRejection(dioBadResponse(503)), isFalse);
+      });
+
+      test('returns false when no response', () {
+        final error = DioException(
+          requestOptions: RequestOptions(),
+          type: DioExceptionType.connectionTimeout,
+        );
+        expect(classifier.isServerRejection(error), isFalse);
+      });
+    });
+
+    group('ArgumentError — RFC 6749 §5.2 standard codes', () {
+      ArgumentError appAuthError(String code, {String desc = 'some description'}) =>
+          ArgumentError('Invalid argument(s): Failed to get token: [error: $code, description: $desc]');
+
+      test('returns true for invalid_grant', () {
+        expect(classifier.isServerRejection(appAuthError('invalid_grant')), isTrue);
+      });
+
+      test('returns true for invalid_client', () {
+        expect(classifier.isServerRejection(appAuthError('invalid_client')), isTrue);
+      });
+
+      test('returns true for invalid_request', () {
+        expect(classifier.isServerRejection(appAuthError('invalid_request')), isTrue);
+      });
+
+      test('returns true for invalid_scope', () {
+        expect(classifier.isServerRejection(appAuthError('invalid_scope')), isTrue);
+      });
+
+      test('returns true for unauthorized_client', () {
+        expect(classifier.isServerRejection(appAuthError('unauthorized_client')), isTrue);
+      });
+    });
+
+    group('ArgumentError — non-standard / unknown codes', () {
+      ArgumentError appAuthError(String code, {String desc = 'some description'}) =>
+          ArgumentError('Invalid argument(s): Failed to get token: [error: $code, description: $desc]');
+
+      test('returns false for token_failed with invalid_grant in description', () {
+        // "token_failed" is not RFC 6749; unknown HTTP status — keep session
+        expect(
+          classifier.isServerRejection(appAuthError('token_failed', desc: 'invalid_grant')),
+          isFalse,
+        );
+      });
+
+      test('returns false for token_failed with invalid_request in description', () {
+        expect(
+          classifier.isServerRejection(appAuthError('token_failed', desc: 'invalid_request')),
+          isFalse,
+        );
+      });
+
+      test('returns false for token_failed with empty description', () {
+        expect(classifier.isServerRejection(appAuthError('token_failed', desc: '')), isFalse);
+      });
+    });
+
+    group('ArgumentError — unrelated errors', () {
+      test('returns false for Invalid or corrupted pad block', () {
+        expect(
+          classifier.isServerRejection(ArgumentError('Invalid or corrupted pad block')),
+          isFalse,
+        );
+      });
+
+      test('returns false for ArgumentError with null message', () {
+        expect(classifier.isServerRejection(ArgumentError(null)), isFalse);
+      });
+    });
+
+    group('other error types', () {
+      test('returns false for generic Exception', () {
+        expect(classifier.isServerRejection(Exception('boom')), isFalse);
+      });
+
+      test('returns false for StateError', () {
+        expect(classifier.isServerRejection(StateError('bad state')), isFalse);
+      });
+    });
+  });
+
+  group('WebRefreshTokenErrorClassifier::buildSentryExtras', () {
+    test('uses web_server_rejected_refresh for AccessTokenInvalidException', () {
+      final extras = classifier.buildSentryExtras(AccessTokenInvalidException());
+      expect(extras['auth_error_type'], equals('web_server_rejected_refresh'));
+    });
+
+    test('uses web_server_rejected_refresh for DioException 401', () {
+      final error = DioException(
+        requestOptions: RequestOptions(),
+        response: Response(requestOptions: RequestOptions(), statusCode: 401),
+        type: DioExceptionType.badResponse,
+      );
+      final extras = classifier.buildSentryExtras(error);
+      expect(extras['auth_error_type'], equals('web_server_rejected_refresh'));
+    });
+
+    test('uses web_token_unknown_error for DioException 503', () {
+      final error = DioException(
+        requestOptions: RequestOptions(),
+        response: Response(requestOptions: RequestOptions(), statusCode: 503),
+        type: DioExceptionType.badResponse,
+      );
+      final extras = classifier.buildSentryExtras(error);
+      expect(extras['auth_error_type'], equals('web_token_unknown_error'));
+    });
+
+    group('ArgumentError oauth fields', () {
+      test('parses code and description for invalid_grant', () {
+        final error = ArgumentError(
+          'Invalid argument(s): Failed to get token: [error: invalid_grant, description: Token has expired]',
+        );
+        final extras = classifier.buildSentryExtras(error);
+        expect(extras['auth_error_type'], equals('web_server_rejected_refresh'));
+        expect(extras['oauth_error_code'], equals('invalid_grant'));
+        expect(extras['oauth_error_description'], equals('Token has expired'));
+      });
+
+      test('parses code and description for token_failed (unknown)', () {
+        final error = ArgumentError(
+          'Invalid argument(s): Failed to get token: [error: token_failed, description: invalid_request]',
+        );
+        final extras = classifier.buildSentryExtras(error);
+        expect(extras['auth_error_type'], equals('web_token_unknown_error'));
+        expect(extras['oauth_error_code'], equals('token_failed'));
+        expect(extras['oauth_error_description'], equals('invalid_request'));
+      });
+
+      test('returns unknown for unrecognized message format', () {
+        final error = ArgumentError('Invalid or corrupted pad block');
+        final extras = classifier.buildSentryExtras(error);
+        expect(extras['auth_error_type'], equals('web_token_unknown_error'));
+        expect(extras['oauth_error_code'], equals('unknown'));
+        expect(extras['oauth_error_description'], equals('unknown'));
+      });
+
+      test('returns unknown when message is null', () {
+        final extras = classifier.buildSentryExtras(ArgumentError(null));
+        expect(extras['oauth_error_code'], equals('unknown'));
+        expect(extras['oauth_error_description'], equals('unknown'));
+      });
+    });
+  });
+}

--- a/test/features/login/data/network/authentication_client/web_refresh_token_error_classifier_test.dart
+++ b/test/features/login/data/network/authentication_client/web_refresh_token_error_classifier_test.dart
@@ -72,6 +72,10 @@ void main() {
       test('returns true for unauthorized_client', () {
         expect(classifier.isServerRejection(appAuthError('unauthorized_client')), isTrue);
       });
+
+      test('returns true for unsupported_grant_type', () {
+        expect(classifier.isServerRejection(appAuthError('unsupported_grant_type')), isTrue);
+      });
     });
 
     group('ArgumentError — non-standard / unknown codes', () {


### PR DESCRIPTION
## Issue

#4598

## Problem

On web, when the OIDC token endpoint rejects a refresh request, `flutter_appauth_web` throws `ArgumentError` instead of a `DioException`. The original fix added a blanket `on ArgumentError catch` that always triggered logout — but this caused two regressions:

1. **Sentry crashes** — `super.onError(originalError.copyWith(error: ArgumentError(...)), handler)` propagated a raw `ArgumentError` through the Dio pipeline; `RemoteExceptionThrower` did not recognise it, causing unhandled exceptions in Sentry:
   - `ArgumentError: Failed to get token: [error: token_failed, description: invalid_request]`
   - `ArgumentError: Invalid or corrupted pad block`

2. **Over-eager logout** — non-standard codes such as `token_failed` have no confirmed HTTP status; logging out without a known 400/401 is incorrect.

3. **No tracing context** — Sentry events arrived with no `auth_error_type`, `oauth_error_code`, or `oauth_error_description`, making triage impossible.

## Root Cause

```
flutter_appauth_web.requestToken()         ← throws ArgumentError("token_failed/invalid_grant")
  _refreshTokenThenRetry                   ← on DioException: NO MATCH → falls through
    _handleRefreshErrorOnWeb               ← blanket ArgumentError → always logout
      super.onError(copyWith(ArgumentError)) ← raw ArgumentError propagated into Dio
        RemoteExceptionThrower             ← unrecognised type → CRASH → Sentry untagged error
```

## Fix

### Classification strategy

Introduced `WebRefreshTokenErrorClassifier` (SRP — RFC 6749 §5.2 knowledge isolated from Dio infrastructure):

| Error type | `isServerRejection` | Action |
|---|---|---|
| `AccessTokenInvalidException` | `true` | logout |
| `DioException` with 400 or 401 response | `true` | logout |
| `ArgumentError` with RFC 6749 standard code (`invalid_grant`, `invalid_client`, `invalid_request`, `invalid_scope`, `unauthorized_client`) | `true` | logout |
| `ArgumentError` with non-standard code (e.g. `token_failed`) | `false` | keep session + `logError` to Sentry with `oauth_error_code` / `oauth_error_description` for tracing |
| `DioException` with 5xx / no response | `false` | keep session, `logWarning` only |

RFC 6749 §5.2 reference: https://datatracker.ietf.org/doc/html/rfc6749#section-5.2

### Sentry trace map (after fix)

**Logout path** (RFC 6749 standard code or 400/401):

| # | Location | Level | `auth_error_type` |
|---|---|---|---|
| 1 | `AuthorizationInterceptors._handleRefreshErrorOnWeb` | `logError` ✅ | `web_server_rejected_refresh` |
| 2 | `BaseController.handleRefreshTokenFailedException` | `logError` ✅ | `refresh_token_failed` |

**Keep-session path** (non-standard code — tracing only):

| # | Location | Level | extras |
|---|---|---|---|
| 1 | `AuthorizationInterceptors._handleRefreshErrorOnWeb` | `logError` ✅ | `oauth_error_code`, `oauth_error_description`, `auth_error_type=web_token_unknown_error` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added web refresh-token error classification to decide when to clear session state versus keep it, with consistent enriched error reporting.

* **Bug Fixes**
  * Improved web refresh failure handling: more accurate forced-logout behavior for specific OAuth/RFC server rejections, while transient/other errors now preserve session as expected.
  * Refined logging so refresh failures are reported correctly and avoid duplicate error events.

* **Tests**
  * Updated and expanded web interceptor and classifier tests to match the new logout/session-preservation rules and logging expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->