### PR TITLE
[Sentry] Fix Calendar error be minified

### DIFF
--- a/lib/features/composer/domain/exceptions/set_method_exception.dart
+++ b/lib/features/composer/domain/exceptions/set_method_exception.dart
@@ -1,11 +1,12 @@
 import 'package:jmap_dart_client/jmap/core/error/set_error.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:core/domain/exceptions/app_base_exception.dart';
+import 'package:model/extensions/set_error_extension.dart';
 
 class SetMethodException extends AppBaseException {
   final Map<Id, SetError> mapErrors;
 
-  SetMethodException(this.mapErrors) : super('Errors: $mapErrors');
+  SetMethodException(this.mapErrors) : super('Errors: {${mapErrors.toLogMessage()}}');
 
   @override
   String get exceptionName => 'SetMethodException';

--- a/lib/features/email/domain/exceptions/calendar_event_exceptions.dart
+++ b/lib/features/email/domain/exceptions/calendar_event_exceptions.dart
@@ -1,6 +1,7 @@
 import 'package:jmap_dart_client/jmap/core/error/set_error.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:core/domain/exceptions/app_base_exception.dart';
+import 'package:model/extensions/set_error_extension.dart';
 
 class NotFoundCalendarEventException extends AppBaseException {
   NotFoundCalendarEventException([super.message]);
@@ -41,7 +42,7 @@ class CannotReplyCalendarEventException extends AppBaseException {
   final Map<Id, SetError>? mapErrors;
 
   CannotReplyCalendarEventException({this.mapErrors})
-      : super(mapErrors != null ? 'Errors: $mapErrors' : null);
+      : super(mapErrors != null ? 'Errors: {${mapErrors.toLogMessage()}}' : null);
 
   @override
   String get exceptionName => 'CannotReplyCalendarEventException';

--- a/model/lib/extensions/set_error_extension.dart
+++ b/model/lib/extensions/set_error_extension.dart
@@ -1,0 +1,20 @@
+import 'package:jmap_dart_client/jmap/core/error/set_error.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+
+/// Stable, minification-proof string helpers for JMAP [SetError].
+///
+/// [SetError] and [Id] don't override `toString()`, so in a release/web build
+/// their default `toString()` emits the minified runtime type name
+/// (e.g. `Instance of 'minified:eK'`). Interpolating them directly into
+/// exception messages or logs produces unreadable output like
+/// `{minified:b2: minified:eK}` in Sentry. These helpers format them from the
+/// stable string fields (`type.value`, `description`, `Id.value`) instead.
+extension SetErrorLogExtension on SetError {
+  String get logMessage => '[${type.value}] ${description ?? ''}';
+}
+
+extension MapIdSetErrorLogExtension on Map<Id, SetError> {
+  /// Formats the errors as `id: [type] description, ...` with no minified types.
+  String toLogMessage() =>
+      entries.map((e) => '${e.key.value}: ${e.value.logMessage}').join(', ');
+}

--- a/model/lib/model.dart
+++ b/model/lib/model.dart
@@ -62,6 +62,7 @@ export 'extensions/utc_date_extension.dart';
 export 'extensions/contact_support_capability_extension.dart';
 export 'extensions/list_id_extension.dart';
 export 'extensions/set_email_body_part_extension.dart';
+export 'extensions/set_error_extension.dart';
 export 'extensions/oidc_user_info_extension.dart';
 // Identity
 export 'identity/identity_request_dto.dart';

--- a/model/test/extensions/set_error_extension_test.dart
+++ b/model/test/extensions/set_error_extension_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/error/set_error.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:model/extensions/set_error_extension.dart';
+
+void main() {
+  group('SetErrorLogExtension::logMessage', () {
+    test('formats type and description with stable strings', () {
+      final setError = SetError(
+        SetError.invalidArguments,
+        description: 'Blob not an attendee',
+      );
+      expect(setError.logMessage, '[invalidArguments] Blob not an attendee');
+    });
+
+    test('omits null description', () {
+      final setError = SetError(SetError.notFound);
+      expect(setError.logMessage, '[notFound] ');
+    });
+  });
+
+  group('MapIdSetErrorLogExtension::toLogMessage', () {
+    test('formats each entry as `id: [type] description`', () {
+      final mapErrors = {
+        Id('blob123'): SetError(
+          SetError.forbidden,
+          description: 'Not allowed',
+        ),
+      };
+      expect(mapErrors.toLogMessage(), 'blob123: [forbidden] Not allowed');
+    });
+
+    test('joins multiple entries with a comma', () {
+      final mapErrors = {
+        Id('blobA'): SetError(SetError.notFound, description: 'gone'),
+        Id('blobB'): SetError(SetError.serverFail, description: 'boom'),
+      };
+      expect(
+        mapErrors.toLogMessage(),
+        'blobA: [notFound] gone, blobB: [serverFail] boom',
+      );
+    });
+
+    test('returns empty string for empty map', () {
+      final mapErrors = <Id, SetError>{};
+      expect(mapErrors.toLogMessage(), '');
+    });
+
+    test('produces no minified runtime type tokens', () {
+      final mapErrors = {
+        Id('blob123'): SetError(SetError.invalidArguments, description: 'bad'),
+      };
+      final message = 'Errors: {${mapErrors.toLogMessage()}}';
+      expect(message, 'Errors: {blob123: [invalidArguments] bad}');
+      expect(message.contains('minified'), isFalse);
+      expect(message.contains('Instance of'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
### Desc
https://errors.cozycloud.cc/organizations/cozycloud/issues/385092

```
CannotReplyCalendarEventException
CannotReplyCalendarEventException: Errors: {minified:b2: minified:eK}
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error messages are now clearer and more consistent when displaying validation issues, especially for grouped field errors.

* **Bug Fixes**
  * Improved formatting of exception text to avoid noisy, unstable output and make messages easier to read in logs and support reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->