### PR TITLE
TF-4213 Fix alignment keyboard shortcuts settings

### DIFF
--- a/lib/features/manage_account/presentation/extensions/keyboard_shortcut_extension.dart
+++ b/lib/features/manage_account/presentation/extensions/keyboard_shortcut_extension.dart
@@ -2,25 +2,6 @@ import 'package:core/presentation/resources/image_paths.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/keyboard_shortcuts/keyboard_shortcut.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
-extension ShortcutContextText on ShortcutContext {
-  String getDisplayName(AppLocalizations appLocalizations) {
-    switch (this) {
-      case ShortcutContext.mailComposer:
-        return appLocalizations.mailComposer;
-      case ShortcutContext.focusOnSearch:
-        return appLocalizations.focusOnSearch;
-      case ShortcutContext.openedModal:
-        return appLocalizations.openedModal;
-      case ShortcutContext.mailboxList:
-        return appLocalizations.mailboxList;
-      case ShortcutContext.openedMailView:
-        return appLocalizations.openedMailView;
-      case ShortcutContext.mailboxListWithSelectedEmail:
-        return appLocalizations.mailboxListWithSelectedMail;
-    }
-  }
-}
-
 extension ShortcutCategoryText on ShortcutCategory {
   String getDisplayName(
     AppLocalizations appLocalizations, {

--- a/lib/features/manage_account/presentation/keyboard_shortcuts/keyboard_shortcuts_view.dart
+++ b/lib/features/manage_account/presentation/keyboard_shortcuts/keyboard_shortcuts_view.dart
@@ -1,24 +1,14 @@
-import 'package:core/presentation/extensions/color_extension.dart';
-import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/utils/theme_utils.dart';
-import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_custom_tab_bar/custom_tab_bar.dart';
 import 'package:flutter_custom_tab_bar/indicator/custom_indicator.dart';
-import 'package:flutter_custom_tab_bar/indicator/linear_indicator.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/base/setting_detail_view_builder.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/extensions/keyboard_shortcut_extension.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/keyboard_shortcuts/widgets/shortcut_category_list_widget.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/keyboard_shortcuts/widgets/shortcut_tab_bar_widget.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/keyboard_shortcuts/widgets/keyboard_shortcuts_tab_view_widget.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/menu/settings_utils.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/model/keyboard_shortcuts/keyboard_shortcut.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/model/keyboard_shortcuts/keyboard_shortcuts_manager.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/widgets/setting_explanation_widget.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/widgets/setting_header_widget.dart';
-import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 class KeyboardShortcutsView extends StatefulWidget {
   const KeyboardShortcutsView({Key? key}) : super(key: key);
@@ -28,12 +18,7 @@ class KeyboardShortcutsView extends StatefulWidget {
 }
 
 class _KeyboardShortcutsViewState extends State<KeyboardShortcutsView> {
-  static const double _desktopTabViewMaxWidth = 618;
-  static const double _desktopShortcutRowMaxWidth = 440;
-
   final _responsiveUtils = Get.find<ResponsiveUtils>();
-  final _imagePaths = Get.find<ImagePaths>();
-  final _categories = ShortcutCategory.values;
 
   late final CustomTabBarController _tabBarController;
   late final PageController _pageController;
@@ -53,12 +38,7 @@ class _KeyboardShortcutsViewState extends State<KeyboardShortcutsView> {
 
   @override
   Widget build(BuildContext context) {
-    final appLocalizations = AppLocalizations.of(context);
-    final allShortcuts = KeyboardShortcutsManager.generateKeyboardShortcuts(
-      appLocalizations,
-    );
     final isDesktop = _responsiveUtils.isDesktop(context);
-    double tabBarMaxHeight = isDesktop ? 52 : 82;
 
     return SettingDetailViewBuilder(
       responsiveUtils: _responsiveUtils,
@@ -103,91 +83,9 @@ class _KeyboardShortcutsViewState extends State<KeyboardShortcutsView> {
                   context,
                   _responsiveUtils,
                 ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    LayoutBuilder(
-                      builder: (context, constraints) {
-                        final maxWidth = constraints.maxWidth;
-                        final countCategories = _categories.length;
-
-                        return Stack(
-                          children: [
-                            // CustomTabBar indicator uses LTR-based pixel math
-                            // with no RTL support; pin to LTR to keep it aligned.
-                            Directionality(
-                              textDirection: TextDirection.ltr,
-                              child: CustomTabBar(
-                                tabBarController: _tabBarController,
-                                height: tabBarMaxHeight,
-                                width: isDesktop
-                                    ? _desktopTabViewMaxWidth
-                                    : maxWidth,
-                                itemCount: countCategories,
-                                builder: (_, index) {
-                                  final category = _categories[index];
-                                  return ShortcutTabBarWidget(
-                                    index: index,
-                                    label: category.getDisplayName(
-                                      appLocalizations,
-                                      isDesktop: isDesktop,
-                                    ),
-                                    icon: isDesktop
-                                        ? null
-                                        : category.getIcon(_imagePaths),
-                                    width: isDesktop
-                                        ? category.getTabWidth()
-                                        : maxWidth / countCategories,
-                                    height: tabBarMaxHeight,
-                                  );
-                                },
-                                indicator: LinearIndicator(
-                                  color: AppColor.primaryLinShare,
-                                  height: 1,
-                                  bottom: 0,
-                                ),
-                                pageController: _pageController,
-                              ),
-                            ),
-                            PositionedDirectional(
-                              bottom: 0,
-                              start: 0,
-                              end: 0,
-                              child: Divider(
-                                color: Colors.black.withValues(alpha: 0.12),
-                              ),
-                            ),
-                          ],
-                        );
-                      }
-                    ),
-                    Expanded(
-                      child: SizedBox(
-                        width: isDesktop
-                            ? _desktopTabViewMaxWidth
-                            : double.infinity,
-                        child: PageView.builder(
-                          controller: _pageController,
-                          itemCount: _categories.length,
-                          physics: PlatformInfo.isMobile
-                              ? const PageScrollPhysics()
-                              : const NeverScrollableScrollPhysics(),
-                          itemBuilder: (_, index) {
-                            final category = _categories[index];
-                            final shortcutsByCategory = allShortcuts
-                              .where((shortcut) => shortcut.category == category)
-                              .toList();
-                            return ShortcutCategoryList(
-                              shortcutsByCategory: shortcutsByCategory,
-                              rowMaxWidth: isDesktop
-                                  ? _desktopShortcutRowMaxWidth
-                                  : null,
-                            );
-                          },
-                        ),
-                      ),
-                    ),
-                  ],
+                child: KeyboardShortcutsTabView(
+                  tabBarController: _tabBarController,
+                  pageController: _pageController,
                 ),
               ),
             ),

--- a/lib/features/manage_account/presentation/keyboard_shortcuts/keyboard_shortcuts_view.dart
+++ b/lib/features/manage_account/presentation/keyboard_shortcuts/keyboard_shortcuts_view.dart
@@ -113,36 +113,41 @@ class _KeyboardShortcutsViewState extends State<KeyboardShortcutsView> {
 
                         return Stack(
                           children: [
-                            CustomTabBar(
-                              tabBarController: _tabBarController,
-                              height: tabBarMaxHeight,
-                              width: isDesktop
-                                  ? _desktopTabViewMaxWidth
-                                  : maxWidth,
-                              itemCount: countCategories,
-                              builder: (_, index) {
-                                final category = _categories[index];
-                                return ShortcutTabBarWidget(
-                                  index: index,
-                                  label: category.getDisplayName(
-                                    appLocalizations,
-                                    isDesktop: isDesktop,
-                                  ),
-                                  icon: isDesktop
-                                      ? null
-                                      : category.getIcon(_imagePaths),
-                                  width: isDesktop
-                                      ? category.getTabWidth()
-                                      : maxWidth / countCategories,
-                                  height: tabBarMaxHeight,
-                                );
-                              },
-                              indicator: LinearIndicator(
-                                color: AppColor.primaryLinShare,
-                                height: 1,
-                                bottom: 0,
+                            // CustomTabBar indicator uses LTR-based pixel math
+                            // with no RTL support; pin to LTR to keep it aligned.
+                            Directionality(
+                              textDirection: TextDirection.ltr,
+                              child: CustomTabBar(
+                                tabBarController: _tabBarController,
+                                height: tabBarMaxHeight,
+                                width: isDesktop
+                                    ? _desktopTabViewMaxWidth
+                                    : maxWidth,
+                                itemCount: countCategories,
+                                builder: (_, index) {
+                                  final category = _categories[index];
+                                  return ShortcutTabBarWidget(
+                                    index: index,
+                                    label: category.getDisplayName(
+                                      appLocalizations,
+                                      isDesktop: isDesktop,
+                                    ),
+                                    icon: isDesktop
+                                        ? null
+                                        : category.getIcon(_imagePaths),
+                                    width: isDesktop
+                                        ? category.getTabWidth()
+                                        : maxWidth / countCategories,
+                                    height: tabBarMaxHeight,
+                                  );
+                                },
+                                indicator: LinearIndicator(
+                                  color: AppColor.primaryLinShare,
+                                  height: 1,
+                                  bottom: 0,
+                                ),
+                                pageController: _pageController,
                               ),
-                              pageController: _pageController,
                             ),
                             PositionedDirectional(
                               bottom: 0,

--- a/lib/features/manage_account/presentation/keyboard_shortcuts/keyboard_shortcuts_view.dart
+++ b/lib/features/manage_account/presentation/keyboard_shortcuts/keyboard_shortcuts_view.dart
@@ -29,6 +29,7 @@ class KeyboardShortcutsView extends StatefulWidget {
 
 class _KeyboardShortcutsViewState extends State<KeyboardShortcutsView> {
   static const double _desktopTabViewMaxWidth = 618;
+  static const double _desktopShortcutRowMaxWidth = 440;
 
   final _responsiveUtils = Get.find<ResponsiveUtils>();
   final _imagePaths = Get.find<ImagePaths>();
@@ -173,6 +174,9 @@ class _KeyboardShortcutsViewState extends State<KeyboardShortcutsView> {
                               .toList();
                             return ShortcutCategoryList(
                               shortcutsByCategory: shortcutsByCategory,
+                              rowMaxWidth: isDesktop
+                                  ? _desktopShortcutRowMaxWidth
+                                  : null,
                             );
                           },
                         ),

--- a/lib/features/manage_account/presentation/keyboard_shortcuts/widgets/keyboard_shortcuts_tab_view_widget.dart
+++ b/lib/features/manage_account/presentation/keyboard_shortcuts/widgets/keyboard_shortcuts_tab_view_widget.dart
@@ -1,0 +1,140 @@
+import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/utils/platform_info.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_custom_tab_bar/custom_tab_bar.dart';
+import 'package:flutter_custom_tab_bar/indicator/custom_indicator.dart';
+import 'package:flutter_custom_tab_bar/indicator/linear_indicator.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/extensions/keyboard_shortcut_extension.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/keyboard_shortcuts/widgets/shortcut_category_list_widget.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/keyboard_shortcuts/widgets/shortcut_tab_bar_widget.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/model/keyboard_shortcuts/keyboard_shortcut.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/model/keyboard_shortcuts/keyboard_shortcuts_manager.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+/// Category tab bar plus its paged shortcut lists, sharing controllers and RTL handling.
+class KeyboardShortcutsTabView extends StatelessWidget {
+  static const double _tabViewMaxWidth = 618;
+  static const double _rowMaxWidth = 440;
+
+  final CustomTabBarController tabBarController;
+  final PageController pageController;
+
+  KeyboardShortcutsTabView({
+    super.key,
+    required this.tabBarController,
+    required this.pageController,
+  });
+
+  final _responsiveUtils = Get.find<ResponsiveUtils>();
+  final _imagePaths = Get.find<ImagePaths>();
+  final _categories = ShortcutCategory.values;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildTabBar(context),
+        Expanded(child: _buildPageView(context)),
+      ],
+    );
+  }
+
+  Widget _buildTabBar(BuildContext context) {
+    final isDesktop = _responsiveUtils.isDesktop(context);
+    final appLocalizations = AppLocalizations.of(context);
+    final ambientTextDirection = Directionality.of(context);
+    final tabBarHeight = isDesktop ? 52.0 : 82.0;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final maxWidth = constraints.maxWidth;
+        final countCategories = _categories.length;
+
+        return Stack(
+          children: [
+            // CustomTabBar has no RTL support; pin to LTR, restore item direction.
+            Directionality(
+              textDirection: TextDirection.ltr,
+              child: CustomTabBar(
+                tabBarController: tabBarController,
+                height: tabBarHeight,
+                width: isDesktop ? _tabViewMaxWidth : maxWidth,
+                itemCount: countCategories,
+                builder: (_, index) {
+                  final category = _categories[index];
+                  return Directionality(
+                    textDirection: ambientTextDirection,
+                    child: ShortcutTabBarWidget(
+                      index: index,
+                      label: category.getDisplayName(
+                        appLocalizations,
+                        isDesktop: isDesktop,
+                      ),
+                      icon: isDesktop ? null : category.getIcon(_imagePaths),
+                      width: isDesktop
+                          ? category.getTabWidth()
+                          : maxWidth / countCategories,
+                      height: tabBarHeight,
+                    ),
+                  );
+                },
+                indicator: LinearIndicator(
+                  color: AppColor.primaryLinShare,
+                  height: 1,
+                  bottom: 0,
+                ),
+                pageController: pageController,
+              ),
+            ),
+            PositionedDirectional(
+              bottom: 0,
+              start: 0,
+              end: 0,
+              child: Divider(color: Colors.black.withValues(alpha: 0.12)),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildPageView(BuildContext context) {
+    final isDesktop = _responsiveUtils.isDesktop(context);
+    final ambientTextDirection = Directionality.of(context);
+    final allShortcuts = KeyboardShortcutsManager.generateKeyboardShortcuts(
+      AppLocalizations.of(context),
+    );
+
+    return SizedBox(
+      width: isDesktop ? _tabViewMaxWidth : double.infinity,
+      // Match the LTR-pinned tab bar; restore page content direction.
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: PageView.builder(
+          controller: pageController,
+          itemCount: _categories.length,
+          physics: PlatformInfo.isMobile
+              ? const PageScrollPhysics()
+              : const NeverScrollableScrollPhysics(),
+          itemBuilder: (_, index) {
+            final category = _categories[index];
+            final shortcutsByCategory = allShortcuts
+                .where((shortcut) => shortcut.category == category)
+                .toList();
+            return Directionality(
+              textDirection: ambientTextDirection,
+              child: ShortcutCategoryList(
+                shortcutsByCategory: shortcutsByCategory,
+                rowMaxWidth: isDesktop ? _rowMaxWidth : null,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/manage_account/presentation/keyboard_shortcuts/widgets/keyboard_shortcuts_tab_view_widget.dart
+++ b/lib/features/manage_account/presentation/keyboard_shortcuts/widgets/keyboard_shortcuts_tab_view_widget.dart
@@ -1,7 +1,6 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
-import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_custom_tab_bar/custom_tab_bar.dart';
 import 'package:flutter_custom_tab_bar/indicator/custom_indicator.dart';
@@ -34,19 +33,26 @@ class KeyboardShortcutsTabView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isDesktop = _responsiveUtils.isDesktop(context);
+    final ambientTextDirection = Directionality.of(context);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        _buildTabBar(context),
-        Expanded(child: _buildPageView(context)),
+        _buildTabBar(context, isDesktop, ambientTextDirection),
+        Expanded(
+          child: _buildPageView(context, isDesktop, ambientTextDirection),
+        ),
       ],
     );
   }
 
-  Widget _buildTabBar(BuildContext context) {
-    final isDesktop = _responsiveUtils.isDesktop(context);
+  Widget _buildTabBar(
+    BuildContext context,
+    bool isDesktop,
+    TextDirection ambientTextDirection,
+  ) {
     final appLocalizations = AppLocalizations.of(context);
-    final ambientTextDirection = Directionality.of(context);
     final tabBarHeight = isDesktop ? 52.0 : 82.0;
 
     return LayoutBuilder(
@@ -102,9 +108,11 @@ class KeyboardShortcutsTabView extends StatelessWidget {
     );
   }
 
-  Widget _buildPageView(BuildContext context) {
-    final isDesktop = _responsiveUtils.isDesktop(context);
-    final ambientTextDirection = Directionality.of(context);
+  Widget _buildPageView(
+    BuildContext context,
+    bool isDesktop,
+    TextDirection ambientTextDirection,
+  ) {
     final allShortcuts = KeyboardShortcutsManager.generateKeyboardShortcuts(
       AppLocalizations.of(context),
     );
@@ -117,9 +125,10 @@ class KeyboardShortcutsTabView extends StatelessWidget {
         child: PageView.builder(
           controller: pageController,
           itemCount: _categories.length,
-          physics: PlatformInfo.isMobile
-              ? const PageScrollPhysics()
-              : const NeverScrollableScrollPhysics(),
+          // Align swipe gesture with the responsive layout breakpoint.
+          physics: isDesktop
+              ? const NeverScrollableScrollPhysics()
+              : const PageScrollPhysics(),
           itemBuilder: (_, index) {
             final category = _categories[index];
             final shortcutsByCategory = allShortcuts

--- a/lib/features/manage_account/presentation/keyboard_shortcuts/widgets/shortcut_category_list_widget.dart
+++ b/lib/features/manage_account/presentation/keyboard_shortcuts/widgets/shortcut_category_list_widget.dart
@@ -5,9 +5,14 @@ import 'package:tmail_ui_user/features/manage_account/presentation/model/keyboar
 class ShortcutCategoryList extends StatelessWidget {
   final List<KeyboardShortcut> shortcutsByCategory;
 
+  /// Constrains each row width so the key chips align in a fixed column.
+  /// When null, rows span the full available width (mobile).
+  final double? rowMaxWidth;
+
   const ShortcutCategoryList({
     super.key,
     required this.shortcutsByCategory,
+    this.rowMaxWidth,
   });
 
   @override
@@ -16,8 +21,16 @@ class ShortcutCategoryList extends StatelessWidget {
       padding: const EdgeInsets.only(top: 40),
       itemCount: shortcutsByCategory.length,
       itemBuilder: (_, index) {
-        final item = shortcutsByCategory[index];
-        return ShortcutRow(item: item);
+        final row = ShortcutRow(item: shortcutsByCategory[index]);
+        if (rowMaxWidth == null) return row;
+
+        return Align(
+          alignment: AlignmentDirectional.centerStart,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(maxWidth: rowMaxWidth!),
+            child: row,
+          ),
+        );
       },
     );
   }

--- a/lib/features/manage_account/presentation/keyboard_shortcuts/widgets/shortcut_row_widget.dart
+++ b/lib/features/manage_account/presentation/keyboard_shortcuts/widgets/shortcut_row_widget.dart
@@ -1,10 +1,7 @@
-import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:flutter/material.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/extensions/keyboard_shortcut_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/keyboard_shortcuts/widgets/shortcut_key_widget.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/keyboard_shortcuts/keyboard_shortcut.dart';
-import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 class ShortcutRow extends StatelessWidget {
   final KeyboardShortcut item;
@@ -18,23 +15,18 @@ class ShortcutRow extends StatelessWidget {
         top: 5,
         bottom: 21,
       ),
-      child: Wrap(
-        spacing: 27,
-        runSpacing: 8,
-        crossAxisAlignment: WrapCrossAlignment.center,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          Text(
-            item.label,
-            style: ThemeUtils.textStyleBodyBody3(
-              color: Colors.black,
+          Expanded(
+            child: Text(
+              item.label,
+              style: ThemeUtils.textStyleBodyBody3(
+                color: Colors.black,
+              ),
             ),
           ),
-          Text(
-            item.context.getDisplayName(AppLocalizations.of(context)),
-            style: ThemeUtils.textStyleBodyBody3(
-              color: AppColor.gray424244.withValues(alpha: 0.64),
-            ),
-          ),
+          const SizedBox(width: 16),
           Row(
             mainAxisSize: MainAxisSize.min,
             children:

--- a/lib/features/manage_account/presentation/model/keyboard_shortcuts/keyboard_shortcut.dart
+++ b/lib/features/manage_account/presentation/model/keyboard_shortcuts/keyboard_shortcut.dart
@@ -6,25 +6,14 @@ enum ShortcutCategory {
   messageManagementAndSelection,
 }
 
-enum ShortcutContext {
-  mailComposer,
-  focusOnSearch,
-  openedModal,
-  mailboxList,
-  mailboxListWithSelectedEmail,
-  openedMailView,
-}
-
 class KeyboardShortcut with EquatableMixin {
   final String label;
   final ShortcutCategory category;
-  final ShortcutContext context;
   final List<String> keys;
 
   const KeyboardShortcut({
     required this.label,
     required this.category,
-    required this.context,
     required this.keys,
   });
 
@@ -32,7 +21,6 @@ class KeyboardShortcut with EquatableMixin {
   List<Object?> get props => [
     label,
     category,
-    context,
     keys,
   ];
 }

--- a/lib/features/manage_account/presentation/model/keyboard_shortcuts/keyboard_shortcuts_manager.dart
+++ b/lib/features/manage_account/presentation/model/keyboard_shortcuts/keyboard_shortcuts_manager.dart
@@ -12,31 +12,26 @@ class KeyboardShortcutsManager {
       KeyboardShortcut(
         label: appLocalizations.closeMailComposer,
         category: ShortcutCategory.navigationAndClosing,
-        context: ShortcutContext.mailComposer,
         keys: ['ESC'],
       ),
       KeyboardShortcut(
         label: appLocalizations.closeMailDetailView,
         category: ShortcutCategory.navigationAndClosing,
-        context: ShortcutContext.openedMailView,
         keys: ['ESC'],
       ),
       KeyboardShortcut(
         label: appLocalizations.removeFocusFromSearch,
         category: ShortcutCategory.navigationAndClosing,
-        context: ShortcutContext.focusOnSearch,
         keys: ['ESC'],
       ),
       KeyboardShortcut(
         label: appLocalizations.closeModalWindow,
         category: ShortcutCategory.navigationAndClosing,
-        context: ShortcutContext.openedModal,
         keys: ['ESC'],
       ),
       KeyboardShortcut(
         label: appLocalizations.openNewMessage,
         category: ShortcutCategory.navigationAndClosing,
-        context: ShortcutContext.mailboxList,
         keys: ['N'],
       ),
 
@@ -44,31 +39,26 @@ class KeyboardShortcutsManager {
       KeyboardShortcut(
         label: appLocalizations.reply,
         category: ShortcutCategory.readingAndReplying,
-        context: ShortcutContext.openedMailView,
         keys: ['R'],
       ),
       KeyboardShortcut(
         label: appLocalizations.replyToAll,
         category: ShortcutCategory.readingAndReplying,
-        context: ShortcutContext.openedMailView,
         keys: ['Shift', 'R'],
       ),
       KeyboardShortcut(
         label: appLocalizations.forward,
         category: ShortcutCategory.readingAndReplying,
-        context: ShortcutContext.openedMailView,
         keys: ['F'],
       ),
       KeyboardShortcut(
         label: appLocalizations.mark_as_read,
         category: ShortcutCategory.readingAndReplying,
-        context: ShortcutContext.openedMailView,
         keys: ['Q'],
       ),
       KeyboardShortcut(
         label: appLocalizations.mark_as_unread,
         category: ShortcutCategory.readingAndReplying,
-        context: ShortcutContext.openedMailView,
         keys: ['U'],
       ),
 
@@ -76,25 +66,16 @@ class KeyboardShortcutsManager {
       KeyboardShortcut(
         label: appLocalizations.deleteMessage,
         category: ShortcutCategory.messageManagementAndSelection,
-        context: ShortcutContext.openedMailView,
-        keys: ['Delete'],
-      ),
-      KeyboardShortcut(
-        label: appLocalizations.deleteMessage,
-        category: ShortcutCategory.messageManagementAndSelection,
-        context: ShortcutContext.mailboxListWithSelectedEmail,
         keys: ['Delete'],
       ),
       KeyboardShortcut(
         label: appLocalizations.mark_as_read,
         category: ShortcutCategory.messageManagementAndSelection,
-        context: ShortcutContext.mailboxListWithSelectedEmail,
         keys: ['Q'],
       ),
       KeyboardShortcut(
         label: appLocalizations.mark_as_unread,
         category: ShortcutCategory.messageManagementAndSelection,
-        context: ShortcutContext.mailboxListWithSelectedEmail,
         keys: ['U'],
       ),
     ];

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -5366,42 +5366,6 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "mailComposer": "Editeur de mails",
-  "@mailComposer": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "focusOnSearch": "Focus sur la recherche",
-  "@focusOnSearch": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "openedModal": "Fenêtre pop-up ouverte",
-  "@openedModal": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "mailboxList": "Liste des mails",
-  "@mailboxList": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "openedMailView": "Mail ouvert",
-  "@openedMailView": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "mailboxListWithSelectedMail": "Liste des boîtes aux lettres (e-mail sélectionné)",
-  "@mailboxListWithSelectedMail": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
   "replyToAll": "Répondre à tous",
   "@replyToAll": {
     "type": "text",

--- a/lib/l10n/intl_ga.arb
+++ b/lib/l10n/intl_ga.arb
@@ -5125,42 +5125,6 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "mailComposer": "Cumadóir ríomhphoist",
-  "@mailComposer": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "focusOnSearch": "Dírigh ar chuardach",
-  "@focusOnSearch": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "openedModal": "Modúil oscailte",
-  "@openedModal": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "mailboxList": "Liosta bosca poist",
-  "@mailboxList": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "openedMailView": "Radharc ríomhphoist oscailte",
-  "@openedMailView": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "mailboxListWithSelectedMail": "Liosta bosca poist (ríomhphost roghnaithe)",
-  "@mailboxListWithSelectedMail": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
   "replyToAll": "Freagra a thabhairt do chách",
   "@replyToAll": {
     "type": "text",

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2026-07-06T13:42:02.887001",
+  "@@last_modified": "2026-07-15T18:21:15.082129",
   "initializing_data": "Initializing data...",
   "@initializing_data": {
     "type": "text",
@@ -5060,42 +5060,6 @@
   },
   "openNewMessage": "Open new message",
   "@openNewMessage": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "mailComposer": "Mail composer",
-  "@mailComposer": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "focusOnSearch": "Focus on search",
-  "@focusOnSearch": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "openedModal": "Opened modal",
-  "@openedModal": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "mailboxList": "Mailbox list",
-  "@mailboxList": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "openedMailView": "Opened mail view",
-  "@openedMailView": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "mailboxListWithSelectedMail": "Mailbox list (selected mail)",
-  "@mailboxListWithSelectedMail": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/l10n/intl_mn.arb
+++ b/lib/l10n/intl_mn.arb
@@ -5051,42 +5051,6 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "mailComposer": "Имэйл бичигч",
-  "@mailComposer": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "focusOnSearch": "Хайлтад фокус тавих",
-  "@focusOnSearch": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "openedModal": "Нээлттэй модал",
-  "@openedModal": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "mailboxList": "Шуудангийн хайрцгийн жагсаалт",
-  "@mailboxList": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "openedMailView": "Нээлттэй имэйлийн харагдац",
-  "@openedMailView": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "mailboxListWithSelectedMail": "Шуудангийн хайрцгийн жагсаалт (сонгосон имэйл)",
-  "@mailboxListWithSelectedMail": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
   "replyToAll": "Бүгдэд хариулах",
   "@replyToAll": {
     "type": "text",

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -5390,42 +5390,6 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "mailComposer": "Редактор письма",
-  "@mailComposer": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "focusOnSearch": "Фокус на поиске",
-  "@focusOnSearch": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "openedModal": "Открытое модальное окно",
-  "@openedModal": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "mailboxList": "Список почтовых ящиков",
-  "@mailboxList": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "openedMailView": "Вид открытого письма",
-  "@openedMailView": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "mailboxListWithSelectedMail": "Список почтовых ящиков (выбранное письмо)",
-  "@mailboxListWithSelectedMail": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
   "replyToAll": "Ответить всем",
   "@replyToAll": {
     "type": "text",

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -5053,42 +5053,6 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "mailComposer": "Компонувальник пошти",
-  "@mailComposer": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "focusOnSearch": "Зосередьтеся на пошуку",
-  "@focusOnSearch": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "openedModal": "Відкрито модальне вікно",
-  "@openedModal": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "mailboxList": "Список поштових скриньок",
-  "@mailboxList": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "openedMailView": "Відкрито перегляд пошти",
-  "@openedMailView": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "mailboxListWithSelectedMail": "Список поштових скриньок (вибрана пошта)",
-  "@mailboxListWithSelectedMail": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
   "replyToAll": "Відповісти до всіх",
   "@replyToAll": {
     "type": "text",

--- a/lib/l10n/intl_vi.arb
+++ b/lib/l10n/intl_vi.arb
@@ -5372,42 +5372,6 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "mailComposer": "Trình soạn thư",
-  "@mailComposer": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "focusOnSearch": "Tìm kiếm",
-  "@focusOnSearch": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "openedModal": "Hộp thoại đã mở",
-  "@openedModal": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "mailboxList": "Danh sách thư",
-  "@mailboxList": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "openedMailView": "Thư đã mở",
-  "@openedMailView": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "mailboxListWithSelectedMail": "Danh sách thư (đã lựa chọn)",
-  "@mailboxListWithSelectedMail": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
   "replyToAll": "Trả lời tất cả",
   "@replyToAll": {
     "type": "text",

--- a/lib/l10n/intl_zh_Hans.arb
+++ b/lib/l10n/intl_zh_Hans.arb
@@ -5119,42 +5119,6 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "mailComposer": "邮件编辑器",
-  "@mailComposer": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "focusOnSearch": "聚焦搜索框",
-  "@focusOnSearch": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "openedModal": "已打开的模态窗口",
-  "@openedModal": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "mailboxList": "邮箱列表",
-  "@mailboxList": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "openedMailView": "已打开的邮件视图",
-  "@openedMailView": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
-  "mailboxListWithSelectedMail": "邮箱列表（已选邮件）",
-  "@mailboxListWithSelectedMail": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
   "replyToAll": "全部回复",
   "@replyToAll": {
     "type": "text",

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -5358,48 +5358,6 @@ class AppLocalizations {
     );
   }
 
-  String get mailComposer {
-    return Intl.message(
-      'Mail composer',
-      name: 'mailComposer',
-    );
-  }
-
-  String get focusOnSearch {
-    return Intl.message(
-      'Focus on search',
-      name: 'focusOnSearch',
-    );
-  }
-
-  String get openedModal {
-    return Intl.message(
-      'Opened modal',
-      name: 'openedModal',
-    );
-  }
-
-  String get mailboxList {
-    return Intl.message(
-      'Mailbox list',
-      name: 'mailboxList',
-    );
-  }
-
-  String get openedMailView {
-    return Intl.message(
-      'Opened mail view',
-      name: 'openedMailView',
-    );
-  }
-
-  String get mailboxListWithSelectedMail {
-    return Intl.message(
-      'Mailbox list (selected mail)',
-      name: 'mailboxListWithSelectedMail',
-    );
-  }
-
   String get replyToAll {
     return Intl.message(
       'Reply to all',

--- a/test/features/manage_account/presentation/model/keyboard_shortcuts/keyboard_shortcuts_manager_test.dart
+++ b/test/features/manage_account/presentation/model/keyboard_shortcuts/keyboard_shortcuts_manager_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/model/keyboard_shortcuts/keyboard_shortcut.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/model/keyboard_shortcuts/keyboard_shortcuts_manager.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+void main() {
+  final appLocalizations = AppLocalizations();
+
+  List<KeyboardShortcut> shortcutsOf(ShortcutCategory category) =>
+      KeyboardShortcutsManager.generateKeyboardShortcuts(appLocalizations)
+          .where((shortcut) => shortcut.category == category)
+          .toList();
+
+  group('KeyboardShortcutsManager::generateKeyboardShortcuts', () {
+    test('should generate shortcuts for every category', () {
+      final shortcuts =
+          KeyboardShortcutsManager.generateKeyboardShortcuts(appLocalizations);
+
+      for (final category in ShortcutCategory.values) {
+        expect(
+          shortcuts.any((shortcut) => shortcut.category == category),
+          isTrue,
+          reason: 'Missing shortcuts for $category',
+        );
+      }
+    });
+
+    test('should not produce duplicate rows within any category', () {
+      for (final category in ShortcutCategory.values) {
+        final rows = shortcutsOf(category);
+
+        expect(
+          rows.toSet().length,
+          rows.length,
+          reason: 'Duplicate shortcut rows found in $category',
+        );
+      }
+    });
+
+    test(
+        'should expose a single Delete row in message management category '
+        'after removing context distinction', () {
+      final deleteRows = shortcutsOf(
+        ShortcutCategory.messageManagementAndSelection,
+      ).where((shortcut) => shortcut.keys.contains('Delete')).toList();
+
+      expect(deleteRows.length, 1);
+    });
+  });
+}


### PR DESCRIPTION
Closes #4213

## Changes

### 1. New keyboard shortcuts UI

<img width="768" height="438" alt="Screenshot 2026-07-15 at 15 27 17" src="https://github.com/user-attachments/assets/36e7c310-bccd-4985-9522-bac2b9fd9e64" />


### 2. Fix tab indicator under RTL
- `flutter_custom_tab_bar` computes its indicator with LTR-based pixel math and has no RTL support, so in Arabic the tabs mirrored while the indicator did not — landing under the wrong tab. Pinned the tab bar to `TextDirection.ltr` to keep the indicator aligned with the selected page.


## Demo



https://github.com/user-attachments/assets/7cb28322-d7c0-404d-8614-8058413f2322



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated keyboard shortcuts tab view with synchronized tab/page navigation.

* **Bug Fixes**
  * Simplified shortcut display by removing extra context text and consolidating context-specific duplicates so actions (including Delete) appear once.
  * Improved alignment by constraining shortcut row widths (desktop) and enhancing RTL correctness for tab/page layout.
  * Updated keyboard-shortcut-related wording to use “Open new message”.

* **Tests**
  * Added coverage for category completeness, duplicate prevention, and Delete shortcut uniqueness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->