### PR TITLE
Fix: Reply-to shows raw email address instead of display name (#4249, #4624)

### DIFF
--- a/lib/features/composer/presentation/extensions/create_email_request_extension.dart
+++ b/lib/features/composer/presentation/extensions/create_email_request_extension.dart
@@ -51,11 +51,22 @@ extension CreateEmailRequestExtension on CreateEmailRequest {
 
     if (isNotReplyTo) return null;
 
-    return identity?.replyTo?.isNotEmpty == true
-      ? identity!.replyTo!
-      : ownEmailAddress.isNotEmpty
-        ? {EmailAddress(null, ownEmailAddress)}
+    if (identity?.replyTo?.isNotEmpty == true) {
+      return identity!.replyTo!.map((address) {
+        if (address.name?.isNotEmpty == true) return address;
+        return EmailAddress(identity!.name, address.email);
+      }).toSet();
+    }
+
+    if (identity != null) {
+      return identity!.email?.isNotEmpty == true
+        ? {EmailAddress(identity!.name, identity!.email)}
         : null;
+    }
+
+    return ownEmailAddress.isNotEmpty
+      ? {EmailAddress(null, ownEmailAddress)}
+      : null;
   }
 
 

--- a/lib/features/identity_creator/presentation/identity_creator_controller.dart
+++ b/lib/features/identity_creator/presentation/identity_creator_controller.dart
@@ -401,7 +401,7 @@ class IdentityCreatorController extends BaseController with DragDropFileMixin im
 
     if (identity?.replyTo?.isNotEmpty == true) {
       replyToOfIdentity.value = listEmailAddressOfReplyTo
-        .firstWhereOrNull((emailAddress) => emailAddress ==  identity!.replyTo!.first);
+        .firstWhereOrNull((emailAddress) => emailAddress.email == identity!.replyTo!.first.email);
 
       if (replyToOfIdentity.value == null && identity!.replyTo!.first == noneEmailAddress) {
         replyToOfIdentity.value = noneEmailAddress;
@@ -530,7 +530,7 @@ class IdentityCreatorController extends BaseController with DragDropFileMixin im
         : <EmailAddress>{};
     Set<EmailAddress> replyToAddress;
     if (replyToOfIdentity.value != null && (replyToOfIdentity.value != noneEmailAddress || forCache)) {
-      replyToAddress = {replyToOfIdentity.value!};
+      replyToAddress = {EmailAddress(_nameIdentity, replyToOfIdentity.value!.email)};
     } else {
       replyToAddress = {};
     }

--- a/test/features/composer/presentation/extensions/create_email_request_extension_test.dart
+++ b/test/features/composer/presentation/extensions/create_email_request_extension_test.dart
@@ -2,7 +2,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/identities/identity.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_body_part.dart';
 import 'package:jmap_dart_client/jmap/mail/email/individual_header_identifier.dart';
 import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
@@ -358,6 +360,159 @@ void main() {
 
         expect(cache.displayMode, ScreenDisplayMode.normal);
       });
+    });
+  });
+
+  group('createReplyToRecipients:', () {
+    const ownEmail = 'alice@domain.tld';
+
+    CreateEmailRequest buildRequest({
+      Identity? identity,
+      Set<EmailAddress>? replyToRecipients,
+      String ownEmailAddress = ownEmail,
+    }) {
+      return CreateEmailRequest(
+        session: SessionFixtures.aliceSession,
+        accountId: AccountFixtures.aliceAccountId,
+        emailActionType: EmailActionType.compose,
+        ownEmailAddress: ownEmailAddress,
+        subject: 'subject',
+        emailContent: 'content',
+        identity: identity,
+        replyToRecipients: replyToRecipients,
+      );
+    }
+
+    test(
+      'should return own email address without display name '
+      'when no identity is set',
+    () {
+      final request = buildRequest();
+
+      final result = request.createReplyToRecipients();
+
+      expect(result, {EmailAddress(null, ownEmail)});
+    });
+
+    test(
+      'should return null '
+      'when no identity is set and ownEmailAddress is empty',
+    () {
+      final request = buildRequest(ownEmailAddress: '');
+
+      final result = request.createReplyToRecipients();
+
+      expect(result, isNull);
+    });
+
+    test(
+      'should return identity email with display name '
+      'when identity has no replyTo configured',
+    () {
+      final identity = Identity(
+        name: 'Alice Smith',
+        email: ownEmail,
+        replyTo: {},
+      );
+      final request = buildRequest(identity: identity);
+
+      final result = request.createReplyToRecipients();
+
+      expect(result, {EmailAddress('Alice Smith', ownEmail)});
+    });
+
+    test(
+      'should supplement identity name on replyTo address '
+      'when identity replyTo items have no display name',
+    () {
+      const replyToEmail = 'reply@domain.tld';
+      final identity = Identity(
+        name: 'Alice Smith',
+        email: ownEmail,
+        replyTo: {EmailAddress(null, replyToEmail)},
+      );
+      final request = buildRequest(identity: identity);
+
+      final result = request.createReplyToRecipients();
+
+      expect(result, {EmailAddress('Alice Smith', replyToEmail)});
+    });
+
+    test(
+      'should preserve existing display name on replyTo address '
+      'when replyTo items already have a display name',
+    () {
+      const replyToEmail = 'reply@domain.tld';
+      final identity = Identity(
+        name: 'Alice Smith',
+        email: ownEmail,
+        replyTo: {EmailAddress('Custom Name', replyToEmail)},
+      );
+      final request = buildRequest(identity: identity);
+
+      final result = request.createReplyToRecipients();
+
+      expect(result, {EmailAddress('Custom Name', replyToEmail)});
+    });
+
+    test(
+      'should supplement identity name only on items missing display name '
+      'when identity replyTo contains mixed items',
+    () {
+      const namedEmail = 'named@domain.tld';
+      const unnamedEmail = 'unnamed@domain.tld';
+      final identity = Identity(
+        name: 'Alice Smith',
+        email: ownEmail,
+        replyTo: {
+          EmailAddress('Custom Name', namedEmail),
+          EmailAddress(null, unnamedEmail),
+        },
+      );
+      final request = buildRequest(identity: identity);
+
+      final result = request.createReplyToRecipients();
+
+      expect(result, {
+        EmailAddress('Custom Name', namedEmail),
+        EmailAddress('Alice Smith', unnamedEmail),
+      });
+    });
+
+    test(
+      'should return null '
+      'when isDraft is true regardless of identity',
+    () {
+      final identity = Identity(
+        name: 'Alice Smith',
+        email: ownEmail,
+        replyTo: {EmailAddress(null, 'reply@domain.tld')},
+      );
+      final request = buildRequest(identity: identity);
+
+      final result = request.createReplyToRecipients(isNotReplyTo: true);
+
+      expect(result, isNull);
+    });
+
+    test(
+      'should return manually set replyToRecipients as-is '
+      'when replyToRecipients is provided',
+    () {
+      final manualReplyTo = {EmailAddress('Bob', 'bob@domain.tld')};
+      final identity = Identity(
+        name: 'Alice Smith',
+        email: ownEmail,
+        replyTo: {EmailAddress(null, 'reply@domain.tld')},
+      );
+      final request = buildRequest(
+        identity: identity,
+        replyToRecipients: manualReplyTo,
+      );
+
+      final result = request.createReplyToRecipients();
+
+      expect(result, manualReplyTo);
     });
   });
 }

--- a/test/features/identity_creator/presentation/identity_creator_controller_test.dart
+++ b/test/features/identity_creator/presentation/identity_creator_controller_test.dart
@@ -20,6 +20,7 @@ import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:jmap_dart_client/jmap/identities/identity.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:tmail_ui_user/features/base/before_reconnect_manager.dart';
@@ -37,6 +38,7 @@ import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_i
 import 'package:tmail_ui_user/features/mailbox_creator/domain/state/verify_name_view_state.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/usecases/verify_name_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/state/get_all_identities_state.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_all_identities_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/identities/utils/identity_utils.dart';
@@ -376,6 +378,115 @@ void main() {
       )).called(1);
 
       PlatformInfo.isTestingForWeb = false;
+    });
+
+    test(
+      'should save replyTo with identity display name '
+      'when screen is reloaded and replyTo is selected',
+    () async {
+      // arrange
+      PlatformInfo.isTestingForWeb = true;
+      const htmlContent = '<p>test</p>';
+      const identityName = 'Alice Smith';
+      const replyToEmail = 'alice@example.com';
+      identityCreatorController.arguments = IdentityCreatorArguments(
+        accountId,
+        session,
+        ownEmailAddress,
+      );
+      when(mockVerifyNameInteractor.execute(any, any)).thenAnswer((_) => Right(VerifyNameViewState()));
+
+      // act
+      identityCreatorController.onReady();
+      final context = MockBuildContext();
+      identityCreatorController.updateNameIdentity(context, identityName);
+      identityCreatorController.updateContentHtmlEditor(htmlContent);
+      identityCreatorController.replyToOfIdentity.value = EmailAddress(null, replyToEmail);
+
+      identityCreatorController.onUnloadBrowserListener(Event(''));
+      await untilCalled(mockSaveIdentityCacheOnWebInteractor.execute(
+        any,
+        any,
+        identityCache: anyNamed('identityCache'),
+      ));
+
+      // assert
+      verify(mockSaveIdentityCacheOnWebInteractor.execute(
+        accountId,
+        session.username,
+        identityCache: IdentityCache(
+          identity: Identity(
+            name: identityName,
+            bcc: {},
+            replyTo: {EmailAddress(identityName, replyToEmail)},
+            htmlSignature: Signature(htmlContent)
+          ),
+          identityActionType: IdentityActionType.create,
+          isDefault: false,
+          publicAssetsInIdentityArguments: PublicAssetsInIdentityArguments(
+            htmlSignature: htmlContent,
+            preExistingPublicAssetIds: [],
+            newlyPickedPublicAssetIds: []
+          )
+        ),
+      )).called(1);
+
+      PlatformInfo.isTestingForWeb = false;
+    });
+
+    test(
+      'should pre-select replyTo by email '
+      'when stored replyTo has a display name that differs from the dropdown item name',
+    () async {
+      // arrange
+      const replyToEmail = 'bob@example.com';
+      const displayName = 'Bob Smith';
+      final identityId = IdentityId(Id('identity-1'));
+      final identityWithNamedReplyTo = Identity(
+        id: identityId,
+        name: 'Test Identity',
+        email: replyToEmail,
+        replyTo: {EmailAddress(displayName, replyToEmail)},
+        mayDelete: true,
+      );
+
+      identityCreatorController.listEmailAddressDefault.clear();
+      identityCreatorController.listEmailAddressOfReplyTo.clear();
+      identityCreatorController.replyToOfIdentity.value = null;
+
+      identityCreatorController.arguments = IdentityCreatorArguments(
+        accountId,
+        session,
+        ownEmailAddress,
+        identity: identityWithNamedReplyTo,
+        actionType: IdentityActionType.edit,
+      );
+
+      when(mockGetAllIdentitiesInteractor.execute(
+        any,
+        any,
+        properties: anyNamed('properties'),
+      )).thenAnswer((_) => Stream.value(Right(GetAllIdentitiesSuccess(
+        [
+          Identity(
+            id: identityId,
+            name: 'Test Identity',
+            email: replyToEmail,
+            mayDelete: true,
+          ),
+        ],
+        null,
+      ))));
+
+      // act
+      identityCreatorController.onReady();
+      await pumpEventQueue();
+
+      // assert - replyTo is pre-selected by email, ignoring display name mismatch
+      expect(
+        identityCreatorController.replyToOfIdentity.value?.email,
+        equals(replyToEmail),
+      );
     });
   });
 }


### PR DESCRIPTION
## Issue

#4249 
#4624 

## Analysis

When a user sends an email, the outgoing JMAP `Email/set` request includes a `replyTo` header. If that header contains `EmailAddress` objects with `name = null`, mail clients that use `replyTo` to pre-fill recipients on reply will show a raw email address instead of a display name.

Two issues share this root cause:
- **#4249**: Sent folder shows raw email addresses for known contacts (e.g. `testuser@example.com` instead of `"Test User"`).
- **#4624**: Reply screen pre-fills recipients from `replyTo` without display names.

## Root Cause

**Layer 1 — upstream (identity creation):** When saving an identity, `IdentityCreatorController` collects the selected replyTo address as `replyToOfIdentity.value!` (raw `EmailAddress` from the dropdown, which carries no name because the dropdown was populated via `toEmailAddressNoName()`). The saved `identity.replyTo` therefore always contains `EmailAddress(null, email)`.

**Layer 2 — downstream (email generation):** `CreateEmailRequestExtension.createReplyToRecipients()` forwarded `identity.replyTo` as-is without supplementing missing names. The fallback paths (identity with empty replyTo, or no identity) also used `EmailAddress(null, ...)`.

## Solution

### `IdentityCreatorController` (upstream fix)

- **Save path** (`_collectReplyToAddress`, line ~530): wrap the selected address with the identity name before saving:
  ```dart
  // before
  replyToAddress = {replyToOfIdentity.value!};
  // after
  replyToAddress = {EmailAddress(_nameIdentity, replyToOfIdentity.value!.email)};
  ```

- **Restore path** (`_setUpAllFieldEmailAddress`, line ~404): match stored replyTo back to the dropdown by `.email` only, since the stored object now carries a name but the dropdown items may not:
  ```dart
  // before
  .firstWhereOrNull((emailAddress) => emailAddress == identity!.replyTo!.first);
  // after
  .firstWhereOrNull((emailAddress) => emailAddress.email == identity!.replyTo!.first.email);
  ```

### `CreateEmailRequestExtension` (downstream fix / last defence)

Rewrote `createReplyToRecipients` to supplement any name-less address before it reaches the outgoing email:

| Scenario | Before | After |
|---|---|---|
| `identity.replyTo` non-empty, name missing | `EmailAddress(null, addr)` | `EmailAddress(identity.name, addr)` |
| `identity.replyTo` non-empty, name present | unchanged | unchanged |
| Identity exists, `replyTo` empty | `EmailAddress(null, ownEmail)` | `EmailAddress(identity.name, identity.email)` |
| No identity | `EmailAddress(null, ownEmail)` | `EmailAddress(null, ownEmail)` (unchanged) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of reply-to addresses when composing emails, including filling in missing display names and using identity email details more consistently.
  * Fixed reply-to selection so matching works even if the stored display name differs from what’s shown in the UI.

* **Tests**
  * Added coverage for reply-to recipient generation and identity reply-to selection, including empty, named, unnamed, and draft scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->