### PR TITLE
TF-4673 PDF preview error handling

### DIFF
--- a/core/lib/presentation/views/dialog/confirmation_dialog_builder.dart
+++ b/core/lib/presentation/views/dialog/confirmation_dialog_builder.dart
@@ -261,8 +261,9 @@ class _BodyContent extends StatelessWidget {
   }
 
   Widget _buildContent(BuildContext context) {
+    Widget? child;
     if (textContent.trim().isNotEmpty) {
-      return Padding(
+      child = Padding(
         padding: const EdgeInsetsDirectional.only(top: 32),
         child: Text(
           textContent,
@@ -270,7 +271,7 @@ class _BodyContent extends StatelessWidget {
         ),
       );
     } else if (listTextSpan != null) {
-      return Padding(
+      child = Padding(
         padding: const EdgeInsetsDirectional.only(top: 32),
         child: RichText(
           text: TextSpan(
@@ -280,7 +281,12 @@ class _BodyContent extends StatelessWidget {
         ),
       );
     }
-    return const SizedBox.shrink();
+    if (child == null) return const SizedBox.shrink();
+    return Flexible(
+      child: SingleChildScrollView(
+        child: child,
+      ),
+    );
   }
 
   Widget _buildAdditionalContent() {

--- a/lib/features/download/presentation/extensions/preview_attachment_download_controller_extension.dart
+++ b/lib/features/download/presentation/extensions/preview_attachment_download_controller_extension.dart
@@ -229,6 +229,7 @@ extension PreviewAttachmentDownloadControllerExtension on DownloadController {
             attachment: attachment,
             accountId: accountId,
             downloadUrl: downloadUrl,
+            imagePaths: imagePaths,
             downloadAction: (bytes, name) =>
                 downloadFileWeb(fileName: name, fileBytes: bytes),
             printAction: printUtils.printPDFFile,

--- a/lib/features/email/presentation/widgets/pdf_viewer/pdf_viewer.dart
+++ b/lib/features/email/presentation/widgets/pdf_viewer/pdf_viewer.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
+import 'package:core/presentation/views/dialog/confirmation_dialog_builder.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:dartz/dartz.dart' as dartz;
 import 'package:device_info_plus/device_info_plus.dart';
@@ -31,6 +33,7 @@ class PDFViewer extends StatefulWidget {
   final Attachment attachment;
   final AccountId accountId;
   final String downloadUrl;
+  final ImagePaths imagePaths;
   final DownloadPDFFileAction? downloadAction;
   final PrintPDFFileAction? printAction;
 
@@ -39,6 +42,7 @@ class PDFViewer extends StatefulWidget {
     required this.attachment,
     required this.accountId,
     required this.downloadUrl,
+    required this.imagePaths,
     this.downloadAction,
     this.printAction,
   });
@@ -129,6 +133,7 @@ class _PDFViewerState extends State<PDFViewer> {
         return ValueListenableBuilder(
           valueListenable: _pdfViewStateNotifier,
           builder: (context, viewState, child) {
+            final appLocalizations = AppLocalizations.of(context);
             final previewerState = switch (viewState) {
               DownloadAttachmentForWebSuccess() => PreviewerState.success,
               DownloadAttachmentForWebFailure() => PreviewerState.failure,
@@ -164,8 +169,17 @@ class _PDFViewerState extends State<PDFViewer> {
                   logWarning('_PDFViewerState::build:openData:onError:: $error');
                   _pdfViewStateNotifier.value = DownloadAttachmentForWebFailure(exception: error);
                 },
-                errorMessage: AppLocalizations.of(context).noPreviewAvailable,
+                errorMessage: appLocalizations.noPreviewAvailable,
               ),
+              errorBannerBuilder: (_, error, _, _) {
+                return ConfirmationDialogBuilder(
+                  imagePath: widget.imagePaths,
+                  title: appLocalizations.cannotPreviewPdf,
+                  textContent: error.toString(),
+                  confirmText: appLocalizations.close,
+                  onConfirmButtonAction: popBack,
+                );
+              },
               loadingOptions: LoadingOptions(
                 progress: downloadProgress,
                 progressColor: AppColor.primaryColor,

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2026-06-02T10:52:48.670230",
+  "@@last_modified": "2026-07-06T13:42:02.887001",
   "initializing_data": "Initializing data...",
   "@initializing_data": {
     "type": "text",
@@ -1472,6 +1472,12 @@
     "placeholders_order": [],
     "placeholders": {}
   },
+  "ssoRedirectFailedMessage": "We could not complete the single sign-on redirection. Please try again.",
+  "@ssoRedirectFailedMessage": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
   "moveFolder": "Move folder",
   "@moveFolder": {
     "type": "text",
@@ -1526,6 +1532,12 @@
   },
   "noPreviewAvailable": "No preview available",
   "@noPreviewAvailable": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "cannotPreviewPdf": "Cannot preview PDF",
+  "@cannotPreviewPdf": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}
@@ -1638,6 +1650,12 @@
     "placeholders_order": [],
     "placeholders": {}
   },
+  "languageMongolian": "Mongolian",
+  "@languageMongolian": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
   "languageVietnamese": "Vietnamese",
   "@languageVietnamese": {
     "type": "text",
@@ -1664,12 +1682,6 @@
   },
   "languageItalian": "Italian",
   "@languageItalian": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "languageMongolian": "Mongolian",
-  "@languageMongolian": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -1541,6 +1541,13 @@ class AppLocalizations {
     );
   }
 
+  String get cannotPreviewPdf {
+    return Intl.message(
+      'Cannot preview PDF',
+      name: 'cannotPreviewPdf',
+    );
+  }
+
   String get wrongUrlMessage {
     return Intl.message('Server URL is not valid, please try again',
         name: 'wrongUrlMessage');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2450,10 +2450,10 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "9e65dce2bb6c3cd43dce962fc7f546434fce6b55"
+      resolved-ref: fdfc1813a3a263446a18becc795c45fbae4d8f3b
       url: "https://github.com/linagora/twake-previewer-flutter.git"
     source: git
-    version: "0.1.0"
+    version: "0.1.1"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## Issue
- #4673 
 
## Demo

https://github.com/user-attachments/assets/91460463-d44b-4bea-b607-bda7276f2cc1




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved PDF preview fallback: when preview isn’t available, users now see a localized “Cannot preview PDF” banner with a confirmation dialog to close the viewer.
* **Bug Fixes**
  * Improved confirmation dialog content layout so long text and lists scroll consistently.
* **Localization**
  * Added localized messaging for “Cannot preview PDF” and SSO redirect failures, and updated language localization ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->