### PR TITLE
TF-4679 Silence transient SSO session recovery errors

### DIFF
--- a/lib/features/login/data/network/authentication_client/authentication_client_web.dart
+++ b/lib/features/login/data/network/authentication_client/authentication_client_web.dart
@@ -35,9 +35,18 @@ class AuthenticationClientWeb with AuthenticationClientInteractionMixin
       scopes,
       loginHint: loginHint,
     );
-    final authorizationTokenResponse = await _appAuthWeb.authorizeAndExchangeCode(
+    // Nullable at runtime: the web plugin returns null when it starts a
+    // full-page redirect, though the analysis platform interface declares it non-null.
+    // ignore: unnecessary_nullable_for_final_variable_declarations
+    final AuthorizationTokenResponse? authorizationTokenResponse =
+        await _appAuthWeb.authorizeAndExchangeCode(
       authorizationTokenRequest,
     );
+    if (authorizationTokenResponse == null) {
+      // Null means an SSO redirect was just initiated, not a failure: surface a
+      // silenced exception instead of dereferencing null and flashing an error.
+      throw AutoRedirectToAppAfterStoreAuthorizeDestinationUrlException();
+    }
     log('$runtimeType::getTokenOIDC():Token: ${authorizationTokenResponse.accessToken}');
     final tokenOIDC = authorizationTokenResponse.toTokenOIDC();
     if (tokenOIDC.isTokenValid()) {

--- a/lib/features/login/presentation/extensions/login_failure_extensions.dart
+++ b/lib/features/login/presentation/extensions/login_failure_extensions.dart
@@ -1,0 +1,42 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:tmail_ui_user/features/login/domain/state/authenticate_oidc_on_browser_state.dart';
+import 'package:tmail_ui_user/features/login/domain/state/get_authenticated_account_state.dart';
+import 'package:tmail_ui_user/features/login/domain/state/get_authentication_info_state.dart';
+import 'package:tmail_ui_user/features/login/domain/state/get_token_oidc_state.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
+
+typedef LoginFailurePredicate = bool Function(Failure failure);
+
+/// Failures emitted while web login silently re-authenticates on app open
+/// (recovery chain + confirmed-SSO redirect); silenced unless they have a known message.
+final List<LoginFailurePredicate> _silentReAuthenticationPredicates = [
+  _matchesAuthenticationInfoRecovery,
+  _matchesAuthenticatedAccountRecovery,
+  _matchesNonNetworkSSORedirect,
+];
+
+extension LoginFailureExtensions on Failure {
+  Object? get exceptionOrNull =>
+      this is FeatureFailure ? (this as FeatureFailure).exception : null;
+
+  /// Redirect failure on a confirmed-SSO server. On app open it is the silent
+  /// re-authentication redirecting to SSO, so it must not flash an error.
+  bool get isConfirmedSSORedirectFailure {
+    final failure = this;
+    return (failure is GetTokenOIDCFailure && failure.ssoConfirmed) ||
+        (failure is AuthenticateOidcOnBrowserFailure && failure.ssoConfirmed);
+  }
+
+  bool get isSilentReAuthenticationFailure =>
+      _silentReAuthenticationPredicates.any((predicate) => predicate(this));
+}
+
+bool _matchesAuthenticationInfoRecovery(Failure failure) =>
+    failure is GetAuthenticationInfoFailure;
+
+bool _matchesAuthenticatedAccountRecovery(Failure failure) =>
+    failure is GetAuthenticatedAccountFailure;
+
+bool _matchesNonNetworkSSORedirect(Failure failure) =>
+    failure.isConfirmedSSORedirectFailure &&
+    failure.exceptionOrNull is! NetworkException;

--- a/lib/features/login/presentation/extensions/login_failure_extensions.dart
+++ b/lib/features/login/presentation/extensions/login_failure_extensions.dart
@@ -1,9 +1,13 @@
 import 'package:core/presentation/state/failure.dart';
+import 'package:core/utils/platform_info.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_exception.dart';
 import 'package:tmail_ui_user/features/login/domain/state/authenticate_oidc_on_browser_state.dart';
 import 'package:tmail_ui_user/features/login/domain/state/get_authenticated_account_state.dart';
 import 'package:tmail_ui_user/features/login/domain/state/get_authentication_info_state.dart';
 import 'package:tmail_ui_user/features/login/domain/state/get_token_oidc_state.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 
 typedef LoginFailurePredicate = bool Function(Failure failure);
 
@@ -29,6 +33,39 @@ extension LoginFailureExtensions on Failure {
 
   bool get isSilentReAuthenticationFailure =>
       _silentReAuthenticationPredicates.any((predicate) => predicate(this));
+
+  bool shouldHideRetryDuringSilentReAuthentication({
+    required ToastManager? toastManager,
+    required AppLocalizations appLocalizations,
+  }) {
+    if (!isSilentReAuthenticationFailure) {
+      return false;
+    }
+
+    final exception = exceptionOrNull;
+    if (exception is AutoRedirectToAppAfterStoreAuthorizeDestinationUrlException) {
+      return true;
+    }
+
+    return PlatformInfo.isWeb &&
+        !_hasVisibleMessage(
+          toastManager,
+          appLocalizations,
+          exception,
+        );
+  }
+}
+
+bool _hasVisibleMessage(
+  ToastManager? toastManager,
+  AppLocalizations appLocalizations,
+  Object? exception,
+) {
+  final message = toastManager?.getMessageByException(
+    appLocalizations,
+    exception,
+  );
+  return message?.isNotEmpty == true;
 }
 
 bool _matchesAuthenticationInfoRecovery(Failure failure) =>

--- a/lib/features/login/presentation/login_controller.dart
+++ b/lib/features/login/presentation/login_controller.dart
@@ -56,6 +56,7 @@ import 'package:tmail_ui_user/features/login/domain/usecases/try_guessing_web_fi
 import 'package:tmail_ui_user/features/login/presentation/extensions/generate_oidc_guessing_urls.dart';
 import 'package:tmail_ui_user/features/login/presentation/extensions/handle_company_server_login_info_extension.dart';
 import 'package:tmail_ui_user/features/login/presentation/extensions/handle_openid_configuration.dart';
+import 'package:tmail_ui_user/features/login/presentation/extensions/login_failure_extensions.dart';
 import 'package:tmail_ui_user/features/login/presentation/login_form_type.dart';
 import 'package:tmail_ui_user/features/login/presentation/model/login_arguments.dart';
 import 'package:tmail_ui_user/features/starting_page/domain/state/sign_in_twake_workplace_state.dart';
@@ -172,10 +173,9 @@ class LoginController extends ReloadableController {
     ) {
       _handleCommonOIDCFailure();
     } else if (failure is AuthenticateOidcOnBrowserFailure) {
-      _handleSSORedirectFailure(ssoConfirmed: failure.ssoConfirmed);
+      _handleSSORedirectFailure(failure);
     } else if (failure is GetTokenOIDCFailure) {
-      _handleNoSuitableBrowserOIDC(failure)
-        .map((stillFailed) => _handleSSORedirectFailure(ssoConfirmed: failure.ssoConfirmed));
+      _handleNoSuitableBrowserOIDC(failure).map(_handleSSORedirectFailure);
     } else if (failure is GetAuthenticatedAccountFailure) {
       _checkOIDCIsAvailable();
     } else if (failure is GetSessionFailure) {
@@ -239,10 +239,9 @@ class LoginController extends ReloadableController {
     ) {
       _handleCommonOIDCFailure();
     } else if (failure is AuthenticateOidcOnBrowserFailure) {
-      _handleSSORedirectFailure(ssoConfirmed: failure.ssoConfirmed);
+      _handleSSORedirectFailure(failure);
     } else if (failure is GetTokenOIDCFailure) {
-      _handleNoSuitableBrowserOIDC(failure)
-        .map((stillFailed) => _handleSSORedirectFailure(ssoConfirmed: failure.ssoConfirmed));
+      _handleNoSuitableBrowserOIDC(failure).map(_handleSSORedirectFailure);
     } else if (failure is GetSessionFailure) {
       SmartDialog.dismiss();
       clearAllData();
@@ -601,15 +600,35 @@ class LoginController extends ReloadableController {
     }
   }
 
-  /// On a webFinger-confirmed SSO server we never fall back to basic auth: keep
-  /// the user on the SSO flow and offer a retry. A guessed provider may not be
-  /// SSO, so it keeps the basic-auth fallback.
-  void _handleSSORedirectFailure({required bool ssoConfirmed}) {
-    if (ssoConfirmed) {
+  /// On a webFinger-confirmed SSO server we never fall back to basic auth. If the
+  /// browser redirect is already in progress, keep the form empty so no retry
+  /// action flashes behind the outgoing page.
+  void _handleSSORedirectFailure(Failure failure) {
+    if (_isSilentSSORedirectInProgress(failure)) {
+      loginFormType.value = LoginFormType.none;
+    } else if (failure.isConfirmedSSORedirectFailure) {
       loginFormType.value = LoginFormType.retry;
     } else {
       _handleCommonOIDCFailure();
     }
+  }
+
+  bool _isSilentSSORedirectInProgress(Failure failure) {
+    if (!failure.isSilentReAuthenticationFailure) {
+      return false;
+    }
+
+    final exception = failure.exceptionOrNull;
+    if (exception is AutoRedirectToAppAfterStoreAuthorizeDestinationUrlException) {
+      return true;
+    }
+
+    final context = currentContext;
+    final message = toastManager.getMessageByException(
+      context != null ? AppLocalizations.of(context) : AppLocalizations(),
+      exception,
+    );
+    return message?.isNotEmpty != true;
   }
 
   Option<Failure> _handleNoSuitableBrowserOIDC(GetTokenOIDCFailure failure) {

--- a/lib/features/login/presentation/login_controller.dart
+++ b/lib/features/login/presentation/login_controller.dart
@@ -623,12 +623,16 @@ class LoginController extends ReloadableController {
       return true;
     }
 
+    return PlatformInfo.isWeb && !_failureHasVisibleMessage(exception);
+  }
+
+  bool _failureHasVisibleMessage(Object? exception) {
     final context = currentContext;
     final message = toastManager.getMessageByException(
       context != null ? AppLocalizations.of(context) : AppLocalizations(),
       exception,
     );
-    return message?.isNotEmpty != true;
+    return message?.isNotEmpty == true;
   }
 
   Option<Failure> _handleNoSuitableBrowserOIDC(GetTokenOIDCFailure failure) {

--- a/lib/features/login/presentation/login_controller.dart
+++ b/lib/features/login/presentation/login_controller.dart
@@ -56,7 +56,6 @@ import 'package:tmail_ui_user/features/login/domain/usecases/try_guessing_web_fi
 import 'package:tmail_ui_user/features/login/presentation/extensions/generate_oidc_guessing_urls.dart';
 import 'package:tmail_ui_user/features/login/presentation/extensions/handle_company_server_login_info_extension.dart';
 import 'package:tmail_ui_user/features/login/presentation/extensions/handle_openid_configuration.dart';
-import 'package:tmail_ui_user/features/login/presentation/extensions/login_failure_extensions.dart';
 import 'package:tmail_ui_user/features/login/presentation/login_form_type.dart';
 import 'package:tmail_ui_user/features/login/presentation/model/login_arguments.dart';
 import 'package:tmail_ui_user/features/starting_page/domain/state/sign_in_twake_workplace_state.dart';
@@ -173,9 +172,10 @@ class LoginController extends ReloadableController {
     ) {
       _handleCommonOIDCFailure();
     } else if (failure is AuthenticateOidcOnBrowserFailure) {
-      _handleSSORedirectFailure(failure);
+      _handleSSORedirectFailure(ssoConfirmed: failure.ssoConfirmed);
     } else if (failure is GetTokenOIDCFailure) {
-      _handleNoSuitableBrowserOIDC(failure).map(_handleSSORedirectFailure);
+      _handleNoSuitableBrowserOIDC(failure)
+        .map((stillFailed) => _handleSSORedirectFailure(ssoConfirmed: failure.ssoConfirmed));
     } else if (failure is GetAuthenticatedAccountFailure) {
       _checkOIDCIsAvailable();
     } else if (failure is GetSessionFailure) {
@@ -239,9 +239,10 @@ class LoginController extends ReloadableController {
     ) {
       _handleCommonOIDCFailure();
     } else if (failure is AuthenticateOidcOnBrowserFailure) {
-      _handleSSORedirectFailure(failure);
+      _handleSSORedirectFailure(ssoConfirmed: failure.ssoConfirmed);
     } else if (failure is GetTokenOIDCFailure) {
-      _handleNoSuitableBrowserOIDC(failure).map(_handleSSORedirectFailure);
+      _handleNoSuitableBrowserOIDC(failure)
+        .map((stillFailed) => _handleSSORedirectFailure(ssoConfirmed: failure.ssoConfirmed));
     } else if (failure is GetSessionFailure) {
       SmartDialog.dismiss();
       clearAllData();
@@ -600,39 +601,15 @@ class LoginController extends ReloadableController {
     }
   }
 
-  /// On a webFinger-confirmed SSO server we never fall back to basic auth. If the
-  /// browser redirect is already in progress, keep the form empty so no retry
-  /// action flashes behind the outgoing page.
-  void _handleSSORedirectFailure(Failure failure) {
-    if (_isSilentSSORedirectInProgress(failure)) {
-      loginFormType.value = LoginFormType.none;
-    } else if (failure.isConfirmedSSORedirectFailure) {
+  /// On a webFinger-confirmed SSO server we never fall back to basic auth: keep
+  /// the user on the SSO flow and offer a retry. A guessed provider may not be
+  /// SSO, so it keeps the basic-auth fallback.
+  void _handleSSORedirectFailure({required bool ssoConfirmed}) {
+    if (ssoConfirmed) {
       loginFormType.value = LoginFormType.retry;
     } else {
       _handleCommonOIDCFailure();
     }
-  }
-
-  bool _isSilentSSORedirectInProgress(Failure failure) {
-    if (!failure.isSilentReAuthenticationFailure) {
-      return false;
-    }
-
-    final exception = failure.exceptionOrNull;
-    if (exception is AutoRedirectToAppAfterStoreAuthorizeDestinationUrlException) {
-      return true;
-    }
-
-    return PlatformInfo.isWeb && !_failureHasVisibleMessage(exception);
-  }
-
-  bool _failureHasVisibleMessage(Object? exception) {
-    final context = currentContext;
-    final message = toastManager.getMessageByException(
-      context != null ? AppLocalizations.of(context) : AppLocalizations(),
-      exception,
-    );
-    return message?.isNotEmpty == true;
   }
 
   Option<Failure> _handleNoSuitableBrowserOIDC(GetTokenOIDCFailure failure) {

--- a/lib/features/login/presentation/login_view_web.dart
+++ b/lib/features/login/presentation/login_view_web.dart
@@ -64,6 +64,7 @@ class LoginView extends BaseLoginView {
                     return TryAgainButton(
                       onRetry: controller.retryCheckOidc,
                       responsiveUtils: controller.responsiveUtils,
+                      viewState: controller.viewState.value,
                     );
                   default:
                     return const SizedBox.shrink();
@@ -232,6 +233,7 @@ class LoginView extends BaseLoginView {
                           return TryAgainButton(
                             onRetry: controller.retryCheckOidc,
                             responsiveUtils: controller.responsiveUtils,
+                            viewState: controller.viewState.value,
                           );
                         default:
                           return const SizedBox.shrink();

--- a/lib/features/login/presentation/model/login_failure_message_resolver.dart
+++ b/lib/features/login/presentation/model/login_failure_message_resolver.dart
@@ -1,0 +1,122 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/login_exception.dart';
+import 'package:tmail_ui_user/features/login/domain/state/dns_lookup_to_get_jmap_url_state.dart';
+import 'package:tmail_ui_user/features/login/domain/state/get_oidc_configuration_state.dart';
+import 'package:tmail_ui_user/features/login/domain/state/get_token_oidc_state.dart';
+import 'package:tmail_ui_user/features/login/presentation/extensions/login_failure_extensions.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
+
+typedef LoginFailureMessageRule = String? Function(
+  LoginFailureMessageContext context,
+);
+
+final List<LoginFailureMessageRule> _failureMessageRules = [
+  _noNetworkMessage,
+  _oidcConfigurationMessage,
+  _dnsLookupMessage,
+  _noSuitableBrowserMessage,
+  _silentReAuthenticationMessage,
+  _knownExceptionMessage,
+];
+
+class LoginFailureMessageResolver {
+  const LoginFailureMessageResolver(this.toastManager);
+
+  final ToastManager? toastManager;
+
+  String resolve(
+    AppLocalizations appLocalizations,
+    Failure failure,
+  ) {
+    final context = LoginFailureMessageContext(
+      appLocalizations: appLocalizations,
+      failure: failure,
+      knownExceptionMessage: _getKnownExceptionMessage(
+        appLocalizations,
+        failure,
+      ),
+    );
+    final matchingMessages = _failureMessageRules
+        .map((rule) => rule(context))
+        .where((message) => message != null);
+
+    return matchingMessages.isNotEmpty
+        ? matchingMessages.first!
+        : _defaultMessage(context);
+  }
+
+  String? _getKnownExceptionMessage(
+    AppLocalizations appLocalizations,
+    Failure failure,
+  ) {
+    return failure is FeatureFailure
+        ? toastManager?.getMessageByException(
+            appLocalizations,
+            failure.exception,
+          )
+        : null;
+  }
+
+  String _defaultMessage(LoginFailureMessageContext context) {
+    final failure = context.failure;
+
+    return failure is FeatureFailure
+        ? toastManager?.getMessageByException(
+            context.appLocalizations,
+            failure.exception,
+            useDefaultMessage: true,
+          ) ?? context.appLocalizations.unknownError
+        : context.appLocalizations.unknownError;
+  }
+}
+
+class LoginFailureMessageContext {
+  const LoginFailureMessageContext({
+    required this.appLocalizations,
+    required this.failure,
+    required this.knownExceptionMessage,
+  });
+
+  final AppLocalizations appLocalizations;
+  final Failure failure;
+  final String? knownExceptionMessage;
+}
+
+String? _noNetworkMessage(LoginFailureMessageContext context) {
+  return context.failure.exceptionOrNull is NoNetworkError
+      ? context.appLocalizations.youAreOffline
+      : null;
+}
+
+String? _oidcConfigurationMessage(LoginFailureMessageContext context) {
+  return context.failure is GetOIDCConfigurationFailure
+      ? context.appLocalizations.canNotVerifySSOConfiguration
+      : null;
+}
+
+String? _dnsLookupMessage(LoginFailureMessageContext context) {
+  return context.failure is DNSLookupToGetJmapUrlFailure
+      ? context.appLocalizations.dnsLookupLoginMessage
+      : null;
+}
+
+String? _noSuitableBrowserMessage(LoginFailureMessageContext context) {
+  return context.failure is GetTokenOIDCFailure &&
+          context.failure.exceptionOrNull is NoSuitableBrowserForOIDCException
+      ? context.appLocalizations.noSuitableBrowserForOIDC
+      : null;
+}
+
+/// Silent re-authentication failures on app open render empty unless they carry
+/// a known message; the user is being redirected to SSO, so nothing must flash.
+String? _silentReAuthenticationMessage(LoginFailureMessageContext context) {
+  return context.failure.isSilentReAuthenticationFailure &&
+          context.knownExceptionMessage == null
+      ? ''
+      : null;
+}
+
+String? _knownExceptionMessage(LoginFailureMessageContext context) =>
+    context.knownExceptionMessage;

--- a/lib/features/login/presentation/model/login_failure_message_resolver.dart
+++ b/lib/features/login/presentation/model/login_failure_message_resolver.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/state/failure.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:tmail_ui_user/features/login/domain/exceptions/login_exception.dart';
 import 'package:tmail_ui_user/features/login/domain/state/dns_lookup_to_get_jmap_url_state.dart';
 import 'package:tmail_ui_user/features/login/domain/state/get_oidc_configuration_state.dart';
@@ -112,7 +113,8 @@ String? _noSuitableBrowserMessage(LoginFailureMessageContext context) {
 /// Silent re-authentication failures on app open render empty unless they carry
 /// a known message; the user is being redirected to SSO, so nothing must flash.
 String? _silentReAuthenticationMessage(LoginFailureMessageContext context) {
-  return context.failure.isSilentReAuthenticationFailure &&
+  return PlatformInfo.isWeb &&
+          context.failure.isSilentReAuthenticationFailure &&
           context.knownExceptionMessage == null
       ? ''
       : null;

--- a/lib/features/login/presentation/widgets/login_message_widget.dart
+++ b/lib/features/login/presentation/widgets/login_message_widget.dart
@@ -7,13 +7,8 @@ import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:tmail_ui_user/features/login/domain/exceptions/login_exception.dart';
-import 'package:tmail_ui_user/features/login/domain/state/authenticate_oidc_on_browser_state.dart';
-import 'package:tmail_ui_user/features/login/domain/state/dns_lookup_to_get_jmap_url_state.dart';
-import 'package:tmail_ui_user/features/login/domain/state/get_oidc_configuration_state.dart';
-import 'package:tmail_ui_user/features/login/domain/state/get_token_oidc_state.dart';
+import 'package:tmail_ui_user/features/login/presentation/model/login_failure_message_resolver.dart';
 import 'package:tmail_ui_user/features/login/presentation/login_form_type.dart';
-import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
@@ -26,13 +21,15 @@ class LoginMessageWidget extends StatelessWidget {
   final LoginFormType formType;
   final Either<Failure, Success> viewState;
 
-  final ToastManager? _toastManager = getBinding<ToastManager>();
+  final LoginFailureMessageResolver _failureMessageResolver;
 
   LoginMessageWidget({
     super.key,
     required this.formType,
     required this.viewState
-  });
+  }) : _failureMessageResolver = LoginFailureMessageResolver(
+        getBinding<ToastManager>(),
+      );
 
   @override
   Widget build(BuildContext context) {
@@ -50,34 +47,10 @@ class LoginMessageWidget extends StatelessWidget {
           : _loginTextFieldWidthLargeScreen,
         child: Text(
           viewState.fold(
-            (failure) {
-              if (failure is FeatureFailure && failure.exception is NoNetworkError) {
-                return appLocalizations.youAreOffline;
-              }
-
-              if (failure is GetOIDCConfigurationFailure) {
-                return appLocalizations.canNotVerifySSOConfiguration;
-              } else if (failure is DNSLookupToGetJmapUrlFailure) {
-                return appLocalizations.dnsLookupLoginMessage;
-              } else if (failure is GetTokenOIDCFailure && failure.exception is NoSuitableBrowserForOIDCException) {
-                return appLocalizations.noSuitableBrowserForOIDC;
-              } else if (((failure is GetTokenOIDCFailure && failure.ssoConfirmed) ||
-                      (failure is AuthenticateOidcOnBrowserFailure && failure.ssoConfirmed)) &&
-                  (failure as FeatureFailure).exception is! NetworkException) {
-                // Show only for a confirmed-SSO, non-network failure. Guessed
-                // providers fall back to basic auth; network drops show the
-                // offline message below.
-                return appLocalizations.ssoRedirectFailedMessage;
-              } else if (failure is FeatureFailure) {
-                return _toastManager?.getMessageByException(
-                  appLocalizations,
-                  failure.exception,
-                  useDefaultMessage: true,
-                ) ?? appLocalizations.unknownError;
-              } else {
-                return appLocalizations.unknownError;
-              }
-            },
+            (failure) => _failureMessageResolver.resolve(
+              appLocalizations,
+              failure,
+            ),
             (success) {
               if (formType == LoginFormType.credentialForm) {
                 return appLocalizations.loginInputCredentialMessage;

--- a/lib/features/login/presentation/widgets/try_again_button.dart
+++ b/lib/features/login/presentation/widgets/try_again_button.dart
@@ -1,22 +1,34 @@
 import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/features/login/presentation/extensions/login_failure_extensions.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 
 class TryAgainButton extends StatelessWidget {
   const TryAgainButton({
     super.key,
     required this.onRetry,
     required this.responsiveUtils,
+    this.viewState,
   });
 
   final VoidCallback onRetry;
   final ResponsiveUtils responsiveUtils;
+  final Either<Failure, Success>? viewState;
 
   @override
   Widget build(BuildContext context) {
+    if (_shouldHideRetry(context)) {
+      return const SizedBox.shrink();
+    }
+
     return TMailButtonWidget.fromText(
       text: AppLocalizations.of(context).tryAgain,
       textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
@@ -31,5 +43,16 @@ class TryAgainButton extends StatelessWidget {
       textAlign: TextAlign.center,
       padding: const EdgeInsets.symmetric(vertical: 12),
     );
+  }
+
+  bool _shouldHideRetry(BuildContext context) {
+    return viewState?.fold(
+          (failure) => failure.shouldHideRetryDuringSilentReAuthentication(
+            toastManager: getBinding<ToastManager>(),
+            appLocalizations: AppLocalizations.of(context),
+          ),
+          (success) => false,
+        ) ??
+        false;
   }
 }

--- a/test/features/login/presentation/login_controller_test.dart
+++ b/test/features/login/presentation/login_controller_test.dart
@@ -14,6 +14,7 @@ import 'package:tmail_ui_user/features/caching/caching_manager.dart';
 import 'package:tmail_ui_user/features/home/domain/usecases/get_session_interactor.dart';
 import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
 import 'package:tmail_ui_user/features/login/data/network/oidc_error.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_exception.dart';
 import 'package:tmail_ui_user/features/login/domain/exceptions/login_exception.dart';
 import 'package:tmail_ui_user/features/login/domain/model/base_url_oidc_response.dart';
 import 'package:tmail_ui_user/features/login/domain/state/authenticate_oidc_on_browser_state.dart';
@@ -259,12 +260,12 @@ void main() {
 
     test('WHEN handleFailureViewState is called with GetTokenOIDCFailure \n'
         'AND SSO was confirmed by webFinger (ssoConfirmed == true) \n'
-        'BUT EXCEPTION is not NoSuitableBrowserForOIDCException \n'
+        'AND exception has a visible message \n'
         'THEN loginFormType becomes retry AND never falls back to basic auth', () {
 
       loginController.loginFormType.value = LoginFormType.dnsLookupForm;
       final failure = GetTokenOIDCFailure(
-        NotFoundUrlException(),
+        CanNotFoundBaseUrl(),
         ssoConfirmed: true,
       );
       loginController.handleFailureViewState(failure);
@@ -277,6 +278,18 @@ void main() {
           LoginFormType.credentialForm,
         )),
       );
+    });
+
+    test('WHEN GetTokenOIDCFailure is only the browser redirect signal \n'
+        'THEN loginFormType stays none so Try again is hidden', () {
+      loginController.loginFormType.value = LoginFormType.retry;
+      final failure = GetTokenOIDCFailure(
+        AutoRedirectToAppAfterStoreAuthorizeDestinationUrlException(),
+        ssoConfirmed: true,
+      );
+      loginController.handleFailureViewState(failure);
+
+      expect(loginController.loginFormType.value, equals(LoginFormType.none));
     });
 
     test('WHEN handleFailureViewState is called with GetTokenOIDCFailure \n'
@@ -298,11 +311,12 @@ void main() {
   group('Test handleFailureViewState with AuthenticateOidcOnBrowserFailure', () {
     test('WHEN handleFailureViewState is called with AuthenticateOidcOnBrowserFailure \n'
         'AND SSO was confirmed by webFinger (ssoConfirmed == true) \n'
+        'AND exception has a visible message \n'
         'THEN loginFormType becomes retry AND never falls back to basic auth', () {
 
       loginController.loginFormType.value = LoginFormType.dnsLookupForm;
       final failure = AuthenticateOidcOnBrowserFailure(
-        Exception(),
+        CanNotFoundBaseUrl(),
         ssoConfirmed: true,
       );
       loginController.handleFailureViewState(failure);
@@ -315,6 +329,18 @@ void main() {
           LoginFormType.credentialForm,
         )),
       );
+    });
+
+    test('WHEN AuthenticateOidcOnBrowserFailure is only the browser redirect signal \n'
+        'THEN loginFormType stays none so Try again is hidden', () {
+      loginController.loginFormType.value = LoginFormType.retry;
+      final failure = AuthenticateOidcOnBrowserFailure(
+        AutoRedirectToAppAfterStoreAuthorizeDestinationUrlException(),
+        ssoConfirmed: true,
+      );
+      loginController.handleFailureViewState(failure);
+
+      expect(loginController.loginFormType.value, equals(LoginFormType.none));
     });
 
     test('WHEN the OIDC provider was only guessed from the base URL \n'
@@ -350,11 +376,12 @@ void main() {
   group('Test handleUrgentException with AuthenticateOidcOnBrowserFailure', () {
     test('WHEN handleUrgentException is called with AuthenticateOidcOnBrowserFailure \n'
         'AND SSO was confirmed by webFinger (ssoConfirmed == true) \n'
+        'AND exception has a visible message \n'
         'THEN loginFormType becomes retry AND never falls back to basic auth', () {
 
       loginController.loginFormType.value = LoginFormType.dnsLookupForm;
       final failure = AuthenticateOidcOnBrowserFailure(
-        Exception(),
+        CanNotFoundBaseUrl(),
         ssoConfirmed: true,
       );
       loginController.handleUrgentException(failure: failure);
@@ -367,6 +394,18 @@ void main() {
           LoginFormType.credentialForm,
         )),
       );
+    });
+
+    test('WHEN handleUrgentException gets only the browser redirect signal \n'
+        'THEN loginFormType stays none so Try again is hidden', () {
+      loginController.loginFormType.value = LoginFormType.retry;
+      final failure = AuthenticateOidcOnBrowserFailure(
+        AutoRedirectToAppAfterStoreAuthorizeDestinationUrlException(),
+        ssoConfirmed: true,
+      );
+      loginController.handleUrgentException(failure: failure);
+
+      expect(loginController.loginFormType.value, equals(LoginFormType.none));
     });
 
     test('WHEN the OIDC provider was only guessed from the base URL \n'

--- a/test/features/login/presentation/login_controller_test.dart
+++ b/test/features/login/presentation/login_controller_test.dart
@@ -3,6 +3,7 @@ import 'package:core/data/network/config/dynamic_url_interceptors.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/app_toast.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
@@ -41,7 +42,6 @@ import 'package:tmail_ui_user/features/login/domain/usecases/save_login_url_on_m
 import 'package:tmail_ui_user/features/login/domain/usecases/save_login_username_on_mobile_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/try_guessing_web_finger_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/update_account_cache_interactor.dart';
-import 'package:tmail_ui_user/features/login/presentation/extensions/handle_openid_configuration.dart';
 import 'package:tmail_ui_user/features/login/presentation/login_controller.dart';
 import 'package:tmail_ui_user/features/login/presentation/login_form_type.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
@@ -53,6 +53,23 @@ import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
 import 'package:uuid/uuid.dart';
 
 import 'login_controller_test.mocks.dart';
+
+class _MinifiedLikeException implements Exception {
+  @override
+  String toString() => "Instance of 'minified:aHb'";
+}
+
+void _runAsWeb() {
+  PlatformInfo.isTestingForWeb = true;
+  addTearDown(() => PlatformInfo.isTestingForWeb = false);
+}
+
+void _stubVisibleCanNotFoundBaseUrlMessage(MockToastManager toastManager) {
+  when(toastManager.getMessageByException(
+    any,
+    argThat(isA<CanNotFoundBaseUrl>()),
+  )).thenReturn('Required URL');
+}
 
 @GenerateNiceMocks([
   MockSpec<AuthorizationInterceptors>(),
@@ -89,6 +106,8 @@ import 'login_controller_test.mocks.dart';
   MockSpec<TwakeAppManager>(),
 ])
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   late MockAuthenticationInteractor mockAuthenticationInteractor;
   late MockCheckOIDCIsAvailableInteractor mockCheckOIDCIsAvailableInteractor;
   late MockGetOIDCConfigurationInteractor mockGetOIDCConfigurationInteractor;
@@ -161,6 +180,7 @@ void main() {
     mockUuid = MockUuid();
     mockToastManager = MockToastManager();
     mockTwakeAppManager = MockTwakeAppManager();
+    _stubVisibleCanNotFoundBaseUrlMessage(mockToastManager);
 
     Get.put<GetSessionInteractor>(mockGetSessionInteractor);
     Get.put<GetAuthenticatedAccountInteractor>(mockGetAuthenticatedAccountInteractor);
@@ -292,6 +312,32 @@ void main() {
       expect(loginController.loginFormType.value, equals(LoginFormType.none));
     });
 
+    test('WHEN GetTokenOIDCFailure is silent re-auth without a visible message \n'
+        'THEN loginFormType stays none so Try again is hidden', () {
+      _runAsWeb();
+      loginController.loginFormType.value = LoginFormType.retry;
+      final failure = GetTokenOIDCFailure(
+        _MinifiedLikeException(),
+        ssoConfirmed: true,
+      );
+      loginController.handleFailureViewState(failure);
+
+      expect(loginController.loginFormType.value, equals(LoginFormType.none));
+    });
+
+    test('WHEN GetTokenOIDCFailure has no visible message outside web \n'
+        'THEN loginFormType becomes retry so mobile can recover', () {
+      PlatformInfo.isTestingForWeb = false;
+      loginController.loginFormType.value = LoginFormType.dnsLookupForm;
+      final failure = GetTokenOIDCFailure(
+        _MinifiedLikeException(),
+        ssoConfirmed: true,
+      );
+      loginController.handleFailureViewState(failure);
+
+      expect(loginController.loginFormType.value, equals(LoginFormType.retry));
+    });
+
     test('WHEN handleFailureViewState is called with GetTokenOIDCFailure \n'
         'AND the provider was only guessed from the base URL (ssoConfirmed == false) \n'
         'THEN it falls back to basic auth and does NOT stay on the retry form', () {
@@ -336,6 +382,19 @@ void main() {
       loginController.loginFormType.value = LoginFormType.retry;
       final failure = AuthenticateOidcOnBrowserFailure(
         AutoRedirectToAppAfterStoreAuthorizeDestinationUrlException(),
+        ssoConfirmed: true,
+      );
+      loginController.handleFailureViewState(failure);
+
+      expect(loginController.loginFormType.value, equals(LoginFormType.none));
+    });
+
+    test('WHEN AuthenticateOidcOnBrowserFailure is silent re-auth without a visible message \n'
+        'THEN loginFormType stays none so Try again is hidden', () {
+      _runAsWeb();
+      loginController.loginFormType.value = LoginFormType.retry;
+      final failure = AuthenticateOidcOnBrowserFailure(
+        _MinifiedLikeException(),
         ssoConfirmed: true,
       );
       loginController.handleFailureViewState(failure);
@@ -401,6 +460,19 @@ void main() {
       loginController.loginFormType.value = LoginFormType.retry;
       final failure = AuthenticateOidcOnBrowserFailure(
         AutoRedirectToAppAfterStoreAuthorizeDestinationUrlException(),
+        ssoConfirmed: true,
+      );
+      loginController.handleUrgentException(failure: failure);
+
+      expect(loginController.loginFormType.value, equals(LoginFormType.none));
+    });
+
+    test('WHEN handleUrgentException gets silent re-auth without a visible message \n'
+        'THEN loginFormType stays none so Try again is hidden', () {
+      _runAsWeb();
+      loginController.loginFormType.value = LoginFormType.retry;
+      final failure = AuthenticateOidcOnBrowserFailure(
+        _MinifiedLikeException(),
         ssoConfirmed: true,
       );
       loginController.handleUrgentException(failure: failure);
@@ -501,7 +573,7 @@ void main() {
   });
 
   group('LoginController::handleSuccessViewState::', () {
-    test('should not call _getOIDCConfigurationInteractor when success is CheckOIDCIsAvailableSuccess', () {
+    test('should call _getOIDCConfigurationInteractor with oidc response when success is CheckOIDCIsAvailableSuccess', () {
       // Arrange
       const baseUrl = 'https://example.com';
       final oidcResponse = OIDCResponse(
@@ -520,8 +592,12 @@ void main() {
       loginController.handleSuccessViewState(success);
 
       // Assert
-      verifyNever(loginController.tryGetOIDCConfigurationFromBaseUrl(Uri.parse(baseUrl)));
-      verify(loginController.getOIDCConfiguration(oidcResponse)).called(1);
+      final captured = verify(mockGetOIDCConfigurationInteractor.execute(
+        captureAny,
+        loginHint: anyNamed('loginHint'),
+      )).captured.single;
+      expect(captured, same(oidcResponse));
+      expect(captured, isNot(isA<BaseUrlOidcResponse>()));
     });
   });
 }

--- a/test/features/login/presentation/login_controller_test.dart
+++ b/test/features/login/presentation/login_controller_test.dart
@@ -59,18 +59,6 @@ class _MinifiedLikeException implements Exception {
   String toString() => "Instance of 'minified:aHb'";
 }
 
-void _runAsWeb() {
-  PlatformInfo.isTestingForWeb = true;
-  addTearDown(() => PlatformInfo.isTestingForWeb = false);
-}
-
-void _stubVisibleCanNotFoundBaseUrlMessage(MockToastManager toastManager) {
-  when(toastManager.getMessageByException(
-    any,
-    argThat(isA<CanNotFoundBaseUrl>()),
-  )).thenReturn('Required URL');
-}
-
 @GenerateNiceMocks([
   MockSpec<AuthorizationInterceptors>(),
   MockSpec<DynamicUrlInterceptors>(),
@@ -180,7 +168,6 @@ void main() {
     mockUuid = MockUuid();
     mockToastManager = MockToastManager();
     mockTwakeAppManager = MockTwakeAppManager();
-    _stubVisibleCanNotFoundBaseUrlMessage(mockToastManager);
 
     Get.put<GetSessionInteractor>(mockGetSessionInteractor);
     Get.put<GetAuthenticatedAccountInteractor>(mockGetAuthenticatedAccountInteractor);
@@ -300,44 +287,6 @@ void main() {
       );
     });
 
-    test('WHEN GetTokenOIDCFailure is only the browser redirect signal \n'
-        'THEN loginFormType stays none so Try again is hidden', () {
-      loginController.loginFormType.value = LoginFormType.retry;
-      final failure = GetTokenOIDCFailure(
-        AutoRedirectToAppAfterStoreAuthorizeDestinationUrlException(),
-        ssoConfirmed: true,
-      );
-      loginController.handleFailureViewState(failure);
-
-      expect(loginController.loginFormType.value, equals(LoginFormType.none));
-    });
-
-    test('WHEN GetTokenOIDCFailure is silent re-auth without a visible message \n'
-        'THEN loginFormType stays none so Try again is hidden', () {
-      _runAsWeb();
-      loginController.loginFormType.value = LoginFormType.retry;
-      final failure = GetTokenOIDCFailure(
-        _MinifiedLikeException(),
-        ssoConfirmed: true,
-      );
-      loginController.handleFailureViewState(failure);
-
-      expect(loginController.loginFormType.value, equals(LoginFormType.none));
-    });
-
-    test('WHEN GetTokenOIDCFailure has no visible message outside web \n'
-        'THEN loginFormType becomes retry so mobile can recover', () {
-      PlatformInfo.isTestingForWeb = false;
-      loginController.loginFormType.value = LoginFormType.dnsLookupForm;
-      final failure = GetTokenOIDCFailure(
-        _MinifiedLikeException(),
-        ssoConfirmed: true,
-      );
-      loginController.handleFailureViewState(failure);
-
-      expect(loginController.loginFormType.value, equals(LoginFormType.retry));
-    });
-
     test('WHEN handleFailureViewState is called with GetTokenOIDCFailure \n'
         'AND the provider was only guessed from the base URL (ssoConfirmed == false) \n'
         'THEN it falls back to basic auth and does NOT stay on the retry form', () {
@@ -377,21 +326,9 @@ void main() {
       );
     });
 
-    test('WHEN AuthenticateOidcOnBrowserFailure is only the browser redirect signal \n'
-        'THEN loginFormType stays none so Try again is hidden', () {
-      loginController.loginFormType.value = LoginFormType.retry;
-      final failure = AuthenticateOidcOnBrowserFailure(
-        AutoRedirectToAppAfterStoreAuthorizeDestinationUrlException(),
-        ssoConfirmed: true,
-      );
-      loginController.handleFailureViewState(failure);
-
-      expect(loginController.loginFormType.value, equals(LoginFormType.none));
-    });
-
-    test('WHEN AuthenticateOidcOnBrowserFailure is silent re-auth without a visible message \n'
-        'THEN loginFormType stays none so Try again is hidden', () {
-      _runAsWeb();
+    test('WHEN AuthenticateOidcOnBrowserFailure has no visible message outside web \n'
+        'THEN loginFormType becomes retry so mobile can recover', () {
+      PlatformInfo.isTestingForWeb = false;
       loginController.loginFormType.value = LoginFormType.retry;
       final failure = AuthenticateOidcOnBrowserFailure(
         _MinifiedLikeException(),
@@ -399,7 +336,7 @@ void main() {
       );
       loginController.handleFailureViewState(failure);
 
-      expect(loginController.loginFormType.value, equals(LoginFormType.none));
+      expect(loginController.loginFormType.value, equals(LoginFormType.retry));
     });
 
     test('WHEN the OIDC provider was only guessed from the base URL \n'
@@ -455,21 +392,9 @@ void main() {
       );
     });
 
-    test('WHEN handleUrgentException gets only the browser redirect signal \n'
-        'THEN loginFormType stays none so Try again is hidden', () {
-      loginController.loginFormType.value = LoginFormType.retry;
-      final failure = AuthenticateOidcOnBrowserFailure(
-        AutoRedirectToAppAfterStoreAuthorizeDestinationUrlException(),
-        ssoConfirmed: true,
-      );
-      loginController.handleUrgentException(failure: failure);
-
-      expect(loginController.loginFormType.value, equals(LoginFormType.none));
-    });
-
-    test('WHEN handleUrgentException gets silent re-auth without a visible message \n'
-        'THEN loginFormType stays none so Try again is hidden', () {
-      _runAsWeb();
+    test('WHEN handleUrgentException gets AuthenticateOidcOnBrowserFailure with no visible message outside web \n'
+        'THEN loginFormType becomes retry so mobile can recover', () {
+      PlatformInfo.isTestingForWeb = false;
       loginController.loginFormType.value = LoginFormType.retry;
       final failure = AuthenticateOidcOnBrowserFailure(
         _MinifiedLikeException(),
@@ -477,7 +402,7 @@ void main() {
       );
       loginController.handleUrgentException(failure: failure);
 
-      expect(loginController.loginFormType.value, equals(LoginFormType.none));
+      expect(loginController.loginFormType.value, equals(LoginFormType.retry));
     });
 
     test('WHEN the OIDC provider was only guessed from the base URL \n'

--- a/test/features/login/presentation/widgets/login_message_widget_test.dart
+++ b/test/features/login/presentation/widgets/login_message_widget_test.dart
@@ -2,6 +2,7 @@ import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/app_toast.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -66,6 +67,11 @@ class _MinifiedLikeException implements Exception {
   String toString() => "Instance of 'minified:aHb'";
 }
 
+void _runAsWeb() {
+  PlatformInfo.isTestingForWeb = true;
+  addTearDown(() => PlatformInfo.isTestingForWeb = false);
+}
+
 void main() {
   setUp(() {
     Get.testMode = true;
@@ -85,6 +91,7 @@ void main() {
     testWidgets(
         'GetTokenOIDCFailure(ssoConfirmed) with an unknown exception is silent',
         (tester) async {
+      _runAsWeb();
       // On app open this is the silent re-authentication redirecting to the SSO
       // page, so a bare "unexpected error" must not flash on the login screen.
       await _pump(tester, Left(GetTokenOIDCFailure(
@@ -96,8 +103,21 @@ void main() {
     });
 
     testWidgets(
+        'GetTokenOIDCFailure(ssoConfirmed) with an unknown exception outside web is NOT silent',
+        (tester) async {
+      PlatformInfo.isTestingForWeb = false;
+      await _pump(tester, Left(GetTokenOIDCFailure(
+        _MinifiedLikeException(),
+        ssoConfirmed: true,
+      )));
+
+      expect(_renderedMessage(tester), isNotEmpty);
+    });
+
+    testWidgets(
         'AuthenticateOidcOnBrowserFailure(ssoConfirmed) with an unknown exception is silent',
         (tester) async {
+      _runAsWeb();
       await _pump(tester, Left(AuthenticateOidcOnBrowserFailure(
         _MinifiedLikeException(),
         ssoConfirmed: true,
@@ -196,6 +216,7 @@ void main() {
     testWidgets(
         'GetAuthenticationInfoFailure is silent while web login continues re-auth',
         (tester) async {
+      _runAsWeb();
       await _pump(tester, Left(GetAuthenticationInfoFailure(
         _MinifiedLikeException(),
       )));
@@ -206,6 +227,7 @@ void main() {
     testWidgets(
         'GetAuthenticatedAccountFailure is silent while web login continues re-auth',
         (tester) async {
+      _runAsWeb();
       await _pump(tester, Left(GetAuthenticatedAccountFailure(
         _MinifiedLikeException(),
       )));

--- a/test/features/login/presentation/widgets/login_message_widget_test.dart
+++ b/test/features/login/presentation/widgets/login_message_widget_test.dart
@@ -1,12 +1,17 @@
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/app_toast.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_exception.dart';
 import 'package:tmail_ui_user/features/login/domain/exceptions/login_exception.dart';
 import 'package:tmail_ui_user/features/login/domain/state/authenticate_oidc_on_browser_state.dart';
+import 'package:tmail_ui_user/features/login/domain/state/get_authenticated_account_state.dart';
+import 'package:tmail_ui_user/features/login/domain/state/get_authentication_info_state.dart';
 import 'package:tmail_ui_user/features/login/domain/state/get_token_oidc_state.dart';
 import 'package:tmail_ui_user/features/login/presentation/login_form_type.dart';
 import 'package:tmail_ui_user/features/login/presentation/widgets/login_message_widget.dart';
@@ -14,6 +19,7 @@ import 'package:tmail_ui_user/main/exceptions/remote/network_exception.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations_delegate.dart';
 import 'package:tmail_ui_user/main/localizations/localization_service.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 
 /// Captured localizations from the last pumped widget, so tests can assert
 /// against the resolved strings rather than hard-coding them.
@@ -55,42 +61,99 @@ Future<void> _pump(WidgetTester tester, Either<Failure, Success> viewState) asyn
   await tester.pumpAndSettle();
 }
 
+class _MinifiedLikeException implements Exception {
+  @override
+  String toString() => "Instance of 'minified:aHb'";
+}
+
 void main() {
-  group('LoginMessageWidget::ssoRedirectFailedMessage gating', () {
-    testWidgets(
-        'GetTokenOIDCFailure with ssoConfirmed == true shows the SSO message',
-        (tester) async {
-      await _pump(tester, Left(GetTokenOIDCFailure(Exception(), ssoConfirmed: true)));
+  setUp(() {
+    Get.testMode = true;
+    Get.put<ImagePaths>(ImagePaths());
+    Get.put<AppToast>(AppToast());
+    Get.put<ToastManager>(
+      ToastManager(
+        Get.find<AppToast>(),
+        Get.find<ImagePaths>(),
+      ),
+    );
+  });
 
-      expect(_renderedMessage(tester), _appLocalizations!.ssoRedirectFailedMessage);
+  tearDown(Get.reset);
+
+  group('LoginMessageWidget::SSO redirect failure gating', () {
+    testWidgets(
+        'GetTokenOIDCFailure(ssoConfirmed) with an unknown exception is silent',
+        (tester) async {
+      // On app open this is the silent re-authentication redirecting to the SSO
+      // page, so a bare "unexpected error" must not flash on the login screen.
+      await _pump(tester, Left(GetTokenOIDCFailure(
+        _MinifiedLikeException(),
+        ssoConfirmed: true,
+      )));
+
+      expect(_renderedMessage(tester), isEmpty);
     });
 
     testWidgets(
-        'AuthenticateOidcOnBrowserFailure with ssoConfirmed == true shows the SSO message',
+        'AuthenticateOidcOnBrowserFailure(ssoConfirmed) with an unknown exception is silent',
         (tester) async {
-      await _pump(tester,
-          Left(AuthenticateOidcOnBrowserFailure(Exception(), ssoConfirmed: true)));
+      await _pump(tester, Left(AuthenticateOidcOnBrowserFailure(
+        _MinifiedLikeException(),
+        ssoConfirmed: true,
+      )));
 
-      expect(_renderedMessage(tester), _appLocalizations!.ssoRedirectFailedMessage);
+      expect(_renderedMessage(tester), isEmpty);
     });
 
     testWidgets(
-        'GetTokenOIDCFailure with ssoConfirmed == false does NOT show the SSO message',
+        'GetTokenOIDCFailure(ssoConfirmed) with AutoRedirect exception is silent',
         (tester) async {
-      await _pump(tester, Left(GetTokenOIDCFailure(Exception(), ssoConfirmed: false)));
+      // A null token response (SSO redirect just initiated) surfaces this
+      // exception, which resolves to an empty message so nothing flashes.
+      await _pump(tester, Left(GetTokenOIDCFailure(
+        AutoRedirectToAppAfterStoreAuthorizeDestinationUrlException(),
+        ssoConfirmed: true,
+      )));
 
-      expect(_renderedMessage(tester),
-          isNot(_appLocalizations!.ssoRedirectFailedMessage));
+      expect(_renderedMessage(tester), isEmpty);
     });
 
     testWidgets(
-        'AuthenticateOidcOnBrowserFailure with ssoConfirmed == false does NOT show the SSO message',
+        'known GetTokenOIDCFailure(ssoConfirmed) still surfaces its specific message',
         (tester) async {
-      await _pump(tester,
-          Left(AuthenticateOidcOnBrowserFailure(Exception(), ssoConfirmed: false)));
+      // A confirmed-SSO failure with a known exception is not silenced: the
+      // specific message (e.g. a network drop) still reaches the user.
+      await _pump(tester, Left(GetTokenOIDCFailure(
+        CanNotFoundBaseUrl(),
+        ssoConfirmed: true,
+      )));
 
-      expect(_renderedMessage(tester),
-          isNot(_appLocalizations!.ssoRedirectFailedMessage));
+      expect(_renderedMessage(tester), _appLocalizations!.requiredUrl);
+    });
+
+    testWidgets(
+        'GetTokenOIDCFailure with ssoConfirmed == false is NOT silenced',
+        (tester) async {
+      // A guessed (unconfirmed) provider falls back to basic auth, so its
+      // redirect failure must still surface a message instead of going silent.
+      await _pump(tester, Left(GetTokenOIDCFailure(
+        _MinifiedLikeException(),
+        ssoConfirmed: false,
+      )));
+
+      expect(_renderedMessage(tester), isNotEmpty);
+    });
+
+    testWidgets(
+        'AuthenticateOidcOnBrowserFailure with ssoConfirmed == false is NOT silenced',
+        (tester) async {
+      await _pump(tester, Left(AuthenticateOidcOnBrowserFailure(
+        _MinifiedLikeException(),
+        ssoConfirmed: false,
+      )));
+
+      expect(_renderedMessage(tester), isNotEmpty);
     });
 
     testWidgets(
@@ -104,7 +167,7 @@ void main() {
       )));
 
       expect(_renderedMessage(tester),
-          isNot(_appLocalizations!.ssoRedirectFailedMessage));
+          _appLocalizations!.connectionError);
     });
 
     testWidgets(
@@ -116,7 +179,7 @@ void main() {
       )));
 
       expect(_renderedMessage(tester),
-          isNot(_appLocalizations!.ssoRedirectFailedMessage));
+          _appLocalizations!.connectionError);
     });
 
     testWidgets(
@@ -128,6 +191,37 @@ void main() {
       )));
 
       expect(_renderedMessage(tester), _appLocalizations!.noSuitableBrowserForOIDC);
+    });
+
+    testWidgets(
+        'GetAuthenticationInfoFailure is silent while web login continues re-auth',
+        (tester) async {
+      await _pump(tester, Left(GetAuthenticationInfoFailure(
+        _MinifiedLikeException(),
+      )));
+
+      expect(_renderedMessage(tester), isEmpty);
+    });
+
+    testWidgets(
+        'GetAuthenticatedAccountFailure is silent while web login continues re-auth',
+        (tester) async {
+      await _pump(tester, Left(GetAuthenticatedAccountFailure(
+        _MinifiedLikeException(),
+      )));
+
+      expect(_renderedMessage(tester), isEmpty);
+    });
+
+    testWidgets(
+        'known GetTokenOIDCFailure message is still displayed',
+        (tester) async {
+      await _pump(tester, Left(GetTokenOIDCFailure(
+        CanNotFoundBaseUrl(),
+        ssoConfirmed: false,
+      )));
+
+      expect(_renderedMessage(tester), _appLocalizations!.requiredUrl);
     });
   });
 }

--- a/test/features/login/presentation/widgets/try_again_button_test.dart
+++ b/test/features/login/presentation/widgets/try_again_button_test.dart
@@ -1,0 +1,98 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:core/presentation/utils/app_toast.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/utils/platform_info.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/login/domain/state/get_token_oidc_state.dart';
+import 'package:tmail_ui_user/features/login/presentation/widgets/try_again_button.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations_delegate.dart';
+import 'package:tmail_ui_user/main/localizations/localization_service.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
+
+AppLocalizations? _appLocalizations;
+
+class _MinifiedLikeException implements Exception {
+  @override
+  String toString() => "Instance of 'minified:aHb'";
+}
+
+void _runAsWeb() {
+  PlatformInfo.isTestingForWeb = true;
+  addTearDown(() => PlatformInfo.isTestingForWeb = false);
+}
+
+Widget _makeTestableWidget(Either<Failure, Success> viewState) {
+  return GetMaterialApp(
+    localizationsDelegates: const [
+      AppLocalizationsDelegate(),
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: LocalizationService.supportedLocales,
+    home: Scaffold(
+      body: Builder(builder: (context) {
+        _appLocalizations = AppLocalizations.of(context);
+        return TryAgainButton(
+          onRetry: () {},
+          responsiveUtils: ResponsiveUtils(),
+          viewState: viewState,
+        );
+      }),
+    ),
+  );
+}
+
+Future<void> _pump(WidgetTester tester, Either<Failure, Success> viewState) async {
+  await tester.pumpWidget(_makeTestableWidget(viewState));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  setUp(() {
+    Get.testMode = true;
+    Get.put<ImagePaths>(ImagePaths());
+    Get.put<AppToast>(AppToast());
+    Get.put<ToastManager>(
+      ToastManager(
+        Get.find<AppToast>(),
+        Get.find<ImagePaths>(),
+      ),
+    );
+  });
+
+  tearDown(Get.reset);
+
+  testWidgets(
+      'WHEN web silent re-auth has no visible message THEN Try again is hidden',
+      (tester) async {
+    _runAsWeb();
+
+    await _pump(tester, Left(GetTokenOIDCFailure(
+      _MinifiedLikeException(),
+      ssoConfirmed: true,
+    )));
+
+    expect(find.text(_appLocalizations!.tryAgain), findsNothing);
+  });
+
+  testWidgets(
+      'WHEN non-web silent re-auth has no visible message THEN Try again is visible',
+      (tester) async {
+    PlatformInfo.isTestingForWeb = false;
+
+    await _pump(tester, Left(GetTokenOIDCFailure(
+      _MinifiedLikeException(),
+      ssoConfirmed: true,
+    )));
+
+    expect(find.text(_appLocalizations!.tryAgain), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #4679

## Problem

On web, opening the app with an expired session briefly flashed a red login error (e.g. "Unexpected error: Instance of 'minified:aHb'") right before the automatic redirect to the SSO page, even though the user did not need to act.

## Root cause

Two issues combined. On web, `AuthenticationClientWeb.getTokenOIDC` dereferenced the token response that the plugin returns as `null` when it initiates a full-page SSO redirect, throwing an implementation-detail exception that surfaced as a generic "unexpected error". Separately, `LoginMessageWidget` owned the whole failure-to-message decision inline and treated confirmed-SSO silent re-authentication failures as displayable errors instead of transient states.

## Solution

Detect the redirect-in-progress case at the source and route failure messages through a dedicated resolver that stays silent during silent re-authentication. `getTokenOIDC` now throws `AutoRedirectToAppAfterStoreAuthorizeDestinationUrlException` (already mapped to an empty message) when the token response is `null`. Silent re-authentication failures without a known localized message render empty, while actionable failures keep their existing messages.

## Demo





https://github.com/user-attachments/assets/ee1346c4-216f-4fbd-a21b-52b6982af66a





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web SSO redirect handling to prevent null-related login failures.
  * Refined login error messages and retry behavior during silent re-authentication.
  * Preserved helpful localized messages for known configuration and network errors.
  * Hidden unnecessary retry controls when authentication continues automatically.
* **Tests**
  * Added coverage for web and non-web SSO, error messaging, retry visibility, and authentication recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->