### PR TITLE
[WIP] TF-4449 Add download-and-attach drive files feature

### DIFF
--- a/lib/features/composer/presentation/composer_bindings.dart
+++ b/lib/features/composer/presentation/composer_bindings.dart
@@ -76,6 +76,11 @@ import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.da
 import 'package:tmail_ui_user/main/exceptions/thrower/remote_exception_thrower.dart';
 import 'package:tmail_ui_user/main/utils/ios_sharing_manager.dart';
 import 'package:uuid/uuid.dart';
+import 'package:workplace/data/datasource/drive_file_datasource.dart';
+import 'package:workplace/data/datasource_impl/drive_file_datasource_impl.dart';
+import 'package:workplace/data/repository_impl/drive_file_repository_impl.dart';
+import 'package:workplace/domain/repository/drive_file_repository.dart';
+import 'package:workplace/domain/usecases/download_drive_file_interactor.dart';
 
 abstract class ComposerBindings extends BaseBindings {
 
@@ -174,6 +179,7 @@ abstract class ComposerBindings extends BaseBindings {
       Get.find<SessionStorageManager>(),
       Get.find<CacheExceptionThrower>(),
     ), tag: composerId);
+    Get.lazyPut(() => DriveFileDatasourceImpl(), tag: composerId);
     bindPlatformCacheDatasourceImpl();
   }
 
@@ -211,6 +217,10 @@ abstract class ComposerBindings extends BaseBindings {
       () => Get.find<PrintFileDataSourceImpl>(tag: composerId),
       tag: composerId,
     );
+    Get.lazyPut<DriveFileDatasource>(
+      () => Get.find<DriveFileDatasourceImpl>(tag: composerId),
+      tag: composerId,
+    );
     bindPlatformComposerCacheDatasource();
   }
 
@@ -237,6 +247,10 @@ abstract class ComposerBindings extends BaseBindings {
       },
       Get.find<StateDataSource>(tag: composerId),
     ), tag: composerId);
+    Get.lazyPut(
+      () => DriveFileRepositoryImpl(Get.find<DriveFileDatasource>(tag: composerId)),
+      tag: composerId,
+    );
     Get.lazyPut(() => EmailRepositoryImpl(
       {
         DataSourceType.network: Get.find<EmailDataSource>(tag: composerId),
@@ -270,6 +284,10 @@ abstract class ComposerBindings extends BaseBindings {
     );
     Get.lazyPut<EmailRepository>(
       () => Get.find<EmailRepositoryImpl>(tag: composerId),
+      tag: composerId,
+    );
+    Get.lazyPut<DriveFileRepository>(
+      () => Get.find<DriveFileRepositoryImpl>(tag: composerId),
       tag: composerId,
     );
   }
@@ -340,16 +358,23 @@ abstract class ComposerBindings extends BaseBindings {
       Get.find<ComposerRepository>(tag: composerId),
       Get.find<EmailRepository>(tag: composerId),
     ), tag: composerId);
+    Get.lazyPut(
+      () => DownloadDriveFileInteractor(Get.find<DriveFileRepository>(tag: composerId)),
+      tag: composerId,
+    );
   }
 
   @override
   void bindingsController() {
-    Get.lazyPut(() => const DriveAttachmentHandler(), tag: composerId);
     bindPlatformRichTextController();
     Get.lazyPut(
       () => UploadController(Get.find<UploadAttachmentInteractor>(tag: composerId)),
       tag: composerId,
     );
+    Get.lazyPut(() => DriveAttachmentHandler(
+      uploadController: Get.find<UploadController>(tag: composerId),
+      downloadDriveFileInteractor: Get.find<DownloadDriveFileInteractor>(tag: composerId),
+    ), tag: composerId);
     Get.lazyPut(() => ComposerController(
       Get.find<LocalFilePickerInteractor>(tag: composerId),
       Get.find<LocalImagePickerInteractor>(tag: composerId),
@@ -428,6 +453,11 @@ abstract class ComposerBindings extends BaseBindings {
     Get.delete<HtmlEmailTransformerAdapter>(tag: composerId);
     Get.delete<PrintEmailInteractor>(tag: composerId);
     Get.delete<SaveTemplateEmailInteractor>(tag: composerId);
+    Get.delete<DownloadDriveFileInteractor>(tag: composerId);
+    Get.delete<DriveFileDatasourceImpl>(tag: composerId);
+    Get.delete<DriveFileDatasource>(tag: composerId);
+    Get.delete<DriveFileRepositoryImpl>(tag: composerId);
+    Get.delete<DriveFileRepository>(tag: composerId);
 
     IdentityInteractorsBindings(composerId: composerId).dispose();
     PreferencesInteractorsBindings(composerId: composerId).dispose();

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1017,6 +1017,7 @@ class ComposerController extends BaseController
             htmlEditorApi?.insertHtml(html);
           }
         },
+        uploadFiles: uploadAttachmentsAction,
       );
     } catch (e) {
       logWarning('ComposerController::handleDrivePickResult:Exception = $e');

--- a/lib/features/composer/presentation/manager/drive_attachment_handler.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_handler.dart
@@ -1,17 +1,52 @@
+import 'dart:async';
 import 'dart:convert';
 
+import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/build_utils.dart';
+import 'package:model/model.dart';
+import 'package:tmail_ui_user/features/upload/presentation/controller/upload_controller.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
+import 'package:workplace/domain/state/download_drive_file_state.dart';
+import 'package:workplace/domain/usecases/download_drive_file_interactor.dart';
 
 class DriveAttachmentHandler {
-  const DriveAttachmentHandler();
+  final UploadController uploadController;
+  final DownloadDriveFileInteractor downloadDriveFileInteractor;
+
+  const DriveAttachmentHandler({
+    required this.uploadController,
+    required this.downloadDriveFileInteractor,
+  });
 
   void handleDrivePickResult(
     List<DriveDocument> result, {
     required void Function(String html) insertHtml,
+    required void Function({required List<FileInfo> pickedFiles}) uploadFiles,
+    void Function(Object error)? onError,
   }) {
-    final linkDocs = result.where((doc) => doc.sharingLink != null).toList();
-    insertDriveLinkHtml(linkDocs, insertHtml: insertHtml);
+    final partition = _partitionDriveDocs(result);
+    insertDriveLinkHtml(partition.linkDocs, insertHtml: insertHtml);
+    unawaited(
+      downloadAndUploadDriveFile(
+        partition.attachmentDocs,
+        uploadFiles: uploadFiles,
+        onError: onError,
+      ),
+    );
+  }
+
+  static ({List<DriveDocument> linkDocs, List<DriveDocument> attachmentDocs})
+  _partitionDriveDocs(List<DriveDocument> docs) {
+    final linkDocs = <DriveDocument>[];
+    final attachmentDocs = <DriveDocument>[];
+    for (final doc in docs) {
+      if (doc.sharingLink != null) {
+        linkDocs.add(doc);
+      } else if (doc.downloadLink != null) {
+        attachmentDocs.add(doc);
+      }
+    }
+    return (linkDocs: linkDocs, attachmentDocs: attachmentDocs);
   }
 
   void insertDriveLinkHtml(
@@ -44,5 +79,55 @@ class DriveAttachmentHandler {
     ).convert(link.toString());
     final label = const HtmlEscape().convert(doc.name);
     return '<a href="$href">$label</a>';
+  }
+
+  Future<void> downloadAndUploadDriveFile(
+    List<DriveDocument> docs, {
+    required void Function({required List<FileInfo> pickedFiles}) uploadFiles,
+    void Function(Object error)? onError,
+  }) async {
+    final downloadableDocs = docs
+        .where((doc) => doc.downloadLink != null)
+        .toList();
+    if (downloadableDocs.isEmpty) return;
+    try {
+      uploadController.validateTotalSizeAttachmentsBeforeUpload(
+        totalSizePreparedFiles: downloadableDocs.fold(
+          0,
+          (prev, doc) => prev + doc.size,
+        ),
+        onValidationSuccess: () => _processDownloadableDocs(
+          downloadableDocs,
+          uploadFiles: uploadFiles,
+        ),
+      );
+    } catch (e) {
+      logWarning('DriveAttachmentHandler::downloadAndUploadDriveFile: $e');
+      onError?.call(e);
+    }
+  }
+
+  Future<void> _processDownloadableDocs(
+    List<DriveDocument> docs, {
+    required void Function({required List<FileInfo> pickedFiles}) uploadFiles,
+  }) async {
+    final downloadedFiles = <FileInfo>[];
+    for (final doc in docs) {
+      await for (final state in downloadDriveFileInteractor.execute(doc)) {
+        state.fold(
+          (failure) => logWarning(
+            'DriveAttachmentHandler::downloadAndUploadDriveFile: Fail to process ${doc.name}: $failure',
+          ),
+          (success) {
+            if (success is DownloadDriveFileSuccess) {
+              downloadedFiles.add(success.fileInfo);
+            }
+          },
+        );
+      }
+    }
+    if (downloadedFiles.isNotEmpty) {
+      uploadFiles(pickedFiles: downloadedFiles);
+    }
   }
 }

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -5308,6 +5308,12 @@
     "placeholders_order": [],
     "placeholders": {}
   },
+  "driveAttachmentFailed": "Failed to attach file from Drive.",
+  "@driveAttachmentFailed": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
   "labelAs": "Label as",
   "@labelAs": {
     "type": "text",

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -5640,6 +5640,13 @@ class AppLocalizations {
     );
   }
 
+  String get driveAttachmentFailed {
+    return Intl.message(
+      'Failed to attach file from Drive.',
+      name: 'driveAttachmentFailed',
+    );
+  }
+
   String get labelAs {
     return Intl.message(
       'Label as',

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -72,6 +72,7 @@ import 'package:tmail_ui_user/features/upload/domain/usecases/local_file_picker_
 import 'package:tmail_ui_user/features/upload/domain/usecases/local_image_picker_interactor.dart';
 import 'package:tmail_ui_user/features/upload/presentation/controller/upload_controller.dart';
 import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_state.dart';
+import 'package:workplace/domain/usecases/download_drive_file_interactor.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
 import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.dart';
 import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
@@ -208,6 +209,7 @@ class MockMailboxDashBoardController extends Mock implements MailboxDashBoardCon
   MockSpec<PrintEmailInteractor>(),
   MockSpec<ComposerRepository>(),
   MockSpec<SaveTemplateEmailInteractor>(),
+  MockSpec<DownloadDriveFileInteractor>(),
 
   // Additional Getx dependencies mock specs
   MockSpec<NetworkConnectionController>(fallbackGenerators: fallbackGenerators),
@@ -1230,8 +1232,8 @@ void main() {
           // after the (unawaited) call.
           composerController?.onLocalFileDropZoneListener(
             context: capturedContext,
-            details: DropDoneDetails(
-              files: const [],
+            details: const DropDoneDetails(
+              files: [],
               localPosition: Offset.zero,
               globalPosition: Offset.zero,
             ),

--- a/test/features/composer/presentation/manager/drive_attachment_handler_download_upload_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_download_upload_test.dart
@@ -1,0 +1,185 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/upload/file_info.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_handler.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+import 'package:workplace/domain/state/download_drive_file_state.dart';
+
+import 'drive_attachment_handler_test.mocks.dart';
+import 'drive_attachment_handler_test_helper.dart';
+
+void _stubValidationSuccess(MockUploadController mock) {
+  when(mock.validateTotalSizeAttachmentsBeforeUpload(
+    totalSizePreparedFiles: anyNamed('totalSizePreparedFiles'),
+    onValidationSuccess: anyNamed('onValidationSuccess'),
+  )).thenAnswer((invocation) {
+    final callback = invocation.namedArguments[#onValidationSuccess] as VoidCallback?;
+    callback?.call();
+  });
+}
+
+void _stubDownloadSuccess(
+  MockDownloadDriveFileInteractor mock,
+  DriveDocument doc,
+  FileInfo fileInfo,
+) {
+  when(mock.execute(doc)).thenAnswer(
+    (_) => Stream.value(Right(DownloadDriveFileSuccess(fileInfo))),
+  );
+}
+
+void main() {
+  late MockUploadController mockUploadController;
+  late MockDownloadDriveFileInteractor mockDownloadInteractor;
+  late List<List<FileInfo>> uploadedFiles;
+  late DriveAttachmentHandler handler;
+
+  setUp(() {
+    Get.testMode = true;
+    mockUploadController = MockUploadController();
+    mockDownloadInteractor = MockDownloadDriveFileInteractor();
+    uploadedFiles = [];
+
+    handler = DriveAttachmentHandler(
+      uploadController: mockUploadController,
+      downloadDriveFileInteractor: mockDownloadInteractor,
+    );
+  });
+
+  tearDown(() => Get.reset());
+
+  group('DriveAttachmentHandler::downloadAndUploadDriveFile::', () {
+    test('Should skip validation when no docs have downloadLink', () {
+      handler.downloadAndUploadDriveFile(
+        [noLinkDoc],
+        uploadFiles: ({required pickedFiles}) => uploadedFiles.add(pickedFiles),
+      );
+
+      verifyNever(mockUploadController.validateTotalSizeAttachmentsBeforeUpload(
+        totalSizePreparedFiles: anyNamed('totalSizePreparedFiles'),
+        onValidationSuccess: anyNamed('onValidationSuccess'),
+      ));
+    });
+
+    test('Should pass summed size to validateTotalSizeAttachmentsBeforeUpload', () {
+      final doc2 = DriveDocument(
+        id: '6',
+        name: 'Second',
+        size: 300,
+        mimeType: 'image/png',
+        downloadLink: Uri.parse('https://example.com/second.png'),
+      );
+
+        handler.downloadAndUploadDriveFile(
+          [attachmentDoc, doc2],
+          uploadFiles: ({required pickedFiles}) =>
+              uploadedFiles.add(pickedFiles),
+        );
+
+      verify(mockUploadController.validateTotalSizeAttachmentsBeforeUpload(
+        totalSizePreparedFiles: 500,
+        onValidationSuccess: anyNamed('onValidationSuccess'),
+      )).called(1);
+    });
+
+    test('Should call uploadFiles once with all downloaded files', () async {
+      final fileInfo1 = FileInfo(fileName: 'photo.jpg', fileSize: 200, filePath: '/tmp/photo.jpg', type: 'image/jpeg');
+      final fileInfo2 = FileInfo(fileName: 'second.png', fileSize: 300, filePath: '/tmp/second.png', type: 'image/png');
+
+      final doc2 = DriveDocument(
+        id: '7',
+        name: 'second.png',
+        size: 300,
+        mimeType: 'image/png',
+        downloadLink: Uri.parse('https://example.com/second.png'),
+      );
+
+      _stubDownloadSuccess(mockDownloadInteractor, attachmentDoc, fileInfo1);
+      _stubDownloadSuccess(mockDownloadInteractor, doc2, fileInfo2);
+
+      _stubValidationSuccess(mockUploadController);
+
+      await handler.downloadAndUploadDriveFile(
+        [attachmentDoc, doc2],
+        uploadFiles: ({required pickedFiles}) => uploadedFiles.add(pickedFiles),
+      );
+      await Future.delayed(Duration.zero);
+
+      expect(uploadedFiles, hasLength(1));
+      expect(uploadedFiles.first, containsAll([fileInfo1, fileInfo2]));
+    });
+
+    test('Should upload single file when only one download succeeds', () async {
+      final fileInfo = FileInfo(fileName: 'photo.jpg', fileSize: 200, filePath: '/tmp/photo.jpg', type: 'image/jpeg');
+
+      _stubDownloadSuccess(mockDownloadInteractor, attachmentDoc, fileInfo);
+      _stubValidationSuccess(mockUploadController);
+
+      await handler.downloadAndUploadDriveFile(
+        [attachmentDoc],
+        uploadFiles: ({required pickedFiles}) => uploadedFiles.add(pickedFiles),
+      );
+      await Future.delayed(Duration.zero);
+
+      expect(uploadedFiles, hasLength(1));
+      expect(uploadedFiles.first, equals([fileInfo]));
+    });
+
+    test('Should not upload file when download emits failure', () async {
+      when(mockDownloadInteractor.execute(attachmentDoc)).thenAnswer(
+        (_) => Stream.value(Left(DownloadDriveFileFailure(Exception('Network error')))),
+      );
+
+      _stubValidationSuccess(mockUploadController);
+
+      await handler.downloadAndUploadDriveFile(
+        [attachmentDoc],
+        uploadFiles: ({required pickedFiles}) => uploadedFiles.add(pickedFiles),
+      );
+      await Future.delayed(Duration.zero);
+
+      expect(uploadedFiles, isEmpty);
+    });
+
+    test('Should skip DownloadingDriveFile progress state and still upload success file', () async {
+      final fileInfo = FileInfo(fileName: 'photo.jpg', fileSize: 200, filePath: '/tmp/photo.jpg', type: 'image/jpeg');
+
+      when(mockDownloadInteractor.execute(attachmentDoc)).thenAnswer(
+        (_) => Stream.fromIterable([
+          Right(DownloadingDriveFile()),
+          Right(DownloadDriveFileSuccess(fileInfo)),
+        ]),
+      );
+
+      _stubValidationSuccess(mockUploadController);
+
+        await handler.downloadAndUploadDriveFile(
+          [attachmentDoc],
+          uploadFiles: ({required pickedFiles}) =>
+              uploadedFiles.add(pickedFiles),
+        );
+      await Future.delayed(Duration.zero);
+
+      expect(uploadedFiles, hasLength(1));
+      expect(uploadedFiles.first, equals([fileInfo]));
+    });
+
+    test('Should not call onValidationSuccess when validation fails', () async {
+      when(mockUploadController.validateTotalSizeAttachmentsBeforeUpload(
+        totalSizePreparedFiles: anyNamed('totalSizePreparedFiles'),
+        onValidationSuccess: anyNamed('onValidationSuccess'),
+      )).thenReturn(null);
+
+      await handler.downloadAndUploadDriveFile(
+        [attachmentDoc],
+        uploadFiles: ({required pickedFiles}) => uploadedFiles.add(pickedFiles),
+      );
+
+      verifyNever(mockDownloadInteractor.execute(any));
+      expect(uploadedFiles, isEmpty);
+    });
+  });
+}

--- a/test/features/composer/presentation/manager/drive_attachment_handler_insert_link_html_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_insert_link_html_test.dart
@@ -1,18 +1,31 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_handler.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
 
+import 'drive_attachment_handler_test.mocks.dart';
 import 'drive_attachment_handler_test_helper.dart';
 
 void main() {
+  late MockUploadController mockUploadController;
+  late MockDownloadDriveFileInteractor mockDownloadInteractor;
   late List<String> insertedHtml;
   late DriveAttachmentHandler handler;
 
   setUp(() {
+    Get.testMode = true;
+    mockUploadController = MockUploadController();
+    mockDownloadInteractor = MockDownloadDriveFileInteractor();
     insertedHtml = [];
-    handler = const DriveAttachmentHandler();
+
+    handler = DriveAttachmentHandler(
+      uploadController: mockUploadController,
+      downloadDriveFileInteractor: mockDownloadInteractor,
+    );
   });
+
+  tearDown(() => Get.reset());
 
   group('DriveAttachmentHandler::insertDriveLinkHtml::', () {
     test('Should generate anchor tag with escaped href and label', () {

--- a/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
@@ -1,28 +1,79 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/upload/file_info.dart';
 import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_handler.dart';
+import 'package:tmail_ui_user/features/upload/presentation/controller/upload_controller.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
+import 'package:workplace/domain/usecases/download_drive_file_interactor.dart';
 
+import 'drive_attachment_handler_test.mocks.dart';
 import 'drive_attachment_handler_test_helper.dart';
 
+mockControllerCallback() => InternalFinalCallback<void>(callback: () {});
+const fallbackGenerators = {
+  #onStart: mockControllerCallback,
+  #onDelete: mockControllerCallback,
+};
+
+@GenerateNiceMocks([
+  MockSpec<UploadController>(fallbackGenerators: fallbackGenerators),
+  MockSpec<DownloadDriveFileInteractor>(),
+])
 void main() {
+  late MockUploadController mockUploadController;
+  late MockDownloadDriveFileInteractor mockDownloadInteractor;
   late List<String> insertedHtml;
+  late List<List<FileInfo>> uploadedFiles;
   late DriveAttachmentHandler handler;
 
   setUp(() {
+    Get.testMode = true;
+    mockUploadController = MockUploadController();
+    mockDownloadInteractor = MockDownloadDriveFileInteractor();
     insertedHtml = [];
-    handler = const DriveAttachmentHandler();
+    uploadedFiles = [];
+
+    handler = DriveAttachmentHandler(
+      uploadController: mockUploadController,
+      downloadDriveFileInteractor: mockDownloadInteractor,
+    );
   });
+
+  tearDown(() => Get.reset());
 
   group('DriveAttachmentHandler::handleDrivePickResult::', () {
     test('Should insert link html for docs with sharingLink', () {
-      handler.handleDrivePickResult([
-        linkDoc,
-      ], insertHtml: (html) => insertedHtml.add(html));
+      handler.handleDrivePickResult(
+        [linkDoc],
+        insertHtml: (html) => insertedHtml.add(html),
+        uploadFiles: ({required pickedFiles}) => uploadedFiles.add(pickedFiles),
+      );
 
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, contains('https://drive.example.com/report'));
       expect(insertedHtml.first, contains('Report'));
     });
+
+    test(
+      'Should call validateTotalSizeAttachmentsBeforeUpload for docs with downloadLink',
+      () {
+        handler.handleDrivePickResult(
+          [attachmentDoc],
+          insertHtml: (html) => insertedHtml.add(html),
+          uploadFiles: ({required pickedFiles}) =>
+              uploadedFiles.add(pickedFiles),
+        );
+
+        verify(
+          mockUploadController.validateTotalSizeAttachmentsBeforeUpload(
+            totalSizePreparedFiles: anyNamed('totalSizePreparedFiles'),
+            onValidationSuccess: anyNamed('onValidationSuccess'),
+          ),
+        ).called(1);
+      },
+    );
 
     test('Should prefer sharingLink over downloadLink when doc has both', () {
       final bothLinksDoc = DriveDocument(
@@ -34,32 +85,53 @@ void main() {
         downloadLink: Uri.parse('https://drive.example.com/both-dl'),
       );
 
-      handler.handleDrivePickResult([
-        bothLinksDoc,
-      ], insertHtml: (html) => insertedHtml.add(html));
+      handler.handleDrivePickResult(
+        [bothLinksDoc],
+        insertHtml: (html) => insertedHtml.add(html),
+        uploadFiles: ({required pickedFiles}) => uploadedFiles.add(pickedFiles),
+      );
 
       expect(insertedHtml, hasLength(1));
-      expect(insertedHtml.first, contains('https://drive.example.com/both'));
+      verifyNever(
+        mockUploadController.validateTotalSizeAttachmentsBeforeUpload(
+          totalSizePreparedFiles: anyNamed('totalSizePreparedFiles'),
+          onValidationSuccess: anyNamed('onValidationSuccess'),
+        ),
+      );
     });
 
     test('Should skip docs with neither sharingLink nor downloadLink', () {
-      handler.handleDrivePickResult([
-        noLinkDoc,
-      ], insertHtml: (html) => insertedHtml.add(html));
+      handler.handleDrivePickResult(
+        [noLinkDoc],
+        insertHtml: (html) => insertedHtml.add(html),
+        uploadFiles: ({required pickedFiles}) => uploadedFiles.add(pickedFiles),
+      );
 
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, isEmpty);
+      verifyNever(
+        mockUploadController.validateTotalSizeAttachmentsBeforeUpload(
+          totalSizePreparedFiles: anyNamed('totalSizePreparedFiles'),
+          onValidationSuccess: anyNamed('onValidationSuccess'),
+        ),
+      );
     });
 
-    test('Should handle mixed docs correctly — only link docs inserted', () {
-      handler.handleDrivePickResult([
-        linkDoc,
-        attachmentDoc,
-        noLinkDoc,
-      ], insertHtml: (html) => insertedHtml.add(html));
+    test('Should handle mixed docs correctly', () {
+      handler.handleDrivePickResult(
+        [linkDoc, attachmentDoc, noLinkDoc],
+        insertHtml: (html) => insertedHtml.add(html),
+        uploadFiles: ({required pickedFiles}) => uploadedFiles.add(pickedFiles),
+      );
 
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, contains('Report'));
+      verify(
+        mockUploadController.validateTotalSizeAttachmentsBeforeUpload(
+          totalSizePreparedFiles: anyNamed('totalSizePreparedFiles'),
+          onValidationSuccess: anyNamed('onValidationSuccess'),
+        ),
+      ).called(1);
     });
   });
 }

--- a/workplace/lib/data/datasource/drive_file_datasource.dart
+++ b/workplace/lib/data/datasource/drive_file_datasource.dart
@@ -1,0 +1,6 @@
+import 'package:model/upload/file_info.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+
+abstract class DriveFileDatasource {
+  Future<FileInfo> downloadFile(DriveDocument doc);
+}

--- a/workplace/lib/data/datasource_impl/drive_file_datasource_impl.dart
+++ b/workplace/lib/data/datasource_impl/drive_file_datasource_impl.dart
@@ -1,0 +1,31 @@
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:model/upload/file_info.dart';
+import 'package:workplace/data/datasource/drive_file_datasource.dart';
+import 'package:workplace/data/workplace_dio.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+
+class DriveFileDatasourceImpl implements DriveFileDatasource {
+  final Dio _dio;
+
+  DriveFileDatasourceImpl({Dio? dio}) : _dio = dio ?? WorkplaceDio.instance;
+
+  @override
+  Future<FileInfo> downloadFile(DriveDocument doc) async {
+    final downloadLink = doc.downloadLink;
+    if (downloadLink == null) throw Exception('No download link for ${doc.name}');
+    final response = await _dio.get<List<int>>(
+      downloadLink.toString(),
+      options: Options(responseType: ResponseType.bytes),
+    );
+    final data = response.data;
+    if (data == null) throw Exception('No data received for ${doc.name}');
+    return FileInfo(
+      fileName: doc.name,
+      fileSize: doc.size,
+      bytes: Uint8List.fromList(data),
+      type: doc.mimeType,
+    );
+  }
+}

--- a/workplace/lib/data/repository_impl/drive_file_repository_impl.dart
+++ b/workplace/lib/data/repository_impl/drive_file_repository_impl.dart
@@ -1,0 +1,15 @@
+import 'package:model/upload/file_info.dart';
+import 'package:workplace/data/datasource/drive_file_datasource.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+import 'package:workplace/domain/repository/drive_file_repository.dart';
+
+class DriveFileRepositoryImpl implements DriveFileRepository {
+  final DriveFileDatasource _datasource;
+
+  DriveFileRepositoryImpl(this._datasource);
+
+  @override
+  Future<FileInfo> downloadFile(DriveDocument doc) {
+    return _datasource.downloadFile(doc);
+  }
+}

--- a/workplace/lib/domain/repository/drive_file_repository.dart
+++ b/workplace/lib/domain/repository/drive_file_repository.dart
@@ -1,0 +1,6 @@
+import 'package:model/upload/file_info.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+
+abstract class DriveFileRepository {
+  Future<FileInfo> downloadFile(DriveDocument doc);
+}

--- a/workplace/lib/domain/state/download_drive_file_state.dart
+++ b/workplace/lib/domain/state/download_drive_file_state.dart
@@ -1,0 +1,18 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:model/upload/file_info.dart';
+
+class DownloadingDriveFile extends UIState {}
+
+class DownloadDriveFileSuccess extends UIState {
+  final FileInfo fileInfo;
+
+  DownloadDriveFileSuccess(this.fileInfo);
+
+  @override
+  List<Object?> get props => [fileInfo];
+}
+
+class DownloadDriveFileFailure extends FeatureFailure {
+  DownloadDriveFileFailure(dynamic exception) : super(exception: exception);
+}

--- a/workplace/lib/domain/usecases/download_drive_file_interactor.dart
+++ b/workplace/lib/domain/usecases/download_drive_file_interactor.dart
@@ -1,0 +1,22 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+import 'package:workplace/domain/repository/drive_file_repository.dart';
+import 'package:workplace/domain/state/download_drive_file_state.dart';
+
+class DownloadDriveFileInteractor {
+  final DriveFileRepository _repository;
+
+  DownloadDriveFileInteractor(this._repository);
+
+  Stream<Either<Failure, Success>> execute(DriveDocument doc) async* {
+    try {
+      yield Right(DownloadingDriveFile());
+      final fileInfo = await _repository.downloadFile(doc);
+      yield Right(DownloadDriveFileSuccess(fileInfo));
+    } catch (e) {
+      yield Left(DownloadDriveFileFailure(e));
+    }
+  }
+}


### PR DESCRIPTION
Adds the "add as attachment" flow on top of the link-only base:
- Drive file datasource, repository, interactor, and state layers
- DownloadDriveFileInteractor DI wiring in ComposerBindings
- DriveAttachmentHandler download/upload path and partition logic
- handleDriveAttachmentError in ComposerController
- addAsAttachment locale strings in all ARBs and modal shell UI
- driveAttachmentFailed in intl_messages and AppLocalizations
- addAsAttachment parameter in pickerFetchIntent signatures
- Download/upload tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Add as attachment” option for Drive items in the composer, enabling downloadable Drive files to be attached to the message.
  * Drive picks now process both share links and downloadable files, uploading successful downloads as attachments.

* **Bug Fixes**
  * Improved Drive attachment failure handling with a new localized toast message (“Failed to attach file from Drive”).
  * Strengthened safety for Drive link rendering by escaping both the displayed label and the target URL to prevent unsafe HTML injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->