### PR TITLE
TF-4646 SSOT Part 5.2 — PR 3 — Retire the last web-search `Obx`/memory state to Riverpod  

### DIFF
--- a/lib/features/email/presentation/email_view.dart
+++ b/lib/features/email/presentation/email_view.dart
@@ -6,6 +6,7 @@ import 'package:core/presentation/views/html_viewer/html_content_viewer_widget.d
 import 'package:core/presentation/views/tooltip/iframe_tooltip_overlay.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/mail/calendar/calendar_event.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
@@ -44,6 +45,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_open_context_menu_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/verify_display_overlay_view_on_iframe_extension.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/extensions/vacation_response_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/vacation/widgets/vacation_notification_message_widget.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
@@ -86,12 +88,16 @@ class EmailView extends GetWidget<SingleEmailController> {
           return Column(
             children: [
               if (!isInsideThreadDetailView)
-                Obx(
+                Consumer(builder: (context, ref, child) {
+                  final isSearchEmailRunning = ref.watch(
+                    searchViewStateProvider.select((state) => state.isSearchEmailRunning),
+                  );
+                  return Obx(
                   () => EmailViewAppBarWidget(
                     key: const Key('email_view_app_bar_widget'),
                     presentationEmail: currentEmail,
                     mailboxContain: _getMailboxContain(currentEmail),
-                    isSearchActivated: controller.mailboxDashBoardController.searchController.isSearchEmailRunning,
+                    isSearchActivated: isSearchEmailRunning,
                     onBackAction: () => controller.closeEmailView(context: context),
                     onEmailActionClick: controller.handleEmailAction,
                     onMoreActionClick: (presentationEmail, position) {
@@ -135,7 +141,8 @@ class EmailView extends GetWidget<SingleEmailController> {
                     emailLoaded: controller.currentEmailLoaded.value,
                     isInsideThreadDetailView: isInsideThreadDetailView,
                   ),
-                ),
+                  );
+                }),
               if (!isInsideThreadDetailView)
                 Obx(() {
                   final vacation = controller.mailboxDashBoardController.vacationResponse.value;

--- a/lib/features/mailbox/presentation/base_mailbox_view.dart
+++ b/lib/features/mailbox/presentation/base_mailbox_view.dart
@@ -3,6 +3,7 @@ import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/list/tree_view.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:model/extensions/presentation_mailbox_extension.dart';
@@ -32,6 +33,8 @@ import 'package:tmail_ui_user/features/mailbox/presentation/widgets/mailbox_load
 import 'package:tmail_ui_user/features/mailbox/presentation/widgets/sending_queue_mailbox_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
 
 abstract class BaseMailboxView extends GetWidget<MailboxController>
     with AppLoaderMixin {
@@ -200,7 +203,9 @@ abstract class BaseMailboxView extends GetWidget<MailboxController>
     }
 
     return parentNode.childrenItems!.map((mailboxNode) {
-      final mailboxItemWidget = Obx(() => MailboxItemWidget(
+      final mailboxItemWidget = Consumer(builder: (context, ref, child) {
+        final isSearchByStarredOnly = _isSearchByStarredOnly(ref);
+        return Obx(() => MailboxItemWidget(
         mailboxNode: mailboxNode,
         mailboxNodeSelected: controller
           .mailboxDashBoardController
@@ -209,7 +214,7 @@ abstract class BaseMailboxView extends GetWidget<MailboxController>
         isDraggingMailbox: controller
             .mailboxDashBoardController
             .isDraggingMailbox,
-        isHighlighted: isFolderHighlighted(mailboxNode),
+        isHighlighted: isFolderHighlighted(mailboxNode, isSearchByStarredOnly),
         onOpenMailboxFolderClick: (mailboxNode) =>
             mailboxNode != null
                 ? controller.openMailbox(context, mailboxNode.item)
@@ -239,6 +244,7 @@ abstract class BaseMailboxView extends GetWidget<MailboxController>
             mailboxNode.item,
           ),
       ));
+      });
 
       if (mailboxNode.hasChildren()) {
         return TreeViewChild(
@@ -254,15 +260,17 @@ abstract class BaseMailboxView extends GetWidget<MailboxController>
     }).toList();
   }
 
-  bool get isSearchByStarredOnly {
-    final searchController =
-        controller.mailboxDashBoardController.searchController;
-
-    return searchController.isSearchEmailRunning &&
-        searchController.searchEmailFilter.value.isOnlyStarredApplied;
+  bool _isSearchByStarredOnly(WidgetRef ref) {
+    final isSearchEmailRunning = ref.watch(
+      searchViewStateProvider.select((state) => state.isSearchEmailRunning),
+    );
+    final isOnlyStarredApplied = ref.watch(
+      searchFilterProvider.select((filter) => filter.isOnlyStarredApplied),
+    );
+    return isSearchEmailRunning && isOnlyStarredApplied;
   }
 
-  bool isFolderHighlighted(MailboxNode mailboxNode) =>
+  bool isFolderHighlighted(MailboxNode mailboxNode, bool isSearchByStarredOnly) =>
       mailboxNode.item.isFavorite && isSearchByStarredOnly;
 
   Widget buildListMailbox(BuildContext context) {

--- a/lib/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart
@@ -189,13 +189,6 @@ class AdvancedFilterController extends BaseController {
 
     notKeyWordFilterInputController.text = StringConvert.writeNullToEmpty(
       _committedFilter.notKeyword.join(','));
-
-    _viewStateNotifier.setFromAddressExpandMode(
-      _committedFilter.from.isEmpty ? ExpandMode.EXPAND : ExpandMode.COLLAPSE,
-    );
-    _viewStateNotifier.setToAddressExpandMode(
-      _committedFilter.to.isEmpty ? ExpandMode.EXPAND : ExpandMode.COLLAPSE,
-    );
   }
 
   void selectDateRange(
@@ -311,15 +304,18 @@ class AdvancedFilterController extends BaseController {
     }
   }
 
-  void showFullEmailAddress(FilterField field) {
+  void showFullEmailAddress(
+    FilterField field,
+    AdvancedFilterViewStateNotifier viewStateNotifier,
+  ) {
     FocusManager.instance.primaryFocus?.unfocus();
 
     switch(field) {
       case FilterField.from:
-        _viewStateNotifier.setFromAddressExpandMode(ExpandMode.EXPAND);
+        viewStateNotifier.setFromAddressExpandMode(ExpandMode.EXPAND);
         break;
       case FilterField.to:
-        _viewStateNotifier.setToAddressExpandMode(ExpandMode.EXPAND);
+        viewStateNotifier.setToAddressExpandMode(ExpandMode.EXPAND);
         break;
       default:
         break;
@@ -480,6 +476,7 @@ class AdvancedFilterController extends BaseController {
   void removeDraggableEmailAddress(
     DraggableEmailAddress draggableEmailAddress,
     SearchFilterNotifier filterNotifier,
+    AdvancedFilterViewStateNotifier viewStateNotifier,
   ) {
     log('AdvancedFilterController::removeDraggableEmailAddress:removeDraggableEmailAddress: $draggableEmailAddress');
     switch(draggableEmailAddress.filterField) {
@@ -487,13 +484,13 @@ class AdvancedFilterController extends BaseController {
         filterNotifier.removeRecipient(
           draggableEmailAddress.emailAddress.emailAddress
               .asSearchFilterEmailAddress());
-        _viewStateNotifier.setToAddressExpandMode(ExpandMode.EXPAND);
+        viewStateNotifier.setToAddressExpandMode(ExpandMode.EXPAND);
         break;
       case FilterField.from:
         filterNotifier.removeSender(
           draggableEmailAddress.emailAddress.emailAddress
               .asSearchFilterEmailAddress());
-        _viewStateNotifier.setFromAddressExpandMode(ExpandMode.EXPAND);
+        viewStateNotifier.setFromAddressExpandMode(ExpandMode.EXPAND);
         break;
       default:
         break;

--- a/lib/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart
@@ -16,6 +16,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/search_controller.dart' as search;
 import 'package:tmail_ui_user/features/base/model/filter_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/advanced_filter_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
@@ -28,8 +29,8 @@ import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
 typedef _AddressFocusConfig = ({
   FocusNode focusNode,
-  Rx<ExpandMode> expandMode,
-  Rx<ExpandMode> otherExpandMode,
+  void Function(ExpandMode mode) setExpandMode,
+  void Function(ExpandMode mode) setOtherExpandMode,
   void Function() autoCreateTag,
 });
 
@@ -45,8 +46,6 @@ class AdvancedFilterController extends BaseController {
 
   final GlobalKey<TagsEditorState> keyFromEmailTagEditor = GlobalKey<TagsEditorState>();
   final GlobalKey<TagsEditorState> keyToEmailTagEditor = GlobalKey<TagsEditorState>();
-  final fromAddressExpandMode = ExpandMode.EXPAND.obs;
-  final toAddressExpandMode = ExpandMode.EXPAND.obs;
 
   TextEditingController fromEmailAddressController = TextEditingController();
   TextEditingController toEmailAddressController = TextEditingController();
@@ -71,6 +70,9 @@ class AdvancedFilterController extends BaseController {
   /// or copyWith plumbing. See ADR-0093.
   SearchFilterNotifier get _filterNotifier =>
       appProviderContainer.read(searchFilterProvider.notifier);
+
+  AdvancedFilterViewStateNotifier get _viewStateNotifier =>
+      appProviderContainer.read(advancedFilterViewStateProvider.notifier);
 
   List<EmailAddress> get listFromEmailAddress =>
       _toEmailAddresses(_committedFilter.from);
@@ -105,10 +107,9 @@ class AdvancedFilterController extends BaseController {
   }
 
   void clearSearchFilter() {
-    // Route through SearchController so the obs mirror's stale cursors are dropped
-    // too; a bare notifier.clear() only resets the committed SSOT. See ADR-0093.
     searchController.clearSearchFilter();
     _clearAllTextFieldInput();
+    _viewStateNotifier.reset();
     _mailboxDashBoardController.handleClearAdvancedSearchFilterEmail();
   }
 
@@ -158,7 +159,7 @@ class AdvancedFilterController extends BaseController {
     } else {
       searchController.deactivateAdvancedSearch();
     }
-    searchController.isAdvancedSearchViewOpen.value = false;
+    searchController.closeAdvanceSearch();
     _mailboxDashBoardController.handleAdvancedSearchEmail();
   }
 
@@ -189,17 +190,12 @@ class AdvancedFilterController extends BaseController {
     notKeyWordFilterInputController.text = StringConvert.writeNullToEmpty(
       _committedFilter.notKeyword.join(','));
 
-    if (_committedFilter.from.isEmpty) {
-      fromAddressExpandMode.value = ExpandMode.EXPAND;
-    } else {
-      fromAddressExpandMode.value = ExpandMode.COLLAPSE;
-    }
-
-    if (_committedFilter.to.isEmpty) {
-      toAddressExpandMode.value = ExpandMode.EXPAND;
-    } else {
-      toAddressExpandMode.value = ExpandMode.COLLAPSE;
-    }
+    _viewStateNotifier.setFromAddressExpandMode(
+      _committedFilter.from.isEmpty ? ExpandMode.EXPAND : ExpandMode.COLLAPSE,
+    );
+    _viewStateNotifier.setToAddressExpandMode(
+      _committedFilter.to.isEmpty ? ExpandMode.EXPAND : ExpandMode.COLLAPSE,
+    );
   }
 
   void selectDateRange(
@@ -275,11 +271,11 @@ class AdvancedFilterController extends BaseController {
   void _onAddressFieldFocusChange(FilterField field) {
     final config = _addressFocusConfig(field);
     if (config.focusNode.hasFocus) {
-      config.expandMode.value = ExpandMode.EXPAND;
-      config.otherExpandMode.value = ExpandMode.COLLAPSE;
+      config.setExpandMode(ExpandMode.EXPAND);
+      config.setOtherExpandMode(ExpandMode.COLLAPSE);
       _closeSuggestionBox();
     } else {
-      config.expandMode.value = ExpandMode.COLLAPSE;
+      config.setExpandMode(ExpandMode.COLLAPSE);
       config.autoCreateTag();
     }
   }
@@ -289,15 +285,15 @@ class AdvancedFilterController extends BaseController {
       case FilterField.from:
         return (
           focusNode: focusManager.fromFieldFocusNode,
-          expandMode: fromAddressExpandMode,
-          otherExpandMode: toAddressExpandMode,
+          setExpandMode: _viewStateNotifier.setFromAddressExpandMode,
+          setOtherExpandMode: _viewStateNotifier.setToAddressExpandMode,
           autoCreateTag: _autoCreateTagFromField,
         );
       case FilterField.to:
         return (
           focusNode: focusManager.toFieldFocusNode,
-          expandMode: toAddressExpandMode,
-          otherExpandMode: fromAddressExpandMode,
+          setExpandMode: _viewStateNotifier.setToAddressExpandMode,
+          setOtherExpandMode: _viewStateNotifier.setFromAddressExpandMode,
           autoCreateTag: _autoCreateTagToField,
         );
       default:
@@ -320,10 +316,10 @@ class AdvancedFilterController extends BaseController {
 
     switch(field) {
       case FilterField.from:
-        fromAddressExpandMode.value = ExpandMode.EXPAND;
+        _viewStateNotifier.setFromAddressExpandMode(ExpandMode.EXPAND);
         break;
       case FilterField.to:
-        toAddressExpandMode.value = ExpandMode.EXPAND;
+        _viewStateNotifier.setToAddressExpandMode(ExpandMode.EXPAND);
         break;
       default:
         break;
@@ -443,8 +439,8 @@ class AdvancedFilterController extends BaseController {
 
   void _handleClearAllFieldOfAdvancedSearch() {
     _clearAllTextFieldInput();
-    // Cursor-safe clear: also drop stale cursors on the obs mirror. See ADR-0093.
     searchController.clearSearchFilter();
+    _viewStateNotifier.reset();
   }
 
   void onSearchAction({
@@ -491,15 +487,13 @@ class AdvancedFilterController extends BaseController {
         filterNotifier.removeRecipient(
           draggableEmailAddress.emailAddress.emailAddress
               .asSearchFilterEmailAddress());
-        toAddressExpandMode.value = ExpandMode.EXPAND;
-        toAddressExpandMode.refresh();
+        _viewStateNotifier.setToAddressExpandMode(ExpandMode.EXPAND);
         break;
       case FilterField.from:
         filterNotifier.removeSender(
           draggableEmailAddress.emailAddress.emailAddress
               .asSearchFilterEmailAddress());
-        fromAddressExpandMode.value = ExpandMode.EXPAND;
-        fromAddressExpandMode.refresh();
+        _viewStateNotifier.setFromAddressExpandMode(ExpandMode.EXPAND);
         break;
       default:
         break;
@@ -511,7 +505,7 @@ class AdvancedFilterController extends BaseController {
     _clearAllTextFieldInput();
     searchController.searchInputController.clear();
     searchController.deactivateAdvancedSearch();
-    searchController.isAdvancedSearchViewOpen.value = false;
+    searchController.closeAdvanceSearch();
     _filterNotifier.addSender(emailAddress.emailAddress.asSearchFilterEmailAddress());
     _mailboxDashBoardController.dispatchAction(StartSearchEmailAction());
   }

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -7,6 +7,7 @@ import 'package:dartz/dartz.dart';
 import 'package:email_recovery/email_recovery/email_recovery_action.dart';
 import 'package:email_recovery/email_recovery/email_recovery_action_id.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -361,6 +362,8 @@ class MailboxDashBoardController extends ReloadableController
   LinagoraEcosystem? cachedLinagoraEcosystem;
   PaywallController? paywallController;
   final workerObxVariables = <Worker>[];
+  ProviderSubscription<bool>? advancedSearchViewSubscription;
+  ProviderSubscription<bool>? searchInputFocusSubscription;
 
   final StreamController<Either<Failure, Success>> progressStateController =
     StreamController<Either<Failure, Success>>.broadcast();
@@ -1095,7 +1098,7 @@ class MailboxDashBoardController extends ReloadableController
     }
     _unSelectedMailbox();
     FocusManager.instance.primaryFocus?.unfocus();
-    storeEmailSortOrder(searchController.searchEmailFilter.value.sortOrderType);
+    storeEmailSortOrder(searchController.committedSearchFilter.sortOrderType);
     dispatchAction(StartSearchEmailAction());
   }
 
@@ -1129,7 +1132,7 @@ class MailboxDashBoardController extends ReloadableController
         ? Some({queryString})
         : null);
 
-    if (searchController.searchEmailFilter.value.isContainFlagged) {
+    if (searchController.committedSearchFilter.isContainFlagged) {
       filterMessageOption.value = FilterMessageOption.starred;
     }
 
@@ -2255,7 +2258,7 @@ class MailboxDashBoardController extends ReloadableController
     final contactArgument = ContactArguments(
       accountId: accountId.value!,
       session: sessionCurrent!,
-      selectedContactList: searchController.searchEmailFilter.value.from,
+      selectedContactList: searchController.committedSearchFilter.from,
       contactViewTitle: '${appLocalizations.findEmails} ${appLocalizations.from_email_address_prefix.toLowerCase()}'
     );
 
@@ -2278,7 +2281,7 @@ class MailboxDashBoardController extends ReloadableController
     final contactArgument = ContactArguments(
       accountId: accountId.value!,
       session: sessionCurrent!,
-      selectedContactList: searchController.searchEmailFilter.value.to,
+      selectedContactList: searchController.committedSearchFilter.to,
       contactViewTitle: '${appLocalizations.findEmails} ${appLocalizations.to_email_address_prefix.toLowerCase()}'
     );
 
@@ -3413,7 +3416,7 @@ class MailboxDashBoardController extends ReloadableController
   }
 
   bool get isSearchFilterHasApplied {
-    return searchController.searchEmailFilter.value.isApplied ||
+    return searchController.committedSearchFilter.isApplied ||
       filterMessageOption.value != FilterMessageOption.all;
   }
 
@@ -3463,6 +3466,7 @@ class MailboxDashBoardController extends ReloadableController
       worker.dispose();
     }
     workerObxVariables.clear();
+    disposeReactiveSearchStateListeners();
   }
 
   @override

--- a/lib/features/mailbox_dashboard/presentation/controller/search_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/search_controller.dart
@@ -4,7 +4,6 @@ import 'package:core/utils/app_logger.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:jmap_dart_client/jmap/core/utc_date.dart';
@@ -27,8 +26,6 @@ import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filte
 import 'package:tmail_ui_user/features/search/email/presentation/providers/search_session_reset.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
-import 'package:tmail_ui_user/features/thread/presentation/model/search_state.dart';
-import 'package:tmail_ui_user/features/thread/presentation/model/search_status.dart';
 import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 
 class SearchController extends BaseController with DateRangePickerMixin {
@@ -38,21 +35,13 @@ class SearchController extends BaseController with DateRangePickerMixin {
 
   final searchInputController = TextEditingController();
 
-  /// Read-only mirror of the committed SSOT ([searchFilterProvider]) for existing
-  /// `Obx` widgets. Cursors (position/before/after) are still written here locally
-  /// by [updateFilterEmail] until the executor owns them (ticket 5).
-  final searchEmailFilter = SearchEmailFilter.initial().obs;
-  final searchState = SearchState.initial().obs;
-  final isAdvancedSearchViewOpen = false.obs;
-  final simpleSearchIsActivated = RxBool(false);
-  final advancedSearchIsActivated = RxBool(false);
-  final isSearchInputFocused = RxBool(false);
+  SearchEmailFilter get committedSearchFilter =>
+      appProviderContainer.read(searchFilterProvider);
 
-  SearchQuery? get searchQuery => searchEmailFilter.value.text;
+  SearchQuery? get searchQuery => committedSearchFilter.text;
 
   FocusNode searchFocus = FocusNode();
   FocusNode? keyboardFocusNode;
-  String currentSearchText = '';
   ProviderSubscription<SearchEmailFilter>? _committedFilterSubscription;
 
   SearchViewStateNotifier get _searchViewStateNotifier =>
@@ -73,21 +62,9 @@ class SearchController extends BaseController with DateRangePickerMixin {
     super.onInit();
     searchFocus.addListener(_onSearchFocusChanged);
     onKeyboardShortcutInit();
-    // Mirror committed SSOT → obs so existing Obx widgets keep reading it.
-    // The SSOT never tracks cursors (before/after/position), so re-layer the
-    // obs's local cursors onto every synced value; otherwise an unrelated
-    // user-intent update would silently wipe active pagination (until the
-    // executor owns cursors — ticket 5).
     _committedFilterSubscription = appProviderContainer.listen<SearchEmailFilter>(
       searchFilterProvider,
       (_, next) {
-        searchEmailFilter.value = next.copyWith(
-          beforeOption: optionOf(searchEmailFilter.value.before),
-          afterOption: optionOf(searchEmailFilter.value.after),
-          positionOption: optionOf(searchEmailFilter.value.position),
-        );
-        // The search bar and the advanced "has the words" field are the same
-        // full-text term (SSOT.text); keep the bar in lockstep with it.
         _syncSearchInputFromFilter(next.text);
       },
       fireImmediately: true,
@@ -120,7 +97,7 @@ class SearchController extends BaseController with DateRangePickerMixin {
 
   void _onSearchFocusChanged() {
     log('SearchController::_onSearchFocusChanged: ${searchFocus.hasFocus}');
-    isSearchInputFocused.value = searchFocus.hasFocus;
+    _searchViewStateNotifier.setSearchInputFocused(searchFocus.hasFocus);
     if (searchFocus.hasFocus) {
       refocusKeyboardShortcutFocus();
     } else {
@@ -129,19 +106,17 @@ class SearchController extends BaseController with DateRangePickerMixin {
   }
 
   void openAdvanceSearch() {
-    isAdvancedSearchViewOpen.value = true;
+    _searchViewStateNotifier.openAdvancedSearch();
   }
 
   void closeAdvanceSearch() {
-    isAdvancedSearchViewOpen.value = false;
+    _searchViewStateNotifier.closeAdvancedSearch();
   }
 
   void clearSearchFilter({EmailSortOrderType? sortOrderType}) {
     final restoredSortOrder =
-        sortOrderType ?? searchEmailFilter.value.sortOrderType;
+        sortOrderType ?? committedSearchFilter.sortOrderType;
     final clearedFilter = SearchEmailFilter.withSortOrder(restoredSortOrder);
-    searchEmailFilter.value = clearedFilter;
-
     appProviderContainer
         .read(searchFilterProvider.notifier)
         .set(clearedFilter);
@@ -167,7 +142,6 @@ class SearchController extends BaseController with DateRangePickerMixin {
     Option<EmailSortOrderType>? sortOrderTypeOption,
     Option<Label>? labelOption,
   }) {
-    // User intent → committed SSOT; the mirror syncs it back into the obs.
     final userIntentOptions = [
       fromOption, toOption, textOption, subjectOption, notKeywordOption,
       hasKeywordOption, mailboxOption, emailReceiveTimeTypeOption,
@@ -193,19 +167,10 @@ class SearchController extends BaseController with DateRangePickerMixin {
               ..sortOrderTypeOption = sortOrderTypeOption
               ..labelOption = labelOption);
     }
-    // Cursors aren't user intent — layered onto the obs only, until the executor
-    // owns them (ticket 5).
-    if (beforeOption != null || afterOption != null || positionOption != null) {
-      searchEmailFilter.value = searchEmailFilter.value.copyWith(
-        beforeOption: beforeOption,
-        afterOption: afterOption,
-        positionOption: positionOption,
-      );
-      searchEmailFilter.refresh();
-    }
   }
 
-  EmailReceiveTimeType get receiveTimeFiltered => searchEmailFilter.value.emailReceiveTimeType;
+  EmailReceiveTimeType get receiveTimeFiltered =>
+      committedSearchFilter.emailReceiveTimeType;
 
   void updateSortOrderFilter(EmailSortOrderType sortOrder) {
     updateFilterEmail(
@@ -216,31 +181,13 @@ class SearchController extends BaseController with DateRangePickerMixin {
     );
   }
 
-  /// Resets load-more cursors before a fresh search so stale pagination state
-  /// never leaks into the next query.
-  ///
-  /// The `before`/`after` time cursors are always cleared (the date-range bounds
-  /// in `startDate`/`endDate` are preserved). Position-based pagination
-  /// (relevance sort or collapsed threads) restarts from offset 0; otherwise the
-  /// position is cleared too.
-  void resetCursorsForFreshSearch({required bool isCollapseThreadsEnabled}) {
-    final usesPositionPagination =
-        searchEmailFilter.value.sortOrderType.isScrollByPosition() ||
-            isCollapseThreadsEnabled;
-    updateFilterEmail(
-      beforeOption: const None(),
-      afterOption: const None(),
-      positionOption: option(usesPositionPagination, 0),
-    );
-  }
-
   /// Toggles a suggestion-bar chip straight on the committed SSOT (no staging), so
   /// the selection takes effect immediately — the fix for #4421.
   void toggleQuickSearchFilter(
     QuickSearchFilter filter, {
     required String currentUserEmail,
   }) {
-    final current = searchEmailFilter.value;
+    final current = committedSearchFilter;
     switch (filter) {
       case QuickSearchFilter.hasAttachment:
         updateFilterEmail(
@@ -289,34 +236,35 @@ class SearchController extends BaseController with DateRangePickerMixin {
     }
   }
 
-  DateTime? get startDateFiltered => searchEmailFilter.value.startDate?.value.toLocal();
+  DateTime? get startDateFiltered =>
+      committedSearchFilter.startDate?.value.toLocal();
 
-  DateTime? get endDateFiltered => searchEmailFilter.value.endDate?.value.toLocal();
+  DateTime? get endDateFiltered => committedSearchFilter.endDate?.value.toLocal();
 
-  PresentationMailbox? get mailboxFiltered => searchEmailFilter.value.mailbox;
+  PresentationMailbox? get mailboxFiltered => committedSearchFilter.mailbox;
 
-  Label? get labelFiltered => searchEmailFilter.value.label;
+  Label? get labelFiltered => committedSearchFilter.label;
 
-  Set<String> get listAddressOfToFiltered => searchEmailFilter.value.to;
+  Set<String> get listAddressOfToFiltered => committedSearchFilter.to;
 
-  Set<String> get listAddressOfFromFiltered => searchEmailFilter.value.from;
+  Set<String> get listAddressOfFromFiltered => committedSearchFilter.from;
 
   Set<String> get listHasKeywordFiltered =>
-      Set<String>.unmodifiable(searchEmailFilter.value.hasKeyword);
+      Set<String>.unmodifiable(committedSearchFilter.hasKeyword);
 
-  bool get unreadFiltered => searchEmailFilter.value.unread;
+  bool get unreadFiltered => committedSearchFilter.unread;
 
-  bool get notIncludeEventsFiltered => searchEmailFilter.value.notIncludeEvents;
+  bool get notIncludeEventsFiltered => committedSearchFilter.notIncludeEvents;
 
-  EmailSortOrderType get sortOrderFiltered => searchEmailFilter.value.sortOrderType;
+  EmailSortOrderType get sortOrderFiltered => committedSearchFilter.sortOrderType;
 
   bool isSearchActive() =>
-      searchState.value.searchStatus == SearchStatus.ACTIVE;
+      appProviderContainer.read(searchViewStateProvider).isSearchActive;
 
-  bool get isSearchEmailRunning => simpleSearchIsActivated.isTrue || advancedSearchIsActivated.isTrue;
+  bool get isSearchEmailRunning =>
+      appProviderContainer.read(searchViewStateProvider).isSearchEmailRunning;
 
   void enableSearch() {
-    searchState.value = searchState.value.enableSearchState();
     _searchViewStateNotifier.enableSearch();
   }
 
@@ -356,31 +304,26 @@ class SearchController extends BaseController with DateRangePickerMixin {
   }
 
   void activateSimpleSearch() {
-    simpleSearchIsActivated.value = true;
     _searchViewStateNotifier.activateSimpleSearch();
   }
 
   void deactivateSimpleSearch() {
-    simpleSearchIsActivated.value = false;
     _searchViewStateNotifier.deactivateSimpleSearch();
   }
 
   void activateAdvancedSearch() {
-    advancedSearchIsActivated.value = true;
     _searchViewStateNotifier.activateAdvancedSearch();
   }
 
   void deactivateAdvancedSearch() {
-    advancedSearchIsActivated.value = false;
     _searchViewStateNotifier.deactivateAdvancedSearch();
   }
 
   void hideAdvancedSearchFormView() {
-    isAdvancedSearchViewOpen.value = false;
+    closeAdvanceSearch();
   }
 
   void hideSimpleSearchFormView() {
-    searchState.value = searchState.value.disableSearchState();
     _searchViewStateNotifier.disableSearch();
   }
 

--- a/lib/features/mailbox_dashboard/presentation/extensions/handle_reactive_obx_variable_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/handle_reactive_obx_variable_extension.dart
@@ -1,22 +1,30 @@
 
 import 'package:core/utils/app_logger.dart';
-import 'package:get/get_rx/src/rx_workers/rx_workers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/action/dashboard_action.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/action/thread_detail_ui_action.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 
 extension HandleReactiveObxVariableExtension on MailboxDashBoardController {
 
   void registerReactiveObxVariableListener() {
-    workerObxVariables.add(ever(
-      searchController.isAdvancedSearchViewOpen,
-      _onAdvancedSearchVisibleChanged
-    ));
+    advancedSearchViewSubscription ??= appProviderContainer.listen(
+      searchViewStateProvider.select((state) => state.isAdvancedSearchViewOpen),
+      (_, visible) => _onAdvancedSearchVisibleChanged(visible),
+    );
+    searchInputFocusSubscription ??= appProviderContainer.listen(
+      searchViewStateProvider.select((state) => state.isSearchInputFocused),
+      (_, focused) => onSearchInputFocusChanged(focused),
+    );
+  }
 
-    workerObxVariables.add(ever(
-      searchController.isSearchInputFocused,
-      onSearchInputFocusChanged
-    ));
+  void disposeReactiveSearchStateListeners() {
+    advancedSearchViewSubscription?.close();
+    searchInputFocusSubscription?.close();
+    advancedSearchViewSubscription = null;
+    searchInputFocusSubscription = null;
   }
 
   void _onAdvancedSearchVisibleChanged(bool visible) {

--- a/lib/features/mailbox_dashboard/presentation/extensions/quick_search_emails_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/quick_search_emails_extension.dart
@@ -7,7 +7,9 @@ import 'package:model/email/presentation_email.dart';
 import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/quick_search_email_state.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/search_controller.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 
 extension QuickSearchEmailsExtension on SearchController {
   Future<List<PresentationEmail>> quickSearchEmails({
@@ -16,8 +18,10 @@ extension QuickSearchEmailsExtension on SearchController {
     required String query,
     Set<MailboxId>? trashSpamMailboxIds,
   }) async {
-    currentSearchText = query;
-    final filter = searchEmailFilter.value;
+    appProviderContainer
+        .read(searchEmailPresentationProvider.notifier)
+        .setCurrentSearchText(query);
+    final filter = committedSearchFilter;
     return await quickSearchEmailInteractor.execute(
       session,
       accountId,

--- a/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view.dart
+++ b/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:focus_detector_v2/focus_detector_v2.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/email_view_empty_widget.dart';
@@ -12,6 +13,7 @@ import 'package:tmail_ui_user/features/search/email/presentation/search_email_vi
 import 'package:tmail_ui_user/features/sending_queue/presentation/sending_queue_view.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_view.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/thread_detail_view.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 
 class MailboxDashBoardView extends BaseMailboxDashBoardView {
   MailboxDashBoardView({Key? key}) : super(key: key);
@@ -35,8 +37,12 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
       child: Scaffold(
         drawerEnableOpenDragGesture:
             controller.responsiveUtils.hasLeftMenuDrawerActive(context),
-        body: Obx(() {
-          switch (controller.dashboardRoute.value) {
+        body: Consumer(builder: (context, ref, child) {
+          final isSearchEmailRunning = ref.watch(
+            searchViewStateProvider.select((state) => state.isSearchEmailRunning),
+          );
+          return Obx(() {
+            switch (controller.dashboardRoute.value) {
             case DashboardRoutes.thread:
               return buildResponsiveWithDrawer(
                 left: ThreadView(),
@@ -45,7 +51,7 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
               );
 
             case DashboardRoutes.threadDetailed:
-              return controller.searchController.isSearchEmailRunning
+              return isSearchEmailRunning
                   ? const ThreadDetailView()
                   : buildResponsiveWithDrawer(
                       left: ThreadView(),
@@ -61,7 +67,8 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
 
             case DashboardRoutes.waiting:
               return _loadingIndicator();
-          }
+            }
+          });
         }),
       ),
     );

--- a/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart
+++ b/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart
@@ -2,6 +2,7 @@ import 'package:core/core.dart';
 import 'package:cozy/cozy_config_manager/cozy_config_manager.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_portal/flutter_portal.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
@@ -61,6 +62,8 @@ import 'package:tmail_ui_user/features/thread/presentation/thread_view.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/thread_detail_view.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/delegates/mailbox_dashboard_provider_listener_delegate_factories.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/riverpod_widgets/mailbox_dashboard_provider_listener_widget.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
@@ -300,27 +303,32 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
                 ],
               ),
             ),
-            tabletLarge: Obx(() {
-              switch (controller.dashboardRoute.value) {
-                case DashboardRoutes.searchEmail:
-                  return const SearchEmailView();
-                case DashboardRoutes.threadDetailed:
-                  return controller.searchController.isSearchEmailRunning
-                      ? const ThreadDetailView()
-                      : buildResponsiveWithDrawer(
-                          left: ThreadView(),
-                          right: const ThreadDetailView(),
-                          mobile: const ThreadDetailView(),
-                        );
-                default:
-                  return controller.searchController.isSearchEmailRunning
-                      ? const ThreadDetailView()
-                      : buildResponsiveWithDrawer(
-                          left: ThreadView(),
-                          right: const EmailViewEmptyWidget(),
-                          mobile: ThreadView(),
-                        );
-              }
+            tabletLarge: Consumer(builder: (context, ref, child) {
+              final isSearchEmailRunning = ref.watch(
+                searchViewStateProvider.select((state) => state.isSearchEmailRunning),
+              );
+              return Obx(() {
+                switch (controller.dashboardRoute.value) {
+                  case DashboardRoutes.searchEmail:
+                    return const SearchEmailView();
+                  case DashboardRoutes.threadDetailed:
+                    return isSearchEmailRunning
+                        ? const ThreadDetailView()
+                        : buildResponsiveWithDrawer(
+                            left: ThreadView(),
+                            right: const ThreadDetailView(),
+                            mobile: const ThreadDetailView(),
+                          );
+                  default:
+                    return isSearchEmailRunning
+                        ? const ThreadDetailView()
+                        : buildResponsiveWithDrawer(
+                            left: ThreadView(),
+                            right: const EmailViewEmptyWidget(),
+                            mobile: ThreadView(),
+                          );
+                }
+              });
             }),
             mobile: Obx(() {
               switch(controller.dashboardRoute.value) {
@@ -485,24 +493,29 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
           );
         }
       }),
-      Obx(() {
-        final filterMessageCurrent = controller.filterMessageOption.value;
+      Consumer(builder: (context, ref, child) {
+        final isSearchEmailRunning = ref.watch(
+          searchViewStateProvider.select((state) => state.isSearchEmailRunning),
+        );
+        return Obx(() {
+          final filterMessageCurrent = controller.filterMessageOption.value;
 
-        if (controller.validateNoEmailsInTrashAndSpamFolder() ||
-            controller.searchController.isSearchEmailRunning) {
-          return const SizedBox.shrink();
-        } else {
-          return Padding(
-            padding: FilterMessageButtonStyle.buttonMargin,
-            child: FilterMessageButton(
-              filterMessageOption: filterMessageCurrent,
-              imagePaths: controller.imagePaths,
-              isSelected: filterMessageCurrent != FilterMessageOption.all,
-              onSelectFilterMessageOptionAction: _onSelectFilterMessageOptionAction,
-              onDeleteFilterMessageOptionAction: (_) => _onDeleteFilterMessageOptionAction(),
-            ),
-          );
-        }
+          if (controller.validateNoEmailsInTrashAndSpamFolder() ||
+              isSearchEmailRunning) {
+            return const SizedBox.shrink();
+          } else {
+            return Padding(
+              padding: FilterMessageButtonStyle.buttonMargin,
+              child: FilterMessageButton(
+                filterMessageOption: filterMessageCurrent,
+                imagePaths: controller.imagePaths,
+                isSelected: filterMessageCurrent != FilterMessageOption.all,
+                onSelectFilterMessageOptionAction: _onSelectFilterMessageOptionAction,
+                onDeleteFilterMessageOptionAction: (_) => _onDeleteFilterMessageOptionAction(),
+              ),
+            );
+          }
+        });
       }),
       Obx(() {
         if (controller.selectedMailbox.value?.isTrashPersonal == true) {
@@ -519,19 +532,23 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
           return const SizedBox.shrink();
         }
       }),
-      Obx(() {
-        if (controller.searchController.isSearchEmailRunning &&
-            controller.dashboardRoute.value == DashboardRoutes.thread) {
-          return Padding(
-            padding: const EdgeInsetsDirectional.only(start: 16),
-            child: _buildQuickSearchFilterButton(
-              context,
-              QuickSearchFilter.sortBy,
-            ),
-          );
-        } else {
-          return const SizedBox.shrink();
-        }
+      Consumer(builder: (context, ref, child) {
+        final isSearchEmailRunning = ref.watch(
+          searchViewStateProvider.select((state) => state.isSearchEmailRunning),
+        );
+        return Obx(() {
+          if (_isQuickSearchFilterVisible(isSearchEmailRunning)) {
+            return Padding(
+              padding: const EdgeInsetsDirectional.only(start: 16),
+              child: _buildQuickSearchFilterButton(
+                context,
+                QuickSearchFilter.sortBy,
+              ),
+            );
+          } else {
+            return const SizedBox.shrink();
+          }
+        });
       })
     ]);
   }
@@ -656,119 +673,140 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
   }
 
   Widget _buildListButtonQuickSearchFilter(BuildContext context) {
-    return Obx(() {
-      final isSearchEmailRunning =
-          controller.searchController.isSearchEmailRunning;
-      final isThreadRoute =
-          controller.dashboardRoute.value == DashboardRoutes.thread;
-      final isLabelAvailable = controller.isLabelAvailable;
-      final labelList = controller.labelController.labels;
+    return Consumer(builder: (context, ref, child) {
+      final isSearchEmailRunning = ref.watch(
+        searchViewStateProvider.select((state) => state.isSearchEmailRunning),
+      );
+      final isSearchFilterApplied = ref.watch(
+        searchFilterProvider.select((filter) => filter.isApplied),
+      );
+      return Obx(() {
+        if (!_isQuickSearchFilterVisible(isSearchEmailRunning)) {
+          return const SizedBox.shrink();
+        }
 
-      if (isSearchEmailRunning && isThreadRoute) {
         return Padding(
           padding: const EdgeInsetsDirectional.only(end: 16),
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Flexible(
-                child: SizedBox(
-                  height: 45,
-                  child: ScrollbarListView(
-                    scrollBehavior: ScrollConfiguration.of(context).copyWith(
-                      dragDevices: {
-                        PointerDeviceKind.touch,
-                        PointerDeviceKind.mouse,
-                        PointerDeviceKind.trackpad
-                      },
-                      scrollbars: false
-                    ),
-                    scrollController: controller.listSearchFilterScrollController!,
-                    child: ListView(
-                      scrollDirection: Axis.horizontal,
-                      shrinkWrap: true,
-                      padding: const EdgeInsetsDirectional.only(bottom: 10),
-                      controller: controller.listSearchFilterScrollController!,
-                      children: [
-                        _buildQuickSearchFilterButton(context, QuickSearchFilter.folder),
-                        MailboxDashboardViewWebStyle.searchFilterSizeBoxMargin,
-                        if (isLabelAvailable && labelList.isNotEmpty)
-                          ...[
-                            _buildQuickSearchFilterButton(
-                              context,
-                              QuickSearchFilter.labels,
-                            ),
-                            MailboxDashboardViewWebStyle.searchFilterSizeBoxMargin,
-                          ],
-                        _buildQuickSearchFilterButton(context, QuickSearchFilter.from),
-                        MailboxDashboardViewWebStyle.searchFilterSizeBoxMargin,
-                        _buildQuickSearchFilterButton(context, QuickSearchFilter.to),
-                        MailboxDashboardViewWebStyle.searchFilterSizeBoxMargin,
-                        _buildQuickSearchFilterButton(context, QuickSearchFilter.dateTime),
-                        MailboxDashboardViewWebStyle.searchFilterSizeBoxMargin,
-                        _buildQuickSearchFilterButton(context, QuickSearchFilter.hasAttachment),
-                        MailboxDashboardViewWebStyle.searchFilterSizeBoxMargin,
-                        _buildQuickSearchFilterButton(context, QuickSearchFilter.starred),
-                        MailboxDashboardViewWebStyle.searchFilterSizeBoxMargin,
-                        _buildQuickSearchFilterButton(context, QuickSearchFilter.unread),
-                        MailboxDashboardViewWebStyle.searchFilterSizeBoxMargin,
-                        _buildQuickSearchFilterButton(
-                          context,
-                          QuickSearchFilter.events,
-                        ),
-                      ],
-                    ),
-                  ),
-                )
-              ),
-              if (controller.isSearchFilterHasApplied)
-                TMailButtonWidget.fromText(
-                  text: AppLocalizations.of(context).clearFilter,
-                  backgroundColor: Colors.transparent,
-                  margin: const EdgeInsetsDirectional.only(start: 8),
-                  borderRadius: 10,
-                  textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
-                    color: AppColor.primaryColor,
-                    fontSize: 13,
-                    fontWeight: FontWeight.w500),
-                  onTapActionCallback: controller.clearAllSearchFilterApplied)
-              else
-                TMailButtonWidget.fromText(
-                  text: AppLocalizations.of(context).advancedSearch,
-                  backgroundColor: Colors.transparent,
-                  margin: const EdgeInsetsDirectional.only(start: 8),
-                  borderRadius: 10,
-                  textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
-                    color: AppColor.primaryColor,
-                    fontSize: 13,
-                    fontWeight: FontWeight.w500),
-                  onTapActionCallback: controller.openAdvancedSearchView)
-            ]
+              _buildQuickSearchFilterList(context),
+              _buildSearchFilterActionButton(context, isSearchFilterApplied),
+            ],
           ),
         );
-      } else {
-        return const SizedBox.shrink();
-      }
+      });
     });
+  }
+
+  bool _isQuickSearchFilterVisible(bool isSearchEmailRunning) {
+    // Read dashboardRoute.value unconditionally so the enclosing Obx always
+    // subscribes to it; a short-circuit on isSearchEmailRunning (a non-observable
+    // Riverpod value) would otherwise leave the Obx with no observable and crash.
+    final isThreadRoute =
+        controller.dashboardRoute.value == DashboardRoutes.thread;
+    return isSearchEmailRunning && isThreadRoute;
+  }
+
+  Widget _buildQuickSearchFilterList(BuildContext context) {
+    final showLabelFilter = controller.isLabelAvailable &&
+        controller.labelController.labels.isNotEmpty;
+
+    return Flexible(
+      child: SizedBox(
+        height: 45,
+        child: ScrollbarListView(
+          scrollBehavior: ScrollConfiguration.of(context).copyWith(
+            dragDevices: {
+              PointerDeviceKind.touch,
+              PointerDeviceKind.mouse,
+              PointerDeviceKind.trackpad,
+            },
+            scrollbars: false,
+          ),
+          scrollController: controller.listSearchFilterScrollController!,
+          child: ListView(
+            scrollDirection: Axis.horizontal,
+            shrinkWrap: true,
+            padding: const EdgeInsetsDirectional.only(bottom: 10),
+            controller: controller.listSearchFilterScrollController!,
+            children: _buildQuickSearchFilterButtons(context, showLabelFilter),
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildQuickSearchFilterButtons(
+    BuildContext context,
+    bool showLabelFilter,
+  ) {
+    final quickSearchFilters = <QuickSearchFilter>[
+      QuickSearchFilter.folder,
+      if (showLabelFilter) QuickSearchFilter.labels,
+      QuickSearchFilter.from,
+      QuickSearchFilter.to,
+      QuickSearchFilter.dateTime,
+      QuickSearchFilter.hasAttachment,
+      QuickSearchFilter.starred,
+      QuickSearchFilter.unread,
+      QuickSearchFilter.events,
+    ];
+
+    return [
+      for (final filter in quickSearchFilters) ...[
+        if (filter != quickSearchFilters.first)
+          MailboxDashboardViewWebStyle.searchFilterSizeBoxMargin,
+        _buildQuickSearchFilterButton(context, filter),
+      ],
+    ];
+  }
+
+  Widget _buildSearchFilterActionButton(
+    BuildContext context,
+    bool isSearchFilterApplied,
+  ) {
+    final isMessageFilterApplied =
+        controller.filterMessageOption.value != FilterMessageOption.all;
+    final showClearFilter = isSearchFilterApplied || isMessageFilterApplied;
+    final localizations = AppLocalizations.of(context);
+
+    return TMailButtonWidget.fromText(
+      text: showClearFilter
+          ? localizations.clearFilter
+          : localizations.advancedSearch,
+      backgroundColor: Colors.transparent,
+      margin: const EdgeInsetsDirectional.only(start: 8),
+      borderRadius: 10,
+      textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+        color: AppColor.primaryColor,
+        fontSize: 13,
+        fontWeight: FontWeight.w500,
+      ),
+      onTapActionCallback: showClearFilter
+          ? controller.clearAllSearchFilterApplied
+          : controller.openAdvancedSearchView,
+    );
   }
 
   Widget _buildQuickSearchFilterButton(
     BuildContext context,
     QuickSearchFilter searchFilter,
   ) {
-    return Obx(() {
-      final searchEmailFilter = controller.searchController.searchEmailFilter.value;
-      final sortOrderType = controller.searchController.sortOrderFiltered;
-      final listAddressOfFrom = controller.searchController.listAddressOfFromFiltered;
+    return Consumer(builder: (context, ref, child) {
+      final searchEmailFilter = ref.watch(searchFilterProvider);
+      final sortOrderType = searchEmailFilter.sortOrderType;
+      final listAddressOfFrom = searchEmailFilter.from;
       final currentUserEmail = controller.sessionCurrent?.getOwnEmailAddressOrEmpty();
-      final startDate = controller.searchController.startDateFiltered;
-      final endDate = controller.searchController.endDateFiltered;
-      final receiveTimeType = controller.searchController.receiveTimeFiltered;
-      final mailbox = controller.searchController.mailboxFiltered;
-      final label = controller.searchController.labelFiltered;
-      final listAddressOfTo = controller.searchController.listAddressOfToFiltered;
-      final listHasKeywordFiltered = controller.searchController.listHasKeywordFiltered;
-      final unreadFiltered = controller.searchController.unreadFiltered;
-      final notIncludeEventsFiltered = controller.searchController.notIncludeEventsFiltered;
+      final startDate = searchEmailFilter.startDate?.value.toLocal();
+      final endDate = searchEmailFilter.endDate?.value.toLocal();
+      final receiveTimeType = searchEmailFilter.emailReceiveTimeType;
+      final mailbox = searchEmailFilter.mailbox;
+      final label = searchEmailFilter.label;
+      final listAddressOfTo = searchEmailFilter.to;
+      final listHasKeywordFiltered = searchEmailFilter.hasKeyword;
+      final unreadFiltered = searchEmailFilter.unread;
+      final notIncludeEventsFiltered = searchEmailFilter.notIncludeEvents;
 
       final isSelected = searchFilter.isSelected(
         context,

--- a/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart
+++ b/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart
@@ -65,6 +65,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/riverpod_w
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
 class MailboxDashBoardView extends BaseMailboxDashBoardView {
@@ -900,7 +901,8 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
         break;
       case QuickSearchFilter.labels:
         final listLabels = controller.labelController.labels;
-        final selectedLabel = controller.searchController.labelFiltered;
+        final selectedLabel =
+            appProviderContainer.read(searchFilterProvider).label;
 
         controller.openLabelsFilterModal(
           context: context,
@@ -917,13 +919,15 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
   }
 
   void _openPopupMenuDateFilter(BuildContext context, RelativeRect position) {
+    final selectedReceiveTime =
+        appProviderContainer.read(searchFilterProvider).emailReceiveTimeType;
     final popupMenuItems = EmailReceiveTimeType.valuesForSearch.map((timeType) {
       return PopupMenuItem(
         padding: EdgeInsets.zero,
         child: PopupMenuItemActionWidget(
           menuAction: PopupMenuItemDateFilterAction(
             timeType,
-            controller.searchController.receiveTimeFiltered,
+            selectedReceiveTime,
             AppLocalizations.of(context),
             controller.imagePaths,
           ),
@@ -942,13 +946,15 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
   }
 
   void _openPopupMenuSortFilter(BuildContext context, RelativeRect position) {
+    final selectedSortOrder =
+        appProviderContainer.read(searchFilterProvider).sortOrderType;
     final popupMenuItems = EmailSortOrderType.values.map((sortType) {
       return PopupMenuItem(
         padding: EdgeInsets.zero,
         child: PopupMenuItemActionWidget(
           menuAction: PopupMenuItemSortOrderTypeAction(
             sortType,
-            controller.searchController.sortOrderFiltered,
+            selectedSortOrder,
             AppLocalizations.of(context),
             controller.imagePaths,
           ),

--- a/lib/features/mailbox_dashboard/presentation/model/search/advanced_filter_view_state.dart
+++ b/lib/features/mailbox_dashboard/presentation/model/search/advanced_filter_view_state.dart
@@ -1,0 +1,31 @@
+import 'package:equatable/equatable.dart';
+import 'package:model/mailbox/expand_mode.dart';
+
+class AdvancedFilterViewState with EquatableMixin {
+  final ExpandMode fromAddressExpandMode;
+  final ExpandMode toAddressExpandMode;
+
+  const AdvancedFilterViewState({
+    required this.fromAddressExpandMode,
+    required this.toAddressExpandMode,
+  });
+
+  factory AdvancedFilterViewState.initial() => const AdvancedFilterViewState(
+        fromAddressExpandMode: ExpandMode.EXPAND,
+        toAddressExpandMode: ExpandMode.EXPAND,
+      );
+
+  AdvancedFilterViewState copyWith({
+    ExpandMode? fromAddressExpandMode,
+    ExpandMode? toAddressExpandMode,
+  }) {
+    return AdvancedFilterViewState(
+      fromAddressExpandMode:
+          fromAddressExpandMode ?? this.fromAddressExpandMode,
+      toAddressExpandMode: toAddressExpandMode ?? this.toAddressExpandMode,
+    );
+  }
+
+  @override
+  List<Object?> get props => [fromAddressExpandMode, toAddressExpandMode];
+}

--- a/lib/features/mailbox_dashboard/presentation/notifier/advanced_filter_view_state_notifier.dart
+++ b/lib/features/mailbox_dashboard/presentation/notifier/advanced_filter_view_state_notifier.dart
@@ -1,0 +1,24 @@
+import 'package:model/mailbox/expand_mode.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/advanced_filter_view_state.dart';
+
+part 'advanced_filter_view_state_notifier.g.dart';
+
+@Riverpod(keepAlive: true)
+class AdvancedFilterViewStateNotifier
+    extends _$AdvancedFilterViewStateNotifier {
+  @override
+  AdvancedFilterViewState build() => AdvancedFilterViewState.initial();
+
+  void setFromAddressExpandMode(ExpandMode mode) {
+    state = state.copyWith(fromAddressExpandMode: mode);
+  }
+
+  void setToAddressExpandMode(ExpandMode mode) {
+    state = state.copyWith(toAddressExpandMode: mode);
+  }
+
+  void reset() {
+    state = AdvancedFilterViewState.initial();
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/notifier/advanced_filter_view_state_notifier.dart
+++ b/lib/features/mailbox_dashboard/presentation/notifier/advanced_filter_view_state_notifier.dart
@@ -1,14 +1,20 @@
 import 'package:model/mailbox/expand_mode.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/advanced_filter_view_state.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
 
 part 'advanced_filter_view_state_notifier.g.dart';
 
-@Riverpod(keepAlive: true)
+/// View-state SSOT for the advanced-search form's address expand modes.
+///
+/// Autodisposes with the form: the initial expand mode is derived from the
+/// committed filter each time the form (re)mounts, and every mutation happens
+/// while the form is on screen, so there is no state to preserve across closes.
+@riverpod
 class AdvancedFilterViewStateNotifier
     extends _$AdvancedFilterViewStateNotifier {
   @override
-  AdvancedFilterViewState build() => AdvancedFilterViewState.initial();
+  AdvancedFilterViewState build() => _deriveFromCommittedFilter();
 
   void setFromAddressExpandMode(ExpandMode mode) {
     state = state.copyWith(fromAddressExpandMode: mode);
@@ -19,6 +25,20 @@ class AdvancedFilterViewStateNotifier
   }
 
   void reset() {
-    state = AdvancedFilterViewState.initial();
+    state = _deriveFromCommittedFilter();
   }
+
+  /// A field with committed addresses opens collapsed to a summary; an empty
+  /// field opens expanded for input. Reads once (no [ref.watch]) so later filter
+  /// edits do not override focus-driven expand state.
+  AdvancedFilterViewState _deriveFromCommittedFilter() {
+    final filter = ref.read(searchFilterProvider);
+    return AdvancedFilterViewState(
+      fromAddressExpandMode: _expandModeFor(filter.from.isEmpty),
+      toAddressExpandMode: _expandModeFor(filter.to.isEmpty),
+    );
+  }
+
+  ExpandMode _expandModeFor(bool isEmpty) =>
+      isEmpty ? ExpandMode.EXPAND : ExpandMode.COLLAPSE;
 }

--- a/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_input_form.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_input_form.dart
@@ -13,6 +13,7 @@ import 'package:tmail_ui_user/features/mailbox/presentation/extensions/presentat
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/advanced_filter_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_field_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_filter_form_bottom_view.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/advanced_search/label_drop_down_button.dart';
@@ -22,7 +23,7 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 typedef _AddressFieldConfig = ({
   List<EmailAddress> Function(WidgetRef ref) listEmailAddress,
-  ExpandMode Function() expandMode,
+  ExpandMode Function(WidgetRef ref) expandMode,
   TextEditingController textEditingController,
   GlobalKey<TagsEditorState> keyTagEditor,
   FocusNode focusNode,
@@ -69,7 +70,9 @@ class AdvancedSearchInputForm extends GetWidget<AdvancedFilterController> {
       config: (
         listEmailAddress: (ref) => _toEmailAddresses(ref.watch(
           searchFilterProvider.select((filter) => filter.from))),
-        expandMode: () => controller.fromAddressExpandMode.value,
+        expandMode: (ref) => ref.watch(advancedFilterViewStateProvider.select(
+          (state) => state.fromAddressExpandMode,
+        )),
         textEditingController: controller.fromEmailAddressController,
         keyTagEditor: controller.keyFromEmailTagEditor,
         focusNode: controller.focusManager.fromFieldFocusNode,
@@ -81,7 +84,9 @@ class AdvancedSearchInputForm extends GetWidget<AdvancedFilterController> {
       config: (
         listEmailAddress: (ref) => _toEmailAddresses(ref.watch(
           searchFilterProvider.select((filter) => filter.to))),
-        expandMode: () => controller.toAddressExpandMode.value,
+        expandMode: (ref) => ref.watch(advancedFilterViewStateProvider.select(
+          (state) => state.toAddressExpandMode,
+        )),
         textEditingController: controller.toEmailAddressController,
         keyTagEditor: controller.keyToEmailTagEditor,
         focusNode: controller.focusManager.toFieldFocusNode,
@@ -125,10 +130,10 @@ class AdvancedSearchInputForm extends GetWidget<AdvancedFilterController> {
       useHeight: false,
       child: Consumer(builder: (context, ref, _) {
         final listEmailAddress = config.listEmailAddress(ref);
-        return Obx(() => DefaultAutocompleteInputFieldWidget(
+        return DefaultAutocompleteInputFieldWidget(
           field: field,
           listEmailAddress: listEmailAddress,
-          expandMode: config.expandMode(),
+          expandMode: config.expandMode(ref),
           minInputLengthAutocomplete: controller
             .mailboxDashBoardController
             .minInputLengthAutocomplete,
@@ -150,7 +155,7 @@ class AdvancedSearchInputForm extends GetWidget<AdvancedFilterController> {
               controller.removeDraggableEmailAddress(
                 draggableEmailAddress,
                 ref.read(searchFilterProvider.notifier)),
-        ));
+        );
       }),
     );
   }

--- a/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_input_form.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_input_form.dart
@@ -141,7 +141,10 @@ class AdvancedSearchInputForm extends GetWidget<AdvancedFilterController> {
           focusNode: config.focusNode,
           nextFocusNode: config.nextFocusNode,
           keyTagEditor: config.keyTagEditor,
-          onShowFullListEmailAddressAction: controller.showFullEmailAddress,
+          onShowFullListEmailAddressAction: (field) =>
+              controller.showFullEmailAddress(
+                field,
+                ref.read(advancedFilterViewStateProvider.notifier)),
           onUpdateListEmailAddressAction: (field, listEmailAddress) =>
               controller.updateListEmailAddress(
                 field,
@@ -154,7 +157,8 @@ class AdvancedSearchInputForm extends GetWidget<AdvancedFilterController> {
           onRemoveDraggableEmailAddressAction: (draggableEmailAddress) =>
               controller.removeDraggableEmailAddress(
                 draggableEmailAddress,
-                ref.read(searchFilterProvider.notifier)),
+                ref.read(searchFilterProvider.notifier),
+                ref.read(advancedFilterViewStateProvider.notifier)),
         );
       }),
     );

--- a/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/icon_open_advanced_search_widget.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/icon_open_advanced_search_widget.dart
@@ -3,10 +3,12 @@ import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/search_controller.dart'  as search;
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 
 class IconOpenAdvancedSearchWidget extends StatelessWidget {
   IconOpenAdvancedSearchWidget({Key? key}) : super(key: key);
@@ -17,8 +19,9 @@ class IconOpenAdvancedSearchWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Obx(() {
-      if (searchController.isAdvancedSearchViewOpen.isTrue) {
+    return Consumer(builder: (context, ref, child) {
+      final searchViewState = ref.watch(searchViewStateProvider);
+      if (searchViewState.isAdvancedSearchViewOpen) {
         return const SizedBox.shrink();
       }
 
@@ -26,7 +29,7 @@ class IconOpenAdvancedSearchWidget extends StatelessWidget {
         key: const ValueKey(UiKeys.openAdvancedSearchButton),
         icon: _imagePaths.icFilterAdvanced,
         iconSize: 22,
-        iconColor: searchController.advancedSearchIsActivated.isTrue
+        iconColor: searchViewState.advancedSearchIsActivated
           ? AppColor.primaryMain
           : AppColor.steelGray400,
         padding: const EdgeInsets.all(4),

--- a/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
@@ -13,6 +13,7 @@ import 'package:core/presentation/views/quick_search/quick_search_text_field_con
 import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/direction_utils.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_portal/flutter_portal.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
@@ -29,6 +30,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_keyboard_shortcut_actions_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_constants.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_filter_overlay.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/advanced_search/icon_open_advanced_search_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/quick_search/contact_quick_search_item.dart';
@@ -36,6 +38,8 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/qu
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/quick_search/recent_search_item_tile_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_filters/search_filter_button.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
@@ -55,7 +59,11 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
 
   @override
   Widget build(BuildContext context) {
-    return Obx(() {
+    return Consumer(builder: (context, ref, child) {
+      final searchViewState = ref.watch(searchViewStateProvider);
+      final currentSearchText = ref.watch(searchEmailPresentationProvider.select(
+        (state) => state.currentSearchText,
+      ));
       Widget searchInputForm = QuickSearchInputForm<PresentationEmail, EmailAddress, RecentSearch>(
         maxHeight: 52,
         suggestionsBoxVerticalOffset: 0.0,
@@ -134,7 +142,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
         itemBuilder: (context, email) => EmailQuickSearchItemTileWidget(
             email,
             _dashBoardController.selectedMailbox.value,
-            searchQuery: SearchQuery(_searchController.currentSearchText.trim())),
+            searchQuery: SearchQuery(currentSearchText.trim())),
         onSuggestionSelected: _invokeSelectSuggestionItem,
         contactItemBuilder: (context, emailAddress) => ContactQuickSearchItem(emailAddress: emailAddress),
         contactSuggestionsCallback: _dashBoardController.getContactSuggestion,
@@ -150,7 +158,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
       }
 
       return PortalTarget(
-        visible: _searchController.isAdvancedSearchViewOpen.isTrue,
+        visible: searchViewState.isAdvancedSearchViewOpen,
         portalFollower: PointerInterceptor(
           child: GestureDetector(
             behavior: HitTestBehavior.opaque,
@@ -158,7 +166,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
           ),
         ),
         child: PortalTarget(
-          visible: _searchController.isAdvancedSearchViewOpen.isTrue,
+          visible: searchViewState.isAdvancedSearchViewOpen,
           anchor: const Aligned(
             follower: Alignment.topRight,
             target: Alignment.bottomRight,
@@ -301,10 +309,11 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
     QuickSearchFilter searchFilter,
     QuickSearchSuggestionListState suggestionsListState
   ) {
-    return Obx(() {
+    return Consumer(builder: (context, ref, child) {
+      final searchEmailFilter = ref.watch(searchFilterProvider);
       final isSelected = searchFilter.isSelected(
         context,
-        _searchController.searchEmailFilter.value,
+        searchEmailFilter,
         _searchController.sortOrderFiltered,
         _dashBoardController.ownEmailAddress.value,
       );

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -73,6 +73,8 @@ import 'package:tmail_ui_user/features/search/email/presentation/service/search_
 import 'package:tmail_ui_user/features/search/email/presentation/service/search_execution_observer.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/service/search_executor_service.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/providers/search_executor_provider.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/thread/presentation/extensions/handle_email_filter_extension.dart';
 import 'package:tmail_ui_user/features/thread/presentation/extensions/handle_keyboard_shortcut_actions_extension.dart';
 import 'package:tmail_ui_user/features/thread/presentation/extensions/list_presentation_email_extensions.dart';
@@ -83,6 +85,7 @@ import 'package:tmail_ui_user/features/thread/presentation/model/delete_action_t
 import 'package:tmail_ui_user/features/thread/presentation/model/loading_more_status.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/mail_list_shortcut_action_view_event.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/search_status.dart';
+import 'package:tmail_ui_user/features/thread/presentation/model/search_state.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/method_level_exception.dart';
 import 'package:tmail_ui_user/main/routes/app_routes.dart';
 import 'package:tmail_ui_user/main/routes/navigation_router.dart';
@@ -112,7 +115,7 @@ class ThreadController extends BaseController with EmailActionController {
   final loadingMoreStatus = Rx(LoadingMoreStatus.idle);
 
   bool canLoadMore = true;
-  bool canSearchMore = true;
+  ProviderSubscription<SearchState>? _searchStateSubscription;
   MailboxId? _currentMemoryMailboxId;
   int _peakEmailCount = 0;
   final ScrollController listEmailController = ScrollController();
@@ -139,7 +142,10 @@ class ThreadController extends BaseController with EmailActionController {
 
   search.SearchController get searchController => mailboxDashBoardController.searchController;
 
-  SearchEmailFilter get _searchEmailFilter => searchController.searchEmailFilter.value;
+  SearchEmailFilter get _searchEmailFilter => searchController.committedSearchFilter;
+
+  bool get canSearchMore =>
+      appProviderContainer.read(searchEmailPresentationProvider).canSearchMore;
 
   bool get _isCollapseThreadsEnabled =>
       appProviderContainer.read(localSettingsProvider).threadConfig.isEnabled;
@@ -194,6 +200,7 @@ class ThreadController extends BaseController with EmailActionController {
     }
     _webSocketQueueHandler?.dispose();
     _localSettingsSubscription?.close();
+    _searchStateSubscription?.close();
     if (PlatformInfo.isWeb) {
       _searchService.unregister(_searchExecutionObserver);
     }
@@ -306,11 +313,14 @@ class ThreadController extends BaseController with EmailActionController {
       }
     });
 
-    ever(searchController.searchState, (searchState) {
+    _searchStateSubscription = appProviderContainer.listen(
+      searchViewStateProvider.select((state) => state.searchState),
+      (_, searchState) {
       if (searchState.searchStatus == SearchStatus.ACTIVE) {
         cancelSelectEmail();
       }
-    });
+      },
+    );
 
     ever(mailboxDashBoardController.dashBoardAction, (action) {
       if (action is SelectionAllEmailAction) {
@@ -363,7 +373,9 @@ class ThreadController extends BaseController with EmailActionController {
         if (listEmailController.hasClients) {
           listEmailController.jumpTo(0);
         }
-        canSearchMore = true;
+        appProviderContainer
+            .read(searchEmailPresentationProvider.notifier)
+            .resetSearchMore();
         mailboxDashBoardController.emailsInCurrentMailbox.clear();
       } else if (action is ReclaimMailListKeyboardShortcutFocusAction) {
         refocusMailShortcutFocus();
@@ -605,7 +617,9 @@ class ThreadController extends BaseController with EmailActionController {
     mailboxDashBoardController.listEmailSelected.clear();
     mailboxDashBoardController.currentSelectMode.value = SelectMode.INACTIVE;
     canLoadMore = true;
-    canSearchMore = true;
+    appProviderContainer
+        .read(searchEmailPresentationProvider.notifier)
+        .resetSearchMore();
     loadingMoreStatus.value = LoadingMoreStatus.idle;
   }
 

--- a/lib/features/thread/presentation/thread_search_execution_observer.dart
+++ b/lib/features/thread/presentation/thread_search_execution_observer.dart
@@ -24,7 +24,9 @@ class ThreadSearchExecutionObserver implements SearchExecutionObserver {
       _controller.listEmailController.jumpTo(0);
     }
     _controller.mailboxDashBoardController.emailsInCurrentMailbox.clear();
-    _controller.canSearchMore = true;
+    appProviderContainer
+        .read(searchEmailPresentationProvider.notifier)
+        .resetSearchMore();
     _controller.loadingMoreStatus.value = LoadingMoreStatus.idle;
     _controller.searchController.activateSimpleSearch();
   }
@@ -66,7 +68,9 @@ class ThreadSearchExecutionObserver implements SearchExecutionObserver {
           _controller.listEmailSelected;
     }
 
-    _controller.canSearchMore = result.canLoadMore;
+    appProviderContainer
+        .read(searchEmailPresentationProvider.notifier)
+        .setCanSearchMore(result.canLoadMore);
     _controller.loadingMoreStatus.value =
         result.loadMore == LoadMoreState.inProgress
             ? LoadingMoreStatus.running
@@ -83,7 +87,9 @@ class ThreadSearchExecutionObserver implements SearchExecutionObserver {
     final failure = asSearchEmailFailure(error);
     _controller.mailboxDashBoardController
         .updateRefreshAllEmailState(Left(RefreshAllEmailFailure()));
-    _controller.canSearchMore = false;
+    appProviderContainer
+        .read(searchEmailPresentationProvider.notifier)
+        .setCanSearchMore(false);
     _controller.loadingMoreStatus.value = LoadingMoreStatus.idle;
     _controller.mailboxDashBoardController.emailsInCurrentMailbox.clear();
     // Clear the loading state so the spinner stops on a failed search too.

--- a/lib/features/thread/presentation/thread_view.dart
+++ b/lib/features/thread/presentation/thread_view.dart
@@ -1,6 +1,7 @@
 import 'package:core/core.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_portal/flutter_portal.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
@@ -30,6 +31,8 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/open_and_close_composer_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/empty_trash_banner_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/recover_deleted_message_loading_banner_widget.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/extensions/vacation_response_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/vacation/widgets/vacation_notification_message_widget.dart';
 import 'package:tmail_ui_user/features/network_connection/presentation/network_connection_banner_widget.dart';
@@ -321,16 +324,18 @@ class ThreadView extends GetWidget<ThreadController>
       return const SizedBox.shrink();
     }
 
-    return Obx(() {
-      final isAdvancedSearchViewOpen = controller.searchController.isAdvancedSearchViewOpen.value;
-      final isTrashViewOpen = controller.isMailboxTrash;
-      final isSelectModeActive = controller.mailboxDashBoardController.currentSelectMode.value == SelectMode.ACTIVE;
-      if (
-        !controller.searchController.isSearchActive()
-        && !isAdvancedSearchViewOpen
-        && !isTrashViewOpen
-        && !isSelectModeActive
-      ) {
+    return Consumer(builder: (context, ref, child) {
+      final isSearchActive = ref.watch(
+        searchViewStateProvider.select((state) => state.isSearchActive),
+      );
+      final isAdvancedSearchViewOpen = ref.watch(
+        searchViewStateProvider.select((state) => state.isAdvancedSearchViewOpen),
+      );
+      return Obx(() {
+      if (_canShowComposeButton(
+        isSearchActive: isSearchActive,
+        isAdvancedSearchViewOpen: isAdvancedSearchViewOpen,
+      )) {
         return Container(
           padding: PlatformInfo.isMobile && controller.listEmailSelected.isNotEmpty
             ? EdgeInsets.only(bottom: controller.responsiveUtils.isTabletLarge(context) ? 85 : 70)
@@ -344,7 +349,19 @@ class ThreadView extends GetWidget<ThreadController>
       } else {
         return const SizedBox.shrink();
       }
+      });
     });
+  }
+
+  bool _canShowComposeButton({
+    required bool isSearchActive,
+    required bool isAdvancedSearchViewOpen,
+  }) {
+    if (isSearchActive) return false;
+    if (isAdvancedSearchViewOpen) return false;
+    if (controller.isMailboxTrash) return false;
+    return controller.mailboxDashBoardController.currentSelectMode.value !=
+        SelectMode.ACTIVE;
   }
 
   Widget _buildResultListEmail(BuildContext context, List<PresentationEmail> listPresentationEmail) {
@@ -443,25 +460,45 @@ class ThreadView extends GetWidget<ThreadController>
   }
 
   Widget _buildLoadMoreButton(BuildContext context, LoadingMoreStatus loadingMoreStatus) {
-    if (((controller.canLoadMore && !controller.isSearchActive) ||
-        (controller.canSearchMore && controller.isSearchActive)) &&
-        !loadingMoreStatus.isRunning) {
-      return Center(
-        child: OutlinedButton(
-          style: OutlinedButton.styleFrom(
-            backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-          ),
-          onPressed: controller.handleLoadMoreEmailsRequest,
-          child: Text(
-            AppLocalizations.of(context).loadMore,
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: Colors.black
-            )
-          ),
-        ),
+    return Consumer(builder: (context, ref, child) {
+      final isSearchEmailRunning = ref.watch(
+        searchViewStateProvider.select((state) => state.isSearchEmailRunning),
       );
-    }
-    return const SizedBox.shrink();
+      final canSearchMore = ref.watch(
+        searchEmailPresentationProvider.select((state) => state.canSearchMore),
+      );
+      if (_canShowLoadMoreButton(
+        isSearchEmailRunning: isSearchEmailRunning,
+        canSearchMore: canSearchMore,
+        loadingMoreStatus: loadingMoreStatus,
+      )) {
+        return Center(
+          child: OutlinedButton(
+            style: OutlinedButton.styleFrom(
+              backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+            ),
+            onPressed: controller.handleLoadMoreEmailsRequest,
+            child: Text(
+              AppLocalizations.of(context).loadMore,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: Colors.black
+              )
+            ),
+          ),
+        );
+      }
+      return const SizedBox.shrink();
+    });
+  }
+
+  bool _canShowLoadMoreButton({
+    required bool isSearchEmailRunning,
+    required bool canSearchMore,
+    required LoadingMoreStatus loadingMoreStatus,
+  }) {
+    if (loadingMoreStatus.isRunning) return false;
+    if (isSearchEmailRunning) return canSearchMore;
+    return controller.canLoadMore;
   }
 
   Widget _buildLoadMoreProgressBar(LoadingMoreStatus loadingMoreStatus) {
@@ -503,7 +540,11 @@ class ThreadView extends GetWidget<ThreadController>
   Widget _buildEmailItemWhenDragging(BuildContext context, PresentationEmail presentationEmail) {
     final dashboardController = controller.mailboxDashBoardController;
 
-    return Obx(() {
+    return Consumer(builder: (context, ref, child) {
+      final isSearchEmailRunning = ref.watch(
+        searchViewStateProvider.select((state) => state.isSearchEmailRunning),
+      );
+      return Obx(() {
       final selectAllMode = dashboardController.currentSelectMode.value;
 
       final isSenderImportantFlagEnabled =
@@ -511,9 +552,6 @@ class ThreadView extends GetWidget<ThreadController>
 
       final isShowingEmailContent =
           dashboardController.selectedEmail.value?.id == presentationEmail.id;
-
-      final isSearchEmailRunning =
-          controller.searchController.isSearchEmailRunning;
 
       final isAINeedsActionEnabled = dashboardController.isAINeedsActionEnabled;
 
@@ -533,13 +571,18 @@ class ThreadView extends GetWidget<ThreadController>
         isSenderImportantFlagEnabled: isSenderImportantFlagEnabled,
         isAINeedsActionEnabled: isAINeedsActionEnabled,
       );
+      });
     });
   }
 
   Widget _buildEmailItemNotDraggable(BuildContext context, PresentationEmail presentationEmail) {
     final dashboardController = controller.mailboxDashBoardController;
 
-    return Obx(() {
+    return Consumer(builder: (context, ref, child) {
+      final isSearchEmailRunning = ref.watch(
+        searchViewStateProvider.select((state) => state.isSearchEmailRunning),
+      );
+      return Obx(() {
       final selectModeAll = dashboardController.currentSelectMode.value;
 
       final isSenderImportantFlagEnabled =
@@ -547,9 +590,6 @@ class ThreadView extends GetWidget<ThreadController>
 
       final isShowingEmailContent =
           dashboardController.selectedEmail.value?.id == presentationEmail.id;
-
-      final isSearchEmailRunning =
-          controller.searchController.isSearchEmailRunning;
 
       final isAINeedsActionEnabled = dashboardController.isAINeedsActionEnabled;
 
@@ -605,6 +645,7 @@ class ThreadView extends GetWidget<ThreadController>
           ),
         ),
       );
+      });
     });
   }
 

--- a/test/features/mailbox_dashboard/presentation/controller/advanced_filter_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/advanced_filter_controller_test.dart
@@ -32,6 +32,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/quick_s
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/save_recent_search_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/store_email_sort_order_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/advanced_filter_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/search_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
@@ -123,6 +124,9 @@ void main() {
 
   SearchFilterNotifier filterNotifier() =>
       appProviderContainer.read(searchFilterProvider.notifier);
+
+  AdvancedFilterViewStateNotifier viewStateNotifier() =>
+      appProviderContainer.read(advancedFilterViewStateProvider.notifier);
 
   SearchEmailFilter committedFilter() =>
       appProviderContainer.read(searchFilterProvider);
@@ -362,7 +366,8 @@ void main() {
           DraggableEmailAddress(
             emailAddress: EmailAddress(null, 'a@example.com'),
             filterField: FilterField.from),
-          filterNotifier());
+          filterNotifier(),
+          viewStateNotifier());
 
         // Assert
         expect(
@@ -383,7 +388,8 @@ void main() {
           DraggableEmailAddress(
             emailAddress: EmailAddress(null, 'a@example.com'),
             filterField: FilterField.to),
-          filterNotifier());
+          filterNotifier(),
+          viewStateNotifier());
 
         // Assert
         expect(

--- a/test/features/mailbox_dashboard/presentation/controller/advanced_filter_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/advanced_filter_controller_test.dart
@@ -37,6 +37,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_filter_form_bottom_view.dart';
 import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
@@ -200,7 +201,7 @@ void main() {
         .set(SearchEmailFilter.initial());
     searchController.deactivateAdvancedSearch();
     searchController.deactivateSimpleSearch();
-    searchController.isAdvancedSearchViewOpen.value = false;
+    searchController.closeAdvanceSearch();
     clearInteractions(mockMailboxDashBoardController);
   });
 
@@ -237,7 +238,7 @@ void main() {
         await untilCalled(mockMailboxDashBoardController.handleAdvancedSearchEmail());
 
         final committedSearchFilter = appProviderContainer.read(searchFilterProvider);
-        final searchFilter = searchController.searchEmailFilter.value;
+        final searchFilter = searchController.committedSearchFilter;
 
         // Assert
         verify(mockMailboxDashBoardController.handleAdvancedSearchEmail()).called(1);
@@ -258,7 +259,10 @@ void main() {
         await untilCalled(mockMailboxDashBoardController.handleAdvancedSearchEmail());
 
         // Assert
-        expect(searchController.advancedSearchIsActivated.value, isTrue);
+        expect(
+          appProviderContainer.read(searchViewStateProvider).advancedSearchIsActivated,
+          isTrue,
+        );
       });
 
       test(
@@ -276,7 +280,10 @@ void main() {
         await untilCalled(mockMailboxDashBoardController.handleAdvancedSearchEmail());
 
         // Assert
-        expect(searchController.advancedSearchIsActivated.value, isFalse);
+        expect(
+          appProviderContainer.read(searchViewStateProvider).advancedSearchIsActivated,
+          isFalse,
+        );
       });
     });
 
@@ -612,7 +619,10 @@ void main() {
             checkboxCase.readFlag(
               appProviderContainer.read(searchFilterProvider)),
             isTrue);
-          expect(searchController.advancedSearchIsActivated.value, isFalse);
+          expect(
+            appProviderContainer.read(searchViewStateProvider).advancedSearchIsActivated,
+            isFalse,
+          );
           verifyNever(
             mockMailboxDashBoardController.handleAdvancedSearchEmail());
         });
@@ -637,7 +647,10 @@ void main() {
             checkboxCase.readFlag(
               appProviderContainer.read(searchFilterProvider)),
             isFalse);
-          expect(searchController.advancedSearchIsActivated.value, isFalse);
+          expect(
+            appProviderContainer.read(searchViewStateProvider).advancedSearchIsActivated,
+            isFalse,
+          );
           verifyNever(
             mockMailboxDashBoardController.handleAdvancedSearchEmail());
         });
@@ -663,7 +676,10 @@ void main() {
 
         verify(
           mockMailboxDashBoardController.handleAdvancedSearchEmail()).called(1);
-        expect(searchController.advancedSearchIsActivated.value, isTrue);
+        expect(
+          appProviderContainer.read(searchViewStateProvider).advancedSearchIsActivated,
+          isTrue,
+        );
         expect(
           appProviderContainer.read(searchFilterProvider).hasAttachment,
           isTrue);
@@ -690,7 +706,10 @@ void main() {
 
         verify(
           mockMailboxDashBoardController.handleAdvancedSearchEmail()).called(1);
-        expect(searchController.advancedSearchIsActivated.value, isFalse);
+        expect(
+          appProviderContainer.read(searchViewStateProvider).advancedSearchIsActivated,
+          isFalse,
+        );
         expect(
           appProviderContainer.read(searchFilterProvider).hasAttachment,
           isFalse);

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -4,13 +4,11 @@ import 'package:core/data/network/config/dynamic_url_interceptors.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/app_toast.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
-import 'package:dartz/dartz.dart' hide State;
 import 'package:flutter/widgets.dart' hide State;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
-import 'package:jmap_dart_client/jmap/core/utc_date.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
@@ -407,6 +405,9 @@ void main() {
 
   group('search/sort/filter feature:', () {
     setUp(() {
+      appProviderContainer
+          .read(searchFilterProvider.notifier)
+          .set(SearchEmailFilter.initial());
       getEmailsInMailboxInteractor = MockGetEmailsInMailboxInteractor();
 
       when(emailReceiveManager.pendingSharedFileInfo).thenAnswer((_) => BehaviorSubject.seeded([]));
@@ -465,7 +466,7 @@ void main() {
       
       // expect query in search controller update as expected
       mailboxDashboardController.searchEmailByQueryString(queryString);
-      expect(searchController.searchEmailFilter.value.text, SearchQuery(queryString));
+      expect(searchController.committedSearchFilter.text, SearchQuery(queryString));
       
       // expect sort in search controller update as expected
       mailboxDashboardController.selectSortOrderQuickSearchFilter(
@@ -474,9 +475,9 @@ void main() {
 
       // expect filter in search controller update as expected
       mailboxDashboardController.selectHasAttachmentSearchFilter();
-      expect(searchController.searchEmailFilter.value.hasAttachment, true);
+      expect(searchController.committedSearchFilter.hasAttachment, true);
       mailboxDashboardController.selectReceiveTimeQuickSearchFilter(context, EmailReceiveTimeType.last30Days);
-      expect(searchController.searchEmailFilter.value.emailReceiveTimeType, EmailReceiveTimeType.last30Days);
+      expect(searchController.committedSearchFilter.emailReceiveTimeType, EmailReceiveTimeType.last30Days);
 
       // expect mailbox dashboard controller calls GetEmailsInMailboxInteractor
       // when [selectedMailbox] is changed and triggered obx listener in thread controller
@@ -494,7 +495,7 @@ void main() {
         collapseThreads: anyNamed('collapseThreads'),
       ));
       expect(searchController.sortOrderFiltered, EmailSortOrderType.oldest);
-      expect(searchController.searchEmailFilter.value, SearchEmailFilter.withSortOrder(EmailSortOrderType.oldest));
+      expect(searchController.committedSearchFilter, SearchEmailFilter.withSortOrder(EmailSortOrderType.oldest));
       verify(getEmailsInMailboxInteractor.execute(
         testSession, testAccountId,
         limit: ThreadConstants.defaultLimit,
@@ -541,7 +542,7 @@ void main() {
       advancedFilterController.applyAdvancedSearchFilter(
         committedFilter: appProviderContainer.read(searchFilterProvider),
         filterNotifier: filterNotifier);
-      final filterAfterAdvancedSearch = searchController.searchEmailFilter.value;
+      final filterAfterAdvancedSearch = searchController.committedSearchFilter;
       expect(filterAfterAdvancedSearch.from, equals({fromEmailAddress.email!}));
       expect(filterAfterAdvancedSearch.to, equals({toEmailAddress.email!}));
       expect(filterAfterAdvancedSearch.subject, equals(emailSubject));
@@ -573,7 +574,7 @@ void main() {
         collapseThreads: anyNamed('collapseThreads'),
       ));
       expect(searchController.sortOrderFiltered, SearchEmailFilter.defaultSortOrder);
-      expect(searchController.searchEmailFilter.value, SearchEmailFilter.initial());
+      expect(searchController.committedSearchFilter, SearchEmailFilter.initial());
       verify(getEmailsInMailboxInteractor.execute(
         testSession, testAccountId,
         limit: ThreadConstants.defaultLimit,
@@ -612,7 +613,7 @@ void main() {
       properties: anyNamed('properties')));
 
     // assert
-    final filterAfterQuickSearch = searchController.searchEmailFilter.value;
+    final filterAfterQuickSearch = searchController.committedSearchFilter;
     expect(filterAfterQuickSearch.text, equals(SearchQuery(queryString)));
     expect(filterAfterQuickSearch.emailReceiveTimeType, equals(EmailReceiveTimeType.last30Days));
     expect(filterAfterQuickSearch.hasAttachment, isTrue);
@@ -632,24 +633,7 @@ void main() {
       mailboxDashboardController.setUpDefaultEmailSortOrder(EmailSortOrderType.oldest);
 
       expect(searchController.sortOrderFiltered, EmailSortOrderType.oldest);
-      expect(searchController.searchEmailFilter.value.sortOrderType, EmailSortOrderType.oldest);
-    });
-
-    test(
-      'WHEN setUpDefaultEmailSortOrder is called while load-more cursors are set\n'
-      'SHOULD clear before/after/position so restoring the sort order never leaks a stale cursor',
-    () {
-      searchController.updateFilterEmail(
-        beforeOption: Some(UTCDate(DateTime.now())),
-        afterOption: Some(UTCDate(DateTime.now())),
-        positionOption: const Some(20),
-      );
-
-      mailboxDashboardController.setUpDefaultEmailSortOrder(EmailSortOrderType.oldest);
-
-      expect(searchController.searchEmailFilter.value.before, isNull);
-      expect(searchController.searchEmailFilter.value.after, isNull);
-      expect(searchController.searchEmailFilter.value.position, isNull);
+      expect(searchController.committedSearchFilter.sortOrderType, EmailSortOrderType.oldest);
     });
 
     test(

--- a/test/features/mailbox_dashboard/presentation/controller/search_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/search_controller_test.dart
@@ -91,26 +91,25 @@ void main() {
       searchController.toggleQuickSearchFilter(filter, currentUserEmail: _me);
 
   group('updateFilterEmail', () {
-    test('user intent writes the committed SSOT and the mirror syncs the obs', () {
+    test('user intent writes the committed SSOT', () {
       searchController.updateFilterEmail(unreadOption: const Some(true));
 
       expect(committed().unread, isTrue);
-      expect(searchController.searchEmailFilter.value.unread, isTrue);
+      expect(searchController.committedSearchFilter.unread, isTrue);
     });
 
-    test('cursor options stay on the obs, never in the committed SSOT', () {
+    test('cursor options never enter the committed SSOT', () {
       searchController.updateFilterEmail(positionOption: const Some(40));
 
       expect(committed().position, isNull);
-      expect(searchController.searchEmailFilter.value.position, 40);
     });
 
-    test('a later user-intent update must not clobber an existing cursor', () {
+    test('a later user-intent update keeps pagination out of the SSOT', () {
       searchController.updateFilterEmail(positionOption: const Some(40));
       searchController.updateFilterEmail(unreadOption: const Some(true));
 
-      expect(searchController.searchEmailFilter.value.position, 40);
-      expect(searchController.searchEmailFilter.value.unread, isTrue);
+      expect(committed().position, isNull);
+      expect(searchController.committedSearchFilter.unread, isTrue);
     });
   });
 
@@ -163,7 +162,7 @@ void main() {
         isNot(contains(KeyWordIdentifier.emailFlagged.value)),
       );
       expect(
-        searchController.searchEmailFilter.value.hasKeyword,
+        searchController.listHasKeywordFiltered,
         isNot(contains(KeyWordIdentifier.emailFlagged.value)),
       );
     });
@@ -232,17 +231,6 @@ void main() {
       expect(committed().sortOrderType, EmailSortOrderType.oldest);
     });
 
-    // Clearing must drop a stale cursor left on the obs mirror. The
-    // committed SSOT never tracks cursors, so a bare notifier.clear() can't null
-    // it — every clear entry point must route through here. See ADR-0093.
-    test('drops a stale position cursor left on the obs', () {
-      searchController.updateFilterEmail(positionOption: const Some(40));
-      expect(searchController.searchEmailFilter.value.position, 40);
-
-      searchController.clearSearchFilter();
-
-      expect(searchController.searchEmailFilter.value.position, isNull);
-    });
   });
 
   // The search bar and the advanced "has the words" field are one full-text

--- a/test/features/mailbox_dashboard/presentation/extensions/quick_search_emails_extension_test.dart
+++ b/test/features/mailbox_dashboard/presentation/extensions/quick_search_emails_extension_test.dart
@@ -1,6 +1,5 @@
 import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:get/state_manager.dart';
 import 'package:jmap_dart_client/jmap/core/filter/filter.dart';
 import 'package:jmap_dart_client/jmap/core/filter/filter_operator.dart';
 import 'package:jmap_dart_client/jmap/core/filter/operator/logic_filter_operator.dart';
@@ -61,8 +60,8 @@ void main() {
       'when sortOrderType is null',
       () async {
         sortOrderType = null;
-        when(searchController.searchEmailFilter)
-            .thenReturn(SearchEmailFilter(sortOrderType: sortOrderType).obs);
+        when(searchController.committedSearchFilter)
+            .thenReturn(SearchEmailFilter(sortOrderType: sortOrderType));
         await searchController.quickSearchEmails(
           session: session,
           accountId: accountId,
@@ -84,8 +83,8 @@ void main() {
       'when sortOrderType is not null',
       () async {
         sortOrderType = EmailSortOrderType.oldest;
-        when(searchController.searchEmailFilter)
-            .thenReturn(SearchEmailFilter(sortOrderType: sortOrderType).obs);
+        when(searchController.committedSearchFilter)
+            .thenReturn(SearchEmailFilter(sortOrderType: sortOrderType));
         await searchController.quickSearchEmails(
           session: session,
           accountId: accountId,
@@ -107,11 +106,11 @@ void main() {
       () async {
         final start = UTCDate(DateTime.utc(2026, 1, 1));
         final end = UTCDate(DateTime.utc(2026, 1, 31));
-        when(searchController.searchEmailFilter).thenReturn(SearchEmailFilter(
+        when(searchController.committedSearchFilter).thenReturn(SearchEmailFilter(
           emailReceiveTimeType: EmailReceiveTimeType.customRange,
           startDate: start,
           endDate: end,
-        ).obs);
+        ));
 
         await searchController.quickSearchEmails(
           session: session,
@@ -138,11 +137,11 @@ void main() {
       'so previously-dropped filters (subject, mailbox, unread) are applied',
       () async {
         final mailbox = PresentationMailbox(MailboxId(Id('mailbox-1')));
-        when(searchController.searchEmailFilter).thenReturn(SearchEmailFilter(
+        when(searchController.committedSearchFilter).thenReturn(SearchEmailFilter(
           subject: 'invoice',
           mailbox: mailbox,
           unread: true,
-        ).obs);
+        ));
 
         await searchController.quickSearchEmails(
           session: session,
@@ -169,9 +168,9 @@ void main() {
     test(
       'should apply the recipient (to/cc/bcc) filter dropped by the old suggestion mapping',
       () async {
-        when(searchController.searchEmailFilter).thenReturn(SearchEmailFilter(
+        when(searchController.committedSearchFilter).thenReturn(SearchEmailFilter(
           to: {'bob@linagora.com'},
-        ).obs);
+        ));
 
         await searchController.quickSearchEmails(
           session: session,
@@ -210,8 +209,8 @@ void main() {
     test(
       'should drop the text condition when the query is blank',
       () async {
-        when(searchController.searchEmailFilter)
-            .thenReturn(SearchEmailFilter(subject: 'invoice').obs);
+        when(searchController.committedSearchFilter)
+            .thenReturn(SearchEmailFilter(subject: 'invoice'));
 
         await searchController.quickSearchEmails(
           session: session,

--- a/test/features/mailbox_dashboard/presentation/notifier/advanced_filter_view_state_notifier_test.dart
+++ b/test/features/mailbox_dashboard/presentation/notifier/advanced_filter_view_state_notifier_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/mailbox/expand_mode.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/advanced_filter_view_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/advanced_filter_view_state_notifier.dart';
+
+void main() {
+  late ProviderContainer container;
+
+  setUp(() => container = ProviderContainer());
+  tearDown(() => container.dispose());
+
+  AdvancedFilterViewState state() =>
+      container.read(advancedFilterViewStateProvider);
+
+  test('starts expanded', () {
+    expect(state().fromAddressExpandMode, ExpandMode.EXPAND);
+    expect(state().toAddressExpandMode, ExpandMode.EXPAND);
+  });
+
+  test('updates each address mode independently', () {
+    final notifier = container.read(advancedFilterViewStateProvider.notifier);
+
+    notifier.setFromAddressExpandMode(ExpandMode.COLLAPSE);
+    notifier.setToAddressExpandMode(ExpandMode.EXPAND);
+
+    expect(state().fromAddressExpandMode, ExpandMode.COLLAPSE);
+    expect(state().toAddressExpandMode, ExpandMode.EXPAND);
+  });
+
+  test('reset restores both address modes', () {
+    final notifier = container.read(advancedFilterViewStateProvider.notifier);
+    notifier.setFromAddressExpandMode(ExpandMode.COLLAPSE);
+    notifier.setToAddressExpandMode(ExpandMode.COLLAPSE);
+
+    notifier.reset();
+
+    expect(state(), AdvancedFilterViewState.initial());
+  });
+}

--- a/test/features/mailbox_dashboard/presentation/notifier/advanced_filter_view_state_notifier_test.dart
+++ b/test/features/mailbox_dashboard/presentation/notifier/advanced_filter_view_state_notifier_test.dart
@@ -2,7 +2,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:model/mailbox/expand_mode.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/advanced_filter_view_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/advanced_filter_view_state_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
 
 void main() {
   late ProviderContainer container;
@@ -13,8 +15,18 @@ void main() {
   AdvancedFilterViewState state() =>
       container.read(advancedFilterViewStateProvider);
 
-  test('starts expanded', () {
+  void seedCommittedFilter(SearchEmailFilter filter) =>
+      container.read(searchFilterProvider.notifier).set(filter);
+
+  test('starts expanded when the committed filter has no addresses', () {
     expect(state().fromAddressExpandMode, ExpandMode.EXPAND);
+    expect(state().toAddressExpandMode, ExpandMode.EXPAND);
+  });
+
+  test('opens collapsed for address fields already committed', () {
+    seedCommittedFilter(SearchEmailFilter(from: {'a@example.com'}));
+
+    expect(state().fromAddressExpandMode, ExpandMode.COLLAPSE);
     expect(state().toAddressExpandMode, ExpandMode.EXPAND);
   });
 

--- a/test/features/search/verify_before_time_in_search_email_filter_test.dart
+++ b/test/features/search/verify_before_time_in_search_email_filter_test.dart
@@ -54,6 +54,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_all_identities_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
@@ -68,6 +69,7 @@ import 'package:tmail_ui_user/features/thread/domain/usecases/empty_spam_folder_
 import 'package:tmail_ui_user/features/thread/domain/usecases/get_email_by_id_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/get_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/load_more_emails_in_mailbox_interactor.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/mark_as_multiple_email_read_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/mark_as_star_multiple_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/move_multiple_email_to_mailbox_interactor.dart';
@@ -403,11 +405,11 @@ void main() {
 
   group('SearchController::updateSortOrderFilter', () {
     setUp(() {
-      searchController.searchEmailFilter.value = SearchEmailFilter.initial();
+      appProviderContainer.read(searchFilterProvider.notifier).set(SearchEmailFilter.initial());
     });
 
     test(
-      'SHOULD preserve startDate and endDate AND clear before, after and position '
+      'SHOULD preserve startDate and endDate '
       'WHEN sort order changes on any filter',
     () {
       // Arrange: snapshotted date bounds set when last7Days was selected
@@ -424,8 +426,8 @@ void main() {
       // Act
       searchController.updateSortOrderFilter(EmailSortOrderType.mostRecent);
 
-      // Assert: date bounds are preserved; only load-more cursors are cleared
-      final filter = searchController.searchEmailFilter.value;
+      // Assert: user date bounds are preserved
+      final filter = searchController.committedSearchFilter;
       expect(filter.sortOrderType, equals(EmailSortOrderType.mostRecent));
       expect(filter.startDate, equals(snapshotStart));
       expect(filter.endDate, equals(snapshotEnd));
@@ -452,132 +454,13 @@ void main() {
       searchController.updateSortOrderFilter(EmailSortOrderType.mostRecent);
 
       // Assert
-      final filter = searchController.searchEmailFilter.value;
+      final filter = searchController.committedSearchFilter;
       expect(filter.sortOrderType, equals(EmailSortOrderType.mostRecent));
       expect(filter.startDate, equals(start));
       expect(filter.endDate, equals(end));
       expect(filter.before, isNull);
       expect(filter.after, isNull);
       expect(filter.position, isNull);
-    });
-
-    test(
-      'SHOULD clear after cursor WHEN sort order changes while after cursor is active',
-    () {
-      // Arrange: simulate oldest sort load-more → after cursor set by ThreadController
-      final cursor = UTCDate(DateTime.parse('2026-06-10T00:00:00.000Z'));
-      searchController.updateFilterEmail(
-        sortOrderTypeOption: const Some(EmailSortOrderType.oldest),
-        emailReceiveTimeTypeOption: const Some(EmailReceiveTimeType.allTime),
-        afterOption: Some(cursor),
-      );
-      expect(searchController.searchEmailFilter.value.after, equals(cursor));
-
-      // Act: user changes sort order
-      searchController.updateSortOrderFilter(EmailSortOrderType.mostRecent);
-
-      // Assert: after cursor cleared
-      final filter = searchController.searchEmailFilter.value;
-      expect(filter.sortOrderType, equals(EmailSortOrderType.mostRecent));
-      expect(filter.after, isNull);
-      expect(filter.before, isNull);
-      expect(filter.position, isNull);
-    });
-
-    test(
-      'SHOULD clear before cursor WHEN sort order changes while before cursor is active',
-    () {
-      // Arrange: simulate mostRecent sort load-more → before cursor set by ThreadController
-      final cursor = UTCDate(DateTime.parse('2026-06-16T08:00:00.000Z'));
-      searchController.updateFilterEmail(
-        sortOrderTypeOption: const Some(EmailSortOrderType.mostRecent),
-        emailReceiveTimeTypeOption: const Some(EmailReceiveTimeType.allTime),
-        beforeOption: Some(cursor),
-      );
-      expect(searchController.searchEmailFilter.value.before, equals(cursor));
-
-      // Act: user changes sort order
-      searchController.updateSortOrderFilter(EmailSortOrderType.oldest);
-
-      // Assert: before cursor cleared
-      final filter = searchController.searchEmailFilter.value;
-      expect(filter.sortOrderType, equals(EmailSortOrderType.oldest));
-      expect(filter.before, isNull);
-      expect(filter.after, isNull);
-      expect(filter.position, isNull);
-    });
-  });
-
-  group('SearchController::resetCursorsForFreshSearch', () {
-    setUp(() {
-      searchController.searchEmailFilter.value = SearchEmailFilter.initial();
-    });
-
-    test(
-      'SHOULD clear before/after and the position '
-      'WHEN the sort order is time-based (oldest)',
-    () {
-      // Arrange: oldest sort load-more left an after cursor and a position
-      searchController.updateFilterEmail(
-        sortOrderTypeOption: const Some(EmailSortOrderType.oldest),
-        startDateOption: Some(UTCDate(DateTime.parse('2026-01-10T00:00:00.000Z'))),
-        afterOption: Some(UTCDate(DateTime.parse('2026-06-10T00:00:00.000Z'))),
-        positionOption: const Some(20),
-      );
-
-      // Act
-      searchController.resetCursorsForFreshSearch(isCollapseThreadsEnabled: false);
-
-      // Assert: cursors cleared, date bound preserved
-      final filter = searchController.searchEmailFilter.value;
-      expect(filter.before, isNull);
-      expect(filter.after, isNull);
-      expect(filter.position, isNull);
-      expect(filter.startDate, equals(UTCDate(DateTime.parse('2026-01-10T00:00:00.000Z'))));
-    });
-
-    test(
-      'SHOULD clear the stale before/after cursors AND restart position at 0 '
-      'WHEN the sort order is position-based (subjectAscending)',
-    () {
-      // Arrange: stale time cursors (both before and after) linger from a
-      // previous time-based sort
-      searchController.updateFilterEmail(
-        sortOrderTypeOption: const Some(EmailSortOrderType.subjectAscending),
-        beforeOption: Some(UTCDate(DateTime.parse('2026-06-15T00:00:00.000Z'))),
-        afterOption: Some(UTCDate(DateTime.parse('2026-06-10T00:00:00.000Z'))),
-        positionOption: const Some(20),
-      );
-
-      // Act
-      searchController.resetCursorsForFreshSearch(isCollapseThreadsEnabled: false);
-
-      // Assert: stale cursor cleared so it cannot truncate the fresh query
-      final filter = searchController.searchEmailFilter.value;
-      expect(filter.before, isNull);
-      expect(filter.after, isNull);
-      expect(filter.position, equals(0));
-    });
-
-    test(
-      'SHOULD clear the stale before/after cursors AND restart position at 0 '
-      'WHEN collapsed threads are enabled on a time-based sort',
-    () {
-      // Arrange: oldest sort with a leftover after cursor, then collapse enabled
-      searchController.updateFilterEmail(
-        sortOrderTypeOption: const Some(EmailSortOrderType.oldest),
-        afterOption: Some(UTCDate(DateTime.parse('2026-06-10T00:00:00.000Z'))),
-        positionOption: const Some(20),
-      );
-
-      // Act: collapsed threads switch pagination to position mode
-      searchController.resetCursorsForFreshSearch(isCollapseThreadsEnabled: true);
-
-      // Assert: no stale cursor leaks into the collapsed-thread query
-      final filter = searchController.searchEmailFilter.value;
-      expect(filter.before, isNull);
-      expect(filter.after, isNull);
-      expect(filter.position, equals(0));
     });
   });
 }

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -33,6 +33,7 @@ import 'package:tmail_ui_user/features/thread/domain/constants/thread_constants.
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/search_email_state.dart';
+import 'package:tmail_ui_user/features/thread/domain/state/search_more_email_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/clean_and_get_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/get_email_by_id_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/get_emails_in_mailbox_interactor.dart';
@@ -41,14 +42,14 @@ import 'package:tmail_ui_user/features/thread/domain/state/load_more_emails_stat
 import 'package:tmail_ui_user/features/thread/domain/state/refresh_changes_all_email_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/load_more_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_more_email_interactor.dart';
 import 'package:tmail_ui_user/features/search/email/domain/model/search_email_result.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/auto_load_more_policy.dart';
-import 'package:tmail_ui_user/features/thread/presentation/model/search_state.dart';
-import 'package:tmail_ui_user/features/thread/presentation/model/search_status.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
 import 'package:uuid/uuid.dart';
@@ -313,8 +314,6 @@ void main() {
           when(mockMailboxDashBoardController.trashSpamMailboxIds)
               .thenReturn(null);
           when(mockSearchController.isSearchEmailRunning).thenReturn(true);
-          when(mockSearchController.searchState)
-              .thenReturn(Rx(SearchState.initial()));
           when(mockRefreshChangesEmailsInMailboxInteractor.execute(
             any,
             any,
@@ -394,11 +393,10 @@ void main() {
         when(mockMailboxDashBoardController.currentSelectMode).thenReturn(Rx(SelectMode.INACTIVE));
         when(mockMailboxDashBoardController.listEmailSelected).thenReturn(RxList([]));
         when(mockMailboxDashBoardController.isSelectionEnabled()).thenReturn(false);
-        when(mockSearchController.searchState).thenReturn(Rx(SearchState.initial()));
-        when(mockSearchController.isAdvancedSearchViewOpen).thenReturn(RxBool(false));
         when(mockSearchController.isSearchEmailRunning).thenReturn(true);
         when(mockSearchController.searchQuery).thenReturn(null);
-        when(mockSearchController.searchEmailFilter).thenReturn(Rx(SearchEmailFilter.initial()));
+        when(mockSearchController.committedSearchFilter)
+            .thenReturn(SearchEmailFilter.initial());
         when(mockSearchEmailInteractor.execute(
           any,
           any,
@@ -480,8 +478,6 @@ void main() {
         when(mockMailboxDashBoardController.listEmailSelected).thenReturn(RxList());
         when(mockMailboxDashBoardController.currentSelectMode).thenReturn(Rx(SelectMode.INACTIVE));
         when(mockMailboxDashBoardController.filterMessageOption).thenReturn(Rx(FilterMessageOption.all));
-        when(mockSearchController.searchState).thenReturn(SearchState(SearchStatus.INACTIVE).obs);
-
         // act
         obxListenerController.onInit();
         mockMailboxDashBoardController.selectedMailbox.value = mailboxAfter;
@@ -540,8 +536,6 @@ void main() {
         when(mockMailboxDashBoardController.listEmailSelected).thenReturn(RxList());
         when(mockMailboxDashBoardController.currentSelectMode).thenReturn(Rx(SelectMode.INACTIVE));
         when(mockMailboxDashBoardController.filterMessageOption).thenReturn(Rx(FilterMessageOption.all));
-        when(mockSearchController.searchState).thenReturn(SearchState(SearchStatus.INACTIVE).obs);
-
         limitEmailFetchedController.onInit();
       });
 
@@ -894,6 +888,12 @@ void main() {
     });
 
     group('canLoadMore lifecycle & guard regression:', () {
+      tearDown(() {
+        appProviderContainer
+            .read(searchEmailPresentationProvider.notifier)
+            .resetSearchMore();
+      });
+
       test(
         'GIVEN canLoadMore was exhausted (false) '
         'WHEN resetToOriginalValue runs (e.g. switching mailbox) '
@@ -944,16 +944,61 @@ void main() {
       test(
         'GIVEN search is active '
         'WHEN handleLoadMoreEmailsRequest is invoked '
-        'THEN it routes to search-more, NOT load-more (canLoadMore is not consulted)',
-      () {
+        'THEN it invokes search-more, NOT load-more (canLoadMore is not consulted)',
+      () async {
         when(mockMailboxDashBoardController.searchController)
             .thenReturn(mockSearchController);
         when(mockSearchController.isSearchEmailRunning).thenReturn(true);
-        threadController.canSearchMore = false;
-        threadController.canLoadMore = true;
+        appProviderContainer
+            .read(searchEmailPresentationProvider.notifier)
+            .setCanSearchMore(true);
+        when(mockMailboxDashBoardController.sessionCurrent)
+            .thenReturn(SessionFixtures.aliceSession);
+        when(mockMailboxDashBoardController.accountId)
+            .thenReturn(Rxn(AccountFixtures.aliceAccountId));
+        when(mockMailboxDashBoardController.trashSpamMailboxIds)
+            .thenReturn(null);
+        final email = PresentationEmail(id: EmailId(Id('search-more-email')));
+        when(mockMailboxDashBoardController.emailsInCurrentMailbox)
+            .thenReturn(RxList([email]));
+        when(mockSearchMoreEmailInteractor.execute(
+          any,
+          any,
+          limit: anyNamed('limit'),
+          sort: anyNamed('sort'),
+          position: anyNamed('position'),
+          filter: anyNamed('filter'),
+          properties: anyNamed('properties'),
+          collapseThreads: anyNamed('collapseThreads'),
+          lastEmailId: anyNamed('lastEmailId'),
+        )).thenAnswer((_) => Stream.value(Right(SearchMoreEmailSuccess([]))));
+        threadController.canLoadMore = false;
 
         threadController.handleLoadMoreEmailsRequest();
 
+        await untilCalled(mockSearchMoreEmailInteractor.execute(
+          any,
+          any,
+          limit: anyNamed('limit'),
+          sort: anyNamed('sort'),
+          position: anyNamed('position'),
+          filter: anyNamed('filter'),
+          properties: anyNamed('properties'),
+          collapseThreads: anyNamed('collapseThreads'),
+          lastEmailId: anyNamed('lastEmailId'),
+        ));
+
+        verify(mockSearchMoreEmailInteractor.execute(
+          any,
+          any,
+          limit: anyNamed('limit'),
+          sort: anyNamed('sort'),
+          position: anyNamed('position'),
+          filter: anyNamed('filter'),
+          properties: anyNamed('properties'),
+          collapseThreads: anyNamed('collapseThreads'),
+          lastEmailId: anyNamed('lastEmailId'),
+        )).called(1);
         verifyNever(mockLoadMoreEmailsInMailboxInteractor.execute(any));
       });
     });


### PR DESCRIPTION
Part of [#4646](https://github.com/linagora/tmail-flutter/issues/4646)

## Summary

- Add `SearchViewStateNotifier` and `AdvancedFilterViewStateNotifier` as the Riverpod SSOT for web-search view state (activation, focus, advanced-panel visibility, `searchState`, address expand modes).
- Route `SearchController`, `AdvancedFilterController`, and `ThreadController` through these notifiers and the committed search filter — removing the GetX `.obs` mirrors, `ever` workers, and controller memory fields (`searchEmailFilter`, `canSearchMore`, expand-mode obs).
- Convert search widgets from `Obx` to `Consumer`/`ref.watch`, extract show/hide predicates into helpers, and update bindings and related tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved search consistency by synchronizing entered text, committed filters, sorting, and quick-filter selections.
  * Advanced search now preserves filter state more reliably and provides smoother From/To field expansion behavior.
  * Search-related mailbox, thread, and email views update more responsively as search state changes.
  * Improved search result pagination and load-more behavior, including better handling when additional results are available.

* **Bug Fixes**
  * Fixed inconsistencies between displayed search controls and the filters applied to results.

* **Tests**
  * Expanded coverage for advanced filters, committed search state, and search pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->