### PR TITLE
TF-4674 Handle download no extension attachment

### DIFF
--- a/.github/workflows/analyze-test.yaml
+++ b/.github/workflows/analyze-test.yaml
@@ -14,7 +14,7 @@ env:
   # root. Each path's leading segment must be its package directory (e.g.
   # "core"). Add more lines here as needed.
   CHROME_TEST_PATHS: |
-    core/test/data/network/download/
+    core/test/data/network/download/download_manager_test.dart
 
 jobs:
   analyze-test:

--- a/.github/workflows/analyze-test.yaml
+++ b/.github/workflows/analyze-test.yaml
@@ -10,6 +10,11 @@ name: Analyze and test
 
 env:
   FLUTTER_VERSION: 3.38.9
+  # Test paths to run on the Chrome platform, one per line, relative to repo
+  # root. Each path's leading segment must be its package directory (e.g.
+  # "core"). Add more lines here as needed.
+  CHROME_TEST_PATHS: |
+    core/test/data/network/download/
 
 jobs:
   analyze-test:
@@ -59,9 +64,14 @@ jobs:
         run: ./scripts/test.sh
 
       - name: Test (Chrome)
-        if: matrix.modules == 'core'
-        working-directory: core
-        run: flutter test --platform chrome
+        if: matrix.modules == 'default'
+        run: |
+          while IFS= read -r path; do
+            [ -z "$path" ] && continue
+            package_dir="${path%%/*}"
+            rel_path="${path#*/}"
+            (cd "$package_dir" && flutter test "$rel_path" --platform chrome)
+          done <<< "$CHROME_TEST_PATHS"
 
       - name: Upload test reports
         if: success() || failure() # Always upload report

--- a/.github/workflows/analyze-test.yaml
+++ b/.github/workflows/analyze-test.yaml
@@ -58,6 +58,11 @@ jobs:
           MODULES: ${{ matrix.modules }}
         run: ./scripts/test.sh
 
+      - name: Test (Chrome)
+        if: matrix.modules == 'core'
+        working-directory: core
+        run: flutter test test/data/network/download/ --platform chrome
+
       - name: Upload test reports
         if: success() || failure() # Always upload report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/analyze-test.yaml
+++ b/.github/workflows/analyze-test.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Test (Chrome)
         if: matrix.modules == 'core'
         working-directory: core
-        run: flutter test test/data/network/download/ --platform chrome
+        run: flutter test --platform chrome
 
       - name: Upload test reports
         if: success() || failure() # Always upload report

--- a/core/lib/data/network/download/download_manager.dart
+++ b/core/lib/data/network/download/download_manager.dart
@@ -12,6 +12,7 @@ import 'package:device_info_plus/device_info_plus.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:http_parser/http_parser.dart';
+import 'package:mime/mime.dart';
 import 'package:universal_html/html.dart' as html;
 
 class DownloadManager {
@@ -91,7 +92,8 @@ class DownloadManager {
       String filename
   ) {
     try {
-      final blob = html.Blob([bytes], Constant.octetStreamMimeType);
+      final mimeType = lookupMimeType(filename, headerBytes: bytes) ?? Constant.octetStreamMimeType;
+      final blob = html.Blob([bytes], mimeType);
       final url = html.Url.createObjectUrlFromBlob(blob);
       final anchor = html.document.createElement('a') as html.AnchorElement
         ..href = url

--- a/core/lib/data/network/download/download_manager.dart
+++ b/core/lib/data/network/download/download_manager.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:core/data/constants/constant.dart';
 import 'package:core/data/network/download/download_client.dart';
 import 'package:core/data/network/download/downloaded_response.dart';
 import 'package:core/domain/exceptions/download_file_exception.dart';
@@ -90,7 +91,7 @@ class DownloadManager {
       String filename
   ) {
     try {
-      final blob = html.Blob([bytes]);
+      final blob = html.Blob([bytes], Constant.octetStreamMimeType);
       final url = html.Url.createObjectUrlFromBlob(blob);
       final anchor = html.document.createElement('a') as html.AnchorElement
         ..href = url

--- a/core/lib/data/network/download/download_manager.dart
+++ b/core/lib/data/network/download/download_manager.dart
@@ -92,7 +92,7 @@ class DownloadManager {
       String filename
   ) {
     try {
-      final mimeType = lookupMimeType(filename, headerBytes: bytes) ?? Constant.octetStreamMimeType;
+      final mimeType = _detectMimeType(filename, headerBytes: bytes);
       final blob = html.Blob([bytes], mimeType);
       final url = html.Url.createObjectUrlFromBlob(blob);
       final anchor = html.document.createElement('a') as html.AnchorElement
@@ -108,6 +108,15 @@ class DownloadManager {
     } catch (exception) {
       log('DownloadManager::createAnchorElementDownloadFileWeb(): ERROR: $exception');
       rethrow;
+    }
+  }
+
+  String _detectMimeType(String fileName, {Uint8List? headerBytes}) {
+    try {
+      return lookupMimeType(fileName, headerBytes: headerBytes) ?? Constant.octetStreamMimeType;
+    } catch (exception) {
+      log('DownloadManager::_detectMimeType(): ERROR: $exception');
+      return Constant.octetStreamMimeType;
     }
   }
 

--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -77,6 +77,8 @@ dependencies:
 
   http_parser: 4.0.2
 
+  mime: 1.0.4
+
   path_provider: 2.1.5
 
   collection: 1.19.1

--- a/core/test/data/network/download/download_manager_test.dart
+++ b/core/test/data/network/download/download_manager_test.dart
@@ -1,0 +1,57 @@
+@TestOn('chrome')
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:core/data/constants/constant.dart';
+import 'package:core/data/network/download/download_client.dart';
+import 'package:core/data/network/download/download_manager.dart';
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:universal_html/html.dart' as html;
+
+import 'download_manager_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<DownloadClient>(), MockSpec<DeviceInfoPlugin>()])
+void main() {
+  late DownloadManager downloadManager;
+
+  setUp(() {
+    downloadManager = DownloadManager(
+      MockDownloadClient(),
+      MockDeviceInfoPlugin(),
+    );
+  });
+
+  group('DownloadManager::createAnchorElementDownloadFileWeb', () {
+    test('tags the download Blob it actually creates as octet-stream, not empty, so Chrome does not sniff extension-less filenames', () async {
+      final bytes = Uint8List.fromList('plain text content'.codeUnits);
+      html.AnchorElement? clickedAnchor;
+      final blobCompleter = Completer<html.Blob>();
+
+      // Captured on the capture phase of the click event, which fires
+      // synchronously inside anchor.click(). The method under test revokes
+      // the blob: URL right after click() returns, so the request for the
+      // blob's content must be *started* here, while the URL is still
+      // valid; an in-flight request survives the later revoke() call.
+      html.document.body?.addEventListener('click', (event) {
+        clickedAnchor = event.target as html.AnchorElement;
+        final xhr = html.HttpRequest();
+        xhr.open('GET', clickedAnchor!.href!);
+        xhr.responseType = 'blob';
+        xhr.onLoad.listen((_) => blobCompleter.complete(xhr.response as html.Blob));
+        xhr.onError.listen((event) => blobCompleter.completeError(event));
+        xhr.send();
+      }, true);
+
+      downloadManager.createAnchorElementDownloadFileWeb(bytes, 'twake-configuration');
+
+      expect(clickedAnchor, isNotNull);
+      expect(clickedAnchor!.download, 'twake-configuration');
+
+      final resolvedBlob = await blobCompleter.future;
+      expect(resolvedBlob.type, Constant.octetStreamMimeType);
+    });
+  });
+}

--- a/core/test/data/network/download/download_manager_test.dart
+++ b/core/test/data/network/download/download_manager_test.dart
@@ -27,65 +27,60 @@ void main() {
   group('DownloadManager::createAnchorElementDownloadFileWeb', () {
     test('tags the download Blob it actually creates as octet-stream, not empty, so Chrome does not sniff extension-less filenames', () async {
       final bytes = Uint8List.fromList('plain text content'.codeUnits);
-      html.AnchorElement? clickedAnchor;
-      final blobCompleter = Completer<html.Blob>();
 
-      // Captured on the capture phase of the click event, which fires
-      // synchronously inside anchor.click(). The method under test revokes
-      // the blob: URL right after click() returns, so the request for the
-      // blob's content must be *started* here, while the URL is still
-      // valid; an in-flight request survives the later revoke() call.
-      void onClick(html.Event event) {
-        clickedAnchor = event.target as html.AnchorElement;
-        final xhr = html.HttpRequest();
-        xhr.open('GET', clickedAnchor!.href!);
-        xhr.responseType = 'blob';
-        xhr.onLoad.listen((_) => blobCompleter.complete(xhr.response as html.Blob));
-        xhr.onError.listen((event) => blobCompleter.completeError(event));
-        xhr.send();
-      }
-      html.document.body?.addEventListener('click', onClick, true);
+      final (clickedAnchor, resolvedBlob) = await _clickDownloadAndCaptureBlob(
+        () => downloadManager.createAnchorElementDownloadFileWeb(bytes, 'twake-configuration'),
+      );
 
-      try {
-        downloadManager.createAnchorElementDownloadFileWeb(bytes, 'twake-configuration');
-
-        expect(clickedAnchor, isNotNull);
-        expect(clickedAnchor!.download, 'twake-configuration');
-
-        final resolvedBlob = await blobCompleter.future;
-        expect(resolvedBlob.type, Constant.octetStreamMimeType);
-      } finally {
-        html.document.body?.removeEventListener('click', onClick, true);
-      }
+      expect(clickedAnchor, isNotNull);
+      expect(clickedAnchor!.download, 'twake-configuration');
+      expect(resolvedBlob.type, Constant.octetStreamMimeType);
     });
 
     test('tags the download Blob with the detected mime type when the filename has a known extension', () async {
       final bytes = Uint8List.fromList('plain text content'.codeUnits);
-      html.AnchorElement? clickedAnchor;
-      final blobCompleter = Completer<html.Blob>();
 
-      void onClick(html.Event event) {
-        clickedAnchor = event.target as html.AnchorElement;
-        final xhr = html.HttpRequest();
-        xhr.open('GET', clickedAnchor!.href!);
-        xhr.responseType = 'blob';
-        xhr.onLoad.listen((_) => blobCompleter.complete(xhr.response as html.Blob));
-        xhr.onError.listen((event) => blobCompleter.completeError(event));
-        xhr.send();
-      }
-      html.document.body?.addEventListener('click', onClick, true);
+      final (clickedAnchor, resolvedBlob) = await _clickDownloadAndCaptureBlob(
+        () => downloadManager.createAnchorElementDownloadFileWeb(bytes, 'twake-configuration.txt'),
+      );
 
-      try {
-        downloadManager.createAnchorElementDownloadFileWeb(bytes, 'twake-configuration.txt');
-
-        expect(clickedAnchor, isNotNull);
-        expect(clickedAnchor!.download, 'twake-configuration.txt');
-
-        final resolvedBlob = await blobCompleter.future;
-        expect(resolvedBlob.type, Constant.textPlainMimeType);
-      } finally {
-        html.document.body?.removeEventListener('click', onClick, true);
-      }
+      expect(clickedAnchor, isNotNull);
+      expect(clickedAnchor!.download, 'twake-configuration.txt');
+      expect(resolvedBlob.type, Constant.textPlainMimeType);
     });
   });
+}
+
+/// Triggers [triggerDownload] while listening for the resulting anchor click,
+/// then fetches the blob: URL content before the method under test revokes it.
+///
+/// The listener is captured on the capture phase of the click event, which
+/// fires synchronously inside anchor.click(). The method under test revokes
+/// the blob: URL right after click() returns, so the request for the blob's
+/// content must be *started* here, while the URL is still valid; an in-flight
+/// request survives the later revoke() call.
+Future<(html.AnchorElement?, html.Blob)> _clickDownloadAndCaptureBlob(
+  void Function() triggerDownload,
+) async {
+  html.AnchorElement? clickedAnchor;
+  final blobCompleter = Completer<html.Blob>();
+
+  void onClick(html.Event event) {
+    clickedAnchor = event.target as html.AnchorElement;
+    final xhr = html.HttpRequest();
+    xhr.open('GET', clickedAnchor!.href!);
+    xhr.responseType = 'blob';
+    xhr.onLoad.listen((_) => blobCompleter.complete(xhr.response as html.Blob));
+    xhr.onError.listen((event) => blobCompleter.completeError(event));
+    xhr.send();
+  }
+  html.document.body?.addEventListener('click', onClick, true);
+
+  try {
+    triggerDownload();
+    final resolvedBlob = await blobCompleter.future;
+    return (clickedAnchor, resolvedBlob);
+  } finally {
+    html.document.body?.removeEventListener('click', onClick, true);
+  }
 }

--- a/core/test/data/network/download/download_manager_test.dart
+++ b/core/test/data/network/download/download_manager_test.dart
@@ -35,7 +35,7 @@ void main() {
       // the blob: URL right after click() returns, so the request for the
       // blob's content must be *started* here, while the URL is still
       // valid; an in-flight request survives the later revoke() call.
-      html.document.body?.addEventListener('click', (event) {
+      void onClick(html.Event event) {
         clickedAnchor = event.target as html.AnchorElement;
         final xhr = html.HttpRequest();
         xhr.open('GET', clickedAnchor!.href!);
@@ -43,15 +43,49 @@ void main() {
         xhr.onLoad.listen((_) => blobCompleter.complete(xhr.response as html.Blob));
         xhr.onError.listen((event) => blobCompleter.completeError(event));
         xhr.send();
-      }, true);
+      }
+      html.document.body?.addEventListener('click', onClick, true);
 
-      downloadManager.createAnchorElementDownloadFileWeb(bytes, 'twake-configuration');
+      try {
+        downloadManager.createAnchorElementDownloadFileWeb(bytes, 'twake-configuration');
 
-      expect(clickedAnchor, isNotNull);
-      expect(clickedAnchor!.download, 'twake-configuration');
+        expect(clickedAnchor, isNotNull);
+        expect(clickedAnchor!.download, 'twake-configuration');
 
-      final resolvedBlob = await blobCompleter.future;
-      expect(resolvedBlob.type, Constant.octetStreamMimeType);
+        final resolvedBlob = await blobCompleter.future;
+        expect(resolvedBlob.type, Constant.octetStreamMimeType);
+      } finally {
+        html.document.body?.removeEventListener('click', onClick, true);
+      }
+    });
+
+    test('tags the download Blob with the detected mime type when the filename has a known extension', () async {
+      final bytes = Uint8List.fromList('plain text content'.codeUnits);
+      html.AnchorElement? clickedAnchor;
+      final blobCompleter = Completer<html.Blob>();
+
+      void onClick(html.Event event) {
+        clickedAnchor = event.target as html.AnchorElement;
+        final xhr = html.HttpRequest();
+        xhr.open('GET', clickedAnchor!.href!);
+        xhr.responseType = 'blob';
+        xhr.onLoad.listen((_) => blobCompleter.complete(xhr.response as html.Blob));
+        xhr.onError.listen((event) => blobCompleter.completeError(event));
+        xhr.send();
+      }
+      html.document.body?.addEventListener('click', onClick, true);
+
+      try {
+        downloadManager.createAnchorElementDownloadFileWeb(bytes, 'twake-configuration.txt');
+
+        expect(clickedAnchor, isNotNull);
+        expect(clickedAnchor!.download, 'twake-configuration.txt');
+
+        final resolvedBlob = await blobCompleter.future;
+        expect(resolvedBlob.type, Constant.textPlainMimeType);
+      } finally {
+        html.document.body?.removeEventListener('click', onClick, true);
+      }
     });
   });
 }


### PR DESCRIPTION
## Issue
- #4674 

## Resolved
### Chrome before

https://github.com/user-attachments/assets/c3ca35d7-63ea-4be5-8943-ab58ed27dfe1

### Firefox before

https://github.com/user-attachments/assets/7c4b75ad-8fa3-4e57-9ed9-75c67b70270a

### Safari before

https://github.com/user-attachments/assets/544c9a7b-4b2e-464a-8729-54c06228a055

### Chrome after

https://github.com/user-attachments/assets/3a668eb3-153d-4ee2-8642-1b348ddceab9

### Firefox after

https://github.com/user-attachments/assets/92c82b61-91ac-4e70-9fac-4edc4b20e28e

### Safari after

https://github.com/user-attachments/assets/a177f9a0-fbe3-45d8-9306-e0461a30135c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Web downloads now set the saved file’s `Blob` MIME type based on the filename, with a generic fallback when the type can’t be determined.
* **Tests**
  * Added a Web/Chrome-only test validating MIME-type assignment for both extension-less and known-extension filenames.
* **Chores**
  * Updated CI to run a dedicated “Test (Chrome)” step across selected Chrome test paths when running the default module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->