### PR TITLE
HOTFIX Composer mobile Getx invalid

### DIFF
--- a/lib/features/composer/presentation/composer_view.dart
+++ b/lib/features/composer/presentation/composer_view.dart
@@ -83,7 +83,7 @@ class ComposerView extends GetWidget<ComposerController> {
                       ),
                   )))
                 else
-                  Obx(() => Consumer(builder: (_, ref, __) => AppBarComposerWidget(
+                  Consumer(builder: (_, ref, __) => Obx(() => AppBarComposerWidget(
                     imagePaths: controller.imagePaths,
                     isSendButtonEnabled: controller.isEnableEmailSendButton.value,
                     onCloseViewAction: () => controller.handleClickCloseComposer(context),


### PR DESCRIPTION
## Issue
```console

════════ Exception caught by widgets library ═══════════════════════════════════
The following message was thrown building Obx(has builder, dirty, state: ObxState#04763):
[Get] the improper use of a GetX has been detected. 
      You should only use GetX or Obx for the specific widget that will be updated.
      If you are seeing this error, you probably did not insert any observable variables into GetX/Obx 
      or insert them outside the scope that GetX considers suitable for an update 
      (example: GetX => HeavyWidget => variableObservable).
      If you need to update a parent widget and a child widget, wrap each one in an Obx/GetX.

The relevant error-causing widget was:
    Obx Obx:file:///Users/dangdat/Desktop/dev/linagora-master/tmail-flutter/lib/features/composer/presentation/composer_view.dart:86:19
```

## Resolved

![Uploading Screenshot_1782895184.png…]()


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how composer UI updates are handled on mobile in portrait mode, helping the interface refresh more efficiently when state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->