### PR TITLE
TW-4484 Display X-TWP-Message warnings when opening a mail

### DIFF
--- a/docs/adr/0093-urgent-exception-handling-for-riverpod-flows.md
+++ b/docs/adr/0093-urgent-exception-handling-for-riverpod-flows.md
@@ -1,0 +1,42 @@
+# 93. Urgent-exception handling for Riverpod flows
+
+Date: 2026-06-29
+
+## Status
+
+Accepted
+
+## Related ADRs
+
+- [ADR-0085](./0085-riverpod-state-management-for-local-settings.md) — GetX + Riverpod coexistence
+- [ADR-0092](./0092-upgrade-flutter-riverpod-3.md) — `appProviderContainer` frozen; migrate to `ConsumerWidget`
+
+## Context
+
+GetX controllers consume interactors through `BaseController.consumeState`, whose `onData` / `onError` run `validateUrgentException(...)` → `handleUrgentException(...)`.
+That routing drives re-login / save-and-reconnect / connection-error UX for `NoNetworkError`, `BadCredentialsException`, `ConnectionError`, `RefreshTokenFailedException`.
+Riverpod notifiers consume interactors directly (`interactor.execute(...).last`), bypassing `consumeState`. They therefore lose this routing: a dismiss that fails on an expired token would show a generic toast instead of triggering a re-login. The `empty_folder` delegate had already re-implemented a partial version of this inline, handling only a bare exception (not a `Left(FeatureFailure)`).
+
+## Decision
+
+Add one shared primitive, `handleUrgentExceptionIfNeeded({Failure? failure, Object? exception})` (`lib/features/base/handle_urgent_exception.dart`). It resolves the registered `UrgentExceptionHandler` via the `getBinding` bridge, unwraps both carriers exactly like `BaseController` (`FeatureFailure.exception` or a bare exception), routes urgent  exceptions to `handleUrgentException`, and returns `true` when it handled one.
+
+**Rule:** any Riverpod flow consuming an interactor result MUST call this on failure. The caller skips its own failure UI when it returns `true`. `TwpWarningDismiss` adopts it (reporting `TwpWarningDismissResult.urgentHandled`); the `empty_folder` delegate is refactored onto it, removing the duplicated inline logic.
+
+### Handler is a lifetime service, not a screen controller
+
+The `UrgentExceptionHandler` slot was bound to `MailboxDashBoardController` (`Get.put<UrgentExceptionHandler>(Get.find<MailboxDashBoardController>())`). That controller is absent on a web reload onto a non-dashboard route (e.g. Settings, where `MailboxDashBoardBindings` does not run — cf. ADR-0085), so `getBinding` would return `null` and urgent exceptions on those screens would be silently dropped.
+Bind the slot instead to `UrgentExceptionHandlerService` — a dedicated `BaseController` subclass registered `lazyPut(fenix: true)` in `MainBindings` (which runs at every bootstrap, before `runApp`). It reuses the proven `BaseController` routing unchanged and exists for the app lifetime regardless of the mounted screen. The dashboard keeps its own `handleUrgentExceptionOnMobile` override for its own `consumeState` path (that calls `this.handleUrgentException`, not the registered slot).
+
+## Consequences
+
+**Positive**
+- Re-login / reconnect handling is no longer silently dropped in Riverpod flows.
+- Single source of truth; future Riverpod implementers call one documented function.
+- No new `appProviderContainer` call site (ADR-0092 compliant).
+- Urgent handling works on every route, including direct web reloads onto Settings or other non-dashboard screens.
+
+**Negative**
+- Still depends on `getBinding<UrgentExceptionHandler>()` — the GetX bridge. When the handler is exposed as a Riverpod provider, `handle_urgent_exception.dart` and `UrgentExceptionHandlerService` are the only places to change.
+- The contract is a convention, not enforced by the type system; reviewers must check new Riverpod failure paths call it.
+- `UrgentExceptionHandlerService` subclasses `BaseController` to reuse its routing; the cleaner end-state is to extract the routing into a framework-free service / Riverpod provider once GetX is removed.

--- a/integration_test/models/provisioning_twp_warning_email.dart
+++ b/integration_test/models/provisioning_twp_warning_email.dart
@@ -1,0 +1,25 @@
+import 'package:model/model.dart';
+
+/// Request describing an Inbox email to provision with a backend-positioned
+/// `X-TWP-Message` warning header. A value object so callers pass one typed
+/// argument instead of several loose strings.
+class ProvisioningTwpWarningEmail {
+  final String subject;
+  final String message;
+  final TwpWarningLevel level;
+  final String? code;
+
+  const ProvisioningTwpWarningEmail({
+    required this.subject,
+    required this.message,
+    this.level = TwpWarningLevel.warn,
+    this.code,
+  });
+
+  /// The raw `X-TWP-Message` header value: `level:<level> [code:<code>] <message>`.
+  String get headerValue => [
+    'level:${level.name}',
+    if (code != null) 'code:$code',
+    message,
+  ].join(' ');
+}

--- a/integration_test/provisioning/twp_warning_email_provisioner.dart
+++ b/integration_test/provisioning/twp_warning_email_provisioner.dart
@@ -1,0 +1,122 @@
+import 'package:get/get.dart';
+import 'package:jmap_dart_client/http/http_client.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/jmap_request.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email_header_value.dart';
+import 'package:jmap_dart_client/jmap/mail/email/individual_header_identifier.dart';
+import 'package:jmap_dart_client/jmap/mail/email/set/set_email_method.dart';
+import 'package:jmap_dart_client/jmap/mail/email/set/set_email_response.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/model.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
+import 'package:tmail_ui_user/main/error/capability_validator.dart';
+import 'package:uuid/uuid.dart';
+
+import '../models/provisioning_twp_warning_email.dart';
+import '../utils/wait_for_mailbox_ready.dart';
+
+/// Provisions an Inbox email that already carries a backend-positioned
+/// `X-TWP-Message` warning header.
+///
+/// The standard send flow cannot set arbitrary headers, so this creates the
+/// message directly via JMAP `Email/set` create. Headers on create must be set
+/// through `header:Name:form` properties (`individualHeaders`), like MDN /
+/// User-Agent — the `headers` set is not settable on create.
+///
+/// Kept out of `ScenarioUtilsMixin` so provisioning concerns don't accumulate on
+/// that mixin (SRP); new server-state helpers should follow the same pattern.
+class TwpWarningEmailProvisioner {
+  const TwpWarningEmailProvisioner();
+
+  Future<void> provision(ProvisioningTwpWarningEmail request) async {
+    await waitForMailboxReady();
+    final context = _resolveInboxContext();
+    await _createEmailWithWarningHeader(context, request);
+    await Get.find<ThreadController>().refreshAllEmail();
+  }
+
+  _InboxProvisioningContext _resolveInboxContext() {
+    final dashboard = Get.find<MailboxDashBoardController>();
+    return _InboxProvisioningContext(
+      session: _required(dashboard.sessionCurrent, 'session'),
+      accountId: _required(dashboard.accountId.value, 'accountId'),
+      inboxId: _required(
+        dashboard.mapDefaultMailboxIdByRole[PresentationMailbox.roleInbox],
+        'inbox mailbox',
+      ),
+      ownEmail: dashboard.ownEmailAddress.value,
+    );
+  }
+
+  Future<void> _createEmailWithWarningHeader(
+    _InboxProvisioningContext context,
+    ProvisioningTwpWarningEmail request,
+  ) async {
+    final requestBuilder = JmapRequestBuilder(
+      Get.find<HttpClient>(),
+      ProcessingInvocation(),
+    );
+    final setEmailMethod = SetEmailMethod(context.accountId)
+      ..addCreate(
+        Id(const Uuid().v1()),
+        Email(
+          mailboxIds: {context.inboxId: true},
+          from: {EmailAddress(null, context.ownEmail)},
+          to: {EmailAddress(null, context.ownEmail)},
+          subject: request.subject,
+          individualHeaders: {
+            IndividualHeaderIdentifier(
+              'header:${EmailProperty.headerTwpMessageKey}:asText',
+            ): TextHeaderValue(
+              request.headerValue,
+            ),
+          },
+        ),
+      );
+    final invocation = requestBuilder.invocation(setEmailMethod);
+    final response =
+        await (requestBuilder..usings(
+              setEmailMethod.requiredCapabilities
+                  .toCapabilitiesSupportTeamMailboxes(
+                    context.session,
+                    context.accountId,
+                  ),
+            ))
+            .build()
+            .execute();
+    final created = response
+        .parse<SetEmailResponse>(
+          invocation.methodCallId,
+          SetEmailResponse.deserialize,
+        )
+        ?.created;
+    if (created == null || created.isEmpty) {
+      throw StateError('TwpWarningEmailProvisioner: email creation failed');
+    }
+  }
+
+  /// Returns [value] or throws a descriptive [StateError] — avoids a multi-term
+  /// null-check conditional in the caller.
+  T _required<T>(T? value, String name) =>
+      value ??
+      (throw StateError('TwpWarningEmailProvisioner: $name is unavailable'));
+}
+
+class _InboxProvisioningContext {
+  final Session session;
+  final AccountId accountId;
+  final MailboxId inboxId;
+  final String ownEmail;
+
+  const _InboxProvisioningContext({
+    required this.session,
+    required this.accountId,
+    required this.inboxId,
+    required this.ownEmail,
+  });
+}

--- a/integration_test/robots/abstract/abstract_email_assertion_robot.dart
+++ b/integration_test/robots/abstract/abstract_email_assertion_robot.dart
@@ -1,0 +1,6 @@
+/// Assertion sub-robot for the email detail view. All methods are pure
+/// (no side effects) and may be overridden per platform.
+abstract class AbstractEmailAssertionRobot {
+  Future<void> expectTwpWarningBannerVisible();
+  Future<void> expectTwpWarningBannerNotVisible();
+}

--- a/integration_test/robots/abstract/abstract_email_robot.dart
+++ b/integration_test/robots/abstract/abstract_email_robot.dart
@@ -1,4 +1,13 @@
+import 'abstract_email_assertion_robot.dart';
+import 'abstract_email_twp_warning_robot.dart';
+
 abstract class AbstractEmailRobot {
   Future<void> tapDownloadAllButton();
   Future<void> expectDownloadSaveDialogVisible();
+
+  /// Pure assertions for the email detail view.
+  AbstractEmailAssertionRobot get assertion;
+
+  /// Actions on the `X-TWP-Message` warning banner.
+  AbstractEmailTwpWarningRobot get twpWarning;
 }

--- a/integration_test/robots/abstract/abstract_email_robot.dart
+++ b/integration_test/robots/abstract/abstract_email_robot.dart
@@ -5,6 +5,9 @@ abstract class AbstractEmailRobot {
   Future<void> tapDownloadAllButton();
   Future<void> expectDownloadSaveDialogVisible();
 
+  /// Navigates back from the email detail view to the thread list.
+  Future<void> onTapBackButton();
+
   /// Pure assertions for the email detail view.
   AbstractEmailAssertionRobot get assertion;
 

--- a/integration_test/robots/abstract/abstract_email_twp_warning_robot.dart
+++ b/integration_test/robots/abstract/abstract_email_twp_warning_robot.dart
@@ -1,0 +1,5 @@
+/// Feature sub-robot: actions on the backend-positioned `X-TWP-Message`
+/// warning banner shown in the opened email.
+abstract class AbstractEmailTwpWarningRobot {
+  Future<void> tapDismissWarning();
+}

--- a/integration_test/robots/email_assertion_robot.dart
+++ b/integration_test/robots/email_assertion_robot.dart
@@ -1,0 +1,20 @@
+import 'package:tmail_ui_user/features/email/presentation/widgets/twp_warning_banner.dart';
+
+import '../base/core_robot.dart';
+import '../utils/wait_for_condition.dart';
+import 'abstract/abstract_email_assertion_robot.dart';
+
+class EmailAssertionRobot extends CoreRobot
+    implements AbstractEmailAssertionRobot {
+  EmailAssertionRobot(super.$);
+
+  @override
+  Future<void> expectTwpWarningBannerVisible() async {
+    await $.waitUntilVisible($(TwpWarningBanner));
+  }
+
+  @override
+  Future<void> expectTwpWarningBannerNotVisible() async {
+    await waitForCondition(() async => $(TwpWarningBanner).evaluate().isEmpty);
+  }
+}

--- a/integration_test/robots/email_robot.dart
+++ b/integration_test/robots/email_robot.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/patrol.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/base/widget/labels/tag_widget.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/attachment_item_widget.dart';
@@ -10,9 +11,22 @@ import 'package:tmail_ui_user/features/labels/presentation/widgets/label_widget.
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../base/core_robot.dart';
+import 'abstract/abstract_email_assertion_robot.dart';
+import 'abstract/abstract_email_twp_warning_robot.dart';
+import 'email_assertion_robot.dart';
+import 'email_twp_warning_robot.dart';
 
 class EmailRobot extends CoreRobot {
-  EmailRobot(super.$);
+  final AbstractEmailAssertionRobot assertion;
+  final AbstractEmailTwpWarningRobot twpWarning;
+
+  EmailRobot(
+    PatrolIntegrationTester $, {
+    AbstractEmailAssertionRobot? assertionRobot,
+    AbstractEmailTwpWarningRobot? twpWarningRobot,
+  })  : assertion = assertionRobot ?? EmailAssertionRobot($),
+        twpWarning = twpWarningRobot ?? EmailTwpWarningRobot($),
+        super($);
 
   Future<void> onTapForwardEmail() async {
     await $(#forward_email_button).tap();

--- a/integration_test/robots/email_twp_warning_robot.dart
+++ b/integration_test/robots/email_twp_warning_robot.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
+
+import '../base/core_robot.dart';
+import 'abstract/abstract_email_twp_warning_robot.dart';
+
+class EmailTwpWarningRobot extends CoreRobot
+    implements AbstractEmailTwpWarningRobot {
+  EmailTwpWarningRobot(super.$);
+
+  @override
+  Future<void> tapDismissWarning() async {
+    await $(const Key('${UiKeys.twpWarningDismissButtonPrefix}0')).tap();
+    await $.pumpAndSettle();
+  }
+}

--- a/integration_test/robots/mobile/mobile_email_robot.dart
+++ b/integration_test/robots/mobile/mobile_email_robot.dart
@@ -6,7 +6,11 @@ import '../email_robot.dart';
 import '../../utils/test_timeouts.dart';
 
 class MobileEmailRobot extends EmailRobot implements AbstractEmailRobot {
-  MobileEmailRobot(super.$);
+  MobileEmailRobot(
+    super.$, {
+    super.assertionRobot,
+    super.twpWarningRobot,
+  });
 
   @override
   Future<void> expectDownloadSaveDialogVisible() async {

--- a/integration_test/robots/web/web_email_assertion_robot.dart
+++ b/integration_test/robots/web/web_email_assertion_robot.dart
@@ -1,0 +1,16 @@
+import 'package:tmail_ui_user/features/email/presentation/widgets/twp_warning_banner.dart';
+
+import '../../utils/wait_for_condition.dart';
+import '../email_assertion_robot.dart';
+
+class WebEmailAssertionRobot extends EmailAssertionRobot {
+  WebEmailAssertionRobot(super.$);
+
+  @override
+  Future<void> expectTwpWarningBannerVisible() async {
+    // Web: the banner is not reliably hit-testable — assert via the element tree.
+    await waitForCondition(
+      () async => $(TwpWarningBanner).evaluate().isNotEmpty,
+    );
+  }
+}

--- a/integration_test/robots/web/web_email_robot.dart
+++ b/integration_test/robots/web/web_email_robot.dart
@@ -1,9 +1,14 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/patrol.dart';
 
 import '../mobile/mobile_email_robot.dart';
+import 'web_email_assertion_robot.dart';
 
 class WebEmailRobot extends MobileEmailRobot {
-  WebEmailRobot(super.$);
+  // Inject the web assertion sub-robot (non-hit-testable waits) — composite
+  // platform injection instead of overriding assertions on the root.
+  WebEmailRobot(PatrolIntegrationTester $)
+      : super($, assertionRobot: WebEmailAssertionRobot($));
 
   @override
   Future<void> expectDownloadSaveDialogVisible() async {

--- a/integration_test/scenarios/email_detailed/dismiss_twp_warning_banner_scenario.dart
+++ b/integration_test/scenarios/email_detailed/dismiss_twp_warning_banner_scenario.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/model.dart';
+
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_twp_warning_email.dart';
+import '../../provisioning/twp_warning_email_provisioner.dart';
+
+/// Opens an email that arrives with a backend-positioned `X-TWP-Message`
+/// warning header, asserts the warning banner is shown, dismisses it, and
+/// asserts it disappears.
+class DismissTwpWarningBannerScenario extends BaseTestScenario {
+  const DismissTwpWarningBannerScenario(super.$, super.robots);
+
+  @override
+  Future<void> runTestLogic() async {
+    const subject = 'TWP warning banner email';
+    final threadRobot = robots.threadRobot();
+    final emailRobot = robots.emailRobot();
+
+    await const TwpWarningEmailProvisioner().provision(
+      const ProvisioningTwpWarningEmail(
+        subject: subject,
+        level: TwpWarningLevel.warn,
+        code: 'virus',
+        message: 'This email contains a virus in its attachments!',
+      ),
+    );
+    await $.pumpAndSettle();
+
+    await threadRobot.openEmailWithSubject(subject);
+    await $.pumpAndSettle();
+
+    await emailRobot.assertion.expectTwpWarningBannerVisible();
+
+    await emailRobot.twpWarning.tapDismissWarning();
+    await emailRobot.assertion.expectTwpWarningBannerNotVisible();
+  }
+}

--- a/integration_test/scenarios/email_detailed/dismiss_twp_warning_banner_scenario.dart
+++ b/integration_test/scenarios/email_detailed/dismiss_twp_warning_banner_scenario.dart
@@ -33,6 +33,13 @@ class DismissTwpWarningBannerScenario extends BaseTestScenario {
     await emailRobot.assertion.expectTwpWarningBannerVisible();
 
     await emailRobot.twpWarning.tapDismissWarning();
+
+    // Reopen the mail to prove the dismissal was persisted to the backend
+    // (SetEmail keyword), not just optimistically hidden in the current view.
+    await emailRobot.onTapBackButton();
+    await threadRobot.openEmailWithSubject(subject);
+    await $.pumpAndSettle();
+
     await emailRobot.assertion.expectTwpWarningBannerNotVisible();
   }
 }

--- a/integration_test/tests/email_detailed/dismiss_twp_warning_banner_test.dart
+++ b/integration_test/tests/email_detailed/dismiss_twp_warning_banner_test.dart
@@ -1,0 +1,12 @@
+import '../../base/test_base.dart';
+import '../../models/test_tags.dart';
+import '../../scenarios/email_detailed/dismiss_twp_warning_banner_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description:
+        'Should hide the TWP warning banner when dismissing it on an opened email',
+    scenarioBuilder: ($, robots) => DismissTwpWarningBannerScenario($, robots),
+    tags: [TestTags.android, TestTags.ios, TestTags.web],
+  );
+}

--- a/lib/features/base/handle_urgent_exception.dart
+++ b/lib/features/base/handle_urgent_exception.dart
@@ -1,0 +1,29 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+
+/// Routes an interactor failure through the centrally-registered
+/// [UrgentExceptionHandler] (re-login, reconnect, connection errors), mirroring
+/// `BaseController.onData`/`onError` for Riverpod flows that bypass
+/// `consumeState`. Any such flow MUST call this on failure. See ADR-0093.
+///
+/// Unwraps either carrier like `BaseController`: a `Left(FeatureFailure)` (via
+/// [FeatureFailure.exception]) or a bare [exception]. Returns `true` when the
+/// exception was urgent and handled — the caller then skips its own error UI.
+bool handleUrgentExceptionIfNeeded({Failure? failure, Object? exception}) {
+  final handler = getBinding<UrgentExceptionHandler>();
+  if (handler == null) return false;
+
+  final resolvedException =
+      exception ?? (failure is FeatureFailure ? failure.exception : null);
+  if (resolvedException == null ||
+      !handler.validateUrgentException(resolvedException)) {
+    return false;
+  }
+
+  handler.handleUrgentException(
+    failure: failure,
+    exception: resolvedException is Exception ? resolvedException : null,
+  );
+  return true;
+}

--- a/lib/features/base/model/ui_keys.dart
+++ b/lib/features/base/model/ui_keys.dart
@@ -31,4 +31,8 @@ class UiKeys {
 
   static const String mailboxMoreActionButton = 'mailbox_more_action_button';
   static const String cleanMessageBannerNotVisible = 'clean_message_banner_not_visible';
+
+  // TWP warning banner (X-TWP-Message). Keys are suffixed with the warning index.
+  static const String twpWarningBannerPrefix = 'twp_warning_banner_';
+  static const String twpWarningDismissButtonPrefix = 'twp_warning_dismiss_button_';
 }

--- a/lib/features/base/urgent_exception_handler_service.dart
+++ b/lib/features/base/urgent_exception_handler_service.dart
@@ -1,0 +1,16 @@
+import 'package:tmail_ui_user/features/base/base_controller.dart';
+import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
+
+/// App-lifetime [UrgentExceptionHandler], decoupled from any screen controller.
+///
+/// Bound permanently at bootstrap (`MainBindings`) so Riverpod flows and
+/// delegates can route urgent exceptions on any screen — including where
+/// `MailboxDashBoardController` is absent (e.g. a Settings web-reload). Reuses
+/// the `BaseController` routing unchanged; owns no view. See ADR-0093.
+class UrgentExceptionHandlerService extends BaseController {
+  @override
+  void onReady() {
+    // No super call: this service has no view, so it must not register the
+    // browser-unload listeners the base sets up — those belong to the screen.
+  }
+}

--- a/lib/features/email/data/datasource/email_datasource.dart
+++ b/lib/features/email/data/datasource/email_datasource.dart
@@ -169,6 +169,8 @@ abstract class EmailDataSource {
 
   Future<void> unsubscribeMail(Session session, AccountId accountId, EmailId emailId);
 
+  Future<void> dismissTwpWarning(Session session, AccountId accountId, EmailId emailId, int index);
+
   Future<EmailRecoveryAction> restoreDeletedMessage(RestoredDeletedMessageRequest restoredDeletedMessageRequest);
 
   Future<EmailRecoveryAction> getRestoredDeletedMessage(EmailRecoveryActionId emailRecoveryActionId);

--- a/lib/features/email/data/datasource_impl/email_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_datasource_impl.dart
@@ -366,6 +366,13 @@ class EmailDataSourceImpl extends EmailDataSource {
   }
 
   @override
+  Future<void> dismissTwpWarning(Session session, AccountId accountId, EmailId emailId, int index) {
+    return Future.sync(() async {
+      return await emailAPI.dismissTwpWarning(session, accountId, emailId, index);
+    }).catchError(_exceptionThrower.throwException);
+  }
+
+  @override
   Future<EmailRecoveryAction> restoreDeletedMessage(RestoredDeletedMessageRequest restoredDeletedMessageRequest) {
     return Future.sync(() async {
       return await emailAPI.restoreDeletedMessage(restoredDeletedMessageRequest);

--- a/lib/features/email/data/datasource_impl/email_hive_cache_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_hive_cache_datasource_impl.dart
@@ -475,6 +475,11 @@ class EmailHiveCacheDataSourceImpl extends EmailDataSource {
   }
 
   @override
+  Future<void> dismissTwpWarning(Session session, AccountId accountId, EmailId emailId, int index) {
+    throw UnimplementedError();
+  }
+
+  @override
   Future<EmailRecoveryAction> restoreDeletedMessage(RestoredDeletedMessageRequest restoredDeletedMessageRequest) {
     throw UnimplementedError();
   }

--- a/lib/features/email/data/datasource_impl/email_local_storage_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_local_storage_datasource_impl.dart
@@ -202,6 +202,11 @@ class EmailLocalStorageDataSourceImpl extends EmailDataSource {
   }
 
   @override
+  Future<void> dismissTwpWarning(Session session, AccountId accountId, EmailId emailId, int index) {
+    throw UnimplementedError();
+  }
+
+  @override
   Future<Email> updateEmailDrafts(Session session, AccountId accountId, Email newEmail, EmailId oldEmailId, {CancelToken? cancelToken, bool isUpdateDraftToClose = false}) {
     throw UnimplementedError();
   }

--- a/lib/features/email/data/datasource_impl/email_session_storage_datasource_impl.dart
+++ b/lib/features/email/data/datasource_impl/email_session_storage_datasource_impl.dart
@@ -182,6 +182,11 @@ class EmailSessionStorageDatasourceImpl extends EmailDataSource {
   }
 
   @override
+  Future<void> dismissTwpWarning(Session session, AccountId accountId, EmailId emailId, int index) {
+    throw UnimplementedError();
+  }
+
+  @override
   Future<Email> updateEmailDrafts(Session session, AccountId accountId, Email newEmail, EmailId oldEmailId, {CancelToken? cancelToken, bool isUpdateDraftToClose = false}) {
     throw UnimplementedError();
   }

--- a/lib/features/email/data/network/email_api.dart
+++ b/lib/features/email/data/network/email_api.dart
@@ -861,6 +861,37 @@ class EmailAPI
     }
   }
 
+  Future<void> dismissTwpWarning(Session session, AccountId accountId, EmailId emailId, int index) async {
+    final setEmailMethod = SetEmailMethod(accountId)
+      ..addUpdates(emailId.generateMapUpdateObjectDismissTwpWarning(index));
+
+    final requestBuilder = JmapRequestBuilder(_httpClient, ProcessingInvocation());
+    requestBuilder.invocation(setEmailMethod);
+    final setEmailInvocation = requestBuilder.invocation(setEmailMethod);
+
+    final capabilities = setEmailMethod.requiredCapabilities.toCapabilitiesSupportTeamMailboxes(session, accountId);
+
+      final response = await (requestBuilder
+          ..usings(capabilities))
+        .build()
+        .execute();
+
+    final setEmailResponse = response.parse<SetEmailResponse>(
+      setEmailInvocation.methodCallId,
+      SetEmailResponse.deserialize,
+    );
+
+    final emailIdUpdated = setEmailResponse?.updated
+        ?.keys
+        .map((id) => EmailId(id))
+        .toList() ?? [];
+    final mapErrors = handleSetResponse([setEmailResponse]);
+
+    if (emailIdUpdated.isEmpty) {
+      throw SetMethodException(mapErrors);
+    }
+  }
+
   Future<EmailRecoveryAction> restoreDeletedMessage(RestoredDeletedMessageRequest restoredDeletedMessageRequest) async {
     final processingInvocation = ProcessingInvocation();
     final requestBuilder = JmapRequestBuilder(_httpClient, processingInvocation);

--- a/lib/features/email/data/network/email_api.dart
+++ b/lib/features/email/data/network/email_api.dart
@@ -870,8 +870,7 @@ class EmailAPI
 
     final capabilities = setEmailMethod.requiredCapabilities.toCapabilitiesSupportTeamMailboxes(session, accountId);
 
-      final response = await (requestBuilder
-          ..usings(capabilities))
+    final response = await (requestBuilder..usings(capabilities))
         .build()
         .execute();
 

--- a/lib/features/email/data/network/email_api.dart
+++ b/lib/features/email/data/network/email_api.dart
@@ -866,7 +866,6 @@ class EmailAPI
       ..addUpdates(emailId.generateMapUpdateObjectDismissTwpWarning(index));
 
     final requestBuilder = JmapRequestBuilder(_httpClient, ProcessingInvocation());
-    requestBuilder.invocation(setEmailMethod);
     final setEmailInvocation = requestBuilder.invocation(setEmailMethod);
 
     final capabilities = setEmailMethod.requiredCapabilities.toCapabilitiesSupportTeamMailboxes(session, accountId);

--- a/lib/features/email/data/repository/email_repository_impl.dart
+++ b/lib/features/email/data/repository/email_repository_impl.dart
@@ -467,6 +467,11 @@ class EmailRepositoryImpl extends EmailRepository {
   }
 
   @override
+  Future<void> dismissTwpWarning(Session session, AccountId accountId, EmailId emailId, int index) {
+    return emailDataSource[DataSourceType.network]!.dismissTwpWarning(session, accountId, emailId, index);
+  }
+
+  @override
   Future<EmailRecoveryAction> restoreDeletedMessage(RestoredDeletedMessageRequest restoredDeletedMessageRequest) {
     return emailDataSource[DataSourceType.network]!.restoreDeletedMessage(restoredDeletedMessageRequest);
   }

--- a/lib/features/email/domain/repository/email_repository.dart
+++ b/lib/features/email/domain/repository/email_repository.dart
@@ -157,6 +157,8 @@ abstract class EmailRepository {
 
   Future<void> unsubscribeMail(Session session, AccountId accountId, EmailId emailId);
 
+  Future<void> dismissTwpWarning(Session session, AccountId accountId, EmailId emailId, int index);
+
   Future<EmailRecoveryAction> restoreDeletedMessage(RestoredDeletedMessageRequest restoredDeletedMessageRequest);
 
   Future<EmailRecoveryAction> getRestoredDeletedMessage(EmailRecoveryActionId emailRecoveryActionId);

--- a/lib/features/email/domain/state/dismiss_twp_warning_state.dart
+++ b/lib/features/email/domain/state/dismiss_twp_warning_state.dart
@@ -13,8 +13,8 @@ class DismissTwpWarningSuccess extends UIState {
 }
 
 class DismissTwpWarningFailure extends FeatureFailure {
-
   final int? index;
 
-  DismissTwpWarningFailure({this.index, dynamic exception}) : super(exception: exception);
+  DismissTwpWarningFailure({this.index, dynamic exception})
+    : super(exception: exception);
 }

--- a/lib/features/email/domain/state/dismiss_twp_warning_state.dart
+++ b/lib/features/email/domain/state/dismiss_twp_warning_state.dart
@@ -1,0 +1,20 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+
+class DismissTwpWarningSuccess extends UIState {
+  DismissTwpWarningSuccess(this.emailId, this.index);
+
+  final EmailId emailId;
+  final int index;
+
+  @override
+  List<Object?> get props => [emailId, index];
+}
+
+class DismissTwpWarningFailure extends FeatureFailure {
+
+  final int? index;
+
+  DismissTwpWarningFailure({this.index, dynamic exception}) : super(exception: exception);
+}

--- a/lib/features/email/domain/usecases/dismiss_twp_warning_interactor.dart
+++ b/lib/features/email/domain/usecases/dismiss_twp_warning_interactor.dart
@@ -1,0 +1,28 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:tmail_ui_user/features/email/domain/repository/email_repository.dart';
+import 'package:tmail_ui_user/features/email/domain/state/dismiss_twp_warning_state.dart';
+
+class DismissTwpWarningInteractor {
+  final EmailRepository emailRepository;
+
+  DismissTwpWarningInteractor(this.emailRepository);
+
+  Stream<Either<Failure, Success>> execute(
+    Session session,
+    AccountId accountId,
+    EmailId emailId,
+    int index,
+  ) async* {
+    try {
+      await emailRepository.dismissTwpWarning(session, accountId, emailId, index);
+      yield Right(DismissTwpWarningSuccess(emailId, index));
+    } catch (e) {
+      yield Left(DismissTwpWarningFailure(index: index, exception: e));
+    }
+  }
+}

--- a/lib/features/email/domain/usecases/dismiss_twp_warning_interactor.dart
+++ b/lib/features/email/domain/usecases/dismiss_twp_warning_interactor.dart
@@ -19,7 +19,12 @@ class DismissTwpWarningInteractor {
     int index,
   ) async* {
     try {
-      await emailRepository.dismissTwpWarning(session, accountId, emailId, index);
+      await emailRepository.dismissTwpWarning(
+        session,
+        accountId,
+        emailId,
+        index,
+      );
       yield Right(DismissTwpWarningSuccess(emailId, index));
     } catch (e) {
       yield Left(DismissTwpWarningFailure(index: index, exception: e));

--- a/lib/features/email/presentation/bindings/email_bindings.dart
+++ b/lib/features/email/presentation/bindings/email_bindings.dart
@@ -1,6 +1,5 @@
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
-import 'package:tmail_ui_user/features/email/domain/usecases/dismiss_twp_warning_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_email_content_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_email_read_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_star_email_interactor.dart';
@@ -25,7 +24,6 @@ class EmailBindings extends Bindings {
       Get.find<GetAllIdentitiesInteractor>(),
       Get.find<StoreOpenedEmailInteractor>(),
       Get.find<PrintEmailInteractor>(),
-      Get.find<DismissTwpWarningInteractor>(),
       currentEmailId: currentEmailId,
     ), tag: tag);
   }

--- a/lib/features/email/presentation/bindings/email_bindings.dart
+++ b/lib/features/email/presentation/bindings/email_bindings.dart
@@ -1,5 +1,6 @@
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/dismiss_twp_warning_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_email_content_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_email_read_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_star_email_interactor.dart';
@@ -24,6 +25,7 @@ class EmailBindings extends Bindings {
       Get.find<GetAllIdentitiesInteractor>(),
       Get.find<StoreOpenedEmailInteractor>(),
       Get.find<PrintEmailInteractor>(),
+      Get.find<DismissTwpWarningInteractor>(),
       currentEmailId: currentEmailId,
     ), tag: tag);
   }

--- a/lib/features/email/presentation/bindings/email_interactor_bindings.dart
+++ b/lib/features/email/presentation/bindings/email_interactor_bindings.dart
@@ -16,6 +16,7 @@ import 'package:tmail_ui_user/features/email/data/local/html_analyzer.dart';
 import 'package:tmail_ui_user/features/email/data/network/email_api.dart';
 import 'package:tmail_ui_user/features/email/data/repository/email_repository_impl.dart';
 import 'package:tmail_ui_user/features/email/domain/repository/email_repository.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/dismiss_twp_warning_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_email_content_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_entire_message_as_document_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_stored_email_state_interactor.dart';
@@ -109,6 +110,7 @@ class EmailInteractorBindings extends InteractorsBindings {
     Get.lazyPut(() => MarkAsEmailReadInteractor(Get.find<EmailRepository>()));
     Get.lazyPut(() => MoveToMailboxInteractor(Get.find<EmailRepository>()));
     Get.lazyPut(() => MarkAsStarEmailInteractor(Get.find<EmailRepository>()));
+    Get.lazyPut(() => DismissTwpWarningInteractor(Get.find<EmailRepository>()));
     Get.lazyPut(() => GetStoredEmailStateInteractor(Get.find<EmailRepository>()));
     Get.lazyPut(() => StoreOpenedEmailInteractor(Get.find<EmailRepository>()));
     Get.lazyPut(() => PrintEmailInteractor(Get.find<EmailRepository>()));

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -880,14 +880,31 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
   bool get isNetworkConnectionAvailable =>
       mailboxDashBoardController.networkConnectionController.isNetworkConnectionAvailable();
 
-  /// Mirrors the dismissal keyword for `X-TWP-Message` warning [index] onto the
-  /// in-memory email so it stays hidden on reopen-within-session. Called by
-  /// `TwpWarningBannerList` after the backend persisted it; the transient
-  /// dismissed set itself lives in the Riverpod `TwpWarningDismiss` notifier.
-  void markTwpWarningDismissedLocally(int index) {
-    _syncKeywordsToCurrentEmail({
-      KeyWordIdentifierExtension.twpWarningDismissed(index): true,
+  /// Optimistically mirrors the `X-TWP-Message` dismissal for [index] onto the
+  /// in-memory email — both the open view and the mailbox list — so the banner
+  /// hides immediately and stays hidden on reopen. Called by
+  /// `TwpWarningBannerList`; reverted by [clearTwpWarningDismissedLocally] if the
+  /// backend persist fails. The transient dismissed set itself lives in the
+  /// Riverpod `TwpWarningDismiss` notifier.
+  void markTwpWarningDismissedLocally(int index) =>
+      _applyTwpWarningDismissedKeyword(index, dismissed: true);
+
+  /// Reverts [markTwpWarningDismissedLocally] on persist failure so the banner
+  /// reappears.
+  void clearTwpWarningDismissedLocally(int index) =>
+      _applyTwpWarningDismissedKeyword(index, dismissed: false);
+
+  void _applyTwpWarningDismissedKeyword(int index, {required bool dismissed}) {
+    final emailId = _syncKeywordsToCurrentEmail({
+      KeyWordIdentifierExtension.twpWarningDismissed(index): dismissed,
     });
+    if (emailId == null) return;
+
+    mailboxDashBoardController.updateEmailTwpWarningDismissed(
+      emailId,
+      index,
+      dismissed: dismissed,
+    );
   }
 
   void handleEmailAction(

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -38,6 +38,7 @@ import 'package:tmail_ui_user/features/email/domain/state/calendar_event_counter
 import 'package:tmail_ui_user/features/email/domain/state/calendar_event_maybe_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/calendar_event_reject_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/calendar_event_reply_state.dart';
+import 'package:tmail_ui_user/features/email/domain/state/dismiss_twp_warning_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/get_email_content_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/get_entire_message_as_document_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/mark_as_email_read_state.dart';
@@ -49,6 +50,7 @@ import 'package:tmail_ui_user/features/email/domain/state/unsubscribe_email_stat
 import 'package:tmail_ui_user/features/email/domain/usecases/calendar_event_accept_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/calendar_event_counter_accept_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/calendar_event_reject_interactor.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/dismiss_twp_warning_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_email_content_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_entire_message_as_document_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_email_read_interactor.dart';
@@ -119,6 +121,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
   final GetAllIdentitiesInteractor _getAllIdentitiesInteractor;
   final StoreOpenedEmailInteractor _storeOpenedEmailInteractor;
   final PrintEmailInteractor _printEmailInteractor;
+  final DismissTwpWarningInteractor _dismissTwpWarningInteractor;
   final EmailId? _currentEmailId;
 
   CreateNewEmailRuleFilterInteractor? _createNewEmailRuleFilterInteractor;
@@ -140,6 +143,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
   final attachmentsViewState = RxMap<Id, Either<Failure, Success>>();
   final isEmailContentHidden = RxBool(false);
   final currentEmailLoaded = Rxn<EmailLoaded>();
+  final dismissedTwpWarningIndexes = <int>{}.obs;
   final isEmailContentClipped = RxBool(false);
   final attendanceStatus = Rxn<AttendanceStatus>();
   final htmlContentViewKey = GlobalKey<HtmlContentViewState>();
@@ -188,7 +192,8 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
     this._markAsStarEmailInteractor,
     this._getAllIdentitiesInteractor,
     this._storeOpenedEmailInteractor,
-    this._printEmailInteractor, {
+    this._printEmailInteractor,
+    this._dismissTwpWarningInteractor, {
     EmailId? currentEmailId,
   }) : _currentEmailId = currentEmailId;
 
@@ -244,6 +249,8 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
       _handlePrintEmailSuccess(success);
     } else if (success is CalendarEventReplySuccess) {
       calendarEventSuccess(success);
+    } else if (success is DismissTwpWarningSuccess) {
+      _dismissTwpWarningSuccess(success);
     } else {
       super.handleSuccessViewState(success);
     }
@@ -261,6 +268,8 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
       _showMessageWhenEmailPrintingFailed(failure);
     } else if (failure is CalendarEventReplyFailure) {
       _calendarEventFailure(failure);
+    } else if (failure is DismissTwpWarningFailure) {
+      _dismissTwpWarningFailure(failure);
     } else {
       super.handleFailureViewState(failure);
     }
@@ -664,6 +673,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
   void _resetToOriginalValue({bool isEmailClosing = false}) {
     emailContents.value = null;
     currentEmailLoaded.value = null;
+    dismissedTwpWarningIndexes.clear();
     attachments.clear();
     attachmentsViewState.value = {};
     blobCalendarEvent.value = null;
@@ -867,6 +877,70 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
     );
 
     toastManager.showMessageSuccess(success);
+  }
+
+  bool get isNetworkConnectionAvailable =>
+      mailboxDashBoardController.networkConnectionController.isNetworkConnectionAvailable();
+
+  /// Warnings positioned by the backend (`X-TWP-Message`) that are still
+  /// visible: not persisted as dismissed (keyword) nor dismissed locally.
+  List<TwpWarning> get visibleTwpWarnings {
+    final warnings =
+        currentEmailLoaded.value?.emailCurrent?.headers.twpWarnings ?? const [];
+    if (warnings.isEmpty) return const [];
+
+    final email = currentEmail;
+    return warnings
+        .where((warning) =>
+            !dismissedTwpWarningIndexes.contains(warning.index) &&
+            email?.isTwpWarningDismissed(warning.index) != true)
+        .toList();
+  }
+
+  void dismissTwpWarning(int index) {
+    final emailId = currentEmail?.id;
+    if (emailId == null || session == null || accountId == null) return;
+
+    // Dismissing persists a keyword through the backend, so it is disabled when
+    // offline (the banner stays visible until a connection is available).
+    if (!isNetworkConnectionAvailable) return;
+
+    dismissedTwpWarningIndexes.add(index);
+    consumeState(_dismissTwpWarningInteractor.execute(
+      session!,
+      accountId!,
+      emailId,
+      index,
+    ));
+  }
+
+  void _dismissTwpWarningSuccess(DismissTwpWarningSuccess success) {
+    final newKeywords = {
+      KeyWordIdentifierExtension.twpWarningDismissed(success.index): true,
+    };
+
+    final newEmail = currentEmail?.updateKeywords(newKeywords);
+    final emailId = newEmail?.id;
+    if (emailId == null) return;
+
+    if (PlatformInfo.isMobile && !isThreadDetailEnabled) {
+      mailboxDashBoardController.selectedEmail.value?.resyncKeywords(newKeywords);
+    } else {
+      _threadDetailController?.emailIdsPresentation[emailId] = newEmail;
+    }
+  }
+
+  void _dismissTwpWarningFailure(DismissTwpWarningFailure failure) {
+    final index = failure.index;
+    if (index != null) {
+      dismissedTwpWarningIndexes.remove(index);
+    }
+    if (currentContext != null && currentOverlayContext != null) {
+      appToast.showToastErrorMessage(
+        currentOverlayContext!,
+        AppLocalizations.of(currentContext!).an_error_occurred,
+      );
+    }
   }
 
   void handleEmailAction(

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -38,7 +38,6 @@ import 'package:tmail_ui_user/features/email/domain/state/calendar_event_counter
 import 'package:tmail_ui_user/features/email/domain/state/calendar_event_maybe_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/calendar_event_reject_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/calendar_event_reply_state.dart';
-import 'package:tmail_ui_user/features/email/domain/state/dismiss_twp_warning_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/get_email_content_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/get_entire_message_as_document_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/mark_as_email_read_state.dart';
@@ -50,7 +49,6 @@ import 'package:tmail_ui_user/features/email/domain/state/unsubscribe_email_stat
 import 'package:tmail_ui_user/features/email/domain/usecases/calendar_event_accept_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/calendar_event_counter_accept_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/calendar_event_reject_interactor.dart';
-import 'package:tmail_ui_user/features/email/domain/usecases/dismiss_twp_warning_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_email_content_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_entire_message_as_document_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_email_read_interactor.dart';
@@ -121,7 +119,6 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
   final GetAllIdentitiesInteractor _getAllIdentitiesInteractor;
   final StoreOpenedEmailInteractor _storeOpenedEmailInteractor;
   final PrintEmailInteractor _printEmailInteractor;
-  final DismissTwpWarningInteractor _dismissTwpWarningInteractor;
   final EmailId? _currentEmailId;
 
   CreateNewEmailRuleFilterInteractor? _createNewEmailRuleFilterInteractor;
@@ -143,7 +140,6 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
   final attachmentsViewState = RxMap<Id, Either<Failure, Success>>();
   final isEmailContentHidden = RxBool(false);
   final currentEmailLoaded = Rxn<EmailLoaded>();
-  final dismissedTwpWarningIndexes = <int>{}.obs;
   final isEmailContentClipped = RxBool(false);
   final attendanceStatus = Rxn<AttendanceStatus>();
   final htmlContentViewKey = GlobalKey<HtmlContentViewState>();
@@ -192,8 +188,7 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
     this._markAsStarEmailInteractor,
     this._getAllIdentitiesInteractor,
     this._storeOpenedEmailInteractor,
-    this._printEmailInteractor,
-    this._dismissTwpWarningInteractor, {
+    this._printEmailInteractor, {
     EmailId? currentEmailId,
   }) : _currentEmailId = currentEmailId;
 
@@ -249,8 +244,6 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
       _handlePrintEmailSuccess(success);
     } else if (success is CalendarEventReplySuccess) {
       calendarEventSuccess(success);
-    } else if (success is DismissTwpWarningSuccess) {
-      _dismissTwpWarningSuccess(success);
     } else {
       super.handleSuccessViewState(success);
     }
@@ -268,8 +261,6 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
       _showMessageWhenEmailPrintingFailed(failure);
     } else if (failure is CalendarEventReplyFailure) {
       _calendarEventFailure(failure);
-    } else if (failure is DismissTwpWarningFailure) {
-      _dismissTwpWarningFailure(failure);
     } else {
       super.handleFailureViewState(failure);
     }
@@ -673,7 +664,6 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
   void _resetToOriginalValue({bool isEmailClosing = false}) {
     emailContents.value = null;
     currentEmailLoaded.value = null;
-    dismissedTwpWarningIndexes.clear();
     attachments.clear();
     attachmentsViewState.value = {};
     blobCalendarEvent.value = null;
@@ -855,21 +845,29 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
     }
   }
 
-  void _markAsEmailStarSuccess(MarkAsStarEmailSuccess success) {
-    final newKeywords = {
-      KeyWordIdentifier.emailFlagged:
-        success.markStarAction == MarkStarAction.markStar,
-    };
-
+  /// Mirrors [newKeywords] onto the in-memory current email (no refetch): on
+  /// mobile non-thread-detail the dashboard's `selectedEmail` is resynced in
+  /// place; otherwise the thread-detail map is updated. Returns the affected
+  /// [EmailId], or `null` when there is no current email.
+  EmailId? _syncKeywordsToCurrentEmail(Map<KeyWordIdentifier, bool> newKeywords) {
     final newEmail = currentEmail?.updateKeywords(newKeywords);
     final emailId = newEmail?.id;
-    if (emailId == null) return;
+    if (emailId == null) return null;
 
     if (PlatformInfo.isMobile && !isThreadDetailEnabled) {
       mailboxDashBoardController.selectedEmail.value?.resyncKeywords(newKeywords);
     } else {
       _threadDetailController?.emailIdsPresentation[emailId] = newEmail;
     }
+    return emailId;
+  }
+
+  void _markAsEmailStarSuccess(MarkAsStarEmailSuccess success) {
+    final emailId = _syncKeywordsToCurrentEmail({
+      KeyWordIdentifier.emailFlagged:
+          success.markStarAction == MarkStarAction.markStar,
+    });
+    if (emailId == null) return;
 
     mailboxDashBoardController.updateEmailFlagByEmailIds(
       [emailId],
@@ -882,65 +880,14 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
   bool get isNetworkConnectionAvailable =>
       mailboxDashBoardController.networkConnectionController.isNetworkConnectionAvailable();
 
-  /// Warnings positioned by the backend (`X-TWP-Message`) that are still
-  /// visible: not persisted as dismissed (keyword) nor dismissed locally.
-  List<TwpWarning> get visibleTwpWarnings {
-    final warnings =
-        currentEmailLoaded.value?.emailCurrent?.headers.twpWarnings ?? const [];
-    if (warnings.isEmpty) return const [];
-
-    final email = currentEmail;
-    return warnings
-        .where((warning) =>
-            !dismissedTwpWarningIndexes.contains(warning.index) &&
-            email?.isTwpWarningDismissed(warning.index) != true)
-        .toList();
-  }
-
-  void dismissTwpWarning(int index) {
-    final emailId = currentEmail?.id;
-    if (emailId == null || session == null || accountId == null) return;
-
-    // Dismissing persists a keyword through the backend, so it is disabled when
-    // offline (the banner stays visible until a connection is available).
-    if (!isNetworkConnectionAvailable) return;
-
-    dismissedTwpWarningIndexes.add(index);
-    consumeState(_dismissTwpWarningInteractor.execute(
-      session!,
-      accountId!,
-      emailId,
-      index,
-    ));
-  }
-
-  void _dismissTwpWarningSuccess(DismissTwpWarningSuccess success) {
-    final newKeywords = {
-      KeyWordIdentifierExtension.twpWarningDismissed(success.index): true,
-    };
-
-    final newEmail = currentEmail?.updateKeywords(newKeywords);
-    final emailId = newEmail?.id;
-    if (emailId == null) return;
-
-    if (PlatformInfo.isMobile && !isThreadDetailEnabled) {
-      mailboxDashBoardController.selectedEmail.value?.resyncKeywords(newKeywords);
-    } else {
-      _threadDetailController?.emailIdsPresentation[emailId] = newEmail;
-    }
-  }
-
-  void _dismissTwpWarningFailure(DismissTwpWarningFailure failure) {
-    final index = failure.index;
-    if (index != null) {
-      dismissedTwpWarningIndexes.remove(index);
-    }
-    if (currentContext != null && currentOverlayContext != null) {
-      appToast.showToastErrorMessage(
-        currentOverlayContext!,
-        AppLocalizations.of(currentContext!).an_error_occurred,
-      );
-    }
+  /// Mirrors the dismissal keyword for `X-TWP-Message` warning [index] onto the
+  /// in-memory email so it stays hidden on reopen-within-session. Called by
+  /// `TwpWarningBannerList` after the backend persisted it; the transient
+  /// dismissed set itself lives in the Riverpod `TwpWarningDismiss` notifier.
+  void markTwpWarningDismissedLocally(int index) {
+    _syncKeywordsToCurrentEmail({
+      KeyWordIdentifierExtension.twpWarningDismissed(index): true,
+    });
   }
 
   void handleEmailAction(

--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -39,6 +39,7 @@ import 'package:tmail_ui_user/features/email/presentation/widgets/email_view_emp
 import 'package:tmail_ui_user/features/email/presentation/widgets/email_view_loading_bar_widget.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/information_sender_and_receiver_builder.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/mail_unsubscribed_banner.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/twp_warning_banner.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/view_entire_message_with_message_clipped_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_ai_needs_action_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_open_context_menu_extension.dart';
@@ -355,6 +356,21 @@ class EmailView extends GetWidget<SingleEmailController> {
           presentationEmail: controller.currentEmail,
           emailUnsubscribe: controller.emailUnsubscribe.value
         )),
+        Obx(() {
+          final warnings = controller.visibleTwpWarnings;
+          if (warnings.isEmpty) return const SizedBox.shrink();
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: warnings
+                .map((warning) => TwpWarningBanner(
+                      warning: warning,
+                      isDismissable: controller.isNetworkConnectionAvailable,
+                      onDismissAction: controller.dismissTwpWarning,
+                    ))
+                .toList(),
+          );
+        }),
         Obx(() => EmailViewLoadingBarWidget(
           viewState: controller.emailLoadedViewState.value
         )),

--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -39,7 +39,7 @@ import 'package:tmail_ui_user/features/email/presentation/widgets/email_view_emp
 import 'package:tmail_ui_user/features/email/presentation/widgets/email_view_loading_bar_widget.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/information_sender_and_receiver_builder.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/mail_unsubscribed_banner.dart';
-import 'package:tmail_ui_user/features/email/presentation/widgets/twp_warning_banner.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/twp_warning_banner_list.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/view_entire_message_with_message_clipped_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_ai_needs_action_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_open_context_menu_extension.dart';
@@ -356,21 +356,7 @@ class EmailView extends GetWidget<SingleEmailController> {
           presentationEmail: controller.currentEmail,
           emailUnsubscribe: controller.emailUnsubscribe.value
         )),
-        Obx(() {
-          final warnings = controller.visibleTwpWarnings;
-          if (warnings.isEmpty) return const SizedBox.shrink();
-          return Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: warnings
-                .map((warning) => TwpWarningBanner(
-                      warning: warning,
-                      isDismissable: controller.isNetworkConnectionAvailable,
-                      onDismissAction: controller.dismissTwpWarning,
-                    ))
-                .toList(),
-          );
-        }),
+        TwpWarningBannerList(controller: controller),
         Obx(() => EmailViewLoadingBarWidget(
           viewState: controller.emailLoadedViewState.value
         )),

--- a/lib/features/email/presentation/model/twp_warning_code.dart
+++ b/lib/features/email/presentation/model/twp_warning_code.dart
@@ -1,14 +1,10 @@
 import 'package:model/model.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
-/// Resolves the message displayed for a [TwpWarning].
+/// Resolves the displayed message for a [TwpWarning]: the localized string for a
+/// known [TwpWarning.code], else the server-provided `fallbackText`.
 ///
-/// The backend ships a fallback text inside the `X-TWP-Message` header together
-/// with a [TwpWarning.code]. When the code is known to the frontend we favour
-/// the localized message; otherwise (unknown code or no localization) we fall
-/// back to the server provided text.
-///
-/// New codes only require a new entry in [_registry] and its localized getter.
+/// New codes only need an entry in [_registry] plus a localized getter.
 class TwpWarningCodeResolver {
   TwpWarningCodeResolver._();
 
@@ -18,9 +14,14 @@ class TwpWarningCodeResolver {
     'virus-removed': (l10n) => l10n.twpWarningVirusRemoved,
   };
 
-  static String resolveMessage(TwpWarning warning, AppLocalizations appLocalizations) {
+  static String resolveMessage(
+    TwpWarning warning,
+    AppLocalizations appLocalizations,
+  ) {
     final code = warning.code;
-    final localizedMessage = code != null ? _registry[code]?.call(appLocalizations) : null;
+    final localizedMessage = code != null
+        ? _registry[code]?.call(appLocalizations)
+        : null;
     if (localizedMessage != null && localizedMessage.isNotEmpty) {
       return localizedMessage;
     }

--- a/lib/features/email/presentation/model/twp_warning_code.dart
+++ b/lib/features/email/presentation/model/twp_warning_code.dart
@@ -1,0 +1,29 @@
+import 'package:model/model.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+/// Resolves the message displayed for a [TwpWarning].
+///
+/// The backend ships a fallback text inside the `X-TWP-Message` header together
+/// with a [TwpWarning.code]. When the code is known to the frontend we favour
+/// the localized message; otherwise (unknown code or no localization) we fall
+/// back to the server provided text.
+///
+/// New codes only require a new entry in [_registry] and its localized getter.
+class TwpWarningCodeResolver {
+  TwpWarningCodeResolver._();
+
+  static final Map<String, String Function(AppLocalizations)> _registry = {
+    'suspicious-sender': (l10n) => l10n.twpWarningSuspiciousSender,
+    'virus': (l10n) => l10n.twpWarningVirus,
+    'virus-removed': (l10n) => l10n.twpWarningVirusRemoved,
+  };
+
+  static String resolveMessage(TwpWarning warning, AppLocalizations appLocalizations) {
+    final code = warning.code;
+    final localizedMessage = code != null ? _registry[code]?.call(appLocalizations) : null;
+    if (localizedMessage != null && localizedMessage.isNotEmpty) {
+      return localizedMessage;
+    }
+    return warning.fallbackText;
+  }
+}

--- a/lib/features/email/presentation/providers/twp_warning_dismiss_notifier.dart
+++ b/lib/features/email/presentation/providers/twp_warning_dismiss_notifier.dart
@@ -1,0 +1,87 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:tmail_ui_user/features/base/handle_urgent_exception.dart';
+import 'package:tmail_ui_user/features/email/domain/state/dismiss_twp_warning_state.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/dismiss_twp_warning_interactor.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+
+part 'twp_warning_dismiss_notifier.g.dart';
+
+/// Outcome of [TwpWarningDismiss.dismiss]. [urgentHandled] means the failure was
+/// an urgent exception already routed centrally (re-login, etc.), so the caller
+/// must not show its own error UI.
+enum TwpWarningDismissResult { dismissed, failed, urgentHandled }
+
+/// Per-email set of `X-TWP-Message` warning indexes dismissed this session.
+///
+/// `autoDispose`: alive only while the email view `ref.watch`es it, so the set
+/// clears when the view closes (no leak; replaces the old controller reset).
+/// Cross-session persistence is the backend keyword `twp-warning-dismissed-<index>`
+/// (see [DismissTwpWarningInteractor], [PresentationEmail.isTwpWarningDismissed]).
+@riverpod
+class TwpWarningDismiss extends _$TwpWarningDismiss {
+  @override
+  Set<int> build(String emailId) => const <int>{};
+
+  /// Optimistically hides the warning at [index], then persists the dismissal
+  /// keyword via [DismissTwpWarningInteractor]. Rolls back on failure; urgent
+  /// exceptions are routed centrally (see [handleUrgentExceptionIfNeeded]) and
+  /// reported as [TwpWarningDismissResult.urgentHandled].
+  Future<TwpWarningDismissResult> dismiss(
+    Session session,
+    AccountId accountId,
+    EmailId emailId,
+    int index,
+  ) async {
+    if (state.contains(index)) return TwpWarningDismissResult.dismissed;
+
+    state = {...state, index};
+
+    final interactor = getBinding<DismissTwpWarningInteractor>();
+    if (interactor == null) {
+      _rollback(index);
+      return TwpWarningDismissResult.failed;
+    }
+
+    try {
+      final result = await interactor
+          .execute(session, accountId, emailId, index)
+          .last;
+
+      return result.fold((failure) => _onFailure(index, failure: failure), (
+        success,
+      ) {
+        if (success is DismissTwpWarningSuccess) {
+          return TwpWarningDismissResult.dismissed;
+        }
+        _rollback(index);
+        return TwpWarningDismissResult.failed;
+      });
+    } catch (e) {
+      return _onFailure(index, exception: e);
+    }
+  }
+
+  TwpWarningDismissResult _onFailure(
+    int index, {
+    Failure? failure,
+    Object? exception,
+  }) {
+    _rollback(index);
+    final isUrgent = handleUrgentExceptionIfNeeded(
+      failure: failure,
+      exception: exception,
+    );
+    return isUrgent
+        ? TwpWarningDismissResult.urgentHandled
+        : TwpWarningDismissResult.failed;
+  }
+
+  void _rollback(int index) {
+    if (!ref.mounted) return;
+    state = {...state}..remove(index);
+  }
+}

--- a/lib/features/email/presentation/styles/twp_warning_banner_style.dart
+++ b/lib/features/email/presentation/styles/twp_warning_banner_style.dart
@@ -1,0 +1,86 @@
+import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:flutter/material.dart';
+import 'package:model/model.dart';
+
+/// Visual configuration for `TwpWarningBanner`, centralised in one place
+/// (matching the project's `*_banner_style.dart` convention) so layout metrics
+/// and the per-level palette live outside the widget and can be unit-tested.
+///
+/// Background + accent (icon) colors reuse [AppColor] tokens for consistency
+/// with the rest of the app. Border and text colors are tuned locally because
+/// [AppColor] has no soft-border / readable on-container text tokens (the bright
+/// accent colors are unreadable as text on the light tints). The app ships no
+/// dark theme, so there are no dark variants.
+class TwpWarningBannerStyle {
+  const TwpWarningBannerStyle._();
+
+  static const EdgeInsetsGeometry margin = EdgeInsetsDirectional.symmetric(
+    vertical: 6,
+    horizontal: 16,
+  );
+  static const EdgeInsetsGeometry padding = EdgeInsetsDirectional.symmetric(
+    vertical: 5,
+    horizontal: 12,
+  );
+  static const double borderRadius = 10;
+  static const double iconSize = 20;
+  static const double iconSpacing = 10;
+  static const double messageFontSize = 14;
+  static const double messageLineHeight = 1.35;
+  static const double dismissSpacing = 4;
+  static const double dismissIconSize = 18;
+  static const EdgeInsets dismissPadding = EdgeInsets.all(6);
+
+  /// Resolves the color/icon palette for a warning [level].
+  static TwpWarningLevelStyle ofLevel(TwpWarningLevel level) {
+    switch (level) {
+      case TwpWarningLevel.error:
+        return _error;
+      case TwpWarningLevel.warn:
+        return _warn;
+      case TwpWarningLevel.info:
+        return _info;
+    }
+  }
+
+  static const _error = TwpWarningLevelStyle(
+    backgroundColor: AppColor.colorBackgroundErrorState,
+    borderColor: Color(0xFFF5C6C0),
+    textColor: Color(0xFF8B1A10),
+    iconColor: AppColor.colorErrorState,
+    icon: Icons.dangerous_outlined,
+  );
+
+  static const _warn = TwpWarningLevelStyle(
+    backgroundColor: AppColor.colorBackgroundNotificationVacationSetting,
+    borderColor: Color(0xFFF3E0A6),
+    textColor: Color(0xFF7A5A00),
+    iconColor: AppColor.warningColor,
+    icon: Icons.warning_amber_rounded,
+  );
+
+  static const _info = TwpWarningLevelStyle(
+    backgroundColor: AppColor.primarySelectedColor,
+    borderColor: Color(0xFFBBD6FB),
+    textColor: Color(0xFF0B4A8F),
+    iconColor: AppColor.primaryColor,
+    icon: Icons.info_outline,
+  );
+}
+
+/// Color + icon palette for a single [TwpWarningLevel].
+class TwpWarningLevelStyle {
+  final Color backgroundColor;
+  final Color borderColor;
+  final Color textColor;
+  final Color iconColor;
+  final IconData icon;
+
+  const TwpWarningLevelStyle({
+    required this.backgroundColor,
+    required this.borderColor,
+    required this.textColor,
+    required this.iconColor,
+    required this.icon,
+  });
+}

--- a/lib/features/email/presentation/widgets/twp_warning_banner.dart
+++ b/lib/features/email/presentation/widgets/twp_warning_banner.dart
@@ -1,0 +1,121 @@
+import 'package:core/presentation/utils/theme_utils.dart';
+import 'package:flutter/material.dart';
+import 'package:model/model.dart';
+import 'package:tmail_ui_user/features/email/presentation/model/twp_warning_code.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+typedef OnDismissTwpWarningAction = void Function(int index);
+
+/// Colored banner displayed between the header section and the body of the read
+/// view for a backend positioned `X-TWP-Message` warning.
+///
+/// The color follows [TwpWarning.level] (info -> blue, warn -> yellow,
+/// error -> red). A dismiss button persists the decision through a keyword; it
+/// is hidden when [isDismissable] is false (e.g. offline).
+class TwpWarningBanner extends StatelessWidget {
+  final TwpWarning warning;
+  final bool isDismissable;
+  final OnDismissTwpWarningAction onDismissAction;
+
+  const TwpWarningBanner({
+    super.key,
+    required this.warning,
+    required this.onDismissAction,
+    this.isDismissable = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final style = _TwpWarningBannerStyle.fromLevel(warning.level);
+    final message = TwpWarningCodeResolver.resolveMessage(
+      warning,
+      AppLocalizations.of(context),
+    );
+
+    return Container(
+      margin: const EdgeInsetsDirectional.symmetric(vertical: 8, horizontal: 16),
+      padding: const EdgeInsetsDirectional.symmetric(vertical: 12, horizontal: 16),
+      decoration: BoxDecoration(
+        color: style.backgroundColor,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: style.borderColor),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsetsDirectional.only(end: 12, top: 2),
+            child: Icon(style.icon, color: style.iconColor, size: 20),
+          ),
+          Expanded(
+            child: Text(
+              message,
+              style: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                fontWeight: FontWeight.normal,
+                fontSize: 15,
+                color: style.textColor,
+              ),
+            ),
+          ),
+          if (isDismissable)
+            Padding(
+              padding: const EdgeInsetsDirectional.only(start: 8),
+              child: InkWell(
+                onTap: () => onDismissAction(warning.index),
+                customBorder: const CircleBorder(),
+                child: Tooltip(
+                  message: AppLocalizations.of(context).dismiss,
+                  child: Icon(Icons.close, color: style.iconColor, size: 20),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TwpWarningBannerStyle {
+  final Color backgroundColor;
+  final Color borderColor;
+  final Color textColor;
+  final Color iconColor;
+  final IconData icon;
+
+  const _TwpWarningBannerStyle({
+    required this.backgroundColor,
+    required this.borderColor,
+    required this.textColor,
+    required this.iconColor,
+    required this.icon,
+  });
+
+  factory _TwpWarningBannerStyle.fromLevel(TwpWarningLevel level) {
+    switch (level) {
+      case TwpWarningLevel.error:
+        return const _TwpWarningBannerStyle(
+          backgroundColor: Color(0xFFFDECEA),
+          borderColor: Color(0xFFF5C6C0),
+          textColor: Color(0xFF8B1A10),
+          iconColor: Color(0xFFD32F2F),
+          icon: Icons.dangerous_outlined,
+        );
+      case TwpWarningLevel.warn:
+        return const _TwpWarningBannerStyle(
+          backgroundColor: Color(0xFFFFF8E1),
+          borderColor: Color(0xFFF3E0A6),
+          textColor: Color(0xFF7A5A00),
+          iconColor: Color(0xFFF9A825),
+          icon: Icons.warning_amber_rounded,
+        );
+      case TwpWarningLevel.info:
+        return const _TwpWarningBannerStyle(
+          backgroundColor: Color(0xFFE8F1FE),
+          borderColor: Color(0xFFBBD6FB),
+          textColor: Color(0xFF0B4A8F),
+          iconColor: Color(0xFF1A73E8),
+          icon: Icons.info_outline,
+        );
+    }
+  }
+}

--- a/lib/features/email/presentation/widgets/twp_warning_banner.dart
+++ b/lib/features/email/presentation/widgets/twp_warning_banner.dart
@@ -1,124 +1,91 @@
+import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/theme_utils.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:model/model.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/twp_warning_code.dart';
+import 'package:tmail_ui_user/features/email/presentation/styles/twp_warning_banner_style.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 typedef OnDismissTwpWarningAction = void Function(int index);
 
-/// Colored banner displayed between the header section and the body of the read
-/// view for a backend positioned `X-TWP-Message` warning.
+/// Colored banner for one backend-positioned `X-TWP-Message` warning, shown
+/// between the header section and the body. Color follows [TwpWarning.level]
+/// (info→blue, warn→yellow, error→red). The dismiss button (hidden when
+/// [isDismissable] is false, e.g. offline) invokes [onDismissAction].
 ///
-/// The color follows [TwpWarning.level] (info -> blue, warn -> yellow,
-/// error -> red). A dismiss button persists the decision through a keyword; it
-/// is hidden when [isDismissable] is false (e.g. offline).
+/// Layout/colors come from [TwpWarningBannerStyle].
 class TwpWarningBanner extends StatelessWidget {
   final TwpWarning warning;
   final bool isDismissable;
   final OnDismissTwpWarningAction onDismissAction;
+  final ImagePaths imagePaths;
 
   const TwpWarningBanner({
     super.key,
     required this.warning,
     required this.onDismissAction,
+    required this.imagePaths,
     this.isDismissable = true,
   });
 
   @override
   Widget build(BuildContext context) {
-    final style = _TwpWarningBannerStyle.fromLevel(warning.level);
+    final style = TwpWarningBannerStyle.ofLevel(warning.level);
     final message = TwpWarningCodeResolver.resolveMessage(
       warning,
       AppLocalizations.of(context),
     );
 
     return Container(
-      margin: const EdgeInsetsDirectional.symmetric(vertical: 8, horizontal: 16),
-      padding: const EdgeInsetsDirectional.symmetric(vertical: 12, horizontal: 16),
+      key: Key('${UiKeys.twpWarningBannerPrefix}${warning.index}'),
+      margin: TwpWarningBannerStyle.margin,
+      padding: TwpWarningBannerStyle.padding,
       decoration: BoxDecoration(
         color: style.backgroundColor,
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: const BorderRadius.all(
+          Radius.circular(TwpWarningBannerStyle.borderRadius),
+        ),
         border: Border.all(color: style.borderColor),
       ),
       child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          Padding(
-            padding: const EdgeInsetsDirectional.only(end: 12, top: 2),
-            child: Icon(style.icon, color: style.iconColor, size: 20),
+          Icon(
+            style.icon,
+            color: style.iconColor,
+            size: TwpWarningBannerStyle.iconSize,
           ),
+          const SizedBox(width: TwpWarningBannerStyle.iconSpacing),
           Expanded(
             child: Text(
               message,
               style: ThemeUtils.defaultTextStyleInterFont.copyWith(
-                fontWeight: FontWeight.normal,
-                fontSize: 15,
+                fontWeight: FontWeight.w400,
+                fontSize: TwpWarningBannerStyle.messageFontSize,
+                height: TwpWarningBannerStyle.messageLineHeight,
                 color: style.textColor,
               ),
             ),
           ),
-          if (isDismissable)
-            Padding(
-              padding: const EdgeInsetsDirectional.only(start: 8),
-              child: InkWell(
-                onTap: () => onDismissAction(warning.index),
-                customBorder: const CircleBorder(),
-                child: Tooltip(
-                  message: AppLocalizations.of(context).dismiss,
-                  child: Padding(
-                    padding: const EdgeInsets.all(8),
-                    child: Icon(Icons.close, color: style.iconColor, size: 20),
-                  ),
-                ),
+          if (isDismissable) ...[
+            const SizedBox(width: TwpWarningBannerStyle.dismissSpacing),
+            TMailButtonWidget.fromIcon(
+              key: Key(
+                '${UiKeys.twpWarningDismissButtonPrefix}${warning.index}',
               ),
+              icon: imagePaths.icClose,
+              iconSize: TwpWarningBannerStyle.dismissIconSize,
+              iconColor: style.iconColor,
+              backgroundColor: Colors.transparent,
+              padding: TwpWarningBannerStyle.dismissPadding,
+              tooltipMessage: AppLocalizations.of(context).dismiss,
+              onTapActionCallback: () => onDismissAction(warning.index),
             ),
+          ],
         ],
       ),
     );
-  }
-}
-
-class _TwpWarningBannerStyle {
-  final Color backgroundColor;
-  final Color borderColor;
-  final Color textColor;
-  final Color iconColor;
-  final IconData icon;
-
-  const _TwpWarningBannerStyle({
-    required this.backgroundColor,
-    required this.borderColor,
-    required this.textColor,
-    required this.iconColor,
-    required this.icon,
-  });
-
-  factory _TwpWarningBannerStyle.fromLevel(TwpWarningLevel level) {
-    switch (level) {
-      case TwpWarningLevel.error:
-        return const _TwpWarningBannerStyle(
-          backgroundColor: Color(0xFFFDECEA),
-          borderColor: Color(0xFFF5C6C0),
-          textColor: Color(0xFF8B1A10),
-          iconColor: Color(0xFFD32F2F),
-          icon: Icons.dangerous_outlined,
-        );
-      case TwpWarningLevel.warn:
-        return const _TwpWarningBannerStyle(
-          backgroundColor: Color(0xFFFFF8E1),
-          borderColor: Color(0xFFF3E0A6),
-          textColor: Color(0xFF7A5A00),
-          iconColor: Color(0xFFF9A825),
-          icon: Icons.warning_amber_rounded,
-        );
-      case TwpWarningLevel.info:
-        return const _TwpWarningBannerStyle(
-          backgroundColor: Color(0xFFE8F1FE),
-          borderColor: Color(0xFFBBD6FB),
-          textColor: Color(0xFF0B4A8F),
-          iconColor: Color(0xFF1A73E8),
-          icon: Icons.info_outline,
-        );
-    }
   }
 }

--- a/lib/features/email/presentation/widgets/twp_warning_banner.dart
+++ b/lib/features/email/presentation/widgets/twp_warning_banner.dart
@@ -65,7 +65,10 @@ class TwpWarningBanner extends StatelessWidget {
                 customBorder: const CircleBorder(),
                 child: Tooltip(
                   message: AppLocalizations.of(context).dismiss,
-                  child: Icon(Icons.close, color: style.iconColor, size: 20),
+                  child: Padding(
+                    padding: const EdgeInsets.all(8),
+                    child: Icon(Icons.close, color: style.iconColor, size: 20),
+                  ),
                 ),
               ),
             ),

--- a/lib/features/email/presentation/widgets/twp_warning_banner_list.dart
+++ b/lib/features/email/presentation/widgets/twp_warning_banner_list.dart
@@ -90,14 +90,20 @@ class TwpWarningBannerList extends StatelessWidget {
     // Dismissal persists a keyword to the backend, so it is disabled offline.
     if (!controller.isNetworkConnectionAvailable) return;
 
+    // Optimistically mirror the dismissal onto the in-memory email so the banner
+    // hides immediately and stays hidden across reopen, before the backend
+    // confirms. Reverted below if persistence fails.
+    controller.markTwpWarningDismissedLocally(index);
+
     final result = await ref
         .read(twpWarningDismissProvider(emailId.asString).notifier)
         .dismiss(session, accountId, emailId, index);
 
     switch (result) {
       case TwpWarningDismissResult.dismissed:
-        controller.markTwpWarningDismissedLocally(index);
+        break;
       case TwpWarningDismissResult.failed:
+        controller.clearTwpWarningDismissedLocally(index);
         if (context.mounted) {
           ref
               .read(appToastProvider)
@@ -108,7 +114,7 @@ class TwpWarningBannerList extends StatelessWidget {
         }
       case TwpWarningDismissResult.urgentHandled:
         // Central handler already owns the UX (re-login, etc.); no extra toast.
-        break;
+        controller.clearTwpWarningDismissedLocally(index);
     }
   }
 }

--- a/lib/features/email/presentation/widgets/twp_warning_banner_list.dart
+++ b/lib/features/email/presentation/widgets/twp_warning_banner_list.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:get/get.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:model/model.dart';
+import 'package:tmail_ui_user/features/email/presentation/controller/single_email_controller.dart';
+import 'package:tmail_ui_user/features/email/presentation/providers/twp_warning_dismiss_notifier.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/twp_warning_banner.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/providers/app_toast_provider.dart';
+
+/// Renders the backend-positioned `X-TWP-Message` warnings of the currently
+/// displayed email as stacked banners between the header section and the body.
+///
+/// GetX reactivity (the loaded email + connectivity) is provided by the outer
+/// [Obx]; the per-email dismissed set is provided by the inner [Consumer] via
+/// [twpWarningDismissProvider]. A warning is hidden when it was dismissed this
+/// session (notifier) or persisted as dismissed (keyword on the email).
+class TwpWarningBannerList extends StatelessWidget {
+  final SingleEmailController controller;
+
+  const TwpWarningBannerList({super.key, required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(() {
+      final email = controller.currentEmail;
+      final emailId = email?.id;
+      final warnings =
+          controller
+              .currentEmailLoaded
+              .value
+              ?.emailCurrent
+              ?.headers
+              .twpWarnings ??
+          const <TwpWarning>[];
+      // Read inside Obx so the banner reacts to connectivity changes.
+      final isOnline = controller.isNetworkConnectionAvailable;
+
+      if (email == null || emailId == null || warnings.isEmpty) {
+        return const SizedBox.shrink();
+      }
+
+      return Consumer(
+        builder: (context, ref, _) {
+          final dismissedLocally = ref.watch(
+            twpWarningDismissProvider(emailId.asString),
+          );
+
+          final visibleWarnings = warnings
+              .where(
+                (warning) =>
+                    !dismissedLocally.contains(warning.index) &&
+                    !email.isTwpWarningDismissed(warning.index),
+              )
+              .toList();
+
+          if (visibleWarnings.isEmpty) return const SizedBox.shrink();
+
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: visibleWarnings
+                .map(
+                  (warning) => TwpWarningBanner(
+                    warning: warning,
+                    isDismissable: isOnline,
+                    imagePaths: controller.imagePaths,
+                    onDismissAction: (index) =>
+                        _onDismiss(context, ref, emailId, index),
+                  ),
+                )
+                .toList(),
+          );
+        },
+      );
+    });
+  }
+
+  Future<void> _onDismiss(
+    BuildContext context,
+    WidgetRef ref,
+    EmailId emailId,
+    int index,
+  ) async {
+    final session = controller.session;
+    final accountId = controller.accountId;
+    if (session == null || accountId == null) return;
+
+    // Dismissal persists a keyword to the backend, so it is disabled offline.
+    if (!controller.isNetworkConnectionAvailable) return;
+
+    final result = await ref
+        .read(twpWarningDismissProvider(emailId.asString).notifier)
+        .dismiss(session, accountId, emailId, index);
+
+    switch (result) {
+      case TwpWarningDismissResult.dismissed:
+        controller.markTwpWarningDismissedLocally(index);
+      case TwpWarningDismissResult.failed:
+        if (context.mounted) {
+          ref
+              .read(appToastProvider)
+              .showToastErrorMessage(
+                context,
+                AppLocalizations.of(context).an_error_occurred,
+              );
+        }
+      case TwpWarningDismissResult.urgentHandled:
+        // Central handler already owns the UX (re-login, etc.); no extra toast.
+        break;
+    }
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
@@ -8,7 +8,6 @@ import 'package:core/utils/preview_eml_file_utils.dart';
 import 'package:core/utils/print_utils.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/base_bindings.dart';
-import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
 import 'package:tmail_ui_user/features/caching/caching_manager.dart';
 import 'package:tmail_ui_user/features/caching/utils/local_storage_manager.dart';
 import 'package:tmail_ui_user/features/caching/utils/session_storage_manager.dart';
@@ -271,7 +270,6 @@ abstract class MailboxDashBoardBindings extends BaseBindings {
       Get.find<StoreEmailSortOrderInteractor>(),
       Get.find<GetStoredEmailSortOrderInteractor>(),
     ));
-    Get.put<UrgentExceptionHandler>(Get.find<MailboxDashBoardController>());
     Get.put(AdvancedFilterController());
   }
 

--- a/lib/features/mailbox_dashboard/presentation/delegates/empty_folder_provider_listener_delegate.dart
+++ b/lib/features/mailbox_dashboard/presentation/delegates/empty_folder_provider_listener_delegate.dart
@@ -155,8 +155,11 @@ class EmptyFolderProviderListenerDelegate
         _stateSubscription?.close();
         _stateSubscription = null;
         _resetProgress(dashboardController);
-        _showEmptyFolderFailureToast(context, ref);
-        _handleUrgentException(exception);
+        // Skip the generic failure toast when the urgent handler already owns
+        // the UX (re-login, reconnect), to avoid a duplicate error surface.
+        if (!_handleUrgentException(exception)) {
+          _showEmptyFolderFailureToast(context, ref);
+        }
 
       case EmptyFolderIdle():
         break;
@@ -178,10 +181,12 @@ class EmptyFolderProviderListenerDelegate
     }
   }
 
-  // Routes urgent exceptions through the shared helper (ADR-0093).
-  void _handleUrgentException(Object? exception) {
-    if (exception == null) return;
-    handleUrgentExceptionIfNeeded(exception: exception);
+  // Routes urgent exceptions through the shared helper (ADR-0093). Returns true
+  // when the failure was urgent and handled centrally, so the caller can skip
+  // its own error UI.
+  bool _handleUrgentException(Object? exception) {
+    if (exception == null) return false;
+    return handleUrgentExceptionIfNeeded(exception: exception);
   }
 
   void _resetProgress(MailboxDashBoardController dashboardController) {

--- a/lib/features/mailbox_dashboard/presentation/delegates/empty_folder_provider_listener_delegate.dart
+++ b/lib/features/mailbox_dashboard/presentation/delegates/empty_folder_provider_listener_delegate.dart
@@ -8,7 +8,7 @@ import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/extensions/presentation_mailbox_extension.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
-import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
+import 'package:tmail_ui_user/features/base/handle_urgent_exception.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/empty_folder_request.dart';
 import 'package:tmail_ui_user/features/email/presentation/action/email_ui_action.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/empty_spam_folder_state.dart';
@@ -178,17 +178,10 @@ class EmptyFolderProviderListenerDelegate
     }
   }
 
-  // Resolves the urgent-exception handler by contract, not the concrete
-  // controller — keeps session/logout handling decoupled from this delegate.
+  // Routes urgent exceptions through the shared helper (ADR-0093).
   void _handleUrgentException(Object? exception) {
     if (exception == null) return;
-    final handler = getBinding<UrgentExceptionHandler>();
-    if (handler == null) return;
-    if (handler.validateUrgentException(exception)) {
-      handler.handleUrgentException(
-        exception: exception is Exception ? exception : null,
-      );
-    }
+    handleUrgentExceptionIfNeeded(exception: exception);
   }
 
   void _resetProgress(MailboxDashBoardController dashboardController) {

--- a/lib/features/mailbox_dashboard/presentation/extensions/update_current_emails_flags_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/update_current_emails_flags_extension.dart
@@ -3,6 +3,8 @@ import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
 import 'package:model/email/mark_star_action.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:model/email/read_actions.dart';
+import 'package:model/extensions/keyword_identifier_extension.dart';
+import 'package:model/extensions/presentation_email_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/action/thread_detail_ui_action.dart';
@@ -116,5 +118,28 @@ extension UpdateCurrentEmailsFlagsExtension on MailboxDashBoardController {
     dispatchThreadDetailUIAction(ThreadDetailUIAction());
 
     updateEmailFlagByEmailIds([emailId], markAsForwarded: true);
+  }
+
+  /// Adds (or removes, when [dismissed] is `false`) the
+  /// `twp-warning-dismissed-<index>` keyword on the matching list email.
+  ///
+  /// Required because a single-email thread reuses the list email on reopen
+  /// instead of refetching (see `InitializeThreadDetailEmails`): without the
+  /// keyword on the list email, a dismissed `X-TWP-Message` warning reappears.
+  void updateEmailTwpWarningDismissed(
+    EmailId emailId,
+    int index, {
+    required bool dismissed,
+  }) {
+    final currentEmails = dashboardRoute.value == DashboardRoutes.searchEmail
+        ? listResultSearch
+        : emailsInCurrentMailbox;
+
+    final emailIndex = currentEmails.indexWhere((email) => email.id == emailId);
+    if (emailIndex == -1) return;
+
+    currentEmails[emailIndex] = currentEmails[emailIndex].updateKeywords({
+      KeyWordIdentifierExtension.twpWarningDismissed(index): dismissed,
+    });
   }
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -2585,6 +2585,24 @@
     "placeholders_order": [],
     "placeholders": {}
   },
+  "twpWarningSuspiciousSender": "This email is from an external sender immitating known users, double check the mail address.",
+  "@twpWarningSuspiciousSender": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "twpWarningVirus": "This email is having virus in its attachments!",
+  "@twpWarningVirus": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "twpWarningVirusRemoved": "This email was having virus in its attachment, that we removed for your security.",
+  "@twpWarningVirusRemoved": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
   "disableSpamReport": "Disable Spam report",
   "@disableSpamReport": {
     "type": "text",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -2585,19 +2585,19 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "twpWarningSuspiciousSender": "This email is from an external sender immitating known users, double check the mail address.",
+  "twpWarningSuspiciousSender": "This email is from an external sender imitating known users, double-check the mail address.",
   "@twpWarningSuspiciousSender": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "twpWarningVirus": "This email is having virus in its attachments!",
+  "twpWarningVirus": "This email contains a virus in its attachments!",
   "@twpWarningVirus": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "twpWarningVirusRemoved": "This email was having virus in its attachment, that we removed for your security.",
+  "twpWarningVirusRemoved": "This email contained a virus in its attachment, which we removed for your security.",
   "@twpWarningVirusRemoved": {
     "type": "text",
     "placeholders_order": [],

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -2585,19 +2585,19 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "twpWarningSuspiciousSender": "This email is from an external sender imitating known users, double-check the mail address.",
+  "twpWarningSuspiciousSender": "This email is from an external sender immitating known users, double check the mail address.",
   "@twpWarningSuspiciousSender": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "twpWarningVirus": "This email contains a virus in its attachments!",
+  "twpWarningVirus": "This email is having virus in its attachments!",
   "@twpWarningVirus": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "twpWarningVirusRemoved": "This email contained a virus in its attachment, which we removed for your security.",
+  "twpWarningVirusRemoved": "This email was having virus in its attachment, that we removed for your security.",
   "@twpWarningVirusRemoved": {
     "type": "text",
     "placeholders_order": [],

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -2694,19 +2694,19 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "twpWarningSuspiciousSender": "This email is from an external sender imitating known users, double-check the mail address.",
+  "twpWarningSuspiciousSender": "This email is from an external sender immitating known users, double check the mail address.",
   "@twpWarningSuspiciousSender": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "twpWarningVirus": "This email contains a virus in its attachments!",
+  "twpWarningVirus": "This email is having virus in its attachments!",
   "@twpWarningVirus": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
   },
-  "twpWarningVirusRemoved": "This email contained a virus in its attachment, which we removed for your security.",
+  "twpWarningVirusRemoved": "This email was having virus in its attachment, that we removed for your security.",
   "@twpWarningVirusRemoved": {
     "type": "text",
     "placeholders_order": [],

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -2694,6 +2694,24 @@
     "placeholders_order": [],
     "placeholders": {}
   },
+  "twpWarningSuspiciousSender": "This email is from an external sender imitating known users, double-check the mail address.",
+  "@twpWarningSuspiciousSender": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "twpWarningVirus": "This email contains a virus in its attachments!",
+  "@twpWarningVirus": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "twpWarningVirusRemoved": "This email contained a virus in its attachment, which we removed for your security.",
+  "@twpWarningVirusRemoved": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
   "disableSpamReport": "Disable Spam report",
   "@disableSpamReport": {
     "type": "text",

--- a/lib/main/bindings/main_bindings.dart
+++ b/lib/main/bindings/main_bindings.dart
@@ -1,5 +1,7 @@
 import 'package:core/utils/platform_info.dart';
 import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
+import 'package:tmail_ui_user/features/base/urgent_exception_handler_service.dart';
 import 'package:tmail_ui_user/features/login/presentation/bindings/company_server_login_interactor_bindings.dart';
 import 'package:tmail_ui_user/main/bindings/core/core_bindings.dart';
 import 'package:tmail_ui_user/main/bindings/credential/credential_bindings.dart';
@@ -26,5 +28,11 @@ class MainBindings extends Bindings {
       CompanyServerLoginInteractorBindings().dependencies();
       DeepLinkBindings().dependencies();
     }
+    // App-lifetime urgent-exception handler for Riverpod flows on any screen.
+    // Lazy so its `Get.find` fields resolve on first use, not at bootstrap.
+    Get.lazyPut<UrgentExceptionHandler>(
+      () => UrgentExceptionHandlerService(),
+      fenix: true,
+    );
   }
 }

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -2746,6 +2746,27 @@ class AppLocalizations {
     );
   }
 
+  String get twpWarningSuspiciousSender {
+    return Intl.message(
+      'This email is from an external sender immitating known users, double check the mail address.',
+      name: 'twpWarningSuspiciousSender',
+    );
+  }
+
+  String get twpWarningVirus {
+    return Intl.message(
+      'This email is having virus in its attachments!',
+      name: 'twpWarningVirus',
+    );
+  }
+
+  String get twpWarningVirusRemoved {
+    return Intl.message(
+      'This email was having virus in its attachment, that we removed for your security.',
+      name: 'twpWarningVirusRemoved',
+    );
+  }
+
   String get disableSpamReport {
     return Intl.message(
       'Disable Spam report',

--- a/model/lib/email/email_property.dart
+++ b/model/lib/email/email_property.dart
@@ -26,4 +26,5 @@ class EmailProperty {
   static const String headerUnsubscribeKey = 'List-Unsubscribe';
   static const String headerSMimeStatusKey = 'X-SMIME-Status';
   static const String headerListPostKey = 'List-Post';
+  static const String headerTwpMessageKey = 'X-TWP-Message';
 }

--- a/model/lib/email/presentation_email.dart
+++ b/model/lib/email/presentation_email.dart
@@ -141,6 +141,9 @@ class PresentationEmail with EquatableMixin, SearchSnippetMixin, OptionParamMixi
 
   bool get isSubscribed => keywords?.containsKey(KeyWordIdentifierExtension.unsubscribeMail) == true;
 
+  bool isTwpWarningDismissed(int index) =>
+      keywords?.containsKey(KeyWordIdentifierExtension.twpWarningDismissed(index)) == true;
+
   bool get hasNeedAction =>
       keywords?.containsKey(KeyWordIdentifierExtension.needsActionMail) == true;
 

--- a/model/lib/email/twp_warning/twp_warning.dart
+++ b/model/lib/email/twp_warning/twp_warning.dart
@@ -1,21 +1,19 @@
-
 import 'package:equatable/equatable.dart';
 import 'package:model/email/twp_warning/twp_warning_level.dart';
 
-/// A warning the backend positions on a message through an `X-TWP-Message`
-/// header, displayed as a colored banner between the header section and the
-/// body of the read view.
+/// A warning the backend positions on a message via an `X-TWP-Message` header.
 ///
-/// The header value follows the format:
+/// Format — `level:` and `code:` are optional leading tokens; the rest is
+/// server-provided fallback text, used when [code] cannot be localized:
 /// ```
-/// X-TWP-Message: level:info code:suspicious-sender This email is from an external sender immitating known users, double check the mail address.
+/// X-TWP-Message: level:info code:suspicious-sender This email is from an external sender.
 /// ```
-/// where `level:` and `code:` are optional leading tokens and the remaining
-/// text is a server provided fallback message used when the frontend cannot
-/// localize the [code].
 class TwpWarning with EquatableMixin {
   static const String _levelToken = 'level:';
   static const String _codeToken = 'code:';
+
+  /// Hoisted so the pattern is compiled once, not on every [parse] call.
+  static final RegExp _whitespace = RegExp(r'\s+');
 
   final TwpWarningLevel level;
   final String? code;
@@ -42,7 +40,7 @@ class TwpWarning with EquatableMixin {
     final remainingTokens = <String>[];
 
     var parsingTokens = true;
-    for (final token in rawValue.trim().split(RegExp(r'\s+'))) {
+    for (final token in rawValue.trim().split(_whitespace)) {
       if (parsingTokens && token.toLowerCase().startsWith(_levelToken)) {
         level = token.substring(_levelToken.length);
       } else if (parsingTokens && token.toLowerCase().startsWith(_codeToken)) {

--- a/model/lib/email/twp_warning/twp_warning.dart
+++ b/model/lib/email/twp_warning/twp_warning.dart
@@ -1,0 +1,68 @@
+
+import 'package:equatable/equatable.dart';
+import 'package:model/email/twp_warning/twp_warning_level.dart';
+
+/// A warning the backend positions on a message through an `X-TWP-Message`
+/// header, displayed as a colored banner between the header section and the
+/// body of the read view.
+///
+/// The header value follows the format:
+/// ```
+/// X-TWP-Message: level:info code:suspicious-sender This email is from an external sender immitating known users, double check the mail address.
+/// ```
+/// where `level:` and `code:` are optional leading tokens and the remaining
+/// text is a server provided fallback message used when the frontend cannot
+/// localize the [code].
+class TwpWarning with EquatableMixin {
+  static const String _levelToken = 'level:';
+  static const String _codeToken = 'code:';
+
+  final TwpWarningLevel level;
+  final String? code;
+  final String fallbackText;
+
+  /// Position of this warning among the `X-TWP-Message` headers of the message
+  /// (0-based). Used to persist a per-warning dismissal keyword.
+  final int index;
+
+  TwpWarning({
+    required this.level,
+    required this.code,
+    required this.fallbackText,
+    required this.index,
+  });
+
+  /// Parses a raw `X-TWP-Message` header value into a [TwpWarning].
+  ///
+  /// Tolerant of missing `level:` / `code:` tokens; everything that is not a
+  /// recognized leading token is kept as the [fallbackText].
+  factory TwpWarning.parse(String rawValue, int index) {
+    String? level;
+    String? code;
+    final remainingTokens = <String>[];
+
+    var parsingTokens = true;
+    for (final token in rawValue.trim().split(RegExp(r'\s+'))) {
+      if (parsingTokens && token.toLowerCase().startsWith(_levelToken)) {
+        level = token.substring(_levelToken.length);
+      } else if (parsingTokens && token.toLowerCase().startsWith(_codeToken)) {
+        code = token.substring(_codeToken.length);
+      } else {
+        parsingTokens = false;
+        remainingTokens.add(token);
+      }
+    }
+
+    final trimmedCode = code?.trim();
+
+    return TwpWarning(
+      level: TwpWarningLevel.fromValue(level),
+      code: trimmedCode?.isNotEmpty == true ? trimmedCode : null,
+      fallbackText: remainingTokens.join(' '),
+      index: index,
+    );
+  }
+
+  @override
+  List<Object?> get props => [level, code, fallbackText, index];
+}

--- a/model/lib/email/twp_warning/twp_warning_level.dart
+++ b/model/lib/email/twp_warning/twp_warning_level.dart
@@ -1,4 +1,3 @@
-
 /// Severity level carried by an `X-TWP-Message` header.
 ///
 /// Maps to the banner color displayed in the read view:

--- a/model/lib/email/twp_warning/twp_warning_level.dart
+++ b/model/lib/email/twp_warning/twp_warning_level.dart
@@ -1,0 +1,24 @@
+
+/// Severity level carried by an `X-TWP-Message` header.
+///
+/// Maps to the banner color displayed in the read view:
+/// info -> blue, warn -> yellow, error -> red.
+enum TwpWarningLevel {
+  info,
+  warn,
+  error;
+
+  /// Parses the `level:` token value case-insensitively.
+  ///
+  /// Unknown or missing levels default to [TwpWarningLevel.info].
+  static TwpWarningLevel fromValue(String? value) {
+    switch (value?.trim().toLowerCase()) {
+      case 'warn':
+        return TwpWarningLevel.warn;
+      case 'error':
+        return TwpWarningLevel.error;
+      default:
+        return TwpWarningLevel.info;
+    }
+  }
+}

--- a/model/lib/extensions/email_id_extensions.dart
+++ b/model/lib/extensions/email_id_extensions.dart
@@ -11,4 +11,11 @@ extension EmailIdExtension on EmailId {
       id: KeyWordIdentifierExtension.unsubscribeMail.generateUnsubscribeActionPath()
     };
   }
+
+  Map<Id, PatchObject> generateMapUpdateObjectDismissTwpWarning(int index) {
+    return {
+      id: KeyWordIdentifierExtension.twpWarningDismissed(index)
+          .generateDismissTwpWarningActionPath()
+    };
+  }
 }

--- a/model/lib/extensions/keyword_identifier_extension.dart
+++ b/model/lib/extensions/keyword_identifier_extension.dart
@@ -8,6 +8,13 @@ extension KeyWordIdentifierExtension on KeyWordIdentifier {
   static final needsActionMail = KeyWordIdentifier('needs-action');
   static final eventsMail = KeyWordIdentifier('event');
 
+  static const String twpWarningDismissedPrefix = 'twp-warning-dismissed-';
+
+  /// Keyword persisting the dismissal of the `X-TWP-Message` warning at the
+  /// given 0-based position in the message header list.
+  static KeyWordIdentifier twpWarningDismissed(int index) =>
+      KeyWordIdentifier('$twpWarningDismissedPrefix$index');
+
   String generatePath() => '${PatchObject.keywordsProperty}/$value';
 
   /// General helper to generate a boolean patch.
@@ -28,6 +35,8 @@ extension KeyWordIdentifierExtension on KeyWordIdentifier {
   PatchObject generateForwardedActionPath() => _boolPatch(true);
 
   PatchObject generateUnsubscribeActionPath() => _boolPatch(true);
+
+  PatchObject generateDismissTwpWarningActionPath() => _boolPatch(true);
 
   PatchObject generateLabelActionPath({bool remove = false}) =>
       _boolPatch(remove ? null : true);

--- a/model/lib/extensions/list_email_header_extension.dart
+++ b/model/lib/extensions/list_email_header_extension.dart
@@ -31,16 +31,13 @@ extension ListEmailHeaderExtension on Set<EmailHeader>? {
     return listPost?.value;
   }
 
-  /// All `X-TWP-Message` warnings positioned on the message, in header order.
+  /// All `X-TWP-Message` warnings on the message, in header order. Each
+  /// [TwpWarning.index] is the 0-based position used for its dismissal keyword.
   ///
-  /// Each warning's [TwpWarning.index] is its 0-based position among the
-  /// `X-TWP-Message` headers, used to persist a per-warning dismissal keyword.
-  ///
-  /// Ordering is stable: `headers` is a `LinkedHashSet` that preserves the JMAP
-  /// response order, which matches the order the backend positions the warnings,
-  /// so this positional index aligns with the backend dismissal contract.
-  /// Note: [EmailHeader] uses value equality, so byte-identical warnings are
-  /// already deduplicated by the Set upstream and therefore share no index here.
+  /// Order is stable: `headers` is a `LinkedHashSet` preserving JMAP response
+  /// order, which matches how the backend positions warnings. Caveat:
+  /// [EmailHeader] has value equality, so byte-identical warnings are
+  /// deduplicated upstream and won't get distinct indexes.
   List<TwpWarning> get twpWarnings {
     final headers = this;
     if (headers == null) return const [];

--- a/model/lib/extensions/list_email_header_extension.dart
+++ b/model/lib/extensions/list_email_header_extension.dart
@@ -2,6 +2,7 @@
 import 'package:collection/collection.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_header.dart';
 import 'package:model/email/email_property.dart';
+import 'package:model/email/twp_warning/twp_warning.dart';
 import 'package:core/utils/app_logger.dart' as logger;
 
 extension ListEmailHeaderExtension on Set<EmailHeader>? {
@@ -28,5 +29,24 @@ extension ListEmailHeaderExtension on Set<EmailHeader>? {
   String? get listPost {
     final listPost = this?.firstWhereOrNull((header) => header.name == EmailProperty.headerListPostKey);
     return listPost?.value;
+  }
+
+  /// All `X-TWP-Message` warnings positioned on the message, in header order.
+  ///
+  /// Each warning's [TwpWarning.index] is its 0-based position among the
+  /// `X-TWP-Message` headers, used to persist a per-warning dismissal keyword.
+  List<TwpWarning> get twpWarnings {
+    final headers = this;
+    if (headers == null) return const [];
+
+    final warnings = <TwpWarning>[];
+    var index = 0;
+    for (final header in headers) {
+      if (header.name == EmailProperty.headerTwpMessageKey) {
+        warnings.add(TwpWarning.parse(header.value, index));
+        index++;
+      }
+    }
+    return warnings;
   }
 }

--- a/model/lib/extensions/list_email_header_extension.dart
+++ b/model/lib/extensions/list_email_header_extension.dart
@@ -35,6 +35,12 @@ extension ListEmailHeaderExtension on Set<EmailHeader>? {
   ///
   /// Each warning's [TwpWarning.index] is its 0-based position among the
   /// `X-TWP-Message` headers, used to persist a per-warning dismissal keyword.
+  ///
+  /// Ordering is stable: `headers` is a `LinkedHashSet` that preserves the JMAP
+  /// response order, which matches the order the backend positions the warnings,
+  /// so this positional index aligns with the backend dismissal contract.
+  /// Note: [EmailHeader] uses value equality, so byte-identical warnings are
+  /// already deduplicated by the Set upstream and therefore share no index here.
   List<TwpWarning> get twpWarnings {
     final headers = this;
     if (headers == null) return const [];

--- a/model/lib/model.dart
+++ b/model/lib/model.dart
@@ -19,6 +19,8 @@ export 'email/email_action_type.dart';
 export 'email/email_content.dart';
 export 'email/email_content_type.dart';
 export 'email/email_property.dart';
+export 'email/twp_warning/twp_warning.dart';
+export 'email/twp_warning/twp_warning_level.dart';
 export 'email/mark_star_action.dart';
 export 'email/prefix_email_address.dart';
 // Email

--- a/model/test/email/twp_warning/twp_warning_test.dart
+++ b/model/test/email/twp_warning/twp_warning_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/email/twp_warning/twp_warning.dart';
+import 'package:model/email/twp_warning/twp_warning_level.dart';
+
+void main() {
+  group('TwpWarning.parse', () {
+    test('parses level, code and fallback text', () {
+      final warning = TwpWarning.parse(
+        'level:warn code:virus This email contains a virus',
+        0,
+      );
+      expect(warning.level, TwpWarningLevel.warn);
+      expect(warning.code, 'virus');
+      expect(warning.fallbackText, 'This email contains a virus');
+      expect(warning.index, 0);
+    });
+
+    test('accepts the level and code tokens in any leading order', () {
+      final warning = TwpWarning.parse('code:virus level:error Boom', 2);
+      expect(warning.level, TwpWarningLevel.error);
+      expect(warning.code, 'virus');
+      expect(warning.fallbackText, 'Boom');
+      expect(warning.index, 2);
+    });
+
+    test('treats a plain message as info with no code', () {
+      final warning = TwpWarning.parse('A plain warning message', 0);
+      expect(warning.level, TwpWarningLevel.info);
+      expect(warning.code, isNull);
+      expect(warning.fallbackText, 'A plain warning message');
+    });
+
+    test('stops token parsing at the first non-token word', () {
+      // `level:warn` after free text is body, not a leading token.
+      final warning = TwpWarning.parse('Hello level:warn', 0);
+      expect(warning.level, TwpWarningLevel.info);
+      expect(warning.code, isNull);
+      expect(warning.fallbackText, 'Hello level:warn');
+    });
+
+    test('defaults to info for an unknown level value', () {
+      final warning = TwpWarning.parse('level:critical code:virus Text', 0);
+      expect(warning.level, TwpWarningLevel.info);
+      expect(warning.code, 'virus');
+    });
+
+    test('treats an empty code token as no code', () {
+      final warning = TwpWarning.parse('level:warn code: Text', 0);
+      expect(warning.code, isNull);
+      expect(warning.fallbackText, 'Text');
+    });
+
+    test('collapses surrounding and repeated whitespace', () {
+      final warning = TwpWarning.parse(
+        '  level:warn   code:virus   A   B  ',
+        0,
+      );
+      expect(warning.level, TwpWarningLevel.warn);
+      expect(warning.code, 'virus');
+      expect(warning.fallbackText, 'A B');
+    });
+
+    test('value equality on level, code, fallbackText and index', () {
+      final a = TwpWarning.parse('level:warn code:virus Text', 1);
+      final b = TwpWarning.parse('level:warn code:virus Text', 1);
+      final c = TwpWarning.parse('level:warn code:virus Text', 2);
+      expect(a, b);
+      expect(a, isNot(c));
+    });
+  });
+
+  group('TwpWarningLevel.fromValue', () {
+    test('maps known values', () {
+      expect(TwpWarningLevel.fromValue('warn'), TwpWarningLevel.warn);
+      expect(TwpWarningLevel.fromValue('error'), TwpWarningLevel.error);
+      expect(TwpWarningLevel.fromValue('info'), TwpWarningLevel.info);
+    });
+
+    test('is case-insensitive and trims whitespace', () {
+      expect(TwpWarningLevel.fromValue('WARN'), TwpWarningLevel.warn);
+      expect(TwpWarningLevel.fromValue('  Error '), TwpWarningLevel.error);
+    });
+
+    test('defaults to info for null, empty or unknown values', () {
+      expect(TwpWarningLevel.fromValue(null), TwpWarningLevel.info);
+      expect(TwpWarningLevel.fromValue(''), TwpWarningLevel.info);
+      expect(TwpWarningLevel.fromValue('whatever'), TwpWarningLevel.info);
+    });
+  });
+}

--- a/model/test/extensions/list_email_header_extension_test.dart
+++ b/model/test/extensions/list_email_header_extension_test.dart
@@ -89,6 +89,22 @@ void main() {
       expect(warnings[1].code, 'virus-removed');
     });
 
+    test('collapses byte-identical `X-TWP-Message` headers into a single warning', () {
+      // `EmailHeader` (jmap_dart_client) is `EquatableMixin` on (name, value),
+      // so two byte-identical headers are deduplicated by the backing Set before
+      // they reach this extension. This documents that current behavior: such
+      // warnings cannot be distinguished by index here.
+      final emailHeaders = {
+        EmailHeader(EmailProperty.headerTwpMessageKey, 'level:warn code:virus Virus found'),
+        EmailHeader(EmailProperty.headerTwpMessageKey, 'level:warn code:virus Virus found'),
+      };
+
+      final warnings = emailHeaders.twpWarnings;
+      expect(warnings.length, 1);
+      expect(warnings.single.index, 0);
+      expect(warnings.single.code, 'virus');
+    });
+
     test('defaults to info level and null code when tokens are missing', () {
       final emailHeaders = {
         EmailHeader(EmailProperty.headerTwpMessageKey, 'A plain warning message')

--- a/model/test/extensions/list_email_header_extension_test.dart
+++ b/model/test/extensions/list_email_header_extension_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_header.dart';
 import 'package:model/email/email_property.dart';
+import 'package:model/email/twp_warning/twp_warning_level.dart';
 import 'package:model/extensions/list_email_header_extension.dart';
 
 void main() {
@@ -43,6 +44,70 @@ void main() {
         EmailHeader(EmailProperty.headerSMimeStatusKey, ' Good signature ')
       };
       expect(emailHeaders.sMimeStatus, 'Good signature');
+    });
+  });
+
+  group('ListEmailHeaderExtension::twpWarnings', () {
+    test('returns empty list when no `X-TWP-Message` header is present', () {
+      final emailHeaders = {EmailHeader('OtherHeader', 'Value')};
+      expect(emailHeaders.twpWarnings, isEmpty);
+    });
+
+    test('returns empty list for null set', () {
+      Set<EmailHeader>? emailHeaders;
+      expect(emailHeaders.twpWarnings, isEmpty);
+    });
+
+    test('parses a single warning with level, code and fallback text', () {
+      final emailHeaders = {
+        EmailHeader(
+          EmailProperty.headerTwpMessageKey,
+          'level:info code:suspicious-sender This email is from an external sender.',
+        )
+      };
+
+      final warnings = emailHeaders.twpWarnings;
+      expect(warnings.length, 1);
+      expect(warnings.first.level, TwpWarningLevel.info);
+      expect(warnings.first.code, 'suspicious-sender');
+      expect(warnings.first.fallbackText, 'This email is from an external sender.');
+      expect(warnings.first.index, 0);
+    });
+
+    test('parses several warnings and assigns positional indexes', () {
+      final emailHeaders = {
+        EmailHeader(EmailProperty.headerTwpMessageKey, 'level:warn code:virus Virus found'),
+        EmailHeader(EmailProperty.headerTwpMessageKey, 'level:error code:virus-removed Virus removed'),
+      };
+
+      final warnings = emailHeaders.twpWarnings;
+      expect(warnings.length, 2);
+      expect(warnings[0].index, 0);
+      expect(warnings[0].level, TwpWarningLevel.warn);
+      expect(warnings[1].index, 1);
+      expect(warnings[1].level, TwpWarningLevel.error);
+      expect(warnings[1].code, 'virus-removed');
+    });
+
+    test('defaults to info level and null code when tokens are missing', () {
+      final emailHeaders = {
+        EmailHeader(EmailProperty.headerTwpMessageKey, 'A plain warning message')
+      };
+
+      final warning = emailHeaders.twpWarnings.single;
+      expect(warning.level, TwpWarningLevel.info);
+      expect(warning.code, isNull);
+      expect(warning.fallbackText, 'A plain warning message');
+    });
+
+    test('defaults to info level when the level value is unknown', () {
+      final emailHeaders = {
+        EmailHeader(EmailProperty.headerTwpMessageKey, 'level:unknown code:virus Text')
+      };
+
+      final warning = emailHeaders.twpWarnings.single;
+      expect(warning.level, TwpWarningLevel.info);
+      expect(warning.code, 'virus');
     });
   });
 }

--- a/model/test/extensions/twp_warning_dismiss_keyword_test.dart
+++ b/model/test/extensions/twp_warning_dismiss_keyword_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/patch_object.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:model/email/presentation_email.dart';
+import 'package:model/extensions/email_id_extensions.dart';
+import 'package:model/extensions/keyword_identifier_extension.dart';
+
+void main() {
+  // Locks the backend dismissal contract: the keyword name and the SetEmail
+  // patch shape the server relies on to remember a dismissed warning.
+  group('TWP warning dismissal keyword', () {
+    test('keyword name is twp-warning-dismissed-<index>', () {
+      expect(
+        KeyWordIdentifierExtension.twpWarningDismissedPrefix,
+        'twp-warning-dismissed-',
+      );
+      expect(
+        KeyWordIdentifierExtension.twpWarningDismissed(0).value,
+        'twp-warning-dismissed-0',
+      );
+      expect(
+        KeyWordIdentifierExtension.twpWarningDismissed(3).value,
+        'twp-warning-dismissed-3',
+      );
+    });
+
+    test('generates a keywords/<keyword> = true patch', () {
+      final patch = KeyWordIdentifierExtension.twpWarningDismissed(
+        1,
+      ).generateDismissTwpWarningActionPath();
+      expect(patch, PatchObject({'keywords/twp-warning-dismissed-1': true}));
+    });
+
+    test('builds the SetEmail update map keyed by the email id', () {
+      final emailId = EmailId(Id('email-1'));
+      final updates = emailId.generateMapUpdateObjectDismissTwpWarning(2);
+
+      expect(updates.keys.single, emailId.id);
+      expect(
+        updates[emailId.id],
+        PatchObject({'keywords/twp-warning-dismissed-2': true}),
+      );
+    });
+  });
+
+  group('PresentationEmail.isTwpWarningDismissed', () {
+    test('is true only for an index whose keyword is present', () {
+      final email = PresentationEmail(
+        keywords: {KeyWordIdentifierExtension.twpWarningDismissed(1): true},
+      );
+      expect(email.isTwpWarningDismissed(1), isTrue);
+      expect(email.isTwpWarningDismissed(0), isFalse);
+    });
+
+    test('is false when there are no keywords', () {
+      expect(PresentationEmail().isTwpWarningDismissed(0), isFalse);
+    });
+  });
+}

--- a/test/features/base/handle_urgent_exception_test.dart
+++ b/test/features/base/handle_urgent_exception_test.dart
@@ -1,0 +1,104 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/base/handle_urgent_exception.dart';
+import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
+
+import 'handle_urgent_exception_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<UrgentExceptionHandler>()])
+class _TestFeatureFailure extends FeatureFailure {
+  _TestFeatureFailure({super.exception});
+}
+
+class _PlainFailure extends Failure {
+  @override
+  List<Object?> get props => [];
+}
+
+class _UrgentException implements Exception {}
+
+void main() {
+  late MockUrgentExceptionHandler handler;
+
+  setUp(() {
+    handler = MockUrgentExceptionHandler();
+    Get.put<UrgentExceptionHandler>(handler);
+  });
+
+  tearDown(Get.reset);
+
+  group('handleUrgentExceptionIfNeeded', () {
+    test('routes and returns true for an urgent bare exception', () {
+      final exception = _UrgentException();
+      when(handler.validateUrgentException(exception)).thenReturn(true);
+
+      final result = handleUrgentExceptionIfNeeded(exception: exception);
+
+      expect(result, isTrue);
+      verify(handler.validateUrgentException(exception)).called(1);
+      verify(
+        handler.handleUrgentException(failure: null, exception: exception),
+      ).called(1);
+    });
+
+    test('returns false and does not route a non-urgent exception', () {
+      final exception = _UrgentException();
+      when(handler.validateUrgentException(exception)).thenReturn(false);
+
+      final result = handleUrgentExceptionIfNeeded(exception: exception);
+
+      expect(result, isFalse);
+      verifyNever(
+        handler.handleUrgentException(
+          failure: anyNamed('failure'),
+          exception: anyNamed('exception'),
+        ),
+      );
+    });
+
+    test('unwraps and routes an urgent FeatureFailure.exception', () {
+      final exception = _UrgentException();
+      final failure = _TestFeatureFailure(exception: exception);
+      when(handler.validateUrgentException(exception)).thenReturn(true);
+
+      final result = handleUrgentExceptionIfNeeded(failure: failure);
+
+      expect(result, isTrue);
+      verify(
+        handler.handleUrgentException(failure: failure, exception: exception),
+      ).called(1);
+    });
+
+    test('returns false for a FeatureFailure with a non-urgent exception', () {
+      final exception = _UrgentException();
+      final failure = _TestFeatureFailure(exception: exception);
+      when(handler.validateUrgentException(exception)).thenReturn(false);
+
+      expect(handleUrgentExceptionIfNeeded(failure: failure), isFalse);
+    });
+
+    test('returns false for a FeatureFailure with no exception', () {
+      expect(
+        handleUrgentExceptionIfNeeded(failure: _TestFeatureFailure()),
+        isFalse,
+      );
+      verifyNever(handler.validateUrgentException(any));
+    });
+
+    test('returns false for a non-FeatureFailure failure', () {
+      expect(handleUrgentExceptionIfNeeded(failure: _PlainFailure()), isFalse);
+      verifyNever(handler.validateUrgentException(any));
+    });
+
+    test('returns false without throwing when no handler is registered', () {
+      Get.reset();
+      expect(
+        handleUrgentExceptionIfNeeded(exception: _UrgentException()),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/features/base/urgent_exception_handler_service_test.dart
+++ b/test/features/base/urgent_exception_handler_service_test.dart
@@ -1,0 +1,91 @@
+import 'package:core/core.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:mockito/annotations.dart';
+import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
+import 'package:tmail_ui_user/features/base/urgent_exception_handler_service.dart';
+import 'package:tmail_ui_user/features/caching/caching_manager.dart';
+import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oidc_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
+import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
+import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
+import 'package:uuid/uuid.dart';
+
+import 'urgent_exception_handler_service_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<CachingManager>(),
+  MockSpec<LanguageCacheManager>(),
+  MockSpec<AuthorizationInterceptors>(),
+  MockSpec<DynamicUrlInterceptors>(),
+  MockSpec<DeleteCredentialInteractor>(),
+  MockSpec<LogoutOidcInteractor>(),
+  MockSpec<DeleteAuthorityOidcInteractor>(),
+  MockSpec<AppToast>(),
+  MockSpec<ImagePaths>(),
+  MockSpec<ResponsiveUtils>(),
+  MockSpec<Uuid>(),
+  MockSpec<ToastManager>(),
+  MockSpec<TwakeAppManager>(),
+])
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late UrgentExceptionHandlerService service;
+
+  setUp(() {
+    // BaseController resolves these app-wide singletons in its field
+    // initializers; register them so the service is constructible standalone.
+    Get.put<CachingManager>(MockCachingManager());
+    Get.put<LanguageCacheManager>(MockLanguageCacheManager());
+    Get.put<AuthorizationInterceptors>(MockAuthorizationInterceptors());
+    Get.put<AuthorizationInterceptors>(
+      MockAuthorizationInterceptors(),
+      tag: BindingTag.isolateTag,
+    );
+    Get.put<DynamicUrlInterceptors>(MockDynamicUrlInterceptors());
+    Get.put<DeleteCredentialInteractor>(MockDeleteCredentialInteractor());
+    Get.put<LogoutOidcInteractor>(MockLogoutOidcInteractor());
+    Get.put<DeleteAuthorityOidcInteractor>(MockDeleteAuthorityOidcInteractor());
+    Get.put<AppToast>(MockAppToast());
+    Get.put<ImagePaths>(MockImagePaths());
+    Get.put<ResponsiveUtils>(MockResponsiveUtils());
+    Get.put<Uuid>(MockUuid());
+    Get.put<ToastManager>(MockToastManager());
+    Get.put<TwakeAppManager>(MockTwakeAppManager());
+
+    service = UrgentExceptionHandlerService();
+  });
+
+  tearDown(Get.reset);
+
+  group('UrgentExceptionHandlerService', () {
+    test('is an UrgentExceptionHandler', () {
+      expect(service, isA<UrgentExceptionHandler>());
+    });
+
+    test('classifies session/network exceptions as urgent', () {
+      expect(
+        service.validateUrgentException(const BadCredentialsException()),
+        isTrue,
+      );
+      expect(
+        service.validateUrgentException(RefreshTokenFailedException()),
+        isTrue,
+      );
+      expect(service.validateUrgentException(const ConnectionError()), isTrue);
+      expect(service.validateUrgentException(const NoNetworkError()), isTrue);
+    });
+
+    test('does not classify ordinary errors as urgent', () {
+      expect(service.validateUrgentException(Exception('boom')), isFalse);
+      expect(service.validateUrgentException(null), isFalse);
+    });
+  });
+}

--- a/test/features/email/domain/usecases/dismiss_twp_warning_interactor_test.dart
+++ b/test/features/email/domain/usecases/dismiss_twp_warning_interactor_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/email/domain/repository/email_repository.dart';
+import 'package:tmail_ui_user/features/email/domain/state/dismiss_twp_warning_state.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/dismiss_twp_warning_interactor.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import '../../../../fixtures/session_fixtures.dart';
+import 'dismiss_twp_warning_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<EmailRepository>()])
+void main() {
+  late MockEmailRepository repository;
+  late DismissTwpWarningInteractor interactor;
+
+  final session = SessionFixtures.aliceSession;
+  final accountId = AccountFixtures.aliceAccountId;
+  final emailId = EmailId(Id('email-1'));
+  const index = 1;
+
+  setUp(() {
+    repository = MockEmailRepository();
+    interactor = DismissTwpWarningInteractor(repository);
+  });
+
+  group('DismissTwpWarningInteractor', () {
+    test(
+      'emits DismissTwpWarningSuccess with the email id and index',
+      () async {
+        when(
+          repository.dismissTwpWarning(session, accountId, emailId, index),
+        ).thenAnswer((_) async {});
+
+        final state = await interactor
+            .execute(session, accountId, emailId, index)
+            .last;
+
+        expect(
+          state.fold((failure) => failure, (success) => success),
+          DismissTwpWarningSuccess(emailId, index),
+        );
+        verify(
+          repository.dismissTwpWarning(session, accountId, emailId, index),
+        ).called(1);
+      },
+    );
+
+    test(
+      'emits DismissTwpWarningFailure carrying index and exception on error',
+      () async {
+        final exception = Exception('set failed');
+        when(
+          repository.dismissTwpWarning(session, accountId, emailId, index),
+        ).thenThrow(exception);
+
+        final state = await interactor
+            .execute(session, accountId, emailId, index)
+            .last;
+
+        final failure = state.fold((f) => f, (_) => null);
+        expect(failure, isA<DismissTwpWarningFailure>());
+        expect((failure as DismissTwpWarningFailure).index, index);
+        expect(failure.exception, exception);
+      },
+    );
+  });
+}

--- a/test/features/email/presentation/controller/single_email_controller_test.dart
+++ b/test/features/email/presentation/controller/single_email_controller_test.dart
@@ -30,6 +30,7 @@ import 'package:tmail_ui_user/features/email/domain/state/get_email_content_stat
 import 'package:tmail_ui_user/features/email/domain/state/parse_calendar_event_state.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/calendar_event_accept_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/calendar_event_reject_interactor.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/dismiss_twp_warning_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_email_content_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_email_read_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_star_email_interactor.dart';
@@ -88,6 +89,7 @@ const fallbackGenerators = {
   MockSpec<ResponsiveUtils>(),
   MockSpec<Uuid>(),
   MockSpec<PrintEmailInteractor>(),
+  MockSpec<DismissTwpWarningInteractor>(),
   MockSpec<AcceptCalendarEventInteractor>(),
   MockSpec<MaybeCalendarEventInteractor>(),
   MockSpec<RejectCalendarEventInteractor>(),
@@ -121,6 +123,7 @@ void main() {
   final responsiveUtils = MockResponsiveUtils();
   final uuid = MockUuid();
   final printEmailInteractor = MockPrintEmailInteractor();
+  final dismissTwpWarningInteractor = MockDismissTwpWarningInteractor();
   final printUtils = MockPrintUtils();
   final mockToastManager = MockToastManager();
   final mockTwakeAppManager = MockTwakeAppManager();
@@ -172,6 +175,7 @@ void main() {
       getAllIdentitiesInteractor,
       storeOpenedEmailInteractor,
       printEmailInteractor,
+      dismissTwpWarningInteractor,
     );
   });
 

--- a/test/features/email/presentation/controller/single_email_controller_test.dart
+++ b/test/features/email/presentation/controller/single_email_controller_test.dart
@@ -30,7 +30,6 @@ import 'package:tmail_ui_user/features/email/domain/state/get_email_content_stat
 import 'package:tmail_ui_user/features/email/domain/state/parse_calendar_event_state.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/calendar_event_accept_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/calendar_event_reject_interactor.dart';
-import 'package:tmail_ui_user/features/email/domain/usecases/dismiss_twp_warning_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_email_content_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_email_read_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_star_email_interactor.dart';
@@ -89,7 +88,6 @@ const fallbackGenerators = {
   MockSpec<ResponsiveUtils>(),
   MockSpec<Uuid>(),
   MockSpec<PrintEmailInteractor>(),
-  MockSpec<DismissTwpWarningInteractor>(),
   MockSpec<AcceptCalendarEventInteractor>(),
   MockSpec<MaybeCalendarEventInteractor>(),
   MockSpec<RejectCalendarEventInteractor>(),
@@ -123,7 +121,6 @@ void main() {
   final responsiveUtils = MockResponsiveUtils();
   final uuid = MockUuid();
   final printEmailInteractor = MockPrintEmailInteractor();
-  final dismissTwpWarningInteractor = MockDismissTwpWarningInteractor();
   final printUtils = MockPrintUtils();
   final mockToastManager = MockToastManager();
   final mockTwakeAppManager = MockTwakeAppManager();
@@ -175,7 +172,6 @@ void main() {
       getAllIdentitiesInteractor,
       storeOpenedEmailInteractor,
       printEmailInteractor,
-      dismissTwpWarningInteractor,
     );
   });
 

--- a/test/features/email/presentation/model/twp_warning_code_resolver_test.dart
+++ b/test/features/email/presentation/model/twp_warning_code_resolver_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/email/twp_warning/twp_warning.dart';
+import 'package:model/email/twp_warning/twp_warning_level.dart';
+import 'package:tmail_ui_user/features/email/presentation/model/twp_warning_code.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import 'twp_warning_code_resolver_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<AppLocalizations>()])
+void main() {
+  late MockAppLocalizations l10n;
+
+  TwpWarning warning({String? code, String fallbackText = 'server fallback'}) =>
+      TwpWarning(
+        level: TwpWarningLevel.warn,
+        code: code,
+        fallbackText: fallbackText,
+        index: 0,
+      );
+
+  setUp(() {
+    l10n = MockAppLocalizations();
+    when(l10n.twpWarningSuspiciousSender).thenReturn('localized suspicious');
+    when(l10n.twpWarningVirus).thenReturn('localized virus');
+    when(l10n.twpWarningVirusRemoved).thenReturn('localized virus removed');
+  });
+
+  group('TwpWarningCodeResolver.resolveMessage', () {
+    test('returns the localized message for known codes', () {
+      expect(
+        TwpWarningCodeResolver.resolveMessage(
+          warning(code: 'suspicious-sender'),
+          l10n,
+        ),
+        'localized suspicious',
+      );
+      expect(
+        TwpWarningCodeResolver.resolveMessage(warning(code: 'virus'), l10n),
+        'localized virus',
+      );
+      expect(
+        TwpWarningCodeResolver.resolveMessage(
+          warning(code: 'virus-removed'),
+          l10n,
+        ),
+        'localized virus removed',
+      );
+    });
+
+    test('falls back to server text for an unknown code', () {
+      expect(
+        TwpWarningCodeResolver.resolveMessage(
+          warning(code: 'unknown', fallbackText: 'raw text'),
+          l10n,
+        ),
+        'raw text',
+      );
+    });
+
+    test('falls back to server text when there is no code', () {
+      expect(
+        TwpWarningCodeResolver.resolveMessage(
+          warning(code: null, fallbackText: 'raw text'),
+          l10n,
+        ),
+        'raw text',
+      );
+    });
+
+    test('falls back to server text when the localized string is empty', () {
+      when(l10n.twpWarningVirus).thenReturn('');
+      expect(
+        TwpWarningCodeResolver.resolveMessage(
+          warning(code: 'virus', fallbackText: 'raw text'),
+          l10n,
+        ),
+        'raw text',
+      );
+    });
+  });
+}

--- a/test/features/email/presentation/providers/twp_warning_dismiss_notifier_test.dart
+++ b/test/features/email/presentation/providers/twp_warning_dismiss_notifier_test.dart
@@ -35,19 +35,24 @@ void main() {
   Set<int> readState() => container.read(twpWarningDismissProvider(emailIdKey));
 
   void stubSuccess() {
-    when(mockInteractor.execute(any, any, any, any)).thenAnswer(
-      (_) => Stream.value(
-        Right<Failure, Success>(DismissTwpWarningSuccess(emailId, index)),
-      ),
-    );
+    when(mockInteractor.execute(any, any, any, any)).thenAnswer((invocation) {
+      final invokedEmailId = invocation.positionalArguments[2] as EmailId;
+      final invokedIndex = invocation.positionalArguments[3] as int;
+      return Stream.value(
+        Right<Failure, Success>(
+          DismissTwpWarningSuccess(invokedEmailId, invokedIndex),
+        ),
+      );
+    });
   }
 
   void stubFailure() {
-    when(mockInteractor.execute(any, any, any, any)).thenAnswer(
-      (_) => Stream.value(
-        Left<Failure, Success>(DismissTwpWarningFailure(index: index)),
-      ),
-    );
+    when(mockInteractor.execute(any, any, any, any)).thenAnswer((invocation) {
+      final invokedIndex = invocation.positionalArguments[3] as int;
+      return Stream.value(
+        Left<Failure, Success>(DismissTwpWarningFailure(index: invokedIndex)),
+      );
+    });
   }
 
   setUp(() {

--- a/test/features/email/presentation/providers/twp_warning_dismiss_notifier_test.dart
+++ b/test/features/email/presentation/providers/twp_warning_dismiss_notifier_test.dart
@@ -1,0 +1,222 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
+import 'package:tmail_ui_user/features/email/domain/state/dismiss_twp_warning_state.dart';
+import 'package:tmail_ui_user/features/email/domain/usecases/dismiss_twp_warning_interactor.dart';
+import 'package:tmail_ui_user/features/email/presentation/providers/twp_warning_dismiss_notifier.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import '../../../../fixtures/session_fixtures.dart';
+import 'twp_warning_dismiss_notifier_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<DismissTwpWarningInteractor>(),
+  MockSpec<UrgentExceptionHandler>(),
+])
+void main() {
+  late MockDismissTwpWarningInteractor mockInteractor;
+  late ProviderContainer container;
+  late TwpWarningDismiss notifier;
+
+  final session = SessionFixtures.aliceSession;
+  final accountId = AccountFixtures.aliceAccountId;
+  final emailId = EmailId(Id('email-1'));
+  const emailIdKey = 'email-1';
+  const index = 0;
+
+  Set<int> readState() => container.read(twpWarningDismissProvider(emailIdKey));
+
+  void stubSuccess() {
+    when(mockInteractor.execute(any, any, any, any)).thenAnswer(
+      (_) => Stream.value(
+        Right<Failure, Success>(DismissTwpWarningSuccess(emailId, index)),
+      ),
+    );
+  }
+
+  void stubFailure() {
+    when(mockInteractor.execute(any, any, any, any)).thenAnswer(
+      (_) => Stream.value(
+        Left<Failure, Success>(DismissTwpWarningFailure(index: index)),
+      ),
+    );
+  }
+
+  setUp(() {
+    mockInteractor = MockDismissTwpWarningInteractor();
+    Get.put<DismissTwpWarningInteractor>(mockInteractor);
+
+    container = ProviderContainer();
+    // Keep the autoDispose provider alive for the duration of each test so
+    // reads observe the same instance the notifier mutates.
+    container.listen(
+      twpWarningDismissProvider(emailIdKey),
+      (_, __) {},
+      fireImmediately: true,
+    );
+    notifier = container.read(twpWarningDismissProvider(emailIdKey).notifier);
+  });
+
+  tearDown(() {
+    container.dispose();
+    Get.reset();
+  });
+
+  group('TwpWarningDismiss', () {
+    test('initial state is empty', () {
+      expect(readState(), isEmpty);
+    });
+
+    test('dismiss adds the index optimistically before completion', () async {
+      when(mockInteractor.execute(any, any, any, any)).thenAnswer((_) async* {
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        yield Right<Failure, Success>(DismissTwpWarningSuccess(emailId, index));
+      });
+
+      final future = notifier.dismiss(session, accountId, emailId, index);
+
+      // Optimistic update is applied synchronously before awaiting the backend.
+      expect(readState(), contains(index));
+
+      expect(await future, TwpWarningDismissResult.dismissed);
+      expect(readState(), contains(index));
+    });
+
+    test('dismiss keeps the index and returns dismissed on success', () async {
+      stubSuccess();
+
+      final result = await notifier.dismiss(session, accountId, emailId, index);
+
+      expect(result, TwpWarningDismissResult.dismissed);
+      expect(readState(), contains(index));
+      verify(
+        mockInteractor.execute(session, accountId, emailId, index),
+      ).called(1);
+    });
+
+    test(
+      'dismiss rolls back and returns failed on a non-urgent failure',
+      () async {
+        stubFailure();
+
+        final result = await notifier.dismiss(
+          session,
+          accountId,
+          emailId,
+          index,
+        );
+
+        expect(result, TwpWarningDismissResult.failed);
+        expect(readState(), isEmpty);
+      },
+    );
+
+    test(
+      'dismiss rolls back and returns failed when the stream errors',
+      () async {
+        when(
+          mockInteractor.execute(any, any, any, any),
+        ).thenAnswer((_) => Stream.error(Exception('boom')));
+
+        final result = await notifier.dismiss(
+          session,
+          accountId,
+          emailId,
+          index,
+        );
+
+        expect(result, TwpWarningDismissResult.failed);
+        expect(readState(), isEmpty);
+      },
+    );
+
+    test(
+      'dismiss rolls back and returns failed when interactor is missing',
+      () async {
+        Get.reset();
+
+        final result = await notifier.dismiss(
+          session,
+          accountId,
+          emailId,
+          index,
+        );
+
+        expect(result, TwpWarningDismissResult.failed);
+        expect(readState(), isEmpty);
+      },
+    );
+
+    test(
+      'dismiss routes urgent exceptions centrally and returns urgentHandled',
+      () async {
+        final handler = MockUrgentExceptionHandler();
+        when(handler.validateUrgentException(any)).thenReturn(true);
+        Get.put<UrgentExceptionHandler>(handler);
+        when(mockInteractor.execute(any, any, any, any)).thenAnswer(
+          (_) => Stream.value(
+            Left<Failure, Success>(
+              DismissTwpWarningFailure(
+                index: index,
+                exception: Exception('401'),
+              ),
+            ),
+          ),
+        );
+
+        final result = await notifier.dismiss(
+          session,
+          accountId,
+          emailId,
+          index,
+        );
+
+        expect(result, TwpWarningDismissResult.urgentHandled);
+        expect(readState(), isEmpty);
+        verify(
+          handler.handleUrgentException(
+            failure: anyNamed('failure'),
+            exception: anyNamed('exception'),
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'dismissing an already dismissed index is a no-op returning dismissed',
+      () async {
+        stubSuccess();
+        await notifier.dismiss(session, accountId, emailId, index);
+        clearInteractions(mockInteractor);
+
+        final result = await notifier.dismiss(
+          session,
+          accountId,
+          emailId,
+          index,
+        );
+
+        expect(result, TwpWarningDismissResult.dismissed);
+        expect(readState(), contains(index));
+        verifyNever(mockInteractor.execute(any, any, any, any));
+      },
+    );
+
+    test('multiple distinct indexes accumulate in state', () async {
+      stubSuccess();
+
+      await notifier.dismiss(session, accountId, emailId, 0);
+      await notifier.dismiss(session, accountId, emailId, 1);
+
+      expect(readState(), containsAll(<int>[0, 1]));
+    });
+  });
+}

--- a/test/features/email/presentation/widgets/twp_warning_banner_test.dart
+++ b/test/features/email/presentation/widgets/twp_warning_banner_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:model/model.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/twp_warning_banner.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../../../../fixtures/widget_fixtures.dart';
 
@@ -64,7 +65,11 @@ void _messageTests() {
     );
     await tester.pumpAndSettle();
 
+    final l10n = AppLocalizations.of(
+      tester.element(find.byType(TwpWarningBanner)),
+    );
     // A known code resolves to the localized string, not the raw fallback.
+    expect(find.text(l10n.twpWarningVirus), findsOneWidget);
     expect(find.text('Raw server fallback'), findsNothing);
   });
 }

--- a/test/features/email/presentation/widgets/twp_warning_banner_test.dart
+++ b/test/features/email/presentation/widgets/twp_warning_banner_test.dart
@@ -1,0 +1,104 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/model.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/twp_warning_banner.dart';
+
+import '../../../../fixtures/widget_fixtures.dart';
+
+TwpWarning _warning({
+  TwpWarningLevel level = TwpWarningLevel.warn,
+  String? code,
+  String fallbackText = 'A fallback warning message',
+  int index = 0,
+}) => TwpWarning(
+  level: level,
+  code: code,
+  fallbackText: fallbackText,
+  index: index,
+);
+
+Widget _makeWidget(
+  TwpWarning value, {
+  bool isDismissable = true,
+  void Function(int)? onDismiss,
+}) {
+  return WidgetFixtures.makeTestableWidget(
+    child: TwpWarningBanner(
+      warning: value,
+      isDismissable: isDismissable,
+      imagePaths: ImagePaths(),
+      onDismissAction: onDismiss ?? (_) {},
+    ),
+  );
+}
+
+Finder _dismissButton(int index) =>
+    find.byKey(Key('${UiKeys.twpWarningDismissButtonPrefix}$index'));
+
+void main() {
+  group('TwpWarningBanner', () {
+    _messageTests();
+    _dismissButtonTests();
+  });
+}
+
+void _messageTests() {
+  testWidgets('renders the server fallback text when the code is unknown', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _makeWidget(
+        _warning(code: 'totally-unknown-code', fallbackText: 'Raw server text'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Raw server text'), findsOneWidget);
+  });
+
+  testWidgets('renders the localized message for a known code', (tester) async {
+    await tester.pumpWidget(
+      _makeWidget(_warning(code: 'virus', fallbackText: 'Raw server fallback')),
+    );
+    await tester.pumpAndSettle();
+
+    // A known code resolves to the localized string, not the raw fallback.
+    expect(find.text('Raw server fallback'), findsNothing);
+  });
+}
+
+void _dismissButtonTests() {
+  testWidgets('shows the dismiss button when dismissable', (tester) async {
+    await tester.pumpWidget(_makeWidget(_warning(), isDismissable: true));
+    await tester.pumpAndSettle();
+
+    expect(_dismissButton(0), findsOneWidget);
+  });
+
+  testWidgets('hides the dismiss button when not dismissable', (tester) async {
+    await tester.pumpWidget(_makeWidget(_warning(), isDismissable: false));
+    await tester.pumpAndSettle();
+
+    expect(_dismissButton(0), findsNothing);
+  });
+
+  testWidgets('invokes onDismissAction with the warning index on tap', (
+    tester,
+  ) async {
+    int? dismissedIndex;
+    await tester.pumpWidget(
+      _makeWidget(
+        _warning(index: 3),
+        onDismiss: (index) => dismissedIndex = index,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(_dismissButton(3));
+    await tester.pumpAndSettle();
+
+    expect(dismissedIndex, 3);
+  });
+}

--- a/test/features/mailbox_dashboard/presentation/extensions/update_current_emails_flags_extension_test.dart
+++ b/test/features/mailbox_dashboard/presentation/extensions/update_current_emails_flags_extension_test.dart
@@ -8,6 +8,7 @@ import 'package:mockito/mockito.dart';
 import 'package:model/email/mark_star_action.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:model/email/read_actions.dart';
+import 'package:model/extensions/keyword_identifier_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/update_current_emails_flags_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
@@ -20,133 +21,139 @@ void main() {
   late List<EmailId> emailIds;
   final mailboxDashBoardController = MockMailboxDashBoardController();
 
+  /// Stubs `emailsInCurrentMailbox` with one email per id, each seeded with its
+  /// own copy of [keywords] (independent maps so in-place flag updates on one
+  /// email never leak into another).
+  void stubEmails([Map<KeyWordIdentifier, bool> keywords = const {}]) {
+    when(mailboxDashBoardController.emailsInCurrentMailbox).thenReturn(
+      emailIds
+          .map((emailId) => PresentationEmail(id: emailId, keywords: {...keywords}))
+          .toList()
+          .obs,
+    );
+  }
+
+  /// Asserts [flag] evaluated over the current list emails equals [expected],
+  /// position by position.
+  void expectFlagPerEmail(
+    bool Function(PresentationEmail email) flag,
+    List<bool> expected,
+  ) {
+    final actual =
+        mailboxDashBoardController.emailsInCurrentMailbox.map(flag).toList();
+    expect(actual, expected);
+  }
+
+  void dismissWarning(EmailId emailId, {int index = 0, bool dismissed = true}) {
+    mailboxDashBoardController.updateEmailTwpWarningDismissed(
+      emailId,
+      index,
+      dismissed: dismissed,
+    );
+  }
+
   setUp(() {
     emailIds = List.generate(
       numberOfEmails,
       (index) => EmailId(Id('email-id-$index')),
     );
-    when(mailboxDashBoardController.dashboardRoute).thenReturn(DashboardRoutes.thread.obs);
+    when(mailboxDashBoardController.dashboardRoute)
+        .thenReturn(DashboardRoutes.thread.obs);
   });
 
   group('updateEmailFlagByEmailIds test:', () {
-    test(
-      'should mark emails as read',
-    () {
-      // arrange
-      final readEmailIds = emailIds.sublist(1);
-      when(mailboxDashBoardController.emailsInCurrentMailbox).thenReturn(
-        emailIds.map((emailId) => PresentationEmail(
-          id: emailId,
-          keywords: {},
-        )).toList().obs,
-      );
-      expect(
-        mailboxDashBoardController.emailsInCurrentMailbox.every(
-          (presentationEmail) => !presentationEmail.hasRead,
-        ),
-        true,
-      );
-      
-      // act
+    test('should mark emails as read', () {
+      stubEmails();
+
       mailboxDashBoardController.updateEmailFlagByEmailIds(
-        readEmailIds,
+        emailIds.sublist(1),
         readAction: ReadActions.markAsRead,
       );
-      
-      // assert
-      expect(mailboxDashBoardController.emailsInCurrentMailbox[0].hasRead, false);
-      expect(mailboxDashBoardController.emailsInCurrentMailbox[1].hasRead, true);
-      expect(mailboxDashBoardController.emailsInCurrentMailbox[2].hasRead, true);
+
+      expectFlagPerEmail((email) => email.hasRead, [false, true, true]);
     });
 
-    test(
-      'should mark emails as unread',
-    () {
-      // arrange
-      final unreadEmailIds = emailIds.sublist(1);
-      when(mailboxDashBoardController.emailsInCurrentMailbox).thenReturn(
-        emailIds.map((emailId) => PresentationEmail(
-          id: emailId,
-          keywords: {KeyWordIdentifier.emailSeen: true},
-        )).toList().obs,
-      );
-      expect(
-        mailboxDashBoardController.emailsInCurrentMailbox.every(
-          (presentationEmail) => presentationEmail.hasRead,
-        ),
-        true,
-      );
-      
-      // act
+    test('should mark emails as unread', () {
+      stubEmails({KeyWordIdentifier.emailSeen: true});
+
       mailboxDashBoardController.updateEmailFlagByEmailIds(
-        unreadEmailIds,
+        emailIds.sublist(1),
         readAction: ReadActions.markAsUnread,
       );
-      
-      // assert
-      expect(mailboxDashBoardController.emailsInCurrentMailbox[0].hasRead, true);
-      expect(mailboxDashBoardController.emailsInCurrentMailbox[1].hasRead, false);
-      expect(mailboxDashBoardController.emailsInCurrentMailbox[2].hasRead, false);
+
+      expectFlagPerEmail((email) => email.hasRead, [true, false, false]);
     });
 
-    test(
-      'should mark emails as starred',
-    () {
-      // arrange
-      final starredEmailIds = emailIds.sublist(1);
-      when(mailboxDashBoardController.emailsInCurrentMailbox).thenReturn(
-        emailIds.map((emailId) => PresentationEmail(
-          id: emailId,
-          keywords: {},
-        )).toList().obs,
-      );
-      expect(
-        mailboxDashBoardController.emailsInCurrentMailbox.every(
-          (presentationEmail) => !presentationEmail.hasStarred,
-        ),
-        true,
-      );
-      
-      // act
+    test('should mark emails as starred', () {
+      stubEmails();
+
       mailboxDashBoardController.updateEmailFlagByEmailIds(
-        starredEmailIds,
+        emailIds.sublist(1),
         markStarAction: MarkStarAction.markStar,
       );
-      
-      // assert
-      expect(mailboxDashBoardController.emailsInCurrentMailbox[0].hasStarred, false);
-      expect(mailboxDashBoardController.emailsInCurrentMailbox[1].hasStarred, true);
-      expect(mailboxDashBoardController.emailsInCurrentMailbox[2].hasStarred, true);
+
+      expectFlagPerEmail((email) => email.hasStarred, [false, true, true]);
     });
 
-    test(
-      'should mark emails as unstarred',
-    () {
-      // arrange
-      final unstarredEmailIds = emailIds.sublist(1);
-      when(mailboxDashBoardController.emailsInCurrentMailbox).thenReturn(
-        emailIds.map((emailId) => PresentationEmail(
-          id: emailId,
-          keywords: {KeyWordIdentifier.emailFlagged: true},
-        )).toList().obs,
-      );
-      expect(
-        mailboxDashBoardController.emailsInCurrentMailbox.every(
-          (presentationEmail) => presentationEmail.hasStarred,
-        ),
-        true,
-      );
-      
-      // act
+    test('should mark emails as unstarred', () {
+      stubEmails({KeyWordIdentifier.emailFlagged: true});
+
       mailboxDashBoardController.updateEmailFlagByEmailIds(
-        unstarredEmailIds,
+        emailIds.sublist(1),
         markStarAction: MarkStarAction.unMarkStar,
       );
-      
-      // assert
-      expect(mailboxDashBoardController.emailsInCurrentMailbox[0].hasStarred, true);
-      expect(mailboxDashBoardController.emailsInCurrentMailbox[1].hasStarred, false);
-      expect(mailboxDashBoardController.emailsInCurrentMailbox[2].hasStarred, false);
+
+      expectFlagPerEmail((email) => email.hasStarred, [true, false, false]);
+    });
+  });
+
+  group('updateEmailTwpWarningDismissed test:', () {
+    test('should add the dismissed keyword to the matching list email', () {
+      stubEmails();
+
+      dismissWarning(emailIds[1]);
+
+      expectFlagPerEmail(
+        (email) => email.isTwpWarningDismissed(0),
+        [false, true, false],
+      );
+    });
+
+    test('should remove the dismissed keyword when dismissed is false', () {
+      stubEmails({KeyWordIdentifierExtension.twpWarningDismissed(0): true});
+
+      dismissWarning(emailIds[1], dismissed: false);
+
+      expectFlagPerEmail(
+        (email) => email.isTwpWarningDismissed(0),
+        [true, false, true],
+      );
+    });
+
+    test('should keep other warning indexes untouched', () {
+      stubEmails({KeyWordIdentifierExtension.twpWarningDismissed(1): true});
+
+      dismissWarning(emailIds[1]);
+
+      expectFlagPerEmail(
+        (email) => email.isTwpWarningDismissed(0),
+        [false, true, false],
+      );
+      expectFlagPerEmail(
+        (email) => email.isTwpWarningDismissed(1),
+        [true, true, true],
+      );
+    });
+
+    test('should do nothing when no list email matches the id', () {
+      stubEmails();
+
+      dismissWarning(EmailId(Id('not-in-list')));
+
+      expectFlagPerEmail(
+        (email) => email.isTwpWarningDismissed(0),
+        [false, false, false],
+      );
     });
   });
 }


### PR DESCRIPTION
Closes #4484

## Why
Allow the backend to position warning banners on a message (suspicious sender, virus, virus removed, …) so that they are surfaced when the user opens the mail.

## What
Renders backend positioned warnings carried by `X-TWP-Message` headers as a colored banner between the header section and the body of the read view.

Header contract (confirmed in the issue):
```
X-TWP-Message: level:info code:suspicious-sender This email is from an external sender immitating known users, double check the mail address.
```
- One header per warning, several headers per message (stacked banners), order is stable.
- Levels `info` / `warn` / `error` map to blue / yellow / red.
- Display text: localized message for a known `code`, otherwise the server provided fallback text.

### Implementation
- **Model** (`model`): `TwpWarning` + `TwpWarningLevel` with a tolerant parser; `ListEmailHeaderExtension.twpWarnings` extracts and indexes the warnings (the header set is already fetched via `EmailProperty.headers`); `PresentationEmail.isTwpWarningDismissed(index)`; positional `twp-warning-dismissed-<index>` keyword helpers.
- **Display**: `TwpWarningBanner` widget + a `TwpWarningCodeResolver` registry (`suspicious-sender`, `virus`, `virus-removed`) — easy to extend with new codes. Inserted in `EmailView` right after the header block.
- **Dismiss**: per-position keyword persisted through a `SetEmail` flow (`DismissTwpWarningInteractor` -> `EmailRepository` -> `EmailApi`), mirroring the existing unsubscribe/markAsStar flows. Applied optimistically and **disabled while offline**.

### Tests
- Added `ListEmailHeaderExtension.twpWarnings` parser tests (single/multiple warnings, positional indexes, missing/unknown tokens defaulting to `info`).

> Note: a Flutter/Dart toolchain was not available in this environment, so the change was not compiled locally. It closely mirrors the existing `unsubscribe` and `markAsStar` data/interactor flows. Generated mocks (`*.mocks.dart`, git-ignored) are regenerated by build_runner; the `@GenerateNiceMocks` annotation was updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-email **X-TWP-Message** warning banners with severity styling, localized messages (when a matching code exists), and dismiss buttons per warning.
  * Dismissals update the UI immediately and persist so the banner stays hidden after reopening.
  * Added support for dismiss state tracking at the email level.
* **Bug Fixes**
  * Improved dismissal behavior and user-facing error handling for urgent failure scenarios.
* **Tests**
  * Added unit/widget/provider and end-to-end coverage for warning parsing, rendering/dismissal, and urgent exception routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->