### PR TITLE
HOTFIX Enable mobile experimental toggle

### DIFF
--- a/lib/features/manage_account/presentation/menu/settings/settings_controller.dart
+++ b/lib/features/manage_account/presentation/menu/settings/settings_controller.dart
@@ -12,6 +12,9 @@ import 'package:tmail_ui_user/features/manage_account/presentation/extensions/ha
 import 'package:tmail_ui_user/features/manage_account/presentation/manage_account_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/settings_page_level.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/providers/experimental_preferences_revealed_provider.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/providers/reveal_experimental_preferences_provider.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/utils/app_utils.dart';
 
 class SettingsController extends GetxController with ContactSupportMixin {
@@ -43,6 +46,11 @@ class SettingsController extends GetxController with ContactSupportMixin {
 
   void showExportTraceLogConfirmDialog(BuildContext context) {
     manageAccountDashboardController.showExportTraceLogConfirmDialog(context);
+  }
+
+  Future<void> revealExperimentalPreferences() async {
+    await appProviderContainer.read(revealExperimentalPreferencesProvider.future);
+    appProviderContainer.invalidate(experimentalPreferencesRevealedProvider);
   }
 
   void goToCommonSetting(OidcUserInfo oidcUserInfo) {

--- a/lib/features/manage_account/presentation/menu/settings/settings_view.dart
+++ b/lib/features/manage_account/presentation/menu/settings/settings_view.dart
@@ -43,6 +43,13 @@ class SettingsView extends GetWidget<SettingsController> {
             onBackAction: () => controller.onBackSettingAction(context),
             onExportTraceLogAction: () =>
                 controller.showExportTraceLogConfirmDialog(context),
+            onMultiClickAction: controller
+                    .manageAccountDashboardController
+                    .accountMenuItemSelected
+                    .value ==
+                AccountMenuItem.preferences
+                ? controller.revealExperimentalPreferences
+                : null,
           );
         }),
         Obx(() {


### PR DESCRIPTION
[untitled.webm](https://github.com/user-attachments/assets/2d9204fe-e444-4765-a36b-805e5a142ce6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hidden multi-click action in the account preferences screen to reveal experimental preferences.
  * This action is only available while viewing Preferences, keeping other account sections unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->