### PR TITLE
TF-4484 Propose ADR for TWP message

### DIFF
--- a/docs/adr/0098-twp-warning-banners-and-header-cache-consolidation.md
+++ b/docs/adr/0098-twp-warning-banners-and-header-cache-consolidation.md
@@ -21,7 +21,7 @@ Backend contract:
 - One header per warning, several may appear on one message, order is stable.
 - Format always `level:<info|warn|error> code:<code> <fallback text>`.
 - All levels dismissable. Unknown level defaults to `info`.
-- Dismissal is per-header (per list position), persisted as a keyword; disabled (local-only) when offline.
+- Dismissal is per-warning (per position in the deduplicated list), persisted as a keyword; shows a red error toast when offline — no local hide, no queued mutation.
 - Frontend prefers a localized message for known `code`s, falling back to the header's trailing text.
 
 Separately: consolidate the cache classes' individual-header storage onto a single `individualHeaders`-shaped field per cache class (mirroring `Email.individualHeaders`), using `X-TWP-Message` as the forcing function. The legacy raw `Set<EmailHeader>? headers` field is unrelated and out of scope — not touched, not merged with `individualHeaders`.
@@ -30,8 +30,8 @@ Separately: consolidate the cache classes' individual-header storage onto a sing
 
 Three independently-shippable phases:
 
-1. **[ADR-0099](0099-twp-warning-banners-visible.md)** — parse `X-TWP-Message`, plumb through cache/presentation, render banners read-only.
-2. **[ADR-0100](0100-twp-warning-dismiss-persistence.md)** — per-header dismiss, persisted keyword, offline-disabled.
+1. **[ADR-0099](0099-twp-warning-banners-visible.md)** — parse `X-TWP-Message`, deduplicate, plumb through cache/presentation, render banners read-only via Riverpod `TwpWarningNotifier`.
+2. **[ADR-0100](0100-twp-warning-dismiss-persistence.md)** — per-header dismiss via notifier, persisted keyword, red error toast when offline.
 3. **[ADR-0101](0101-consolidate-individual-header-cache-fields.md)** — consolidate `EmailCache`/`DetailedEmailHiveCache`'s separate per-header fields into one `individualHeaders` field each; fetch MDN/List-Post as individual headers.
 
 ### Ground rules across all phases
@@ -40,8 +40,9 @@ Three independently-shippable phases:
 - `X-TWP-Message` does not get a typed preset/getter on `Email` (unlike `xPriorityHeader` etc.) — it's a `List`, not a single value. Stays an inline `IndividualHeaderIdentifier.asText('X-TWP-Message').all()` lookup.
 - Hive field indices are additive-only — never reused/reordered once shipped. Old per-header fields' indices stay reserved/unused once superseded, not deleted.
 - Domain/presentation layers (`PresentationEmail`, `DetailedEmail`) keep their existing typed per-header fields unchanged — consolidation is scoped to the two Hive cache classes only.
-- `TwpWarningBanner` is a plain `StatelessWidget` (GetX feature area, not Riverpod), required `PresentationEmail` (no nullable/optional injection), owns its own visibility via internal `if` — no call-site checks.
-- Code→localized-message registry lives in `lib/main/localizations/`, not `model/`. `model/` is a plain Dart module with no `BuildContext`/`AppLocalizations` access; the mapping is a presentation-layer concern, built near `TwpWarningBanner`, matching `MailUnsubscribedBanner`'s existing direct use of `AppLocalizations.of(context)`.
+- **Header deduplication before display:** raw TWP headers are deduplicated by exact `(level, code, fallbackText)` triplet before being exposed as the warning list or used for dismiss indexing. Indices in `TwpWarning` reflect position in the deduplicated list.
+- **`TwpWarningBanner` is a Riverpod `ConsumerWidget`** with no constructor arguments. It reads all warning and dismissal state from `TwpWarningNotifier` (`NotifierProvider`). `SingleEmailController` feeds the notifier from two live sources: **warnings** from the content-load `PresentationEmail` (`GetEmailContentSuccess`/`GetEmailContentFromCacheSuccess.emailCurrent`, fetched with `propertiesGetEmailContent`), and **keywords** from `currentEmail.keywords` (the WebSocket-updated open email — `emailIdsPresentation[_currentEmailId]` on web/tablet, or `selectedEmail` on mobile). `DetailedEmail`/`DetailedEmailHiveCache` are not a live source and never feed the notifier directly; they back only the offline content-read path. The notifier maintains its own optimistic dismissed-keyword set and never writes back into any email object.
+- Code→localized-message registry lives in `lib/main/localizations/`, not `model/`. `model/` is a plain Dart module with no `BuildContext`/`AppLocalizations` access; the mapping is a presentation-layer concern, matching `MailUnsubscribedBanner`'s existing direct use of `AppLocalizations.of(context)`.
 
 ## Open questions
-- Ask backend/product: is per-index dismissal safe if warning count changes between fetches, or should dismissal key on `code` when present?
+- Ask backend/product: is per-index-in-deduplicated-list dismissal safe if warning count changes between fetches, or should dismissal key on `code` alone when it is unique per email?

--- a/docs/adr/0098-twp-warning-banners-and-header-cache-consolidation.md
+++ b/docs/adr/0098-twp-warning-banners-and-header-cache-consolidation.md
@@ -1,0 +1,47 @@
+# 98. TWP Warning Banners and Individual-Header Cache Consolidation
+
+Date: 2026-07-01
+
+## Status
+
+Proposed
+
+## Reference
+GitHub issue #4484
+
+## Context
+
+Server-driven warning banners on the email read view (e.g. "external sender", "virus detected"), signalled via a repeatable header:
+
+```
+X-TWP-Message: level:info code:suspicious-sender This email is from an external sender...
+```
+
+Backend contract:
+- One header per warning, several may appear on one message, order is stable.
+- Format always `level:<info|warn|error> code:<code> <fallback text>`.
+- All levels dismissable. Unknown level defaults to `info`.
+- Dismissal is per-header (per list position), persisted as a keyword; disabled (local-only) when offline.
+- Frontend prefers a localized message for known `code`s, falling back to the header's trailing text.
+
+Separately: consolidate the cache classes' individual-header storage onto a single `individualHeaders`-shaped field per cache class (mirroring `Email.individualHeaders`), using `X-TWP-Message` as the forcing function. The legacy raw `Set<EmailHeader>? headers` field is unrelated and out of scope — not touched, not merged with `individualHeaders`.
+
+## Decision
+
+Three independently-shippable phases:
+
+1. **[ADR-0099](0099-twp-warning-banners-visible.md)** — parse `X-TWP-Message`, plumb through cache/presentation, render banners read-only.
+2. **[ADR-0100](0100-twp-warning-dismiss-persistence.md)** — per-header dismiss, persisted keyword, offline-disabled.
+3. **[ADR-0101](0101-consolidate-individual-header-cache-fields.md)** — consolidate `EmailCache`/`DetailedEmailHiveCache`'s separate per-header fields into one `individualHeaders` field each; fetch MDN/List-Post as individual headers.
+
+### Ground rules across all phases
+
+- `Email` keeps both the legacy `Set<EmailHeader>? headers` field and `Map<IndividualHeaderIdentifier, EmailHeaderValue> individualHeaders` — two unrelated fields. Only `individualHeaders`-feeding storage is reshaped; `headers` stays untouched everywhere.
+- `X-TWP-Message` does not get a typed preset/getter on `Email` (unlike `xPriorityHeader` etc.) — it's a `List`, not a single value. Stays an inline `IndividualHeaderIdentifier.asText('X-TWP-Message').all()` lookup.
+- Hive field indices are additive-only — never reused/reordered once shipped. Old per-header fields' indices stay reserved/unused once superseded, not deleted.
+- Domain/presentation layers (`PresentationEmail`, `DetailedEmail`) keep their existing typed per-header fields unchanged — consolidation is scoped to the two Hive cache classes only.
+- `TwpWarningBanner` is a plain `StatelessWidget` (GetX feature area, not Riverpod), required `PresentationEmail` (no nullable/optional injection), owns its own visibility via internal `if` — no call-site checks.
+- Code→localized-message registry lives in `lib/main/localizations/`, not `model/`. `model/` is a plain Dart module with no `BuildContext`/`AppLocalizations` access; the mapping is a presentation-layer concern, built near `TwpWarningBanner`, matching `MailUnsubscribedBanner`'s existing direct use of `AppLocalizations.of(context)`.
+
+## Open questions
+- Ask backend/product: is per-index dismissal safe if warning count changes between fetches, or should dismissal key on `code` when present?

--- a/docs/adr/0099-twp-warning-banners-visible.md
+++ b/docs/adr/0099-twp-warning-banners-visible.md
@@ -16,46 +16,59 @@ Phase 1 of #4484: users see server-driven warning banners (e.g. "external sender
 Key facts:
 - `Email.fromJson`/`toJson` already handle arbitrary `header:X:form[:all]` keys generically — a new repeatable header needs zero changes to `Email` itself.
 - `EmailHeaderValue.fromJson` branches on the `:all` suffix, returning `AllHeaderValue(List<EmailHeaderValue>)`; each element is a `TextHeaderValue`.
-- First use of `.all()`/`AllHeaderValue` in this codebase — every other individual header (`xPriorityHeader`, `listUnsubscribeHeader`, `sMimeStatusHeader`, `identityHeader`, `listPostHeader`, `headerCalendarEvent`) is singular. Treat parsing as untested territory.
-- `MailUnsubscribedBanner` (`lib/features/email/presentation/widgets/mail_unsubscribed_banner.dart`) is the structural template: plain `StatelessWidget`, internal `if`-branches, `const SizedBox.shrink()` when nothing to show, copy via `AppLocalizations.of(context)`.
-- This phase introduces the new consolidated `individualHeaders` cache field (not a standalone `twpMessages` field) on `DetailedEmailHiveCache` only — `EmailCache` gets the same field in Phase 3, which later reuses it.
+- First use of `.all()`/`AllHeaderValue` in this codebase — every other individual header is singular. Treat parsing as untested territory.
+- This phase introduces the new consolidated `individualHeaders` cache field on `DetailedEmailHiveCache` only — `EmailCache` gets the same field in Phase 3.
 
 ## Decision
 
-### Parsing
-`model/lib/email/twp_warning.dart`: `TwpWarningLevel` enum, `TwpWarning` model, tolerant parser `TwpWarning.parse(String raw, int index)`, `twpMessageHeaderName` constant.
-- Unknown/missing level → `info`. Malformed lines degrade to best-effort (treat remainder as fallback text once `level:`/`code:` tokens are consumed) — never throws.
-- Banner order = header arrival order (JMAP `:all` guarantees this server-side); parser preserves list order, never re-sorts.
-- Prefer a localized message for known `code`s, else the header's own trailing text. The code→localized-message registry lives in `lib/main/localizations/`, not `model/`: `model/` is a plain Dart module with no `BuildContext`/`AppLocalizations` access, so the mapping is a presentation-layer concern, built near `TwpWarningBanner`, matching `MailUnsubscribedBanner`'s existing direct `AppLocalizations.of(context)` use.
+### Parsing and deduplication
+`model/lib/email/twp_warning.dart`: `TwpWarningLevel` enum, `TwpWarning` model, tolerant parser `TwpWarning.parse(String raw, int index)`, deduplication helper `deduplicateTwpWarnings(List<TwpWarning>)`, `twpMessageHeaderName` constant.
+- Unknown/missing level → `info`. Malformed lines degrade to best-effort — never throws.
+- Parser always produces a non-empty `code` (default `'unknown'`).
+- **Deduplication:** the raw parsed list is filtered by exact `(level, code, fallbackText)` triplet before being exposed. First occurrence wins; subsequent exact matches are dropped. Indices in the resulting `TwpWarning` list reflect deduplicated-list position (0-based, contiguous).
+- Banner order = deduplicated-list order (JMAP `:all` guarantees server-side order; deduplication preserves first-occurrence order).
+- Prefer a localized message for known `code`s, else the header's trailing text. The code→localized-message registry lives in `lib/main/localizations/`, not `model/`.
 
 ### Property wiring
-Add the property string to both `ThreadConstants.propertiesGetEmailContent` and `propertiesGetDetailedEmail` (read view only — not `propertiesDefault`/thread list).
+Add the property string to both `ThreadConstants.propertiesGetEmailContent` and `propertiesGetDetailedEmail` (read view only — not thread list).
 
 ### Cache shape
-New field, uniform value type across both cache classes:
+New field, uniform value type:
 ```dart
-Map<String, List<String>>? individualHeaders
+@HiveField(11) Map<String, List<String>>? individualHeaders
 ```
-Every individual header (single- or multi-valued) stored as an ordered list of raw string values — re-parsed into `TwpWarning`s on read. Avoids new Hive nested-type registration.
+Every individual header stored as an ordered list of raw string values — re-parsed and re-deduplicated on read. Avoids new Hive nested-type registration.
 - `DetailedEmailHiveCache`: `@HiveField(11)` (verify free at implementation time).
-- `EmailCache`: introduced in Phase 3, not here (Phase 1 only touches `DetailedEmailHiveCache`).
-- Old cached emails (fetched before this shipped) show no banners until next refresh — correct, not a bug, no backfill.
+- `EmailCache`: introduced in Phase 3, not here.
+- Old cached emails show no banners until next refresh — correct, not a bug.
 
 ### Domain/presentation flow
 ```
 Email.individualHeaders['header:X-TWP-Message:asText:all'] : AllHeaderValue
-  → EmailExtension.twpWarnings : List<TwpWarning>
+  → EmailExtension.twpWarnings : List<TwpWarning>  (parsed + deduplicated)
     → toPresentationEmail() → PresentationEmail.twpWarnings
-      → TwpWarningBanner(presentationEmail) in email_view.dart, after MailUnsubscribedBanner
 
-DetailedEmail.twpMessages : List<String>?  (domain layer, unchanged shape)
-  ↔ DetailedEmailHiveCache.individualHeaders[twpMessageHeaderName]
-     → re-parsed via the same parser on read
+Offline content-read path only (not a live source):
+  DetailedEmail.twpMessages : List<String>?  (domain layer, raw headers)
+    ↔ DetailedEmailHiveCache.individualHeaders[twpMessageHeaderName]
+       → re-parsed + re-deduplicated on read → GetEmailContentFromCacheSuccess.emailCurrent.twpWarnings
 ```
 
-`TwpWarningBanner`: `StatelessWidget`, required `PresentationEmail`, `if (twpWarnings.isEmpty) return const SizedBox.shrink()`, else a `Column` of one row per warning colored by level.
+### Riverpod notifier
+`TwpWarningNotifier extends Notifier<TwpWarningState>` (`twpWarningNotifierProvider`):
+- `TwpWarningState` holds `List<TwpWarning> warnings` (deduplicated) and `Set<String> dismissedKeywords`.
+- `setWarnings(List<TwpWarning>)` replaces the warning list.
+- `setKeywords(Map<KeyWordIdentifier, bool>?)` recomputes the dismissed set from TWP-prefixed keyword entries (Phase 2 unions this with a local optimistic set).
+- `SingleEmailController` feeds it from two independent inputs, kept separate so a keyword-only update never wipes the warnings:
+  - `setWarnings(emailCurrent.twpWarnings)` on content-load success (`GetEmailContentSuccess`/`GetEmailContentFromCacheSuccess`, fetched with `propertiesGetEmailContent`, which carries the TWP header).
+  - `setKeywords(currentEmail.keywords)` from the controller's Obx/Worker listener on the open email. `currentEmail` resolves to `emailIdsPresentation[_currentEmailId]` on web/tablet or `selectedEmail` on mobile — the WebSocket-updated object. Its `keywords` are in `propertiesDefault`, so they stay current; the TWP header is not, which is why warnings come from the content load instead.
+- The notifier is not fed from `DetailedEmail`/`DetailedEmailHiveCache` directly — those are not live and never update on WebSocket.
+- The controller accesses the notifier via a widget-layer bridge (a `ConsumerStatefulWidget` wrapper that watches the controller's Rx open-email/content state and forwards to the notifier via `ref`) — not via a global `ProviderContainer`.
+
+### Banner widget
+`TwpWarningBanner`: `ConsumerWidget`, no constructor arguments. `ref.watch(twpWarningNotifierProvider)`. If `state.warnings.isEmpty` → `const SizedBox.shrink()`. Else a `Column` of one banner row per warning (in Phase 2, dismissed ones are hidden based on `state.dismissedKeywords`), colored by level. Inserted in `email_view.dart` after `MailUnsubscribedBanner` block.
 
 ## Consequences
-- Banner fallback/localized text renders as plain `Text` — no HTML injection risk from a malicious backend header value.
-- Phase 2 depends on `TwpWarning.index` being stable and on this banner widget existing to attach a dismiss affordance to.
+- Banner fallback/localized text renders as plain `Text` — no HTML injection risk.
+- Phase 2 depends on `TwpWarning.index` (deduplicated position) being stable, `TwpWarningNotifier` existing, and this widget existing.
 - Phase 3 reuses `DetailedEmailHiveCache.individualHeaders` — whichever phase lands second must not redeclare the field under a different `@HiveField` index.

--- a/docs/adr/0099-twp-warning-banners-visible.md
+++ b/docs/adr/0099-twp-warning-banners-visible.md
@@ -18,7 +18,7 @@ Key facts:
 - `EmailHeaderValue.fromJson` branches on the `:all` suffix, returning `AllHeaderValue(List<EmailHeaderValue>)`; each element is a `TextHeaderValue`.
 - First use of `.all()`/`AllHeaderValue` in this codebase — every other individual header (`xPriorityHeader`, `listUnsubscribeHeader`, `sMimeStatusHeader`, `identityHeader`, `listPostHeader`, `headerCalendarEvent`) is singular. Treat parsing as untested territory.
 - `MailUnsubscribedBanner` (`lib/features/email/presentation/widgets/mail_unsubscribed_banner.dart`) is the structural template: plain `StatelessWidget`, internal `if`-branches, `const SizedBox.shrink()` when nothing to show, copy via `AppLocalizations.of(context)`.
-- This phase introduces the new consolidated `individualHeaders` cache field (not a standalone `twpMessages` field) on both `EmailCache` and `DetailedEmailHiveCache` — Phase 3 later reuses it.
+- This phase introduces the new consolidated `individualHeaders` cache field (not a standalone `twpMessages` field) on `DetailedEmailHiveCache` only — `EmailCache` gets the same field in Phase 3, which later reuses it.
 
 ## Decision
 

--- a/docs/adr/0099-twp-warning-banners-visible.md
+++ b/docs/adr/0099-twp-warning-banners-visible.md
@@ -1,0 +1,61 @@
+# 99. TWP Warning Banners — Read-Only Visibility
+
+Date: 2026-07-01
+
+## Status
+
+Proposed
+
+## Reference
+Parent: [ADR-0098](0098-twp-warning-banners-and-header-cache-consolidation.md)
+
+## Context
+
+Phase 1 of #4484: users see server-driven warning banners (e.g. "external sender") on the email read view, always shown — no dismiss yet (Phase 2).
+
+Key facts:
+- `Email.fromJson`/`toJson` already handle arbitrary `header:X:form[:all]` keys generically — a new repeatable header needs zero changes to `Email` itself.
+- `EmailHeaderValue.fromJson` branches on the `:all` suffix, returning `AllHeaderValue(List<EmailHeaderValue>)`; each element is a `TextHeaderValue`.
+- First use of `.all()`/`AllHeaderValue` in this codebase — every other individual header (`xPriorityHeader`, `listUnsubscribeHeader`, `sMimeStatusHeader`, `identityHeader`, `listPostHeader`, `headerCalendarEvent`) is singular. Treat parsing as untested territory.
+- `MailUnsubscribedBanner` (`lib/features/email/presentation/widgets/mail_unsubscribed_banner.dart`) is the structural template: plain `StatelessWidget`, internal `if`-branches, `const SizedBox.shrink()` when nothing to show, copy via `AppLocalizations.of(context)`.
+- This phase introduces the new consolidated `individualHeaders` cache field (not a standalone `twpMessages` field) on both `EmailCache` and `DetailedEmailHiveCache` — Phase 3 later reuses it.
+
+## Decision
+
+### Parsing
+`model/lib/email/twp_warning.dart`: `TwpWarningLevel` enum, `TwpWarning` model, tolerant parser `TwpWarning.parse(String raw, int index)`, `twpMessageHeaderName` constant.
+- Unknown/missing level → `info`. Malformed lines degrade to best-effort (treat remainder as fallback text once `level:`/`code:` tokens are consumed) — never throws.
+- Banner order = header arrival order (JMAP `:all` guarantees this server-side); parser preserves list order, never re-sorts.
+- Prefer a localized message for known `code`s, else the header's own trailing text. The code→localized-message registry lives in `lib/main/localizations/`, not `model/`: `model/` is a plain Dart module with no `BuildContext`/`AppLocalizations` access, so the mapping is a presentation-layer concern, built near `TwpWarningBanner`, matching `MailUnsubscribedBanner`'s existing direct `AppLocalizations.of(context)` use.
+
+### Property wiring
+Add the property string to both `ThreadConstants.propertiesGetEmailContent` and `propertiesGetDetailedEmail` (read view only — not `propertiesDefault`/thread list).
+
+### Cache shape
+New field, uniform value type across both cache classes:
+```dart
+Map<String, List<String>>? individualHeaders
+```
+Every individual header (single- or multi-valued) stored as an ordered list of raw string values — re-parsed into `TwpWarning`s on read. Avoids new Hive nested-type registration.
+- `DetailedEmailHiveCache`: `@HiveField(11)` (verify free at implementation time).
+- `EmailCache`: introduced in Phase 3, not here (Phase 1 only touches `DetailedEmailHiveCache`).
+- Old cached emails (fetched before this shipped) show no banners until next refresh — correct, not a bug, no backfill.
+
+### Domain/presentation flow
+```
+Email.individualHeaders['header:X-TWP-Message:asText:all'] : AllHeaderValue
+  → EmailExtension.twpWarnings : List<TwpWarning>
+    → toPresentationEmail() → PresentationEmail.twpWarnings
+      → TwpWarningBanner(presentationEmail) in email_view.dart, after MailUnsubscribedBanner
+
+DetailedEmail.twpMessages : List<String>?  (domain layer, unchanged shape)
+  ↔ DetailedEmailHiveCache.individualHeaders[twpMessageHeaderName]
+     → re-parsed via the same parser on read
+```
+
+`TwpWarningBanner`: `StatelessWidget`, required `PresentationEmail`, `if (twpWarnings.isEmpty) return const SizedBox.shrink()`, else a `Column` of one row per warning colored by level.
+
+## Consequences
+- Banner fallback/localized text renders as plain `Text` — no HTML injection risk from a malicious backend header value.
+- Phase 2 depends on `TwpWarning.index` being stable and on this banner widget existing to attach a dismiss affordance to.
+- Phase 3 reuses `DetailedEmailHiveCache.individualHeaders` — whichever phase lands second must not redeclare the field under a different `@HiveField` index.

--- a/docs/adr/0099-twp-warning-banners-visible.md
+++ b/docs/adr/0099-twp-warning-banners-visible.md
@@ -33,11 +33,11 @@ Key facts:
 Add the property string to both `ThreadConstants.propertiesGetEmailContent` and `propertiesGetDetailedEmail` (read view only — not thread list).
 
 ### Cache shape
-New field, uniform value type:
+New field, mixed value type — **not** a uniform `List<String>`:
 ```dart
-@HiveField(11) Map<String, List<String>>? individualHeaders
+@HiveField(11) Map<String, dynamic>? individualHeaders
 ```
-Every individual header stored as an ordered list of raw string values — re-parsed and re-deduplicated on read. Avoids new Hive nested-type registration.
+A header requested singularly (`asText`, no `:all`) stores its raw `String` value directly. A header requested with the `:all` suffix (currently only `X-TWP-Message`) always stores a `List<String>`, **even when the server returns exactly one value** — the value's Dart runtime type (`String` vs `List<String>`), not its length, is what distinguishes "singular header" from "`:all` header" on read. This mirrors `EmailHeaderValue.fromJson`'s own branching (the `:all` suffix always produces `AllHeaderValue`, regardless of element count) and avoids the read-side bug where a single-warning email would otherwise reconstruct as `TextHeaderValue` instead of `AllHeaderValue`, silently diverging from the network-fetched shape. Avoids new Hive nested-type registration (`dynamic` here is always `String` or `List<String>`, nothing else).
 - `DetailedEmailHiveCache`: `@HiveField(11)` (verify free at implementation time).
 - `EmailCache`: introduced in Phase 3, not here.
 - Old cached emails show no banners until next refresh — correct, not a bug.
@@ -56,11 +56,11 @@ Offline content-read path only (not a live source):
 
 ### Riverpod notifier
 `TwpWarningNotifier extends Notifier<TwpWarningState>` (`twpWarningNotifierProvider`):
-- `TwpWarningState` holds `List<TwpWarning> warnings` (deduplicated) and `Set<String> dismissedKeywords`.
-- `setWarnings(List<TwpWarning>)` replaces the warning list.
+- `TwpWarningState` holds `EmailId? emailId`, `List<TwpWarning> warnings` (deduplicated), and `Set<String> dismissedKeywords`.
+- `setWarnings(EmailId emailId, List<TwpWarning> warnings)` replaces both the owning email id and the warning list **in one call** — `emailId` is known at exactly the same point `warnings` is (content-load success), so there is no separate "which email does this state belong to" step. This is what Phase 2's dismiss action reads to know which email to patch, instead of re-deriving it from the controller (see ADR-0100).
 - `setKeywords(Map<KeyWordIdentifier, bool>?)` recomputes the dismissed set from TWP-prefixed keyword entries (Phase 2 unions this with a local optimistic set).
 - `SingleEmailController` feeds it from two independent inputs, kept separate so a keyword-only update never wipes the warnings:
-  - `setWarnings(emailCurrent.twpWarnings)` on content-load success (`GetEmailContentSuccess`/`GetEmailContentFromCacheSuccess`, fetched with `propertiesGetEmailContent`, which carries the TWP header).
+  - `setWarnings(emailCurrent.id, emailCurrent.twpWarnings)` on content-load success (`GetEmailContentSuccess`/`GetEmailContentFromCacheSuccess`, fetched with `propertiesGetEmailContent`, which carries the TWP header).
   - `setKeywords(currentEmail.keywords)` from the controller's Obx/Worker listener on the open email. `currentEmail` resolves to `emailIdsPresentation[_currentEmailId]` on web/tablet or `selectedEmail` on mobile — the WebSocket-updated object. Its `keywords` are in `propertiesDefault`, so they stay current; the TWP header is not, which is why warnings come from the content load instead.
 - The notifier is not fed from `DetailedEmail`/`DetailedEmailHiveCache` directly — those are not live and never update on WebSocket.
 - The controller accesses the notifier via a widget-layer bridge (a `ConsumerStatefulWidget` wrapper that watches the controller's Rx open-email/content state and forwards to the notifier via `ref`) — not via a global `ProviderContainer`.
@@ -70,5 +70,5 @@ Offline content-read path only (not a live source):
 
 ## Consequences
 - Banner fallback/localized text renders as plain `Text` — no HTML injection risk.
-- Phase 2 depends on `TwpWarning.index` (deduplicated position) being stable, `TwpWarningNotifier` existing, and this widget existing.
+- Phase 2 depends on `TwpWarning`'s dedup identity (`level`+`code`+`fallbackText`), `TwpWarningState.emailId`, `TwpWarningNotifier` existing, and this widget existing.
 - Phase 3 reuses `DetailedEmailHiveCache.individualHeaders` — whichever phase lands second must not redeclare the field under a different `@HiveField` index.

--- a/docs/adr/0099-twp-warning-banners-visible.md
+++ b/docs/adr/0099-twp-warning-banners-visible.md
@@ -54,6 +54,8 @@ Offline content-read path only (not a live source):
        → re-parsed + re-deduplicated on read → GetEmailContentFromCacheSuccess.emailCurrent.twpWarnings
 ```
 
+`GetEmailContentFromCacheSuccess.emailCurrent` is rebuilt in `get_email_content_interactor.dart`'s `_getStoredOpenedEmail`/`_getStoredNewEmail`, which merge specific `DetailedEmail` fields back into `emailCache.individualHeaders` by name (today: `sMimeStatusHeader`, `identityHeader`). Both merge blocks must also merge `detailedEmail.twpMessages` in as an `AllHeaderValue` (unconditionally, even for a single warning — never collapsed to a bare string), or offline/cached opens silently show zero banners even though `DetailedEmailHiveCache` stores the header correctly.
+
 ### Riverpod notifier
 `TwpWarningNotifier extends Notifier<TwpWarningState>` (`twpWarningNotifierProvider`):
 - `TwpWarningState` holds `EmailId? emailId`, `List<TwpWarning> warnings` (deduplicated), and `Set<String> dismissedKeywords`.

--- a/docs/adr/0100-twp-warning-dismiss-persistence.md
+++ b/docs/adr/0100-twp-warning-dismiss-persistence.md
@@ -16,7 +16,7 @@ Phase 2 of #4484: dismissing a warning persists across app restarts; shows a red
 Closest existing analogue: the unsubscribe-mail flow (`KeyWordIdentifierExtension.unsubscribeMail` → `EmailIdExtension.generateMapUpdateObjectUnsubscribeMail()` → `EmailApi.unsubscribeMail()` → `SetEmailMethod.addUpdates`).
 
 Key facts:
-- `KeyWordIdentifierExtension` has only static, non-parameterized keyword entries today. `twpWarningDismissed(String code, int index)` is the first parameterized `KeyWordIdentifier` factory in this codebase.
+- `KeyWordIdentifierExtension` has only static, non-parameterized keyword entries today. `twpWarningDismissed(TwpWarning warning)` is the first parameterized `KeyWordIdentifier` factory in this codebase.
 - `NetworkConnectionController` is already used by `thread_detail_controller.dart`; this is the first time `SingleEmailController` consumes it.
 - No existing keyword supports removal/un-dismiss — every keyword patch is add-only (`true` at `keywords/<value>`).
 
@@ -24,25 +24,36 @@ Key facts:
 
 ### Keyword
 ```dart
-static KeyWordIdentifier twpWarningDismissed(String code, int index) =>
-    KeyWordIdentifier('twp-warning-dismissed-$code-$index');
+static KeyWordIdentifier twpWarningDismissed(TwpWarning warning) =>
+    KeyWordIdentifier('twp-warning-dismissed-${warning.stableId}');
 ```
-`code` is the backend-stable semantic identifier; `index` is the zero-based position within the **deduplicated** warning list, acting as a tiebreaker for the unlikely case of duplicate codes on one email. A stored keyword survives warning reordering across fetches because `code` is the primary key.
+`TwpWarning.stableId` (new, `model/lib/email/twp_warning.dart`) is content-derived, never position-derived, so it is stable across reordering, insertion, or removal of *other* warnings on the same email:
+```dart
+String get stableId {
+  final normalizedCode = code.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '-');
+  final contentHash = fnv1a32('$level|$code|$fallbackText').toRadixString(16);
+  return '$normalizedCode-$contentHash';
+}
+```
+- `normalizedCode` slugifies `code` to `[a-z0-9-]` only, so a backend `code` containing `/`, whitespace, uppercase, or unicode can never produce an invalid JMAP keyword path or collide with keyword syntax — see "Keyword safety" below.
+- `contentHash` is a deterministic hash (FNV-1a 32-bit, or equivalent fixed, stable-across-app-versions algorithm) of the same `(level, code, fallbackText)` triplet used as the deduplication identity in ADR-0099 — the dismiss key and the dedup key are the same logical identity, computed once.
 
 ### Flow
+`TwpWarningBanner` reads `emailId` from `TwpWarningState.emailId` (ADR-0099 — fed into the notifier in the same `setWarnings` call as the warning list, so it's always in sync with what's on screen) rather than reaching into `SingleEmailController` or taking it as a constructor argument.
 ```
 TwpWarningBanner (ConsumerWidget, dismiss tap)
+  → emailId = ref.read(twpWarningNotifierProvider).emailId   // fed by setWarnings, ADR-0099
   → SingleEmailController.dismissTwpWarning(emailId, TwpWarning warning)
     → if NOT NetworkConnectionController.isNetworkConnectionAvailable():
          show red error toast — return (banner stays visible, no network call, nothing queued)
     → else:
-         DismissTwpWarningInteractor.execute(session, accountId, emailId, warning.code, warning.index)
+         DismissTwpWarningInteractor.execute(session, accountId, emailId, warning)
            → EmailRepository.dismissTwpWarning(...)
              → EmailApi: SetEmailMethod(accountId)..addUpdates(
                  {emailId.id: KeyWordIdentifierExtension
-                     .twpWarningDismissed(code, index).generatePath(): true})
+                     .twpWarningDismissed(warning).generatePath(): true})
          on success:
-           ref.read(twpWarningNotifierProvider.notifier).markDismissed(code, index)
+           ref.read(twpWarningNotifierProvider.notifier).markDismissed(warning)
            → notifier adds keyword string to its local optimistic set
            → Riverpod state update → ConsumerWidget rebuilds → banner row disappears immediately
            (no email object touched)
@@ -52,8 +63,8 @@ TwpWarningBanner (ConsumerWidget, dismiss tap)
 Live keywords are fed separately: whenever `currentEmail` changes (incl. WebSocket), the controller calls `notifier.setKeywords(currentEmail.keywords)`; effective dismissed set = live ∪ optimistic.
 
 New pieces mirror existing shapes exactly:
-- `DismissTwpWarningInteractor` — 4-line shape like `UnsubscribeEmailInteractor`, parameterized by `code` + `index`.
-- `EmailIdExtension.generateMapUpdateObjectDismissTwpWarning(String code, int index)` — mirrors `generateMapUpdateObjectUnsubscribeMail()`.
+- `DismissTwpWarningInteractor` — 4-line shape like `UnsubscribeEmailInteractor`, parameterized by the `TwpWarning` being dismissed.
+- `EmailIdExtension.generateMapUpdateObjectDismissTwpWarning(TwpWarning warning)` — mirrors `generateMapUpdateObjectUnsubscribeMail()`.
 - Reuses existing `PatchObject`/`SetEmailMethod` machinery — no new JMAP method type.
 
 ### Offline semantics
@@ -62,19 +73,22 @@ When offline, dismiss shows a red error toast and returns immediately. No local 
 ### Keyword source and dismiss success → immediate UI update
 Live dismissal keywords come from `currentEmail.keywords` (the WebSocket-updated `PresentationEmail`), fed to the notifier via Phase 1's `setKeywords`. The notifier additionally keeps a local optimistic set; its effective dismissed set is the union of the two, so `setKeywords` refreshing the live portion never drops an in-flight dismiss.
 
-On a successful JMAP call, `TwpWarningNotifier.markDismissed(String code, int index)` adds the keyword to the local optimistic set. The `TwpWarningBanner` `ConsumerWidget` watches this state and rebuilds immediately — the dismissed banner disappears without waiting for a WebSocket update or email re-fetch. No email object (`DetailedEmail` or `PresentationEmail`) is modified. When the WebSocket update later brings the keyword into `currentEmail`, `setKeywords` folds it into the live set and the union stays consistent.
+On a successful JMAP call, `TwpWarningNotifier.markDismissed(TwpWarning warning)` adds `KeyWordIdentifierExtension.twpWarningDismissed(warning).value` to the local optimistic set. The `TwpWarningBanner` `ConsumerWidget` watches this state and rebuilds immediately — the dismissed banner disappears without waiting for a WebSocket update or email re-fetch. No email object (`DetailedEmail` or `PresentationEmail`) is modified. When the WebSocket update later brings the keyword into `currentEmail`, `setKeywords` folds it into the live set and the union stays consistent.
+
+### Keyword safety
+`code` is backend-supplied and not guaranteed to be a safe keyword-path fragment (JMAP keyword paths are `keywords/<value>`; an unsanitized `code` containing `/`, whitespace, or mixed case could produce an invalid patch path or two visually-different codes that collide once lowercased elsewhere). `TwpWarning.stableId` (above) sanitizes this at the source — `code` is slugified to `[a-z0-9-]` before being embedded, and the human-readable/variable-length part of the identity (`fallbackText`) never appears verbatim in the keyword at all, only as a fixed-length hash. There is no path where a raw, unvalidated `code` or `fallbackText` reaches `KeyWordIdentifier`.
 
 ## Consequences
 - Dismiss button per-banner, trailing corner, with a11y tooltip (new ARB string).
 - Red error toast string for offline and API failure cases (new ARB string).
 - Un-dismiss (re-show) is out of scope — no existing keyword in this codebase supports removal.
+- `emailId` ownership is resolved by construction: `TwpWarningState.emailId` (ADR-0099) is set in the same call as `warnings`, so the banner and its dismiss action always agree on which email they belong to without a separate lookup.
 
 ## Risks
 
-- **Dismissal key stability**: combining `code` with `index` (deduplicated position) ensures a stored keyword survives reordering. Residual gap: if the backend reuses a `code` on a semantically different warning in the future, the old dismissal would still fire. Unfixable without a server-generated stable ID — flagged for backend/product.
+- **Dismissal key stability**: `stableId` is keyed on warning content (`level` + `code` + `fallbackText`, hashed), independent of list position, so reordering other warnings never invalidates a stored dismissal. Residual gap: if the backend reuses a `code` on a semantically different warning *with the same fallback text* in the future, the old dismissal would still fire. Unfixable without a server-generated stable ID — flagged for backend/product.
 - **Optimistic/live reconciliation**: the effective dismissed set is `currentEmail.keywords` (live) ∪ local optimistic set. `setKeywords` must union, not replace, so an in-flight dismiss isn't dropped before the WebSocket update lands; the optimistic entry becomes redundant once the live keyword arrives.
 
 ## Open questions
 - Should un-dismiss be in scope? Assume out of scope unless product says otherwise.
 - Confirm exact binding/DI file used for `UnsubscribeEmailInteractor` registration before creating a new one for `DismissTwpWarningInteractor`.
-- How is `emailId` passed to the dismiss call from inside `TwpWarningBanner`? Options: held in notifier state, or read from `SingleEmailController` directly in the widget. Decide at implementation time.

--- a/docs/adr/0100-twp-warning-dismiss-persistence.md
+++ b/docs/adr/0100-twp-warning-dismiss-persistence.md
@@ -1,0 +1,64 @@
+# 100. TWP Warning Dismiss Persistence
+
+Date: 2026-07-01
+
+## Status
+
+Proposed
+
+## Reference
+Parent: [ADR-0098](0098-twp-warning-banners-and-header-cache-consolidation.md); builds on [ADR-0099](0099-twp-warning-banners-visible.md)
+
+## Context
+
+Phase 2 of #4484: dismissing a warning persists across app restarts; disabled (optimistic-hide only) when offline.
+
+Closest existing analogue, traced end-to-end and reused as the template: the unsubscribe-mail flow (`KeyWordIdentifierExtension.unsubscribeMail` → `EmailIdExtension.generateMapUpdateObjectUnsubscribeMail()` → `EmailApi.unsubscribeMail()` → `SetEmailMethod.addUpdates`).
+
+Key facts:
+- `KeyWordIdentifierExtension` has only static, non-parameterized keyword entries today. `twpWarningDismissed(int index)` is the first parameterized `KeyWordIdentifier` factory in this codebase.
+- `NetworkConnectionController` is already used by `thread_detail_controller.dart`; this is the first time `SingleEmailController` consumes it.
+- No existing keyword supports removal/un-dismiss — every keyword patch is add-only (`true` at `keywords/<value>`).
+
+## Decision
+
+### Keyword
+```dart
+static KeyWordIdentifier twpWarningDismissed(int index) => KeyWordIdentifier('twp-warning-dismissed-$index');
+```
+Dismissal targets exactly one `TwpWarning` by its stable `index` (list position).
+
+### Flow
+```
+TwpWarningBanner (dismiss tap)
+  → SingleEmailController.dismissTwpWarning(emailId, index)
+    → if NetworkConnectionController.isNetworkConnectionAvailable():
+         DismissTwpWarningInteractor.execute(session, accountId, emailId, index)
+           → EmailRepository.dismissTwpWarning(...)
+             → EmailApi: SetEmailMethod(accountId)..addUpdates(
+                 {emailId.id: KeyWordIdentifierExtension.twpWarningDismissed(index).generatePath(): true})
+       else:
+         optimistic local-only hide, no network call (per "disabled when offline" contract — not queued/retried)
+    → on success: PresentationEmail.isTwpWarningDismissed(index) reads true from updated keywords map
+```
+
+New pieces mirror existing shapes exactly:
+- `DismissTwpWarningInteractor` — 4-line shape like `UnsubscribeEmailInteractor`, parameterized by `index`.
+- `PresentationEmail.isTwpWarningDismissed(int index)` — mirrors `isSubscribed`'s keyword-lookup shape.
+- `EmailIdExtension.generateMapUpdateObjectDismissTwpWarning(int index)` — mirrors `generateMapUpdateObjectUnsubscribeMail()`.
+- Reuses existing `PatchObject`/`SetEmailMethod` machinery — no new JMAP method type.
+
+### Offline semantics
+Per confirmed backend contract, offline dismiss is a local-only, non-persistent hide — not an offline-queued mutation. Going back online does not retroactively send a queued dismiss.
+
+## Consequences
+- Dismiss button per-banner, trailing corner, with a11y tooltip (new ARB string).
+- Un-dismiss (re-show) is out of scope — no existing keyword in this codebase supports removal, and the issue doesn't ask for it.
+
+## Risks
+
+- **Index-based dismissal fragility**: if the set/order of `X-TWP-Message` headers changes between two fetches (a resolved warning, or a new one landing at the same index), a stored `twp-warning-dismissed-N` keyword could silently apply to a different warning next time. Not fixed speculatively (backend contract guarantees order stability within one response, not across time) — flagged for backend/product.
+
+## Open questions
+- Should un-dismiss be in scope? Assume out of scope unless product says otherwise.
+- Dismiss key on `code` instead of/alongside `index`, to survive warning-count changes across fetches?

--- a/docs/adr/0100-twp-warning-dismiss-persistence.md
+++ b/docs/adr/0100-twp-warning-dismiss-persistence.md
@@ -24,9 +24,10 @@ Key facts:
 
 ### Keyword
 ```dart
-static KeyWordIdentifier twpWarningDismissed(int index) => KeyWordIdentifier('twp-warning-dismissed-$index');
+static KeyWordIdentifier twpWarningDismissed(String code, int index) =>
+    KeyWordIdentifier('twp-warning-dismissed-$code-$index');
 ```
-Dismissal targets exactly one `TwpWarning` by its stable `index` (list position).
+Dismissal targets exactly one `TwpWarning` by `code` (backend-stable identifier) combined with `index` (tiebreaker for the unlikely case of duplicate codes on one email). Using `code` as the primary key means that if warning count or order changes across fetches, a stored keyword still maps to the same logical warning rather than the wrong index position.
 
 ### Flow
 ```
@@ -57,8 +58,8 @@ Per confirmed backend contract, offline dismiss is a local-only, non-persistent 
 
 ## Risks
 
-- **Index-based dismissal fragility**: if the set/order of `X-TWP-Message` headers changes between two fetches (a resolved warning, or a new one landing at the same index), a stored `twp-warning-dismissed-N` keyword could silently apply to a different warning next time. Not fixed speculatively (backend contract guarantees order stability within one response, not across time) — flagged for backend/product.
+- **Dismissal key stability**: combining `code` with `index` ensures a stored keyword survives reordering (a different warning at the same index won't inherit a dismissal). Residual gap: if the backend reuses a `code` on a semantically different warning in the future, the old dismissal would still fire. This is an application-layer convention risk, not fixable without a server-generated stable ID — flagged for backend/product.
 
 ## Open questions
 - Should un-dismiss be in scope? Assume out of scope unless product says otherwise.
-- Dismiss key on `code` instead of/alongside `index`, to survive warning-count changes across fetches?
+- What happens if `TwpWarning.code` is ever empty or missing? The parser must guarantee a non-empty code string (defaulting to e.g. `unknown`) so the keyword key is always well-formed — confirm this invariant in the `TwpWarning.parse` implementation.

--- a/docs/adr/0100-twp-warning-dismiss-persistence.md
+++ b/docs/adr/0100-twp-warning-dismiss-persistence.md
@@ -11,12 +11,12 @@ Parent: [ADR-0098](0098-twp-warning-banners-and-header-cache-consolidation.md); 
 
 ## Context
 
-Phase 2 of #4484: dismissing a warning persists across app restarts; disabled (optimistic-hide only) when offline.
+Phase 2 of #4484: dismissing a warning persists across app restarts; shows a red error toast when offline.
 
-Closest existing analogue, traced end-to-end and reused as the template: the unsubscribe-mail flow (`KeyWordIdentifierExtension.unsubscribeMail` → `EmailIdExtension.generateMapUpdateObjectUnsubscribeMail()` → `EmailApi.unsubscribeMail()` → `SetEmailMethod.addUpdates`).
+Closest existing analogue: the unsubscribe-mail flow (`KeyWordIdentifierExtension.unsubscribeMail` → `EmailIdExtension.generateMapUpdateObjectUnsubscribeMail()` → `EmailApi.unsubscribeMail()` → `SetEmailMethod.addUpdates`).
 
 Key facts:
-- `KeyWordIdentifierExtension` has only static, non-parameterized keyword entries today. `twpWarningDismissed(int index)` is the first parameterized `KeyWordIdentifier` factory in this codebase.
+- `KeyWordIdentifierExtension` has only static, non-parameterized keyword entries today. `twpWarningDismissed(String code, int index)` is the first parameterized `KeyWordIdentifier` factory in this codebase.
 - `NetworkConnectionController` is already used by `thread_detail_controller.dart`; this is the first time `SingleEmailController` consumes it.
 - No existing keyword supports removal/un-dismiss — every keyword patch is add-only (`true` at `keywords/<value>`).
 
@@ -27,39 +27,54 @@ Key facts:
 static KeyWordIdentifier twpWarningDismissed(String code, int index) =>
     KeyWordIdentifier('twp-warning-dismissed-$code-$index');
 ```
-Dismissal targets exactly one `TwpWarning` by `code` (backend-stable identifier) combined with `index` (tiebreaker for the unlikely case of duplicate codes on one email). Using `code` as the primary key means that if warning count or order changes across fetches, a stored keyword still maps to the same logical warning rather than the wrong index position.
+`code` is the backend-stable semantic identifier; `index` is the zero-based position within the **deduplicated** warning list, acting as a tiebreaker for the unlikely case of duplicate codes on one email. A stored keyword survives warning reordering across fetches because `code` is the primary key.
 
 ### Flow
 ```
-TwpWarningBanner (dismiss tap)
-  → SingleEmailController.dismissTwpWarning(emailId, index)
-    → if NetworkConnectionController.isNetworkConnectionAvailable():
-         DismissTwpWarningInteractor.execute(session, accountId, emailId, index)
+TwpWarningBanner (ConsumerWidget, dismiss tap)
+  → SingleEmailController.dismissTwpWarning(emailId, TwpWarning warning)
+    → if NOT NetworkConnectionController.isNetworkConnectionAvailable():
+         show red error toast — return (banner stays visible, no network call, nothing queued)
+    → else:
+         DismissTwpWarningInteractor.execute(session, accountId, emailId, warning.code, warning.index)
            → EmailRepository.dismissTwpWarning(...)
              → EmailApi: SetEmailMethod(accountId)..addUpdates(
-                 {emailId.id: KeyWordIdentifierExtension.twpWarningDismissed(index).generatePath(): true})
-       else:
-         optimistic local-only hide, no network call (per "disabled when offline" contract — not queued/retried)
-    → on success: PresentationEmail.isTwpWarningDismissed(index) reads true from updated keywords map
+                 {emailId.id: KeyWordIdentifierExtension
+                     .twpWarningDismissed(code, index).generatePath(): true})
+         on success:
+           ref.read(twpWarningNotifierProvider.notifier).markDismissed(code, index)
+           → notifier adds keyword string to its local optimistic set
+           → Riverpod state update → ConsumerWidget rebuilds → banner row disappears immediately
+           (no email object touched)
+         on failure:
+           show red error toast (banner stays visible)
 ```
+Live keywords are fed separately: whenever `currentEmail` changes (incl. WebSocket), the controller calls `notifier.setKeywords(currentEmail.keywords)`; effective dismissed set = live ∪ optimistic.
 
 New pieces mirror existing shapes exactly:
-- `DismissTwpWarningInteractor` — 4-line shape like `UnsubscribeEmailInteractor`, parameterized by `index`.
-- `PresentationEmail.isTwpWarningDismissed(int index)` — mirrors `isSubscribed`'s keyword-lookup shape.
-- `EmailIdExtension.generateMapUpdateObjectDismissTwpWarning(int index)` — mirrors `generateMapUpdateObjectUnsubscribeMail()`.
+- `DismissTwpWarningInteractor` — 4-line shape like `UnsubscribeEmailInteractor`, parameterized by `code` + `index`.
+- `EmailIdExtension.generateMapUpdateObjectDismissTwpWarning(String code, int index)` — mirrors `generateMapUpdateObjectUnsubscribeMail()`.
 - Reuses existing `PatchObject`/`SetEmailMethod` machinery — no new JMAP method type.
 
 ### Offline semantics
-Per confirmed backend contract, offline dismiss is a local-only, non-persistent hide — not an offline-queued mutation. Going back online does not retroactively send a queued dismiss.
+When offline, dismiss shows a red error toast and returns immediately. No local banner hide, no queued mutation, no optimistic update. The banner remains visible until the user is online and successfully dismisses.
+
+### Keyword source and dismiss success → immediate UI update
+Live dismissal keywords come from `currentEmail.keywords` (the WebSocket-updated `PresentationEmail`), fed to the notifier via Phase 1's `setKeywords`. The notifier additionally keeps a local optimistic set; its effective dismissed set is the union of the two, so `setKeywords` refreshing the live portion never drops an in-flight dismiss.
+
+On a successful JMAP call, `TwpWarningNotifier.markDismissed(String code, int index)` adds the keyword to the local optimistic set. The `TwpWarningBanner` `ConsumerWidget` watches this state and rebuilds immediately — the dismissed banner disappears without waiting for a WebSocket update or email re-fetch. No email object (`DetailedEmail` or `PresentationEmail`) is modified. When the WebSocket update later brings the keyword into `currentEmail`, `setKeywords` folds it into the live set and the union stays consistent.
 
 ## Consequences
 - Dismiss button per-banner, trailing corner, with a11y tooltip (new ARB string).
-- Un-dismiss (re-show) is out of scope — no existing keyword in this codebase supports removal, and the issue doesn't ask for it.
+- Red error toast string for offline and API failure cases (new ARB string).
+- Un-dismiss (re-show) is out of scope — no existing keyword in this codebase supports removal.
 
 ## Risks
 
-- **Dismissal key stability**: combining `code` with `index` ensures a stored keyword survives reordering (a different warning at the same index won't inherit a dismissal). Residual gap: if the backend reuses a `code` on a semantically different warning in the future, the old dismissal would still fire. This is an application-layer convention risk, not fixable without a server-generated stable ID — flagged for backend/product.
+- **Dismissal key stability**: combining `code` with `index` (deduplicated position) ensures a stored keyword survives reordering. Residual gap: if the backend reuses a `code` on a semantically different warning in the future, the old dismissal would still fire. Unfixable without a server-generated stable ID — flagged for backend/product.
+- **Optimistic/live reconciliation**: the effective dismissed set is `currentEmail.keywords` (live) ∪ local optimistic set. `setKeywords` must union, not replace, so an in-flight dismiss isn't dropped before the WebSocket update lands; the optimistic entry becomes redundant once the live keyword arrives.
 
 ## Open questions
 - Should un-dismiss be in scope? Assume out of scope unless product says otherwise.
-- What happens if `TwpWarning.code` is ever empty or missing? The parser must guarantee a non-empty code string (defaulting to e.g. `unknown`) so the keyword key is always well-formed — confirm this invariant in the `TwpWarning.parse` implementation.
+- Confirm exact binding/DI file used for `UnsubscribeEmailInteractor` registration before creating a new one for `DismissTwpWarningInteractor`.
+- How is `emailId` passed to the dismiss call from inside `TwpWarningBanner`? Options: held in notifier state, or read from `SingleEmailController` directly in the widget. Decide at implementation time.

--- a/docs/adr/0101-consolidate-individual-header-cache-fields.md
+++ b/docs/adr/0101-consolidate-individual-header-cache-fields.md
@@ -23,20 +23,22 @@ This is the widest-blast-radius phase in the plan: it touches every individual h
 
 ## Decision
 
-One consolidated field per cache class, mirroring `Email.individualHeaders`'s single-map shape:
+One consolidated field per cache class, mirroring `Email.individualHeaders`'s single-map shape. Value type is `dynamic`, holding either a `String` or a `List<String>` — the runtime type, not the value's length, records which JMAP request form (`asText` vs. `asText:all`) produced it:
 ```dart
-Map<String, List<String>>? individualHeaders
+Map<String, dynamic>? individualHeaders
 ```
 - `EmailCache`: new field at next free `@HiveField` index (23, re-verify at implementation time). Replaces `headerCalendarEvent`/`xPriorityHeader`/`importanceHeader`/`priorityHeader`/`unsubscribeHeader` as the source for `_buildIndividualHeaders()`; old fields stay declared but unwritten (Hive fields are additive-only, never reused/reordered).
 
-**Cache-to-domain type conversion (required in `_buildIndividualHeaders()` and its `DetailedEmailHiveCache` equivalent):**
-`Email.individualHeaders` is `Map<IndividualHeaderIdentifier, EmailHeaderValue>`, not `Map<String, List<String>>`. `_buildIndividualHeaders()` must convert each entry:
-- Key: the stored `String` is the `IndividualHeaderIdentifier.value`; reconstruct via `IndividualHeaderIdentifier(value: key)`.
-- Value: `List<String>` → `EmailHeaderValue`:
-  - Single value (`list.length == 1`): `TextHeaderValue(list.first)`
-  - Multiple values: `AllHeaderValue(list.map((s) => TextHeaderValue(s)).toList())`
+A header requested singularly (`asText`, e.g. MDN, List-Post, S/MIME status, identity) writes a raw `String`. A header requested with the `:all` suffix (currently only `X-TWP-Message`) writes a `List<String>` unconditionally, even for a single returned value — a one-warning email must reconstruct as `AllHeaderValue` on read, matching what the network path produces, not collapse to `TextHeaderValue`.
 
-This matches how the JMAP layer produces `EmailHeaderValue` via `EmailHeaderValue.fromJson` today (the `:all` suffix produces `AllHeaderValue`; a singular `asText` key produces `TextHeaderValue`). The conversion in `_buildIndividualHeaders()` must mirror that shape faithfully.
+**Cache-to-domain type conversion (required in `_buildIndividualHeaders()` and its `DetailedEmailHiveCache` equivalent):**
+`Email.individualHeaders` is `Map<IndividualHeaderIdentifier, EmailHeaderValue>`, not `Map<String, dynamic>`. `_buildIndividualHeaders()` must convert each entry:
+- Key: the stored `String` is the `IndividualHeaderIdentifier.value`; reconstruct via `IndividualHeaderIdentifier(key)` (positional constructor — `IndividualHeaderIdentifier` has no named `value` parameter).
+- Value: branch on the stored value's **runtime type**, not its length:
+  - `String` (singularly-requested header, e.g. MDN, List-Post, S/MIME status): `TextHeaderValue(value)`.
+  - `List<String>` (a header requested with `:all`, currently only `X-TWP-Message`): `AllHeaderValue(value.map((s) => TextHeaderValue(s)).toList())` — **regardless of element count**, including a single-element list.
+
+This matches how the JMAP layer produces `EmailHeaderValue` via `EmailHeaderValue.fromJson` today (the `:all` suffix produces `AllHeaderValue` unconditionally; a singular `asText` key produces `TextHeaderValue`). The write side must store consistently with this: singular headers write a raw `String`; `:all` headers write a `List<String>` unconditionally, never collapsed to `String` even for one value.
 - `DetailedEmailHiveCache`: reuses Phase 1's field (index 11) rather than redeclaring — gains `headerMdn`/`listPostHeader`/`sMimeStatusHeader`/`identityHeader` entries; old fields (9, 10) stay declared but unwritten.
 
 ### New header requests
@@ -49,17 +51,17 @@ Existing fallback logic needs no call-site changes once these arrive:
 ### Scope boundary
 `EmailProperty.headers` / the raw `Set<EmailHeader>` field is never touched. Domain/presentation layers (`PresentationEmail`, `DetailedEmail`) keep their existing typed per-header fields unchanged — only the two Hive cache classes' storage shape changes.
 
-**Upgrade-time regression (transient, expected):** on first app launch after this ships, emails that were cached before the upgrade have their header data only in the now-unwritten per-field slots, not in the new `individualHeaders` field. Header-derived UI (calendar-event badges, priority markers, unsubscribe banners, S/MIME status, identity display) will be absent for those cached emails until they are next refreshed from the server. This is the same no-backfill pattern as Phase 1. No migration is added — the regression is transient and bounded to one refresh cycle.
+**Read-side fallback — no user-visible regression.** `_buildIndividualHeaders()` (and its `DetailedEmailHiveCache` equivalent) reads the new `individualHeaders` field first; for any `IndividualHeaderIdentifier` **not present** in it, it falls back to reading the corresponding legacy per-header field (`headerCalendarEvent`/`xPriorityHeader`/`importanceHeader`/`priorityHeader`/`unsubscribeHeader` on `EmailCache`; `sMimeStatusHeader`/`identityHeader` on `DetailedEmailHiveCache`) using the existing pre-consolidation reconstruction logic. No cached email loses any header-derived UI at any point, upgrade or not. The legacy fields keep being read (never written) until a later, separate cleanup change confirms every entry has been refreshed at least once post-upgrade and removes the fallback — that cleanup is out of scope here and not required for this phase to ship correctly.
 
 ### Sequencing with Phase 1
 Whichever of Phase 1 / Phase 3 lands second must check the other hasn't already claimed `DetailedEmailHiveCache.individualHeaders` before adding a new `@HiveField`. `EmailCache` has no such dependency — Phase 1 doesn't touch it.
 
 ## Consequences
-- Old cached entries (populated only in the now-unwritten per-field slots) read as absent from the new field until next server refresh — correct, no backfill, matches Phase 1's pattern.
-- `_buildIndividualHeaders()` (and its `DetailedEmailHiveCache` equivalent) become simple single-field reads instead of a multi-field merge loop.
+- Old cached entries keep working via the legacy-field read fallback until they're next refreshed from the server and start populating the new consolidated field — no user-visible gap.
+- `_buildIndividualHeaders()` (and its `DetailedEmailHiveCache` equivalent) gain one fallback branch per legacy field instead of becoming a pure single-field read; this fallback is removable once a future cleanup phase confirms full migration.
 
 ## Risks
-- Regression surface spans every consolidated header (calendar-event, priority/importance, list-unsubscribe, S/MIME status, identity header), not just MDN/List-Post — regression-test all of them.
+- Fallback surface spans every consolidated header (calendar-event, priority/importance, list-unsubscribe, S/MIME status, identity header), not just MDN/List-Post — regression-test all of them, including the legacy-field fallback path itself.
 - Duplicate `listPostHeader` entry in `trackedHeaderIds` would iterate twice for no effect — verify none exists before merging.
 
 ## Open questions

--- a/docs/adr/0101-consolidate-individual-header-cache-fields.md
+++ b/docs/adr/0101-consolidate-individual-header-cache-fields.md
@@ -28,6 +28,15 @@ One consolidated field per cache class, mirroring `Email.individualHeaders`'s si
 Map<String, List<String>>? individualHeaders
 ```
 - `EmailCache`: new field at next free `@HiveField` index (23, re-verify at implementation time). Replaces `headerCalendarEvent`/`xPriorityHeader`/`importanceHeader`/`priorityHeader`/`unsubscribeHeader` as the source for `_buildIndividualHeaders()`; old fields stay declared but unwritten (Hive fields are additive-only, never reused/reordered).
+
+**Cache-to-domain type conversion (required in `_buildIndividualHeaders()` and its `DetailedEmailHiveCache` equivalent):**
+`Email.individualHeaders` is `Map<IndividualHeaderIdentifier, EmailHeaderValue>`, not `Map<String, List<String>>`. `_buildIndividualHeaders()` must convert each entry:
+- Key: the stored `String` is the `IndividualHeaderIdentifier.value`; reconstruct via `IndividualHeaderIdentifier(value: key)`.
+- Value: `List<String>` → `EmailHeaderValue`:
+  - Single value (`list.length == 1`): `TextHeaderValue(list.first)`
+  - Multiple values: `AllHeaderValue(list.map((s) => TextHeaderValue(s)).toList())`
+
+This matches how the JMAP layer produces `EmailHeaderValue` via `EmailHeaderValue.fromJson` today (the `:all` suffix produces `AllHeaderValue`; a singular `asText` key produces `TextHeaderValue`). The conversion in `_buildIndividualHeaders()` must mirror that shape faithfully.
 - `DetailedEmailHiveCache`: reuses Phase 1's field (index 11) rather than redeclaring — gains `headerMdn`/`listPostHeader`/`sMimeStatusHeader`/`identityHeader` entries; old fields (9, 10) stay declared but unwritten.
 
 ### New header requests
@@ -38,7 +47,9 @@ Existing fallback logic needs no call-site changes once these arrive:
 - `listPost`: `headers.listPost?.trim() ?? listPostHeader?.value?.trim() ?? ''`.
 
 ### Scope boundary
-`EmailProperty.headers` / the raw `Set<EmailHeader>` field is never touched. Domain/presentation layers (`PresentationEmail`, `DetailedEmail`) keep their existing typed per-header fields unchanged — only the two Hive cache classes' storage shape changes. No user-visible behavior change.
+`EmailProperty.headers` / the raw `Set<EmailHeader>` field is never touched. Domain/presentation layers (`PresentationEmail`, `DetailedEmail`) keep their existing typed per-header fields unchanged — only the two Hive cache classes' storage shape changes.
+
+**Upgrade-time regression (transient, expected):** on first app launch after this ships, emails that were cached before the upgrade have their header data only in the now-unwritten per-field slots, not in the new `individualHeaders` field. Header-derived UI (calendar-event badges, priority markers, unsubscribe banners, S/MIME status, identity display) will be absent for those cached emails until they are next refreshed from the server. This is the same no-backfill pattern as Phase 1. No migration is added — the regression is transient and bounded to one refresh cycle.
 
 ### Sequencing with Phase 1
 Whichever of Phase 1 / Phase 3 lands second must check the other hasn't already claimed `DetailedEmailHiveCache.individualHeaders` before adding a new `@HiveField`. `EmailCache` has no such dependency — Phase 1 doesn't touch it.

--- a/docs/adr/0101-consolidate-individual-header-cache-fields.md
+++ b/docs/adr/0101-consolidate-individual-header-cache-fields.md
@@ -1,0 +1,55 @@
+# 101. Consolidate Individual-Header Cache Fields
+
+Date: 2026-07-01
+
+## Status
+
+Proposed
+
+## Reference
+Parent: [ADR-0098](0098-twp-warning-banners-and-header-cache-consolidation.md); shares `DetailedEmailHiveCache.individualHeaders` introduced in [ADR-0099](0099-twp-warning-banners-visible.md)
+
+## Context
+
+Tech-debt payoff requested alongside #4484, not part of the banner feature itself. Current state:
+
+- `EmailCache` (`lib/features/thread/data/model/email_cache.dart`): five separate `Map<String, String?>?` `@HiveField`s — `headerCalendarEvent` (14), `xPriorityHeader` (16), `importanceHeader` (17), `priorityHeader` (18), `unsubscribeHeader` (20) — reassembled at read time by `EmailCacheExtension._buildIndividualHeaders()`.
+- `DetailedEmailHiveCache`: two separate fields — `sMimeStatusHeader` (9), `identityHeader` (10).
+- Two headers never fetched as individual headers despite having presets: MDN (`Disposition-Notification-To`, `IndividualHeaderIdentifier.headerMdn`) and `List-Post` (`IndividualHeaderIdentifier.listPostHeader`).
+- `listPostHeader` is already in `mergeTrackedIndividualHeaders`'s `trackedHeaderIds` but never actually requested as a property — currently dead code. `headerMdn` is missing from `trackedHeaderIds` entirely.
+- `sMimeStatusHeader`/`identityHeader` are fetched but not tracked — never refreshed by incremental `Email/changes` merges (pre-existing gap, not fixed here).
+
+This is the widest-blast-radius phase in the plan: it touches every individual header currently read from cache, not just the two new ones.
+
+## Decision
+
+One consolidated field per cache class, mirroring `Email.individualHeaders`'s single-map shape:
+```dart
+Map<String, List<String>>? individualHeaders
+```
+- `EmailCache`: new field at next free `@HiveField` index (23, re-verify at implementation time). Replaces `headerCalendarEvent`/`xPriorityHeader`/`importanceHeader`/`priorityHeader`/`unsubscribeHeader` as the source for `_buildIndividualHeaders()`; old fields stay declared but unwritten (Hive fields are additive-only, never reused/reordered).
+- `DetailedEmailHiveCache`: reuses Phase 1's field (index 11) rather than redeclaring — gains `headerMdn`/`listPostHeader`/`sMimeStatusHeader`/`identityHeader` entries; old fields (9, 10) stay declared but unwritten.
+
+### New header requests
+Add `IndividualHeaderIdentifier.headerMdn.value` and `.listPostHeader.value` to both `ThreadConstants.propertiesGetEmailContent` and `propertiesGetDetailedEmail`. Add only `headerMdn` to `trackedHeaderIds` (`listPostHeader` already present — do not duplicate).
+
+Existing fallback logic needs no call-site changes once these arrive:
+- `hasRequestReadReceipt`: `headers.readReceiptHasBeenRequested || headerMdn != null`.
+- `listPost`: `headers.listPost?.trim() ?? listPostHeader?.value?.trim() ?? ''`.
+
+### Scope boundary
+`EmailProperty.headers` / the raw `Set<EmailHeader>` field is never touched. Domain/presentation layers (`PresentationEmail`, `DetailedEmail`) keep their existing typed per-header fields unchanged — only the two Hive cache classes' storage shape changes. No user-visible behavior change.
+
+### Sequencing with Phase 1
+Whichever of Phase 1 / Phase 3 lands second must check the other hasn't already claimed `DetailedEmailHiveCache.individualHeaders` before adding a new `@HiveField`. `EmailCache` has no such dependency — Phase 1 doesn't touch it.
+
+## Consequences
+- Old cached entries (populated only in the now-unwritten per-field slots) read as absent from the new field until next server refresh — correct, no backfill, matches Phase 1's pattern.
+- `_buildIndividualHeaders()` (and its `DetailedEmailHiveCache` equivalent) become simple single-field reads instead of a multi-field merge loop.
+
+## Risks
+- Regression surface spans every consolidated header (calendar-event, priority/importance, list-unsubscribe, S/MIME status, identity header), not just MDN/List-Post — regression-test all of them.
+- Duplicate `listPostHeader` entry in `trackedHeaderIds` would iterate twice for no effect — verify none exists before merging.
+
+## Open questions
+- Confirm `EmailCache`'s next free index (23) and `DetailedEmailHiveCache`'s (11, or next-after-Phase-1) immediately before implementation.

--- a/docs/adr/0101-consolidate-individual-header-cache-fields.md
+++ b/docs/adr/0101-consolidate-individual-header-cache-fields.md
@@ -44,12 +44,33 @@ This matches how the JMAP layer produces `EmailHeaderValue` via `EmailHeaderValu
 ### New header requests
 Add `IndividualHeaderIdentifier.headerMdn.value` and `.listPostHeader.value` to both `ThreadConstants.propertiesGetEmailContent` and `propertiesGetDetailedEmail`. Add only `headerMdn` to `trackedHeaderIds` (`listPostHeader` already present — do not duplicate).
 
-Existing fallback logic needs no call-site changes once these arrive:
-- `hasRequestReadReceipt`: `headers.readReceiptHasBeenRequested || headerMdn != null`.
-- `listPost`: `headers.listPost?.trim() ?? listPostHeader?.value?.trim() ?? ''`.
+`listPost` (`email_extension.dart`) needs no call-site change: `headers.listPost?.trim() ?? listPostHeader?.value?.trim() ?? ''` already falls back to the new header once it arrives.
+
+`hasRequestReadReceipt` (`email_extension.dart`) also needs no change: `headers.readReceiptHasBeenRequested || headerMdn != null`. But this getter is **not** what drives the read-receipt prompt on the read view. That prompt is triggered by `Email.hasReadReceipt(Map<MailboxId, PresentationMailbox>)`, called as `success.emailCurrent.hasReadReceipt(...)` from `SingleEmailController`. Its current implementation only checks the raw header:
+```dart
+bool hasReadReceipt(Map<MailboxId, PresentationMailbox> mapMailbox) {
+  final mailboxCurrent = findMailboxContain(mapMailbox);
+  return !hasMdnSent &&
+      headers.readReceiptHasBeenRequested &&
+      mailboxCurrent?.isSent != true;
+}
+```
+This must be updated to also accept `headerMdn`, e.g. `(headers.readReceiptHasBeenRequested || headerMdn != null) && ...`, otherwise the read-receipt prompt keeps missing emails where the MDN signal only arrives via the new individual header.
 
 ### Scope boundary
-`EmailProperty.headers` / the raw `Set<EmailHeader>` field is never touched. Domain/presentation layers (`PresentationEmail`, `DetailedEmail`) keep their existing typed per-header fields unchanged — only the two Hive cache classes' storage shape changes.
+`EmailProperty.headers` / the raw `Set<EmailHeader>` field is never touched. `PresentationEmail` keeps its existing typed per-header fields unchanged, with the one addition above to `hasReadReceipt()`. `DetailedEmail` gains `headerMdn`/`listPostHeader` fields (`TextHeaderValue?`), mirroring its existing `sMimeStatusHeader`/`identityHeader` fields.
+
+### Offline rebuild path must carry the new fields through
+`GetEmailContentFromCacheSuccess.emailCurrent` is rebuilt in `get_email_content_interactor.dart`'s `_getStoredOpenedEmail`/`_getStoredNewEmail`, which merge specific `DetailedEmail` fields back into `emailCache.individualHeaders` by name:
+```dart
+final map = emailCache.individualHeaders.merge({
+  if (detailedEmail.sMimeStatusHeader != null)
+    IndividualHeaderIdentifier.sMimeStatusHeader: detailedEmail.sMimeStatusHeader!,
+  if (detailedEmail.identityHeader != null)
+    IndividualHeaderIdentifier.identityHeader: detailedEmail.identityHeader!,
+});
+```
+Both merge blocks must gain `headerMdn`/`listPostHeader` entries the same way, or offline/cached content reads silently drop these two headers even though `DetailedEmailHiveCache` stores them correctly — breaking the read-receipt prompt and List-Post UI specifically for offline/cached opens. While touching these blocks, also fix the pre-existing inconsistency where `_getStoredOpenedEmail`'s merge is missing the `identityHeader` entry that `_getStoredNewEmail` already has.
 
 **Read-side fallback — no user-visible regression.** `_buildIndividualHeaders()` (and its `DetailedEmailHiveCache` equivalent) reads the new `individualHeaders` field first; for any `IndividualHeaderIdentifier` **not present** in it, it falls back to reading the corresponding legacy per-header field (`headerCalendarEvent`/`xPriorityHeader`/`importanceHeader`/`priorityHeader`/`unsubscribeHeader` on `EmailCache`; `sMimeStatusHeader`/`identityHeader` on `DetailedEmailHiveCache`) using the existing pre-consolidation reconstruction logic. No cached email loses any header-derived UI at any point, upgrade or not. The legacy fields keep being read (never written) until a later, separate cleanup change confirms every entry has been refreshed at least once post-upgrade and removes the fallback — that cleanup is out of scope here and not required for this phase to ship correctly.
 
@@ -63,6 +84,8 @@ Whichever of Phase 1 / Phase 3 lands second must check the other hasn't already 
 ## Risks
 - Fallback surface spans every consolidated header (calendar-event, priority/importance, list-unsubscribe, S/MIME status, identity header), not just MDN/List-Post — regression-test all of them, including the legacy-field fallback path itself.
 - Duplicate `listPostHeader` entry in `trackedHeaderIds` would iterate twice for no effect — verify none exists before merging.
+- `Email.hasReadReceipt()` (the actual read-receipt prompt trigger, distinct from the unused-by-that-path `hasRequestReadReceipt` getter) must be updated to check `headerMdn`, or the prompt keeps missing MDN-only-signaled emails.
+- `get_email_content_interactor.dart`'s two offline-rebuild merge blocks must add `headerMdn`/`listPostHeader` entries, or offline/cached content reads silently drop these headers even though the cache stores them correctly.
 
 ## Open questions
 - Confirm `EmailCache`'s next free index (23) and `DetailedEmailHiveCache`'s (11, or next-after-Phase-1) immediately before implementation.


### PR DESCRIPTION
## Issue
- #4484 

## Summary

Proposes ADRs 0098–0101 for TWP warning banners: server-driven warning banners on the email read view, plus a related cache consolidation cleanup.

- **ADR-0098** — Umbrella decision. Parses repeatable `X-TWP-Message` headers (`level:<info|warn|error> code:<code> <fallback text>`) into dismissable warning banners, **deduplicated by exact `(level, code, fallbackText)` triplet before display and indexing**. Splits work into 3 independently-shippable phases and sets ground rules (legacy `headers` field untouched, additive-only Hive indices, `TwpWarningBanner` as a self-contained Riverpod `ConsumerWidget` with no constructor args, fed by `SingleEmailController` from live `PresentationEmail` data — never from `DetailedEmail`).

- **ADR-0099** — Phase 1: parse, deduplicate, and render banners read-only. Adds `TwpWarning` model/parser + dedup helper, wires the header property into `Email/get`, introduces a consolidated `individualHeaders: Map<String, List<String>>?` field on `DetailedEmailHiveCache` only (`EmailCache` is Phase 3). `TwpWarningBanner` is a `ConsumerWidget` reading `TwpWarningNotifier`, rendered next to `MailUnsubscribedBanner`. The notifier is fed from two live sources: **warnings** from the content-load `PresentationEmail` (`propertiesGetEmailContent`, carries the TWP header), **keywords** from `currentEmail.keywords` (the WebSocket-updated open email — `emailIdsPresentation[_currentEmailId]` on web/tablet, `selectedEmail` on mobile). `DetailedEmail` is not WebSocket-updated and never feeds the notifier directly (offline content-read path only).

- **ADR-0100** — Phase 2: per-warning dismiss persisted via a new parameterized keyword `twp-warning-dismissed-<code>-<index>`, following the existing unsubscribe-mail flow. `code` is the primary stable identifier; `index` (deduplicated-list position) is a tiebreaker for duplicate codes. Live dismissal keywords come from `currentEmail.keywords`; on successful dismiss the notifier adds the keyword to a local optimistic set (effective set = live ∪ optimistic) for immediate UI update without touching any email object. **Offline dismiss shows a red error toast and does nothing else** — no local hide, no queued mutation. Residual risk: backend reusing a `code` for a different warning could cause stale dismissals — flagged for backend/product.

- **ADR-0101** — Phase 3 (tech-debt, not part of the feature): consolidates 5 separate per-header fields on `EmailCache` and 2 on `DetailedEmailHiveCache` into single `individualHeaders` maps (reusing Phase 1's field on the detailed cache). Also fetches two previously-dead/missing headers (MDN, List-Post) as individual headers. `_buildIndividualHeaders()` must convert `Map<String, List<String>>` → `Map<IndividualHeaderIdentifier, EmailHeaderValue>` (key: `IndividualHeaderIdentifier(value: key)`; value: `TextHeaderValue` for single, `AllHeaderValue` for multi). **Transient upgrade regression expected:** cached emails lose header-derived UI (calendar badges, priority, unsubscribe banner, S/MIME, identity) until next server refresh — no backfill, old fields kept declared-but-unwritten per Hive additive-only rule.

## Open questions

- Is un-dismiss (re-show) in scope? Currently assumed out of scope.
- Is `TwpWarning.code` guaranteed non-empty by the backend? Parser must default to `'unknown'` if missing to keep the keyword key well-formed.
- Confirm Hive field indices 23 (`EmailCache`) / 11 (`DetailedEmailHiveCache`) still free at implementation time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Added ADRs outlining server-driven TWP warning banners for the email read view, including read-only visibility, tolerant parsing with safe defaults, stable deduplication, preserved ordering, and presentation-layer localized messaging.
  - Documented dismissal persistence across restarts using keyword-backed storage, including online/offline behavior and reconciliation rules.
  - Defined a phased approach to consolidate cached per-header Hive storage into a single `individualHeaders` map for email caches, covering new header properties and clarifying no backfill after upgrade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->