### PR TITLE
TF-4660 Add temporarly drive loading

### DIFF
--- a/lib/features/composer/presentation/providers/composer_attachment_extension_registry_provider.dart
+++ b/lib/features/composer/presentation/providers/composer_attachment_extension_registry_provider.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/extensions/composer_attachment_extension_registry.dart';
 import 'package:core/utils/app_logger.dart';
+import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
 import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
@@ -19,6 +20,11 @@ ComposerAttachmentExtensionRegistry composerAttachmentExtensionRegistry(Ref ref)
       workplaceUri: uriNotifier,
       oidcTokenGetter: () => getBinding<AuthorizationInterceptors>()?.currentOidcIdToken,
       onPickState: (composerId, state) {
+        if (state is DrivePickLoading && !SmartDialog.checkExist()) {
+          SmartDialog.showLoading();
+        } else if (SmartDialog.checkExist()) {
+          SmartDialog.dismiss();
+        }
         if (state is DrivePickResult) {
           try {
             getBinding<ComposerController>(tag: composerId)?.handleDrivePickResult(state.documents);

--- a/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
+++ b/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
@@ -36,6 +36,7 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
     final fetch = pickerFetchIntent;
     _modalOpen = true;
     try {
+      pickerOnCallback?.call(DrivePickLoading());
       final l10n = AppLocalizations.of(context)!;
       final intent = await fetch(
         addAsLinkTitle: l10n.addAsLink,
@@ -44,6 +45,7 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
       if (!mounted) {
         throw WorkplaceUIDisposedException();
       }
+      pickerOnCallback?.call(DrivePickDisplaying());
       final result = await showDialog<List<DriveDocument>?>(
         context: context,
         builder: (_) => DriveIntentWebViewModal(

--- a/workplace/lib/presentation/model/drive_pick_state.dart
+++ b/workplace/lib/presentation/model/drive_pick_state.dart
@@ -6,6 +6,16 @@ import 'package:workplace/domain/entity/drive_document.dart';
 
 sealed class DrivePickState extends Equatable {}
 
+final class DrivePickLoading extends DrivePickState {
+  @override
+  List<Object?> get props => [];
+}
+
+final class DrivePickDisplaying extends DrivePickState {
+  @override
+  List<Object?> get props => [];
+}
+
 final class DrivePickResult extends DrivePickState {
   final List<DriveDocument> documents;
   DrivePickResult(this.documents);


### PR DESCRIPTION
## Issue
- #4660 

## Demo

https://github.com/user-attachments/assets/3246eda8-f070-4b8c-aded-576a2e8d4466


 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer drive-picking status updates, including loading and displaying states.
  * Improved the app’s handling of drive selection so users see more responsive feedback while content is loading.
* **Bug Fixes**
  * Prevents duplicate loading dialogs during drive picking, reducing flicker and inconsistent modal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->