### PR TITLE
Gives text fields focus on right click

### DIFF
--- a/core/lib/presentation/views/color/color_picker_modal.dart
+++ b/core/lib/presentation/views/color/color_picker_modal.dart
@@ -1,6 +1,8 @@
 import 'dart:math' as math;
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart'
+    show RightClickFocus;
 import 'package:core/presentation/extensions/string_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
@@ -200,51 +202,54 @@ class _ColorPickerModalState extends State<ColorPickerModal> {
                                   start: 12,
                                   top: 6,
                                 ),
-                                child: TextField(
-                                  controller: _hexColorInputController,
+                                child: RightClickFocus(
                                   focusNode: _hexColorFocusNode,
-                                  style: theme.textTheme.bodySmall?.copyWith(
-                                    color: Colors.black,
+                                  child: TextField(
+                                    controller: _hexColorInputController,
+                                    focusNode: _hexColorFocusNode,
+                                    style: theme.textTheme.bodySmall?.copyWith(
+                                      color: Colors.black,
+                                    ),
+                                    cursorColor: AppColor.primaryColor,
+                                    decoration: InputDecoration(
+                                      border: UnderlineInputBorder(
+                                        borderSide: BorderSide(
+                                          color: Colors.black.withValues(
+                                            alpha: 0.12,
+                                          ),
+                                          width: 1,
+                                        ),
+                                      ),
+                                      enabledBorder: UnderlineInputBorder(
+                                        borderSide: BorderSide(
+                                          color: Colors.black.withValues(
+                                            alpha: 0.12,
+                                          ),
+                                          width: 1,
+                                        ),
+                                      ),
+                                      focusedBorder: UnderlineInputBorder(
+                                        borderSide: BorderSide(
+                                          color: Colors.black.withValues(
+                                            alpha: 0.12,
+                                          ),
+                                          width: 1,
+                                        ),
+                                      ),
+                                      isDense: true,
+                                      contentPadding: const EdgeInsets.only(
+                                        bottom: 2,
+                                      ),
+                                    ),
+                                    keyboardType: TextInputType.text,
+                                    textInputAction: TextInputAction.done,
+                                    inputFormatters: [
+                                      FilteringTextInputFormatter.allow(
+                                        RegExp(r'[0-9A-Fa-f#]'),
+                                      ),
+                                    ],
+                                    onChanged: _onHexColorChanged,
                                   ),
-                                  cursorColor: AppColor.primaryColor,
-                                  decoration: InputDecoration(
-                                    border: UnderlineInputBorder(
-                                      borderSide: BorderSide(
-                                        color: Colors.black.withValues(
-                                          alpha: 0.12,
-                                        ),
-                                        width: 1,
-                                      ),
-                                    ),
-                                    enabledBorder: UnderlineInputBorder(
-                                      borderSide: BorderSide(
-                                        color: Colors.black.withValues(
-                                          alpha: 0.12,
-                                        ),
-                                        width: 1,
-                                      ),
-                                    ),
-                                    focusedBorder: UnderlineInputBorder(
-                                      borderSide: BorderSide(
-                                        color: Colors.black.withValues(
-                                          alpha: 0.12,
-                                        ),
-                                        width: 1,
-                                      ),
-                                    ),
-                                    isDense: true,
-                                    contentPadding: const EdgeInsets.only(
-                                      bottom: 2,
-                                    ),
-                                  ),
-                                  keyboardType: TextInputType.text,
-                                  textInputAction: TextInputAction.done,
-                                  inputFormatters: [
-                                    FilteringTextInputFormatter.allow(
-                                      RegExp(r'[0-9A-Fa-f#]'),
-                                    ),
-                                  ],
-                                  onChanged: _onHexColorChanged,
                                 ),
                               )
                             ],

--- a/core/lib/presentation/views/quick_search/type_ahead_field_quick_search.dart
+++ b/core/lib/presentation/views/quick_search/type_ahead_field_quick_search.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart'
+    show RightClickFocus;
 import 'package:core/presentation/views/quick_search/quick_search_action_define.dart';
 import 'package:core/presentation/views/quick_search/quick_search_suggestion_box.dart';
 import 'package:core/presentation/views/quick_search/quick_search_suggestion_box_controller.dart';
@@ -669,43 +671,46 @@ class _TypeAheadFieldQuickSearchState<T, P, R>
             if (widget.textFieldConfiguration.leftButton != null)
               widget.textFieldConfiguration.leftButton!,
             Expanded(
-              child: TextField(
+              child: RightClickFocus(
                 focusNode: _effectiveFocusNode,
-                controller: _effectiveController,
-                decoration: widget.textFieldConfiguration.decoration,
-                style: widget.textFieldConfiguration.style,
-                textAlign: widget.textFieldConfiguration.textAlign,
-                enabled: widget.textFieldConfiguration.enabled,
-                keyboardType: widget.textFieldConfiguration.keyboardType,
-                autofocus: widget.textFieldConfiguration.autofocus,
-                inputFormatters: widget.textFieldConfiguration.inputFormatters,
-                autocorrect: widget.textFieldConfiguration.autocorrect,
-                maxLines: widget.textFieldConfiguration.maxLines,
-                textAlignVertical:
-                    widget.textFieldConfiguration.textAlignVertical,
-                minLines: widget.textFieldConfiguration.minLines,
-                maxLength: widget.textFieldConfiguration.maxLength,
-                maxLengthEnforcement:
-                    widget.textFieldConfiguration.maxLengthEnforcement,
-                obscureText: widget.textFieldConfiguration.obscureText,
-                onChanged: _onTextChange,
-                onSubmitted: widget.textFieldConfiguration.onSubmitted,
-                onEditingComplete:
-                    widget.textFieldConfiguration.onEditingComplete,
-                onTap: widget.textFieldConfiguration.onTap,
-                scrollPadding: widget.textFieldConfiguration.scrollPadding,
-                textInputAction: widget.textFieldConfiguration.textInputAction,
-                textCapitalization:
-                    widget.textFieldConfiguration.textCapitalization,
-                keyboardAppearance:
-                    widget.textFieldConfiguration.keyboardAppearance,
-                cursorWidth: widget.textFieldConfiguration.cursorWidth,
-                cursorRadius: widget.textFieldConfiguration.cursorRadius,
-                cursorColor: widget.textFieldConfiguration.cursorColor,
-                textDirection: _textDirection,
-                enableInteractiveSelection:
-                    widget.textFieldConfiguration.enableInteractiveSelection,
-                readOnly: widget.hideKeyboard,
+                child: TextField(
+                  focusNode: _effectiveFocusNode,
+                  controller: _effectiveController,
+                  decoration: widget.textFieldConfiguration.decoration,
+                  style: widget.textFieldConfiguration.style,
+                  textAlign: widget.textFieldConfiguration.textAlign,
+                  enabled: widget.textFieldConfiguration.enabled,
+                  keyboardType: widget.textFieldConfiguration.keyboardType,
+                  autofocus: widget.textFieldConfiguration.autofocus,
+                  inputFormatters: widget.textFieldConfiguration.inputFormatters,
+                  autocorrect: widget.textFieldConfiguration.autocorrect,
+                  maxLines: widget.textFieldConfiguration.maxLines,
+                  textAlignVertical:
+                      widget.textFieldConfiguration.textAlignVertical,
+                  minLines: widget.textFieldConfiguration.minLines,
+                  maxLength: widget.textFieldConfiguration.maxLength,
+                  maxLengthEnforcement:
+                      widget.textFieldConfiguration.maxLengthEnforcement,
+                  obscureText: widget.textFieldConfiguration.obscureText,
+                  onChanged: _onTextChange,
+                  onSubmitted: widget.textFieldConfiguration.onSubmitted,
+                  onEditingComplete:
+                      widget.textFieldConfiguration.onEditingComplete,
+                  onTap: widget.textFieldConfiguration.onTap,
+                  scrollPadding: widget.textFieldConfiguration.scrollPadding,
+                  textInputAction: widget.textFieldConfiguration.textInputAction,
+                  textCapitalization:
+                      widget.textFieldConfiguration.textCapitalization,
+                  keyboardAppearance:
+                      widget.textFieldConfiguration.keyboardAppearance,
+                  cursorWidth: widget.textFieldConfiguration.cursorWidth,
+                  cursorRadius: widget.textFieldConfiguration.cursorRadius,
+                  cursorColor: widget.textFieldConfiguration.cursorColor,
+                  textDirection: _textDirection,
+                  enableInteractiveSelection:
+                      widget.textFieldConfiguration.enableInteractiveSelection,
+                  readOnly: widget.hideKeyboard,
+                ),
               ),
             ),
             if (widget.textFieldConfiguration.clearTextButton != null &&

--- a/core/lib/presentation/views/text/text_field_builder.dart
+++ b/core/lib/presentation/views/text/text_field_builder.dart
@@ -3,6 +3,8 @@ import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/semantics/text_field_semantics.dart';
 import 'package:core/utils/direction_utils.dart';
 import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart'
+    show RightClickFocus;
 
 class TextFieldBuilder extends StatefulWidget {
 
@@ -69,6 +71,10 @@ class _TextFieldBuilderState extends State<TextFieldBuilder> {
 
   late TextDirection _textDirection;
 
+  FocusNode? _internalFocusNode;
+  FocusNode get _effectiveFocusNode =>
+      widget.focusNode ?? (_internalFocusNode ??= FocusNode());
+
   @override
   void initState() {
     super.initState();
@@ -102,7 +108,7 @@ class _TextFieldBuilderState extends State<TextFieldBuilder> {
       obscureText: widget.obscureText,
       keyboardType: widget.keyboardType,
       autofocus: widget.autoFocus,
-      focusNode: widget.focusNode,
+      focusNode: _effectiveFocusNode,
       textDirection: _textDirection,
       readOnly: widget.readOnly,
       mouseCursor: widget.mouseCursor,
@@ -112,15 +118,17 @@ class _TextFieldBuilderState extends State<TextFieldBuilder> {
       onTapOutside: widget.onTapOutside,
     );
 
+    final Widget content;
     if (widget.semanticLabel != null) {
-      return TextFieldSemantics(
+      content = TextFieldSemantics(
         label: widget.semanticLabel!,
         value: _controller?.text ?? '',
         child: textField,
       );
     } else {
-      return textField;
+      content = textField;
     }
+    return RightClickFocus(focusNode: _effectiveFocusNode, child: content);
   }
 
   void _onTextChanged(String value) {
@@ -140,6 +148,7 @@ class _TextFieldBuilderState extends State<TextFieldBuilder> {
     if (widget.controller == null) {
       _controller?.dispose();
     }
+    _internalFocusNode?.dispose();
     super.dispose();
   }
 }

--- a/core/lib/presentation/views/text/text_form_field_builder.dart
+++ b/core/lib/presentation/views/text/text_form_field_builder.dart
@@ -2,6 +2,8 @@ import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/utils/direction_utils.dart';
 import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart'
+    show RightClickFocus;
 
 class TextFormFieldBuilder extends StatefulWidget {
 
@@ -61,6 +63,10 @@ class _TextFieldFormBuilderState extends State<TextFormFieldBuilder> {
   late TextEditingController _controller;
   late TextDirection _textDirection;
 
+  FocusNode? _internalFocusNode;
+  FocusNode get _effectiveFocusNode =>
+      widget.focusNode ?? (_internalFocusNode ??= FocusNode());
+
   @override
   void initState() {
     if (widget.fromValue != null) {
@@ -76,40 +82,43 @@ class _TextFieldFormBuilderState extends State<TextFormFieldBuilder> {
 
   @override
   Widget build(BuildContext context) {
-    return TextField(
-      key: widget.key,
-      controller: _controller,
-      cursorColor: widget.cursorColor,
-      autocorrect: widget.autocorrect,
-      textInputAction: widget.textInputAction,
-      decoration: widget.decoration,
-      maxLines: widget.maxLines,
-      minLines: widget.minLines,
-      keyboardAppearance: widget.keyboardAppearance,
-      style: widget.textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
-        color: AppColor.textFieldTextColor,
-      ),
-      obscureText: widget.obscureText,
-      keyboardType: widget.keyboardType,
-      autofocus: widget.autoFocus,
-      focusNode: widget.focusNode,
-      textDirection: _textDirection,
-      readOnly: widget.readOnly,
-      mouseCursor: widget.mouseCursor,
-      autofillHints: widget.autofillHints,
-      onChanged: (value) {
-        widget.onTextChange?.call(value);
-        if (value.isNotEmpty) {
-          final directionByText = DirectionUtils.getDirectionByEndsText(value);
-          if (directionByText != _textDirection) {
-            setState(() {
-              _textDirection = directionByText;
-            });
+    return RightClickFocus(
+      focusNode: _effectiveFocusNode,
+      child: TextField(
+        key: widget.key,
+        controller: _controller,
+        cursorColor: widget.cursorColor,
+        autocorrect: widget.autocorrect,
+        textInputAction: widget.textInputAction,
+        decoration: widget.decoration,
+        maxLines: widget.maxLines,
+        minLines: widget.minLines,
+        keyboardAppearance: widget.keyboardAppearance,
+        style: widget.textStyle ?? ThemeUtils.defaultTextStyleInterFont.copyWith(
+          color: AppColor.textFieldTextColor,
+        ),
+        obscureText: widget.obscureText,
+        keyboardType: widget.keyboardType,
+        autofocus: widget.autoFocus,
+        focusNode: _effectiveFocusNode,
+        textDirection: _textDirection,
+        readOnly: widget.readOnly,
+        mouseCursor: widget.mouseCursor,
+        autofillHints: widget.autofillHints,
+        onChanged: (value) {
+          widget.onTextChange?.call(value);
+          if (value.isNotEmpty) {
+            final directionByText = DirectionUtils.getDirectionByEndsText(value);
+            if (directionByText != _textDirection) {
+              setState(() {
+                _textDirection = directionByText;
+              });
+            }
           }
-        }
-      },
-      onSubmitted: widget.onTextSubmitted,
-      onTap: widget.onTap,
+        },
+        onSubmitted: widget.onTextSubmitted,
+        onTap: widget.onTap,
+      ),
     );
   }
 
@@ -118,6 +127,7 @@ class _TextFieldFormBuilderState extends State<TextFormFieldBuilder> {
     if (widget.fromValue == null && widget.controller == null) {
       _controller.dispose();
     }
+    _internalFocusNode?.dispose();
     super.dispose();
   }
 }

--- a/core/lib/presentation/views/text/type_ahead_form_field_builder.dart
+++ b/core/lib/presentation/views/text/type_ahead_form_field_builder.dart
@@ -3,6 +3,8 @@ import 'package:core/presentation/views/quick_search/quick_search_action_define.
 import 'package:core/utils/direction_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart'
+    show RightClickFocus;
 
 typedef SuggestionBoxDecorationBuilder = Widget Function(Widget child);
 
@@ -64,6 +66,10 @@ class _TypeAheadFormFieldBuilderState<T> extends State<TypeAheadFormFieldBuilder
   late TextEditingController _controller;
   late TextDirection _textDirection;
 
+  FocusNode? _internalFocusNode;
+  FocusNode get _effectiveFocusNode =>
+      widget.focusNode ?? (_internalFocusNode ??= FocusNode());
+
   @override
   void initState() {
     super.initState();
@@ -76,31 +82,34 @@ class _TypeAheadFormFieldBuilderState<T> extends State<TypeAheadFormFieldBuilder
     return TypeAheadField<T>(
       key: widget.key,
       controller: widget.controller,
-      focusNode: widget.focusNode,
+      focusNode: _effectiveFocusNode,
       builder: (_, controller, focusNode) {
-        return TextField(
-          controller: controller,
+        return RightClickFocus(
           focusNode: focusNode,
-          textInputAction: widget.textInputAction,
-          autocorrect: widget.autocorrect,
-          autofillHints: widget.autofillHints,
-          style: widget.textStyle,
-          keyboardType: widget.keyboardType,
-          decoration: widget.decoration,
-          textDirection: _textDirection,
-          cursorColor: widget.cursorColor,
-          onChanged: (value) {
-            widget.onTextChange?.call(value);
-            if (value.isNotEmpty) {
-              final directionByText = DirectionUtils.getDirectionByEndsText(value);
-              if (directionByText != _textDirection) {
-                setState(() {
-                  _textDirection = directionByText;
-                });
+          child: TextField(
+            controller: controller,
+            focusNode: focusNode,
+            textInputAction: widget.textInputAction,
+            autocorrect: widget.autocorrect,
+            autofillHints: widget.autofillHints,
+            style: widget.textStyle,
+            keyboardType: widget.keyboardType,
+            decoration: widget.decoration,
+            textDirection: _textDirection,
+            cursorColor: widget.cursorColor,
+            onChanged: (value) {
+              widget.onTextChange?.call(value);
+              if (value.isNotEmpty) {
+                final directionByText = DirectionUtils.getDirectionByEndsText(value);
+                if (directionByText != _textDirection) {
+                  setState(() {
+                    _textDirection = directionByText;
+                  });
+                }
               }
-            }
-          },
-          onSubmitted: widget.onTextSubmitted
+            },
+            onSubmitted: widget.onTextSubmitted
+          ),
         );
       },
       debounceDuration: widget.debounceDuration,
@@ -132,6 +141,7 @@ class _TypeAheadFormFieldBuilderState<T> extends State<TypeAheadFormFieldBuilder
     if (widget.controller == null) {
       _controller.dispose();
     }
+    _internalFocusNode?.dispose();
     super.dispose();
   }
 }

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -38,6 +38,8 @@ dependencies:
       ref: support_mail
       path: sanitize_html
 
+  linagora_design_flutter:
+
   ### Dependencies from pub.dev ###
   cupertino_icons: 1.0.6
 

--- a/integration_test/extensions/patrol_finder_extension.dart
+++ b/integration_test/extensions/patrol_finder_extension.dart
@@ -1,4 +1,5 @@
 
+import 'package:flutter/gestures.dart';
 import 'package:patrol_log/patrol_log.dart';
 import 'package:patrol_finders/patrol_finders.dart';
 
@@ -16,4 +17,17 @@ extension PatrolFinderExtension on PatrolFinder {
         enablePatrolLog: false,
       ),
     );
+
+  /// Presses the secondary (right) mouse button at the center of this widget, then releases.
+  Future<void> rightClick() async => wrapWithPatrolLog(
+    action: 'rightClick',
+    color: AnsiCodes.magenta,
+    function: () async {
+      final resolved = await tester.waitUntilVisible(this, enablePatrolLog: false);
+      final widgetTester = tester.tester;
+      final gesture = await widgetTester.startGesture(widgetTester.getCenter(resolved.first), kind: PointerDeviceKind.mouse, buttons: kSecondaryButton);
+      await gesture.up();
+      await widgetTester.pump();
+    },
+  );
 }

--- a/integration_test/scenarios/search/right_click_focus_search_field_scenario.dart
+++ b/integration_test/scenarios/search/right_click_focus_search_field_scenario.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/patrol.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../extensions/patrol_finder_extension.dart';
+import '../../utils/test_timeouts.dart';
+import '../../utils/wait_for_condition.dart';
+
+class RightClickFocusSearchFieldScenario extends BaseTestScenario {
+  const RightClickFocusSearchFieldScenario(super.$, super.robots);
+
+  @override
+  Future<void> runTestLogic() async {
+    final commonRobot = robots.commonRobot();
+
+    // The dashboard search bar only mounts once the seeded-credentials login
+    // settles, so wait for the dashboard to be ready first.
+    await commonRobot.waitForMailboxReady();
+
+    final searchField = $(SearchInputFormWidget).$(TextField);
+    await $.waitUntilVisible(searchField);
+
+    // Precondition: the search field is not focused on load.
+    expect(_isFocused(searchField), isFalse);
+
+    // A secondary (right) mouse-button press should focus the field on web,
+    // through the RightClickFocus wrapper introduced in linagora-design-flutter.
+    await searchField.rightClick();
+    await waitForCondition(
+      () async => _isFocused(searchField),
+      timeout: TestTimeouts.short,
+    );
+
+    expect(_isFocused(searchField), isTrue);
+  }
+
+  bool _isFocused(PatrolFinder searchField) => searchField.which<TextField>((field) => field.focusNode?.hasFocus ?? false).exists;
+}

--- a/integration_test/tests/search/right_click_focus_search_field_test.dart
+++ b/integration_test/tests/search/right_click_focus_search_field_test.dart
@@ -1,0 +1,11 @@
+import '../../base/test_base.dart';
+import '../../models/test_tags.dart';
+import '../../scenarios/search/right_click_focus_search_field_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Should focus the search field when right clicking on it',
+    tags: [TestTags.web],
+    scenarioBuilder: ($, robots) => RightClickFocusSearchFieldScenario($, robots),
+  );
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1440,11 +1440,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: master
-      resolved-ref: "66d09a271f20243badd92352a8bb5866b430020d"
+      ref: "v0.2.0"
+      resolved-ref: "160531adb37004898cff78009f5ebdbafdf54a32"
       url: "https://github.com/linagora/linagora-design-flutter.git"
     source: git
-    version: "0.0.1"
+    version: "0.2.0"
   linkify:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -325,7 +325,7 @@ dependency_overrides:
   linagora_design_flutter:
     git:
       url: https://github.com/linagora/linagora-design-flutter.git
-      ref: master
+      ref: v0.2.0
 
   ### Original dependency is abandoned, so we use fork
   intl_generator:

--- a/scribe/lib/scribe/ai/presentation/widgets/search/ai_scribe_bar.dart
+++ b/scribe/lib/scribe/ai/presentation/widgets/search/ai_scribe_bar.dart
@@ -2,6 +2,8 @@ import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart'
+    show RightClickFocus;
 import 'package:scribe/scribe.dart';
 
 typedef OnCustomPromptCallback = void Function(String customPrompt);
@@ -90,20 +92,23 @@ class _AIScribeBarState extends State<AIScribeBar> {
               child: KeyboardListener(
                 focusNode: _keyboardListenerFocusNode,
                 onKeyEvent: _handleKeyboardEvent,
-                child: TextField(
-                  controller: _controller,
+                child: RightClickFocus(
                   focusNode: _textFieldFocusNode,
-                  decoration: InputDecoration(
-                    hintText: ScribeLocalizations.of(context).customPromptAction,
-                    hintStyle: AIScribeTextStyles.searchBarHint,
-                    border: InputBorder.none,
-                    contentPadding: const EdgeInsets.symmetric(vertical: 8),
-                    isDense: true,
+                  child: TextField(
+                    controller: _controller,
+                    focusNode: _textFieldFocusNode,
+                    decoration: InputDecoration(
+                      hintText: ScribeLocalizations.of(context).customPromptAction,
+                      hintStyle: AIScribeTextStyles.searchBarHint,
+                      border: InputBorder.none,
+                      contentPadding: const EdgeInsets.symmetric(vertical: 8),
+                      isDense: true,
+                    ),
+                    style: AIScribeTextStyles.searchBar,
+                    maxLines: null,
+                    keyboardType: TextInputType.multiline,
+                    cursorHeight: 16,
                   ),
-                  style: AIScribeTextStyles.searchBar,
-                  maxLines: null,
-                  keyboardType: TextInputType.multiline,
-                  cursorHeight: 16,
                 ),
               ),
             ),

--- a/scribe/pubspec.yaml
+++ b/scribe/pubspec.yaml
@@ -22,6 +22,8 @@ dependencies:
   ### Dependencies from git ###
   jmap_dart_client:
 
+  linagora_design_flutter:
+
   ### Dependencies from pub.dev ###
   dartz: 0.10.1
 


### PR DESCRIPTION
## Ticket
Fixes https://github.com/linagora/twake-on-matrix/issues/3055 (Same issue as Twake Chat)

## Changes
- Updates linagora-design-flutter to v0.2.0
- Implements `RightClickFocus` behavior (introduced in linagora-design-flutter) wrapper that focuses the field on a secondary mouse-button press, web only.

## Demo

https://github.com/user-attachments/assets/c74f7fb6-8333-4fea-af07-0ce328774ac6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Right-clicking text inputs now reliably focuses the field across the color picker modal, quick search, the AI search bar, and typeahead/text form components (including web).

* **Updates**
  * Improved focus behavior when focus is managed automatically, leading to more consistent keyboard and interaction handling in search and form UI.

* **Tests**
  * Added an end-to-end web scenario and test covering right-click focusing on the dashboard search field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->