### PR TITLE
TF-4667 Never fall back to basic auth when SSO redirects fail

### DIFF
--- a/docs/adr/0102-no-basic-auth-fallback-on-sso-detected.md
+++ b/docs/adr/0102-no-basic-auth-fallback-on-sso-detected.md
@@ -1,0 +1,36 @@
+# 102. No Basic Auth Fallback When SSO Is Detected
+
+Date: 2026-07-03
+
+## Status
+
+Proposed
+
+## Context
+
+#4667: on a server where SSO (OIDC) was actually advertised, the redirect/token exchange failed and the app silently fell back to the basic-auth form. On an SSO-only server that form can never succeed, trapping the user with a misleading password prompt. It is also a downgrade surface: suppressing webFinger (forcing a 404) would push users to a credential-harvesting basic-auth form.
+
+Root cause: the login flow treated every OIDC failure the same, whether the provider was **confirmed** by webFinger or merely **guessed** from the base URL. Only the guessed case is a legitimate basic-auth fallback.
+
+Key facts:
+- `getOIDCConfiguration` is reached two ways: a real webFinger hit (`CheckOIDCIsAvailableSuccess` / `TryGuessingWebFingerSuccess`) or a base-URL guess (`BaseUrlOidcResponse`). The response type is the only signal available at that point.
+- Guessing (`generateOidcGuessingUrls`) only probes the user's own domain (`domain`, `autodiscover.domain`, `jmap.domain`), so a webFinger hit is always the user's own infrastructure — there is no cross-domain false-positive to guard against.
+- Web OIDC is a full-page redirect: the in-memory config is destroyed and rebuilt from cache to finish the token exchange after the redirect (`_getAuthenticationInfo → _getStoredOidcConfiguration → _getTokenOIDCAction`). So the config must be persisted at discovery time, and a stored config may be an unconfirmed/incomplete one — "presence of a stored config" cannot stand in for the flag.
+
+## Decision
+
+Introduce a single boolean `OIDCConfiguration.ssoConfirmed`, set once in `GetOIDCConfigurationInteractor` as `oidcResponse is! BaseUrlOidcResponse`, and thread it through the failure states (`GetTokenOIDCFailure`, `AuthenticateOidcOnBrowserFailure`).
+
+- **Routing:** `_handleSSORedirectFailure` sends `ssoConfirmed == true` to `LoginFormType.retry` (never basic auth); `false` keeps the existing `_handleCommonOIDCFailure` fallback. This drops the old `featureFailure != null` guard, so the decision now depends on `ssoConfirmed` alone.
+- **Messaging:** the `ssoRedirectFailedMessage` banner is gated on the same `ssoConfirmed`, so the guessed-provider path keeps its exception-specific message. A `NetworkException` is further excluded, so an offline/connection drop mid-redirect surfaces the accurate network message instead of blaming the SSO redirect. The inline banner is the single explanation surface — no extra toast is layered on top of it.
+- **Persistence:** `ssoConfirmed` is persisted as a nullable Hive field because web must rebuild the config from cache after the redirect. In-memory threading already covers the whole single-session flow (all of mobile, plus web first-login), so the persisted flag drives the retry-vs-basic-auth decision only on web relaunch. Legacy entries read back `null`, deliberately treated as `false` — a base-URL-guess config is also persisted, so `false` is the only safe default, and the fix applies once the user re-authenticates through confirmed SSO.
+
+**Boundary:** only a webFinger 200 carrying OIDC links confirms SSO. Every other outcome — 404, 401, 5xx, timeout, TLS failure, empty-links, proxy/captive-portal HTML — is treated as unconfirmed and may still offer basic auth, because none of them is positive proof of an SSO server.
+
+## Consequences
+
+- Confirmed-SSO failures (redirect error, token error, closed browser, broken authority discovery) stay on the SSO retry flow on both web and mobile, with no basic-auth trap.
+- Guessed-provider and transient-discovery failures behave exactly as before.
+- One-time, web only: an existing confirmed-SSO web user still sees basic auth once on relaunch, until their next successful discovery rewrites the cache. Mobile re-discovers every session, so it is correct immediately.
+- Known limitation (rare, web-only): if a server disables SSO after a config was cached with `ssoConfirmed == true`, web relaunch trusts the stale flag and keeps the user on retry until the cache is rewritten. A future option is to re-run webFinger on web relaunch instead of trusting the cached flag.
+- Out of scope: TWP/SaaS (`SignInTwakeWorkplaceFailure`) still routes to `_handleCommonOIDCFailure`, and the web auto-login path (`HomeController`) still reloads the login page rather than surfacing the retry directly.

--- a/lib/features/login/data/extensions/oidc_configutation_cache_extension.dart
+++ b/lib/features/login/data/extensions/oidc_configutation_cache_extension.dart
@@ -11,6 +11,9 @@ extension OidcConfigutationCacheExtension on OidcConfigurationCache {
       isTWP: isTWP,
       clientId: OIDCConstant.clientId,
       scopes: AppConfig.oidcScopes,
+      // Legacy entries predate this field; treat a missing value as unconfirmed
+      // so basic auth stays available rather than trapping the user on retry.
+      ssoConfirmed: ssoConfirmed ?? false,
     );
   }
 }

--- a/lib/features/login/data/extensions/oidc_configutation_cache_extension.dart
+++ b/lib/features/login/data/extensions/oidc_configutation_cache_extension.dart
@@ -11,8 +11,7 @@ extension OidcConfigutationCacheExtension on OidcConfigurationCache {
       isTWP: isTWP,
       clientId: OIDCConstant.clientId,
       scopes: AppConfig.oidcScopes,
-      // Legacy entries predate this field; treat a missing value as unconfirmed
-      // so basic auth stays available rather than trapping the user on retry.
+      // Pre-existing entries lack this field; unconfirmed keeps basic auth open.
       ssoConfirmed: ssoConfirmed ?? false,
     );
   }

--- a/lib/features/login/data/model/oidc_configuration_cache.dart
+++ b/lib/features/login/data/model/oidc_configuration_cache.dart
@@ -13,8 +13,12 @@ class OidcConfigurationCache extends HiveObject with EquatableMixin {
   @HiveField(1)
   final bool isTWP;
 
-  OidcConfigurationCache(this.authority, this.isTWP);
+  // Nullable so entries cached before this field existed read back as null.
+  @HiveField(2)
+  final bool? ssoConfirmed;
+
+  OidcConfigurationCache(this.authority, this.isTWP, {this.ssoConfirmed});
 
   @override
-  List<Object?> get props => [authority, isTWP];
+  List<Object?> get props => [authority, isTWP, ssoConfirmed];
 }

--- a/lib/features/login/domain/extensions/oidc_configuration_extensions.dart
+++ b/lib/features/login/domain/extensions/oidc_configuration_extensions.dart
@@ -57,6 +57,6 @@ extension OidcConfigurationExtensions on OIDCConfiguration {
     .generateEndpointPath();
 
   OidcConfigurationCache toOidcConfigurationCache() {
-    return OidcConfigurationCache(authority, isTWP);
+    return OidcConfigurationCache(authority, isTWP, ssoConfirmed: ssoConfirmed);
   }
 }

--- a/lib/features/login/domain/state/authenticate_oidc_on_browser_state.dart
+++ b/lib/features/login/domain/state/authenticate_oidc_on_browser_state.dart
@@ -7,5 +7,13 @@ class AuthenticateOidcOnBrowserSuccess extends UIState {}
 
 class AuthenticateOidcOnBrowserFailure extends FeatureFailure {
 
-  AuthenticateOidcOnBrowserFailure(dynamic exception) : super(exception: exception);
+  /// Whether SSO was confirmed by webFinger for the attempted config. When
+  /// `false` the provider was only guessed from the base URL, so basic auth
+  /// stays a valid fallback.
+  final bool ssoConfirmed;
+
+  AuthenticateOidcOnBrowserFailure(
+    dynamic exception, {
+    this.ssoConfirmed = false,
+  }) : super(exception: exception);
 }

--- a/lib/features/login/domain/state/authenticate_oidc_on_browser_state.dart
+++ b/lib/features/login/domain/state/authenticate_oidc_on_browser_state.dart
@@ -7,9 +7,7 @@ class AuthenticateOidcOnBrowserSuccess extends UIState {}
 
 class AuthenticateOidcOnBrowserFailure extends FeatureFailure {
 
-  /// Whether SSO was confirmed by webFinger for the attempted config. When
-  /// `false` the provider was only guessed from the base URL, so basic auth
-  /// stays a valid fallback.
+  /// Mirrors the attempted config's `OIDCConfiguration.ssoConfirmed`.
   final bool ssoConfirmed;
 
   AuthenticateOidcOnBrowserFailure(

--- a/lib/features/login/domain/state/get_token_oidc_state.dart
+++ b/lib/features/login/domain/state/get_token_oidc_state.dart
@@ -23,5 +23,13 @@ class GetTokenOIDCSuccess extends UIState {
 
 class GetTokenOIDCFailure extends FeatureFailure {
 
-  GetTokenOIDCFailure(dynamic exception) : super(exception: exception);
+  /// Whether SSO was confirmed by webFinger for the attempted config. When
+  /// `false` the provider was only guessed from the base URL, so basic auth
+  /// stays a valid fallback.
+  final bool ssoConfirmed;
+
+  GetTokenOIDCFailure(
+    dynamic exception, {
+    this.ssoConfirmed = false,
+  }) : super(exception: exception);
 }

--- a/lib/features/login/domain/state/get_token_oidc_state.dart
+++ b/lib/features/login/domain/state/get_token_oidc_state.dart
@@ -23,9 +23,7 @@ class GetTokenOIDCSuccess extends UIState {
 
 class GetTokenOIDCFailure extends FeatureFailure {
 
-  /// Whether SSO was confirmed by webFinger for the attempted config. When
-  /// `false` the provider was only guessed from the base URL, so basic auth
-  /// stays a valid fallback.
+  /// Mirrors the attempted config's `OIDCConfiguration.ssoConfirmed`.
   final bool ssoConfirmed;
 
   GetTokenOIDCFailure(

--- a/lib/features/login/domain/usecases/authenticate_oidc_on_browser_interactor.dart
+++ b/lib/features/login/domain/usecases/authenticate_oidc_on_browser_interactor.dart
@@ -25,7 +25,9 @@ class AuthenticateOidcOnBrowserInteractor {
       yield Right<Failure, Success>(AuthenticateOidcOnBrowserSuccess());
     } catch (e) {
       logWarning('AuthenticateOidcOnBrowserInteractor::execute(): $e');
-      yield Left<Failure, Success>(AuthenticateOidcOnBrowserFailure(e));
+      yield Left<Failure, Success>(
+        AuthenticateOidcOnBrowserFailure(e, ssoConfirmed: config.ssoConfirmed),
+      );
     }
   }
 }

--- a/lib/features/login/domain/usecases/get_oidc_configuration_interactor.dart
+++ b/lib/features/login/domain/usecases/get_oidc_configuration_interactor.dart
@@ -22,8 +22,7 @@ class GetOIDCConfigurationInteractor {
       final oidcConfiguration = await _oidcRepository.getOIDCConfiguration(oidcResponse);
       final configWithLoginHint = oidcConfiguration.copyWidth(
         loginHint: loginHint,
-        // Only a base-URL guess uses [BaseUrlOidcResponse]; any other response
-        // came from webFinger, which means SSO was actually advertised.
+        // A BaseUrlOidcResponse is a base-URL guess; anything else is webFinger.
         ssoConfirmed: oidcResponse is! BaseUrlOidcResponse,
       );
       await _oidcRepository.persistOidcConfiguration(configWithLoginHint);

--- a/lib/features/login/domain/usecases/get_oidc_configuration_interactor.dart
+++ b/lib/features/login/domain/usecases/get_oidc_configuration_interactor.dart
@@ -22,6 +22,9 @@ class GetOIDCConfigurationInteractor {
       final oidcConfiguration = await _oidcRepository.getOIDCConfiguration(oidcResponse);
       final configWithLoginHint = oidcConfiguration.copyWidth(
         loginHint: loginHint,
+        // Only a base-URL guess uses [BaseUrlOidcResponse]; any other response
+        // came from webFinger, which means SSO was actually advertised.
+        ssoConfirmed: oidcResponse is! BaseUrlOidcResponse,
       );
       await _oidcRepository.persistOidcConfiguration(configWithLoginHint);
       yield Right<Failure, Success>(

--- a/lib/features/login/domain/usecases/get_token_oidc_interactor.dart
+++ b/lib/features/login/domain/usecases/get_token_oidc_interactor.dart
@@ -55,13 +55,20 @@ class GetTokenOIDCInteractor {
     } on PlatformException catch (e) {
       logWarning('GetTokenOIDCInteractor::execute(): PlatformException ${e.message} - ${e.stacktrace}');
       if (NoSuitableBrowserForOIDCException.verifyException(e)) {
-        yield Left<Failure, Success>(GetTokenOIDCFailure(NoSuitableBrowserForOIDCException()));
+        yield Left<Failure, Success>(GetTokenOIDCFailure(
+          NoSuitableBrowserForOIDCException(),
+          ssoConfirmed: config.ssoConfirmed,
+        ));
       } else {
-        yield Left<Failure, Success>(GetTokenOIDCFailure(e));
+        yield Left<Failure, Success>(
+          GetTokenOIDCFailure(e, ssoConfirmed: config.ssoConfirmed),
+        );
       }
     } catch (e) {
       logWarning('GetTokenOIDCInteractor::execute(): $e');
-      yield Left<Failure, Success>(GetTokenOIDCFailure(e));
+      yield Left<Failure, Success>(
+        GetTokenOIDCFailure(e, ssoConfirmed: config.ssoConfirmed),
+      );
     }
   }
 }

--- a/lib/features/login/presentation/login_controller.dart
+++ b/lib/features/login/presentation/login_controller.dart
@@ -601,17 +601,9 @@ class LoginController extends ReloadableController {
     }
   }
 
-  /// Handles a failure while going through the OIDC browser redirect / token
-  /// exchange.
-  ///
-  /// [ssoConfirmed] tells whether webFinger actually advertised SSO for the
-  /// attempted server. When it did not, the provider was only guessed from the
-  /// base URL, so the server may not be an SSO server and basic auth remains a
-  /// legitimate fallback.
-  ///
-  /// When SSO was confirmed, we must never fall back to basic auth; we keep the
-  /// user on the SSO flow, surface the error and offer a retry so they can
-  /// attempt the redirects again.
+  /// On a webFinger-confirmed SSO server we never fall back to basic auth: keep
+  /// the user on the SSO flow and offer a retry. A guessed provider may not be
+  /// SSO, so it keeps the basic-auth fallback.
   void _handleSSORedirectFailure({required bool ssoConfirmed}) {
     if (ssoConfirmed) {
       loginFormType.value = LoginFormType.retry;

--- a/lib/features/login/presentation/login_controller.dart
+++ b/lib/features/login/presentation/login_controller.dart
@@ -104,6 +104,7 @@ class LoginController extends ReloadableController {
   Password? _password;
   Uri? _baseUri;
   FeatureFailure? featureFailure;
+
   DeepLinksManager? _deepLinksManager;
   StreamSubscription<DeepLinkData?>? _deepLinkDataStreamSubscription;
 
@@ -170,11 +171,11 @@ class LoginController extends ReloadableController {
         failure is SignInTwakeWorkplaceFailure
     ) {
       _handleCommonOIDCFailure();
-    } else if (failure is AuthenticateOidcOnBrowserFailure && featureFailure != null) {
-      _handleCommonOIDCFailure();
+    } else if (failure is AuthenticateOidcOnBrowserFailure) {
+      _handleSSORedirectFailure(ssoConfirmed: failure.ssoConfirmed);
     } else if (failure is GetTokenOIDCFailure) {
       _handleNoSuitableBrowserOIDC(failure)
-        .map((stillFailed) => _handleCommonOIDCFailure());
+        .map((stillFailed) => _handleSSORedirectFailure(ssoConfirmed: failure.ssoConfirmed));
     } else if (failure is GetAuthenticatedAccountFailure) {
       _checkOIDCIsAvailable();
     } else if (failure is GetSessionFailure) {
@@ -237,11 +238,11 @@ class LoginController extends ReloadableController {
         failure is SignInTwakeWorkplaceFailure
     ) {
       _handleCommonOIDCFailure();
-    } else if (failure is AuthenticateOidcOnBrowserFailure && featureFailure != null) {
-      _handleCommonOIDCFailure();
+    } else if (failure is AuthenticateOidcOnBrowserFailure) {
+      _handleSSORedirectFailure(ssoConfirmed: failure.ssoConfirmed);
     } else if (failure is GetTokenOIDCFailure) {
       _handleNoSuitableBrowserOIDC(failure)
-        .map((stillFailed) => _handleCommonOIDCFailure());
+        .map((stillFailed) => _handleSSORedirectFailure(ssoConfirmed: failure.ssoConfirmed));
     } else if (failure is GetSessionFailure) {
       SmartDialog.dismiss();
       clearAllData();
@@ -597,6 +598,25 @@ class LoginController extends ReloadableController {
       _showPasswordForm();
     } else {
       _showCredentialForm();
+    }
+  }
+
+  /// Handles a failure while going through the OIDC browser redirect / token
+  /// exchange.
+  ///
+  /// [ssoConfirmed] tells whether webFinger actually advertised SSO for the
+  /// attempted server. When it did not, the provider was only guessed from the
+  /// base URL, so the server may not be an SSO server and basic auth remains a
+  /// legitimate fallback.
+  ///
+  /// When SSO was confirmed, we must never fall back to basic auth; we keep the
+  /// user on the SSO flow, surface the error and offer a retry so they can
+  /// attempt the redirects again.
+  void _handleSSORedirectFailure({required bool ssoConfirmed}) {
+    if (ssoConfirmed) {
+      loginFormType.value = LoginFormType.retry;
+    } else {
+      _handleCommonOIDCFailure();
     }
   }
 

--- a/lib/features/login/presentation/widgets/login_message_widget.dart
+++ b/lib/features/login/presentation/widgets/login_message_widget.dart
@@ -8,6 +8,7 @@ import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/login/domain/exceptions/login_exception.dart';
+import 'package:tmail_ui_user/features/login/domain/state/authenticate_oidc_on_browser_state.dart';
 import 'package:tmail_ui_user/features/login/domain/state/dns_lookup_to_get_jmap_url_state.dart';
 import 'package:tmail_ui_user/features/login/domain/state/get_oidc_configuration_state.dart';
 import 'package:tmail_ui_user/features/login/domain/state/get_token_oidc_state.dart';
@@ -60,6 +61,8 @@ class LoginMessageWidget extends StatelessWidget {
                 return appLocalizations.dnsLookupLoginMessage;
               } else if (failure is GetTokenOIDCFailure && failure.exception is NoSuitableBrowserForOIDCException) {
                 return appLocalizations.noSuitableBrowserForOIDC;
+              } else if (failure is GetTokenOIDCFailure || failure is AuthenticateOidcOnBrowserFailure) {
+                return appLocalizations.ssoRedirectFailedMessage;
               } else if (failure is FeatureFailure) {
                 return _toastManager?.getMessageByException(
                   appLocalizations,

--- a/lib/features/login/presentation/widgets/login_message_widget.dart
+++ b/lib/features/login/presentation/widgets/login_message_widget.dart
@@ -61,7 +61,12 @@ class LoginMessageWidget extends StatelessWidget {
                 return appLocalizations.dnsLookupLoginMessage;
               } else if (failure is GetTokenOIDCFailure && failure.exception is NoSuitableBrowserForOIDCException) {
                 return appLocalizations.noSuitableBrowserForOIDC;
-              } else if (failure is GetTokenOIDCFailure || failure is AuthenticateOidcOnBrowserFailure) {
+              } else if (((failure is GetTokenOIDCFailure && failure.ssoConfirmed) ||
+                      (failure is AuthenticateOidcOnBrowserFailure && failure.ssoConfirmed)) &&
+                  (failure as FeatureFailure).exception is! NetworkException) {
+                // Show only for a confirmed-SSO, non-network failure. Guessed
+                // providers fall back to basic auth; network drops show the
+                // offline message below.
                 return appLocalizations.ssoRedirectFailedMessage;
               } else if (failure is FeatureFailure) {
                 return _toastManager?.getMessageByException(

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1393,6 +1393,12 @@
     "placeholders_order": [],
     "placeholders": {}
   },
+  "ssoRedirectFailedMessage": "We could not complete the single sign-on redirection. Please try again.",
+  "@ssoRedirectFailedMessage": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
   "moveFolder": "Move folder",
   "@moveFolder": {
     "type": "text",

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -1485,6 +1485,12 @@ class AppLocalizations {
         name: 'canNotGetToken');
   }
 
+  String get ssoRedirectFailedMessage {
+    return Intl.message(
+        'We could not complete the single sign-on redirection. Please try again.',
+        name: 'ssoRedirectFailedMessage');
+  }
+
   String get moveFolder {
     return Intl.message(
       'Move folder',

--- a/model/lib/oidc/oidc_configuration.dart
+++ b/model/lib/oidc/oidc_configuration.dart
@@ -10,11 +10,8 @@ class OIDCConfiguration with EquatableMixin {
   final bool isTWP;
   final String? loginHint;
 
-  /// Whether webFinger actually advertised SSO for this server.
-  ///
-  /// `true` means SSO was confirmed by discovery; `false` means the provider was
-  /// only guessed from the base URL, so the server may not be an SSO server and
-  /// basic auth remains a legitimate fallback when authentication fails.
+  /// Whether webFinger advertised SSO for this server. `false` means it was only
+  /// guessed from the base URL, so basic auth stays a valid fallback on failure.
   final bool ssoConfirmed;
 
   OIDCConfiguration({

--- a/model/lib/oidc/oidc_configuration.dart
+++ b/model/lib/oidc/oidc_configuration.dart
@@ -10,12 +10,20 @@ class OIDCConfiguration with EquatableMixin {
   final bool isTWP;
   final String? loginHint;
 
+  /// Whether webFinger actually advertised SSO for this server.
+  ///
+  /// `true` means SSO was confirmed by discovery; `false` means the provider was
+  /// only guessed from the base URL, so the server may not be an SSO server and
+  /// basic auth remains a legitimate fallback when authentication fails.
+  final bool ssoConfirmed;
+
   OIDCConfiguration({
     required this.authority,
     required this.clientId,
     required this.scopes,
     this.isTWP = false,
     this.loginHint,
+    this.ssoConfirmed = false,
   });
 
   String get discoveryUrl {
@@ -33,6 +41,7 @@ class OIDCConfiguration with EquatableMixin {
     scopes,
     isTWP,
     loginHint,
+    ssoConfirmed,
   ];
 }
 
@@ -43,6 +52,7 @@ extension OIDCConfigurationExtension on OIDCConfiguration {
     List<String>? scopes,
     bool? isTWP,
     String? loginHint,
+    bool? ssoConfirmed,
   }) =>
       OIDCConfiguration(
         authority: authority ?? this.authority,
@@ -50,5 +60,6 @@ extension OIDCConfigurationExtension on OIDCConfiguration {
         scopes: scopes ?? this.scopes,
         isTWP: isTWP ?? this.isTWP,
         loginHint: loginHint ?? this.loginHint,
+        ssoConfirmed: ssoConfirmed ?? this.ssoConfirmed,
       );
 }

--- a/test/features/login/data/extensions/oidc_configutation_cache_extension_test.dart
+++ b/test/features/login/data/extensions/oidc_configutation_cache_extension_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/oidc/oidc_configuration.dart';
+import 'package:tmail_ui_user/features/login/data/extensions/oidc_configutation_cache_extension.dart';
+import 'package:tmail_ui_user/features/login/data/model/oidc_configuration_cache.dart';
+import 'package:tmail_ui_user/features/login/domain/extensions/oidc_configuration_extensions.dart';
+
+void main() {
+  const authority = 'https://sso.example.com';
+
+  group('OidcConfigurationCache <-> OIDCConfiguration ssoConfirmed mapping', () {
+    test('WHEN cache.ssoConfirmed is null (legacy entry) THEN it maps to false', () {
+      final config = OidcConfigurationCache(authority, false).toOIDCConfiguration();
+
+      expect(config.ssoConfirmed, isFalse);
+    });
+
+    test('WHEN cache.ssoConfirmed is true THEN it maps to true', () {
+      final config = OidcConfigurationCache(authority, false, ssoConfirmed: true)
+          .toOIDCConfiguration();
+
+      expect(config.ssoConfirmed, isTrue);
+    });
+
+    test('WHEN a confirmed config is cached and read back THEN ssoConfirmed survives the round-trip', () {
+      final restored = OIDCConfiguration(
+        authority: authority,
+        clientId: 'client-id',
+        scopes: const ['openid'],
+        ssoConfirmed: true,
+      ).toOidcConfigurationCache().toOIDCConfiguration();
+
+      expect(restored.ssoConfirmed, isTrue);
+    });
+
+    test('WHEN a guessed config is cached and read back THEN ssoConfirmed stays false', () {
+      final restored = OIDCConfiguration(
+        authority: authority,
+        clientId: 'client-id',
+        scopes: const ['openid'],
+      ).toOidcConfigurationCache().toOIDCConfiguration();
+
+      expect(restored.ssoConfirmed, isFalse);
+    });
+  });
+}

--- a/test/features/login/domain/usecases/authenticate_oidc_on_browser_interactor_test.dart
+++ b/test/features/login/domain/usecases/authenticate_oidc_on_browser_interactor_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/oidc/oidc_configuration.dart';
+import 'package:tmail_ui_user/features/login/domain/state/authenticate_oidc_on_browser_state.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/authenticate_oidc_on_browser_interactor.dart';
+
+// Reuse the AuthenticationOIDCRepository mock generated for the sibling test.
+import 'try_guessing_web_finger_interactor_test.mocks.dart';
+
+void main() {
+  late MockAuthenticationOIDCRepository repository;
+  late AuthenticateOidcOnBrowserInteractor interactor;
+
+  OIDCConfiguration configWith(bool ssoConfirmed) => OIDCConfiguration(
+        authority: 'https://sso.example.com',
+        clientId: 'client-id',
+        scopes: const ['openid'],
+        ssoConfirmed: ssoConfirmed,
+      );
+
+  setUp(() {
+    repository = MockAuthenticationOIDCRepository();
+    interactor = AuthenticateOidcOnBrowserInteractor(repository);
+    when(repository.authenticateOidcOnBrowser(any, any, any, any))
+        .thenThrow(Exception('browser redirect failed'));
+  });
+
+  AuthenticateOidcOnBrowserFailure emittedFailure(List states) => states
+      .map((either) => either.fold((failure) => failure, (_) => null))
+      .whereType<AuthenticateOidcOnBrowserFailure>()
+      .single;
+
+  test('WHEN authentication fails THEN the failure carries the config ssoConfirmed == true', () async {
+    final states = await interactor.execute(configWith(true)).toList();
+
+    expect(emittedFailure(states).ssoConfirmed, isTrue);
+  });
+
+  test('WHEN authentication fails THEN the failure carries the config ssoConfirmed == false', () async {
+    final states = await interactor.execute(configWith(false)).toList();
+
+    expect(emittedFailure(states).ssoConfirmed, isFalse);
+  });
+}

--- a/test/features/login/domain/usecases/get_oidc_configuration_interactor_test.dart
+++ b/test/features/login/domain/usecases/get_oidc_configuration_interactor_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/oidc/oidc_configuration.dart';
+import 'package:model/oidc/response/oidc_link_dto.dart';
+import 'package:model/oidc/response/oidc_response.dart';
+import 'package:tmail_ui_user/features/login/domain/model/base_url_oidc_response.dart';
+import 'package:tmail_ui_user/features/login/domain/state/get_oidc_configuration_state.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/get_oidc_configuration_interactor.dart';
+
+// Reuse the AuthenticationOIDCRepository mock generated for the sibling test.
+import 'try_guessing_web_finger_interactor_test.mocks.dart';
+
+void main() {
+  late MockAuthenticationOIDCRepository repository;
+  late GetOIDCConfigurationInteractor interactor;
+
+  final rawConfig = OIDCConfiguration(
+    authority: 'https://sso.example.com',
+    clientId: 'client-id',
+    scopes: ['openid'],
+  );
+
+  setUp(() {
+    repository = MockAuthenticationOIDCRepository();
+    interactor = GetOIDCConfigurationInteractor(repository);
+    when(repository.getOIDCConfiguration(any)).thenAnswer((_) async => rawConfig);
+    when(repository.persistOidcConfiguration(any))
+        .thenAnswer((_) => Future<void>.value());
+  });
+
+  GetOIDCConfigurationSuccess emittedSuccess(List states) => states
+      .map((either) => either.fold((_) => null, (success) => success))
+      .whereType<GetOIDCConfigurationSuccess>()
+      .single;
+
+  test('WHEN the response comes from webFinger (a plain OIDCResponse) \n'
+      'THEN the emitted and persisted config is marked ssoConfirmed == true', () async {
+    // A webFinger hit — even one found by guessing the webFinger URL — is a
+    // real SSO advertisement, so it must count as confirmed.
+    final response = OIDCResponse('https://example.com', [
+      OIDCLinkDto(
+        Uri.parse('https://sso.example.com'),
+        Uri.parse('https://sso.example.com'),
+      ),
+    ]);
+
+    final states = await interactor.execute(response).toList();
+
+    expect(emittedSuccess(states).oidcConfiguration.ssoConfirmed, isTrue);
+    final persisted = verify(repository.persistOidcConfiguration(captureAny))
+        .captured
+        .single as OIDCConfiguration;
+    expect(persisted.ssoConfirmed, isTrue);
+  });
+
+  test('WHEN the response is a BaseUrlOidcResponse (base-URL guess) \n'
+      'THEN the emitted and persisted config is marked ssoConfirmed == false', () async {
+    final response = BaseUrlOidcResponse(Uri.parse('https://example.com'));
+
+    final states = await interactor.execute(response).toList();
+
+    expect(emittedSuccess(states).oidcConfiguration.ssoConfirmed, isFalse);
+    final persisted = verify(repository.persistOidcConfiguration(captureAny))
+        .captured
+        .single as OIDCConfiguration;
+    expect(persisted.ssoConfirmed, isFalse);
+  });
+}

--- a/test/features/login/presentation/login_controller_test.dart
+++ b/test/features/login/presentation/login_controller_test.dart
@@ -329,6 +329,22 @@ void main() {
       expect(loginController.loginFormType.value, equals(LoginFormType.passwordForm));
       expect(loginController.loginFormType.value, isNot(LoginFormType.retry));
     });
+
+    test('WHEN AuthenticateOidcOnBrowserFailure(ssoConfirmed == false) occurs \n'
+        'AND featureFailure is null (previously guarded by featureFailure != null) \n'
+        'THEN it still falls back to basic auth instead of the generic handler', () {
+
+      // Guards the removal of the old `featureFailure != null` condition: the
+      // fallback decision must depend on ssoConfirmed only, not on whether a
+      // prior discovery failure was recorded.
+      loginController.featureFailure = null;
+      loginController.loginFormType.value = LoginFormType.dnsLookupForm;
+      loginController.handleFailureViewState(
+        AuthenticateOidcOnBrowserFailure(Exception(), ssoConfirmed: false),
+      );
+
+      expect(loginController.loginFormType.value, equals(LoginFormType.passwordForm));
+    });
   });
 
   group('Test handleUrgentException with AuthenticateOidcOnBrowserFailure', () {

--- a/test/features/login/presentation/login_controller_test.dart
+++ b/test/features/login/presentation/login_controller_test.dart
@@ -15,7 +15,10 @@ import 'package:tmail_ui_user/features/home/domain/usecases/get_session_interact
 import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
 import 'package:tmail_ui_user/features/login/data/network/oidc_error.dart';
 import 'package:tmail_ui_user/features/login/domain/exceptions/login_exception.dart';
+import 'package:tmail_ui_user/features/login/domain/model/base_url_oidc_response.dart';
+import 'package:tmail_ui_user/features/login/domain/state/authenticate_oidc_on_browser_state.dart';
 import 'package:tmail_ui_user/features/login/domain/state/check_oidc_is_available_state.dart';
+import 'package:tmail_ui_user/features/login/domain/state/try_guessing_web_finger_state.dart';
 import 'package:tmail_ui_user/features/login/domain/state/get_oidc_configuration_state.dart';
 import 'package:tmail_ui_user/features/login/domain/state/get_token_oidc_state.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/authenticate_oidc_on_browser_interactor.dart';
@@ -252,6 +255,145 @@ void main() {
 
       expect(loginController.loginFormType.value,
           equals(LoginFormType.baseUrlForm));
+    });
+
+    test('WHEN handleFailureViewState is called with GetTokenOIDCFailure \n'
+        'AND SSO was confirmed by webFinger (ssoConfirmed == true) \n'
+        'BUT EXCEPTION is not NoSuitableBrowserForOIDCException \n'
+        'THEN loginFormType becomes retry AND never falls back to basic auth', () {
+
+      loginController.loginFormType.value = LoginFormType.dnsLookupForm;
+      final failure = GetTokenOIDCFailure(
+        NotFoundUrlException(),
+        ssoConfirmed: true,
+      );
+      loginController.handleFailureViewState(failure);
+
+      expect(loginController.loginFormType.value, equals(LoginFormType.retry));
+      expect(
+        loginController.loginFormType.value,
+        isNot(anyOf(
+          LoginFormType.passwordForm,
+          LoginFormType.credentialForm,
+        )),
+      );
+    });
+
+    test('WHEN handleFailureViewState is called with GetTokenOIDCFailure \n'
+        'AND the provider was only guessed from the base URL (ssoConfirmed == false) \n'
+        'THEN it falls back to basic auth and does NOT stay on the retry form', () {
+
+      loginController.loginFormType.value = LoginFormType.dnsLookupForm;
+      final failure = GetTokenOIDCFailure(
+        NotFoundUrlException(),
+        ssoConfirmed: false,
+      );
+      loginController.handleFailureViewState(failure);
+
+      expect(loginController.loginFormType.value, equals(LoginFormType.passwordForm));
+      expect(loginController.loginFormType.value, isNot(LoginFormType.retry));
+    });
+  });
+
+  group('Test handleFailureViewState with AuthenticateOidcOnBrowserFailure', () {
+    test('WHEN handleFailureViewState is called with AuthenticateOidcOnBrowserFailure \n'
+        'AND SSO was confirmed by webFinger (ssoConfirmed == true) \n'
+        'THEN loginFormType becomes retry AND never falls back to basic auth', () {
+
+      loginController.loginFormType.value = LoginFormType.dnsLookupForm;
+      final failure = AuthenticateOidcOnBrowserFailure(
+        Exception(),
+        ssoConfirmed: true,
+      );
+      loginController.handleFailureViewState(failure);
+
+      expect(loginController.loginFormType.value, equals(LoginFormType.retry));
+      expect(
+        loginController.loginFormType.value,
+        isNot(anyOf(
+          LoginFormType.passwordForm,
+          LoginFormType.credentialForm,
+        )),
+      );
+    });
+
+    test('WHEN the OIDC provider was only guessed from the base URL \n'
+        '(ssoConfirmed == false) AND AuthenticateOidcOnBrowserFailure occurs \n'
+        'THEN it falls back to basic auth and does NOT stay on the retry form', () {
+
+      loginController.loginFormType.value = LoginFormType.dnsLookupForm;
+      loginController.handleFailureViewState(
+        AuthenticateOidcOnBrowserFailure(Exception(), ssoConfirmed: false),
+      );
+
+      expect(loginController.loginFormType.value, equals(LoginFormType.passwordForm));
+      expect(loginController.loginFormType.value, isNot(LoginFormType.retry));
+    });
+  });
+
+  group('Test handleUrgentException with AuthenticateOidcOnBrowserFailure', () {
+    test('WHEN handleUrgentException is called with AuthenticateOidcOnBrowserFailure \n'
+        'AND SSO was confirmed by webFinger (ssoConfirmed == true) \n'
+        'THEN loginFormType becomes retry AND never falls back to basic auth', () {
+
+      loginController.loginFormType.value = LoginFormType.dnsLookupForm;
+      final failure = AuthenticateOidcOnBrowserFailure(
+        Exception(),
+        ssoConfirmed: true,
+      );
+      loginController.handleUrgentException(failure: failure);
+
+      expect(loginController.loginFormType.value, equals(LoginFormType.retry));
+      expect(
+        loginController.loginFormType.value,
+        isNot(anyOf(
+          LoginFormType.passwordForm,
+          LoginFormType.credentialForm,
+        )),
+      );
+    });
+
+    test('WHEN the OIDC provider was only guessed from the base URL \n'
+        '(ssoConfirmed == false) AND handleUrgentException gets AuthenticateOidcOnBrowserFailure \n'
+        'THEN it falls back to basic auth and does NOT stay on the retry form', () {
+
+      loginController.loginFormType.value = LoginFormType.dnsLookupForm;
+      loginController.handleUrgentException(
+        failure: AuthenticateOidcOnBrowserFailure(Exception(), ssoConfirmed: false),
+      );
+
+      expect(loginController.loginFormType.value, equals(LoginFormType.passwordForm));
+      expect(loginController.loginFormType.value, isNot(LoginFormType.retry));
+    });
+  });
+
+  group('Test TryGuessingWebFingerSuccess is treated as confirmed SSO', () {
+    test('WHEN webFinger-URL guessing succeeds (mobile DNS-lookup fallback) \n'
+        'THEN getOIDCConfiguration runs with a NON-speculative response \n'
+        'so the config is classified as SSO-confirmed, not a base-URL guess', () {
+
+      when(mockGetOIDCConfigurationInteractor.execute(
+        any,
+        loginHint: anyNamed('loginHint'),
+      )).thenAnswer((_) => const Stream.empty());
+
+      final oidcResponse = OIDCResponse('https://example.com', [
+        OIDCLinkDto(
+          Uri.parse('https://sso.example.com'),
+          Uri.parse('https://sso.example.com'),
+        ),
+      ]);
+
+      loginController.handleSuccessViewState(
+        TryGuessingWebFingerSuccess(oidcResponse),
+      );
+
+      final captured = verify(mockGetOIDCConfigurationInteractor.execute(
+        captureAny,
+        loginHint: anyNamed('loginHint'),
+      )).captured.single;
+      expect(captured, same(oidcResponse));
+      expect(captured, isNot(isA<BaseUrlOidcResponse>()));
     });
   });
 

--- a/test/features/login/presentation/widgets/login_message_widget_test.dart
+++ b/test/features/login/presentation/widgets/login_message_widget_test.dart
@@ -1,0 +1,133 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/login_exception.dart';
+import 'package:tmail_ui_user/features/login/domain/state/authenticate_oidc_on_browser_state.dart';
+import 'package:tmail_ui_user/features/login/domain/state/get_token_oidc_state.dart';
+import 'package:tmail_ui_user/features/login/presentation/login_form_type.dart';
+import 'package:tmail_ui_user/features/login/presentation/widgets/login_message_widget.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations_delegate.dart';
+import 'package:tmail_ui_user/main/localizations/localization_service.dart';
+
+/// Captured localizations from the last pumped widget, so tests can assert
+/// against the resolved strings rather than hard-coding them.
+AppLocalizations? _appLocalizations;
+
+Widget _makeTestableWidget(Either<Failure, Success> viewState) {
+  return GetMaterialApp(
+    localizationsDelegates: const [
+      AppLocalizationsDelegate(),
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: LocalizationService.supportedLocales,
+    home: Scaffold(
+      body: Builder(builder: (context) {
+        _appLocalizations = AppLocalizations.of(context);
+        return LoginMessageWidget(
+          formType: LoginFormType.retry,
+          viewState: viewState,
+        );
+      }),
+    ),
+  );
+}
+
+String _renderedMessage(WidgetTester tester) {
+  final text = tester.widget<Text>(
+    find.descendant(
+      of: find.byType(LoginMessageWidget),
+      matching: find.byType(Text),
+    ),
+  );
+  return text.data ?? '';
+}
+
+Future<void> _pump(WidgetTester tester, Either<Failure, Success> viewState) async {
+  await tester.pumpWidget(_makeTestableWidget(viewState));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('LoginMessageWidget::ssoRedirectFailedMessage gating', () {
+    testWidgets(
+        'GetTokenOIDCFailure with ssoConfirmed == true shows the SSO message',
+        (tester) async {
+      await _pump(tester, Left(GetTokenOIDCFailure(Exception(), ssoConfirmed: true)));
+
+      expect(_renderedMessage(tester), _appLocalizations!.ssoRedirectFailedMessage);
+    });
+
+    testWidgets(
+        'AuthenticateOidcOnBrowserFailure with ssoConfirmed == true shows the SSO message',
+        (tester) async {
+      await _pump(tester,
+          Left(AuthenticateOidcOnBrowserFailure(Exception(), ssoConfirmed: true)));
+
+      expect(_renderedMessage(tester), _appLocalizations!.ssoRedirectFailedMessage);
+    });
+
+    testWidgets(
+        'GetTokenOIDCFailure with ssoConfirmed == false does NOT show the SSO message',
+        (tester) async {
+      await _pump(tester, Left(GetTokenOIDCFailure(Exception(), ssoConfirmed: false)));
+
+      expect(_renderedMessage(tester),
+          isNot(_appLocalizations!.ssoRedirectFailedMessage));
+    });
+
+    testWidgets(
+        'AuthenticateOidcOnBrowserFailure with ssoConfirmed == false does NOT show the SSO message',
+        (tester) async {
+      await _pump(tester,
+          Left(AuthenticateOidcOnBrowserFailure(Exception(), ssoConfirmed: false)));
+
+      expect(_renderedMessage(tester),
+          isNot(_appLocalizations!.ssoRedirectFailedMessage));
+    });
+
+    testWidgets(
+        'GetTokenOIDCFailure(ssoConfirmed) with a NetworkException does NOT show the SSO message',
+        (tester) async {
+      // A network drop mid-redirect must surface as offline/connection, not as
+      // a blamed SSO redirect.
+      await _pump(tester, Left(GetTokenOIDCFailure(
+        const ConnectionError(),
+        ssoConfirmed: true,
+      )));
+
+      expect(_renderedMessage(tester),
+          isNot(_appLocalizations!.ssoRedirectFailedMessage));
+    });
+
+    testWidgets(
+        'AuthenticateOidcOnBrowserFailure(ssoConfirmed) with a NetworkException does NOT show the SSO message',
+        (tester) async {
+      await _pump(tester, Left(AuthenticateOidcOnBrowserFailure(
+        const ConnectionError(),
+        ssoConfirmed: true,
+      )));
+
+      expect(_renderedMessage(tester),
+          isNot(_appLocalizations!.ssoRedirectFailedMessage));
+    });
+
+    testWidgets(
+        'NoSuitableBrowserForOIDCException wins over the SSO message',
+        (tester) async {
+      await _pump(tester, Left(GetTokenOIDCFailure(
+        NoSuitableBrowserForOIDCException(),
+        ssoConfirmed: true,
+      )));
+
+      expect(_renderedMessage(tester), _appLocalizations!.noSuitableBrowserForOIDC);
+    });
+  });
+}


### PR DESCRIPTION
Closes #4667

## Problem

When a SSO/OIDC setup is detected but the app fails to go through the auth web redirects (as reported on the Twake Android app), the login flow silently falls back to the **basic auth** credential/password form. This is wrong: if an SSO setup was detected we should never offer basic auth.

## Fix

When the SSO redirects fail after an OIDC configuration was successfully detected:
- `GetTokenOIDCFailure` (mobile browser redirect flow)
- `AuthenticateOidcOnBrowserFailure` (web redirect flow)

we now keep the user on the SSO flow instead of showing the basic auth form:
- Surface an explicit error message explaining the single sign-on redirection failed (`ssoRedirectFailedMessage`).
- Offer the existing `retry` form / retry button so the user can attempt the SSO redirects again.

The `NoSuitableBrowserForOIDCException` case keeps its dedicated message and behavior, and the genuine "OIDC is not available" paths (no SSO configured) still fall back to basic auth as before.

## Changes
- `login_controller.dart`: route `GetTokenOIDCFailure` / `AuthenticateOidcOnBrowserFailure` to a new `_handleSSORedirectFailure()` (shows the retry form) instead of `_handleCommonOIDCFailure()` (basic auth).
- `login_message_widget.dart`: display the SSO redirect failure message.
- Localization: new `ssoRedirectFailedMessage` string.
- Test: assert `GetTokenOIDCFailure` leads to the retry form and never to the password/credential (basic auth) form.

---
*Generated automatically*
4484


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved single sign-on login handling with clearer retry behavior when SSO is confirmed.
  * Added a specific message when SSO redirection cannot be completed.

* **Bug Fixes**
  * Login failures now route more consistently to the correct recovery screen.
  * SSO status is now preserved more reliably across login attempts and cached configurations.
  * Error messages for browser-based sign-in failures are now more specific and helpful.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->