### PR TITLE
Remove cancel button on send

### DIFF
--- a/lib/features/composer/domain/exceptions/compose_email_exception.dart
+++ b/lib/features/composer/domain/exceptions/compose_email_exception.dart
@@ -1,12 +1,5 @@
 import 'package:core/domain/exceptions/app_base_exception.dart';
 
-class SendingEmailCanceledException extends AppBaseException {
-  SendingEmailCanceledException([super.message]);
-
-  @override
-  String get exceptionName => 'SendingEmailCanceledException';
-}
-
 class SavingEmailToDraftsCanceledException extends AppBaseException {
   SavingEmailToDraftsCanceledException([super.message]);
 

--- a/lib/features/composer/domain/state/send_email_state.dart
+++ b/lib/features/composer/domain/state/send_email_state.dart
@@ -49,5 +49,3 @@ class SendEmailFailure extends FeatureFailure {
     sendingEmailActionType,
   ];
 }
-
-class CancelSendingEmail extends LoadingState {}

--- a/lib/features/composer/domain/usecases/create_new_and_send_email_interactor.dart
+++ b/lib/features/composer/domain/usecases/create_new_and_send_email_interactor.dart
@@ -2,11 +2,9 @@ import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:dartz/dartz.dart' as dartz;
-import 'package:dio/dio.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
-import 'package:tmail_ui_user/features/composer/domain/exceptions/compose_email_exception.dart';
 import 'package:tmail_ui_user/features/composer/domain/repository/composer_repository.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/generate_email_state.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/send_email_state.dart';
@@ -15,7 +13,6 @@ import 'package:tmail_ui_user/features/composer/presentation/model/create_email_
 import 'package:tmail_ui_user/features/email/domain/exceptions/email_exceptions.dart';
 import 'package:tmail_ui_user/features/email/domain/repository/email_repository.dart';
 import 'package:tmail_ui_user/features/sending_queue/presentation/model/sending_email_arguments.dart';
-import 'package:tmail_ui_user/main/exceptions/remote/unknown_remote_exception.dart';
 
 class CreateNewAndSendEmailInteractor {
   final EmailRepository _emailRepository;
@@ -28,7 +25,6 @@ class CreateNewAndSendEmailInteractor {
 
   Stream<dartz.Either<Failure, Success>> execute({
     required CreateEmailRequest createEmailRequest,
-    CancelToken? cancelToken
   }) async* {
     SendingEmailArguments? sendingEmailArguments;
     try {
@@ -44,7 +40,6 @@ class CreateNewAndSendEmailInteractor {
           sendingEmailArguments.accountId,
           sendingEmailArguments.emailRequest,
           mailboxRequest: sendingEmailArguments.mailboxRequest,
-          cancelToken: cancelToken
         );
 
         if (sendingEmailArguments.emailRequest.emailIdDestroyed != null) {
@@ -52,7 +47,6 @@ class CreateNewAndSendEmailInteractor {
             session: sendingEmailArguments.session,
             accountId: sendingEmailArguments.accountId,
             draftEmailId: sendingEmailArguments.emailRequest.emailIdDestroyed!,
-            cancelToken: cancelToken
           );
         }
 
@@ -66,23 +60,13 @@ class CreateNewAndSendEmailInteractor {
       }
     } catch (e) {
       logWarning('CreateNewAndSendEmailInteractor::execute: Exception: $e');
-      if (e is UnknownRemoteException && e.error is List<SendingEmailCanceledException>) {
-        yield dartz.Left<Failure, Success>(SendEmailFailure(
-          exception: SendingEmailCanceledException(),
-          session: sendingEmailArguments?.session,
-          accountId: sendingEmailArguments?.accountId,
-          emailRequest: sendingEmailArguments?.emailRequest,
-          mailboxRequest: sendingEmailArguments?.mailboxRequest,
-        ));
-      } else {
-        yield dartz.Left<Failure, Success>(SendEmailFailure(
-          exception: e,
-          session: sendingEmailArguments?.session,
-          accountId: sendingEmailArguments?.accountId,
-          emailRequest: sendingEmailArguments?.emailRequest,
-          mailboxRequest: sendingEmailArguments?.mailboxRequest,
-        ));
-      }
+      yield dartz.Left<Failure, Success>(SendEmailFailure(
+        exception: e,
+        session: sendingEmailArguments?.session,
+        accountId: sendingEmailArguments?.accountId,
+        emailRequest: sendingEmailArguments?.emailRequest,
+        mailboxRequest: sendingEmailArguments?.mailboxRequest,
+      ));
     }
   }
 
@@ -101,14 +85,12 @@ class CreateNewAndSendEmailInteractor {
     required Session session,
     required AccountId accountId,
     required EmailId draftEmailId,
-    CancelToken? cancelToken
   }) async {
     try {
       await _emailRepository.deleteEmailPermanently(
         session,
         accountId,
         draftEmailId,
-        cancelToken: cancelToken
       );
     } catch (e) {
       logWarning('CreateNewAndSendEmailInteractor::_deleteOldDraftsEmail: Exception: $e');

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -970,14 +970,12 @@ class ComposerController extends BaseController
     required String emailContent,
   }) async {
     final uploadUri = _getUploadUriFromSession(session, accountId);
-    final cancelToken = CancelToken();
     final resultState = await _showSendingMessageDialog(
       session: session,
       accountId: accountId,
       arguments: arguments,
       emailContent: emailContent,
       uploadUri: uploadUri,
-      cancelToken: cancelToken,
     );
 
     if (resultState is SendEmailSuccess ||
@@ -985,9 +983,6 @@ class ComposerController extends BaseController
             .validateSendingEmailFailedWhenNetworkIsLostOnMobile(resultState)) {
       _sendButtonState = ButtonState.enabled;
       _closeComposerAction(result: resultState);
-    } else if (resultState is SendEmailFailure &&
-        resultState.exception is SendingEmailCanceledException) {
-      _sendButtonState = ButtonState.enabled;
     } else if (resultState is SendEmailFailure ||
         resultState is GenerateEmailFailure) {
       if (resultState.exception is BadCredentialsException) {
@@ -1029,7 +1024,6 @@ class ComposerController extends BaseController
     required ComposerArguments arguments,
     required String emailContent,
     required Uri? uploadUri,
-    CancelToken? cancelToken,
   }) {
     final childWidget = PointerInterceptor(
       child: SendingMessageDialogView(
@@ -1062,8 +1056,6 @@ class ComposerController extends BaseController
           uploadUri: uploadUri,
         ),
         createNewAndSendEmailInteractor: _createNewAndSendEmailInteractor,
-        onCancelSendingEmailAction: _handleCancelSendingMessage,
-        cancelToken: cancelToken,
       ),
     );
 
@@ -1074,10 +1066,6 @@ class ComposerController extends BaseController
       barrierDismissible: false,
       barrierColor: AppColor.colorDefaultCupertinoActionSheet,
     );
-  }
-
-  void _handleCancelSendingMessage({CancelToken? cancelToken}) {
-    cancelToken?.cancel([SendingEmailCanceledException()]);
   }
 
   Future<void> _showConfirmDialogWhenSendMessageFailure({

--- a/lib/features/composer/presentation/widgets/sending_message_dialog_view.dart
+++ b/lib/features/composer/presentation/widgets/sending_message_dialog_view.dart
@@ -5,36 +5,26 @@ import 'package:core/presentation/extensions/capitalize_extension.dart';
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
-import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:dartz/dartz.dart' as dartz;
-import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:tmail_ui_user/features/composer/domain/exceptions/compose_email_exception.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/generate_email_state.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/send_email_state.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/create_new_and_send_email_interactor.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/create_email_request.dart';
-import 'package:tmail_ui_user/main/exceptions/remote/unknown_remote_exception.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
-
-typedef OnCancelSendingEmailAction = Function({CancelToken? cancelToken});
 
 class SendingMessageDialogView extends StatefulWidget {
 
   final CreateEmailRequest createEmailRequest;
   final CreateNewAndSendEmailInteractor createNewAndSendEmailInteractor;
-  final OnCancelSendingEmailAction? onCancelSendingEmailAction;
-  final CancelToken? cancelToken;
 
   const SendingMessageDialogView({
     super.key,
     required this.createEmailRequest,
     required this.createNewAndSendEmailInteractor,
-    this.onCancelSendingEmailAction,
-    this.cancelToken,
   });
 
   @override
@@ -52,7 +42,6 @@ class _SendingMessageDialogViewState extends State<SendingMessageDialogView> {
     _streamSubscription = widget.createNewAndSendEmailInteractor
       .execute(
         createEmailRequest: widget.createEmailRequest,
-        cancelToken: widget.cancelToken
       )
       .listen(
         _handleDataStream,
@@ -79,11 +68,7 @@ class _SendingMessageDialogViewState extends State<SendingMessageDialogView> {
 
   void _handleErrorStream(Object error, StackTrace stackTrace) {
     logWarning('_SendingMessageDialogViewState::_handleErrorStream: Exception = $error');
-    if (error is UnknownRemoteException && error.error is List<SendingEmailCanceledException>) {
-      popBack(result: SendEmailFailure(exception: SendingEmailCanceledException()));
-    } else {
-      popBack(result: SendEmailFailure(exception: error));
-    }
+    popBack(result: SendEmailFailure(exception: error));
   }
 
   @override
@@ -196,23 +181,6 @@ class _SendingMessageDialogViewState extends State<SendingMessageDialogView> {
                     ],
                   ),
                 ),
-                if (widget.onCancelSendingEmailAction != null)
-                  Align(
-                    alignment: AlignmentDirectional.centerEnd,
-                    child: TMailButtonWidget.fromText(
-                      text: AppLocalizations.of(context).cancel,
-                      textStyle: Theme.of(context).textTheme.labelSmall?.copyWith(
-                        color: Colors.black87,
-                        fontSize: 15
-                      ),
-                      padding: const EdgeInsetsDirectional.symmetric(horizontal: 20, vertical: 8),
-                      margin: const EdgeInsetsDirectional.only(start: 12, end: 12, bottom: 16),
-                      onTapActionCallback: () {
-                        _viewStateNotifier.value = dartz.Right<Failure, Success>(CancelSendingEmail());
-                        widget.onCancelSendingEmailAction!(cancelToken: widget.cancelToken);
-                      },
-                    ),
-                  )
               ],
             )
           ],
@@ -224,8 +192,6 @@ class _SendingMessageDialogViewState extends State<SendingMessageDialogView> {
   String _getStatusMessage(Success success) {
     if (success is GenerateEmailLoading) {
       return AppLocalizations.of(context).creatingMessage;
-    } else if (success is CancelSendingEmail) {
-      return AppLocalizations.of(context).canceling;
     } else {
       return AppLocalizations.of(context).sendingMessage;
     }

--- a/test/features/composer/domain/usecases/create_new_and_send_email_interactor_test.dart
+++ b/test/features/composer/domain/usecases/create_new_and_send_email_interactor_test.dart
@@ -103,7 +103,6 @@ void main() {
         any,
         any,
         mailboxRequest: anyNamed('mailboxRequest'),
-        cancelToken: anyNamed('cancelToken'),
       )).thenAnswer((_) async {});
 
       // act
@@ -124,7 +123,6 @@ void main() {
         any,
         any,
         mailboxRequest: anyNamed('mailboxRequest'),
-        cancelToken: anyNamed('cancelToken'),
       )).called(1);
     });
 
@@ -140,7 +138,6 @@ void main() {
         any,
         any,
         mailboxRequest: anyNamed('mailboxRequest'),
-        cancelToken: anyNamed('cancelToken'),
       )).thenThrow(exception);
 
       // act
@@ -172,13 +169,11 @@ void main() {
         any,
         any,
         mailboxRequest: anyNamed('mailboxRequest'),
-        cancelToken: anyNamed('cancelToken'),
       )).thenAnswer((_) async {});
       when(emailRepository.deleteEmailPermanently(
         any,
         any,
         any,
-        cancelToken: anyNamed('cancelToken'),
       )).thenAnswer((_) async => true);
 
       // act
@@ -191,7 +186,6 @@ void main() {
         any,
         any,
         draftsEmailId,
-        cancelToken: anyNamed('cancelToken'),
       )).called(1);
     });
   });

--- a/test/features/composer/domain/usecases/create_new_and_send_email_interactor_test.dart
+++ b/test/features/composer/domain/usecases/create_new_and_send_email_interactor_test.dart
@@ -11,6 +11,7 @@ import 'package:tmail_ui_user/features/composer/domain/state/generate_email_stat
 import 'package:tmail_ui_user/features/composer/domain/state/send_email_state.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/create_new_and_send_email_interactor.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/create_email_request.dart';
+import 'package:tmail_ui_user/features/email/domain/exceptions/email_exceptions.dart';
 import 'package:tmail_ui_user/features/email/domain/repository/email_repository.dart';
 
 import '../../../../fixtures/account_fixtures.dart';
@@ -153,6 +154,129 @@ void main() {
         .firstOrNull;
       expect(failure, isNotNull);
       expect(failure!.exception, exception);
+    });
+
+    test(
+      'should propagate the sending context on SendEmailFailure '
+      'when sendEmail throws',
+    () async {
+      // arrange
+      final createEmailRequest = buildCreateEmailRequest();
+      when(emailRepository.sendEmail(
+        any,
+        any,
+        any,
+        mailboxRequest: anyNamed('mailboxRequest'),
+      )).thenThrow(Exception('send failed'));
+
+      // act
+      final states = await createNewAndSendEmailInteractor
+        .execute(createEmailRequest: createEmailRequest)
+        .toList();
+
+      // assert
+      final failure = states
+        .whereType<Left>()
+        .map((left) => left.value)
+        .whereType<SendEmailFailure>()
+        .first;
+      expect(failure.session, SessionFixtures.aliceSession);
+      expect(failure.accountId, AccountFixtures.aliceAccountId);
+      expect(failure.emailRequest, isNotNull);
+    });
+
+    test(
+      'should emit GenerateEmailFailure and not call sendEmail '
+      'when the email object cannot be created',
+    () async {
+      // arrange
+      final createEmailRequest = buildCreateEmailRequest();
+      when(composerRepository.generateEmail(
+        any,
+        withIdentityHeader: anyNamed('withIdentityHeader'),
+        isDraft: anyNamed('isDraft'),
+      )).thenThrow(Exception('cannot generate email'));
+
+      // act
+      final states = await createNewAndSendEmailInteractor
+        .execute(createEmailRequest: createEmailRequest)
+        .toList();
+
+      // assert
+      final failure = states
+        .whereType<Left>()
+        .map((left) => left.value)
+        .whereType<GenerateEmailFailure>()
+        .firstOrNull;
+      expect(failure, isNotNull);
+      expect(failure!.exception, isA<CannotCreateEmailObjectException>());
+      verifyNever(emailRepository.sendEmail(
+        any,
+        any,
+        any,
+        mailboxRequest: anyNamed('mailboxRequest'),
+      ));
+    });
+
+    test(
+      'should not delete any draft after sending '
+      'when emailIdDestroyed is not set',
+    () async {
+      // arrange
+      final createEmailRequest = buildCreateEmailRequest();
+      when(emailRepository.sendEmail(
+        any,
+        any,
+        any,
+        mailboxRequest: anyNamed('mailboxRequest'),
+      )).thenAnswer((_) async {});
+
+      // act
+      await createNewAndSendEmailInteractor
+        .execute(createEmailRequest: createEmailRequest)
+        .toList();
+
+      // assert
+      verifyNever(emailRepository.deleteEmailPermanently(any, any, any));
+    });
+
+    test(
+      'should still emit SendEmailSuccess '
+      'when deleting the old draft fails',
+    () async {
+      // arrange
+      final draftsEmailId = EmailId(Id('draft-email-id'));
+      final createEmailRequest = buildCreateEmailRequest(
+        draftsEmailId: draftsEmailId,
+      );
+      when(emailRepository.sendEmail(
+        any,
+        any,
+        any,
+        mailboxRequest: anyNamed('mailboxRequest'),
+      )).thenAnswer((_) async {});
+      when(emailRepository.deleteEmailPermanently(
+        any,
+        any,
+        any,
+      )).thenThrow(Exception('delete draft failed'));
+
+      // act
+      final states = await createNewAndSendEmailInteractor
+        .execute(createEmailRequest: createEmailRequest)
+        .toList();
+
+      // assert
+      final successStates = states
+        .whereType<Right>()
+        .map((right) => right.value)
+        .toList();
+      expect(successStates.last, isA<SendEmailSuccess>());
+      verify(emailRepository.deleteEmailPermanently(
+        any,
+        any,
+        draftsEmailId,
+      )).called(1);
     });
 
     test(

--- a/test/features/composer/domain/usecases/create_new_and_send_email_interactor_test.dart
+++ b/test/features/composer/domain/usecases/create_new_and_send_email_interactor_test.dart
@@ -1,10 +1,14 @@
+import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:model/email/email_action_type.dart';
 import 'package:model/extensions/session_extension.dart';
 import 'package:tmail_ui_user/features/composer/domain/repository/composer_repository.dart';
+import 'package:tmail_ui_user/features/composer/domain/state/generate_email_state.dart';
+import 'package:tmail_ui_user/features/composer/domain/state/send_email_state.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/create_new_and_send_email_interactor.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/create_email_request.dart';
 import 'package:tmail_ui_user/features/email/domain/repository/email_repository.dart';
@@ -23,6 +27,31 @@ void main() {
   final createNewAndSendEmailInteractor = CreateNewAndSendEmailInteractor(
     emailRepository,
     composerRepository);
+
+  CreateEmailRequest buildCreateEmailRequest({EmailId? draftsEmailId}) {
+    return CreateEmailRequest(
+      session: SessionFixtures.aliceSession,
+      accountId: AccountFixtures.aliceAccountId,
+      emailActionType: EmailActionType.editDraft,
+      ownEmailAddress: SessionFixtures
+        .aliceSession
+        .getOwnEmailAddressOrEmpty(),
+      subject: 'subject',
+      emailContent: 'emailContent',
+      draftsEmailId: draftsEmailId,
+    );
+  }
+
+  setUp(() {
+    reset(emailRepository);
+    reset(composerRepository);
+    when(composerRepository.generateEmail(
+      any,
+      withIdentityHeader: anyNamed('withIdentityHeader'),
+      isDraft: anyNamed('isDraft'),
+    )).thenAnswer((_) async => Email());
+  });
+
   group('create new and send email interactor test:', () {
     test(
       'should call generateEmail from composerRepository with withIdentityHeader is false '
@@ -60,6 +89,109 @@ void main() {
         createEmailRequest,
         withIdentityHeader: false,
         isDraft: false,
+      )).called(1);
+    });
+
+    test(
+      'should emit GenerateEmailLoading, SendEmailLoading and SendEmailSuccess '
+      'and call sendEmail when sending succeeds',
+    () async {
+      // arrange
+      final createEmailRequest = buildCreateEmailRequest();
+      when(emailRepository.sendEmail(
+        any,
+        any,
+        any,
+        mailboxRequest: anyNamed('mailboxRequest'),
+        cancelToken: anyNamed('cancelToken'),
+      )).thenAnswer((_) async {});
+
+      // act
+      final states = await createNewAndSendEmailInteractor
+        .execute(createEmailRequest: createEmailRequest)
+        .toList();
+
+      // assert
+      final successStates = states
+        .whereType<Right>()
+        .map((right) => right.value)
+        .toList();
+      expect(successStates[0], isA<GenerateEmailLoading>());
+      expect(successStates[1], isA<SendEmailLoading>());
+      expect(successStates.last, isA<SendEmailSuccess>());
+      verify(emailRepository.sendEmail(
+        any,
+        any,
+        any,
+        mailboxRequest: anyNamed('mailboxRequest'),
+        cancelToken: anyNamed('cancelToken'),
+      )).called(1);
+    });
+
+    test(
+      'should emit SendEmailFailure carrying the thrown exception '
+      'when sendEmail throws',
+    () async {
+      // arrange
+      final createEmailRequest = buildCreateEmailRequest();
+      final exception = Exception('send failed');
+      when(emailRepository.sendEmail(
+        any,
+        any,
+        any,
+        mailboxRequest: anyNamed('mailboxRequest'),
+        cancelToken: anyNamed('cancelToken'),
+      )).thenThrow(exception);
+
+      // act
+      final states = await createNewAndSendEmailInteractor
+        .execute(createEmailRequest: createEmailRequest)
+        .toList();
+
+      // assert
+      final failure = states
+        .whereType<Left>()
+        .map((left) => left.value)
+        .whereType<SendEmailFailure>()
+        .firstOrNull;
+      expect(failure, isNotNull);
+      expect(failure!.exception, exception);
+    });
+
+    test(
+      'should delete the old draft after sending '
+      'when emailIdDestroyed is set',
+    () async {
+      // arrange
+      final draftsEmailId = EmailId(Id('draft-email-id'));
+      final createEmailRequest = buildCreateEmailRequest(
+        draftsEmailId: draftsEmailId,
+      );
+      when(emailRepository.sendEmail(
+        any,
+        any,
+        any,
+        mailboxRequest: anyNamed('mailboxRequest'),
+        cancelToken: anyNamed('cancelToken'),
+      )).thenAnswer((_) async {});
+      when(emailRepository.deleteEmailPermanently(
+        any,
+        any,
+        any,
+        cancelToken: anyNamed('cancelToken'),
+      )).thenAnswer((_) async => true);
+
+      // act
+      await createNewAndSendEmailInteractor
+        .execute(createEmailRequest: createEmailRequest)
+        .toList();
+
+      // assert
+      verify(emailRepository.deleteEmailPermanently(
+        any,
+        any,
+        draftsEmailId,
+        cancelToken: anyNamed('cancelToken'),
       )).called(1);
     });
   });

--- a/test/features/composer/domain/usecases/create_new_and_send_email_interactor_test.dart
+++ b/test/features/composer/domain/usecases/create_new_and_send_email_interactor_test.dart
@@ -116,9 +116,14 @@ void main() {
         .whereType<Right>()
         .map((right) => right.value)
         .toList();
-      expect(successStates[0], isA<GenerateEmailLoading>());
-      expect(successStates[1], isA<SendEmailLoading>());
-      expect(successStates.last, isA<SendEmailSuccess>());
+      expect(
+        successStates.map((state) => state.runtimeType).toList(),
+        equals([
+          GenerateEmailLoading,
+          SendEmailLoading,
+          SendEmailSuccess,
+        ]),
+      );
       verify(emailRepository.sendEmail(
         any,
         any,
@@ -271,6 +276,7 @@ void main() {
         .whereType<Right>()
         .map((right) => right.value)
         .toList();
+      expect(states.whereType<Left>(), isEmpty);
       expect(successStates.last, isA<SendEmailSuccess>());
       verify(emailRepository.deleteEmailPermanently(
         any,

--- a/test/features/composer/presentation/widgets/sending_message_dialog_view_test.dart
+++ b/test/features/composer/presentation/widgets/sending_message_dialog_view_test.dart
@@ -1,0 +1,77 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/email/email_action_type.dart';
+import 'package:model/extensions/session_extension.dart';
+import 'package:tmail_ui_user/features/composer/domain/state/generate_email_state.dart';
+import 'package:tmail_ui_user/features/composer/domain/state/send_email_state.dart';
+import 'package:tmail_ui_user/features/composer/domain/usecases/create_new_and_send_email_interactor.dart';
+import 'package:tmail_ui_user/features/composer/presentation/model/create_email_request.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/sending_message_dialog_view.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import '../../../../fixtures/session_fixtures.dart';
+import '../../../../fixtures/widget_fixtures.dart';
+import 'sending_message_dialog_view_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<CreateNewAndSendEmailInteractor>(),
+])
+void main() {
+  final interactor = MockCreateNewAndSendEmailInteractor();
+
+  final createEmailRequest = CreateEmailRequest(
+    session: SessionFixtures.aliceSession,
+    accountId: AccountFixtures.aliceAccountId,
+    emailActionType: EmailActionType.editDraft,
+    ownEmailAddress: SessionFixtures.aliceSession.getOwnEmailAddressOrEmpty(),
+    subject: 'subject',
+    emailContent: 'emailContent',
+  );
+
+  Widget buildDialog() {
+    return WidgetFixtures.makeTestableWidget(
+      child: SendingMessageDialogView(
+        createEmailRequest: createEmailRequest,
+        createNewAndSendEmailInteractor: interactor,
+      ),
+    );
+  }
+
+  setUp(() {
+    reset(interactor);
+  });
+
+  group('SendingMessageDialogView', () {
+    testWidgets(
+      'should show the sending progress without a Cancel button '
+      'while the email is being sent',
+      (tester) async {
+        // arrange: keep the stream on the loading states so the dialog
+        // stays open (terminal states pop the dialog back).
+        when(interactor.execute(
+          createEmailRequest: anyNamed('createEmailRequest'),
+        )).thenAnswer((_) => Stream.fromIterable([
+          Right<Failure, Success>(GenerateEmailLoading()),
+          Right<Failure, Success>(SendEmailLoading()),
+        ]));
+
+        // act
+        await tester.pumpWidget(buildDialog());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        // assert: the dialog renders its progress UI ...
+        expect(find.byType(LinearProgressIndicator), findsOneWidget);
+        // ... but never offers a Cancel button (the removed behaviour).
+        expect(find.text(AppLocalizations().cancel), findsNothing);
+        expect(find.text(AppLocalizations().canceling), findsNothing);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #4436

## What

Removes the **Cancel** button from the "Sending message" dialog (`SendingMessageDialogView`) and tears down the now-dead cancellation code paths it triggered, as requested in the issue ("Yes full cleanup").

## Changes

- `sending_message_dialog_view.dart`: remove the cancel button, the `OnCancelSendingEmailAction` typedef, the `onCancelSendingEmailAction` / `cancelToken` fields, the `CancelSendingEmail` status branch, and the `SendingEmailCanceledException` error handling.
- `composer_controller.dart`: drop the `_handleCancelSendingMessage` callback, the `CancelToken` created for the send flow, and the unreachable `SendingEmailCanceledException` branch in `_sendMessageToServer`.
- `create_new_and_send_email_interactor.dart`: remove the `CancelToken` parameter (no longer cancellable) and the `SendingEmailCanceledException` catch branch.
- `send_email_state.dart`: remove the unused `CancelSendingEmail` state.
- `compose_email_exception.dart`: remove the now-unused `SendingEmailCanceledException`.

## Scope note

The separate **save-to-drafts** cancel feature (`SavingMessageDialogView` / `SavingEmailToDraftsCanceledException`) is intentionally left untouched — the issue concerns the send action only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sending now uses a unified failure handling path with fewer cancellation/interruption states.
  * The sending dialog no longer offers email cancellation, and cancellation-specific status handling was removed.
* **Refactor**
  * Removed cancellation plumbing from the sending interactor, controller, dialog view, and related cancellation exception/state.
  * Simplified error mapping to a single `SendEmailFailure` outcome with preserved context.
* **Tests**
  * Updated/expanded interactor tests to assert emitted state sequences and draft cleanup behavior.
  * Added a widget test to verify the dialog shows progress without any cancel UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->