### PR TITLE
Rename AiScribeConstants to AiCapabilities and move it to the model package

### DIFF
--- a/lib/features/home/domain/extensions/session_extensions.dart
+++ b/lib/features/home/domain/extensions/session_extensions.dart
@@ -14,11 +14,11 @@ import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
 import 'package:labels/model/labels_capability.dart';
 import 'package:labels/utils/labels_constants.dart';
+import 'package:model/ai/ai_capabilities.dart';
 import 'package:model/download_all/download_all_capability.dart';
 import 'package:model/mailbox/mailbox_constants.dart';
 import 'package:model/model.dart';
 import 'package:scribe/scribe/ai/presentation/model/ai_capability.dart';
-import 'package:scribe/scribe/ai/presentation/utils/ai_scribe_constants.dart';
 import 'package:server_settings/server_settings/capability_server_settings.dart';
 import 'package:tmail_ui_user/features/home/data/model/session_hive_obj.dart';
 import 'package:tmail_ui_user/features/home/domain/converter/session_account_converter.dart';
@@ -37,7 +37,7 @@ extension SessionExtensions on Session {
     linagoraDownloadAllCapability: DownloadAllCapability.deserialize,
     capabilityServerSettings: SettingsCapability.deserialize,
     linagoraSaaSCapability: SaaSAccountCapability.deserialize,
-    AiScribeConstants.aiCapability: AICapability.fromJson,
+    AiCapabilities.aiCapability: AICapability.fromJson,
     LabelsConstants.labelsCapability: LabelsCapability.fromJson,
   };
 
@@ -187,13 +187,13 @@ extension SessionExtensions on Session {
 
   AICapability? getAICapability(AccountId accountId) {
     try {
-      if (!AiScribeConstants.aiCapability.isSupported(this, accountId)) {
+      if (!AiCapabilities.aiCapability.isSupported(this, accountId)) {
         return null;
       }
 
       final aiCapability = getCapabilityProperties<AICapability>(
         accountId,
-        AiScribeConstants.aiCapability,
+        AiCapabilities.aiCapability,
       );
       log('SessionExtensions::getAICapability:aiCapability = $aiCapability');
       return aiCapability;

--- a/lib/features/mailbox_dashboard/presentation/extensions/handle_ai_needs_action_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/handle_ai_needs_action_extension.dart
@@ -1,4 +1,4 @@
-import 'package:scribe/scribe/ai/presentation/utils/ai_scribe_constants.dart';
+import 'package:model/ai/ai_capabilities.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
 
@@ -11,7 +11,7 @@ extension HandleAiNeedsActionExtension on MailboxDashBoardController {
       return false;
     }
 
-    return AiScribeConstants.aiCapability.isSupported(
+    return AiCapabilities.aiCapability.isSupported(
       currentSession,
       currentAccountId,
     );

--- a/lib/features/manage_account/presentation/manage_account_dashboard_controller.dart
+++ b/lib/features/manage_account/presentation/manage_account_dashboard_controller.dart
@@ -11,9 +11,9 @@ import 'package:jmap_dart_client/jmap/core/capability/capability_identifier.dart
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/mail/vacation/vacation_response.dart';
 import 'package:jmap_dart_client/jmap/quotas/quota.dart';
+import 'package:model/ai/ai_capabilities.dart';
 import 'package:model/model.dart';
 import 'package:rule_filter/rule_filter/capability_rule_filter.dart';
-import 'package:scribe/scribe/ai/presentation/utils/ai_scribe_constants.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:server_settings/server_settings/capability_server_settings.dart';
 import 'package:tmail_ui_user/features/base/action/ui_action.dart';
@@ -360,7 +360,7 @@ class ManageAccountDashBoardController extends ReloadableController
 
   bool get isAICapabilitySupported {
     if (accountId.value != null && sessionCurrent != null) {
-      return AiScribeConstants.aiCapability.isSupported(sessionCurrent!, accountId.value!);
+      return AiCapabilities.aiCapability.isSupported(sessionCurrent!, accountId.value!);
     } else {
       return false;
     }

--- a/model/lib/ai/ai_capabilities.dart
+++ b/model/lib/ai/ai_capabilities.dart
@@ -1,7 +1,7 @@
 import 'package:jmap_dart_client/jmap/core/capability/capability_identifier.dart';
 
-class AiScribeConstants {
-  AiScribeConstants._();
+class AiCapabilities {
+  AiCapabilities._();
 
   static final CapabilityIdentifier aiCapability =
       CapabilityIdentifier(Uri.parse('com:linagora:params:jmap:aibot'));

--- a/scribe/lib/scribe.dart
+++ b/scribe/lib/scribe.dart
@@ -22,7 +22,6 @@ export 'scribe/ai/presentation/model/modal/modal_cross_axis_alignment.dart';
 export 'scribe/ai/presentation/model/modal/modal_placement.dart';
 export 'scribe/ai/presentation/model/text_selection_model.dart';
 export 'scribe/ai/presentation/styles/ai_scribe_styles.dart';
-export 'scribe/ai/presentation/utils/ai_scribe_constants.dart';
 export 'scribe/ai/presentation/utils/ai_scribe_mobile_utils.dart';
 export 'scribe/ai/presentation/utils/context_menu/hover_submenu_controller.dart';
 export 'scribe/ai/presentation/utils/context_menu/context_submenu_controller.dart';

--- a/test/fixtures/session_fixtures.dart
+++ b/test/fixtures/session_fixtures.dart
@@ -12,8 +12,8 @@ import 'package:jmap_dart_client/jmap/core/sort/collation_identifier.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart';
 import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
+import 'package:model/ai/ai_capabilities.dart';
 import 'package:scribe/scribe/ai/presentation/model/ai_capability.dart';
-import 'package:scribe/scribe/ai/presentation/utils/ai_scribe_constants.dart';
 
 import 'account_fixtures.dart';
 
@@ -207,7 +207,7 @@ class SessionFixtures {
 
   static final aliceSessionWithAICapability = Session(
     {
-      AiScribeConstants.aiCapability: AICapability(),
+      AiCapabilities.aiCapability: AICapability(),
     },
     {
       AccountFixtures.aliceAccountId: Account(
@@ -215,12 +215,12 @@ class SessionFixtures {
         true,
         false,
         {
-          AiScribeConstants.aiCapability: AICapability(),
+          AiCapabilities.aiCapability: AICapability(),
         },
       )
     },
     {
-      AiScribeConstants.aiCapability: AccountFixtures.aliceAccountId,
+      AiCapabilities.aiCapability: AccountFixtures.aliceAccountId,
     },
     UserName('alice@domain.tld'),
     Uri.parse('http://domain.com/jmap'),


### PR DESCRIPTION
Closes #4682

The `com:linagora:params:jmap:aibot` capability identifier was declared as `AiScribeConstants.aiCapability` inside the `scribe` feature package. That name dates back to AI Scribe being the first AI feature, but the same capability now gates **Needs Action** and **auto-labeling** too, so the Scribe-flavored name was misleading and forced unrelated AI features to depend on the Scribe module.

## Changes

- Renamed `AiScribeConstants` to `AiCapabilities`.
- Moved it out of the feature-specific `scribe` package into the shared `model` package, at `model/lib/ai/ai_capabilities.dart`. This sits next to the other shared capability identifiers already living there (e.g. `model/lib/principals/capability_principals.dart`).
- Dropped the now-dead export from the `scribe` barrel file and updated the four call sites (`session_extensions.dart`, `manage_account_dashboard_controller.dart`, `handle_ai_needs_action_extension.dart`, and the `session_fixtures.dart` test fixture).

No behavior change: the capability URN is untouched. Git tracks the file as a pure rename.

Note: the `AICapability` *properties* class stays in `scribe`, since it is only a deserialization model and moving it is out of scope here.

---
*Generated automatically*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized the app’s AI capability reference across key areas.
  * Updated capability checks and session handling to use a single shared AI capability source.
* **Tests**
  * Aligned test fixtures with the updated AI capability reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->