### PR TITLE
Fix gray_screen composer when binding with wrong composerId

### DIFF
--- a/lib/features/composer/presentation/widgets/recipient_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/recipient_composer_widget.dart
@@ -416,10 +416,10 @@ class _RecipientComposerWidgetState extends State<RecipientComposerWidget> {
       _ => false,
     };
 
-    // Native platforms (mobile + tablet) always use the compact expand button;
-    // the inline prefix buttons are a web-only, wide-screen affordance.
-    return shouldCheckPrefix &&
-        (isMobileResponsive || !PlatformInfo.isWeb || widget.isTestingForWeb);
+    // The compact expand button is the exact complement of the inline prefix
+    // buttons (`_isWeb && !isMobileResponsive`): it shows on native platforms
+    // (mobile + tablet) or on a narrow web window.
+    return shouldCheckPrefix && (isMobileResponsive || !_isWeb);
   }
 
   Widget _buildExpandButton() {

--- a/lib/features/composer/presentation/widgets/recipient_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/recipient_composer_widget.dart
@@ -416,7 +416,10 @@ class _RecipientComposerWidgetState extends State<RecipientComposerWidget> {
       _ => false,
     };
 
-    return shouldCheckPrefix && (isMobileResponsive || widget.isTestingForWeb);
+    // Native platforms (mobile + tablet) always use the compact expand button;
+    // the inline prefix buttons are a web-only, wide-screen affordance.
+    return shouldCheckPrefix &&
+        (isMobileResponsive || !PlatformInfo.isWeb || widget.isTestingForWeb);
   }
 
   Widget _buildExpandButton() {

--- a/lib/features/mailbox_dashboard/presentation/extensions/open_and_close_composer_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/open_and_close_composer_extension.dart
@@ -71,7 +71,7 @@ extension OpenAndCloseComposerExtension on MailboxDashBoardController {
 
       result = await Get.to(
         () => const ComposerView(),
-        binding: ComposerBindings(composerId: composerId),
+        binding: ComposerBindings(),
         opaque: false,
         arguments: argsWithId,
       );

--- a/test/features/composer/recipient_composer_widget_test.dart
+++ b/test/features/composer/recipient_composer_widget_test.dart
@@ -464,6 +464,7 @@ void main() {
         EmailAddress('test1', 'test1@example.com'),
       ];
 
+      // Native mobile (no isTestingForWeb): compact expand button, no inline buttons.
       final widget = makeTestableWidget(
         child: RecipientComposerWidget(
           prefix: prefix,
@@ -472,7 +473,6 @@ void main() {
           imagePaths: imagePaths,
           maxWidth: 360,
           keyTagEditor: keyEmailTagEditor,
-          isTestingForWeb: true,
           toState: PrefixRecipientState.enabled,
         ),
       );
@@ -557,13 +557,13 @@ void main() {
       expect(recipientFromButtonFinder, findsOneWidget);
       expect(recipientCcButtonFinder, findsOneWidget);
       expect(recipientBccButtonFinder, findsOneWidget);
+      // Web wide is inline-only: the compact expand button must NOT also render
+      // (guards mutual exclusivity between the two recipient-add affordances).
+      expect(find.byKey(Key('prefix_${prefix.name}_recipient_expand_button')), findsNothing);
     });
 
     testWidgets('WHEN on a native (non-web) tablet-width screen (>= 600)\n'
         'To field SHOULD show the expand chevron (same as mobile) and NO inline Cc/Bcc buttons', (tester) async {
-      // Simulate an iPad/tablet-width native screen: no isTestingForWeb, so
-      // PlatformInfo.isWeb == false. Regression guard for the bug where native
-      // tablet rendered neither the inline buttons nor the expand chevron.
       tester.view.physicalSize = const Size(1024, 768);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
@@ -581,6 +581,44 @@ void main() {
           imagePaths: imagePaths,
           maxWidth: 900,
           keyTagEditor: keyEmailTagEditor,
+          toState: PrefixRecipientState.enabled,
+        ),
+      );
+
+      await tester.pumpWidget(widget);
+      await tester.pumpAndSettle();
+
+      final recipientExpandButtonFinder = find.byKey(Key('prefix_${prefix.name}_recipient_expand_button'));
+      final recipientCcButtonFinder = find.byKey(Key('prefix_${prefix.name}_recipient_cc_button'));
+      final recipientBccButtonFinder = find.byKey(Key('prefix_${prefix.name}_recipient_bcc_button'));
+
+      expect(recipientExpandButtonFinder, findsOneWidget);
+      expect(recipientCcButtonFinder, findsNothing);
+      expect(recipientBccButtonFinder, findsNothing);
+    });
+
+    testWidgets('WHEN on web with a narrow (< 600) window (web-responsive)\n'
+        'To field SHOULD show the expand chevron and NO inline Cc/Bcc buttons', (tester) async {
+      // Simulate web (isTestingForWeb) at a phone-width window: the inline
+      // buttons collapse to the compact expand chevron, same as mobile.
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final listEmailAddress = <EmailAddress>[
+        EmailAddress('test1', 'test1@example.com'),
+      ];
+
+      final widget = makeTestableWidget(
+        child: RecipientComposerWidget(
+          prefix: prefix,
+          prefixRootState: prefix,
+          listEmailAddress: listEmailAddress,
+          imagePaths: imagePaths,
+          maxWidth: 360,
+          keyTagEditor: keyEmailTagEditor,
+          isTestingForWeb: true,
           toState: PrefixRecipientState.enabled,
         ),
       );

--- a/test/features/composer/recipient_composer_widget_test.dart
+++ b/test/features/composer/recipient_composer_widget_test.dart
@@ -558,5 +558,43 @@ void main() {
       expect(recipientCcButtonFinder, findsOneWidget);
       expect(recipientBccButtonFinder, findsOneWidget);
     });
+
+    testWidgets('WHEN on a native (non-web) tablet-width screen (>= 600)\n'
+        'To field SHOULD show the expand chevron (same as mobile) and NO inline Cc/Bcc buttons', (tester) async {
+      // Simulate an iPad/tablet-width native screen: no isTestingForWeb, so
+      // PlatformInfo.isWeb == false. Regression guard for the bug where native
+      // tablet rendered neither the inline buttons nor the expand chevron.
+      tester.view.physicalSize = const Size(1024, 768);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final listEmailAddress = <EmailAddress>[
+        EmailAddress('test1', 'test1@example.com'),
+      ];
+
+      final widget = makeTestableWidget(
+        child: RecipientComposerWidget(
+          prefix: prefix,
+          prefixRootState: prefix,
+          listEmailAddress: listEmailAddress,
+          imagePaths: imagePaths,
+          maxWidth: 900,
+          keyTagEditor: keyEmailTagEditor,
+          toState: PrefixRecipientState.enabled,
+        ),
+      );
+
+      await tester.pumpWidget(widget);
+      await tester.pumpAndSettle();
+
+      final recipientExpandButtonFinder = find.byKey(Key('prefix_${prefix.name}_recipient_expand_button'));
+      final recipientCcButtonFinder = find.byKey(Key('prefix_${prefix.name}_recipient_cc_button'));
+      final recipientBccButtonFinder = find.byKey(Key('prefix_${prefix.name}_recipient_bcc_button'));
+
+      expect(recipientExpandButtonFinder, findsOneWidget);
+      expect(recipientCcButtonFinder, findsNothing);
+      expect(recipientBccButtonFinder, findsNothing);
+    });
   });
 }


### PR DESCRIPTION
### Reproduce

<img width="500"  alt="Screenshot 2026-07-03 at 4 26 37 PM" src="https://github.com/user-attachments/assets/2848036d-3ec8-43f7-8a67-a9317028e243" />

### Root cause
- mismatch DI tag for composer in Tablet 
- only affected to Tablet 

### Demo

<img width="500" alt="Simulator Screenshot - iPad Pro 13-inch (M5) - 2026-07-03 at 18 11 54" src="https://github.com/user-attachments/assets/5d60787b-f4a8-4e24-a6de-7ebb59cacc55" />
<img width="500" alt="Simulator Screenshot - iPad Pro 13-inch (M5) - 2026-07-03 at 18 11 08" src="https://github.com/user-attachments/assets/a85ab083-8869-4b63-8f47-1af474d8a4d5" />
<img width="500" alt="Simulator Screenshot - iPad Pro 13-inch (M5) - 2026-07-03 at 18 10 52" src="https://github.com/user-attachments/assets/f41467df-e368-4fe1-bbb6-c8b0cf2ed6bb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Corrected the composer open flow on tablet devices so it opens with the proper composer setup.
  * Adjusted recipient composer expand-button logic so it can appear on native (non-web) layouts even when mobile responsiveness is disabled, while keeping Cc/Bcc inline behavior consistent.
* **Tests**
  * Updated widget tests to reflect true native (non-web) behavior.
  * Added coverage for web “wide/inline-only” to ensure the expand chevron is not shown.
  * Added a native tablet-width widget test to verify expand-chevron visibility and the absence of inline Cc/Bcc.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->