### PR TITLE
Publish linagora/tmail-web-pr images to ease self testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,8 @@ pipeline {
 
     environment {
         FLUTTER_VERSION = '3.38.9'
+        DOCKER_HUB_CREDENTIAL = credentials('dockerHub')
+        GITHUB_CREDENTIAL = credentials('github')
     }
 
     stages {
@@ -27,6 +29,82 @@ pipeline {
             steps {
                 sh './scripts/patrol-web-integration-test-with-docker.sh'
             }
+        }
+
+        stage('Deliver Docker image for PR') {
+          when {
+            changeRequest()
+          }
+          steps {
+            script {
+              if (env.CHANGE_FORK) {
+                def forkOwner = env.CHANGE_FORK.split('/')[0]
+                def memberStatus = sh(
+                  script: """curl -s -o /dev/null -w "%{http_code}" \
+                    -H "Authorization: token \${GITHUB_CREDENTIAL_PSW}" \
+                    "https://api.github.com/orgs/linagora/members/${forkOwner}" """,
+                  returnStdout: true
+                ).trim()
+                echo "GitHub org membership check returned HTTP ${memberStatus} for '${forkOwner}'"
+                if (memberStatus == '204') {
+                  echo "Fork owner '${forkOwner}' is a linagora org member, proceeding."
+                } else if (memberStatus == '404') {
+                  echo "Fork owner '${forkOwner}' is not a member of the linagora organization."
+                  def approvedByMember = false
+                  def commentsJson = sh(
+                    script: """curl -s \
+                      -H "Authorization: token \${GITHUB_CREDENTIAL_PSW}" \
+                      "https://api.github.com/repos/linagora/tmail-flutter/issues/\${CHANGE_ID}/comments" """,
+                    returnStdout: true
+                  ).trim()
+                  def comments = new groovy.json.JsonSlurper().parseText(commentsJson)
+                  for (comment in comments) {
+                    if (comment.body.trim().toLowerCase() == 'build this please') {
+                      def commenter = comment.user.login
+                      def commenterStatus = sh(
+                        script: """curl -s -o /dev/null -w "%{http_code}" \
+                          -H "Authorization: token \${GITHUB_CREDENTIAL_PSW}" \
+                          "https://api.github.com/orgs/linagora/members/${commenter}" """,
+                        returnStdout: true
+                      ).trim()
+                      if (commenterStatus == '204') {
+                        echo "Build approved by linagora member '${commenter}', proceeding."
+                        approvedByMember = true
+                        break
+                      }
+                    }
+                  }
+                  if (!approvedByMember) {
+                    echo "No linagora member approval found. Skipping PR image delivery."
+                    return
+                  }
+                } else if (memberStatus == '401' || memberStatus == '403') {
+                  error("Authentication/permission error validating fork owner: ${memberStatus}")
+                } else {
+                  error("GitHub API error ${memberStatus} while checking membership for '${forkOwner}'")
+                }
+              }
+
+              // Build and push the web Docker image tagged with the PR number to ease testing.
+              sh '''
+                docker build --build-arg FLUTTER_VERSION=$FLUTTER_VERSION -t linagora/tmail-web-pr:$CHANGE_ID .
+                echo "$DOCKER_HUB_CREDENTIAL_PSW" | docker login -u "$DOCKER_HUB_CREDENTIAL_USR" --password-stdin
+                docker push linagora/tmail-web-pr:$CHANGE_ID
+                docker logout
+              '''
+              sh """
+                HTTP_STATUS=\$(curl -s -o /tmp/gh_comment_response.json -w "%{http_code}" -X POST \\
+                  -H "Authorization: token \${GITHUB_CREDENTIAL_PSW}" \\
+                  -H "Content-Type: application/json" \\
+                  -d "{\\"body\\": \\"Docker image published for this PR: linagora/tmail-web-pr:\${CHANGE_ID}\\"}" \\
+                  "https://api.github.com/repos/linagora/tmail-flutter/issues/\${CHANGE_ID}/comments")
+                if [ "\$HTTP_STATUS" -lt 200 ] || [ "\$HTTP_STATUS" -ge 300 ]; then
+                  echo "WARNING: GitHub API comment failed with HTTP \$HTTP_STATUS"
+                  cat /tmp/gh_comment_response.json
+                fi
+              """
+            }
+          }
         }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,8 +14,6 @@ pipeline {
 
     environment {
         FLUTTER_VERSION = '3.38.9'
-        DOCKER_HUB_CREDENTIAL = credentials('dockerHub')
-        GITHUB_CREDENTIAL = credentials('github')
     }
 
     stages {
@@ -35,6 +33,10 @@ pipeline {
           when {
             changeRequest()
           }
+          environment {
+            DOCKER_HUB_CREDENTIAL = credentials('dockerHub')
+            GITHUB_CREDENTIAL = credentials('github')
+          }
           steps {
             script {
               if (env.CHANGE_FORK) {
@@ -51,12 +53,16 @@ pipeline {
                 } else if (memberStatus == '404') {
                   echo "Fork owner '${forkOwner}' is not a member of the linagora organization."
                   def approvedByMember = false
-                  def commentsJson = sh(
-                    script: """curl -s \
+                  def commentsStatus = sh(
+                    script: """curl -s -o /tmp/pr_comments_${CHANGE_ID}.json -w "%{http_code}" \
                       -H "Authorization: token \${GITHUB_CREDENTIAL_PSW}" \
                       "https://api.github.com/repos/linagora/tmail-flutter/issues/\${CHANGE_ID}/comments" """,
                     returnStdout: true
                   ).trim()
+                  if (commentsStatus != '200') {
+                    error("GitHub API error ${commentsStatus} while fetching PR comments for approval check")
+                  }
+                  def commentsJson = readFile("/tmp/pr_comments_${CHANGE_ID}.json")
                   def comments = new groovy.json.JsonSlurper().parseText(commentsJson)
                   for (comment in comments) {
                     if (comment.body.trim().toLowerCase() == 'build this please') {
@@ -87,10 +93,16 @@ pipeline {
 
               // Build and push the web Docker image tagged with the PR number to ease testing.
               sh '''
+                set -eu
+                export DOCKER_CONFIG="$(mktemp -d)"
+                cleanup() {
+                  docker logout || true
+                  rm -rf "$DOCKER_CONFIG"
+                }
+                trap cleanup EXIT
                 docker build --build-arg FLUTTER_VERSION=$FLUTTER_VERSION -t linagora/tmail-web-pr:$CHANGE_ID .
                 echo "$DOCKER_HUB_CREDENTIAL_PSW" | docker login -u "$DOCKER_HUB_CREDENTIAL_USR" --password-stdin
                 docker push linagora/tmail-web-pr:$CHANGE_ID
-                docker logout
               '''
               sh """
                 HTTP_STATUS=\$(curl -s -o /tmp/gh_comment_response.json -w "%{http_code}" -X POST \\


### PR DESCRIPTION
Cc @Arsnael 

For context @hoangdat that will allow me to self test easily my changes on Web...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated workflow to build and publish PR-tagged Docker images.
  * When delivery succeeds, the workflow posts a comment announcing the published image details.
  * For forked pull requests, image delivery is allowed only after an explicit approval signal is detected and confirmed as coming from an authorized org member.
  * If approval or authorization checks fail, the delivery step is skipped or the build fails accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->