### PR TITLE
TF-4507 Composer mailto focus fix

### DIFF
--- a/lib/features/composer/presentation/extensions/setup_email_content_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_content_extension.dart
@@ -80,7 +80,7 @@ extension SetupEmailContentExtension on ComposerController {
   }
 
   void _loadSimpleEmailContent(String content) {
-    if (PlatformInfo.isWeb) setTextEditorWeb(content);
+    if (PlatformInfo.isWeb && content.isNotEmpty) setTextEditorWeb(content);
     emailContentsViewState.value = Right(GetEmailContentSuccess(htmlEmailContent: content));
   }
 

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -43,6 +43,7 @@ import 'package:tmail_ui_user/features/composer/presentation/controller/rich_tex
 import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_web_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/handle_mobile_auto_save_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/refresh_composer_attachments_extension.dart';
+import 'package:tmail_ui_user/features/composer/presentation/extensions/setup_email_content_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/setup_selected_identity_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/formatting_options_state.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/saved_composing_email.dart';
@@ -1147,6 +1148,57 @@ void main() {
         expect(composerController?.currentTemplateEmailId, equals(newEmailId));
         verify(mockUploadController.refreshAllAttachments([], [])).called(1);
       });
+    });
+
+    group('setupEmailContent - mailto textEditorWeb:', () {
+      for (final actionType in [
+        EmailActionType.composeFromMailtoUri,
+        EmailActionType.composeFromUnsubscribeMailtoLink,
+      ]) {
+        test(
+          'Should NOT set textEditorWeb\n'
+          'When $actionType with empty body\n'
+          'So that web editor falls back to editorStartTags (2 blank lines before signature)',
+        () async {
+          PlatformInfo.isTestingForWeb = true;
+          try {
+            composerController?.currentEmailActionType = actionType;
+            final arguments = ComposerArguments(
+              emailActionType: actionType,
+              displayMode: ScreenDisplayMode.normal,
+              body: '',
+            );
+
+            await composerController?.setupEmailContent(arguments);
+
+            expect(composerController?.textEditorWeb, isNull);
+          } finally {
+            PlatformInfo.isTestingForWeb = false;
+          }
+        });
+
+        test(
+          'Should set textEditorWeb to body content\n'
+          'When $actionType with non-empty body',
+        () async {
+          PlatformInfo.isTestingForWeb = true;
+          try {
+            composerController?.currentEmailActionType = actionType;
+            const body = '<p>Hello from mailto body</p>';
+            final arguments = ComposerArguments(
+              emailActionType: actionType,
+              displayMode: ScreenDisplayMode.normal,
+              body: body,
+            );
+
+            await composerController?.setupEmailContent(arguments);
+
+            expect(composerController?.textEditorWeb, equals(body));
+          } finally {
+            PlatformInfo.isTestingForWeb = false;
+          }
+        });
+      }
     });
   });
 }


### PR DESCRIPTION
## Issue
- #4507 

---

## Problem

Opening composer via mailto URL (e.g., clicking `<a href="mailto:someone@example.com">`) prefills the TO field. Pressing TAB from subject lands the cursor **on the signature**, not the first blank line above it.

Compose-button behavior (correct): 2 blank lines above signature → TAB → blank line 1.  
Mailto behavior (buggy): 1 blank line above signature → TAB → signature start.

---

## Root Cause

### Layer 1 — Wrong initial content (`''` instead of `<div><br><br></div>`)

`composeFromMailtoUri` with empty body calls `_loadSimpleEmailContent('')`:

```dart
// setup_email_content_extension.dart (before fix)
void _loadSimpleEmailContent(String content) {
  if (PlatformInfo.isWeb) setTextEditorWeb(content);  // sets _textEditorWeb = ''
  emailContentsViewState.value = Right(GetEmailContentSuccess(htmlEmailContent: content));
}
```

In `web_editor_view.dart`, the content passed to `WebEditorWidget` is:

```dart
content: currentWebContent ?? newContent
// currentWebContent = controller.textEditorWeb = '' (empty string, NOT null)
// Dart: '' ?? fallback = '' — null-coalescing never fires on non-null
```

So `WebEditorWidget` receives `''` instead of the intended fallback `HtmlExtension.editorStartTags = '<div><br><br></div>'`.

For regular compose, `_textEditorWeb` is never set, stays `null` → `null ?? '<div><br><br></div>'` = correct.

### Layer 2 — Why the blank line is skipped (Summernote cursor placement)

With empty initial content, Summernote initializes the editor with `emptyPara = '<p><br></p>'`. After `insertSignature` appends:

```html
<div class="note-editable">
  <p><br></p>                        ← blank line (only 1)
  <div class="tmail-signature">…</div>
</div>
```

Summernote's `setFocus()` is called when "Tab" from subject field → `$editable.focus()` → fires `focus` event → `setLastRange()`:

```javascript
// summernote-lite-unminified.js
setLastRange: function(t) {
  t ? this.lastRange = t
    : (this.lastRange = tk.create(this.editable), ...)
}

// tk.create() calls createFromSelection() first:
var i = document.getSelection();
if (!i || 0 === i.rangeCount || th.isBody(i.anchorNode)) return null;
```

When `.focus()` is called **programmatically** (no user click), the browser does not create a selection → `rangeCount === 0` → `createFromSelection()` returns `null`.

Summernote falls back:

```javascript
return th.isEditable(a) && (a = a.lastChild),  // ← lastChild = signature
  this.createFromBodyElement(a, th.emptyPara === arguments[0].innerHTML)
// emptyPara !== current innerHTML → e = false → .collapse(false) → END of signature
```

`lastRange` is stored as **end of signature**. When user later TABs from subject → browser restores cursor to that position → lands on signature.

### Why the fix also resolves Layer 2

With `<div><br><br></div>` as initial content (same as compose button), when `setFocus()` is called, the browser **does** create a real cursor at the beginning of this non-empty, non-`emptyPara` `<div>`. `createFromSelection()` returns that position (blank line 1) → `lastRange` = blank line 1 → TAB restores correctly.

---

## Fix

**File:** `lib/features/composer/presentation/extensions/setup_email_content_extension.dart`

```dart
// Before
void _loadSimpleEmailContent(String content) {
  if (PlatformInfo.isWeb) setTextEditorWeb(content);
  emailContentsViewState.value = Right(GetEmailContentSuccess(htmlEmailContent: content));
}

// After
void _loadSimpleEmailContent(String content) {
  if (PlatformInfo.isWeb && content.isNotEmpty) setTextEditorWeb(content);
  emailContentsViewState.value = Right(GetEmailContentSuccess(htmlEmailContent: content));
}
```

`setTextEditorWeb` is skipped when body is empty → `_textEditorWeb` stays `null` → `null ?? editorStartTags` = `'<div><br><br></div>'` → same DOM structure as compose button.

Affects both `composeFromMailtoUri` and `composeFromUnsubscribeMailtoLink` (both use `_loadSimpleEmailContent`). Non-empty mailto body still sets `_textEditorWeb` correctly.

## Reproduce

https://github.com/user-attachments/assets/22758808-dc9a-4c51-80f8-2faef8666fa3


## Resolved

https://github.com/user-attachments/assets/24b37ce3-fc2d-436b-b733-9de3c3e3246a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email content handling in the web composer by preventing unnecessary processing of empty email content in the text editor.

* **Tests**
  * Added test coverage for email content setup in mailto actions to verify proper handling of empty and non-empty content scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->