### PR TITLE
TF-4679 Suppress error toast when SSO session is dead

### DIFF
--- a/lib/features/base/reloadable/reloadable_controller.dart
+++ b/lib/features/base/reloadable/reloadable_controller.dart
@@ -157,12 +157,17 @@ abstract class ReloadableController extends BaseController {
 
   void handleGetSessionFailure(GetSessionFailure failure) {
     final exception = failure.exception;
-    if (exception is! BadCredentialsException) {
+    final willLogout = exception is BadCredentialsException ||
+        exception is RefreshTokenFailedException ||
+        exception is NotFoundSessionException;
+    // Do not surface an error toast when the session is definitively dead:
+    // the app immediately clears data and redirects to the SSO login, so the
+    // toast would only flash briefly (e.g. "Unexpected error: ...") before the
+    // redirect and confuse the user.
+    if (!willLogout) {
       toastManager.showMessageFailure(failure);
     }
-    if (exception is BadCredentialsException ||
-        exception is RefreshTokenFailedException ||
-        exception is NotFoundSessionException) {
+    if (willLogout) {
       final authErrorType = _sessionLogoutAuthErrorType(exception);
       logError(
         '$runtimeType::handleGetSessionFailure: '

--- a/test/features/base/reloadable_controller_test.dart
+++ b/test/features/base/reloadable_controller_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 import 'package:tmail_ui_user/features/base/reloadable/reloadable_controller.dart';
 import 'package:tmail_ui_user/features/caching/caching_manager.dart';
 import 'package:tmail_ui_user/features/home/domain/state/get_session_state.dart';
@@ -230,6 +231,58 @@ void main() {
         controller.handleGetSessionFailure(GetSessionFailure(const BadCredentialsException()));
 
         expect(controller.wasLoggedOut, isTrue);
+      },
+    );
+  });
+
+  group(
+    'Issue 4679 — handleGetSessionFailure does NOT show an error toast '
+    'when the session is dead and the app redirects to SSO', () {
+    late MockToastManager mockToastManager;
+
+    setUp(() {
+      mockToastManager = Get.find<ToastManager>() as MockToastManager;
+      reset(mockToastManager);
+      controller.wasLoggedOut = false;
+    });
+
+    test(
+      'WHEN GetSessionFailure carries RefreshTokenFailedException\n'
+      'THEN no error toast is shown (redirect to SSO instead)',
+      () {
+        controller.handleGetSessionFailure(GetSessionFailure(RefreshTokenFailedException()));
+
+        verifyNever(mockToastManager.showMessageFailure(any));
+      },
+    );
+
+    test(
+      'WHEN GetSessionFailure carries NotFoundSessionException\n'
+      'THEN no error toast is shown (redirect to SSO instead)',
+      () {
+        controller.handleGetSessionFailure(GetSessionFailure(NotFoundSessionException()));
+
+        verifyNever(mockToastManager.showMessageFailure(any));
+      },
+    );
+
+    test(
+      'WHEN GetSessionFailure carries BadCredentialsException\n'
+      'THEN no error toast is shown (redirect to SSO instead)',
+      () {
+        controller.handleGetSessionFailure(GetSessionFailure(const BadCredentialsException()));
+
+        verifyNever(mockToastManager.showMessageFailure(any));
+      },
+    );
+
+    test(
+      'WHEN GetSessionFailure carries a transient error (ConnectionTimeout)\n'
+      'THEN the error toast IS shown (session may still recover)',
+      () {
+        controller.handleGetSessionFailure(GetSessionFailure(const ConnectionTimeout()));
+
+        verify(mockToastManager.showMessageFailure(any)).called(1);
       },
     );
   });


### PR DESCRIPTION
Closes #4679

## Problem

When the SSO session becomes invalid (expired access/refresh token), a red toast `Unexpected error: Instance of 'minified:aHb'` flashes for a few milliseconds before the app redirects to the SSO login page.

## Root cause

In `ReloadableController.handleGetSessionFailure`, the error toast was only suppressed for `BadCredentialsException`. A dead session actually surfaces as `RefreshTokenFailedException` (and sometimes `NotFoundSessionException`). `RefreshTokenFailedException` is not mapped in `ToastManager.getMessageByException`, so it falls back to the default `unexpectedError(exception.toString())` message — producing the minified `Instance of '...'` text.

Since those exceptions all lead to an immediate logout + redirect to SSO, showing any toast is misleading.

## Fix

Suppress the error toast for **every** exception that triggers a logout (`BadCredentialsException`, `RefreshTokenFailedException`, `NotFoundSessionException`). Transient errors (e.g. `ConnectionTimeout`) still show a toast, since the session may recover.

## Tests

Added tests in `reloadable_controller_test.dart` asserting that:
- no toast is shown for `RefreshTokenFailedException`, `NotFoundSessionException`, `BadCredentialsException`;
- a toast is still shown for a transient `ConnectionTimeout`.

---
*Generated automatically*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session-failure handling so users redirected to sign-in no longer see an extra error toast.
  * Kept error messages for temporary connection issues, while continuing logout behavior for invalid or expired sessions.
* **Tests**
  * Added coverage for session-failure cases to verify toast behavior during logout and non-logout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->