### PR TITLE
add more log and try to write token before prune safety for update token 

### DIFF
--- a/lib/features/caching/config/hive_cache_config.dart
+++ b/lib/features/caching/config/hive_cache_config.dart
@@ -115,6 +115,7 @@ class HiveCacheConfig {
       logError(
         'HiveCacheConfig::getEncryptionKey(): '
         'encryption_key_unavailable=true | reason=cache_manager_binding_missing',
+        stackTrace: StackTrace.current,
       );
       return null;
     }
@@ -128,6 +129,7 @@ class HiveCacheConfig {
       logError(
         'HiveCacheConfig::getEncryptionKey(): '
         'encryption_key_unavailable=true | reason=key_cache_empty',
+        stackTrace: StackTrace.current,
       );
       return null;
     }

--- a/lib/features/caching/config/hive_cache_config.dart
+++ b/lib/features/caching/config/hive_cache_config.dart
@@ -109,17 +109,26 @@ class HiveCacheConfig {
   Future<Uint8List?> getEncryptionKey() async {
     final encryptionKeyCacheManager = getBinding<EncryptionKeyCacheManager>() ?? getBinding<EncryptionKeyCacheManager>(tag: BindingTag.isolateTag);
     if (encryptionKeyCacheManager == null) {
-      log('HiveCacheConfig::getEncryptionKey(): encryptionKeyCacheManager not found');
+      // No key → an encrypted box (incl. the OIDC token box) opens without a
+      // cipher and cannot be decrypted, surfacing later as a "no token" startup
+      // logout. Emit remotely so this silent root cause is observable.
+      logError(
+        'HiveCacheConfig::getEncryptionKey(): '
+        'encryption_key_unavailable=true | reason=cache_manager_binding_missing',
+      );
       return null;
     }
     var encryptionKeyCache = await encryptionKeyCacheManager.getEncryptionKeyStored();
 
     if (encryptionKeyCache != null) {
-      final encryptionKey = encryptionKeyCache.value;
-      log('HiveCacheConfig::getEncryptionKey(): encryptionKey: $encryptionKey');
+      log('HiveCacheConfig::getEncryptionKey(): encryption key resolved');
       final encryptionKeyDecode = base64Decode(encryptionKeyCache.value);
       return encryptionKeyDecode;
     } else {
+      logError(
+        'HiveCacheConfig::getEncryptionKey(): '
+        'encryption_key_unavailable=true | reason=key_cache_empty',
+      );
       return null;
     }
   }

--- a/lib/features/login/data/local/account_cache_manager.dart
+++ b/lib/features/login/data/local/account_cache_manager.dart
@@ -30,18 +30,35 @@ class AccountCacheManager extends CacheManagerInteraction {
     final newAccountCache = newAccount.toCache();
     final allAccounts = await _accountCacheClient.getAll();
     log('AccountCacheManager::setCurrentAccount::allAccounts(): length: ${allAccounts.length}, $allAccounts');
+
+    // Crash-safe: write the new (selected) account FIRST so the box is never
+    // empty / never without a selected account if the process is killed mid-write.
+    await _accountCacheClient.insertItem(newAccountCache.id, newAccountCache);
+
     if (allAccounts.isNotEmpty) {
-      final newAllAccounts = allAccounts
+      // Keep the OTHER accounts, unselected & de-duplicated, minus the stale
+      // version of the account we just wrote (same accountId, different hash id).
+      final otherAccounts = allAccounts
         .unselected()
         .removeDuplicated()
         .whereNot((account) => account.accountId == newAccountCache.accountId)
         .toList();
-      await _accountCacheClient.clearAllData();
-      if (newAllAccounts.isNotEmpty) {
-        await _accountCacheClient.updateMultipleItem(newAllAccounts.toMap());
+      if (otherAccounts.isNotEmpty) {
+        await _accountCacheClient.updateMultipleItem(otherAccounts.toMap());
+      }
+
+      final keepKeys = {
+        newAccountCache.id,
+        ...otherAccounts.map((account) => account.id),
+      };
+      final staleKeys = allAccounts
+        .map((account) => account.id)
+        .where((id) => !keepKeys.contains(id))
+        .toList();
+      if (staleKeys.isNotEmpty) {
+        await _accountCacheClient.deleteMultipleItem(staleKeys);
       }
     }
-    return _accountCacheClient.insertItem(newAccountCache.id, newAccountCache);
   }
 
   Future<void> deleteCurrentAccount(String hashId) {

--- a/lib/features/login/data/local/token_oidc_cache_manager.dart
+++ b/lib/features/login/data/local/token_oidc_cache_manager.dart
@@ -23,7 +23,8 @@ class TokenOidcCacheManager extends CacheManagerInteraction {
   }
 
   Future<void> persistOneTokenOidc(TokenOIDC tokenOIDC) async {
-    // Crash-safe persist: write the new token FIRST, then prune stale entries.
+    // Crash-safe persist: write the new token FIRST, then prune stale entries, so
+    // the box is never empty if the process is killed mid-write → forced re-login.
     log('TokenOidcCacheManager::persistOneTokenOidc(): keyHash: ${tokenOIDC.tokenIdHash}');
     await _tokenOidcCacheClient.insertItem(tokenOIDC.tokenIdHash, tokenOIDC.toTokenOidcCache());
     await _removeStaleTokens(keepKey: tokenOIDC.tokenIdHash);

--- a/lib/features/login/data/local/token_oidc_cache_manager.dart
+++ b/lib/features/login/data/local/token_oidc_cache_manager.dart
@@ -23,13 +23,21 @@ class TokenOidcCacheManager extends CacheManagerInteraction {
   }
 
   Future<void> persistOneTokenOidc(TokenOIDC tokenOIDC) async {
-    log('TokenOidcCacheManager::persistOneTokenOidc(): $tokenOIDC');
-    await clear();
-    log('TokenOidcCacheManager::persistOneTokenOidc(): key: ${tokenOIDC.tokenId.uuid}');
-    log('TokenOidcCacheManager::persistOneTokenOidc(): key\'s hash: ${tokenOIDC.tokenIdHash}');
-    log('TokenOidcCacheManager::persistOneTokenOidc(): token: ${tokenOIDC.token}');
+    // Crash-safe persist: write the new token FIRST, then prune stale entries.
+    log('TokenOidcCacheManager::persistOneTokenOidc(): keyHash: ${tokenOIDC.tokenIdHash}');
     await _tokenOidcCacheClient.insertItem(tokenOIDC.tokenIdHash, tokenOIDC.toTokenOidcCache());
+    await _removeStaleTokens(keepKey: tokenOIDC.tokenIdHash);
     log('TokenOidcCacheManager::persistOneTokenOidc(): done');
+  }
+
+  /// Removes every token except [keepKey] so the box keeps exactly one entry
+  Future<void> _removeStaleTokens({required String keepKey}) async {
+    final allItems = await _tokenOidcCacheClient.getMapItems();
+    final staleKeys = allItems.keys.where((key) => key != keepKey).toList();
+    if (staleKeys.isNotEmpty) {
+      log('TokenOidcCacheManager::_removeStaleTokens(): removing ${staleKeys.length} stale token(s)');
+      await _tokenOidcCacheClient.deleteMultipleItem(staleKeys);
+    }
   }
 
   Future<void> clear() async {

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -481,8 +481,9 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
   Future<PersonalAccount> _updateCurrentAccount({required TokenOIDC tokenOIDC}) async {
     final currentAccount = await _accountCacheManager.getCurrentAccount();
 
-    await _accountCacheManager.deleteCurrentAccount(currentAccount.id);
-
+    // Persist the new token BEFORE mutating the account cache. persistOneTokenOidc
+    // is crash-safe (write-before-prune), so the token box always holds a usable
+    // token even if the process is killed mid-update.
     await _tokenOidcCacheManager.persistOneTokenOidc(tokenOIDC);
 
     final personalAccount = PersonalAccount(

--- a/lib/features/login/domain/usecases/get_stored_token_oidc_interactor.dart
+++ b/lib/features/login/domain/usecases/get_stored_token_oidc_interactor.dart
@@ -46,11 +46,35 @@ class GetStoredTokenOidcInteractor {
       } else {
         yield Left(GetStoredTokenOidcFailure(InvalidBaseUrl()));
       }
-    } catch (e) {
-      log('GetStoredTokenOidcInteractor::execute(): $e');
+    } catch (e, stackTrace) {
+      // Startup token read failed → the app silently routes to the login form.
+      logError(
+        'GetStoredTokenOidcInteractor::execute(): '
+        'startup_token_unavailable=true | reason=${_classifyStartupFailure(e)} | '
+        'accountId=${personalAccount.id} | error=$e',
+        exception: e,
+        stackTrace: stackTrace,
+        extras: {
+          'startup_token_unavailable': true,
+          'reason': _classifyStartupFailure(e),
+          'error_type': e.runtimeType.toString(),
+        },
+      );
       yield Left(GetStoredTokenOidcFailure(e));
     }
   }
 
   bool _isCredentialValid(Uri baseUrl) => baseUrl.isBaseUrlValid();
+
+  String _classifyStartupFailure(Object error) {
+    if (error is NotFoundStoredTokenException) {
+      return 'no_stored_token';
+    }
+    final typeName = error.runtimeType.toString();
+    if (typeName.contains('Hive') || error.toString().contains('Hive')) {
+      // e.g. HiveError: unknown typeId / corrupted box / wrong encryption key.
+      return 'hive_read_or_decrypt_error';
+    }
+    return 'other';
+  }
 }

--- a/lib/features/login/domain/usecases/get_stored_token_oidc_interactor.dart
+++ b/lib/features/login/domain/usecases/get_stored_token_oidc_interactor.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:core/utils/app_logger.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:dartz/dartz.dart';
 import 'package:jmap_dart_client/jmap/push/state_change.dart';
 import 'package:model/account/personal_account.dart';
@@ -48,18 +49,26 @@ class GetStoredTokenOidcInteractor {
       }
     } catch (e, stackTrace) {
       // Startup token read failed → the app silently routes to the login form.
-      logError(
+      // Report to remote logging on MOBILE only: that is where a missing token
+      // means a real "logged out overnight" regression.
+      final message =
         'GetStoredTokenOidcInteractor::execute(): '
         'startup_token_unavailable=true | reason=${_classifyStartupFailure(e)} | '
-        'accountId=${personalAccount.id} | error=$e',
-        exception: e,
-        stackTrace: stackTrace,
-        extras: {
-          'startup_token_unavailable': true,
-          'reason': _classifyStartupFailure(e),
-          'error_type': e.runtimeType.toString(),
-        },
-      );
+        'accountId=${personalAccount.id} | error=$e';
+      if (PlatformInfo.isMobile) {
+        logError(
+          message,
+          exception: e,
+          stackTrace: stackTrace,
+          extras: {
+            'startup_token_unavailable': true,
+            'reason': _classifyStartupFailure(e),
+            'error_type': e.runtimeType.toString(),
+          },
+        );
+      } else {
+        logWarning(message);
+      }
       yield Left(GetStoredTokenOidcFailure(e));
     }
   }

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -2531,7 +2531,7 @@ void main() {
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         when(accountCacheManager.getCurrentAccount())
             .thenAnswer((_) async => AccountFixtures.aliceAccount);
-        when(accountCacheManager.deleteCurrentAccount(AccountFixtures.aliceAccount.id))
+        when(tokenOidcCacheManager.persistOneTokenOidc(OIDCFixtures.newTokenOidc))
             .thenThrow(Exception('Cache write failure'));
 
         await expectLater(

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -500,6 +500,103 @@ void main() {
     );
   });
 
+  group('onError: _updateCurrentAccount persists token before account', () {
+    // Drives a full successful refresh so onError → _refreshTokenThenRetry →
+    // _updateCurrentAccount runs, then asserts the crash-safe contract.
+    Future<void> arrangeSuccessfulRefresh() async {
+      authorizationInterceptors.setTokenAndAuthorityOidc(
+        newToken: OIDCFixtures.tokenOidcExpiredTime,
+        newConfig: OIDCFixtures.oidcConfiguration,
+      );
+
+      dioAdapter.onPost(
+        baseUrl,
+        (server) => server.throws(responseStatusCode401, makeDioError401()),
+        headers: {
+          HttpHeaders.authorizationHeader:
+              'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+        },
+      );
+      dioAdapter.onPost(
+        baseUrl,
+        (server) =>
+            server.reply(responseStatusCode200, dataRequestSuccessfully),
+        headers: {
+          HttpHeaders.authorizationHeader:
+              'Bearer ${OIDCFixtures.newTokenOidc.token}',
+        },
+      );
+
+      when(authenticationClient.refreshingTokensOIDC(
+        OIDCFixtures.oidcConfiguration.clientId,
+        OIDCFixtures.oidcConfiguration.redirectUrl,
+        OIDCFixtures.oidcConfiguration.discoveryUrl,
+        OIDCFixtures.oidcConfiguration.scopes,
+        OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+      )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
+      stubAccountCache();
+    }
+
+    // The account _updateCurrentAccount builds from the refreshed token + the
+    // current account (aliceAccount).
+    final expectedAccount = PersonalAccount(
+      OIDCFixtures.newTokenOidc.tokenIdHash,
+      AuthenticationType.oidc,
+      isSelected: true,
+      accountId: AccountFixtures.aliceAccountId,
+      apiUrl: AccountFixtures.aliceAccount.apiUrl,
+      userName: AccountFixtures.aliceAccount.userName,
+    );
+
+    test(
+      'WHEN refresh succeeds\n'
+      'THEN the new token is persisted AND the new account is set',
+      () async {
+        await arrangeSuccessfulRefresh();
+
+        final response = await dio.post(baseUrl);
+        expect(response.statusCode, responseStatusCode200);
+
+        verify(tokenOidcCacheManager
+                .persistOneTokenOidc(OIDCFixtures.newTokenOidc))
+            .called(1);
+        verify(accountCacheManager.setCurrentAccount(expectedAccount))
+            .called(1);
+      },
+    );
+
+    test(
+      'WHEN refresh succeeds\n'
+      'THEN the token is persisted BEFORE the account is set\n'
+      '(crash-safe: token box is never the empty one mid-update)',
+      () async {
+        await arrangeSuccessfulRefresh();
+
+        await dio.post(baseUrl);
+
+        verifyInOrder([
+          accountCacheManager.getCurrentAccount(),
+          tokenOidcCacheManager.persistOneTokenOidc(OIDCFixtures.newTokenOidc),
+          accountCacheManager.setCurrentAccount(expectedAccount),
+        ]);
+      },
+    );
+
+    test(
+      'WHEN refresh succeeds\n'
+      'THEN the redundant pre-delete of the current account is NOT performed\n'
+      '(setCurrentAccount already replaces it — no destroy-before-write window)',
+      () async {
+        await arrangeSuccessfulRefresh();
+
+        await dio.post(baseUrl);
+
+        verifyNever(
+            accountCacheManager.deleteCurrentAccount(AccountFixtures.aliceAccount.id));
+      },
+    );
+  });
+
   // ============================================================
   // onError: refresh fails with DioException
   // ============================================================

--- a/test/features/login/data/local/account_cache_manager_test.dart
+++ b/test/features/login/data/local/account_cache_manager_test.dart
@@ -226,9 +226,131 @@ void main() {
       final oldTwo = await accountCacheClient.getItem(account2.id);
       expect(oldTwo!.isSelected, false);
 
-      final newSelected = await accountCacheManager.getCurrentAccount(); 
+      final newSelected = await accountCacheManager.getCurrentAccount();
       expect(newSelected, personalAccount3);
       expect(newSelected.isSelected, true);
+    });
+  });
+
+  group('setCurrentAccount prune logic', () {
+    setUp(() {
+      accountCacheClient = MemoryAccountCacheClient();
+      accountCacheManager = AccountCacheManager(accountCacheClient);
+    });
+
+    test('WHEN a stored account has the SAME accountId but a different hash id \n'
+        '(token refresh changed the id) \n'
+        'THEN the stale version is REMOVED, leaving only the new account', () async {
+      const sharedAccountId =
+          'ae08b34da40b48f30ec0b94db05675894262fbc5c2e278644f9517aaf25e8246';
+      final staleVersion = AccountCache(
+        'old-hash',
+        'oidc',
+        isSelected: true,
+        accountId: sharedAccountId,
+        apiUrl: 'https://jmap.domain.com/oidc/jmap',
+        userName: 'username@domain.com',
+      );
+      final refreshedAccount = PersonalAccount(
+        'new-hash',
+        AuthenticationType.oidc,
+        isSelected: true,
+        accountId: AccountId(Id(sharedAccountId)),
+        apiUrl: 'https://jmap.domain.com/oidc/jmap',
+        userName: UserName('username@domain.com'),
+      );
+      await accountCacheClient.insertItem(staleVersion.id, staleVersion);
+
+      // act
+      await accountCacheManager.setCurrentAccount(refreshedAccount);
+
+      // assert — old hash gone, only the new one remains and is selected
+      final allAccounts = await accountCacheClient.getAll();
+      expect(allAccounts.length, 1);
+      expect(await accountCacheClient.getItem('old-hash'), isNull);
+      final current = await accountCacheManager.getCurrentAccount();
+      expect(current.id, 'new-hash');
+      expect(current.isSelected, true);
+    });
+
+    test('WHEN the box has duplicate entries for one accountId \n'
+        'THEN setting a different account collapses the duplicates \n'
+        'AND keeps exactly one selected account', () async {
+      const duplicatedAccountId =
+          'f30ec0b94db05675894262fbc5c2e27ae08b34da40b488644f9517aaf25e8246';
+      final dup1 = AccountCache(
+        'dup-1',
+        'oidc',
+        isSelected: true,
+        accountId: duplicatedAccountId,
+        apiUrl: 'https://jmap.domain.com/oidc/jmap',
+        userName: 'dup@domain.com',
+      );
+      final dup2 = AccountCache(
+        'dup-2',
+        'oidc',
+        isSelected: true,
+        accountId: duplicatedAccountId,
+        apiUrl: 'https://jmap.domain.com/oidc/jmap',
+        userName: 'dup@domain.com',
+      );
+      final newAccount = PersonalAccount(
+        'new-hash',
+        AuthenticationType.oidc,
+        isSelected: true,
+        accountId: AccountId(Id(
+            '5675894262fbc5c2e278644f9517aaf25e8246ae08b34da40b48f30ec0b94db0')),
+        apiUrl: 'https://jmap.domain.com/oidc/jmap',
+        userName: UserName('new@domain.com'),
+      );
+      await accountCacheClient.insertMultipleItem({
+        dup1.id: dup1,
+        dup2.id: dup2,
+      });
+
+      // act
+      await accountCacheManager.setCurrentAccount(newAccount);
+
+      // assert — duplicates collapsed to one (unselected) + new (selected)
+      final allAccounts = await accountCacheClient.getAll();
+      expect(allAccounts.length, 2);
+      expect(allAccounts.where((account) => account.isSelected).length, 1);
+      final current = await accountCacheManager.getCurrentAccount();
+      expect(current.id, 'new-hash');
+    });
+
+    test('WHEN re-selecting the account that is already stored \n'
+        '(same id, same accountId) \n'
+        'THEN the box still holds exactly that one selected account', () async {
+      const accountId =
+          'aaaa894262fbc5c2e278644f9517aaf25e8246ae08b34da40b48f30ec0b94db0';
+      final existing = AccountCache(
+        'same-hash',
+        'oidc',
+        isSelected: true,
+        accountId: accountId,
+        apiUrl: 'https://jmap.domain.com/oidc/jmap',
+        userName: 'self@domain.com',
+      );
+      final reselect = PersonalAccount(
+        'same-hash',
+        AuthenticationType.oidc,
+        isSelected: true,
+        accountId: AccountId(Id(accountId)),
+        apiUrl: 'https://jmap.domain.com/oidc/jmap',
+        userName: UserName('self@domain.com'),
+      );
+      await accountCacheClient.insertItem(existing.id, existing);
+
+      // act
+      await accountCacheManager.setCurrentAccount(reselect);
+
+      // assert — idempotent: one selected account, not pruned to empty
+      final allAccounts = await accountCacheClient.getAll();
+      expect(allAccounts.length, 1);
+      final current = await accountCacheManager.getCurrentAccount();
+      expect(current.id, 'same-hash');
+      expect(current.isSelected, true);
     });
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer account and token persistence: writes now occur before pruning to avoid temporary cache loss during updates and refreshes; redundant deletes during refresh flows removed.
  * Improved error logging for encryption/credential retrieval: emits structured classified errors (with reason and stack trace) and stops logging raw encryption key values.

* **Tests**
  * Added/updated tests covering cache prune/idempotency scenarios and token-persist failure handling in refresh flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->