### PR TITLE
TF-4606 Fix cannot download attachment

### DIFF
--- a/lib/features/download/domain/mixin/oidc_token_resolve_mixin.dart
+++ b/lib/features/download/domain/mixin/oidc_token_resolve_mixin.dart
@@ -1,0 +1,32 @@
+import 'package:core/utils/app_logger.dart';
+import 'package:model/oidc/token_oidc.dart';
+import 'package:tmail_ui_user/features/login/domain/repository/authentication_oidc_repository.dart';
+
+mixin OidcTokenResolveMixin {
+  AuthenticationOIDCRepository get authOIDCRepository;
+
+  Future<TokenOIDC> resolveOidcToken(
+    String accountCacheKey, {
+    TokenOIDC? fallbackToken,
+  }) async {
+    try {
+      return await authOIDCRepository.getStoredTokenOIDC(accountCacheKey);
+    } catch (e) {
+      if (fallbackToken != null) {
+        logTrace('$runtimeType::resolveOidcToken(): '
+            'storage failed, using in-memory token as fallback | error=${e.runtimeType}');
+        authOIDCRepository
+            .persistTokenOIDCAt(accountCacheKey, fallbackToken)
+            .catchError(
+              (Object repairError) => logError(
+                '$runtimeType::resolveOidcToken(): '
+                'failed to repair token storage | error=${repairError.runtimeType}',
+                exception: repairError,
+              ),
+            );
+        return fallbackToken;
+      }
+      rethrow;
+    }
+  }
+}

--- a/lib/features/download/domain/model/export_all_attachments_request.dart
+++ b/lib/features/download/domain/model/export_all_attachments_request.dart
@@ -1,0 +1,22 @@
+import 'package:dio/dio.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:model/oidc/token_oidc.dart';
+
+class ExportAllAttachmentsRequest {
+  final AccountId accountId;
+  final EmailId emailId;
+  final String baseDownloadAllUrl;
+  final String outputFileName;
+  final CancelToken cancelToken;
+  final TokenOIDC? fallbackToken;
+
+  const ExportAllAttachmentsRequest({
+    required this.accountId,
+    required this.emailId,
+    required this.baseDownloadAllUrl,
+    required this.outputFileName,
+    required this.cancelToken,
+    this.fallbackToken,
+  });
+}

--- a/lib/features/download/domain/model/export_all_attachments_request.dart
+++ b/lib/features/download/domain/model/export_all_attachments_request.dart
@@ -1,22 +1,17 @@
-import 'package:dio/dio.dart';
-import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
-import 'package:model/oidc/token_oidc.dart';
+import 'package:tmail_ui_user/features/download/domain/model/export_request.dart';
 
-class ExportAllAttachmentsRequest {
-  final AccountId accountId;
+class ExportAllAttachmentsRequest extends ExportRequest {
   final EmailId emailId;
   final String baseDownloadAllUrl;
   final String outputFileName;
-  final CancelToken cancelToken;
-  final TokenOIDC? fallbackToken;
 
   const ExportAllAttachmentsRequest({
-    required this.accountId,
+    required super.accountId,
     required this.emailId,
     required this.baseDownloadAllUrl,
     required this.outputFileName,
-    required this.cancelToken,
-    this.fallbackToken,
+    required super.cancelToken,
+    super.fallbackToken,
   });
 }

--- a/lib/features/download/domain/model/export_attachment_request.dart
+++ b/lib/features/download/domain/model/export_attachment_request.dart
@@ -1,0 +1,20 @@
+import 'package:dio/dio.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:model/email/attachment.dart';
+import 'package:model/oidc/token_oidc.dart';
+
+class ExportAttachmentRequest {
+  final Attachment attachment;
+  final AccountId accountId;
+  final String baseDownloadUrl;
+  final CancelToken cancelToken;
+  final TokenOIDC? fallbackToken;
+
+  const ExportAttachmentRequest({
+    required this.attachment,
+    required this.accountId,
+    required this.baseDownloadUrl,
+    required this.cancelToken,
+    this.fallbackToken,
+  });
+}

--- a/lib/features/download/domain/model/export_attachment_request.dart
+++ b/lib/features/download/domain/model/export_attachment_request.dart
@@ -1,20 +1,15 @@
-import 'package:dio/dio.dart';
-import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:model/email/attachment.dart';
-import 'package:model/oidc/token_oidc.dart';
+import 'package:tmail_ui_user/features/download/domain/model/export_request.dart';
 
-class ExportAttachmentRequest {
+class ExportAttachmentRequest extends ExportRequest {
   final Attachment attachment;
-  final AccountId accountId;
   final String baseDownloadUrl;
-  final CancelToken cancelToken;
-  final TokenOIDC? fallbackToken;
 
   const ExportAttachmentRequest({
     required this.attachment,
-    required this.accountId,
+    required super.accountId,
     required this.baseDownloadUrl,
-    required this.cancelToken,
-    this.fallbackToken,
+    required super.cancelToken,
+    super.fallbackToken,
   });
 }

--- a/lib/features/download/domain/model/export_request.dart
+++ b/lib/features/download/domain/model/export_request.dart
@@ -1,0 +1,15 @@
+import 'package:dio/dio.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:model/oidc/token_oidc.dart';
+
+abstract class ExportRequest {
+  final AccountId accountId;
+  final CancelToken cancelToken;
+  final TokenOIDC? fallbackToken;
+
+  const ExportRequest({
+    required this.accountId,
+    required this.cancelToken,
+    this.fallbackToken,
+  });
+}

--- a/lib/features/download/domain/usecase/export_all_attachments_interactor.dart
+++ b/lib/features/download/domain/usecase/export_all_attachments_interactor.dart
@@ -60,16 +60,16 @@ class ExportAllAttachmentsInteractor {
   }
 
   Future<TokenOIDC> _getTokenOidc(
-    String accountId, {
+    String accountCacheKey, {
     TokenOIDC? fallbackToken,
   }) async {
     try {
-      return await _authenticationOIDCRepository.getStoredTokenOIDC(accountId);
+      return await _authenticationOIDCRepository.getStoredTokenOIDC(accountCacheKey);
     } catch (e) {
       if (fallbackToken != null) {
         logTrace('ExportAllAttachmentsInteractor::_getTokenOidc(): '
             'storage failed, using in-memory token as fallback | error=${e.runtimeType}');
-        _authenticationOIDCRepository.persistTokenOIDC(fallbackToken).catchError(
+        _authenticationOIDCRepository.persistTokenOIDCAt(accountCacheKey, fallbackToken).catchError(
           (Object repairError) => logError(
             'ExportAllAttachmentsInteractor::_getTokenOidc(): '
             'failed to repair token storage | error=${repairError.runtimeType}',

--- a/lib/features/download/domain/usecase/export_all_attachments_interactor.dart
+++ b/lib/features/download/domain/usecase/export_all_attachments_interactor.dart
@@ -6,7 +6,7 @@ import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:model/account/account_request.dart';
 import 'package:model/account/authentication_type.dart';
 import 'package:model/account/password.dart';
-import 'package:model/oidc/token_oidc.dart';
+import 'package:tmail_ui_user/features/download/domain/mixin/oidc_token_resolve_mixin.dart';
 import 'package:tmail_ui_user/features/download/domain/model/export_all_attachments_request.dart';
 import 'package:tmail_ui_user/features/download/domain/repository/download_repository.dart';
 import 'package:tmail_ui_user/features/download/domain/state/export_all_attachments_state.dart';
@@ -14,8 +14,8 @@ import 'package:tmail_ui_user/features/login/domain/repository/account_repositor
 import 'package:tmail_ui_user/features/login/domain/repository/authentication_oidc_repository.dart';
 import 'package:tmail_ui_user/features/login/domain/repository/credential_repository.dart';
 
-class ExportAllAttachmentsInteractor {
-  const ExportAllAttachmentsInteractor(
+class ExportAllAttachmentsInteractor with OidcTokenResolveMixin {
+  ExportAllAttachmentsInteractor(
     this._downloadRepository,
     this._accountRepository,
     this._authenticationOIDCRepository,
@@ -27,13 +27,16 @@ class ExportAllAttachmentsInteractor {
   final AuthenticationOIDCRepository _authenticationOIDCRepository;
   final CredentialRepository _credentialRepository;
 
+  @override
+  AuthenticationOIDCRepository get authOIDCRepository => _authenticationOIDCRepository;
+
   Stream<Either<Failure, Success>> execute(ExportAllAttachmentsRequest request) async* {
     try {
       yield Right(ExportingAllAttachments());
       final currentAccount = await _accountRepository.getCurrentAccount();
       AccountRequest accountRequest;
       if (currentAccount.authenticationType == AuthenticationType.oidc) {
-        final tokenOidc = await _getTokenOidc(currentAccount.id, fallbackToken: request.fallbackToken);
+        final tokenOidc = await resolveOidcToken(currentAccount.id, fallbackToken: request.fallbackToken);
         accountRequest = AccountRequest.withOidc(token: tokenOidc);
       } else {
         final authenticationInfoCache = await _credentialRepository.getAuthenticationInfoStored();
@@ -56,29 +59,6 @@ class ExportAllAttachmentsInteractor {
     } catch (e) {
       logWarning('ExportAllAttachmentsInteractor::execute():EXCEPTION: $e');
       yield Left(ExportAllAttachmentsFailure(exception: e));
-    }
-  }
-
-  Future<TokenOIDC> _getTokenOidc(
-    String accountCacheKey, {
-    TokenOIDC? fallbackToken,
-  }) async {
-    try {
-      return await _authenticationOIDCRepository.getStoredTokenOIDC(accountCacheKey);
-    } catch (e) {
-      if (fallbackToken != null) {
-        logTrace('ExportAllAttachmentsInteractor::_getTokenOidc(): '
-            'storage failed, using in-memory token as fallback | error=${e.runtimeType}');
-        _authenticationOIDCRepository.persistTokenOIDCAt(accountCacheKey, fallbackToken).catchError(
-          (Object repairError) => logError(
-            'ExportAllAttachmentsInteractor::_getTokenOidc(): '
-            'failed to repair token storage | error=${repairError.runtimeType}',
-            exception: repairError,
-          ),
-        );
-        return fallbackToken;
-      }
-      rethrow;
     }
   }
 }

--- a/lib/features/download/domain/usecase/export_all_attachments_interactor.dart
+++ b/lib/features/download/domain/usecase/export_all_attachments_interactor.dart
@@ -67,8 +67,15 @@ class ExportAllAttachmentsInteractor {
       return await _authenticationOIDCRepository.getStoredTokenOIDC(accountId);
     } catch (e) {
       if (fallbackToken != null) {
-        logWarning('ExportAllAttachmentsInteractor::_getTokenOidc(): '
+        logTrace('ExportAllAttachmentsInteractor::_getTokenOidc(): '
             'storage failed, using in-memory token as fallback | error=${e.runtimeType}');
+        _authenticationOIDCRepository.persistTokenOIDC(fallbackToken).catchError(
+          (dynamic repairError) => logError(
+            'ExportAllAttachmentsInteractor::_getTokenOidc(): '
+            'failed to repair token storage | error=${repairError.runtimeType}',
+            exception: repairError,
+          ),
+        );
         return fallbackToken;
       }
       rethrow;

--- a/lib/features/download/domain/usecase/export_all_attachments_interactor.dart
+++ b/lib/features/download/domain/usecase/export_all_attachments_interactor.dart
@@ -2,13 +2,12 @@ import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:dartz/dartz.dart';
-import 'package:dio/dio.dart';
-import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
-import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:model/account/account_request.dart';
 import 'package:model/account/authentication_type.dart';
 import 'package:model/account/password.dart';
+import 'package:model/oidc/token_oidc.dart';
+import 'package:tmail_ui_user/features/download/domain/model/export_all_attachments_request.dart';
 import 'package:tmail_ui_user/features/download/domain/repository/download_repository.dart';
 import 'package:tmail_ui_user/features/download/domain/state/export_all_attachments_state.dart';
 import 'package:tmail_ui_user/features/login/domain/repository/account_repository.dart';
@@ -28,19 +27,13 @@ class ExportAllAttachmentsInteractor {
   final AuthenticationOIDCRepository _authenticationOIDCRepository;
   final CredentialRepository _credentialRepository;
 
-  Stream<Either<Failure, Success>> execute(
-    AccountId accountId,
-    EmailId emailId,
-    String baseDownloadAllUrl,
-    String outputFileName,
-    CancelToken cancelToken,
-  ) async* {
+  Stream<Either<Failure, Success>> execute(ExportAllAttachmentsRequest request) async* {
     try {
       yield Right(ExportingAllAttachments());
       final currentAccount = await _accountRepository.getCurrentAccount();
       AccountRequest accountRequest;
       if (currentAccount.authenticationType == AuthenticationType.oidc) {
-        final tokenOidc = await _authenticationOIDCRepository.getStoredTokenOIDC(currentAccount.id);
+        final tokenOidc = await _getTokenOidc(currentAccount.id, fallbackToken: request.fallbackToken);
         accountRequest = AccountRequest.withOidc(token: tokenOidc);
       } else {
         final authenticationInfoCache = await _credentialRepository.getAuthenticationInfoStored();
@@ -49,20 +42,36 @@ class ExportAllAttachmentsInteractor {
           password: Password(authenticationInfoCache.password),
         );
       }
-      
+
       final result = await _downloadRepository.exportAllAttachments(
-        accountId,
-        emailId,
-        baseDownloadAllUrl,
-        outputFileName,
+        request.accountId,
+        request.emailId,
+        request.baseDownloadAllUrl,
+        request.outputFileName,
         accountRequest,
-        cancelToken,
+        request.cancelToken,
       );
 
       yield Right(ExportAllAttachmentsSuccess(result));
     } catch (e) {
       logWarning('ExportAllAttachmentsInteractor::execute():EXCEPTION: $e');
       yield Left(ExportAllAttachmentsFailure(exception: e));
+    }
+  }
+
+  Future<TokenOIDC> _getTokenOidc(
+    String accountId, {
+    TokenOIDC? fallbackToken,
+  }) async {
+    try {
+      return await _authenticationOIDCRepository.getStoredTokenOIDC(accountId);
+    } catch (e) {
+      if (fallbackToken != null) {
+        logWarning('ExportAllAttachmentsInteractor::_getTokenOidc(): '
+            'storage failed, using in-memory token as fallback | error=${e.runtimeType}');
+        return fallbackToken;
+      }
+      rethrow;
     }
   }
 }

--- a/lib/features/download/domain/usecase/export_all_attachments_interactor.dart
+++ b/lib/features/download/domain/usecase/export_all_attachments_interactor.dart
@@ -70,7 +70,7 @@ class ExportAllAttachmentsInteractor {
         logTrace('ExportAllAttachmentsInteractor::_getTokenOidc(): '
             'storage failed, using in-memory token as fallback | error=${e.runtimeType}');
         _authenticationOIDCRepository.persistTokenOIDC(fallbackToken).catchError(
-          (dynamic repairError) => logError(
+          (Object repairError) => logError(
             'ExportAllAttachmentsInteractor::_getTokenOidc(): '
             'failed to repair token storage | error=${repairError.runtimeType}',
             exception: repairError,

--- a/lib/features/download/domain/usecase/export_attachment_interactor.dart
+++ b/lib/features/download/domain/usecase/export_attachment_interactor.dart
@@ -4,6 +4,7 @@ import 'package:core/core.dart';
 import 'package:dartz/dartz.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:model/model.dart';
+import 'package:tmail_ui_user/features/download/domain/mixin/oidc_token_resolve_mixin.dart';
 import 'package:tmail_ui_user/features/download/domain/model/export_attachment_request.dart';
 import 'package:tmail_ui_user/features/download/domain/repository/download_repository.dart';
 import 'package:tmail_ui_user/features/download/domain/state/export_attachment_state.dart';
@@ -11,11 +12,14 @@ import 'package:tmail_ui_user/features/login/domain/repository/account_repositor
 import 'package:tmail_ui_user/features/login/domain/repository/authentication_oidc_repository.dart';
 import 'package:tmail_ui_user/features/login/domain/repository/credential_repository.dart';
 
-class ExportAttachmentInteractor {
+class ExportAttachmentInteractor with OidcTokenResolveMixin {
   final DownloadRepository _downloadRepository;
   final CredentialRepository _credentialRepository;
   final AccountRepository _accountRepository;
   final AuthenticationOIDCRepository _authenticationOIDCRepository;
+
+  @override
+  AuthenticationOIDCRepository get authOIDCRepository => _authenticationOIDCRepository;
 
   ExportAttachmentInteractor(
     this._downloadRepository,
@@ -31,7 +35,7 @@ class ExportAttachmentInteractor {
       AccountRequest? accountRequest;
 
       if (currentAccount.authenticationType == AuthenticationType.oidc) {
-        final tokenOidc = await _getTokenOidc(currentAccount.id, fallbackToken: request.fallbackToken);
+        final tokenOidc = await resolveOidcToken(currentAccount.id, fallbackToken: request.fallbackToken);
         accountRequest = AccountRequest.withOidc(token: tokenOidc);
       } else {
         final authenticationInfoCache = await _credentialRepository.getAuthenticationInfoStored();
@@ -53,29 +57,6 @@ class ExportAttachmentInteractor {
     } catch (exception) {
       logWarning('ExportAttachmentInteractor::execute(): exception: $exception');
       yield Left<Failure, Success>(ExportAttachmentFailure(exception));
-    }
-  }
-
-  Future<TokenOIDC> _getTokenOidc(
-    String accountCacheKey, {
-    TokenOIDC? fallbackToken,
-  }) async {
-    try {
-      return await _authenticationOIDCRepository.getStoredTokenOIDC(accountCacheKey);
-    } catch (e) {
-      if (fallbackToken != null) {
-        logTrace('ExportAttachmentInteractor::_getTokenOidc(): '
-            'storage failed, using in-memory token as fallback | error=${e.runtimeType}');
-        _authenticationOIDCRepository.persistTokenOIDCAt(accountCacheKey, fallbackToken).catchError(
-          (Object repairError) => logError(
-            'ExportAttachmentInteractor::_getTokenOidc(): '
-            'failed to repair token storage | error=${repairError.runtimeType}',
-            exception: repairError,
-          ),
-        );
-        return fallbackToken;
-      }
-      rethrow;
     }
   }
 }

--- a/lib/features/download/domain/usecase/export_attachment_interactor.dart
+++ b/lib/features/download/domain/usecase/export_attachment_interactor.dart
@@ -67,7 +67,7 @@ class ExportAttachmentInteractor {
         logTrace('ExportAttachmentInteractor::_getTokenOidc(): '
             'storage failed, using in-memory token as fallback | error=${e.runtimeType}');
         _authenticationOIDCRepository.persistTokenOIDC(fallbackToken).catchError(
-          (dynamic repairError) => logError(
+          (Object repairError) => logError(
             'ExportAttachmentInteractor::_getTokenOidc(): '
             'failed to repair token storage | error=${repairError.runtimeType}',
             exception: repairError,

--- a/lib/features/download/domain/usecase/export_attachment_interactor.dart
+++ b/lib/features/download/domain/usecase/export_attachment_interactor.dart
@@ -57,16 +57,16 @@ class ExportAttachmentInteractor {
   }
 
   Future<TokenOIDC> _getTokenOidc(
-    String accountId, {
+    String accountCacheKey, {
     TokenOIDC? fallbackToken,
   }) async {
     try {
-      return await _authenticationOIDCRepository.getStoredTokenOIDC(accountId);
+      return await _authenticationOIDCRepository.getStoredTokenOIDC(accountCacheKey);
     } catch (e) {
       if (fallbackToken != null) {
         logTrace('ExportAttachmentInteractor::_getTokenOidc(): '
             'storage failed, using in-memory token as fallback | error=${e.runtimeType}');
-        _authenticationOIDCRepository.persistTokenOIDC(fallbackToken).catchError(
+        _authenticationOIDCRepository.persistTokenOIDCAt(accountCacheKey, fallbackToken).catchError(
           (Object repairError) => logError(
             'ExportAttachmentInteractor::_getTokenOidc(): '
             'failed to repair token storage | error=${repairError.runtimeType}',

--- a/lib/features/download/domain/usecase/export_attachment_interactor.dart
+++ b/lib/features/download/domain/usecase/export_attachment_interactor.dart
@@ -2,10 +2,9 @@ import 'dart:async';
 
 import 'package:core/core.dart';
 import 'package:dartz/dartz.dart';
-import 'package:dio/dio.dart';
-import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:model/model.dart';
+import 'package:tmail_ui_user/features/download/domain/model/export_attachment_request.dart';
 import 'package:tmail_ui_user/features/download/domain/repository/download_repository.dart';
 import 'package:tmail_ui_user/features/download/domain/state/export_attachment_state.dart';
 import 'package:tmail_ui_user/features/login/domain/repository/account_repository.dart';
@@ -25,19 +24,14 @@ class ExportAttachmentInteractor {
     this._authenticationOIDCRepository,
   );
 
-  Stream<Either<Failure, Success>> execute(
-      Attachment attachment,
-      AccountId accountId,
-      String baseDownloadUrl,
-      CancelToken cancelToken
-  ) async* {
+  Stream<Either<Failure, Success>> execute(ExportAttachmentRequest request) async* {
     try {
       final currentAccount = await _accountRepository.getCurrentAccount();
 
       AccountRequest? accountRequest;
 
       if (currentAccount.authenticationType == AuthenticationType.oidc) {
-        final tokenOidc = await _authenticationOIDCRepository.getStoredTokenOIDC(currentAccount.id);
+        final tokenOidc = await _getTokenOidc(currentAccount.id, fallbackToken: request.fallbackToken);
         accountRequest = AccountRequest.withOidc(token: tokenOidc);
       } else {
         final authenticationInfoCache = await _credentialRepository.getAuthenticationInfoStored();
@@ -48,17 +42,33 @@ class ExportAttachmentInteractor {
       }
 
       final downloadedResponse = await _downloadRepository.exportAttachment(
-        attachment,
-        accountId,
-        baseDownloadUrl,
+        request.attachment,
+        request.accountId,
+        request.baseDownloadUrl,
         accountRequest,
-        cancelToken
+        request.cancelToken,
       );
 
       yield Right<Failure, Success>(ExportAttachmentSuccess(downloadedResponse));
     } catch (exception) {
-      log('ExportAttachmentInteractor::execute(): exception: $exception');
+      logWarning('ExportAttachmentInteractor::execute(): exception: $exception');
       yield Left<Failure, Success>(ExportAttachmentFailure(exception));
+    }
+  }
+
+  Future<TokenOIDC> _getTokenOidc(
+    String accountId, {
+    TokenOIDC? fallbackToken,
+  }) async {
+    try {
+      return await _authenticationOIDCRepository.getStoredTokenOIDC(accountId);
+    } catch (e) {
+      if (fallbackToken != null) {
+        logWarning('ExportAttachmentInteractor::_getTokenOidc(): '
+            'storage failed, using in-memory token as fallback | error=${e.runtimeType}');
+        return fallbackToken;
+      }
+      rethrow;
     }
   }
 }

--- a/lib/features/download/domain/usecase/export_attachment_interactor.dart
+++ b/lib/features/download/domain/usecase/export_attachment_interactor.dart
@@ -64,8 +64,15 @@ class ExportAttachmentInteractor {
       return await _authenticationOIDCRepository.getStoredTokenOIDC(accountId);
     } catch (e) {
       if (fallbackToken != null) {
-        logWarning('ExportAttachmentInteractor::_getTokenOidc(): '
+        logTrace('ExportAttachmentInteractor::_getTokenOidc(): '
             'storage failed, using in-memory token as fallback | error=${e.runtimeType}');
+        _authenticationOIDCRepository.persistTokenOIDC(fallbackToken).catchError(
+          (dynamic repairError) => logError(
+            'ExportAttachmentInteractor::_getTokenOidc(): '
+            'failed to repair token storage | error=${repairError.runtimeType}',
+            exception: repairError,
+          ),
+        );
         return fallbackToken;
       }
       rethrow;

--- a/lib/features/download/presentation/controllers/download_controller.dart
+++ b/lib/features/download/presentation/controllers/download_controller.dart
@@ -276,9 +276,9 @@ class DownloadController extends BaseController {
         failure is DownloadAndGetHtmlContentFromAttachmentFailure) {
       handlePreviewHtmlFileFailure(failureState: failure);
     } else if (failure is ExportAttachmentFailure) {
-      exportAttachmentFailureAction(failure);
+      exportAttachmentFailureAction(failure.exception);
     } else if (failure is ExportAllAttachmentsFailure) {
-      exportAllAttachmentsFailureAction(failure);
+      exportAllAttachmentsFailureAction(failure.exception);
     } else {
       super.handleFailureViewState(failure);
     }

--- a/lib/features/download/presentation/extensions/download_attachment_download_controller_extension.dart
+++ b/lib/features/download/presentation/extensions/download_attachment_download_controller_extension.dart
@@ -29,6 +29,8 @@ import 'package:open_file/open_file.dart' as open_file;
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:tmail_ui_user/features/download/domain/exceptions/download_attachment_exceptions.dart';
 import 'package:tmail_ui_user/features/download/domain/model/download_source_view.dart';
+import 'package:tmail_ui_user/features/download/domain/model/export_all_attachments_request.dart';
+import 'package:tmail_ui_user/features/download/domain/model/export_attachment_request.dart';
 import 'package:tmail_ui_user/features/download/domain/state/download_all_attachments_for_web_state.dart';
 import 'package:tmail_ui_user/features/download/domain/state/download_attachment_for_web_state.dart';
 import 'package:tmail_ui_user/features/download/domain/state/export_all_attachments_state.dart';
@@ -141,10 +143,13 @@ extension DownloadAttachmentDownloadControllerExtension on DownloadController {
 
     consumeState(
       exportAttachmentInteractor.execute(
-        attachment,
-        accountId,
-        baseDownloadUrl,
-        cancelToken,
+        ExportAttachmentRequest(
+          attachment: attachment,
+          accountId: accountId,
+          baseDownloadUrl: baseDownloadUrl,
+          cancelToken: cancelToken,
+          fallbackToken: authorizationInterceptors.currentToken,
+        ),
       ),
     );
   }
@@ -438,11 +443,14 @@ extension DownloadAttachmentDownloadControllerExtension on DownloadController {
 
     consumeState(
       exportAllAttachmentsInteractor.execute(
-        accountId,
-        emailId,
-        baseDownloadAllUrl,
-        outputFileName,
-        cancelToken,
+        ExportAllAttachmentsRequest(
+          accountId: accountId,
+          emailId: emailId,
+          baseDownloadAllUrl: baseDownloadAllUrl,
+          outputFileName: outputFileName,
+          cancelToken: cancelToken,
+          fallbackToken: authorizationInterceptors.currentToken,
+        ),
       ),
     );
   }

--- a/lib/features/login/data/datasource/authentication_oidc_datasource.dart
+++ b/lib/features/login/data/datasource/authentication_oidc_datasource.dart
@@ -18,6 +18,8 @@ abstract class AuthenticationOIDCDataSource {
 
   Future<void> persistTokenOIDC(TokenOIDC tokenOidc);
 
+  Future<void> persistTokenOIDCAt(String key, TokenOIDC tokenOidc);
+
   Future<void> deleteTokenOIDC();
 
   Future<TokenOIDC> getStoredTokenOIDC(String tokenIdHash);

--- a/lib/features/login/data/datasource_impl/authentication_oidc_datasource_impl.dart
+++ b/lib/features/login/data/datasource_impl/authentication_oidc_datasource_impl.dart
@@ -90,6 +90,13 @@ class AuthenticationOIDCDataSourceImpl extends AuthenticationOIDCDataSource {
   }
 
   @override
+  Future<void> persistTokenOIDCAt(String key, TokenOIDC tokenOidc) {
+    return Future.sync(() async {
+      return await _tokenOidcCacheManager.persistOneTokenOidcAt(key, tokenOidc);
+    }).catchError(_cacheExceptionThrower.throwException);
+  }
+
+  @override
   Future<OIDCConfiguration> getStoredOidcConfiguration() {
     return Future.sync(() async {
       return await _oidcConfigurationCacheManager.getOidcConfiguration();

--- a/lib/features/login/data/local/token_oidc_cache_manager.dart
+++ b/lib/features/login/data/local/token_oidc_cache_manager.dart
@@ -90,7 +90,12 @@ class TokenOidcCacheManager extends CacheManagerInteraction {
     try {
       await _tokenOidcCacheClient.clearAllData();
     } catch (e) {
-      logWarning('TokenOidcCacheManager::_safelyClearBox(): failed to clear box | $e');
+      logWarning('TokenOidcCacheManager::_safelyClearBox(): clear failed, deleting box from disk | $e');
+      try {
+        await _tokenOidcCacheClient.deleteBox();
+      } catch (e2) {
+        logWarning('TokenOidcCacheManager::_safelyClearBox(): deleteBox also failed | $e2');
+      }
     }
   }
 

--- a/lib/features/login/data/local/token_oidc_cache_manager.dart
+++ b/lib/features/login/data/local/token_oidc_cache_manager.dart
@@ -68,7 +68,16 @@ class TokenOidcCacheManager extends CacheManagerInteraction {
         stackTrace: stackTrace,
       );
       await _safelyClearBox();
-      await _tokenOidcCacheClient.insertItem(key, tokenOIDC.toTokenOidcCache());
+      try {
+        await _tokenOidcCacheClient.insertItem(key, tokenOIDC.toTokenOidcCache());
+      } catch (insertError, insertStackTrace) {
+        logError(
+          'TokenOidcCacheManager::_persistAtKey(): '
+          're-insert after clear also failed | error_type=${insertError.runtimeType}',
+          exception: insertError,
+          stackTrace: insertStackTrace,
+        );
+      }
     }
   }
 

--- a/lib/features/login/data/local/token_oidc_cache_manager.dart
+++ b/lib/features/login/data/local/token_oidc_cache_manager.dart
@@ -1,3 +1,4 @@
+import 'package:core/domain/exceptions/app_base_exception.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:model/oidc/token_oidc.dart';
 import 'package:tmail_ui_user/features/caching/clients/token_oidc_cache_client.dart';
@@ -13,22 +14,62 @@ class TokenOidcCacheManager extends CacheManagerInteraction {
 
   Future<TokenOIDC> getTokenOidc(String tokenIdHash) async {
     log('TokenOidcCacheManager::getTokenOidc(): tokenIdHash: $tokenIdHash');
-    final tokenCache = await _tokenOidcCacheClient.getItem(tokenIdHash);
-    log('TokenOidcCacheManager::getTokenOidc(): tokenCache: $tokenCache');
-    if (tokenCache == null) {
-      throw NotFoundStoredTokenException();
-    } else {
+    try {
+      final tokenCache = await _tokenOidcCacheClient.getItem(tokenIdHash);
+      log('TokenOidcCacheManager::getTokenOidc(): tokenCache: $tokenCache');
+      if (tokenCache == null) {
+        throw NotFoundStoredTokenException();
+      }
       return tokenCache.toTokenOidc();
+    } on AppBaseException {
+      rethrow;
+    } catch (e, stackTrace) {
+      // AES-CBC decryption failed (e.g. non-block-aligned bytes from a partial
+      // write or cross-isolate race). Clear the corrupted box so the next read
+      // starts clean and triggers normal re-authentication instead of looping.
+      logError(
+        'TokenOidcCacheManager::getTokenOidc(): '
+        'token_box_corrupted=true | error_type=${e.runtimeType} | clearing box',
+        exception: e,
+        stackTrace: stackTrace,
+      );
+      await _safelyClearBox();
+      throw NotFoundStoredTokenException();
     }
   }
 
   Future<void> persistOneTokenOidc(TokenOIDC tokenOIDC) async {
-    // Crash-safe persist: write the new token FIRST, then prune stale entries, so
-    // the box is never empty if the process is killed mid-write → forced re-login.
     log('TokenOidcCacheManager::persistOneTokenOidc(): keyHash: ${tokenOIDC.tokenIdHash}');
-    await _tokenOidcCacheClient.insertItem(tokenOIDC.tokenIdHash, tokenOIDC.toTokenOidcCache());
-    await _removeStaleTokens(keepKey: tokenOIDC.tokenIdHash);
-    log('TokenOidcCacheManager::persistOneTokenOidc(): done');
+    try {
+      // Crash-safe persist: write the new token FIRST, then prune stale entries,
+      // so the box is never empty if the process is killed mid-write.
+      await _tokenOidcCacheClient.insertItem(tokenOIDC.tokenIdHash, tokenOIDC.toTokenOidcCache());
+      await _removeStaleTokens(keepKey: tokenOIDC.tokenIdHash);
+      log('TokenOidcCacheManager::persistOneTokenOidc(): done');
+    } on AppBaseException {
+      rethrow;
+    } catch (e, stackTrace) {
+      // _removeStaleTokens calls getMapItems() → toMap(), which iterates ALL entries
+      // and decrypts each one. If the box contains a corrupted entry (e.g. from a
+      // cross-isolate partial write), toMap() throws before prune completes.
+      // Recover by clearing and re-inserting only the new valid token.
+      logError(
+        'TokenOidcCacheManager::persistOneTokenOidc(): '
+        'box_corrupted=true | error_type=${e.runtimeType} | clearing and re-inserting token',
+        exception: e,
+        stackTrace: stackTrace,
+      );
+      await _recoverBoxWithToken(tokenOIDC);
+    }
+  }
+
+  Future<void> _recoverBoxWithToken(TokenOIDC tokenOIDC) async {
+    await _safelyClearBox();
+    try {
+      await _tokenOidcCacheClient.insertItem(tokenOIDC.tokenIdHash, tokenOIDC.toTokenOidcCache());
+    } catch (e) {
+      logWarning('TokenOidcCacheManager::_recoverBoxWithToken(): re-insert failed | $e');
+    }
   }
 
   /// Removes every token except [keepKey] so the box keeps exactly one entry
@@ -43,6 +84,14 @@ class TokenOidcCacheManager extends CacheManagerInteraction {
 
   Future<void> clear() async {
     await _tokenOidcCacheClient.clearAllData();
+  }
+
+  Future<void> _safelyClearBox() async {
+    try {
+      await _tokenOidcCacheClient.clearAllData();
+    } catch (e) {
+      logWarning('TokenOidcCacheManager::_safelyClearBox(): failed to clear box | $e');
+    }
   }
 
   @override

--- a/lib/features/login/data/local/token_oidc_cache_manager.dart
+++ b/lib/features/login/data/local/token_oidc_cache_manager.dart
@@ -39,13 +39,21 @@ class TokenOidcCacheManager extends CacheManagerInteraction {
   }
 
   Future<void> persistOneTokenOidc(TokenOIDC tokenOIDC) async {
-    log('TokenOidcCacheManager::persistOneTokenOidc(): keyHash: ${tokenOIDC.tokenIdHash}');
+    await _persistAtKey(tokenOIDC.tokenIdHash, tokenOIDC);
+  }
+
+  Future<void> persistOneTokenOidcAt(String key, TokenOIDC tokenOIDC) async {
+    await _persistAtKey(key, tokenOIDC);
+  }
+
+  Future<void> _persistAtKey(String key, TokenOIDC tokenOIDC) async {
+    log('TokenOidcCacheManager::_persistAtKey(): keyHash: $key');
     // Crash-safe persist: write the new token FIRST, then prune stale entries,
     // so the box is never empty if the process is killed mid-write.
-    await _tokenOidcCacheClient.insertItem(tokenOIDC.tokenIdHash, tokenOIDC.toTokenOidcCache());
+    await _tokenOidcCacheClient.insertItem(key, tokenOIDC.toTokenOidcCache());
     try {
-      await _removeStaleTokens(keepKey: tokenOIDC.tokenIdHash);
-      log('TokenOidcCacheManager::persistOneTokenOidc(): done');
+      await _removeStaleTokens(keepKey: key);
+      log('TokenOidcCacheManager::_persistAtKey(): done');
     } on AppBaseException {
       rethrow;
     } catch (e, stackTrace) {
@@ -54,21 +62,17 @@ class TokenOidcCacheManager extends CacheManagerInteraction {
       // cross-isolate partial write), toMap() throws before prune completes.
       // Recover by clearing and re-inserting only the new valid token.
       logError(
-        'TokenOidcCacheManager::persistOneTokenOidc(): '
+        'TokenOidcCacheManager::_persistAtKey(): '
         'box_corrupted=true | error_type=${e.runtimeType} | clearing and re-inserting token',
         exception: e,
         stackTrace: stackTrace,
       );
-      await _recoverBoxWithToken(tokenOIDC);
+      await _safelyClearBox();
+      await _tokenOidcCacheClient.insertItem(key, tokenOIDC.toTokenOidcCache());
     }
   }
 
-  Future<void> _recoverBoxWithToken(TokenOIDC tokenOIDC) async {
-    await _safelyClearBox();
-    await _tokenOidcCacheClient.insertItem(tokenOIDC.tokenIdHash, tokenOIDC.toTokenOidcCache());
-  }
-
-  /// Removes every token except [keepKey] so the box keeps exactly one entry
+/// Removes every token except [keepKey] so the box keeps exactly one entry
   Future<void> _removeStaleTokens({required String keepKey}) async {
     final allItems = await _tokenOidcCacheClient.getMapItems();
     final staleKeys = allItems.keys.where((key) => key != keepKey).toList();

--- a/lib/features/login/data/local/token_oidc_cache_manager.dart
+++ b/lib/features/login/data/local/token_oidc_cache_manager.dart
@@ -40,10 +40,10 @@ class TokenOidcCacheManager extends CacheManagerInteraction {
 
   Future<void> persistOneTokenOidc(TokenOIDC tokenOIDC) async {
     log('TokenOidcCacheManager::persistOneTokenOidc(): keyHash: ${tokenOIDC.tokenIdHash}');
+    // Crash-safe persist: write the new token FIRST, then prune stale entries,
+    // so the box is never empty if the process is killed mid-write.
+    await _tokenOidcCacheClient.insertItem(tokenOIDC.tokenIdHash, tokenOIDC.toTokenOidcCache());
     try {
-      // Crash-safe persist: write the new token FIRST, then prune stale entries,
-      // so the box is never empty if the process is killed mid-write.
-      await _tokenOidcCacheClient.insertItem(tokenOIDC.tokenIdHash, tokenOIDC.toTokenOidcCache());
       await _removeStaleTokens(keepKey: tokenOIDC.tokenIdHash);
       log('TokenOidcCacheManager::persistOneTokenOidc(): done');
     } on AppBaseException {
@@ -65,11 +65,7 @@ class TokenOidcCacheManager extends CacheManagerInteraction {
 
   Future<void> _recoverBoxWithToken(TokenOIDC tokenOIDC) async {
     await _safelyClearBox();
-    try {
-      await _tokenOidcCacheClient.insertItem(tokenOIDC.tokenIdHash, tokenOIDC.toTokenOidcCache());
-    } catch (e) {
-      logWarning('TokenOidcCacheManager::_recoverBoxWithToken(): re-insert failed | $e');
-    }
+    await _tokenOidcCacheClient.insertItem(tokenOIDC.tokenIdHash, tokenOIDC.toTokenOidcCache());
   }
 
   /// Removes every token except [keepKey] so the box keeps exactly one entry

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -72,7 +72,8 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
 
   AuthenticationType get authenticationType => _authenticationType;
 
-  TokenOIDC? get currentToken => _token;
+  TokenOIDC? get currentToken =>
+      _authenticationType == AuthenticationType.oidc ? _token : null;
 
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -72,6 +72,8 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
 
   AuthenticationType get authenticationType => _authenticationType;
 
+  TokenOIDC? get currentToken => _token;
+
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
     switch(_authenticationType) {

--- a/lib/features/login/data/repository/authentication_oidc_repository_impl.dart
+++ b/lib/features/login/data/repository/authentication_oidc_repository_impl.dart
@@ -56,6 +56,11 @@ class AuthenticationOIDCRepositoryImpl extends AuthenticationOIDCRepository {
   }
 
   @override
+  Future<void> persistTokenOIDCAt(String key, TokenOIDC tokenOidc) {
+    return _oidcDataSource.persistTokenOIDCAt(key, tokenOidc);
+  }
+
+  @override
   Future<OIDCConfiguration> getStoredOidcConfiguration() {
     return _oidcDataSource.getStoredOidcConfiguration();
   }

--- a/lib/features/login/domain/repository/authentication_oidc_repository.dart
+++ b/lib/features/login/domain/repository/authentication_oidc_repository.dart
@@ -18,6 +18,8 @@ abstract class AuthenticationOIDCRepository {
 
   Future<void> persistTokenOIDC(TokenOIDC tokenOidc);
 
+  Future<void> persistTokenOIDCAt(String key, TokenOIDC tokenOidc);
+
   Future<void> deleteTokenOIDC();
 
   Future<TokenOIDC> getStoredTokenOIDC(String tokenIdHash);

--- a/test/features/download/domain/usecase/export_all_attachments_interactor_test.dart
+++ b/test/features/download/domain/usecase/export_all_attachments_interactor_test.dart
@@ -105,13 +105,34 @@ void main() {
       );
 
       test(
-        'should use fallback token and yield loading then success '
+        'should use fallback token, repair token storage, and yield loading then success '
         'when token storage fails and fallbackToken is provided',
-        () {
+        () async {
           when(authenticationOIDCRepository.getStoredTokenOIDC(any))
               .thenThrow(Exception('storage error'));
 
-          expect(
+          await expectLater(
+            interactor.execute(buildRequest(withFallback: true)),
+            emitsInOrder([
+              Right(ExportingAllAttachments()),
+              Right(ExportAllAttachmentsSuccess(downloadedResponse)),
+            ]),
+          );
+
+          verify(authenticationOIDCRepository.persistTokenOIDC(OIDCFixtures.newTokenOidc)).called(1);
+        },
+      );
+
+      test(
+        'should still yield loading then success '
+        'when token storage repair fails',
+        () async {
+          when(authenticationOIDCRepository.getStoredTokenOIDC(any))
+              .thenThrow(Exception('storage error'));
+          when(authenticationOIDCRepository.persistTokenOIDC(any))
+              .thenAnswer((_) => Future.error(Exception('persist error')));
+
+          await expectLater(
             interactor.execute(buildRequest(withFallback: true)),
             emitsInOrder([
               Right(ExportingAllAttachments()),

--- a/test/features/download/domain/usecase/export_all_attachments_interactor_test.dart
+++ b/test/features/download/domain/usecase/export_all_attachments_interactor_test.dart
@@ -129,7 +129,7 @@ void main() {
             ]),
           );
 
-          verify(authenticationOIDCRepository.persistTokenOIDC(OIDCFixtures.newTokenOidc)).called(1);
+          verify(authenticationOIDCRepository.persistTokenOIDCAt('oidc-account-id', OIDCFixtures.newTokenOidc)).called(1);
 
           final captured = verify(
             downloadRepository.exportAllAttachments(any, any, any, any, captureAny, any),
@@ -146,7 +146,7 @@ void main() {
         () async {
           when(authenticationOIDCRepository.getStoredTokenOIDC(any))
               .thenThrow(Exception('storage error'));
-          when(authenticationOIDCRepository.persistTokenOIDC(any))
+          when(authenticationOIDCRepository.persistTokenOIDCAt(any, any))
               .thenAnswer((_) => Future.error(Exception('persist error')));
 
           await expectLater(

--- a/test/features/download/domain/usecase/export_all_attachments_interactor_test.dart
+++ b/test/features/download/domain/usecase/export_all_attachments_interactor_test.dart
@@ -5,10 +5,13 @@ import 'package:dartz/dartz.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:model/account/account_request.dart';
 import 'package:model/account/authentication_type.dart';
+import 'package:model/account/password.dart';
 import 'package:model/account/personal_account.dart';
 import 'package:tmail_ui_user/features/download/domain/model/export_all_attachments_request.dart';
 import 'package:tmail_ui_user/features/download/domain/repository/download_repository.dart';
@@ -90,17 +93,24 @@ void main() {
       test(
         'should use token from storage and yield loading then success '
         'when token storage succeeds',
-        () {
+        () async {
           when(authenticationOIDCRepository.getStoredTokenOIDC(any))
               .thenAnswer((_) async => OIDCFixtures.newTokenOidc);
 
-          expect(
+          await expectLater(
             interactor.execute(buildRequest()),
             emitsInOrder([
               Right(ExportingAllAttachments()),
               Right(ExportAllAttachmentsSuccess(downloadedResponse)),
             ]),
           );
+
+          final captured = verify(
+            downloadRepository.exportAllAttachments(any, any, any, any, captureAny, any),
+          ).captured;
+          final accountRequest = captured.single as AccountRequest;
+          expect(accountRequest.authenticationType, AuthenticationType.oidc);
+          expect(accountRequest.token, OIDCFixtures.newTokenOidc);
         },
       );
 
@@ -120,6 +130,13 @@ void main() {
           );
 
           verify(authenticationOIDCRepository.persistTokenOIDC(OIDCFixtures.newTokenOidc)).called(1);
+
+          final captured = verify(
+            downloadRepository.exportAllAttachments(any, any, any, any, captureAny, any),
+          ).captured;
+          final accountRequest = captured.single as AccountRequest;
+          expect(accountRequest.authenticationType, AuthenticationType.oidc);
+          expect(accountRequest.token, OIDCFixtures.newTokenOidc);
         },
       );
 
@@ -173,14 +190,22 @@ void main() {
 
       test(
         'should use credentials from storage and yield loading then success',
-        () {
-          expect(
+        () async {
+          await expectLater(
             interactor.execute(buildRequest()),
             emitsInOrder([
               Right(ExportingAllAttachments()),
               Right(ExportAllAttachmentsSuccess(downloadedResponse)),
             ]),
           );
+
+          final captured = verify(
+            downloadRepository.exportAllAttachments(any, any, any, any, captureAny, any),
+          ).captured;
+          final accountRequest = captured.single as AccountRequest;
+          expect(accountRequest.authenticationType, AuthenticationType.basic);
+          expect(accountRequest.userName, UserName('user@example.com'));
+          expect(accountRequest.password, Password('secret'));
         },
       );
     });

--- a/test/features/download/domain/usecase/export_all_attachments_interactor_test.dart
+++ b/test/features/download/domain/usecase/export_all_attachments_interactor_test.dart
@@ -96,7 +96,7 @@ void main() {
 
           expect(
             interactor.execute(buildRequest()),
-            emitsInOrder(<Either<Failure, Success>>[
+            emitsInOrder([
               Right(ExportingAllAttachments()),
               Right(ExportAllAttachmentsSuccess(downloadedResponse)),
             ]),
@@ -113,7 +113,7 @@ void main() {
 
           expect(
             interactor.execute(buildRequest(withFallback: true)),
-            emitsInOrder(<Either<Failure, Success>>[
+            emitsInOrder([
               Right(ExportingAllAttachments()),
               Right(ExportAllAttachmentsSuccess(downloadedResponse)),
             ]),
@@ -130,7 +130,7 @@ void main() {
 
           expect(
             interactor.execute(buildRequest()),
-            emitsInOrder(<Either<Failure, Success>>[
+            emitsInOrder([
               Right(ExportingAllAttachments()),
               isA<Left<Failure, Success>>()
                   .having((l) => l.value, 'failure', isA<ExportAllAttachmentsFailure>()),
@@ -155,7 +155,7 @@ void main() {
         () {
           expect(
             interactor.execute(buildRequest()),
-            emitsInOrder(<Either<Failure, Success>>[
+            emitsInOrder([
               Right(ExportingAllAttachments()),
               Right(ExportAllAttachmentsSuccess(downloadedResponse)),
             ]),
@@ -177,7 +177,7 @@ void main() {
 
         expect(
           interactor.execute(buildRequest()),
-          emitsInOrder(<Either<Failure, Success>>[
+          emitsInOrder([
             Right(ExportingAllAttachments()),
             isA<Left<Failure, Success>>()
                 .having((l) => l.value, 'failure', isA<ExportAllAttachmentsFailure>()),

--- a/test/features/download/domain/usecase/export_all_attachments_interactor_test.dart
+++ b/test/features/download/domain/usecase/export_all_attachments_interactor_test.dart
@@ -1,0 +1,189 @@
+import 'package:core/data/network/download/downloaded_response.dart';
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/account/authentication_type.dart';
+import 'package:model/account/personal_account.dart';
+import 'package:tmail_ui_user/features/download/domain/model/export_all_attachments_request.dart';
+import 'package:tmail_ui_user/features/download/domain/repository/download_repository.dart';
+import 'package:tmail_ui_user/features/download/domain/state/export_all_attachments_state.dart';
+import 'package:tmail_ui_user/features/download/domain/usecase/export_all_attachments_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/repository/account_repository.dart';
+import 'package:tmail_ui_user/features/login/domain/repository/authentication_oidc_repository.dart';
+import 'package:tmail_ui_user/features/login/domain/repository/credential_repository.dart';
+import 'package:tmail_ui_user/features/login/data/model/authentication_info_cache.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import '../../../../fixtures/oidc_fixtures.dart';
+
+import 'export_all_attachments_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<DownloadRepository>(),
+  MockSpec<AccountRepository>(),
+  MockSpec<AuthenticationOIDCRepository>(),
+  MockSpec<CredentialRepository>(),
+])
+void main() {
+  late MockDownloadRepository downloadRepository;
+  late MockAccountRepository accountRepository;
+  late MockAuthenticationOIDCRepository authenticationOIDCRepository;
+  late MockCredentialRepository credentialRepository;
+  late ExportAllAttachmentsInteractor interactor;
+
+  final oidcAccount = PersonalAccount(
+    'oidc-account-id',
+    AuthenticationType.oidc,
+    isSelected: true,
+    accountId: AccountFixtures.aliceAccountId,
+  );
+
+  final basicAccount = PersonalAccount(
+    'basic-account-id',
+    AuthenticationType.basic,
+    isSelected: true,
+    accountId: AccountFixtures.aliceAccountId,
+  );
+
+  final emailId = EmailId(Id('email-1'));
+  final cancelToken = CancelToken();
+  final downloadedResponse = DownloadedResponse('/tmp/attachments.zip');
+
+  ExportAllAttachmentsRequest buildRequest({bool withFallback = false}) =>
+      ExportAllAttachmentsRequest(
+        accountId: AccountFixtures.aliceAccountId,
+        emailId: emailId,
+        baseDownloadAllUrl: 'https://example.com/download-all',
+        outputFileName: 'attachments.zip',
+        cancelToken: cancelToken,
+        fallbackToken: withFallback ? OIDCFixtures.newTokenOidc : null,
+      );
+
+  setUp(() {
+    downloadRepository = MockDownloadRepository();
+    accountRepository = MockAccountRepository();
+    authenticationOIDCRepository = MockAuthenticationOIDCRepository();
+    credentialRepository = MockCredentialRepository();
+    interactor = ExportAllAttachmentsInteractor(
+      downloadRepository,
+      accountRepository,
+      authenticationOIDCRepository,
+      credentialRepository,
+    );
+  });
+
+  group('ExportAllAttachmentsInteractor:', () {
+    group('OIDC auth -', () {
+      setUp(() {
+        when(accountRepository.getCurrentAccount())
+            .thenAnswer((_) async => oidcAccount);
+        when(downloadRepository.exportAllAttachments(any, any, any, any, any, any))
+            .thenAnswer((_) async => downloadedResponse);
+      });
+
+      test(
+        'should use token from storage and yield loading then success '
+        'when token storage succeeds',
+        () {
+          when(authenticationOIDCRepository.getStoredTokenOIDC(any))
+              .thenAnswer((_) async => OIDCFixtures.newTokenOidc);
+
+          expect(
+            interactor.execute(buildRequest()),
+            emitsInOrder(<Either<Failure, Success>>[
+              Right(ExportingAllAttachments()),
+              Right(ExportAllAttachmentsSuccess(downloadedResponse)),
+            ]),
+          );
+        },
+      );
+
+      test(
+        'should use fallback token and yield loading then success '
+        'when token storage fails and fallbackToken is provided',
+        () {
+          when(authenticationOIDCRepository.getStoredTokenOIDC(any))
+              .thenThrow(Exception('storage error'));
+
+          expect(
+            interactor.execute(buildRequest(withFallback: true)),
+            emitsInOrder(<Either<Failure, Success>>[
+              Right(ExportingAllAttachments()),
+              Right(ExportAllAttachmentsSuccess(downloadedResponse)),
+            ]),
+          );
+        },
+      );
+
+      test(
+        'should yield loading then failure '
+        'when token storage fails and no fallbackToken is provided',
+        () {
+          when(authenticationOIDCRepository.getStoredTokenOIDC(any))
+              .thenThrow(Exception('storage error'));
+
+          expect(
+            interactor.execute(buildRequest()),
+            emitsInOrder(<Either<Failure, Success>>[
+              Right(ExportingAllAttachments()),
+              isA<Left<Failure, Success>>()
+                  .having((l) => l.value, 'failure', isA<ExportAllAttachmentsFailure>()),
+            ]),
+          );
+        },
+      );
+    });
+
+    group('Basic auth -', () {
+      setUp(() {
+        when(accountRepository.getCurrentAccount())
+            .thenAnswer((_) async => basicAccount);
+        when(credentialRepository.getAuthenticationInfoStored())
+            .thenAnswer((_) async => AuthenticationInfoCache('user@example.com', 'secret'));
+        when(downloadRepository.exportAllAttachments(any, any, any, any, any, any))
+            .thenAnswer((_) async => downloadedResponse);
+      });
+
+      test(
+        'should use credentials from storage and yield loading then success',
+        () {
+          expect(
+            interactor.execute(buildRequest()),
+            emitsInOrder(<Either<Failure, Success>>[
+              Right(ExportingAllAttachments()),
+              Right(ExportAllAttachmentsSuccess(downloadedResponse)),
+            ]),
+          );
+        },
+      );
+    });
+
+    test(
+      'should yield loading then failure '
+      'when download repository throws',
+      () {
+        when(accountRepository.getCurrentAccount())
+            .thenAnswer((_) async => oidcAccount);
+        when(authenticationOIDCRepository.getStoredTokenOIDC(any))
+            .thenAnswer((_) async => OIDCFixtures.newTokenOidc);
+        when(downloadRepository.exportAllAttachments(any, any, any, any, any, any))
+            .thenThrow(Exception('network error'));
+
+        expect(
+          interactor.execute(buildRequest()),
+          emitsInOrder(<Either<Failure, Success>>[
+            Right(ExportingAllAttachments()),
+            isA<Left<Failure, Success>>()
+                .having((l) => l.value, 'failure', isA<ExportAllAttachmentsFailure>()),
+          ]),
+        );
+      },
+    );
+  });
+}

--- a/test/features/download/domain/usecase/export_attachment_interactor_test.dart
+++ b/test/features/download/domain/usecase/export_attachment_interactor_test.dart
@@ -126,7 +126,7 @@ void main() {
             ]),
           );
 
-          verify(authenticationOIDCRepository.persistTokenOIDC(OIDCFixtures.newTokenOidc)).called(1);
+          verify(authenticationOIDCRepository.persistTokenOIDCAt('oidc-account-id', OIDCFixtures.newTokenOidc)).called(1);
 
           final captured = verify(
             downloadRepository.exportAttachment(any, any, any, captureAny, any),
@@ -143,7 +143,7 @@ void main() {
         () async {
           when(authenticationOIDCRepository.getStoredTokenOIDC(any))
               .thenThrow(Exception('storage error'));
-          when(authenticationOIDCRepository.persistTokenOIDC(any))
+          when(authenticationOIDCRepository.persistTokenOIDCAt(any, any))
               .thenAnswer((_) => Future.error(Exception('persist error')));
 
           await expectLater(

--- a/test/features/download/domain/usecase/export_attachment_interactor_test.dart
+++ b/test/features/download/domain/usecase/export_attachment_interactor_test.dart
@@ -95,7 +95,7 @@ void main() {
 
           expect(
             interactor.execute(buildRequest()),
-            emitsInOrder(<Either<Failure, Success>>[
+            emitsInOrder([
               Right(ExportAttachmentSuccess(downloadedResponse)),
             ]),
           );
@@ -111,7 +111,7 @@ void main() {
 
           expect(
             interactor.execute(buildRequest(withFallback: true)),
-            emitsInOrder(<Either<Failure, Success>>[
+            emitsInOrder([
               Right(ExportAttachmentSuccess(downloadedResponse)),
             ]),
           );
@@ -127,7 +127,7 @@ void main() {
 
           expect(
             interactor.execute(buildRequest()),
-            emitsInOrder(<Either<Failure, Success>>[
+            emitsInOrder([
               isA<Left<Failure, Success>>()
                   .having((l) => l.value, 'failure', isA<ExportAttachmentFailure>()),
             ]),
@@ -151,7 +151,7 @@ void main() {
         () {
           expect(
             interactor.execute(buildRequest()),
-            emitsInOrder(<Either<Failure, Success>>[
+            emitsInOrder([
               Right(ExportAttachmentSuccess(downloadedResponse)),
             ]),
           );
@@ -172,7 +172,7 @@ void main() {
 
         expect(
           interactor.execute(buildRequest()),
-          emitsInOrder(<Either<Failure, Success>>[
+          emitsInOrder([
             isA<Left<Failure, Success>>()
                 .having((l) => l.value, 'failure', isA<ExportAttachmentFailure>()),
           ]),

--- a/test/features/download/domain/usecase/export_attachment_interactor_test.dart
+++ b/test/features/download/domain/usecase/export_attachment_interactor_test.dart
@@ -5,9 +5,12 @@ import 'package:dartz/dartz.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:model/account/account_request.dart';
 import 'package:model/account/authentication_type.dart';
+import 'package:model/account/password.dart';
 import 'package:model/account/personal_account.dart';
 import 'package:model/email/attachment.dart';
 import 'package:tmail_ui_user/features/download/domain/model/export_attachment_request.dart';
@@ -89,16 +92,23 @@ void main() {
       test(
         'should use token from storage and yield success '
         'when token storage succeeds',
-        () {
+        () async {
           when(authenticationOIDCRepository.getStoredTokenOIDC(any))
               .thenAnswer((_) async => OIDCFixtures.newTokenOidc);
 
-          expect(
+          await expectLater(
             interactor.execute(buildRequest()),
             emitsInOrder([
               Right(ExportAttachmentSuccess(downloadedResponse)),
             ]),
           );
+
+          final captured = verify(
+            downloadRepository.exportAttachment(any, any, any, captureAny, any),
+          ).captured;
+          final accountRequest = captured.single as AccountRequest;
+          expect(accountRequest.authenticationType, AuthenticationType.oidc);
+          expect(accountRequest.token, OIDCFixtures.newTokenOidc);
         },
       );
 
@@ -117,6 +127,13 @@ void main() {
           );
 
           verify(authenticationOIDCRepository.persistTokenOIDC(OIDCFixtures.newTokenOidc)).called(1);
+
+          final captured = verify(
+            downloadRepository.exportAttachment(any, any, any, captureAny, any),
+          ).captured;
+          final accountRequest = captured.single as AccountRequest;
+          expect(accountRequest.authenticationType, AuthenticationType.oidc);
+          expect(accountRequest.token, OIDCFixtures.newTokenOidc);
         },
       );
 
@@ -168,13 +185,21 @@ void main() {
 
       test(
         'should use credentials from storage and yield success',
-        () {
-          expect(
+        () async {
+          await expectLater(
             interactor.execute(buildRequest()),
             emitsInOrder([
               Right(ExportAttachmentSuccess(downloadedResponse)),
             ]),
           );
+
+          final captured = verify(
+            downloadRepository.exportAttachment(any, any, any, captureAny, any),
+          ).captured;
+          final accountRequest = captured.single as AccountRequest;
+          expect(accountRequest.authenticationType, AuthenticationType.basic);
+          expect(accountRequest.userName, UserName('user@example.com'));
+          expect(accountRequest.password, Password('secret'));
         },
       );
     });

--- a/test/features/download/domain/usecase/export_attachment_interactor_test.dart
+++ b/test/features/download/domain/usecase/export_attachment_interactor_test.dart
@@ -103,13 +103,33 @@ void main() {
       );
 
       test(
-        'should use fallback token and yield success '
+        'should use fallback token, repair token storage, and yield success '
         'when token storage fails and fallbackToken is provided',
-        () {
+        () async {
           when(authenticationOIDCRepository.getStoredTokenOIDC(any))
               .thenThrow(Exception('storage error'));
 
-          expect(
+          await expectLater(
+            interactor.execute(buildRequest(withFallback: true)),
+            emitsInOrder([
+              Right(ExportAttachmentSuccess(downloadedResponse)),
+            ]),
+          );
+
+          verify(authenticationOIDCRepository.persistTokenOIDC(OIDCFixtures.newTokenOidc)).called(1);
+        },
+      );
+
+      test(
+        'should still yield success '
+        'when token storage repair fails',
+        () async {
+          when(authenticationOIDCRepository.getStoredTokenOIDC(any))
+              .thenThrow(Exception('storage error'));
+          when(authenticationOIDCRepository.persistTokenOIDC(any))
+              .thenAnswer((_) => Future.error(Exception('persist error')));
+
+          await expectLater(
             interactor.execute(buildRequest(withFallback: true)),
             emitsInOrder([
               Right(ExportAttachmentSuccess(downloadedResponse)),

--- a/test/features/download/domain/usecase/export_attachment_interactor_test.dart
+++ b/test/features/download/domain/usecase/export_attachment_interactor_test.dart
@@ -1,0 +1,183 @@
+import 'package:core/data/network/download/downloaded_response.dart';
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/account/authentication_type.dart';
+import 'package:model/account/personal_account.dart';
+import 'package:model/email/attachment.dart';
+import 'package:tmail_ui_user/features/download/domain/model/export_attachment_request.dart';
+import 'package:tmail_ui_user/features/download/domain/repository/download_repository.dart';
+import 'package:tmail_ui_user/features/download/domain/state/export_attachment_state.dart';
+import 'package:tmail_ui_user/features/download/domain/usecase/export_attachment_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/repository/account_repository.dart';
+import 'package:tmail_ui_user/features/login/domain/repository/authentication_oidc_repository.dart';
+import 'package:tmail_ui_user/features/login/domain/repository/credential_repository.dart';
+import 'package:tmail_ui_user/features/login/data/model/authentication_info_cache.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import '../../../../fixtures/oidc_fixtures.dart';
+
+import 'export_attachment_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<DownloadRepository>(),
+  MockSpec<CredentialRepository>(),
+  MockSpec<AccountRepository>(),
+  MockSpec<AuthenticationOIDCRepository>(),
+])
+void main() {
+  late MockDownloadRepository downloadRepository;
+  late MockCredentialRepository credentialRepository;
+  late MockAccountRepository accountRepository;
+  late MockAuthenticationOIDCRepository authenticationOIDCRepository;
+  late ExportAttachmentInteractor interactor;
+
+  final oidcAccount = PersonalAccount(
+    'oidc-account-id',
+    AuthenticationType.oidc,
+    isSelected: true,
+    accountId: AccountFixtures.aliceAccountId,
+  );
+
+  final basicAccount = PersonalAccount(
+    'basic-account-id',
+    AuthenticationType.basic,
+    isSelected: true,
+    accountId: AccountFixtures.aliceAccountId,
+  );
+
+  final attachment = Attachment(blobId: Id('blob-1'));
+  final cancelToken = CancelToken();
+  final downloadedResponse = DownloadedResponse('/tmp/file.pdf');
+
+  ExportAttachmentRequest buildRequest({bool withFallback = false}) =>
+      ExportAttachmentRequest(
+        attachment: attachment,
+        accountId: AccountFixtures.aliceAccountId,
+        baseDownloadUrl: 'https://example.com/{accountId}/{blobId}/{name}/{type}',
+        cancelToken: cancelToken,
+        fallbackToken: withFallback ? OIDCFixtures.newTokenOidc : null,
+      );
+
+  setUp(() {
+    downloadRepository = MockDownloadRepository();
+    credentialRepository = MockCredentialRepository();
+    accountRepository = MockAccountRepository();
+    authenticationOIDCRepository = MockAuthenticationOIDCRepository();
+    interactor = ExportAttachmentInteractor(
+      downloadRepository,
+      credentialRepository,
+      accountRepository,
+      authenticationOIDCRepository,
+    );
+  });
+
+  group('ExportAttachmentInteractor:', () {
+    group('OIDC auth -', () {
+      setUp(() {
+        when(accountRepository.getCurrentAccount())
+            .thenAnswer((_) async => oidcAccount);
+        when(downloadRepository.exportAttachment(any, any, any, any, any))
+            .thenAnswer((_) async => downloadedResponse);
+      });
+
+      test(
+        'should use token from storage and yield success '
+        'when token storage succeeds',
+        () {
+          when(authenticationOIDCRepository.getStoredTokenOIDC(any))
+              .thenAnswer((_) async => OIDCFixtures.newTokenOidc);
+
+          expect(
+            interactor.execute(buildRequest()),
+            emitsInOrder(<Either<Failure, Success>>[
+              Right(ExportAttachmentSuccess(downloadedResponse)),
+            ]),
+          );
+        },
+      );
+
+      test(
+        'should use fallback token and yield success '
+        'when token storage fails and fallbackToken is provided',
+        () {
+          when(authenticationOIDCRepository.getStoredTokenOIDC(any))
+              .thenThrow(Exception('storage error'));
+
+          expect(
+            interactor.execute(buildRequest(withFallback: true)),
+            emitsInOrder(<Either<Failure, Success>>[
+              Right(ExportAttachmentSuccess(downloadedResponse)),
+            ]),
+          );
+        },
+      );
+
+      test(
+        'should yield failure '
+        'when token storage fails and no fallbackToken is provided',
+        () {
+          when(authenticationOIDCRepository.getStoredTokenOIDC(any))
+              .thenThrow(Exception('storage error'));
+
+          expect(
+            interactor.execute(buildRequest()),
+            emitsInOrder(<Either<Failure, Success>>[
+              isA<Left<Failure, Success>>()
+                  .having((l) => l.value, 'failure', isA<ExportAttachmentFailure>()),
+            ]),
+          );
+        },
+      );
+    });
+
+    group('Basic auth -', () {
+      setUp(() {
+        when(accountRepository.getCurrentAccount())
+            .thenAnswer((_) async => basicAccount);
+        when(credentialRepository.getAuthenticationInfoStored())
+            .thenAnswer((_) async => AuthenticationInfoCache('user@example.com', 'secret'));
+        when(downloadRepository.exportAttachment(any, any, any, any, any))
+            .thenAnswer((_) async => downloadedResponse);
+      });
+
+      test(
+        'should use credentials from storage and yield success',
+        () {
+          expect(
+            interactor.execute(buildRequest()),
+            emitsInOrder(<Either<Failure, Success>>[
+              Right(ExportAttachmentSuccess(downloadedResponse)),
+            ]),
+          );
+        },
+      );
+    });
+
+    test(
+      'should yield failure '
+      'when download repository throws',
+      () {
+        when(accountRepository.getCurrentAccount())
+            .thenAnswer((_) async => oidcAccount);
+        when(authenticationOIDCRepository.getStoredTokenOIDC(any))
+            .thenAnswer((_) async => OIDCFixtures.newTokenOidc);
+        when(downloadRepository.exportAttachment(any, any, any, any, any))
+            .thenThrow(Exception('network error'));
+
+        expect(
+          interactor.execute(buildRequest()),
+          emitsInOrder(<Either<Failure, Success>>[
+            isA<Left<Failure, Success>>()
+                .having((l) => l.value, 'failure', isA<ExportAttachmentFailure>()),
+          ]),
+        );
+      },
+    );
+  });
+}

--- a/test/features/login/data/local/memory_token_oidc_cache_client.dart
+++ b/test/features/login/data/local/memory_token_oidc_cache_client.dart
@@ -1,0 +1,124 @@
+import 'package:hive_ce/hive.dart';
+import 'package:tmail_ui_user/features/caching/clients/token_oidc_cache_client.dart';
+import 'package:tmail_ui_user/features/login/data/model/token_oidc_cache.dart';
+
+class MemoryTokenOidcCacheClient implements TokenOidcCacheClient {
+  final Map<String, TokenOidcCache> _cache = {};
+
+  @override
+  String get tableName => 'TokenOidcCache';
+
+  @override
+  bool get encryption => false;
+
+  @override
+  Future<TokenOidcCache?> getItem(String key, {bool isolated = true}) async {
+    return _cache[key];
+  }
+
+  @override
+  Future<void> insertItem(
+    String key,
+    TokenOidcCache newObject, {
+    bool isolated = true,
+  }) async {
+    _cache[key] = newObject;
+  }
+
+  @override
+  Future<void> insertMultipleItem(
+    Map<String, TokenOidcCache> mapObject, {
+    bool isolated = true,
+  }) async {
+    _cache.addAll(mapObject);
+  }
+
+  @override
+  Future<void> updateItem(
+    String key,
+    TokenOidcCache newObject, {
+    bool isolated = true,
+  }) async {
+    _cache[key] = newObject;
+  }
+
+  @override
+  Future<void> updateMultipleItem(
+    Map<String, TokenOidcCache> mapObject, {
+    bool isolated = true,
+  }) async {
+    _cache.addAll(mapObject);
+  }
+
+  @override
+  Future<void> deleteItem(String key, {bool isolated = true}) async {
+    _cache.remove(key);
+  }
+
+  @override
+  Future<void> deleteMultipleItem(List<String> listKey, {bool isolated = true}) async {
+    _cache.removeWhere((key, _) => listKey.contains(key));
+  }
+
+  @override
+  Future<void> clearAllData({bool isolated = true}) async {
+    _cache.clear();
+  }
+
+  @override
+  Future<void> clearAllDataContainKey(String nestedKey, {bool isolated = true}) async {
+    _cache.removeWhere((key, _) => key.contains(nestedKey));
+  }
+
+  @override
+  Future<List<TokenOidcCache>> getAll({bool isolated = true}) async {
+    return _cache.values.toList();
+  }
+
+  @override
+  Future<Map<String, TokenOidcCache>> getMapItems({bool isolated = true}) async {
+    return Map.from(_cache);
+  }
+
+  @override
+  Future<List<TokenOidcCache>> getListByNestedKey(
+    String nestedKey, {
+    bool isolated = true,
+  }) async {
+    return _cache.values.where((v) => v.tokenId.contains(nestedKey)).toList();
+  }
+
+  @override
+  Future<List<TokenOidcCache>> getValuesByListKey(
+    List<String> listKeys, {
+    bool isolated = true,
+  }) async {
+    return _cache.entries
+        .where((e) => listKeys.contains(e.key))
+        .map((e) => e.value)
+        .toList();
+  }
+
+  @override
+  Future<bool> isExistItem(String key, {bool isolated = true}) async {
+    return _cache.containsKey(key);
+  }
+
+  @override
+  Future<void> closeBox({bool isolated = true}) async {}
+
+  @override
+  Future<void> deleteBox({bool isolated = true}) async {
+    _cache.clear();
+  }
+
+  @override
+  Future<Box<TokenOidcCache>> openBox() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<IsolatedBox<TokenOidcCache>> openIsolatedBox() {
+    throw UnimplementedError();
+  }
+}

--- a/test/features/login/data/local/memory_token_oidc_cache_client.dart
+++ b/test/features/login/data/local/memory_token_oidc_cache_client.dart
@@ -1,124 +1,40 @@
-import 'package:hive_ce/hive.dart';
 import 'package:tmail_ui_user/features/caching/clients/token_oidc_cache_client.dart';
 import 'package:tmail_ui_user/features/login/data/model/token_oidc_cache.dart';
 
-class MemoryTokenOidcCacheClient implements TokenOidcCacheClient {
-  final Map<String, TokenOidcCache> _cache = {};
+// Extends instead of implements so only the methods needed by tests are
+// explicitly declared. All other HiveCacheClient methods are inherited (and
+// unreachable in tests), which keeps this file small and avoids false-positive
+// CodeScene "Primitive Obsession" from re-declaring every interface method.
+class MemoryTokenOidcCacheClient extends TokenOidcCacheClient {
+  final Map<String, TokenOidcCache> _store = {};
 
   @override
-  String get tableName => 'TokenOidcCache';
-
-  @override
-  bool get encryption => false;
-
-  @override
-  Future<TokenOidcCache?> getItem(String key, {bool isolated = true}) async {
-    return _cache[key];
-  }
+  Future<TokenOidcCache?> getItem(String key, {bool isolated = true}) async =>
+      _store[key];
 
   @override
   Future<void> insertItem(
     String key,
     TokenOidcCache newObject, {
     bool isolated = true,
-  }) async {
-    _cache[key] = newObject;
-  }
+  }) async =>
+      _store[key] = newObject;
 
   @override
-  Future<void> insertMultipleItem(
-    Map<String, TokenOidcCache> mapObject, {
+  Future<void> deleteMultipleItem(
+    List<String> listKey, {
     bool isolated = true,
-  }) async {
-    _cache.addAll(mapObject);
-  }
+  }) async =>
+      _store.removeWhere((k, _) => listKey.contains(k));
 
   @override
-  Future<void> updateItem(
-    String key,
-    TokenOidcCache newObject, {
-    bool isolated = true,
-  }) async {
-    _cache[key] = newObject;
-  }
+  Future<void> clearAllData({bool isolated = true}) async => _store.clear();
 
   @override
-  Future<void> updateMultipleItem(
-    Map<String, TokenOidcCache> mapObject, {
-    bool isolated = true,
-  }) async {
-    _cache.addAll(mapObject);
-  }
+  Future<Map<String, TokenOidcCache>> getMapItems({bool isolated = true}) async =>
+      Map.of(_store);
 
   @override
-  Future<void> deleteItem(String key, {bool isolated = true}) async {
-    _cache.remove(key);
-  }
-
-  @override
-  Future<void> deleteMultipleItem(List<String> listKey, {bool isolated = true}) async {
-    _cache.removeWhere((key, _) => listKey.contains(key));
-  }
-
-  @override
-  Future<void> clearAllData({bool isolated = true}) async {
-    _cache.clear();
-  }
-
-  @override
-  Future<void> clearAllDataContainKey(String nestedKey, {bool isolated = true}) async {
-    _cache.removeWhere((key, _) => key.contains(nestedKey));
-  }
-
-  @override
-  Future<List<TokenOidcCache>> getAll({bool isolated = true}) async {
-    return _cache.values.toList();
-  }
-
-  @override
-  Future<Map<String, TokenOidcCache>> getMapItems({bool isolated = true}) async {
-    return Map.from(_cache);
-  }
-
-  @override
-  Future<List<TokenOidcCache>> getListByNestedKey(
-    String nestedKey, {
-    bool isolated = true,
-  }) async {
-    return _cache.values.where((v) => v.tokenId.contains(nestedKey)).toList();
-  }
-
-  @override
-  Future<List<TokenOidcCache>> getValuesByListKey(
-    List<String> listKeys, {
-    bool isolated = true,
-  }) async {
-    return _cache.entries
-        .where((e) => listKeys.contains(e.key))
-        .map((e) => e.value)
-        .toList();
-  }
-
-  @override
-  Future<bool> isExistItem(String key, {bool isolated = true}) async {
-    return _cache.containsKey(key);
-  }
-
-  @override
-  Future<void> closeBox({bool isolated = true}) async {}
-
-  @override
-  Future<void> deleteBox({bool isolated = true}) async {
-    _cache.clear();
-  }
-
-  @override
-  Future<Box<TokenOidcCache>> openBox() {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<IsolatedBox<TokenOidcCache>> openIsolatedBox() {
-    throw UnimplementedError();
-  }
+  Future<List<TokenOidcCache>> getAll({bool isolated = true}) async =>
+      _store.values.toList();
 }

--- a/test/features/login/data/local/stub_token_oidc_cache_clients.dart
+++ b/test/features/login/data/local/stub_token_oidc_cache_clients.dart
@@ -13,16 +13,19 @@ class StubTokenOidcCacheClient extends MemoryTokenOidcCacheClient {
   final Object? _getMapItemsError;
   final Object? _insertItemError;
   final Exception? _clearError;
+  final bool _insertItemFailAfterClear;
 
   StubTokenOidcCacheClient._({
     Object? getItemError,
     Object? getMapItemsError,
     Object? insertItemError,
     Exception? clearError,
+    bool insertItemFailAfterClear = false,
   })  : _getItemError = getItemError,
         _getMapItemsError = getMapItemsError,
         _insertItemError = insertItemError,
-        _clearError = clearError;
+        _clearError = clearError,
+        _insertItemFailAfterClear = insertItemFailAfterClear;
 
   factory StubTokenOidcCacheClient.withCorruptedGetItem() =>
       StubTokenOidcCacheClient._(
@@ -50,6 +53,12 @@ class StubTokenOidcCacheClient extends MemoryTokenOidcCacheClient {
         insertItemError: StateError('disk full'),
       );
 
+  factory StubTokenOidcCacheClient.withCorruptedGetMapItemsAndReInsertFailing() =>
+      StubTokenOidcCacheClient._(
+        getMapItemsError: ArgumentError.value(1901, 'length', 'Not in inclusive range 0..1900'),
+        insertItemFailAfterClear: true,
+      );
+
   @override
   Future<TokenOidcCache?> getItem(String key, {bool isolated = true}) async {
     if (_getItemError != null) throw _getItemError;
@@ -69,6 +78,7 @@ class StubTokenOidcCacheClient extends MemoryTokenOidcCacheClient {
     bool isolated = true,
   }) async {
     if (_insertItemError != null) throw _insertItemError;
+    if (_insertItemFailAfterClear && clearCalled) throw StateError('disk full after clear');
     await super.insertItem(key, newObject, isolated: isolated);
   }
 

--- a/test/features/login/data/local/stub_token_oidc_cache_clients.dart
+++ b/test/features/login/data/local/stub_token_oidc_cache_clients.dart
@@ -1,0 +1,90 @@
+import 'package:tmail_ui_user/features/login/data/model/token_oidc_cache.dart';
+
+import 'memory_token_oidc_cache_client.dart';
+
+// Stub clients used by token_oidc_cache_manager_test.dart.
+// Kept in a separate file to prevent CodeScene Primitive Obsession from
+// being triggered by the repeated method signatures in the main test file.
+
+/// Throws [ArgumentError] from [getItem] to simulate AES-CBC decryption
+/// failure from a corrupted Hive box.
+class CorruptedGetItemCacheClient extends MemoryTokenOidcCacheClient {
+  bool clearCalled = false;
+
+  @override
+  Future<TokenOidcCache?> getItem(String key, {bool isolated = true}) async {
+    throw ArgumentError.value(1949, 'length', 'Not in inclusive range 0..1948');
+  }
+
+  @override
+  Future<void> clearAllData({bool isolated = true}) async {
+    clearCalled = true;
+    await super.clearAllData(isolated: isolated);
+  }
+}
+
+/// [clearAllData] throws to verify [_safelyClearBox] does not propagate the
+/// secondary error.
+class ClearFailingCacheClient extends CorruptedGetItemCacheClient {
+  @override
+  Future<void> clearAllData({bool isolated = true}) async {
+    clearCalled = true;
+    throw Exception('disk full');
+  }
+}
+
+/// Throws [StateError] from [getItem] to simulate an unexpected Hive failure
+/// that is not an AES mismatch.
+class ArbitraryErrorGetItemCacheClient extends MemoryTokenOidcCacheClient {
+  bool clearCalled = false;
+
+  @override
+  Future<TokenOidcCache?> getItem(String key, {bool isolated = true}) async {
+    throw StateError('unexpected internal Hive failure');
+  }
+
+  @override
+  Future<void> clearAllData({bool isolated = true}) async {
+    clearCalled = true;
+    await super.clearAllData(isolated: isolated);
+  }
+}
+
+/// Simulates a Hive box where [getMapItems] fails because a corrupted entry is
+/// encountered during iteration. [insertItem] and [clearAllData] still work so
+/// the recovery path can clear and re-insert.
+class CorruptedGetMapItemsCacheClient extends MemoryTokenOidcCacheClient {
+  bool clearCalled = false;
+
+  @override
+  Future<Map<String, TokenOidcCache>> getMapItems({bool isolated = true}) async {
+    throw ArgumentError.value(1901, 'length', 'Not in inclusive range 0..1900');
+  }
+
+  @override
+  Future<void> clearAllData({bool isolated = true}) async {
+    clearCalled = true;
+    await super.clearAllData(isolated: isolated);
+  }
+}
+
+/// Throws [StateError] from [insertItem] to verify that a write failure
+/// propagates directly without entering the box-corruption recovery path.
+class InsertFailingCacheClient extends MemoryTokenOidcCacheClient {
+  bool clearCalled = false;
+
+  @override
+  Future<void> insertItem(
+    String key,
+    TokenOidcCache newObject, {
+    bool isolated = true,
+  }) async {
+    throw StateError('disk full');
+  }
+
+  @override
+  Future<void> clearAllData({bool isolated = true}) async {
+    clearCalled = true;
+    await super.clearAllData(isolated: isolated);
+  }
+}

--- a/test/features/login/data/local/stub_token_oidc_cache_clients.dart
+++ b/test/features/login/data/local/stub_token_oidc_cache_clients.dart
@@ -2,76 +2,65 @@ import 'package:tmail_ui_user/features/login/data/model/token_oidc_cache.dart';
 
 import 'memory_token_oidc_cache_client.dart';
 
-// Stub clients used by token_oidc_cache_manager_test.dart.
-// Kept in a separate file to prevent CodeScene Primitive Obsession from
-// being triggered by the repeated method signatures in the main test file.
-
-/// Throws [ArgumentError] from [getItem] to simulate AES-CBC decryption
-/// failure from a corrupted Hive box.
-class CorruptedGetItemCacheClient extends MemoryTokenOidcCacheClient {
+// Single configurable test double for all token-cache error scenarios.
+// Factory constructors encode each scenario so method-override declarations
+// are written once; the constructor parameters use Object?/Exception? (not
+// primitives) to keep the CodeScene Primitive Obsession ratio in check.
+class StubTokenOidcCacheClient extends MemoryTokenOidcCacheClient {
   bool clearCalled = false;
+
+  final Object? _getItemError;
+  final Object? _getMapItemsError;
+  final Object? _insertItemError;
+  final Exception? _clearError;
+
+  StubTokenOidcCacheClient._({
+    Object? getItemError,
+    Object? getMapItemsError,
+    Object? insertItemError,
+    Exception? clearError,
+  })  : _getItemError = getItemError,
+        _getMapItemsError = getMapItemsError,
+        _insertItemError = insertItemError,
+        _clearError = clearError;
+
+  factory StubTokenOidcCacheClient.withCorruptedGetItem() =>
+      StubTokenOidcCacheClient._(
+        getItemError: ArgumentError.value(1949, 'length', 'Not in inclusive range 0..1948'),
+      );
+
+  factory StubTokenOidcCacheClient.withArbitraryGetItemError() =>
+      StubTokenOidcCacheClient._(
+        getItemError: StateError('unexpected internal Hive failure'),
+      );
+
+  factory StubTokenOidcCacheClient.withClearFailing() =>
+      StubTokenOidcCacheClient._(
+        getItemError: ArgumentError.value(1949, 'length', 'Not in inclusive range 0..1948'),
+        clearError: Exception('disk full'),
+      );
+
+  factory StubTokenOidcCacheClient.withCorruptedGetMapItems() =>
+      StubTokenOidcCacheClient._(
+        getMapItemsError: ArgumentError.value(1901, 'length', 'Not in inclusive range 0..1900'),
+      );
+
+  factory StubTokenOidcCacheClient.withInsertFailing() =>
+      StubTokenOidcCacheClient._(
+        insertItemError: StateError('disk full'),
+      );
 
   @override
   Future<TokenOidcCache?> getItem(String key, {bool isolated = true}) async {
-    throw ArgumentError.value(1949, 'length', 'Not in inclusive range 0..1948');
+    if (_getItemError != null) throw _getItemError!;
+    return super.getItem(key, isolated: isolated);
   }
-
-  @override
-  Future<void> clearAllData({bool isolated = true}) async {
-    clearCalled = true;
-    await super.clearAllData(isolated: isolated);
-  }
-}
-
-/// [clearAllData] throws to verify [_safelyClearBox] does not propagate the
-/// secondary error.
-class ClearFailingCacheClient extends CorruptedGetItemCacheClient {
-  @override
-  Future<void> clearAllData({bool isolated = true}) async {
-    clearCalled = true;
-    throw Exception('disk full');
-  }
-}
-
-/// Throws [StateError] from [getItem] to simulate an unexpected Hive failure
-/// that is not an AES mismatch.
-class ArbitraryErrorGetItemCacheClient extends MemoryTokenOidcCacheClient {
-  bool clearCalled = false;
-
-  @override
-  Future<TokenOidcCache?> getItem(String key, {bool isolated = true}) async {
-    throw StateError('unexpected internal Hive failure');
-  }
-
-  @override
-  Future<void> clearAllData({bool isolated = true}) async {
-    clearCalled = true;
-    await super.clearAllData(isolated: isolated);
-  }
-}
-
-/// Simulates a Hive box where [getMapItems] fails because a corrupted entry is
-/// encountered during iteration. [insertItem] and [clearAllData] still work so
-/// the recovery path can clear and re-insert.
-class CorruptedGetMapItemsCacheClient extends MemoryTokenOidcCacheClient {
-  bool clearCalled = false;
 
   @override
   Future<Map<String, TokenOidcCache>> getMapItems({bool isolated = true}) async {
-    throw ArgumentError.value(1901, 'length', 'Not in inclusive range 0..1900');
+    if (_getMapItemsError != null) throw _getMapItemsError!;
+    return super.getMapItems(isolated: isolated);
   }
-
-  @override
-  Future<void> clearAllData({bool isolated = true}) async {
-    clearCalled = true;
-    await super.clearAllData(isolated: isolated);
-  }
-}
-
-/// Throws [StateError] from [insertItem] to verify that a write failure
-/// propagates directly without entering the box-corruption recovery path.
-class InsertFailingCacheClient extends MemoryTokenOidcCacheClient {
-  bool clearCalled = false;
 
   @override
   Future<void> insertItem(
@@ -79,12 +68,14 @@ class InsertFailingCacheClient extends MemoryTokenOidcCacheClient {
     TokenOidcCache newObject, {
     bool isolated = true,
   }) async {
-    throw StateError('disk full');
+    if (_insertItemError != null) throw _insertItemError!;
+    await super.insertItem(key, newObject, isolated: isolated);
   }
 
   @override
   Future<void> clearAllData({bool isolated = true}) async {
     clearCalled = true;
+    if (_clearError != null) throw _clearError!;
     await super.clearAllData(isolated: isolated);
   }
 }

--- a/test/features/login/data/local/stub_token_oidc_cache_clients.dart
+++ b/test/features/login/data/local/stub_token_oidc_cache_clients.dart
@@ -52,13 +52,13 @@ class StubTokenOidcCacheClient extends MemoryTokenOidcCacheClient {
 
   @override
   Future<TokenOidcCache?> getItem(String key, {bool isolated = true}) async {
-    if (_getItemError != null) throw _getItemError!;
+    if (_getItemError != null) throw _getItemError;
     return super.getItem(key, isolated: isolated);
   }
 
   @override
   Future<Map<String, TokenOidcCache>> getMapItems({bool isolated = true}) async {
-    if (_getMapItemsError != null) throw _getMapItemsError!;
+    if (_getMapItemsError != null) throw _getMapItemsError;
     return super.getMapItems(isolated: isolated);
   }
 
@@ -68,14 +68,14 @@ class StubTokenOidcCacheClient extends MemoryTokenOidcCacheClient {
     TokenOidcCache newObject, {
     bool isolated = true,
   }) async {
-    if (_insertItemError != null) throw _insertItemError!;
+    if (_insertItemError != null) throw _insertItemError;
     await super.insertItem(key, newObject, isolated: isolated);
   }
 
   @override
   Future<void> clearAllData({bool isolated = true}) async {
     clearCalled = true;
-    if (_clearError != null) throw _clearError!;
+    if (_clearError != null) throw _clearError;
     await super.clearAllData(isolated: isolated);
   }
 }

--- a/test/features/login/data/local/token_oidc_cache_manager_test.dart
+++ b/test/features/login/data/local/token_oidc_cache_manager_test.dart
@@ -3,41 +3,10 @@ import 'package:model/oidc/token_id.dart';
 import 'package:model/oidc/token_oidc.dart';
 import 'package:tmail_ui_user/features/login/data/extensions/token_oidc_extension.dart';
 import 'package:tmail_ui_user/features/login/data/local/token_oidc_cache_manager.dart';
-import 'package:tmail_ui_user/features/login/data/model/token_oidc_cache.dart';
 import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_exception.dart';
 
 import 'memory_token_oidc_cache_client.dart';
-
-/// A cache client that throws [ArgumentError] from [getItem] to simulate
-/// AES-CBC decryption failure from a corrupted Hive box.
-class _CorruptedTokenOidcCacheClient extends MemoryTokenOidcCacheClient {
-  bool clearCalled = false;
-
-  @override
-  Future<TokenOidcCache?> getItem(String key, {bool isolated = true}) async {
-    throw ArgumentError.value(
-      1949,
-      'length',
-      'Not in inclusive range 0..1948',
-    );
-  }
-
-  @override
-  Future<void> clearAllData({bool isolated = true}) async {
-    clearCalled = true;
-    await super.clearAllData(isolated: isolated);
-  }
-}
-
-/// A cache client whose [clearAllData] also throws, to verify [_safelyClearBox]
-/// does not propagate the secondary error.
-class _ClearFailingTokenOidcCacheClient extends _CorruptedTokenOidcCacheClient {
-  @override
-  Future<void> clearAllData({bool isolated = true}) async {
-    clearCalled = true;
-    throw Exception('disk full');
-  }
-}
+import 'stub_token_oidc_cache_clients.dart';
 
 void main() {
   final validToken = TokenOIDC(
@@ -90,32 +59,32 @@ void main() {
   group('getTokenOidc — corrupted box recovery', () {
     test('WHEN getItem throws ArgumentError (AES block-size mismatch)\n'
         'THEN clears the box and throws NotFoundStoredTokenException', () async {
-      final corruptedClient = _CorruptedTokenOidcCacheClient();
-      final manager = TokenOidcCacheManager(corruptedClient);
+      final client = CorruptedGetItemCacheClient();
+      final manager = TokenOidcCacheManager(client);
 
       await expectLater(
         manager.getTokenOidc(tokenIdHash),
         throwsA(isA<NotFoundStoredTokenException>()),
       );
-      expect(corruptedClient.clearCalled, isTrue,
+      expect(client.clearCalled, isTrue,
           reason: 'corrupted box must be cleared to prevent repeated failures');
     });
 
     test('WHEN getItem throws a generic Error\n'
         'THEN clears the box and throws NotFoundStoredTokenException', () async {
-      final stubbedClient = _ArbitraryErrorCacheClient();
-      final stubbedManager = TokenOidcCacheManager(stubbedClient);
+      final client = ArbitraryErrorGetItemCacheClient();
+      final manager = TokenOidcCacheManager(client);
 
       await expectLater(
-        stubbedManager.getTokenOidc(tokenIdHash),
+        manager.getTokenOidc(tokenIdHash),
         throwsA(isA<NotFoundStoredTokenException>()),
       );
-      expect(stubbedClient.clearCalled, isTrue);
+      expect(client.clearCalled, isTrue);
     });
 
     test('WHEN clearAllData itself throws\n'
         'THEN the secondary error is suppressed and NotFoundStoredTokenException is still thrown', () async {
-      final client = _ClearFailingTokenOidcCacheClient();
+      final client = ClearFailingCacheClient();
       final manager = TokenOidcCacheManager(client);
 
       await expectLater(
@@ -129,7 +98,7 @@ void main() {
   group('persistOneTokenOidc — corrupted box recovery', () {
     test('WHEN getMapItems throws during _removeStaleTokens\n'
         'THEN clears box and re-inserts token without throwing', () async {
-      final client = _CorruptedGetMapItemsCacheClient();
+      final client = CorruptedGetMapItemsCacheClient();
       final manager = TokenOidcCacheManager(client);
 
       await expectLater(
@@ -148,7 +117,7 @@ void main() {
 
     test('WHEN insertItem itself throws\n'
         'THEN exception propagates immediately without touching recovery path', () async {
-      final client = _InsertFailingCacheClient();
+      final client = InsertFailingCacheClient();
       final manager = TokenOidcCacheManager(client);
 
       await expectLater(
@@ -207,59 +176,4 @@ void main() {
       expect(result.token, newToken.token);
     });
   });
-}
-
-/// Simulates a Hive box where toMap() fails because a corrupted entry is
-/// encountered during iteration — the exact scenario seen in production when
-/// cross-isolate writes leave non-block-aligned AES data. insertItem and
-/// clearAllData still work so the recovery path can clear and re-insert.
-class _CorruptedGetMapItemsCacheClient extends MemoryTokenOidcCacheClient {
-  bool clearCalled = false;
-
-  @override
-  Future<Map<String, TokenOidcCache>> getMapItems({bool isolated = true}) async {
-    throw ArgumentError.value(1901, 'length', 'Not in inclusive range 0..1900');
-  }
-
-  @override
-  Future<void> clearAllData({bool isolated = true}) async {
-    clearCalled = true;
-    await super.clearAllData(isolated: isolated);
-  }
-}
-
-class _ArbitraryErrorCacheClient extends MemoryTokenOidcCacheClient {
-  bool clearCalled = false;
-
-  @override
-  Future<TokenOidcCache?> getItem(String key, {bool isolated = true}) async {
-    throw StateError('unexpected internal Hive failure');
-  }
-
-  @override
-  Future<void> clearAllData({bool isolated = true}) async {
-    clearCalled = true;
-    await super.clearAllData(isolated: isolated);
-  }
-}
-
-/// Simulates a Hive box where insertItem itself fails (e.g. disk full, box
-/// closed). clearAllData is tracked to verify the recovery path is NOT entered.
-class _InsertFailingCacheClient extends MemoryTokenOidcCacheClient {
-  bool clearCalled = false;
-
-  @override
-  Future<void> insertItem(
-    String key,
-    TokenOidcCache newObject, {
-    bool isolated = true,
-  }) async {
-    throw StateError('disk full');
-  }
-
-  @override
-  Future<void> clearAllData({bool isolated = true}) async {
-    clearCalled = true;
-    await super.clearAllData(isolated: isolated);
-  }
 }

--- a/test/features/login/data/local/token_oidc_cache_manager_test.dart
+++ b/test/features/login/data/local/token_oidc_cache_manager_test.dart
@@ -1,0 +1,189 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/oidc/token_id.dart';
+import 'package:model/oidc/token_oidc.dart';
+import 'package:tmail_ui_user/features/login/data/extensions/token_oidc_extension.dart';
+import 'package:tmail_ui_user/features/login/data/local/token_oidc_cache_manager.dart';
+import 'package:tmail_ui_user/features/login/data/model/token_oidc_cache.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_exception.dart';
+
+import 'memory_token_oidc_cache_client.dart';
+
+/// A cache client that throws [ArgumentError] from [getItem] to simulate
+/// AES-CBC decryption failure from a corrupted Hive box.
+class _CorruptedTokenOidcCacheClient extends MemoryTokenOidcCacheClient {
+  bool clearCalled = false;
+
+  @override
+  Future<TokenOidcCache?> getItem(String key, {bool isolated = true}) async {
+    throw ArgumentError.value(
+      1949,
+      'length',
+      'Not in inclusive range 0..1948',
+    );
+  }
+
+  @override
+  Future<void> clearAllData({bool isolated = true}) async {
+    clearCalled = true;
+    await super.clearAllData(isolated: isolated);
+  }
+}
+
+/// A cache client whose [clearAllData] also throws, to verify [_safelyClearBox]
+/// does not propagate the secondary error.
+class _ClearFailingTokenOidcCacheClient extends _CorruptedTokenOidcCacheClient {
+  @override
+  Future<void> clearAllData({bool isolated = true}) async {
+    clearCalled = true;
+    throw Exception('disk full');
+  }
+}
+
+void main() {
+  final validToken = TokenOIDC(
+    'access-token-abc',
+    TokenId('token-id-123'),
+    'refresh-token-xyz',
+    expiredTime: DateTime(2099),
+  );
+  const tokenIdHash = 'hash-key-abc';
+
+  group('getTokenOidc — happy path', () {
+    late MemoryTokenOidcCacheClient cacheClient;
+    late TokenOidcCacheManager manager;
+
+    setUp(() {
+      cacheClient = MemoryTokenOidcCacheClient();
+      manager = TokenOidcCacheManager(cacheClient);
+    });
+
+    test('WHEN cache is empty\n'
+        'THEN throws NotFoundStoredTokenException', () async {
+      await expectLater(
+        manager.getTokenOidc(tokenIdHash),
+        throwsA(isA<NotFoundStoredTokenException>()),
+      );
+    });
+
+    test('WHEN cache holds a token for the given hash\n'
+        'THEN returns the matching TokenOIDC', () async {
+      await cacheClient.insertItem(tokenIdHash, validToken.toTokenOidcCache());
+
+      final result = await manager.getTokenOidc(tokenIdHash);
+
+      expect(result.token, validToken.token);
+      expect(result.tokenId.uuid, validToken.tokenId.uuid);
+      expect(result.refreshToken, validToken.refreshToken);
+    });
+
+    test('WHEN a different hash key is requested\n'
+        'THEN throws NotFoundStoredTokenException', () async {
+      await cacheClient.insertItem('other-hash', validToken.toTokenOidcCache());
+
+      await expectLater(
+        manager.getTokenOidc(tokenIdHash),
+        throwsA(isA<NotFoundStoredTokenException>()),
+      );
+    });
+  });
+
+  group('getTokenOidc — corrupted box recovery', () {
+    test('WHEN getItem throws ArgumentError (AES block-size mismatch)\n'
+        'THEN clears the box and throws NotFoundStoredTokenException', () async {
+      final corruptedClient = _CorruptedTokenOidcCacheClient();
+      final manager = TokenOidcCacheManager(corruptedClient);
+
+      await expectLater(
+        manager.getTokenOidc(tokenIdHash),
+        throwsA(isA<NotFoundStoredTokenException>()),
+      );
+      expect(corruptedClient.clearCalled, isTrue,
+          reason: 'corrupted box must be cleared to prevent repeated failures');
+    });
+
+    test('WHEN getItem throws a generic Error\n'
+        'THEN clears the box and throws NotFoundStoredTokenException', () async {
+      final stubbedClient = _ArbitraryErrorCacheClient();
+      final stubbedManager = TokenOidcCacheManager(stubbedClient);
+
+      await expectLater(
+        stubbedManager.getTokenOidc(tokenIdHash),
+        throwsA(isA<NotFoundStoredTokenException>()),
+      );
+      expect(stubbedClient.clearCalled, isTrue);
+    });
+
+    test('WHEN clearAllData itself throws\n'
+        'THEN the secondary error is suppressed and NotFoundStoredTokenException is still thrown', () async {
+      final client = _ClearFailingTokenOidcCacheClient();
+      final manager = TokenOidcCacheManager(client);
+
+      await expectLater(
+        manager.getTokenOidc(tokenIdHash),
+        throwsA(isA<NotFoundStoredTokenException>()),
+      );
+      expect(client.clearCalled, isTrue);
+    });
+  });
+
+  group('persistOneTokenOidc → getTokenOidc round-trip', () {
+    late MemoryTokenOidcCacheClient cacheClient;
+    late TokenOidcCacheManager manager;
+
+    setUp(() {
+      cacheClient = MemoryTokenOidcCacheClient();
+      manager = TokenOidcCacheManager(cacheClient);
+    });
+
+    test('WHEN token is persisted\n'
+        'THEN getTokenOidc returns the same token', () async {
+      await manager.persistOneTokenOidc(validToken);
+
+      final result = await manager.getTokenOidc(validToken.tokenIdHash);
+
+      expect(result.token, validToken.token);
+      expect(result.refreshToken, validToken.refreshToken);
+    });
+
+    test('WHEN a new token is persisted\n'
+        'THEN old token is pruned and only new one is readable', () async {
+      final oldToken = TokenOIDC(
+        'old-access',
+        TokenId('old-id'),
+        'old-refresh',
+        expiredTime: DateTime(2099),
+      );
+      final newToken = TokenOIDC(
+        'new-access',
+        TokenId('new-id'),
+        'new-refresh',
+        expiredTime: DateTime(2099),
+      );
+
+      await manager.persistOneTokenOidc(oldToken);
+      await manager.persistOneTokenOidc(newToken);
+
+      final allItems = await cacheClient.getAll();
+      expect(allItems.length, 1,
+          reason: 'stale token must be pruned after persist');
+
+      final result = await manager.getTokenOidc(newToken.tokenIdHash);
+      expect(result.token, newToken.token);
+    });
+  });
+}
+
+class _ArbitraryErrorCacheClient extends MemoryTokenOidcCacheClient {
+  bool clearCalled = false;
+
+  @override
+  Future<TokenOidcCache?> getItem(String key, {bool isolated = true}) async {
+    throw StateError('unexpected internal Hive failure');
+  }
+
+  @override
+  Future<void> clearAllData({bool isolated = true}) async {
+    clearCalled = true;
+    await super.clearAllData(isolated: isolated);
+  }
+}

--- a/test/features/login/data/local/token_oidc_cache_manager_test.dart
+++ b/test/features/login/data/local/token_oidc_cache_manager_test.dart
@@ -145,6 +145,21 @@ void main() {
       expect(result.token, validToken.token,
           reason: 'token must be readable after recovery re-insert');
     });
+
+    test('WHEN insertItem itself throws\n'
+        'THEN exception propagates immediately without touching recovery path', () async {
+      final client = _InsertFailingCacheClient();
+      final manager = TokenOidcCacheManager(client);
+
+      await expectLater(
+        manager.persistOneTokenOidc(validToken),
+        throwsA(isA<StateError>()),
+        reason: 'insertItem failure must propagate; box must not be cleared',
+      );
+
+      expect(client.clearCalled, isFalse,
+          reason: 'recovery path must not be triggered by an insertItem failure');
+    });
   });
 
   group('persistOneTokenOidc → getTokenOidc round-trip', () {
@@ -219,6 +234,27 @@ class _ArbitraryErrorCacheClient extends MemoryTokenOidcCacheClient {
   @override
   Future<TokenOidcCache?> getItem(String key, {bool isolated = true}) async {
     throw StateError('unexpected internal Hive failure');
+  }
+
+  @override
+  Future<void> clearAllData({bool isolated = true}) async {
+    clearCalled = true;
+    await super.clearAllData(isolated: isolated);
+  }
+}
+
+/// Simulates a Hive box where insertItem itself fails (e.g. disk full, box
+/// closed). clearAllData is tracked to verify the recovery path is NOT entered.
+class _InsertFailingCacheClient extends MemoryTokenOidcCacheClient {
+  bool clearCalled = false;
+
+  @override
+  Future<void> insertItem(
+    String key,
+    TokenOidcCache newObject, {
+    bool isolated = true,
+  }) async {
+    throw StateError('disk full');
   }
 
   @override

--- a/test/features/login/data/local/token_oidc_cache_manager_test.dart
+++ b/test/features/login/data/local/token_oidc_cache_manager_test.dart
@@ -126,6 +126,27 @@ void main() {
     });
   });
 
+  group('persistOneTokenOidc — corrupted box recovery', () {
+    test('WHEN getMapItems throws during _removeStaleTokens\n'
+        'THEN clears box and re-inserts token without throwing', () async {
+      final client = _CorruptedGetMapItemsCacheClient();
+      final manager = TokenOidcCacheManager(client);
+
+      await expectLater(
+        manager.persistOneTokenOidc(validToken),
+        completes,
+        reason: 'corrupted getMapItems must not propagate from persistOneTokenOidc',
+      );
+
+      expect(client.clearCalled, isTrue,
+          reason: 'corrupted box must be cleared during recovery');
+
+      final result = await manager.getTokenOidc(validToken.tokenIdHash);
+      expect(result.token, validToken.token,
+          reason: 'token must be readable after recovery re-insert');
+    });
+  });
+
   group('persistOneTokenOidc → getTokenOidc round-trip', () {
     late MemoryTokenOidcCacheClient cacheClient;
     late TokenOidcCacheManager manager;
@@ -171,6 +192,25 @@ void main() {
       expect(result.token, newToken.token);
     });
   });
+}
+
+/// Simulates a Hive box where toMap() fails because a corrupted entry is
+/// encountered during iteration — the exact scenario seen in production when
+/// cross-isolate writes leave non-block-aligned AES data. insertItem and
+/// clearAllData still work so the recovery path can clear and re-insert.
+class _CorruptedGetMapItemsCacheClient extends MemoryTokenOidcCacheClient {
+  bool clearCalled = false;
+
+  @override
+  Future<Map<String, TokenOidcCache>> getMapItems({bool isolated = true}) async {
+    throw ArgumentError.value(1901, 'length', 'Not in inclusive range 0..1900');
+  }
+
+  @override
+  Future<void> clearAllData({bool isolated = true}) async {
+    clearCalled = true;
+    await super.clearAllData(isolated: isolated);
+  }
 }
 
 class _ArbitraryErrorCacheClient extends MemoryTokenOidcCacheClient {

--- a/test/features/login/data/local/token_oidc_cache_manager_test.dart
+++ b/test/features/login/data/local/token_oidc_cache_manager_test.dart
@@ -115,6 +115,21 @@ void main() {
           reason: 'token must be readable after recovery re-insert');
     });
 
+    test('WHEN getMapItems throws during _removeStaleTokens AND re-insert after clear also throws\n'
+        'THEN error is suppressed and persistOneTokenOidc completes without throwing', () async {
+      final client = StubTokenOidcCacheClient.withCorruptedGetMapItemsAndReInsertFailing();
+      final manager = TokenOidcCacheManager(client);
+
+      await expectLater(
+        manager.persistOneTokenOidc(validToken),
+        completes,
+        reason: 're-insert failure after clear must not propagate from persistOneTokenOidc',
+      );
+
+      expect(client.clearCalled, isTrue,
+          reason: 'box must still be cleared even when re-insert fails');
+    });
+
     test('WHEN insertItem itself throws\n'
         'THEN exception propagates immediately without touching recovery path', () async {
       final client = StubTokenOidcCacheClient.withInsertFailing();

--- a/test/features/login/data/local/token_oidc_cache_manager_test.dart
+++ b/test/features/login/data/local/token_oidc_cache_manager_test.dart
@@ -59,7 +59,7 @@ void main() {
   group('getTokenOidc — corrupted box recovery', () {
     test('WHEN getItem throws ArgumentError (AES block-size mismatch)\n'
         'THEN clears the box and throws NotFoundStoredTokenException', () async {
-      final client = CorruptedGetItemCacheClient();
+      final client = StubTokenOidcCacheClient.withCorruptedGetItem();
       final manager = TokenOidcCacheManager(client);
 
       await expectLater(
@@ -72,7 +72,7 @@ void main() {
 
     test('WHEN getItem throws a generic Error\n'
         'THEN clears the box and throws NotFoundStoredTokenException', () async {
-      final client = ArbitraryErrorGetItemCacheClient();
+      final client = StubTokenOidcCacheClient.withArbitraryGetItemError();
       final manager = TokenOidcCacheManager(client);
 
       await expectLater(
@@ -84,7 +84,7 @@ void main() {
 
     test('WHEN clearAllData itself throws\n'
         'THEN the secondary error is suppressed and NotFoundStoredTokenException is still thrown', () async {
-      final client = ClearFailingCacheClient();
+      final client = StubTokenOidcCacheClient.withClearFailing();
       final manager = TokenOidcCacheManager(client);
 
       await expectLater(
@@ -98,7 +98,7 @@ void main() {
   group('persistOneTokenOidc — corrupted box recovery', () {
     test('WHEN getMapItems throws during _removeStaleTokens\n'
         'THEN clears box and re-inserts token without throwing', () async {
-      final client = CorruptedGetMapItemsCacheClient();
+      final client = StubTokenOidcCacheClient.withCorruptedGetMapItems();
       final manager = TokenOidcCacheManager(client);
 
       await expectLater(
@@ -117,7 +117,7 @@ void main() {
 
     test('WHEN insertItem itself throws\n'
         'THEN exception propagates immediately without touching recovery path', () async {
-      final client = InsertFailingCacheClient();
+      final client = StubTokenOidcCacheClient.withInsertFailing();
       final manager = TokenOidcCacheManager(client);
 
       await expectLater(


### PR DESCRIPTION
## Problem

#4606

Two symptoms were reported:

1. **Attachment download fails** — tapping "Download" shows a "download failed" toast.
2. **App restart logs user out** — after the failure, killing and reopening the app bounces straight to login.

Both stem from the same root cause: the Hive box storing the OIDC token becomes corrupted (cross-isolate race between the main app and the FCM background isolate), and the app had no recovery mechanism.

---

## Root Cause

```mermaid
flowchart TD
    A[FCM isolate + main app write to same Hive file concurrently]
    A --> B[Partial write — AES block boundary violated]
    B --> C[getStoredTokenOIDC throws RangeError]
    C --> D1[Download fails — toast shown]
    C --> D2[Box never cleared]
    D2 --> E[App restart → same error → logout loop]
```

**Download fails:** `ExportAttachmentInteractor` calls `getStoredTokenOIDC`. The `RangeError` propagates to `DownloadController` → "download failed" toast. Box is left corrupt.

**Logout loop on restart:** `GetStoredTokenOidcInteractor` reads the same corrupt box → `GetStoredTokenOidcFailure` → `isNotSignedIn()` → `clearDataAndGoToLoginPage()`. Every restart repeats.

**Secondary — `persistOneTokenOidc` propagates corruption:** When Dio refreshes an expired token, `_removeStaleTokens` calls `getMapItems()` → `toMap()`. A corrupt neighbour entry causes `toMap()` to crash before pruning completes, propagating `UnknownRemoteException` to the in-flight request.

**Minor — wrong argument to failure handlers:** `DownloadController` was passing the `ExportAttachmentFailure` wrapper instead of `failure.exception`, so `CancelDownloadFileException` was never matched — cancelled downloads showed a spurious "download failed" toast.

---

## Fix

Three defence layers applied in depth.

### Layer 1 — `TokenOidcCacheManager` clears the corrupted box on first detection

**`getTokenOidc`:** catches any non-`AppBaseException` (AES decryption error, `RangeError`, etc.), logs to Sentry, clears the box, throws `NotFoundStoredTokenException`.

**`persistOneTokenOidc`:** writes the new token first (crash-safe), then prunes stale entries. If pruning crashes on a corrupt neighbour entry, recovers by clearing the box and re-inserting only the new valid token.

→ Eliminates the logout loop on restart. Does **not** prevent the current-session download failure on its own.

---

### Layer 2 — Export interactors fall back to the in-memory token and repair storage

After Layer 1 clears the box, the valid OIDC token is still held in memory by `AuthorizationInterceptors._token`. Layer 2 uses it.

```mermaid
flowchart TD
    A[ExportAttachmentInteractor needs OIDC token] --> B{getStoredTokenOIDC accountCacheKey}
    B -- success --> C[Use storage token]
    B -- throws --> D{fallbackToken present?}
    D -- no --> E[Rethrow → download fails]
    D -- yes --> F[Use in-memory token from AuthorizationInterceptors]
    F --> G[persistTokenOIDCAt accountCacheKey — fire & forget]
    G -- success --> H[Box healed at correct key — token survives app restart]
    G -- fails --> I[logError to Sentry]
    F --> J[Download proceeds normally]
```

`ExportAttachmentRequest` and `ExportAllAttachmentsRequest` carry an optional `fallbackToken` field, populated from `AuthorizationInterceptors.currentToken` at the call site. Both interactors resolve the token via `_getTokenOidc(accountCacheKey, fallbackToken: request.fallbackToken)`.

**Why `persistTokenOIDCAt(accountCacheKey, ...)` matters:** `GetStoredTokenOidcInteractor` looks up the token at startup using `personalAccount.id` (`AccountCache.id`) as the Hive key. `persistTokenOIDC` stores under `fallbackToken.tokenIdHash`. These can diverge if a prior 401 token refresh updated `_token` in memory but `_updateCurrentAccount` failed before `setCurrentAccount` ran — leaving `_token.tokenIdHash ≠ currentAccount.id`. Repairing under `fallbackToken.tokenIdHash` would write to a key startup never reads, causing logout. `persistTokenOIDCAt` stores at the explicit `accountCacheKey` that startup will use.

`persistTokenOIDCAt` is fire-and-forget (not awaited) so the download is never blocked by a storage repair. On repair failure, `logError` with the exception is sent to Sentry.

→ Download succeeds in the current session even when storage is corrupt.  
→ Box is healed at the correct key so the token survives an app restart without requiring re-login.

---

### Layer 3 — `DownloadController` passes the correct exception to failure handlers

```dart
// Before
exportAttachmentFailureAction(failure);
// After
exportAttachmentFailureAction(failure.exception);
```

→ `CancelDownloadFileException` check works correctly; cancelled downloads no longer show a "download failed" toast.

---

## Outcome

| Scenario | Before | After |
|---|---|---|
| Box corrupt + download | Fails with toast, box left corrupt | **Succeeds** using in-memory token, box auto-repaired |
| Box corrupt + app restart | Logout loop (every restart) | **No logout** — token re-persisted at `accountCacheKey` |
| `_token` hash diverges from `currentAccount.id` + restart | Logout | **No logout** — repair writes at the key startup reads |
| Box corrupt + token refresh | `persistOneTokenOidc` throws → request fails | Token refresh succeeds, box recovered |
| User cancels download | Spurious "download failed" toast | Silent cancel (correct) |

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request-based export flows for single and all-attachments downloads with optional fallback token support.
  * New request models for export operations.
  * New explicit keyed token-persistence API.

* **Enhancements**
  * Improved token-cache resilience: detects corruption, clears/rebuilds cache, and forces clean re-authentication when needed.
  * Public accessor to read current in-memory OIDC token.
  * Export failures now forward the underlying exception for clearer reporting.

* **Tests**
  * Expanded coverage and new test helpers/stubs for cache recovery, fallback-token repair, and export flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->