### PR TITLE
[CI] Try to run web E2E in release also

### DIFF
--- a/.github/workflows/image-sentry.yaml
+++ b/.github/workflows/image-sentry.yaml
@@ -12,8 +12,14 @@ permissions:
   id-token: write
 
 jobs:
+  # Blocking gate: the release image is only built if the web E2E run passes on this tag.
+  web_e2e:
+    name: Run web integration tests
+    uses: ./.github/workflows/reusable-web-integration-test.yaml
+
   build-release-image-with-sentry:
     name: Build release image with Sentry
+    needs: web_e2e
     if: github.event_name == 'workflow_dispatch' || (github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
     environment: prod

--- a/.github/workflows/patrol-web-integration-test.yaml
+++ b/.github/workflows/patrol-web-integration-test.yaml
@@ -8,30 +8,6 @@ on:
       - "Jenkinsfile"
       - "**/*.md"
 
-env:
-  FLUTTER_VERSION: 3.38.9
-
 jobs:
   web_integration_test:
-    permissions:
-      contents: "read"
-      id-token: "write"
-
-    name: Run integration tests for web
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: "stable"
-          cache: true
-
-      - name: Run prebuild
-        run: ./scripts/prebuild.sh
-
-      - name: Test
-        run: ./scripts/patrol-web-integration-test-with-docker.sh
+    uses: ./.github/workflows/reusable-web-integration-test.yaml

--- a/.github/workflows/reusable-web-integration-test.yaml
+++ b/.github/workflows/reusable-web-integration-test.yaml
@@ -1,0 +1,36 @@
+name: Web integration tests (reusable)
+
+# Reusable definition of the web E2E run. Called by:
+#   - patrol-web-integration-test.yaml (on pull_request)
+#   - image-sentry.yaml (on tag push, as a blocking gate before the release image)
+# Keeping the steps here means the E2E setup is defined once and both callers stay in sync.
+on:
+  workflow_call:
+
+env:
+  FLUTTER_VERSION: 3.38.9
+
+jobs:
+  web_integration_test:
+    permissions:
+      contents: "read"
+      id-token: "write"
+
+    name: Run integration tests for web
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: "stable"
+          cache: true
+
+      - name: Run prebuild
+        run: ./scripts/prebuild.sh
+
+      - name: Test
+        run: ./scripts/patrol-web-integration-test-with-docker.sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable web integration test workflow to standardize how web end-to-end tests are run.

* **Bug Fixes**
  * Release image builds now wait for web end-to-end tests to pass first, reducing the chance of shipping issues.
  * Web integration testing has been streamlined to use the shared workflow, improving consistency across runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->