### PR TITLE
Urgent-exception handling for Riverpod flows

### DIFF
--- a/docs/adr/0103-urgent-exception-handling-for-riverpod-flows.md
+++ b/docs/adr/0103-urgent-exception-handling-for-riverpod-flows.md
@@ -1,0 +1,44 @@
+# 103. Urgent-exception handling for Riverpod flows
+
+Date: 2026-07-07
+
+## Status
+
+Accepted
+
+## Related ADRs
+
+- [ADR-0085](./0085-riverpod-state-management-for-local-settings.md) — GetX + Riverpod coexistence
+- [ADR-0092](./0092-upgrade-flutter-riverpod-3.md) — `appProviderContainer` frozen; migrate to `ConsumerWidget`
+
+## Context
+
+GetX controllers consume interactors through `BaseController.consumeState`, whose `onData` / `onError` run `validateUrgentException(...)` → `handleUrgentException(...)`.
+That routing drives re-login / save-and-reconnect / connection-error UX for `NoNetworkError`, `BadCredentialsException`, `ConnectionError`, `RefreshTokenFailedException`.
+Riverpod notifiers consume interactors directly (`interactor.execute(...).last`), bypassing `consumeState`. They therefore lose this routing: a dismiss that fails on an expired token would show a generic toast instead of triggering a re-login. The `empty_folder` delegate had already re-implemented a partial version of this inline, handling only a bare exception (not a `Left(FeatureFailure)`).
+
+## Decision
+
+Add one shared primitive, `handleUrgentExceptionIfNeeded({Failure? failure, Object? exception})` (`lib/features/base/handle_urgent_exception.dart`). It resolves the registered `UrgentExceptionHandler` via the `getBinding` bridge, unwraps both carriers exactly like `BaseController` (`FeatureFailure.exception` or a bare exception), routes urgent  exceptions to `handleUrgentException`, and returns `true` when it handled one.
+
+**Rule:** any Riverpod flow consuming an interactor result MUST call this on failure. The caller skips its own failure UI when it returns `true`. The `empty_folder` delegate is refactored onto it, removing the duplicated inline logic.
+
+### Handler is a lifetime service, not a screen controller
+
+The `UrgentExceptionHandler` slot was bound to `MailboxDashBoardController` (`Get.put<UrgentExceptionHandler>(Get.find<MailboxDashBoardController>())`). That controller is absent on a web reload onto a non-dashboard route (e.g. Settings, where `MailboxDashBoardBindings` does not run — cf. ADR-0085), so `getBinding` would return `null` and urgent exceptions on those screens would be silently dropped.
+Bind the slot instead to `UrgentExceptionHandlerService` — a dedicated `BaseController` subclass registered `lazyPut(fenix: true)` in `MainBindings` (which runs at every bootstrap, before `runApp`). It reuses the proven `BaseController` routing unchanged and exists for the app lifetime regardless of the mounted screen. The dashboard keeps its own `handleUrgentExceptionOnMobile` override for its own `consumeState` path (that calls `this.handleUrgentException`, not the registered slot).
+
+It stays a GetX registration, not a Riverpod provider, for two reasons: the routing it reuses is `BaseController` (GetX-bound), and `handleUrgentExceptionIfNeeded` reads it from a plain function with no `Ref`, where a provider would force a frozen `appProviderContainer` read (ADR-0092).
+
+## Consequences
+
+**Positive**
+- Re-login / reconnect handling is no longer silently dropped in Riverpod flows.
+- Single source of truth; future Riverpod implementers call one documented function.
+- No new `appProviderContainer` call site (ADR-0092 compliant).
+- Urgent handling works on every route, including direct web reloads onto Settings or other non-dashboard screens.
+
+**Negative**
+- Still depends on `getBinding<UrgentExceptionHandler>()` — the GetX bridge. When the handler is exposed as a Riverpod provider, `handle_urgent_exception.dart` and `UrgentExceptionHandlerService` are the only places to change.
+- The contract is a convention, not enforced by the type system; reviewers must check new Riverpod failure paths call it.
+- `UrgentExceptionHandlerService` subclasses `BaseController` to reuse its routing; the cleaner end-state is to extract the routing into a framework-free service / Riverpod provider once GetX is removed.

--- a/lib/features/base/handle_urgent_exception.dart
+++ b/lib/features/base/handle_urgent_exception.dart
@@ -1,0 +1,29 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+
+/// Routes an interactor failure through the centrally-registered
+/// [UrgentExceptionHandler] (re-login, reconnect, connection errors), mirroring
+/// `BaseController.onData`/`onError` for Riverpod flows that bypass
+/// `consumeState`. Any such flow MUST call this on failure. See ADR-0103.
+///
+/// Unwraps either carrier like `BaseController`: a `Left(FeatureFailure)` (via
+/// [FeatureFailure.exception]) or a bare [exception]. Returns `true` when the
+/// exception was urgent and handled — the caller then skips its own error UI.
+bool handleUrgentExceptionIfNeeded({Failure? failure, Object? exception}) {
+  final handler = getBinding<UrgentExceptionHandler>();
+  if (handler == null) return false;
+
+  final resolvedException =
+      exception ?? (failure is FeatureFailure ? failure.exception : null);
+  if (resolvedException == null ||
+      !handler.validateUrgentException(resolvedException)) {
+    return false;
+  }
+
+  handler.handleUrgentException(
+    failure: failure,
+    exception: resolvedException is Exception ? resolvedException : null,
+  );
+  return true;
+}

--- a/lib/features/base/urgent_exception_handler_service.dart
+++ b/lib/features/base/urgent_exception_handler_service.dart
@@ -1,0 +1,16 @@
+import 'package:tmail_ui_user/features/base/base_controller.dart';
+import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
+
+/// App-lifetime [UrgentExceptionHandler], decoupled from any screen controller.
+///
+/// Bound permanently at bootstrap (`MainBindings`) so Riverpod flows and
+/// delegates can route urgent exceptions on any screen — including where
+/// `MailboxDashBoardController` is absent (e.g. a Settings web-reload). Reuses
+/// the `BaseController` routing unchanged; owns no view. See ADR-0103.
+class UrgentExceptionHandlerService extends BaseController {
+  @override
+  void onReady() {
+    // No super call: this service has no view, so it must not register the
+    // browser-unload listeners the base sets up — those belong to the screen.
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
+++ b/lib/features/mailbox_dashboard/presentation/bindings/mailbox_dashboard_bindings.dart
@@ -8,7 +8,6 @@ import 'package:core/utils/preview_eml_file_utils.dart';
 import 'package:core/utils/print_utils.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/base_bindings.dart';
-import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
 import 'package:tmail_ui_user/features/caching/caching_manager.dart';
 import 'package:tmail_ui_user/features/caching/utils/local_storage_manager.dart';
 import 'package:tmail_ui_user/features/caching/utils/session_storage_manager.dart';
@@ -271,7 +270,6 @@ abstract class MailboxDashBoardBindings extends BaseBindings {
       Get.find<StoreEmailSortOrderInteractor>(),
       Get.find<GetStoredEmailSortOrderInteractor>(),
     ));
-    Get.put<UrgentExceptionHandler>(Get.find<MailboxDashBoardController>());
     Get.put(AdvancedFilterController());
   }
 

--- a/lib/features/mailbox_dashboard/presentation/delegates/empty_folder_provider_listener_delegate.dart
+++ b/lib/features/mailbox_dashboard/presentation/delegates/empty_folder_provider_listener_delegate.dart
@@ -155,8 +155,9 @@ class EmptyFolderProviderListenerDelegate
         _stateSubscription?.close();
         _stateSubscription = null;
         _resetProgress(dashboardController);
-        _showEmptyFolderFailureToast(context, ref);
-        _handleUrgentException(exception);
+        if (!_handleUrgentException(exception)) {
+          _showEmptyFolderFailureToast(context, ref);
+        }
 
       case EmptyFolderIdle():
         break;
@@ -179,9 +180,10 @@ class EmptyFolderProviderListenerDelegate
   }
 
   // Routes urgent exceptions through the shared helper (ADR-0103).
-  void _handleUrgentException(Object? exception) {
-    if (exception == null) return;
-    handleUrgentExceptionIfNeeded(exception: exception);
+  // Returns true when the exception was urgent and handled.
+  bool _handleUrgentException(Object? exception) {
+    if (exception == null) return false;
+    return handleUrgentExceptionIfNeeded(exception: exception);
   }
 
   void _resetProgress(MailboxDashBoardController dashboardController) {

--- a/lib/features/mailbox_dashboard/presentation/delegates/empty_folder_provider_listener_delegate.dart
+++ b/lib/features/mailbox_dashboard/presentation/delegates/empty_folder_provider_listener_delegate.dart
@@ -8,7 +8,7 @@ import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/extensions/presentation_mailbox_extension.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
-import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
+import 'package:tmail_ui_user/features/base/handle_urgent_exception.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/empty_folder_request.dart';
 import 'package:tmail_ui_user/features/email/presentation/action/email_ui_action.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/empty_spam_folder_state.dart';
@@ -178,17 +178,10 @@ class EmptyFolderProviderListenerDelegate
     }
   }
 
-  // Resolves the urgent-exception handler by contract, not the concrete
-  // controller — keeps session/logout handling decoupled from this delegate.
+  // Routes urgent exceptions through the shared helper (ADR-0103).
   void _handleUrgentException(Object? exception) {
     if (exception == null) return;
-    final handler = getBinding<UrgentExceptionHandler>();
-    if (handler == null) return;
-    if (handler.validateUrgentException(exception)) {
-      handler.handleUrgentException(
-        exception: exception is Exception ? exception : null,
-      );
-    }
+    handleUrgentExceptionIfNeeded(exception: exception);
   }
 
   void _resetProgress(MailboxDashBoardController dashboardController) {

--- a/lib/main/bindings/main_bindings.dart
+++ b/lib/main/bindings/main_bindings.dart
@@ -1,5 +1,7 @@
 import 'package:core/utils/platform_info.dart';
 import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
+import 'package:tmail_ui_user/features/base/urgent_exception_handler_service.dart';
 import 'package:tmail_ui_user/features/login/presentation/bindings/company_server_login_interactor_bindings.dart';
 import 'package:tmail_ui_user/main/bindings/core/core_bindings.dart';
 import 'package:tmail_ui_user/main/bindings/credential/credential_bindings.dart';
@@ -26,5 +28,11 @@ class MainBindings extends Bindings {
       CompanyServerLoginInteractorBindings().dependencies();
       DeepLinkBindings().dependencies();
     }
+    // App-lifetime urgent-exception handler for Riverpod flows on any screen.
+    // Lazy so its `Get.find` fields resolve on first use, not at bootstrap.
+    Get.lazyPut<UrgentExceptionHandler>(
+      () => UrgentExceptionHandlerService(),
+      fenix: true,
+    );
   }
 }

--- a/test/features/base/handle_urgent_exception_test.dart
+++ b/test/features/base/handle_urgent_exception_test.dart
@@ -1,0 +1,104 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/base/handle_urgent_exception.dart';
+import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
+
+import 'handle_urgent_exception_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<UrgentExceptionHandler>()])
+class _TestFeatureFailure extends FeatureFailure {
+  _TestFeatureFailure({super.exception});
+}
+
+class _PlainFailure extends Failure {
+  @override
+  List<Object?> get props => [];
+}
+
+class _UrgentException implements Exception {}
+
+void main() {
+  late MockUrgentExceptionHandler handler;
+
+  setUp(() {
+    handler = MockUrgentExceptionHandler();
+    Get.put<UrgentExceptionHandler>(handler);
+  });
+
+  tearDown(Get.reset);
+
+  group('handleUrgentExceptionIfNeeded', () {
+    test('routes and returns true for an urgent bare exception', () {
+      final exception = _UrgentException();
+      when(handler.validateUrgentException(exception)).thenReturn(true);
+
+      final result = handleUrgentExceptionIfNeeded(exception: exception);
+
+      expect(result, isTrue);
+      verify(handler.validateUrgentException(exception)).called(1);
+      verify(
+        handler.handleUrgentException(failure: null, exception: exception),
+      ).called(1);
+    });
+
+    test('returns false and does not route a non-urgent exception', () {
+      final exception = _UrgentException();
+      when(handler.validateUrgentException(exception)).thenReturn(false);
+
+      final result = handleUrgentExceptionIfNeeded(exception: exception);
+
+      expect(result, isFalse);
+      verifyNever(
+        handler.handleUrgentException(
+          failure: anyNamed('failure'),
+          exception: anyNamed('exception'),
+        ),
+      );
+    });
+
+    test('unwraps and routes an urgent FeatureFailure.exception', () {
+      final exception = _UrgentException();
+      final failure = _TestFeatureFailure(exception: exception);
+      when(handler.validateUrgentException(exception)).thenReturn(true);
+
+      final result = handleUrgentExceptionIfNeeded(failure: failure);
+
+      expect(result, isTrue);
+      verify(
+        handler.handleUrgentException(failure: failure, exception: exception),
+      ).called(1);
+    });
+
+    test('returns false for a FeatureFailure with a non-urgent exception', () {
+      final exception = _UrgentException();
+      final failure = _TestFeatureFailure(exception: exception);
+      when(handler.validateUrgentException(exception)).thenReturn(false);
+
+      expect(handleUrgentExceptionIfNeeded(failure: failure), isFalse);
+    });
+
+    test('returns false for a FeatureFailure with no exception', () {
+      expect(
+        handleUrgentExceptionIfNeeded(failure: _TestFeatureFailure()),
+        isFalse,
+      );
+      verifyNever(handler.validateUrgentException(any));
+    });
+
+    test('returns false for a non-FeatureFailure failure', () {
+      expect(handleUrgentExceptionIfNeeded(failure: _PlainFailure()), isFalse);
+      verifyNever(handler.validateUrgentException(any));
+    });
+
+    test('returns false without throwing when no handler is registered', () {
+      Get.reset();
+      expect(
+        handleUrgentExceptionIfNeeded(exception: _UrgentException()),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/features/base/urgent_exception_handler_service_test.dart
+++ b/test/features/base/urgent_exception_handler_service_test.dart
@@ -1,0 +1,91 @@
+import 'package:core/core.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:mockito/annotations.dart';
+import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
+import 'package:tmail_ui_user/features/base/urgent_exception_handler_service.dart';
+import 'package:tmail_ui_user/features/caching/caching_manager.dart';
+import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oidc_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
+import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
+import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
+import 'package:uuid/uuid.dart';
+
+import 'urgent_exception_handler_service_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<CachingManager>(),
+  MockSpec<LanguageCacheManager>(),
+  MockSpec<AuthorizationInterceptors>(),
+  MockSpec<DynamicUrlInterceptors>(),
+  MockSpec<DeleteCredentialInteractor>(),
+  MockSpec<LogoutOidcInteractor>(),
+  MockSpec<DeleteAuthorityOidcInteractor>(),
+  MockSpec<AppToast>(),
+  MockSpec<ImagePaths>(),
+  MockSpec<ResponsiveUtils>(),
+  MockSpec<Uuid>(),
+  MockSpec<ToastManager>(),
+  MockSpec<TwakeAppManager>(),
+])
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late UrgentExceptionHandlerService service;
+
+  setUp(() {
+    // BaseController resolves these app-wide singletons in its field
+    // initializers; register them so the service is constructible standalone.
+    Get.put<CachingManager>(MockCachingManager());
+    Get.put<LanguageCacheManager>(MockLanguageCacheManager());
+    Get.put<AuthorizationInterceptors>(MockAuthorizationInterceptors());
+    Get.put<AuthorizationInterceptors>(
+      MockAuthorizationInterceptors(),
+      tag: BindingTag.isolateTag,
+    );
+    Get.put<DynamicUrlInterceptors>(MockDynamicUrlInterceptors());
+    Get.put<DeleteCredentialInteractor>(MockDeleteCredentialInteractor());
+    Get.put<LogoutOidcInteractor>(MockLogoutOidcInteractor());
+    Get.put<DeleteAuthorityOidcInteractor>(MockDeleteAuthorityOidcInteractor());
+    Get.put<AppToast>(MockAppToast());
+    Get.put<ImagePaths>(MockImagePaths());
+    Get.put<ResponsiveUtils>(MockResponsiveUtils());
+    Get.put<Uuid>(MockUuid());
+    Get.put<ToastManager>(MockToastManager());
+    Get.put<TwakeAppManager>(MockTwakeAppManager());
+
+    service = UrgentExceptionHandlerService();
+  });
+
+  tearDown(Get.reset);
+
+  group('UrgentExceptionHandlerService', () {
+    test('is an UrgentExceptionHandler', () {
+      expect(service, isA<UrgentExceptionHandler>());
+    });
+
+    test('classifies session/network exceptions as urgent', () {
+      expect(
+        service.validateUrgentException(const BadCredentialsException()),
+        isTrue,
+      );
+      expect(
+        service.validateUrgentException(RefreshTokenFailedException()),
+        isTrue,
+      );
+      expect(service.validateUrgentException(const ConnectionError()), isTrue);
+      expect(service.validateUrgentException(const NoNetworkError()), isTrue);
+    });
+
+    test('does not classify ordinary errors as urgent', () {
+      expect(service.validateUrgentException(Exception('boom')), isFalse);
+      expect(service.validateUrgentException(null), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## What

Adds a shared primitive `handleUrgentExceptionIfNeeded({Failure? failure, Object? exception})` and an app-lifetime `UrgentExceptionHandlerService`, so flows that consume interactors directly (bypassing `BaseController.consumeState`) still route urgent exceptions — re-login, save-and-reconnect, connection errors — instead of showing a generic toast.

## Why

`BaseController.consumeState` runs `validateUrgentException` → `handleUrgentException` on every result, driving the re-login / reconnect UX for `NoNetworkError`, `BadCredentialsException`, `ConnectionError`, and `RefreshTokenFailedException`. Riverpod notifiers call `interactor.execute(...).last` directly and lose that routing: a dismiss failing on an expired token would toast instead of re-authenticating. The `empty_folder` delegate had already re-implemented a partial, bare-exception-only version of this inline.

## Tests

- `handle_urgent_exception_test`: routes and returns `true` for an urgent bare exception; unwraps and routes an urgent `FeatureFailure.exception`; returns `false` without routing for a non-urgent exception, a `FeatureFailure` with a non-urgent or absent exception, a non-`FeatureFailure` failure, and when no handler is registered (no throw).
- `urgent_exception_handler_service_test`: is an `UrgentExceptionHandler`; classifies `BadCredentialsException` / `RefreshTokenFailedException` / `ConnectionError` / `NoNetworkError` as urgent; does not classify ordinary errors or `null` as urgent.

See ADR-0103 for the decision, the lifetime-service rationale, and consequences.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized urgent-exception routing so urgent issues are handled consistently across app screens, including after reloads.
  * Introduced an application-wide urgent exception handler registered at app startup for full lifecycle coverage.

* **Bug Fixes**
  * Fixed inconsistent urgent error handling by unifying how failures and exceptions are interpreted and dispatched.
  * Prevented duplicate/competing UI handling for urgent failures (e.g., empty-folder error paths).

* **Tests**
  * Added unit tests covering urgent vs non-urgent behavior and handler-not-registered cases.

* **Documentation**
  * Documented the new urgent exception handling approach in an ADR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->