### PR TITLE
HOTFIX Drive link card UI

### DIFF
--- a/core/lib/presentation/extensions/composer_attachment_extension_registry.dart
+++ b/core/lib/presentation/extensions/composer_attachment_extension_registry.dart
@@ -26,14 +26,12 @@ class ComposerAttachmentExtensionRegistry {
 
   List<Widget> buildContextMenuTiles(
     BuildContext context, {
-    required String composerId,
     required ImagePaths imagePaths,
     required String label,
   }) => extensions
       .map(
         (e) => e.buildContextMenuTile(
           context,
-          composerId: composerId,
           imagePaths: imagePaths,
           label: label,
         ),

--- a/core/lib/presentation/extensions/composer_attachment_plugin.dart
+++ b/core/lib/presentation/extensions/composer_attachment_plugin.dart
@@ -12,7 +12,6 @@ abstract class ComposerAttachmentPlugin {
 
   Widget buildContextMenuTile(
     BuildContext context, {
-    required String composerId,
     required ImagePaths imagePaths,
     required String label,
   });

--- a/core/lib/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart
@@ -5,14 +5,16 @@ import 'package:core/presentation/utils/html_transformer/sanitize_html.dart';
 class StandardizeHtmlSanitizingTransformers extends TextTransformer {
   static final SanitizeHtml _sanitizer = SanitizeHtml();
 
-  const StandardizeHtmlSanitizingTransformers();
+  final List<String>? allowAttributes;
+
+  const StandardizeHtmlSanitizingTransformers({this.allowAttributes});
 
   @override
   String process(String text, HtmlEscape htmlEscape) {
     if (text.isEmpty) return '';
     return _sanitizer.process(
       inputHtml: text,
-      allowAttributes: const ['contenteditable'],
+      allowAttributes: allowAttributes,
     );
   }
 }

--- a/core/lib/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart
@@ -1,8 +1,12 @@
 import 'dart:convert';
 import 'package:core/presentation/utils/html_transformer/base/text_transformer.dart';
 import 'package:core/presentation/utils/html_transformer/sanitize_html.dart';
+import 'package:html/parser.dart' show parseFragment;
 
 class StandardizeHtmlSanitizingTransformers extends TextTransformer {
+  static const _driveLinkCardClassName = 'tmail-file-link-card';
+  static const _contentEditableAttribute = 'contenteditable';
+
   static final SanitizeHtml _sanitizer = SanitizeHtml();
 
   final List<String>? allowAttributes;
@@ -12,9 +16,31 @@ class StandardizeHtmlSanitizingTransformers extends TextTransformer {
   @override
   String process(String text, HtmlEscape htmlEscape) {
     if (text.isEmpty) return '';
+
+    final scopedText = allowAttributes?.contains(_contentEditableAttribute) == true
+      ? _stripContentEditableOutsideDriveLinkCard(text)
+      : text;
+
     return _sanitizer.process(
-      inputHtml: text,
+      inputHtml: scopedText,
       allowAttributes: allowAttributes,
     );
+  }
+
+  /// The sanitizer's [allowAttributes] allow-list is attribute-name based, so
+  /// allowing `contenteditable` preserves it on any element, not only the
+  /// Drive link card. Strip it from every element except
+  /// `a.tmail-file-link-card` before sanitizing, so the allow-list can only
+  /// ever surface it on that card.
+  String _stripContentEditableOutsideDriveLinkCard(String html) {
+    final fragment = parseFragment(html);
+    for (final element in fragment.querySelectorAll('[$_contentEditableAttribute]')) {
+      final isDriveLinkCard = element.localName == 'a' &&
+        element.classes.contains(_driveLinkCardClassName);
+      if (!isDriveLinkCard) {
+        element.attributes.remove(_contentEditableAttribute);
+      }
+    }
+    return fragment.outerHtml;
   }
 }

--- a/core/lib/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart
@@ -10,6 +10,9 @@ class StandardizeHtmlSanitizingTransformers extends TextTransformer {
   @override
   String process(String text, HtmlEscape htmlEscape) {
     if (text.isEmpty) return '';
-    return _sanitizer.process(inputHtml: text);
+    return _sanitizer.process(
+      inputHtml: text,
+      allowAttributes: const ['contenteditable'],
+    );
   }
 }

--- a/core/lib/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:core/presentation/utils/html_transformer/base/text_transformer.dart';
 import 'package:core/presentation/utils/html_transformer/sanitize_html.dart';
+import 'package:core/utils/app_logger.dart';
 import 'package:html/parser.dart' show parseFragment;
 
 class StandardizeHtmlSanitizingTransformers extends TextTransformer {
@@ -33,14 +34,22 @@ class StandardizeHtmlSanitizingTransformers extends TextTransformer {
   /// `a.tmail-file-link-card` before sanitizing, so the allow-list can only
   /// ever surface it on that card.
   String _stripContentEditableOutsideDriveLinkCard(String html) {
-    final fragment = parseFragment(html);
-    for (final element in fragment.querySelectorAll('[$_contentEditableAttribute]')) {
-      final isDriveLinkCard = element.localName == 'a' &&
-        element.classes.contains(_driveLinkCardClassName);
-      if (!isDriveLinkCard) {
-        element.attributes.remove(_contentEditableAttribute);
+    try {
+      final fragment = parseFragment(html);
+      for (final element in fragment.querySelectorAll(
+        '[$_contentEditableAttribute]',
+      )) {
+        final isDriveLinkCard =
+            element.localName == 'a' &&
+            element.classes.contains(_driveLinkCardClassName);
+        if (!isDriveLinkCard) {
+          element.attributes.remove(_contentEditableAttribute);
+        }
       }
+      return fragment.outerHtml;
+    } catch (e) {
+      log('Failed to strip contenteditable attribute from HTML: $e');
+      return html;
     }
-    return fragment.outerHtml;
   }
 }

--- a/core/lib/presentation/utils/html_transformer/transform_configuration.dart
+++ b/core/lib/presentation/utils/html_transformer/transform_configuration.dart
@@ -96,7 +96,10 @@ class TransformConfiguration {
   factory TransformConfiguration.forPreviewEmail() => TransformConfiguration.standardConfiguration;
 
   factory TransformConfiguration.forRestoreEmail() => TransformConfiguration.create(
-    customDomTransformers: [const ImageTransformer()]
+    customDomTransformers: [const ImageTransformer()],
+    customTextTransformers: const [
+      StandardizeHtmlSanitizingTransformers(allowAttributes: ['contenteditable']),
+    ],
   );
 
   factory TransformConfiguration.forPrintEmail() => TransformConfiguration.fromDomTransformers([

--- a/core/lib/presentation/utils/html_transformer/transform_configuration.dart
+++ b/core/lib/presentation/utils/html_transformer/transform_configuration.dart
@@ -62,12 +62,20 @@ class TransformConfiguration {
       const NormalizeLineHeightInStyleTransformer(),
     ]
   );
+  /// Reloading a draft feeds its HTML back into the composer's editable
+  /// webview, so unlike [forPreviewEmail]/[forDraftsEmail] (read-only), the
+  /// sanitizer here must let `contenteditable` survive - otherwise a drive
+  /// link card loses its `contenteditable="false"` guard and becomes an
+  /// editable region inside the editor.
   factory TransformConfiguration.forEditDraftsEmail() => TransformConfiguration.create(
     customDomTransformers: [
       ...TransformConfiguration.forDraftsEmail().domTransformers,
       if (PlatformInfo.isWeb)
         const HideDraftSignatureTransformer()
-    ]
+    ],
+    customTextTransformers: const [
+      StandardizeHtmlSanitizingTransformers(allowAttributes: ['contenteditable']),
+    ],
   );
 
   factory TransformConfiguration.forPreviewEmailOnWeb() => TransformConfiguration.create(

--- a/core/lib/presentation/utils/html_transformer/transform_configuration.dart
+++ b/core/lib/presentation/utils/html_transformer/transform_configuration.dart
@@ -90,10 +90,17 @@ class TransformConfiguration {
       const NormalizeLineHeightInStyleTransformer(),
       const ResponsiveTableCellTransformer(),
       const RemoveNegativeMarginFloatTransformer(),
-    ]
+    ],
+    customTextTransformers: const [
+      StandardizeHtmlSanitizingTransformers(allowAttributes: ['contenteditable']),
+    ],
   );
 
-  factory TransformConfiguration.forPreviewEmail() => TransformConfiguration.standardConfiguration;
+  factory TransformConfiguration.forPreviewEmail() => TransformConfiguration.create(
+    customTextTransformers: const [
+      StandardizeHtmlSanitizingTransformers(allowAttributes: ['contenteditable']),
+    ],
+  );
 
   factory TransformConfiguration.forRestoreEmail() => TransformConfiguration.create(
     customDomTransformers: [const ImageTransformer()],

--- a/core/lib/utils/html/file_link_card_html_builder.dart
+++ b/core/lib/utils/html/file_link_card_html_builder.dart
@@ -40,7 +40,7 @@ class FileLinkCardHtmlBuilder {
     final safeTitle = _textEscape.convert(content.title);
     final safeActionLabel = _textEscape.convert(content.actionLabel);
 
-    return '<a href="$safeHref" target="_blank" rel="noopener noreferrer" contenteditable="false" tabindex="-1" style="display:inline-block;vertical-align:top;width:${size.cardWidthPx}px;'
+    return '<a href="$safeHref" target="_blank" rel="noopener noreferrer" contenteditable="false" tabindex="-1" class="tmail-file-link-card" style="display:inline-block;vertical-align:top;width:${size.cardWidthPx}px;'
         'min-height:${size.cardMinHeightPx}px;margin:0 8px 8px 0;border:1px solid #E5E7EB;'
         'border-radius:10px;overflow:hidden;background:#FFFFFF;color:inherit;text-decoration:none;">'
         '${content.iconZoneHtml}'

--- a/core/lib/utils/html/file_link_card_html_builder.dart
+++ b/core/lib/utils/html/file_link_card_html_builder.dart
@@ -69,8 +69,16 @@ class FileLinkCardHtmlBuilder {
         '</div>';
   }
 
-  static String wrapFileCardsHtml(String cardsHtml) {
-    if (cardsHtml.isEmpty) return '';
-    return '<div style="display:block;max-width:100%;">$cardsHtml</div><br>';
+  static String wrapFileCardsHtml(List<String> cards) {
+    if (cards.isEmpty) return '';
+    // The row div is left editable (not contenteditable="false") so each
+    // card stays individually selectable/deletable as an atomic unit -
+    // browsers already let you select and Backspace a non-editable child
+    // without entering it. Enter anywhere inside this row is handled by
+    // HtmlUtils.registerFileLinkRowEnterKeyHandler, which recognizes the row
+    // by its direct contenteditable="false" <a> children and redirects the
+    // caret to the trailing <p><br></p> below instead of letting the
+    // editor's native (card-unaware) paragraph-split run.
+    return '<div style="display:block;max-width:100%;">${cards.join()}</div><p><br></p>';
   }
 }

--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -349,6 +349,62 @@ class HtmlUtils {
         name: 'registerFileLinkRowEnterKeyHandler',
       );
 
+  /// `target="_blank"` on the card anchor doesn't survive
+  /// StandardizeHtmlSanitizingTransformers (draft reload strips it), and
+  /// Summernote's image-handle module hijacks mousedown on any `<img>` before
+  /// it reaches the anchor - so this bypasses both by opening the link itself
+  /// on a capture-phase listener.
+  static ({String name, String script}) registerFileLinkCardClickHandler({
+    bool isWebPlatform = false,
+  }) =>
+      (
+        script: '''
+      (() => {
+        const isWebPlatform = $isWebPlatform;
+        const root = isWebPlatform
+          ? document.querySelector('.note-editor .note-editable')
+          : document.querySelector('#editor');
+        if (!root || root.dataset.fileLinkCardClickHandlerAttached) return;
+        root.dataset.fileLinkCardClickHandlerAttached = 'true';
+
+        function closestCardAnchor(node) {
+          let el = node && node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
+          while (el && el !== root.parentElement) {
+            if (el.tagName === 'A' && el.getAttribute('contenteditable') === 'false') {
+              return el;
+            }
+            el = el.parentElement;
+          }
+          return null;
+        }
+
+        root.addEventListener('mousedown', function (event) {
+          if (closestCardAnchor(event.target)) {
+            event.preventDefault();
+            event.stopPropagation();
+          }
+        }, true);
+
+        root.addEventListener('click', function (event) {
+          const anchor = closestCardAnchor(event.target);
+          if (!anchor) return;
+
+          event.preventDefault();
+          event.stopPropagation();
+
+          try {
+            const href = anchor.getAttribute('href');
+            if (href) {
+              window.open(href, '_blank', 'noopener,noreferrer');
+            }
+          } catch (error) {
+            console.error('File link card click handler error:', error);
+          }
+        }, true);
+      })();''',
+        name: 'registerFileLinkCardClickHandler',
+      );
+
   static const collapseSelectionToEnd = (
     script: '''
       (() => {

--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -363,11 +363,19 @@ class HtmlUtils {
         name: 'registerFileLinkRowEnterKeyHandler',
       );
 
+  /// JS handler name used to bridge file-link-card taps back to Dart on
+  /// mobile, since `window.open()` inside the InAppWebView editor has no
+  /// `onCreateWindow` wired up and is silently swallowed.
+  static const String fileLinkCardClickHandlerName = 'tmailFileLinkCardClick';
+
   /// `target="_blank"` on the card anchor doesn't survive
   /// StandardizeHtmlSanitizingTransformers (draft reload strips it), and
   /// Summernote's image-handle module hijacks mousedown on any `<img>` before
   /// it reaches the anchor - so this bypasses both by opening the link itself
-  /// on a capture-phase listener.
+  /// on a capture-phase listener. On mobile, `window.open()` inside the
+  /// InAppWebView editor has no `onCreateWindow` handler and is silently
+  /// swallowed, so the tap is bridged to Dart instead, which opens the link
+  /// via `url_launcher`.
   static ({String name, String script}) registerFileLinkCardClickHandler({
     bool isWebPlatform = false,
   }) =>
@@ -418,7 +426,11 @@ class HtmlUtils {
           try {
             const href = anchor.getAttribute('href');
             if (href && isSafeCardHref(href)) {
-              window.open(href, '_blank', 'noopener,noreferrer');
+              if (isWebPlatform) {
+                window.open(href, '_blank', 'noopener,noreferrer');
+              } else {
+                window.flutter_inappwebview.callHandler('$fileLinkCardClickHandlerName', href);
+              }
             }
           } catch (error) {
             console.error('File link card click handler error:', error);

--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -331,15 +331,19 @@ class HtmlUtils {
         root.addEventListener('keydown', function (event) {
           if (event.key !== 'Enter') return;
 
-          const selection = window.getSelection();
-          if (!selection || selection.rangeCount === 0) return;
+          try {
+            const selection = window.getSelection();
+            if (!selection || selection.rangeCount === 0) return;
 
-          const row = findFileLinkCardRow(selection.anchorNode);
-          if (!row) return;
+            const row = findFileLinkCardRow(selection.anchorNode);
+            if (!row) return;
 
-          event.preventDefault();
+            event.preventDefault();
 
-          splitRowAt(row, getSplitIndex(row, selection), selection);
+            splitRowAt(row, getSplitIndex(row, selection), selection);
+          } catch (error) {
+            console.error('File link row Enter handler error:', error);
+          }
         }, true);
       })();''',
         name: 'registerFileLinkRowEnterKeyHandler',

--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -192,6 +192,159 @@ class HtmlUtils {
         name: 'onSelectionChange',
       );
 
+  /// Intercepts Enter inside a drive-link file card row (a DIV whose direct
+  /// children include a `contenteditable="false"` card) and breaks the row
+  /// into two rows at the caret's position, with a new empty paragraph in
+  /// between - instead of letting the editor's native paragraph-split run.
+  /// Pressing Enter at the very start/end of the row just adds a blank line
+  /// before/after it instead of producing a pointless empty row.
+  ///
+  /// Neither editor's own Enter can be reused here, and the reason is worth
+  /// recording because the alternative looks tempting. The row contains only
+  /// cards, so it holds no text node. Summernote's `insertParagraph` first
+  /// calls `range.normalize()`, which for a collapsed caret walks *backward*
+  /// looking for a "visible point"; that check accepts any text node but never
+  /// consults `contenteditable`, so with nothing at row level it descends into
+  /// the previous card and lands on its title text. `ancestor(sc, isPara)`
+  /// then resolves to the card's inner DIV - Summernote's `isPara` matches
+  /// `/^DIV|^P|^LI|^H[1-7]/` - and `splitTree` splits *inside* the card, which
+  /// is what made Enter grow the card before the caret. Mobile's raw
+  /// `contenteditable` div hits the same missing-text-node problem natively.
+  ///
+  /// Padding the row with zero-width text nodes to give the caret somewhere
+  /// legal to sit was measured and rejected: it fixes only the row's two ends,
+  /// and each filler costs an extra arrow press to cross because its two
+  /// offsets render at the same pixel.
+  static ({String name, String script}) registerFileLinkRowEnterKeyHandler({
+    bool isWebPlatform = false,
+  }) =>
+      (
+        script: '''
+      (() => {
+        const isWebPlatform = $isWebPlatform;
+        const root = isWebPlatform
+          ? document.querySelector('.note-editor .note-editable')
+          : document.querySelector('#editor');
+        if (!root || root.dataset.fileLinkRowEnterHandlerAttached) return;
+        root.dataset.fileLinkRowEnterHandlerAttached = 'true';
+
+        function isFileLinkCardRow(el) {
+          if (!el || el.tagName !== 'DIV') return false;
+          let child = el.firstElementChild;
+          while (child) {
+            if (child.tagName === 'A' && child.getAttribute('contenteditable') === 'false') {
+              return true;
+            }
+            child = child.nextElementSibling;
+          }
+          return false;
+        }
+
+        function findFileLinkCardRow(node) {
+          let el = node && node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
+          while (el && el !== root) {
+            if (isFileLinkCardRow(el)) return el;
+            el = el.parentElement;
+          }
+          return null;
+        }
+
+        function isEmptyBlock(el) {
+          return !!el
+            && (el.tagName === 'P' || el.tagName === 'DIV')
+            && !isFileLinkCardRow(el)
+            && el.textContent.trim() === '';
+        }
+
+        // The row has no text nodes between cards, so a caret resting
+        // between two cards (or at either end) has the row itself as
+        // selection.anchorNode, with anchorOffset as the card index to
+        // split at. If the caret somehow ends up inside a card's subtree
+        // (e.g. via a non-click selection API), treat it as being right
+        // after that card.
+        function getSplitIndex(row, selection) {
+          const node = selection.anchorNode;
+          if (node === row) return selection.anchorOffset;
+          let el = node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
+          while (el && el.parentElement !== row) {
+            el = el.parentElement;
+          }
+          if (!el) return row.children.length;
+          const index = Array.prototype.indexOf.call(row.children, el);
+          return index < 0 ? row.children.length : index + 1;
+        }
+
+        function makeEmptyParagraph() {
+          const p = document.createElement('p');
+          p.innerHTML = '<br>';
+          return p;
+        }
+
+        function placeCaretAtStart(selection, target) {
+          const range = document.createRange();
+          range.setStart(target, 0);
+          range.collapse(true);
+          selection.removeAllRanges();
+          selection.addRange(range);
+        }
+
+        // Reuses an already-empty block sibling of `row` (on `side`) as the
+        // caret's landing line instead of stacking a new blank line on top
+        // of one that's already there, creating one only if needed.
+        function placeCaretInAdjacentLine(row, side, selection) {
+          const sibling = side === 'before' ? row.previousElementSibling : row.nextElementSibling;
+          let target = sibling;
+          if (!isEmptyBlock(target)) {
+            target = makeEmptyParagraph();
+            row.parentNode.insertBefore(target, side === 'before' ? row : row.nextSibling);
+          }
+          placeCaretAtStart(selection, target);
+        }
+
+        // Splits `row`'s cards at `splitIndex`, inserting a fresh empty line
+        // at that point. `splitIndex` at either edge (0 or cardCount) means
+        // there's nothing to actually split off, so it just docks the caret
+        // in the adjacent line instead of producing an empty row.
+        function splitRowAt(row, splitIndex, selection) {
+          const cardCount = row.children.length;
+
+          if (splitIndex <= 0) {
+            placeCaretInAdjacentLine(row, 'before', selection);
+            return;
+          }
+          if (splitIndex >= cardCount) {
+            placeCaretInAdjacentLine(row, 'after', selection);
+            return;
+          }
+
+          const children = Array.prototype.slice.call(row.children);
+          const secondRow = row.cloneNode(false);
+          for (let i = splitIndex; i < children.length; i++) {
+            secondRow.appendChild(children[i]);
+          }
+          const newLine = makeEmptyParagraph();
+          row.parentNode.insertBefore(newLine, row.nextSibling);
+          row.parentNode.insertBefore(secondRow, newLine.nextSibling);
+          placeCaretAtStart(selection, newLine);
+        }
+
+        root.addEventListener('keydown', function (event) {
+          if (event.key !== 'Enter') return;
+
+          const selection = window.getSelection();
+          if (!selection || selection.rangeCount === 0) return;
+
+          const row = findFileLinkCardRow(selection.anchorNode);
+          if (!row) return;
+
+          event.preventDefault();
+
+          splitRowAt(row, getSplitIndex(row, selection), selection);
+        }, true);
+      })();''',
+        name: 'registerFileLinkRowEnterKeyHandler',
+      );
+
   static const collapseSelectionToEnd = (
     script: '''
       (() => {

--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -256,22 +256,30 @@ class HtmlUtils {
             && el.textContent.trim() === '';
         }
 
-        // The row has no text nodes between cards, so a caret resting
-        // between two cards (or at either end) has the row itself as
-        // selection.anchorNode, with anchorOffset as the card index to
-        // split at. If the caret somehow ends up inside a card's subtree
-        // (e.g. via a non-click selection API), treat it as being right
-        // after that card.
+        // Index into row.childNodes (not just element children), splitting
+        // a text node in two if the caret sits mid-text - handles text typed
+        // between cards, which lands as a direct child text node of `row`.
         function getSplitIndex(row, selection) {
           const node = selection.anchorNode;
-          if (node === row) return selection.anchorOffset;
-          let el = node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
-          while (el && el.parentElement !== row) {
-            el = el.parentElement;
+          const offset = selection.anchorOffset;
+
+          if (node === row) return Math.min(offset, row.childNodes.length);
+
+          if (node.nodeType === Node.TEXT_NODE && node.parentNode === row) {
+            if (offset > 0 && offset < node.length) {
+              node.splitText(offset);
+            }
+            const index = Array.prototype.indexOf.call(row.childNodes, node);
+            return offset === 0 ? index : index + 1;
           }
-          if (!el) return row.children.length;
-          const index = Array.prototype.indexOf.call(row.children, el);
-          return index < 0 ? row.children.length : index + 1;
+
+          let el = node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
+          while (el && el.parentNode !== row) {
+            el = el.parentNode;
+          }
+          if (!el) return row.childNodes.length;
+          const index = Array.prototype.indexOf.call(row.childNodes, el);
+          return index < 0 ? row.childNodes.length : index + 1;
         }
 
         function makeEmptyParagraph() {
@@ -301,27 +309,32 @@ class HtmlUtils {
           placeCaretAtStart(selection, target);
         }
 
-        // Splits `row`'s cards at `splitIndex`, inserting a fresh empty line
-        // at that point. `splitIndex` at either edge (0 or cardCount) means
-        // there's nothing to actually split off, so it just docks the caret
-        // in the adjacent line instead of producing an empty row.
-        function splitRowAt(row, splitIndex, selection) {
-          const cardCount = row.children.length;
+        function hasCard(nodes) {
+          return nodes.some(function (node) {
+            return node.nodeType === Node.ELEMENT_NODE && node.tagName === 'A';
+          });
+        }
 
-          if (splitIndex <= 0) {
+        // Splits row's child nodes at splitIndex. If a side has no card
+        // left, docks the caret in the adjacent line instead.
+        function splitRowAt(row, splitIndex, selection) {
+          const childNodes = Array.prototype.slice.call(row.childNodes);
+          const before = childNodes.slice(0, splitIndex);
+          const after = childNodes.slice(splitIndex);
+
+          if (!hasCard(before)) {
             placeCaretInAdjacentLine(row, 'before', selection);
             return;
           }
-          if (splitIndex >= cardCount) {
+          if (!hasCard(after)) {
             placeCaretInAdjacentLine(row, 'after', selection);
             return;
           }
 
-          const children = Array.prototype.slice.call(row.children);
           const secondRow = row.cloneNode(false);
-          for (let i = splitIndex; i < children.length; i++) {
-            secondRow.appendChild(children[i]);
-          }
+          after.forEach(function (node) {
+            secondRow.appendChild(node);
+          });
           const newLine = makeEmptyParagraph();
           row.parentNode.insertBefore(newLine, row.nextSibling);
           row.parentNode.insertBefore(secondRow, newLine.nextSibling);
@@ -1136,6 +1149,7 @@ class HtmlUtils {
     bool removeStyle = true,
     bool removeScript = true,
     bool removeTMailSignature = true,
+    bool removeFileLinkCards = true,
   }) {
     var cleaned = html;
 
@@ -1156,6 +1170,13 @@ class HtmlUtils {
     }
     if (removeTMailSignature) {
       doc.querySelectorAll('div.tmail-signature').forEach((e) => e.remove());
+    }
+    if (removeFileLinkCards) {
+      // File-link cards (e.g. Drive attachments, see FileLinkCardHtmlBuilder)
+      // carry the "tmail-file-link-card" class. Their title/action-label
+      // text is card chrome, not user-authored content, so it must not feed
+      // the attachment-reminder keyword scan.
+      doc.querySelectorAll('a.tmail-file-link-card').forEach((e) => e.remove());
     }
 
     cleaned = doc.outerHtml;

--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -232,7 +232,7 @@ class HtmlUtils {
           if (!el || el.tagName !== 'DIV') return false;
           let child = el.firstElementChild;
           while (child) {
-            if (child.tagName === 'A' && child.getAttribute('contenteditable') === 'false') {
+            if (child.tagName === 'A' && child.classList.contains('tmail-file-link-card')) {
               return true;
             }
             child = child.nextElementSibling;
@@ -354,6 +354,7 @@ class HtmlUtils {
             event.preventDefault();
 
             splitRowAt(row, getSplitIndex(row, selection), selection);
+            root.dispatchEvent(new Event('input', { bubbles: true }));
           } catch (error) {
             console.error('File link row Enter handler error:', error);
           }
@@ -383,12 +384,21 @@ class HtmlUtils {
         function closestCardAnchor(node) {
           let el = node && node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
           while (el && el !== root.parentElement) {
-            if (el.tagName === 'A' && el.getAttribute('contenteditable') === 'false') {
+            if (el.tagName === 'A' && el.classList.contains('tmail-file-link-card')) {
               return el;
             }
             el = el.parentElement;
           }
           return null;
+        }
+
+        function isSafeCardHref(href) {
+          try {
+            const protocol = new URL(href, window.location.href).protocol;
+            return protocol === 'http:' || protocol === 'https:';
+          } catch (error) {
+            return false;
+          }
         }
 
         root.addEventListener('mousedown', function (event) {
@@ -407,7 +417,7 @@ class HtmlUtils {
 
           try {
             const href = anchor.getAttribute('href');
-            if (href) {
+            if (href && isSafeCardHref(href)) {
               window.open(href, '_blank', 'noopener,noreferrer');
             }
           } catch (error) {

--- a/core/test/utils/html/file_link_card_html_builder_test.dart
+++ b/core/test/utils/html/file_link_card_html_builder_test.dart
@@ -96,18 +96,22 @@ void main() {
   });
 
   group('FileLinkCardHtmlBuilder wrapFileCardsHtml tests', () {
-    test('Should return empty string when cardsHtml is empty', () {
-      final result = FileLinkCardHtmlBuilder.wrapFileCardsHtml('');
+    test('Should return empty string when cards is empty', () {
+      final result = FileLinkCardHtmlBuilder.wrapFileCardsHtml([]);
 
       expect(result, isEmpty);
     });
 
-    test('Should wrap cardsHtml in a block-level div followed by a line break', () {
-      const cardsHtml = '<a>card1</a><a>card2</a>';
+    test('Should wrap cards in an editable block-level div followed by an empty paragraph', () {
+      final result = FileLinkCardHtmlBuilder.wrapFileCardsHtml(['<a>card1</a>', '<a>card2</a>']);
 
-      final result = FileLinkCardHtmlBuilder.wrapFileCardsHtml(cardsHtml);
+      expect(result, '<div style="display:block;max-width:100%;"><a>card1</a><a>card2</a></div><p><br></p>');
+    });
 
-      expect(result, '<div style="display:block;max-width:100%;">$cardsHtml</div><br>');
+    test('Should concatenate cards without inserting anything between them', () {
+      final result = FileLinkCardHtmlBuilder.wrapFileCardsHtml(['<a>card1</a>', '<a>card2</a>', '<a>card3</a>']);
+
+      expect(result, contains('<a>card1</a><a>card2</a><a>card3</a>'));
     });
   });
 }

--- a/core/test/utils/html/html_utils_test.dart
+++ b/core/test/utils/html/html_utils_test.dart
@@ -144,10 +144,10 @@ void main() {
       expect(result.script, contains("'#editor'"));
     });
 
-    test('Should identify a file-link card row only via a direct contenteditable="false" anchor child', () {
+    test('Should identify a file-link card row only via a direct tmail-file-link-card anchor child', () {
       final result = HtmlUtils.registerFileLinkRowEnterKeyHandler();
 
-      expect(result.script, contains('contenteditable') );
+      expect(result.script, contains("classList.contains('tmail-file-link-card')"));
       expect(result.script, contains('firstElementChild'));
     });
 

--- a/core/test/utils/html/html_utils_test.dart
+++ b/core/test/utils/html/html_utils_test.dart
@@ -120,4 +120,57 @@ void main() {
     });
   });
 
+  group('HtmlUtils registerFileLinkRowEnterKeyHandler tests', () {
+    test('Should return a stable script name regardless of platform', () {
+      final web = HtmlUtils.registerFileLinkRowEnterKeyHandler(isWebPlatform: true);
+      final mobile = HtmlUtils.registerFileLinkRowEnterKeyHandler(isWebPlatform: false);
+
+      expect(web.name, 'registerFileLinkRowEnterKeyHandler');
+      expect(mobile.name, 'registerFileLinkRowEnterKeyHandler');
+    });
+
+    test('Should target the Summernote editable root when isWebPlatform is true', () {
+      final result = HtmlUtils.registerFileLinkRowEnterKeyHandler(isWebPlatform: true);
+
+      expect(result.script, contains('const isWebPlatform = true'));
+      expect(result.script, contains(".note-editor .note-editable'"));
+    });
+
+    test('Should target the mobile editor root when isWebPlatform is false', () {
+      final result = HtmlUtils.registerFileLinkRowEnterKeyHandler(isWebPlatform: false);
+
+      expect(result.script, contains('const isWebPlatform = false'));
+      expect(result.script, contains("'#editor'"));
+    });
+
+    test('Should identify a file-link card row only via a direct contenteditable="false" anchor child', () {
+      final result = HtmlUtils.registerFileLinkRowEnterKeyHandler();
+
+      expect(result.script, contains('contenteditable') );
+      expect(result.script, contains('firstElementChild'));
+    });
+
+    test('Should split the row into two at the caret index rather than always inserting after it', () {
+      final result = HtmlUtils.registerFileLinkRowEnterKeyHandler();
+
+      expect(result.script, contains('function splitRowAt'));
+      expect(result.script, contains('function getSplitIndex'));
+      expect(result.script, contains('cloneNode(false)'));
+    });
+
+    test('Should fall back to a blank line before/after the row at its edges instead of an empty split', () {
+      final result = HtmlUtils.registerFileLinkRowEnterKeyHandler();
+
+      expect(result.script, contains('function placeCaretInAdjacentLine'));
+      expect(result.script, contains('splitIndex <= 0'));
+      expect(result.script, contains('splitIndex >= cardCount'));
+    });
+
+    test('Should reuse an existing empty adjacent line instead of stacking a new one', () {
+      final result = HtmlUtils.registerFileLinkRowEnterKeyHandler();
+
+      expect(result.script, contains('function isEmptyBlock'));
+      expect(result.script, contains('if (!isEmptyBlock(target))'));
+    });
+  });
 }

--- a/core/test/utils/html/html_utils_test.dart
+++ b/core/test/utils/html/html_utils_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:core/utils/html/html_utils.dart';
+import 'package:core/utils/html/file_link_card_html_builder.dart';
 import 'package:universal_html/html.dart' as html;
 
 void main() {
@@ -162,8 +163,9 @@ void main() {
       final result = HtmlUtils.registerFileLinkRowEnterKeyHandler();
 
       expect(result.script, contains('function placeCaretInAdjacentLine'));
-      expect(result.script, contains('splitIndex <= 0'));
-      expect(result.script, contains('splitIndex >= cardCount'));
+      expect(result.script, contains('function hasCard'));
+      expect(result.script, contains('if (!hasCard(before))'));
+      expect(result.script, contains('if (!hasCard(after))'));
     });
 
     test('Should reuse an existing empty adjacent line instead of stacking a new one', () {
@@ -171,6 +173,45 @@ void main() {
 
       expect(result.script, contains('function isEmptyBlock'));
       expect(result.script, contains('if (!isEmptyBlock(target))'));
+    });
+  });
+
+  group('HtmlUtils extractPlainText file link card tests', () {
+    final card = FileLinkCardHtmlBuilder.buildFileLinkCard(
+      const FileLinkCardContent(
+        href: 'https://drive.example.com/file/1',
+        title: 'report_attachment.pdf',
+        actionLabel: 'Open in Drive',
+        iconZoneHtml: '',
+      ),
+    );
+
+    test('Should strip file link card title/action text by default', () {
+      final result = HtmlUtils.extractPlainText('<p>Hello there</p>$card');
+
+      expect(result, contains('Hello there'));
+      expect(result, isNot(contains('report_attachment.pdf')));
+      expect(result, isNot(contains('Open in Drive')));
+    });
+
+    test('Should keep file link card text when removeFileLinkCards is false', () {
+      final result = HtmlUtils.extractPlainText(
+        '<p>Hello there</p>$card',
+        removeFileLinkCards: false,
+      );
+
+      expect(result, contains('Hello there'));
+      expect(result, contains('report_attachment.pdf'));
+      expect(result, contains('Open in Drive'));
+    });
+
+    test('Should still detect user-typed attachment mentions outside the card', () {
+      final result = HtmlUtils.extractPlainText(
+        '<p>I forgot the attachment</p>$card',
+      );
+
+      expect(result, contains('I forgot the attachment'));
+      expect(result, isNot(contains('report_attachment.pdf')));
     });
   });
 }

--- a/core/test/utils/html_transform_text_html_test.dart
+++ b/core/test/utils/html_transform_text_html_test.dart
@@ -481,17 +481,24 @@ void main() {
 
       test('SHOULD preserve contenteditable="false" on a drive-link card row', () async {
         const html =
-            '<div><a href="https://drive.example.com/file" contenteditable="false">file.pdf</a></div>';
+            '<div><a class="tmail-file-link-card" href="https://drive.example.com/file" contenteditable="false">file.pdf</a></div>';
         final out = await transformWithEditDraftsConfig(html);
         expect(out, contains('contenteditable="false"'));
       });
 
       test('SHOULD still strip <script> while preserving drive-link card contenteditable', () async {
         const html = '<script>alert(1)</script>'
-            '<a href="https://drive.example.com/file" contenteditable="false">file.pdf</a>';
+            '<a class="tmail-file-link-card" href="https://drive.example.com/file" contenteditable="false">file.pdf</a>';
         final out = await transformWithEditDraftsConfig(html);
         expect(out, isNot(contains('<script')));
         expect(out, contains('contenteditable="false"'));
+      });
+
+      test('SHOULD strip contenteditable="false" from a non-drive-link-card element', () async {
+        const html =
+            '<div><a href="https://drive.example.com/file" contenteditable="false">file.pdf</a></div>';
+        final out = await transformWithEditDraftsConfig(html);
+        expect(out, isNot(contains('contenteditable')));
       });
     });
 

--- a/core/test/utils/html_transform_text_html_test.dart
+++ b/core/test/utils/html_transform_text_html_test.dart
@@ -428,13 +428,15 @@ void main() {
       });
     });
 
-    group('Drive-link card config — used by GetHtmlContentFromUploadFileInteractor and PreviewAttachmentDownloadControllerExtension', () {
-      // Both consumers build their pipeline as:
+    group('HTML-attachment preview config — used by GetHtmlContentFromUploadFileInteractor and PreviewAttachmentDownloadControllerExtension', () {
+      // Both consumers preview an arbitrary .html file (attacker-controlled if
+      // it came from a received email's attachment), so this must behave like
+      // read-only email preview: no contenteditable survives. Pipeline:
       // TransformConfiguration.create(
       //   customDomTransformers: [SanitizeHyperLinkTagInHtmlTransformer()],
       //   customTextTransformers: [StandardizeHtmlSanitizingTransformers()],
       // )
-      Future<String> transformWithDriveLinkConfig(String content) =>
+      Future<String> transformWithHtmlAttachmentConfig(String content) =>
           htmlTransform.transformToHtml(
             htmlContent: content,
             transformConfiguration: TransformConfiguration.create(
@@ -443,29 +445,52 @@ void main() {
             ),
           );
 
-      test('SHOULD preserve contenteditable="false" on a drive-link card row', () async {
+      test('SHOULD strip contenteditable from a crafted .html attachment', () async {
         const html =
             '<div><a href="https://drive.example.com/file" contenteditable="false">file.pdf</a></div>';
-        final out = await transformWithDriveLinkConfig(html);
-        expect(out, contains('contenteditable="false"'));
+        final out = await transformWithHtmlAttachmentConfig(html);
+        expect(out, isNot(contains('contenteditable')));
       });
 
       test('SHOULD still add target/rel to plain links AND strip <script>', () async {
         const input =
             HtmlEmailCorpus.htmlWithScriptTag + HtmlEmailCorpus.htmlWithBoldAndLink;
-        final out = await transformWithDriveLinkConfig(input);
+        final out = await transformWithHtmlAttachmentConfig(input);
         expect(out, isNot(contains('<script')));
         expect(out, contains('target="_blank"'));
         expect(out, contains('rel="noreferrer"'));
       });
 
-      test('SHOULD sanitize javascript: href while preserving drive-link card contenteditable', () async {
+      test('SHOULD sanitize javascript: href AND strip contenteditable', () async {
         const html = '<div>'
             '<a href="javascript:alert(1)">evil</a>'
             '<a href="https://drive.example.com/file" contenteditable="false">file.pdf</a>'
             '</div>';
-        final out = await transformWithDriveLinkConfig(html);
+        final out = await transformWithHtmlAttachmentConfig(html);
         expect(out, isNot(contains('javascript:')));
+        expect(out, isNot(contains('contenteditable')));
+      });
+    });
+
+    group('Draft-reload config — TransformConfiguration.forEditDraftsEmail (composer editing a saved draft)', () {
+      Future<String> transformWithEditDraftsConfig(String content) =>
+          htmlTransform.transformToHtml(
+            htmlContent: content,
+            transformConfiguration: TransformConfiguration.forEditDraftsEmail(),
+          );
+
+      test('SHOULD preserve contenteditable="false" on a drive-link card row', () async {
+        const html =
+            '<div><a href="https://drive.example.com/file" contenteditable="false">file.pdf</a></div>';
+        final out = await transformWithEditDraftsConfig(html);
+        expect(out, contains('contenteditable="false"'));
+      });
+
+      test('SHOULD still strip <script> while preserving drive-link card contenteditable', () async {
+        const html = '<script>alert(1)</script>'
+            '<a href="https://drive.example.com/file" contenteditable="false">file.pdf</a>';
+        final out = await transformWithEditDraftsConfig(html);
+        expect(out, isNot(contains('<script')));
         expect(out, contains('contenteditable="false"'));
       });
     });

--- a/core/test/utils/html_transform_text_html_test.dart
+++ b/core/test/utils/html_transform_text_html_test.dart
@@ -6,6 +6,7 @@ import 'package:core/presentation/utils/html_transformer/dom/responsive_table_ce
 import 'package:core/presentation/utils/html_transformer/dom/sanitize_hyper_link_tag_in_html_transformers.dart';
 import 'package:core/presentation/utils/html_transformer/dom/script_transformers.dart';
 import 'package:core/presentation/utils/html_transformer/html_transform.dart';
+import 'package:core/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart';
 import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
@@ -424,6 +425,48 @@ void main() {
           contains('After'),
           contains('Hello'),
         ));
+      });
+    });
+
+    group('Drive-link card config — used by GetHtmlContentFromUploadFileInteractor and PreviewAttachmentDownloadControllerExtension', () {
+      // Both consumers build their pipeline as:
+      // TransformConfiguration.create(
+      //   customDomTransformers: [SanitizeHyperLinkTagInHtmlTransformer()],
+      //   customTextTransformers: [StandardizeHtmlSanitizingTransformers()],
+      // )
+      Future<String> transformWithDriveLinkConfig(String content) =>
+          htmlTransform.transformToHtml(
+            htmlContent: content,
+            transformConfiguration: TransformConfiguration.create(
+              customDomTransformers: [SanitizeHyperLinkTagInHtmlTransformer()],
+              customTextTransformers: const [StandardizeHtmlSanitizingTransformers()],
+            ),
+          );
+
+      test('SHOULD preserve contenteditable="false" on a drive-link card row', () async {
+        const html =
+            '<div><a href="https://drive.example.com/file" contenteditable="false">file.pdf</a></div>';
+        final out = await transformWithDriveLinkConfig(html);
+        expect(out, contains('contenteditable="false"'));
+      });
+
+      test('SHOULD still add target/rel to plain links AND strip <script>', () async {
+        const input =
+            HtmlEmailCorpus.htmlWithScriptTag + HtmlEmailCorpus.htmlWithBoldAndLink;
+        final out = await transformWithDriveLinkConfig(input);
+        expect(out, isNot(contains('<script')));
+        expect(out, contains('target="_blank"'));
+        expect(out, contains('rel="noreferrer"'));
+      });
+
+      test('SHOULD sanitize javascript: href while preserving drive-link card contenteditable', () async {
+        const html = '<div>'
+            '<a href="javascript:alert(1)">evil</a>'
+            '<a href="https://drive.example.com/file" contenteditable="false">file.pdf</a>'
+            '</div>';
+        final out = await transformWithDriveLinkConfig(html);
+        expect(out, isNot(contains('javascript:')));
+        expect(out, contains('contenteditable="false"'));
       });
     });
 

--- a/core/test/utils/standardize_html_sanitizing_transformers_test.dart
+++ b/core/test/utils/standardize_html_sanitizing_transformers_test.dart
@@ -178,13 +178,23 @@ void main() {
             equals('<a href="https://example.com">card</a>'));
       });
 
-      test('SHOULD preserve contenteditable="false" on <a> WHEN allowAttributes opts in (drive link card)', () {
+      test('SHOULD preserve contenteditable="false" on the Drive link card <a> WHEN allowAttributes opts in', () {
         const driveCardTransformer =
             StandardizeHtmlSanitizingTransformers(allowAttributes: ['contenteditable']);
-        const html = '<a href="https://example.com" contenteditable="false">card</a>';
+        const html = '<a href="https://example.com" class="tmail-file-link-card" contenteditable="false">card</a>';
         expect(
             driveCardTransformer.process(html, htmlEscape).trim(),
-            equals('<a href="https://example.com" contenteditable="false">card</a>'));
+            equals('<a href="https://example.com" class="tmail-file-link-card" contenteditable="false">card</a>'));
+      });
+
+      test('SHOULD strip contenteditable FROM non-Drive-card elements EVEN WHEN allowAttributes opts in', () {
+        const driveCardTransformer =
+            StandardizeHtmlSanitizingTransformers(allowAttributes: ['contenteditable']);
+        const html = '<a href="https://example.com" contenteditable="false">plain link</a>'
+            '<div contenteditable="false">editable island</div>';
+        expect(
+            driveCardTransformer.process(html, htmlEscape).trim(),
+            equals('<a href="https://example.com">plain link</a><div>editable island</div>'));
       });
     });
 

--- a/core/test/utils/standardize_html_sanitizing_transformers_test.dart
+++ b/core/test/utils/standardize_html_sanitizing_transformers_test.dart
@@ -170,6 +170,13 @@ void main() {
             sanitize('<img src="cid:email123">'),
             equals('<img src="cid:email123">'));
       });
+
+      test('SHOULD preserve contenteditable="false" on <a> (drive link card)', () {
+        const html = '<a href="https://example.com" contenteditable="false">card</a>';
+        expect(
+            sanitize(html),
+            equals('<a href="https://example.com" contenteditable="false">card</a>'));
+      });
     });
 
     group('Unknown tags, structural tags – unwrap or preserve safely', () {

--- a/core/test/utils/standardize_html_sanitizing_transformers_test.dart
+++ b/core/test/utils/standardize_html_sanitizing_transformers_test.dart
@@ -171,10 +171,19 @@ void main() {
             equals('<img src="cid:email123">'));
       });
 
-      test('SHOULD preserve contenteditable="false" on <a> (drive link card)', () {
+      test('SHOULD strip contenteditable on <a> BY DEFAULT (email preview)', () {
         const html = '<a href="https://example.com" contenteditable="false">card</a>';
         expect(
             sanitize(html),
+            equals('<a href="https://example.com">card</a>'));
+      });
+
+      test('SHOULD preserve contenteditable="false" on <a> WHEN allowAttributes opts in (drive link card)', () {
+        const driveCardTransformer =
+            StandardizeHtmlSanitizingTransformers(allowAttributes: ['contenteditable']);
+        const html = '<a href="https://example.com" contenteditable="false">card</a>';
+        expect(
+            driveCardTransformer.process(html, htmlEscape).trim(),
             equals('<a href="https://example.com" contenteditable="false">card</a>'));
       });
     });

--- a/lib/features/composer/presentation/composer_bindings.dart
+++ b/lib/features/composer/presentation/composer_bindings.dart
@@ -347,6 +347,7 @@ abstract class ComposerBindings extends BaseBindings {
     Get.lazyPut(
       () => DriveAttachmentHandler(requireHttps: BuildUtils.isReleaseMode),
       tag: composerId,
+      fenix: true,
     );
     bindPlatformRichTextController();
     Get.lazyPut(

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1908,6 +1908,7 @@ class ComposerController extends BaseController
   }
 
   Future<void> onInitialContentLoadCompleteWeb(String? initContent) async {
+    await restoreCollapsibleSignatureButton(initContent);
     await setupSelectedIdentity();
     _autoFocusFieldWhenLauncher();
   }

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1001,15 +1001,17 @@ class ComposerController extends BaseController
     }
   }
 
-  void handleDrivePickResult(List<DriveDocument> result) {
+  Future<void> handleDrivePickResult(List<DriveDocument> result) async {
     try {
-      getBinding<DriveAttachmentHandler>(tag: composerId)?.handleDrivePickResult(
+      await getBinding<DriveAttachmentHandler>(tag: composerId)?.handleDrivePickResult(
         result,
-        insertHtml: (html) {
+        insertHtml: (html) async {
           if (PlatformInfo.isWeb) {
             richTextWebController?.editorController.insertHtml(html);
           } else {
-            htmlEditorApi?.insertHtml(html);
+            popBack();
+            await richTextMobileTabletController?.restoreMobileEditorFocus();
+            await htmlEditorApi?.insertHtml(html);
           }
         },
         appLocalizations: currentContext != null ? AppLocalizations.of(currentContext!) : null,

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1195,7 +1195,15 @@ class ComposerController extends BaseController
     }
   }
 
-  void openPickAttachmentMenu(BuildContext context, List<Widget> actionTiles) {
+  void openPickAttachmentMenu(BuildContext context, List<Widget> actionTiles) async {
+    if (PlatformInfo.isMobile) {
+      try {
+        await htmlEditorApi?.storeSelectionRange();
+      } catch (e) {
+        log('ComposerController::openPickAttachmentMenu(): $e');
+      }
+    }
+    if (!context.mounted) return;
     clearFocus();
 
     (ContextMenuBuilder(context)
@@ -1900,7 +1908,6 @@ class ComposerController extends BaseController
   }
 
   Future<void> onInitialContentLoadCompleteWeb(String? initContent) async {
-    await restoreCollapsibleSignatureButton(initContent);
     await setupSelectedIdentity();
     _autoFocusFieldWhenLauncher();
   }

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1195,7 +1195,7 @@ class ComposerController extends BaseController
     }
   }
 
-  void openPickAttachmentMenu(BuildContext context, List<Widget> actionTiles) async {
+  Future<void> openPickAttachmentMenu(BuildContext context, List<Widget> actionTiles) async {
     if (PlatformInfo.isMobile) {
       try {
         await htmlEditorApi?.storeSelectionRange();

--- a/lib/features/composer/presentation/composer_view.dart
+++ b/lib/features/composer/presentation/composer_view.dart
@@ -497,7 +497,6 @@ class ComposerView extends GetWidget<ComposerController> {
           .watch(composerAttachmentExtensionRegistryProvider)
           .buildContextMenuTiles(
             context,
-            composerId: controller.composerId ?? '',
             imagePaths: controller.imagePaths,
             label: AppLocalizations.of(context).browse,
           ),

--- a/lib/features/composer/presentation/extensions/sanitize_signature_in_email_content_extension.dart
+++ b/lib/features/composer/presentation/extensions/sanitize_signature_in_email_content_extension.dart
@@ -4,6 +4,24 @@ import 'package:tmail_ui_user/features/composer/presentation/composer_controller
 
 extension SanitizeSignatureInEmailContentExtension on ComposerController {
 
+  Future<void> restoreCollapsibleSignatureButton(String? emailContent) async {
+    try {
+      if (emailContent == null) return;
+
+      final emailDocument = parse(emailContent);
+      final existedSignatureButton = emailDocument.querySelector('.tmail-signature-button');
+      if (existedSignatureButton != null) return;
+
+      final signature = emailDocument.querySelector('.tmail-signature');
+      if (signature == null) return;
+
+      restoringSignatureButton = true;
+      await applySignature(signature.innerHtml);
+    } catch (e) {
+      logWarning('SanitizeSignatureInEmailContentExtension::restoreCollapsibleSignatureButton:Exception = $e');
+    }
+  }
+
   void synchronizeInitEmailDraftHash(String? emailContent) {
     try {
       final emailDocument = parse(emailContent);

--- a/lib/features/composer/presentation/extensions/sanitize_signature_in_email_content_extension.dart
+++ b/lib/features/composer/presentation/extensions/sanitize_signature_in_email_content_extension.dart
@@ -4,24 +4,6 @@ import 'package:tmail_ui_user/features/composer/presentation/composer_controller
 
 extension SanitizeSignatureInEmailContentExtension on ComposerController {
 
-  Future<void> restoreCollapsibleSignatureButton(String? emailContent) async {
-    try {
-      if (emailContent == null) return;
-
-      final emailDocument = parse(emailContent);
-      final existedSignatureButton = emailDocument.querySelector('.tmail-signature-button');
-      if (existedSignatureButton != null) return;
-
-      final signature = emailDocument.querySelector('.tmail-signature');
-      if (signature == null) return;
-
-      restoringSignatureButton = true;
-      await applySignature(signature.innerHtml);
-    } catch (e) {
-      logWarning('SanitizeSignatureInEmailContentExtension::restoreCollapsibleSignatureButton:Exception = $e');
-    }
-  }
-
   void synchronizeInitEmailDraftHash(String? emailContent) {
     try {
       final emailDocument = parse(emailContent);

--- a/lib/features/composer/presentation/extensions/setup_selected_identity_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_selected_identity_extension.dart
@@ -30,8 +30,7 @@ extension SetupSelectedIdentityExtension on ComposerController {
       ) ?? listFromIdentities.first;
 
       if (currentEmailActionType == EmailActionType.editDraft ||
-          currentEmailActionType == EmailActionType.reopenComposerBrowser &&
-              savedActionType == EmailActionType.editDraft) {
+          currentEmailActionType == EmailActionType.reopenComposerBrowser) {
         identitySelected.value = currentIdentity;
       } else if (currentEmailActionType == EmailActionType.editAsNewEmail) {
         identitySelected.value = currentIdentity;

--- a/lib/features/composer/presentation/extensions/setup_selected_identity_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_selected_identity_extension.dart
@@ -30,7 +30,8 @@ extension SetupSelectedIdentityExtension on ComposerController {
       ) ?? listFromIdentities.first;
 
       if (currentEmailActionType == EmailActionType.editDraft ||
-          currentEmailActionType == EmailActionType.reopenComposerBrowser) {
+          currentEmailActionType == EmailActionType.reopenComposerBrowser &&
+              savedActionType == EmailActionType.editDraft) {
         identitySelected.value = currentIdentity;
       } else if (currentEmailActionType == EmailActionType.editAsNewEmail) {
         identitySelected.value = currentIdentity;

--- a/lib/features/composer/presentation/manager/drive_attachment_handler.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_handler.dart
@@ -47,7 +47,7 @@ class DriveAttachmentHandler {
           ),
         )
         .nonNulls
-        .join();
+        .toList();
     return FileLinkCardHtmlBuilder.wrapFileCardsHtml(cards);
   }
 

--- a/lib/features/composer/presentation/manager/drive_attachment_handler.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_handler.dart
@@ -12,25 +12,25 @@ class DriveAttachmentHandler {
   /// without this class depending on `BuildUtils` directly.
   final bool requireHttps;
 
-  void handleDrivePickResult(
+  Future<void> handleDrivePickResult(
     List<DriveDocument> result, {
-    required void Function(String html) insertHtml,
+    required Future<void> Function(String html) insertHtml,
     AppLocalizations? appLocalizations,
-  }) {
+  }) async {
     final linkDocs = result.where((doc) => doc.sharingLink != null).toList();
-    insertDriveLinkHtml(
+    await insertDriveLinkHtml(
       linkDocs,
       insertHtml: insertHtml,
       appLocalizations: appLocalizations,
     );
   }
 
-  void insertDriveLinkHtml(
+  Future<void> insertDriveLinkHtml(
     List<DriveDocument> docs, {
-    required void Function(String html) insertHtml,
+    required Future<void> Function(String html) insertHtml,
     AppLocalizations? appLocalizations,
-  }) {
-    insertHtml(
+  }) async {
+    await insertHtml(
       buildDriveLinksHtml(docs, appLocalizations: appLocalizations),
     );
   }

--- a/lib/features/composer/presentation/providers/composer_attachment_extension_registry_provider.dart
+++ b/lib/features/composer/presentation/providers/composer_attachment_extension_registry_provider.dart
@@ -18,10 +18,10 @@ ComposerAttachmentExtensionRegistry composerAttachmentExtensionRegistry(Ref ref)
     WorkplaceComposerAttachmentExtension(
       workplaceUri: uriNotifier,
       oidcTokenGetter: () => getBinding<AuthorizationInterceptors>()?.currentOidcIdToken,
-      onPickState: (composerId, state) {
+      onPickState: (composerId, state) async {
         if (state is DrivePickResult) {
           try {
-            getBinding<ComposerController>(tag: composerId)?.handleDrivePickResult(state.documents);
+            await getBinding<ComposerController>(tag: composerId)?.handleDrivePickResult(state.documents);
           } catch (e) {
             logWarning('ComposerAttachmentExtensionRegistry::onPickState: $e');
           }

--- a/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
@@ -98,6 +98,11 @@ class _MobileEditorState extends State<MobileEditorWidget> with TextSelectionMix
         isWebPlatform: PlatformInfo.isWeb,
       ).script,
     );
+    await _editorController?.evaluateJavascript(
+      source: HtmlUtils.registerFileLinkCardClickHandler(
+        isWebPlatform: PlatformInfo.isWeb,
+      ).script,
+    );
   }
 
   Future<void> _onWebViewCreated(HtmlEditorApi editorApi) async {

--- a/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
@@ -7,6 +7,7 @@ import 'package:core/utils/html/html_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:rich_text_composer/rich_text_composer.dart';
 import 'package:tmail_ui_user/features/composer/presentation/mixin/text_selection_mixin.dart';
+import 'package:url_launcher/url_launcher.dart' as launcher;
 
 typedef OnCreatedEditorAction = Function(BuildContext context, HtmlEditorApi editorApi, String content);
 typedef OnLoadCompletedEditorAction = Function(HtmlEditorApi editorApi, WebUri? url);
@@ -90,6 +91,11 @@ class _MobileEditorState extends State<MobileEditorWidget> with TextSelectionMix
       },
     );
 
+    _editorController?.addJavaScriptHandler(
+      handlerName: HtmlUtils.fileLinkCardClickHandlerName,
+      callback: (args) => _handleFileLinkCardClick(args),
+    );
+
     await _editorController?.evaluateJavascript(
       source: registerSelectionChange!.script,
     );
@@ -103,6 +109,24 @@ class _MobileEditorState extends State<MobileEditorWidget> with TextSelectionMix
         isWebPlatform: PlatformInfo.isWeb,
       ).script,
     );
+  }
+
+  Future<void> _handleFileLinkCardClick(List<dynamic> args) async {
+    if (args.isEmpty) return;
+
+    final href = args[0];
+    if (href is! String) return;
+
+    final uri = Uri.tryParse(href);
+    if (uri == null) return;
+
+    try {
+      if (await launcher.canLaunchUrl(uri)) {
+        await launcher.launchUrl(uri, mode: launcher.LaunchMode.externalApplication);
+      }
+    } catch (e) {
+      logWarning('MobileEditorWidget::_handleFileLinkCardClick: $e');
+    }
   }
 
   Future<void> _onWebViewCreated(HtmlEditorApi editorApi) async {

--- a/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
@@ -93,6 +93,11 @@ class _MobileEditorState extends State<MobileEditorWidget> with TextSelectionMix
     await _editorController?.evaluateJavascript(
       source: registerSelectionChange!.script,
     );
+    await _editorController?.evaluateJavascript(
+      source: HtmlUtils.registerFileLinkRowEnterKeyHandler(
+        isWebPlatform: PlatformInfo.isWeb,
+      ).script,
+    );
   }
 
   Future<void> _onWebViewCreated(HtmlEditorApi editorApi) async {

--- a/lib/features/composer/presentation/widgets/web/web_editor_scripts.dart
+++ b/lib/features/composer/presentation/widgets/web/web_editor_scripts.dart
@@ -1,0 +1,70 @@
+import 'package:core/utils/html/html_utils.dart';
+import 'package:html_editor_enhanced/html_editor.dart';
+
+List<WebScript> buildWebEditorInitialScripts({
+  required double maxHeight,
+  required WebScript selectionChangeScript,
+}) {
+  return [
+    WebScript(
+      name: HtmlUtils.removeLineHeight1px.name,
+      script: HtmlUtils.removeLineHeight1px.script,
+    ),
+    WebScript(
+      name: HtmlUtils.registerDropListener.name,
+      script: HtmlUtils.registerDropListener.script,
+    ),
+    WebScript(
+      name: HtmlUtils.unregisterDropListener.name,
+      script: HtmlUtils.unregisterDropListener.script,
+    ),
+    WebScript(
+      name: selectionChangeScript.name,
+      script: selectionChangeScript.script,
+    ),
+    WebScript(
+      name: HtmlUtils.collapseSelectionToEnd.name,
+      script: HtmlUtils.collapseSelectionToEnd.script,
+    ),
+    WebScript(
+      name: HtmlUtils.deleteSelectionContent.name,
+      script: HtmlUtils.deleteSelectionContent.script,
+    ),
+    WebScript(
+      name: HtmlUtils.saveSelection.name,
+      script: HtmlUtils.saveSelection.script,
+    ),
+    WebScript(
+      name: HtmlUtils.restoreSelection.name,
+      script: HtmlUtils.restoreSelection.script,
+    ),
+    WebScript(
+      name: HtmlUtils.getSavedSelection.name,
+      script: HtmlUtils.getSavedSelection.script,
+    ),
+    WebScript(
+      name: HtmlUtils.clearSavedSelection.name,
+      script: HtmlUtils.clearSavedSelection.script,
+    ),
+    WebScript(
+      name: HtmlUtils.recalculateEditorHeight(maxHeight: maxHeight).name,
+      script: HtmlUtils.recalculateEditorHeight(maxHeight: maxHeight).script,
+    ),
+    WebScript(
+      name: HtmlUtils.registerFileLinkRowEnterKeyHandler(
+        isWebPlatform: true,
+      ).name,
+      script: HtmlUtils.registerFileLinkRowEnterKeyHandler(
+        isWebPlatform: true,
+      ).script,
+    ),
+    WebScript(
+      name: HtmlUtils.registerFileLinkCardClickHandler(
+        isWebPlatform: true,
+      ).name,
+      script: HtmlUtils.registerFileLinkCardClickHandler(
+        isWebPlatform: true,
+      ).script,
+    ),
+  ];
+}

--- a/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
@@ -233,6 +233,14 @@ class _WebEditorState extends State<WebEditorWidget> with TextSelectionMixin {
               isWebPlatform: true,
             ).script,
           ),
+          WebScript(
+            name: HtmlUtils.registerFileLinkCardClickHandler(
+              isWebPlatform: true,
+            ).name,
+            script: HtmlUtils.registerFileLinkCardClickHandler(
+              isWebPlatform: true,
+            ).script,
+          ),
         ])
       ),
       htmlToolbarOptions: const HtmlToolbarOptions(
@@ -252,6 +260,11 @@ class _WebEditorState extends State<WebEditorWidget> with TextSelectionMixin {
               _selectionChangeScript.name);
             _editorController.evaluateJavascriptWeb(
               HtmlUtils.registerFileLinkRowEnterKeyHandler(
+                isWebPlatform: true,
+              ).name,
+            );
+            _editorController.evaluateJavascriptWeb(
+              HtmlUtils.registerFileLinkCardClickHandler(
                 isWebPlatform: true,
               ).name,
             );

--- a/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
@@ -225,6 +225,14 @@ class _WebEditorState extends State<WebEditorWidget> with TextSelectionMixin {
             name: HtmlUtils.recalculateEditorHeight(maxHeight: maxHeight).name,
             script: HtmlUtils.recalculateEditorHeight(maxHeight: maxHeight).script,
           ),
+          WebScript(
+            name: HtmlUtils.registerFileLinkRowEnterKeyHandler(
+              isWebPlatform: true,
+            ).name,
+            script: HtmlUtils.registerFileLinkRowEnterKeyHandler(
+              isWebPlatform: true,
+            ).script,
+          ),
         ])
       ),
       htmlToolbarOptions: const HtmlToolbarOptions(
@@ -242,6 +250,11 @@ class _WebEditorState extends State<WebEditorWidget> with TextSelectionMixin {
               HtmlUtils.registerDropListener.name);
             _editorController.evaluateJavascriptWeb(
               _selectionChangeScript.name);
+            _editorController.evaluateJavascriptWeb(
+              HtmlUtils.registerFileLinkRowEnterKeyHandler(
+                isWebPlatform: true,
+              ).name,
+            );
             _editorListenerRegistered = true;
           }
         },

--- a/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/web/web_editor_widget.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:html_editor_enhanced/html_editor.dart';
 import 'package:tmail_ui_user/features/composer/presentation/mixin/text_selection_mixin.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/web/signature_tooltip_widget.dart';
+import 'package:tmail_ui_user/features/composer/presentation/widgets/web/web_editor_scripts.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:universal_html/html.dart' hide VoidCallback;
 
@@ -180,68 +181,12 @@ class _WebEditorState extends State<WebEditorWidget> with TextSelectionMixin {
         disableDragAndDrop: true,
         normalizeHtmlTextWhenDropping: true,
         normalizeHtmlTextWhenPasting: true,
-        webInitialScripts: UnmodifiableListView([
-          WebScript(
-            name: HtmlUtils.removeLineHeight1px.name,
-            script: HtmlUtils.removeLineHeight1px.script,
+        webInitialScripts: UnmodifiableListView(
+          buildWebEditorInitialScripts(
+            maxHeight: maxHeight,
+            selectionChangeScript: _selectionChangeScript,
           ),
-          WebScript(
-            name: HtmlUtils.registerDropListener.name,
-            script: HtmlUtils.registerDropListener.script,
-          ),
-          WebScript(
-            name: HtmlUtils.unregisterDropListener.name,
-            script: HtmlUtils.unregisterDropListener.script,
-          ),
-          WebScript(
-            name: _selectionChangeScript.name,
-            script: _selectionChangeScript.script,
-          ),
-          WebScript(
-            name: HtmlUtils.collapseSelectionToEnd.name,
-            script: HtmlUtils.collapseSelectionToEnd.script,
-          ),
-          WebScript(
-            name: HtmlUtils.deleteSelectionContent.name,
-            script: HtmlUtils.deleteSelectionContent.script,
-          ),
-          WebScript(
-            name: HtmlUtils.saveSelection.name,
-            script: HtmlUtils.saveSelection.script,
-          ),
-          WebScript(
-            name: HtmlUtils.restoreSelection.name,
-            script: HtmlUtils.restoreSelection.script,
-          ),
-          WebScript(
-            name: HtmlUtils.getSavedSelection.name,
-            script: HtmlUtils.getSavedSelection.script,
-          ),
-          WebScript(
-            name: HtmlUtils.clearSavedSelection.name,
-            script: HtmlUtils.clearSavedSelection.script,
-          ),
-          WebScript(
-            name: HtmlUtils.recalculateEditorHeight(maxHeight: maxHeight).name,
-            script: HtmlUtils.recalculateEditorHeight(maxHeight: maxHeight).script,
-          ),
-          WebScript(
-            name: HtmlUtils.registerFileLinkRowEnterKeyHandler(
-              isWebPlatform: true,
-            ).name,
-            script: HtmlUtils.registerFileLinkRowEnterKeyHandler(
-              isWebPlatform: true,
-            ).script,
-          ),
-          WebScript(
-            name: HtmlUtils.registerFileLinkCardClickHandler(
-              isWebPlatform: true,
-            ).name,
-            script: HtmlUtils.registerFileLinkCardClickHandler(
-              isWebPlatform: true,
-            ).script,
-          ),
-        ])
+        )
       ),
       htmlToolbarOptions: const HtmlToolbarOptions(
         toolbarType: ToolbarType.hide,
@@ -253,23 +198,7 @@ class _WebEditorState extends State<WebEditorWidget> with TextSelectionMixin {
         onChangeContent: widget.onChangeContent,
         onInit: () {
           widget.onInitial?.call(widget.content);
-          if (!_editorListenerRegistered) {
-            _editorController.evaluateJavascriptWeb(
-              HtmlUtils.registerDropListener.name);
-            _editorController.evaluateJavascriptWeb(
-              _selectionChangeScript.name);
-            _editorController.evaluateJavascriptWeb(
-              HtmlUtils.registerFileLinkRowEnterKeyHandler(
-                isWebPlatform: true,
-              ).name,
-            );
-            _editorController.evaluateJavascriptWeb(
-              HtmlUtils.registerFileLinkCardClickHandler(
-                isWebPlatform: true,
-              ).name,
-            );
-            _editorListenerRegistered = true;
-          }
+          _registerEditorScripts();
         },
         onFocus: widget.onFocus,
         onUnFocus: widget.onUnFocus,
@@ -302,6 +231,26 @@ class _WebEditorState extends State<WebEditorWidget> with TextSelectionMixin {
         onKeyDown: widget.onKeyDownEditorAction,
       ),
     );
+  }
+
+  void _registerEditorScripts() {
+    if (_editorListenerRegistered) return;
+
+    _editorController.evaluateJavascriptWeb(
+      HtmlUtils.registerDropListener.name);
+    _editorController.evaluateJavascriptWeb(
+      _selectionChangeScript.name);
+    _editorController.evaluateJavascriptWeb(
+      HtmlUtils.registerFileLinkRowEnterKeyHandler(
+        isWebPlatform: true,
+      ).name,
+    );
+    _editorController.evaluateJavascriptWeb(
+      HtmlUtils.registerFileLinkCardClickHandler(
+        isWebPlatform: true,
+      ).name,
+    );
+    _editorListenerRegistered = true;
   }
 
   void _showSignatureTooltipAtPosition(

--- a/test/features/composer/presentation/manager/drive_attachment_handler_insert_link_html_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_insert_link_html_test.dart
@@ -64,10 +64,10 @@ void main() {
 
       final html = insertedHtml.first;
       expect('<a '.allMatches(html).length, 1);
-      expect(html, matches(RegExp(r'^<div style="display:block[^>]*><a href="https://example\.com/report\.pdf"[^>]*>.*Report\.pdf.*</a></div><br>$')));
+      expect(html, matches(RegExp(r'^<div style="display:block[^>]*>.*<a href="https://example\.com/report\.pdf"[^>]*>.*Report\.pdf.*</a>.*</div><p><br></p>$')));
     });
 
-    test('Should render multiple docs as cards in one wrapping row ending with a single <br>', () async {
+    test('Should render multiple docs as cards in one wrapping row ending with an empty paragraph', () async {
       final doc2 = DriveDocument(
         id: '2',
         name: 'Second',
@@ -84,9 +84,9 @@ void main() {
       final html = insertedHtml.first;
       expect(html, contains('Report'));
       expect(html, contains('Second'));
-      expect('<br>'.allMatches(html).length, 1);
-      expect(html, endsWith('<br>'));
-      expect(html, matches(RegExp(r'^<div style="display:block[^>]*>.*</div><br>$')));
+      expect('<p><br></p>'.allMatches(html).length, 1);
+      expect(html, endsWith('<p><br></p>'));
+      expect(html, matches(RegExp(r'^<div style="display:block[^>]*>.*</div><p><br></p>$')));
     });
 
     test('Should produce empty string for docs with null sharingLink', () async {

--- a/test/features/composer/presentation/manager/drive_attachment_handler_insert_link_html_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_insert_link_html_test.dart
@@ -26,7 +26,7 @@ void main() {
 
       handler.insertDriveLinkHtml([
         doc,
-      ], insertHtml: (html) => insertedHtml.add(html), appLocalizations: AppLocalizations());
+      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
 
       expect(insertedHtml.first, contains('&amp;'));
       expect(insertedHtml.first, contains('My &lt;Report&gt;'));
@@ -44,7 +44,7 @@ void main() {
 
       handler.insertDriveLinkHtml([
         doc,
-      ], insertHtml: (html) => insertedHtml.add(html));
+      ], insertHtml: (html) async => insertedHtml.add(html));
 
       expect(insertedHtml.first, contains('Open in drive'));
     });
@@ -60,7 +60,7 @@ void main() {
 
       handler.insertDriveLinkHtml([
         doc,
-      ], insertHtml: (html) => insertedHtml.add(html), appLocalizations: AppLocalizations());
+      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
 
       final html = insertedHtml.first;
       expect('<a '.allMatches(html).length, 1);
@@ -79,7 +79,7 @@ void main() {
       handler.insertDriveLinkHtml([
         linkDoc,
         doc2,
-      ], insertHtml: (html) => insertedHtml.add(html), appLocalizations: AppLocalizations());
+      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
 
       final html = insertedHtml.first;
       expect(html, contains('Report'));
@@ -92,7 +92,7 @@ void main() {
     test('Should produce empty string for docs with null sharingLink', () async {
       handler.insertDriveLinkHtml([
         noLinkDoc,
-      ], insertHtml: (html) => insertedHtml.add(html), appLocalizations: AppLocalizations());
+      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
 
       expect(insertedHtml.first, isEmpty);
     });
@@ -109,7 +109,7 @@ void main() {
 
       handler.insertDriveLinkHtml([
         imageDoc,
-      ], insertHtml: (html) => insertedHtml.add(html), appLocalizations: AppLocalizations());
+      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
 
       expect(insertedHtml.first, contains('<img src="https://cdn.example.com/thumbnails/photo.png"'));
     });
@@ -125,7 +125,7 @@ void main() {
 
       handler.insertDriveLinkHtml([
         xlsDoc,
-      ], insertHtml: (html) => insertedHtml.add(html), appLocalizations: AppLocalizations());
+      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
 
       expect(insertedHtml.first, isNot(contains('<img')));
     });
@@ -143,7 +143,7 @@ void main() {
 
       strictHandler.insertDriveLinkHtml([
         untrustedHttpDoc,
-      ], insertHtml: (html) => insertedHtml.add(html), appLocalizations: AppLocalizations());
+      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
 
       expect(insertedHtml.first, isNot(contains('<img')));
     });
@@ -160,7 +160,7 @@ void main() {
 
       handler.insertDriveLinkHtml([
         httpThumbnailDoc,
-      ], insertHtml: (html) => insertedHtml.add(html), appLocalizations: AppLocalizations());
+      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
 
       expect(insertedHtml.first, contains('<img src="http://cdn.example.com/thumbnails/photo3.png"'));
     });
@@ -177,7 +177,7 @@ void main() {
 
       strictHandler.insertDriveLinkHtml([
         httpDoc,
-      ], insertHtml: (html) => insertedHtml.add(html), appLocalizations: AppLocalizations());
+      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
 
       expect(insertedHtml.first, isEmpty);
     });
@@ -193,7 +193,7 @@ void main() {
 
       handler.insertDriveLinkHtml([
         httpDoc,
-      ], insertHtml: (html) => insertedHtml.add(html), appLocalizations: AppLocalizations());
+      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
 
       expect(insertedHtml.first, contains('http://example.com/file'));
     });

--- a/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
@@ -17,7 +17,7 @@ void main() {
 
   group('DriveAttachmentHandler::handleDrivePickResult::', () {
     test('Should insert link html for docs with sharingLink', () async {
-      handler.handleDrivePickResult([
+      await handler.handleDrivePickResult([
         linkDoc,
       ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
 
@@ -27,7 +27,7 @@ void main() {
     });
 
     test('Should still work and fall back to hardcoded English label when appLocalizations is omitted', () async {
-      handler.handleDrivePickResult([
+      await handler.handleDrivePickResult([
         linkDoc,
       ], insertHtml: (html) async => insertedHtml.add(html));
 
@@ -45,7 +45,7 @@ void main() {
         downloadLink: Uri.parse('https://drive.example.com/both-dl'),
       );
 
-      handler.handleDrivePickResult([
+      await handler.handleDrivePickResult([
         bothLinksDoc,
       ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
 
@@ -54,7 +54,7 @@ void main() {
     });
 
     test('Should skip docs with neither sharingLink nor downloadLink', () async {
-      handler.handleDrivePickResult([
+      await handler.handleDrivePickResult([
         noLinkDoc,
       ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
 
@@ -63,7 +63,7 @@ void main() {
     });
 
     test('Should handle mixed docs correctly — only link docs inserted', () async {
-      handler.handleDrivePickResult([
+      await handler.handleDrivePickResult([
         linkDoc,
         attachmentDoc,
         noLinkDoc,

--- a/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
@@ -19,7 +19,7 @@ void main() {
     test('Should insert link html for docs with sharingLink', () async {
       handler.handleDrivePickResult([
         linkDoc,
-      ], insertHtml: (html) => insertedHtml.add(html), appLocalizations: appLocalizations);
+      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
 
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, contains('https://drive.example.com/report'));
@@ -29,7 +29,7 @@ void main() {
     test('Should still work and fall back to hardcoded English label when appLocalizations is omitted', () async {
       handler.handleDrivePickResult([
         linkDoc,
-      ], insertHtml: (html) => insertedHtml.add(html));
+      ], insertHtml: (html) async => insertedHtml.add(html));
 
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, contains('Open in drive'));
@@ -47,7 +47,7 @@ void main() {
 
       handler.handleDrivePickResult([
         bothLinksDoc,
-      ], insertHtml: (html) => insertedHtml.add(html), appLocalizations: appLocalizations);
+      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
 
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, contains('https://drive.example.com/both'));
@@ -56,7 +56,7 @@ void main() {
     test('Should skip docs with neither sharingLink nor downloadLink', () async {
       handler.handleDrivePickResult([
         noLinkDoc,
-      ], insertHtml: (html) => insertedHtml.add(html), appLocalizations: appLocalizations);
+      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
 
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, isEmpty);
@@ -67,7 +67,7 @@ void main() {
         linkDoc,
         attachmentDoc,
         noLinkDoc,
-      ], insertHtml: (html) => insertedHtml.add(html), appLocalizations: appLocalizations);
+      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
 
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, contains('Report'));

--- a/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
+++ b/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
@@ -17,7 +17,7 @@ import 'package:workplace/presentation/widget/drive_attachment_context_menu_tile
 import 'package:workplace/presentation/widget/drive_attachment_picker_button.dart';
 
 typedef OnDrivePickStateChanged =
-    void Function(String composerId, DrivePickState state);
+    void Function(String? composerId, DrivePickState state);
 
 class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
   final ValueListenable<Uri?> workplaceUri;
@@ -140,7 +140,6 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
   @override
   Widget buildContextMenuTile(
     BuildContext context, {
-    required String composerId,
     required ImagePaths imagePaths,
     required String label,
   }) {
@@ -149,13 +148,12 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
       builder: (_, uri, __) {
         if (uri == null) return const SizedBox.shrink();
         return DriveAttachmentContextMenuTile(
-          composerId: composerId,
           imagePaths: imagePaths,
           workplaceUri: uri,
           label: label,
           onPickCallback: onPickState == null
               ? null
-              : (state) => onPickState!(composerId, state),
+              : (state) => onPickState!(null, state),
           onFetchIntent: ({required addAsLinkTitle, required addAsAttachmentTitle}) => _fetchIntent(
             uri,
             addAsLinkTitle: addAsLinkTitle,

--- a/workplace/lib/presentation/widget/drive_attachment_context_menu_tile.dart
+++ b/workplace/lib/presentation/widget/drive_attachment_context_menu_tile.dart
@@ -8,7 +8,6 @@ import 'package:workplace/presentation/mixin/drive_picker_state_mixin.dart';
 import 'package:workplace/presentation/mixin/web_window_message_mixin.dart';
 
 class DriveAttachmentContextMenuTile extends StatefulWidget {
-  final String composerId;
   final ImagePaths imagePaths;
   final Uri workplaceUri;
   final String label;
@@ -17,7 +16,6 @@ class DriveAttachmentContextMenuTile extends StatefulWidget {
 
   const DriveAttachmentContextMenuTile({
     super.key,
-    required this.composerId,
     required this.imagePaths,
     required this.workplaceUri,
     required this.label,

--- a/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
+++ b/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
@@ -245,7 +245,6 @@ void main() {
         home: Builder(
           builder: (ctx) => ext.buildContextMenuTile(
             ctx,
-            composerId: _composerId,
             imagePaths: imagePaths,
             label: _label,
           ),
@@ -264,7 +263,6 @@ void main() {
           body: Builder(
             builder: (ctx) => ext.buildContextMenuTile(
               ctx,
-              composerId: _composerId,
               imagePaths: imagePaths,
               label: _label,
             ),
@@ -284,7 +282,6 @@ void main() {
           body: Builder(
             builder: (ctx) => ext.buildContextMenuTile(
               ctx,
-              composerId: _composerId,
               imagePaths: imagePaths,
               label: _label,
             ),
@@ -308,7 +305,6 @@ void main() {
           body: Builder(
             builder: (ctx) => ext.buildContextMenuTile(
               ctx,
-              composerId: _composerId,
               imagePaths: imagePaths,
               label: _label,
             ),
@@ -331,7 +327,6 @@ void main() {
           body: Builder(
             builder: (ctx) => ext.buildContextMenuTile(
               ctx,
-              composerId: _composerId,
               imagePaths: imagePaths,
               label: _label,
             ),
@@ -363,7 +358,6 @@ void main() {
           body: Builder(
             builder: (ctx) => ext.buildContextMenuTile(
               ctx,
-              composerId: _composerId,
               imagePaths: imagePaths,
               label: _label,
             ),
@@ -377,7 +371,7 @@ void main() {
       final fakeState = DrivePickFailure(Exception('test'));
       tile.onPickCallback!(fakeState);
 
-      expect(receivedId, equals(_composerId));
+      expect(receivedId, isNull);
       expect(receivedState, equals(fakeState));
     });
   });


### PR DESCRIPTION

https://github.com/user-attachments/assets/ee2acb2a-3f30-4e94-8632-746809e36a98



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved file-link cards in the composer with reliable click behavior (opens correctly on web and mobile).
  * Pressing Enter inside a file-link card row now splits into a new line at the cursor.
  * Plain-text extraction now excludes file-link card content by default.
* **Bug Fixes**
  * Improved HTML sanitization to preserve editing attributes only where needed for draft reloading and drive-card links.
  * Updated attachment HTML insertion to improve consistency across web and mobile editors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->