### PR TITLE
[Sentry] fix UnsupportedError FixedLengthListMixin.clear

### DIFF
--- a/lib/features/push_notification/data/repository/fcm_repository_impl.dart
+++ b/lib/features/push_notification/data/repository/fcm_repository_impl.dart
@@ -21,6 +21,7 @@ import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:tmail_ui_user/features/mailbox/data/datasource/mailbox_datasource.dart';
 import 'package:tmail_ui_user/features/push_notification/data/datasource/fcm_datasource.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/exceptions/fcm_exception.dart';
+import 'package:tmail_ui_user/features/push_notification/domain/model/email_changes_properties.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/model/register_new_token_request.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/model/update_token_expired_time_request.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/repository/fcm_repository.dart';
@@ -44,18 +45,15 @@ class FCMRepositoryImpl extends FCMRepository {
   Future<EmailsResponse> getEmailChangesToPushNotification(
     Session session,
     AccountId accountId,
-    jmap.State currentState,
-    {
-      Properties? propertiesCreated,
-      Properties? propertiesUpdated
-    }
-  ) async {
+    jmap.State currentState, {
+    EmailChangesProperties? properties,
+  }) async {
     final emailChangeResponse = await _threadDataSource.getAllEmailChanges(
       session,
       accountId,
       currentState,
-      propertiesCreated: propertiesCreated,
-      propertiesUpdated: propertiesUpdated
+      propertiesCreated: properties?.created,
+      propertiesUpdated: properties?.updated,
     );
 
     final listEmails = emailChangeResponse?.created ?? [];
@@ -141,18 +139,15 @@ class FCMRepositoryImpl extends FCMRepository {
   Future<List<EmailId>> getEmailChangesToRemoveNotification(
     Session session,
     AccountId accountId,
-    jmap.State currentState,
-    {
-      Properties? propertiesCreated,
-      Properties? propertiesUpdated
-    }
-  ) async {
+    jmap.State currentState, {
+    EmailChangesProperties? properties,
+  }) async {
     final emailChangeResponse = await _threadDataSource.getAllEmailChanges(
       session,
       accountId,
       currentState,
-      propertiesCreated: propertiesCreated,
-      propertiesUpdated: propertiesUpdated
+      propertiesCreated: properties?.created,
+      propertiesUpdated: properties?.updated,
     );
 
     if (emailChangeResponse != null) {

--- a/lib/features/push_notification/domain/model/email_changes_properties.dart
+++ b/lib/features/push_notification/domain/model/email_changes_properties.dart
@@ -1,0 +1,14 @@
+import 'package:equatable/equatable.dart';
+import 'package:jmap_dart_client/jmap/core/properties/properties.dart';
+
+/// JMAP `Email` properties to fetch when resolving an `Email/changes` query:
+/// [created] for newly created emails, [updated] for modified ones.
+class EmailChangesProperties with EquatableMixin {
+  final Properties? created;
+  final Properties? updated;
+
+  const EmailChangesProperties({this.created, this.updated});
+
+  @override
+  List<Object?> get props => [created, updated];
+}

--- a/lib/features/push_notification/domain/repository/fcm_repository.dart
+++ b/lib/features/push_notification/domain/repository/fcm_repository.dart
@@ -3,11 +3,11 @@ import 'package:fcm/model/firebase_registration.dart';
 import 'package:fcm/model/firebase_registration_id.dart';
 import 'package:fcm/model/type_name.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
-import 'package:jmap_dart_client/jmap/core/properties/properties.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/push_notification/domain/model/email_changes_properties.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/model/register_new_token_request.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/model/update_token_expired_time_request.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/email_response.dart';
@@ -17,12 +17,9 @@ abstract class FCMRepository {
   Future<EmailsResponse> getEmailChangesToPushNotification(
     Session session,
     AccountId accountId,
-    jmap.State currentState,
-    {
-      Properties? propertiesCreated,
-      Properties? propertiesUpdated
-    }
-  );
+    jmap.State currentState, {
+    EmailChangesProperties? properties,
+  });
 
   Future<void> storeStateToRefresh(AccountId accountId, UserName userName, TypeName typeName, jmap.State newState);
 
@@ -49,12 +46,9 @@ abstract class FCMRepository {
   Future<List<EmailId>> getEmailChangesToRemoveNotification(
     Session session,
     AccountId accountId,
-    jmap.State currentState,
-    {
-      Properties? propertiesCreated,
-      Properties? propertiesUpdated
-    }
-  );
+    jmap.State currentState, {
+    EmailChangesProperties? properties,
+  });
 
   Future<List<EmailId>> getNewReceiveEmailFromNotification(Session session, AccountId accountId, jmap.State currentState);
 }

--- a/lib/features/push_notification/domain/usecases/get_email_changes_to_push_notification_interactor.dart
+++ b/lib/features/push_notification/domain/usecases/get_email_changes_to_push_notification_interactor.dart
@@ -37,7 +37,7 @@ class GetEmailChangesToPushNotificationInteractor {
 
       final presentationEmailList = emailsResponse.emailList
         ?.map((email) => email.toPresentationEmail())
-        .toList() ?? List.empty();
+        .toList() ?? [];
 
       yield Right<Failure, Success>(GetEmailChangesToPushNotificationSuccess(accountId, userName, presentationEmailList));
     } catch (e) {

--- a/lib/features/push_notification/domain/usecases/get_email_changes_to_push_notification_interactor.dart
+++ b/lib/features/push_notification/domain/usecases/get_email_changes_to_push_notification_interactor.dart
@@ -7,6 +7,7 @@ import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:model/extensions/email_extension.dart';
+import 'package:tmail_ui_user/features/push_notification/domain/model/email_changes_properties.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/repository/fcm_repository.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/state/get_email_changes_to_push_notification_state.dart';
 
@@ -32,8 +33,11 @@ class GetEmailChangesToPushNotificationInteractor {
         session,
         accountId,
         currentState,
-        propertiesCreated: propertiesCreated,
-        propertiesUpdated: propertiesUpdated);
+        properties: EmailChangesProperties(
+          created: propertiesCreated,
+          updated: propertiesUpdated,
+        ),
+      );
 
       final presentationEmailList = emailsResponse.emailList
         ?.map((email) => email.toPresentationEmail())

--- a/lib/features/push_notification/domain/usecases/get_email_changes_to_remove_notification_interactor.dart
+++ b/lib/features/push_notification/domain/usecases/get_email_changes_to_remove_notification_interactor.dart
@@ -8,6 +8,7 @@ import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 import 'package:tmail_ui_user/features/email/domain/repository/email_repository.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/exceptions/fcm_exception.dart';
+import 'package:tmail_ui_user/features/push_notification/domain/model/email_changes_properties.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/repository/fcm_repository.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/state/get_email_changes_to_remove_notification_state.dart';
 
@@ -36,8 +37,11 @@ class GetEmailChangesToRemoveNotificationInteractor {
           session,
           accountId,
           currentState,
-          propertiesCreated: propertiesCreated,
-          propertiesUpdated: propertiesUpdated);
+          properties: EmailChangesProperties(
+            created: propertiesCreated,
+            updated: propertiesUpdated,
+          ),
+        );
         yield Right<Failure, Success>(GetEmailChangesToRemoveNotificationSuccess(session.username, emailIds));
       } else {
         yield Left<Failure, Success>(GetEmailChangesToRemoveNotificationFailure(const NotFoundEmailStateException()));

--- a/lib/features/push_notification/presentation/listener/email_change_listener.dart
+++ b/lib/features/push_notification/presentation/listener/email_change_listener.dart
@@ -322,7 +322,7 @@ class EmailChangeListener extends ChangeListener {
         countNotifications: countNotifications);
     }
 
-    _emailsAvailablePushNotification.clear();
+    _emailsAvailablePushNotification = [];
   }
 
   void _handleRemoveNotificationWhenEmailMarkAsRead(jmap.State newState, AccountId accountId, Session? session) {

--- a/lib/features/push_notification/presentation/listener/email_change_listener.dart
+++ b/lib/features/push_notification/presentation/listener/email_change_listener.dart
@@ -298,7 +298,7 @@ class EmailChangeListener extends ChangeListener {
   }) async {
     log('EmailChangeListener::_handleLocalPushNotification(): EMAIL_LENGTH = ${emailList.length}');
     if (emailList.isEmpty) {
-      _emailsAvailablePushNotification.clear();
+      _emailsAvailablePushNotification = [];
       return;
     }
 

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -1230,8 +1230,8 @@ void main() {
           // after the (unawaited) call.
           composerController?.onLocalFileDropZoneListener(
             context: capturedContext,
-            details: DropDoneDetails(
-              files: const [],
+            details: const DropDoneDetails(
+              files: [],
               localPosition: Offset.zero,
               globalPosition: Offset.zero,
             ),

--- a/test/features/push_notification/domain/usecases/get_email_changes_to_push_notification_interactor_test.dart
+++ b/test/features/push_notification/domain/usecases/get_email_changes_to_push_notification_interactor_test.dart
@@ -1,9 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
-import 'package:jmap_dart_client/jmap/core/properties/properties.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:tmail_ui_user/features/push_notification/domain/model/email_changes_properties.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/repository/fcm_repository.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/state/get_email_changes_to_push_notification_state.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/usecases/get_email_changes_to_push_notification_interactor.dart';
@@ -21,15 +21,12 @@ class _FakeFCMRepository implements FCMRepository {
   _FakeFCMRepository(this.emailsResponse);
 
   @override
-    Future<EmailsResponse> getEmailChangesToPushNotification(
+  Future<EmailsResponse> getEmailChangesToPushNotification(
     Session session,
     AccountId accountId,
-    jmap.State currentState,
-    {
-      Properties? propertiesCreated,
-      Properties? propertiesUpdated
-    }
-  ) async =>
+    jmap.State currentState, {
+    EmailChangesProperties? properties,
+  }) async =>
       emailsResponse;
 
   @override

--- a/test/features/push_notification/domain/usecases/get_email_changes_to_push_notification_interactor_test.dart
+++ b/test/features/push_notification/domain/usecases/get_email_changes_to_push_notification_interactor_test.dart
@@ -1,9 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/properties/properties.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
-import 'package:tmail_ui_user/features/push_notification/domain/model/email_changes_properties.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/repository/fcm_repository.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/state/get_email_changes_to_push_notification_state.dart';
 import 'package:tmail_ui_user/features/push_notification/domain/usecases/get_email_changes_to_push_notification_interactor.dart';
@@ -21,12 +21,15 @@ class _FakeFCMRepository implements FCMRepository {
   _FakeFCMRepository(this.emailsResponse);
 
   @override
-  Future<EmailsResponse> getEmailChangesToPushNotification(
+    Future<EmailsResponse> getEmailChangesToPushNotification(
     Session session,
     AccountId accountId,
-    jmap.State currentState, {
-    EmailChangesProperties? properties,
-  }) async =>
+    jmap.State currentState,
+    {
+      Properties? propertiesCreated,
+      Properties? propertiesUpdated
+    }
+  ) async =>
       emailsResponse;
 
   @override

--- a/test/features/push_notification/domain/usecases/get_email_changes_to_push_notification_interactor_test.dart
+++ b/test/features/push_notification/domain/usecases/get_email_changes_to_push_notification_interactor_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
+import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:tmail_ui_user/features/push_notification/domain/model/email_changes_properties.dart';
+import 'package:tmail_ui_user/features/push_notification/domain/repository/fcm_repository.dart';
+import 'package:tmail_ui_user/features/push_notification/domain/state/get_email_changes_to_push_notification_state.dart';
+import 'package:tmail_ui_user/features/push_notification/domain/usecases/get_email_changes_to_push_notification_interactor.dart';
+import 'package:tmail_ui_user/features/thread/domain/model/email_response.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import '../../../../fixtures/session_fixtures.dart';
+import '../../../../fixtures/state_fixtures.dart';
+
+/// Minimal fake that only answers [getEmailChangesToPushNotification]; every
+/// other [FCMRepository] member forwards to [noSuchMethod] (unused by tests).
+class _FakeFCMRepository implements FCMRepository {
+  final EmailsResponse emailsResponse;
+
+  _FakeFCMRepository(this.emailsResponse);
+
+  @override
+  Future<EmailsResponse> getEmailChangesToPushNotification(
+    Session session,
+    AccountId accountId,
+    jmap.State currentState, {
+    EmailChangesProperties? properties,
+  }) async =>
+      emailsResponse;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  final userName = UserName('alice@domain.tld');
+
+  test(
+    'should emit a growable email list when the JMAP response has no emails '
+    'so that a downstream clear() does not throw on a fixed-length list',
+    () async {
+      final interactor = GetEmailChangesToPushNotificationInteractor(
+        _FakeFCMRepository(const EmailsResponse(emailList: null)),
+      );
+
+      final states = await interactor
+          .execute(
+            SessionFixtures.aliceSession,
+            AccountFixtures.aliceAccountId,
+            userName,
+            StateFixtures.currentEmailState,
+          )
+          .toList();
+
+      final success = states
+              .lastWhere((either) => either.isRight())
+              .fold((_) => null, (success) => success)
+          as GetEmailChangesToPushNotificationSuccess;
+
+      expect(success.emailList, isEmpty);
+      expect(() => success.emailList.clear(), returnsNormally);
+    },
+  );
+}


### PR DESCRIPTION
Sentry error: https://errors.cozycloud.cc/organizations/cozycloud/issues/375141/

```
split_config.arm64_v8a.apk
+0x540274
FixedLengthListMixin.clear (list.dart:55)
split_config.arm64_v8a.apk
+0xe9b800
EmailChangeListener._handleLocalPushNotification (email_change_listener.dart:293)
split_config.arm64_v8a.apk
+0x7ca958
EmailChangeListener.handleSuccessViewState (email_change_listener.dart:226)
split_config.arm64_v8a.apk
+0x7ca840
EmailChangeListener.handleSuccessViewState (email_change_listener.dart:214)
split_config.arm64_v8a.apk
+0x7ca7dc
Right.fold (either.dart:200)
split_config.arm64_v8a.apk
+0x7ca7dc
ChangeListener._handleStateStream (change_listener.dart:22)
split_config.arm64_v8a.apk
+0x7ca6c4
ChangeListener._handleStateStream (change_listener.dart:21)
split_config.arm64_v8a.apk
+0xf3ced0
_RootZone.runUnaryGuarded (zone.dart:1778)
split_config.arm64_v8a.apk
+0xc1aa2c
_BufferingStreamSubscription._sendData (stream_impl.dart:381)
split_config.arm64_v8a.apk
+0xbee3d4
_BufferingStreamSubscription._add (stream_impl.dart:312)
split_config.arm64_v8a.apk
+0xbedf80
_SyncStreamControllerDispatch._sendData (stream_controller.dart:798)
split_config.arm64_v8a.apk
+0xbedf80
_StreamController._add (stream_controller.dart:663)
split_config.arm64_v8a.apk
+0x491cc4
_StreamController.add (stream_controller.dart:618)
split_config.arm64_v8a.apk
+0xdacd58
_AsyncStarStreamController.add (async_patch.dart:81)
split_config.arm64_v8a.apk
+0xe9c50c
GetMailboxesNotPutNotificationsInteractor.execute (get_mailboxes_not_put_notifications_interactor.dart)
<unknown>
<unknown> (<asynchronous suspension>)
split_config.arm64_v8a.apk
+0x7ca6a0
ChangeListener.consumeState.<T> (change_listener.dart:14)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved push notification email-change handling when no emails are returned by resetting availability to a fresh empty list (avoids issues from reusing/clearing the same list instance).
  * Standardized how notification email property selections are requested across both push and removal email-change flows using a unified properties object.
* **Tests**
  * Added unit test coverage for the email-change interactor to confirm null/empty email responses produce a successful result with a clearable, non-fixed-length empty list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->