### PR TITLE
TF-4646 SSOT Part 5 — PR 1 — Search view-state SSOT foundation

### DIFF
--- a/lib/features/mailbox_dashboard/presentation/model/search/search_activation_state.dart
+++ b/lib/features/mailbox_dashboard/presentation/model/search/search_activation_state.dart
@@ -1,0 +1,33 @@
+import 'package:equatable/equatable.dart';
+
+/// Tracks independent simple/advanced search activation.
+/// Advanced also drives icon state; simple keeps [isRunning] true.
+class SearchActivationState with EquatableMixin {
+  final bool simpleIsActivated;
+  final bool advancedIsActivated;
+
+  const SearchActivationState({
+    required this.simpleIsActivated,
+    required this.advancedIsActivated,
+  });
+
+  factory SearchActivationState.initial() => const SearchActivationState(
+    simpleIsActivated: false,
+    advancedIsActivated: false,
+  );
+
+  bool get isRunning => simpleIsActivated || advancedIsActivated;
+
+  SearchActivationState copyWith({
+    bool? simpleIsActivated,
+    bool? advancedIsActivated,
+  }) {
+    return SearchActivationState(
+      simpleIsActivated: simpleIsActivated ?? this.simpleIsActivated,
+      advancedIsActivated: advancedIsActivated ?? this.advancedIsActivated,
+    );
+  }
+
+  @override
+  List<Object?> get props => [simpleIsActivated, advancedIsActivated];
+}

--- a/lib/features/mailbox_dashboard/presentation/model/search/search_constants.dart
+++ b/lib/features/mailbox_dashboard/presentation/model/search/search_constants.dart
@@ -1,0 +1,6 @@
+class SearchConstants {
+  /// Debounce for the email search bar. The suggestion fetch and the input→SSOT
+  /// commit share this cadence so both settle on the same query value before it
+  /// runs. Keep them equal by referencing this single constant.
+  static const inputDebounceDuration = Duration(milliseconds: 300);
+}

--- a/lib/features/mailbox_dashboard/presentation/model/search/search_view_state.dart
+++ b/lib/features/mailbox_dashboard/presentation/model/search/search_view_state.dart
@@ -1,0 +1,63 @@
+import 'package:equatable/equatable.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_activation_state.dart';
+import 'package:tmail_ui_user/features/thread/presentation/model/search_state.dart';
+import 'package:tmail_ui_user/features/thread/presentation/model/search_status.dart';
+
+class SearchViewState with EquatableMixin {
+  final SearchState searchState;
+  final bool isAdvancedSearchViewOpen;
+  final SearchActivationState activation;
+  final bool isSearchInputFocused;
+
+  const SearchViewState({
+    required this.searchState,
+    required this.isAdvancedSearchViewOpen,
+    required this.activation,
+    required this.isSearchInputFocused,
+  });
+
+  factory SearchViewState.initial() => SearchViewState(
+    searchState: SearchState.initial(),
+    isAdvancedSearchViewOpen: false,
+    activation: SearchActivationState.initial(),
+    isSearchInputFocused: false,
+  );
+
+  bool get advancedSearchIsActivated => activation.advancedIsActivated;
+
+  /// True for the whole active search session (search bar open), independent of
+  /// whether a query is currently executing.
+  bool get isSearchActive => searchState.searchStatus == SearchStatus.ACTIVE;
+
+  bool get isSearchEmailRunning => activation.isRunning;
+
+  /// True while the user is in any search UI — an open session, a running query,
+  /// or the advanced-search panel. Both session and running are checked because
+  /// [isSearchEmailRunning] drops to false once results load.
+  bool get isSearchEngaged =>
+      isSearchActive || isSearchEmailRunning || isAdvancedSearchViewOpen;
+
+  SearchViewState copyWith({
+    SearchState? searchState,
+    bool? isAdvancedSearchViewOpen,
+    SearchActivationState? activation,
+    bool? isSearchInputFocused,
+  }) {
+    return SearchViewState(
+      searchState: searchState ?? this.searchState,
+      isAdvancedSearchViewOpen:
+          isAdvancedSearchViewOpen ?? this.isAdvancedSearchViewOpen,
+      activation: activation ?? this.activation,
+      isSearchInputFocused:
+          isSearchInputFocused ?? this.isSearchInputFocused,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    searchState,
+    isAdvancedSearchViewOpen,
+    activation,
+    isSearchInputFocused,
+  ];
+}

--- a/lib/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart
+++ b/lib/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart
@@ -1,0 +1,58 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_view_state.dart';
+
+part 'search_view_state_notifier.g.dart';
+
+@Riverpod(keepAlive: true)
+class SearchViewStateNotifier extends _$SearchViewStateNotifier {
+  @override
+  SearchViewState build() => SearchViewState.initial();
+
+  void setSearchInputFocused(bool focused) {
+    state = state.copyWith(isSearchInputFocused: focused);
+  }
+
+  void openAdvancedSearch() {
+    state = state.copyWith(isAdvancedSearchViewOpen: true);
+  }
+
+  void closeAdvancedSearch() {
+    state = state.copyWith(isAdvancedSearchViewOpen: false);
+  }
+
+  void activateSimpleSearch() {
+    state = state.copyWith(
+      activation: state.activation.copyWith(simpleIsActivated: true),
+    );
+  }
+
+  void deactivateSimpleSearch() {
+    state = state.copyWith(
+      activation: state.activation.copyWith(simpleIsActivated: false),
+    );
+  }
+
+  void activateAdvancedSearch() {
+    state = state.copyWith(
+      activation: state.activation.copyWith(advancedIsActivated: true),
+    );
+  }
+
+  void deactivateAdvancedSearch() {
+    state = state.copyWith(
+      activation: state.activation.copyWith(advancedIsActivated: false),
+    );
+  }
+
+  void enableSearch() {
+    state = state.copyWith(searchState: state.searchState.enableSearchState());
+  }
+
+  void disableSearch() {
+    state = state.copyWith(searchState: state.searchState.disableSearchState());
+  }
+
+  void release() {
+    ref.invalidateSelf();
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
@@ -28,6 +28,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/search_controller.dart' as search;
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_keyboard_shortcut_actions_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_constants.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_filter_overlay.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/advanced_search/icon_open_advanced_search_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/quick_search/contact_quick_search_item.dart';
@@ -64,7 +65,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
           color: Colors.white,
           borderRadius: BorderRadius.all(Radius.circular(16)),
         ),
-        debounceDuration: const Duration(milliseconds: 300),
+        debounceDuration: SearchConstants.inputDebounceDuration,
         listActionButton: const [
           QuickSearchFilter.hasAttachment,
           QuickSearchFilter.last7Days,

--- a/test/features/mailbox_dashboard/presentation/model/search/search_activation_state_test.dart
+++ b/test/features/mailbox_dashboard/presentation/model/search/search_activation_state_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_activation_state.dart';
+
+void main() {
+  group('SearchActivationState', () {
+    test('initial is inactive for both simple and advanced', () {
+      final state = SearchActivationState.initial();
+
+      expect(state.simpleIsActivated, isFalse);
+      expect(state.advancedIsActivated, isFalse);
+      expect(state.isRunning, isFalse);
+    });
+
+    test('isRunning is true when simple search is activated', () {
+      final state = SearchActivationState.initial().copyWith(
+        simpleIsActivated: true,
+      );
+
+      expect(state.isRunning, isTrue);
+    });
+
+    test('isRunning is true when advanced search is activated', () {
+      final state = SearchActivationState.initial().copyWith(
+        advancedIsActivated: true,
+      );
+
+      expect(state.isRunning, isTrue);
+    });
+
+    test('copyWith preserves the untouched flag', () {
+      final state = SearchActivationState.initial()
+          .copyWith(simpleIsActivated: true)
+          .copyWith(advancedIsActivated: true);
+
+      expect(state.simpleIsActivated, isTrue);
+      expect(state.advancedIsActivated, isTrue);
+    });
+  });
+}

--- a/test/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier_test.dart
+++ b/test/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_view_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
+import 'package:tmail_ui_user/features/thread/presentation/model/search_status.dart';
+
+typedef _SearchViewMutation = void Function();
+typedef _SearchActivationFlag = bool Function();
+
+void main() {
+  late ProviderContainer container;
+  late _DisposeObserver disposeObserver;
+
+  setUp(() {
+    disposeObserver = _DisposeObserver();
+    container = ProviderContainer(observers: [disposeObserver]);
+  });
+  tearDown(() => container.dispose());
+
+  SearchViewStateNotifier notifier() =>
+      container.read(searchViewStateProvider.notifier);
+  SearchViewState state() => container.read(searchViewStateProvider);
+
+  test('starts from an inactive, closed, unfocused state', () {
+    expect(state().isAdvancedSearchViewOpen, isFalse);
+    expect(state().isSearchInputFocused, isFalse);
+    expect(state().isSearchActive, isFalse);
+    expect(state().isSearchEmailRunning, isFalse);
+  });
+
+  test('openAdvancedSearch then closeAdvancedSearch toggles the advanced view', () {
+    notifier().openAdvancedSearch();
+    expect(state().isAdvancedSearchViewOpen, isTrue);
+
+    notifier().closeAdvancedSearch();
+    expect(state().isAdvancedSearchViewOpen, isFalse);
+  });
+
+  test('setSearchInputFocused reflects focus both ways', () {
+    notifier().setSearchInputFocused(true);
+    expect(state().isSearchInputFocused, isTrue);
+
+    notifier().setSearchInputFocused(false);
+    expect(state().isSearchInputFocused, isFalse);
+  });
+
+  test('enableSearch then disableSearch flips the search status', () {
+    notifier().enableSearch();
+    expect(state().isSearchActive, isTrue);
+    expect(state().searchState.searchStatus, SearchStatus.ACTIVE);
+
+    notifier().disableSearch();
+    expect(state().isSearchActive, isFalse);
+    expect(state().searchState.searchStatus, SearchStatus.INACTIVE);
+  });
+
+  void testIndependentActivation({
+    required String description,
+    required _SearchViewMutation activatePreserved,
+    required _SearchViewMutation activateTarget,
+    required _SearchViewMutation deactivateTarget,
+    required _SearchActivationFlag targetIsActivated,
+    required _SearchActivationFlag preservedIsActivated,
+    required String preservedReason,
+  }) {
+    test(description, () {
+      activatePreserved();
+
+      activateTarget();
+      expect(targetIsActivated(), isTrue);
+      expect(preservedIsActivated(), isTrue);
+
+      deactivateTarget();
+      expect(targetIsActivated(), isFalse);
+      expect(preservedIsActivated(), isTrue, reason: preservedReason);
+    });
+  }
+
+  testIndependentActivation(
+    description: 'simple activation toggles on and off without touching advanced',
+    activatePreserved: () => notifier().activateAdvancedSearch(),
+    activateTarget: () => notifier().activateSimpleSearch(),
+    deactivateTarget: () => notifier().deactivateSimpleSearch(),
+    targetIsActivated: () => state().activation.simpleIsActivated,
+    preservedIsActivated: () => state().advancedSearchIsActivated,
+    preservedReason: 'advanced activation must be independent of simple',
+  );
+
+  testIndependentActivation(
+    description: 'advanced activation toggles on and off without touching simple',
+    activatePreserved: () => notifier().activateSimpleSearch(),
+    activateTarget: () => notifier().activateAdvancedSearch(),
+    deactivateTarget: () => notifier().deactivateAdvancedSearch(),
+    targetIsActivated: () => state().advancedSearchIsActivated,
+    preservedIsActivated: () => state().activation.simpleIsActivated,
+    preservedReason: 'simple activation must be independent of advanced',
+  );
+
+  test('isSearchEmailRunning is true while either simple or advanced is active', () {
+    expect(state().isSearchEmailRunning, isFalse);
+
+    notifier().activateSimpleSearch();
+    expect(state().isSearchEmailRunning, isTrue);
+
+    notifier().deactivateSimpleSearch();
+    notifier().activateAdvancedSearch();
+    expect(state().isSearchEmailRunning, isTrue);
+
+    notifier().deactivateAdvancedSearch();
+    expect(state().isSearchEmailRunning, isFalse);
+  });
+
+  test('isSearchEngaged is true for a session, a running query, or advanced open', () {
+    expect(state().isSearchEngaged, isFalse);
+
+    notifier().enableSearch();
+    expect(state().isSearchEngaged, isTrue, reason: 'active session');
+
+    notifier().disableSearch();
+    notifier().activateSimpleSearch();
+    expect(state().isSearchEngaged, isTrue, reason: 'query running');
+
+    notifier().deactivateSimpleSearch();
+    notifier().openAdvancedSearch();
+    expect(state().isSearchEngaged, isTrue, reason: 'advanced panel open');
+
+    notifier().closeAdvancedSearch();
+    expect(state().isSearchEngaged, isFalse);
+  });
+
+  test('release disposes the keepAlive provider back to initial', () async {
+    notifier().openAdvancedSearch();
+    notifier().enableSearch();
+
+    notifier().release();
+    await container.pump();
+
+    expect(disposeObserver.searchViewStateDisposeCount, greaterThan(0));
+    expect(state().isAdvancedSearchViewOpen, isFalse);
+    expect(state().isSearchActive, isFalse);
+  });
+}
+
+final class _DisposeObserver extends ProviderObserver {
+  int searchViewStateDisposeCount = 0;
+
+  @override
+  void didDisposeProvider(ProviderObserverContext context) {
+    if (context.provider == searchViewStateProvider) {
+      searchViewStateDisposeCount++;
+    }
+  }
+}

--- a/test/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier_test.dart
+++ b/test/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier_test.dart
@@ -82,7 +82,7 @@ void main() {
     activateTarget: () => notifier().activateSimpleSearch(),
     deactivateTarget: () => notifier().deactivateSimpleSearch(),
     targetIsActivated: () => state().activation.simpleIsActivated,
-    preservedIsActivated: () => state().advancedSearchIsActivated,
+    preservedIsActivated: () => state().activation.advancedIsActivated,
     preservedReason: 'advanced activation must be independent of simple',
   );
 
@@ -91,7 +91,7 @@ void main() {
     activatePreserved: () => notifier().activateSimpleSearch(),
     activateTarget: () => notifier().activateAdvancedSearch(),
     deactivateTarget: () => notifier().deactivateAdvancedSearch(),
-    targetIsActivated: () => state().advancedSearchIsActivated,
+    targetIsActivated: () => state().activation.advancedIsActivated,
     preservedIsActivated: () => state().activation.simpleIsActivated,
     preservedReason: 'simple activation must be independent of advanced',
   );


### PR DESCRIPTION
Part of [#4646](https://github.com/linagora/tmail-flutter/issues/4646) 

Pure additions — no existing screen or behaviour changes. PR 2 wires these in.

## What this PR does

- Adds the search view-state value objects: `SearchActivationState`, `SearchViewState`, `SearchConstants`.
- Adds `SearchViewStateNotifier` — single source of truth for search view-state (input focus, advanced-panel open, simple/advanced activation, search status).
- Tests: value objects + notifier (13 cases).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified search state management for simple and advanced search modes.
  * Added controls for opening advanced search, tracking input focus, and enabling or disabling searches.
  * Added derived search status indicators to reflect active, running, and engaged search sessions.
  * Added a consistent 300 ms delay before processing search input.

* **Tests**
  * Expanded coverage for search activation, view state transitions, focus handling, and search lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->