### PR TITLE
TF-4474 Bound token refresh with a timeout so uploads fail visibly instead of hanging

### DIFF
--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -25,6 +25,12 @@ import 'package:tmail_ui_user/main/utils/ios_sharing_manager.dart';
 class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
   static const String _refreshAttemptedKey = '_authInterceptorRefreshAttempted';
 
+  /// Upper bound for a single token-refresh round-trip. Without it, a refresh
+  /// that stalls (e.g. connectivity dropped mid-refresh) would never settle,
+  /// leaving the enclosing request — such as an attachment upload — hanging
+  /// "in progress" forever with no error surfaced to the user (see #4474).
+  static const Duration _refreshTokenTimeout = Duration(seconds: 30);
+
   final Dio _dio;
   final AuthenticationClientBase _authenticationClient;
   final TokenOidcCacheManager _tokenOidcCacheManager;
@@ -299,9 +305,10 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         'AuthorizationInterceptors::onError: Perform get New Token',
         webConsoleEnabled: true,
       );
-      final newTokenOidc = PlatformInfo.isIOS
-        ? await _getNewTokenForIOSPlatform()
-        : await _getNewTokenForOtherPlatform();
+      final newTokenOidc = await (PlatformInfo.isIOS
+        ? _getNewTokenForIOSPlatform()
+        : _getNewTokenForOtherPlatform())
+        .timeout(_refreshTokenTimeout);
 
       if (newTokenOidc.token == _token?.token) {
         // Refresh returned the SAME token — retrying cannot clear the 401, so it
@@ -377,6 +384,26 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
           requestOptions: err.requestOptions,
           error: e,
           type: DioExceptionType.connectionError,
+        ),
+        handler,
+      );
+    } on TimeoutException catch (e, st) {
+      // The refresh round-trip stalled past [_refreshTokenTimeout] — typically
+      // connectivity dropped mid-refresh (the "stuck at 99%" upload symptom in
+      // #4474). Surface it as a connection timeout so the session is kept and
+      // the enclosing request (e.g. attachment upload) fails with an error the
+      // user can see, instead of hanging forever.
+      logError(
+        'AuthorizationInterceptors: auth_error_type=token_refresh_timeout | '
+        'will_logout=false — error=$e',
+        exception: e,
+        stackTrace: st,
+      );
+      return super.onError(
+        DioException(
+          requestOptions: err.requestOptions,
+          error: e,
+          type: DioExceptionType.connectionTimeout,
         ),
         handler,
       );

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -1,4 +1,5 @@
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:core/data/constants/constant.dart';
@@ -952,6 +953,51 @@ void main() {
           throwsA(predicate<DioException>((e) {
             return e.type == DioExceptionType.connectionError &&
                 e.error is PlatformException &&
+                e.response == null;
+          })),
+        );
+
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.oidc,
+        );
+      },
+    );
+  });
+
+  group('onError: refresh times out (connectivity dropped mid-refresh)', () {
+    test(
+      'WHEN the token refresh stalls and times out\n'
+      'THEN propagates as DioException with type=connectionTimeout (no response)\n'
+      'AND OIDC state is NOT cleared (session kept)',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+          },
+        );
+
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenThrow(TimeoutException('Refresh timed out'));
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) {
+            return e.type == DioExceptionType.connectionTimeout &&
+                e.error is TimeoutException &&
                 e.response == null;
           })),
         );


### PR DESCRIPTION
Closes #4474

## Problem

When writing an email and uploading an attachment on Web, the progress bar could get stuck at ~99% forever with **no error shown**, only recovering after a full tab reload. The console showed a `401 "Invalid OIDC token when user info check"` on the `/upload/...` request.

The reporter (@Crash--) narrowed it down: an automatic token refresh does kick in on the 401, **but if connectivity drops during that refresh, we get stuck somewhere with no indication.**

## Root cause

On a 401, `AuthorizationInterceptors.onError` refreshes the OIDC token then retries the request (uploads included). The refresh round-trip (`_invokeRefreshTokenFromServer` → `refreshingTokensOIDC`) has **no time bound**. If the network drops mid-refresh, that future never settles, so the enclosing upload future never completes nor rejects. The existing error path (`401` → `BadCredentialsException` → `ErrorAttachmentUploadState` → toast) only fires **if the future settles** — so the UI stays "uploading" indefinitely.

## Fix

Bound the refresh round-trip with a 30s timeout (`_refreshTokenTimeout`). On timeout, the failure is surfaced as a `connectionTimeout` `DioException` and routed through the **existing** no-response handling, which:

- keeps the session (no forced logout — this is a connectivity failure, not a server rejection), and
- lets the enclosing request settle with an error, so the attachment upload shows the "cannot upload" toast instead of hanging forever.

This mirrors the existing `PlatformException` (native network failure) branch, which already converts to `connectionError` and keeps the session.

Ask #1 in the issue (auto-refresh on expiry) already exists in the interceptor; this PR fixes ask #2 (never leave the user in the dark) for the specific "stuck during refresh" case the reporter confirmed.

## Test

Added a regression test in `authorization_interceptor_test.dart`: when the refresh times out, the request propagates as `connectionTimeout` (no response) and the OIDC session is **not** cleared.

> Note: I couldn't compile/run the Dart tests locally (no Flutter SDK on this machine); relying on CI to validate.

---
*Generated automatically*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when refreshing login tokens by stopping refresh attempts that take too long.
  * If a refresh stalls, the app now returns a timeout error instead of waiting indefinitely, helping avoid hangs during sign-in recovery.
  * Existing session handling remains unchanged for other non-server failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->