### PR TITLE
TF-4647 SSOT Part 6— Wire dashboard filter into search SSOT & remove `position`

### DIFF
--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -197,6 +197,7 @@ import 'package:tmail_ui_user/features/push_notification/presentation/services/f
 import 'package:tmail_ui_user/features/push_notification/presentation/utils/fcm_utils.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/mixin/search_label_filter_modal_mixin.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/service/dashboard_search_coordinator.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/model/sending_email.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/state/get_all_sending_email_state.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/state/update_sending_email_state.dart';
@@ -364,6 +365,7 @@ class MailboxDashBoardController extends ReloadableController
   final workerObxVariables = <Worker>[];
   ProviderSubscription<bool>? advancedSearchViewSubscription;
   ProviderSubscription<bool>? searchInputFocusSubscription;
+  DashboardSearchCoordinator? _dashboardSearchCoordinator;
 
   final StreamController<Either<Failure, Success>> progressStateController =
     StreamController<Either<Failure, Success>>.broadcast();
@@ -421,6 +423,10 @@ class MailboxDashBoardController extends ReloadableController
       _registerDeepLinks();
     }
     _registerStreamListener();
+    _dashboardSearchCoordinator ??= DashboardSearchCoordinator(
+      readFilterMessageOption: () => filterMessageOption.value,
+      writeFilterMessageOption: (option) => filterMessageOption.value = option,
+    )..start();
     registerLabelReactiveObxListener();
     BackButtonInterceptor.add(onBackButtonInterceptor, name: AppRoutes.dashboard);
     WidgetsBinding.instance.addPostFrameCallback((_) async {
@@ -3504,6 +3510,8 @@ class MailboxDashBoardController extends ReloadableController
     cachedLinagoraEcosystem = null;
     _sentryEcosystem = null;
     _disposeWorkerObxVariables();
+    _dashboardSearchCoordinator?.dispose();
+    _dashboardSearchCoordinator = null;
     super.onClose();
   }
 

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -423,10 +423,17 @@ class MailboxDashBoardController extends ReloadableController
       _registerDeepLinks();
     }
     _registerStreamListener();
-    _dashboardSearchCoordinator ??= DashboardSearchCoordinator(
-      readFilterMessageOption: () => filterMessageOption.value,
-      writeFilterMessageOption: (option) => filterMessageOption.value = option,
-    )..start();
+    if (_dashboardSearchCoordinator == null) {
+      _dashboardSearchCoordinator = DashboardSearchCoordinator(
+        readFilterMessageOption: () => filterMessageOption.value,
+        writeFilterMessageOption: (option) => filterMessageOption.value = option,
+      )..start();
+      workerObxVariables.add(ever(
+        filterMessageOption,
+        (option) =>
+            _dashboardSearchCoordinator?.onFilterMessageOptionChanged(option),
+      ));
+    }
     registerLabelReactiveObxListener();
     BackButtonInterceptor.add(onBackButtonInterceptor, name: AppRoutes.dashboard);
     WidgetsBinding.instance.addPostFrameCallback((_) async {

--- a/lib/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart
+++ b/lib/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart
@@ -39,7 +39,6 @@ class SearchEmailFilter with EquatableMixin, OptionParamMixin {
   final UTCDate? after;
   final UTCDate? startDate;
   final UTCDate? endDate;
-  final int? position;
   final EmailSortOrderType sortOrderType;
   final Label? label;
 
@@ -56,7 +55,6 @@ class SearchEmailFilter with EquatableMixin, OptionParamMixin {
     this.after,
     this.startDate,
     this.endDate,
-    this.position,
     this.label,
     Set<String>? from,
     Set<String>? to,
@@ -94,7 +92,6 @@ class SearchEmailFilter with EquatableMixin, OptionParamMixin {
     Option<UTCDate>? afterOption,
     Option<UTCDate>? startDateOption,
     Option<UTCDate>? endDateOption,
-    Option<int>? positionOption,
     Option<EmailSortOrderType>? sortOrderTypeOption,
     Option<Label>? labelOption,
   }) {
@@ -114,7 +111,6 @@ class SearchEmailFilter with EquatableMixin, OptionParamMixin {
       after: getOptionParam(afterOption, after),
       startDate: getOptionParam(startDateOption, startDate),
       endDate: getOptionParam(endDateOption, endDate),
-      position: getOptionParam(positionOption, position),
       sortOrderType: getOptionParam(sortOrderTypeOption, sortOrderType),
       label: getOptionParam(labelOption, label),
     );
@@ -126,11 +122,11 @@ class SearchEmailFilter with EquatableMixin, OptionParamMixin {
   bool isOnlySender(String address) =>
       address.isNotEmpty && from.length == 1 && from.first == address;
 
-  /// Strips pagination cursors (`position`, `before`, `after`), keeping all user
-  /// intent (incl. `startDate`/`endDate` bounds). Notifiers run full replacements
-  /// through this so a stale cursor can never enter the SSOT (ADR-0093).
+  /// Strips the load-more date cursors (`before`, `after`), keeping all user intent
+  /// (incl. `startDate`/`endDate` bounds). Notifiers run full replacements through
+  /// this so a stale cursor can never enter the SSOT (ADR-0093). Pagination `position`
+  /// no longer lives on the model — it is resolved on the transient `SearchRequestSpec`.
   SearchEmailFilter clearPaginationCursors() => copyWith(
-        positionOption: const None(),
         beforeOption: const None(),
         afterOption: const None(),
       );
@@ -302,7 +298,6 @@ class SearchEmailFilter with EquatableMixin, OptionParamMixin {
     after,
     startDate,
     endDate,
-    position,
     sortOrderType,
     label,
   ];

--- a/lib/features/mailbox_dashboard/presentation/widgets/search_filters/filter_message_button.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/search_filters/filter_message_button.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/styles/filter_message_button_style.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
+import 'package:tmail_ui_user/features/thread/presentation/extensions/filter_message_option_style_extension.dart';
 
 typedef OnSelectFilterMessageOptionAction = Function(BuildContext context,
     FilterMessageOption filterMessageOption, RelativeRect buttonPosition);

--- a/lib/features/search/email/presentation/service/dashboard_search_coordinator.dart
+++ b/lib/features/search/email/presentation/service/dashboard_search_coordinator.dart
@@ -1,25 +1,23 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_view_state.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
-import 'package:tmail_ui_user/features/search/email/domain/notifier/search_email_notifier.dart';
 import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
-import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/providers/search_session_reset.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
 import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 
 /// Reads the dashboard's current filter-message option.
 typedef FilterMessageOptionGetter = FilterMessageOption Function();
 
-/// Writes the dashboard's filter-message option (used to restore it on search exit).
+/// Writes the dashboard's filter-message option.
 typedef FilterMessageOptionSetter = void Function(FilterMessageOption option);
 
-/// Owns the dashboard's search-session side-effects on the search-filter SSOT, so
-/// [MailboxDashBoardController] stays focused (SRP). While a search session is active
-/// it mirrors the dashboard [FilterMessageOption] into the committed filter — applied
-/// when search opens (so chips and the JMAP query honour it, #4490/#4590) and restored
-/// when it closes. On [dispose] it resets every search provider so no committed filter
-/// or cached result leaks into the next session (ADR-0093). GetX→Riverpod bridge: it
-/// reads/writes the dashboard option through injected callbacks, never GetX directly.
+/// Keeps the [FilterMessageOption] button and the committed search filter in sync
+/// so [MailboxDashBoardController] stays focused. The sync is
+/// asymmetric: the button mirrors into search, but search only ever *clears* the
+/// button — never sets it — so a criterion enabled directly in search is not
+/// mistaken for a button selection. Bridges GetX→Riverpod via injected callbacks.
 class DashboardSearchCoordinator {
   DashboardSearchCoordinator({
     required FilterMessageOptionGetter readFilterMessageOption,
@@ -33,50 +31,94 @@ class DashboardSearchCoordinator {
   final FilterMessageOptionSetter _writeFilterMessageOption;
   final ProviderContainer _container;
 
-  ProviderSubscription<SearchViewState>? _subscription;
-  FilterMessageOption? _optionBeforeSearch;
+  ProviderSubscription<SearchViewState>? _viewStateSubscription;
+  ProviderSubscription<SearchEmailFilter>? _filterSubscription;
 
-  /// Starts mirroring the filter-message option across search-session transitions.
+  /// The criterion the button currently owns in the committed filter, so a later
+  /// option switch knows which one to drop.
+  FilterMessageOption _appliedOption = FilterMessageOption.all;
+
+  /// Starts the two-way sync between the button and the committed search filter.
   void start() {
-    _subscription = _container.listen<SearchViewState>(
+    _viewStateSubscription = _container.listen<SearchViewState>(
       searchViewStateProvider,
       _onSearchViewStateChanged,
     );
+    _filterSubscription = _container.listen<SearchEmailFilter>(
+      searchFilterProvider,
+      _onSearchFilterChanged,
+    );
   }
 
+  /// Button → search: re-mirror the button whenever a search surface opens, so a
+  /// reopened surface reflects it even after it was toggled off while open.
   void _onSearchViewStateChanged(
     SearchViewState? previous,
     SearchViewState next,
   ) {
-    final wasSearchActive = previous?.isSearchActive ?? false;
-    if (!wasSearchActive && next.isSearchActive) {
-      _applyFilterMessageOptionToSearch();
-    } else if (wasSearchActive && !next.isSearchActive) {
-      _restoreFilterMessageOption();
+    if (_enteredSearchSurface(previous, next)) {
+      _applyOptionToSearch(_readFilterMessageOption());
     }
   }
 
-  /// Writes the current filter-message option into the committed filter, keeping the
-  /// prior value so [_restoreFilterMessageOption] can put it back on search exit.
-  void _applyFilterMessageOptionToSearch() {
-    _optionBeforeSearch = _readFilterMessageOption();
-    final resolved =
-        _optionBeforeSearch!.applyTo(_container.read(searchFilterProvider));
-    _container.read(searchFilterProvider.notifier).set(resolved);
+  /// True when [next] opens a search surface that was closed in [previous]: the
+  /// active session, the advanced-search panel, or the focused suggestion
+  /// dropdown. Each is tracked on its own so reopening one re-seeds even while
+  /// another stays open.
+  bool _enteredSearchSurface(SearchViewState? previous, SearchViewState next) {
+    bool opened(bool Function(SearchViewState) isOpen) =>
+        !(previous != null && isOpen(previous)) && isOpen(next);
+    return opened((state) => state.isSearchActive) ||
+        opened((state) => state.isAdvancedSearchViewOpen) ||
+        opened((state) => state.isSearchInputFocused);
   }
 
-  void _restoreFilterMessageOption() {
-    _writeFilterMessageOption(_optionBeforeSearch ?? FilterMessageOption.all);
-    _optionBeforeSearch = null;
+  /// Button → search: mirror a live button change into the committed filter.
+  void onFilterMessageOptionChanged(FilterMessageOption option) {
+    _applyOptionToSearch(option);
   }
 
-  /// Stops mirroring and resets the search providers. Invalidate before any post-logout
-  /// rebuild reads them (ADR-0093 §Decision, #4490/#4590).
+  void _applyOptionToSearch(FilterMessageOption option) {
+    final current = _container.read(searchFilterProvider);
+    var resolved = current;
+    if (_appliedOption != option) {
+      resolved = _appliedOption.removeFrom(resolved);
+    }
+    resolved = option.applyTo(resolved);
+    _appliedOption = option;
+    if (resolved != current) {
+      _container.read(searchFilterProvider.notifier).set(resolved);
+    }
+  }
+
+  /// Search → button (clear only): while search is active, clear the button once
+  /// its own criterion is switched off. The active-state guard ignores the
+  /// teardown reset, which runs after search is already inactive.
+  void _onSearchFilterChanged(
+    SearchEmailFilter? previous,
+    SearchEmailFilter next,
+  ) {
+    if (!_container.read(searchViewStateProvider).isSearchActive) return;
+    final option = _readFilterMessageOption();
+    if (option == FilterMessageOption.all) return;
+    if (!option.isActiveIn(next)) {
+      _appliedOption = FilterMessageOption.all;
+      _writeFilterMessageOption(FilterMessageOption.all);
+    }
+  }
+
+  /// Stops the sync and resets the search session on dashboard teardown (logout).
+  /// [appProviderContainer] is a process-lifetime singleton (ADR-0092), so these
+  /// keepAlive providers keep their state across logout; without this reset the
+  /// next account's session would inherit the previous filter and cached results
+  /// (#4490/#4590). [resetSearchResultSession] clears the results and the
+  /// executor's replay marker; the committed filter is reset here.
   void dispose() {
-    _subscription?.close();
-    _subscription = null;
+    _viewStateSubscription?.close();
+    _viewStateSubscription = null;
+    _filterSubscription?.close();
+    _filterSubscription = null;
+    resetSearchResultSession(_container);
     _container.invalidate(searchFilterProvider);
-    _container.invalidate(searchEmailProvider);
-    _container.invalidate(searchEmailPresentationProvider);
   }
 }

--- a/lib/features/search/email/presentation/service/dashboard_search_coordinator.dart
+++ b/lib/features/search/email/presentation/service/dashboard_search_coordinator.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_view_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_email_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
+import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
+
+/// Reads the dashboard's current filter-message option.
+typedef FilterMessageOptionGetter = FilterMessageOption Function();
+
+/// Writes the dashboard's filter-message option (used to restore it on search exit).
+typedef FilterMessageOptionSetter = void Function(FilterMessageOption option);
+
+/// Owns the dashboard's search-session side-effects on the search-filter SSOT, so
+/// [MailboxDashBoardController] stays focused (SRP). While a search session is active
+/// it mirrors the dashboard [FilterMessageOption] into the committed filter — applied
+/// when search opens (so chips and the JMAP query honour it, #4490/#4590) and restored
+/// when it closes. On [dispose] it resets every search provider so no committed filter
+/// or cached result leaks into the next session (ADR-0093). GetX→Riverpod bridge: it
+/// reads/writes the dashboard option through injected callbacks, never GetX directly.
+class DashboardSearchCoordinator {
+  DashboardSearchCoordinator({
+    required FilterMessageOptionGetter readFilterMessageOption,
+    required FilterMessageOptionSetter writeFilterMessageOption,
+    ProviderContainer? container,
+  })  : _readFilterMessageOption = readFilterMessageOption,
+        _writeFilterMessageOption = writeFilterMessageOption,
+        _container = container ?? appProviderContainer;
+
+  final FilterMessageOptionGetter _readFilterMessageOption;
+  final FilterMessageOptionSetter _writeFilterMessageOption;
+  final ProviderContainer _container;
+
+  ProviderSubscription<SearchViewState>? _subscription;
+  FilterMessageOption? _optionBeforeSearch;
+
+  /// Starts mirroring the filter-message option across search-session transitions.
+  void start() {
+    _subscription = _container.listen<SearchViewState>(
+      searchViewStateProvider,
+      _onSearchViewStateChanged,
+    );
+  }
+
+  void _onSearchViewStateChanged(
+    SearchViewState? previous,
+    SearchViewState next,
+  ) {
+    final wasSearchActive = previous?.isSearchActive ?? false;
+    if (!wasSearchActive && next.isSearchActive) {
+      _applyFilterMessageOptionToSearch();
+    } else if (wasSearchActive && !next.isSearchActive) {
+      _restoreFilterMessageOption();
+    }
+  }
+
+  /// Writes the current filter-message option into the committed filter, keeping the
+  /// prior value so [_restoreFilterMessageOption] can put it back on search exit.
+  void _applyFilterMessageOptionToSearch() {
+    _optionBeforeSearch = _readFilterMessageOption();
+    final resolved =
+        _optionBeforeSearch!.applyTo(_container.read(searchFilterProvider));
+    _container.read(searchFilterProvider.notifier).set(resolved);
+  }
+
+  void _restoreFilterMessageOption() {
+    _writeFilterMessageOption(_optionBeforeSearch ?? FilterMessageOption.all);
+    _optionBeforeSearch = null;
+  }
+
+  /// Stops mirroring and resets the search providers. Invalidate before any post-logout
+  /// rebuild reads them (ADR-0093 §Decision, #4490/#4590).
+  void dispose() {
+    _subscription?.close();
+    _subscription = null;
+    _container.invalidate(searchFilterProvider);
+    _container.invalidate(searchEmailProvider);
+    _container.invalidate(searchEmailPresentationProvider);
+  }
+}

--- a/lib/features/thread/domain/model/filter_message_option.dart
+++ b/lib/features/thread/domain/model/filter_message_option.dart
@@ -1,8 +1,11 @@
 
 import 'package:core/core.dart';
+import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
 import 'package:model/model.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 enum FilterMessageOption {
@@ -76,6 +79,27 @@ extension FilterMessageOptionExtension on FilterMessageOption {
         return email.withAttachments;
       case FilterMessageOption.starred:
         return email.hasStarred;
+    }
+  }
+
+  /// Maps the selected dashboard filter into the search-filter SSOT so the search
+  /// chips and the JMAP query both honour it (ADR-0093 §Decision). `starred` is the
+  /// flagged keyword merged into `hasKeyword`, not a bool field; `all` is a no-op.
+  SearchEmailFilter applyTo(SearchEmailFilter filter) {
+    switch (this) {
+      case FilterMessageOption.all:
+        return filter;
+      case FilterMessageOption.unread:
+        return filter.copyWith(unreadOption: const Some(true));
+      case FilterMessageOption.attachments:
+        return filter.copyWith(hasAttachmentOption: const Some(true));
+      case FilterMessageOption.starred:
+        return filter.copyWith(
+          hasKeywordOption: Some({
+            ...filter.hasKeyword,
+            KeyWordIdentifier.emailFlagged.value,
+          }),
+        );
     }
   }
 

--- a/lib/features/thread/domain/model/filter_message_option.dart
+++ b/lib/features/thread/domain/model/filter_message_option.dart
@@ -1,178 +1,103 @@
-
-import 'package:core/core.dart';
 import 'package:dartz/dartz.dart';
-import 'package:flutter/material.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
 import 'package:model/model.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
-import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 enum FilterMessageOption {
-  all,
-  unread,
-  attachments,
-  starred,
+  all(_NoCriterion()),
+  unread(_UnreadCriterion()),
+  attachments(_AttachmentCriterion()),
+  starred(_StarredCriterion());
+
+  const FilterMessageOption(this._criterion);
+
+  final _SearchCriterion _criterion;
+
+  /// Whether [email] passes this option's client-side filter.
+  bool filterEmail(Email email) => _criterion.matchesEmail(email);
+
+  /// Whether this option's criterion is currently set on [filter].
+  bool isActiveIn(SearchEmailFilter filter) => _criterion.isActiveIn(filter);
+
+  /// Sets this option's criterion on [filter] (search chips + JMAP query).
+  SearchEmailFilter applyTo(SearchEmailFilter filter) =>
+      _criterion.write(filter, active: true);
+
+  /// Clears this option's criterion from [filter] (undo of [applyTo]).
+  SearchEmailFilter removeFrom(SearchEmailFilter filter) =>
+      _criterion.write(filter, active: false);
 }
 
-extension FilterMessageOptionExtension on FilterMessageOption {
+/// The one filter dimension a [FilterMessageOption] maps to, over a cached
+/// [Email] and the committed [SearchEmailFilter]. A new option means a new
+/// criterion, never editing a switch (Open/Closed).
+abstract class _SearchCriterion {
+  const _SearchCriterion();
 
-  String getIconToast(ImagePaths imagePaths) {
-    switch(this) {
-      case FilterMessageOption.all:
-        return imagePaths.icFilterMessageAll;
-      case FilterMessageOption.unread:
-        return imagePaths.icUnreadToast;
-      case FilterMessageOption.attachments:
-        return imagePaths.icFilterMessageAttachments;
-      case FilterMessageOption.starred:
-        return imagePaths.icStar;
-    }
-  }
+  bool matchesEmail(Email email);
 
-  String getMessageToast(BuildContext context) {
-    switch(this) {
-      case FilterMessageOption.all:
-        return AppLocalizations.of(context).disable_filter_message_toast;
-      case FilterMessageOption.unread:
-        return AppLocalizations.of(context).filter_message_toast(AppLocalizations.of(context).unread);
-      case FilterMessageOption.attachments:
-        return AppLocalizations.of(context).filter_message_toast(AppLocalizations.of(context).with_attachments);
-      case FilterMessageOption.starred:
-        return AppLocalizations.of(context).filter_message_toast(AppLocalizations.of(context).starred);
-    }
-  }
+  bool isActiveIn(SearchEmailFilter filter);
 
-  String getTitle(BuildContext context) {
-    switch(this) {
-      case FilterMessageOption.all:
-        return AppLocalizations.of(context).filter_messages;
-      case FilterMessageOption.unread:
-        return AppLocalizations.of(context).with_unread;
-      case FilterMessageOption.attachments:
-        return AppLocalizations.of(context).with_attachments.capitalizeFirstEach;
-      case FilterMessageOption.starred:
-        return AppLocalizations.of(context).with_starred;
-    }
-  }
+  SearchEmailFilter write(SearchEmailFilter filter, {required bool active});
+}
 
-  bool filterPresentationEmail(PresentationEmail email) {
-    switch(this) {
-      case FilterMessageOption.all:
-        return true;
-      case FilterMessageOption.unread:
-        return !email.hasRead;
-      case FilterMessageOption.attachments:
-        return email.withAttachments;
-      case FilterMessageOption.starred:
-        return email.hasStarred;
-    }
-  }
+class _NoCriterion extends _SearchCriterion {
+  const _NoCriterion();
 
-  bool filterEmail(Email email) {
-    switch(this) {
-      case FilterMessageOption.all:
-        return true;
-      case FilterMessageOption.unread:
-        return !email.hasRead;
-      case FilterMessageOption.attachments:
-        return email.withAttachments;
-      case FilterMessageOption.starred:
-        return email.hasStarred;
-    }
-  }
+  @override
+  bool matchesEmail(Email email) => true;
 
-  /// Maps the selected dashboard filter into the search-filter SSOT so the search
-  /// chips and the JMAP query both honour it (ADR-0093 §Decision). `starred` is the
-  /// flagged keyword merged into `hasKeyword`, not a bool field; `all` is a no-op.
-  SearchEmailFilter applyTo(SearchEmailFilter filter) {
-    switch (this) {
-      case FilterMessageOption.all:
-        return filter;
-      case FilterMessageOption.unread:
-        return filter.copyWith(unreadOption: const Some(true));
-      case FilterMessageOption.attachments:
-        return filter.copyWith(hasAttachmentOption: const Some(true));
-      case FilterMessageOption.starred:
-        return filter.copyWith(
-          hasKeywordOption: Some({
-            ...filter.hasKeyword,
-            KeyWordIdentifier.emailFlagged.value,
-          }),
-        );
-    }
-  }
+  @override
+  bool isActiveIn(SearchEmailFilter filter) => false;
 
-  String getName(AppLocalizations appLocalizations) {
-    switch(this) {
-      case FilterMessageOption.all:
-        return '';
-      case FilterMessageOption.unread:
-        return appLocalizations.unread;
-      case FilterMessageOption.attachments:
-        return appLocalizations.with_attachments;
-      case FilterMessageOption.starred:
-        return appLocalizations.starred;
-    }
-  }
+  @override
+  SearchEmailFilter write(SearchEmailFilter filter, {required bool active}) =>
+      filter;
+}
 
-  String getContextMenuIcon(ImagePaths imagePaths) {
-    switch(this) {
-      case FilterMessageOption.all:
-        return '';
-      case FilterMessageOption.unread:
-        return imagePaths.icUnread;
-      case FilterMessageOption.attachments:
-        return imagePaths.icAttachment;
-      case FilterMessageOption.starred:
-        return imagePaths.icUnStar;
-    }
-  }
+class _UnreadCriterion extends _SearchCriterion {
+  const _UnreadCriterion();
 
-  String getIcon(ImagePaths imagePaths) {
-    switch(this) {
-      case FilterMessageOption.all:
-        return imagePaths.icFilterAdvanced;
-      case FilterMessageOption.unread:
-      case FilterMessageOption.attachments:
-      case FilterMessageOption.starred:
-        return imagePaths.icSelectedSB;
-    }
-  }
+  @override
+  bool matchesEmail(Email email) => !email.hasRead;
 
-  Color getIconColor() {
-    switch(this) {
-      case FilterMessageOption.all:
-        return AppColor.colorFilterMessageIcon;
-      case FilterMessageOption.unread:
-      case FilterMessageOption.attachments:
-      case FilterMessageOption.starred:
-        return AppColor.primaryColor;
-    }
-  }
+  @override
+  bool isActiveIn(SearchEmailFilter filter) => filter.unread;
 
-  Color getBackgroundColor({bool isSelected = false}) {
-    if (isSelected) {
-      return AppColor.primaryColor.withValues(alpha: 0.06);
-    } else {
-      return AppColor.colorFilterMessageButton.withValues(alpha: 0.6);
-    }
-  }
+  @override
+  SearchEmailFilter write(SearchEmailFilter filter, {required bool active}) =>
+      filter.copyWith(unreadOption: Some(active));
+}
 
-  TextStyle getTextStyle() {
-    switch(this) {
-      case FilterMessageOption.all:
-        return ThemeUtils.defaultTextStyleInterFont.copyWith(
-          fontSize: 13,
-          fontWeight: FontWeight.normal,
-          color: AppColor.colorFilterMessageTitle);
-      case FilterMessageOption.unread:
-      case FilterMessageOption.attachments:
-      case FilterMessageOption.starred:
-        return ThemeUtils.defaultTextStyleInterFont.copyWith(
-          fontSize: 13,
-          fontWeight: FontWeight.normal,
-          color: AppColor.primaryColor);
-    }
+class _AttachmentCriterion extends _SearchCriterion {
+  const _AttachmentCriterion();
+
+  @override
+  bool matchesEmail(Email email) => email.withAttachments;
+
+  @override
+  bool isActiveIn(SearchEmailFilter filter) => filter.hasAttachment;
+
+  @override
+  SearchEmailFilter write(SearchEmailFilter filter, {required bool active}) =>
+      filter.copyWith(hasAttachmentOption: Some(active));
+}
+
+class _StarredCriterion extends _SearchCriterion {
+  const _StarredCriterion();
+
+  @override
+  bool matchesEmail(Email email) => email.hasStarred;
+
+  @override
+  bool isActiveIn(SearchEmailFilter filter) => filter.isContainFlagged;
+
+  @override
+  SearchEmailFilter write(SearchEmailFilter filter, {required bool active}) {
+    final keywords = Set<String>.of(filter.hasKeyword);
+    final flagged = KeyWordIdentifier.emailFlagged.value;
+    active ? keywords.add(flagged) : keywords.remove(flagged);
+    return filter.copyWith(hasKeywordOption: Some(keywords));
   }
 }

--- a/lib/features/thread/presentation/extensions/filter_message_option_style_extension.dart
+++ b/lib/features/thread/presentation/extensions/filter_message_option_style_extension.dart
@@ -46,7 +46,7 @@ extension FilterMessageOptionStyleExtension on FilterMessageOption {
           (name: appLocalizations.unread, title: appLocalizations.with_unread),
         FilterMessageOption.attachments => (
             name: appLocalizations.with_attachments,
-            title: appLocalizations.with_attachments.capitalizeFirstEach
+            title: appLocalizations.with_attachments
           ),
         FilterMessageOption.starred => (
             name: appLocalizations.starred,

--- a/lib/features/thread/presentation/extensions/filter_message_option_style_extension.dart
+++ b/lib/features/thread/presentation/extensions/filter_message_option_style_extension.dart
@@ -1,0 +1,72 @@
+import 'package:core/core.dart';
+import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+/// Presentation-layer styling for the Filter Message button, kept out of the
+/// domain [FilterMessageOption] so the model stays free of Flutter/l10n.
+extension FilterMessageOptionStyleExtension on FilterMessageOption {
+  bool get _isAll => this == FilterMessageOption.all;
+
+  String getIconToast(ImagePaths imagePaths) => _icons(imagePaths).toast;
+
+  String getContextMenuIcon(ImagePaths imagePaths) => _icons(imagePaths).menu;
+
+  ({String toast, String menu}) _icons(ImagePaths imagePaths) => switch (this) {
+        FilterMessageOption.all =>
+          (toast: imagePaths.icFilterMessageAll, menu: ''),
+        FilterMessageOption.unread =>
+          (toast: imagePaths.icUnreadToast, menu: imagePaths.icUnread),
+        FilterMessageOption.attachments => (
+            toast: imagePaths.icFilterMessageAttachments,
+            menu: imagePaths.icAttachment
+          ),
+        FilterMessageOption.starred =>
+          (toast: imagePaths.icStar, menu: imagePaths.icUnStar),
+      };
+
+  String getName(AppLocalizations appLocalizations) =>
+      _labels(appLocalizations).name;
+
+  String getTitle(BuildContext context) =>
+      _labels(AppLocalizations.of(context)).title;
+
+  String getMessageToast(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context);
+    return _isAll
+        ? appLocalizations.disable_filter_message_toast
+        : appLocalizations.filter_message_toast(getName(appLocalizations));
+  }
+
+  ({String name, String title}) _labels(AppLocalizations appLocalizations) =>
+      switch (this) {
+        FilterMessageOption.all =>
+          (name: '', title: appLocalizations.filter_messages),
+        FilterMessageOption.unread =>
+          (name: appLocalizations.unread, title: appLocalizations.with_unread),
+        FilterMessageOption.attachments => (
+            name: appLocalizations.with_attachments,
+            title: appLocalizations.with_attachments.capitalizeFirstEach
+          ),
+        FilterMessageOption.starred => (
+            name: appLocalizations.starred,
+            title: appLocalizations.with_starred
+          ),
+      };
+
+  String getIcon(ImagePaths imagePaths) =>
+      _isAll ? imagePaths.icFilterAdvanced : imagePaths.icSelectedSB;
+
+  Color getIconColor() =>
+      _isAll ? AppColor.colorFilterMessageIcon : AppColor.primaryColor;
+
+  Color getBackgroundColor({bool isSelected = false}) => isSelected
+      ? AppColor.primaryColor.withValues(alpha: 0.06)
+      : AppColor.colorFilterMessageButton.withValues(alpha: 0.6);
+
+  TextStyle getTextStyle() => ThemeUtils.defaultTextStyleInterFont.copyWith(
+        fontSize: 13,
+        fontWeight: FontWeight.normal,
+        color: _isAll ? AppColor.colorFilterMessageTitle : AppColor.primaryColor,
+      );
+}

--- a/lib/features/thread/presentation/model/context_item_filter_message_option_action.dart
+++ b/lib/features/thread/presentation/model/context_item_filter_message_option_action.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:tmail_ui_user/features/base/widget/context_menu/context_menu_item_action.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
+import 'package:tmail_ui_user/features/thread/presentation/extensions/filter_message_option_style_extension.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 class ContextItemFilterMessageOptionAction

--- a/lib/features/thread/presentation/model/popup_menu_item_filter_message_action.dart
+++ b/lib/features/thread/presentation/model/popup_menu_item_filter_message_action.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:tmail_ui_user/features/base/model/popup_menu_item_action.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
+import 'package:tmail_ui_user/features/thread/presentation/extensions/filter_message_option_style_extension.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
 class PopupMenuItemFilterMessageAction

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -50,6 +50,7 @@ import 'package:tmail_ui_user/features/search/email/presentation/search_email_bi
 import 'package:tmail_ui_user/features/thread/data/extensions/email_change_response_extension.dart';
 import 'package:tmail_ui_user/features/thread/domain/constants/thread_constants.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
+import 'package:tmail_ui_user/features/thread/presentation/extensions/filter_message_option_style_extension.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/get_email_request.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/clean_and_get_all_email_state.dart';

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -86,7 +86,6 @@ import 'package:tmail_ui_user/features/thread/presentation/model/delete_action_t
 import 'package:tmail_ui_user/features/thread/presentation/model/loading_more_status.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/mail_list_shortcut_action_view_event.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/search_status.dart';
-import 'package:tmail_ui_user/features/thread/presentation/model/search_state.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/method_level_exception.dart';
 import 'package:tmail_ui_user/main/routes/app_routes.dart';
 import 'package:tmail_ui_user/main/routes/navigation_router.dart';
@@ -116,7 +115,7 @@ class ThreadController extends BaseController with EmailActionController {
   final loadingMoreStatus = Rx(LoadingMoreStatus.idle);
 
   bool canLoadMore = true;
-  ProviderSubscription<SearchState>? _searchStateSubscription;
+  ProviderSubscription<SearchStatus>? _searchStateSubscription;
   MailboxId? _currentMemoryMailboxId;
   int _peakEmailCount = 0;
   final ScrollController listEmailController = ScrollController();
@@ -315,11 +314,13 @@ class ThreadController extends BaseController with EmailActionController {
     });
 
     _searchStateSubscription = appProviderContainer.listen(
-      searchViewStateProvider.select((state) => state.searchState),
-      (_, searchState) {
-      if (searchState.searchStatus == SearchStatus.ACTIVE) {
-        cancelSelectEmail();
-      }
+      searchViewStateProvider.select((state) => state.searchState.searchStatus),
+      (previous, next) {
+        // Only clear the selection on the transition into active search, so a
+        // later state change that stays ACTIVE cannot wipe a fresh selection.
+        if (previous != SearchStatus.ACTIVE && next == SearchStatus.ACTIVE) {
+          cancelSelectEmail();
+        }
       },
     );
 

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -86,6 +86,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/sear
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
 import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
 import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_all_identities_interactor.dart';
@@ -552,7 +553,6 @@ void main() {
       expect(filterAfterAdvancedSearch.emailReceiveTimeType, equals(EmailReceiveTimeType.last30Days));
       // Pagination cursors are resolved per search request, not committed to
       // the shared search filter.
-      expect(filterAfterAdvancedSearch.position, isNull);
       expect(filterAfterAdvancedSearch.startDate, isNotNull);
       expect(filterAfterAdvancedSearch.endDate, isNotNull);
       expect(filterAfterAdvancedSearch.before, isNull);
@@ -619,7 +619,6 @@ void main() {
     expect(filterAfterQuickSearch.hasAttachment, isTrue);
     // Pagination cursors are resolved per search request, not committed to
     // the shared search filter.
-    expect(filterAfterQuickSearch.position, isNull);
     expect(filterAfterQuickSearch.startDate, isNotNull);
     expect(filterAfterQuickSearch.endDate, isNotNull);
     expect(filterAfterQuickSearch.before, isNull);
@@ -674,6 +673,32 @@ void main() {
         EmailSortOrderType.subjectAscending,
       );
       expect(searchController.sortOrderFiltered, EmailSortOrderType.subjectAscending);
+    });
+
+    test(
+      'WHEN the dashboard closes\n'
+      'SHOULD reset the committed filter and cached result state '
+      'via the DashboardSearchCoordinator',
+    () {
+      appProviderContainer
+          .read(searchFilterProvider.notifier)
+          .set(SearchEmailFilter(subject: 'invoice'));
+      appProviderContainer
+          .read(searchEmailPresentationProvider.notifier)
+          .setCurrentSearchText('invoice');
+
+      mailboxDashboardController.onClose();
+
+      expect(
+        appProviderContainer.read(searchFilterProvider),
+        SearchEmailFilter.initial(),
+      );
+      expect(
+        appProviderContainer
+            .read(searchEmailPresentationProvider)
+            .currentSearchText,
+        isEmpty,
+      );
     });
 
     tearDown(Get.deleteAll);

--- a/test/features/mailbox_dashboard/presentation/controller/search_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/search_controller_test.dart
@@ -101,17 +101,21 @@ void main() {
 
     test('cursor options never enter the committed SSOT', () {
       searchController.updateFilterEmail(
-        beforeOption: Some(UTCDate(DateTime.parse('2026-06-16T08:00:00.000Z'))));
+        beforeOption: Some(UTCDate(DateTime.parse('2026-06-16T08:00:00.000Z'))),
+        afterOption: Some(UTCDate(DateTime.parse('2026-06-15T08:00:00.000Z'))));
 
       expect(committed().before, isNull);
+      expect(committed().after, isNull);
     });
 
     test('a later user-intent update keeps pagination out of the SSOT', () {
       searchController.updateFilterEmail(
-        beforeOption: Some(UTCDate(DateTime.parse('2026-06-16T08:00:00.000Z'))));
+        beforeOption: Some(UTCDate(DateTime.parse('2026-06-16T08:00:00.000Z'))),
+        afterOption: Some(UTCDate(DateTime.parse('2026-06-15T08:00:00.000Z'))));
       searchController.updateFilterEmail(unreadOption: const Some(true));
 
       expect(committed().before, isNull);
+      expect(committed().after, isNull);
       expect(searchController.committedSearchFilter.unread, isTrue);
     });
   });

--- a/test/features/mailbox_dashboard/presentation/controller/search_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/search_controller_test.dart
@@ -5,6 +5,7 @@ import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
+import 'package:jmap_dart_client/jmap/core/utc_date.dart';
 import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
 import 'package:mockito/annotations.dart';
 import 'package:tmail_ui_user/features/caching/caching_manager.dart';
@@ -99,16 +100,18 @@ void main() {
     });
 
     test('cursor options never enter the committed SSOT', () {
-      searchController.updateFilterEmail(positionOption: const Some(40));
+      searchController.updateFilterEmail(
+        beforeOption: Some(UTCDate(DateTime.parse('2026-06-16T08:00:00.000Z'))));
 
-      expect(committed().position, isNull);
+      expect(committed().before, isNull);
     });
 
     test('a later user-intent update keeps pagination out of the SSOT', () {
-      searchController.updateFilterEmail(positionOption: const Some(40));
+      searchController.updateFilterEmail(
+        beforeOption: Some(UTCDate(DateTime.parse('2026-06-16T08:00:00.000Z'))));
       searchController.updateFilterEmail(unreadOption: const Some(true));
 
-      expect(committed().position, isNull);
+      expect(committed().before, isNull);
       expect(searchController.committedSearchFilter.unread, isTrue);
     });
   });

--- a/test/features/search/email/domain/execution/search_pagination_strategy_test.dart
+++ b/test/features/search/email/domain/execution/search_pagination_strategy_test.dart
@@ -51,7 +51,6 @@ void main() {
     required Object? after,
   }) {
     expect(spec.position, position);
-    expect(spec.filter.position, isNull);
     expect(spec.filter.before, before);
     expect(spec.filter.after, after);
   }
@@ -208,7 +207,6 @@ void main() {
         intent: intent,
         committed: SearchEmailFilter(
           sortOrderType: sortOrder,
-          position: 99,
           before: lastDate,
           after: lastDate,
         ),

--- a/test/features/search/email/domain/notifier/search_email_notifier_test.dart
+++ b/test/features/search/email/domain/notifier/search_email_notifier_test.dart
@@ -227,7 +227,6 @@ void main() {
         subject: 'invoice',
         before: cursorDate,
         after: cursorDate,
-        position: 99,
         sortOrderType: EmailSortOrderType.relevance,
       );
       final container = containerWith(committed: committed);

--- a/test/features/search/email/domain/notifier/search_filter_notifier_test.dart
+++ b/test/features/search/email/domain/notifier/search_filter_notifier_test.dart
@@ -246,7 +246,6 @@ void main() {
         after: cursor,
         startDate: startDate,
         endDate: endDate,
-        position: 5,
       ));
 
       expect(stateOf().subject, 'invoice'); // intent preserved
@@ -254,7 +253,6 @@ void main() {
       expect(stateOf().endDate, endDate);
       expect(stateOf().before, isNull);
       expect(stateOf().after, isNull);
-      expect(stateOf().position, isNull);
     });
 
     test('snapshots filter sets instead of aliasing replacement state', () {

--- a/test/features/search/email/presentation/service/dashboard_search_coordinator_test.dart
+++ b/test/features/search/email/presentation/service/dashboard_search_coordinator_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/service/dashboard_search_coordinator.dart';
+import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
+
+void main() {
+  late ProviderContainer container;
+  late FilterMessageOption dashboardOption;
+  late DashboardSearchCoordinator coordinator;
+
+  setUp(() {
+    container = ProviderContainer();
+    dashboardOption = FilterMessageOption.all;
+    coordinator = DashboardSearchCoordinator(
+      readFilterMessageOption: () => dashboardOption,
+      writeFilterMessageOption: (option) => dashboardOption = option,
+      container: container,
+    )..start();
+  });
+
+  tearDown(() => container.dispose());
+
+  SearchEmailFilter committed() => container.read(searchFilterProvider);
+  void enableSearch() =>
+      container.read(searchViewStateProvider.notifier).enableSearch();
+  void disableSearch() =>
+      container.read(searchViewStateProvider.notifier).disableSearch();
+
+  group('applies filter-message option into the committed SSOT on search entry', () {
+    test('unread → unread flag', () async {
+      dashboardOption = FilterMessageOption.unread;
+
+      enableSearch();
+      await pumpEventQueue();
+
+      expect(committed().unread, isTrue);
+    });
+
+    test('attachments → hasAttachment flag', () async {
+      dashboardOption = FilterMessageOption.attachments;
+
+      enableSearch();
+      await pumpEventQueue();
+
+      expect(committed().hasAttachment, isTrue);
+    });
+
+    test('starred → flagged keyword', () async {
+      dashboardOption = FilterMessageOption.starred;
+
+      enableSearch();
+      await pumpEventQueue();
+
+      expect(committed().isContainFlagged, isTrue);
+    });
+
+    test('all → committed filter stays at its initial value', () async {
+      dashboardOption = FilterMessageOption.all;
+
+      enableSearch();
+      await pumpEventQueue();
+
+      expect(committed(), SearchEmailFilter.initial());
+    });
+  });
+
+  test('restores the option that was active before search on search exit', () async {
+    dashboardOption = FilterMessageOption.starred;
+    enableSearch();
+    await pumpEventQueue();
+
+    // Search cleared the dashboard option while active…
+    dashboardOption = FilterMessageOption.all;
+    disableSearch();
+    await pumpEventQueue();
+
+    expect(dashboardOption, FilterMessageOption.starred);
+  });
+
+  test('dispose resets the committed filter and cached result state', () {
+    container
+        .read(searchFilterProvider.notifier)
+        .set(SearchEmailFilter(subject: 'invoice'));
+    container
+        .read(searchEmailPresentationProvider.notifier)
+        .setCurrentSearchText('invoice');
+
+    coordinator.dispose();
+
+    expect(container.read(searchFilterProvider), SearchEmailFilter.initial());
+    expect(
+      container.read(searchEmailPresentationProvider).currentSearchText,
+      isEmpty,
+    );
+  });
+}

--- a/test/features/search/email/presentation/service/dashboard_search_coordinator_test.dart
+++ b/test/features/search/email/presentation/service/dashboard_search_coordinator_test.dart
@@ -1,23 +1,47 @@
+import 'package:dartz/dartz.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/providers/search_executor_provider.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/service/dashboard_search_coordinator.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/service/search_executor_service.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
+
+class _RecordingExecutor extends SearchExecutorService {
+  _RecordingExecutor(this._ownContainer) : super(_ownContainer);
+
+  final ProviderContainer _ownContainer;
+
+  int resetSessionCount = 0;
+
+  @override
+  void resetSession() => resetSessionCount++;
+
+  void disposeContainer() => _ownContainer.dispose();
+}
 
 void main() {
   late ProviderContainer container;
   late FilterMessageOption dashboardOption;
   late DashboardSearchCoordinator coordinator;
 
+  // Mimics the GetX `ever(filterMessageOption, ...)` bridge the controller wires:
+  // a button write both stores the option and notifies the coordinator (on change).
+  void writeOption(FilterMessageOption option) {
+    if (dashboardOption == option) return;
+    dashboardOption = option;
+    coordinator.onFilterMessageOptionChanged(option);
+  }
+
   setUp(() {
     container = ProviderContainer();
     dashboardOption = FilterMessageOption.all;
     coordinator = DashboardSearchCoordinator(
       readFilterMessageOption: () => dashboardOption,
-      writeFilterMessageOption: (option) => dashboardOption = option,
+      writeFilterMessageOption: writeOption,
       container: container,
     )..start();
   });
@@ -25,13 +49,33 @@ void main() {
   tearDown(() => container.dispose());
 
   SearchEmailFilter committed() => container.read(searchFilterProvider);
+  void setCommitted(SearchEmailFilter filter) =>
+      container.read(searchFilterProvider.notifier).set(filter);
   void enableSearch() =>
       container.read(searchViewStateProvider.notifier).enableSearch();
-  void disableSearch() =>
-      container.read(searchViewStateProvider.notifier).disableSearch();
+  void openAdvancedSearch() =>
+      container.read(searchViewStateProvider.notifier).openAdvancedSearch();
+  void closeAdvancedSearch() =>
+      container.read(searchViewStateProvider.notifier).closeAdvancedSearch();
+  void focusSearchInput() =>
+      container.read(searchViewStateProvider.notifier).setSearchInputFocused(true);
 
-  group('applies filter-message option into the committed SSOT on search entry', () {
-    test('unread → unread flag', () async {
+  // Selects `unread` on the button, opens [openSurface] and verifies it reached
+  // the committed filter, then unchecks `unread` there as a search surface would.
+  Future<void> selectUnreadThenUncheckInSurface(
+    void Function() openSurface,
+  ) async {
+    dashboardOption = FilterMessageOption.unread;
+    openSurface();
+    await pumpEventQueue();
+    expect(committed().unread, isTrue);
+
+    setCommitted(committed().copyWith(unreadOption: const Some(false)));
+    await pumpEventQueue();
+  }
+
+  group('button → search: applies the option into the committed filter', () {
+    test('unread → unread flag on search entry', () async {
       dashboardOption = FilterMessageOption.unread;
 
       enableSearch();
@@ -40,7 +84,7 @@ void main() {
       expect(committed().unread, isTrue);
     });
 
-    test('attachments → hasAttachment flag', () async {
+    test('attachments → hasAttachment flag on search entry', () async {
       dashboardOption = FilterMessageOption.attachments;
 
       enableSearch();
@@ -49,7 +93,7 @@ void main() {
       expect(committed().hasAttachment, isTrue);
     });
 
-    test('starred → flagged keyword', () async {
+    test('starred → flagged keyword on search entry', () async {
       dashboardOption = FilterMessageOption.starred;
 
       enableSearch();
@@ -66,25 +110,128 @@ void main() {
 
       expect(committed(), SearchEmailFilter.initial());
     });
+
+    test('a live button change mirrors into the committed filter', () async {
+      writeOption(FilterMessageOption.unread);
+      await pumpEventQueue();
+
+      expect(committed().unread, isTrue);
+    });
+
+    test('switching option drops the previous criterion and applies the new one',
+        () async {
+      writeOption(FilterMessageOption.unread);
+      await pumpEventQueue();
+      expect(committed().unread, isTrue);
+
+      writeOption(FilterMessageOption.attachments);
+      await pumpEventQueue();
+
+      expect(committed().unread, isFalse);
+      expect(committed().hasAttachment, isTrue);
+    });
+
+    test('re-seeds when the advanced-search panel opens', () async {
+      dashboardOption = FilterMessageOption.unread;
+
+      openAdvancedSearch();
+      await pumpEventQueue();
+
+      expect(committed().unread, isTrue);
+    });
+
+    test('re-seeds when the suggestion dropdown (input focus) opens', () async {
+      dashboardOption = FilterMessageOption.attachments;
+
+      focusSearchInput();
+      await pumpEventQueue();
+
+      expect(committed().hasAttachment, isTrue);
+    });
   });
 
-  test('restores the option that was active before search on search exit', () async {
-    dashboardOption = FilterMessageOption.starred;
-    enableSearch();
-    await pumpEventQueue();
+  group('search → button: clear-only, while search is active', () {
+    test('turning the button criterion OFF in an active session clears the button',
+        () async {
+      await selectUnreadThenUncheckInSurface(enableSearch);
 
-    // Search cleared the dashboard option while active…
-    dashboardOption = FilterMessageOption.all;
-    disableSearch();
-    await pumpEventQueue();
+      expect(dashboardOption, FilterMessageOption.all);
+    });
 
-    expect(dashboardOption, FilterMessageOption.starred);
+    test('turning a criterion ON in search never sets the button', () async {
+      dashboardOption = FilterMessageOption.all;
+      enableSearch();
+      await pumpEventQueue();
+
+      setCommitted(committed().copyWith(hasAttachmentOption: const Some(true)));
+      await pumpEventQueue();
+
+      expect(dashboardOption, FilterMessageOption.all);
+    });
+
+    test('re-enabling a criterion after it cleared the button leaves it off',
+        () async {
+      await selectUnreadThenUncheckInSurface(enableSearch);
+      expect(dashboardOption, FilterMessageOption.all);
+
+      setCommitted(committed().copyWith(unreadOption: const Some(true)));
+      await pumpEventQueue();
+
+      expect(dashboardOption, FilterMessageOption.all);
+    });
+
+    test('a different criterion turned off does not clear the button', () async {
+      dashboardOption = FilterMessageOption.unread;
+      enableSearch();
+      await pumpEventQueue();
+
+      // Attachment (not the button's criterion) toggles off; button stays.
+      setCommitted(committed().copyWith(hasAttachmentOption: const Some(false)));
+      await pumpEventQueue();
+
+      expect(dashboardOption, FilterMessageOption.unread);
+    });
+
+    test('a filter reset while search is inactive keeps the button', () async {
+      dashboardOption = FilterMessageOption.unread;
+
+      // Search never activated (e.g. teardown reset path).
+      setCommitted(SearchEmailFilter.initial());
+      await pumpEventQueue();
+
+      expect(dashboardOption, FilterMessageOption.unread);
+    });
+
+    test('unchecking in the advanced panel (not an active session) keeps the button',
+        () async {
+      await selectUnreadThenUncheckInSurface(openAdvancedSearch);
+
+      expect(dashboardOption, FilterMessageOption.unread);
+    });
   });
+
+  test(
+    'reopening the advanced panel re-applies the still-selected button after it '
+    'was unchecked in the panel',
+    () async {
+      // Select the button, open the panel, then uncheck there: the button stays,
+      // the committed filter drops it.
+      await selectUnreadThenUncheckInSurface(openAdvancedSearch);
+      expect(dashboardOption, FilterMessageOption.unread);
+      expect(committed().unread, isFalse);
+
+      // Close then reopen: the still-selected button is re-applied.
+      closeAdvancedSearch();
+      await pumpEventQueue();
+      openAdvancedSearch();
+      await pumpEventQueue();
+
+      expect(committed().unread, isTrue);
+    },
+  );
 
   test('dispose resets the committed filter and cached result state', () {
-    container
-        .read(searchFilterProvider.notifier)
-        .set(SearchEmailFilter(subject: 'invoice'));
+    setCommitted(SearchEmailFilter(subject: 'invoice'));
     container
         .read(searchEmailPresentationProvider.notifier)
         .setCurrentSearchText('invoice');
@@ -96,5 +243,26 @@ void main() {
       container.read(searchEmailPresentationProvider).currentSearchText,
       isEmpty,
     );
+  });
+
+  test('dispose ends the executor session so no stale search replays next session',
+      () {
+    final executor = _RecordingExecutor(ProviderContainer());
+    final ownContainer = ProviderContainer(overrides: [
+      searchExecutorServiceProvider.overrideWithValue(executor),
+    ]);
+    final ownCoordinator = DashboardSearchCoordinator(
+      readFilterMessageOption: () => FilterMessageOption.all,
+      writeFilterMessageOption: (_) {},
+      container: ownContainer,
+    )..start();
+    addTearDown(() {
+      ownContainer.dispose();
+      executor.disposeContainer();
+    });
+
+    ownCoordinator.dispose();
+
+    expect(executor.resetSessionCount, 1);
   });
 }

--- a/test/features/search/search_email_filter_test.dart
+++ b/test/features/search/search_email_filter_test.dart
@@ -195,7 +195,6 @@ void main() {
           before: UTCDate(DateTime.parse('2024-10-30 12:00:00')),
           startDate: UTCDate(DateTime.parse('2024-10-30 12:00:00')),
           endDate: UTCDate(DateTime.parse('2024-10-31 12:00:00')),
-          position: 0,
           sortOrderType: EmailSortOrderType.oldest,
         );
 
@@ -878,7 +877,6 @@ void main() {
           beforeOption: const None(),
           startDateOption: const None(),
           endDateOption: const None(),
-          positionOption: const Some(0),
         );
 
         expect(afterSortChange.startDate, isNull);
@@ -902,7 +900,6 @@ void main() {
           beforeOption: const None(),
           startDateOption: const None(),
           endDateOption: const None(),
-          positionOption: const Some(0),
         );
 
         // startDate cleared → no after bound in the JMAP filter
@@ -926,7 +923,6 @@ void main() {
           beforeOption: const None(),
           startDateOption: const None(),
           endDateOption: const None(),
-          positionOption: const Some(0),
         );
 
         expect(afterSortChange.before, isNull);
@@ -947,7 +943,6 @@ void main() {
         final afterSortChange = filter.copyWith(
           sortOrderTypeOption: const Some(EmailSortOrderType.relevance),
           beforeOption: const None(),
-          positionOption: const Some(0),
         );
 
         expect(afterSortChange.startDate, equals(start));
@@ -965,14 +960,13 @@ void main() {
         var filter = SearchEmailFilter(
           emailReceiveTimeType: EmailReceiveTimeType.allTime,
           sortOrderType: EmailSortOrderType.relevance,
-        ).copyWith(positionOption: const Some(20));
+        );
 
         filter = filter.copyWith(
           sortOrderTypeOption: const Some(EmailSortOrderType.oldest),
           beforeOption: const None(),
           startDateOption: const None(),
           endDateOption: const None(),
-          positionOption: const None(),
         );
         expect(filter.startDate, isNull);
 
@@ -984,7 +978,6 @@ void main() {
           beforeOption: const None(),
           startDateOption: const None(),
           endDateOption: const None(),
-          positionOption: const None(),
         );
         expect(filter.startDate, isNull);
 
@@ -996,7 +989,6 @@ void main() {
           beforeOption: const None(),
           startDateOption: const None(),
           endDateOption: const None(),
-          positionOption: const None(),
         );
         expect(filter.before, isNull);
 
@@ -1008,7 +1000,6 @@ void main() {
           beforeOption: const None(),
           startDateOption: const None(),
           endDateOption: const None(),
-          positionOption: const Some(0),
         );
         expect(filter.startDate, isNull);
         expect(filter.before, isNull);
@@ -1031,7 +1022,6 @@ void main() {
           beforeOption: const None(),
           startDateOption: const None(),
           endDateOption: const None(),
-          positionOption: const None(),
         );
         expect(filter.startDate, isNull);
 
@@ -1043,7 +1033,6 @@ void main() {
           beforeOption: const None(),
           startDateOption: const None(),
           endDateOption: const None(),
-          positionOption: const None(),
         );
         expect(filter.before, isNull);
 
@@ -1055,7 +1044,6 @@ void main() {
           beforeOption: const None(),
           startDateOption: const None(),
           endDateOption: const None(),
-          positionOption: const Some(0),
         );
         // startDate cleared → no after bound in JMAP filter (cursors fully reset)
         expect(filter.startDate, isNull);
@@ -1083,7 +1071,6 @@ void main() {
           startDateOption: const None(),
           endDateOption: const None(),
           beforeOption: const None(),
-          positionOption: const None(),
         );
 
         expect(filter.before, isNull);
@@ -1111,7 +1098,6 @@ void main() {
           startDateOption: Some(userStart),
           endDateOption: Some(userEnd),
           beforeOption: const None(),
-          positionOption: const None(),
         );
 
         expect(filter.before, isNull);
@@ -1141,14 +1127,12 @@ void main() {
           sortOrderTypeOption: const Some(EmailSortOrderType.mostRecent),
           beforeOption: const None(),
           afterOption: const None(),
-          positionOption: const None(),
         );
 
         expect(filter.startDate, equals(snapshotStart));
         expect(filter.endDate, equals(snapshotEnd));
         expect(filter.before, isNull);
         expect(filter.after, isNull);
-        expect(filter.position, isNull);
         expect(filter.sortOrderType, equals(EmailSortOrderType.mostRecent));
       });
 
@@ -1169,7 +1153,6 @@ void main() {
           startDateOption: optionOf(dateRange.start),
           endDateOption: optionOf(dateRange.end),
           beforeOption: const None(),
-          positionOption: const None(),
         );
 
         expect(filter.before, isNull);
@@ -1196,7 +1179,6 @@ void main() {
           startDateOption: const None(),
           endDateOption: const None(),
           beforeOption: const None(),
-          positionOption: const None(),
         );
         expect(filter.before, isNull);
 
@@ -1211,7 +1193,6 @@ void main() {
           startDateOption: const None(),
           endDateOption: const None(),
           beforeOption: const None(),
-          positionOption: const None(),
         );
         expect(filter.startDate, isNull);
 

--- a/test/features/search/verify_before_time_in_search_email_filter_test.dart
+++ b/test/features/search/verify_before_time_in_search_email_filter_test.dart
@@ -433,7 +433,6 @@ void main() {
       expect(filter.endDate, equals(snapshotEnd));
       expect(filter.before, isNull);
       expect(filter.after, isNull);
-      expect(filter.position, isNull);
     });
 
     test(
@@ -460,7 +459,6 @@ void main() {
       expect(filter.endDate, equals(end));
       expect(filter.before, isNull);
       expect(filter.after, isNull);
-      expect(filter.position, isNull);
     });
   });
 }

--- a/test/features/thread/domain/model/filter_message_option_test.dart
+++ b/test/features/thread/domain/model/filter_message_option_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
+
+void main() {
+  group('FilterMessageOption.applyTo', () {
+    test('all leaves the filter unchanged', () {
+      final filter = SearchEmailFilter.initial();
+
+      final result = FilterMessageOption.all.applyTo(filter);
+
+      expect(result, filter);
+    });
+
+    test('unread sets the unread flag', () {
+      final result =
+          FilterMessageOption.unread.applyTo(SearchEmailFilter.initial());
+
+      expect(result.unread, isTrue);
+    });
+
+    test('attachments sets the hasAttachment flag', () {
+      final result =
+          FilterMessageOption.attachments.applyTo(SearchEmailFilter.initial());
+
+      expect(result.hasAttachment, isTrue);
+    });
+
+    test('starred adds the flagged keyword to hasKeyword', () {
+      final result =
+          FilterMessageOption.starred.applyTo(SearchEmailFilter.initial());
+
+      expect(
+        result.hasKeyword,
+        contains(KeyWordIdentifier.emailFlagged.value),
+      );
+    });
+
+    test('starred merges the flagged keyword with existing keywords', () {
+      final filter = SearchEmailFilter(hasKeyword: {'existing-keyword'});
+
+      final result = FilterMessageOption.starred.applyTo(filter);
+
+      expect(
+        result.hasKeyword,
+        containsAll(<String>{
+          'existing-keyword',
+          KeyWordIdentifier.emailFlagged.value,
+        }),
+      );
+    });
+
+    test('preserves other user-intent fields already on the filter', () {
+      final filter = SearchEmailFilter(subject: 'invoice');
+
+      final result = FilterMessageOption.unread.applyTo(filter);
+
+      expect(result.subject, 'invoice');
+      expect(result.unread, isTrue);
+    });
+  });
+}

--- a/test/features/thread/domain/model/filter_message_option_test.dart
+++ b/test/features/thread/domain/model/filter_message_option_test.dart
@@ -1,9 +1,43 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
 
 void main() {
+  group('FilterMessageOption.filterEmail', () {
+    test('all matches every email', () {
+      expect(FilterMessageOption.all.filterEmail(Email()), isTrue);
+    });
+
+    test('unread matches only emails without the seen keyword', () {
+      expect(FilterMessageOption.unread.filterEmail(Email()), isTrue);
+      expect(
+        FilterMessageOption.unread
+            .filterEmail(Email(keywords: {KeyWordIdentifier.emailSeen: true})),
+        isFalse,
+      );
+    });
+
+    test('attachments matches only emails with attachments', () {
+      expect(
+        FilterMessageOption.attachments.filterEmail(Email(hasAttachment: true)),
+        isTrue,
+      );
+      expect(FilterMessageOption.attachments.filterEmail(Email()), isFalse);
+    });
+
+    test('starred matches only flagged emails', () {
+      expect(
+        FilterMessageOption.starred.filterEmail(
+          Email(keywords: {KeyWordIdentifier.emailFlagged: true}),
+        ),
+        isTrue,
+      );
+      expect(FilterMessageOption.starred.filterEmail(Email()), isFalse);
+    });
+  });
+
   group('FilterMessageOption.applyTo', () {
     test('all leaves the filter unchanged', () {
       final filter = SearchEmailFilter.initial();
@@ -58,6 +92,80 @@ void main() {
 
       expect(result.subject, 'invoice');
       expect(result.unread, isTrue);
+    });
+  });
+
+  group('FilterMessageOption.isActiveIn', () {
+    test('all is never active', () {
+      expect(
+        FilterMessageOption.all.isActiveIn(SearchEmailFilter(unread: true)),
+        isFalse,
+      );
+    });
+
+    test('unread reflects the unread flag', () {
+      expect(
+        FilterMessageOption.unread.isActiveIn(SearchEmailFilter(unread: true)),
+        isTrue,
+      );
+      expect(
+        FilterMessageOption.unread.isActiveIn(SearchEmailFilter.initial()),
+        isFalse,
+      );
+    });
+
+    test('attachments reflects the hasAttachment flag', () {
+      expect(
+        FilterMessageOption.attachments
+            .isActiveIn(SearchEmailFilter(hasAttachment: true)),
+        isTrue,
+      );
+    });
+
+    test('starred reflects the flagged keyword', () {
+      expect(
+        FilterMessageOption.starred.isActiveIn(
+          SearchEmailFilter(hasKeyword: {KeyWordIdentifier.emailFlagged.value}),
+        ),
+        isTrue,
+      );
+      expect(
+        FilterMessageOption.starred.isActiveIn(SearchEmailFilter.initial()),
+        isFalse,
+      );
+    });
+  });
+
+  group('FilterMessageOption.removeFrom', () {
+    test('all leaves the filter unchanged', () {
+      final filter = SearchEmailFilter(unread: true);
+
+      expect(FilterMessageOption.all.removeFrom(filter), filter);
+    });
+
+    test('unread clears the unread flag', () {
+      final result =
+          FilterMessageOption.unread.removeFrom(SearchEmailFilter(unread: true));
+
+      expect(result.unread, isFalse);
+    });
+
+    test('attachments clears the hasAttachment flag', () {
+      final result = FilterMessageOption.attachments
+          .removeFrom(SearchEmailFilter(hasAttachment: true));
+
+      expect(result.hasAttachment, isFalse);
+    });
+
+    test('starred removes only the flagged keyword, keeping the others', () {
+      final filter = SearchEmailFilter(
+        hasKeyword: {KeyWordIdentifier.emailFlagged.value, 'other-keyword'},
+      );
+
+      final result = FilterMessageOption.starred.removeFrom(filter);
+
+      expect(result.isContainFlagged, isFalse);
+      expect(result.hasKeyword, contains('other-keyword'));
     });
   });
 }

--- a/test/features/thread/presentation/extensions/filter_message_option_style_extension_test.dart
+++ b/test/features/thread/presentation/extensions/filter_message_option_style_extension_test.dart
@@ -1,8 +1,12 @@
 import 'package:core/core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
 import 'package:tmail_ui_user/features/thread/presentation/extensions/filter_message_option_style_extension.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations_delegate.dart';
+import 'package:tmail_ui_user/main/localizations/localization_service.dart';
 
 void main() {
   final imagePaths = ImagePaths();
@@ -13,6 +17,27 @@ void main() {
     FilterMessageOption.attachments,
     FilterMessageOption.starred,
   ];
+
+  /// Pumps a localized app and hands a [BuildContext] with
+  /// [AppLocalizations] available to [body].
+  Future<void> withLocalizedContext(
+    WidgetTester tester,
+    void Function(BuildContext context) body,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(
+      localizationsDelegates: [
+        AppLocalizationsDelegate(),
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: LocalizationService.supportedLocales,
+      locale: LocalizationService.defaultLocale,
+      home: Scaffold(body: SizedBox()),
+    ));
+    await tester.pumpAndSettle();
+    body(tester.element(find.byType(SizedBox)));
+  }
 
   group('getIcon / getIconColor: all vs the rest', () {
     test('all uses the advanced-filter icon and its own colour', () {
@@ -31,22 +56,110 @@ void main() {
   });
 
   group('per-option icons', () {
-    test('toast and context-menu icons are distinct per option', () {
-      expect(FilterMessageOption.starred.getIconToast(imagePaths),
-          imagePaths.icStar);
-      expect(FilterMessageOption.starred.getContextMenuIcon(imagePaths),
-          imagePaths.icUnStar);
-      expect(FilterMessageOption.all.getContextMenuIcon(imagePaths), '');
+    test('toast and context-menu icons map per option', () {
+      final expectedIcons = {
+        FilterMessageOption.all: (
+          toast: imagePaths.icFilterMessageAll,
+          menu: '',
+        ),
+        FilterMessageOption.unread: (
+          toast: imagePaths.icUnreadToast,
+          menu: imagePaths.icUnread,
+        ),
+        FilterMessageOption.attachments: (
+          toast: imagePaths.icFilterMessageAttachments,
+          menu: imagePaths.icAttachment,
+        ),
+        FilterMessageOption.starred: (
+          toast: imagePaths.icStar,
+          menu: imagePaths.icUnStar,
+        ),
+      };
+
+      for (final entry in expectedIcons.entries) {
+        expect(entry.key.getIconToast(imagePaths), entry.value.toast,
+            reason: '${entry.key} toast icon');
+        expect(entry.key.getContextMenuIcon(imagePaths), entry.value.menu,
+            reason: '${entry.key} context-menu icon');
+      }
     });
   });
 
   group('getName', () {
     test('all has no name; others map to their label', () {
-      expect(FilterMessageOption.all.getName(appLocalizations), '');
-      expect(FilterMessageOption.unread.getName(appLocalizations),
-          appLocalizations.unread);
-      expect(FilterMessageOption.starred.getName(appLocalizations),
-          appLocalizations.starred);
+      final expectedNames = {
+        FilterMessageOption.all: '',
+        FilterMessageOption.unread: appLocalizations.unread,
+        FilterMessageOption.attachments: appLocalizations.with_attachments,
+        FilterMessageOption.starred: appLocalizations.starred,
+      };
+
+      for (final entry in expectedNames.entries) {
+        expect(entry.key.getName(appLocalizations), entry.value,
+            reason: '${entry.key} name');
+      }
+    });
+  });
+
+  group('getTitle', () {
+    testWidgets('maps every option to its localized title', (tester) async {
+      await withLocalizedContext(tester, (context) {
+        final expectedTitles = {
+          FilterMessageOption.all: appLocalizations.filter_messages,
+          FilterMessageOption.unread: appLocalizations.with_unread,
+          FilterMessageOption.attachments: appLocalizations.with_attachments,
+          FilterMessageOption.starred: appLocalizations.with_starred,
+        };
+
+        for (final entry in expectedTitles.entries) {
+          expect(entry.key.getTitle(context), entry.value,
+              reason: '${entry.key} title');
+        }
+      });
+    });
+  });
+
+  group('getMessageToast', () {
+    testWidgets(
+        'all announces the disabled filter; others quote their name',
+        (tester) async {
+      await withLocalizedContext(tester, (context) {
+        expect(FilterMessageOption.all.getMessageToast(context),
+            appLocalizations.disable_filter_message_toast);
+
+        for (final option in nonAllOptions) {
+          expect(
+              option.getMessageToast(context),
+              appLocalizations
+                  .filter_message_toast(option.getName(appLocalizations)),
+              reason: '$option toast message');
+        }
+      });
+    });
+  });
+
+  group('getBackgroundColor', () {
+    test('selection toggles the background for every option', () {
+      for (final option in FilterMessageOption.values) {
+        expect(option.getBackgroundColor(isSelected: true),
+            AppColor.primaryColor.withValues(alpha: 0.06),
+            reason: '$option selected background');
+        expect(option.getBackgroundColor(),
+            AppColor.colorFilterMessageButton.withValues(alpha: 0.6),
+            reason: '$option unselected background');
+      }
+    });
+  });
+
+  group('getTextStyle', () {
+    test('all uses the neutral title colour; others the primary colour', () {
+      expect(FilterMessageOption.all.getTextStyle().color,
+          AppColor.colorFilterMessageTitle);
+
+      for (final option in nonAllOptions) {
+        expect(option.getTextStyle().color, AppColor.primaryColor,
+            reason: '$option text colour');
+      }
     });
   });
 }

--- a/test/features/thread/presentation/extensions/filter_message_option_style_extension_test.dart
+++ b/test/features/thread/presentation/extensions/filter_message_option_style_extension_test.dart
@@ -1,0 +1,52 @@
+import 'package:core/core.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
+import 'package:tmail_ui_user/features/thread/presentation/extensions/filter_message_option_style_extension.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+void main() {
+  final imagePaths = ImagePaths();
+  final appLocalizations = AppLocalizations();
+
+  const nonAllOptions = [
+    FilterMessageOption.unread,
+    FilterMessageOption.attachments,
+    FilterMessageOption.starred,
+  ];
+
+  group('getIcon / getIconColor: all vs the rest', () {
+    test('all uses the advanced-filter icon and its own colour', () {
+      expect(FilterMessageOption.all.getIcon(imagePaths),
+          imagePaths.icFilterAdvanced);
+      expect(FilterMessageOption.all.getIconColor(),
+          AppColor.colorFilterMessageIcon);
+    });
+
+    test('non-all options share the selected icon and primary colour', () {
+      for (final option in nonAllOptions) {
+        expect(option.getIcon(imagePaths), imagePaths.icSelectedSB);
+        expect(option.getIconColor(), AppColor.primaryColor);
+      }
+    });
+  });
+
+  group('per-option icons', () {
+    test('toast and context-menu icons are distinct per option', () {
+      expect(FilterMessageOption.starred.getIconToast(imagePaths),
+          imagePaths.icStar);
+      expect(FilterMessageOption.starred.getContextMenuIcon(imagePaths),
+          imagePaths.icUnStar);
+      expect(FilterMessageOption.all.getContextMenuIcon(imagePaths), '');
+    });
+  });
+
+  group('getName', () {
+    test('all has no name; others map to their label', () {
+      expect(FilterMessageOption.all.getName(appLocalizations), '');
+      expect(FilterMessageOption.unread.getName(appLocalizations),
+          appLocalizations.unread);
+      expect(FilterMessageOption.starred.getName(appLocalizations),
+          appLocalizations.starred);
+    });
+  });
+}


### PR DESCRIPTION
Closes [#4647](https://github.com/linagora/tmail-flutter/issues/4647) + [#4648](https://github.com/linagora/tmail-flutter/issues/4648)
## Context

Part 5 removed the hidden `moreFilterCondition: getFilterCondition()` path from `ThreadController`. With no replacement, the dashboard's **filter-message option** (unread / starred / attachments) had **no path into search at all** — select a filter, open search, and the chips and the JMAP query both ignored it. That is the SSOT half of **#4590 / #4490**.

This PR wires that option into the committed search filter through the SSOT, and lands the final model cleanup (**#4648**): removing the `position` field now that no caller reads it.

## What this PR does

### #4647 — dashboard filter-message option → search SSOT

- **`FilterMessageOption.applyTo(SearchEmailFilter)`** — pure per-case mapping into the committed filter (`unread` → `unread`, `attachments` → `hasAttachment`, `starred` → merge the flagged keyword into `hasKeyword`, `all` → no-op).
- **`DashboardSearchCoordinator`** (`search/email/presentation/service/`) — owns the dashboard's search-session side-effects so `MailboxDashBoardController` stays focused (SRP):
  - `start()` listens to `searchViewStateProvider`; on search open it applies the current filter-message option to the committed filter, on close it restores the option that was active before search.
  - `dispose()` invalidates `searchFilterProvider`, `searchEmailProvider`, `searchEmailPresentationProvider` **before** any post-logout rebuild reads them (no committed filter or cached result leaks into the next session).
  - Decoupled from GetX via typedef callbacks (`FilterMessageOptionGetter` / `Setter`) + an injected `ProviderContainer`, following the existing `SearchRefreshCoordinator` precedent.
- **`MailboxDashBoardController`** gains only ~7 lines: build + `start()` the coordinator in `onInit`, `dispose()` it in `onClose`. No apply/restore/invalidate logic on the controller itself.

### #4648 — remove `position` from `SearchEmailFilter`

- Deletes the field, constructor param, `positionOption` in `copyWith`, and the `props` entry; `clearPaginationCursors()` now strips only the `before` / `after` date cursors. Pagination `position` continues to live on the transient `SearchRequestSpec` (resolved per request by the strategies) — untouched.
- Makes "cursors never live in the committed SSOT" **type-enforced**.

### #4490 - #4590)

- `MailboxDashBoardController.onClose()` now invalidates the three `keepAlive` search providers —
  `searchEmailPresentationProvider`, `searchEmailProvider`, `searchFilterProvider` — **before** any post-logout
  rebuild reads them, so no committed filter or cached results leak into the next session (#4490 / #4590).
- Adds the `searchEmailProvider` import (the other two were already imported).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard filter buttons now stay synchronized with active email searches and advanced search filters.
  * Filter options consistently apply to unread, attachment, and starred email results.
  * Updated filter icons, labels, colors, titles, and toast messages across dashboard and thread menus.

* **Bug Fixes**
  * Improved search-session cleanup when closing the dashboard or search experience.
  * Prevented pagination state from affecting saved search filters.
  * Email selection is cleared only when a search becomes active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->