### PR TITLE
Fix sharing text variety mime type

### DIFF
--- a/integration_test/scenarios/composer/android/share_mailto_before_mailbox_ready_opens_composer_scenario.dart
+++ b/integration_test/scenarios/composer/android/share_mailto_before_mailbox_ready_opens_composer_scenario.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
+import 'package:model/email/email_action_type.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+
+import '../../../base/base_test_scenario.dart';
+import '../../../utils/receive_sharing_intent_simulator.dart';
+import '../../../utils/wait_for_condition.dart';
+import '../../../utils/wait_for_mailbox_ready.dart';
+
+/// Simulates a `mailto:` link tapped in an external browser while Twake
+/// Mail's process is already running but the user hasn't reached the
+/// mailbox yet (login/session still in flight) — the scenario a real user
+/// hits when the app was previously opened and is still warm in the
+/// background, but not currently showing the mailbox.
+///
+/// Guards the regression where `MailboxDashBoardController` was the only
+/// subscriber to the live `receive_sharing_intent` EventChannel: a share
+/// emitted before that controller existed was silently dropped, since
+/// EventChannel streams don't replay events emitted before a listener
+/// attaches. The fix moves the buffering into `EmailReceiveManager`,
+/// started at `HomeController.onInit()` (effectively app boot), so it is
+/// already listening by the time this scenario emits the share.
+class ShareMailtoBeforeMailboxReadyOpensComposerScenario extends BaseTestScenario {
+  const ShareMailtoBeforeMailboxReadyOpensComposerScenario(super.$, super.robots);
+
+  @override
+  Future<void> runTestLogic() async {
+    final composerRobot = robots.composerRobot();
+
+    // Emitted before the mailbox controller exists — must not be dropped.
+    await emitSharedMediaEvent([
+      sharedMediaMap(
+        path: 'mailto:shared-recipient@example.com?subject=Hello&body=World',
+        type: 'url',
+      ),
+    ]);
+
+    await waitForMailboxReady();
+    await $.pumpAndTrySettle();
+
+    // The composer must open with the share that arrived before the mailbox
+    // was ready — before the fix, this share was dropped and nothing opened.
+    await expectViewVisible($(ComposerView));
+
+    await waitForCondition(() =>
+        composerRobot.findComposerController()?.currentEmailActionType ==
+        EmailActionType.composeFromMailtoUri);
+
+    final composerArguments =
+        composerRobot.findComposerController()?.composerArguments.value;
+    expect(
+      composerArguments?.listEmailAddress,
+      [EmailAddress(null, 'shared-recipient@example.com')],
+    );
+    expect(composerArguments?.subject, 'Hello');
+    expect(composerArguments?.body, 'World');
+  }
+}

--- a/integration_test/scenarios/composer/android/share_text_from_external_opens_composer_scenario.dart
+++ b/integration_test/scenarios/composer/android/share_text_from_external_opens_composer_scenario.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/email/email_action_type.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+
+import '../../../base/base_test_scenario.dart';
+import '../../../utils/receive_sharing_intent_simulator.dart';
+import '../../../utils/wait_for_condition.dart';
+import '../../../utils/wait_for_mailbox_ready.dart';
+
+/// Simulates an external app sharing plain text into the mailbox and asserts the
+/// composer opens with that text as the body.
+///
+/// Guards the regression where a text share whose mimeType is not exactly
+/// `text/plain` (e.g. `text/plain;charset=utf-8`, `text/html`) was dropped and
+/// the composer never opened.
+///
+/// The share is delivered through the real `receive_sharing_intent` EventChannel,
+/// so the app's own stream wiring runs (getMediaStream -> EmailReceiveManager ->
+/// MailboxDashBoardController -> openComposer).
+class ShareTextFromExternalOpensComposerScenario extends BaseTestScenario {
+  const ShareTextFromExternalOpensComposerScenario(
+    super.$,
+    super.robots, {
+    required this.sharedText,
+    required this.mimeType,
+  });
+
+  final String sharedText;
+  final String mimeType;
+
+  @override
+  Future<void> runTestLogic() async {
+    final composerRobot = robots.composerRobot();
+
+    await waitForMailboxReady();
+
+    await emitSharedMediaEvent([
+      sharedMediaMap(path: sharedText, type: 'text', mimeType: mimeType),
+    ]);
+    await $.pumpAndTrySettle();
+
+    // The composer must open — before the fix a non-plain text mimeType opened
+    // nothing.
+    await expectViewVisible($(ComposerView));
+
+    // And the shared text must be routed as body content (not dropped/attached).
+    await waitForCondition(() =>
+        composerRobot.findComposerController()?.currentEmailActionType ==
+        EmailActionType.composeFromContentShared);
+    expect(
+      composerRobot.findComposerController()?.composerArguments.value?.emailContents,
+      sharedText,
+    );
+  }
+}

--- a/integration_test/tests/composer/share_mailto_before_mailbox_ready_opens_composer_test.dart
+++ b/integration_test/tests/composer/share_mailto_before_mailbox_ready_opens_composer_test.dart
@@ -1,0 +1,14 @@
+import '../../base/test_base.dart';
+import '../../models/test_tags.dart';
+import '../../scenarios/composer/android/share_mailto_before_mailbox_ready_opens_composer_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description:
+        'Should open composer with mailto data when the share arrives '
+        'before the mailbox is ready',
+    tags: [TestTags.android],
+    scenarioBuilder: ($, robots) =>
+        ShareMailtoBeforeMailboxReadyOpensComposerScenario($, robots),
+  );
+}

--- a/integration_test/tests/composer/share_text_with_charset_mimetype_opens_composer_test.dart
+++ b/integration_test/tests/composer/share_text_with_charset_mimetype_opens_composer_test.dart
@@ -1,0 +1,18 @@
+import '../../base/test_base.dart';
+import '../../models/test_tags.dart';
+import '../../scenarios/composer/android/share_text_from_external_opens_composer_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description:
+        'Should open composer with shared text when an external app shares '
+        'text with a charset-suffixed plain-text mimeType',
+    tags: [TestTags.android],
+    scenarioBuilder: ($, robots) => ShareTextFromExternalOpensComposerScenario(
+      $,
+      robots,
+      sharedText: 'Shared plain text from an external app',
+      mimeType: 'text/plain;charset=utf-8',
+    ),
+  );
+}

--- a/integration_test/tests/composer/share_text_with_html_mimetype_opens_composer_test.dart
+++ b/integration_test/tests/composer/share_text_with_html_mimetype_opens_composer_test.dart
@@ -1,0 +1,18 @@
+import '../../base/test_base.dart';
+import '../../models/test_tags.dart';
+import '../../scenarios/composer/android/share_text_from_external_opens_composer_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description:
+        'Should open composer with shared text when an external app shares '
+        'text with an HTML mimeType',
+    tags: [TestTags.android],
+    scenarioBuilder: ($, robots) => ShareTextFromExternalOpensComposerScenario(
+      $,
+      robots,
+      sharedText: 'Shared rich text from an external app',
+      mimeType: 'text/html',
+    ),
+  );
+}

--- a/integration_test/utils/receive_sharing_intent_simulator.dart
+++ b/integration_test/utils/receive_sharing_intent_simulator.dart
@@ -1,0 +1,35 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// EventChannel `receive_sharing_intent` uses to stream content shared into the
+/// app while it is running. Pushing an event onto it simulates the OS delivering
+/// an external share, so the app's real `getMediaStream()` wiring runs end to end
+/// (stream -> EmailReceiveManager -> MailboxDashBoardController handler).
+const String _sharingMediaEventChannel = 'receive_sharing_intent/events-media';
+
+/// Builds one shared-media entry in the JSON shape the plugin decodes
+/// (see `SharedMediaFile.fromMap`). `type` is a [SharedMediaType] value string
+/// such as `text`, `image`, `file`, `url` or `mailto`.
+Map<String, dynamic> sharedMediaMap({
+  required String path,
+  required String type,
+  String? mimeType,
+}) => {
+  'path': path,
+  'type': type,
+  if (mimeType != null) 'mimeType': mimeType,
+};
+
+/// Emits a shared-media event as if an external app shared [mediaList] to us.
+///
+/// The plugin streams a JSON string per event and decodes it back into
+/// `List<SharedMediaFile>`, so the payload is wrapped in a standard success
+/// envelope and delivered through the app's already-registered channel listener.
+Future<void> emitSharedMediaEvent(List<Map<String, dynamic>> mediaList) async {
+  final envelope =
+      const StandardMethodCodec().encodeSuccessEnvelope(jsonEncode(mediaList));
+  await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .handlePlatformMessage(_sharingMediaEventChannel, envelope, (_) {});
+}

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -25,14 +25,14 @@ import flutter_local_notifications
         }
         
         let sharingIntent = SwiftReceiveSharingIntentPlugin.instance
-        if let url = launchOptions?[UIApplication.LaunchOptionsKey.url] as? URL {
-            if url.scheme == "mailto" {
-                if let url = handleEmailAndress(open: url) {
-                    let corrected = launchOptions!.map { (key, value) in key != .url ? (key, value) : (key, url) }
-                    
-                    return sharingIntent.application(application, didFinishLaunchingWithOptions: Dictionary(uniqueKeysWithValues: corrected))
-                }
-            }
+        if let url = launchOptions?[UIApplication.LaunchOptionsKey.url] as? URL,
+           url.scheme == "mailto",
+           let shareUrl = handleMailtoUrl(open: url) {
+            // Buffer the mailto share as the plugin's initial media, then fall
+            // through to the normal Flutter launch — returning the plugin's
+            // result directly would skip FlutterAppDelegate's engine and window
+            // setup when a mailto tap cold-starts the app.
+            _ = sharingIntent.application(application, didFinishLaunchingWithOptions: [UIApplication.LaunchOptionsKey.url: shareUrl])
         }
 
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
@@ -88,26 +88,34 @@ import flutter_local_notifications
         }
         
         if url.scheme == "mailto" {
-            if let url = handleEmailAndress(open: url) {
+            if let url = handleMailtoUrl(open: url) {
                 return sharingIntent.application(app, open: url, options: options)
             }
         }
-        
+
         return super.application(app, open: url, options:options)
     }
-    
-    private func handleEmailAndress(open url: URL) -> URL? {
+
+    // Bridges a tapped mailto: link into receive_sharing_intent's pipeline by
+    // writing the same JSON-encoded [SharedMediaFile] blob the share extension
+    // produces — the plugin's handleUrl only decodes that format — and
+    // returning the plugin's ShareMedia redirect URL. The full mailto URI is
+    // kept as the path so Dart can parse recipient, subject and body query
+    // parameters from it.
+    //
+    // Internal (not private): under the UIScene lifecycle UIKit delivers URL
+    // opens to the SceneDelegate, which reuses this bridge; the AppDelegate
+    // paths below only run under the classic lifecycle.
+    func handleMailtoUrl(open url: URL) -> URL? {
         let appDomain = Bundle.main.bundleIdentifier!
-        let appGroupId = (Bundle.main.object(forInfoDictionaryKey: "AppGroupId") as? String) ?? "group.\(Bundle.main.bundleIdentifier!)"
-        let sharedKey = "ShareKey"
-        var sharedText: [String] = []
-        if let email = url.absoluteString.components(separatedBy: ":").last {
-            sharedText.append(email)
-        }
+        let appGroupId = (Bundle.main.object(forInfoDictionaryKey: kAppGroupIdKey) as? String) ?? "group.\(appDomain)"
+        let sharedFile = SharedMediaFile(path: url.absoluteString, type: .url)
+        guard let json = try? JSONEncoder().encode([sharedFile]) else { return nil }
         let userDefaults = UserDefaults(suiteName: appGroupId)
-        userDefaults?.set(sharedText, forKey: sharedKey)
+        userDefaults?.set(json, forKey: kUserDefaultsKey)
+        userDefaults?.removeObject(forKey: kUserDefaultsMessageKey)
         userDefaults?.synchronize()
-        return URL(string: "ShareMedia-\(appDomain)://dataUrl=\(sharedKey)#text")
+        return URL(string: "\(kSchemePrefix)-\(appDomain):share")
     }
     
     // Receive displayed notifications for iOS 10 or later devices.

--- a/ios/Runner/SceneDelegate.swift
+++ b/ios/Runner/SceneDelegate.swift
@@ -1,7 +1,52 @@
 import Flutter
 import UIKit
+import receive_sharing_intent
 
 class SceneDelegate: FlutterSceneDelegate {
+    // Under the UIScene lifecycle (mandatory with the iOS 26 SDK) UIKit
+    // delivers URL opens to the scene delegate — the AppDelegate's
+    // application(_:open:options:) override is never called — so mailto
+    // links must be bridged into receive_sharing_intent from here.
+    // FlutterSceneDelegate's own forwarding only reaches plugins, and the
+    // sharing plugin ignores every URL without its ShareMedia scheme prefix.
+
+    override func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
+        if let mailtoUrl = connectionOptions.urlContexts.first(
+            where: { $0.url.scheme == "mailto" }
+        )?.url,
+           let appDelegate = UIApplication.shared.delegate as? AppDelegate,
+           let shareUrl = appDelegate.handleMailtoUrl(open: mailtoUrl) {
+            TwakeLogger.shared.log(message: "SceneDelegate::willConnectTo::bridging cold-start mailto share")
+            // Cold start by a mailto tap: register it as the plugin's initial
+            // media so Dart's getInitialMedia picks it up once the app is ready.
+            _ = SwiftReceiveSharingIntentPlugin.instance.application(
+                UIApplication.shared,
+                didFinishLaunchingWithOptions: [UIApplication.LaunchOptionsKey.url: shareUrl]
+            )
+        }
+        super.scene(scene, willConnectTo: session, options: connectionOptions)
+    }
+
+    override func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        for context in URLContexts where context.url.scheme == "mailto" {
+            if let appDelegate = UIApplication.shared.delegate as? AppDelegate,
+               let shareUrl = appDelegate.handleMailtoUrl(open: context.url) {
+                TwakeLogger.shared.log(message: "SceneDelegate::openURLContexts::bridging warm mailto share")
+                // Warm mailto tap: emit on the plugin's live media stream.
+                _ = SwiftReceiveSharingIntentPlugin.instance.application(
+                    UIApplication.shared,
+                    open: shareUrl,
+                    options: [:]
+                )
+            }
+        }
+        super.scene(scene, openURLContexts: URLContexts)
+    }
+
     override func sceneDidBecomeActive(_ scene: UIScene) {
         removeAppBadger()
         updateApplicationStateInUserDefaults(true)

--- a/lib/features/composer/presentation/extensions/shared_media_file_extension.dart
+++ b/lib/features/composer/presentation/extensions/shared_media_file_extension.dart
@@ -8,6 +8,13 @@ import 'package:tmail_ui_user/features/composer/presentation/extensions/file_ext
 extension SharedMediaFileExtension on SharedMediaFile {
   File toFile() => File(path);
 
+  /// Whether [path] points at an actual file on disk (a shared file copied
+  /// into the app cache) rather than holding literal shared text. Android
+  /// reports both a shared sentence and a shared text-format file (.vcf,
+  /// .ics, .csv, ...) with a `text/*` mime type and [SharedMediaType.text],
+  /// so the payload kind can only be told apart by checking the filesystem.
+  bool get isFileShare => File(path).existsSync();
+
   FileInfo toFileInfo({bool? isShared}) =>
     toFile().toFileInfo(
       isInline: type == SharedMediaType.image,

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -704,7 +704,9 @@ class MailboxDashBoardController extends ReloadableController
             openComposer(
               ComposerArguments.fromFileShared([sharedMediaFile]),
             );
-          } else if (sharedMediaFile.mimeType == Constant.textPlainMimeType) {
+          } else {
+            // Any other text share (null / charset-suffixed / non-plain text
+            // subtype) is treated as body content so the composer always opens.
             openComposer(
               ComposerArguments.fromContentShared(sharedMediaFile.path.trim()),
             );

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -350,7 +350,6 @@ class MailboxDashBoardController extends ReloadableController
   jmap.State? _currentEmailState;
   ScrollController? listSearchFilterScrollController;
   StreamSubscription? _pendingSharedFileInfoSubscription;
-  StreamSubscription? _receivingFileSharingStreamSubscription;
   StreamSubscription? _currentEmailIdInNotificationIOSStreamSubscription;
   bool _isFirstSessionLoad = false;
   DeepLinksManager? _deepLinksManager;
@@ -660,15 +659,6 @@ class MailboxDashBoardController extends ReloadableController
   }
 
   void _registerReceivingFileSharingStream() {
-    _receivingFileSharingStreamSubscription = _emailReceiveManager
-      .receivingFileSharingStream
-      .listen(
-        _emailReceiveManager.setPendingFileInfo,
-        onError: (err) {
-          logWarning('MailboxDashBoardController::_registerReceivingFileSharingStream::receivingFileSharingStream:Exception = $err');
-        },
-      );
-
     _pendingSharedFileInfoSubscription = _emailReceiveManager
       .pendingSharedFileInfo
       .listen(
@@ -3448,7 +3438,6 @@ class MailboxDashBoardController extends ReloadableController
     }
     if (PlatformInfo.isMobile) {
       _pendingSharedFileInfoSubscription?.cancel();
-      _receivingFileSharingStreamSubscription?.cancel();
       _emailReceiveManager.closeEmailReceiveManagerStream();
       _deepLinkDataStreamSubscription?.cancel();
     }

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -726,6 +726,16 @@ class MailboxDashBoardController extends ReloadableController
                 body: navigationRouter.body,
               ),
             );
+          } else if (PlatformInfo.isIOS) {
+            // On iOS a url-type event can only originate from the share
+            // extension (the plugin ignores every other URL), so a non-mailto
+            // link share goes into the email body. On Android, shared links
+            // arrive as text/plain and never reach here — its url-type events
+            // are deep-link VIEW intents (e.g. twakemail.mobile://openApp)
+            // owned by DeepLinksManager and must stay ignored.
+            openComposer(
+              ComposerArguments.fromContentShared(sharedMediaFile.path.trim()),
+            );
           }
           break;
         case SharedMediaType.mailto:

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -662,19 +662,20 @@ class MailboxDashBoardController extends ReloadableController
     _pendingSharedFileInfoSubscription = _emailReceiveManager
       .pendingSharedFileInfo
       .listen(
-        _handleReceivingFileSharing,
+        handleReceivingFileSharing,
         onError: (err) {
           logWarning('MailboxDashBoardController::_registerReceivingFileSharingStream::pendingSharedFileInfo:Exception = $err');
         },
       );
   }
 
-  void _handleReceivingFileSharing(List<SharedMediaFile> listSharedMediaFile) {
-    log('MailboxDashBoardController::_handleReceivingFileSharing: LIST_LENGTH = ${listSharedMediaFile.length}');
+  @visibleForTesting
+  void handleReceivingFileSharing(List<SharedMediaFile> listSharedMediaFile) {
+    log('MailboxDashBoardController::handleReceivingFileSharing: LIST_LENGTH = ${listSharedMediaFile.length}');
     if (listSharedMediaFile.isEmpty) return;
 
     for (var file in listSharedMediaFile) {
-      log('MailboxDashBoardController::_handleReceivingFileSharing:SharedMediaFile = ${file.toMap()}');
+      log('MailboxDashBoardController::handleReceivingFileSharing:SharedMediaFile = ${file.toMap()}');
     }
 
     if (listSharedMediaFile.length == 1) {
@@ -690,13 +691,19 @@ class MailboxDashBoardController extends ReloadableController
           );
           break;
         case SharedMediaType.text:
-          if (sharedMediaFile.mimeType == Constant.textVCardMimeType) {
+          // Strip any MIME parameters (e.g. ";charset=utf-8") and normalize
+          // case before matching, so a vCard shared as "text/x-vcard;charset=..."
+          // or with different casing still routes to the file branch instead of
+          // leaking its file path into the body.
+          final normalizedMimeType =
+              sharedMediaFile.mimeType?.split(';').first.trim().toLowerCase();
+          if (normalizedMimeType == Constant.textVCardMimeType) {
             openComposer(
               ComposerArguments.fromFileShared([sharedMediaFile]),
             );
           } else {
-            // Any other text share (null / charset-suffixed / non-plain text
-            // subtype) is treated as body content so the composer always opens.
+            // Any other text share (null / non-vCard subtype) is treated as
+            // body content so the composer always opens.
             openComposer(
               ComposerArguments.fromContentShared(sharedMediaFile.path.trim()),
             );

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -3438,7 +3438,7 @@ class MailboxDashBoardController extends ReloadableController
     }
     if (PlatformInfo.isMobile) {
       _pendingSharedFileInfoSubscription?.cancel();
-      _emailReceiveManager.closeEmailReceiveManagerStream();
+      _emailReceiveManager.clearPendingFileInfo();
       _deepLinkDataStreamSubscription?.cancel();
     }
     progressStateController.close();

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -675,6 +675,13 @@ class MailboxDashBoardController extends ReloadableController
     log('MailboxDashBoardController::handleReceivingFileSharing: LIST_LENGTH = ${listSharedMediaFile.length}');
     if (listSharedMediaFile.isEmpty) return;
 
+    // Consume the share as soon as it is taken for processing:
+    // pendingSharedFileInfo is a BehaviorSubject that replays its latest
+    // value, so a handled share left in place would re-open the composer
+    // for any future (re)subscriber. Clearing emits an empty list, which
+    // the guard above ignores, so this cannot recurse.
+    _emailReceiveManager.clearPendingFileInfo();
+
     for (var file in listSharedMediaFile) {
       log('MailboxDashBoardController::handleReceivingFileSharing:SharedMediaFile = ${file.toMap()}');
     }

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -50,6 +50,7 @@ import 'package:tmail_ui_user/features/composer/domain/usecases/get_autocomplete
 import 'package:tmail_ui_user/features/composer/domain/usecases/send_email_interactor.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/email_action_type_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/list_identities_extension.dart';
+import 'package:tmail_ui_user/features/composer/presentation/extensions/shared_media_file_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/manager/composer_manager.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/compose_action_mode.dart';
 import 'package:tmail_ui_user/features/contact/presentation/model/contact_arguments.dart';
@@ -691,19 +692,18 @@ class MailboxDashBoardController extends ReloadableController
           );
           break;
         case SharedMediaType.text:
-          // Strip any MIME parameters (e.g. ";charset=utf-8") and normalize
-          // case before matching, so a vCard shared as "text/x-vcard;charset=..."
-          // or with different casing still routes to the file branch instead of
-          // leaking its file path into the body.
-          final normalizedMimeType =
-              sharedMediaFile.mimeType?.split(';').first.trim().toLowerCase();
-          if (normalizedMimeType == Constant.textVCardMimeType) {
+          // Android delivers both a shared sentence (EXTRA_TEXT) and a shared
+          // text-format file such as .vcf/.ics/.csv (EXTRA_STREAM) with a
+          // text/* mime type and SharedMediaType.text, so the mime type alone
+          // cannot tell them apart. Only a file share leaves a real file on
+          // disk behind `path` — literal text arrives as the characters
+          // themselves — so route files to attachments and literal text to
+          // the email body.
+          if (sharedMediaFile.isFileShare) {
             openComposer(
               ComposerArguments.fromFileShared([sharedMediaFile]),
             );
           } else {
-            // Any other text share (null / non-vCard subtype) is treated as
-            // body content so the composer always opens.
             openComposer(
               ComposerArguments.fromContentShared(sharedMediaFile.path.trim()),
             );

--- a/lib/main/utils/email_receive_manager.dart
+++ b/lib/main/utils/email_receive_manager.dart
@@ -43,8 +43,10 @@ class EmailReceiveManager {
     });
   }
 
-  void closeEmailReceiveManagerStream() {
-    _pendingSharedFileInfo.close();
+  void clearPendingFileInfo() {
+    if (!_pendingSharedFileInfo.isClosed) {
+      _pendingSharedFileInfo.add(List.empty(growable: true));
+    }
   }
 
   void setPendingFileInfo(List<SharedMediaFile> list) {

--- a/lib/main/utils/email_receive_manager.dart
+++ b/lib/main/utils/email_receive_manager.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:core/utils/app_logger.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -19,15 +20,27 @@ class EmailReceiveManager {
   /// still on the login screen — isn't dropped: the live stream itself
   /// doesn't buffer events emitted before a listener attaches.
   void registerReceivingFileSharingStreamWhileAppClosed() {
-    ReceiveSharingIntent.instance.getInitialMedia().then((value) {
-      setPendingFileInfo(value);
-
-      ReceiveSharingIntent.instance.reset();
-    });
-
     _mediaStreamSubscription ??= ReceiveSharingIntent.instance
       .getMediaStream()
-      .listen(setPendingFileInfo);
+      .listen(
+        setPendingFileInfo,
+        onError: (error) {
+          logWarning('EmailReceiveManager::registerReceivingFileSharingStreamWhileAppClosed::getMediaStream: Exception = $error');
+        },
+      );
+
+    ReceiveSharingIntent.instance.getInitialMedia().then((value) {
+      // A share can land on the live stream above before getInitialMedia
+      // resolves. getInitialMedia returns empty on a normal (non-share) launch,
+      // so applying it unconditionally would overwrite that just-arrived share
+      // with an empty list. Only apply the cold-start share when non-empty.
+      if (value.isNotEmpty) {
+        setPendingFileInfo(value);
+      }
+      ReceiveSharingIntent.instance.reset();
+    }).catchError((error) {
+      logWarning('EmailReceiveManager::registerReceivingFileSharingStreamWhileAppClosed::getInitialMedia: Exception = $error');
+    });
   }
 
   void closeEmailReceiveManagerStream() {

--- a/lib/main/utils/email_receive_manager.dart
+++ b/lib/main/utils/email_receive_manager.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 import 'package:rxdart/rxdart.dart';
@@ -8,15 +9,25 @@ class EmailReceiveManager {
   BehaviorSubject<List<SharedMediaFile>> get pendingSharedFileInfo =>
     _pendingSharedFileInfo;
 
-  Stream<List<SharedMediaFile>> get receivingFileSharingStream =>
-    ReceiveSharingIntent.instance.getMediaStream();
+  StreamSubscription<List<SharedMediaFile>>? _mediaStreamSubscription;
 
+  /// Buffers both the cold-start share (app launched by an external share)
+  /// and any share arriving later on the live EventChannel into
+  /// [pendingSharedFileInfo], which replays its latest value to late
+  /// subscribers. Must run from app start (not from the mailbox controller)
+  /// so a share tapped before the user reaches the mailbox — e.g. while
+  /// still on the login screen — isn't dropped: the live stream itself
+  /// doesn't buffer events emitted before a listener attaches.
   void registerReceivingFileSharingStreamWhileAppClosed() {
     ReceiveSharingIntent.instance.getInitialMedia().then((value) {
       setPendingFileInfo(value);
 
       ReceiveSharingIntent.instance.reset();
     });
+
+    _mediaStreamSubscription ??= ReceiveSharingIntent.instance
+      .getMediaStream()
+      .listen(setPendingFileInfo);
   }
 
   void closeEmailReceiveManagerStream() {

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -17,7 +17,11 @@ import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:core/utils/platform_info.dart';
+import 'package:model/email/email_action_type.dart';
+import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 import 'package:rxdart/subjects.dart';
+import 'package:tmail_ui_user/features/email/presentation/model/composer_arguments.dart';
 import 'package:tmail_ui_user/features/base/extensions/handle_mailbox_action_type_extension.dart';
 import 'package:tmail_ui_user/features/base/model/filter_filter.dart';
 import 'package:tmail_ui_user/features/caching/caching_manager.dart';
@@ -800,5 +804,83 @@ void main() {
 
       expect(() => mailboxController.getSubAddress(userEmail, folderName), throwsA(isA<InvalidMailFormatException>()));
     });
+  });
+
+  group('handleReceivingFileSharing text share routing:', () {
+    setUp(() {
+      // Force the web path so openComposer routes through the mocked
+      // ComposerManager (the mobile path navigates and can't be observed here).
+      PlatformInfo.isTestingForWeb = true;
+      when(emailReceiveManager.pendingSharedFileInfo)
+          .thenAnswer((_) => BehaviorSubject.seeded([]));
+      when(downloadController.downloadUIAction)
+          .thenAnswer((_) => Rxn(DownloadUIAction.idle));
+      when(labelController.isLabelSettingEnabled).thenReturn(RxBool(false));
+      when(mockTwakeAppManager.hasComposer).thenReturn(false);
+
+      Get.put(mailboxDashboardController);
+    });
+
+    tearDown(() {
+      PlatformInfo.isTestingForWeb = false;
+    });
+
+    SharedMediaFile textShare(String path, String? mimeType) => SharedMediaFile(
+          path: path,
+          type: SharedMediaType.text,
+          mimeType: mimeType,
+        );
+
+    ComposerArguments capturedComposerArguments() =>
+        verify(composerManager.addComposer(captureAny)).captured.single
+            as ComposerArguments;
+
+    test(
+      'a vCard whose mime carries a charset parameter still opens the composer '
+      'from the shared file (composeFromFileShared)',
+      () {
+        mailboxDashboardController.handleReceivingFileSharing([
+          textShare('/tmp/contact.vcf', 'text/x-vcard;charset=utf-8'),
+        ]);
+
+        final arguments = capturedComposerArguments();
+        expect(arguments.emailActionType, EmailActionType.composeFromFileShared);
+        expect(arguments.listSharedMediaFile?.single.path, '/tmp/contact.vcf');
+      },
+    );
+
+    test(
+      'a text/plain share with mixed-case charset parameter opens the composer '
+      'from body content (composeFromContentShared)',
+      () {
+        mailboxDashboardController.handleReceivingFileSharing([
+          textShare('shared body text', 'Text/Plain; Charset=UTF-8'),
+        ]);
+
+        final arguments = capturedComposerArguments();
+        expect(
+          arguments.emailActionType,
+          EmailActionType.composeFromContentShared,
+        );
+        expect(arguments.emailContents, 'shared body text');
+      },
+    );
+
+    test(
+      'a text/html share opens the composer from body content '
+      '(composeFromContentShared)',
+      () {
+        mailboxDashboardController.handleReceivingFileSharing([
+          textShare('<p>hi</p>', 'text/html;charset=utf-8'),
+        ]);
+
+        final arguments = capturedComposerArguments();
+        expect(
+          arguments.emailActionType,
+          EmailActionType.composeFromContentShared,
+        );
+        expect(arguments.emailContents, '<p>hi</p>');
+      },
+    );
   });
 }

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:core/data/network/config/dynamic_url_interceptors.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/app_toast.dart';
@@ -807,10 +809,13 @@ void main() {
   });
 
   group('handleReceivingFileSharing text share routing:', () {
+    late Directory tempShareDir;
+
     setUp(() {
       // Force the web path so openComposer routes through the mocked
       // ComposerManager (the mobile path navigates and can't be observed here).
       PlatformInfo.isTestingForWeb = true;
+      tempShareDir = Directory.systemTemp.createTempSync('shared_media_test');
       when(emailReceiveManager.pendingSharedFileInfo)
           .thenAnswer((_) => BehaviorSubject.seeded([]));
       when(downloadController.downloadUIAction)
@@ -823,6 +828,7 @@ void main() {
 
     tearDown(() {
       PlatformInfo.isTestingForWeb = false;
+      tempShareDir.deleteSync(recursive: true);
     });
 
     SharedMediaFile textShare(String path, String? mimeType) => SharedMediaFile(
@@ -831,21 +837,57 @@ void main() {
           mimeType: mimeType,
         );
 
+    // A text-category share whose payload is a real file on disk, the shape
+    // Android produces for text-format files (EXTRA_STREAM copied to cache).
+    SharedMediaFile textFileShare(String fileName, String? mimeType) {
+      final file = File('${tempShareDir.path}/$fileName')
+        ..writeAsStringSync('file content');
+      return textShare(file.path, mimeType);
+    }
+
     ComposerArguments capturedComposerArguments() =>
         verify(composerManager.addComposer(captureAny)).captured.single
             as ComposerArguments;
 
     test(
-      'a vCard whose mime carries a charset parameter still opens the composer '
-      'from the shared file (composeFromFileShared)',
+      'a vCard file whose mime carries a charset parameter still opens the '
+      'composer from the shared file (composeFromFileShared)',
       () {
-        mailboxDashboardController.handleReceivingFileSharing([
-          textShare('/tmp/contact.vcf', 'text/x-vcard;charset=utf-8'),
-        ]);
+        final share = textFileShare('contact.vcf', 'text/x-vcard;charset=utf-8');
+
+        mailboxDashboardController.handleReceivingFileSharing([share]);
 
         final arguments = capturedComposerArguments();
         expect(arguments.emailActionType, EmailActionType.composeFromFileShared);
-        expect(arguments.listSharedMediaFile?.single.path, '/tmp/contact.vcf');
+        expect(arguments.listSharedMediaFile?.single.path, share.path);
+      },
+    );
+
+    test(
+      'a vCard file with the standard text/vcard mime (not the legacy x-vcard) '
+      'opens the composer from the shared file (composeFromFileShared)',
+      () {
+        final share = textFileShare('contact.vcf', 'text/vcard');
+
+        mailboxDashboardController.handleReceivingFileSharing([share]);
+
+        final arguments = capturedComposerArguments();
+        expect(arguments.emailActionType, EmailActionType.composeFromFileShared);
+        expect(arguments.listSharedMediaFile?.single.path, share.path);
+      },
+    );
+
+    test(
+      'a calendar (.ics) file share opens the composer from the shared file, '
+      'not with the file path pasted into the body',
+      () {
+        final share = textFileShare('event.ics', 'text/calendar');
+
+        mailboxDashboardController.handleReceivingFileSharing([share]);
+
+        final arguments = capturedComposerArguments();
+        expect(arguments.emailActionType, EmailActionType.composeFromFileShared);
+        expect(arguments.listSharedMediaFile?.single.path, share.path);
       },
     );
 
@@ -880,6 +922,23 @@ void main() {
           EmailActionType.composeFromContentShared,
         );
         expect(arguments.emailContents, '<p>hi</p>');
+      },
+    );
+
+    test(
+      'a literal text share without any mime type opens the composer from '
+      'body content (composeFromContentShared)',
+      () {
+        mailboxDashboardController.handleReceivingFileSharing([
+          textShare('plain sentence with no mime', null),
+        ]);
+
+        final arguments = capturedComposerArguments();
+        expect(
+          arguments.emailActionType,
+          EmailActionType.composeFromContentShared,
+        );
+        expect(arguments.emailContents, 'plain sentence with no mime');
       },
     );
   });

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -824,6 +824,12 @@ void main() {
       when(mockTwakeAppManager.hasComposer).thenReturn(false);
 
       Get.put(mailboxDashboardController);
+
+      // The mocks are shared across the whole file; drop interactions
+      // recorded by earlier tests (and by onInit above) so per-test
+      // verify/verifyNever counts start from zero.
+      clearInteractions(composerManager);
+      clearInteractions(emailReceiveManager);
     });
 
     tearDown(() {
@@ -939,6 +945,29 @@ void main() {
           EmailActionType.composeFromContentShared,
         );
         expect(arguments.emailContents, 'plain sentence with no mime');
+      },
+    );
+
+    test(
+      'a handled share is consumed from the manager, so the replaying subject '
+      'cannot re-deliver it to a future subscriber',
+      () {
+        mailboxDashboardController.handleReceivingFileSharing([
+          textShare('shared body text', 'text/plain'),
+        ]);
+
+        verify(emailReceiveManager.clearPendingFileInfo()).called(1);
+      },
+    );
+
+    test(
+      'an empty share event is ignored without touching the manager '
+      '(guards against clear-emits-empty recursion)',
+      () {
+        mailboxDashboardController.handleReceivingFileSharing([]);
+
+        verifyNever(emailReceiveManager.clearPendingFileInfo());
+        verifyNever(composerManager.addComposer(any));
       },
     );
   });

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -808,7 +808,7 @@ void main() {
     });
   });
 
-  group('handleReceivingFileSharing text share routing:', () {
+  group('handleReceivingFileSharing share routing:', () {
     late Directory tempShareDir;
 
     setUp(() {
@@ -967,6 +967,38 @@ void main() {
         mailboxDashboardController.handleReceivingFileSharing([]);
 
         verifyNever(emailReceiveManager.clearPendingFileInfo());
+        verifyNever(composerManager.addComposer(any));
+      },
+    );
+
+    SharedMediaFile urlShare(String path) => SharedMediaFile(
+          path: path,
+          type: SharedMediaType.url,
+        );
+
+    test(
+      'a mailto url share opens the composer with recipient and subject '
+      'parsed from the mailto link (composeFromMailtoUri)',
+      () {
+        mailboxDashboardController.handleReceivingFileSharing([
+          urlShare('mailto:user@example.com?subject=Hello'),
+        ]);
+
+        final arguments = capturedComposerArguments();
+        expect(arguments.emailActionType, EmailActionType.composeFromMailtoUri);
+        expect(arguments.listEmailAddress?.first.email, 'user@example.com');
+        expect(arguments.subject, 'Hello');
+      },
+    );
+
+    test(
+      'a non-mailto url share opens nothing on non-iOS platforms — Android '
+      'url-type events are deep-link VIEW intents owned by DeepLinksManager',
+      () {
+        mailboxDashboardController.handleReceivingFileSharing([
+          urlShare('twakemail.mobile://openApp?registrationUrl=example.com'),
+        ]);
+
         verifyNever(composerManager.addComposer(any));
       },
     );

--- a/test/main/utils/email_receive_manager_test.dart
+++ b/test/main/utils/email_receive_manager_test.dart
@@ -1,0 +1,75 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/main/utils/email_receive_manager.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const messagesChannel = MethodChannel('receive_sharing_intent/messages');
+  const mediaEventChannel = EventChannel('receive_sharing_intent/events-media');
+  final messenger = TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  Future<void> emitSharedMediaEvent(List<Map<String, dynamic>> mediaList) async {
+    final envelope =
+        const StandardMethodCodec().encodeSuccessEnvelope(jsonEncode(mediaList));
+    await messenger.handlePlatformMessage(mediaEventChannel.name, envelope, (_) {});
+  }
+
+  setUp(() {
+    messenger.setMockMethodCallHandler(messagesChannel, (call) async => null);
+  });
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(messagesChannel, null);
+  });
+
+  group('EmailReceiveManager', () {
+    test(
+      'registerReceivingFileSharingStreamWhileAppClosed buffers a share that '
+      'arrives on the live EventChannel before anyone subscribes to '
+      'pendingSharedFileInfo',
+      () async {
+        final manager = EmailReceiveManager();
+
+        manager.registerReceivingFileSharingStreamWhileAppClosed();
+        // Let getInitialMedia's mocked round trip (empty result) settle first,
+        // so it can't race with and clobber the event emitted below.
+        await Future<void>.delayed(Duration.zero);
+
+        await emitSharedMediaEvent([
+          {'path': 'mailto:test@example.com', 'type': 'url'},
+        ]);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(manager.pendingSharedFileInfo.value, hasLength(1));
+        expect(
+          manager.pendingSharedFileInfo.value.first.path,
+          'mailto:test@example.com',
+        );
+      },
+    );
+
+    test(
+      'pendingSharedFileInfo replays the buffered share to a subscriber that '
+      'attaches after the event already arrived',
+      () async {
+        final manager = EmailReceiveManager();
+
+        manager.registerReceivingFileSharingStreamWhileAppClosed();
+        await Future<void>.delayed(Duration.zero);
+
+        await emitSharedMediaEvent([
+          {'path': 'mailto:late@example.com', 'type': 'url'},
+        ]);
+        await Future<void>.delayed(Duration.zero);
+
+        final received = await manager.pendingSharedFileInfo.first;
+
+        expect(received, hasLength(1));
+        expect(received.first.path, 'mailto:late@example.com');
+      },
+    );
+  });
+}

--- a/test/main/utils/email_receive_manager_test.dart
+++ b/test/main/utils/email_receive_manager_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 import 'package:tmail_ui_user/main/utils/email_receive_manager.dart';
 
 void main() {
@@ -104,6 +105,50 @@ void main() {
           manager.pendingSharedFileInfo.value.first.path,
           'mailto:warm@example.com',
         );
+      },
+    );
+
+    test(
+      'clearPendingFileInfo drops pending data but keeps the subject open, so a '
+      'dashboard that reattaches after a teardown still receives later shares',
+      () async {
+        final manager = EmailReceiveManager();
+        manager.registerReceivingFileSharingStreamWhileAppClosed();
+        await Future<void>.delayed(Duration.zero);
+
+        // A first dashboard consumes a share.
+        await emitSharedMediaEvent([
+          {'path': 'mailto:first@example.com', 'type': 'url'},
+        ]);
+        await Future<void>.delayed(Duration.zero);
+        expect(manager.pendingSharedFileInfo.value, hasLength(1));
+
+        // Dashboard tears down: clears the consumed share without closing the
+        // subject (closing would strand the next dashboard's listener).
+        final subjectBeforeClear = manager.pendingSharedFileInfo;
+        manager.clearPendingFileInfo();
+        expect(manager.pendingSharedFileInfo.isClosed, isFalse);
+        expect(manager.pendingSharedFileInfo.value, isEmpty);
+
+        // A new dashboard reattaches to the same, still-open subject.
+        final received = <List<SharedMediaFile>>[];
+        final subscription = manager.pendingSharedFileInfo.listen(received.add);
+
+        // A later live share must reach the reattached listener.
+        await emitSharedMediaEvent([
+          {'path': 'mailto:second@example.com', 'type': 'url'},
+        ]);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          identical(manager.pendingSharedFileInfo, subjectBeforeClear),
+          isTrue,
+        );
+        expect(manager.pendingSharedFileInfo.value, hasLength(1));
+        expect(received.last, hasLength(1));
+        expect(received.last.first.path, 'mailto:second@example.com');
+
+        await subscription.cancel();
       },
     );
   });

--- a/test/main/utils/email_receive_manager_test.dart
+++ b/test/main/utils/email_receive_manager_test.dart
@@ -19,6 +19,12 @@ void main() {
     await messenger.handlePlatformMessage(mediaEventChannel.name, envelope, (_) {});
   }
 
+  Future<void> emitSharedMediaError() async {
+    final envelope = const StandardMethodCodec()
+        .encodeErrorEnvelope(code: 'ERROR', message: 'platform stream failure');
+    await messenger.handlePlatformMessage(mediaEventChannel.name, envelope, (_) {});
+  }
+
   setUp(() {
     messenger.setMockMethodCallHandler(messagesChannel, (call) async => null);
   });
@@ -149,6 +155,34 @@ void main() {
         expect(received.last.first.path, 'mailto:second@example.com');
 
         await subscription.cancel();
+      },
+    );
+
+    test(
+      'an error on the media EventChannel is swallowed and does not stop later '
+      'shares from being delivered',
+      () async {
+        final manager = EmailReceiveManager();
+        manager.registerReceivingFileSharingStreamWhileAppClosed();
+        await Future<void>.delayed(Duration.zero);
+
+        // An error on the platform stream must not throw or tear down the
+        // subscription (cancelOnError is false).
+        await emitSharedMediaError();
+        await Future<void>.delayed(Duration.zero);
+        expect(manager.pendingSharedFileInfo.isClosed, isFalse);
+
+        // A subsequent valid share is still delivered after the error.
+        await emitSharedMediaEvent([
+          {'path': 'mailto:after-error@example.com', 'type': 'url'},
+        ]);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(manager.pendingSharedFileInfo.value, hasLength(1));
+        expect(
+          manager.pendingSharedFileInfo.value.first.path,
+          'mailto:after-error@example.com',
+        );
       },
     );
   });

--- a/test/main/utils/email_receive_manager_test.dart
+++ b/test/main/utils/email_receive_manager_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/services.dart';
@@ -69,6 +70,40 @@ void main() {
 
         expect(received, hasLength(1));
         expect(received.first.path, 'mailto:late@example.com');
+      },
+    );
+
+    test(
+      'an empty getInitialMedia result that resolves after a live share arrives '
+      'must not clobber that share',
+      () async {
+        // Hold getInitialMedia (and reset) pending until we release the gate,
+        // so the live share below is guaranteed to arrive first — reproducing a
+        // warm-app share landing while startup is still settling.
+        final initialMediaGate = Completer<void>();
+        messenger.setMockMethodCallHandler(messagesChannel, (call) async {
+          await initialMediaGate.future;
+          return null; // getInitialMedia -> empty list
+        });
+
+        final manager = EmailReceiveManager();
+        manager.registerReceivingFileSharingStreamWhileAppClosed();
+
+        await emitSharedMediaEvent([
+          {'path': 'mailto:warm@example.com', 'type': 'url'},
+        ]);
+        await Future<void>.delayed(Duration.zero);
+
+        // Now let the empty cold-start result resolve; the guard must keep it
+        // from overwriting the already-buffered live share.
+        initialMediaGate.complete();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(manager.pendingSharedFileInfo.value, hasLength(1));
+        expect(
+          manager.pendingSharedFileInfo.value.first.path,
+          'mailto:warm@example.com',
+        );
       },
     );
   });


### PR DESCRIPTION
(writing e2e test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded incoming share support for external plain text (including charset-suffixed MIME types), HTML-like text, vCard, calendar files, and mailto links, with correct composer prefill as body content or attachments.
* **Bug Fixes**
  * Prevented missed or duplicated shared content when shares arrive before the inbox/composer is ready.
  * Improved handling of empty/failed share payloads so later shares still work reliably.
  * Enhanced iOS URL/deep-link bridging for mailto sharing from cold and warm opens.
* **Tests**
  * Added integration and unit test coverage for share intake routing, timing, and buffering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Demo
iOS

https://github.com/user-attachments/assets/9664efd4-bb57-41c2-9089-51e93647c8d7

