### PR TITLE
Reduce flaky test not rely on toast 

### DIFF
--- a/integration_test/scenarios/composer/base_save_draft_then_reopen_scenario.dart
+++ b/integration_test/scenarios/composer/base_save_draft_then_reopen_scenario.dart
@@ -1,7 +1,11 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/composer/domain/state/save_email_as_drafts_state.dart';
+import 'package:tmail_ui_user/features/composer/domain/state/update_email_drafts_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../../robots/abstract/abstract_composer_robot.dart';
+import '../../utils/wait_for_view_state.dart';
 import 'base_save_and_reopen_scenario.dart';
 
 abstract class BaseSaveDraftThenReopenScenario extends BaseSaveAndReopenScenario {
@@ -18,9 +22,10 @@ abstract class BaseSaveDraftThenReopenScenario extends BaseSaveAndReopenScenario
     await composerRobot.tapCloseComposer();
     await $.pumpAndTrySettle();
     await expectViewVisible($(#confirm_dialog_action));
+
+    final saved = _waitForDraftSaved();
     await composerRobot.tapSaveButtonOnSaveDraftConfirmDialog(l10n);
-    await $.pumpAndTrySettle();
-    await _expectSaveDraftSuccessToast(l10n);
+    await saved;
     await $.pumpAndTrySettle();
   }
 
@@ -29,12 +34,15 @@ abstract class BaseSaveDraftThenReopenScenario extends BaseSaveAndReopenScenario
     AbstractComposerRobot composerRobot,
     AppLocalizations l10n,
   ) async {
+    final saved = _waitForDraftSaved();
     await composerRobot.tapSaveAsDraftButton();
-    await $.pumpAndTrySettle();
-    await _expectSaveDraftSuccessToast(l10n);
+    await saved;
   }
 
-  Future<void> _expectSaveDraftSuccessToast(AppLocalizations l10n) async {
-    await expectViewVisible($(l10n.drafts_saved));
-  }
+  Future<void> _waitForDraftSaved() => waitForViewState(
+    Get.find<MailboxDashBoardController>(),
+    matcher: (state) =>
+        state is SaveEmailAsDraftsSuccess || state is UpdateEmailDraftsSuccess,
+    description: 'SaveEmailAsDraftsSuccess/UpdateEmailDraftsSuccess',
+  );
 }

--- a/integration_test/scenarios/composer/base_save_draft_then_reopen_scenario.dart
+++ b/integration_test/scenarios/composer/base_save_draft_then_reopen_scenario.dart
@@ -40,6 +40,7 @@ abstract class BaseSaveDraftThenReopenScenario extends BaseSaveAndReopenScenario
     AppLocalizations l10n,
   ) async {
     await _saveDraftAndWaitForOutcome(composerRobot.tapSaveAsDraftButton);
+    await $.pumpAndTrySettle();
   }
 
   /// Runs [saveAction], then returns once the save has actually resolved: either the

--- a/integration_test/scenarios/composer/base_save_draft_then_reopen_scenario.dart
+++ b/integration_test/scenarios/composer/base_save_draft_then_reopen_scenario.dart
@@ -41,8 +41,12 @@ abstract class BaseSaveDraftThenReopenScenario extends BaseSaveAndReopenScenario
 
   Future<void> _waitForDraftSaved() => waitForViewState(
     Get.find<MailboxDashBoardController>(),
-    matcher: (state) =>
-        state is SaveEmailAsDraftsSuccess || state is UpdateEmailDraftsSuccess,
-    description: 'SaveEmailAsDraftsSuccess/UpdateEmailDraftsSuccess',
+    ViewStateExpectation(
+      matcher: (state) =>
+          state is SaveEmailAsDraftsSuccess || state is UpdateEmailDraftsSuccess,
+      failureMatcher: (state) =>
+          state is SaveEmailAsDraftsFailure || state is UpdateEmailDraftsFailure,
+      description: 'SaveEmailAsDraftsSuccess/UpdateEmailDraftsSuccess',
+    ),
   );
 }

--- a/integration_test/scenarios/composer/base_save_draft_then_reopen_scenario.dart
+++ b/integration_test/scenarios/composer/base_save_draft_then_reopen_scenario.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/save_email_as_drafts_state.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/update_email_drafts_state.dart';
@@ -5,7 +6,8 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../../robots/abstract/abstract_composer_robot.dart';
-import '../../utils/wait_for_view_state.dart';
+import '../../utils/test_timeouts.dart';
+import '../../utils/wait_for_condition.dart';
 import 'base_save_and_reopen_scenario.dart';
 
 abstract class BaseSaveDraftThenReopenScenario extends BaseSaveAndReopenScenario {
@@ -23,9 +25,12 @@ abstract class BaseSaveDraftThenReopenScenario extends BaseSaveAndReopenScenario
     await $.pumpAndTrySettle();
     await expectViewVisible($(#confirm_dialog_action));
 
-    final saved = _waitForDraftSaved();
-    await composerRobot.tapSaveButtonOnSaveDraftConfirmDialog(l10n);
-    await saved;
+    await _saveDraftAndWaitForOutcome(() async {
+      await composerRobot.tapSaveButtonOnSaveDraftConfirmDialog(l10n);
+      // The close→save-draft confirm dialog reuses #confirm_dialog_action; settle so
+      // it is gone before the race treats a visible dialog as the failure signal.
+      await $.pumpAndTrySettle();
+    });
     await $.pumpAndTrySettle();
   }
 
@@ -34,19 +39,47 @@ abstract class BaseSaveDraftThenReopenScenario extends BaseSaveAndReopenScenario
     AbstractComposerRobot composerRobot,
     AppLocalizations l10n,
   ) async {
-    final saved = _waitForDraftSaved();
-    await composerRobot.tapSaveAsDraftButton();
-    await saved;
+    await _saveDraftAndWaitForOutcome(composerRobot.tapSaveAsDraftButton);
   }
 
-  Future<void> _waitForDraftSaved() => waitForViewState(
-    Get.find<MailboxDashBoardController>(),
-    ViewStateExpectation(
-      matcher: (state) =>
-          state is SaveEmailAsDraftsSuccess || state is UpdateEmailDraftsSuccess,
-      failureMatcher: (state) =>
-          state is SaveEmailAsDraftsFailure || state is UpdateEmailDraftsFailure,
-      description: 'SaveEmailAsDraftsSuccess/UpdateEmailDraftsSuccess',
-    ),
-  );
+  /// Runs [saveAction], then returns once the save has actually resolved: either the
+  /// success state lands on the dashboard bus, or the failure confirm dialog appears.
+  ///
+  /// A draft-save failure never reaches this bus — it is surfaced as a confirm dialog
+  /// — so that dialog is the failure signal. The subscription is set up *before*
+  /// [saveAction] runs because the success state is momentary and is usually emitted
+  /// before the tree settles, so sampling it afterwards would race and miss it.
+  /// Racing success against the dialog means a failed save reports in seconds instead
+  /// of burning the full timeout.
+  Future<void> _saveDraftAndWaitForOutcome(
+    Future<void> Function() saveAction,
+  ) async {
+    final dashboardController = Get.find<MailboxDashBoardController>();
+    var saveSucceeded = false;
+    final subscription = dashboardController.viewState.stream.listen((state) {
+      state.fold((_) {}, (success) {
+        if (success is SaveEmailAsDraftsSuccess ||
+            success is UpdateEmailDraftsSuccess) {
+          saveSucceeded = true;
+        }
+      });
+    });
+
+    try {
+      await saveAction();
+      await waitForCondition(
+        () => saveSucceeded || $(#confirm_dialog_action).visible,
+        timeout: TestTimeouts.long,
+      );
+    } finally {
+      await subscription.cancel();
+    }
+
+    expect(
+      $(#confirm_dialog_action).visible,
+      isFalse,
+      reason:
+          'Draft failed to save: a confirm dialog is shown instead of being persisted.',
+    );
+  }
 }

--- a/integration_test/scenarios/send_email_scenario.dart
+++ b/integration_test/scenarios/send_email_scenario.dart
@@ -1,8 +1,13 @@
+import 'package:core/utils/platform_info.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
 import 'package:model/email/prefix_email_address.dart';
-import 'package:tmail_ui_user/features/thread/presentation/thread_view.dart';
+import 'package:tmail_ui_user/features/composer/domain/state/send_email_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 import '../base/base_test_scenario.dart';
+import '../robots/abstract/abstract_composer_robot.dart';
 import '../utils/test_timeouts.dart';
 import '../utils/wait_for_condition.dart';
 
@@ -15,29 +20,70 @@ class SendEmailScenario extends BaseTestScenario {
   Future<void> runTestLogic() async {
     const additionalRecipient = String.fromEnvironment('ADDITIONAL_MAIL_RECIPIENT');
     const email = String.fromEnvironment('BASIC_AUTH_EMAIL');
-    const subject = 'Test subject';
     const content = 'Test content';
+    final subject = customSubject ?? 'Test subject';
+    final l10n = AppLocalizations();
+    final composerRobot = robots.composerRobot();
+    final threadRobot = robots.threadRobot();
+    final mailboxMenuRobot = robots.mailboxMenuRobot();
 
-    await robots.threadRobot().openComposer();
-    await robots.composerRobot().expectComposerViewVisible();
+    await threadRobot.openComposer();
+    await composerRobot.expectComposerViewVisible();
 
-    await robots.composerRobot().grantContactPermission();
+    await composerRobot.grantContactPermission();
 
-    await robots.composerRobot().addRecipient(PrefixEmailAddress.to, email);
-    await robots.composerRobot().addRecipient(PrefixEmailAddress.to, additionalRecipient);
-    await robots.composerRobot().addSubject(customSubject ?? subject);
-    await robots.composerRobot().addContent(content);
-    await robots.composerRobot().send();
+    await composerRobot.addRecipient(PrefixEmailAddress.to, email);
+    await composerRobot.addRecipient(PrefixEmailAddress.to, additionalRecipient);
+    await composerRobot.addSubject(subject);
+    await composerRobot.addContent(content);
 
-    await waitForCondition(
-      () => $(ThreadView).visible || $(#confirm_dialog_action).visible,
-      timeout: TestTimeouts.long,
+    await _sendAndWaitForCompletion(composerRobot);
+
+    // A visible thread list is not proof the email was sent: on web the composer is
+    // an overlay and the thread list stays mounted behind it, so it reads as visible
+    // before the send even completes. Confirm delivery by finding the message in the
+    // Sent mailbox instead.
+    await $.pumpAndTrySettle();
+    if (PlatformInfo.isMobile) {
+      await threadRobot.openMailbox();
+    }
+    await mailboxMenuRobot.navigation.openFolder(
+      mailboxMenuRobot.mailboxItemByName(l10n.sentMailboxDisplayName),
     );
+    await waitForCondition(() => $(subject).exists);
+  }
+
+  /// Taps Send and returns once the send has actually resolved: either the success
+  /// state lands on the dashboard bus, or the failure confirm dialog appears.
+  ///
+  /// The subscription is set up *before* the tap because [SendEmailSuccess] is
+  /// momentary and is usually emitted before the tree settles, so reading it after
+  /// the tap would race and miss it. A send failure never reaches this bus — it is
+  /// surfaced as a confirm dialog — so that dialog is the failure signal. Racing the
+  /// two means a failed send reports in seconds instead of burning the full timeout.
+  Future<void> _sendAndWaitForCompletion(AbstractComposerRobot composerRobot) async {
+    final dashboardController = Get.find<MailboxDashBoardController>();
+    var sendSucceeded = false;
+    final subscription = dashboardController.viewState.stream.listen((state) {
+      state.fold((_) {}, (success) {
+        if (success is SendEmailSuccess) sendSucceeded = true;
+      });
+    });
+
+    try {
+      await composerRobot.send();
+      await waitForCondition(
+        () => sendSucceeded || $(#confirm_dialog_action).visible,
+        timeout: TestTimeouts.long,
+      );
+    } finally {
+      await subscription.cancel();
+    }
+
     expect(
       $(#confirm_dialog_action).visible,
       isFalse,
-      reason: 'Email failed to send: a confirm dialog is shown instead of returning to the thread list.',
+      reason: 'Email failed to send: a confirm dialog is shown instead of being filed to Sent.',
     );
-    await expectViewVisible($(ThreadView));
   }
 }

--- a/integration_test/scenarios/send_email_scenario.dart
+++ b/integration_test/scenarios/send_email_scenario.dart
@@ -1,8 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:model/email/prefix_email_address.dart';
-import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/features/thread/presentation/thread_view.dart';
 
 import '../base/base_test_scenario.dart';
+import '../utils/test_timeouts.dart';
+import '../utils/wait_for_condition.dart';
 
 class SendEmailScenario extends BaseTestScenario {
   const SendEmailScenario(super.$, super.robots, {this.customSubject});
@@ -27,12 +29,15 @@ class SendEmailScenario extends BaseTestScenario {
     await robots.composerRobot().addContent(content);
     await robots.composerRobot().send();
 
-    await _expectSendEmailSuccessToast();
-  }
-
-  Future<void> _expectSendEmailSuccessToast() async {
-    await expectViewVisible(
-      $(find.text(AppLocalizations().message_has_been_sent_successfully)),
+    await waitForCondition(
+      () => $(ThreadView).visible || $(#confirm_dialog_action).visible,
+      timeout: TestTimeouts.long,
     );
+    expect(
+      $(#confirm_dialog_action).visible,
+      isFalse,
+      reason: 'Email failed to send: a confirm dialog is shown instead of returning to the thread list.',
+    );
+    await expectViewVisible($(ThreadView));
   }
 }

--- a/integration_test/utils/wait_for_condition.dart
+++ b/integration_test/utils/wait_for_condition.dart
@@ -13,12 +13,14 @@ Future<void> waitForCondition(
   Duration interval = const Duration(milliseconds: 200),
 }) async {
   final elapsed = Stopwatch()..start();
+  Never timedOut() => throw TimeoutException('waitForCondition timed out', timeout);
 
   while (true) {
-    if (await condition()) return;
+    final remaining = timeout - elapsed.elapsed;
+    if (remaining <= Duration.zero) timedOut();
 
-    if (elapsed.elapsed >= timeout) {
-      throw TimeoutException('waitForCondition timed out', timeout);
+    if (await Future.sync(condition).timeout(remaining, onTimeout: timedOut)) {
+      return;
     }
     await Future.delayed(interval);
   }

--- a/integration_test/utils/wait_for_condition.dart
+++ b/integration_test/utils/wait_for_condition.dart
@@ -2,16 +2,27 @@ import 'dart:async';
 
 import 'test_timeouts.dart';
 
+/// Polls [condition] until it returns true, or throws [TimeoutException] after
+/// [timeout].
+///
+/// Only suitable for conditions that stay true once reached. To observe a
+/// momentary signal, subscribe before triggering it — see `waitForViewState`.
 Future<void> waitForCondition(
   FutureOr<bool> Function() condition, {
   Duration timeout = TestTimeouts.medium,
   Duration interval = const Duration(milliseconds: 200),
 }) async {
-  await Future.doWhile(() async {
-    if (await condition()) {
-      return false;
+  final deadline = DateTime.now().add(timeout);
+
+  while (true) {
+    if (await condition()) return;
+
+    // Checked after the condition so the deadline stops the loop itself; a
+    // timeout wrapped around the loop would leave it polling forever in the
+    // background and bleed into later tests.
+    if (!DateTime.now().isBefore(deadline)) {
+      throw TimeoutException('waitForCondition timed out', timeout);
     }
     await Future.delayed(interval);
-    return true;
-  }).timeout(timeout);
+  }
 }

--- a/integration_test/utils/wait_for_condition.dart
+++ b/integration_test/utils/wait_for_condition.dart
@@ -12,15 +12,12 @@ Future<void> waitForCondition(
   Duration timeout = TestTimeouts.medium,
   Duration interval = const Duration(milliseconds: 200),
 }) async {
-  final deadline = DateTime.now().add(timeout);
+  final elapsed = Stopwatch()..start();
 
   while (true) {
     if (await condition()) return;
 
-    // Checked after the condition so the deadline stops the loop itself; a
-    // timeout wrapped around the loop would leave it polling forever in the
-    // background and bleed into later tests.
-    if (!DateTime.now().isBefore(deadline)) {
+    if (elapsed.elapsed >= timeout) {
       throw TimeoutException('waitForCondition timed out', timeout);
     }
     await Future.delayed(interval);

--- a/integration_test/utils/wait_for_view_state.dart
+++ b/integration_test/utils/wait_for_view_state.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:tmail_ui_user/features/base/base_controller.dart';
+
+import 'test_timeouts.dart';
+
+/// Waits for a controller view state matching [matcher].
+///
+/// Call this *before* firing the action that produces the state, then await the
+/// returned future afterwards:
+///
+/// ```dart
+/// final saved = waitForViewState(
+///   Get.find<MailboxDashBoardController>(),
+///   matcher: (state) => state is UpdateEmailDraftsSuccess,
+///   description: 'UpdateEmailDraftsSuccess',
+/// );
+/// await composerRobot.tapSaveAsDraftButton();
+/// await saved;
+/// ```
+///
+/// Subscribing up front is what makes this reliable. States are momentary: by
+/// the time an action has been tapped and the tree pumped, the state has often
+/// already been emitted and replaced. Anything that samples after the fact
+/// (polling for a toast, reading `viewState.value`) races that window and loses
+/// on slow devices. A subscription cannot miss an event it is already listening
+/// for, however long the action takes.
+///
+/// Prefer this over asserting on a toast. Toasts self-dismiss on a timer and
+/// are skipped entirely when there is no overlay context, so a missing toast
+/// cannot distinguish "the action failed" from "the action worked but the toast
+/// was gone or never rendered".
+Future<Success> waitForViewState(
+  BaseController controller, {
+  required bool Function(Success state) matcher,
+  required String description,
+  Duration timeout = TestTimeouts.long,
+}) {
+  final completer = Completer<Success>();
+  late final StreamSubscription<Either<Failure, Success>> subscription;
+
+  subscription = controller.viewState.stream.listen((state) {
+    state.fold(
+      (_) {},
+      (success) {
+        if (!completer.isCompleted && matcher(success)) {
+          completer.complete(success);
+        }
+      },
+    );
+  });
+
+  return completer.future.timeout(
+    timeout,
+    onTimeout: () => throw TimeoutException(
+      'waitForViewState: no $description emitted by ${controller.runtimeType} '
+      'within ${timeout.inSeconds}s',
+      timeout,
+    ),
+  ).whenComplete(subscription.cancel);
+}

--- a/integration_test/utils/wait_for_view_state.dart
+++ b/integration_test/utils/wait_for_view_state.dart
@@ -33,6 +33,12 @@ import 'test_timeouts.dart';
 /// are skipped entirely when there is no overlay context, so a missing toast
 /// cannot distinguish "the action failed" from "the action worked but the toast
 /// was gone or never rendered".
+///
+/// Deliberately never completes on a [Failure]. `MailboxDashBoardController` in
+/// particular is a shared bus — vacation fetch, mark-as-read, token refresh and
+/// others all push onto the same `viewState` — so aborting on any failure would
+/// let unrelated background work fail an otherwise healthy test. Failures are
+/// instead collected and reported in the timeout message.
 Future<Success> waitForViewState(
   BaseController controller, {
   required bool Function(Success state) matcher,
@@ -40,11 +46,12 @@ Future<Success> waitForViewState(
   Duration timeout = TestTimeouts.long,
 }) {
   final completer = Completer<Success>();
+  final failuresSeen = <Failure>[];
   late final StreamSubscription<Either<Failure, Success>> subscription;
 
   subscription = controller.viewState.stream.listen((state) {
     state.fold(
-      (_) {},
+      failuresSeen.add,
       (success) {
         if (!completer.isCompleted && matcher(success)) {
           completer.complete(success);
@@ -57,8 +64,20 @@ Future<Success> waitForViewState(
     timeout,
     onTimeout: () => throw TimeoutException(
       'waitForViewState: no $description emitted by ${controller.runtimeType} '
-      'within ${timeout.inSeconds}s',
+      'within ${timeout.inSeconds}s.\n${_describeFailures(failuresSeen)}',
       timeout,
     ),
   ).whenComplete(subscription.cancel);
+}
+
+/// Failures are reported but never awaited on, so a timeout can still say what
+/// went wrong instead of only that nothing arrived.
+String _describeFailures(List<Failure> failures) {
+  if (failures.isEmpty) {
+    return 'No failure state was emitted either — the action likely never '
+        'reached the controller.';
+  }
+  return 'Failures emitted while waiting (this controller is a shared bus, so '
+      'these may be unrelated background work):\n'
+      '${failures.map((failure) => '  - $failure').join('\n')}';
 }

--- a/integration_test/utils/wait_for_view_state.dart
+++ b/integration_test/utils/wait_for_view_state.dart
@@ -3,11 +3,37 @@ import 'dart:async';
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart' show TestFailure;
 import 'package:tmail_ui_user/features/base/base_controller.dart';
 
 import 'test_timeouts.dart';
 
-/// Waits for a controller view state matching [matcher].
+/// What a [waitForViewState] call is waiting for: the success meaning the action
+/// landed, the failures meaning it failed, and a name to report both under.
+///
+/// [failureMatcher] declares which failures mean *this* action failed. Those
+/// abort the wait immediately, so a rejected save reports in seconds instead of
+/// burning the whole timeout to report a timeout it already knew the answer to.
+///
+/// Match narrowly — name the failures your action produces, nothing else.
+/// `MailboxDashBoardController` in particular is a shared bus: vacation fetch,
+/// mark-as-read, token refresh and others all push onto the same `viewState`,
+/// so a broad [failureMatcher] lets unrelated background work fail an otherwise
+/// healthy test. Unmatched failures are not fatal; they are collected and
+/// reported if the wait times out.
+class ViewStateExpectation {
+  final bool Function(Success state) matcher;
+  final bool Function(Failure state) failureMatcher;
+  final String description;
+
+  const ViewStateExpectation({
+    required this.matcher,
+    required this.failureMatcher,
+    required this.description,
+  });
+}
+
+/// Waits for a view state on [controller] matching [expectation].
 ///
 /// Call this *before* firing the action that produces the state, then await the
 /// returned future afterwards:
@@ -15,8 +41,11 @@ import 'test_timeouts.dart';
 /// ```dart
 /// final saved = waitForViewState(
 ///   Get.find<MailboxDashBoardController>(),
-///   matcher: (state) => state is UpdateEmailDraftsSuccess,
-///   description: 'UpdateEmailDraftsSuccess',
+///   ViewStateExpectation(
+///     matcher: (state) => state is UpdateEmailDraftsSuccess,
+///     failureMatcher: (state) => state is UpdateEmailDraftsFailure,
+///     description: 'UpdateEmailDraftsSuccess',
+///   ),
 /// );
 /// await composerRobot.tapSaveAsDraftButton();
 /// await saved;
@@ -33,16 +62,9 @@ import 'test_timeouts.dart';
 /// are skipped entirely when there is no overlay context, so a missing toast
 /// cannot distinguish "the action failed" from "the action worked but the toast
 /// was gone or never rendered".
-///
-/// Deliberately never completes on a [Failure]. `MailboxDashBoardController` in
-/// particular is a shared bus — vacation fetch, mark-as-read, token refresh and
-/// others all push onto the same `viewState` — so aborting on any failure would
-/// let unrelated background work fail an otherwise healthy test. Failures are
-/// instead collected and reported in the timeout message.
 Future<Success> waitForViewState(
-  BaseController controller, {
-  required bool Function(Success state) matcher,
-  required String description,
+  BaseController controller,
+  ViewStateExpectation expectation, {
   Duration timeout = TestTimeouts.long,
 }) {
   final completer = Completer<Success>();
@@ -51,33 +73,54 @@ Future<Success> waitForViewState(
 
   subscription = controller.viewState.stream.listen((state) {
     state.fold(
-      failuresSeen.add,
+      (failure) {
+        if (!expectation.failureMatcher(failure)) {
+          failuresSeen.add(failure);
+          return;
+        }
+        if (!completer.isCompleted) {
+          completer.completeError(TestFailure(
+            'waitForViewState: ${controller.runtimeType} emitted $failure '
+            'while waiting for ${expectation.description}',
+          ));
+        }
+      },
       (success) {
-        if (!completer.isCompleted && matcher(success)) {
+        if (!completer.isCompleted && expectation.matcher(success)) {
           completer.complete(success);
         }
       },
     );
   });
 
-  return completer.future.timeout(
+  final result = completer.future.timeout(
     timeout,
     onTimeout: () => throw TimeoutException(
-      'waitForViewState: no $description emitted by ${controller.runtimeType} '
-      'within ${timeout.inSeconds}s.\n${_describeFailures(failuresSeen)}',
+      'waitForViewState: no ${expectation.description} emitted by '
+      '${controller.runtimeType} within ${timeout.inSeconds}s.\n'
+      '${_describeFailures(failuresSeen)}',
       timeout,
     ),
   ).whenComplete(subscription.cancel);
+
+  // Callers await this only *after* firing the action, so a failure arriving
+  // mid-action would land on a future with no listener yet and be reported as
+  // an unhandled async error, crashing the run instead of failing the test.
+  // Marking it ignored suppresses that; the pending await still receives it.
+  result.ignore();
+
+  return result;
 }
 
-/// Failures are reported but never awaited on, so a timeout can still say what
-/// went wrong instead of only that nothing arrived.
+/// Anything reaching here was rejected by [ViewStateExpectation.failureMatcher],
+/// so it is not the cause — but printing it still beats a timeout that says only
+/// that nothing arrived.
 String _describeFailures(List<Failure> failures) {
   if (failures.isEmpty) {
     return 'No failure state was emitted either — the action likely never '
         'reached the controller.';
   }
-  return 'Failures emitted while waiting (this controller is a shared bus, so '
-      'these may be unrelated background work):\n'
+  return 'Unmatched failures emitted while waiting (background work on this '
+      'shared bus, not the awaited action — unless the matcher is too narrow):\n'
       '${failures.map((failure) => '  - $failure').join('\n')}';
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved draft-save integration flows by waiting for confirmed draft-save completion via view-state changes, with failure handling tied to the confirmation dialog.
  * Strengthened email send scenarios to verify completion through state changes and sent mailbox contents, removing reliance on transient success notifications.
  * Enhanced test utilities for conditional waiting and view-state validation, including improved timeout behavior and clearer error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->