### PR TITLE
TF-4683 Ignore ctrl/meta modifiers for mail view keyboard shortcuts

### DIFF
--- a/core/lib/presentation/views/html_viewer/html_content_viewer_on_web_widget.dart
+++ b/core/lib/presentation/views/html_viewer/html_content_viewer_on_web_widget.dart
@@ -325,6 +325,8 @@ class _HtmlContentViewerOnWebState extends State<HtmlContentViewerOnWeb>
         key: data['key'] as String,
         code: data['code'] as String,
         shift: data['shift'] == true,
+        ctrl: data['ctrl'] == true,
+        meta: data['meta'] == true,
       );
       log('$runtimeType::_handleOnIFrameKeyboardEvent:📥 Shortcut pressed: $shortcut');
       widget.onIFrameKeyboardShortcutAction?.call(shortcut);

--- a/core/lib/presentation/views/shortcut/key_shortcut.dart
+++ b/core/lib/presentation/views/shortcut/key_shortcut.dart
@@ -15,11 +15,11 @@ class KeyShortcut with EquatableMixin{
     this.meta = false,
   });
 
-  bool matches(String expectedKey, {bool shift = false}) {
+  bool matches(String expectedKey, {bool shift = false, bool ctrl = false, bool meta = false}) {
     return key.toLowerCase() == expectedKey.toLowerCase() &&
         this.shift == shift &&
-        !ctrl &&
-        !meta;
+        this.ctrl == ctrl &&
+        this.meta == meta;
   }
 
   @override

--- a/core/lib/presentation/views/shortcut/key_shortcut.dart
+++ b/core/lib/presentation/views/shortcut/key_shortcut.dart
@@ -4,18 +4,24 @@ class KeyShortcut with EquatableMixin{
   final String key;
   final String code;
   final bool shift;
+  final bool ctrl;
+  final bool meta;
 
   KeyShortcut({
     required this.key,
     required this.code,
     this.shift = false,
+    this.ctrl = false,
+    this.meta = false,
   });
 
   bool matches(String expectedKey, {bool shift = false}) {
     return key.toLowerCase() == expectedKey.toLowerCase() &&
-        this.shift == shift;
+        this.shift == shift &&
+        !ctrl &&
+        !meta;
   }
 
   @override
-  List<Object?> get props => [key, code, shift];
+  List<Object?> get props => [key, code, shift, ctrl, meta];
 }

--- a/core/lib/utils/html/html_interaction.dart
+++ b/core/lib/utils/html/html_interaction.dart
@@ -399,7 +399,9 @@ class HtmlInteraction {
           type: 'toDart: iframeKeydown',
           key: event.key,
           code: event.code,
-          shift: event.shiftKey
+          shift: event.shiftKey,
+          ctrl: event.ctrlKey,
+          meta: event.metaKey
         };
         window.parent.postMessage(JSON.stringify(payload), "*");
       }

--- a/test/features/thread_detail/presentation/extension/key_shortcut_extension_test.dart
+++ b/test/features/thread_detail/presentation/extension/key_shortcut_extension_test.dart
@@ -1,0 +1,53 @@
+import 'package:core/presentation/views/shortcut/key_shortcut.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/base/shortcut/mail/mail_view_action_shortcut_type.dart';
+import 'package:tmail_ui_user/features/thread_detail/presentation/extension/key_shortcut_extension.dart';
+
+void main() {
+  group('KeyShortcutExtension::mailViewActionShortcutType', () {
+    test('SHOULD return forward WHEN pressing f without modifiers', () {
+      final shortcut = KeyShortcut(key: 'f', code: 'KeyF');
+
+      expect(
+        shortcut.mailViewActionShortcutType,
+        MailViewActionShortcutType.forward,
+      );
+    });
+
+    test('SHOULD return null WHEN pressing meta + f (browser search)', () {
+      final shortcut = KeyShortcut(key: 'f', code: 'KeyF', meta: true);
+
+      expect(shortcut.mailViewActionShortcutType, isNull);
+    });
+
+    test('SHOULD return null WHEN pressing ctrl + f (browser search)', () {
+      final shortcut = KeyShortcut(key: 'f', code: 'KeyF', ctrl: true);
+
+      expect(shortcut.mailViewActionShortcutType, isNull);
+    });
+
+    test('SHOULD return reply WHEN pressing r without modifiers', () {
+      final shortcut = KeyShortcut(key: 'r', code: 'KeyR');
+
+      expect(
+        shortcut.mailViewActionShortcutType,
+        MailViewActionShortcutType.reply,
+      );
+    });
+
+    test('SHOULD return replyAll WHEN pressing shift + r', () {
+      final shortcut = KeyShortcut(key: 'r', code: 'KeyR', shift: true);
+
+      expect(
+        shortcut.mailViewActionShortcutType,
+        MailViewActionShortcutType.replyAll,
+      );
+    });
+
+    test('SHOULD return null WHEN pressing meta + r', () {
+      final shortcut = KeyShortcut(key: 'r', code: 'KeyR', meta: true);
+
+      expect(shortcut.mailViewActionShortcutType, isNull);
+    });
+  });
+}


### PR DESCRIPTION
Closes #4683

## Problem

On macOS, pressing `Cmd+F` (or `Ctrl+F` on other platforms) while an email is open opened the browser's find-in-page search **and** the "Forward email" composer.

## Root cause

The iframe keydown listener injected into the email content viewer only forwarded the `shift` modifier to the Flutter side. `KeyShortcut.matches('f')` therefore returned `true` for `Cmd+F`, matching the single-letter `f` = forward shortcut regardless of the command/control modifier being held.

## Fix

- Propagate `ctrlKey` / `metaKey` from the iframe `keydown` event (`html_interaction.dart`) through to the `KeyShortcut` model (`html_content_viewer_on_web_widget.dart`).
- `KeyShortcut.matches(...)` now requires `ctrl` and `meta` to be absent, so modifier combos such as `Cmd+F` fall through to the browser instead of triggering a mail action.

## Tests

Added `key_shortcut_extension_test.dart` covering:
- `f` → forward
- `Cmd+F` / `Ctrl+F` → no action (null)
- `r` → reply, `Shift+R` → reply all, `Cmd+R` → no action

---
*Generated automatically*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut handling in the web viewer so modifier keys like Ctrl and Meta are recognized correctly.
  * Prevented unintended shortcut matches by ensuring modifier state is considered when identifying shortcuts.
* **Tests**
  * Added/updated coverage for shortcut-to-action mapping, including cases with Ctrl/Meta modifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->