### PR TITLE
Cherry-pick maintenance fixes from `v0.29.x` to `master` (e2e test stabilization, v0.29.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [0.29.6] - 2026-06-16
+## [0.29.8] - 2026-06-17
+### Changed
+- Translation vi, ru, fr
+
+## [0.29.7] - 2026-06-16
 ### Fixed
 - flaky mobile e2e test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.29.6] - 2026-06-16
+### Fixed
+- flaky mobile e2e test
+
 ## [0.29.6] - 2026-06-13
 ### Fixed
 - fix: cannot download because of no way to get token from corrupt box

--- a/integration_test/extensions/mailbox_dashboard_controller_integration_test_extensions.dart
+++ b/integration_test/extensions/mailbox_dashboard_controller_integration_test_extensions.dart
@@ -5,6 +5,7 @@ extension MailboxDashboardControllerIntegrationTestExtensions on MailboxDashBoar
     return this != null &&
         this!.sessionCurrent != null &&
         this!.accountId.value != null &&
-        this!.selectedMailbox.value != null;
+        this!.selectedMailbox.value != null &&
+        this!.mapDefaultMailboxIdByRole.isNotEmpty;
   }
 }

--- a/integration_test/mixin/provisioning_label_scenario_mixin.dart
+++ b/integration_test/mixin/provisioning_label_scenario_mixin.dart
@@ -6,10 +6,8 @@ import 'package:tmail_ui_user/features/labels/domain/usecases/create_new_label_i
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
-import '../extensions/mailbox_dashboard_controller_integration_test_extensions.dart';
 import '../models/provisioning_email.dart';
 import '../models/provisioning_label.dart';
-import '../utils/wait_for_condition.dart';
 import '../utils/wait_for_mailbox_ready.dart';
 
 mixin ProvisioningLabelScenarioMixin {

--- a/integration_test/mixin/provisioning_label_scenario_mixin.dart
+++ b/integration_test/mixin/provisioning_label_scenario_mixin.dart
@@ -10,6 +10,7 @@ import '../extensions/mailbox_dashboard_controller_integration_test_extensions.d
 import '../models/provisioning_email.dart';
 import '../models/provisioning_label.dart';
 import '../utils/wait_for_condition.dart';
+import '../utils/wait_for_mailbox_ready.dart';
 
 mixin ProvisioningLabelScenarioMixin {
   Future<List<Label>> provisionLabels(
@@ -19,9 +20,7 @@ mixin ProvisioningLabelScenarioMixin {
       return [];
     }
 
-    await waitForCondition(
-      () => getBinding<MailboxDashBoardController>().isReady,
-    );
+    await waitForMailboxReady();
 
     final dashboardController = getBinding<MailboxDashBoardController>();
     final createLabelInteractor = getBinding<CreateNewLabelInteractor>();

--- a/integration_test/mixin/scenario_utils_mixin.dart
+++ b/integration_test/mixin/scenario_utils_mixin.dart
@@ -38,15 +38,12 @@ import 'package:tmail_ui_user/features/manage_account/presentation/identities/id
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
 import 'package:tmail_ui_user/features/upload/domain/state/attachment_upload_state.dart';
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
-import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:uuid/uuid.dart';
 
-import '../extensions/mailbox_dashboard_controller_integration_test_extensions.dart';
 import '../extensions/patrol_file_extensions.dart';
 import '../models/provisioning_email.dart';
 import '../models/provisioning_identity.dart';
 import '../resources/test_images.dart';
-import '../utils/wait_for_condition.dart';
 import '../utils/wait_for_mailbox_ready.dart';
 
 mixin ScenarioUtilsMixin {

--- a/integration_test/mixin/scenario_utils_mixin.dart
+++ b/integration_test/mixin/scenario_utils_mixin.dart
@@ -38,12 +38,15 @@ import 'package:tmail_ui_user/features/manage_account/presentation/identities/id
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
 import 'package:tmail_ui_user/features/upload/domain/state/attachment_upload_state.dart';
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:uuid/uuid.dart';
 
+import '../extensions/mailbox_dashboard_controller_integration_test_extensions.dart';
 import '../extensions/patrol_file_extensions.dart';
 import '../models/provisioning_email.dart';
 import '../models/provisioning_identity.dart';
 import '../resources/test_images.dart';
+import '../utils/wait_for_condition.dart';
 import '../utils/wait_for_mailbox_ready.dart';
 
 mixin ScenarioUtilsMixin {

--- a/integration_test/mixin/scenario_utils_mixin.dart
+++ b/integration_test/mixin/scenario_utils_mixin.dart
@@ -38,16 +38,13 @@ import 'package:tmail_ui_user/features/manage_account/presentation/identities/id
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
 import 'package:tmail_ui_user/features/upload/domain/state/attachment_upload_state.dart';
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
-import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:uuid/uuid.dart';
 
-import '../extensions/mailbox_dashboard_controller_integration_test_extensions.dart';
 import '../extensions/patrol_file_extensions.dart';
 import '../models/provisioning_email.dart';
 import '../models/provisioning_identity.dart';
 import '../resources/test_images.dart';
-import '../utils/test_timeouts.dart';
-import '../utils/wait_for_condition.dart';
+import '../utils/wait_for_mailbox_ready.dart';
 
 mixin ScenarioUtilsMixin {
   @Deprecated('Provision email from CommonRobot instead.')
@@ -59,10 +56,7 @@ mixin ScenarioUtilsMixin {
   }) async {
     ComposerBindings().dependencies();
 
-    await waitForCondition(
-      () => getBinding<MailboxDashBoardController>().isReady,
-      timeout: TestTimeouts.long,
-    );
+    await waitForMailboxReady();
     final mailboxDashBoardController = Get.find<MailboxDashBoardController>();
     final createNewAndSendEmailInteractor =
         Get.find<CreateNewAndSendEmailInteractor>();
@@ -263,10 +257,7 @@ mixin ScenarioUtilsMixin {
       List<ProvisioningIdentity> provisioningIdentities) async {
     IdentityInteractorsBindings().dependencies();
 
-    await waitForCondition(
-      () => getBinding<MailboxDashBoardController>().isReady,
-      timeout: TestTimeouts.long,
-    );
+    await waitForMailboxReady();
 
     final mailboxDashBoardController = Get.find<MailboxDashBoardController>();
     final createNewIdentityInteractor = Get.find<CreateNewIdentityInteractor>();

--- a/integration_test/mixin/scenario_utils_mixin.dart
+++ b/integration_test/mixin/scenario_utils_mixin.dart
@@ -263,6 +263,11 @@ mixin ScenarioUtilsMixin {
       List<ProvisioningIdentity> provisioningIdentities) async {
     IdentityInteractorsBindings().dependencies();
 
+    await waitForCondition(
+      () => getBinding<MailboxDashBoardController>().isReady,
+      timeout: TestTimeouts.long,
+    );
+
     final mailboxDashBoardController = Get.find<MailboxDashBoardController>();
     final createNewIdentityInteractor = Get.find<CreateNewIdentityInteractor>();
     final createNewDefaultIdentityInteractor =

--- a/integration_test/mixin/scenario_utils_mixin.dart
+++ b/integration_test/mixin/scenario_utils_mixin.dart
@@ -293,9 +293,7 @@ mixin ScenarioUtilsMixin {
   }
 
   Future<void> provisionTrashSubfolder(String subfolderName) async {
-    await waitForCondition(
-      () => getBinding<MailboxDashBoardController>().isReady,
-    );
+    await waitForMailboxReady();
     final dashboardController = Get.find<MailboxDashBoardController>();
     final session = dashboardController.sessionCurrent
         ?? (throw StateError('provisionTrashSubfolder: session is null'));

--- a/integration_test/robots/abstract/abstract_common_robot.dart
+++ b/integration_test/robots/abstract/abstract_common_robot.dart
@@ -19,29 +19,19 @@ import 'package:tmail_ui_user/features/manage_account/domain/state/get_all_ident
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_all_identities_interactor.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
 import 'package:tmail_ui_user/features/upload/domain/state/attachment_upload_state.dart';
-import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
 import '../../base/core_robot.dart';
-import '../../extensions/mailbox_dashboard_controller_integration_test_extensions.dart';
 import '../../models/provisioning_email.dart';
 import '../../utils/test_timeouts.dart';
-import '../../utils/wait_for_condition.dart';
+import '../../utils/wait_for_mailbox_ready.dart' as wait_for_mailbox_ready;
 
 abstract class AbstractCommonRobot extends CoreRobot {
   AbstractCommonRobot(super.$);
 
-  /// Waits until the mailbox dashboard is fully loaded (session, account id and
-  /// selected mailbox are available). The app reaches this state only after the
-  /// silent (seeded-credentials) login completes, so callers that provision data
-  /// directly through controllers must await this before touching them.
   Future<void> waitForMailboxReady({
     Duration timeout = TestTimeouts.long,
-  }) async {
-    await waitForCondition(
-      () => getBinding<MailboxDashBoardController>().isReady,
-      timeout: timeout,
-    );
-  }
+  }) =>
+      wait_for_mailbox_ready.waitForMailboxReady(timeout: timeout);
 
   Future<void> provisionEmail(
     List<ProvisioningEmail> provisioningEmails, {

--- a/integration_test/robots/abstract/abstract_search_assertion_robot.dart
+++ b/integration_test/robots/abstract/abstract_search_assertion_robot.dart
@@ -9,6 +9,7 @@ abstract class AbstractSearchAssertionRobot {
   // On web, showMenu popup has no container key — asserts via PopupMenuItemActionWidget.
   Future<void> expectDateTimeFilterContextMenuVisible();
   Future<void> expectEmailListCount(int count);
+  Future<void> expectEmailListCountAtLeast(int count);
   Future<void> expectEmailListSortedByMostRecent();
   Future<void> expectEmailListSortedByOldest();
   Future<void> expectEmailListSortedBySenderAscending(List<String> usernames);

--- a/integration_test/robots/composer_robot.dart
+++ b/integration_test/robots/composer_robot.dart
@@ -28,6 +28,8 @@ import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import '../base/core_robot.dart';
 import '../extensions/patrol_file_extensions.dart';
 import '../extensions/patrol_finder_extension.dart';
+import '../utils/test_timeouts.dart';
+import '../utils/wait_for_condition.dart';
 
 class ComposerRobot extends CoreRobot {
   ComposerRobot(super.$);
@@ -138,6 +140,19 @@ class ComposerRobot extends CoreRobot {
   }
 
   ComposerController? findComposerController() => getBinding<ComposerController>();
+
+  /// Waits until an in-progress save-as-draft has committed. For a freshly
+  /// composed email the composer records the saved draft's [EmailId] only after
+  /// SaveEmailAsDraftsSuccess is handled (by which point the saving dialog has
+  /// already popped). This is a deterministic alternative to waiting on the
+  /// transient "Draft saved" toast, which only renders for ~3s and is easily
+  /// missed under live frame scheduling.
+  Future<void> waitForDraftSaved() async {
+    await waitForCondition(
+      () => findComposerController()?.emailIdEditing != null,
+      timeout: TestTimeouts.long,
+    );
+  }
 
   Future<void> addAttachment(File file) async {
     final controller = findComposerController()!;

--- a/integration_test/robots/composer_robot.dart
+++ b/integration_test/robots/composer_robot.dart
@@ -28,8 +28,6 @@ import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import '../base/core_robot.dart';
 import '../extensions/patrol_file_extensions.dart';
 import '../extensions/patrol_finder_extension.dart';
-import '../utils/test_timeouts.dart';
-import '../utils/wait_for_condition.dart';
 
 class ComposerRobot extends CoreRobot {
   ComposerRobot(super.$);
@@ -140,19 +138,6 @@ class ComposerRobot extends CoreRobot {
   }
 
   ComposerController? findComposerController() => getBinding<ComposerController>();
-
-  /// Waits until an in-progress save-as-draft has committed. For a freshly
-  /// composed email the composer records the saved draft's [EmailId] only after
-  /// SaveEmailAsDraftsSuccess is handled (by which point the saving dialog has
-  /// already popped). This is a deterministic alternative to waiting on the
-  /// transient "Draft saved" toast, which only renders for ~3s and is easily
-  /// missed under live frame scheduling.
-  Future<void> waitForDraftSaved() async {
-    await waitForCondition(
-      () => findComposerController()?.emailIdEditing != null,
-      timeout: TestTimeouts.long,
-    );
-  }
 
   Future<void> addAttachment(File file) async {
     final controller = findComposerController()!;

--- a/integration_test/robots/search_robot.dart
+++ b/integration_test/robots/search_robot.dart
@@ -14,6 +14,8 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../base/core_robot.dart';
 import '../extensions/patrol_finder_extension.dart';
+import '../utils/test_timeouts.dart';
+import '../utils/wait_for_condition.dart';
 import 'abstract/abstract_search_robot.dart';
 
 class SearchRobot extends CoreRobot implements AbstractSearchRobot {
@@ -158,6 +160,32 @@ class SearchRobot extends CoreRobot implements AbstractSearchRobot {
   @override
   Future<void> expectEmailListCount(int count) async {
     expect(find.byType(EmailTileBuilder), findsNWidgets(count));
+  }
+
+  @override
+  Future<void> expectEmailListCountAtLeast(int count) async {
+    // Wait for the search result container — confirms searchIsRunning=true
+    // and listResultSearch is non-empty before checking individual tiles.
+    await $.waitUntilVisible(
+      $(#search_email_list_notification_listener),
+      timeout: TestTimeouts.medium,
+    );
+    await waitForCondition(
+      () async {
+        final tiles = $(#search_email_list_notification_listener)
+            .$(EmailTileBuilder)
+            .evaluate();
+        return tiles.length >= count;
+      },
+      timeout: TestTimeouts.medium,
+    );
+    expect(
+      $(#search_email_list_notification_listener)
+          .$(EmailTileBuilder)
+          .evaluate()
+          .length,
+      greaterThanOrEqualTo(count),
+    );
   }
 
   @override

--- a/integration_test/robots/thread_robot.dart
+++ b/integration_test/robots/thread_robot.dart
@@ -2,17 +2,13 @@ import 'package:core/presentation/views/search/search_bar_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:labels/extensions/label_extension.dart';
-import 'package:patrol/patrol.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
-import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_view.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/scroll_to_top_button_widget.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
-import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
 import '../base/core_robot.dart';
-import '../utils/test_timeouts.dart';
 import '../utils/wait_for_condition.dart';
 import 'abstract/abstract_thread_assertion_robot.dart';
 import 'abstract/abstract_thread_empty_trash_robot.dart';

--- a/integration_test/robots/thread_robot.dart
+++ b/integration_test/robots/thread_robot.dart
@@ -4,12 +4,15 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:labels/extensions/label_extension.dart';
 import 'package:patrol/patrol.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
+import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_view.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/scroll_to_top_button_widget.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
 import '../base/core_robot.dart';
+import '../utils/test_timeouts.dart';
 import '../utils/wait_for_condition.dart';
 import 'abstract/abstract_thread_assertion_robot.dart';
 import 'abstract/abstract_thread_empty_trash_robot.dart';

--- a/integration_test/robots/thread_robot.dart
+++ b/integration_test/robots/thread_robot.dart
@@ -2,6 +2,7 @@ import 'package:core/presentation/views/search/search_bar_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:labels/extensions/label_extension.dart';
+import 'package:patrol/patrol.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_view.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart';

--- a/integration_test/robots/web/web_search_robot.dart
+++ b/integration_test/robots/web/web_search_robot.dart
@@ -164,6 +164,22 @@ class WebSearchRobot extends SearchRobot implements AbstractSearchRobot {
   }
 
   @override
+  Future<void> expectEmailListCountAtLeast(int count) async {
+    // Web desktop: results render in ThreadView (no #search_email_list_notification_listener).
+    // $.pump() advances the widget tree each retry so GetX rebuilds from JMAP responses
+    // are processed; Future.delayed inside waitForCondition then yields to the browser
+    // event loop so XHR callbacks can fire before the next retry.
+    await waitForCondition(
+      () async {
+        await $.pump();
+        return $(EmailTileBuilder).evaluate().length >= count;
+      },
+      timeout: TestTimeouts.medium,
+    );
+    expect($(EmailTileBuilder).evaluate().length, greaterThanOrEqualTo(count));
+  }
+
+  @override
   Future<void> expectEmptyResults() async {
     await $(const Key(UiKeys.emptyThreadView)).waitUntilVisible();
   }

--- a/integration_test/scenarios/composer/attachment_reminder_scenario.dart
+++ b/integration_test/scenarios/composer/attachment_reminder_scenario.dart
@@ -12,6 +12,8 @@ import '../../models/provisioning_identity.dart';
 import '../../robots/composer_robot.dart';
 import '../../robots/identities_list_menu_robot.dart';
 import '../../robots/thread_robot.dart';
+import '../../utils/test_timeouts.dart';
+import '../../utils/wait_for_condition.dart';
 
 class AttachmentReminderScenario extends BaseTestScenario {
   const AttachmentReminderScenario(super.$, super.robots);
@@ -91,12 +93,12 @@ class AttachmentReminderScenario extends BaseTestScenario {
           'in your message but did not add any attachments. Do you still want to send?')));
 
   Future<void> _expectIdentityVisible(Identity identity) async {
-    expect(
-      $(FromComposerMobileWidget)
+    await waitForCondition(
+      () => $(FromComposerMobileWidget)
           .which<FromComposerMobileWidget>(
               (widget) => widget.selectedIdentity?.name == identity.name)
           .visible,
-      isTrue,
+      timeout: TestTimeouts.medium,
     );
   }
 

--- a/integration_test/scenarios/composer/base_save_and_reopen_scenario.dart
+++ b/integration_test/scenarios/composer/base_save_and_reopen_scenario.dart
@@ -48,6 +48,8 @@ abstract class BaseSaveAndReopenScenario extends BaseTestScenario {
     final composerRobot = robots.composerRobot();
     final appLocalizations = AppLocalizations();
 
+    await robots.commonRobot().waitForMailboxReady();
+
     await onPreComposerSetup();
 
     await threadRobot.openComposer();

--- a/integration_test/scenarios/composer/change_identity_in_draft_email_scenario.dart
+++ b/integration_test/scenarios/composer/change_identity_in_draft_email_scenario.dart
@@ -70,11 +70,10 @@ class ChangeIdentityInDraftEmailScenario extends BaseTestScenario {
     await _expectSaveAsDraftOptionPopupMenuVisible();
 
     await composerRobot.tapSaveAsDraftPopupItemOnMenu();
-    // Wait for the save to actually commit before closing, instead of racing the
-    // transient "Draft saved" toast. The draft's existence is then asserted
-    // durably below by reopening it from the Drafts folder.
-    await composerRobot.waitForDraftSaved();
-
+    // The "saving to drafts" modal (barrierDismissible:false / canPop:false) covers
+    // the close button until the save commits, so tapCloseComposer naturally blocks
+    // until the button is hit-testable again — no extra wait needed. The draft's
+    // existence is asserted durably below by reopening it from the Drafts folder.
     await composerRobot.tapCloseComposer(imagePaths);
 
     await threadRobot.openMailbox();

--- a/integration_test/scenarios/composer/change_identity_in_draft_email_scenario.dart
+++ b/integration_test/scenarios/composer/change_identity_in_draft_email_scenario.dart
@@ -12,6 +12,8 @@ import '../../robots/composer_robot.dart';
 import '../../robots/identities_list_menu_robot.dart';
 import '../../robots/mailbox_menu_robot.dart';
 import '../../robots/thread_robot.dart';
+import '../../utils/test_timeouts.dart';
+import '../../utils/wait_for_condition.dart';
 
 class ChangeIdentityInDraftEmailScenario extends BaseTestScenario {
   const ChangeIdentityInDraftEmailScenario(super.$, super.robots);
@@ -96,9 +98,12 @@ class ChangeIdentityInDraftEmailScenario extends BaseTestScenario {
       expectViewVisible($(#save_as_draft_popup_item));
 
   Future<void> _expectIdentityVisible(Identity identity) async {
-    final identityFinder = $(FromComposerMobileWidget).which<FromComposerMobileWidget>(
-      (widget) => widget.selectedIdentity?.name == identity.name
+    await waitForCondition(
+      () => $(FromComposerMobileWidget)
+          .which<FromComposerMobileWidget>(
+              (widget) => widget.selectedIdentity?.name == identity.name)
+          .visible,
+      timeout: TestTimeouts.medium,
     );
-    await expectViewVisible(identityFinder);
   }
 }

--- a/integration_test/scenarios/composer/change_identity_in_draft_email_scenario.dart
+++ b/integration_test/scenarios/composer/change_identity_in_draft_email_scenario.dart
@@ -68,7 +68,10 @@ class ChangeIdentityInDraftEmailScenario extends BaseTestScenario {
     await _expectSaveAsDraftOptionPopupMenuVisible();
 
     await composerRobot.tapSaveAsDraftPopupItemOnMenu();
-    await _expectSaveAsDraftEmailSuccessToast(appLocalizations);
+    // Wait for the save to actually commit before closing, instead of racing the
+    // transient "Draft saved" toast. The draft's existence is then asserted
+    // durably below by reopening it from the Drafts folder.
+    await composerRobot.waitForDraftSaved();
 
     await composerRobot.tapCloseComposer(imagePaths);
 
@@ -91,11 +94,6 @@ class ChangeIdentityInDraftEmailScenario extends BaseTestScenario {
 
   Future<void> _expectSaveAsDraftOptionPopupMenuVisible() =>
       expectViewVisible($(#save_as_draft_popup_item));
-
-  Future<void> _expectSaveAsDraftEmailSuccessToast(
-    AppLocalizations appLocalizations,
-  ) =>
-      expectViewVisible($(appLocalizations.drafts_saved));
 
   Future<void> _expectIdentityVisible(Identity identity) async {
     final identityFinder = $(FromComposerMobileWidget).which<FromComposerMobileWidget>(

--- a/integration_test/scenarios/composer/open_insert_link_dialog_via_keyboard_shortcut_scenario.dart
+++ b/integration_test/scenarios/composer/open_insert_link_dialog_via_keyboard_shortcut_scenario.dart
@@ -7,6 +7,8 @@ class OpenInsertLinkDialogViaKeyboardShortcutScenario extends BaseTestScenario {
 
   @override
   Future<void> runTestLogic() async {
+    await robots.commonRobot().waitForMailboxReady();
+
     final composerRobot = robots.composerRobot();
     final appLocalizations = AppLocalizations();
 

--- a/integration_test/scenarios/composer/send_email_with_read_receipt_enabled_scenario.dart
+++ b/integration_test/scenarios/composer/send_email_with_read_receipt_enabled_scenario.dart
@@ -14,6 +14,8 @@ class SendEmailWithReadReceiptEnabledScenario extends BaseTestScenario {
 
   @override
   Future<void> runTestLogic() async {
+    await robots.commonRobot().waitForMailboxReady();
+
     const additionalRecipient = String.fromEnvironment('ADDITIONAL_MAIL_RECIPIENT');
     const email = String.fromEnvironment('BASIC_AUTH_EMAIL');
     const subject = 'Test read receipt subject';

--- a/integration_test/scenarios/email_detailed/display_and_scroll_email_with_long_content_scenario.dart
+++ b/integration_test/scenarios/email_detailed/display_and_scroll_email_with_long_content_scenario.dart
@@ -9,6 +9,7 @@ import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_bu
 import '../../base/base_test_scenario.dart';
 import '../../models/provisioning_email.dart';
 import '../../robots/thread_robot.dart';
+import '../../utils/test_timeouts.dart';
 import '../../utils/wait_for_condition.dart';
 
 class DisplayAndScrollEmailWithLongContentScenario extends BaseTestScenario {
@@ -67,7 +68,8 @@ class DisplayAndScrollEmailWithLongContentScenario extends BaseTestScenario {
   Future<void> _expectEmailViewScrollableWithLongContent() async {
     expect($(EmailSubjectWidget).visible, isTrue);
     await waitForCondition(
-      () => $(#integration_testing_email_detailed_divider).hitTestable().exists,
+      () => $(#integration_testing_email_detailed_divider).exists,
+      timeout: TestTimeouts.long,
     );
 
     await $.scrollUntilVisible(

--- a/integration_test/scenarios/save_as_template_scenario.dart
+++ b/integration_test/scenarios/save_as_template_scenario.dart
@@ -12,6 +12,8 @@ class SaveAsTemplateScenario extends BaseTestScenario {
 
   @override
   Future<void> runTestLogic() async {
+    await robots.commonRobot().waitForMailboxReady();
+
     final imagePaths = ImagePaths();
     final appLocalizations = AppLocalizations();
     final mailboxMenuRobot = MailboxMenuRobot($);

--- a/integration_test/scenarios/search/search_email_with_tag_scenario.dart
+++ b/integration_test/scenarios/search/search_email_with_tag_scenario.dart
@@ -43,12 +43,17 @@ class SearchEmailWithTagScenario extends BaseTestScenario
     }
 
     // Wait for provisioned emails to appear in the inbox.
-    // waitForCondition uses Future.delayed between retries, which yields to the
-    // browser event loop on web so JMAP XHR callbacks can fire.
+    // Check by subject (contains label name) rather than exact label badge text,
+    // since the inbox delivery copy may not carry over custom keywords for badge rendering.
     if (labels.isNotEmpty) {
+      final firstLabelName = labels.first.safeDisplayName;
       await waitForCondition(
-        () async => $(labels.first.safeDisplayName).evaluate().isNotEmpty,
-        timeout: TestTimeouts.medium,
+        () async => $(EmailTileBuilder)
+            .which<EmailTileBuilder>(
+                (widget) => widget.subjectContains(firstLabelName))
+            .evaluate()
+            .isNotEmpty,
+        timeout: TestTimeouts.long,
       );
     }
 
@@ -85,21 +90,31 @@ class SearchEmailWithTagScenario extends BaseTestScenario
     required String tagDisplayName,
     required int emailCount,
   }) async {
-    // waitForCondition yields to the browser event loop between retries (via
-    // Future.delayed), allowing JMAP XHR callbacks to fire on web.
+    // First wait for the search result list container — confirms searchIsRunning=true
+    // AND listResultSearch is non-empty before checking individual tiles.
+    await $.waitUntilVisible(
+      $(#search_email_list_notification_listener),
+      timeout: TestTimeouts.medium,
+    );
+
+    // The search result list already appeared (#search_email_list_notification_listener
+    // is visible). Wait for EmailTileBuilder widgets to be rendered inside it.
     await waitForCondition(
       () async {
-        final count = $(EmailTileBuilder).which<EmailTileBuilder>((widget) =>
-            widget.subjectContains(tagDisplayName)).evaluate().length;
-        return count >= emailCount;
+        final tiles = $(#search_email_list_notification_listener)
+            .$(EmailTileBuilder)
+            .evaluate();
+        return tiles.length >= emailCount;
       },
       timeout: TestTimeouts.medium,
     );
 
-    final listEmailTileWithTag = $(EmailTileBuilder).which<EmailTileBuilder>((widget) =>
-        widget.subjectContains(tagDisplayName)).allCandidates;
+    final count = $(#search_email_list_notification_listener)
+        .$(EmailTileBuilder)
+        .evaluate()
+        .length;
 
-    expect(listEmailTileWithTag.length, greaterThanOrEqualTo(emailCount));
+    expect(count, greaterThanOrEqualTo(emailCount));
   }
 }
 

--- a/integration_test/scenarios/search/search_email_with_tag_scenario.dart
+++ b/integration_test/scenarios/search/search_email_with_tag_scenario.dart
@@ -66,10 +66,7 @@ class SearchEmailWithTagScenario extends BaseTestScenario
       await _expectLabelListContextMenuVisible();
 
       await commonRobot.selectContextMenuItemByName(labelDisplayName);
-      await _expectEmailListDisplayedCorrectByTag(
-        tagDisplayName: labelDisplayName,
-        emailCount: emailCount,
-      );
+      await searchRobot.expectEmailListCountAtLeast(emailCount);
 
       await $.pumpAndSettle(duration: const Duration(seconds: 1));
     }
@@ -86,36 +83,6 @@ class SearchEmailWithTagScenario extends BaseTestScenario
     );
   }
 
-  Future<void> _expectEmailListDisplayedCorrectByTag({
-    required String tagDisplayName,
-    required int emailCount,
-  }) async {
-    // First wait for the search result list container — confirms searchIsRunning=true
-    // AND listResultSearch is non-empty before checking individual tiles.
-    await $.waitUntilVisible(
-      $(#search_email_list_notification_listener),
-      timeout: TestTimeouts.medium,
-    );
-
-    // The search result list already appeared (#search_email_list_notification_listener
-    // is visible). Wait for EmailTileBuilder widgets to be rendered inside it.
-    await waitForCondition(
-      () async {
-        final tiles = $(#search_email_list_notification_listener)
-            .$(EmailTileBuilder)
-            .evaluate();
-        return tiles.length >= emailCount;
-      },
-      timeout: TestTimeouts.medium,
-    );
-
-    final count = $(#search_email_list_notification_listener)
-        .$(EmailTileBuilder)
-        .evaluate()
-        .length;
-
-    expect(count, greaterThanOrEqualTo(emailCount));
-  }
 }
 
 extension on EmailTileBuilder {

--- a/integration_test/scenarios/send_email_with_mark_as_important_scenario.dart
+++ b/integration_test/scenarios/send_email_with_mark_as_important_scenario.dart
@@ -14,6 +14,8 @@ class SendEmailWithMarkAsImportantScenario extends BaseTestScenario {
 
   @override
   Future<void> runTestLogic() async {
+    await robots.commonRobot().waitForMailboxReady();
+
     const emailUser = String.fromEnvironment('BASIC_AUTH_EMAIL');
     const emailContent = 'Mark email as important';
 

--- a/integration_test/scenarios/setting/identity/create_new_identity_scenario.dart
+++ b/integration_test/scenarios/setting/identity/create_new_identity_scenario.dart
@@ -18,6 +18,8 @@ class CreateNewIdentityScenario extends BaseTestScenario {
 
   @override
   Future<void> runTestLogic() async {
+    await robots.commonRobot().waitForMailboxReady();
+
     final threadRobot = ThreadRobot($);
     final mailboxMenuRobot = MailboxMenuRobot($);
     final settingRobot = SettingRobot($);

--- a/integration_test/utils/wait_for_condition.dart
+++ b/integration_test/utils/wait_for_condition.dart
@@ -5,7 +5,7 @@ import 'test_timeouts.dart';
 Future<void> waitForCondition(
   FutureOr<bool> Function() condition, {
   Duration timeout = TestTimeouts.medium,
-  Duration interval = const Duration(seconds: 1),
+  Duration interval = const Duration(milliseconds: 200),
 }) async {
   await Future.doWhile(() async {
     if (await condition()) {

--- a/integration_test/utils/wait_for_mailbox_ready.dart
+++ b/integration_test/utils/wait_for_mailbox_ready.dart
@@ -1,0 +1,21 @@
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+
+import '../extensions/mailbox_dashboard_controller_integration_test_extensions.dart';
+import 'test_timeouts.dart';
+import 'wait_for_condition.dart';
+
+/// Waits until the mailbox dashboard is fully loaded (session, account id and
+/// selected mailbox are available).
+///
+/// The app reaches this state only after the silent (seeded-credentials) login
+/// completes, so anything that touches the dashboard before then — provisioning
+/// directly through controllers, or tapping UI that only the thread view renders
+/// (e.g. the compose button) — must await this first.
+Future<void> waitForMailboxReady({
+  Duration timeout = TestTimeouts.long,
+}) =>
+    waitForCondition(
+      () => getBinding<MailboxDashBoardController>().isReady,
+      timeout: timeout,
+    );

--- a/lib/features/search/email/presentation/search_email_controller.dart
+++ b/lib/features/search/email/presentation/search_email_controller.dart
@@ -178,7 +178,6 @@ class SearchEmailController extends BaseController
   void onInit() {
     super.onInit();
     _initializeDebounceTimeTextSearchChange();
-    _initializeTextInputFocus();
     _initWorkerListener();
     _initWebSocketQueueHandler();
     onKeyboardShortcutInit();
@@ -275,8 +274,8 @@ class SearchEmailController extends BaseController
     });
   }
 
-  void _initializeTextInputFocus() {
-    textInputSearchFocus.addListener(_onSearchTextInputListener);
+  void onSearchFieldTap() {
+    searchIsRunning.value = false;
   }
 
   void _initWorkerListener() {
@@ -397,11 +396,6 @@ class SearchEmailController extends BaseController
     }
   }
 
-  void _onSearchTextInputListener() {
-    if (textInputSearchFocus.hasFocus) {
-      searchIsRunning.value = false;
-    }
-  }
 
   void _handleRefreshChangesSearchEmailsSuccess(RefreshChangesSearchEmailSuccess success) {
     final resultEmailSearchList = success.emailList
@@ -1212,7 +1206,6 @@ class SearchEmailController extends BaseController
 
   @override
   void onClose() {
-    textInputSearchFocus.removeListener(_onSearchTextInputListener);
     textInputSearchController.dispose();
     textInputSearchFocus.dispose();
     resultSearchScrollController.dispose();

--- a/lib/features/search/email/presentation/search_email_view.dart
+++ b/lib/features/search/email/presentation/search_email_view.dart
@@ -214,6 +214,7 @@ class SearchEmailView extends GetWidget<SearchEmailController>
           ),
           Expanded(child: TextFieldBuilder(
             key: const Key('search_email_text_field'),
+            onTap: controller.onSearchFieldTap,
             onTextChange: controller.onTextSearchChange,
             textInputAction: TextInputAction.search,
             controller: controller.textInputSearchController,

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -5875,5 +5875,35 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
+  },
+  "confirm": "Confirmer",
+  "@confirm": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "titleConfirmRuleWithRejectAction": "Rejeter tous les e-mails qui correspondent à ce critère ?",
+  "@titleConfirmRuleWithRejectAction": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "messageConfirmationRuleWithRejectAction": "Cette action est irréversible. Confirmez-vous vouloir continuer ?",
+  "@messageConfirmationRuleWithRejectAction": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "aiLabelCategorization": "Libellés de catégorisation",
+  "@aiLabelCategorization": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "aiLabelCategorizationToggleDescription": "Activer la catégorisation par libellés",
+  "@aiLabelCategorizationToggleDescription": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -5905,5 +5905,11 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
+  },
+  "aiLabelCategorizationSettingExplanation": "Appliquer mes libellés sur les e-mails entrants en utilisant leur description",
+  "@aiLabelCategorizationSettingExplanation": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
 }

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -5893,5 +5893,41 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
+  },
+  "confirm": "Подтвердить",
+  "@confirm": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "titleConfirmRuleWithRejectAction": "Отклонить все письма, соответствующие условию?",
+  "@titleConfirmRuleWithRejectAction": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "messageConfirmationRuleWithRejectAction": "Это действие нельзя отменить. Хотите продолжить?",
+  "@messageConfirmationRuleWithRejectAction": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "aiLabelCategorization": "Категоризация меток",
+  "@aiLabelCategorization": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "aiLabelCategorizationToggleDescription": "Включить категоризацию меток",
+  "@aiLabelCategorizationToggleDescription": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "aiLabelCategorizationSettingExplanation": "Применять мои метки к входящим письмам, используя их описание",
+  "@aiLabelCategorizationSettingExplanation": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
 }

--- a/lib/l10n/intl_vi.arb
+++ b/lib/l10n/intl_vi.arb
@@ -5881,5 +5881,41 @@
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
+  },
+  "confirm": "Xác nhận",
+  "@confirm": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "titleConfirmRuleWithRejectAction": "Từ chối tất cả thư với điều kiện này?",
+  "@titleConfirmRuleWithRejectAction": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "messageConfirmationRuleWithRejectAction": "Hành động này là không thể khôi phục. Bạn có chắc chắn muốn tiếp tục?",
+  "@messageConfirmationRuleWithRejectAction": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "aiLabelCategorization": "Nhãn phân loại tự động",
+  "@aiLabelCategorization": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "aiLabelCategorizationToggleDescription": "Kích hoạt nhãn phân loại tự động",
+  "@aiLabelCategorizationToggleDescription": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "aiLabelCategorizationSettingExplanation": "Gán nhãn tự động dựa trên nội dung mô tả của nhãn",
+  "@aiLabelCategorizationSettingExplanation": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
 }

--- a/lib/l10n/intl_zh_Hans.arb
+++ b/lib/l10n/intl_zh_Hans.arb
@@ -4533,7 +4533,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "thread": "线程",
+  "thread": "邮件串",
   "@thread": {
     "type": "text",
     "placeholders_order": [],
@@ -4545,7 +4545,7 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "threadToggleDescription": "启用线程",
+  "threadToggleDescription": "启用邮件串",
   "@threadToggleDescription": {
     "type": "text",
     "placeholders_order": [],
@@ -5547,6 +5547,138 @@
   },
   "createALabel": "创建标签",
   "@createALabel": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "addLabel": "添加标签",
+  "@addLabel": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "areYouSureYouWantToDeleteTheLabel": "是否确定要删除标签“{labelName}”？",
+  "@areYouSureYouWantToDeleteTheLabel": {
+    "type": "text",
+    "placeholders_order": [
+      "labelName"
+    ],
+    "placeholders": {
+      "labelName": {}
+    }
+  },
+  "confirm": "确认",
+  "@confirm": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "titleConfirmRuleWithRejectAction": "拒绝所有符合此条件的电子邮件？",
+  "@titleConfirmRuleWithRejectAction": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "messageConfirmationRuleWithRejectAction": "此操作不可逆。是否确定要继续？",
+  "@messageConfirmationRuleWithRejectAction": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "addLabelToEmailSuccessfullyMessage": "标签“{labelName}”已添加到电子邮件",
+  "@addLabelToEmailSuccessfullyMessage": {
+    "type": "text",
+    "placeholders_order": [
+      "labelName"
+    ],
+    "placeholders": {
+      "labelName": {}
+    }
+  },
+  "addLabelToEmailFailureMessage": "无法将标签“{labelName}”添加到电子邮件",
+  "@addLabelToEmailFailureMessage": {
+    "type": "text",
+    "placeholders_order": [
+      "labelName"
+    ],
+    "placeholders": {
+      "labelName": {}
+    }
+  },
+  "addLabelToThreadSuccessfullyMessage": "标签“{labelName}”已添加到邮件串中的所有电子邮件",
+  "@addLabelToThreadSuccessfullyMessage": {
+    "type": "text",
+    "placeholders_order": [
+      "labelName"
+    ],
+    "placeholders": {
+      "labelName": {}
+    }
+  },
+  "addLabelToThreadFailureMessage": "无法将标签“{labelName}”添加到邮件串中的所有电子邮件",
+  "@addLabelToThreadFailureMessage": {
+    "type": "text",
+    "placeholders_order": [
+      "labelName"
+    ],
+    "placeholders": {
+      "labelName": {}
+    }
+  },
+  "removeLabelFromEmailSuccessfullyMessage": "已从电子邮件中移除标签“{labelName}”",
+  "@removeLabelFromEmailSuccessfullyMessage": {
+    "type": "text",
+    "placeholders_order": [
+      "labelName"
+    ],
+    "placeholders": {
+      "labelName": {}
+    }
+  },
+  "removeLabelFromEmailFailureMessage": "无法从电子邮件中移除标签“{labelName}”",
+  "@removeLabelFromEmailFailureMessage": {
+    "type": "text",
+    "placeholders_order": [
+      "labelName"
+    ],
+    "placeholders": {
+      "labelName": {}
+    }
+  },
+  "removeLabelFromThreadSuccessfullyMessage": "已从邮件串中的所有电子邮件中移除标签“{labelName}”",
+  "@removeLabelFromThreadSuccessfullyMessage": {
+    "type": "text",
+    "placeholders_order": [
+      "labelName"
+    ],
+    "placeholders": {
+      "labelName": {}
+    }
+  },
+  "removeLabelFromThreadFailureMessage": "无法从邮件串中的所有电子邮件中移除标签“{labelName}”",
+  "@removeLabelFromThreadFailureMessage": {
+    "type": "text",
+    "placeholders_order": [
+      "labelName"
+    ],
+    "placeholders": {
+      "labelName": {}
+    }
+  },
+  "aiLabelCategorization": "标签分类",
+  "@aiLabelCategorization": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "aiLabelCategorizationToggleDescription": "启用标签分类",
+  "@aiLabelCategorizationToggleDescription": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "aiLabelCategorizationSettingExplanation": "使用描述将我的标签应用于收到的电子邮件",
+  "@aiLabelCategorizationSettingExplanation": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ workspace:
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.29.7
+version: 0.29.8
 
 environment:
   sdk: ">=3.9.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ workspace:
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.29.6
+version: 0.29.7
 
 environment:
   sdk: ">=3.9.0 <4.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new UI text for rule-rejection confirmations and AI-assisted label categorization settings.
  * Search behavior now reacts immediately when the search field is tapped.

* **Bug Fixes**
  * Improved mailbox readiness synchronization to make app flows and automated scenarios more stable.
  * Fixed a flaky mobile end-to-end test.

* **Localization**
  * Updated translations in Vietnamese, Russian, French, and Chinese (including thread/label wording and related confirmation messages).

* **Chores**
  * Bumped the app version to **0.29.8**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->