### PR TITLE
TF-4684 Add drive card hover close button

### DIFF
--- a/core/lib/utils/html/file_link_card_html_builder.dart
+++ b/core/lib/utils/html/file_link_card_html_builder.dart
@@ -28,6 +28,10 @@ class FileLinkCardContent {
 
 /// Builds the inline HTML card used to represent a linked file (e.g. a Drive
 /// attachment) inside the composer body.
+///
+/// The `tmail-file-link-card` class is the selector used by
+/// `WorkplaceScripts.registerDriveCardDeleteOverlay` to attach the
+/// hover-delete UI.
 class FileLinkCardHtmlBuilder {
   static const _attributeEscape = HtmlEscape(HtmlEscapeMode.attribute);
   static const _textEscape = HtmlEscape();

--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -413,6 +413,12 @@ class HtmlUtils {
           if (closestCardAnchor(event.target)) {
             event.preventDefault();
             event.stopPropagation();
+            // preventDefault() also blocks the native focus shift, so the
+            // app's onFocus->hideMenu bridge never fires. Refocus explicitly
+            // (preventScroll avoids the iframe scroll-into-view jump).
+            if (document.activeElement !== root) {
+              root.focus({ preventScroll: true });
+            }
           }
         }, true);
 

--- a/core/test/utils/html/file_link_card_html_builder_test.dart
+++ b/core/test/utils/html/file_link_card_html_builder_test.dart
@@ -16,6 +16,7 @@ void main() {
       expect(result, startsWith('<a href="https://example.com/file"'));
       expect(result, contains('target="_blank"'));
       expect(result, contains('rel="noopener noreferrer"'));
+      expect(result, contains('class="tmail-file-link-card"'));
       expect(result, contains('<div>icon</div>'));
       expect(result, contains('title="My File">My File</div>'));
       expect(result, contains('Open in drive ↗'));

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1914,10 +1914,37 @@ class ComposerController extends BaseController
   }
 
   void handleOnFocusHtmlEditorWeb() {
+    // This handler only ever runs because the html editor's own native DOM
+    // element just gained focus (wired exclusively to the editor widget's
+    // `onFocus` callback), so calling editorController.setFocus() again is
+    // redundant unless something else in this method actually diverted
+    // focus away in the meantime. Calling it unconditionally created a
+    // steady stream of redundant async round-trips (postMessage to the
+    // iframe) that could resolve later, at an unrelated moment — e.g. right
+    // after a *different* click's native mousedown-triggered blur — at
+    // which point Summernote's `hasFocus() || focus()` finds the editable
+    // blurred and performs a real, un-prevented native `.focus()`, which
+    // the browser auto-scrolls into view and can shift page content
+    // mid-click so the click misses its target. Only re-assert focus if we
+    // actually took focus away from something else in this same call.
+    final recipientsWereFocused = toAddressFocusNode?.hasFocus == true ||
+        ccAddressFocusNode?.hasFocus == true ||
+        bccAddressFocusNode?.hasFocus == true ||
+        replyToAddressFocusNode?.hasFocus == true;
     clearFocusRecipients();
+    final subjectWasFocused = subjectEmailInputFocusNode?.hasFocus == true;
     clearFocusSubject();
-    FocusManager.instance.primaryFocus?.unfocus();
-    if (richTextWebController?.codeViewEnabled != true) {
+    // `FocusScopeNode`s (root scope, Navigator scope, modal route scope,
+    // etc.) are ambient focus-tree scaffolding, not a real focused widget —
+    // only a genuine leaf FocusNode counts as "something else was focused".
+    final primaryFocus = FocusManager.instance.primaryFocus;
+    var primaryWasUnfocused = false;
+    if (primaryFocus != null && primaryFocus is! FocusScopeNode) {
+      primaryFocus.unfocus();
+      primaryWasUnfocused = true;
+    }
+    if (richTextWebController?.codeViewEnabled != true &&
+        (recipientsWereFocused || subjectWasFocused || primaryWasUnfocused)) {
       richTextWebController?.editorController.setFocus();
     }
     richTextWebController?.closeAllMenuPopup();

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -12,6 +12,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:filesize/filesize.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:html_editor_enhanced/html_editor.dart';
@@ -1012,6 +1013,7 @@ class ComposerController extends BaseController
             popBack();
             await richTextMobileTabletController?.restoreMobileEditorFocus();
             await htmlEditorApi?.insertHtml(html);
+            await SchedulerBinding.instance.endOfFrame;
           }
         },
         appLocalizations: currentContext != null ? AppLocalizations.of(currentContext!) : null,

--- a/lib/features/composer/presentation/controller/rich_text_web_controller.dart
+++ b/lib/features/composer/presentation/controller/rich_text_web_controller.dart
@@ -46,6 +46,27 @@ class RichTextWebController extends GetxController {
   final menuParagraphController = CustomPopupMenuController();
   final menuOrderListController = CustomPopupMenuController();
 
+  // Only reassert focus on the editor when something OTHER than the editor
+  // itself genuinely holds Flutter focus right now (e.g. a real toolbar
+  // button's own FocusNode). `FocusScopeNode`s (root scope, Navigator scope,
+  // modal route scope, etc.) are just ambient focus-tree scaffolding, not a
+  // real focused widget. This matters here because onEditorSettingsChange/
+  // onEditorTextSizeChanged are wired to the package's native
+  // `document.onselectionchange`/`summernote.mouseup` events, which fire on
+  // any selection change or mouseup already inside the editor (including
+  // our own drive-card delete overlay's own selection manipulation) — i.e.
+  // the editor already has focus in the common case, so calling
+  // editorController.setFocus() unconditionally there created a
+  // near-continuous stream of redundant async round-trips that could
+  // resolve later, at an unrelated moment, causing an un-prevented native
+  // re-focus/scroll-jump.
+  void _reclaimFocusIfDivertedElsewhere() {
+    final primaryFocus = FocusManager.instance.primaryFocus;
+    if (primaryFocus != null && primaryFocus is! FocusScopeNode) {
+      editorController.setFocus();
+    }
+  }
+
   @override
   void onReady() {
     super.onReady();
@@ -64,12 +85,12 @@ class RichTextWebController extends GetxController {
     _updateBackgroundTextColor(settings);
     _updateOrderList(settings);
     _updateParagraph(settings);
-    editorController.setFocus();
+    _reclaimFocusIfDivertedElsewhere();
   }
 
   void onEditorTextSizeChanged(int? size) {
     _updateFontSize(size);
-    editorController.setFocus();
+    _reclaimFocusIfDivertedElsewhere();
   }
 
   void _updateTextStyle(EditorSettings settings) {

--- a/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
@@ -1,4 +1,3 @@
-
 import 'package:core/presentation/constants/constants_ui.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/build_utils.dart';
@@ -8,7 +7,9 @@ import 'package:core/utils/html/html_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:rich_text_composer/rich_text_composer.dart';
 import 'package:tmail_ui_user/features/composer/presentation/mixin/text_selection_mixin.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:url_launcher/url_launcher.dart' as launcher;
+import 'package:workplace/presentation/utils/workplace_scripts.dart';
 
 typedef OnCreatedEditorAction = Function(BuildContext context, HtmlEditorApi editorApi, String content);
 typedef OnLoadCompletedEditorAction = Function(HtmlEditorApi editorApi, WebUri? url);
@@ -139,9 +140,18 @@ class _MobileEditorState extends State<MobileEditorWidget> with TextSelectionMix
     widget.onLoadCompletedEditorAction(editorApi, webUri);
     try {
       await _setupSelectionListener(editorApi);
+      await _registerDriveCardDeleteOverlay(editorApi);
     } catch (e) {
       logWarning('Error onWebViewCreated: $e');
     }
+  }
+
+  Future<void> _registerDriveCardDeleteOverlay(HtmlEditorApi editorApi) async {
+    if (!mounted) return;
+    final script = WorkplaceScripts.registerDriveCardDeleteOverlay(
+      AppLocalizations.of(context).remove,
+    );
+    await editorApi.webViewController.evaluateJavascript(source: script.script);
   }
 
 

--- a/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
@@ -150,6 +150,7 @@ class _MobileEditorState extends State<MobileEditorWidget> with TextSelectionMix
     if (!mounted) return;
     final script = WorkplaceScripts.registerDriveCardDeleteOverlay(
       AppLocalizations.of(context).remove,
+      viewId: _createdViewId,
     );
     await editorApi.webViewController.evaluateJavascript(source: script.script);
   }

--- a/lib/features/composer/presentation/widgets/web/web_editor_scripts.dart
+++ b/lib/features/composer/presentation/widgets/web/web_editor_scripts.dart
@@ -6,9 +6,11 @@ List<WebScript> buildWebEditorInitialScripts({
   required double maxHeight,
   required WebScript selectionChangeScript,
   required String driveCardDeleteOverlayRemoveLabel,
+  required String driveCardDeleteOverlayViewId,
 }) {
   final driveCardDeleteOverlayScript = WorkplaceScripts.registerDriveCardDeleteOverlay(
     driveCardDeleteOverlayRemoveLabel,
+    viewId: driveCardDeleteOverlayViewId,
     isWebPlatform: true,
   );
 

--- a/lib/features/composer/presentation/widgets/web/web_editor_scripts.dart
+++ b/lib/features/composer/presentation/widgets/web/web_editor_scripts.dart
@@ -1,10 +1,16 @@
 import 'package:core/utils/html/html_utils.dart';
 import 'package:html_editor_enhanced/html_editor.dart';
+import 'package:workplace/presentation/utils/workplace_scripts.dart';
 
 List<WebScript> buildWebEditorInitialScripts({
   required double maxHeight,
   required WebScript selectionChangeScript,
+  required String driveCardDeleteOverlayRemoveLabel,
 }) {
+  final driveCardDeleteOverlayScript = WorkplaceScripts.registerDriveCardDeleteOverlay(
+    driveCardDeleteOverlayRemoveLabel,
+  );
+
   return [
     WebScript(
       name: HtmlUtils.removeLineHeight1px.name,
@@ -65,6 +71,14 @@ List<WebScript> buildWebEditorInitialScripts({
       script: HtmlUtils.registerFileLinkCardClickHandler(
         isWebPlatform: true,
       ).script,
+    ),
+    WebScript(
+      name: driveCardDeleteOverlayScript.name,
+      script: driveCardDeleteOverlayScript.script,
+    ),
+    WebScript(
+      name: WorkplaceScripts.unregisterDriveCardDeleteOverlay.name,
+      script: WorkplaceScripts.unregisterDriveCardDeleteOverlay.script,
     ),
   ];
 }

--- a/lib/features/composer/presentation/widgets/web/web_editor_scripts.dart
+++ b/lib/features/composer/presentation/widgets/web/web_editor_scripts.dart
@@ -9,6 +9,7 @@ List<WebScript> buildWebEditorInitialScripts({
 }) {
   final driveCardDeleteOverlayScript = WorkplaceScripts.registerDriveCardDeleteOverlay(
     driveCardDeleteOverlayRemoveLabel,
+    isWebPlatform: true,
   );
 
   return [

--- a/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
@@ -123,6 +123,8 @@ class _WebEditorState extends State<WebEditorWidget> with TextSelectionMixin {
           } else if (data['name'] == _selectionChangeScript.name
               && data['viewId'] == _createdViewId) {
             handleSelectionChange(data);
+          } else if (data['type'] == 'toDart: driveCardDeleted') {
+            _syncContentAfterDriveCardDeleted();
           }
         }
       } catch (e) {
@@ -235,6 +237,14 @@ class _WebEditorState extends State<WebEditorWidget> with TextSelectionMixin {
         onKeyDown: widget.onKeyDownEditorAction,
       ),
     );
+  }
+
+  /// Syncs draft content after a Drive card is removed, bypassing
+  /// Summernote's `onChangeContent` pipeline (which triggers
+  /// html_editor_enhanced's scroll-to-top `ensureVisible()`).
+  Future<void> _syncContentAfterDriveCardDeleted() async {
+    final text = await _editorController.getText();
+    widget.onChangeContent?.call(text);
   }
 
   void _registerEditorScripts() {

--- a/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
@@ -123,7 +123,8 @@ class _WebEditorState extends State<WebEditorWidget> with TextSelectionMixin {
           } else if (data['name'] == _selectionChangeScript.name
               && data['viewId'] == _createdViewId) {
             handleSelectionChange(data);
-          } else if (data['type'] == 'toDart: driveCardDeleted') {
+          } else if (data['type'] == 'toDart: driveCardDeleted'
+              && data['viewId'] == _createdViewId) {
             _syncContentAfterDriveCardDeleted();
           }
         }
@@ -191,6 +192,7 @@ class _WebEditorState extends State<WebEditorWidget> with TextSelectionMixin {
             maxHeight: maxHeight,
             selectionChangeScript: _selectionChangeScript,
             driveCardDeleteOverlayRemoveLabel: AppLocalizations.of(context).remove,
+            driveCardDeleteOverlayViewId: _createdViewId,
           ),
         )
       ),
@@ -267,6 +269,8 @@ class _WebEditorState extends State<WebEditorWidget> with TextSelectionMixin {
     _editorController.evaluateJavascriptWeb(
       WorkplaceScripts.registerDriveCardDeleteOverlay(
         AppLocalizations.of(context).remove,
+        viewId: _createdViewId,
+        isWebPlatform: true,
       ).name,
     );
     _editorListenerRegistered = true;

--- a/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
@@ -12,6 +12,7 @@ import 'package:tmail_ui_user/features/composer/presentation/widgets/web/signatu
 import 'package:tmail_ui_user/features/composer/presentation/widgets/web/web_editor_scripts.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:universal_html/html.dart' hide VoidCallback;
+import 'package:workplace/presentation/utils/workplace_scripts.dart';
 
 typedef OnChangeContentEditorAction = Function(String? text);
 typedef OnInitialContentEditorAction = Function(String text);
@@ -147,6 +148,8 @@ class _WebEditorState extends State<WebEditorWidget> with TextSelectionMixin {
   void dispose() {
     _editorController.evaluateJavascriptWeb(
       HtmlUtils.unregisterDropListener.name);
+    _editorController.evaluateJavascriptWeb(
+      WorkplaceScripts.unregisterDriveCardDeleteOverlay.name);
     if (_editorListener != null) {
       window.removeEventListener("message", _editorListener!);
       _editorListener = null;
@@ -185,6 +188,7 @@ class _WebEditorState extends State<WebEditorWidget> with TextSelectionMixin {
           buildWebEditorInitialScripts(
             maxHeight: maxHeight,
             selectionChangeScript: _selectionChangeScript,
+            driveCardDeleteOverlayRemoveLabel: AppLocalizations.of(context).remove,
           ),
         )
       ),
@@ -248,6 +252,11 @@ class _WebEditorState extends State<WebEditorWidget> with TextSelectionMixin {
     _editorController.evaluateJavascriptWeb(
       HtmlUtils.registerFileLinkCardClickHandler(
         isWebPlatform: true,
+      ).name,
+    );
+    _editorController.evaluateJavascriptWeb(
+      WorkplaceScripts.registerDriveCardDeleteOverlay(
+        AppLocalizations.of(context).remove,
       ).name,
     );
     _editorListenerRegistered = true;

--- a/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
@@ -77,5 +77,43 @@ void main() {
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, contains('Report'));
     });
+
+    test('Should await an async insertHtml callback before insertDriveLinkHtml completes', () async {
+      final callOrder = <String>[];
+
+      await handler.insertDriveLinkHtml(
+        [linkDoc],
+        insertHtml: (html) async {
+          callOrder.add('insertHtml-start');
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          insertedHtml.add(html);
+          callOrder.add('insertHtml-end');
+        },
+        appLocalizations: appLocalizations,
+      );
+      callOrder.add('awaited');
+
+      expect(callOrder, ['insertHtml-start', 'insertHtml-end', 'awaited']);
+      expect(insertedHtml, hasLength(1));
+    });
+
+    test('Should propagate exceptions thrown by an async insertHtml callback', () async {
+      Object? caughtError;
+
+      try {
+        await handler.insertDriveLinkHtml(
+          [linkDoc],
+          insertHtml: (html) async {
+            await Future<void>.delayed(const Duration(milliseconds: 5));
+            throw StateError('mobile insertHtml failed');
+          },
+          appLocalizations: appLocalizations,
+        );
+      } catch (e) {
+        caughtError = e;
+      }
+
+      expect(caughtError, isA<StateError>());
+    });
   });
 }

--- a/workplace/lib/presentation/utils/workplace_scripts.dart
+++ b/workplace/lib/presentation/utils/workplace_scripts.dart
@@ -25,6 +25,21 @@ class WorkplaceScripts {
 
           const isWebPlatform = $isWebPlatform;
           const removeLabel = ${jsonEncode(removeLabel)};
+          $_overlayStateSetup
+          $_cardInteractionHelpers
+          if (isTouch) {
+            $_touchOverlayLogic
+          } else {
+            $_hoverOverlayLogic
+          }
+        } catch (e) {}
+      })();''',
+    name: 'registerDriveCardDeleteOverlay',
+  );
+
+  /// Shared card selector/touch-detection and the cleanup registry that
+  /// both the touch and hover branches push their teardown callbacks into.
+  static const _overlayStateSetup = '''
           const cardSelector = '.tmail-file-link-card';
           const isTouch = window.matchMedia &&
             window.matchMedia('(hover: none), (pointer: coarse)').matches;
@@ -43,8 +58,11 @@ class WorkplaceScripts {
             });
             window.__tmailDriveCardDeleteOverlayInstalled = false;
             window.__tmailDriveCardDeleteOverlayCleanup = null;
-          };
+          };''';
 
+  /// Helpers shared by both the touch and hover overlay branches: content
+  /// sync, focus restoration, delete activation, and overlay creation.
+  static const _cardInteractionHelpers = '''
           function syncEditorContent() {
             try {
               const editable = document.querySelector('.note-editable');
@@ -137,9 +155,11 @@ class WorkplaceScripts {
               overlay.style.left = (rect.right - 42) + 'px';
               overlay.style.display = 'flex';
             } catch (e) {}
-          }
+          }''';
 
-          if (isTouch) {
+  /// Touch branch: a persistently visible overlay button per card, synced
+  /// against DOM mutations since touch devices have no hover state to key off.
+  static const _touchOverlayLogic = '''
             const overlaysByCard = new Map();
 
             function bindDelete(card, overlay) {
@@ -212,8 +232,11 @@ class WorkplaceScripts {
             });
 
             trackListener(window, 'scroll', scheduleReposition, true);
-            trackListener(window, 'resize', scheduleReposition, false);
-          } else {
+            trackListener(window, 'resize', scheduleReposition, false);''';
+
+  /// Hover branch: a single reusable overlay button that follows whichever
+  /// card is currently hovered.
+  static const _hoverOverlayLogic = '''
             let activeCard = null;
             const overlay = makeOverlay();
 
@@ -274,12 +297,7 @@ class WorkplaceScripts {
             }, false);
 
             trackListener(window, 'scroll', scheduleReposition, true);
-            trackListener(window, 'resize', scheduleReposition, false);
-          }
-        } catch (e) {}
-      })();''',
-    name: 'registerDriveCardDeleteOverlay',
-  );
+            trackListener(window, 'resize', scheduleReposition, false);''';
 
   /// Tears down everything installed by [registerDriveCardDeleteOverlay]:
   /// cancels the pending animation frame, disconnects the `MutationObserver`,

--- a/workplace/lib/presentation/utils/workplace_scripts.dart
+++ b/workplace/lib/presentation/utils/workplace_scripts.dart
@@ -1,0 +1,248 @@
+import 'dart:convert';
+
+/// JavaScript snippets injected into the composer's HTML editor to support
+/// Workplace Drive attachment cards (`.tmail-file-link-card` elements).
+class WorkplaceScripts {
+  /// Installs a delete affordance for `.tmail-file-link-card` elements, appended
+  /// to `document.body` — never a descendant of `.note-editable` — so it's
+  /// excluded from the composer's HTML content by construction.
+  ///
+  /// Hover-capable devices get a single reusable button that follows the
+  /// hovered card. Touch devices keep a button persistently visible over
+  /// every card. Position is re-synced on scroll/resize/card-mutation via a
+  /// single debounced `requestAnimationFrame`, not a perpetual per-frame
+  /// loop, to avoid forcing a layout reflow every frame while idle.
+  static ({String name, String script}) registerDriveCardDeleteOverlay(
+    String removeLabel,
+  ) => (
+    script:
+        '''
+      (function() {
+        try {
+          if (window.__tmailDriveCardDeleteOverlayInstalled) return;
+          window.__tmailDriveCardDeleteOverlayInstalled = true;
+
+          const removeLabel = ${jsonEncode(removeLabel)};
+          const cardSelector = '.tmail-file-link-card';
+          const isTouch = window.matchMedia &&
+            window.matchMedia('(hover: none), (pointer: coarse)').matches;
+          const cleanupFns = [];
+
+          function trackListener(target, type, handler, options) {
+            target.addEventListener(type, handler, options);
+            cleanupFns.push(function() {
+              target.removeEventListener(type, handler, options);
+            });
+          }
+
+          window.__tmailDriveCardDeleteOverlayCleanup = function() {
+            cleanupFns.forEach(function(fn) {
+              try { fn(); } catch (e) {}
+            });
+            window.__tmailDriveCardDeleteOverlayInstalled = false;
+            window.__tmailDriveCardDeleteOverlayCleanup = null;
+          };
+
+          function syncEditorContent() {
+            try {
+              const editable = document.querySelector('.note-editable');
+              if (editable) {
+                editable.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
+              }
+            } catch (e) {}
+          }
+
+          function removeCardOnActivate(event, card, onOverlayCleanup) {
+            try {
+              event.preventDefault();
+              event.stopPropagation();
+              if (card) card.remove();
+              onOverlayCleanup();
+              syncEditorContent();
+            } catch (e) {}
+          }
+
+          function makeOverlay() {
+            try {
+              const overlay = document.createElement('div');
+              overlay.setAttribute('role', 'button');
+              overlay.setAttribute('tabindex', '0');
+              overlay.setAttribute('aria-label', removeLabel);
+              overlay.title = removeLabel;
+              overlay.textContent = '✕';
+              overlay.style.cssText = 'position:fixed;display:none;align-items:center;' +
+                'justify-content:center;width:36px;height:36px;color:rgba(0,0,0,0.55);' +
+                'font-size:24px;cursor:pointer;z-index:2147483647;';
+              document.body.appendChild(overlay);
+              return overlay;
+            } catch (e) {
+              return null;
+            }
+          }
+
+          function positionOverlay(card, overlay) {
+            try {
+              const rect = card.getBoundingClientRect();
+              if (rect.width === 0 && rect.height === 0) {
+                overlay.style.display = 'none';
+                return;
+              }
+              overlay.style.top = (rect.top + 6) + 'px';
+              overlay.style.left = (rect.right - 42) + 'px';
+              overlay.style.display = 'flex';
+            } catch (e) {}
+          }
+
+          if (isTouch) {
+            const overlaysByCard = new Map();
+
+            function bindDelete(card, overlay) {
+              try {
+                function onActivate(event) {
+                  removeCardOnActivate(event, card, function() {
+                    overlay.remove();
+                    overlaysByCard.delete(card);
+                  });
+                }
+                overlay.addEventListener('click', onActivate);
+                overlay.addEventListener('keydown', function(event) {
+                  if (event.key === 'Enter' || event.key === ' ') onActivate(event);
+                });
+              } catch (e) {}
+            }
+
+            let rafId = null;
+            function scheduleReposition() {
+              if (rafId !== null) return;
+              rafId = requestAnimationFrame(function() {
+                rafId = null;
+                overlaysByCard.forEach(function(overlay, card) {
+                  positionOverlay(card, overlay);
+                });
+              });
+            }
+            cleanupFns.push(function() {
+              if (rafId !== null) cancelAnimationFrame(rafId);
+            });
+
+            function syncTouchOverlays() {
+              try {
+                const seen = new Set();
+                document.querySelectorAll(cardSelector).forEach(function(card) {
+                  seen.add(card);
+                  if (!overlaysByCard.has(card)) {
+                    const overlay = makeOverlay();
+                    if (!overlay) return;
+                    bindDelete(card, overlay);
+                    overlaysByCard.set(card, overlay);
+                  }
+                });
+                overlaysByCard.forEach(function(overlay, card) {
+                  if (!seen.has(card)) {
+                    overlay.remove();
+                    overlaysByCard.delete(card);
+                  }
+                });
+                scheduleReposition();
+              } catch (e) {}
+            }
+
+            syncTouchOverlays();
+
+            try {
+              const editableRoot = document.querySelector('.note-editable') || document.body;
+              const observer = new MutationObserver(syncTouchOverlays);
+              observer.observe(editableRoot, {
+                childList: true,
+                subtree: true,
+              });
+              cleanupFns.push(function() { observer.disconnect(); });
+            } catch (e) {}
+
+            cleanupFns.push(function() {
+              overlaysByCard.forEach(function(overlay) { overlay.remove(); });
+              overlaysByCard.clear();
+            });
+
+            trackListener(window, 'scroll', scheduleReposition, true);
+            trackListener(window, 'resize', scheduleReposition, false);
+          } else {
+            let activeCard = null;
+            const overlay = makeOverlay();
+
+            let rafId = null;
+            function scheduleReposition() {
+              if (rafId !== null) return;
+              rafId = requestAnimationFrame(function() {
+                rafId = null;
+                if (overlay && activeCard && document.body.contains(activeCard)) {
+                  positionOverlay(activeCard, overlay);
+                } else {
+                  activeCard = null;
+                  if (overlay) overlay.style.display = 'none';
+                }
+              });
+            }
+            cleanupFns.push(function() {
+              if (rafId !== null) cancelAnimationFrame(rafId);
+            });
+            if (overlay) {
+              cleanupFns.push(function() { overlay.remove(); });
+            }
+
+            function onActivate(event) {
+              removeCardOnActivate(event, activeCard, function() {
+                activeCard = null;
+                if (overlay) overlay.style.display = 'none';
+              });
+            }
+            if (overlay) {
+              overlay.addEventListener('click', onActivate);
+              overlay.addEventListener('keydown', function(event) {
+                if (event.key === 'Enter' || event.key === ' ') onActivate(event);
+              });
+            }
+
+            trackListener(document, 'mouseover', function(event) {
+              try {
+                const card = event.target.closest && event.target.closest(cardSelector);
+                if (card) {
+                  activeCard = card;
+                  scheduleReposition();
+                }
+              } catch (e) {}
+            }, false);
+            trackListener(document, 'mouseout', function(event) {
+              try {
+                if (!activeCard) return;
+                const related = event.relatedTarget;
+                const movingToActiveCard = related && activeCard.contains(related);
+                const movingToOverlay = related && overlay && overlay.contains(related);
+                if (!movingToActiveCard && !movingToOverlay) {
+                  activeCard = null;
+                  if (overlay) overlay.style.display = 'none';
+                }
+              } catch (e) {}
+            }, false);
+
+            trackListener(window, 'scroll', scheduleReposition, true);
+            trackListener(window, 'resize', scheduleReposition, false);
+          }
+        } catch (e) {}
+      })();''',
+    name: 'registerDriveCardDeleteOverlay',
+  );
+
+  /// Tears down everything installed by [registerDriveCardDeleteOverlay]:
+  /// cancels the pending animation frame, disconnects the `MutationObserver`,
+  /// removes the scroll/resize/mouse listeners, and removes overlay DOM
+  /// nodes. Mirrors the `registerDropListener`/`unregisterDropListener`
+  /// pairing already used elsewhere for injected editor scripts.
+  static const unregisterDriveCardDeleteOverlay = (
+    script: '''
+      if (window.__tmailDriveCardDeleteOverlayCleanup) {
+        window.__tmailDriveCardDeleteOverlayCleanup();
+      }''',
+    name: 'unregisterDriveCardDeleteOverlay',
+  );
+}

--- a/workplace/lib/presentation/utils/workplace_scripts.dart
+++ b/workplace/lib/presentation/utils/workplace_scripts.dart
@@ -13,8 +13,9 @@ class WorkplaceScripts {
   /// single debounced `requestAnimationFrame`, not a perpetual per-frame
   /// loop, to avoid forcing a layout reflow every frame while idle.
   static ({String name, String script}) registerDriveCardDeleteOverlay(
-    String removeLabel,
-  ) => (
+    String removeLabel, {
+    bool isWebPlatform = false,
+  }) => (
     script:
         '''
       (function() {
@@ -22,6 +23,7 @@ class WorkplaceScripts {
           if (window.__tmailDriveCardDeleteOverlayInstalled) return;
           window.__tmailDriveCardDeleteOverlayInstalled = true;
 
+          const isWebPlatform = $isWebPlatform;
           const removeLabel = ${jsonEncode(removeLabel)};
           const cardSelector = '.tmail-file-link-card';
           const isTouch = window.matchMedia &&
@@ -52,13 +54,57 @@ class WorkplaceScripts {
             } catch (e) {}
           }
 
+          function notifyCardDeleted() {
+            if (isWebPlatform) {
+              // A synthetic `input` event would route through Summernote's
+              // `toDart: onChangeContent` message, which html_editor_enhanced
+              // reacts to with `Scrollable.ensureVisible()` on the whole
+              // editor — that's the scroll-to-top bug. Sync content directly
+              // via this app-owned message instead. Mobile's WebView has no
+              // such side effect, so it keeps the normal pipeline below.
+              try {
+                window.parent.postMessage(
+                  JSON.stringify({ type: 'toDart: driveCardDeleted' }),
+                  '*'
+                );
+              } catch (e) {}
+            } else {
+              syncEditorContent();
+            }
+          }
+
+          function refocusEditable() {
+            // Restores focus so the existing onFocus->hideMenu chain still
+            // dismisses any open popup menu, same as clicking editor text.
+            // `preventScroll: true` avoids the browser's default "scroll the
+            // iframe into view in the outer page" behavior on focus.
+            try {
+              const editable = document.querySelector('.note-editable');
+              if (editable && document.activeElement !== editable) {
+                editable.focus({ preventScroll: true });
+              }
+            } catch (e) {}
+          }
+
+          function blockFocusScrollOnMousedown(event) {
+            // Overlay buttons are `tabindex="0"` divs, so mousedown natively
+            // focuses them before `click` runs, triggering the same iframe
+            // scroll-into-view jump — and can even shift the layout enough
+            // to make the click miss the button. Suppress it; refocusEditable
+            // handles focus explicitly afterward with preventScroll.
+            try {
+              event.preventDefault();
+            } catch (e) {}
+          }
+
           function removeCardOnActivate(event, card, onOverlayCleanup) {
             try {
               event.preventDefault();
               event.stopPropagation();
               if (card) card.remove();
               onOverlayCleanup();
-              syncEditorContent();
+              notifyCardDeleted();
+              refocusEditable();
             } catch (e) {}
           }
 
@@ -104,6 +150,7 @@ class WorkplaceScripts {
                     overlaysByCard.delete(card);
                   });
                 }
+                overlay.addEventListener('mousedown', blockFocusScrollOnMousedown);
                 overlay.addEventListener('click', onActivate);
                 overlay.addEventListener('keydown', function(event) {
                   if (event.key === 'Enter' || event.key === ' ') onActivate(event);
@@ -197,6 +244,7 @@ class WorkplaceScripts {
               });
             }
             if (overlay) {
+              overlay.addEventListener('mousedown', blockFocusScrollOnMousedown);
               overlay.addEventListener('click', onActivate);
               overlay.addEventListener('keydown', function(event) {
                 if (event.key === 'Enter' || event.key === ' ') onActivate(event);

--- a/workplace/lib/presentation/utils/workplace_scripts.dart
+++ b/workplace/lib/presentation/utils/workplace_scripts.dart
@@ -14,6 +14,7 @@ class WorkplaceScripts {
   /// loop, to avoid forcing a layout reflow every frame while idle.
   static ({String name, String script}) registerDriveCardDeleteOverlay(
     String removeLabel, {
+    required String viewId,
     bool isWebPlatform = false,
   }) => (
     script:
@@ -25,6 +26,7 @@ class WorkplaceScripts {
 
           const isWebPlatform = $isWebPlatform;
           const removeLabel = ${jsonEncode(removeLabel)};
+          const viewId = ${jsonEncode(viewId)};
           $_overlayStateSetup
           $_cardInteractionHelpers
           if (isTouch) {
@@ -63,9 +65,15 @@ class WorkplaceScripts {
   /// Helpers shared by both the touch and hover overlay branches: content
   /// sync, focus restoration, delete activation, and overlay creation.
   static const _cardInteractionHelpers = '''
+          function getEditableRoot() {
+            return isWebPlatform
+              ? document.querySelector('.note-editor .note-editable')
+              : document.querySelector('#editor');
+          }
+
           function syncEditorContent() {
             try {
-              const editable = document.querySelector('.note-editable');
+              const editable = getEditableRoot();
               if (editable) {
                 editable.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
               }
@@ -82,7 +90,7 @@ class WorkplaceScripts {
               // such side effect, so it keeps the normal pipeline below.
               try {
                 window.parent.postMessage(
-                  JSON.stringify({ type: 'toDart: driveCardDeleted' }),
+                  JSON.stringify({ type: 'toDart: driveCardDeleted', viewId: viewId }),
                   '*'
                 );
               } catch (e) {}
@@ -97,7 +105,7 @@ class WorkplaceScripts {
             // `preventScroll: true` avoids the browser's default "scroll the
             // iframe into view in the outer page" behavior on focus.
             try {
-              const editable = document.querySelector('.note-editable');
+              const editable = getEditableRoot();
               if (editable && document.activeElement !== editable) {
                 editable.focus({ preventScroll: true });
               }
@@ -115,11 +123,54 @@ class WorkplaceScripts {
             } catch (e) {}
           }
 
+          function removeCardViaExecCommand(card) {
+            // Routes the removal through the editor's native delete command
+            // so it lands on the undo/redo history stack, instead of
+            // silently mutating the DOM via card.remove().
+            const editable = getEditableRoot();
+            if (!editable || !editable.contains(card) || !document.execCommand) {
+              return false;
+            }
+            const selection = window.getSelection();
+            if (!selection) return false;
+
+            const originalRange = isWebPlatform && selection.rangeCount > 0
+              ? selection.getRangeAt(0).cloneRange()
+              : null;
+
+            const range = document.createRange();
+            range.selectNode(card);
+            selection.removeAllRanges();
+            selection.addRange(range);
+            const removed = document.execCommand('delete');
+
+            // Web only: execCommand('delete') collapses the caret to where
+            // the card used to sit. Restore whatever the caret actually was
+            // before we hijacked the selection to perform the delete,
+            // unless it's no longer attached (e.g. it was inside the
+            // removed card). Mobile intentionally leaves the caret where
+            // the card was (see removeCardOnActivate).
+            if (removed && originalRange
+                && originalRange.startContainer.isConnected
+                && originalRange.endContainer.isConnected) {
+              selection.removeAllRanges();
+              selection.addRange(originalRange);
+            }
+
+            return removed;
+          }
+
           function removeCardOnActivate(event, card, onOverlayCleanup) {
             try {
               event.preventDefault();
               event.stopPropagation();
-              if (card) card.remove();
+              if (card) {
+                let removed = false;
+                try {
+                  removed = removeCardViaExecCommand(card);
+                } catch (e) {}
+                if (!removed && document.body.contains(card)) card.remove();
+              }
               onOverlayCleanup();
               notifyCardDeleted();
               refocusEditable();
@@ -194,6 +245,7 @@ class WorkplaceScripts {
 
             function syncTouchOverlays() {
               try {
+                if (overlaysByCard.size === 0 && !document.querySelector(cardSelector)) return;
                 const seen = new Set();
                 document.querySelectorAll(cardSelector).forEach(function(card) {
                   seen.add(card);
@@ -217,7 +269,7 @@ class WorkplaceScripts {
             syncTouchOverlays();
 
             try {
-              const editableRoot = document.querySelector('.note-editable') || document.body;
+              const editableRoot = getEditableRoot() || document.body;
               const observer = new MutationObserver(syncTouchOverlays);
               observer.observe(editableRoot, {
                 childList: true,


### PR DESCRIPTION
## Issue

- #4684 

## Demo

https://github.com/user-attachments/assets/fbc4fa5b-9980-450b-9194-2edae6d54f78



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Workplace Drive card delete overlays in the composer for both hover and touch interactions.
  - Drive cards now emit consistent markup (`tmail-drive-card`) so the overlay attaches correctly.
- **Bug Fixes**
  - Improved web editor focus handling to avoid redundant unfocus/refocus loops.
  - Drive link insertion now properly awaits async editor updates across platforms.
  - Context menu/attachment flows better handle missing composer identifier data.
- **Tests**
  - Updated overlay markup assertions and expanded async insertion coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->