### PR TITLE
TF-4645 SSOT Part 4.2 - Add more unit test for SSOT Part 4 — Migrate mobile search to the central executor

### DIFF
--- a/lib/features/search/email/presentation/delegates/search_filter_selection_action_delegate.dart
+++ b/lib/features/search/email/presentation/delegates/search_filter_selection_action_delegate.dart
@@ -78,25 +78,6 @@ class SearchFilterSelectionActionDelegate {
     }
   }
 
-  @visibleForTesting
-  bool handlesSearchFilter(QuickSearchFilter searchFilter) =>
-      _handledSearchFilters.contains(searchFilter);
-
-  static const Set<QuickSearchFilter> _handledSearchFilters = {
-    QuickSearchFilter.dateTime,
-    QuickSearchFilter.sortBy,
-    QuickSearchFilter.from,
-    QuickSearchFilter.hasAttachment,
-    QuickSearchFilter.to,
-    QuickSearchFilter.folder,
-    QuickSearchFilter.starred,
-    QuickSearchFilter.unread,
-    QuickSearchFilter.events,
-    QuickSearchFilter.labels,
-    QuickSearchFilter.last7Days,
-    QuickSearchFilter.fromMe,
-  };
-
   void _selectDateTimeSearchFilter(
     SearchFilterSelectionActionRequest request,
   ) {

--- a/test/features/search/email/domain/notifier/search_filter_notifier_test.dart
+++ b/test/features/search/email/domain/notifier/search_filter_notifier_test.dart
@@ -7,6 +7,7 @@ import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:labels/model/label.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
 import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
@@ -152,6 +153,31 @@ void main() {
       notifierOf().toggleLabel(workLabel);
       notifierOf().toggleLabel(travelLabel);
       expect(stateOf().label, travelLabel);
+    });
+
+    test('resetReceiveTime clears the receive-time range as one invariant', () {
+      final start = UTCDate(DateTime.utc(2026, 1, 1));
+      final end = UTCDate(DateTime.utc(2026, 1, 7));
+      notifierOf().update(SearchFilterPatch()
+        ..emailReceiveTimeTypeOption = const Some(EmailReceiveTimeType.customRange)
+        ..startDateOption = optionOf(start)
+        ..endDateOption = optionOf(end));
+
+      notifierOf().resetReceiveTime();
+
+      expect(stateOf().emailReceiveTimeType, EmailReceiveTimeType.allTime);
+      expect(stateOf().startDate, isNull);
+      expect(stateOf().endDate, isNull);
+    });
+
+    test('clearLabel always removes the selected label', () {
+      notifierOf().toggleLabel(
+        Label(id: Id('work-label'), displayName: 'Work'),
+      );
+
+      notifierOf().clearLabel();
+
+      expect(stateOf().label, isNull);
     });
   });
 

--- a/test/features/search/email/presentation/delegates/search_filter_selection_action_delegate_test.dart
+++ b/test/features/search/email/presentation/delegates/search_filter_selection_action_delegate_test.dart
@@ -52,16 +52,6 @@ void main() {
       return capturedRef;
     }
 
-    test('handles every quick search filter', () {
-      for (final searchFilter in QuickSearchFilter.values) {
-        expect(
-          delegate.handlesSearchFilter(searchFilter),
-          isTrue,
-          reason: '${searchFilter.name} must be registered',
-        );
-      }
-    });
-
     testWidgets('routes hasAttachment to selectHasAttachmentSearchFilter',
         (tester) async {
       final ref = await dispatch(tester, QuickSearchFilter.hasAttachment);

--- a/test/features/search/email/presentation/delegates/search_filter_selection_action_delegate_test.dart
+++ b/test/features/search/email/presentation/delegates/search_filter_selection_action_delegate_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/delegates/search_filter_selection_action_delegate.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/search_email_controller.dart';
+
+class _MockSearchEmailController extends Mock implements SearchEmailController {}
+
+void main() {
+  group('SearchFilterSelectionActionDelegate', () {
+    late _MockSearchEmailController controller;
+    late SearchFilterSelectionActionDelegate delegate;
+
+    setUp(() {
+      controller = _MockSearchEmailController();
+      delegate = SearchFilterSelectionActionDelegate(controller: controller);
+    });
+
+    /// Pumps a [Consumer] to obtain a real [WidgetRef]/[BuildContext], then
+    /// dispatches [filter] through the delegate and returns the [WidgetRef] the
+    /// delegate handed to the controller. [WidgetRef] is sealed in Riverpod 3,
+    /// so it cannot be mocked and must come from a widget tree.
+    Future<WidgetRef> dispatch(
+      WidgetTester tester,
+      QuickSearchFilter filter, {
+      SearchEmailFilter? searchEmailFilter,
+    }) async {
+      late WidgetRef capturedRef;
+      await tester.pumpWidget(
+        ProviderScope(
+          child: Consumer(
+            builder: (context, ref, child) {
+              capturedRef = ref;
+              delegate.onSelectSearchFilterAction(
+                SearchFilterSelectionActionRequest(
+                  ref: ref,
+                  context: context,
+                  searchFilter: filter,
+                  searchEmailFilter:
+                      searchEmailFilter ?? SearchEmailFilter.initial(),
+                ),
+              );
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      return capturedRef;
+    }
+
+    test('handles every quick search filter', () {
+      for (final searchFilter in QuickSearchFilter.values) {
+        expect(
+          delegate.handlesSearchFilter(searchFilter),
+          isTrue,
+          reason: '${searchFilter.name} must be registered',
+        );
+      }
+    });
+
+    testWidgets('routes hasAttachment to selectHasAttachmentSearchFilter',
+        (tester) async {
+      final ref = await dispatch(tester, QuickSearchFilter.hasAttachment);
+
+      verify(controller.selectHasAttachmentSearchFilter(ref)).called(1);
+      verifyNoMoreInteractions(controller);
+    });
+
+    testWidgets('routes unread to selectUnreadSearchFilter', (tester) async {
+      final ref = await dispatch(tester, QuickSearchFilter.unread);
+
+      verify(controller.selectUnreadSearchFilter(ref)).called(1);
+      verifyNoMoreInteractions(controller);
+    });
+
+    testWidgets('routes events to selectNotIncludeEventsSearchFilter',
+        (tester) async {
+      final ref = await dispatch(tester, QuickSearchFilter.events);
+
+      verify(controller.selectNotIncludeEventsSearchFilter(ref)).called(1);
+      verifyNoMoreInteractions(controller);
+    });
+
+    testWidgets('routes starred to selectKeywordsSearchFilter with flagged '
+        'keyword', (tester) async {
+      final ref = await dispatch(tester, QuickSearchFilter.starred);
+
+      verify(
+        controller.selectKeywordsSearchFilter(
+          ref,
+          KeyWordIdentifier.emailFlagged,
+        ),
+      ).called(1);
+      verifyNoMoreInteractions(controller);
+    });
+
+    testWidgets('routes folder to selectMailboxForSearchFilter with the mailbox',
+        (tester) async {
+      final filter = SearchEmailFilter.initial();
+
+      final ref = await dispatch(
+        tester,
+        QuickSearchFilter.folder,
+        searchEmailFilter: filter,
+      );
+
+      verify(
+        controller.selectMailboxForSearchFilter(ref, filter.mailbox),
+      ).called(1);
+      verifyNoMoreInteractions(controller);
+    });
+
+    testWidgets('last7Days is a no-op on the controller', (tester) async {
+      await dispatch(tester, QuickSearchFilter.last7Days);
+
+      verifyZeroInteractions(controller);
+    });
+
+    testWidgets('fromMe is a no-op on the controller', (tester) async {
+      await dispatch(tester, QuickSearchFilter.fromMe);
+
+      verifyZeroInteractions(controller);
+    });
+  });
+}

--- a/test/features/search/email/presentation/notifier/search_email_presentation_notifier_test.dart
+++ b/test/features/search/email/presentation/notifier/search_email_presentation_notifier_test.dart
@@ -179,6 +179,7 @@ void main() {
 
   test('clearAllSearchFilterAppliedState clears filter-related lists', () {
     final stateBeforeClear = populatedState(
+      searchIsRunning: true,
       searchMoreState: SearchMoreState.waiting,
       canSearchMore: false,
     );
@@ -197,5 +198,7 @@ void main() {
         canSearchMore: true,
       ),
     );
+    // Unlike clearAllResultSearchState, this path keeps the running session flag.
+    expect(stateOf().searchIsRunning, isTrue);
   });
 }

--- a/test/features/search/email/presentation/notifier/search_email_presentation_notifier_test.dart
+++ b/test/features/search/email/presentation/notifier/search_email_presentation_notifier_test.dart
@@ -1,0 +1,201 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
+import 'package:model/email/presentation_email.dart';
+import 'package:model/mailbox/select_mode.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/model/recent_search.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/model/search_more_state.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/state/search_email_presentation_state.dart';
+import 'package:tmail_ui_user/features/thread/domain/state/search_email_state.dart';
+
+typedef _SearchPresentationMutation = void Function(
+  SearchEmailPresentationNotifier notifier,
+);
+
+typedef _SearchPresentationExpectation = SearchEmailPresentationState Function(
+  SearchEmailPresentationState state,
+);
+
+SearchEmailPresentationState _withClearedSuggestions(
+  SearchEmailPresentationState state, {
+  String? currentSearchText,
+}) =>
+    state.copyWith(
+      currentSearchText: currentSearchText ?? state.currentSearchText,
+      listSuggestionSearch: const [],
+      listContactSuggestionSearch: const [],
+    );
+
+void main() {
+  late ProviderContainer container;
+
+  PresentationEmail email(String id) => PresentationEmail(id: EmailId(Id(id)));
+
+  setUp(() => container = ProviderContainer());
+  tearDown(() => container.dispose());
+
+  SearchEmailPresentationNotifier notifierOf() =>
+      container.read(searchEmailPresentationProvider.notifier);
+
+  SearchEmailPresentationState stateOf() =>
+      container.read(searchEmailPresentationProvider);
+
+  void applyState(SearchEmailPresentationState state) {
+    notifierOf()
+      ..setCurrentSearchText(state.currentSearchText)
+      ..setRecentSearches(state.listRecentSearch)
+      ..setSuggestionSearches(state.listSuggestionSearch)
+      ..setContactSuggestionSearches(state.listContactSuggestionSearch)
+      ..setResultSearches(state.listResultSearch)
+      ..setSearchIsRunning(state.searchIsRunning)
+      ..setSearchMoreState(state.searchMoreState)
+      ..setCanSearchMore(state.canSearchMore)
+      ..setSelectionMode(state.selectionMode)
+      ..setSuggestionSearchViewState(state.suggestionSearchViewState)
+      ..setResultSearchViewState(state.resultSearchViewState);
+  }
+
+  SearchEmailPresentationState populatedState({
+    bool searchIsRunning = false,
+    SearchMoreState searchMoreState = SearchMoreState.idle,
+    bool canSearchMore = true,
+  }) {
+    final state = SearchEmailPresentationState.initial().copyWith(
+      currentSearchText: 'report',
+      listRecentSearch: [RecentSearch.now('report')],
+      listSuggestionSearch: [email('suggestion-1')],
+      listContactSuggestionSearch: [
+        EmailAddress(null, 'alice@example.com'),
+      ],
+      listResultSearch: [email('email-1')],
+      searchIsRunning: searchIsRunning,
+      searchMoreState: searchMoreState,
+      canSearchMore: canSearchMore,
+    );
+    applyState(state);
+    return state;
+  }
+
+  test('initial state is idle and empty', () {
+    expect(stateOf(), SearchEmailPresentationState.initial());
+  });
+
+  test('updates mobile search presentation state via notifier', () {
+    final resultSearchViewState =
+        Left<Failure, Success>(SearchEmailFailure(Exception('boom')));
+    final expectedState = SearchEmailPresentationState.initial().copyWith(
+      currentSearchText: 'report',
+      searchIsRunning: true,
+      searchMoreState: SearchMoreState.waiting,
+      canSearchMore: false,
+      selectionMode: SelectMode.ACTIVE,
+      listRecentSearch: [RecentSearch.now('report')],
+      listResultSearch: [email('email-1')],
+      resultSearchViewState: resultSearchViewState,
+    );
+
+    applyState(expectedState);
+
+    expect(stateOf(), expectedState);
+  });
+
+  final clearSuggestionStateCases = <({
+    String description,
+    _SearchPresentationMutation mutation,
+    _SearchPresentationExpectation expectedState,
+  })>[
+    (
+      description: 'clearSuggestionState clears email and contact suggestions',
+      mutation: (notifier) => notifier.clearSuggestionState(),
+      expectedState: _withClearedSuggestions,
+    ),
+    (
+      description: 'clearAllTextInputSearchState clears text and suggestions only',
+      mutation: (notifier) => notifier.clearAllTextInputSearchState(),
+      expectedState: (state) => _withClearedSuggestions(
+        state,
+        currentSearchText: '',
+      ),
+    ),
+  ];
+
+  for (final testCase in clearSuggestionStateCases) {
+    test(testCase.description, () {
+      final stateBeforeClear = populatedState();
+
+      testCase.mutation(notifierOf());
+
+      expect(stateOf(), testCase.expectedState(stateBeforeClear));
+    });
+  }
+
+  test('updateResultSearches applies the transform to the current results', () {
+    final stateBeforeUpdate = populatedState();
+
+    notifierOf().updateResultSearches(
+      (current) => [...current, email('email-2')],
+    );
+
+    expect(
+      stateOf().listResultSearch,
+      [...stateBeforeUpdate.listResultSearch, email('email-2')],
+    );
+  });
+
+  test('resetSearchMore restores the default load-more flags', () {
+    final stateBeforeReset = populatedState(
+      searchMoreState: SearchMoreState.waiting,
+      canSearchMore: false,
+    );
+
+    notifierOf().resetSearchMore();
+
+    expect(
+      stateOf(),
+      stateBeforeReset.copyWith(
+        searchMoreState: SearchMoreState.idle,
+        canSearchMore: true,
+      ),
+    );
+  });
+
+  test('clearAllResultSearchState clears result-session state', () {
+    populatedState(
+      searchIsRunning: true,
+      searchMoreState: SearchMoreState.waiting,
+      canSearchMore: false,
+    );
+
+    notifierOf().clearAllResultSearchState();
+
+    expect(stateOf(), SearchEmailPresentationState.initial());
+  });
+
+  test('clearAllSearchFilterAppliedState clears filter-related lists', () {
+    final stateBeforeClear = populatedState(
+      searchMoreState: SearchMoreState.waiting,
+      canSearchMore: false,
+    );
+
+    notifierOf().clearAllSearchFilterAppliedState();
+
+    expect(
+      stateOf(),
+      stateBeforeClear.copyWith(
+        currentSearchText: '',
+        listRecentSearch: const [],
+        listSuggestionSearch: const [],
+        listContactSuggestionSearch: const [],
+        listResultSearch: const [],
+        searchMoreState: SearchMoreState.idle,
+        canSearchMore: true,
+      ),
+    );
+  });
+}

--- a/test/features/search/email/presentation/search_email_controller_test.dart
+++ b/test/features/search/email/presentation/search_email_controller_test.dart
@@ -200,6 +200,38 @@ void main() {
     ).called(1);
   }
 
+  void verifyLoadMoreExecutedOnce() {
+    verify(
+      searchMoreEmailInteractor.execute(
+        any,
+        any,
+        limit: anyNamed('limit'),
+        sort: anyNamed('sort'),
+        position: anyNamed('position'),
+        filter: anyNamed('filter'),
+        properties: anyNamed('properties'),
+        collapseThreads: anyNamed('collapseThreads'),
+        lastEmailId: anyNamed('lastEmailId'),
+      ),
+    ).called(1);
+  }
+
+  void verifyNoLoadMoreExecuted() {
+    verifyNever(
+      searchMoreEmailInteractor.execute(
+        any,
+        any,
+        limit: anyNamed('limit'),
+        sort: anyNamed('sort'),
+        position: anyNamed('position'),
+        filter: anyNamed('filter'),
+        properties: anyNamed('properties'),
+        collapseThreads: anyNamed('collapseThreads'),
+        lastEmailId: anyNamed('lastEmailId'),
+      ),
+    );
+  }
+
   void putBaseDependencies() {
     Get.put<CachingManager>(advanced_mocks.MockCachingManager());
     Get.put<LanguageCacheManager>(advanced_mocks.MockLanguageCacheManager());
@@ -404,6 +436,55 @@ void main() {
   );
 
   test(
+    'load-more is a no-op before any result exists',
+    () async {
+      // The guard also keeps `listResultSearch.last` off an empty list.
+      expect(controller.searchMoreEmailsAction, returnsNormally);
+      await pumpEventQueue();
+
+      verifyNoLoadMoreExecuted();
+    },
+  );
+
+  test(
+    'an empty load-more page stops further load-more requests',
+    () async {
+      stubNewSearchResult(Right(SearchEmailSuccess([email('email-1')])));
+      stubLoadMoreResult(Right(SearchMoreEmailSuccess(const [])));
+
+      controller.searchEmailAction();
+      await pumpEventQueue();
+      controller.searchMoreEmailsAction();
+      await pumpEventQueue();
+      expect(controller.canSearchMore, isFalse);
+
+      // Scrolling again at the end of the results must not re-hit the server.
+      controller.searchMoreEmailsAction();
+      await pumpEventQueue();
+
+      verifyLoadMoreExecutedOnce();
+      expect(resultIds(), ['email-1']);
+    },
+  );
+
+  test(
+    'load-more is a no-op once the session is gone',
+    () async {
+      stubNewSearchResult(Right(SearchEmailSuccess([email('email-1')])));
+      controller.searchEmailAction();
+      await pumpEventQueue();
+
+      when(mailboxDashBoardController.sessionCurrent).thenReturn(null);
+
+      // The guard also keeps the `session!` assertion from throwing.
+      expect(controller.searchMoreEmailsAction, returnsNormally);
+      await pumpEventQueue();
+
+      verifyNoLoadMoreExecuted();
+    },
+  );
+
+  test(
     'new search failure clears the result list and surfaces the failure',
     () async {
       stubNewSearchResult(Right(SearchEmailSuccess([email('email-1')])));
@@ -465,6 +546,31 @@ void main() {
       // Urgent failures keep the current list and state.
       expect(resultIds(), ['email-1']);
       expect(controller.resultSearchViewState.isRight(), isTrue);
+    },
+  );
+
+  test(
+    'new search failure the handler rejects still surfaces the retry UI',
+    () async {
+      final handler = _RecordingUrgentExceptionHandler((_) => false);
+      Get.put<UrgentExceptionHandler>(handler);
+
+      stubNewSearchResult(Right(SearchEmailSuccess([email('email-1')])));
+      controller.searchEmailAction();
+      await pumpEventQueue();
+      expect(resultIds(), ['email-1']);
+
+      stubNewSearchResult(
+        Left<Failure, Success>(SearchEmailFailure(Exception('boom'))),
+      );
+      controller.searchEmailAction();
+      await pumpEventQueue();
+
+      // A registered handler that rejects the exception must not re-login, and
+      // must leave the ordinary failure path intact.
+      expect(handler.handleCallCount, 0);
+      expect(controller.listResultSearch, isEmpty);
+      expect(controller.resultSearchViewState.isLeft(), isTrue);
     },
   );
 

--- a/test/features/search/email/presentation/search_email_controller_test.dart
+++ b/test/features/search/email/presentation/search_email_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:core/data/network/config/dynamic_url_interceptors.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/state/failure.dart';
@@ -13,6 +15,7 @@ import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 import 'package:jmap_dart_client/jmap/core/utc_date.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
 import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:labels/model/label.dart';
@@ -27,6 +30,10 @@ import 'package:tmail_ui_user/features/login/data/network/interceptors/authoriza
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oidc_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/get_all_recent_search_latest_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/quick_search_email_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/save_recent_search_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/model/recent_search.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/action/dashboard_action.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/store_email_sort_order_state.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
@@ -98,6 +105,8 @@ void main() {
       getAllRecentSearchLatestInteractor;
   late advanced_mocks.MockStoreEmailSortOrderInteractor
       storeEmailSortOrderInteractor;
+  late advanced_mocks.MockQuickSearchEmailInteractor quickSearchEmailInteractor;
+  late advanced_mocks.MockSaveRecentSearchInteractor saveRecentSearchInteractor;
 
   Future<WidgetRef> pumpWidgetRef(WidgetTester tester) async {
     late WidgetRef ref;
@@ -307,6 +316,10 @@ void main() {
         advanced_mocks.MockGetAllRecentSearchLatestInteractor();
     storeEmailSortOrderInteractor =
         advanced_mocks.MockStoreEmailSortOrderInteractor();
+    quickSearchEmailInteractor =
+        advanced_mocks.MockQuickSearchEmailInteractor();
+    saveRecentSearchInteractor =
+        advanced_mocks.MockSaveRecentSearchInteractor();
 
     Get.put<NetworkConnectionController>(
       thread_mocks.MockNetworkConnectionController(),
@@ -321,8 +334,8 @@ void main() {
     stubStoreEmailSortOrderResult(Right(StoreEmailSortOrderSuccess()));
 
     controller = SearchEmailController(
-      advanced_mocks.MockQuickSearchEmailInteractor(),
-      advanced_mocks.MockSaveRecentSearchInteractor(),
+      quickSearchEmailInteractor,
+      saveRecentSearchInteractor,
       getAllRecentSearchLatestInteractor,
     );
     controller.onInit();
@@ -841,6 +854,279 @@ void main() {
     expect(
       deleteSearchFilterCases.map((testCase) => testCase.quickFilter).toSet(),
       QuickSearchFilter.values.toSet(),
+    );
+  });
+
+  group('dashboard action worker', () {
+    test(
+      'SynchronizeEmailSortOrderAction commits the sort order and clears the action',
+      () async {
+        mailboxDashBoardController.dashBoardAction.value =
+            SynchronizeEmailSortOrderAction(EmailSortOrderType.oldest);
+        await pumpEventQueue();
+
+        expect(
+          controller.searchEmailFilter.sortOrderType,
+          EmailSortOrderType.oldest,
+        );
+        verify(mailboxDashBoardController.clearDashBoardAction()).called(1);
+      },
+    );
+
+    test(
+      'SelectDateRangeToAdvancedSearch commits the custom receive-time range',
+      () async {
+        mailboxDashBoardController.dashBoardAction.value =
+            SelectDateRangeToAdvancedSearch(
+          receiveTime: EmailReceiveTimeType.customRange,
+          startDate: DateTime.utc(2026, 1, 1),
+          endDate: DateTime.utc(2026, 1, 7),
+        );
+        await pumpEventQueue();
+
+        final committed = controller.searchEmailFilter;
+        expect(
+          committed.emailReceiveTimeType,
+          EmailReceiveTimeType.customRange,
+        );
+        expect(committed.startDate?.value, DateTime.utc(2026, 1, 1));
+        expect(committed.endDate?.value, DateTime.utc(2026, 1, 7));
+        verify(mailboxDashBoardController.clearDashBoardAction()).called(1);
+      },
+    );
+
+    test(
+      'an unhandled dashboard action never clears the dashboard action',
+      () async {
+        mailboxDashBoardController.dashBoardAction.value =
+            OpenAdvancedSearchViewAction();
+        await pumpEventQueue();
+
+        verifyNever(mailboxDashBoardController.clearDashBoardAction());
+      },
+    );
+  });
+
+  group('handleWebSocketMessage', () {
+    test('skips execution when the websocket state is unchanged', () async {
+      when(
+        mailboxDashBoardController.currentEmailState,
+      ).thenReturn(jmap.State('state-1'));
+
+      await controller.handleWebSocketMessage(
+        WebSocketMessage(newState: jmap.State('state-1')),
+      );
+      await pumpEventQueue();
+
+      verifyNever(
+        refreshInteractor.execute(
+          any,
+          any,
+          limit: anyNamed('limit'),
+          position: anyNamed('position'),
+          sort: anyNamed('sort'),
+          filter: anyNamed('filter'),
+          collapseThreads: anyNamed('collapseThreads'),
+          properties: anyNamed('properties'),
+        ),
+      );
+    });
+  });
+
+  group('search suggestion flow', () {
+    test(
+      'getAllRecentSearchAction returns empty when the username is missing',
+      () async {
+        when(mailboxDashBoardController.sessionCurrent).thenReturn(null);
+
+        final result = await controller.getAllRecentSearchAction();
+
+        expect(result, isEmpty);
+        verifyNever(
+          getAllRecentSearchLatestInteractor.execute(
+            any,
+            any,
+            limit: anyNamed('limit'),
+            pattern: anyNamed('pattern'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'getAllRecentSearchAction maps interactor success to the recent list',
+      () async {
+        final recent = [RecentSearch.now('report')];
+        stubRecentSearchResult(
+          Right(GetAllRecentSearchLatestSuccess(recent)),
+        );
+
+        final result =
+            await controller.getAllRecentSearchAction(pattern: 'rep');
+
+        expect(result, recent);
+      },
+    );
+
+    test('saveRecentSearch is a no-op when the username is missing', () {
+      when(mailboxDashBoardController.sessionCurrent).thenReturn(null);
+
+      controller.saveRecentSearch('report');
+
+      verifyNever(saveRecentSearchInteractor.execute(any, any, any));
+    });
+
+    test('saveRecentSearch persists the query through the interactor', () async {
+      when(
+        saveRecentSearchInteractor.execute(any, any, any),
+      ).thenAnswer((_) => Stream.value(Right(SaveRecentSearchSuccess())));
+
+      controller.saveRecentSearch('report');
+      await pumpEventQueue();
+
+      verify(
+        saveRecentSearchInteractor.execute(
+          AccountFixtures.aliceAccountId,
+          SessionFixtures.aliceSession.username,
+          any,
+        ),
+      ).called(1);
+    });
+
+    test(
+      'clearing the search text clears suggestions and loads recent searches',
+      () async {
+        stubRecentSearchResult(
+          Right(GetAllRecentSearchLatestSuccess([RecentSearch.now('report')])),
+        );
+
+        // The debouncer dedupes against its initial '' value, so move it off ''
+        // first; only the coalesced final '' emission is debounced through.
+        controller.onTextSearchChange('report');
+        controller.onTextSearchChange('');
+        await Future.delayed(const Duration(milliseconds: 600));
+        await pumpEventQueue();
+
+        expect(controller.currentSearchText, '');
+        expect(controller.listSuggestionSearch, isEmpty);
+        expect(
+          controller.searchEmailPresentationState.listRecentSearch,
+          hasLength(1),
+        );
+      },
+    );
+
+    test(
+      'non-empty search text loads quick-search and contact suggestions',
+      () async {
+        when(
+          quickSearchEmailInteractor.execute(
+            any,
+            any,
+            limit: anyNamed('limit'),
+            sort: anyNamed('sort'),
+            filter: anyNamed('filter'),
+            properties: anyNamed('properties'),
+            collapseThreads: anyNamed('collapseThreads'),
+          ),
+        ).thenAnswer(
+          (_) async => Right(QuickSearchEmailSuccess([email('suggestion-1')])),
+        );
+        when(
+          mailboxDashBoardController.getContactSuggestion('rep'),
+        ).thenAnswer((_) async => [EmailAddress(null, 'alice@example.com')]);
+
+        controller.onTextSearchChange('rep');
+        await Future.delayed(const Duration(milliseconds: 600));
+        await pumpEventQueue();
+
+        expect(
+          controller.listSuggestionSearch.map((e) => e.id?.id.value),
+          ['suggestion-1'],
+        );
+        expect(
+          controller.searchEmailPresentationState.listContactSuggestionSearch,
+          hasLength(1),
+        );
+      },
+    );
+
+    test(
+      'suggestions are discarded when the search text changes mid-load',
+      () async {
+        final completer = Completer<Either<Failure, Success>>();
+        when(
+          quickSearchEmailInteractor.execute(
+            any,
+            any,
+            limit: anyNamed('limit'),
+            sort: anyNamed('sort'),
+            filter: anyNamed('filter'),
+            properties: anyNamed('properties'),
+            collapseThreads: anyNamed('collapseThreads'),
+          ),
+        ).thenAnswer((_) => completer.future);
+        when(
+          mailboxDashBoardController.getContactSuggestion(any),
+        ).thenAnswer((_) async => <EmailAddress>[]);
+
+        controller.onTextSearchChange('rep');
+        await Future.delayed(const Duration(milliseconds: 600));
+        // The user keeps typing while the first quick-search is still in flight.
+        appProviderContainer
+            .read(searchEmailPresentationProvider.notifier)
+            .setCurrentSearchText('report');
+        completer.complete(
+          Right(QuickSearchEmailSuccess([email('stale-suggestion')])),
+        );
+        await pumpEventQueue();
+
+        // The stale page must not overwrite suggestions for the newer text.
+        expect(controller.listSuggestionSearch, isEmpty);
+      },
+    );
+  });
+
+  group('onTextSearchSubmitted', () {
+    testWidgets(
+      'an email-address query applies the from filter and searches once',
+      (tester) async {
+        final ref = await pumpWidgetRef(tester);
+        stubNewSearchResult(Right(SearchEmailSuccess([email('email-1')])));
+        when(
+          saveRecentSearchInteractor.execute(any, any, any),
+        ).thenAnswer((_) => Stream.value(Right(SaveRecentSearchSuccess())));
+
+        controller.onTextSearchSubmitted(
+          ref,
+          ref.context,
+          'alice@example.com',
+        );
+        await tester.pump();
+
+        final committed = appProviderContainer.read(searchFilterProvider);
+        expect(committed.from, contains('alice@example.com'));
+        expect(committed.text, isNull);
+        verifyNewSearchExecutedOnce();
+      },
+    );
+
+    testWidgets(
+      'a plain query applies the text filter and searches once',
+      (tester) async {
+        final ref = await pumpWidgetRef(tester);
+        stubNewSearchResult(Right(SearchEmailSuccess([email('email-1')])));
+        when(
+          saveRecentSearchInteractor.execute(any, any, any),
+        ).thenAnswer((_) => Stream.value(Right(SaveRecentSearchSuccess())));
+
+        controller.onTextSearchSubmitted(ref, ref.context, 'report');
+        await tester.pump();
+
+        final committed = appProviderContainer.read(searchFilterProvider);
+        expect(committed.text?.value, 'report');
+        verifyNewSearchExecutedOnce();
+      },
     );
   });
 }

--- a/test/features/search/email/presentation/search_email_controller_test.dart
+++ b/test/features/search/email/presentation/search_email_controller_test.dart
@@ -727,4 +727,14 @@ void main() {
       },
     );
   }
+
+  // onDeleteSearchFilterAction resolves its mutation from a map keyed by
+  // QuickSearchFilter and null-asserts the lookup, so an unregistered filter
+  // throws at tap time. Covering every enum value here keeps that unreachable.
+  test('every quick search filter has a delete action', () {
+    expect(
+      deleteSearchFilterCases.map((testCase) => testCase.quickFilter).toSet(),
+      QuickSearchFilter.values.toSet(),
+    );
+  });
 }

--- a/test/features/search/email/presentation/search_email_controller_test.dart
+++ b/test/features/search/email/presentation/search_email_controller_test.dart
@@ -1,0 +1,730 @@
+import 'package:core/data/network/config/dynamic_url_interceptors.dart';
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:core/presentation/utils/app_toast.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:dartz/dartz.dart' hide State;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+import 'package:get/get.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
+import 'package:jmap_dart_client/jmap/core/utc_date.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:labels/model/label.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/email/presentation_email.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/base/action/ui_action.dart';
+import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
+import 'package:tmail_ui_user/features/caching/caching_manager.dart';
+import 'package:tmail_ui_user/features/email/presentation/action/email_ui_action.dart';
+import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oidc_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/get_all_recent_search_latest_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/store_email_sort_order_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
+import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
+import 'package:tmail_ui_user/features/network_connection/presentation/network_connection_controller.dart';
+import 'package:tmail_ui_user/features/push_notification/presentation/websocket/web_socket_message.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_email_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/domain/state/refresh_changes_search_email_state.dart';
+import 'package:tmail_ui_user/features/search/email/domain/usecases/refresh_changes_search_email_interactor.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/model/search_more_state.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/search_email_controller.dart';
+import 'package:tmail_ui_user/features/thread/domain/state/search_email_state.dart';
+import 'package:tmail_ui_user/features/thread/domain/state/search_more_email_state.dart';
+import 'package:tmail_ui_user/features/thread/domain/usecases/search_email_interactor.dart';
+import 'package:tmail_ui_user/features/thread/domain/usecases/search_more_email_interactor.dart';
+import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
+import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import '../../../../fixtures/session_fixtures.dart';
+import '../../../mailbox_dashboard/presentation/controller/advanced_filter_controller_test.mocks.dart'
+    as advanced_mocks;
+import '../../../thread/presentation/controller/thread_controller_test.mocks.dart'
+    as thread_mocks;
+import '../domain/notifier/search_email_notifier_test.mocks.dart'
+    as notifier_mocks;
+
+typedef _SearchFilterClearedMatcher = bool Function(
+  SearchEmailFilter filter,
+);
+
+/// Records urgent exception handling in tests.
+class _RecordingUrgentExceptionHandler implements UrgentExceptionHandler {
+  final bool Function(dynamic exception) _isUrgent;
+  int handleCallCount = 0;
+  Object? lastException;
+
+  _RecordingUrgentExceptionHandler(this._isUrgent);
+
+  @override
+  bool validateUrgentException(dynamic exception) => _isUrgent(exception);
+
+  @override
+  void handleUrgentException({Failure? failure, Exception? exception}) {
+    handleCallCount++;
+    lastException = exception;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SearchEmailController controller;
+  late thread_mocks.MockMailboxDashBoardController mailboxDashBoardController;
+  late thread_mocks.MockSearchController searchController;
+  late notifier_mocks.MockSearchEmailInteractor searchEmailInteractor;
+  late notifier_mocks.MockSearchMoreEmailInteractor searchMoreEmailInteractor;
+  late notifier_mocks.MockRefreshChangesSearchEmailInteractor refreshInteractor;
+  late advanced_mocks.MockGetAllRecentSearchLatestInteractor
+      getAllRecentSearchLatestInteractor;
+  late advanced_mocks.MockStoreEmailSortOrderInteractor
+      storeEmailSortOrderInteractor;
+
+  Future<WidgetRef> pumpWidgetRef(WidgetTester tester) async {
+    late WidgetRef ref;
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: appProviderContainer,
+        child: Consumer(
+          builder: (context, widgetRef, child) {
+            ref = widgetRef;
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+    return ref;
+  }
+
+  PresentationEmail email(String id) => PresentationEmail(id: EmailId(Id(id)));
+
+  List<String?> resultIds() =>
+      controller.listResultSearch.map((email) => email.id?.id.value).toList();
+
+  void stubNewSearchResult(Either<Failure, Success> result) {
+    when(
+      searchEmailInteractor.execute(
+        any,
+        any,
+        limit: anyNamed('limit'),
+        position: anyNamed('position'),
+        sort: anyNamed('sort'),
+        filter: anyNamed('filter'),
+        properties: anyNamed('properties'),
+        collapseThreads: anyNamed('collapseThreads'),
+        needRefreshSearchState: anyNamed('needRefreshSearchState'),
+      ),
+    ).thenAnswer((_) => Stream.value(result));
+  }
+
+  void stubLoadMoreResult(Either<Failure, Success> result) {
+    when(
+      searchMoreEmailInteractor.execute(
+        any,
+        any,
+        limit: anyNamed('limit'),
+        sort: anyNamed('sort'),
+        position: anyNamed('position'),
+        filter: anyNamed('filter'),
+        properties: anyNamed('properties'),
+        collapseThreads: anyNamed('collapseThreads'),
+        lastEmailId: anyNamed('lastEmailId'),
+      ),
+    ).thenAnswer((_) => Stream.value(result));
+  }
+
+  void stubRefreshResult(Either<Failure, Success> result) {
+    when(
+      refreshInteractor.execute(
+        any,
+        any,
+        limit: anyNamed('limit'),
+        position: anyNamed('position'),
+        sort: anyNamed('sort'),
+        filter: anyNamed('filter'),
+        collapseThreads: anyNamed('collapseThreads'),
+        properties: anyNamed('properties'),
+      ),
+    ).thenAnswer((_) => Stream.value(result));
+  }
+
+  void stubRecentSearchResult(Either<Failure, Success> result) {
+    when(
+      getAllRecentSearchLatestInteractor.execute(
+        any,
+        any,
+        limit: anyNamed('limit'),
+        pattern: anyNamed('pattern'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void stubStoreEmailSortOrderResult(Either<Failure, Success> result) {
+    when(
+      storeEmailSortOrderInteractor.execute(any),
+    ).thenAnswer((_) => Stream.value(result));
+  }
+
+  void verifyNewSearchExecutedOnce() {
+    verify(
+      searchEmailInteractor.execute(
+        any,
+        any,
+        limit: anyNamed('limit'),
+        position: anyNamed('position'),
+        sort: anyNamed('sort'),
+        filter: anyNamed('filter'),
+        properties: anyNamed('properties'),
+        collapseThreads: anyNamed('collapseThreads'),
+        needRefreshSearchState: anyNamed('needRefreshSearchState'),
+      ),
+    ).called(1);
+  }
+
+  void putBaseDependencies() {
+    Get.put<CachingManager>(advanced_mocks.MockCachingManager());
+    Get.put<LanguageCacheManager>(advanced_mocks.MockLanguageCacheManager());
+    Get.put<AuthorizationInterceptors>(
+      advanced_mocks.MockAuthorizationInterceptors(),
+    );
+    Get.put<AuthorizationInterceptors>(
+      advanced_mocks.MockAuthorizationInterceptors(),
+      tag: BindingTag.isolateTag,
+    );
+    Get.put<DynamicUrlInterceptors>(
+      advanced_mocks.MockDynamicUrlInterceptors(),
+    );
+    Get.put<DeleteCredentialInteractor>(
+      advanced_mocks.MockDeleteCredentialInteractor(),
+    );
+    Get.put<LogoutOidcInteractor>(advanced_mocks.MockLogoutOidcInteractor());
+    Get.put<DeleteAuthorityOidcInteractor>(
+      advanced_mocks.MockDeleteAuthorityOidcInteractor(),
+    );
+    Get.put<AppToast>(advanced_mocks.MockAppToast());
+    Get.put<ImagePaths>(advanced_mocks.MockImagePaths());
+    Get.put<ResponsiveUtils>(advanced_mocks.MockResponsiveUtils());
+    Get.put<Uuid>(advanced_mocks.MockUuid());
+    Get.put<ToastManager>(advanced_mocks.MockToastManager());
+    Get.put<TwakeAppManager>(advanced_mocks.MockTwakeAppManager());
+  }
+
+  void stubMailboxDashboard() {
+    final accountId = Rxn(AccountFixtures.aliceAccountId);
+
+    when(mailboxDashBoardController.accountId).thenReturn(accountId);
+    when(
+      mailboxDashBoardController.sessionCurrent,
+    ).thenReturn(SessionFixtures.aliceSession);
+    when(
+      mailboxDashBoardController.currentSortOrder,
+    ).thenReturn(SearchEmailFilter.defaultSortOrder);
+    when(mailboxDashBoardController.trashSpamMailboxIds).thenReturn(null);
+    when(mailboxDashBoardController.mapMailboxById).thenReturn({});
+    when(
+      mailboxDashBoardController.dashBoardAction,
+    ).thenReturn(Rxn<UIAction>());
+    when(
+      mailboxDashBoardController.emailUIAction,
+    ).thenReturn(Rxn<EmailUIAction>());
+    when(
+      mailboxDashBoardController.viewState,
+    ).thenReturn(Rx(Right(UIState.idle)));
+    when(
+      mailboxDashBoardController.searchController,
+    ).thenReturn(searchController);
+    when(
+      mailboxDashBoardController.storeEmailSortOrderInteractor,
+    ).thenReturn(storeEmailSortOrderInteractor);
+    when(searchController.isSearchEmailRunning).thenReturn(true);
+  }
+
+  setUp(() {
+    Get.testMode = true;
+    Get.reset();
+    appProviderContainer.invalidate(searchFilterProvider);
+    appProviderContainer.invalidate(searchEmailProvider);
+    appProviderContainer.invalidate(searchEmailPresentationProvider);
+
+    putBaseDependencies();
+    mailboxDashBoardController = thread_mocks.MockMailboxDashBoardController();
+    searchController = thread_mocks.MockSearchController();
+    searchEmailInteractor = notifier_mocks.MockSearchEmailInteractor();
+    searchMoreEmailInteractor = notifier_mocks.MockSearchMoreEmailInteractor();
+    refreshInteractor = notifier_mocks.MockRefreshChangesSearchEmailInteractor();
+    getAllRecentSearchLatestInteractor =
+        advanced_mocks.MockGetAllRecentSearchLatestInteractor();
+    storeEmailSortOrderInteractor =
+        advanced_mocks.MockStoreEmailSortOrderInteractor();
+
+    Get.put<NetworkConnectionController>(
+      thread_mocks.MockNetworkConnectionController(),
+    );
+    Get.put<MailboxDashBoardController>(mailboxDashBoardController);
+    Get.put<SearchEmailInteractor>(searchEmailInteractor);
+    Get.put<SearchMoreEmailInteractor>(searchMoreEmailInteractor);
+    Get.put<RefreshChangesSearchEmailInteractor>(refreshInteractor);
+
+    stubMailboxDashboard();
+    stubRecentSearchResult(Right(GetAllRecentSearchLatestSuccess(const [])));
+    stubStoreEmailSortOrderResult(Right(StoreEmailSortOrderSuccess()));
+
+    controller = SearchEmailController(
+      advanced_mocks.MockQuickSearchEmailInteractor(),
+      advanced_mocks.MockSaveRecentSearchInteractor(),
+      getAllRecentSearchLatestInteractor,
+    );
+    controller.onInit();
+  });
+
+  tearDown(() {
+    controller.onClose();
+    appProviderContainer.invalidate(searchFilterProvider);
+    appProviderContainer.invalidate(searchEmailProvider);
+    appProviderContainer.invalidate(searchEmailPresentationProvider);
+    Get.reset();
+  });
+
+  test(
+    'searchEmailAction delegates new search to central executor and bridges result',
+    () async {
+      final firstPage = [email('email-1')];
+      when(
+        searchEmailInteractor.execute(
+          any,
+          any,
+          limit: anyNamed('limit'),
+          position: anyNamed('position'),
+          sort: anyNamed('sort'),
+          filter: anyNamed('filter'),
+          properties: anyNamed('properties'),
+          collapseThreads: anyNamed('collapseThreads'),
+          needRefreshSearchState: anyNamed('needRefreshSearchState'),
+        ),
+      ).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(firstPage))));
+
+      controller.searchEmailAction();
+      await pumpEventQueue();
+
+      verify(
+        searchEmailInteractor.execute(
+          SessionFixtures.aliceSession,
+          AccountFixtures.aliceAccountId,
+          limit: anyNamed('limit'),
+          position: anyNamed('position'),
+          sort: anyNamed('sort'),
+          filter: anyNamed('filter'),
+          properties: anyNamed('properties'),
+          collapseThreads: false,
+          needRefreshSearchState: anyNamed('needRefreshSearchState'),
+        ),
+      ).called(1);
+      expect(resultIds(), [
+        'email-1',
+      ]);
+    },
+  );
+
+  test(
+    'searchMoreEmailsAction delegates load-more to central executor and bridges append',
+    () async {
+      final firstPage = [email('email-1')];
+      final nextPage = [email('email-2')];
+      when(
+        searchEmailInteractor.execute(
+          any,
+          any,
+          limit: anyNamed('limit'),
+          position: anyNamed('position'),
+          sort: anyNamed('sort'),
+          filter: anyNamed('filter'),
+          properties: anyNamed('properties'),
+          collapseThreads: anyNamed('collapseThreads'),
+          needRefreshSearchState: anyNamed('needRefreshSearchState'),
+        ),
+      ).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(firstPage))));
+      when(
+        searchMoreEmailInteractor.execute(
+          any,
+          any,
+          limit: anyNamed('limit'),
+          sort: anyNamed('sort'),
+          position: anyNamed('position'),
+          filter: anyNamed('filter'),
+          properties: anyNamed('properties'),
+          collapseThreads: anyNamed('collapseThreads'),
+          lastEmailId: anyNamed('lastEmailId'),
+        ),
+      ).thenAnswer(
+        (_) => Stream.value(Right(SearchMoreEmailSuccess(nextPage))),
+      );
+
+      controller.searchEmailAction();
+      await pumpEventQueue();
+      controller.searchMoreEmailsAction();
+      await pumpEventQueue();
+
+      verify(
+        searchMoreEmailInteractor.execute(
+          SessionFixtures.aliceSession,
+          AccountFixtures.aliceAccountId,
+          limit: anyNamed('limit'),
+          sort: anyNamed('sort'),
+          position: anyNamed('position'),
+          filter: anyNamed('filter'),
+          properties: anyNamed('properties'),
+          collapseThreads: false,
+          lastEmailId: firstPage.last.id,
+        ),
+      ).called(1);
+      expect(resultIds(), [
+        'email-1',
+        'email-2',
+      ]);
+    },
+  );
+
+  test(
+    'new search failure clears the result list and surfaces the failure',
+    () async {
+      stubNewSearchResult(Right(SearchEmailSuccess([email('email-1')])));
+      controller.searchEmailAction();
+      await pumpEventQueue();
+      expect(controller.listResultSearch, isNotEmpty);
+
+      stubNewSearchResult(
+        Left<Failure, Success>(SearchEmailFailure(Exception('boom'))),
+      );
+      controller.searchEmailAction();
+      await pumpEventQueue();
+
+      expect(controller.listResultSearch, isEmpty);
+      expect(controller.resultSearchViewState.isLeft(), isTrue);
+    },
+  );
+
+  test(
+    'load-more failure keeps the current page and completes searchMoreState',
+    () async {
+      stubNewSearchResult(Right(SearchEmailSuccess([email('email-1')])));
+      stubLoadMoreResult(
+        Left<Failure, Success>(SearchMoreEmailFailure(Exception('boom'))),
+      );
+
+      controller.searchEmailAction();
+      await pumpEventQueue();
+      controller.searchMoreEmailsAction();
+      await pumpEventQueue();
+
+      expect(resultIds(), [
+        'email-1',
+      ]);
+      expect(controller.searchMoreState, SearchMoreState.completed);
+    },
+  );
+
+  test(
+    'new search urgent failure routes re-login and skips the retry UI',
+    () async {
+      final handler = _RecordingUrgentExceptionHandler((_) => true);
+      Get.put<UrgentExceptionHandler>(handler);
+
+      stubNewSearchResult(Right(SearchEmailSuccess([email('email-1')])));
+      controller.searchEmailAction();
+      await pumpEventQueue();
+      expect(resultIds(), ['email-1']);
+
+      final urgentException = Exception('expired-token');
+      stubNewSearchResult(
+        Left<Failure, Success>(SearchEmailFailure(urgentException)),
+      );
+      controller.searchEmailAction();
+      await pumpEventQueue();
+
+      expect(handler.handleCallCount, 1);
+      expect(handler.lastException, urgentException);
+      // Urgent failures keep the current list and state.
+      expect(resultIds(), ['email-1']);
+      expect(controller.resultSearchViewState.isRight(), isTrue);
+    },
+  );
+
+  test(
+    'load-more urgent failure routes re-login while keeping the current page',
+    () async {
+      final handler = _RecordingUrgentExceptionHandler((_) => true);
+      Get.put<UrgentExceptionHandler>(handler);
+
+      stubNewSearchResult(Right(SearchEmailSuccess([email('email-1')])));
+      final urgentException = Exception('expired-token');
+      stubLoadMoreResult(
+        Left<Failure, Success>(SearchMoreEmailFailure(urgentException)),
+      );
+
+      controller.searchEmailAction();
+      await pumpEventQueue();
+      controller.searchMoreEmailsAction();
+      await pumpEventQueue();
+
+      expect(handler.handleCallCount, 1);
+      expect(handler.lastException, urgentException);
+      expect(resultIds(), ['email-1']);
+      expect(controller.searchMoreState, SearchMoreState.completed);
+    },
+  );
+
+  test(
+    'controller filter getters read the committed searchFilterProvider (single source)',
+    () async {
+      appProviderContainer.read(searchFilterProvider.notifier).update(
+        SearchFilterPatch()
+          ..unreadOption = const Some(true)
+          ..sortOrderTypeOption = const Some(EmailSortOrderType.oldest),
+      );
+
+      expect(controller.searchEmailFilter.unread, isTrue);
+      expect(controller.searchEmailFilter.sortOrderType,
+          EmailSortOrderType.oldest);
+    },
+  );
+
+  testWidgets(
+    'selectKeywordsSearchFilter appends to a fresh keyword set without mutating prior state',
+    (tester) async {
+      final ref = await pumpWidgetRef(tester);
+      stubNewSearchResult(Right(SearchEmailSuccess([email('email-1')])));
+
+      final before = appProviderContainer.read(searchFilterProvider);
+
+      controller.selectKeywordsSearchFilter(ref, KeyWordIdentifier.emailFlagged);
+      await tester.pump();
+
+      final after = appProviderContainer.read(searchFilterProvider);
+      expect(after.hasKeyword, contains(KeyWordIdentifier.emailFlagged.value));
+      // Keep the previous keyword set immutable for Riverpod notifications.
+      expect(before.hasKeyword, isEmpty);
+      expect(identical(before.hasKeyword, after.hasKeyword), isFalse);
+    },
+  );
+
+  test(
+    'clearAllResultSearch resets the committed filter to the default sort order',
+    () async {
+      appProviderContainer
+          .read(searchFilterProvider.notifier)
+          .update(SearchFilterPatch()..unreadOption = const Some(true));
+      expect(controller.searchEmailFilter.unread, isTrue);
+
+      controller.clearAllResultSearch();
+      await pumpEventQueue();
+
+      final committed = appProviderContainer.read(searchFilterProvider);
+      expect(committed.unread, isFalse);
+      expect(committed.sortOrderType, SearchEmailFilter.defaultSortOrder);
+      expect(controller.searchEmailFilter.unread, isFalse);
+    },
+  );
+
+  test(
+    'websocket message replaces the rendered list via RefreshChangesIntent',
+    () async {
+      stubNewSearchResult(Right(SearchEmailSuccess([email('email-1')])));
+      controller.searchEmailAction();
+      await pumpEventQueue();
+
+      when(
+        mailboxDashBoardController.currentEmailState,
+      ).thenReturn(jmap.State('state-1'));
+      stubRefreshResult(
+        Right(RefreshChangesSearchEmailSuccess([
+          email('email-1'),
+          email('email-2'),
+        ])),
+      );
+
+      await controller.handleWebSocketMessage(
+        WebSocketMessage(newState: jmap.State('state-2')),
+      );
+      await pumpEventQueue();
+
+      verify(
+        refreshInteractor.execute(
+          SessionFixtures.aliceSession,
+          AccountFixtures.aliceAccountId,
+          limit: anyNamed('limit'),
+          position: anyNamed('position'),
+          sort: anyNamed('sort'),
+          filter: anyNamed('filter'),
+          collapseThreads: anyNamed('collapseThreads'),
+          properties: anyNamed('properties'),
+        ),
+      ).called(1);
+      expect(resultIds(), [
+        'email-1',
+        'email-2',
+      ]);
+    },
+  );
+
+  test(
+    'websocket refresh failure keeps the rendered list (non-destructive)',
+    () async {
+      stubNewSearchResult(Right(SearchEmailSuccess([email('email-1')])));
+      controller.searchEmailAction();
+      await pumpEventQueue();
+
+      when(
+        mailboxDashBoardController.currentEmailState,
+      ).thenReturn(jmap.State('state-1'));
+      stubRefreshResult(
+        Left<Failure, Success>(SearchEmailFailure(Exception('boom'))),
+      );
+
+      await controller.handleWebSocketMessage(
+        WebSocketMessage(newState: jmap.State('state-2')),
+      );
+      await pumpEventQueue();
+
+      expect(resultIds(), [
+        'email-1',
+      ]);
+      expect(controller.resultSearchViewState.isRight(), isTrue);
+    },
+  );
+
+  final start = UTCDate(DateTime.utc(2026, 1, 1));
+  final end = UTCDate(DateTime.utc(2026, 1, 7));
+  final mailbox = PresentationMailbox(
+    MailboxId(Id('inbox-id')),
+    name: MailboxName('Inbox'),
+  );
+  final label = Label(id: Id('work-label'), displayName: 'Work');
+  final flagged = KeyWordIdentifier.emailFlagged.value;
+  final deleteSearchFilterCases = <({
+    QuickSearchFilter quickFilter,
+    SearchEmailFilter initialFilter,
+    _SearchFilterClearedMatcher isCleared,
+  })>[
+    (
+      quickFilter: QuickSearchFilter.dateTime,
+      initialFilter: SearchEmailFilter(
+        emailReceiveTimeType: EmailReceiveTimeType.customRange,
+        startDate: start,
+        endDate: end,
+      ),
+      isCleared: (filter) =>
+        filter.emailReceiveTimeType == EmailReceiveTimeType.allTime &&
+        filter.startDate == null &&
+        filter.endDate == null,
+    ),
+    (
+      quickFilter: QuickSearchFilter.last7Days,
+      initialFilter: SearchEmailFilter(
+        emailReceiveTimeType: EmailReceiveTimeType.last7Days,
+        startDate: start,
+        endDate: end,
+      ),
+      isCleared: (filter) =>
+        filter.emailReceiveTimeType == EmailReceiveTimeType.allTime &&
+        filter.startDate == null &&
+        filter.endDate == null,
+    ),
+    (
+      quickFilter: QuickSearchFilter.sortBy,
+      initialFilter: SearchEmailFilter(
+        sortOrderType: EmailSortOrderType.oldest,
+      ),
+      isCleared: (filter) =>
+        filter.sortOrderType == SearchEmailFilter.defaultSortOrder,
+    ),
+    (
+      quickFilter: QuickSearchFilter.from,
+      initialFilter: SearchEmailFilter(from: const {'alice@example.com'}),
+      isCleared: (filter) => filter.from.isEmpty,
+    ),
+    (
+      quickFilter: QuickSearchFilter.fromMe,
+      initialFilter: SearchEmailFilter(from: const {'alice@example.com'}),
+      isCleared: (filter) => filter.from.isEmpty,
+    ),
+    (
+      quickFilter: QuickSearchFilter.hasAttachment,
+      initialFilter: SearchEmailFilter(hasAttachment: true),
+      isCleared: (filter) => !filter.hasAttachment,
+    ),
+    (
+      quickFilter: QuickSearchFilter.to,
+      initialFilter: SearchEmailFilter(to: const {'bob@example.com'}),
+      isCleared: (filter) => filter.to.isEmpty,
+    ),
+    (
+      quickFilter: QuickSearchFilter.folder,
+      initialFilter: SearchEmailFilter(mailbox: mailbox),
+      isCleared: (filter) => filter.mailbox == null,
+    ),
+    (
+      quickFilter: QuickSearchFilter.starred,
+      initialFilter: SearchEmailFilter(hasKeyword: {'custom', flagged}),
+      isCleared: (filter) =>
+        !filter.hasKeyword.contains(flagged) &&
+        filter.hasKeyword.contains('custom'),
+    ),
+    (
+      quickFilter: QuickSearchFilter.unread,
+      initialFilter: SearchEmailFilter(unread: true),
+      isCleared: (filter) => !filter.unread,
+    ),
+    (
+      quickFilter: QuickSearchFilter.events,
+      initialFilter: SearchEmailFilter(notIncludeEvents: true),
+      isCleared: (filter) => !filter.notIncludeEvents,
+    ),
+    (
+      quickFilter: QuickSearchFilter.labels,
+      initialFilter: SearchEmailFilter(label: label),
+      isCleared: (filter) => filter.label == null,
+    ),
+  ];
+
+  for (final testCase in deleteSearchFilterCases) {
+    testWidgets(
+      'delete ${testCase.quickFilter.name} clears its filter and searches once',
+      (tester) async {
+        final ref = await pumpWidgetRef(tester);
+        appProviderContainer
+            .read(searchFilterProvider.notifier)
+            .set(testCase.initialFilter);
+        stubNewSearchResult(Right(SearchEmailSuccess([email('email-1')])));
+
+        controller.onDeleteSearchFilterAction(
+          ref,
+          testCase.quickFilter,
+        );
+        await tester.pump();
+
+        final committed = appProviderContainer.read(searchFilterProvider);
+        expect(testCase.isCleared(committed), isTrue);
+        verifyNewSearchExecutedOnce();
+      },
+    );
+  }
+}

--- a/test/features/search/email/presentation/widgets/search_email_riverpod_widgets_test.dart
+++ b/test/features/search/email/presentation/widgets/search_email_riverpod_widgets_test.dart
@@ -1,0 +1,90 @@
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/model/search_more_state.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/riverpod_widgets/clear_search_filter_button.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/widgets/search_email_load_more_indicator.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations_delegate.dart';
+import 'package:tmail_ui_user/main/localizations/localization_service.dart';
+
+void main() {
+  late ProviderContainer container;
+
+  Widget makeTestable(Widget child) => UncontrolledProviderScope(
+        container: container,
+        child: GetMaterialApp(
+          localizationsDelegates: const [
+            AppLocalizationsDelegate(),
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: LocalizationService.supportedLocales,
+          locale: LocalizationService.defaultLocale,
+          home: Scaffold(body: child),
+        ),
+      );
+
+  setUp(() => container = ProviderContainer());
+  tearDown(() => container.dispose());
+
+  group('ClearSearchFilterButton', () {
+    testWidgets('hides when the committed filter is not applied', (tester) async {
+      await tester.pumpWidget(makeTestable(
+        ClearSearchFilterButton(onClearFilter: () {}),
+      ));
+
+      expect(find.byType(TMailButtonWidget), findsNothing);
+    });
+
+    testWidgets('shows and calls clear when the committed filter is applied',
+        (tester) async {
+      var clearCount = 0;
+      container
+          .read(searchFilterProvider.notifier)
+          .set(SearchEmailFilter(unread: true));
+
+      await tester.pumpWidget(makeTestable(
+        ClearSearchFilterButton(onClearFilter: () => clearCount++),
+      ));
+      await tester.pump();
+
+      expect(find.byType(TMailButtonWidget), findsOneWidget);
+
+      await tester.tap(find.byType(TMailButtonWidget));
+      await tester.pump();
+
+      expect(clearCount, 1);
+    });
+  });
+
+  group('SearchEmailLoadMoreIndicator', () {
+    testWidgets('hides when load-more is not waiting', (tester) async {
+      await tester.pumpWidget(makeTestable(
+        const SearchEmailLoadMoreIndicator(),
+      ));
+
+      expect(find.byType(CupertinoActivityIndicator), findsNothing);
+    });
+
+    testWidgets('shows when load-more is waiting', (tester) async {
+      container
+          .read(searchEmailPresentationProvider.notifier)
+          .setSearchMoreState(SearchMoreState.waiting);
+
+      await tester.pumpWidget(makeTestable(
+        const SearchEmailLoadMoreIndicator(),
+      ));
+      await tester.pump();
+
+      expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Closes [#4645](https://github.com/linagora/tmail-flutter/issues/4645). Base: `fix/tf-4645-ssot-4-mobile-search-executor` (PR 1) — review PR 1 first.

## What this PR does

- Adds tests: presentation notifier, selection-action delegate, Riverpod widgets, flags-extension; extends controller + filter-notifier tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for email search, including new searches, pagination, refreshes, failures, and urgent re-login flows.
  - Added validation for search filter selection, clearing labels, resetting date ranges, and deleting quick-search filters.
  - Added widget coverage for filter clearing controls and load-more indicators.
  - Verified search presentation state resets, suggestion clearing, sorting, and unread-filter behavior.
  - Added coverage for preserving results during failures and handling load-more exceptions consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->