### PR TITLE
Fix sort order not applied from search bar on restart

### DIFF
--- a/integration_test/scenarios/search/sort_order_persisted_from_search_bar_on_restart_scenario.dart
+++ b/integration_test/scenarios/search/sort_order_persisted_from_search_bar_on_restart_scenario.dart
@@ -1,0 +1,63 @@
+
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_store_email_sort_order_extension.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+import '../../utils/test_timeouts.dart';
+import '../../utils/wait_for_condition.dart';
+
+class SortOrderPersistedFromSearchBarOnRestartScenario extends BaseTestScenario {
+  const SortOrderPersistedFromSearchBarOnRestartScenario(super.$, super.robots);
+
+  static const queryString = 'sort order restart';
+  static const listUsername = ['Alice', 'Brian', 'Charlotte', 'David', 'Emma'];
+
+  @override
+  Future<void> runTestLogic() async {
+    await robots.commonRobot().provisionEmail(
+      listUsername
+          .map((name) => ProvisioningEmail(
+                toEmail: '${name.toLowerCase()}@example.com',
+                subject: queryString,
+                content: '$queryString for user $name',
+              ))
+          .toList(),
+    );
+    await $.pumpAndSettle();
+
+    final dashboardController = Get.find<MailboxDashBoardController>();
+
+    // Persist 'oldest' sort order as the user's stored preference
+    dashboardController.storeEmailSortOrder(EmailSortOrderType.oldest);
+    await $.pump(const Duration(seconds: 1));
+
+    // Reset to default so the next call reproduces a clean cold-restart state
+    dashboardController.searchController.clearSearchFilter(
+      sortOrderType: SearchEmailFilter.defaultSortOrder,
+    );
+
+    // Simulate app restart: load the stored sort order and wait for it to
+    // propagate into searchController.searchEmailFilter
+    dashboardController.loadStoredEmailSortOrder();
+    await waitForCondition(
+      () async =>
+          dashboardController.searchController.sortOrderFiltered ==
+          EmailSortOrderType.oldest,
+      timeout: TestTimeouts.medium,
+    );
+    await $.pump(const Duration(seconds: 1));
+
+    final searchRobot = robots.searchRobot();
+    await searchRobot.tapOnSearchField();
+    await searchRobot.enterKeyword(queryString);
+    await searchRobot.tapOnShowAllResultsText();
+
+    await searchRobot.expectSearchResultEmailListVisible();
+    await searchRobot.expectEmailListCount(listUsername.length);
+    await searchRobot.expectEmailListSortedByOldest();
+  }
+}

--- a/integration_test/tests/search/sort_order_persisted_from_search_bar_on_restart_test.dart
+++ b/integration_test/tests/search/sort_order_persisted_from_search_bar_on_restart_test.dart
@@ -1,0 +1,15 @@
+import '../../base/test_base.dart';
+import '../../models/test_tags.dart';
+import '../../scenarios/search/sort_order_persisted_from_search_bar_on_restart_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description:
+        'GIVEN user previously stored oldest sort order '
+        'WHEN app restarts and user searches from the inline search bar '
+        'THEN search results should be sorted by oldest',
+    scenarioBuilder: ($, robots) =>
+        SortOrderPersistedFromSearchBarOnRestartScenario($, robots),
+    tags: [TestTags.web],
+  );
+}

--- a/lib/features/mailbox_dashboard/presentation/extensions/handle_store_email_sort_order_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/handle_store_email_sort_order_extension.dart
@@ -1,5 +1,6 @@
 
 import 'package:core/utils/app_logger.dart';
+import 'package:dartz/dartz.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/action/dashboard_action.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
@@ -17,6 +18,7 @@ extension HandleStoreEmailSortOrderExtension on MailboxDashBoardController {
   void setUpDefaultEmailSortOrder(EmailSortOrderType storedSortOrder) {
     log('$runtimeType::setUpDefaultEmailSortOrder: $storedSortOrder');
     currentSortOrder = storedSortOrder;
+    searchController.updateFilterEmail(sortOrderTypeOption: Some(storedSortOrder));
     dispatchAction(SynchronizeEmailSortOrderAction(currentSortOrder));
   }
 }

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -103,6 +103,7 @@ import 'package:tmail_ui_user/features/thread/domain/usecases/move_multiple_emai
 import 'package:tmail_ui_user/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_more_email_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_store_email_sort_order_extension.dart';
 import 'package:tmail_ui_user/features/thread/presentation/extensions/handle_email_filter_extension.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
@@ -606,6 +607,56 @@ void main() {
     expect(filterAfterQuickSearch.before, isNull);
     expect(filterAfterQuickSearch.after, isNull);
   });
+
+    test(
+      'WHEN stored sort order is loaded on app restart\n'
+      'SHOULD sync sort order to SearchController so inline search bar uses it',
+    () {
+      mailboxDashboardController.setUpDefaultEmailSortOrder(EmailSortOrderType.oldest);
+
+      expect(searchController.sortOrderFiltered, EmailSortOrderType.oldest);
+      expect(searchController.searchEmailFilter.value.sortOrderType, EmailSortOrderType.oldest);
+    });
+
+    test(
+      'WHEN setUpDefaultEmailSortOrder is called\n'
+      'SHOULD keep currentSortOrder and searchController.sortOrderFiltered in sync',
+    () {
+      mailboxDashboardController.setUpDefaultEmailSortOrder(EmailSortOrderType.senderAscending);
+
+      expect(
+        mailboxDashboardController.currentSortOrder,
+        EmailSortOrderType.senderAscending,
+      );
+      expect(
+        searchController.sortOrderFiltered,
+        mailboxDashboardController.currentSortOrder,
+      );
+    });
+
+    test(
+      'WHEN setUpDefaultEmailSortOrder is called multiple times\n'
+      'SHOULD reflect the last sort order in both currentSortOrder and searchController',
+    () {
+      mailboxDashboardController.setUpDefaultEmailSortOrder(EmailSortOrderType.oldest);
+      mailboxDashboardController.setUpDefaultEmailSortOrder(EmailSortOrderType.senderDescending);
+
+      expect(mailboxDashboardController.currentSortOrder, EmailSortOrderType.senderDescending);
+      expect(searchController.sortOrderFiltered, EmailSortOrderType.senderDescending);
+    });
+
+    test(
+      'WHEN user changes sort order via storeEmailSortOrder\n'
+      'SHOULD update currentSortOrder and sync searchController immediately',
+    () {
+      mailboxDashboardController.storeEmailSortOrder(EmailSortOrderType.subjectAscending);
+
+      expect(
+        mailboxDashboardController.currentSortOrder,
+        EmailSortOrderType.subjectAscending,
+      );
+      expect(searchController.sortOrderFiltered, EmailSortOrderType.subjectAscending);
+    });
 
     tearDown(Get.deleteAll);
   });


### PR DESCRIPTION
## Reproduce


https://github.com/user-attachments/assets/b6aa5b73-49ec-4080-9374-5e98e2d6cd59



## Root cause

`setUpDefaultEmailSortOrder()` — called on app startup when the stored sort order is loaded from local storage — was updating `currentSortOrder` and dispatching `SynchronizeEmailSortOrderAction`, but **not** syncing `SearchController.searchEmailFilter`.

On web, the inline search bar (`SearchInputFormWidget`) triggers `searchEmailByQueryString()` → `StartSearchEmailAction` → `ThreadController._searchEmail()`, which reads `searchController.searchEmailFilter.sortOrderType` directly. Because that field was never updated on restart, every inline search after a cold start would silently fall back to the default sort order (`relevance`), ignoring the user's stored preference.

## Solution

```dart
// handle_store_email_sort_order_extension.dart
void setUpDefaultEmailSortOrder(EmailSortOrderType storedSortOrder) {
  currentSortOrder = storedSortOrder;
+ searchController.updateFilterEmail(sortOrderTypeOption: Some(storedSortOrder)); // ← fix
  dispatchAction(SynchronizeEmailSortOrderAction(currentSortOrder));
}
```

One line added: propagate the stored sort order into `searchController.searchEmailFilter` so both the restart path (`loadStoredEmailSortOrder`) and the user-change path (`storeEmailSortOrder`) keep `currentSortOrder` and `searchController` in sync.

## Resolved


https://github.com/user-attachments/assets/2d8ef4a3-1040-4637-b4d8-1b35e4dd6d52




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sort order preferences are now correctly persisted and synchronized with the search functionality after app restart.

* **Tests**
  * Added integration test scenario validating sort order persistence in search after app restart.
  * Added unit tests verifying sort order synchronization between email and search controllers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->