### PR TITLE
TF-4648 SSOT Part 7 — Remove position field from SearchEmailFilter model  

### DIFF
--- a/lib/features/mailbox/presentation/base_mailbox_view.dart
+++ b/lib/features/mailbox/presentation/base_mailbox_view.dart
@@ -259,7 +259,7 @@ abstract class BaseMailboxView extends GetWidget<MailboxController>
         controller.mailboxDashBoardController.searchController;
 
     return searchController.isSearchEmailRunning &&
-        searchController.searchEmailFilter.value.isOnlyStarredApplied;
+        searchController.isOnlyStarredApplied;
   }
 
   bool isFolderHighlighted(MailboxNode mailboxNode) =>

--- a/lib/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart
@@ -16,6 +16,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/search_controller.dart' as search;
 import 'package:tmail_ui_user/features/base/model/filter_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/email_address_set_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
@@ -73,10 +74,10 @@ class AdvancedFilterController extends BaseController {
       appProviderContainer.read(searchFilterProvider.notifier);
 
   List<EmailAddress> get listFromEmailAddress =>
-      _toEmailAddresses(_committedFilter.from);
+      _committedFilter.from.toEmailAddresses();
 
   List<EmailAddress> get listToEmailAddress =>
-      _toEmailAddresses(_committedFilter.to);
+      _committedFilter.to.toEmailAddresses();
 
   @override
   void onInit() {
@@ -158,7 +159,7 @@ class AdvancedFilterController extends BaseController {
     } else {
       searchController.deactivateAdvancedSearch();
     }
-    searchController.isAdvancedSearchViewOpen.value = false;
+    searchController.closeAdvanceSearch();
     _mailboxDashBoardController.handleAdvancedSearchEmail();
   }
 
@@ -511,7 +512,7 @@ class AdvancedFilterController extends BaseController {
     _clearAllTextFieldInput();
     searchController.searchInputController.clear();
     searchController.deactivateAdvancedSearch();
-    searchController.isAdvancedSearchViewOpen.value = false;
+    searchController.closeAdvanceSearch();
     _filterNotifier.addSender(emailAddress.emailAddress.asSearchFilterEmailAddress());
     _mailboxDashBoardController.dispatchAction(StartSearchEmailAction());
   }
@@ -528,7 +529,4 @@ class AdvancedFilterController extends BaseController {
     _unregisterWorkerListener();
     super.onClose();
   }
-
-  List<EmailAddress> _toEmailAddresses(Set<String> emails) =>
-      emails.map((email) => EmailAddress(null, email)).toList();
 }

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -3481,9 +3481,9 @@ class MailboxDashBoardController extends ReloadableController
 
   @override
   void onClose() {
-    if (PlatformInfo.isWeb) {
-      _listSearchFilterScrollController?.dispose();
-    }
+    // Dispose unconditionally: the getter lazily creates it on any platform,
+    // so keep creation/disposal symmetric.
+    _listSearchFilterScrollController?.dispose();
     if (PlatformInfo.isIOS) {
       _iosNotificationManager?.dispose();
       _currentEmailIdInNotificationIOSStreamSubscription?.cancel();

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -8,6 +8,7 @@ import 'package:email_recovery/email_recovery/email_recovery_action.dart';
 import 'package:email_recovery/email_recovery/email_recovery_action_id.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
@@ -132,6 +133,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/action/dow
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/app_grid_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/search_controller.dart' as search;
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/spam_report_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_view_state.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/ai_scribe/setup_ai_needs_action_setting_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/ai_scribe/setup_cached_ai_scribe_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/setup_linagora_eco_system_extension.dart';
@@ -153,7 +155,6 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/open_and_close_composer_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/quick_search_emails_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/reopen_composer_cache_extension.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/select_search_filter_action_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/set_error_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/update_current_emails_flags_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/update_text_formatting_menu_state_extension.dart';
@@ -167,8 +168,8 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/drag
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/refresh_action_view_event.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/quick_search_filter_action_notifier.dart';
 import 'package:tmail_ui_user/features/mailto/presentation/model/mailto_arguments.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/ai_scribe_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/state/create_new_rule_filter_state.dart';
@@ -182,7 +183,6 @@ import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_all_id
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_all_vacation_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/save_language_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/update_vacation_interactor.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/extensions/datetime_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/extensions/vacation_response_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/manage_account_arguments.dart';
@@ -195,6 +195,8 @@ import 'package:tmail_ui_user/features/push_notification/presentation/notificati
 import 'package:tmail_ui_user/features/push_notification/presentation/services/fcm_service.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/utils/fcm_utils.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/extensions/datetime_extension.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/mixin/search_label_filter_modal_mixin.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/model/sending_email.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/state/get_all_sending_email_state.dart';
@@ -207,7 +209,6 @@ import 'package:tmail_ui_user/features/sending_queue/presentation/model/sending_
 import 'package:tmail_ui_user/features/server_settings/domain/state/get_server_setting_state.dart';
 import 'package:tmail_ui_user/features/server_settings/domain/usecases/get_server_setting_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
-import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/empty_spam_folder_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/empty_trash_folder_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/get_email_by_id_state.dart';
@@ -257,6 +258,8 @@ class MailboxDashBoardController extends ReloadableController
   final RemoveEmailDraftsInteractor _removeEmailDraftsInteractor = Get.find<RemoveEmailDraftsInteractor>();
   final EmailReceiveManager _emailReceiveManager = Get.find<EmailReceiveManager>();
   final search.SearchController searchController = Get.find<search.SearchController>();
+  SearchFilterNotifier get _searchFilterNotifier =>
+      appProviderContainer.read(searchFilterProvider.notifier);
   final DownloadController downloadController = Get.find<DownloadController>();
   final AppGridDashboardController appGridDashboardController = Get.find<AppGridDashboardController>();
   final SpamReportController spamReportController = Get.find<SpamReportController>();
@@ -320,6 +323,14 @@ class MailboxDashBoardController extends ReloadableController
   final dashboardRoute = DashboardRoutes.waiting.obs;
   final currentSelectMode = SelectMode.INACTIVE.obs;
   final filterMessageOption = FilterMessageOption.all.obs;
+  // Quick-filter snapshot from search entry; null means no active search session.
+  // Used to seed once and restore the mailbox filter after search closes.
+  FilterMessageOption? _filterMessageOptionBeforeSearch;
+  // Sender auto-routed from the search bar when the query was an email address.
+  // Cleared from `from` once the query becomes non-email, so a stale sender does
+  // not silently narrow a later full-text search. Null means the search bar has
+  // no derived sender.
+  String? _searchBarDerivedSender;
   final listEmailSelected = <PresentationEmail>[].obs;
   final viewStateMailboxActionProgress = Rx<Either<Failure, Success>>(Right(UIState.idle));
   final _emptyFolderStreamController = StreamController<EmptyFolderRequest>.broadcast();
@@ -350,7 +361,9 @@ class MailboxDashBoardController extends ReloadableController
   PresentationMailbox? outboxMailbox;
   List<Identity>? _identities;
   jmap.State? _currentEmailState;
-  ScrollController? listSearchFilterScrollController;
+  ScrollController? _listSearchFilterScrollController;
+  ScrollController get listSearchFilterScrollController =>
+      _listSearchFilterScrollController ??= ScrollController();
   StreamSubscription? _pendingSharedFileInfoSubscription;
   StreamSubscription? _currentEmailIdInNotificationIOSStreamSubscription;
   bool _isFirstSessionLoad = false;
@@ -361,6 +374,7 @@ class MailboxDashBoardController extends ReloadableController
   LinagoraEcosystem? cachedLinagoraEcosystem;
   PaywallController? paywallController;
   final workerObxVariables = <Worker>[];
+  ProviderSubscription<SearchViewState>? searchViewStateSubscription;
 
   final StreamController<Either<Failure, Success>> progressStateController =
     StreamController<Either<Failure, Success>>.broadcast();
@@ -434,7 +448,6 @@ class MailboxDashBoardController extends ReloadableController
   @override
   void onReady() {
     if (PlatformInfo.isWeb) {
-      listSearchFilterScrollController = ScrollController();
       twakeAppManager.setExecutingBeforeReconnect(false);
       registerReactiveObxVariableListener();
       initialTextFormattingMenuState();
@@ -1093,15 +1106,17 @@ class MailboxDashBoardController extends ReloadableController
     if (_searchInsideThreadDetailViewIsActive()) {
       _closeEmailDetailedView();
     }
+    applyCurrentFilterMessageOptionToSearch();
     _unSelectedMailbox();
     FocusManager.instance.primaryFocus?.unfocus();
-    storeEmailSortOrder(searchController.searchEmailFilter.value.sortOrderType);
+    storeEmailSortOrder(searchController.sortOrderFiltered);
     dispatchAction(StartSearchEmailAction());
   }
 
   void handleClearAdvancedSearchFilterEmail() {
     log('MailboxDashBoardController::handleClearAdvancedSearchFilterEmail:');
     clearFilterMessageOption();
+    _searchBarDerivedSender = null;
     if (_searchInsideThreadDetailViewIsActive()) {
       _closeEmailDetailedView();
     }
@@ -1111,26 +1126,34 @@ class MailboxDashBoardController extends ReloadableController
     dispatchAction(ClearAdvancedSearchFilterEmailAction());
   }
 
-  void searchEmailByQueryString(String queryString) {
+  void searchEmailByQueryString() {
+    // Flush the live search-bar text into the SSOT, then search from the SSOT —
+    // so the query always matches what the user sees, never a stale keyword.
+    searchController.commitSearchTextNow();
+    final queryString = searchController.searchInputController.text.trim();
     final isMailAddress = EmailUtils.isEmailAddressValid(queryString);
+    final isEnteringSearchSession = !searchController.isSearchEmailRunning;
     log('MailboxDashBoardController::searchEmailByQueryString():QueryString = $queryString | isMailAddress = $isMailAddress');
     if (_searchInsideThreadDetailViewIsActive()) {
       _closeEmailDetailedView();
     }
     _unSelectedMailbox();
 
-    // A bare email address routes to the `from` filter; clear the live text term
-    // so the same string is not also applied as a full-text condition.
-    searchController.updateFilterEmail(
-      textOption: isMailAddress
-        ? const None()
-        : Some(SearchQuery(queryString)),
-      fromOption: isMailAddress
-        ? Some({queryString})
-        : null);
+    // A bare email address routes to the `from` filter instead of full-text; the
+    // committed text was set by the flush above, so only this case rewrites it.
+    // When the query stops being an address, drop the sender we auto-routed so it
+    // does not keep narrowing the now full-text search (address → text).
+    if (isMailAddress) {
+      _searchFilterNotifier.update(SearchFilterPatch()
+        ..textOption = const None()
+        ..fromOption = Some({queryString}));
+      _searchBarDerivedSender = queryString;
+    } else {
+      _clearSearchBarDerivedSender();
+    }
 
-    if (searchController.searchEmailFilter.value.isContainFlagged) {
-      filterMessageOption.value = FilterMessageOption.starred;
+    if (isEnteringSearchSession) {
+      applyCurrentFilterMessageOptionToSearch();
     }
 
     FocusManager.instance.primaryFocus?.unfocus();
@@ -2020,6 +2043,37 @@ class MailboxDashBoardController extends ReloadableController
 
   void clearFilterMessageOption() {
     filterMessageOption.value = FilterMessageOption.all;
+    _filterMessageOptionBeforeSearch = null;
+  }
+
+  /// Removes the sender auto-routed from the search bar (if still committed) and
+  /// forgets it. No-op when the search bar never derived a sender.
+  void _clearSearchBarDerivedSender() {
+    final derivedSender = _searchBarDerivedSender;
+    _searchBarDerivedSender = null;
+    if (derivedSender == null) return;
+    final committedSenders =
+        appProviderContainer.read(searchFilterProvider).from;
+    if (!committedSenders.contains(derivedSender)) return;
+    _searchFilterNotifier.removeSender(
+      derivedSender.asSearchFilterEmailAddress());
+  }
+
+  /// Seeds the mailbox quick-filter into the committed filter once per search.
+  /// The snapshot is restored when search exits (#4490/#4590).
+  void applyCurrentFilterMessageOptionToSearch() {
+    if (_filterMessageOptionBeforeSearch != null) return;
+    _filterMessageOptionBeforeSearch = filterMessageOption.value;
+    _searchFilterNotifier.applyFilterMessageOption(filterMessageOption.value);
+  }
+
+  /// Restores the mailbox quick-filter active before search started.
+  void restoreFilterMessageOptionAfterSearch() {
+    final previousOption = _filterMessageOptionBeforeSearch;
+    _filterMessageOptionBeforeSearch = null;
+    if (previousOption != null) {
+      filterMessageOption.value = previousOption;
+    }
   }
 
   void markAsReadMailboxAction(BuildContext context) {
@@ -2244,18 +2298,16 @@ class MailboxDashBoardController extends ReloadableController
     }
   }
 
-  void selectHasAttachmentSearchFilter() {
-    searchController.updateFilterEmail(hasAttachmentOption: const Some(true));
-    dispatchAction(StartSearchEmailAction());
-  }
-
-  Future<void> selectFromSearchFilter({required AppLocalizations appLocalizations}) async {
+  Future<void> selectFromSearchFilter({
+    required AppLocalizations appLocalizations,
+    required QuickSearchFilterActionNotifier searchFilterActionNotifier,
+  }) async {
     if (accountId.value == null || sessionCurrent == null) return;
 
     final contactArgument = ContactArguments(
       accountId: accountId.value!,
       session: sessionCurrent!,
-      selectedContactList: searchController.searchEmailFilter.value.from,
+      selectedContactList: searchController.listAddressOfFromFiltered,
       contactViewTitle: '${appLocalizations.findEmails} ${appLocalizations.from_email_address_prefix.toLowerCase()}'
     );
 
@@ -2267,18 +2319,22 @@ class MailboxDashBoardController extends ReloadableController
       final listMailAddress = newListContact
         .map((emailAddress) => emailAddress.emailAddress)
         .toSet();
-      searchController.updateFilterEmail(fromOption: Some(listMailAddress));
-      dispatchAction(StartSearchEmailAction());
+      searchFilterActionNotifier.mutateAndSearch(
+        (filter) => filter.setSenders(listMailAddress.asSearchFilterEmailSet()),
+      );
     }
   }
 
-  Future<void> selectToSearchFilter({required AppLocalizations appLocalizations}) async {
+  Future<void> selectToSearchFilter({
+    required AppLocalizations appLocalizations,
+    required QuickSearchFilterActionNotifier searchFilterActionNotifier,
+  }) async {
     if (accountId.value == null || sessionCurrent == null) return;
 
     final contactArgument = ContactArguments(
       accountId: accountId.value!,
       session: sessionCurrent!,
-      selectedContactList: searchController.searchEmailFilter.value.to,
+      selectedContactList: searchController.listAddressOfToFiltered,
       contactViewTitle: '${appLocalizations.findEmails} ${appLocalizations.to_email_address_prefix.toLowerCase()}'
     );
 
@@ -2290,12 +2346,15 @@ class MailboxDashBoardController extends ReloadableController
       final listMailAddress = newListContact
         .map((emailAddress) => emailAddress.emailAddress)
         .toSet();
-      searchController.updateFilterEmail(toOption: Some(listMailAddress));
-      dispatchAction(StartSearchEmailAction());
+      searchFilterActionNotifier.mutateAndSearch(
+        (filter) => filter.setRecipients(listMailAddress.asSearchFilterEmailSet()),
+      );
     }
   }
 
-  Future<void> selectFolderSearchFilter() async {
+  Future<void> selectFolderSearchFilter(
+    QuickSearchFilterActionNotifier searchFilterActionNotifier,
+  ) async {
     if (accountId.value == null || sessionCurrent == null) return;
 
     final mailboxIdSelected = searchController.mailboxFiltered?.id;
@@ -2316,11 +2375,16 @@ class MailboxDashBoardController extends ReloadableController
 
     if (destinationMailbox is! PresentationMailbox) return;
 
-    searchController.updateFilterEmail(mailboxOption: Some(destinationMailbox));
-    dispatchAction(StartSearchEmailAction());
+    searchFilterActionNotifier.mutateAndSearch(
+      (filter) => filter.setMailbox(destinationMailbox),
+    );
   }
 
-  void selectReceiveTimeQuickSearchFilter(BuildContext context, EmailReceiveTimeType receiveTime) {
+  void selectReceiveTimeQuickSearchFilter(
+    BuildContext context,
+    EmailReceiveTimeType receiveTime,
+    QuickSearchFilterActionNotifier searchFilterActionNotifier,
+  ) {
     log('MailboxDashBoardController::selectReceiveTimeQuickSearchFilter():receiveTime: $receiveTime');
     if (receiveTime == EmailReceiveTimeType.customRange) {
       searchController.showMultipleViewDateRangePicker(
@@ -2328,12 +2392,18 @@ class MailboxDashBoardController extends ReloadableController
         searchController.startDateFiltered,
         searchController.endDateFiltered,
         onCallbackAction: (startDate, endDate) =>
-          _applyReceiveTimeFilter(receiveTime, startDate: startDate, endDate: endDate),
+          _applyReceiveTimeFilter(
+            receiveTime,
+            searchFilterActionNotifier,
+            startDate: startDate,
+            endDate: endDate,
+          ),
       );
     } else {
       final dateRange = receiveTime.toDateRange();
       _applyReceiveTimeFilter(
         receiveTime,
+        searchFilterActionNotifier,
         startDate: dateRange.start?.value.toLocal(),
         endDate: dateRange.end?.value.toLocal(),
       );
@@ -2341,7 +2411,8 @@ class MailboxDashBoardController extends ReloadableController
   }
 
   void _applyReceiveTimeFilter(
-    EmailReceiveTimeType receiveTime, {
+    EmailReceiveTimeType receiveTime,
+    QuickSearchFilterActionNotifier searchFilterActionNotifier, {
     DateTime? startDate,
     DateTime? endDate,
   }) {
@@ -2350,83 +2421,24 @@ class MailboxDashBoardController extends ReloadableController
       startDate: startDate,
       endDate: endDate,
     ));
-    searchController.updateFilterEmail(
-      emailReceiveTimeTypeOption: Some(receiveTime),
-      startDateOption: optionOf(startDate?.toUTCDate()),
-      endDateOption: optionOf(endDate?.toUTCDate()),
-      beforeOption: const None(),
-      afterOption: const None(),
-      positionOption: const None(),
+    searchFilterActionNotifier.mutateAndSearch(
+      (filter) => filter.setReceiveTime(
+        receiveTime,
+        startDate: startDate?.toUTCDate(),
+        endDate: endDate?.toUTCDate(),
+      ),
     );
-    dispatchAction(StartSearchEmailAction());
   }
 
-  void selectSortOrderQuickSearchFilter(EmailSortOrderType sortOrder) {
+  void selectSortOrderQuickSearchFilter(
+    EmailSortOrderType sortOrder,
+    QuickSearchFilterActionNotifier searchFilterActionNotifier,
+  ) {
     log('MailboxDashBoardController::selectSortOrderQuickSearchFilter():sortOrder: $sortOrder');
-    searchController.updateSortOrderFilter(sortOrder);
     storeEmailSortOrder(sortOrder);
-    dispatchAction(StartSearchEmailAction());
-  }
-
-  void _deleteDateTimeSearchFilter() {
-    _applyReceiveTimeFilter(EmailReceiveTimeType.allTime);
-  }
-
-  void _deleteSortOrderSearchFilter() {
-    searchController.updateSortOrderFilter(SearchEmailFilter.defaultSortOrder);
-    storeEmailSortOrder(SearchEmailFilter.defaultSortOrder);
-    dispatchAction(StartSearchEmailAction());
-  }
-
-  void _deleteFromSearchFilter() {
-    searchController.updateFilterEmail(fromOption: const None());
-    dispatchAction(StartSearchEmailAction());
-  }
-
-  void _deleteToSearchFilter() {
-    searchController.updateFilterEmail(toOption: const None());
-    dispatchAction(StartSearchEmailAction());
-  }
-
-  void _deleteHasAttachmentSearchFilter() {
-    searchController.updateFilterEmail(hasAttachmentOption: const None());
-    dispatchAction(StartSearchEmailAction());
-  }
-
-  void _deleteFolderSearchFilter() {
-    searchController.updateFilterEmail(mailboxOption: const None());
-    dispatchAction(StartSearchEmailAction());
-  }
-
-  void onDeleteSearchFilterAction(QuickSearchFilter searchFilter) {
-    switch(searchFilter) {
-      case QuickSearchFilter.dateTime:
-        _deleteDateTimeSearchFilter();
-        break;
-      case QuickSearchFilter.sortBy:
-        _deleteSortOrderSearchFilter();
-        break;
-      case QuickSearchFilter.from:
-        _deleteFromSearchFilter();
-        break;
-      case QuickSearchFilter.hasAttachment:
-        _deleteHasAttachmentSearchFilter();
-        break;
-      case QuickSearchFilter.to:
-        _deleteToSearchFilter();
-        break;
-      case QuickSearchFilter.folder:
-        _deleteFolderSearchFilter();
-        break;
-      case QuickSearchFilter.starred:
-      case QuickSearchFilter.unread:
-      case QuickSearchFilter.labels:
-      case QuickSearchFilter.events:
-        deleteQuickSearchFilter(filter: searchFilter);
-        break;
-      default:
-        break;
-    }
+    searchFilterActionNotifier.mutateAndSearch(
+      (filter) => filter.setSortOrder(sortOrder),
+    );
   }
 
   bool _trashHasContent(PresentationMailbox mailbox) =>
@@ -3413,7 +3425,7 @@ class MailboxDashBoardController extends ReloadableController
   }
 
   bool get isSearchFilterHasApplied {
-    return searchController.searchEmailFilter.value.isApplied ||
+    return appProviderContainer.read(searchFilterProvider).isApplied ||
       filterMessageOption.value != FilterMessageOption.all;
   }
 
@@ -3463,12 +3475,14 @@ class MailboxDashBoardController extends ReloadableController
       worker.dispose();
     }
     workerObxVariables.clear();
+    searchViewStateSubscription?.close();
+    searchViewStateSubscription = null;
   }
 
   @override
   void onClose() {
     if (PlatformInfo.isWeb) {
-      listSearchFilterScrollController?.dispose();
+      _listSearchFilterScrollController?.dispose();
     }
     if (PlatformInfo.isIOS) {
       _iosNotificationManager?.dispose();

--- a/lib/features/mailbox_dashboard/presentation/controller/search_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/search_controller.dart
@@ -1,14 +1,10 @@
 import 'dart:async';
 
 import 'package:core/utils/app_logger.dart';
-import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
-import 'package:jmap_dart_client/jmap/core/utc_date.dart';
-import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
 import 'package:labels/model/label.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:tmail_ui_user/features/base/base_controller.dart';
@@ -22,10 +18,12 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_constants.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_view_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
-import 'package:tmail_ui_user/features/thread/presentation/model/search_state.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/search_status.dart';
 import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 
@@ -36,25 +34,32 @@ class SearchController extends BaseController with DateRangePickerMixin {
 
   final searchInputController = TextEditingController();
 
-  /// Read-only mirror of the committed SSOT ([searchFilterProvider]) for existing
-  /// `Obx` widgets. Cursors (position/before/after) are still written here locally
-  /// by [updateFilterEmail] until the executor owns them (ticket 5).
-  final searchEmailFilter = SearchEmailFilter.initial().obs;
-  final searchState = SearchState.initial().obs;
-  final isAdvancedSearchViewOpen = false.obs;
-  final simpleSearchIsActivated = RxBool(false);
-  final advancedSearchIsActivated = RxBool(false);
-  final isSearchInputFocused = RxBool(false);
+  SearchEmailFilter get _committedFilter =>
+      appProviderContainer.read(searchFilterProvider);
 
-  SearchQuery? get searchQuery => searchEmailFilter.value.text;
+  SearchFilterNotifier get _searchFilterNotifier =>
+      appProviderContainer.read(searchFilterProvider.notifier);
+
+  SearchViewState get _searchViewState =>
+      appProviderContainer.read(searchViewStateProvider);
+
+  SearchViewStateNotifier get _searchViewStateNotifier =>
+      appProviderContainer.read(searchViewStateProvider.notifier);
+
+  SearchQuery? get searchQuery => _committedFilter.text;
 
   FocusNode searchFocus = FocusNode();
   FocusNode? keyboardFocusNode;
-  String currentSearchText = '';
   ProviderSubscription<SearchEmailFilter>? _committedFilterSubscription;
 
-  /// Guards the search-bar ↔ SSOT.text round-trip so mirroring the committed
-  /// term back into [searchInputController] never re-enters as a fresh edit.
+  /// Debounces committing the search-bar text into the committed SSOT on the
+  /// shared [SearchConstants.inputDebounceDuration] (same cadence as suggestions).
+  /// Flushed synchronously by [commitSearchTextNow].
+  Timer? _commitSearchTextDebounce;
+
+  /// Local re-entrancy guard for the search-bar ↔ SSOT.text round-trip. Kept as a
+  /// plain field (not shared state) since no widget observes it — only
+  /// [_syncSearchInputFromFilter] reads/writes it, synchronously.
   bool _isSyncingSearchInputFromFilter = false;
 
   SearchController(
@@ -68,40 +73,38 @@ class SearchController extends BaseController with DateRangePickerMixin {
     super.onInit();
     searchFocus.addListener(_onSearchFocusChanged);
     onKeyboardShortcutInit();
-    // Mirror committed SSOT → obs so existing Obx widgets keep reading it.
-    // The SSOT never tracks cursors (before/after/position), so re-layer the
-    // obs's local cursors onto every synced value; otherwise an unrelated
-    // user-intent update would silently wipe active pagination (until the
-    // executor owns cursors — ticket 5).
     _committedFilterSubscription = appProviderContainer.listen<SearchEmailFilter>(
       searchFilterProvider,
-      (_, next) {
-        searchEmailFilter.value = next.copyWith(
-          beforeOption: optionOf(searchEmailFilter.value.before),
-          afterOption: optionOf(searchEmailFilter.value.after),
-          positionOption: optionOf(searchEmailFilter.value.position),
-        );
-        // The search bar and the advanced "has the words" field are the same
-        // full-text term (SSOT.text); keep the bar in lockstep with it.
-        _syncSearchInputFromFilter(next.text);
-      },
+      (_, next) => _syncSearchInputFromFilter(next.text),
       fireImmediately: true,
     );
     searchInputController.addListener(_onSearchInputChanged);
   }
 
-  /// Push search-bar edits into the committed SSOT so the advanced "has the
-  /// words" field (and result chips) always reflect the same full-text term.
+  /// Debounces search-bar edits into the committed filter text (SSOT), so the
+  /// input feeds the SSOT on the same cadence as the suggestion search.
   void _onSearchInputChanged() {
     if (_isSyncingSearchInputFromFilter) return;
-    final value = searchInputController.text.trim();
-    updateFilterEmail(
-      textOption: option(value.isNotEmpty, SearchQuery(value)),
+    _commitSearchTextDebounce?.cancel();
+    _commitSearchTextDebounce =
+        Timer(SearchConstants.inputDebounceDuration, _commitSearchText);
+  }
+
+  void _commitSearchText() {
+    _searchFilterNotifier.setText(
+      searchInputController.text.asSearchFilterTextInput(),
     );
   }
 
-  /// Mirror the committed full-text term back onto the search bar. Compares on
-  /// trimmed text so a trailing space being typed is not wiped mid-edit.
+  /// Flushes the pending debounced search-bar text into the SSOT immediately, so
+  /// the suggestion fetch and submit query read an up-to-date SSOT instead of
+  /// waiting out the debounce.
+  void commitSearchTextNow() {
+    _commitSearchTextDebounce?.cancel();
+    _commitSearchText();
+  }
+
+  /// Mirrors committed filter text back onto the search bar.
   void _syncSearchInputFromFilter(SearchQuery? text) {
     final nextText = text?.value ?? '';
     if (searchInputController.text.trim() == nextText.trim()) return;
@@ -115,7 +118,7 @@ class SearchController extends BaseController with DateRangePickerMixin {
 
   void _onSearchFocusChanged() {
     log('SearchController::_onSearchFocusChanged: ${searchFocus.hasFocus}');
-    isSearchInputFocused.value = searchFocus.hasFocus;
+    _searchViewStateNotifier.setSearchInputFocused(searchFocus.hasFocus);
     if (searchFocus.hasFocus) {
       refocusKeyboardShortcutFocus();
     } else {
@@ -124,197 +127,86 @@ class SearchController extends BaseController with DateRangePickerMixin {
   }
 
   void openAdvanceSearch() {
-    isAdvancedSearchViewOpen.value = true;
+    _searchViewStateNotifier.openAdvancedSearch();
   }
 
   void closeAdvanceSearch() {
-    isAdvancedSearchViewOpen.value = false;
+    _searchViewStateNotifier.closeAdvancedSearch();
   }
 
   void clearSearchFilter({EmailSortOrderType? sortOrderType}) {
     final restoredSortOrder =
-        sortOrderType ?? searchEmailFilter.value.sortOrderType;
+        sortOrderType ?? _committedFilter.sortOrderType;
     final clearedFilter = SearchEmailFilter.withSortOrder(restoredSortOrder);
-    searchEmailFilter.value = clearedFilter;
 
-    appProviderContainer
-        .read(searchFilterProvider.notifier)
-        .set(clearedFilter);
+    _searchFilterNotifier.set(clearedFilter);
   }
 
-  void updateFilterEmail({
-    Option<Set<String>>? fromOption,
-    Option<Set<String>>? toOption,
-    Option<SearchQuery>? textOption,
-    Option<String>? subjectOption,
-    Option<Set<String>>? notKeywordOption,
-    Option<Set<String>>? hasKeywordOption,
-    Option<PresentationMailbox>? mailboxOption,
-    Option<EmailReceiveTimeType>? emailReceiveTimeTypeOption,
-    Option<bool>? hasAttachmentOption,
-    Option<bool>? unreadOption,
-    Option<bool>? notIncludeEventsOption,
-    Option<UTCDate>? beforeOption,
-    Option<UTCDate>? afterOption,
-    Option<UTCDate>? startDateOption,
-    Option<UTCDate>? endDateOption,
-    Option<int>? positionOption,
-    Option<EmailSortOrderType>? sortOrderTypeOption,
-    Option<Label>? labelOption,
-  }) {
-    // User intent → committed SSOT; the mirror syncs it back into the obs.
-    final userIntentOptions = [
-      fromOption, toOption, textOption, subjectOption, notKeywordOption,
-      hasKeywordOption, mailboxOption, emailReceiveTimeTypeOption,
-      hasAttachmentOption, unreadOption, notIncludeEventsOption,
-      startDateOption, endDateOption, sortOrderTypeOption, labelOption,
-    ];
-    if (userIntentOptions.any((option) => option != null)) {
-      appProviderContainer.read(searchFilterProvider.notifier).update(
-            SearchFilterPatch()
-              ..fromOption = fromOption
-              ..toOption = toOption
-              ..textOption = textOption
-              ..subjectOption = subjectOption
-              ..notKeywordOption = notKeywordOption
-              ..hasKeywordOption = hasKeywordOption
-              ..mailboxOption = mailboxOption
-              ..emailReceiveTimeTypeOption = emailReceiveTimeTypeOption
-              ..hasAttachmentOption = hasAttachmentOption
-              ..unreadOption = unreadOption
-              ..notIncludeEventsOption = notIncludeEventsOption
-              ..startDateOption = startDateOption
-              ..endDateOption = endDateOption
-              ..sortOrderTypeOption = sortOrderTypeOption
-              ..labelOption = labelOption);
-    }
-    // Cursors aren't user intent — layered onto the obs only, until the executor
-    // owns them (ticket 5).
-    if (beforeOption != null || afterOption != null || positionOption != null) {
-      searchEmailFilter.value = searchEmailFilter.value.copyWith(
-        beforeOption: beforeOption,
-        afterOption: afterOption,
-        positionOption: positionOption,
-      );
-      searchEmailFilter.refresh();
-    }
-  }
-
-  EmailReceiveTimeType get receiveTimeFiltered => searchEmailFilter.value.emailReceiveTimeType;
+  EmailReceiveTimeType get receiveTimeFiltered => _committedFilter.emailReceiveTimeType;
 
   void updateSortOrderFilter(EmailSortOrderType sortOrder) {
-    updateFilterEmail(
-      sortOrderTypeOption: Some(sortOrder),
-      beforeOption: const None(),
-      afterOption: const None(),
-      positionOption: const None(),
-    );
+    _searchFilterNotifier.setSortOrder(sortOrder);
   }
 
-  /// Resets load-more cursors before a fresh search so stale pagination state
-  /// never leaks into the next query.
-  ///
-  /// The `before`/`after` time cursors are always cleared (the date-range bounds
-  /// in `startDate`/`endDate` are preserved). Position-based pagination
-  /// (relevance sort or collapsed threads) restarts from offset 0; otherwise the
-  /// position is cleared too.
-  void resetCursorsForFreshSearch({required bool isCollapseThreadsEnabled}) {
-    final usesPositionPagination =
-        searchEmailFilter.value.sortOrderType.isScrollByPosition() ||
-            isCollapseThreadsEnabled;
-    updateFilterEmail(
-      beforeOption: const None(),
-      afterOption: const None(),
-      positionOption: option(usesPositionPagination, 0),
-    );
-  }
-
-  /// Toggles a suggestion-bar chip straight on the committed SSOT (no staging), so
-  /// the selection takes effect immediately — the fix for #4421.
+  /// Toggles a suggestion chip directly on the committed filter. Each branch
+  /// self-toggles from the notifier's own state, so callers only pass the
+  /// [searchFilterNotifier] (from `ref`) — no filter snapshot needed.
   void toggleQuickSearchFilter(
     QuickSearchFilter filter, {
     required String currentUserEmail,
+    required SearchFilterNotifier searchFilterNotifier,
   }) {
-    final current = searchEmailFilter.value;
     switch (filter) {
       case QuickSearchFilter.hasAttachment:
-        updateFilterEmail(
-          hasAttachmentOption:
-              current.hasAttachment ? const None() : const Some(true),
-        );
+        searchFilterNotifier.toggleHasAttachment();
         break;
       case QuickSearchFilter.last7Days:
-        if (current.emailReceiveTimeType == EmailReceiveTimeType.last7Days) {
-          updateFilterEmail(
-            emailReceiveTimeTypeOption: const Some(EmailReceiveTimeType.allTime),
-            startDateOption: const None(),
-            endDateOption: const None(),
-          );
-        } else {
-          final range = EmailReceiveTimeType.last7Days.toDateRange();
-          updateFilterEmail(
-            emailReceiveTimeTypeOption: const Some(EmailReceiveTimeType.last7Days),
-            startDateOption: optionOf(range.start),
-            endDateOption: optionOf(range.end),
-          );
-        }
+        searchFilterNotifier.toggleLast7Days();
         break;
       case QuickSearchFilter.fromMe:
-        if (currentUserEmail.isEmpty) return;
-        // Selecting collapses `from` to just the current user; deselecting clears
-        // it. Any other sender means it isn't selected, so a tap selects it.
-        updateFilterEmail(
-          fromOption: Some(
-            current.isOnlySender(currentUserEmail)
-                ? const <String>{}
-                : {currentUserEmail},
-          ),
-        );
+        searchFilterNotifier.toggleOnlySender(currentUserEmail);
         break;
       case QuickSearchFilter.starred:
-        final keywords = Set<String>.of(current.hasKeyword);
-        final flagged = KeyWordIdentifier.emailFlagged.value;
-        keywords.contains(flagged)
-            ? keywords.remove(flagged)
-            : keywords.add(flagged);
-        updateFilterEmail(hasKeywordOption: Some(keywords));
+        searchFilterNotifier.toggleStarred();
         break;
       default:
         break;
     }
   }
 
-  DateTime? get startDateFiltered => searchEmailFilter.value.startDate?.value.toLocal();
+  DateTime? get startDateFiltered => _committedFilter.startDate?.value.toLocal();
 
-  DateTime? get endDateFiltered => searchEmailFilter.value.endDate?.value.toLocal();
+  DateTime? get endDateFiltered => _committedFilter.endDate?.value.toLocal();
 
-  PresentationMailbox? get mailboxFiltered => searchEmailFilter.value.mailbox;
+  PresentationMailbox? get mailboxFiltered => _committedFilter.mailbox;
 
-  Label? get labelFiltered => searchEmailFilter.value.label;
+  Label? get labelFiltered => _committedFilter.label;
 
-  Set<String> get listAddressOfToFiltered => searchEmailFilter.value.to;
+  Set<String> get listAddressOfToFiltered => _committedFilter.to;
 
-  Set<String> get listAddressOfFromFiltered => searchEmailFilter.value.from;
+  Set<String> get listAddressOfFromFiltered => _committedFilter.from;
 
-  Set<String> get listHasKeywordFiltered => searchEmailFilter.value.hasKeyword;
+  Set<String> get listHasKeywordFiltered => _committedFilter.hasKeyword;
 
-  bool get unreadFiltered => searchEmailFilter.value.unread;
+  EmailSortOrderType get sortOrderFiltered => _committedFilter.sortOrderType;
 
-  bool get notIncludeEventsFiltered => searchEmailFilter.value.notIncludeEvents;
+  bool get isOnlyStarredApplied => _committedFilter.isOnlyStarredApplied;
 
-  EmailSortOrderType get sortOrderFiltered => searchEmailFilter.value.sortOrderType;
+  // NOTE: `unread`/`notIncludeEvents` are read straight from `searchFilterProvider`
+  // by their widgets, so no pass-through getters are exposed here.
 
   bool isSearchActive() =>
-      searchState.value.searchStatus == SearchStatus.ACTIVE;
+      _searchViewState.searchState.searchStatus == SearchStatus.ACTIVE;
 
-  bool get isSearchEmailRunning => simpleSearchIsActivated.isTrue || advancedSearchIsActivated.isTrue;
+  bool get isSearchEmailRunning => _searchViewState.isSearchEmailRunning;
 
   void enableSearch() {
-    searchState.value = searchState.value.enableSearchState();
+    _searchViewStateNotifier.enableSearch();
   }
 
   void clearTextSearch() {
     searchInputController.clear();
+    commitSearchTextNow();
     searchFocus.requestFocus();
   }
 
@@ -349,27 +241,27 @@ class SearchController extends BaseController with DateRangePickerMixin {
   }
 
   void activateSimpleSearch() {
-    simpleSearchIsActivated.value = true;
+    _searchViewStateNotifier.activateSimpleSearch();
   }
 
   void deactivateSimpleSearch() {
-    simpleSearchIsActivated.value = false;
+    _searchViewStateNotifier.deactivateSimpleSearch();
   }
 
   void activateAdvancedSearch() {
-    advancedSearchIsActivated.value = true;
+    _searchViewStateNotifier.activateAdvancedSearch();
   }
 
   void deactivateAdvancedSearch() {
-    advancedSearchIsActivated.value = false;
+    _searchViewStateNotifier.deactivateAdvancedSearch();
   }
 
   void hideAdvancedSearchFormView() {
-    isAdvancedSearchViewOpen.value = false;
+    _searchViewStateNotifier.closeAdvancedSearch();
   }
 
   void hideSimpleSearchFormView() {
-    searchState.value = searchState.value.disableSearchState();
+    _searchViewStateNotifier.disableSearch();
   }
 
   void _clearAllTextInputSimpleSearch() {
@@ -396,6 +288,8 @@ class SearchController extends BaseController with DateRangePickerMixin {
 
   @override
   void onClose() {
+    _searchViewStateNotifier.release();
+    _commitSearchTextDebounce?.cancel();
     _committedFilterSubscription?.close();
     searchInputController.removeListener(_onSearchInputChanged);
     searchInputController.dispose();

--- a/lib/features/mailbox_dashboard/presentation/extensions/email_address_set_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/email_address_set_extension.dart
@@ -1,0 +1,7 @@
+import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
+
+extension EmailAddressSetExtension on Set<String> {
+  /// Maps a set of raw email strings to [EmailAddress] entities (no display name).
+  List<EmailAddress> toEmailAddresses() =>
+      map((email) => EmailAddress(null, email)).toList();
+}

--- a/lib/features/mailbox_dashboard/presentation/extensions/handle_reactive_obx_variable_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/handle_reactive_obx_variable_extension.dart
@@ -1,22 +1,28 @@
 
 import 'package:core/utils/app_logger.dart';
-import 'package:get/get_rx/src/rx_workers/rx_workers.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/action/dashboard_action.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_view_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/action/thread_detail_ui_action.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 
 extension HandleReactiveObxVariableExtension on MailboxDashBoardController {
 
   void registerReactiveObxVariableListener() {
-    workerObxVariables.add(ever(
-      searchController.isAdvancedSearchViewOpen,
-      _onAdvancedSearchVisibleChanged
-    ));
-
-    workerObxVariables.add(ever(
-      searchController.isSearchInputFocused,
-      onSearchInputFocusChanged
-    ));
+    searchViewStateSubscription ??=
+        appProviderContainer.listen<SearchViewState>(
+      searchViewStateProvider,
+      (previous, next) {
+        if (previous?.isAdvancedSearchViewOpen !=
+            next.isAdvancedSearchViewOpen) {
+          _onAdvancedSearchVisibleChanged(next.isAdvancedSearchViewOpen);
+        }
+        if (previous?.isSearchInputFocused != next.isSearchInputFocused) {
+          onSearchInputFocusChanged(next.isSearchInputFocused);
+        }
+      },
+    );
   }
 
   void _onAdvancedSearchVisibleChanged(bool visible) {

--- a/lib/features/mailbox_dashboard/presentation/extensions/quick_search_emails_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/quick_search_emails_extension.dart
@@ -1,4 +1,3 @@
-import 'package:dartz/dartz.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
@@ -7,7 +6,8 @@ import 'package:model/email/presentation_email.dart';
 import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/quick_search_email_state.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/search_controller.dart';
-import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 
 extension QuickSearchEmailsExtension on SearchController {
   Future<List<PresentationEmail>> quickSearchEmails({
@@ -16,23 +16,20 @@ extension QuickSearchEmailsExtension on SearchController {
     required String query,
     Set<MailboxId>? trashSpamMailboxIds,
   }) async {
-    currentSearchText = query;
-    final filter = searchEmailFilter.value;
+    appProviderContainer
+        .read(searchFilterProvider.notifier)
+        .setText(query.asSearchFilterTextInput());
+    final filter = appProviderContainer.read(searchFilterProvider);
     return await quickSearchEmailInteractor.execute(
       session,
       accountId,
       limit: UnsignedInt(5),
       sort: filter.sortOrderType.getSortOrder().toNullable(),
-      // Suggestion and result screens must share one filter set. Build the query
-      // from the committed SSOT via the same `mappingToEmailFilterCondition` the
-      // result screen uses, only layering the live query text on top (#SSOT-3).
-      filter: filter
-          .copyWith(
-            textOption: query.trim().isNotEmpty
-                ? Some(SearchQuery(query))
-                : const None(),
-          )
-          .mappingToEmailFilterCondition(trashSpamMailboxIds: trashSpamMailboxIds),
+      // Suggestion and result screens share the committed SSOT.
+      // The debounce callback commits text before building this filter.
+      filter: filter.mappingToEmailFilterCondition(
+        trashSpamMailboxIds: trashSpamMailboxIds,
+      ),
       properties: EmailUtils.getPropertiesForEmailGetMethod(session, accountId),
     ).then((result) => result.fold(
       (failure) => <PresentationEmail>[],

--- a/lib/features/mailbox_dashboard/presentation/extensions/quick_search_emails_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/quick_search_emails_extension.dart
@@ -25,8 +25,8 @@ extension QuickSearchEmailsExtension on SearchController {
       accountId,
       limit: UnsignedInt(5),
       sort: filter.sortOrderType.getSortOrder().toNullable(),
-      // Suggestion and result screens share the committed SSOT.
-      // The debounce callback commits text before building this filter.
+      // Suggestion and result screens share the committed SSOT: the `setText`
+      // above commits this live query so both build from the same filter.
       filter: filter.mappingToEmailFilterCondition(
         trashSpamMailboxIds: trashSpamMailboxIds,
       ),

--- a/lib/features/mailbox_dashboard/presentation/extensions/search_filter_notifier_quick_filter_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/search_filter_notifier_quick_filter_extension.dart
@@ -1,0 +1,53 @@
+import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
+
+typedef _SearchFilterAction = void Function(SearchFilterNotifier notifier);
+
+final _selectQuickSearchFilterActions = <QuickSearchFilter, _SearchFilterAction>{
+  QuickSearchFilter.hasAttachment: (notifier) =>
+      notifier.setHasAttachment(true.asSearchFilterToggle()),
+  QuickSearchFilter.starred: (notifier) =>
+      notifier.addHasKeyword(KeyWordIdentifier.emailFlagged.value),
+  QuickSearchFilter.unread: (notifier) =>
+      notifier.setUnread(true.asSearchFilterToggle()),
+  QuickSearchFilter.events: (notifier) =>
+      notifier.setNotIncludeEvents(true.asSearchFilterToggle()),
+};
+
+final _deleteQuickSearchFilterActions = <QuickSearchFilter, _SearchFilterAction>{
+  QuickSearchFilter.dateTime: (notifier) =>
+      notifier.setReceiveTime(EmailReceiveTimeType.allTime),
+  QuickSearchFilter.sortBy: (notifier) =>
+      notifier.setSortOrder(SearchEmailFilter.defaultSortOrder),
+  QuickSearchFilter.from: (notifier) => notifier.clearSenders(),
+  QuickSearchFilter.hasAttachment: (notifier) =>
+      notifier.setHasAttachment(false.asSearchFilterToggle()),
+  QuickSearchFilter.to: (notifier) => notifier.clearRecipients(),
+  QuickSearchFilter.folder: (notifier) => notifier.clearMailbox(),
+  QuickSearchFilter.labels: (notifier) => notifier.setLabel(null),
+  QuickSearchFilter.starred: (notifier) =>
+      notifier.removeHasKeyword(KeyWordIdentifier.emailFlagged.value),
+  QuickSearchFilter.unread: (notifier) =>
+      notifier.setUnread(false.asSearchFilterToggle()),
+  QuickSearchFilter.events: (notifier) =>
+      notifier.setNotIncludeEvents(false.asSearchFilterToggle()),
+};
+
+extension QuickFilterMutationExtension on SearchFilterNotifier {
+  bool selectQuickSearchFilter(QuickSearchFilter filter) {
+    final action = _selectQuickSearchFilterActions[filter];
+    if (action == null) return false;
+    action(this);
+    return true;
+  }
+
+  bool deleteQuickSearchFilter(QuickSearchFilter filter) {
+    final action = _deleteQuickSearchFilterActions[filter];
+    if (action == null) return false;
+    action(this);
+    return true;
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/extensions/select_search_filter_action_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/select_search_filter_action_extension.dart
@@ -1,68 +1,26 @@
-import 'package:dartz/dartz.dart';
-import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
-import 'package:labels/model/label.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/action/dashboard_action.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_store_email_sort_order_extension.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/quick_search_filter_action_notifier.dart';
 
 extension SelectSearchFilterActionExtension on MailboxDashBoardController {
-  void selectKeywordSearchFilter(KeyWordIdentifier keyword) {
-    final listHasKeywordFiltered = searchController.listHasKeywordFiltered;
-    listHasKeywordFiltered.add(keyword.value);
-    searchController.updateFilterEmail(
-      hasKeywordOption: Some(listHasKeywordFiltered),
-    );
-    dispatchAction(StartSearchEmailAction());
-  }
+  void onDeleteSearchFilterAction(
+    QuickSearchFilterActionNotifier searchFilterActionNotifier,
+    QuickSearchFilter searchFilter,
+  ) {
+    final applied =
+        searchFilterActionNotifier.deleteQuickSearchFilter(searchFilter);
+    if (!applied) return;
 
-  void selectUnreadSearchFilter() {
-    searchController.updateFilterEmail(unreadOption: const Some(true));
-    dispatchAction(StartSearchEmailAction());
-  }
-
-  void selectNotIncludeEventsSearchFilter() {
-    searchController.updateFilterEmail(notIncludeEventsOption: const Some(true));
-    dispatchAction(StartSearchEmailAction());
-  }
-
-  void deleteStarredSearchFilter() {
-    final listHasKeywordFiltered = searchController.listHasKeywordFiltered;
-    listHasKeywordFiltered.remove(KeyWordIdentifier.emailFlagged.value);
-    searchController.updateFilterEmail(
-      hasKeywordOption: Some(listHasKeywordFiltered),
-    );
-  }
-
-  void deleteUnreadSearchFilter() {
-    searchController.updateFilterEmail(unreadOption: const None());
-  }
-
-  void deleteNotIncludeEventsSearchFilter() {
-    searchController.updateFilterEmail(notIncludeEventsOption: const None());
-  }
-
-  void deleteQuickSearchFilter({required QuickSearchFilter filter}) {
-    switch (filter) {
-      case QuickSearchFilter.labels:
-        searchController.updateFilterEmail(labelOption: const None());
-        break;
-      case QuickSearchFilter.starred:
-        deleteStarredSearchFilter();
-        break;
-      case QuickSearchFilter.unread:
-        deleteUnreadSearchFilter();
-        break;
-      case QuickSearchFilter.events:
-        deleteNotIncludeEventsSearchFilter();
-        break;
-      default:
-        break;
+    if (searchFilter == QuickSearchFilter.dateTime) {
+      dispatchAction(SelectDateRangeToAdvancedSearch(
+        receiveTime: EmailReceiveTimeType.allTime,
+      ));
+    } else if (searchFilter == QuickSearchFilter.sortBy) {
+      storeEmailSortOrder(SearchEmailFilter.defaultSortOrder);
     }
-    dispatchAction(StartSearchEmailAction());
-  }
-
-  void onSelectLabelFilter(Label? newLabel) {
-    searchController.updateFilterEmail(labelOption: optionOf(newLabel));
-    dispatchAction(StartSearchEmailAction());
   }
 }

--- a/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view.dart
+++ b/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:focus_detector_v2/focus_detector_v2.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/email_view_empty_widget.dart';
@@ -8,6 +9,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/base_mailb
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/delegates/empty_folder_provider_listener_delegate.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/riverpod_widgets/mailbox_dashboard_provider_listener_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_view.dart';
 import 'package:tmail_ui_user/features/sending_queue/presentation/sending_queue_view.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_view.dart';
@@ -35,33 +37,36 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
       child: Scaffold(
         drawerEnableOpenDragGesture:
             controller.responsiveUtils.hasLeftMenuDrawerActive(context),
-        body: Obx(() {
-          switch (controller.dashboardRoute.value) {
-            case DashboardRoutes.thread:
-              return buildResponsiveWithDrawer(
-                left: ThreadView(),
-                right: const EmailViewEmptyWidget(),
-                mobile: buildScaffoldHaveDrawer(body: ThreadView()),
-              );
+        body: Consumer(builder: (context, ref, _) {
+          final searchViewState = ref.watch(searchViewStateProvider);
+          return Obx(() {
+            switch (controller.dashboardRoute.value) {
+              case DashboardRoutes.thread:
+                return buildResponsiveWithDrawer(
+                  left: ThreadView(),
+                  right: const EmailViewEmptyWidget(),
+                  mobile: buildScaffoldHaveDrawer(body: ThreadView()),
+                );
 
-            case DashboardRoutes.threadDetailed:
-              return controller.searchController.isSearchEmailRunning
-                  ? const ThreadDetailView()
-                  : buildResponsiveWithDrawer(
-                      left: ThreadView(),
-                      right: const ThreadDetailView(),
-                      mobile: const ThreadDetailView(),
-                    );
+              case DashboardRoutes.threadDetailed:
+                return searchViewState.isSearchEmailRunning
+                    ? const ThreadDetailView()
+                    : buildResponsiveWithDrawer(
+                        left: ThreadView(),
+                        right: const ThreadDetailView(),
+                        mobile: const ThreadDetailView(),
+                      );
 
-            case DashboardRoutes.searchEmail:
-              return const SafeArea(child: SearchEmailView());
+              case DashboardRoutes.searchEmail:
+                return const SafeArea(child: SearchEmailView());
 
-            case DashboardRoutes.sendingQueue:
-              return buildScaffoldHaveDrawer(body: const SendingQueueView());
+              case DashboardRoutes.sendingQueue:
+                return buildScaffoldHaveDrawer(body: const SendingQueueView());
 
-            case DashboardRoutes.waiting:
-              return _loadingIndicator();
-          }
+              case DashboardRoutes.waiting:
+                return _loadingIndicator();
+            }
+          });
         }),
       ),
     );

--- a/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart
+++ b/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart
@@ -1,11 +1,9 @@
 import 'package:core/core.dart';
 import 'package:cozy/cozy_config_manager/cozy_config_manager.dart';
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_portal/flutter_portal.dart';
-import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get/get.dart';
-import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
 import 'package:model/extensions/presentation_mailbox_extension.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:model/extensions/session_extension.dart';
@@ -13,7 +11,6 @@ import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/base/widget/clean_messages_banner.dart';
 import 'package:tmail_ui_user/features/base/widget/popup_menu/popup_menu_item_action_widget.dart';
 import 'package:tmail_ui_user/features/base/widget/report_message_banner.dart';
-import 'package:tmail_ui_user/features/base/widget/scrollbar_list_view.dart';
 import 'package:tmail_ui_user/features/composer/presentation/view/web/composer_overlay_view.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/composer_arguments.dart';
 import 'package:tmail_ui_user/features/email/presentation/widgets/email_view_empty_widget.dart';
@@ -33,8 +30,9 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/prof
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/styles/filter_message_button_style.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/styles/mailbox_dashboard_view_web_style.dart';
+import 'package:tmail_ui_user/features/base/model/popup_menu_item_action.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/model/popup_menu_item_date_filter_action.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/model/popup_menu_item_sort_order_type_action.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/compose_button_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/download/download_task_item_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/empty_trash_banner_widget.dart';
@@ -42,16 +40,17 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/ma
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/navigation_bar/navigation_bar_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/profile_setting/profile_setting_icon.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/recover_deleted_message_loading_banner_widget.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_filters/filter_message_button.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_filters/search_filter_button.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_filters/quick_search_filter_bar.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_filters/thread_list_action_bar.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/top_bar_thread_selection.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/quick_search_filter_action_notifier.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/extensions/vacation_response_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/vacation/styles/vacation_notification_message_widget_style.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/vacation/widgets/vacation_notification_message_widget.dart';
 import 'package:tmail_ui_user/features/quotas/presentation/widget/quotas_banner_widget.dart';
-import 'package:tmail_ui_user/features/search/email/presentation/model/popup_menu_item_date_filter_action.dart';
-import 'package:tmail_ui_user/features/search/email/presentation/model/popup_menu_item_sort_order_type_action.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_view.dart';
 import 'package:tmail_ui_user/features/search/mailbox/presentation/search_mailbox_view.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
@@ -62,7 +61,11 @@ import 'package:tmail_ui_user/features/thread_detail/presentation/thread_detail_
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/delegates/empty_folder_provider_listener_delegate.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/riverpod_widgets/mailbox_dashboard_provider_listener_widget.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+
+typedef BuildQuickFilterMenuAction<T> = PopupMenuItemAction<T> Function(T value);
+typedef OnQuickFilterValueSelected<T> = void Function(T value);
 
 class MailboxDashBoardView extends BaseMailboxDashBoardView {
 
@@ -278,7 +281,10 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
                                   return const SizedBox.shrink(key: Key(UiKeys.cleanMessageBannerNotVisible));
                                 }
                               }),
-                              _buildListButtonQuickSearchFilter(context),
+                              QuickSearchFilterBar(
+                                onSelectSearchFilterAction: _onSelectSearchFilterAction,
+                                onDeleteSearchFilterAction: _onDeleteSearchFilterAction,
+                              ),
                               Expanded(
                                 child: Obx(() {
                                   switch(controller.dashboardRoute.value) {
@@ -300,27 +306,30 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
                 ],
               ),
             ),
-            tabletLarge: Obx(() {
-              switch (controller.dashboardRoute.value) {
-                case DashboardRoutes.searchEmail:
-                  return const SearchEmailView();
-                case DashboardRoutes.threadDetailed:
-                  return controller.searchController.isSearchEmailRunning
-                      ? const ThreadDetailView()
-                      : buildResponsiveWithDrawer(
-                          left: ThreadView(),
-                          right: const ThreadDetailView(),
-                          mobile: const ThreadDetailView(),
-                        );
-                default:
-                  return controller.searchController.isSearchEmailRunning
-                      ? const ThreadDetailView()
-                      : buildResponsiveWithDrawer(
-                          left: ThreadView(),
-                          right: const EmailViewEmptyWidget(),
-                          mobile: ThreadView(),
-                        );
-              }
+            tabletLarge: Consumer(builder: (context, ref, _) {
+              final searchViewState = ref.watch(searchViewStateProvider);
+              return Obx(() {
+                switch (controller.dashboardRoute.value) {
+                  case DashboardRoutes.searchEmail:
+                    return const SearchEmailView();
+                  case DashboardRoutes.threadDetailed:
+                    return searchViewState.isSearchEmailRunning
+                        ? const ThreadDetailView()
+                        : buildResponsiveWithDrawer(
+                            left: ThreadView(),
+                            right: const ThreadDetailView(),
+                            mobile: const ThreadDetailView(),
+                          );
+                  default:
+                    return searchViewState.isSearchEmailRunning
+                        ? const ThreadDetailView()
+                        : buildResponsiveWithDrawer(
+                            left: ThreadView(),
+                            right: const EmailViewEmptyWidget(),
+                            mobile: ThreadView(),
+                          );
+                }
+              });
             }),
             mobile: Obx(() {
               switch(controller.dashboardRoute.value) {
@@ -405,7 +414,12 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
             } else {
               return Padding(
                 padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
-                child: _buildListButtonTopBar(context),
+                child: ThreadListActionBar(
+                  onSelectFilterMessageOptionAction: _onSelectFilterMessageOptionAction,
+                  onDeleteFilterMessageOptionAction: (_) => _onDeleteFilterMessageOptionAction(),
+                  onSelectSearchFilterAction: _onSelectSearchFilterAction,
+                  onDeleteSearchFilterAction: _onDeleteSearchFilterAction,
+                ),
               );
             }
           }),
@@ -416,133 +430,15 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
     );
   }
 
-  Widget _buildListButtonTopBar(BuildContext context) {
-    return Row(children: [
-      Obx(() {
-        if (controller.isRefreshingAllMailboxAndEmail) {
-          return TMailContainerWidget(
-            borderRadius: 10,
-            backgroundColor: AppColor.colorFilterMessageButton.withValues(alpha: 0.6),
-            padding: const EdgeInsetsDirectional.symmetric(vertical: 8, horizontal: 8.5),
-            child: const CupertinoLoadingWidget(size: 16));
-        } else {
-          return TMailButtonWidget.fromIcon(
-            key: const Key('refresh_all_mailbox_and_email_button'),
-            icon: controller.imagePaths.icRefresh,
-            borderRadius: 10,
-            iconSize: 16,
-            backgroundColor: AppColor.colorFilterMessageButton.withValues(alpha: 0.6),
-            onTapActionCallback: controller.refreshMailboxAction,
-          );
-        }
-      }),
-      Obx(() {
-        if (controller.emailsInCurrentMailbox.isEmpty) {
-          return const SizedBox.shrink();
-        } else {
-          return Padding(
-            padding: const EdgeInsetsDirectional.only(start: 16),
-            child: Tooltip(
-              message: AppLocalizations.of(context).selectAllMessagesOfThisPage,
-              child: ElevatedButton.icon(
-                onPressed: controller.selectAllEmailAction,
-                icon: SvgPicture.asset(
-                  controller.imagePaths.icSelectAll,
-                  width: 16,
-                  height: 16,
-                  fit: BoxFit.fill,
-                  colorFilter: AppColor.colorFilterMessageIcon.asFilter(),
-                ),
-                label: Text(
-                  AppLocalizations.of(context).selectAllMessagesOfThisPage,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: ThemeUtils.defaultTextStyleInterFont.copyWith(
-                    fontSize: 13,
-                    fontWeight: FontWeight.normal,
-                    color: AppColor.colorFilterMessageTitle,
-                  ),
-                ),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: AppColor.colorFilterMessageButton.withValues(alpha: 0.6),
-                  shadowColor: Colors.transparent,
-                  padding: const EdgeInsetsDirectional.symmetric(horizontal: 12),
-                  shape: const RoundedRectangleBorder(
-                    borderRadius: BorderRadius.all(Radius.circular(10)),
-                  ),
-                  elevation: 0.0,
-                  foregroundColor: AppColor.colorTextButtonHeaderThread,
-                  maximumSize: const Size.fromWidth(250),
-                  fixedSize: const Size.fromHeight(34),
-                  textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
-                    fontSize: 13,
-                    fontWeight: FontWeight.normal,
-                    color: AppColor.colorFilterMessageTitle
-                  ),
-                ),
-              ),
-            ),
-          );
-        }
-      }),
-      Obx(() {
-        final filterMessageCurrent = controller.filterMessageOption.value;
-
-        if (controller.validateNoEmailsInTrashAndSpamFolder() ||
-            controller.searchController.isSearchEmailRunning) {
-          return const SizedBox.shrink();
-        } else {
-          return Padding(
-            padding: FilterMessageButtonStyle.buttonMargin,
-            child: FilterMessageButton(
-              filterMessageOption: filterMessageCurrent,
-              imagePaths: controller.imagePaths,
-              isSelected: filterMessageCurrent != FilterMessageOption.all,
-              onSelectFilterMessageOptionAction: _onSelectFilterMessageOptionAction,
-              onDeleteFilterMessageOptionAction: (_) => _onDeleteFilterMessageOptionAction(),
-            ),
-          );
-        }
-      }),
-      Obx(() {
-        if (controller.selectedMailbox.value?.isTrashPersonal == true) {
-          return TMailButtonWidget.fromIcon(
-            key: const Key('recover_deleted_messages_button'),
-            icon: controller.imagePaths.icRecoverDeletedMessages,
-            borderRadius: 10,
-            iconSize: 16,
-            backgroundColor: AppColor.colorFilterMessageButton.withValues(alpha: 0.6),
-            margin: const EdgeInsetsDirectional.only(start: 16),
-            onTapActionCallback: () => controller.gotoEmailRecovery(),
-          );
-        } else {
-          return const SizedBox.shrink();
-        }
-      }),
-      Obx(() {
-        if (controller.searchController.isSearchEmailRunning &&
-            controller.dashboardRoute.value == DashboardRoutes.thread) {
-          return Padding(
-            padding: const EdgeInsetsDirectional.only(start: 16),
-            child: _buildQuickSearchFilterButton(
-              context,
-              QuickSearchFilter.sortBy,
-            ),
-          );
-        } else {
-          return const SizedBox.shrink();
-        }
-      })
-    ]);
-  }
-
   void _onSelectFilterMessageOptionAction(
     BuildContext context,
     FilterMessageOption filterMessageCurrent,
     RelativeRect buttonPosition
   ) {
     final popupMenuItems = [
-      if (!controller.searchController.isSearchEmailRunning)
+      if (!appProviderContainer
+          .read(searchViewStateProvider)
+          .isSearchEmailRunning)
         FilterMessageOption.attachments,
       if (controller.selectedMailbox.value?.isActionRequired != true)
         FilterMessageOption.unread,
@@ -655,273 +551,139 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
     });
   }
 
-  Widget _buildListButtonQuickSearchFilter(BuildContext context) {
-    return Obx(() {
-      final isSearchEmailRunning =
-          controller.searchController.isSearchEmailRunning;
-      final isThreadRoute =
-          controller.dashboardRoute.value == DashboardRoutes.thread;
-      final isLabelAvailable = controller.isLabelAvailable;
-      final labelList = controller.labelController.labels;
-
-      if (isSearchEmailRunning && isThreadRoute) {
-        return Padding(
-          padding: const EdgeInsetsDirectional.only(end: 16),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Flexible(
-                child: SizedBox(
-                  height: 45,
-                  child: ScrollbarListView(
-                    scrollBehavior: ScrollConfiguration.of(context).copyWith(
-                      dragDevices: {
-                        PointerDeviceKind.touch,
-                        PointerDeviceKind.mouse,
-                        PointerDeviceKind.trackpad
-                      },
-                      scrollbars: false
-                    ),
-                    scrollController: controller.listSearchFilterScrollController!,
-                    child: ListView(
-                      scrollDirection: Axis.horizontal,
-                      shrinkWrap: true,
-                      padding: const EdgeInsetsDirectional.only(bottom: 10),
-                      controller: controller.listSearchFilterScrollController!,
-                      children: [
-                        _buildQuickSearchFilterButton(context, QuickSearchFilter.folder),
-                        MailboxDashboardViewWebStyle.searchFilterSizeBoxMargin,
-                        if (isLabelAvailable && labelList.isNotEmpty)
-                          ...[
-                            _buildQuickSearchFilterButton(
-                              context,
-                              QuickSearchFilter.labels,
-                            ),
-                            MailboxDashboardViewWebStyle.searchFilterSizeBoxMargin,
-                          ],
-                        _buildQuickSearchFilterButton(context, QuickSearchFilter.from),
-                        MailboxDashboardViewWebStyle.searchFilterSizeBoxMargin,
-                        _buildQuickSearchFilterButton(context, QuickSearchFilter.to),
-                        MailboxDashboardViewWebStyle.searchFilterSizeBoxMargin,
-                        _buildQuickSearchFilterButton(context, QuickSearchFilter.dateTime),
-                        MailboxDashboardViewWebStyle.searchFilterSizeBoxMargin,
-                        _buildQuickSearchFilterButton(context, QuickSearchFilter.hasAttachment),
-                        MailboxDashboardViewWebStyle.searchFilterSizeBoxMargin,
-                        _buildQuickSearchFilterButton(context, QuickSearchFilter.starred),
-                        MailboxDashboardViewWebStyle.searchFilterSizeBoxMargin,
-                        _buildQuickSearchFilterButton(context, QuickSearchFilter.unread),
-                        MailboxDashboardViewWebStyle.searchFilterSizeBoxMargin,
-                        _buildQuickSearchFilterButton(
-                          context,
-                          QuickSearchFilter.events,
-                        ),
-                      ],
-                    ),
-                  ),
-                )
-              ),
-              if (controller.isSearchFilterHasApplied)
-                TMailButtonWidget.fromText(
-                  text: AppLocalizations.of(context).clearFilter,
-                  backgroundColor: Colors.transparent,
-                  margin: const EdgeInsetsDirectional.only(start: 8),
-                  borderRadius: 10,
-                  textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
-                    color: AppColor.primaryColor,
-                    fontSize: 13,
-                    fontWeight: FontWeight.w500),
-                  onTapActionCallback: controller.clearAllSearchFilterApplied)
-              else
-                TMailButtonWidget.fromText(
-                  text: AppLocalizations.of(context).advancedSearch,
-                  backgroundColor: Colors.transparent,
-                  margin: const EdgeInsetsDirectional.only(start: 8),
-                  borderRadius: 10,
-                  textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
-                    color: AppColor.primaryColor,
-                    fontSize: 13,
-                    fontWeight: FontWeight.w500),
-                  onTapActionCallback: controller.openAdvancedSearchView)
-            ]
-          ),
-        );
-      } else {
-        return const SizedBox.shrink();
-      }
-    });
-  }
-
-  Widget _buildQuickSearchFilterButton(
+  void _onSelectSearchFilterAction(
     BuildContext context,
-    QuickSearchFilter searchFilter,
-  ) {
-    return Obx(() {
-      final searchEmailFilter = controller.searchController.searchEmailFilter.value;
-      final sortOrderType = controller.searchController.sortOrderFiltered;
-      final listAddressOfFrom = controller.searchController.listAddressOfFromFiltered;
-      final currentUserEmail = controller.sessionCurrent?.getOwnEmailAddressOrEmpty();
-      final startDate = controller.searchController.startDateFiltered;
-      final endDate = controller.searchController.endDateFiltered;
-      final receiveTimeType = controller.searchController.receiveTimeFiltered;
-      final mailbox = controller.searchController.mailboxFiltered;
-      final label = controller.searchController.labelFiltered;
-      final listAddressOfTo = controller.searchController.listAddressOfToFiltered;
-      final listHasKeywordFiltered = controller.searchController.listHasKeywordFiltered;
-      final unreadFiltered = controller.searchController.unreadFiltered;
-      final notIncludeEventsFiltered = controller.searchController.notIncludeEventsFiltered;
-
-      final isSelected = searchFilter.isSelected(
-        context,
-        searchEmailFilter,
-        sortOrderType,
-        currentUserEmail);
-
-      EdgeInsetsGeometry? buttonPadding;
-      if (searchFilter != QuickSearchFilter.sortBy) {
-        buttonPadding = MailboxDashboardViewWebStyle.getSearchFilterButtonPadding(isSelected);
-      }
-
-      final isFilterApplied = listAddressOfFrom.isNotEmpty ||
-          listAddressOfTo.isNotEmpty ||
-          startDate != null ||
-          endDate != null ||
-          receiveTimeType != EmailReceiveTimeType.allTime ||
-          mailbox != null ||
-          listHasKeywordFiltered.contains(KeyWordIdentifier.emailFlagged.value) ||
-          unreadFiltered ||
-          notIncludeEventsFiltered;
-
-      return SearchFilterButton(
-        key: Key('${searchFilter.name}_search_filter_button'),
-        searchFilter: searchFilter,
-        imagePaths: controller.imagePaths,
-        responsiveUtils: controller.responsiveUtils,
-        isSelected: isSelected,
-        receiveTimeType: receiveTimeType,
-        startDate: startDate,
-        endDate: endDate,
-        sortOrderType: sortOrderType,
-        listAddressOfFrom: listAddressOfFrom,
-        listAddressOfTo: listAddressOfTo,
-        mailbox: mailbox,
-        label: label,
-        buttonPadding: buttonPadding,
-        backgroundColor: searchFilter == QuickSearchFilter.sortBy
-          ? isSelected
-              ? AppColor.primaryColor.withValues(alpha: 0.06)
-              : AppColor.colorFilterMessageButton.withValues(alpha: 0.6)
-          : null,
-        isContextMenuAlignEndButton:
-          searchFilter != QuickSearchFilter.labels && isFilterApplied,
-        onSelectSearchFilterAction: _onSelectSearchFilterAction,
-        onDeleteSearchFilterAction: controller.onDeleteSearchFilterAction,
-      );
-    });
-  }
-
-  Future<void> _onSelectSearchFilterAction(
-    BuildContext context,
+    WidgetRef ref,
     QuickSearchFilter searchFilter,
     {RelativeRect? buttonPosition}
-  ) async {
-    switch(searchFilter) {
+  ) {
+    final notifier = ref.read(quickSearchFilterActionProvider.notifier);
+    switch (searchFilter) {
       case QuickSearchFilter.dateTime:
-        if (buttonPosition != null) {
-          _openPopupMenuDateFilter(context, buttonPosition);
-        }
-        break;
+        _openReceiveTimeQuickFilterMenu(context, ref, notifier, buttonPosition);
       case QuickSearchFilter.sortBy:
-        if (buttonPosition != null) {
-          _openPopupMenuSortFilter(context, buttonPosition);
-        }
-        break;
+        _openSortOrderQuickFilterMenu(context, ref, notifier, buttonPosition);
       case QuickSearchFilter.from:
         controller.selectFromSearchFilter(
-          appLocalizations: AppLocalizations.of(context)
+          appLocalizations: AppLocalizations.of(context),
+          searchFilterActionNotifier: notifier,
         );
-        break;
-      case QuickSearchFilter.hasAttachment:
-        controller.selectHasAttachmentSearchFilter();
-        break;
       case QuickSearchFilter.to:
         controller.selectToSearchFilter(
-          appLocalizations: AppLocalizations.of(context)
+          appLocalizations: AppLocalizations.of(context),
+          searchFilterActionNotifier: notifier,
         );
-        break;
       case QuickSearchFilter.folder:
-        controller.selectFolderSearchFilter();
-        break;
-      case QuickSearchFilter.starred:
-        controller.selectKeywordSearchFilter(KeyWordIdentifier.emailFlagged);
-        break;
-      case QuickSearchFilter.unread:
-        controller.selectUnreadSearchFilter();
-        break;
-      case QuickSearchFilter.events:
-        controller.selectNotIncludeEventsSearchFilter();
-        break;
+        controller.selectFolderSearchFilter(notifier);
       case QuickSearchFilter.labels:
-        final listLabels = controller.labelController.labels;
-        final selectedLabel = controller.searchController.labelFiltered;
-
-        controller.openLabelsFilterModal(
-          context: context,
-          position: buttonPosition,
-          labels: listLabels,
-          selectedLabel: selectedLabel,
-          imagePaths: controller.imagePaths,
-          onSelectLabelsActions: controller.onSelectLabelFilter,
-        );
-        break;
-      default:
+        _openLabelsQuickFilterModal(context, ref, notifier, buttonPosition);
+      case QuickSearchFilter.hasAttachment:
+      case QuickSearchFilter.starred:
+      case QuickSearchFilter.unread:
+      case QuickSearchFilter.events:
+        notifier.selectQuickSearchFilter(searchFilter);
+      case QuickSearchFilter.last7Days:
+      case QuickSearchFilter.fromMe:
         break;
     }
   }
 
-  void _openPopupMenuDateFilter(BuildContext context, RelativeRect position) {
-    final popupMenuItems = EmailReceiveTimeType.valuesForSearch.map((timeType) {
-      return PopupMenuItem(
-        padding: EdgeInsets.zero,
-        child: PopupMenuItemActionWidget(
-          menuAction: PopupMenuItemDateFilterAction(
-            timeType,
-            controller.searchController.receiveTimeFiltered,
-            AppLocalizations.of(context),
-            controller.imagePaths,
-          ),
-          menuActionClick: (menuAction) {
-            popBack();
-            controller.selectReceiveTimeQuickSearchFilter(
-              context,
-              menuAction.action,
-            );
-          },
-        ),
-      );
-    }).toList();
-
-    controller.openPopupMenu(context, position, popupMenuItems);
+  void _openReceiveTimeQuickFilterMenu(
+    BuildContext context,
+    WidgetRef ref,
+    QuickSearchFilterActionNotifier notifier,
+    RelativeRect? buttonPosition,
+  ) {
+    final receiveTimeFiltered =
+        ref.read(searchFilterProvider).emailReceiveTimeType;
+    _openQuickFilterPopupMenu<EmailReceiveTimeType>(
+      context,
+      buttonPosition,
+      EmailReceiveTimeType.valuesForSearch,
+      (value) => PopupMenuItemDateFilterAction(
+        value,
+        receiveTimeFiltered,
+        AppLocalizations.of(context),
+        controller.imagePaths,
+      ),
+      (value) => controller.selectReceiveTimeQuickSearchFilter(
+        context,
+        value,
+        notifier,
+      ),
+    );
   }
 
-  void _openPopupMenuSortFilter(BuildContext context, RelativeRect position) {
-    final popupMenuItems = EmailSortOrderType.values.map((sortType) {
+  void _openSortOrderQuickFilterMenu(
+    BuildContext context,
+    WidgetRef ref,
+    QuickSearchFilterActionNotifier notifier,
+    RelativeRect? buttonPosition,
+  ) {
+    final sortOrderFiltered = ref.read(searchFilterProvider).sortOrderType;
+    _openQuickFilterPopupMenu<EmailSortOrderType>(
+      context,
+      buttonPosition,
+      EmailSortOrderType.values,
+      (value) => PopupMenuItemSortOrderTypeAction(
+        value,
+        sortOrderFiltered,
+        AppLocalizations.of(context),
+        controller.imagePaths,
+      ),
+      (value) => controller.selectSortOrderQuickSearchFilter(value, notifier),
+    );
+  }
+
+  void _openLabelsQuickFilterModal(
+    BuildContext context,
+    WidgetRef ref,
+    QuickSearchFilterActionNotifier notifier,
+    RelativeRect? buttonPosition,
+  ) {
+    controller.openLabelsFilterModal(
+      context: context,
+      position: buttonPosition,
+      labels: controller.labelController.labels,
+      selectedLabel: ref.read(searchFilterProvider).label,
+      imagePaths: controller.imagePaths,
+      onSelectLabelsActions: (newLabel) =>
+          notifier.mutateAndSearch((filter) => filter.setLabel(newLabel)),
+    );
+  }
+
+  void _openQuickFilterPopupMenu<T>(
+    BuildContext context,
+    RelativeRect? buttonPosition,
+    Iterable<T> menuValues,
+    BuildQuickFilterMenuAction<T> buildMenuAction,
+    OnQuickFilterValueSelected<T> onSelected,
+  ) {
+    if (buttonPosition == null) return;
+
+    final popupMenuItems = menuValues.map<PopupMenuEntry>((value) {
       return PopupMenuItem(
         padding: EdgeInsets.zero,
         child: PopupMenuItemActionWidget(
-          menuAction: PopupMenuItemSortOrderTypeAction(
-            sortType,
-            controller.searchController.sortOrderFiltered,
-            AppLocalizations.of(context),
-            controller.imagePaths,
-          ),
-          menuActionClick: (menuAction) {
+          menuAction: buildMenuAction(value),
+          menuActionClick: (_) {
             popBack();
-            controller.selectSortOrderQuickSearchFilter(menuAction.action);
+            onSelected(value);
           },
         ),
       );
     }).toList();
 
-    controller.openPopupMenu(context, position, popupMenuItems);
+    controller.openPopupMenu(context, buttonPosition, popupMenuItems);
+  }
+
+  void _onDeleteSearchFilterAction(
+    WidgetRef ref,
+    QuickSearchFilter searchFilter,
+  ) {
+    controller.onDeleteSearchFilterAction(
+      ref.read(quickSearchFilterActionProvider.notifier),
+      searchFilter,
+    );
   }
 }

--- a/lib/features/mailbox_dashboard/presentation/model/search/search_activation_state.dart
+++ b/lib/features/mailbox_dashboard/presentation/model/search/search_activation_state.dart
@@ -1,0 +1,33 @@
+import 'package:equatable/equatable.dart';
+
+/// Tracks independent simple/advanced search activation.
+/// Advanced also drives icon state; simple keeps [isRunning] true.
+class SearchActivationState with EquatableMixin {
+  final bool simpleIsActivated;
+  final bool advancedIsActivated;
+
+  const SearchActivationState({
+    required this.simpleIsActivated,
+    required this.advancedIsActivated,
+  });
+
+  factory SearchActivationState.initial() => const SearchActivationState(
+    simpleIsActivated: false,
+    advancedIsActivated: false,
+  );
+
+  bool get isRunning => simpleIsActivated || advancedIsActivated;
+
+  SearchActivationState copyWith({
+    bool? simpleIsActivated,
+    bool? advancedIsActivated,
+  }) {
+    return SearchActivationState(
+      simpleIsActivated: simpleIsActivated ?? this.simpleIsActivated,
+      advancedIsActivated: advancedIsActivated ?? this.advancedIsActivated,
+    );
+  }
+
+  @override
+  List<Object?> get props => [simpleIsActivated, advancedIsActivated];
+}

--- a/lib/features/mailbox_dashboard/presentation/model/search/search_constants.dart
+++ b/lib/features/mailbox_dashboard/presentation/model/search/search_constants.dart
@@ -1,0 +1,6 @@
+class SearchConstants {
+  /// Debounce for the email search bar. The suggestion fetch and the input→SSOT
+  /// commit share this cadence so both settle on the same query value before it
+  /// runs. Keep them equal by referencing this single constant.
+  static const inputDebounceDuration = Duration(milliseconds: 300);
+}

--- a/lib/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart
+++ b/lib/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart
@@ -231,40 +231,40 @@ class SearchEmailFilter with EquatableMixin, OptionParamMixin {
     }
   }
 
-  /// True when the filter carries at least one active search criterion that
-  /// should mark the current results as filtered/search results.
-  bool get isApplied => from.isNotEmpty ||
+  /// Chip-style narrowing criteria shared by [isApplied] and
+  /// [hasActiveQuickFilter]. Each getter ORs its own extra terms on top, so
+  /// these overlapping terms stay in sync automatically. A unified mailbox does
+  /// not narrow results, so it is excluded.
+  bool get _hasActiveChipCriteria =>
+    from.isNotEmpty ||
     to.isNotEmpty ||
-    text?.value.trim().isNotEmpty == true ||
-    subject?.trim().isNotEmpty == true ||
-    hasKeyword.isNotEmpty ||
-    notKeyword.isNotEmpty ||
     emailReceiveTimeType != EmailReceiveTimeType.allTime ||
-    sortOrderType != SearchEmailFilter.defaultSortOrder ||
     (mailbox != null && mailbox?.isUnifiedMailbox != true) ||
     label != null ||
     hasAttachment ||
     unread ||
     notIncludeEvents;
 
+  /// True when the filter carries at least one active search criterion that
+  /// should mark the current results as filtered/search results.
+  bool get isApplied =>
+    _hasActiveChipCriteria ||
+    text?.value.trim().isNotEmpty == true ||
+    subject?.trim().isNotEmpty == true ||
+    hasKeyword.isNotEmpty ||
+    notKeyword.isNotEmpty ||
+    sortOrderType != SearchEmailFilter.defaultSortOrder;
+
   /// True when any chip-style filter narrows the search (recipients, folder,
   /// label, date range, attachment, starred, unread, events). Drives a filter
   /// button's context-menu alignment: an applied filter makes the button wider,
   /// so its menu aligns to the button's end. Excludes text/subject/sort — not
-  /// chips here. Kept in sync with [isApplied]: a unified mailbox does not narrow
-  /// results, and attachment is a chip.
+  /// chips here.
   bool get hasActiveQuickFilter =>
-      from.isNotEmpty ||
-      to.isNotEmpty ||
+      _hasActiveChipCriteria ||
       startDate != null ||
       endDate != null ||
-      emailReceiveTimeType != EmailReceiveTimeType.allTime ||
-      (mailbox != null && mailbox?.isUnifiedMailbox != true) ||
-      label != null ||
-      hasAttachment ||
-      isContainFlagged ||
-      unread ||
-      notIncludeEvents;
+      isContainFlagged;
 
   bool get isContainFlagged => hasKeyword.contains(KeyWordIdentifier.emailFlagged.value);
 

--- a/lib/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart
+++ b/lib/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart
@@ -136,7 +136,6 @@ class SearchEmailFilter with EquatableMixin, OptionParamMixin {
       );
 
   Filter? mappingToEmailFilterCondition({
-    EmailFilterCondition? moreFilterCondition,
     Set<MailboxId>? trashSpamMailboxIds,
   }) {
     final emailEmailFilterConditionShared = EmailFilterCondition(
@@ -186,8 +185,6 @@ class SearchEmailFilter with EquatableMixin, OptionParamMixin {
         EmailFilterCondition(
           notKeyword: KeyWordIdentifierExtension.eventsMail.value,
         ),
-      if (moreFilterCondition != null && moreFilterCondition.hasCondition)
-        moreFilterCondition
     };
 
     if (listEmailCondition.isEmpty) {
@@ -247,8 +244,27 @@ class SearchEmailFilter with EquatableMixin, OptionParamMixin {
     (mailbox != null && mailbox?.isUnifiedMailbox != true) ||
     label != null ||
     hasAttachment ||
-    unread || 
+    unread ||
     notIncludeEvents;
+
+  /// True when any chip-style filter narrows the search (recipients, folder,
+  /// label, date range, attachment, starred, unread, events). Drives a filter
+  /// button's context-menu alignment: an applied filter makes the button wider,
+  /// so its menu aligns to the button's end. Excludes text/subject/sort — not
+  /// chips here. Kept in sync with [isApplied]: a unified mailbox does not narrow
+  /// results, and attachment is a chip.
+  bool get hasActiveQuickFilter =>
+      from.isNotEmpty ||
+      to.isNotEmpty ||
+      startDate != null ||
+      endDate != null ||
+      emailReceiveTimeType != EmailReceiveTimeType.allTime ||
+      (mailbox != null && mailbox?.isUnifiedMailbox != true) ||
+      label != null ||
+      hasAttachment ||
+      isContainFlagged ||
+      unread ||
+      notIncludeEvents;
 
   bool get isContainFlagged => hasKeyword.contains(KeyWordIdentifier.emailFlagged.value);
 

--- a/lib/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart
+++ b/lib/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart
@@ -39,7 +39,6 @@ class SearchEmailFilter with EquatableMixin, OptionParamMixin {
   final UTCDate? after;
   final UTCDate? startDate;
   final UTCDate? endDate;
-  final int? position;
   final EmailSortOrderType sortOrderType;
   final Label? label;
 
@@ -56,7 +55,6 @@ class SearchEmailFilter with EquatableMixin, OptionParamMixin {
     this.after,
     this.startDate,
     this.endDate,
-    this.position,
     this.label,
     Set<String>? from,
     Set<String>? to,
@@ -94,7 +92,6 @@ class SearchEmailFilter with EquatableMixin, OptionParamMixin {
     Option<UTCDate>? afterOption,
     Option<UTCDate>? startDateOption,
     Option<UTCDate>? endDateOption,
-    Option<int>? positionOption,
     Option<EmailSortOrderType>? sortOrderTypeOption,
     Option<Label>? labelOption,
   }) {
@@ -114,7 +111,6 @@ class SearchEmailFilter with EquatableMixin, OptionParamMixin {
       after: getOptionParam(afterOption, after),
       startDate: getOptionParam(startDateOption, startDate),
       endDate: getOptionParam(endDateOption, endDate),
-      position: getOptionParam(positionOption, position),
       sortOrderType: getOptionParam(sortOrderTypeOption, sortOrderType),
       label: getOptionParam(labelOption, label),
     );
@@ -126,11 +122,10 @@ class SearchEmailFilter with EquatableMixin, OptionParamMixin {
   bool isOnlySender(String address) =>
       address.isNotEmpty && from.length == 1 && from.first == address;
 
-  /// Strips pagination cursors (`position`, `before`, `after`), keeping all user
+  /// Strips the load-more date cursors (`before`, `after`), keeping all user
   /// intent (incl. `startDate`/`endDate` bounds). Notifiers run full replacements
   /// through this so a stale cursor can never enter the SSOT (ADR-0093).
   SearchEmailFilter clearPaginationCursors() => copyWith(
-        positionOption: const None(),
         beforeOption: const None(),
         afterOption: const None(),
       );
@@ -318,7 +313,6 @@ class SearchEmailFilter with EquatableMixin, OptionParamMixin {
     after,
     startDate,
     endDate,
-    position,
     sortOrderType,
     label,
   ];

--- a/lib/features/mailbox_dashboard/presentation/model/search/search_view_state.dart
+++ b/lib/features/mailbox_dashboard/presentation/model/search/search_view_state.dart
@@ -1,0 +1,63 @@
+import 'package:equatable/equatable.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_activation_state.dart';
+import 'package:tmail_ui_user/features/thread/presentation/model/search_state.dart';
+import 'package:tmail_ui_user/features/thread/presentation/model/search_status.dart';
+
+class SearchViewState with EquatableMixin {
+  final SearchState searchState;
+  final bool isAdvancedSearchViewOpen;
+  final SearchActivationState activation;
+  final bool isSearchInputFocused;
+
+  const SearchViewState({
+    required this.searchState,
+    required this.isAdvancedSearchViewOpen,
+    required this.activation,
+    required this.isSearchInputFocused,
+  });
+
+  factory SearchViewState.initial() => SearchViewState(
+    searchState: SearchState.initial(),
+    isAdvancedSearchViewOpen: false,
+    activation: SearchActivationState.initial(),
+    isSearchInputFocused: false,
+  );
+
+  bool get advancedSearchIsActivated => activation.advancedIsActivated;
+
+  /// True for the whole active search session (search bar open), independent of
+  /// whether a query is currently executing.
+  bool get isSearchActive => searchState.searchStatus == SearchStatus.ACTIVE;
+
+  bool get isSearchEmailRunning => activation.isRunning;
+
+  /// True while the user is in any search UI — an open session, a running query,
+  /// or the advanced-search panel. Both session and running are checked because
+  /// [isSearchEmailRunning] drops to false once results load.
+  bool get isSearchEngaged =>
+      isSearchActive || isSearchEmailRunning || isAdvancedSearchViewOpen;
+
+  SearchViewState copyWith({
+    SearchState? searchState,
+    bool? isAdvancedSearchViewOpen,
+    SearchActivationState? activation,
+    bool? isSearchInputFocused,
+  }) {
+    return SearchViewState(
+      searchState: searchState ?? this.searchState,
+      isAdvancedSearchViewOpen:
+          isAdvancedSearchViewOpen ?? this.isAdvancedSearchViewOpen,
+      activation: activation ?? this.activation,
+      isSearchInputFocused:
+          isSearchInputFocused ?? this.isSearchInputFocused,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    searchState,
+    isAdvancedSearchViewOpen,
+    activation,
+    isSearchInputFocused,
+  ];
+}

--- a/lib/features/mailbox_dashboard/presentation/notifier/quick_search_filter_action_notifier.dart
+++ b/lib/features/mailbox_dashboard/presentation/notifier/quick_search_filter_action_notifier.dart
@@ -1,0 +1,58 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/search_filter_notifier_quick_filter_extension.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
+
+part 'quick_search_filter_action_notifier.g.dart';
+
+typedef SearchFilterMutationAction = void Function(SearchFilterNotifier notifier);
+
+/// Edge-trigger revision for search requests; the value has no domain meaning.
+/// Each [next] is distinct so identical searches still notify listeners.
+extension type const SearchRequestRevision(int _value) {
+  SearchRequestRevision get next => SearchRequestRevision(_value + 1);
+}
+
+/// Search trigger for the desktop/web quick-filter bar.
+///
+/// This notifier does not run the search itself. It commits filter changes to
+/// [SearchFilterNotifier], then bumps [SearchRequestRevision] as an edge-trigger
+/// signal. `ThreadController` holds a `listen` on this provider and calls
+/// `_searchEmail` on every revision change, so mutating this state is what
+/// actually executes a search.
+@Riverpod(keepAlive: true)
+class QuickSearchFilterActionNotifier extends _$QuickSearchFilterActionNotifier {
+  @override
+  SearchRequestRevision build() => const SearchRequestRevision(0);
+
+  SearchFilterNotifier get _filterNotifier =>
+      ref.read(searchFilterProvider.notifier);
+
+  void _requestSearch() {
+    // ThreadController listens to this revision and runs `_searchEmail`.
+    state = state.next;
+  }
+
+  /// Triggers a search when the committed filter is already up to date.
+  /// Keeps enter/apply/clear on the same listener path.
+  void requestSearch() => _requestSearch();
+
+  /// Applies one committed-filter mutation, then fires one search request.
+  /// New filter fields reuse this path instead of wrapper methods.
+  void mutateAndSearch(SearchFilterMutationAction mutate) {
+    mutate(_filterNotifier);
+    _requestSearch();
+  }
+
+  bool selectQuickSearchFilter(QuickSearchFilter filter) {
+    if (!_filterNotifier.selectQuickSearchFilter(filter)) return false;
+    _requestSearch();
+    return true;
+  }
+
+  bool deleteQuickSearchFilter(QuickSearchFilter filter) {
+    if (!_filterNotifier.deleteQuickSearchFilter(filter)) return false;
+    _requestSearch();
+    return true;
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart
+++ b/lib/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart
@@ -1,0 +1,58 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_view_state.dart';
+
+part 'search_view_state_notifier.g.dart';
+
+@Riverpod(keepAlive: true)
+class SearchViewStateNotifier extends _$SearchViewStateNotifier {
+  @override
+  SearchViewState build() => SearchViewState.initial();
+
+  void setSearchInputFocused(bool focused) {
+    state = state.copyWith(isSearchInputFocused: focused);
+  }
+
+  void openAdvancedSearch() {
+    state = state.copyWith(isAdvancedSearchViewOpen: true);
+  }
+
+  void closeAdvancedSearch() {
+    state = state.copyWith(isAdvancedSearchViewOpen: false);
+  }
+
+  void activateSimpleSearch() {
+    state = state.copyWith(
+      activation: state.activation.copyWith(simpleIsActivated: true),
+    );
+  }
+
+  void deactivateSimpleSearch() {
+    state = state.copyWith(
+      activation: state.activation.copyWith(simpleIsActivated: false),
+    );
+  }
+
+  void activateAdvancedSearch() {
+    state = state.copyWith(
+      activation: state.activation.copyWith(advancedIsActivated: true),
+    );
+  }
+
+  void deactivateAdvancedSearch() {
+    state = state.copyWith(
+      activation: state.activation.copyWith(advancedIsActivated: false),
+    );
+  }
+
+  void enableSearch() {
+    state = state.copyWith(searchState: state.searchState.enableSearchState());
+  }
+
+  void disableSearch() {
+    state = state.copyWith(searchState: state.searchState.disableSearchState());
+  }
+
+  void release() {
+    ref.invalidateSelf();
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_filter_form_bottom_view.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_filter_form_bottom_view.dart
@@ -131,7 +131,7 @@ class AdvancedSearchFilterFormBottomView extends GetWidget<AdvancedFilterControl
         value: ref.watch(searchFilterProvider.select((filter) => filter.isContainFlagged)),
         onChanged: (isChecked) => ref
           .read(searchFilterProvider.notifier)
-          .toggleStarred((isChecked ?? false).asSearchFilterToggle()),
+          .setStarred((isChecked ?? false).asSearchFilterToggle()),
       ),
     );
   }
@@ -150,7 +150,7 @@ class AdvancedSearchFilterFormBottomView extends GetWidget<AdvancedFilterControl
         value: ref.watch(searchFilterProvider.select((filter) => filter.unread)),
         onChanged: (isChecked) => ref
           .read(searchFilterProvider.notifier)
-          .setUnread((isChecked == true).asSearchFilterToggle()),
+          .setUnread((isChecked ?? false).asSearchFilterToggle()),
       ),
     );
   }
@@ -169,7 +169,7 @@ class AdvancedSearchFilterFormBottomView extends GetWidget<AdvancedFilterControl
         value: ref.watch(searchFilterProvider.select((filter) => filter.notIncludeEvents)),
         onChanged: (isChecked) => ref
           .read(searchFilterProvider.notifier)
-          .setNotIncludeEvents((isChecked == true).asSearchFilterToggle()),
+          .setNotIncludeEvents((isChecked ?? false).asSearchFilterToggle()),
       ),
     );
   }

--- a/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_input_form.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_input_form.dart
@@ -11,6 +11,7 @@ import 'package:tmail_ui_user/features/base/widget/default_field/default_date_dr
 import 'package:tmail_ui_user/features/base/widget/default_field/default_input_field_with_tab_key_widget.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/email_address_set_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_field_widget.dart';
@@ -67,8 +68,8 @@ class AdvancedSearchInputForm extends GetWidget<AdvancedFilterController> {
     (
       field: FilterField.from,
       config: (
-        listEmailAddress: (ref) => _toEmailAddresses(ref.watch(
-          searchFilterProvider.select((filter) => filter.from))),
+        listEmailAddress: (ref) => ref.watch(
+          searchFilterProvider.select((filter) => filter.from)).toEmailAddresses(),
         expandMode: () => controller.fromAddressExpandMode.value,
         textEditingController: controller.fromEmailAddressController,
         keyTagEditor: controller.keyFromEmailTagEditor,
@@ -79,8 +80,8 @@ class AdvancedSearchInputForm extends GetWidget<AdvancedFilterController> {
     (
       field: FilterField.to,
       config: (
-        listEmailAddress: (ref) => _toEmailAddresses(ref.watch(
-          searchFilterProvider.select((filter) => filter.to))),
+        listEmailAddress: (ref) => ref.watch(
+          searchFilterProvider.select((filter) => filter.to)).toEmailAddresses(),
         expandMode: () => controller.toAddressExpandMode.value,
         textEditingController: controller.toEmailAddressController,
         keyTagEditor: controller.keyToEmailTagEditor,
@@ -268,7 +269,4 @@ class AdvancedSearchInputForm extends GetWidget<AdvancedFilterController> {
       )),
     );
   }
-
-  List<EmailAddress> _toEmailAddresses(Set<String> emails) =>
-      emails.map((email) => EmailAddress(null, email)).toList();
 }

--- a/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/icon_open_advanced_search_widget.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/advanced_search/icon_open_advanced_search_widget.dart
@@ -3,12 +3,14 @@ import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/search_controller.dart'  as search;
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 
-class IconOpenAdvancedSearchWidget extends StatelessWidget {
+class IconOpenAdvancedSearchWidget extends ConsumerWidget {
   IconOpenAdvancedSearchWidget({Key? key}) : super(key: key);
 
   final _imagePaths = Get.find<ImagePaths>();
@@ -16,25 +18,24 @@ class IconOpenAdvancedSearchWidget extends StatelessWidget {
   final AdvancedFilterController advancedFilterController = Get.find<AdvancedFilterController>();
 
   @override
-  Widget build(BuildContext context) {
-    return Obx(() {
-      if (searchController.isAdvancedSearchViewOpen.isTrue) {
-        return const SizedBox.shrink();
-      }
+  Widget build(BuildContext context, WidgetRef ref) {
+    final searchViewState = ref.watch(searchViewStateProvider);
+    if (searchViewState.isAdvancedSearchViewOpen) {
+      return const SizedBox.shrink();
+    }
 
-      return TMailButtonWidget.fromIcon(
-        key: const ValueKey(UiKeys.openAdvancedSearchButton),
-        icon: _imagePaths.icFilterAdvanced,
-        iconSize: 22,
-        iconColor: searchController.advancedSearchIsActivated.isTrue
-          ? AppColor.primaryMain
-          : AppColor.steelGray400,
-        padding: const EdgeInsets.all(4),
-        margin: const EdgeInsets.symmetric(horizontal: 12),
-        backgroundColor: Colors.transparent,
-        onTapActionCallback: _onClickOpenAdvancedSearchView,
-      );
-    });
+    return TMailButtonWidget.fromIcon(
+      key: const ValueKey(UiKeys.openAdvancedSearchButton),
+      icon: _imagePaths.icFilterAdvanced,
+      iconSize: 22,
+      iconColor: searchViewState.advancedSearchIsActivated
+        ? AppColor.primaryMain
+        : AppColor.steelGray400,
+      padding: const EdgeInsets.all(4),
+      margin: const EdgeInsets.symmetric(horizontal: 12),
+      backgroundColor: Colors.transparent,
+      onTapActionCallback: _onClickOpenAdvancedSearchView,
+    );
   }
 
   void _onClickOpenAdvancedSearchView() {

--- a/lib/features/mailbox_dashboard/presentation/widgets/search_filters/quick_search_filter_bar.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/search_filters/quick_search_filter_bar.dart
@@ -1,0 +1,154 @@
+import 'package:core/core.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/base/widget/scrollbar_list_view.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/styles/mailbox_dashboard_view_web_style.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_filters/quick_search_filter_button.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
+import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+/// Filter bar shown on the search-result view of the dashboard.
+/// Not used by the search suggestion view.
+class QuickSearchFilterBar extends ConsumerWidget {
+  final _controller = Get.find<MailboxDashBoardController>();
+
+  final OnSelectQuickSearchFilterAction onSelectSearchFilterAction;
+  final OnDeleteQuickSearchFilterAction onDeleteSearchFilterAction;
+
+  QuickSearchFilterBar({
+    super.key,
+    required this.onSelectSearchFilterAction,
+    required this.onDeleteSearchFilterAction,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final searchViewState = ref.watch(searchViewStateProvider);
+    final searchFilter = ref.watch(searchFilterProvider);
+    return Obx(() {
+      final isThreadRoute =
+          _controller.dashboardRoute.value == DashboardRoutes.thread;
+      if (!searchViewState.isSearchEmailRunning || !isThreadRoute) {
+        return const SizedBox.shrink();
+      }
+      return _buildActiveFilterBar(context, searchFilter);
+    });
+  }
+
+  Widget _buildActiveFilterBar(
+    BuildContext context,
+    SearchEmailFilter searchFilter,
+  ) {
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(end: 16),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Flexible(child: _buildFilterList(context)),
+          _buildTrailingButton(context, searchFilter),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFilterList(BuildContext context) {
+    final filters = _visibleFilters();
+    return SizedBox(
+      height: 45,
+      child: ScrollbarListView(
+        scrollBehavior: ScrollConfiguration.of(context).copyWith(
+          dragDevices: {
+            PointerDeviceKind.touch,
+            PointerDeviceKind.mouse,
+            PointerDeviceKind.trackpad,
+          },
+          scrollbars: false,
+        ),
+        scrollController: _controller.listSearchFilterScrollController,
+        child: ListView(
+          scrollDirection: Axis.horizontal,
+          shrinkWrap: true,
+          padding: const EdgeInsetsDirectional.only(bottom: 10),
+          controller: _controller.listSearchFilterScrollController,
+          children: [
+            for (var i = 0; i < filters.length; i++) ...[
+              if (i > 0) MailboxDashboardViewWebStyle.searchFilterSizeBoxMargin,
+              _buildFilterButton(filters[i]),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// The chips shown while a thread search is active, in display order. `labels`
+  /// only appears when the account has labels to filter by.
+  List<QuickSearchFilter> _visibleFilters() {
+    final showLabels = _controller.isLabelAvailable &&
+        _controller.labelController.labels.isNotEmpty;
+    return [
+      QuickSearchFilter.folder,
+      if (showLabels) QuickSearchFilter.labels,
+      QuickSearchFilter.from,
+      QuickSearchFilter.to,
+      QuickSearchFilter.dateTime,
+      QuickSearchFilter.hasAttachment,
+      QuickSearchFilter.starred,
+      QuickSearchFilter.unread,
+      QuickSearchFilter.events,
+    ];
+  }
+
+  Widget _buildFilterButton(QuickSearchFilter searchFilter) {
+    return QuickSearchFilterButton(
+      searchFilter: searchFilter,
+      onSelectSearchFilterAction: onSelectSearchFilterAction,
+      onDeleteSearchFilterAction: onDeleteSearchFilterAction,
+    );
+  }
+
+  Widget _buildTrailingButton(
+    BuildContext context,
+    SearchEmailFilter searchFilter,
+  ) {
+    final hasFilterApplied = searchFilter.isApplied ||
+        _controller.filterMessageOption.value != FilterMessageOption.all;
+
+    return hasFilterApplied
+        ? _trailingTextButton(
+            text: AppLocalizations.of(context).clearFilter,
+            onTap: _controller.clearAllSearchFilterApplied,
+          )
+        : _trailingTextButton(
+            text: AppLocalizations.of(context).advancedSearch,
+            onTap: _controller.openAdvancedSearchView,
+          );
+  }
+
+  Widget _trailingTextButton({
+    required String text,
+    required VoidCallback onTap,
+  }) {
+    return TMailButtonWidget.fromText(
+      text: text,
+      backgroundColor: Colors.transparent,
+      margin: const EdgeInsetsDirectional.only(start: 8),
+      borderRadius: 10,
+      textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+        color: AppColor.primaryColor,
+        fontSize: 13,
+        fontWeight: FontWeight.w500,
+      ),
+      onTapActionCallback: onTap,
+    );
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/widgets/search_filters/quick_search_filter_button.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/search_filters/quick_search_filter_button.dart
@@ -1,0 +1,93 @@
+import 'package:core/presentation/extensions/color_extension.dart';
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/styles/mailbox_dashboard_view_web_style.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_filters/search_filter_button.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
+
+typedef OnSelectQuickSearchFilterAction = void Function(
+    BuildContext context, WidgetRef ref, QuickSearchFilter searchFilter,
+    {RelativeRect? buttonPosition});
+typedef OnDeleteQuickSearchFilterAction = void Function(
+    WidgetRef ref, QuickSearchFilter searchFilter);
+
+/// A single quick-search chip. Reads its state from the committed filter SSOT
+/// and resolves its own DI singletons, so it stays independent of any dashboard
+/// controller.
+class QuickSearchFilterButton extends ConsumerWidget {
+  final _imagePaths = Get.find<ImagePaths>();
+  final _responsiveUtils = Get.find<ResponsiveUtils>();
+
+  final QuickSearchFilter searchFilter;
+  final OnSelectQuickSearchFilterAction onSelectSearchFilterAction;
+  final OnDeleteQuickSearchFilterAction onDeleteSearchFilterAction;
+
+  /// Only consumed by the `fromMe` chip's selected-state check; omit otherwise.
+  final String? currentUserEmail;
+
+  QuickSearchFilterButton({
+    super.key,
+    required this.searchFilter,
+    required this.onSelectSearchFilterAction,
+    required this.onDeleteSearchFilterAction,
+    this.currentUserEmail,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filter = ref.watch(searchFilterProvider);
+    final isSelected = searchFilter.isSelected(
+      context,
+      filter,
+      filter.sortOrderType,
+      currentUserEmail,
+    );
+
+    return SearchFilterButton(
+      key: Key('${searchFilter.name}_search_filter_button'),
+      searchFilter: searchFilter,
+      imagePaths: _imagePaths,
+      responsiveUtils: _responsiveUtils,
+      isSelected: isSelected,
+      receiveTimeType: filter.emailReceiveTimeType,
+      startDate: filter.startDate?.value.toLocal(),
+      endDate: filter.endDate?.value.toLocal(),
+      sortOrderType: filter.sortOrderType,
+      listAddressOfFrom: filter.from,
+      listAddressOfTo: filter.to,
+      mailbox: filter.mailbox,
+      label: filter.label,
+      buttonPadding: _buttonPadding(isSelected),
+      backgroundColor: _backgroundColor(isSelected),
+      isContextMenuAlignEndButton:
+          searchFilter != QuickSearchFilter.labels && filter.hasActiveQuickFilter,
+      onSelectSearchFilterAction: (context, searchFilter, {buttonPosition}) =>
+          onSelectSearchFilterAction(
+            context,
+            ref,
+            searchFilter,
+            buttonPosition: buttonPosition,
+          ),
+      onDeleteSearchFilterAction: (searchFilter) =>
+          onDeleteSearchFilterAction(ref, searchFilter),
+    );
+  }
+
+  /// `sortBy` keeps the default padding; every other chip uses selection-aware padding.
+  EdgeInsetsGeometry? _buttonPadding(bool isSelected) =>
+      searchFilter == QuickSearchFilter.sortBy
+          ? null
+          : MailboxDashboardViewWebStyle.getSearchFilterButtonPadding(isSelected);
+
+  /// Only `sortBy` overrides the background; other chips fall back to their own color.
+  Color? _backgroundColor(bool isSelected) {
+    if (searchFilter != QuickSearchFilter.sortBy) return null;
+    return isSelected
+        ? AppColor.primaryColor.withValues(alpha: 0.06)
+        : AppColor.colorFilterMessageButton.withValues(alpha: 0.6);
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/widgets/search_filters/thread_list_action_bar.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/search_filters/thread_list_action_bar.dart
@@ -1,0 +1,199 @@
+import 'package:core/core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:get/get.dart';
+import 'package:model/extensions/presentation_mailbox_extension.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_view_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/styles/filter_message_button_style.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_filters/filter_message_button.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_filters/quick_search_filter_button.dart';
+import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+class ThreadListActionBar extends ConsumerWidget {
+  final _controller = Get.find<MailboxDashBoardController>();
+  final _imagePaths = Get.find<ImagePaths>();
+
+  static final Color _actionButtonBackgroundColor =
+      AppColor.colorFilterMessageButton.withValues(alpha: 0.6);
+
+  final OnSelectFilterMessageOptionAction onSelectFilterMessageOptionAction;
+  final OnDeleteFilterMessageOptionAction onDeleteFilterMessageOptionAction;
+  final OnSelectQuickSearchFilterAction onSelectSearchFilterAction;
+  final OnDeleteQuickSearchFilterAction onDeleteSearchFilterAction;
+
+  ThreadListActionBar({
+    super.key,
+    required this.onSelectFilterMessageOptionAction,
+    required this.onDeleteFilterMessageOptionAction,
+    required this.onSelectSearchFilterAction,
+    required this.onDeleteSearchFilterAction,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final searchViewState = ref.watch(searchViewStateProvider);
+    return Row(children: [
+      _buildRefreshButton(),
+      _buildSelectAllButton(context),
+      _buildFilterMessageButton(context, searchViewState),
+      _buildRecoverDeletedButton(),
+      _buildSortByButton(context, searchViewState),
+    ]);
+  }
+
+  Widget _buildRefreshButton() {
+    return Obx(() {
+      if (_controller.isRefreshingAllMailboxAndEmail) {
+        return TMailContainerWidget(
+          borderRadius: 10,
+          backgroundColor: _actionButtonBackgroundColor,
+          padding: const EdgeInsetsDirectional.symmetric(vertical: 8, horizontal: 8.5),
+          child: const CupertinoLoadingWidget(size: 16));
+      } else {
+        return _buildIconActionButton(
+          key: const Key('refresh_all_mailbox_and_email_button'),
+          icon: _imagePaths.icRefresh,
+          onTap: _controller.refreshMailboxAction,
+        );
+      }
+    });
+  }
+
+  Widget _buildSelectAllButton(BuildContext context) {
+    return Obx(() {
+      if (_controller.emailsInCurrentMailbox.isEmpty) {
+        return const SizedBox.shrink();
+      } else {
+        return Padding(
+          padding: const EdgeInsetsDirectional.only(start: 16),
+          child: Tooltip(
+            message: AppLocalizations.of(context).selectAllMessagesOfThisPage,
+            child: ElevatedButton.icon(
+              onPressed: _controller.selectAllEmailAction,
+              icon: SvgPicture.asset(
+                _imagePaths.icSelectAll,
+                width: 16,
+                height: 16,
+                fit: BoxFit.fill,
+                colorFilter: AppColor.colorFilterMessageIcon.asFilter(),
+              ),
+              label: Text(
+                AppLocalizations.of(context).selectAllMessagesOfThisPage,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                  fontSize: 13,
+                  fontWeight: FontWeight.normal,
+                  color: AppColor.colorFilterMessageTitle,
+                ),
+              ),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: _actionButtonBackgroundColor,
+                shadowColor: Colors.transparent,
+                padding: const EdgeInsetsDirectional.symmetric(horizontal: 12),
+                shape: const RoundedRectangleBorder(
+                  borderRadius: BorderRadius.all(Radius.circular(10)),
+                ),
+                elevation: 0.0,
+                foregroundColor: AppColor.colorTextButtonHeaderThread,
+                maximumSize: const Size.fromWidth(250),
+                fixedSize: const Size.fromHeight(34),
+                textStyle: ThemeUtils.defaultTextStyleInterFont.copyWith(
+                  fontSize: 13,
+                  fontWeight: FontWeight.normal,
+                  color: AppColor.colorFilterMessageTitle
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+    });
+  }
+
+  Widget _buildFilterMessageButton(
+    BuildContext context,
+    SearchViewState searchViewState,
+  ) {
+    return Obx(() {
+      final filterMessageCurrent = _controller.filterMessageOption.value;
+
+      if (_controller.validateNoEmailsInTrashAndSpamFolder() ||
+          searchViewState.isSearchEmailRunning) {
+        return const SizedBox.shrink();
+      } else {
+        return Padding(
+          padding: FilterMessageButtonStyle.buttonMargin,
+          child: FilterMessageButton(
+            filterMessageOption: filterMessageCurrent,
+            imagePaths: _imagePaths,
+            isSelected: filterMessageCurrent != FilterMessageOption.all,
+            onSelectFilterMessageOptionAction: onSelectFilterMessageOptionAction,
+            onDeleteFilterMessageOptionAction: onDeleteFilterMessageOptionAction,
+          ),
+        );
+      }
+    });
+  }
+
+  Widget _buildRecoverDeletedButton() {
+    return Obx(() {
+      if (_controller.selectedMailbox.value?.isTrashPersonal == true) {
+        return _buildIconActionButton(
+          key: const Key('recover_deleted_messages_button'),
+          icon: _imagePaths.icRecoverDeletedMessages,
+          margin: const EdgeInsetsDirectional.only(start: 16),
+          onTap: _controller.gotoEmailRecovery,
+        );
+      } else {
+        return const SizedBox.shrink();
+      }
+    });
+  }
+
+  Widget _buildSortByButton(
+    BuildContext context,
+    SearchViewState searchViewState,
+  ) {
+    return Obx(() {
+      if (_controller.dashboardRoute.value == DashboardRoutes.thread &&
+          searchViewState.isSearchEmailRunning) {
+        return Padding(
+          padding: const EdgeInsetsDirectional.only(start: 16),
+          child: QuickSearchFilterButton(
+            searchFilter: QuickSearchFilter.sortBy,
+            onSelectSearchFilterAction: onSelectSearchFilterAction,
+            onDeleteSearchFilterAction: onDeleteSearchFilterAction,
+          ),
+        );
+      } else {
+        return const SizedBox.shrink();
+      }
+    });
+  }
+
+  /// The trailing icon-only actions (refresh, recover-deleted) share one look:
+  /// a rounded 16px icon on the shared action-button background.
+  Widget _buildIconActionButton({
+    required Key key,
+    required String icon,
+    required VoidCallback onTap,
+    EdgeInsetsGeometry? margin,
+  }) {
+    return TMailButtonWidget.fromIcon(
+      key: key,
+      icon: icon,
+      borderRadius: 10,
+      iconSize: 16,
+      backgroundColor: _actionButtonBackgroundColor,
+      margin: margin,
+      onTapActionCallback: onTap,
+    );
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
@@ -28,6 +28,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/search_controller.dart' as search;
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_keyboard_shortcut_actions_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_constants.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_filter_overlay.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/advanced_search/icon_open_advanced_search_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/quick_search/contact_quick_search_item.dart';
@@ -64,7 +65,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
           color: Colors.white,
           borderRadius: BorderRadius.all(Radius.circular(16)),
         ),
-        debounceDuration: const Duration(milliseconds: 300),
+        debounceDuration: SearchConstants.inputDebounceDuration,
         listActionButton: const [
           QuickSearchFilter.hasAttachment,
           QuickSearchFilter.last7Days,

--- a/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
@@ -14,6 +14,7 @@ import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/direction_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_portal/flutter_portal.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
@@ -29,16 +30,18 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_keyboard_shortcut_actions_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_constants.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_filter_overlay.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/advanced_search/icon_open_advanced_search_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/quick_search/contact_quick_search_item.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/quick_search/email_quick_search_item_tile_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/quick_search/recent_search_item_tile_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_filters/search_filter_button.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 
-class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
+class SearchInputFormWidget extends ConsumerWidget with AppLoaderMixin {
   final _searchController = Get.find<search.SearchController>();
   final _dashBoardController = Get.find<MailboxDashBoardController>();
   final _imagePaths = Get.find<ImagePaths>();
@@ -54,13 +57,16 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
   final EdgeInsetsGeometry contentPadding;
 
   @override
-  Widget build(BuildContext context) {
-    return Obx(() {
-      Widget searchInputForm = QuickSearchInputForm<PresentationEmail, EmailAddress, RecentSearch>(
+  Widget build(BuildContext context, WidgetRef ref) {
+    final searchViewState = ref.watch(searchViewStateProvider);
+    final committedSearchText =
+        ref.watch(searchFilterProvider.select((filter) => filter.text?.value ?? ''));
+    Widget searchInputForm =
+        QuickSearchInputForm<PresentationEmail, EmailAddress, RecentSearch>(
         maxHeight: 52,
         suggestionsBoxVerticalOffset: 0.0,
         minInputLengthAutocomplete: _dashBoardController.minInputLengthAutocomplete,
-        textFieldConfiguration: _createConfiguration(context),
+        textFieldConfiguration: _createConfiguration(context, ref),
         suggestionsBoxDecoration: const QuickSearchSuggestionsBoxDecoration(
           color: Colors.white,
           borderRadius: BorderRadius.all(Radius.circular(16)),
@@ -87,6 +93,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
             _searchController.toggleQuickSearchFilter(
               filterAction,
               currentUserEmail: _dashBoardController.ownEmailAddress.value,
+              searchFilterNotifier: ref.read(searchFilterProvider.notifier),
             );
           }
         },
@@ -104,7 +111,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
         ),
         buttonShowAllResult: (context, keyword, _) {
           if (keyword is String) {
-            return _buildShowAllResultButton(context, keyword);
+            return _buildShowAllResultButton(context, ref, keyword);
           } else {
             return const SizedBox.shrink();
           }
@@ -129,65 +136,67 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
           }
         },
         itemRecentBuilder: (context, recent) => RecentSearchItemTileWidget(recent),
-        onRecentSelected: _invokeSelectRecentItem,
+        onRecentSelected: (recent) => _invokeSelectRecentItem(recent, ref),
         suggestionsCallback: _dashBoardController.quickSearchEmails,
         itemBuilder: (context, email) => EmailQuickSearchItemTileWidget(
             email,
             _dashBoardController.selectedMailbox.value,
-            searchQuery: SearchQuery(_searchController.currentSearchText.trim())),
+            searchQuery: SearchQuery(committedSearchText.trim())),
         onSuggestionSelected: _invokeSelectSuggestionItem,
-        contactItemBuilder: (context, emailAddress) => ContactQuickSearchItem(emailAddress: emailAddress),
-        contactSuggestionsCallback: _dashBoardController.getContactSuggestion,
-        onContactSuggestionSelected: _invokeSelectContactSuggestion,
+          contactItemBuilder: (context, emailAddress) =>
+              ContactQuickSearchItem(emailAddress: emailAddress),
+          contactSuggestionsCallback: _dashBoardController.getContactSuggestion,
+          onContactSuggestionSelected: (emailAddress) =>
+              _invokeSelectContactSuggestion(emailAddress, ref),
+    );
+
+    if (_searchController.keyboardFocusNode != null) {
+      searchInputForm = KeyboardHandlerWrapper(
+        focusNode: _searchController.keyboardFocusNode!,
+        onKeyDownEventAction: _searchController.onKeyDownEventAction,
+        child: searchInputForm,
       );
+    }
 
-      if (_searchController.keyboardFocusNode != null) {
-        searchInputForm = KeyboardHandlerWrapper(
-          focusNode: _searchController.keyboardFocusNode!,
-          onKeyDownEventAction: _searchController.onKeyDownEventAction,
-          child: searchInputForm,
-        );
-      }
-
-      return PortalTarget(
-        visible: _searchController.isAdvancedSearchViewOpen.isTrue,
-        portalFollower: PointerInterceptor(
-          child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTap: _searchController.closeAdvanceSearch
-          ),
+    return PortalTarget(
+      visible: searchViewState.isAdvancedSearchViewOpen,
+      portalFollower: PointerInterceptor(
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: _searchController.closeAdvanceSearch
         ),
-        child: PortalTarget(
-          visible: _searchController.isAdvancedSearchViewOpen.isTrue,
-          anchor: const Aligned(
+      ),
+      child: PortalTarget(
+        visible: searchViewState.isAdvancedSearchViewOpen,
+        anchor: const Aligned(
+          follower: Alignment.topRight,
+          target: Alignment.bottomRight,
+          widthFactor: 1,
+          backup: Aligned(
             follower: Alignment.topRight,
             target: Alignment.bottomRight,
             widthFactor: 1,
-            backup: Aligned(
-              follower: Alignment.topRight,
-              target: Alignment.bottomRight,
-              widthFactor: 1,
-            ),
           ),
-          portalFollower: const AdvancedSearchFilterOverlay(),
-          child: searchInputForm,
         ),
-      );
-    });
+        portalFollower: const AdvancedSearchFilterOverlay(),
+        child: searchInputForm,
+      ),
+    );
   }
 
-  void _invokeSearchEmailAction(String queryString) {
-    log('SearchInputFormWidget::_invokeSearchEmailAction:QueryString = $queryString');
-    final trimmedQueryString = queryString.trimmed;
+  void _invokeSearchEmailAction(WidgetRef ref) {
+    final trimmedQueryString =
+        _searchController.searchInputController.text.trimmed;
+    log('SearchInputFormWidget::_invokeSearchEmailAction:QueryString = $trimmedQueryString');
 
     _searchController.searchFocus.unfocus();
-    _searchController.enableSearch();
+    ref.read(searchViewStateProvider.notifier).enableSearch();
 
     if (trimmedQueryString.isNotEmpty) {
       _saveRecentSearch(trimmedQueryString);
     }
 
-    _dashBoardController.searchEmailByQueryString(trimmedQueryString);
+    _dashBoardController.searchEmailByQueryString();
   }
 
   void _saveRecentSearch(String queryString) {
@@ -214,16 +223,20 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
     );
   }
 
-  void _invokeSelectRecentItem(RecentSearch recent) {
+  void _invokeSelectRecentItem(RecentSearch recent, WidgetRef ref) {
     _searchController.searchInputController.text = recent.value;
     _searchController.searchFocus.unfocus();
-    _searchController.enableSearch();
-    _dashBoardController.searchEmailByQueryString(recent.value);
+    ref.read(searchViewStateProvider.notifier).enableSearch();
+    _dashBoardController.searchEmailByQueryString();
   }
 
-  Widget _buildShowAllResultButton(BuildContext context, String keyword) {
+  Widget _buildShowAllResultButton(
+    BuildContext context,
+    WidgetRef ref,
+    String keyword,
+  ) {
     return InkWell(
-      onTap: () => _invokeSearchEmailAction(keyword.trim()),
+      onTap: () => _invokeSearchEmailAction(ref),
       child: Padding(
         padding: const EdgeInsets.all(12),
         child: Row(children: [
@@ -249,7 +262,10 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
     );
   }
 
-  QuickSearchTextFieldConfiguration _createConfiguration(BuildContext context) {
+  QuickSearchTextFieldConfiguration _createConfiguration(
+    BuildContext context,
+    WidgetRef ref,
+  ) {
     return QuickSearchTextFieldConfiguration(
       controller: _searchController.searchInputController,
       focusNode: _searchController.searchFocus,
@@ -259,7 +275,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
       textInputAction: TextInputAction.done,
       cursorColor: AppColor.primaryColor,
       textDirection: DirectionUtils.getDirectionByLanguage(context),
-      onSubmitted: (keyword) => _invokeSearchEmailAction(keyword.trim()),
+      onSubmitted: (_) => _invokeSearchEmailAction(ref),
       decoration: InputDecoration(
         border: InputBorder.none,
         focusedBorder: InputBorder.none,
@@ -279,7 +295,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
           iconSize: 22,
           backgroundColor: Colors.transparent,
           padding: const EdgeInsets.all(4),
-          onTapActionCallback: () => _invokeSearchEmailAction(_searchController.searchInputController.text.trim())
+          onTapActionCallback: () => _invokeSearchEmailAction(ref)
         )
       ),
       clearTextButton: buildIconWeb(
@@ -299,13 +315,14 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
   Widget buildListButtonForQuickSearchForm(
     BuildContext context,
     QuickSearchFilter searchFilter,
-    QuickSearchSuggestionListState suggestionsListState
+    QuickSearchSuggestionListState suggestionsListState,
   ) {
-    return Obx(() {
+    return Consumer(builder: (context, ref, _) {
+      final filter = ref.watch(searchFilterProvider);
       final isSelected = searchFilter.isSelected(
         context,
-        _searchController.searchEmailFilter.value,
-        _searchController.sortOrderFiltered,
+        filter,
+        filter.sortOrderType,
         _dashBoardController.ownEmailAddress.value,
       );
 
@@ -320,6 +337,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
           _searchController.toggleQuickSearchFilter(
             searchFilter,
             currentUserEmail: _dashBoardController.ownEmailAddress.value,
+            searchFilterNotifier: ref.read(searchFilterProvider.notifier),
           );
           suggestionsListState.invalidateSuggestions();
         },
@@ -327,10 +345,13 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
     });
   }
 
-  void _invokeSelectContactSuggestion(EmailAddress emailAddress) {
+  void _invokeSelectContactSuggestion(
+    EmailAddress emailAddress,
+    WidgetRef ref,
+  ) {
     _searchController.searchInputController.clear();
     _searchController.searchFocus.unfocus();
-    _searchController.enableSearch();
+    ref.read(searchViewStateProvider.notifier).enableSearch();
     _dashBoardController.quickSearchEmailByFrom(emailAddress);
   }
 }

--- a/lib/features/search/email/domain/notifier/search_email_notifier.dart
+++ b/lib/features/search/email/domain/notifier/search_email_notifier.dart
@@ -48,8 +48,23 @@ class SearchEmailNotifier extends _$SearchEmailNotifier with InteractorConsumer 
   SearchEmailResult get _currentResult =>
       state.value ?? SearchEmailResult.empty();
 
+  /// False while a page is already loading, so repeated scroll/button events
+  /// can't start duplicate backend requests.
+  bool get canLoadMore {
+    final result = state.value;
+    return result?.canLoadMore == true &&
+        result?.loadMore != LoadMoreState.inProgress;
+  }
+
   @override
   AsyncValue<SearchEmailResult> build() => AsyncData(SearchEmailResult.empty());
+
+  /// Advances the request token so any in-flight search that completes after this
+  /// can't restore results for a previous mailbox/filter.
+  void clearResult() {
+    _latestRequestId++;
+    state = AsyncData(SearchEmailResult.empty());
+  }
 
   /// Runs [intent] and updates [state]; never mutates the committed SSOT.
   Future<void> execute(
@@ -104,10 +119,9 @@ class SearchEmailNotifier extends _$SearchEmailNotifier with InteractorConsumer 
     );
   }
 
-  /// Load-more: mark the page in progress, then append it. On failure the loaded
-  /// page stays and [LoadMoreState.failure] lets the UI offer a retry. Concurrency
-  /// (e.g. a socket-driven refresh arriving mid-load) is handled by [_latestRequestId]
-  /// in [_runGuarded], which drops a superseded page — not by [LoadMoreState].
+  /// Load-more: mark in progress, then append the page. On failure the loaded page
+  /// stays and [LoadMoreState.failure] offers a retry. Superseded pages are dropped
+  /// by [_latestRequestId] in [_runGuarded], not by [LoadMoreState].
   Future<void> _runLoadMore(int requestId, SearchExecutionRequest request) {
     state = AsyncData(_currentResult.copyWith(
       loadMore: LoadMoreState.inProgress,
@@ -169,8 +183,8 @@ class SearchEmailNotifier extends _$SearchEmailNotifier with InteractorConsumer 
       onPageLoaded: (page) => state = AsyncData(
         SearchEmailResult(emails: page, canLoadMore: page.isNotEmpty),
       ),
-      // Nothing visible changes on failure — keep the list. The consume seam
-      // routes urgent ones at the failure point (ADR-0103), so repeats all route.
+      // Keep the current list on failure; the consume seam routes urgent
+      // failures at the failure point (ADR-0103).
       onFailure: (_, __) {},
     );
   }

--- a/lib/features/search/email/domain/notifier/search_filter_mutation.dart
+++ b/lib/features/search/email/domain/notifier/search_filter_mutation.dart
@@ -1,4 +1,5 @@
 import 'package:dartz/dartz.dart';
+import 'package:jmap_dart_client/jmap/core/utc_date.dart';
 import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
 import 'package:labels/model/label.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
@@ -7,6 +8,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/sear
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
 import 'package:tmail_ui_user/features/search/email/domain/model/search_filter_input.dart';
+import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
 
 /// Mutation API for the committed [SearchFilterNotifier]: `update`, `set`, and the
 /// field helpers, so no call site owns the copyWith/set-rebuild plumbing. Takes
@@ -40,8 +42,14 @@ mixin SearchFilterMutation on $Notifier<SearchEmailFilter> {
   void setSenders(SearchFilterEmailSet senders) =>
       update(SearchFilterPatch()..fromOption = Some(senders.snapshot()));
 
+  void clearSenders() =>
+      setSenders(const <String>{}.asSearchFilterEmailSet());
+
   void setRecipients(SearchFilterEmailSet recipients) =>
       update(SearchFilterPatch()..toOption = Some(recipients.snapshot()));
+
+  void clearRecipients() =>
+      setRecipients(const <String>{}.asSearchFilterEmailSet());
 
   void setText(SearchFilterTextInput input) =>
       update(SearchFilterPatch()..textOption = input.searchQueryOption);
@@ -57,12 +65,23 @@ mixin SearchFilterMutation on $Notifier<SearchEmailFilter> {
       update(SearchFilterPatch()
         ..hasKeywordOption = Some(hasKeywords.snapshot()));
 
+  void addHasKeyword(String keyword) =>
+      setHasKeywords(({...state.hasKeyword}..add(keyword)).asSearchFilterKeywordSet());
+
+  void removeHasKeyword(String keyword) =>
+      setHasKeywords(({...state.hasKeyword}..remove(keyword)).asSearchFilterKeywordSet());
+
   void setMailbox(PresentationMailbox? mailbox) =>
       update(SearchFilterPatch()..mailboxOption = optionOf(mailbox));
+
+  void clearMailbox() => setMailbox(null);
 
   void setHasAttachment(SearchFilterToggle hasAttachment) =>
       update(SearchFilterPatch()
         ..hasAttachmentOption = hasAttachment.exactOption);
+
+  void toggleHasAttachment() =>
+      setHasAttachment((!state.hasAttachment).asSearchFilterToggle());
 
   void setUnread(SearchFilterToggle unread) =>
       update(SearchFilterPatch()
@@ -81,6 +100,31 @@ mixin SearchFilterMutation on $Notifier<SearchEmailFilter> {
         ..startDateOption = const None()
         ..endDateOption = const None());
 
+  void setReceiveTime(
+    EmailReceiveTimeType receiveTime, {
+    UTCDate? startDate,
+    UTCDate? endDate,
+  }) => update(SearchFilterPatch()
+        ..emailReceiveTimeTypeOption = Some(receiveTime)
+        ..startDateOption = optionOf(startDate)
+        ..endDateOption = optionOf(endDate));
+
+  void toggleLast7Days() {
+    if (state.emailReceiveTimeType == EmailReceiveTimeType.last7Days) {
+      setReceiveTime(EmailReceiveTimeType.allTime);
+    } else {
+      final range = EmailReceiveTimeType.last7Days.toDateRange();
+      setReceiveTime(
+        EmailReceiveTimeType.last7Days,
+        startDate: range.start,
+        endDate: range.end,
+      );
+    }
+  }
+
+  void setLabel(Label? label) =>
+      update(SearchFilterPatch()..labelOption = optionOf(label));
+
   void toggleLabel(Label? label) =>
       update(SearchFilterPatch()
         ..labelOption = optionOf(state.label?.id == label?.id ? null : label));
@@ -89,11 +133,45 @@ mixin SearchFilterMutation on $Notifier<SearchEmailFilter> {
       update(SearchFilterPatch()..labelOption = const None());
   /// 'starred' is the flagged keyword inside `hasKeyword`, not a bool field. Sets or
   /// clears it here so no call site rebuilds the keyword set.
-  void toggleStarred(SearchFilterToggle starred) {
+  void setStarred(SearchFilterToggle starred) {
     final keyword = KeyWordIdentifier.emailFlagged.value;
     final hasKeyword = {...state.hasKeyword}..remove(keyword);
     if (starred.isSelected) hasKeyword.add(keyword);
     setHasKeywords(SearchFilterKeywordSet(hasKeyword));
+  }
+
+  /// Flips 'starred' from the current state — mirrors [toggleHasAttachment] so a
+  /// suggestion chip never has to compute the new value itself.
+  void toggleStarred() =>
+      setStarred((!state.isContainFlagged).asSearchFilterToggle());
+
+  void applyFilterMessageOption(FilterMessageOption option) {
+    _setFilterMessageToggle(option, SearchFilterToggle.selected);
+  }
+
+  void syncFilterMessageOptionChange({
+    required FilterMessageOption previous,
+    required FilterMessageOption next,
+  }) {
+    if (previous == next) return;
+    _setFilterMessageToggle(previous, SearchFilterToggle.unselected);
+    _setFilterMessageToggle(next, SearchFilterToggle.selected);
+  }
+
+  void _setFilterMessageToggle(
+    FilterMessageOption option,
+    SearchFilterToggle toggle,
+  ) {
+    switch (option) {
+      case FilterMessageOption.unread:
+        setUnread(toggle);
+      case FilterMessageOption.attachments:
+        setHasAttachment(toggle);
+      case FilterMessageOption.starred:
+        setStarred(toggle);
+      case FilterMessageOption.all:
+        break;
+    }
   }
 
   /// Adds/removes one address in `from`/`to` — encapsulates the read-set →
@@ -109,6 +187,14 @@ mixin SearchFilterMutation on $Notifier<SearchEmailFilter> {
 
   void removeRecipient(SearchFilterEmailAddress address) =>
       setRecipients(SearchFilterEmailSet({...state.to}..remove(address.value)));
+
+  void toggleOnlySender(String address) {
+    if (address.isEmpty) return;
+    setSenders(
+      (state.isOnlySender(address) ? <String>{} : {address})
+          .asSearchFilterEmailSet(),
+    );
+  }
 
   /// Full replacement (apply a form); strips cursors so none can seed the SSOT.
   void set(SearchEmailFilter filter) => state = filter.clearPaginationCursors();

--- a/lib/features/search/email/presentation/search_email_controller.dart
+++ b/lib/features/search/email/presentation/search_email_controller.dart
@@ -908,6 +908,9 @@ class SearchEmailController extends BaseController
     clearAllTextInputSearchForm();
     clearAllResultSearch();
     mailboxDashBoardController.searchController.disableAllSearchEmail();
+    // Bring back the mailbox quick-filter that was active before search so the
+    // reloaded mailbox shows the same (still-applied) filter (#4490).
+    mailboxDashBoardController.restoreFilterMessageOptionAfterSearch();
     mailboxDashBoardController.dispatchRoute(DashboardRoutes.thread);
     if (PlatformInfo.isWeb) {
       final currentMailbox = mailboxDashBoardController.selectedMailbox.value;
@@ -1139,7 +1142,7 @@ class SearchEmailController extends BaseController
   }
 
   void _clearStarredSearchFilter(SearchFilterNotifier notifier) {
-    notifier.toggleStarred(SearchFilterToggle.unselected);
+    notifier.setStarred(SearchFilterToggle.unselected);
   }
 
   void _clearUnreadSearchFilter(SearchFilterNotifier notifier) {

--- a/lib/features/thread/presentation/extensions/handle_search_email_execution_extension.dart
+++ b/lib/features/thread/presentation/extensions/handle_search_email_execution_extension.dart
@@ -118,6 +118,12 @@ extension HandleSearchEmailExecutionExtension on ThreadController {
     }
     final result = next.value;
     if (result == null) return;
+
+    // `clearResult()` also fires from mailbox reset/switch and the null-session
+    // path, emitting an empty result. Ignore it while no search is active so it
+    // can't overwrite the mailbox list with `SearchEmailSuccess([])`.
+    if (!isSearchActive && result.emails.isEmpty) return;
+
     _applySearchResult(result);
   }
 

--- a/lib/features/thread/presentation/extensions/handle_search_email_execution_extension.dart
+++ b/lib/features/thread/presentation/extensions/handle_search_email_execution_extension.dart
@@ -1,0 +1,200 @@
+part of '../thread_controller.dart';
+
+/// Web search executor bridge for [ThreadController].
+/// Delegates search intents and mirrors [SearchEmailResult] into GetX state.
+extension HandleSearchEmailExecutionExtension on ThreadController {
+  @visibleForTesting
+  Future<void> refreshChangeSearchEmail() => _refreshChangeSearchEmail();
+
+  /// Whether session, account and the current email state are all present — the
+  /// values [_refreshChangeListEmailCache] force-unwraps. A queued websocket
+  /// refresh can arrive after they clear, so guard on this first.
+  bool get _canRefreshSearchChanges =>
+      _session != null &&
+      _accountId != null &&
+      mailboxDashBoardController.currentEmailState != null;
+
+  Future<void> _refreshChangeSearchEmail() async {
+    if (!_canRefreshSearchChanges) return;
+
+    await _refreshChangeListEmailCache();
+
+    // Re-check: session/account can clear while the cache refresh above awaits
+    // (logout, controller teardown), and _executeSearch force-unwraps them.
+    if (!_canRefreshSearchChanges) return;
+
+    loadingMoreStatus.value = LoadingMoreStatus.idle;
+
+    await _executeSearch(RefreshChangesIntent(
+      currentCount: mailboxDashBoardController.emailsInCurrentMailbox.length,
+    ));
+  }
+
+  /// Sends [intent] to the central executor with the shared request context.
+  Future<void> _executeSearch(SearchExecutionIntent intent) {
+    return appProviderContainer.read(searchEmailProvider.notifier).execute(
+      intent,
+      session: _session!,
+      accountId: _accountId!,
+      properties: EmailUtils.getPropertiesForEmailGetMethod(_session!, _accountId!),
+      collapseThreads: _shouldCollapseThreads,
+      trashSpamMailboxIds: mailboxDashBoardController.trashSpamMailboxIds,
+    );
+  }
+
+  @visibleForTesting
+  void searchEmail({bool needRefreshSearchState = false}) =>
+      _searchEmail(needRefreshSearchState: needRefreshSearchState);
+
+  void _searchEmail({bool needRefreshSearchState = false}) {
+    if (_session == null || _accountId == null) {
+      appProviderContainer.read(searchEmailProvider.notifier).clearResult();
+      _handleSearchEmailFailure(SearchEmailFailure(NotFoundSessionException()));
+      return;
+    }
+
+    if (!needRefreshSearchState && listEmailController.hasClients) {
+      isListEmailScrollViewJumping = true;
+      listEmailController.jumpTo(0);
+    }
+    if (!needRefreshSearchState) {
+      mailboxDashBoardController.emailsInCurrentMailbox.clear();
+    }
+    loadingMoreStatus.value = LoadingMoreStatus.idle;
+
+    searchController.activateSimpleSearch();
+
+    // Cursors and limit come from the executor; no `moreFilterCondition` leak.
+    _executeSearch(const NewSearchIntent());
+  }
+
+  @visibleForTesting
+  void searchMoreEmails() => _searchMoreEmails();
+
+  void _searchMoreEmails() {
+    if (!canSearchMore) return;
+
+    if (_session == null || _accountId == null) {
+      _handleSearchMoreEmailFailure();
+      return;
+    }
+
+    final currentEmailList = mailboxDashBoardController.emailsInCurrentMailbox;
+    if (currentEmailList.isEmpty) return;
+
+    final lastEmail = currentEmailList.last;
+
+    // The executor resolves cursors; no cursor is written to the SSOT.
+    _executeSearch(LoadMoreIntent(
+      currentCount: currentEmailList.length,
+      lastEmailDate: lastEmail.receivedAt,
+      lastEmailId: lastEmail.id,
+    ));
+  }
+
+  /// Bridges [searchEmailProvider] into the web GetX result state.
+  /// Mobile search results stay owned by `SearchEmailController`.
+  void _registerSearchEmailResultBridge() {
+    _searchEmailResultSubscription ??=
+        appProviderContainer.listen<AsyncValue<SearchEmailResult>>(
+      searchEmailProvider,
+      _handleSearchEmailResult,
+    );
+  }
+
+  /// Maps first-page loading/error to web view state.
+  /// Load-more/refresh stay `AsyncData`, so they never blank the list.
+  void _handleSearchEmailResult(
+    AsyncValue<SearchEmailResult>? previous,
+    AsyncValue<SearchEmailResult> next,
+  ) {
+    if (next.isLoading) {
+      dispatchState(Right(SearchingState()));
+      return;
+    }
+    if (next.hasError) {
+      _handleSearchEmailFailure(_asSearchEmailFailure(next.error));
+      return;
+    }
+    final result = next.value;
+    if (result == null) return;
+    _applySearchResult(result);
+  }
+
+  void _applySearchResult(SearchEmailResult result) {
+    mailboxDashBoardController.updateRefreshAllEmailState(Right(RefreshAllEmailSuccess()));
+
+    // The executor returns the full accumulated list.
+    // The transform re-carries the current selection.
+    final syncedList = result.emails.toSyncedSearchResults(
+      context: PresentationEmailSyncContext(
+        mapMailboxById: mailboxDashBoardController.mapMailboxById,
+        selectedMailbox: selectedMailbox,
+        searchQuery: searchController.searchQuery,
+        isSearchEmailRunning: isSearchActive,
+      ),
+      previousList: mailboxDashBoardController.emailsInCurrentMailbox,
+    );
+    mailboxDashBoardController.updateEmailList(syncedList);
+    if (mailboxDashBoardController.isSelectionEnabled()) {
+      mailboxDashBoardController.listEmailSelected.value = listEmailSelected;
+    }
+
+    // Settle `viewState` so the searching spinner disappears after results land.
+    dispatchState(Right(SearchEmailSuccess(syncedList)));
+
+    _syncLoadMoreStatus(result.loadMore);
+
+    if (_shouldAutoLoadMoreSearchResult(result)) {
+      _performAutomaticallyLoadMoreEmails();
+    }
+  }
+
+  @visibleForTesting
+  bool shouldAutoLoadMoreSearchResult(SearchEmailResult result) =>
+      _shouldAutoLoadMoreSearchResult(result);
+
+  /// Auto-fetch only after a page settled cleanly (`idle`) and more results
+  /// exist. Excludes `failure` so a failed load-more (incl. urgent) never
+  /// auto-retries; [_isAutoLoadMore] says the viewport still needs rows.
+  bool _shouldAutoLoadMoreSearchResult(SearchEmailResult result) {
+    return result.loadMore == LoadMoreState.idle &&
+        result.canLoadMore &&
+        _isAutoLoadMore;
+  }
+
+  void _syncLoadMoreStatus(LoadMoreState loadMore) {
+    loadingMoreStatus.value = loadMore == LoadMoreState.inProgress
+        ? LoadingMoreStatus.running
+        : LoadingMoreStatus.completed;
+  }
+
+  void _handleSearchEmailFailure(SearchEmailFailure failure) {
+    // Settle `viewState` off `SearchingState` first, so an async first-page error
+    // can't leave the search spinner running indefinitely.
+    dispatchState(Left(failure));
+    loadingMoreStatus.value = LoadingMoreStatus.idle;
+
+    // Urgent failures (re-login / reconnect / connection errors) are already
+    // routed once by the executor's consume seam (ADR-0103); here we only detect
+    // them — without routing again — to skip the destructive retry UI, since the
+    // shared handler owns the screen.
+    if (isUrgentException(failure)) return;
+
+    mailboxDashBoardController.updateRefreshAllEmailState(Left(RefreshAllEmailFailure()));
+    mailboxDashBoardController.emailsInCurrentMailbox.clear();
+    showRetryToast(failure);
+  }
+
+  /// Handles a load-more that never started because session/account is missing.
+  /// Keep the page and allow retry, matching [LoadMoreState.failure].
+  void _handleSearchMoreEmailFailure() {
+    loadingMoreStatus.value = LoadingMoreStatus.completed;
+  }
+
+  SearchEmailFailure _asSearchEmailFailure(Object? error) {
+    if (error is SearchEmailFailure) return error;
+    if (error is FeatureFailure) return SearchEmailFailure(error.exception);
+    return SearchEmailFailure(error);
+  }
+}

--- a/lib/features/thread/presentation/extensions/list_presentation_email_extensions.dart
+++ b/lib/features/thread/presentation/extensions/list_presentation_email_extensions.dart
@@ -2,6 +2,7 @@
 import 'package:core/utils/platform_info.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/email/presentation_email.dart';
+import 'package:model/extensions/list_presentation_email_extension.dart';
 import 'package:model/extensions/presentation_email_extension.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:tmail_ui_user/features/email/presentation/extensions/email_extension.dart';
@@ -12,7 +13,39 @@ import 'package:tmail_ui_user/main/routes/app_routes.dart';
 import 'package:tmail_ui_user/main/routes/navigation_router.dart';
 import 'package:tmail_ui_user/main/routes/route_utils.dart';
 
+/// Inputs for per-row mailbox, selection, and web-route sync.
+class PresentationEmailSyncContext {
+  const PresentationEmailSyncContext({
+    required this.mapMailboxById,
+    this.selectedMailbox,
+    this.searchQuery,
+    this.isSearchEmailRunning = false,
+  });
+
+  final Map<MailboxId, PresentationMailbox> mapMailboxById;
+  final PresentationMailbox? selectedMailbox;
+  final SearchQuery? searchQuery;
+  final bool isSearchEmailRunning;
+}
+
 extension ListPresentationEmailExtensions on List<PresentationEmail> {
+
+  /// Converts the executor's full search result into display-ready rows.
+  /// Keeps current selection by combining with [previousList].
+  List<PresentationEmail> toSyncedSearchResults({
+    required PresentationEmailSyncContext context,
+    required List<PresentationEmail> previousList,
+  }) {
+    return map((email) => email.toSearchPresentationEmail(context.mapMailboxById))
+        .toList()
+        .combine(previousList)
+        .syncPresentationEmail(
+          mapMailboxById: context.mapMailboxById,
+          selectedMailbox: context.selectedMailbox,
+          searchQuery: context.searchQuery,
+          isSearchEmailRunning: context.isSearchEmailRunning,
+        );
+  }
 
   List<PresentationEmail> syncPresentationEmail({
     required Map<MailboxId, PresentationMailbox> mapMailboxById,

--- a/lib/features/thread/presentation/thread_bindings.dart
+++ b/lib/features/thread/presentation/thread_bindings.dart
@@ -34,8 +34,6 @@ class ThreadBindings extends BaseBindings {
       Get.find<GetEmailsInMailboxInteractor>(),
       Get.find<RefreshChangesEmailsInMailboxInteractor>(),
       Get.find<LoadMoreEmailsInMailboxInteractor>(),
-      Get.find<SearchEmailInteractor>(),
-      Get.find<SearchMoreEmailInteractor>(),
       Get.find<GetEmailByIdInteractor>(),
       Get.find<CleanAndGetEmailsInMailboxInteractor>(),
     ));

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -17,6 +17,7 @@ import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/model.dart';
 import 'package:tmail_ui_user/features/base/base_controller.dart';
+import 'package:tmail_ui_user/features/base/handle_urgent_exception.dart';
 import 'package:tmail_ui_user/features/email/domain/model/mark_read_action.dart';
 import 'package:tmail_ui_user/features/email/domain/state/delete_email_permanently_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/delete_multiple_emails_permanently_state.dart';
@@ -35,6 +36,9 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_view_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/quick_search_filter_action_notifier.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/network_connection/presentation/network_connection_controller.dart'
   if (dart.library.html) 'package:tmail_ui_user/features/network_connection/presentation/web_network_connection_controller.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/websocket/web_socket_message.dart';
@@ -60,14 +64,15 @@ import 'package:tmail_ui_user/features/thread/domain/state/move_multiple_email_t
 import 'package:tmail_ui_user/features/thread/domain/state/refresh_all_email_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/refresh_changes_all_email_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/search_email_state.dart';
-import 'package:tmail_ui_user/features/thread/domain/state/search_more_email_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/clean_and_get_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/get_email_by_id_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/get_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/load_more_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor.dart';
-import 'package:tmail_ui_user/features/thread/domain/usecases/search_email_interactor.dart';
-import 'package:tmail_ui_user/features/thread/domain/usecases/search_more_email_interactor.dart';
+import 'package:tmail_ui_user/features/search/email/domain/execution/search_execution_intent.dart';
+import 'package:tmail_ui_user/features/search/email/domain/model/search_email_result.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_email_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
 import 'package:tmail_ui_user/features/thread/presentation/extensions/handle_email_filter_extension.dart';
 import 'package:tmail_ui_user/features/thread/presentation/extensions/handle_keyboard_shortcut_actions_extension.dart';
 import 'package:tmail_ui_user/features/thread/presentation/extensions/list_presentation_email_extensions.dart';
@@ -86,6 +91,8 @@ import 'package:tmail_ui_user/main/routes/route_utils.dart';
 import 'package:tmail_ui_user/main/utils/app_config.dart';
 import 'package:universal_html/html.dart' as html;
 
+part 'extensions/handle_search_email_execution_extension.dart';
+
 typedef StartRangeSelection = int;
 typedef EndRangeSelection = int;
 
@@ -96,8 +103,6 @@ class ThreadController extends BaseController with EmailActionController {
   final GetEmailsInMailboxInteractor _getEmailsInMailboxInteractor;
   final RefreshChangesEmailsInMailboxInteractor _refreshChangesEmailsInMailboxInteractor;
   final LoadMoreEmailsInMailboxInteractor _loadMoreEmailsInMailboxInteractor;
-  final SearchEmailInteractor _searchEmailInteractor;
-  final SearchMoreEmailInteractor _searchMoreEmailInteractor;
   final GetEmailByIdInteractor _getEmailByIdInteractor;
   final CleanAndGetEmailsInMailboxInteractor cleanAndGetEmailsInMailboxInteractor;
 
@@ -107,7 +112,8 @@ class ThreadController extends BaseController with EmailActionController {
   final loadingMoreStatus = Rx(LoadingMoreStatus.idle);
 
   bool canLoadMore = true;
-  bool canSearchMore = true;
+  bool get canSearchMore =>
+      appProviderContainer.read(searchEmailProvider.notifier).canLoadMore;
   MailboxId? _currentMemoryMailboxId;
   int _peakEmailCount = 0;
   final ScrollController listEmailController = ScrollController();
@@ -121,6 +127,9 @@ class ThreadController extends BaseController with EmailActionController {
 
   StreamSubscription<html.Event>? _resizeBrowserStreamSubscription;
   ProviderSubscription<PreferencesSetting>? _localSettingsSubscription;
+  ProviderSubscription<AsyncValue<SearchEmailResult>>? _searchEmailResultSubscription;
+  ProviderSubscription<SearchRequestRevision>? _searchFilterActionSubscription;
+  ProviderSubscription<SearchViewState>? _searchViewStateSubscription;
 
   AccountId? get _accountId => mailboxDashBoardController.accountId.value;
 
@@ -132,7 +141,11 @@ class ThreadController extends BaseController with EmailActionController {
 
   search.SearchController get searchController => mailboxDashBoardController.searchController;
 
-  SearchEmailFilter get _searchEmailFilter => searchController.searchEmailFilter.value;
+  SearchEmailFilter get _searchEmailFilter =>
+      appProviderContainer.read(searchFilterProvider);
+
+  SearchFilterNotifier get _searchFilterNotifier =>
+      appProviderContainer.read(searchFilterProvider.notifier);
 
   bool get _isCollapseThreadsEnabled =>
       appProviderContainer.read(localSettingsProvider).threadConfig.isEnabled;
@@ -145,8 +158,6 @@ class ThreadController extends BaseController with EmailActionController {
     this._getEmailsInMailboxInteractor,
     this._refreshChangesEmailsInMailboxInteractor,
     this._loadMoreEmailsInMailboxInteractor,
-    this._searchEmailInteractor,
-    this._searchMoreEmailInteractor,
     this._getEmailByIdInteractor,
     this.cleanAndGetEmailsInMailboxInteractor,
   );
@@ -157,6 +168,7 @@ class ThreadController extends BaseController with EmailActionController {
     if (PlatformInfo.isWeb) {
       _registerBrowserResizeListener();
       onKeyboardShortcutInit();
+      _registerSearchEmailResultBridge();
     }
     _initWebSocketQueueHandler();
     super.onInit();
@@ -178,6 +190,9 @@ class ThreadController extends BaseController with EmailActionController {
     }
     _webSocketQueueHandler?.dispose();
     _localSettingsSubscription?.close();
+    _searchEmailResultSubscription?.close();
+    _searchFilterActionSubscription?.close();
+    _searchViewStateSubscription?.close();
     super.onClose();
   }
 
@@ -188,11 +203,7 @@ class ThreadController extends BaseController with EmailActionController {
       _getAllEmailSuccess(success);
     } else if (success is LoadMoreEmailsSuccess) {
       _loadMoreEmailsSuccess(success);
-    } else if (success is SearchEmailSuccess) {
-      _searchEmailsSuccess(success);
-    } else if (success is SearchMoreEmailSuccess) {
-      _searchMoreEmailsSuccess(success);
-    } else if (success is SearchingMoreState || success is LoadingMoreEmails) {
+    } else if (success is LoadingMoreEmails) {
       loadingMoreStatus.value = LoadingMoreStatus.running;
     } else if (success is GetEmailByIdLoading) {
       openingEmail.value = true;
@@ -216,16 +227,7 @@ class ThreadController extends BaseController with EmailActionController {
   @override
   void handleFailureViewState(Failure failure) {
     super.handleFailureViewState(failure);
-    if (failure is SearchEmailFailure) {
-      mailboxDashBoardController.updateRefreshAllEmailState(Left(RefreshAllEmailFailure()));
-      canSearchMore = false;
-      loadingMoreStatus.value = LoadingMoreStatus.idle;
-      mailboxDashBoardController.emailsInCurrentMailbox.clear();
-      showRetryToast(failure);
-    } else if (failure is SearchMoreEmailFailure) {
-      loadingMoreStatus.value = LoadingMoreStatus.completed;
-      canSearchMore = true;
-    }  else if (failure is LoadMoreEmailsFailure) {
+    if (failure is LoadMoreEmailsFailure) {
       loadingMoreStatus.value = LoadingMoreStatus.completed;
       canLoadMore = true;
     } else if (failure is GetEmailByIdFailure) {
@@ -300,11 +302,26 @@ class ThreadController extends BaseController with EmailActionController {
       }
     });
 
-    ever(searchController.searchState, (searchState) {
-      if (searchState.searchStatus == SearchStatus.ACTIVE) {
+    _searchViewStateSubscription ??=
+        appProviderContainer.listen<SearchViewState>(
+      searchViewStateProvider,
+      (previous, next) {
+        if (previous?.searchState != next.searchState &&
+            next.searchState.searchStatus == SearchStatus.ACTIVE) {
+          cancelSelectEmail();
+        }
+      },
+    );
+
+    _searchFilterActionSubscription ??=
+        appProviderContainer.listen<SearchRequestRevision>(
+      quickSearchFilterActionProvider,
+      (previous, next) {
         cancelSelectEmail();
-      }
-    });
+        _replaceBrowserHistory();
+        _searchEmail();
+      },
+    );
 
     ever(mailboxDashBoardController.dashBoardAction, (action) {
       if (action is SelectionAllEmailAction) {
@@ -330,9 +347,9 @@ class ThreadController extends BaseController with EmailActionController {
         mailboxDashBoardController.clearDashBoardAction();
       } else if (action is StartSearchEmailAction
           || action is ClearAdvancedSearchFilterEmailAction) {
-        cancelSelectEmail();
-        _replaceBrowserHistory();
-        _searchEmail();
+        // Route session entry/clear through the single search trigger so
+        // `_searchEmail` has exactly one channel (the counter listener above).
+        appProviderContainer.read(quickSearchFilterActionProvider.notifier).requestSearch();
         mailboxDashBoardController.clearDashBoardAction();
       } else if (action is EmptyTrashAction && currentContext != null) {
         deleteSelectionEmailsPermanently(currentContext!, DeleteActionType.all);
@@ -357,7 +374,7 @@ class ThreadController extends BaseController with EmailActionController {
         if (listEmailController.hasClients) {
           listEmailController.jumpTo(0);
         }
-        canSearchMore = true;
+        appProviderContainer.read(searchEmailProvider.notifier).clearResult();
         mailboxDashBoardController.emailsInCurrentMailbox.clear();
       } else if (action is ReclaimMailListKeyboardShortcutFocusAction) {
         refocusMailShortcutFocus();
@@ -450,7 +467,7 @@ class ThreadController extends BaseController with EmailActionController {
       (previous, next) {
         if (previous?.threadConfig == next.threadConfig) return;
         if (searchController.isSearchEmailRunning) {
-          _searchEmail(limit: limitEmailFetched);
+          _searchEmail();
         } else if (forceEmailQuery) {
           getAllEmailAction(
             forceEmailQuery: forceEmailQuery,
@@ -599,7 +616,7 @@ class ThreadController extends BaseController with EmailActionController {
     mailboxDashBoardController.listEmailSelected.clear();
     mailboxDashBoardController.currentSelectMode.value = SelectMode.INACTIVE;
     canLoadMore = true;
-    canSearchMore = true;
+    appProviderContainer.read(searchEmailProvider.notifier).clearResult();
     loadingMoreStatus.value = LoadingMoreStatus.idle;
   }
 
@@ -759,7 +776,7 @@ class ThreadController extends BaseController with EmailActionController {
     cancelSelectEmail();
 
     if (searchController.isSearchEmailRunning) {
-      _searchEmail(limit: limitEmailFetched);
+      _searchEmail();
     } else {
       getAllEmailAction(forceEmailQuery: forceEmailQuery);
     }
@@ -799,55 +816,6 @@ class ThreadController extends BaseController with EmailActionController {
       if (mailboxDashBoardController.currentEmailState != null) {
         _webSocketQueueHandler?.removeMessagesUpToCurrent(
             mailboxDashBoardController.currentEmailState!.value);
-      }
-    }
-  }
-
-  @visibleForTesting
-  Future<void> refreshChangeSearchEmail() => _refreshChangeSearchEmail();
-
-  Future<void> _refreshChangeSearchEmail() async {
-    await _refreshChangeListEmailCache();
-
-    log('ThreadController::_refreshChangeSearchEmail:');
-    canSearchMore = true;
-    loadingMoreStatus.value = LoadingMoreStatus.idle;
-    searchController.resetCursorsForFreshSearch(
-      isCollapseThreadsEnabled: _isCollapseThreadsEnabled,
-    );
-    final searchViewState = await _searchEmailInteractor.execute(
-      _session!,
-      _accountId!,
-      limit: limitEmailFetched,
-      position: _searchEmailFilter.position,
-      sort: _searchEmailFilter.sortOrderType.getSortOrder().toNullable(),
-      filter: _searchEmailFilter.mappingToEmailFilterCondition(
-        moreFilterCondition: getFilterCondition(),
-        trashSpamMailboxIds: mailboxDashBoardController.trashSpamMailboxIds,
-      ),
-      properties: EmailUtils.getPropertiesForEmailGetMethod(
-        _session!,
-        _accountId!,
-      ),
-      collapseThreads: _isCollapseThreadsEnabled,
-      needRefreshSearchState: true,
-    ).last;
-
-    dispatchState(searchViewState);
-
-    final searchState = searchViewState
-        .foldSuccessWithResult<SearchEmailSuccess>();
-
-    if (searchState is SearchEmailSuccess) {
-      _searchEmailsSuccess(searchState);
-    } else {
-      mailboxDashBoardController.updateRefreshAllEmailState(
-          Left(RefreshAllEmailFailure()));
-      canSearchMore = false;
-      loadingMoreStatus.value = LoadingMoreStatus.completed;
-      mailboxDashBoardController.emailsInCurrentMailbox.clear();
-      if (searchState != null) {
-        onDataFailureViewState(searchState);
       }
     }
   }
@@ -1140,11 +1108,16 @@ class ThreadController extends BaseController with EmailActionController {
   }
 
   void filterMessagesAction(FilterMessageOption filterOption) {
-    final newFilterOption = mailboxDashBoardController.filterMessageOption.value == filterOption
+    final previousFilterOption = mailboxDashBoardController.filterMessageOption.value;
+    final newFilterOption = previousFilterOption == filterOption
         ? FilterMessageOption.all
         : filterOption;
 
     mailboxDashBoardController.filterMessageOption.value = newFilterOption;
+    _searchFilterNotifier.syncFilterMessageOptionChange(
+          previous: previousFilterOption,
+          next: newFilterOption,
+        );
 
     if (currentContext != null && currentOverlayContext != null) {
       appToast.showToastMessage(
@@ -1166,52 +1139,6 @@ class ThreadController extends BaseController with EmailActionController {
     searchController.clearTextSearch();
   }
 
-  @visibleForTesting
-  void searchEmail({
-    UnsignedInt? limit,
-    bool needRefreshSearchState = false,
-  }) => _searchEmail(
-    limit: limit,
-    needRefreshSearchState: needRefreshSearchState,
-  );
-
-  void _searchEmail({UnsignedInt? limit, bool needRefreshSearchState = false}) {
-    if (_session != null && _accountId != null) {
-      if (!needRefreshSearchState && listEmailController.hasClients) {
-        isListEmailScrollViewJumping = true;
-        listEmailController.jumpTo(0);
-      }
-      if (!needRefreshSearchState) {
-        mailboxDashBoardController.emailsInCurrentMailbox.clear();
-      }
-      canSearchMore = true;
-      loadingMoreStatus.value = LoadingMoreStatus.idle;
-
-      searchController.resetCursorsForFreshSearch(
-        isCollapseThreadsEnabled: _isCollapseThreadsEnabled,
-      );
-
-      searchController.activateSimpleSearch();
-
-      consumeState(_searchEmailInteractor.execute(
-        _session!,
-        _accountId!,
-        limit: limit ?? ThreadConstants.defaultLimit,
-        position: _searchEmailFilter.position,
-        sort: _searchEmailFilter.sortOrderType.getSortOrder().toNullable(),
-        filter: _searchEmailFilter.mappingToEmailFilterCondition(
-          moreFilterCondition: getFilterCondition(),
-          trashSpamMailboxIds: mailboxDashBoardController.trashSpamMailboxIds,
-        ),
-        properties: EmailUtils.getPropertiesForEmailGetMethod(_session!, _accountId!),
-        collapseThreads: _isCollapseThreadsEnabled,
-        needRefreshSearchState: needRefreshSearchState
-      ));
-    } else {
-      consumeState(Stream.value(Left(SearchEmailFailure(NotFoundSessionException()))));
-    }
-  }
-
   void _replaceBrowserHistory() {
     if (PlatformInfo.isWeb) {
       RouteUtils.replaceBrowserHistory(
@@ -1225,115 +1152,6 @@ class ThreadController extends BaseController with EmailActionController {
           )
         )
       );
-    }
-  }
-
-  void _searchEmailsSuccess(SearchEmailSuccess success) {
-    mailboxDashBoardController.updateRefreshAllEmailState(Right(RefreshAllEmailSuccess()));
-    final emailList = success.emailList;
-    log('ThreadController::_searchEmailsSuccess: COUNT = ${emailList.length}');
-    final resultEmailSearchList = emailList
-        .map((email) => email.toSearchPresentationEmail(mailboxDashBoardController.mapMailboxById))
-        .toList();
-
-    final emailsSearchBeforeChanges = mailboxDashBoardController.emailsInCurrentMailbox;
-    final emailsSearchAfterChanges = resultEmailSearchList;
-    final newListEmailSearch = emailsSearchAfterChanges.combine(emailsSearchBeforeChanges);
-    final newEmailListSynced = newListEmailSearch.syncPresentationEmail(
-      mapMailboxById: mailboxDashBoardController.mapMailboxById,
-      selectedMailbox: selectedMailbox,
-      searchQuery: searchController.searchQuery,
-      isSearchEmailRunning: isSearchActive,
-    );
-    mailboxDashBoardController.updateEmailList(newEmailListSynced);
-    if (mailboxDashBoardController.isSelectionEnabled()) {
-      mailboxDashBoardController.listEmailSelected.value = listEmailSelected;
-    }
-
-    if (_isAutoLoadMore && emailList.isNotEmpty) {
-      _performAutomaticallyLoadMoreEmails();
-    } else {
-      canSearchMore = emailList.isNotEmpty;
-      loadingMoreStatus.value = LoadingMoreStatus.completed;
-    }
-  }
-
-  @visibleForTesting
-  void searchMoreEmails() => _searchMoreEmails();
-
-  void _searchMoreEmails() {
-    log('ThreadController::_searchMoreEmails:');
-    if (!canSearchMore) return;
-
-    if (_session == null || _accountId == null) {
-      consumeState(
-        Stream.value(Left(SearchMoreEmailFailure(NotFoundSessionException()))),
-      );
-      return;
-    }
-
-    final currentEmailList = mailboxDashBoardController.emailsInCurrentMailbox;
-    if (currentEmailList.isEmpty) return;
-
-    final lastEmail = currentEmailList.last;
-    _updateLoadMoreCursor(currentEmailList, lastEmail);
-
-    consumeState(_searchMoreEmailInteractor.execute(
-      _session!,
-      _accountId!,
-      limit: ThreadConstants.defaultLimit,
-      sort: _searchEmailFilter.sortOrderType.getSortOrder().toNullable(),
-      position: _searchEmailFilter.position,
-      filter: _searchEmailFilter.mappingToEmailFilterCondition(
-        moreFilterCondition: getFilterCondition(),
-        trashSpamMailboxIds: mailboxDashBoardController.trashSpamMailboxIds,
-      ),
-      properties: EmailUtils.getPropertiesForEmailGetMethod(_session!, _accountId!),
-      collapseThreads: _isCollapseThreadsEnabled,
-      lastEmailId: lastEmail.id
-    ));
-  }
-
-  /// Advances the load-more cursor for the next page based on the active sort
-  /// order: position-based sorts (or collapsed threads) page by offset, while
-  /// time-based sorts page by the last email's `receivedAt`.
-  void _updateLoadMoreCursor(
-    List<PresentationEmail> currentEmailList,
-    PresentationEmail lastEmail,
-  ) {
-    if (_searchEmailFilter.sortOrderType.isScrollByPosition() || _isCollapseThreadsEnabled) {
-      final nextPosition = currentEmailList.length;
-      log('ThreadController::_searchMoreEmails:nextPosition: $nextPosition');
-      searchController.updateFilterEmail(positionOption: Some(nextPosition));
-    } else if (_searchEmailFilter.sortOrderType == EmailSortOrderType.oldest) {
-      searchController.updateFilterEmail(afterOption: optionOf(lastEmail.receivedAt));
-    } else if (_searchEmailFilter.sortOrderType == EmailSortOrderType.mostRecent) {
-      searchController.updateFilterEmail(beforeOption: optionOf(lastEmail.receivedAt));
-    }
-  }
-
-  void _searchMoreEmailsSuccess(SearchMoreEmailSuccess success) {
-    final emailList = success.emailList;
-    log('ThreadController::_searchMoreEmailsSuccess: COUNT = ${emailList.length}');
-    if (emailList.isNotEmpty) {
-      final resultEmailSearchList = emailList
-          .map((email) => email.toSearchPresentationEmail(mailboxDashBoardController.mapMailboxById))
-          .where((email) => mailboxDashBoardController.emailsInCurrentMailbox.every((emailInCurrentMailbox) => emailInCurrentMailbox.id != email.id))
-          .toList()
-          .syncPresentationEmail(
-            mapMailboxById: mailboxDashBoardController.mapMailboxById,
-            selectedMailbox: selectedMailbox,
-            searchQuery: searchController.searchQuery,
-            isSearchEmailRunning: isSearchActive,
-          );
-      mailboxDashBoardController.emailsInCurrentMailbox.addAll(resultEmailSearchList);
-    }
-
-    if (_isAutoLoadMore && emailList.isNotEmpty) {
-      _performAutomaticallyLoadMoreEmails();
-    } else {
-      canSearchMore = emailList.isNotEmpty;
-      loadingMoreStatus.value = LoadingMoreStatus.completed;
     }
   }
 
@@ -1667,10 +1485,9 @@ class ThreadController extends BaseController with EmailActionController {
     searchController.enableSearch();
     if (searchQuery != null) {
       searchController.updateTextSearch(searchQuery.value);
-      searchController.updateFilterEmail(
-        textOption: Some(searchQuery),
-        sortOrderTypeOption: Some(mailboxDashBoardController.currentSortOrder),
-      );
+      _searchFilterNotifier.update(SearchFilterPatch()
+        ..textOption = Some(searchQuery)
+        ..sortOrderTypeOption = Some(mailboxDashBoardController.currentSortOrder));
       if (currentContext != null) {
         FocusScope.of(currentContext!).unfocus();
       }
@@ -1685,10 +1502,9 @@ class ThreadController extends BaseController with EmailActionController {
     dispatchState(Right(SearchingState()));
     searchController.enableSearch();
     searchController.updateTextSearch(searchQuery.value);
-    searchController.updateFilterEmail(
-      textOption: Some(searchQuery),
-      sortOrderTypeOption: Some(mailboxDashBoardController.currentSortOrder),
-    );
+    _searchFilterNotifier.update(SearchFilterPatch()
+      ..textOption = Some(searchQuery)
+      ..sortOrderTypeOption = Some(mailboxDashBoardController.currentSortOrder));
     if (currentContext != null) {
       FocusScope.of(currentContext!).unfocus();
     }

--- a/lib/features/thread/presentation/thread_view.dart
+++ b/lib/features/thread/presentation/thread_view.dart
@@ -2,6 +2,7 @@ import 'package:core/core.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_portal/flutter_portal.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
@@ -11,7 +12,6 @@ import 'package:tmail_ui_user/features/base/mixin/app_loader_mixin.dart';
 import 'package:tmail_ui_user/features/base/mixin/popup_menu_widget_mixin.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/base/widget/clean_messages_banner.dart';
-import 'package:tmail_ui_user/features/base/widget/compose_floating_button.dart';
 import 'package:tmail_ui_user/features/base/widget/keyboard/keyboard_handler_wrapper.dart';
 import 'package:tmail_ui_user/features/base/widget/report_message_banner.dart';
 import 'package:tmail_ui_user/features/email/presentation/extensions/presentation_email_extension.dart';
@@ -28,12 +28,14 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_open_context_menu_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/labels/handle_logic_label_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/open_and_close_composer_extension.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/empty_trash_banner_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/recover_deleted_message_loading_banner_widget.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/extensions/vacation_response_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/vacation/widgets/vacation_notification_message_widget.dart';
 import 'package:tmail_ui_user/features/network_connection/presentation/network_connection_banner_widget.dart';
 import 'package:tmail_ui_user/features/quotas/presentation/widget/quotas_banner_widget.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/clean_and_get_all_email_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/empty_spam_folder_state.dart';
@@ -57,6 +59,7 @@ import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_bu
   if (dart.library.html) 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_web_builder.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/empty_emails_widget.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/scroll_to_top_button_widget.dart';
+import 'package:tmail_ui_user/features/thread/presentation/widgets/thread_compose_floating_button.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/thread_view_loading_bar_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/dialogs/empty_trash_confirmation_dialog.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
@@ -289,7 +292,16 @@ class ThreadView extends GetWidget<ThreadController>
               return const SizedBox.shrink();
             }
           }),
-          _buildFloatingButtonCompose(context),
+          Obx(() {
+            return ThreadComposeFloatingButton(
+              responsiveUtils: controller.responsiveUtils,
+              scrollController: controller.listEmailController,
+              isTrashViewOpen: controller.isMailboxTrash,
+              isSelectModeActive: controller.mailboxDashBoardController.isSelectionEnabled(),
+              hasSelectedEmails: controller.listEmailSelected.isNotEmpty,
+              onTapCompose: () => controller.mailboxDashBoardController.openComposer(ComposerArguments()),
+            );
+          }),
         ],
       ),
     );
@@ -314,37 +326,6 @@ class ThreadView extends GetWidget<ThreadController>
         controller.responsiveUtils.isTabletLarge(context) ||
         controller.responsiveUtils.isLandscapeTablet(context);
     }
-  }
-
-  Widget _buildFloatingButtonCompose(BuildContext context) {
-    if (controller.responsiveUtils.isWebDesktop(context)) {
-      return const SizedBox.shrink();
-    }
-
-    return Obx(() {
-      final isAdvancedSearchViewOpen = controller.searchController.isAdvancedSearchViewOpen.value;
-      final isTrashViewOpen = controller.isMailboxTrash;
-      final isSelectModeActive = controller.mailboxDashBoardController.currentSelectMode.value == SelectMode.ACTIVE;
-      if (
-        !controller.searchController.isSearchActive()
-        && !isAdvancedSearchViewOpen
-        && !isTrashViewOpen
-        && !isSelectModeActive
-      ) {
-        return Container(
-          padding: PlatformInfo.isMobile && controller.listEmailSelected.isNotEmpty
-            ? EdgeInsets.only(bottom: controller.responsiveUtils.isTabletLarge(context) ? 85 : 70)
-            : EdgeInsets.zero,
-          child: ComposeFloatingButton(
-            key: const ValueKey(UiKeys.composeEmailButton),
-            scrollController: controller.listEmailController,
-            onTap: () => controller.mailboxDashBoardController.openComposer(ComposerArguments())
-          ),
-        );
-      } else {
-        return const SizedBox.shrink();
-      }
-    });
   }
 
   Widget _buildResultListEmail(BuildContext context, List<PresentationEmail> listPresentationEmail) {
@@ -503,108 +484,116 @@ class ThreadView extends GetWidget<ThreadController>
   Widget _buildEmailItemWhenDragging(BuildContext context, PresentationEmail presentationEmail) {
     final dashboardController = controller.mailboxDashBoardController;
 
-    return Obx(() {
-      final selectAllMode = dashboardController.currentSelectMode.value;
+    return Consumer(builder: (context, ref, _) {
+      final searchViewState = ref.watch(searchViewStateProvider);
+      final searchFilter = ref.watch(searchFilterProvider);
+      return Obx(() {
+        final selectAllMode = dashboardController.currentSelectMode.value;
 
-      final isSenderImportantFlagEnabled =
-          dashboardController.isSenderImportantFlagEnabled.value;
+        final isSenderImportantFlagEnabled =
+            dashboardController.isSenderImportantFlagEnabled.value;
 
-      final isShowingEmailContent =
-          dashboardController.selectedEmail.value?.id == presentationEmail.id;
+        final isShowingEmailContent =
+            dashboardController.selectedEmail.value?.id == presentationEmail.id;
 
-      final isSearchEmailRunning =
-          controller.searchController.isSearchEmailRunning;
+        final isSearchEmailRunning =
+            searchViewState.isSearchEmailRunning;
 
-      final isAINeedsActionEnabled = dashboardController.isAINeedsActionEnabled;
+        final isAINeedsActionEnabled = dashboardController.isAINeedsActionEnabled;
 
-      final isLabelMailboxOpened =
-          dashboardController.selectedMailbox.value?.isLabelMailbox == true;
+        final isLabelMailboxOpened =
+            dashboardController.selectedMailbox.value?.isLabelMailbox == true;
 
-      return EmailTileBuilder(
-        key: Key('email_tile_builder_${presentationEmail.id?.asString}'),
-        presentationEmail: presentationEmail,
-        selectAllMode: selectAllMode,
-        isShowingEmailContent: isShowingEmailContent,
-        searchQuery: controller.searchQuery,
-        mailboxContain: presentationEmail.mailboxContain,
-        isSearchEmailRunning: isSearchEmailRunning,
-        isLabelMailboxOpened: isLabelMailboxOpened,
-        isDrag: true,
-        isSenderImportantFlagEnabled: isSenderImportantFlagEnabled,
-        isAINeedsActionEnabled: isAINeedsActionEnabled,
-      );
+        return EmailTileBuilder(
+          key: Key('email_tile_builder_${presentationEmail.id?.asString}'),
+          presentationEmail: presentationEmail,
+          selectAllMode: selectAllMode,
+          isShowingEmailContent: isShowingEmailContent,
+          searchQuery: searchFilter.text,
+          mailboxContain: presentationEmail.mailboxContain,
+          isSearchEmailRunning: isSearchEmailRunning,
+          isLabelMailboxOpened: isLabelMailboxOpened,
+          isDrag: true,
+          isSenderImportantFlagEnabled: isSenderImportantFlagEnabled,
+          isAINeedsActionEnabled: isAINeedsActionEnabled,
+        );
+      });
     });
   }
 
   Widget _buildEmailItemNotDraggable(BuildContext context, PresentationEmail presentationEmail) {
     final dashboardController = controller.mailboxDashBoardController;
 
-    return Obx(() {
-      final selectModeAll = dashboardController.currentSelectMode.value;
+    return Consumer(builder: (context, ref, _) {
+      final searchViewState = ref.watch(searchViewStateProvider);
+      final searchFilter = ref.watch(searchFilterProvider);
+      return Obx(() {
+        final selectModeAll = dashboardController.currentSelectMode.value;
 
-      final isSenderImportantFlagEnabled =
-          dashboardController.isSenderImportantFlagEnabled.value;
+        final isSenderImportantFlagEnabled =
+            dashboardController.isSenderImportantFlagEnabled.value;
 
-      final isShowingEmailContent =
-          dashboardController.selectedEmail.value?.id == presentationEmail.id;
+        final isShowingEmailContent =
+            dashboardController.selectedEmail.value?.id == presentationEmail.id;
 
-      final isSearchEmailRunning =
-          controller.searchController.isSearchEmailRunning;
+        final isSearchEmailRunning =
+            searchViewState.isSearchEmailRunning;
 
-      final isAINeedsActionEnabled = dashboardController.isAINeedsActionEnabled;
+        final isAINeedsActionEnabled = dashboardController.isAINeedsActionEnabled;
 
-      final isLabelAvailable = controller
-          .mailboxDashBoardController.isLabelAvailable;
+        final isLabelAvailable = controller
+            .mailboxDashBoardController.isLabelAvailable;
 
-      final listLabels =
-          controller.mailboxDashBoardController.labelController.labels;
+        final listLabels =
+            controller.mailboxDashBoardController.labelController.labels;
 
-      final isLabelMailboxOpened =
-          controller.selectedMailbox?.isLabelMailbox == true;
+        final isLabelMailboxOpened =
+            controller.selectedMailbox?.isLabelMailbox == true;
 
-      List<Label>? emailLabels;
+        List<Label>? emailLabels;
 
-      if (isLabelAvailable) {
-        emailLabels = presentationEmail.getLabelList(listLabels);
-      }
+        if (isLabelAvailable) {
+          emailLabels = presentationEmail.getLabelList(listLabels);
+        }
 
-      return Dismissible(
-        key: ValueKey<EmailId?>(presentationEmail.id),
-        direction: controller.getSwipeDirection(
-            controller.responsiveUtils.isWebDesktop(context),
-            selectModeAll,
-            presentationEmail
-        ),
-        background: _buildEmailSwipeBackground(context, presentationEmail),
-        secondaryBackground: controller.isInArchiveMailbox(presentationEmail)
-            ? null
-            : _buildEmailSwipeSecondaryBackground(context),
-        confirmDismiss: (direction) => controller.swipeEmailAction(
-          presentationEmail,
-          direction,
-        ),
-        child: EmailTileBuilder(
-          key: Key('email_tile_builder_${presentationEmail.id?.asString}'),
-          presentationEmail: presentationEmail,
-          selectAllMode: selectModeAll,
-          isShowingEmailContent: isShowingEmailContent,
-          isSenderImportantFlagEnabled: isSenderImportantFlagEnabled,
-          searchQuery: controller.searchQuery,
-          mailboxContain: presentationEmail.mailboxContain,
-          isSearchEmailRunning: isSearchEmailRunning,
-          isAINeedsActionEnabled: isAINeedsActionEnabled,
-          isLabelMailboxOpened: isLabelMailboxOpened,
-          labels: emailLabels,
-          emailActionClick: _handleEmailActionClicked,
-          onMoreActionClick: (email, position) => _openMoreActionForEmail(
-            context: context,
-            email: email,
-            position: position,
-            isLabelAvailable: isLabelAvailable,
-            listLabels: listLabels,
+        return Dismissible(
+          key: ValueKey<EmailId?>(presentationEmail.id),
+          direction: controller.getSwipeDirection(
+              controller.responsiveUtils.isWebDesktop(context),
+              selectModeAll,
+              presentationEmail
           ),
-        ),
-      );
+          background: _buildEmailSwipeBackground(context, presentationEmail),
+          secondaryBackground: controller.isInArchiveMailbox(presentationEmail)
+              ? null
+              : _buildEmailSwipeSecondaryBackground(context),
+          confirmDismiss: (direction) => controller.swipeEmailAction(
+            presentationEmail,
+            direction,
+          ),
+          child: EmailTileBuilder(
+            key: Key('email_tile_builder_${presentationEmail.id?.asString}'),
+            presentationEmail: presentationEmail,
+            selectAllMode: selectModeAll,
+            isShowingEmailContent: isShowingEmailContent,
+            isSenderImportantFlagEnabled: isSenderImportantFlagEnabled,
+            searchQuery: searchFilter.text,
+            mailboxContain: presentationEmail.mailboxContain,
+            isSearchEmailRunning: isSearchEmailRunning,
+            isAINeedsActionEnabled: isAINeedsActionEnabled,
+            isLabelMailboxOpened: isLabelMailboxOpened,
+            labels: emailLabels,
+            emailActionClick: _handleEmailActionClicked,
+            onMoreActionClick: (email, position) => _openMoreActionForEmail(
+              context: context,
+              email: email,
+              position: position,
+              isLabelAvailable: isLabelAvailable,
+              listLabels: listLabels,
+            ),
+          ),
+        );
+      });
     });
   }
 

--- a/lib/features/thread/presentation/widgets/thread_compose_floating_button.dart
+++ b/lib/features/thread/presentation/widgets/thread_compose_floating_button.dart
@@ -1,0 +1,72 @@
+import 'package:core/core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
+import 'package:tmail_ui_user/features/base/widget/compose_floating_button.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
+
+typedef OnTapThreadComposeAction = void Function();
+
+class ThreadComposeFloatingButton extends ConsumerWidget {
+  final ResponsiveUtils responsiveUtils;
+  final ScrollController scrollController;
+  final bool isTrashViewOpen;
+  final bool isSelectModeActive;
+  final bool hasSelectedEmails;
+  final OnTapThreadComposeAction onTapCompose;
+
+  const ThreadComposeFloatingButton({
+    super.key,
+    required this.responsiveUtils,
+    required this.scrollController,
+    required this.isTrashViewOpen,
+    required this.isSelectModeActive,
+    required this.hasSelectedEmails,
+    required this.onTapCompose,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (responsiveUtils.isWebDesktop(context)) {
+      return const SizedBox.shrink();
+    }
+
+    final searchViewState = ref.watch(searchViewStateProvider);
+    final canShowComposeButton = _canShowComposeButton(
+      isSearchEngaged: searchViewState.isSearchEngaged,
+      isTrashViewOpen: isTrashViewOpen,
+      isSelectModeActive: isSelectModeActive,
+    );
+
+    if (!canShowComposeButton) {
+      return const SizedBox.shrink();
+    }
+
+    return Padding(
+      padding: _resolveButtonPadding(context),
+      child: ComposeFloatingButton(
+        key: const ValueKey(UiKeys.composeEmailButton),
+        scrollController: scrollController,
+        onTap: onTapCompose
+      ),
+    );
+  }
+
+  /// Hidden inside any search UI, the trash view, or selection mode.
+  bool _canShowComposeButton({
+    required bool isSearchEngaged,
+    required bool isTrashViewOpen,
+    required bool isSelectModeActive,
+  }) =>
+      !isSearchEngaged && !isTrashViewOpen && !isSelectModeActive;
+
+  EdgeInsetsGeometry _resolveButtonPadding(BuildContext context) {
+    // Only mobile with a selection needs to clear the bottom action bar.
+    final needsBottomInset = PlatformInfo.isMobile && hasSelectedEmails;
+    if (!needsBottomInset) return EdgeInsets.zero;
+
+    return EdgeInsets.only(
+      bottom: responsiveUtils.isTabletLarge(context) ? 85 : 70,
+    );
+  }
+}

--- a/test/features/mailbox_dashboard/presentation/controller/advanced_filter_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/advanced_filter_controller_test.dart
@@ -37,6 +37,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/advanced_search/advanced_search_filter_form_bottom_view.dart';
 import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
@@ -126,6 +127,9 @@ void main() {
   SearchEmailFilter committedFilter() =>
       appProviderContainer.read(searchFilterProvider);
 
+  bool advancedSearchActive() =>
+      appProviderContainer.read(searchViewStateProvider).advancedSearchIsActivated;
+
   setUpAll(() {
     Get.testMode = true;
     // Mock base controller
@@ -194,20 +198,21 @@ void main() {
   });
 
   setUp(() {
-    // Reset synchronously (not invalidate) so no deferred rebuild flushes mid-test.
     appProviderContainer
         .read(searchFilterProvider.notifier)
         .set(SearchEmailFilter.initial());
+    // View state is a keepAlive provider with no public reset; invalidate it.
+    appProviderContainer.invalidate(searchViewStateProvider);
     searchController.deactivateAdvancedSearch();
     searchController.deactivateSimpleSearch();
-    searchController.isAdvancedSearchViewOpen.value = false;
+    searchController.closeAdvanceSearch();
     clearInteractions(mockMailboxDashBoardController);
   });
 
   group('AdvancedFilterController::test', () {
     group('applyAdvancedSearchFilter::test', () {
       test(
-        'SHOULD keep the committed filter and search controller mirror in sync\n'
+        'SHOULD execute search from the committed filter SSOT\n'
         'WHEN the committed advanced filter is applied',
       () async {
         // Arrange
@@ -237,11 +242,12 @@ void main() {
         await untilCalled(mockMailboxDashBoardController.handleAdvancedSearchEmail());
 
         final committedSearchFilter = appProviderContainer.read(searchFilterProvider);
-        final searchFilter = searchController.searchEmailFilter.value;
 
         // Assert
         verify(mockMailboxDashBoardController.handleAdvancedSearchEmail()).called(1);
-        expect(committedSearchFilter, equals(searchFilter));
+        expect(committedSearchFilter.from, {'user1@example.com'});
+        expect(committedSearchFilter.to, {'user2@example.com'});
+        expect(committedSearchFilter.subject, 'Subject');
       });
 
       test(
@@ -258,7 +264,7 @@ void main() {
         await untilCalled(mockMailboxDashBoardController.handleAdvancedSearchEmail());
 
         // Assert
-        expect(searchController.advancedSearchIsActivated.value, isTrue);
+        expect(advancedSearchActive(), isTrue);
       });
 
       test(
@@ -276,7 +282,7 @@ void main() {
         await untilCalled(mockMailboxDashBoardController.handleAdvancedSearchEmail());
 
         // Assert
-        expect(searchController.advancedSearchIsActivated.value, isFalse);
+        expect(advancedSearchActive(), isFalse);
       });
     });
 
@@ -612,7 +618,7 @@ void main() {
             checkboxCase.readFlag(
               appProviderContainer.read(searchFilterProvider)),
             isTrue);
-          expect(searchController.advancedSearchIsActivated.value, isFalse);
+          expect(advancedSearchActive(), isFalse);
           verifyNever(
             mockMailboxDashBoardController.handleAdvancedSearchEmail());
         });
@@ -637,7 +643,7 @@ void main() {
             checkboxCase.readFlag(
               appProviderContainer.read(searchFilterProvider)),
             isFalse);
-          expect(searchController.advancedSearchIsActivated.value, isFalse);
+          expect(advancedSearchActive(), isFalse);
           verifyNever(
             mockMailboxDashBoardController.handleAdvancedSearchEmail());
         });
@@ -663,7 +669,7 @@ void main() {
 
         verify(
           mockMailboxDashBoardController.handleAdvancedSearchEmail()).called(1);
-        expect(searchController.advancedSearchIsActivated.value, isTrue);
+        expect(advancedSearchActive(), isTrue);
         expect(
           appProviderContainer.read(searchFilterProvider).hasAttachment,
           isTrue);
@@ -690,7 +696,7 @@ void main() {
 
         verify(
           mockMailboxDashBoardController.handleAdvancedSearchEmail()).called(1);
-        expect(searchController.advancedSearchIsActivated.value, isFalse);
+        expect(advancedSearchActive(), isFalse);
         expect(
           appProviderContainer.read(searchFilterProvider).hasAttachment,
           isFalse);

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -571,9 +571,6 @@ void main() {
       expect(filterAfterAdvancedSearch.text, equals(SearchQuery(emailContainsWord)));
       expect(filterAfterAdvancedSearch.notKeyword, equals({emailNotContainsWord}));
       expect(filterAfterAdvancedSearch.emailReceiveTimeType, equals(EmailReceiveTimeType.last30Days));
-      // Pagination position is resolved on the transient request spec by the
-      // executor; it is never written to the committed SSOT (ADR-0093).
-      expect(filterAfterAdvancedSearch.position, isNull);
       expect(filterAfterAdvancedSearch.startDate, isNotNull);
       expect(filterAfterAdvancedSearch.endDate, isNotNull);
       expect(filterAfterAdvancedSearch.before, isNull);
@@ -644,9 +641,6 @@ void main() {
     expect(filterAfterQuickSearch.text, equals(SearchQuery(queryString)));
     expect(filterAfterQuickSearch.emailReceiveTimeType, equals(EmailReceiveTimeType.last30Days));
     expect(filterAfterQuickSearch.hasAttachment, isTrue);
-    // Pagination position is resolved on the transient request spec by the
-    // executor; it is never written to the committed SSOT (ADR-0093).
-    expect(filterAfterQuickSearch.position, isNull);
     expect(filterAfterQuickSearch.startDate, isNotNull);
     expect(filterAfterQuickSearch.endDate, isNotNull);
     expect(filterAfterQuickSearch.before, isNull);
@@ -686,19 +680,17 @@ void main() {
 
     test(
       'WHEN setUpDefaultEmailSortOrder is called while load-more cursors are set\n'
-      'SHOULD keep before/after/position out of the committed SSOT',
+      'SHOULD keep before/after cursors out of the committed SSOT',
     () {
       searchFilterNotifier().set(SearchEmailFilter(
         before: UTCDate(DateTime.now()),
         after: UTCDate(DateTime.now()),
-        position: 20,
       ));
 
       mailboxDashboardController.setUpDefaultEmailSortOrder(EmailSortOrderType.oldest);
 
       expect(committedFilter().before, isNull);
       expect(committedFilter().after, isNull);
-      expect(committedFilter().position, isNull);
     });
 
     test(

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -77,7 +77,9 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/remove_
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/remove_email_drafts_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/save_recent_search_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/store_email_sort_order_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/action/dashboard_action.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/action/download_ui_action.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/select_search_filter_action_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/advanced_filter_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/app_grid_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
@@ -737,6 +739,99 @@ void main() {
         EmailSortOrderType.subjectAscending,
       );
       expect(searchController.sortOrderFiltered, EmailSortOrderType.subjectAscending);
+    });
+
+    group('onDeleteSearchFilterAction:', () {
+      setUp(() => searchFilterNotifier().set(SearchEmailFilter.initial()));
+
+      test(
+        'WHEN deleting the dateTime quick filter\n'
+        'SHOULD reset receive time to allTime AND dispatch '
+        'SelectDateRangeToAdvancedSearch(allTime)',
+      () {
+        searchFilterNotifier().setReceiveTime(EmailReceiveTimeType.last30Days);
+
+        mailboxDashboardController.onDeleteSearchFilterAction(
+          searchFilterActionNotifier(),
+          QuickSearchFilter.dateTime,
+        );
+
+        expect(
+          committedFilter().emailReceiveTimeType,
+          EmailReceiveTimeType.allTime,
+        );
+        final action = mailboxDashboardController.dashBoardAction.value;
+        expect(action, isA<SelectDateRangeToAdvancedSearch>());
+        expect(
+          (action as SelectDateRangeToAdvancedSearch).receiveTime,
+          EmailReceiveTimeType.allTime,
+        );
+      });
+
+      test(
+        'WHEN deleting the sortBy quick filter\n'
+        'SHOULD reset sort order to default in both the committed filter '
+        'and currentSortOrder',
+      () {
+        searchFilterNotifier().setSortOrder(EmailSortOrderType.oldest);
+
+        mailboxDashboardController.onDeleteSearchFilterAction(
+          searchFilterActionNotifier(),
+          QuickSearchFilter.sortBy,
+        );
+
+        expect(
+          committedFilter().sortOrderType,
+          SearchEmailFilter.defaultSortOrder,
+        );
+        expect(
+          mailboxDashboardController.currentSortOrder,
+          SearchEmailFilter.defaultSortOrder,
+        );
+      });
+
+      test(
+        'WHEN deleting a mapped chip filter that is neither dateTime nor sortBy '
+        '(hasAttachment)\n'
+        'SHOULD clear that filter WITHOUT dispatching a date-range action or '
+        'changing the sort order',
+      () {
+        searchFilterActionNotifier()
+            .selectQuickSearchFilter(QuickSearchFilter.hasAttachment);
+        mailboxDashboardController.storeEmailSortOrder(EmailSortOrderType.oldest);
+        mailboxDashboardController.dashBoardAction.value = null;
+
+        mailboxDashboardController.onDeleteSearchFilterAction(
+          searchFilterActionNotifier(),
+          QuickSearchFilter.hasAttachment,
+        );
+
+        expect(committedFilter().hasAttachment, isFalse);
+        expect(mailboxDashboardController.dashBoardAction.value, isNull);
+        expect(
+          mailboxDashboardController.currentSortOrder,
+          EmailSortOrderType.oldest,
+        );
+      });
+
+      test(
+        'WHEN deleting a quick filter with no delete mapping (fromMe)\n'
+        'SHOULD be a no-op: no action dispatched and sort order unchanged',
+      () {
+        mailboxDashboardController.storeEmailSortOrder(EmailSortOrderType.oldest);
+        mailboxDashboardController.dashBoardAction.value = null;
+
+        mailboxDashboardController.onDeleteSearchFilterAction(
+          searchFilterActionNotifier(),
+          QuickSearchFilter.fromMe,
+        );
+
+        expect(mailboxDashboardController.dashBoardAction.value, isNull);
+        expect(
+          mailboxDashboardController.currentSortOrder,
+          EmailSortOrderType.oldest,
+        );
+      });
     });
 
     tearDown(() {

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -4,7 +4,6 @@ import 'package:core/data/network/config/dynamic_url_interceptors.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/app_toast.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
-import 'package:dartz/dartz.dart' hide State;
 import 'package:flutter/widgets.dart' hide State;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
@@ -86,7 +85,9 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/spam_report_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/quick_search_filter_action_notifier.dart';
 import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
 import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
@@ -327,6 +328,13 @@ void main() {
   final testMailboxId = MailboxId(Id('1'));
   final testAccountId = AccountId(Id('123'));
 
+  SearchEmailFilter committedFilter() =>
+      appProviderContainer.read(searchFilterProvider);
+  SearchFilterNotifier searchFilterNotifier() =>
+      appProviderContainer.read(searchFilterProvider.notifier);
+  QuickSearchFilterActionNotifier searchFilterActionNotifier() =>
+      appProviderContainer.read(quickSearchFilterActionProvider.notifier);
+
   setUp(() {
     Get.put<RemoveEmailDraftsInteractor>(removeEmailDraftsInteractor);
     Get.put<EmailReceiveManager>(emailReceiveManager);
@@ -433,12 +441,14 @@ void main() {
         refreshAllMailboxInteractor);
       mailboxController.onReady();
 
+      // The central SearchEmailNotifier executor resolves its interactors via
+      // Get.find; register the mocks so ThreadController's delegated searches run.
+      Get.put<SearchEmailInteractor>(searchEmailInteractor);
+      Get.put<SearchMoreEmailInteractor>(searchMoreEmailInteractor);
       threadController = ThreadController(
         getEmailsInMailboxInteractor,
         refreshChangesEmailsInMailboxInteractor,
         loadMoreEmailsInMailboxInteractor,
-        searchEmailInteractor,
-        searchMoreEmailInteractor,
         getEmailByIdInteractor,
         cleanAndGetEmailsInMailboxInteractor);
       Get.put(threadController);
@@ -464,19 +474,27 @@ void main() {
       when(labelController.isLabelSettingEnabled).thenReturn(isLabelSettingEnabled);
       
       // expect query in search controller update as expected
-      mailboxDashboardController.searchEmailByQueryString(queryString);
-      expect(searchController.searchEmailFilter.value.text, SearchQuery(queryString));
+      searchController.searchInputController.text = queryString;
+      mailboxDashboardController.searchEmailByQueryString();
+      expect(committedFilter().text, SearchQuery(queryString));
       
       // expect sort in search controller update as expected
       mailboxDashboardController.selectSortOrderQuickSearchFilter(
-        EmailSortOrderType.oldest);
+        EmailSortOrderType.oldest,
+        searchFilterActionNotifier(),
+      );
       expect(searchController.sortOrderFiltered, EmailSortOrderType.oldest);
 
       // expect filter in search controller update as expected
-      mailboxDashboardController.selectHasAttachmentSearchFilter();
-      expect(searchController.searchEmailFilter.value.hasAttachment, true);
-      mailboxDashboardController.selectReceiveTimeQuickSearchFilter(context, EmailReceiveTimeType.last30Days);
-      expect(searchController.searchEmailFilter.value.emailReceiveTimeType, EmailReceiveTimeType.last30Days);
+      searchFilterActionNotifier()
+          .selectQuickSearchFilter(QuickSearchFilter.hasAttachment);
+      expect(committedFilter().hasAttachment, true);
+      mailboxDashboardController.selectReceiveTimeQuickSearchFilter(
+        context,
+        EmailReceiveTimeType.last30Days,
+        searchFilterActionNotifier(),
+      );
+      expect(committedFilter().emailReceiveTimeType, EmailReceiveTimeType.last30Days);
 
       // expect mailbox dashboard controller calls GetEmailsInMailboxInteractor
       // when [selectedMailbox] is changed and triggered obx listener in thread controller
@@ -494,7 +512,7 @@ void main() {
         collapseThreads: anyNamed('collapseThreads'),
       ));
       expect(searchController.sortOrderFiltered, EmailSortOrderType.oldest);
-      expect(searchController.searchEmailFilter.value, SearchEmailFilter.withSortOrder(EmailSortOrderType.oldest));
+      expect(committedFilter(), SearchEmailFilter.withSortOrder(EmailSortOrderType.oldest));
       verify(getEmailsInMailboxInteractor.execute(
         testSession, testAccountId,
         limit: ThreadConstants.defaultLimit,
@@ -541,7 +559,7 @@ void main() {
       advancedFilterController.applyAdvancedSearchFilter(
         committedFilter: appProviderContainer.read(searchFilterProvider),
         filterNotifier: filterNotifier);
-      final filterAfterAdvancedSearch = searchController.searchEmailFilter.value;
+      final filterAfterAdvancedSearch = committedFilter();
       expect(filterAfterAdvancedSearch.from, equals({fromEmailAddress.email!}));
       expect(filterAfterAdvancedSearch.to, equals({toEmailAddress.email!}));
       expect(filterAfterAdvancedSearch.subject, equals(emailSubject));
@@ -549,7 +567,9 @@ void main() {
       expect(filterAfterAdvancedSearch.text, equals(SearchQuery(emailContainsWord)));
       expect(filterAfterAdvancedSearch.notKeyword, equals({emailNotContainsWord}));
       expect(filterAfterAdvancedSearch.emailReceiveTimeType, equals(EmailReceiveTimeType.last30Days));
-      expect(filterAfterAdvancedSearch.position, equals(0));
+      // Pagination position is resolved on the transient request spec by the
+      // executor; it is never written to the committed SSOT (ADR-0093).
+      expect(filterAfterAdvancedSearch.position, isNull);
       expect(filterAfterAdvancedSearch.startDate, isNotNull);
       expect(filterAfterAdvancedSearch.endDate, isNotNull);
       expect(filterAfterAdvancedSearch.before, isNull);
@@ -571,7 +591,7 @@ void main() {
         collapseThreads: anyNamed('collapseThreads'),
       ));
       expect(searchController.sortOrderFiltered, SearchEmailFilter.defaultSortOrder);
-      expect(searchController.searchEmailFilter.value, SearchEmailFilter.initial());
+      expect(committedFilter(), SearchEmailFilter.initial());
       verify(getEmailsInMailboxInteractor.execute(
         testSession, testAccountId,
         limit: ThreadConstants.defaultLimit,
@@ -595,9 +615,15 @@ void main() {
     when(context.owner).thenReturn(BuildOwner(focusManager: FocusManager()));
 
     // act
-    mailboxDashboardController.searchEmailByQueryString(queryString);
-    mailboxDashboardController.selectHasAttachmentSearchFilter();
-    mailboxDashboardController.selectReceiveTimeQuickSearchFilter(context, EmailReceiveTimeType.last30Days);
+    searchController.searchInputController.text = queryString;
+    mailboxDashboardController.searchEmailByQueryString();
+    searchFilterActionNotifier()
+        .selectQuickSearchFilter(QuickSearchFilter.hasAttachment);
+    mailboxDashboardController.selectReceiveTimeQuickSearchFilter(
+      context,
+      EmailReceiveTimeType.last30Days,
+      searchFilterActionNotifier(),
+    );
 
     await untilCalled(searchEmailInteractor.execute(
       any,
@@ -610,16 +636,39 @@ void main() {
       properties: anyNamed('properties')));
 
     // assert
-    final filterAfterQuickSearch = searchController.searchEmailFilter.value;
+    final filterAfterQuickSearch = committedFilter();
     expect(filterAfterQuickSearch.text, equals(SearchQuery(queryString)));
     expect(filterAfterQuickSearch.emailReceiveTimeType, equals(EmailReceiveTimeType.last30Days));
     expect(filterAfterQuickSearch.hasAttachment, isTrue);
-    expect(filterAfterQuickSearch.position, equals(0));
+    // Pagination position is resolved on the transient request spec by the
+    // executor; it is never written to the committed SSOT (ADR-0093).
+    expect(filterAfterQuickSearch.position, isNull);
     expect(filterAfterQuickSearch.startDate, isNotNull);
     expect(filterAfterQuickSearch.endDate, isNotNull);
     expect(filterAfterQuickSearch.before, isNull);
     expect(filterAfterQuickSearch.after, isNull);
   });
+
+    test(
+      'WHEN the search query changes from an email address to plain text\n'
+      'SHOULD drop the auto-routed sender so it no longer narrows the search',
+    () {
+      // arrange
+      when(context.owner).thenReturn(BuildOwner(focusManager: FocusManager()));
+
+      // Search by a bare email address: routed to `from`, text cleared.
+      searchController.searchInputController.text = 'alice@example.com';
+      mailboxDashboardController.searchEmailByQueryString();
+      expect(committedFilter().from, equals({'alice@example.com'}));
+      expect(committedFilter().text, isNull);
+
+      // Search by plain text: the previously derived sender must be cleared so
+      // the next request searches for the text, not "text from Alice".
+      searchController.searchInputController.text = 'invoice';
+      mailboxDashboardController.searchEmailByQueryString();
+      expect(committedFilter().from, isEmpty);
+      expect(committedFilter().text, equals(SearchQuery('invoice')));
+    });
 
     test(
       'WHEN stored sort order is loaded on app restart\n'
@@ -628,24 +677,24 @@ void main() {
       mailboxDashboardController.setUpDefaultEmailSortOrder(EmailSortOrderType.oldest);
 
       expect(searchController.sortOrderFiltered, EmailSortOrderType.oldest);
-      expect(searchController.searchEmailFilter.value.sortOrderType, EmailSortOrderType.oldest);
+      expect(committedFilter().sortOrderType, EmailSortOrderType.oldest);
     });
 
     test(
       'WHEN setUpDefaultEmailSortOrder is called while load-more cursors are set\n'
-      'SHOULD clear before/after/position so restoring the sort order never leaks a stale cursor',
+      'SHOULD keep before/after/position out of the committed SSOT',
     () {
-      searchController.updateFilterEmail(
-        beforeOption: Some(UTCDate(DateTime.now())),
-        afterOption: Some(UTCDate(DateTime.now())),
-        positionOption: const Some(20),
-      );
+      searchFilterNotifier().set(SearchEmailFilter(
+        before: UTCDate(DateTime.now()),
+        after: UTCDate(DateTime.now()),
+        position: 20,
+      ));
 
       mailboxDashboardController.setUpDefaultEmailSortOrder(EmailSortOrderType.oldest);
 
-      expect(searchController.searchEmailFilter.value.before, isNull);
-      expect(searchController.searchEmailFilter.value.after, isNull);
-      expect(searchController.searchEmailFilter.value.position, isNull);
+      expect(committedFilter().before, isNull);
+      expect(committedFilter().after, isNull);
+      expect(committedFilter().position, isNull);
     });
 
     test(
@@ -762,12 +811,12 @@ void main() {
           refreshAllMailboxInteractor);
       mailboxController.onReady();
 
+      Get.put<SearchEmailInteractor>(searchEmailInteractor);
+      Get.put<SearchMoreEmailInteractor>(searchMoreEmailInteractor);
       threadController = ThreadController(
           getEmailsInMailboxInteractor,
           refreshChangesEmailsInMailboxInteractor,
           loadMoreEmailsInMailboxInteractor,
-          searchEmailInteractor,
-          searchMoreEmailInteractor,
           getEmailByIdInteractor,
           cleanAndGetEmailsInMailboxInteractor,
       );

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -416,6 +416,8 @@ void main() {
   group('search/sort/filter feature:', () {
     setUp(() {
       getEmailsInMailboxInteractor = MockGetEmailsInMailboxInteractor();
+      // Reset the committed search-filter SSOT so state can't leak between tests.
+      appProviderContainer.invalidate(searchFilterProvider);
 
       when(emailReceiveManager.pendingSharedFileInfo).thenAnswer((_) => BehaviorSubject.seeded([]));
       when(downloadController.downloadUIAction).thenAnswer((_) => Rxn(DownloadUIAction.idle));
@@ -737,7 +739,10 @@ void main() {
       expect(searchController.sortOrderFiltered, EmailSortOrderType.subjectAscending);
     });
 
-    tearDown(Get.deleteAll);
+    tearDown(() {
+      appProviderContainer.invalidate(searchFilterProvider);
+      Get.deleteAll();
+    });
   });
 
   group('spamMailboxId:test', () {

--- a/test/features/mailbox_dashboard/presentation/controller/search_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/search_controller_test.dart
@@ -4,6 +4,7 @@ import 'package:core/presentation/utils/app_toast.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
+import 'package:jmap_dart_client/jmap/core/utc_date.dart';
 import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
 import 'package:mockito/annotations.dart';
 import 'package:tmail_ui_user/features/caching/caching_manager.dart';
@@ -107,16 +108,16 @@ void main() {
     });
 
     test('cursor options stay out of the committed SSOT', () {
-      notifier().set(SearchEmailFilter(position: 40));
+      notifier().set(SearchEmailFilter(before: UTCDate(DateTime(2026))));
 
-      expect(committed().position, isNull);
+      expect(committed().before, isNull);
     });
 
     test('a later user-intent update keeps cursor state out of the SSOT', () {
-      notifier().set(SearchEmailFilter(position: 40));
+      notifier().set(SearchEmailFilter(before: UTCDate(DateTime(2026))));
       notifier().setUnread(true.asSearchFilterToggle());
 
-      expect(committed().position, isNull);
+      expect(committed().before, isNull);
       expect(committed().unread, isTrue);
     });
   });
@@ -200,11 +201,11 @@ void main() {
     });
 
     test('keeps cursor-only updates out of the committed filter', () {
-      notifier().set(SearchEmailFilter(position: 40));
+      notifier().set(SearchEmailFilter(before: UTCDate(DateTime(2026))));
 
       searchController.clearSearchFilter();
 
-      expect(committed().position, isNull);
+      expect(committed().before, isNull);
     });
   });
 

--- a/test/features/mailbox_dashboard/presentation/controller/search_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/search_controller_test.dart
@@ -2,7 +2,6 @@ import 'package:core/data/network/config/dynamic_url_interceptors.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/app_toast.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
-import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
@@ -19,10 +18,10 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/sear
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
 import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
-import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
 import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
@@ -80,37 +79,45 @@ void main() {
     Get.put<SearchController>(searchController);
   });
 
-  // Reset synchronously (not invalidate) so no deferred rebuild flushes mid-test.
-  setUp(() => appProviderContainer
-      .read(searchFilterProvider.notifier)
-      .set(SearchEmailFilter.initial()));
+  // Filter/input reset synchronously; the view state is a keepAlive provider with
+  // no public reset, so invalidate it back to `initial()`.
+  setUp(() {
+    appProviderContainer
+        .read(searchFilterProvider.notifier)
+        .set(SearchEmailFilter.initial());
+    appProviderContainer.invalidate(searchViewStateProvider);
+  });
 
   SearchEmailFilter committed() => appProviderContainer.read(searchFilterProvider);
+  SearchFilterNotifier notifier() =>
+      appProviderContainer.read(searchFilterProvider.notifier);
 
   void toggle(QuickSearchFilter filter) =>
-      searchController.toggleQuickSearchFilter(filter, currentUserEmail: _me);
+      searchController.toggleQuickSearchFilter(
+        filter,
+        currentUserEmail: _me,
+        searchFilterNotifier: notifier(),
+      );
 
-  group('updateFilterEmail', () {
-    test('user intent writes the committed SSOT and the mirror syncs the obs', () {
-      searchController.updateFilterEmail(unreadOption: const Some(true));
+  group('searchFilterNotifier', () {
+    test('user intent writes the committed SSOT', () {
+      notifier().setUnread(true.asSearchFilterToggle());
 
       expect(committed().unread, isTrue);
-      expect(searchController.searchEmailFilter.value.unread, isTrue);
     });
 
-    test('cursor options stay on the obs, never in the committed SSOT', () {
-      searchController.updateFilterEmail(positionOption: const Some(40));
+    test('cursor options stay out of the committed SSOT', () {
+      notifier().set(SearchEmailFilter(position: 40));
 
       expect(committed().position, isNull);
-      expect(searchController.searchEmailFilter.value.position, 40);
     });
 
-    test('a later user-intent update must not clobber an existing cursor', () {
-      searchController.updateFilterEmail(positionOption: const Some(40));
-      searchController.updateFilterEmail(unreadOption: const Some(true));
+    test('a later user-intent update keeps cursor state out of the SSOT', () {
+      notifier().set(SearchEmailFilter(position: 40));
+      notifier().setUnread(true.asSearchFilterToggle());
 
-      expect(searchController.searchEmailFilter.value.position, 40);
-      expect(searchController.searchEmailFilter.value.unread, isTrue);
+      expect(committed().position, isNull);
+      expect(committed().unread, isTrue);
     });
   });
 
@@ -141,9 +148,8 @@ void main() {
     });
 
     test('fromMe collapses from to only the current user, dropping others', () {
-      searchController.updateFilterEmail(
-        fromOption: const Some({'other@example.com', 'friend@example.com'}),
-      );
+      notifier().setSenders(
+        {'other@example.com', 'friend@example.com'}.asSearchFilterEmailSet());
 
       toggle(QuickSearchFilter.fromMe);
       expect(committed().from, {_me});
@@ -151,20 +157,19 @@ void main() {
 
     test('fromMe replaces the current user when it is already the sole sender',
         () {
-      searchController.updateFilterEmail(fromOption: const Some({_me}));
+      notifier().setSenders({_me}.asSearchFilterEmailSet());
 
       toggle(QuickSearchFilter.fromMe);
       expect(committed().from, isEmpty);
     });
 
     test('fromMe is a no-op when the current user email is empty', () {
-      searchController.updateFilterEmail(
-        fromOption: const Some({'other@example.com'}),
-      );
+      notifier().setSenders({'other@example.com'}.asSearchFilterEmailSet());
 
       searchController.toggleQuickSearchFilter(
         QuickSearchFilter.fromMe,
         currentUserEmail: '',
+        searchFilterNotifier: notifier(),
       );
 
       expect(committed().from, {'other@example.com'});
@@ -185,10 +190,8 @@ void main() {
 
   group('clearSearchFilter', () {
     test('resets committed but keeps the current sort order', () {
-      searchController.updateFilterEmail(
-        unreadOption: const Some(true),
-        sortOrderTypeOption: const Some(EmailSortOrderType.oldest),
-      );
+      notifier().setUnread(true.asSearchFilterToggle());
+      notifier().setSortOrder(EmailSortOrderType.oldest);
 
       searchController.clearSearchFilter();
 
@@ -196,39 +199,55 @@ void main() {
       expect(committed().sortOrderType, EmailSortOrderType.oldest);
     });
 
-    // Clearing must drop a stale cursor left on the obs mirror. The
-    // committed SSOT never tracks cursors, so a bare notifier.clear() can't null
-    // it — every clear entry point must route through here. See ADR-0093.
-    test('drops a stale position cursor left on the obs', () {
-      searchController.updateFilterEmail(positionOption: const Some(40));
-      expect(searchController.searchEmailFilter.value.position, 40);
+    test('keeps cursor-only updates out of the committed filter', () {
+      notifier().set(SearchEmailFilter(position: 40));
 
       searchController.clearSearchFilter();
 
-      expect(searchController.searchEmailFilter.value.position, isNull);
+      expect(committed().position, isNull);
     });
   });
 
   // The search bar and the advanced "has the words" field are one full-text
-  // term (SSOT.text). Editing either surface must reflect in the other.
+  // term (SSOT.text). Editing the bar debounces into the SSOT (same cadence as
+  // the suggestion search); committing the SSOT mirrors straight back.
   group('search bar <-> SSOT.text sync', () {
-    test('typing in the search bar commits the term to the SSOT', () {
+    test('typing does not commit to the SSOT immediately (debounced)', () {
       searchController.searchInputController.text = 'hello';
+
+      expect(committed().text, isNull, reason: 'commit waits for the debounce');
+
+      // Cancel the pending debounce so it cannot leak into a later test.
+      searchController.commitSearchTextNow();
+    });
+
+    test('the debounce eventually commits the typed term to the SSOT', () async {
+      searchController.searchInputController.text = 'hello';
+
+      await Future.delayed(const Duration(milliseconds: 400));
 
       expect(committed().text?.value, 'hello');
     });
 
+    test('commitSearchTextNow flushes the pending text without waiting', () {
+      searchController.searchInputController.text = 'hi';
+      searchController.commitSearchTextNow();
+
+      expect(committed().text?.value, 'hi');
+    });
+
     test('a blank search bar clears the committed term', () {
       searchController.searchInputController.text = 'hello';
+      searchController.commitSearchTextNow();
+
       searchController.searchInputController.text = '   ';
+      searchController.commitSearchTextNow();
 
       expect(committed().text, isNull);
     });
 
     test('committing the term on the SSOT mirrors into the search bar', () {
-      searchController.updateFilterEmail(
-        textOption: Some(SearchQuery('world')),
-      );
+      notifier().setText('world'.asSearchFilterTextInput());
 
       expect(searchController.searchInputController.text, 'world');
       expect(
@@ -238,17 +257,16 @@ void main() {
     });
 
     test('clearing the term on the SSOT clears the search bar', () {
-      searchController.updateFilterEmail(
-        textOption: Some(SearchQuery('world')),
-      );
+      notifier().setText('world'.asSearchFilterTextInput());
 
-      searchController.updateFilterEmail(textOption: const None());
+      notifier().setText(''.asSearchFilterTextInput());
 
       expect(searchController.searchInputController.text, isEmpty);
     });
 
     test('mirroring a committed term back does not wipe the in-progress edit', () {
       searchController.searchInputController.text = 'abc';
+      searchController.commitSearchTextNow();
 
       // The mirror sees the bar already holds the committed term and skips the
       // write-back, so the listener feedback loop never clobbers the edit.

--- a/test/features/mailbox_dashboard/presentation/extensions/quick_search_emails_extension_test.dart
+++ b/test/features/mailbox_dashboard/presentation/extensions/quick_search_emails_extension_test.dart
@@ -1,6 +1,5 @@
 import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:get/state_manager.dart';
 import 'package:jmap_dart_client/jmap/core/filter/filter.dart';
 import 'package:jmap_dart_client/jmap/core/filter/filter_operator.dart';
 import 'package:jmap_dart_client/jmap/core/filter/operator/logic_filter_operator.dart';
@@ -19,6 +18,8 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 
 import '../../../../fixtures/account_fixtures.dart';
 import '../../../../fixtures/session_fixtures.dart';
@@ -41,6 +42,9 @@ void main() {
   setUp(() {
     quickSearchEmailInteractor = MockQuickSearchEmailInteractor();
     searchController = MockSearchController();
+    appProviderContainer
+        .read(searchFilterProvider.notifier)
+        .set(SearchEmailFilter.initial());
     when(searchController.quickSearchEmailInteractor)
         .thenReturn(quickSearchEmailInteractor);
     when(
@@ -55,14 +59,17 @@ void main() {
     ).thenAnswer((_) => Future.value(Right(QuickSearchEmailSuccess([]))));
   });
 
+  void setCommittedFilter(SearchEmailFilter filter) {
+    appProviderContainer.read(searchFilterProvider.notifier).set(filter);
+  }
+
   group('quickSearchEmails', () {
     test(
       'should invoke quickSearchEmailInteractor.execute() with SearchController\'s sort '
       'when sortOrderType is null',
       () async {
         sortOrderType = null;
-        when(searchController.searchEmailFilter)
-            .thenReturn(SearchEmailFilter(sortOrderType: sortOrderType).obs);
+        setCommittedFilter(SearchEmailFilter(sortOrderType: sortOrderType));
         await searchController.quickSearchEmails(
           session: session,
           accountId: accountId,
@@ -84,8 +91,7 @@ void main() {
       'when sortOrderType is not null',
       () async {
         sortOrderType = EmailSortOrderType.oldest;
-        when(searchController.searchEmailFilter)
-            .thenReturn(SearchEmailFilter(sortOrderType: sortOrderType).obs);
+        setCommittedFilter(SearchEmailFilter(sortOrderType: sortOrderType));
         await searchController.quickSearchEmails(
           session: session,
           accountId: accountId,
@@ -107,11 +113,11 @@ void main() {
       () async {
         final start = UTCDate(DateTime.utc(2026, 1, 1));
         final end = UTCDate(DateTime.utc(2026, 1, 31));
-        when(searchController.searchEmailFilter).thenReturn(SearchEmailFilter(
+        setCommittedFilter(SearchEmailFilter(
           emailReceiveTimeType: EmailReceiveTimeType.customRange,
           startDate: start,
           endDate: end,
-        ).obs);
+        ));
 
         await searchController.quickSearchEmails(
           session: session,
@@ -138,11 +144,11 @@ void main() {
       'so previously-dropped filters (subject, mailbox, unread) are applied',
       () async {
         final mailbox = PresentationMailbox(MailboxId(Id('mailbox-1')));
-        when(searchController.searchEmailFilter).thenReturn(SearchEmailFilter(
+        setCommittedFilter(SearchEmailFilter(
           subject: 'invoice',
           mailbox: mailbox,
           unread: true,
-        ).obs);
+        ));
 
         await searchController.quickSearchEmails(
           session: session,
@@ -167,11 +173,38 @@ void main() {
     );
 
     test(
+      'should commit the debounced query to the search filter SSOT',
+      () async {
+        setCommittedFilter(SearchEmailFilter(subject: 'invoice'));
+
+        await searchController.quickSearchEmails(
+          session: session,
+          accountId: accountId,
+          query: '  test  ',
+        );
+
+        final committed = appProviderContainer.read(searchFilterProvider);
+        final captured = verify(quickSearchEmailInteractor.execute(
+          session,
+          accountId,
+          limit: anyNamed('limit'),
+          sort: anyNamed('sort'),
+          filter: captureAnyNamed('filter'),
+          properties: anyNamed('properties'),
+        )).captured.single as EmailFilterCondition;
+
+        expect(committed.text?.value, equals('test'));
+        expect(captured.text, equals('test'));
+        expect(captured.subject, equals('invoice'));
+      },
+    );
+
+    test(
       'should apply the recipient (to/cc/bcc) filter dropped by the old suggestion mapping',
       () async {
-        when(searchController.searchEmailFilter).thenReturn(SearchEmailFilter(
+        setCommittedFilter(SearchEmailFilter(
           to: {'bob@linagora.com'},
-        ).obs);
+        ));
 
         await searchController.quickSearchEmails(
           session: session,
@@ -210,8 +243,10 @@ void main() {
     test(
       'should drop the text condition when the query is blank',
       () async {
-        when(searchController.searchEmailFilter)
-            .thenReturn(SearchEmailFilter(subject: 'invoice').obs);
+        setCommittedFilter(SearchEmailFilter(subject: 'invoice'));
+        appProviderContainer
+            .read(searchFilterProvider.notifier)
+            .setText('old'.asSearchFilterTextInput());
 
         await searchController.quickSearchEmails(
           session: session,
@@ -228,6 +263,7 @@ void main() {
           properties: anyNamed('properties'),
         )).captured.single as EmailFilterCondition;
 
+        expect(appProviderContainer.read(searchFilterProvider).text, isNull);
         expect(captured.text, isNull);
         expect(captured.subject, equals('invoice'));
       },

--- a/test/features/mailbox_dashboard/presentation/extensions/search_filter_notifier_quick_filter_extension_test.dart
+++ b/test/features/mailbox_dashboard/presentation/extensions/search_filter_notifier_quick_filter_extension_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/utc_date.dart';
+import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:labels/model/label.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/search_filter_notifier_quick_filter_extension.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
+
+void main() {
+  late ProviderContainer container;
+
+  setUp(() => container = ProviderContainer());
+  tearDown(() => container.dispose());
+
+  SearchFilterNotifier notifier() =>
+      container.read(searchFilterProvider.notifier);
+  SearchEmailFilter state() => container.read(searchFilterProvider);
+
+  test('selectQuickSearchFilter applies direct quick filters', () {
+    expect(
+      notifier().selectQuickSearchFilter(QuickSearchFilter.hasAttachment),
+      isTrue,
+    );
+    expect(notifier().selectQuickSearchFilter(QuickSearchFilter.starred), isTrue);
+    expect(notifier().selectQuickSearchFilter(QuickSearchFilter.unread), isTrue);
+    expect(notifier().selectQuickSearchFilter(QuickSearchFilter.events), isTrue);
+    expect(notifier().selectQuickSearchFilter(QuickSearchFilter.dateTime), isFalse);
+
+    expect(state().hasAttachment, isTrue);
+    expect(state().hasKeyword, contains(KeyWordIdentifier.emailFlagged.value));
+    expect(state().unread, isTrue);
+    expect(state().notIncludeEvents, isTrue);
+  });
+
+  test('deleteQuickSearchFilter clears mapped quick filters', () {
+    final mailbox = PresentationMailbox(
+      MailboxId(Id('inbox-id')),
+      name: MailboxName('Inbox'),
+    );
+    final label = Label(id: Id('label-id'), displayName: 'Work');
+    final start = UTCDate(DateTime.parse('2026-01-01T00:00:00.000Z'));
+    final end = UTCDate(DateTime.parse('2026-01-07T00:00:00.000Z'));
+
+    notifier().set(SearchEmailFilter(
+      from: {'alice@example.com'},
+      to: {'bob@example.com'},
+      mailbox: mailbox,
+      hasAttachment: true,
+      unread: true,
+      notIncludeEvents: true,
+      hasKeyword: {KeyWordIdentifier.emailFlagged.value},
+      sortOrderType: EmailSortOrderType.oldest,
+      emailReceiveTimeType: EmailReceiveTimeType.customRange,
+      startDate: start,
+      endDate: end,
+      label: label,
+    ));
+
+    for (final filter in [
+      QuickSearchFilter.dateTime,
+      QuickSearchFilter.sortBy,
+      QuickSearchFilter.from,
+      QuickSearchFilter.hasAttachment,
+      QuickSearchFilter.to,
+      QuickSearchFilter.folder,
+      QuickSearchFilter.labels,
+      QuickSearchFilter.starred,
+      QuickSearchFilter.unread,
+      QuickSearchFilter.events,
+    ]) {
+      expect(notifier().deleteQuickSearchFilter(filter), isTrue);
+    }
+    expect(notifier().deleteQuickSearchFilter(QuickSearchFilter.last7Days), isFalse);
+
+    expect(state().emailReceiveTimeType, EmailReceiveTimeType.allTime);
+    expect(state().startDate, isNull);
+    expect(state().endDate, isNull);
+    expect(state().sortOrderType, SearchEmailFilter.defaultSortOrder);
+    expect(state().from, isEmpty);
+    expect(state().to, isEmpty);
+    expect(state().mailbox, isNull);
+    expect(state().hasAttachment, isFalse);
+    expect(state().label, isNull);
+    expect(state().hasKeyword, isEmpty);
+    expect(state().unread, isFalse);
+    expect(state().notIncludeEvents, isFalse);
+  });
+}

--- a/test/features/mailbox_dashboard/presentation/model/search/search_activation_state_test.dart
+++ b/test/features/mailbox_dashboard/presentation/model/search/search_activation_state_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_activation_state.dart';
+
+void main() {
+  group('SearchActivationState', () {
+    test('initial is inactive for both simple and advanced', () {
+      final state = SearchActivationState.initial();
+
+      expect(state.simpleIsActivated, isFalse);
+      expect(state.advancedIsActivated, isFalse);
+      expect(state.isRunning, isFalse);
+    });
+
+    test('isRunning is true when simple search is activated', () {
+      final state = SearchActivationState.initial().copyWith(
+        simpleIsActivated: true,
+      );
+
+      expect(state.isRunning, isTrue);
+    });
+
+    test('isRunning is true when advanced search is activated', () {
+      final state = SearchActivationState.initial().copyWith(
+        advancedIsActivated: true,
+      );
+
+      expect(state.isRunning, isTrue);
+    });
+
+    test('copyWith preserves the untouched flag', () {
+      final state = SearchActivationState.initial()
+          .copyWith(simpleIsActivated: true)
+          .copyWith(advancedIsActivated: true);
+
+      expect(state.simpleIsActivated, isTrue);
+      expect(state.advancedIsActivated, isTrue);
+    });
+  });
+}

--- a/test/features/mailbox_dashboard/presentation/notifier/quick_search_filter_action_notifier_test.dart
+++ b/test/features/mailbox_dashboard/presentation/notifier/quick_search_filter_action_notifier_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:labels/model/label.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/quick_search_filter_action_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
+
+void main() {
+  late ProviderContainer container;
+
+  setUp(() => container = ProviderContainer());
+  tearDown(() => container.dispose());
+
+  QuickSearchFilterActionNotifier actionNotifier() =>
+      container.read(quickSearchFilterActionProvider.notifier);
+
+  test('selectQuickSearchFilter mutates filter and requests search', () {
+    final before = container.read(quickSearchFilterActionProvider);
+
+    final applied = actionNotifier()
+        .selectQuickSearchFilter(QuickSearchFilter.hasAttachment);
+
+    expect(applied, isTrue);
+    expect(container.read(searchFilterProvider).hasAttachment, isTrue);
+    expect(container.read(quickSearchFilterActionProvider), before.next);
+  });
+
+  test('deleteQuickSearchFilter mutates filter and requests search', () {
+    actionNotifier().selectQuickSearchFilter(QuickSearchFilter.hasAttachment);
+    final before = container.read(quickSearchFilterActionProvider);
+
+    final applied = actionNotifier()
+        .deleteQuickSearchFilter(QuickSearchFilter.hasAttachment);
+
+    expect(applied, isTrue);
+    expect(container.read(searchFilterProvider).hasAttachment, isFalse);
+    expect(container.read(quickSearchFilterActionProvider), before.next);
+  });
+
+  test('mutateAndSearch applies the mutation to the committed filter and '
+      'requests search', () {
+    final mailbox = PresentationMailbox(
+      MailboxId(Id('inbox-id')),
+      name: MailboxName('Inbox'),
+    );
+    final before = container.read(quickSearchFilterActionProvider);
+
+    actionNotifier().mutateAndSearch((filter) {
+      filter.setSortOrder(EmailSortOrderType.mostRecent);
+      filter.setMailbox(mailbox);
+    });
+
+    final filter = container.read(searchFilterProvider);
+    expect(filter.sortOrderType, EmailSortOrderType.mostRecent);
+    expect(filter.mailbox, mailbox);
+    expect(container.read(quickSearchFilterActionProvider), before.next);
+  });
+
+  test('mutateAndSearch requests exactly one search per call', () {
+    final before = container.read(quickSearchFilterActionProvider);
+
+    actionNotifier().mutateAndSearch(
+      (filter) => filter.setLabel(Label(id: Id('work'), displayName: 'Work')),
+    );
+    actionNotifier().mutateAndSearch(
+      (filter) => filter.setReceiveTime(EmailReceiveTimeType.last7Days),
+    );
+
+    expect(container.read(quickSearchFilterActionProvider), before.next.next);
+  });
+
+  test('selectQuickSearchFilter returns false and skips search when the '
+      'filter has no select action', () {
+    final before = container.read(quickSearchFilterActionProvider);
+
+    final applied =
+        actionNotifier().selectQuickSearchFilter(QuickSearchFilter.folder);
+
+    expect(applied, isFalse);
+    expect(container.read(quickSearchFilterActionProvider), before);
+  });
+
+  test('deleteQuickSearchFilter returns false and skips search when the '
+      'filter has no delete action', () {
+    final before = container.read(quickSearchFilterActionProvider);
+
+    final applied =
+        actionNotifier().deleteQuickSearchFilter(QuickSearchFilter.fromMe);
+
+    expect(applied, isFalse);
+    expect(container.read(quickSearchFilterActionProvider), before);
+  });
+}

--- a/test/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier_test.dart
+++ b/test/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_view_state.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
+import 'package:tmail_ui_user/features/thread/presentation/model/search_status.dart';
+
+typedef _SearchViewMutation = void Function();
+typedef _SearchActivationFlag = bool Function();
+
+void main() {
+  late ProviderContainer container;
+  late _DisposeObserver disposeObserver;
+
+  setUp(() {
+    disposeObserver = _DisposeObserver();
+    container = ProviderContainer(observers: [disposeObserver]);
+  });
+  tearDown(() => container.dispose());
+
+  SearchViewStateNotifier notifier() =>
+      container.read(searchViewStateProvider.notifier);
+  SearchViewState state() => container.read(searchViewStateProvider);
+
+  test('starts from an inactive, closed, unfocused state', () {
+    expect(state().isAdvancedSearchViewOpen, isFalse);
+    expect(state().isSearchInputFocused, isFalse);
+    expect(state().isSearchActive, isFalse);
+    expect(state().isSearchEmailRunning, isFalse);
+  });
+
+  test('openAdvancedSearch then closeAdvancedSearch toggles the advanced view', () {
+    notifier().openAdvancedSearch();
+    expect(state().isAdvancedSearchViewOpen, isTrue);
+
+    notifier().closeAdvancedSearch();
+    expect(state().isAdvancedSearchViewOpen, isFalse);
+  });
+
+  test('setSearchInputFocused reflects focus both ways', () {
+    notifier().setSearchInputFocused(true);
+    expect(state().isSearchInputFocused, isTrue);
+
+    notifier().setSearchInputFocused(false);
+    expect(state().isSearchInputFocused, isFalse);
+  });
+
+  test('enableSearch then disableSearch flips the search status', () {
+    notifier().enableSearch();
+    expect(state().isSearchActive, isTrue);
+    expect(state().searchState.searchStatus, SearchStatus.ACTIVE);
+
+    notifier().disableSearch();
+    expect(state().isSearchActive, isFalse);
+    expect(state().searchState.searchStatus, SearchStatus.INACTIVE);
+  });
+
+  void testIndependentActivation({
+    required String description,
+    required _SearchViewMutation activatePreserved,
+    required _SearchViewMutation activateTarget,
+    required _SearchViewMutation deactivateTarget,
+    required _SearchActivationFlag targetIsActivated,
+    required _SearchActivationFlag preservedIsActivated,
+    required String preservedReason,
+  }) {
+    test(description, () {
+      activatePreserved();
+
+      activateTarget();
+      expect(targetIsActivated(), isTrue);
+      expect(preservedIsActivated(), isTrue);
+
+      deactivateTarget();
+      expect(targetIsActivated(), isFalse);
+      expect(preservedIsActivated(), isTrue, reason: preservedReason);
+    });
+  }
+
+  testIndependentActivation(
+    description: 'simple activation toggles on and off without touching advanced',
+    activatePreserved: () => notifier().activateAdvancedSearch(),
+    activateTarget: () => notifier().activateSimpleSearch(),
+    deactivateTarget: () => notifier().deactivateSimpleSearch(),
+    targetIsActivated: () => state().activation.simpleIsActivated,
+    preservedIsActivated: () => state().advancedSearchIsActivated,
+    preservedReason: 'advanced activation must be independent of simple',
+  );
+
+  testIndependentActivation(
+    description: 'advanced activation toggles on and off without touching simple',
+    activatePreserved: () => notifier().activateSimpleSearch(),
+    activateTarget: () => notifier().activateAdvancedSearch(),
+    deactivateTarget: () => notifier().deactivateAdvancedSearch(),
+    targetIsActivated: () => state().advancedSearchIsActivated,
+    preservedIsActivated: () => state().activation.simpleIsActivated,
+    preservedReason: 'simple activation must be independent of advanced',
+  );
+
+  test('isSearchEmailRunning is true while either simple or advanced is active', () {
+    expect(state().isSearchEmailRunning, isFalse);
+
+    notifier().activateSimpleSearch();
+    expect(state().isSearchEmailRunning, isTrue);
+
+    notifier().deactivateSimpleSearch();
+    notifier().activateAdvancedSearch();
+    expect(state().isSearchEmailRunning, isTrue);
+
+    notifier().deactivateAdvancedSearch();
+    expect(state().isSearchEmailRunning, isFalse);
+  });
+
+  test('isSearchEngaged is true for a session, a running query, or advanced open', () {
+    expect(state().isSearchEngaged, isFalse);
+
+    notifier().enableSearch();
+    expect(state().isSearchEngaged, isTrue, reason: 'active session');
+
+    notifier().disableSearch();
+    notifier().activateSimpleSearch();
+    expect(state().isSearchEngaged, isTrue, reason: 'query running');
+
+    notifier().deactivateSimpleSearch();
+    notifier().openAdvancedSearch();
+    expect(state().isSearchEngaged, isTrue, reason: 'advanced panel open');
+
+    notifier().closeAdvancedSearch();
+    expect(state().isSearchEngaged, isFalse);
+  });
+
+  test('release disposes the keepAlive provider back to initial', () async {
+    notifier().openAdvancedSearch();
+    notifier().enableSearch();
+
+    notifier().release();
+    await container.pump();
+
+    expect(disposeObserver.searchViewStateDisposeCount, greaterThan(0));
+    expect(state().isAdvancedSearchViewOpen, isFalse);
+    expect(state().isSearchActive, isFalse);
+  });
+}
+
+final class _DisposeObserver extends ProviderObserver {
+  int searchViewStateDisposeCount = 0;
+
+  @override
+  void didDisposeProvider(ProviderObserverContext context) {
+    if (context.provider == searchViewStateProvider) {
+      searchViewStateDisposeCount++;
+    }
+  }
+}

--- a/test/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier_test.dart
+++ b/test/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier_test.dart
@@ -82,7 +82,7 @@ void main() {
     activateTarget: () => notifier().activateSimpleSearch(),
     deactivateTarget: () => notifier().deactivateSimpleSearch(),
     targetIsActivated: () => state().activation.simpleIsActivated,
-    preservedIsActivated: () => state().advancedSearchIsActivated,
+    preservedIsActivated: () => state().activation.advancedIsActivated,
     preservedReason: 'advanced activation must be independent of simple',
   );
 
@@ -91,7 +91,7 @@ void main() {
     activatePreserved: () => notifier().activateSimpleSearch(),
     activateTarget: () => notifier().activateAdvancedSearch(),
     deactivateTarget: () => notifier().deactivateAdvancedSearch(),
-    targetIsActivated: () => state().advancedSearchIsActivated,
+    targetIsActivated: () => state().activation.advancedIsActivated,
     preservedIsActivated: () => state().activation.simpleIsActivated,
     preservedReason: 'simple activation must be independent of advanced',
   );

--- a/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
+++ b/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
@@ -108,6 +108,7 @@ import 'package:tmail_ui_user/features/thread/domain/usecases/mark_as_multiple_e
 import 'package:tmail_ui_user/features/thread/domain/usecases/mark_as_star_multiple_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/move_multiple_email_to_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor.dart';
+import 'package:tmail_ui_user/features/search/email/domain/usecases/refresh_changes_search_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_more_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
@@ -191,6 +192,7 @@ const fallbackGenerators = {
   MockSpec<LoadMoreEmailsInMailboxInteractor>(),
   MockSpec<SearchEmailInteractor>(),
   MockSpec<SearchMoreEmailInteractor>(),
+  MockSpec<RefreshChangesSearchEmailInteractor>(),
   MockSpec<AuthorizationInterceptors>(),
   MockSpec<DynamicUrlInterceptors>(),
   MockSpec<DeleteCredentialInteractor>(),
@@ -300,6 +302,7 @@ void main() {
   final loadMoreEmailsInMailboxInteractor = MockLoadMoreEmailsInMailboxInteractor();
   final searchEmailInteractor = MockSearchEmailInteractor();
   final searchMoreEmailInteractor = MockSearchMoreEmailInteractor();
+  final refreshChangesSearchEmailInteractor = MockRefreshChangesSearchEmailInteractor();
 
   final getQuotasInteractor = MockGetQuotasInteractor();
 
@@ -326,7 +329,7 @@ void main() {
   }
 
   group('MailboxDashboardView', () {
-    setUp(() {
+    void registerMockDependencies() {
       Get.testMode = true;
 
       Get.put<RemoveEmailDraftsInteractor>(removeEmailDraftsInteractor);
@@ -370,7 +373,9 @@ void main() {
       when(downloadController.downloadUIAction).thenAnswer((_) => Rxn(DownloadUIAction.idle));
       final isLabelSettingEnabled = RxBool(false);
       when(labelController.isLabelSettingEnabled).thenReturn(isLabelSettingEnabled);
+    }
 
+    void buildAndRegisterControllers() {
       searchController = SearchController(
         quickSearchEmailInteractor,
         saveRecentSearchInteractor,
@@ -429,12 +434,15 @@ void main() {
       Get.put(mailboxController);
       // mailboxController.onReady();
 
+      // The central SearchEmailNotifier executor resolves its interactors via
+      // Get.find; register the mocks so ThreadController's delegated searches run.
+      Get.put<SearchEmailInteractor>(searchEmailInteractor);
+      Get.put<SearchMoreEmailInteractor>(searchMoreEmailInteractor);
+      Get.put<RefreshChangesSearchEmailInteractor>(refreshChangesSearchEmailInteractor);
       threadController = ThreadController(
         getEmailsInMailboxInteractor,
         refreshChangesEmailsInMailboxInteractor,
         loadMoreEmailsInMailboxInteractor,
-        searchEmailInteractor,
-        searchMoreEmailInteractor,
         getEmailByIdInteractor,
         cleanAndGetEmailsInMailboxInteractor,
       );
@@ -442,10 +450,18 @@ void main() {
 
       quotasController = QuotasController(getQuotasInteractor);
       Get.put(quotasController);
+    }
 
+    void seedInitialDashboardState() {
       mailboxDashboardController.sessionCurrent = SessionFixtures.aliceSession;
       mailboxDashboardController.filterMessageOption.value = FilterMessageOption.all;
       mailboxDashboardController.accountId.value = AccountFixtures.aliceAccountId;
+    }
+
+    setUp(() {
+      registerMockDependencies();
+      buildAndRegisterControllers();
+      seedInitialDashboardState();
     });
 
     group('ThreadView', () {

--- a/test/features/search/email/domain/execution/search_pagination_strategy_test.dart
+++ b/test/features/search/email/domain/execution/search_pagination_strategy_test.dart
@@ -51,7 +51,6 @@ void main() {
     required Object? after,
   }) {
     expect(spec.position, position);
-    expect(spec.filter.position, isNull);
     expect(spec.filter.before, before);
     expect(spec.filter.after, after);
   }
@@ -208,7 +207,6 @@ void main() {
         intent: intent,
         committed: SearchEmailFilter(
           sortOrderType: sortOrder,
-          position: 99,
           before: lastDate,
           after: lastDate,
         ),

--- a/test/features/search/email/domain/notifier/search_email_notifier_test.dart
+++ b/test/features/search/email/domain/notifier/search_email_notifier_test.dart
@@ -221,6 +221,21 @@ void main() {
 
   tearDown(Get.reset);
 
+  test('clearResult resets rows and canLoadMore', () async {
+    final container = containerForSort(EmailSortOrderType.relevance);
+    stubSearch([emailWith('e1')]);
+    final notifier = container.read(searchEmailProvider.notifier);
+
+    await runExecute(container, const NewSearchIntent());
+    expect(notifier.canLoadMore, isTrue);
+
+    notifier.clearResult();
+
+    final result = container.read(searchEmailProvider).value;
+    expect(result?.emails, isEmpty);
+    expect(notifier.canLoadMore, isFalse);
+  });
+
   group('NewSearchIntent', () {
     test('clears load-more cursors regardless of prior SSOT values', () async {
       final committed = SearchEmailFilter(

--- a/test/features/search/email/domain/notifier/search_email_notifier_test.dart
+++ b/test/features/search/email/domain/notifier/search_email_notifier_test.dart
@@ -242,7 +242,6 @@ void main() {
         subject: 'invoice',
         before: cursorDate,
         after: cursorDate,
-        position: 99,
         sortOrderType: EmailSortOrderType.relevance,
       );
       final container = containerWith(committed: committed);

--- a/test/features/search/email/domain/notifier/search_filter_notifier_test.dart
+++ b/test/features/search/email/domain/notifier/search_filter_notifier_test.dart
@@ -469,7 +469,6 @@ void main() {
         after: cursor,
         startDate: startDate,
         endDate: endDate,
-        position: 5,
       ));
 
       expect(stateOf().subject, 'invoice'); // intent preserved
@@ -477,7 +476,6 @@ void main() {
       expect(stateOf().endDate, endDate);
       expect(stateOf().before, isNull);
       expect(stateOf().after, isNull);
-      expect(stateOf().position, isNull);
     });
 
     test('snapshots filter sets instead of aliasing replacement state', () {

--- a/test/features/search/email/domain/notifier/search_filter_notifier_test.dart
+++ b/test/features/search/email/domain/notifier/search_filter_notifier_test.dart
@@ -11,7 +11,14 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/sear
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
 import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
+import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
+
+typedef FilterSnapshot = ({
+  bool unread,
+  bool hasAttachment,
+  bool starred,
+});
 
 void main() {
   late ProviderContainer container;
@@ -22,6 +29,28 @@ void main() {
   SearchFilterNotifier notifierOf() =>
       container.read(searchFilterProvider.notifier);
   SearchEmailFilter stateOf() => container.read(searchFilterProvider);
+
+  FilterSnapshot filterSnapshot({
+    bool unread = false,
+    bool hasAttachment = false,
+    bool starred = false,
+  }) => (
+    unread: unread,
+    hasAttachment: hasAttachment,
+    starred: starred,
+  );
+
+  void expectFilter(FilterSnapshot expected) {
+    expect(stateOf().unread, expected.unread ? isTrue : isFalse);
+    expect(stateOf().hasAttachment, expected.hasAttachment ? isTrue : isFalse);
+    expect(
+      stateOf().hasKeyword,
+      expected.starred
+          ? contains(KeyWordIdentifier.emailFlagged.value)
+          : isEmpty,
+    );
+    expect(stateOf().isContainFlagged, expected.starred ? isTrue : isFalse);
+  }
 
   test('build() starts at SearchEmailFilter.initial()', () {
     expect(stateOf(), SearchEmailFilter.initial());
@@ -140,6 +169,51 @@ void main() {
       expect(stateOf().mailbox, isNull);
     });
 
+    test('clear helpers reset their fields', () {
+      final mailbox = PresentationMailbox(
+        MailboxId(Id('inbox-id')),
+        name: MailboxName('Inbox'),
+      );
+
+      notifierOf().setSenders({'alice@example.com'}.asSearchFilterEmailSet());
+      notifierOf().setRecipients({'bob@example.com'}.asSearchFilterEmailSet());
+      notifierOf().setMailbox(mailbox);
+
+      notifierOf().clearSenders();
+      notifierOf().clearRecipients();
+      notifierOf().clearMailbox();
+
+      expect(stateOf().from, isEmpty);
+      expect(stateOf().to, isEmpty);
+      expect(stateOf().mailbox, isNull);
+    });
+
+    test('setReceiveTime stores receive-time bounds', () {
+      final start = UTCDate(DateTime.parse('2026-01-01T00:00:00.000Z'));
+      final end = UTCDate(DateTime.parse('2026-01-07T00:00:00.000Z'));
+
+      notifierOf().setReceiveTime(
+        EmailReceiveTimeType.customRange,
+        startDate: start,
+        endDate: end,
+      );
+
+      expect(stateOf().emailReceiveTimeType, EmailReceiveTimeType.customRange);
+      expect(stateOf().startDate, start);
+      expect(stateOf().endDate, end);
+    });
+
+    test('setLabel assigns and clears the label without toggling by id', () {
+      final workLabel = Label(id: Id('work-label'), displayName: 'Work');
+
+      notifierOf().setLabel(workLabel);
+      notifierOf().setLabel(workLabel);
+      expect(stateOf().label, workLabel);
+
+      notifierOf().setLabel(null);
+      expect(stateOf().label, isNull);
+    });
+
     test('toggleLabel selects, clears, and replaces labels by id', () {
       final workLabel = Label(id: Id('work-label'), displayName: 'Work');
       final travelLabel = Label(id: Id('travel-label'), displayName: 'Travel');
@@ -181,13 +255,13 @@ void main() {
     });
   });
 
-  group('toggleStarred', () {
+  group('setStarred', () {
     final flagged = KeyWordIdentifier.emailFlagged.value;
 
     test('adds the flagged keyword when starred, keeping other keywords', () {
       notifierOf().setHasKeywords({'custom'}.asSearchFilterKeywordSet());
 
-      notifierOf().toggleStarred(true.asSearchFilterToggle());
+      notifierOf().setStarred(true.asSearchFilterToggle());
 
       expect(stateOf().hasKeyword, {'custom', flagged});
     });
@@ -195,10 +269,159 @@ void main() {
     test('removes only the flagged keyword when unstarred', () {
       notifierOf().setHasKeywords({'custom', flagged}.asSearchFilterKeywordSet());
 
-      notifierOf().toggleStarred(false.asSearchFilterToggle());
+      notifierOf().setStarred(false.asSearchFilterToggle());
 
       expect(stateOf().hasKeyword, {'custom'});
     });
+  });
+
+  group('toggleStarred', () {
+    final flagged = KeyWordIdentifier.emailFlagged.value;
+
+    test('adds the flagged keyword when it is not present', () {
+      notifierOf().setHasKeywords({'custom'}.asSearchFilterKeywordSet());
+
+      notifierOf().toggleStarred();
+
+      expect(stateOf().hasKeyword, {'custom', flagged});
+    });
+
+    test('removes the flagged keyword when it is present', () {
+      notifierOf().setHasKeywords({'custom', flagged}.asSearchFilterKeywordSet());
+
+      notifierOf().toggleStarred();
+
+      expect(stateOf().hasKeyword, {'custom'});
+    });
+  });
+
+  group('keyword helpers', () {
+    final flagged = KeyWordIdentifier.emailFlagged.value;
+
+    test('addHasKeyword and removeHasKeyword preserve other keywords', () {
+      notifierOf().setHasKeywords({'custom'}.asSearchFilterKeywordSet());
+
+      notifierOf().addHasKeyword(flagged);
+      expect(stateOf().hasKeyword, {'custom', flagged});
+
+      notifierOf().removeHasKeyword(flagged);
+      expect(stateOf().hasKeyword, {'custom'});
+    });
+  });
+
+  group('filter message option helpers', () {
+    final emptyFilter = filterSnapshot();
+    final unreadFilter = filterSnapshot(unread: true);
+    final attachmentFilter = filterSnapshot(hasAttachment: true);
+    final starredFilter = filterSnapshot(starred: true);
+    final unreadAndAttachmentFilter = filterSnapshot(
+      unread: true,
+      hasAttachment: true,
+    );
+
+    final seedCases = [
+      (
+        name: 'unread option seeds the unread search filter',
+        option: FilterMessageOption.unread,
+        expected: unreadFilter,
+      ),
+      (
+        name: 'attachments option seeds the has-attachment search filter',
+        option: FilterMessageOption.attachments,
+        expected: attachmentFilter,
+      ),
+      (
+        name: 'starred option seeds the flagged keyword search filter',
+        option: FilterMessageOption.starred,
+        expected: starredFilter,
+      ),
+      (
+        name: 'all option leaves the search filter untouched',
+        option: FilterMessageOption.all,
+        expected: emptyFilter,
+      ),
+    ];
+
+    for (final seedCase in seedCases) {
+      test(seedCase.name, () {
+        notifierOf().applyFilterMessageOption(seedCase.option);
+
+        expectFilter(seedCase.expected);
+      });
+    }
+
+    void testSyncFilterMessageOptionChange(
+      String description, {
+      FilterMessageOption? seed,
+      FilterSnapshot? beforeSync,
+      required FilterMessageOption previous,
+      required FilterMessageOption next,
+      required FilterSnapshot expected,
+    }) {
+      test(description, () {
+        if (seed != null) {
+          notifierOf().applyFilterMessageOption(seed);
+        }
+        if (beforeSync != null) {
+          expectFilter(beforeSync);
+        }
+
+        notifierOf().syncFilterMessageOptionChange(
+          previous: previous,
+          next: next,
+        );
+
+        expectFilter(expected);
+      });
+    }
+
+    testSyncFilterMessageOptionChange(
+      'selecting an option turns its toggle on',
+      previous: FilterMessageOption.all,
+      next: FilterMessageOption.unread,
+      expected: unreadFilter,
+    );
+
+    testSyncFilterMessageOptionChange(
+      'deselecting an option turns its toggle off',
+      seed: FilterMessageOption.unread,
+      beforeSync: unreadFilter,
+      previous: FilterMessageOption.unread,
+      next: FilterMessageOption.all,
+      expected: emptyFilter,
+    );
+
+    testSyncFilterMessageOptionChange(
+      'switching options clears the previous and sets the next',
+      seed: FilterMessageOption.unread,
+      previous: FilterMessageOption.unread,
+      next: FilterMessageOption.attachments,
+      expected: attachmentFilter,
+    );
+
+    testSyncFilterMessageOptionChange(
+      'preserves an unrelated active toggle',
+      seed: FilterMessageOption.attachments,
+      previous: FilterMessageOption.all,
+      next: FilterMessageOption.unread,
+      expected: unreadAndAttachmentFilter,
+    );
+
+    testSyncFilterMessageOptionChange(
+      'switching to starred sets the flagged keyword',
+      previous: FilterMessageOption.all,
+      next: FilterMessageOption.starred,
+      expected: starredFilter,
+    );
+
+    testSyncFilterMessageOptionChange(
+      'switching away from starred clears the flagged keyword',
+      seed: FilterMessageOption.starred,
+      beforeSync: starredFilter,
+      previous: FilterMessageOption.starred,
+      next: FilterMessageOption.unread,
+      expected: unreadFilter,
+    );
   });
 
   group('sender / recipient membership', () {

--- a/test/features/search/search_email_filter_test.dart
+++ b/test/features/search/search_email_filter_test.dart
@@ -179,7 +179,6 @@ void main() {
           before: UTCDate(DateTime.parse('2024-10-30 12:00:00')),
           startDate: UTCDate(DateTime.parse('2024-10-30 12:00:00')),
           endDate: UTCDate(DateTime.parse('2024-10-31 12:00:00')),
-          position: 0,
           sortOrderType: EmailSortOrderType.oldest,
         );
 
@@ -887,9 +886,7 @@ void main() {
           sortOrderTypeOption: const Some(EmailSortOrderType.relevance),
           beforeOption: const None(),
           startDateOption: const None(),
-          endDateOption: const None(),
-          positionOption: const Some(0),
-        );
+          endDateOption: const None(),        );
 
         expect(afterSortChange.startDate, isNull);
         expect(afterSortChange.endDate, isNull);
@@ -911,9 +908,7 @@ void main() {
           sortOrderTypeOption: const Some(EmailSortOrderType.relevance),
           beforeOption: const None(),
           startDateOption: const None(),
-          endDateOption: const None(),
-          positionOption: const Some(0),
-        );
+          endDateOption: const None(),        );
 
         // startDate cleared → no after bound in the JMAP filter
         expect(afterSortChange.startDate, isNull);
@@ -935,9 +930,7 @@ void main() {
           sortOrderTypeOption: const Some(EmailSortOrderType.relevance),
           beforeOption: const None(),
           startDateOption: const None(),
-          endDateOption: const None(),
-          positionOption: const Some(0),
-        );
+          endDateOption: const None(),        );
 
         expect(afterSortChange.before, isNull);
       });
@@ -956,9 +949,7 @@ void main() {
 
         final afterSortChange = filter.copyWith(
           sortOrderTypeOption: const Some(EmailSortOrderType.relevance),
-          beforeOption: const None(),
-          positionOption: const Some(0),
-        );
+          beforeOption: const None(),        );
 
         expect(afterSortChange.startDate, equals(start));
         expect(afterSortChange.endDate, equals(end));
@@ -975,15 +966,13 @@ void main() {
         var filter = SearchEmailFilter(
           emailReceiveTimeType: EmailReceiveTimeType.allTime,
           sortOrderType: EmailSortOrderType.relevance,
-        ).copyWith(positionOption: const Some(20));
+        );
 
         filter = filter.copyWith(
           sortOrderTypeOption: const Some(EmailSortOrderType.oldest),
           beforeOption: const None(),
           startDateOption: const None(),
-          endDateOption: const None(),
-          positionOption: const None(),
-        );
+          endDateOption: const None(),        );
         expect(filter.startDate, isNull);
 
         final cursor1 = UTCDate(DateTime.parse('2026-01-10T00:00:00.000Z'));
@@ -993,9 +982,7 @@ void main() {
           sortOrderTypeOption: const Some(EmailSortOrderType.mostRecent),
           beforeOption: const None(),
           startDateOption: const None(),
-          endDateOption: const None(),
-          positionOption: const None(),
-        );
+          endDateOption: const None(),        );
         expect(filter.startDate, isNull);
 
         final cursor2 = UTCDate(DateTime.parse('2026-01-20T00:00:00.000Z'));
@@ -1005,9 +992,7 @@ void main() {
           sortOrderTypeOption: const Some(EmailSortOrderType.oldest),
           beforeOption: const None(),
           startDateOption: const None(),
-          endDateOption: const None(),
-          positionOption: const None(),
-        );
+          endDateOption: const None(),        );
         expect(filter.before, isNull);
 
         final cursor3 = UTCDate(DateTime.parse('2026-01-05T00:00:00.000Z'));
@@ -1017,9 +1002,7 @@ void main() {
           sortOrderTypeOption: const Some(EmailSortOrderType.relevance),
           beforeOption: const None(),
           startDateOption: const None(),
-          endDateOption: const None(),
-          positionOption: const Some(0),
-        );
+          endDateOption: const None(),        );
         expect(filter.startDate, isNull);
         expect(filter.before, isNull);
         expect(extractAfterFromFilter(filter.mappingToEmailFilterCondition()), isNull);
@@ -1040,9 +1023,7 @@ void main() {
           sortOrderTypeOption: const Some(EmailSortOrderType.mostRecent),
           beforeOption: const None(),
           startDateOption: const None(),
-          endDateOption: const None(),
-          positionOption: const None(),
-        );
+          endDateOption: const None(),        );
         expect(filter.startDate, isNull);
 
         final cursor2 = UTCDate(DateTime.parse('2026-06-15T12:00:00.000Z'));
@@ -1052,9 +1033,7 @@ void main() {
           sortOrderTypeOption: const Some(EmailSortOrderType.oldest),
           beforeOption: const None(),
           startDateOption: const None(),
-          endDateOption: const None(),
-          positionOption: const None(),
-        );
+          endDateOption: const None(),        );
         expect(filter.before, isNull);
 
         final cursor3 = UTCDate(DateTime.parse('2026-06-13T06:00:00.000Z'));
@@ -1064,9 +1043,7 @@ void main() {
           sortOrderTypeOption: const Some(EmailSortOrderType.relevance),
           beforeOption: const None(),
           startDateOption: const None(),
-          endDateOption: const None(),
-          positionOption: const Some(0),
-        );
+          endDateOption: const None(),        );
         // startDate cleared → no after bound in JMAP filter (cursors fully reset)
         expect(filter.startDate, isNull);
         expect(filter.before, isNull);
@@ -1092,9 +1069,7 @@ void main() {
           emailReceiveTimeTypeOption: const Some(EmailReceiveTimeType.last7Days),
           startDateOption: const None(),
           endDateOption: const None(),
-          beforeOption: const None(),
-          positionOption: const None(),
-        );
+          beforeOption: const None(),        );
 
         expect(filter.before, isNull);
         expect(filter.startDate, isNull);
@@ -1120,9 +1095,7 @@ void main() {
           emailReceiveTimeTypeOption: const Some(EmailReceiveTimeType.customRange),
           startDateOption: Some(userStart),
           endDateOption: Some(userEnd),
-          beforeOption: const None(),
-          positionOption: const None(),
-        );
+          beforeOption: const None(),        );
 
         expect(filter.before, isNull);
         expect(filter.startDate, equals(userStart));
@@ -1150,15 +1123,12 @@ void main() {
         filter = filter.copyWith(
           sortOrderTypeOption: const Some(EmailSortOrderType.mostRecent),
           beforeOption: const None(),
-          afterOption: const None(),
-          positionOption: const None(),
-        );
+          afterOption: const None(),        );
 
         expect(filter.startDate, equals(snapshotStart));
         expect(filter.endDate, equals(snapshotEnd));
         expect(filter.before, isNull);
         expect(filter.after, isNull);
-        expect(filter.position, isNull);
         expect(filter.sortOrderType, equals(EmailSortOrderType.mostRecent));
       });
 
@@ -1178,9 +1148,7 @@ void main() {
           emailReceiveTimeTypeOption: const Some(EmailReceiveTimeType.last7Days),
           startDateOption: optionOf(dateRange.start),
           endDateOption: optionOf(dateRange.end),
-          beforeOption: const None(),
-          positionOption: const None(),
-        );
+          beforeOption: const None(),        );
 
         expect(filter.before, isNull);
         expect(filter.startDate, isNotNull);
@@ -1205,9 +1173,7 @@ void main() {
           emailReceiveTimeTypeOption: const Some(EmailReceiveTimeType.last7Days),
           startDateOption: const None(),
           endDateOption: const None(),
-          beforeOption: const None(),
-          positionOption: const None(),
-        );
+          beforeOption: const None(),        );
         expect(filter.before, isNull);
 
         final cursor2 = UTCDate(DateTime.parse('2026-06-14T10:00:00.000Z'));
@@ -1220,9 +1186,7 @@ void main() {
           emailReceiveTimeTypeOption: const Some(EmailReceiveTimeType.last30Days),
           startDateOption: const None(),
           endDateOption: const None(),
-          beforeOption: const None(),
-          positionOption: const None(),
-        );
+          beforeOption: const None(),        );
         expect(filter.startDate, isNull);
 
         // startDate cleared → no after bound in JMAP filter

--- a/test/features/search/search_email_filter_test.dart
+++ b/test/features/search/search_email_filter_test.dart
@@ -164,22 +164,6 @@ void main() {
         );
       });
 
-      test('SHOULD includes moreFilterCondition WHEN provided', () {
-        // Arrange
-        final moreCondition = EmailFilterCondition(text: 'moreFilter');
-        final filter = SearchEmailFilter(
-          text: SearchQuery('example'),
-        );
-
-        // Act
-        final result = filter.mappingToEmailFilterCondition(moreFilterCondition: moreCondition);
-
-        // Assert
-        expect(result, isA<LogicFilterOperator>());
-        final logicOperator = result as LogicFilterOperator;
-        expect(logicOperator.conditions.contains(moreCondition), isTrue);
-      });
-
       test('SHOULD combines multiple fields into an AND filter', () {
         // Arrange
         final filter = SearchEmailFilter(
@@ -586,26 +570,6 @@ void main() {
         expect(sharedCond.inMailboxOtherThan, containsAll([trashId, spamId]));
       });
 
-      test('SHOULD combine events-exclusion with moreFilterCondition in AND WHEN notIncludeEvents is true and no other conditions', () {
-        // Arrange
-        final moreCondition = EmailFilterCondition(text: 'moreFilter');
-        final filter = SearchEmailFilter(notIncludeEvents: true);
-
-        // Act
-        final result = filter.mappingToEmailFilterCondition(moreFilterCondition: moreCondition);
-
-        // Assert
-        // Result: AND(eventsExclusion, moreCondition) — 2 conditions.
-        expect(result, isA<LogicFilterOperator>());
-        final andFilter = result as LogicFilterOperator;
-        expect(andFilter.operator, equals(Operator.AND));
-        expect(andFilter.conditions.length, equals(2));
-        expect(andFilter.conditions.contains(moreCondition), isTrue);
-
-        final eventsExclusion = andFilter.conditions.whereType<EmailFilterCondition>()
-            .firstWhere((c) => c.notKeyword != null);
-        expect(eventsExclusion.notKeyword, KeyWordIdentifierExtension.eventsMail.value);
-      });
     });
 
     group('isApplied::test', () {
@@ -777,6 +741,52 @@ void main() {
         final withCursor = SearchEmailFilter(after: cursor);
         final cleared = withCursor.copyWith(afterOption: const None());
         expect(cleared.after, isNull);
+      });
+    });
+
+    group('hasActiveQuickFilter::test', () {
+      test('SHOULD return false WHEN no chip filter is set', () {
+        expect(SearchEmailFilter().hasActiveQuickFilter, isFalse);
+      });
+
+      test('SHOULD return false WHEN only text, subject or sort '
+          'are set (these are not chip filters)', () {
+        final filter = SearchEmailFilter(
+          text: SearchQuery('hello'),
+          subject: 'invoice',
+          sortOrderType: EmailSortOrderType.oldest,
+        );
+
+        expect(filter.hasActiveQuickFilter, isFalse);
+      });
+
+      test('SHOULD return false WHEN the only mailbox is the unified mailbox '
+          '(it does not narrow results), matching isApplied', () {
+        final filter = SearchEmailFilter(
+          mailbox: PresentationMailbox.unifiedMailbox,
+        );
+
+        expect(filter.hasActiveQuickFilter, isFalse);
+      });
+
+      test('SHOULD return true WHEN any chip filter narrows the search', () {
+        final chipFilters = <SearchEmailFilter>[
+          SearchEmailFilter(from: {'alice@example.com'}),
+          SearchEmailFilter(to: {'bob@example.com'}),
+          SearchEmailFilter(mailbox: PresentationMailbox(MailboxId(Id('m')))),
+          SearchEmailFilter(label: Label(id: Id('l'), displayName: 'Work')),
+          SearchEmailFilter(emailReceiveTimeType: EmailReceiveTimeType.last7Days),
+          SearchEmailFilter(startDate: UTCDate(DateTime.utc(2026, 1, 1))),
+          SearchEmailFilter(endDate: UTCDate(DateTime.utc(2026, 1, 31))),
+          SearchEmailFilter(hasAttachment: true),
+          SearchEmailFilter(hasKeyword: {KeyWordIdentifier.emailFlagged.value}),
+          SearchEmailFilter(unread: true),
+          SearchEmailFilter(notIncludeEvents: true),
+        ];
+
+        for (final filter in chipFilters) {
+          expect(filter.hasActiveQuickFilter, isTrue);
+        }
       });
     });
 

--- a/test/features/search/verify_before_time_in_search_email_filter_test.dart
+++ b/test/features/search/verify_before_time_in_search_email_filter_test.dart
@@ -440,7 +440,6 @@ void main() {
       expect(filter.endDate, equals(snapshotEnd));
       expect(filter.before, isNull);
       expect(filter.after, isNull);
-      expect(filter.position, isNull);
     });
 
     test(
@@ -466,7 +465,6 @@ void main() {
       expect(filter.endDate, equals(end));
       expect(filter.before, isNull);
       expect(filter.after, isNull);
-      expect(filter.position, isNull);
     });
 
     test(
@@ -489,7 +487,6 @@ void main() {
       expect(filter.sortOrderType, equals(EmailSortOrderType.mostRecent));
       expect(filter.after, isNull);
       expect(filter.before, isNull);
-      expect(filter.position, isNull);
     });
 
     test(
@@ -512,7 +509,6 @@ void main() {
       expect(filter.sortOrderType, equals(EmailSortOrderType.oldest));
       expect(filter.before, isNull);
       expect(filter.after, isNull);
-      expect(filter.position, isNull);
     });
   });
 
@@ -532,15 +528,12 @@ void main() {
       notifier().set(SearchEmailFilter(
         sortOrderType: EmailSortOrderType.oldest,
         startDate: UTCDate(DateTime.parse('2026-01-10T00:00:00.000Z')),
-        after: UTCDate(DateTime.parse('2026-06-10T00:00:00.000Z')),
-        position: 20,
-      ));
+        after: UTCDate(DateTime.parse('2026-06-10T00:00:00.000Z')),      ));
 
       // Assert: cursors stay transient; date bound is preserved.
       final filter = committed();
       expect(filter.before, isNull);
       expect(filter.after, isNull);
-      expect(filter.position, isNull);
       expect(filter.startDate, equals(UTCDate(DateTime.parse('2026-01-10T00:00:00.000Z'))));
     });
 
@@ -553,15 +546,12 @@ void main() {
       notifier().set(SearchEmailFilter(
         sortOrderType: EmailSortOrderType.subjectAscending,
         before: UTCDate(DateTime.parse('2026-06-15T00:00:00.000Z')),
-        after: UTCDate(DateTime.parse('2026-06-10T00:00:00.000Z')),
-        position: 20,
-      ));
+        after: UTCDate(DateTime.parse('2026-06-10T00:00:00.000Z')),      ));
 
       // Assert: stale cursors cannot seed the fresh query.
       final filter = committed();
       expect(filter.before, isNull);
       expect(filter.after, isNull);
-      expect(filter.position, isNull);
     });
 
     test(
@@ -571,15 +561,12 @@ void main() {
       // Arrange & Act: oldest sort with a leftover after cursor and position.
       notifier().set(SearchEmailFilter(
         sortOrderType: EmailSortOrderType.oldest,
-        after: UTCDate(DateTime.parse('2026-06-10T00:00:00.000Z')),
-        position: 20,
-      ));
+        after: UTCDate(DateTime.parse('2026-06-10T00:00:00.000Z')),      ));
 
       // Assert: no stale cursor leaks into the committed filter.
       final filter = committed();
       expect(filter.before, isNull);
       expect(filter.after, isNull);
-      expect(filter.position, isNull);
     });
   });
 }

--- a/test/features/search/verify_before_time_in_search_email_filter_test.dart
+++ b/test/features/search/verify_before_time_in_search_email_filter_test.dart
@@ -1,22 +1,14 @@
-import 'dart:math' as math;
 
 import 'package:core/data/network/config/dynamic_url_interceptors.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/app_toast.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
-import 'package:core/utils/app_logger.dart';
 import 'package:dartz/dartz.dart' hide State;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
-import 'package:jmap_dart_client/jmap/core/filter/operator/logic_filter_operator.dart';
-import 'package:jmap_dart_client/jmap/core/id.dart';
-import 'package:jmap_dart_client/jmap/core/state.dart';
 import 'package:jmap_dart_client/jmap/core/utc_date.dart';
-import 'package:jmap_dart_client/jmap/mail/email/email.dart';
-import 'package:jmap_dart_client/jmap/mail/email/email_filter_condition.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
-import 'package:model/email/presentation_email.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:tmail_ui_user/features/caching/caching_manager.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/send_email_interactor.dart';
@@ -30,7 +22,6 @@ import 'package:tmail_ui_user/features/email/domain/usecases/mark_as_star_email_
 import 'package:tmail_ui_user/features/email/domain/usecases/move_to_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/restore_deleted_message_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/unsubscribe_email_interactor.dart';
-import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
 import 'package:tmail_ui_user/features/home/domain/usecases/get_session_interactor.dart';
 import 'package:tmail_ui_user/features/home/domain/usecases/store_session_interactor.dart';
 import 'package:tmail_ui_user/features/identity_creator/domain/usecase/get_identity_cache_on_web_interactor.dart';
@@ -63,6 +54,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_all_identities_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
@@ -71,10 +63,7 @@ import 'package:tmail_ui_user/features/sending_queue/domain/usecases/delete_send
 import 'package:tmail_ui_user/features/sending_queue/domain/usecases/get_all_sending_email_interactor.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/usecases/store_sending_email_interactor.dart';
 import 'package:tmail_ui_user/features/sending_queue/domain/usecases/update_sending_email_interactor.dart';
-import 'package:tmail_ui_user/features/thread/domain/constants/thread_constants.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
-import 'package:tmail_ui_user/features/thread/domain/state/refresh_changes_all_email_state.dart';
-import 'package:tmail_ui_user/features/thread/domain/state/search_email_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/clean_and_get_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/empty_spam_folder_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/get_email_by_id_interactor.dart';
@@ -86,9 +75,9 @@ import 'package:tmail_ui_user/features/thread/domain/usecases/move_multiple_emai
 import 'package:tmail_ui_user/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_more_email_interactor.dart';
-import 'package:tmail_ui_user/features/thread/presentation/extensions/handle_email_filter_extension.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/utils/email_receive_manager.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
@@ -174,20 +163,6 @@ const fallbackGenerators = {
   MockSpec<StoreEmailSortOrderInteractor>(),
   MockSpec<GetStoredEmailSortOrderInteractor>(),
 ])
-UTCDate? _extractBeforeFromFilter(Object? filter) {
-  if (filter is EmailFilterCondition) {
-    return filter.before;
-  } else if (filter is LogicFilterOperator) {
-    for (final condition in filter.conditions) {
-      final before = _extractBeforeFromFilter(condition);
-      if (before != null) {
-        return before;
-      }
-    }
-  }
-  return null;
-}
-
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -410,12 +385,14 @@ void main() {
 
     Get.put<MailboxDashBoardController>(mailboxDashboardController);
 
+    // The central SearchEmailNotifier executor resolves its interactors via
+    // Get.find; register the mocks so any delegated search can run.
+    Get.put<SearchEmailInteractor>(mockSearchEmailInteractor);
+    Get.put<SearchMoreEmailInteractor>(mockSearchMoreEmailInteractor);
     threadController = ThreadController(
       mockGetEmailsInMailboxInteractor,
       mockRefreshChangesEmailsInMailboxInteractor,
       mockLoadMoreEmailsInMailboxInteractor,
-      mockSearchEmailInteractor,
-      mockSearchMoreEmailInteractor,
       mockGetEmailByIdInteractor,
       mockCleanAndGetEmailsInMailboxInteractor,
     );
@@ -428,814 +405,36 @@ void main() {
     mailboxDashboardController.onInit();
   });
 
-  List<PresentationEmail> generateEmailList({
-    required DateTime startDate,
-    required DateTime endDate,
-    required int count,
-    EmailSortOrderType? sortOrderType,
-  }) {
-    const uuid = Uuid();
-    final random = math.Random();
-
-    DateTime randomDate(DateTime start, DateTime end) {
-      final differenceInSeconds = end.difference(start).inSeconds;
-      final randomSeconds = random.nextInt(differenceInSeconds + 1);
-      return start.add(Duration(seconds: randomSeconds));
-    }
-
-    List<PresentationEmail> emails = List.generate(count, (index) {
-      final date = randomDate(startDate, endDate);
-      return PresentationEmail(
-        id: EmailId(Id(uuid.v4())),
-        subject: 'Subject $index',
-        receivedAt: UTCDate(date),
-      );
-    });
-
-    if (sortOrderType != null) {
-      switch (sortOrderType) {
-        case EmailSortOrderType.mostRecent:
-          emails.sort((a, b) => b.receivedAt!.value.compareTo(a.receivedAt!.value));
-          break;
-        case EmailSortOrderType.subjectAscending:
-          emails.sort((a, b) => a.subject!.compareTo(b.subject!));
-          break;
-        default:
-          break;
-      }
-    }
-
-    return emails;
-  }
-
-  group('SearchEmailFilter::test', () {
-    test(
-      'WHEN ThreadController searches for emails in the time range from `2025/01/10` to `2025/01/20`\n'
-      'AND SortBy is `Most recent, the result returns 20 elements.`\n'
-      'THEN perform LOAD MORE EMAILS, now the value of `before` in search filter AND `before` in JMAP request\n'
-      'SHOULD be `receivedAt` of last email',
-    () async {
-      // Arrange
-      final startDate = DateTime(2025, 1, 10);
-      final endDate = DateTime(2025, 1, 20, 23, 59, 59);
-      final emailList = generateEmailList(
-        startDate: startDate,
-        endDate: endDate,
-        count: 20,
-        sortOrderType: EmailSortOrderType.mostRecent,
-      );
-      log('verify_before_time_in_search_email_filter_test::LoadMore::EmailList = ${emailList.map((email) => email.receivedAt.toString()).toList()}');
-      final searchEmailFilter = SearchEmailFilter(
-        sortOrderType: EmailSortOrderType.mostRecent,
-        startDate: UTCDate(startDate),
-        endDate: UTCDate(endDate),
-      );
-
-      when(mockSearchEmailInteractor.execute(
-        any,
-        any,
-        limit: anyNamed('limit'),
-        position: anyNamed('position'),
-        sort: anyNamed('sort'),
-        filter: anyNamed('filter'),
-        collapseThreads: anyNamed('collapseThreads'),
-        properties: anyNamed('properties'),
-        needRefreshSearchState: anyNamed('needRefreshSearchState'),
-      )).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(emailList))));
-
-      // Act
-      searchController.searchEmailFilter.value = searchEmailFilter;
-
-      threadController.searchEmail();
-
-      await untilCalled(mockSearchEmailInteractor.execute(
-        any,
-        any,
-        limit: anyNamed('limit'),
-        position: anyNamed('position'),
-        sort: anyNamed('sort'),
-        filter: anyNamed('filter'),
-        collapseThreads: anyNamed('collapseThreads'),
-        properties: anyNamed('properties'),
-        needRefreshSearchState: anyNamed('needRefreshSearchState'),
-      ));
-
-      // Assert
-      verify(mockSearchEmailInteractor.execute(
-        SessionFixtures.aliceSession,
-        AccountFixtures.aliceAccountId,
-        limit: ThreadConstants.defaultLimit,
-        position: searchController.searchEmailFilter.value.position,
-        sort: searchController.searchEmailFilter.value.sortOrderType.getSortOrder().toNullable(),
-        filter: searchController.searchEmailFilter.value.mappingToEmailFilterCondition(),
-        collapseThreads: false,
-        properties: EmailUtils.getPropertiesForEmailGetMethod(
-          SessionFixtures.aliceSession,
-          AccountFixtures.aliceAccountId,
-        ),
-        needRefreshSearchState: false,
-      )).called(1);
-
-      expect(
-        mailboxDashboardController.emailsInCurrentMailbox,
-        isNotEmpty,
-      );
-      expect(threadController.canSearchMore, isTrue);
-      expect(
-        searchController.searchEmailFilter.value.startDate,
-        equals(UTCDate(startDate)),
-      );
-      expect(
-        searchController.searchEmailFilter.value.endDate,
-        equals(UTCDate(endDate)),
-      );
-      expect(
-        searchController.searchEmailFilter.value.before,
-        isNull,
-      );
-
-      // Act
-      threadController.searchMoreEmails();
-
-      await untilCalled(mockSearchMoreEmailInteractor.execute(
-        any,
-        any,
-        limit: anyNamed('limit'),
-        position: anyNamed('position'),
-        sort: anyNamed('sort'),
-        filter: anyNamed('filter'),
-        collapseThreads: anyNamed('collapseThreads'),
-        properties: anyNamed('properties'),
-        lastEmailId: anyNamed('lastEmailId'),
-      ));
-
-      final filterInJMapRequest = searchController
-        .searchEmailFilter
-        .value
-        .mappingToEmailFilterCondition();
-
-      // Assert
-      verify(mockSearchMoreEmailInteractor.execute(
-        SessionFixtures.aliceSession,
-        AccountFixtures.aliceAccountId,
-        limit: ThreadConstants.defaultLimit,
-        sort: searchController.searchEmailFilter.value.sortOrderType.getSortOrder().toNullable(),
-        position: searchController.searchEmailFilter.value.position,
-        filter: filterInJMapRequest,
-        collapseThreads: false,
-        properties: EmailUtils.getPropertiesForEmailGetMethod(
-          SessionFixtures.aliceSession,
-          AccountFixtures.aliceAccountId,
-        ),
-        lastEmailId: emailList.last.id,
-      )).called(1);
-
-      expect(
-        searchController.searchEmailFilter.value.startDate,
-        equals(UTCDate(startDate)),
-      );
-      expect(
-        searchController.searchEmailFilter.value.endDate,
-        equals(UTCDate(endDate)),
-      );
-      expect(
-        searchController.searchEmailFilter.value.before,
-        equals(emailList.last.receivedAt),
-      );
-
-      expect(_extractBeforeFromFilter(filterInJMapRequest), equals(emailList.last.receivedAt));
-    });
-
-    test(
-      'WHEN ThreadController searches for emails in the time range from `2025/01/10` to `2025/01/20`\n'
-      'AND SortBy is `Subject: A-Z`, the result returns 20 elements.\n'
-      'THEN perform LOAD MORE EMAILS, now the value of `before` in search filter is null AND `before` in JMAP request\n'
-      'SHOULD be `endDate`',
-    () async {
-      // Arrange
-      final startDate = DateTime(2025, 1, 10);
-      final endDate = DateTime(2025, 1, 20, 23, 59, 59);
-      final emailList = generateEmailList(
-        startDate: startDate,
-        endDate: endDate,
-        count: 20,
-        sortOrderType: EmailSortOrderType.subjectAscending
-      );
-      log('verify_before_time_in_search_email_filter_test::LoadMore::EmailList = ${emailList.map((email) => email.subject.toString()).toList()}');
-      final searchEmailFilter = SearchEmailFilter(
-        position: 0,
-        sortOrderType: EmailSortOrderType.subjectAscending,
-        startDate: UTCDate(startDate),
-        endDate: UTCDate(endDate),
-      );
-
-      when(mockSearchEmailInteractor.execute(
-        any,
-        any,
-        limit: anyNamed('limit'),
-        position: anyNamed('position'),
-        sort: anyNamed('sort'),
-        filter: anyNamed('filter'),
-        collapseThreads: anyNamed('collapseThreads'),
-        properties: anyNamed('properties'),
-        needRefreshSearchState: anyNamed('needRefreshSearchState'),
-      )).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(emailList))));
-
-      // Act
-      searchController.searchEmailFilter.value = searchEmailFilter;
-
-      threadController.searchEmail();
-
-      await untilCalled(mockSearchEmailInteractor.execute(
-        any,
-        any,
-        limit: anyNamed('limit'),
-        position: anyNamed('position'),
-        sort: anyNamed('sort'),
-        filter: anyNamed('filter'),
-        collapseThreads: anyNamed('collapseThreads'),
-        properties: anyNamed('properties'),
-        needRefreshSearchState: anyNamed('needRefreshSearchState'),
-      ));
-
-      // Assert
-      verify(mockSearchEmailInteractor.execute(
-        SessionFixtures.aliceSession,
-        AccountFixtures.aliceAccountId,
-        limit: ThreadConstants.defaultLimit,
-        position: searchController.searchEmailFilter.value.position,
-        sort: searchController.searchEmailFilter.value.sortOrderType.getSortOrder().toNullable(),
-        filter: searchController.searchEmailFilter.value.mappingToEmailFilterCondition(),
-        collapseThreads: false,
-        properties: EmailUtils.getPropertiesForEmailGetMethod(
-          SessionFixtures.aliceSession,
-          AccountFixtures.aliceAccountId,
-        ),
-        needRefreshSearchState: false,
-      )).called(1);
-
-      expect(
-        mailboxDashboardController.emailsInCurrentMailbox,
-        isNotEmpty,
-      );
-      expect(threadController.canSearchMore, isTrue);
-      expect(
-        searchController.searchEmailFilter.value.startDate,
-        equals(UTCDate(startDate)),
-      );
-      expect(
-        searchController.searchEmailFilter.value.endDate,
-        equals(UTCDate(endDate)),
-      );
-      expect(
-        searchController.searchEmailFilter.value.position,
-        equals(0),
-      );
-      expect(
-        searchController.searchEmailFilter.value.before,
-        isNull,
-      );
-
-      // Act
-      threadController.searchMoreEmails();
-
-      await untilCalled(mockSearchMoreEmailInteractor.execute(
-        any,
-        any,
-        limit: anyNamed('limit'),
-        position: anyNamed('position'),
-        sort: anyNamed('sort'),
-        filter: anyNamed('filter'),
-        collapseThreads: anyNamed('collapseThreads'),
-        properties: anyNamed('properties'),
-        lastEmailId: anyNamed('lastEmailId'),
-      ));
-
-      final filterInJMapRequest = searchController
-        .searchEmailFilter
-        .value
-        .mappingToEmailFilterCondition();
-
-      // Assert
-      verify(mockSearchMoreEmailInteractor.execute(
-        SessionFixtures.aliceSession,
-        AccountFixtures.aliceAccountId,
-        limit: ThreadConstants.defaultLimit,
-        sort: searchController.searchEmailFilter.value.sortOrderType.getSortOrder().toNullable(),
-        position: searchController.searchEmailFilter.value.position,
-        filter: filterInJMapRequest,
-        collapseThreads: false,
-        properties: EmailUtils.getPropertiesForEmailGetMethod(
-          SessionFixtures.aliceSession,
-          AccountFixtures.aliceAccountId,
-        ),
-        lastEmailId: emailList.last.id,
-      )).called(1);
-
-      expect(
-        searchController.searchEmailFilter.value.startDate,
-        equals(UTCDate(startDate)),
-      );
-      expect(
-        searchController.searchEmailFilter.value.endDate,
-        equals(UTCDate(endDate)),
-      );
-      expect(
-        searchController.searchEmailFilter.value.position,
-        equals(20),
-      );
-      expect(
-        searchController.searchEmailFilter.value.before,
-        isNull,
-      );
-
-      expect(_extractBeforeFromFilter(filterInJMapRequest), equals(UTCDate(endDate)));
-    });
-
-    test(
-      'WHEN ThreadController searches for emails in the time range from `2025/01/10` to `2025/01/20`\n'
-      'AND SortBy is `Most recent`, the result returns 20 elements\n'
-      'THEN perform REFRESH EMAIL CHANGE, now the value of `before` in search filter is null AND `before` in JMAP request\n'
-      'SHOULD be `endDate`',
-    () async {
-      // Arrange
-      final startDate = DateTime(2025, 1, 10);
-      final endDate = DateTime(2025, 1, 20, 23, 59, 59);
-      final emailList = generateEmailList(
-        startDate: startDate,
-        endDate: endDate,
-        count: 20,
-        sortOrderType: EmailSortOrderType.mostRecent,
-      );
-      log('verify_before_time_in_search_email_filter_test::RefreshEmailChange::EmailList = ${emailList.map((email) => email.receivedAt.toString()).toList()}');
-      final searchEmailFilter = SearchEmailFilter(
-        sortOrderType: EmailSortOrderType.mostRecent,
-        startDate: UTCDate(startDate),
-        endDate: UTCDate(endDate),
-      );
-
-      when(mockSearchEmailInteractor.execute(
-        any,
-        any,
-        limit: anyNamed('limit'),
-        position: anyNamed('position'),
-        sort: anyNamed('sort'),
-        filter: anyNamed('filter'),
-        collapseThreads: anyNamed('collapseThreads'),
-        properties: anyNamed('properties'),
-        needRefreshSearchState: anyNamed('needRefreshSearchState'),
-      )).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(emailList))));
-
-      // Act
-      searchController.searchEmailFilter.value = searchEmailFilter;
-
-      threadController.searchEmail();
-
-      await untilCalled(mockSearchEmailInteractor.execute(
-        any,
-        any,
-        limit: anyNamed('limit'),
-        position: anyNamed('position'),
-        sort: anyNamed('sort'),
-        filter: anyNamed('filter'),
-        collapseThreads: anyNamed('collapseThreads'),
-        properties: anyNamed('properties'),
-        needRefreshSearchState: anyNamed('needRefreshSearchState'),
-      ));
-
-      // Assert
-      verify(mockSearchEmailInteractor.execute(
-        SessionFixtures.aliceSession,
-        AccountFixtures.aliceAccountId,
-        limit: ThreadConstants.defaultLimit,
-        position: searchController.searchEmailFilter.value.position,
-        sort: searchController.searchEmailFilter.value.sortOrderType.getSortOrder().toNullable(),
-        filter: searchController.searchEmailFilter.value.mappingToEmailFilterCondition(),
-        collapseThreads: false,
-        properties: EmailUtils.getPropertiesForEmailGetMethod(
-          SessionFixtures.aliceSession,
-          AccountFixtures.aliceAccountId,
-        ),
-        needRefreshSearchState: false,
-      )).called(1);
-
-      expect(
-        mailboxDashboardController.emailsInCurrentMailbox,
-        isNotEmpty,
-      );
-      expect(threadController.canSearchMore, isTrue);
-      expect(
-        searchController.searchEmailFilter.value.startDate,
-        equals(UTCDate(startDate)),
-      );
-      expect(
-        searchController.searchEmailFilter.value.endDate,
-        equals(UTCDate(endDate)),
-      );
-      expect(
-        searchController.searchEmailFilter.value.before,
-        isNull,
-      );
-
-      // Act
-      mailboxDashboardController.setCurrentEmailState(State('current-state'));
-
-      when(mockRefreshChangesEmailsInMailboxInteractor.execute(
-        any,
-        any,
-        any,
-        sort: anyNamed('sort'),
-        limit: anyNamed('limit'),
-        propertiesCreated: anyNamed('propertiesCreated'),
-        propertiesUpdated: anyNamed('propertiesUpdated'),
-        emailFilter: anyNamed('emailFilter'),
-        collapseThreads: anyNamed('collapseThreads'),
-      )).thenAnswer((_) => Stream.value(Right(RefreshChangesAllEmailSuccess(emailList: emailList))));
-
-      when(mockSearchEmailInteractor.execute(
-        any,
-        any,
-        limit: anyNamed('limit'),
-        position: anyNamed('position'),
-        sort: anyNamed('sort'),
-        filter: anyNamed('filter'),
-        collapseThreads: anyNamed('collapseThreads'),
-        properties: anyNamed('properties'),
-        needRefreshSearchState: anyNamed('needRefreshSearchState'),
-      )).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(emailList))));
-
-      await threadController.refreshChangeSearchEmail();
-
-      final filterInJMapRequest = searchController
-        .searchEmailFilter
-        .value
-        .mappingToEmailFilterCondition();
-
-      // Assert
-      verify(mockRefreshChangesEmailsInMailboxInteractor.execute(
-        SessionFixtures.aliceSession,
-        AccountFixtures.aliceAccountId,
-        mailboxDashboardController.currentEmailState!,
-        sort: EmailSortOrderType.mostRecent.getSortOrder().toNullable(),
-        limit: threadController.limitEmailFetched,
-        propertiesCreated: EmailUtils.getPropertiesForEmailGetMethod(
-          SessionFixtures.aliceSession,
-          AccountFixtures.aliceAccountId,
-        ),
-        propertiesUpdated: ThreadConstants.propertiesUpdatedDefault,
-        emailFilter: threadController.getEmailFilterForLoadMailbox(),
-        collapseThreads: false,
-      )).called(1);
-
-      verify(mockSearchEmailInteractor.execute(
-        SessionFixtures.aliceSession,
-        AccountFixtures.aliceAccountId,
-        limit: threadController.limitEmailFetched,
-        position: searchController.searchEmailFilter.value.position,
-        sort: searchController.searchEmailFilter.value.sortOrderType.getSortOrder().toNullable(),
-        filter: searchController.searchEmailFilter.value.mappingToEmailFilterCondition(),
-        collapseThreads: false,
-        properties: EmailUtils.getPropertiesForEmailGetMethod(
-          SessionFixtures.aliceSession,
-          AccountFixtures.aliceAccountId,
-        ),
-        needRefreshSearchState: true,
-      )).called(1);
-
-      expect(
-        searchController.searchEmailFilter.value.startDate,
-        equals(UTCDate(startDate)),
-      );
-      expect(
-        searchController.searchEmailFilter.value.endDate,
-        equals(UTCDate(endDate)),
-      );
-      expect(
-        searchController.searchEmailFilter.value.before,
-        isNull,
-      );
-
-      expect(_extractBeforeFromFilter(filterInJMapRequest), equals(UTCDate(endDate)));
-    });
-
-    test(
-      'WHEN ThreadController searches for emails in the time range from `2025/01/10` to `2025/01/20`\n'
-      'AND SortBy is `Subject: A-Z`, the result returns 20 elements.\n'
-      'THEN perform REFRESH EMAIL CHANGE, now the value of `before` in search filter is null AND `before` in JMAP request\n'
-      'SHOULD be `endDate`',
-    () async {
-      // Arrange
-      final startDate = DateTime(2025, 1, 10);
-      final endDate = DateTime(2025, 1, 20, 23, 59, 59);
-      final emailList = generateEmailList(
-        startDate: startDate,
-        endDate: endDate,
-        count: 20,
-        sortOrderType: EmailSortOrderType.subjectAscending,
-      );
-      log('verify_before_time_in_search_email_filter_test::RefreshEmailChange::EmailList = ${emailList.map((email) => email.subject.toString()).toList()}');
-      final searchEmailFilter = SearchEmailFilter(
-        position: 0,
-        sortOrderType: EmailSortOrderType.subjectAscending,
-        startDate: UTCDate(startDate),
-        endDate: UTCDate(endDate),
-      );
-
-      when(mockSearchEmailInteractor.execute(
-        any,
-        any,
-        limit: anyNamed('limit'),
-        position: anyNamed('position'),
-        sort: anyNamed('sort'),
-        filter: anyNamed('filter'),
-        collapseThreads: anyNamed('collapseThreads'),
-        properties: anyNamed('properties'),
-        needRefreshSearchState: anyNamed('needRefreshSearchState'),
-      )).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(emailList))));
-
-      // Act
-      searchController.searchEmailFilter.value = searchEmailFilter;
-
-      threadController.searchEmail();
-
-      await untilCalled(mockSearchEmailInteractor.execute(
-        any,
-        any,
-        limit: anyNamed('limit'),
-        position: anyNamed('position'),
-        sort: anyNamed('sort'),
-        filter: anyNamed('filter'),
-        collapseThreads: anyNamed('collapseThreads'),
-        properties: anyNamed('properties'),
-        needRefreshSearchState: anyNamed('needRefreshSearchState'),
-      ));
-
-      // Assert
-      verify(mockSearchEmailInteractor.execute(
-        SessionFixtures.aliceSession,
-        AccountFixtures.aliceAccountId,
-        limit: ThreadConstants.defaultLimit,
-        position: searchController.searchEmailFilter.value.position,
-        sort: searchController.searchEmailFilter.value.sortOrderType.getSortOrder().toNullable(),
-        filter: searchController.searchEmailFilter.value.mappingToEmailFilterCondition(),
-        collapseThreads: false,
-        properties: EmailUtils.getPropertiesForEmailGetMethod(
-          SessionFixtures.aliceSession,
-          AccountFixtures.aliceAccountId,
-        ),
-        needRefreshSearchState: false
-      )).called(1);
-
-      expect(
-        mailboxDashboardController.emailsInCurrentMailbox,
-        isNotEmpty,
-      );
-      expect(threadController.canSearchMore, isTrue);
-      expect(
-        searchController.searchEmailFilter.value.startDate,
-        equals(UTCDate(startDate)),
-      );
-      expect(
-        searchController.searchEmailFilter.value.endDate,
-        equals(UTCDate(endDate)),
-      );
-      expect(
-        searchController.searchEmailFilter.value.position,
-        equals(0),
-      );
-      expect(
-        searchController.searchEmailFilter.value.before,
-        isNull,
-      );
-
-      // Act
-      mailboxDashboardController.setCurrentEmailState(State('current-state'));
-
-      when(mockRefreshChangesEmailsInMailboxInteractor.execute(
-        any,
-        any,
-        any,
-        sort: anyNamed('sort'),
-        limit: anyNamed('limit'),
-        propertiesCreated: anyNamed('propertiesCreated'),
-        propertiesUpdated: anyNamed('propertiesUpdated'),
-        emailFilter: anyNamed('emailFilter'),
-        collapseThreads: anyNamed('collapseThreads'),
-      )).thenAnswer((_) => Stream.value(Right(RefreshChangesAllEmailSuccess(emailList: emailList))));
-
-      when(mockSearchEmailInteractor.execute(
-        any,
-        any,
-        limit: anyNamed('limit'),
-        position: anyNamed('position'),
-        sort: anyNamed('sort'),
-        filter: anyNamed('filter'),
-        collapseThreads: anyNamed('collapseThreads'),
-        properties: anyNamed('properties'),
-        needRefreshSearchState: anyNamed('needRefreshSearchState'),
-      )).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(emailList))));
-
-      await threadController.refreshChangeSearchEmail();
-
-      final filterInJMapRequest = searchController
-        .searchEmailFilter
-        .value
-        .mappingToEmailFilterCondition();
-
-      // Assert
-      verify(mockRefreshChangesEmailsInMailboxInteractor.execute(
-        SessionFixtures.aliceSession,
-        AccountFixtures.aliceAccountId,
-        mailboxDashboardController.currentEmailState!,
-        sort: EmailSortOrderType.mostRecent.getSortOrder().toNullable(),
-        limit: threadController.limitEmailFetched,
-        propertiesCreated: EmailUtils.getPropertiesForEmailGetMethod(
-          SessionFixtures.aliceSession,
-          AccountFixtures.aliceAccountId,
-        ),
-        propertiesUpdated: ThreadConstants.propertiesUpdatedDefault,
-        emailFilter: threadController.getEmailFilterForLoadMailbox(),
-        collapseThreads: false,
-      )).called(1);
-
-      verify(mockSearchEmailInteractor.execute(
-        SessionFixtures.aliceSession,
-        AccountFixtures.aliceAccountId,
-        limit: threadController.limitEmailFetched,
-        position: searchController.searchEmailFilter.value.position,
-        sort: searchController.searchEmailFilter.value.sortOrderType.getSortOrder().toNullable(),
-        filter: searchController.searchEmailFilter.value.mappingToEmailFilterCondition(),
-        collapseThreads: false,
-        properties: EmailUtils.getPropertiesForEmailGetMethod(
-          SessionFixtures.aliceSession,
-          AccountFixtures.aliceAccountId,
-        ),
-        needRefreshSearchState: true,
-      )).called(1);
-
-      expect(
-        searchController.searchEmailFilter.value.startDate,
-        equals(UTCDate(startDate)),
-      );
-      expect(
-        searchController.searchEmailFilter.value.endDate,
-        equals(UTCDate(endDate)),
-      );
-      expect(
-        searchController.searchEmailFilter.value.position,
-        equals(0),
-      );
-      expect(
-        searchController.searchEmailFilter.value.before,
-        isNull,
-      );
-
-      expect(_extractBeforeFromFilter(filterInJMapRequest), equals(UTCDate(endDate)));
-    });
-
-    test(
-      'WHEN ThreadController searches & load more for emails in the time range from `2025/01/10` to `2025/01/20`\n'
-      'AND SortBy is `Subject: A-Z`, the result returns 40 elements.\n'
-      'THEN perform REFRESH EMAIL CHANGE, the stale `before` cursor is cleared AND `before` in JMAP request\n'
-      'SHOULD fall back to `endDate`',
-    () async {
-      // Arrange
-      final startDate = DateTime(2025, 1, 10);
-      final endDate = DateTime(2025, 1, 20, 23, 59, 59);
-      final loadMoreDate = DateTime(2025, 1, 15);
-      final emailList = generateEmailList(
-        startDate: startDate,
-        endDate: endDate,
-        count: 40,
-        sortOrderType: EmailSortOrderType.subjectAscending,
-      );
-      log('verify_before_time_in_search_email_filter_test::RefreshEmailChange::EmailList = ${emailList.map((email) => email.subject.toString()).toList()}');
-      final searchEmailFilter = SearchEmailFilter(
-        position: 20,
-        sortOrderType: EmailSortOrderType.subjectAscending,
-        startDate: UTCDate(startDate),
-        endDate: UTCDate(endDate),
-        before: UTCDate(loadMoreDate),
-      );
-
-      // Act
-      mailboxDashboardController.updateEmailList(emailList);
-      searchController.searchEmailFilter.value = searchEmailFilter;
-
-      mailboxDashboardController.setCurrentEmailState(State('current-state'));
-
-      when(mockRefreshChangesEmailsInMailboxInteractor.execute(
-        any,
-        any,
-        any,
-        sort: anyNamed('sort'),
-        limit: anyNamed('limit'),
-        propertiesCreated: anyNamed('propertiesCreated'),
-        propertiesUpdated: anyNamed('propertiesUpdated'),
-        emailFilter: anyNamed('emailFilter'),
-        collapseThreads: anyNamed('collapseThreads'),
-      )).thenAnswer((_) => Stream.value(Right(RefreshChangesAllEmailSuccess(emailList: emailList))));
-
-      when(mockSearchEmailInteractor.execute(
-        any,
-        any,
-        limit: anyNamed('limit'),
-        position: anyNamed('position'),
-        sort: anyNamed('sort'),
-        filter: anyNamed('filter'),
-        collapseThreads: anyNamed('collapseThreads'),
-        properties: anyNamed('properties'),
-        needRefreshSearchState: anyNamed('needRefreshSearchState'),
-      )).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(emailList))));
-
-      await threadController.refreshChangeSearchEmail();
-
-      final filterInJMapRequest = searchController
-        .searchEmailFilter
-        .value
-        .mappingToEmailFilterCondition();
-
-      // Assert
-      verify(mockRefreshChangesEmailsInMailboxInteractor.execute(
-        SessionFixtures.aliceSession,
-        AccountFixtures.aliceAccountId,
-        mailboxDashboardController.currentEmailState!,
-        sort: EmailSortOrderType.mostRecent.getSortOrder().toNullable(),
-        limit: threadController.limitEmailFetched,
-        propertiesCreated: EmailUtils.getPropertiesForEmailGetMethod(
-          SessionFixtures.aliceSession,
-          AccountFixtures.aliceAccountId,
-        ),
-        propertiesUpdated: ThreadConstants.propertiesUpdatedDefault,
-        emailFilter: threadController.getEmailFilterForLoadMailbox(),
-        collapseThreads: false,
-      )).called(1);
-
-      verify(mockSearchEmailInteractor.execute(
-        SessionFixtures.aliceSession,
-        AccountFixtures.aliceAccountId,
-        limit: threadController.limitEmailFetched,
-        position: searchController.searchEmailFilter.value.position,
-        sort: searchController.searchEmailFilter.value.sortOrderType.getSortOrder().toNullable(),
-        filter: searchController.searchEmailFilter.value.mappingToEmailFilterCondition(),
-        collapseThreads: false,
-        properties: EmailUtils.getPropertiesForEmailGetMethod(
-          SessionFixtures.aliceSession,
-          AccountFixtures.aliceAccountId,
-        ),
-        needRefreshSearchState: true,
-      )).called(1);
-
-      expect(
-        searchController.searchEmailFilter.value.startDate,
-        equals(UTCDate(startDate)),
-      );
-      expect(
-        searchController.searchEmailFilter.value.endDate,
-        equals(UTCDate(endDate)),
-      );
-      expect(
-        searchController.searchEmailFilter.value.position,
-        equals(0),
-      );
-      // The stale load-more `before` cursor must be cleared on a fresh refresh,
-      // even for position-based sorts, so it cannot truncate the next query.
-      expect(
-        searchController.searchEmailFilter.value.before,
-        isNull,
-      );
-
-      // With `before` cleared, the JMAP request falls back to the date-range
-      // bound `endDate` instead of the leaked `loadMoreDate`.
-      expect(_extractBeforeFromFilter(filterInJMapRequest), equals(UTCDate(endDate)));
-    });
-  });
+  SearchEmailFilter committed() => appProviderContainer.read(searchFilterProvider);
+  SearchFilterNotifier notifier() =>
+      appProviderContainer.read(searchFilterProvider.notifier);
 
   group('SearchController::updateSortOrderFilter', () {
     setUp(() {
-      searchController.searchEmailFilter.value = SearchEmailFilter.initial();
+      appProviderContainer
+          .read(searchFilterProvider.notifier)
+          .set(SearchEmailFilter.initial());
     });
 
     test(
-      'SHOULD preserve startDate and endDate AND clear before, after and position '
+      'SHOULD preserve startDate/endDate and keep cursors out '
       'WHEN sort order changes on any filter',
     () {
       // Arrange: snapshotted date bounds set when last7Days was selected
       // (last7Days.toDateRange() snapshots both bounds, so seed endDate too)
       final snapshotStart = UTCDate(DateTime.parse('2026-01-10T00:00:00.000Z'));
       final snapshotEnd = UTCDate(DateTime.parse('2026-01-17T00:00:00.000Z'));
-      searchController.updateFilterEmail(
-        sortOrderTypeOption: const Some(EmailSortOrderType.oldest),
-        emailReceiveTimeTypeOption: const Some(EmailReceiveTimeType.last7Days),
-        startDateOption: Some(snapshotStart),
-        endDateOption: Some(snapshotEnd),
-      );
+      notifier().update(SearchFilterPatch()
+        ..sortOrderTypeOption = const Some(EmailSortOrderType.oldest)
+        ..emailReceiveTimeTypeOption = const Some(EmailReceiveTimeType.last7Days)
+        ..startDateOption = Some(snapshotStart)
+        ..endDateOption = Some(snapshotEnd));
 
       // Act
       searchController.updateSortOrderFilter(EmailSortOrderType.mostRecent);
 
-      // Assert: date bounds are preserved; only load-more cursors are cleared
-      final filter = searchController.searchEmailFilter.value;
+      // Assert: date bounds are preserved; cursors stay transient.
+      final filter = committed();
       expect(filter.sortOrderType, equals(EmailSortOrderType.mostRecent));
       expect(filter.startDate, equals(snapshotStart));
       expect(filter.endDate, equals(snapshotEnd));
@@ -1251,18 +450,17 @@ void main() {
       // Arrange: user has a custom date range applied
       final start = UTCDate(DateTime.parse('2026-01-01T00:00:00.000Z'));
       final end = UTCDate(DateTime.parse('2026-03-31T23:59:59.000Z'));
-      searchController.updateFilterEmail(
-        sortOrderTypeOption: const Some(EmailSortOrderType.oldest),
-        emailReceiveTimeTypeOption: const Some(EmailReceiveTimeType.customRange),
-        startDateOption: Some(start),
-        endDateOption: Some(end),
-      );
+      notifier().update(SearchFilterPatch()
+        ..sortOrderTypeOption = const Some(EmailSortOrderType.oldest)
+        ..emailReceiveTimeTypeOption = const Some(EmailReceiveTimeType.customRange)
+        ..startDateOption = Some(start)
+        ..endDateOption = Some(end));
 
       // Act
       searchController.updateSortOrderFilter(EmailSortOrderType.mostRecent);
 
       // Assert
-      final filter = searchController.searchEmailFilter.value;
+      final filter = committed();
       expect(filter.sortOrderType, equals(EmailSortOrderType.mostRecent));
       expect(filter.startDate, equals(start));
       expect(filter.endDate, equals(end));
@@ -1272,22 +470,22 @@ void main() {
     });
 
     test(
-      'SHOULD clear after cursor WHEN sort order changes while after cursor is active',
+      'SHOULD keep after cursor out of the committed SSOT WHEN sort order changes',
     () {
-      // Arrange: simulate oldest sort load-more → after cursor set by ThreadController
+      // Arrange: simulate a cursor reaching the dashboard controller.
       final cursor = UTCDate(DateTime.parse('2026-06-10T00:00:00.000Z'));
-      searchController.updateFilterEmail(
-        sortOrderTypeOption: const Some(EmailSortOrderType.oldest),
-        emailReceiveTimeTypeOption: const Some(EmailReceiveTimeType.allTime),
-        afterOption: Some(cursor),
-      );
-      expect(searchController.searchEmailFilter.value.after, equals(cursor));
+      notifier().set(SearchEmailFilter(
+        sortOrderType: EmailSortOrderType.oldest,
+        emailReceiveTimeType: EmailReceiveTimeType.allTime,
+        after: cursor,
+      ));
+      expect(committed().after, isNull);
 
       // Act: user changes sort order
       searchController.updateSortOrderFilter(EmailSortOrderType.mostRecent);
 
-      // Assert: after cursor cleared
-      final filter = searchController.searchEmailFilter.value;
+      // Assert: after cursor is still outside the SSOT
+      final filter = committed();
       expect(filter.sortOrderType, equals(EmailSortOrderType.mostRecent));
       expect(filter.after, isNull);
       expect(filter.before, isNull);
@@ -1295,22 +493,22 @@ void main() {
     });
 
     test(
-      'SHOULD clear before cursor WHEN sort order changes while before cursor is active',
+      'SHOULD keep before cursor out of the committed SSOT WHEN sort order changes',
     () {
-      // Arrange: simulate mostRecent sort load-more → before cursor set by ThreadController
+      // Arrange: simulate a cursor reaching the dashboard controller.
       final cursor = UTCDate(DateTime.parse('2026-06-16T08:00:00.000Z'));
-      searchController.updateFilterEmail(
-        sortOrderTypeOption: const Some(EmailSortOrderType.mostRecent),
-        emailReceiveTimeTypeOption: const Some(EmailReceiveTimeType.allTime),
-        beforeOption: Some(cursor),
-      );
-      expect(searchController.searchEmailFilter.value.before, equals(cursor));
+      notifier().set(SearchEmailFilter(
+        sortOrderType: EmailSortOrderType.mostRecent,
+        emailReceiveTimeType: EmailReceiveTimeType.allTime,
+        before: cursor,
+      ));
+      expect(committed().before, isNull);
 
       // Act: user changes sort order
       searchController.updateSortOrderFilter(EmailSortOrderType.oldest);
 
-      // Assert: before cursor cleared
-      final filter = searchController.searchEmailFilter.value;
+      // Assert: before cursor is still outside the SSOT
+      final filter = committed();
       expect(filter.sortOrderType, equals(EmailSortOrderType.oldest));
       expect(filter.before, isNull);
       expect(filter.after, isNull);
@@ -1318,28 +516,28 @@ void main() {
     });
   });
 
-  group('SearchController::resetCursorsForFreshSearch', () {
+  group('SearchFilterMutation.set strips pagination cursors', () {
     setUp(() {
-      searchController.searchEmailFilter.value = SearchEmailFilter.initial();
+      appProviderContainer
+          .read(searchFilterProvider.notifier)
+          .set(SearchEmailFilter.initial());
     });
 
     test(
-      'SHOULD clear before/after and the position '
+      'SHOULD keep before/after/position out of the SSOT '
       'WHEN the sort order is time-based (oldest)',
     () {
-      // Arrange: oldest sort load-more left an after cursor and a position
-      searchController.updateFilterEmail(
-        sortOrderTypeOption: const Some(EmailSortOrderType.oldest),
-        startDateOption: Some(UTCDate(DateTime.parse('2026-01-10T00:00:00.000Z'))),
-        afterOption: Some(UTCDate(DateTime.parse('2026-06-10T00:00:00.000Z'))),
-        positionOption: const Some(20),
-      );
+      // Arrange & Act: oldest sort load-more left an after cursor and a position;
+      // committing it through `set` must strip the cursors while keeping the bound.
+      notifier().set(SearchEmailFilter(
+        sortOrderType: EmailSortOrderType.oldest,
+        startDate: UTCDate(DateTime.parse('2026-01-10T00:00:00.000Z')),
+        after: UTCDate(DateTime.parse('2026-06-10T00:00:00.000Z')),
+        position: 20,
+      ));
 
-      // Act
-      searchController.resetCursorsForFreshSearch(isCollapseThreadsEnabled: false);
-
-      // Assert: cursors cleared, date bound preserved
-      final filter = searchController.searchEmailFilter.value;
+      // Assert: cursors stay transient; date bound is preserved.
+      final filter = committed();
       expect(filter.before, isNull);
       expect(filter.after, isNull);
       expect(filter.position, isNull);
@@ -1347,47 +545,41 @@ void main() {
     });
 
     test(
-      'SHOULD clear the stale before/after cursors AND restart position at 0 '
+      'SHOULD keep stale cursors out of the SSOT '
       'WHEN the sort order is position-based (subjectAscending)',
     () {
-      // Arrange: stale time cursors (both before and after) linger from a
-      // previous time-based sort
-      searchController.updateFilterEmail(
-        sortOrderTypeOption: const Some(EmailSortOrderType.subjectAscending),
-        beforeOption: Some(UTCDate(DateTime.parse('2026-06-15T00:00:00.000Z'))),
-        afterOption: Some(UTCDate(DateTime.parse('2026-06-10T00:00:00.000Z'))),
-        positionOption: const Some(20),
-      );
+      // Arrange & Act: stale time cursors (both before and after) linger from a
+      // previous time-based sort; `set` must drop them.
+      notifier().set(SearchEmailFilter(
+        sortOrderType: EmailSortOrderType.subjectAscending,
+        before: UTCDate(DateTime.parse('2026-06-15T00:00:00.000Z')),
+        after: UTCDate(DateTime.parse('2026-06-10T00:00:00.000Z')),
+        position: 20,
+      ));
 
-      // Act
-      searchController.resetCursorsForFreshSearch(isCollapseThreadsEnabled: false);
-
-      // Assert: stale cursor cleared so it cannot truncate the fresh query
-      final filter = searchController.searchEmailFilter.value;
+      // Assert: stale cursors cannot seed the fresh query.
+      final filter = committed();
       expect(filter.before, isNull);
       expect(filter.after, isNull);
-      expect(filter.position, equals(0));
+      expect(filter.position, isNull);
     });
 
     test(
-      'SHOULD clear the stale before/after cursors AND restart position at 0 '
-      'WHEN collapsed threads are enabled on a time-based sort',
+      'SHOULD keep stale cursors out of the SSOT '
+      'WHEN a leftover after cursor and position are committed together',
     () {
-      // Arrange: oldest sort with a leftover after cursor, then collapse enabled
-      searchController.updateFilterEmail(
-        sortOrderTypeOption: const Some(EmailSortOrderType.oldest),
-        afterOption: Some(UTCDate(DateTime.parse('2026-06-10T00:00:00.000Z'))),
-        positionOption: const Some(20),
-      );
+      // Arrange & Act: oldest sort with a leftover after cursor and position.
+      notifier().set(SearchEmailFilter(
+        sortOrderType: EmailSortOrderType.oldest,
+        after: UTCDate(DateTime.parse('2026-06-10T00:00:00.000Z')),
+        position: 20,
+      ));
 
-      // Act: collapsed threads switch pagination to position mode
-      searchController.resetCursorsForFreshSearch(isCollapseThreadsEnabled: true);
-
-      // Assert: no stale cursor leaks into the collapsed-thread query
-      final filter = searchController.searchEmailFilter.value;
+      // Assert: no stale cursor leaks into the committed filter.
+      final filter = committed();
       expect(filter.before, isNull);
       expect(filter.after, isNull);
-      expect(filter.position, equals(0));
+      expect(filter.position, isNull);
     });
   });
 }

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:core/data/network/config/dynamic_url_interceptors.dart';
 import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:core/presentation/utils/app_toast.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
@@ -19,22 +22,23 @@ import 'package:mockito/mockito.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:model/mailbox/select_mode.dart';
+import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
 import 'package:tmail_ui_user/features/caching/caching_manager.dart';
 import 'package:tmail_ui_user/features/email/presentation/action/email_ui_action.dart';
-import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
+import 'package:tmail_ui_user/features/home/data/exceptions/session_exceptions.dart';
 import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oidc_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/action/dashboard_action.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/search_controller.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
 import 'package:tmail_ui_user/features/network_connection/presentation/network_connection_controller.dart';
 import 'package:tmail_ui_user/features/thread/domain/constants/thread_constants.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
+import 'package:tmail_ui_user/features/thread/domain/state/refresh_all_email_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/refresh_changes_all_email_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/search_email_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/clean_and_get_emails_in_mailbox_interactor.dart';
@@ -46,11 +50,18 @@ import 'package:tmail_ui_user/features/thread/domain/usecases/load_more_emails_i
 import 'package:tmail_ui_user/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_more_email_interactor.dart';
+import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
+import 'package:tmail_ui_user/features/search/email/domain/execution/search_execution_intent.dart';
+import 'package:tmail_ui_user/features/search/email/domain/model/search_email_result.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_email_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/domain/state/refresh_changes_search_email_state.dart';
+import 'package:tmail_ui_user/features/search/email/domain/usecases/refresh_changes_search_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/auto_load_more_policy.dart';
-import 'package:tmail_ui_user/features/thread/presentation/model/search_state.dart';
-import 'package:tmail_ui_user/features/thread/presentation/model/search_status.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
 import 'package:uuid/uuid.dart';
@@ -64,6 +75,41 @@ const fallbackGenerators = {
   #onStart: mockControllerCallback,
   #onDelete: mockControllerCallback,
 };
+
+/// Records routing into the shared urgent-exception handler (ADR-0103).
+/// Treats only [BadCredentialsException] as urgent, like `BaseController`.
+class _RecordingUrgentExceptionHandler implements UrgentExceptionHandler {
+  int handleCallCount = 0;
+  Failure? handledFailure;
+  Exception? handledException;
+
+  @override
+  bool validateUrgentException(dynamic exception) =>
+      exception is BadCredentialsException;
+
+  @override
+  void handleUrgentException({Failure? failure, Exception? exception}) {
+    handleCallCount++;
+    handledFailure = failure;
+    handledException = exception;
+  }
+}
+
+/// Pumps the event queue until [condition] holds, so a test waits for the
+/// provider listener to settle instead of sleeping for an arbitrary duration.
+/// Fails if [condition] never becomes true within [timeout].
+Future<void> _pumpUntil(
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 2),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!condition()) {
+    if (DateTime.now().isAfter(deadline)) {
+      fail('Timed out waiting for condition after ${timeout.inMilliseconds}ms');
+    }
+    await pumpEventQueue(times: 1);
+  }
+}
 
 @GenerateNiceMocks([
   // Base controller mock specs
@@ -89,6 +135,7 @@ const fallbackGenerators = {
   MockSpec<LoadMoreEmailsInMailboxInteractor>(),
   MockSpec<SearchEmailInteractor>(),
   MockSpec<SearchMoreEmailInteractor>(),
+  MockSpec<RefreshChangesSearchEmailInteractor>(),
   MockSpec<GetEmailByIdInteractor>(),
   MockSpec<CleanAndGetEmailsInMailboxInteractor>(),
 ])
@@ -101,12 +148,17 @@ void main() {
   late MockSearchController mockSearchController;
   late MockMailboxDashBoardController mockMailboxDashBoardController;
   late MockGetEmailsInMailboxInteractor mockGetEmailsInMailboxInteractor;
-  late MockRefreshChangesEmailsInMailboxInteractor mockRefreshChangesEmailsInMailboxInteractor;
-  late MockLoadMoreEmailsInMailboxInteractor mockLoadMoreEmailsInMailboxInteractor;
+  late MockRefreshChangesEmailsInMailboxInteractor
+  mockRefreshChangesEmailsInMailboxInteractor;
+  late MockLoadMoreEmailsInMailboxInteractor
+  mockLoadMoreEmailsInMailboxInteractor;
   late MockSearchEmailInteractor mockSearchEmailInteractor;
   late MockSearchMoreEmailInteractor mockSearchMoreEmailInteractor;
+  late MockRefreshChangesSearchEmailInteractor
+  mockRefreshChangesSearchEmailInteractor;
   late MockGetEmailByIdInteractor mockGetEmailByIdInteractor;
-  late MockCleanAndGetEmailsInMailboxInteractor mockCleanAndGetEmailsInMailboxInteractor;
+  late MockCleanAndGetEmailsInMailboxInteractor
+  mockCleanAndGetEmailsInMailboxInteractor;
 
   // Declaration base controller
   late MockCachingManager mockCachingManager;
@@ -163,23 +215,33 @@ void main() {
     mockSearchController = MockSearchController();
     mockMailboxDashBoardController = MockMailboxDashBoardController();
     mockGetEmailsInMailboxInteractor = MockGetEmailsInMailboxInteractor();
-    mockRefreshChangesEmailsInMailboxInteractor = MockRefreshChangesEmailsInMailboxInteractor();
-    mockLoadMoreEmailsInMailboxInteractor = MockLoadMoreEmailsInMailboxInteractor();
+    mockRefreshChangesEmailsInMailboxInteractor =
+        MockRefreshChangesEmailsInMailboxInteractor();
+    mockLoadMoreEmailsInMailboxInteractor =
+        MockLoadMoreEmailsInMailboxInteractor();
     mockSearchEmailInteractor = MockSearchEmailInteractor();
     mockSearchMoreEmailInteractor = MockSearchMoreEmailInteractor();
+    mockRefreshChangesSearchEmailInteractor =
+        MockRefreshChangesSearchEmailInteractor();
     mockGetEmailByIdInteractor = MockGetEmailByIdInteractor();
-    mockCleanAndGetEmailsInMailboxInteractor = MockCleanAndGetEmailsInMailboxInteractor();
+    mockCleanAndGetEmailsInMailboxInteractor =
+        MockCleanAndGetEmailsInMailboxInteractor();
 
     Get.put<NetworkConnectionController>(mockNetworkConnectionController);
     Get.put<SearchController>(mockSearchController);
     Get.put<MailboxDashBoardController>(mockMailboxDashBoardController);
+    // The central SearchEmailNotifier executor resolves its interactors via
+    // Get.find; register the mocks so ThreadController's delegated searches run.
+    Get.put<SearchEmailInteractor>(mockSearchEmailInteractor);
+    Get.put<SearchMoreEmailInteractor>(mockSearchMoreEmailInteractor);
+    Get.put<RefreshChangesSearchEmailInteractor>(
+      mockRefreshChangesSearchEmailInteractor,
+    );
 
     threadController = ThreadController(
       mockGetEmailsInMailboxInteractor,
       mockRefreshChangesEmailsInMailboxInteractor,
       mockLoadMoreEmailsInMailboxInteractor,
-      mockSearchEmailInteractor,
-      mockSearchMoreEmailInteractor,
       mockGetEmailByIdInteractor,
       mockCleanAndGetEmailsInMailboxInteractor,
     );
@@ -195,19 +257,28 @@ void main() {
         final emailList = [
           PresentationEmail(
             id: EmailId(Id('email1')),
-            mailboxIds: {MailboxId(Id('mailbox1')): true}),
+            mailboxIds: {MailboxId(Id('mailbox1')): true},
+          ),
           PresentationEmail(
             id: EmailId(Id('email2')),
-            mailboxIds: {selectedMailboxId: true}),
+            mailboxIds: {selectedMailboxId: true},
+          ),
           PresentationEmail(
             id: EmailId(Id('email3')),
-            mailboxIds: {selectedMailboxId: true}),
+            mailboxIds: {selectedMailboxId: true},
+          ),
         ];
 
-        when(mockMailboxDashBoardController.selectedMailbox).thenReturn(Rxn(PresentationMailbox(selectedMailboxId)));
+        when(
+          mockMailboxDashBoardController.selectedMailbox,
+        ).thenReturn(Rxn(PresentationMailbox(selectedMailboxId)));
         when(mockMailboxDashBoardController.mapMailboxById).thenReturn({});
-        when(mockMailboxDashBoardController.emailsInCurrentMailbox).thenReturn(RxList(emailsInCurrentMailbox));
-        when(mockMailboxDashBoardController.searchController).thenReturn(mockSearchController);
+        when(
+          mockMailboxDashBoardController.emailsInCurrentMailbox,
+        ).thenReturn(RxList(emailsInCurrentMailbox));
+        when(
+          mockMailboxDashBoardController.searchController,
+        ).thenReturn(mockSearchController);
         when(mockSearchController.searchQuery).thenReturn(SearchQuery(''));
         when(mockSearchController.isSearchEmailRunning).thenReturn(false);
 
@@ -218,7 +289,8 @@ void main() {
         expect(result.length, 2);
         expect(
           result.map((e) => e.id).toList(),
-          containsAll([EmailId(Id('email2')), EmailId(Id('email3'))]));
+          containsAll([EmailId(Id('email2')), EmailId(Id('email3'))]),
+        );
       });
 
       test('SHOULD filters out duplicated emails', () {
@@ -226,20 +298,30 @@ void main() {
         final emailList = [
           PresentationEmail(
             id: EmailId(Id('email1')),
-            mailboxIds: {MailboxId(Id('mailbox1')): true}),
+            mailboxIds: {MailboxId(Id('mailbox1')): true},
+          ),
           PresentationEmail(
             id: EmailId(Id('email2')),
-            mailboxIds: {selectedMailboxId: true}),
+            mailboxIds: {selectedMailboxId: true},
+          ),
         ];
         emailsInCurrentMailbox.add(
           PresentationEmail(
             id: EmailId(Id('email2')),
-            mailboxIds: {selectedMailboxId: true}));
+            mailboxIds: {selectedMailboxId: true},
+          ),
+        );
 
-        when(mockMailboxDashBoardController.selectedMailbox).thenReturn(Rxn(PresentationMailbox(selectedMailboxId)));
+        when(
+          mockMailboxDashBoardController.selectedMailbox,
+        ).thenReturn(Rxn(PresentationMailbox(selectedMailboxId)));
         when(mockMailboxDashBoardController.mapMailboxById).thenReturn({});
-        when(mockMailboxDashBoardController.emailsInCurrentMailbox).thenReturn(RxList(emailsInCurrentMailbox));
-        when(mockMailboxDashBoardController.searchController).thenReturn(mockSearchController);
+        when(
+          mockMailboxDashBoardController.emailsInCurrentMailbox,
+        ).thenReturn(RxList(emailsInCurrentMailbox));
+        when(
+          mockMailboxDashBoardController.searchController,
+        ).thenReturn(mockSearchController);
         when(mockSearchController.searchQuery).thenReturn(SearchQuery(''));
         when(mockSearchController.isSearchEmailRunning).thenReturn(false);
 
@@ -254,10 +336,16 @@ void main() {
         // Arrange
         final emailList = <PresentationEmail>[];
 
-        when(mockMailboxDashBoardController.selectedMailbox).thenReturn(Rxn(PresentationMailbox(selectedMailboxId)));
+        when(
+          mockMailboxDashBoardController.selectedMailbox,
+        ).thenReturn(Rxn(PresentationMailbox(selectedMailboxId)));
         when(mockMailboxDashBoardController.mapMailboxById).thenReturn({});
-        when(mockMailboxDashBoardController.emailsInCurrentMailbox).thenReturn(RxList(emailsInCurrentMailbox));
-        when(mockMailboxDashBoardController.searchController).thenReturn(mockSearchController);
+        when(
+          mockMailboxDashBoardController.emailsInCurrentMailbox,
+        ).thenReturn(RxList(emailsInCurrentMailbox));
+        when(
+          mockMailboxDashBoardController.searchController,
+        ).thenReturn(mockSearchController);
         when(mockSearchController.searchQuery).thenReturn(SearchQuery(''));
         when(mockSearchController.isSearchEmailRunning).thenReturn(false);
 
@@ -273,12 +361,12 @@ void main() {
       late ThreadController refreshChangesController;
 
       setUp(() {
+        appProviderContainer.invalidate(searchFilterProvider);
+        appProviderContainer.invalidate(searchEmailProvider);
         refreshChangesController = ThreadController(
           mockGetEmailsInMailboxInteractor,
           mockRefreshChangesEmailsInMailboxInteractor,
           mockLoadMoreEmailsInMailboxInteractor,
-          mockSearchEmailInteractor,
-          mockSearchMoreEmailInteractor,
           mockGetEmailByIdInteractor,
           mockCleanAndGetEmailsInMailboxInteractor,
         );
@@ -286,67 +374,104 @@ void main() {
 
       tearDown(() {
         refreshChangesController.onClose();
+        appProviderContainer.invalidate(searchFilterProvider);
+        appProviderContainer.invalidate(searchEmailProvider);
       });
 
-      test(
-        'WHEN thread controller in searching\n'
-        'AND `MarkAsStarEmailSuccess` is coming\n'
-        'THEN `SearchEmailInteractor` is invoked with proper arguments\n'
-        'AND `listEmailController` should not jumped\n'
-        'AND `mailboxDashBoardController.emailsInCurrentMailbox` should not be cleared',
-      () async {
+      test('WHEN thread controller in searching\n'
+          'AND a websocket `RefreshChangeEmailAction` is coming\n'
+          'THEN the central executor invokes `RefreshChangesSearchEmailInteractor`\n'
+          'AND the query carries ONLY the committed filter (no filterMessageOption leak)\n'
+          'AND `listEmailController` should not jump', () async {
         // Arrange
         PlatformInfo.isTestingForWeb = true;
+        addTearDown(() => PlatformInfo.isTestingForWeb = false);
         final emailList = [
           PresentationEmail(
             id: EmailId(Id('email1')),
             subject: 'hello',
-            keywords: {KeyWordIdentifier.emailFlagged: true}),
-          PresentationEmail(
-            id: EmailId(Id('email2')),
-            subject: 'hello')
+            keywords: {KeyWordIdentifier.emailFlagged: true},
+          ),
+          PresentationEmail(id: EmailId(Id('email2')), subject: 'hello'),
         ];
+        final searchRefreshResultController =
+            StreamController<Either<Failure, Success>>();
+        addTearDown(() async => searchRefreshResultController.close());
 
-        when(mockMailboxDashBoardController.sessionCurrent).thenReturn(SessionFixtures.aliceSession);
-        when(mockMailboxDashBoardController.accountId).thenReturn(Rxn(AccountFixtures.aliceAccountId));
-        when(mockMailboxDashBoardController.viewState).thenReturn(Rx(Right(SearchEmailSuccess(emailList))));
-        when(mockMailboxDashBoardController.emailsInCurrentMailbox).thenReturn(RxList(emailList));
-        when(mockMailboxDashBoardController.selectedMailbox).thenReturn(Rxn(null));
-        when(mockMailboxDashBoardController.searchController).thenReturn(mockSearchController);
-        when(mockMailboxDashBoardController.dashBoardAction).thenReturn(Rxn(null));
-        when(mockMailboxDashBoardController.emailUIAction).thenReturn(Rxn(null));
-        when(mockMailboxDashBoardController.viewState).thenReturn(Rx(Right(UIState.idle)));
-        when(mockMailboxDashBoardController.filterMessageOption).thenReturn(Rx(FilterMessageOption.all));
-        when(mockMailboxDashBoardController.currentEmailState).thenReturn(State('old-state'));
-        when(mockSearchController.searchState).thenReturn(Rx(SearchState.initial()));
-        when(mockSearchController.isAdvancedSearchViewOpen).thenReturn(RxBool(false));
+        when(
+          mockMailboxDashBoardController.sessionCurrent,
+        ).thenReturn(SessionFixtures.aliceSession);
+        when(
+          mockMailboxDashBoardController.accountId,
+        ).thenReturn(Rxn(AccountFixtures.aliceAccountId));
+        when(
+          mockMailboxDashBoardController.emailsInCurrentMailbox,
+        ).thenReturn(RxList(emailList));
+        when(
+          mockMailboxDashBoardController.selectedMailbox,
+        ).thenReturn(Rxn(null));
+        when(
+          mockMailboxDashBoardController.searchController,
+        ).thenReturn(mockSearchController);
+        when(
+          mockMailboxDashBoardController.dashBoardAction,
+        ).thenReturn(Rxn(null));
+        when(
+          mockMailboxDashBoardController.emailUIAction,
+        ).thenReturn(Rxn(null));
+        when(
+          mockMailboxDashBoardController.viewState,
+        ).thenReturn(Rx(Right(UIState.idle)));
+        when(
+          mockMailboxDashBoardController.listEmailSelected,
+        ).thenReturn(RxList([]));
+        when(
+          mockMailboxDashBoardController.trashSpamMailboxIds,
+        ).thenReturn(null);
+        when(mockMailboxDashBoardController.mapMailboxById).thenReturn({});
+        // The inbox quick-filter is unread, but the committed filter is empty.
+        // The old `moreFilterCondition` path must not leak into the query.
+        when(
+          mockMailboxDashBoardController.filterMessageOption,
+        ).thenReturn(Rx(FilterMessageOption.unread));
+        when(
+          mockMailboxDashBoardController.currentEmailState,
+        ).thenReturn(State('old-state'));
         when(mockSearchController.isSearchEmailRunning).thenReturn(true);
-        when(mockSearchController.searchEmailFilter).thenReturn(Rx(SearchEmailFilter.initial()));
-        when(mockSearchEmailInteractor.execute(
-          any,
-          any,
-          limit: anyNamed('limit'),
-          position: anyNamed('position'),
-          sort:anyNamed('sort'),
-          filter: anyNamed('filter'),
-          collapseThreads: anyNamed('collapseThreads'),
-          properties: anyNamed('properties'),
-          needRefreshSearchState: anyNamed('needRefreshSearchState'),
-        )).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(emailList))));
+        when(
+          mockRefreshChangesSearchEmailInteractor.execute(
+            any,
+            any,
+            limit: anyNamed('limit'),
+            position: anyNamed('position'),
+            sort: anyNamed('sort'),
+            filter: anyNamed('filter'),
+            collapseThreads: anyNamed('collapseThreads'),
+            properties: anyNamed('properties'),
+          ),
+        ).thenAnswer((_) => searchRefreshResultController.stream);
 
-        when(mockRefreshChangesEmailsInMailboxInteractor.execute(
-          any,
-          any,
-          any,
-          sort: anyNamed('sort'),
-          limit: anyNamed('limit'),
-          propertiesCreated: anyNamed('propertiesCreated'),
-          propertiesUpdated: anyNamed('propertiesUpdated'),
-          emailFilter: anyNamed('emailFilter'),
-          collapseThreads: anyNamed('collapseThreads'),
-        )).thenAnswer((_) => Stream.value(Right(RefreshChangesAllEmailSuccess(
-          emailList: emailList,
-          currentEmailState: State('old-state'))))
+        when(
+          mockRefreshChangesEmailsInMailboxInteractor.execute(
+            any,
+            any,
+            any,
+            sort: anyNamed('sort'),
+            limit: anyNamed('limit'),
+            propertiesCreated: anyNamed('propertiesCreated'),
+            propertiesUpdated: anyNamed('propertiesUpdated'),
+            emailFilter: anyNamed('emailFilter'),
+            collapseThreads: anyNamed('collapseThreads'),
+          ),
+        ).thenAnswer(
+          (_) => Stream.value(
+            Right(
+              RefreshChangesAllEmailSuccess(
+                emailList: emailList,
+                currentEmailState: State('old-state'),
+              ),
+            ),
+          ),
         );
 
         // Act
@@ -356,34 +481,57 @@ void main() {
         mockMailboxDashBoardController.emailUIAction.value =
             RefreshChangeEmailAction(newState: State('new-state'));
 
-        await untilCalled(mockSearchEmailInteractor.execute(
-          any,
-          any,
-          limit: anyNamed('limit'),
-          position: anyNamed('position'),
-          sort:anyNamed('sort'),
-          filter: anyNamed('filter'),
-          collapseThreads: anyNamed('collapseThreads'),
-          properties: anyNamed('properties'),
-          needRefreshSearchState: anyNamed('needRefreshSearchState'),
-        ));
+        await untilCalled(
+          mockRefreshChangesSearchEmailInteractor.execute(
+            any,
+            any,
+            limit: anyNamed('limit'),
+            position: anyNamed('position'),
+            sort: anyNamed('sort'),
+            filter: anyNamed('filter'),
+            collapseThreads: anyNamed('collapseThreads'),
+            properties: anyNamed('properties'),
+          ),
+        );
 
-        // Assert
-        verify(mockSearchEmailInteractor.execute(
-          SessionFixtures.aliceSession,
-          AccountFixtures.aliceAccountId,
-          limit: UnsignedInt(emailList.length),
-          position: null,
-          sort: SearchEmailFilter.defaultSortOrder.getSortOrder().toNullable(),
-          filter: SearchEmailFilter.initial().mappingToEmailFilterCondition(),
-          collapseThreads: false,
-          properties: EmailUtils.getPropertiesForEmailGetMethod(
+        // Refresh uses the executor and current window size.
+        // `filter: null` proves the inbox quick-filter did not leak.
+        verify(
+          mockRefreshChangesSearchEmailInteractor.execute(
             SessionFixtures.aliceSession,
-            AccountFixtures.aliceAccountId),
-          needRefreshSearchState: true
-        )).called(1);
-        expect(mockMailboxDashBoardController.emailsInCurrentMailbox.isNotEmpty, isTrue);
-        expect(mockMailboxDashBoardController.emailsInCurrentMailbox.length, emailList.length);
+            AccountFixtures.aliceAccountId,
+            limit: UnsignedInt(emailList.length),
+            position: anyNamed('position'),
+            sort: anyNamed('sort'),
+            filter: null,
+            collapseThreads: false,
+            properties: anyNamed('properties'),
+          ),
+        ).called(1);
+        // The removed `SearchEmailInteractor` refresh path must not run.
+        verifyNever(
+          mockSearchEmailInteractor.execute(
+            any,
+            any,
+            limit: anyNamed('limit'),
+            position: anyNamed('position'),
+            sort: anyNamed('sort'),
+            filter: anyNamed('filter'),
+            collapseThreads: anyNamed('collapseThreads'),
+            properties: anyNamed('properties'),
+            needRefreshSearchState: anyNamed('needRefreshSearchState'),
+          ),
+        );
+        PlatformInfo.isTestingForWeb = false;
+        searchRefreshResultController.add(
+          Right(RefreshChangesSearchEmailSuccess(emailList)),
+        );
+        await searchRefreshResultController.close();
+        await pumpEventQueue();
+        expect(
+          mockMailboxDashBoardController.emailsInCurrentMailbox.isNotEmpty,
+          isTrue,
+        );
         expect(refreshChangesController.isListEmailScrollViewJumping, isFalse);
         PlatformInfo.isTestingForWeb = false;
       });
@@ -391,81 +539,380 @@ void main() {
       test(
         'WHEN thread controller in searching\n'
         'AND `StartSearchEmailAction` is coming\n'
-        'THEN `SearchEmailInteractor` is invoked with proper arguments\n'
-        'AND `listEmailController` should jumped\n'
+        'THEN the central executor invokes `SearchEmailInteractor` (NewSearchIntent)\n'
+        'AND the query carries ONLY the committed filter (no filterMessageOption leak)\n'
         'AND `mailboxDashBoardController.emailsInCurrentMailbox` should be cleared',
-      () async {
-        // Arrange
-        final emailList = [
-          PresentationEmail(
-            id: EmailId(Id('email1')),
-            subject: 'hello'),
-          PresentationEmail(
-            id: EmailId(Id('email2')),
-            subject: 'hello')
-        ];
+        () async {
+          // Arrange
+          final emailList = [
+            PresentationEmail(id: EmailId(Id('email1')), subject: 'hello'),
+            PresentationEmail(id: EmailId(Id('email2')), subject: 'hello'),
+          ];
 
-        when(mockMailboxDashBoardController.sessionCurrent).thenReturn(SessionFixtures.aliceSession);
-        when(mockMailboxDashBoardController.accountId).thenReturn(Rxn(AccountFixtures.aliceAccountId));
-        when(mockMailboxDashBoardController.viewState).thenReturn(Rx(Right(SearchEmailSuccess(emailList))));
-        when(mockMailboxDashBoardController.emailsInCurrentMailbox).thenReturn(RxList(emailList));
-        when(mockMailboxDashBoardController.selectedMailbox).thenReturn(Rxn(null));
-        when(mockMailboxDashBoardController.searchController).thenReturn(mockSearchController);
-        when(mockMailboxDashBoardController.dashBoardAction).thenReturn(Rxn(null));
-        when(mockMailboxDashBoardController.emailUIAction).thenReturn(Rxn(null));
-        when(mockMailboxDashBoardController.viewState).thenReturn(Rx(Right(UIState.idle)));
-        when(mockMailboxDashBoardController.filterMessageOption).thenReturn(Rx(FilterMessageOption.all));
-        when(mockMailboxDashBoardController.currentSelectMode).thenReturn(Rx(SelectMode.INACTIVE));
-        when(mockMailboxDashBoardController.listEmailSelected).thenReturn(RxList([]));
-        when(mockSearchController.searchState).thenReturn(Rx(SearchState.initial()));
-        when(mockSearchController.isAdvancedSearchViewOpen).thenReturn(RxBool(false));
+          when(
+            mockMailboxDashBoardController.sessionCurrent,
+          ).thenReturn(SessionFixtures.aliceSession);
+          when(
+            mockMailboxDashBoardController.accountId,
+          ).thenReturn(Rxn(AccountFixtures.aliceAccountId));
+          when(
+            mockMailboxDashBoardController.emailsInCurrentMailbox,
+          ).thenReturn(RxList(emailList));
+          when(
+            mockMailboxDashBoardController.selectedMailbox,
+          ).thenReturn(Rxn(null));
+          when(
+            mockMailboxDashBoardController.searchController,
+          ).thenReturn(mockSearchController);
+          when(
+            mockMailboxDashBoardController.dashBoardAction,
+          ).thenReturn(Rxn(null));
+          when(
+            mockMailboxDashBoardController.emailUIAction,
+          ).thenReturn(Rxn(null));
+          when(
+            mockMailboxDashBoardController.viewState,
+          ).thenReturn(Rx(Right(UIState.idle)));
+          when(
+            mockMailboxDashBoardController.filterMessageOption,
+          ).thenReturn(Rx(FilterMessageOption.unread));
+          when(
+            mockMailboxDashBoardController.currentSelectMode,
+          ).thenReturn(Rx(SelectMode.INACTIVE));
+          when(
+            mockMailboxDashBoardController.listEmailSelected,
+          ).thenReturn(RxList([]));
+          when(
+            mockMailboxDashBoardController.trashSpamMailboxIds,
+          ).thenReturn(null);
+          when(mockMailboxDashBoardController.mapMailboxById).thenReturn({});
+          when(mockSearchController.isSearchEmailRunning).thenReturn(true);
+          when(
+            mockSearchEmailInteractor.execute(
+              any,
+              any,
+              limit: anyNamed('limit'),
+              position: anyNamed('position'),
+              sort: anyNamed('sort'),
+              filter: anyNamed('filter'),
+              collapseThreads: anyNamed('collapseThreads'),
+              properties: anyNamed('properties'),
+              needRefreshSearchState: anyNamed('needRefreshSearchState'),
+            ),
+          ).thenAnswer(
+            (_) => Stream.value(Right(SearchEmailSuccess(emailList))),
+          );
+
+          // Act
+          refreshChangesController.onInit();
+          mockMailboxDashBoardController.dashBoardAction.value =
+              StartSearchEmailAction();
+
+          await untilCalled(
+            mockSearchEmailInteractor.execute(
+              any,
+              any,
+              limit: anyNamed('limit'),
+              position: anyNamed('position'),
+              sort: anyNamed('sort'),
+              filter: anyNamed('filter'),
+              collapseThreads: anyNamed('collapseThreads'),
+              properties: anyNamed('properties'),
+              needRefreshSearchState: anyNamed('needRefreshSearchState'),
+            ),
+          );
+
+          // Fresh search uses the default page limit.
+          // `filter: null` proves the inbox quick-filter did not leak.
+          verify(
+            mockSearchEmailInteractor.execute(
+              SessionFixtures.aliceSession,
+              AccountFixtures.aliceAccountId,
+              limit: ThreadConstants.defaultLimit,
+              position: anyNamed('position'),
+              sort: anyNamed('sort'),
+              filter: null,
+              collapseThreads: false,
+              properties: anyNamed('properties'),
+              needRefreshSearchState: anyNamed('needRefreshSearchState'),
+            ),
+          ).called(1);
+          expect(
+            mockMailboxDashBoardController.emailsInCurrentMailbox.isEmpty,
+            isTrue,
+          );
+          expect(
+            mockMailboxDashBoardController.emailsInCurrentMailbox.length,
+            equals(0),
+          );
+        },
+      );
+
+      test('WHEN on web the executor emits search results\n'
+          'THEN the result bridge settles `viewState` off `SearchingState`\n'
+          'SO the searching loading bar disappears (regression)', () async {
+        // Arrange
+        PlatformInfo.isTestingForWeb = true;
+        addTearDown(() => PlatformInfo.isTestingForWeb = false);
+        final emailList = [
+          PresentationEmail(id: EmailId(Id('email1')), subject: 'hello'),
+          PresentationEmail(id: EmailId(Id('email2')), subject: 'hello'),
+        ];
+        final searchResultController =
+            StreamController<Either<Failure, Success>>();
+        addTearDown(() async => searchResultController.close());
+
+        when(
+          mockMailboxDashBoardController.sessionCurrent,
+        ).thenReturn(SessionFixtures.aliceSession);
+        when(
+          mockMailboxDashBoardController.accountId,
+        ).thenReturn(Rxn(AccountFixtures.aliceAccountId));
+        when(
+          mockMailboxDashBoardController.emailsInCurrentMailbox,
+        ).thenReturn(RxList(emailList));
+        when(
+          mockMailboxDashBoardController.selectedMailbox,
+        ).thenReturn(Rxn(null));
+        when(
+          mockMailboxDashBoardController.searchController,
+        ).thenReturn(mockSearchController);
+        when(
+          mockMailboxDashBoardController.dashBoardAction,
+        ).thenReturn(Rxn(null));
+        when(
+          mockMailboxDashBoardController.emailUIAction,
+        ).thenReturn(Rxn(null));
+        when(
+          mockMailboxDashBoardController.viewState,
+        ).thenReturn(Rx(Right(UIState.idle)));
+        when(
+          mockMailboxDashBoardController.filterMessageOption,
+        ).thenReturn(Rx(FilterMessageOption.all));
+        when(
+          mockMailboxDashBoardController.currentSelectMode,
+        ).thenReturn(Rx(SelectMode.INACTIVE));
+        when(
+          mockMailboxDashBoardController.listEmailSelected,
+        ).thenReturn(RxList([]));
+        when(
+          mockMailboxDashBoardController.trashSpamMailboxIds,
+        ).thenReturn(null);
+        when(mockMailboxDashBoardController.mapMailboxById).thenReturn({});
         when(mockSearchController.isSearchEmailRunning).thenReturn(true);
-        when(mockSearchController.searchEmailFilter).thenReturn(Rx(SearchEmailFilter.initial()));
-        when(mockSearchEmailInteractor.execute(
-          any,
-          any,
-          limit: anyNamed('limit'),
-          position: anyNamed('position'),
-          sort:anyNamed('sort'),
-          filter: anyNamed('filter'),
-          collapseThreads: anyNamed('collapseThreads'),
-          properties: anyNamed('properties'),
-          needRefreshSearchState: anyNamed('needRefreshSearchState'),
-        )).thenAnswer((_) => Stream.value(Right(SearchEmailSuccess(emailList))));
+        when(
+          mockSearchEmailInteractor.execute(
+            any,
+            any,
+            limit: anyNamed('limit'),
+            position: anyNamed('position'),
+            sort: anyNamed('sort'),
+            filter: anyNamed('filter'),
+            collapseThreads: anyNamed('collapseThreads'),
+            properties: anyNamed('properties'),
+            needRefreshSearchState: anyNamed('needRefreshSearchState'),
+          ),
+        ).thenAnswer((_) => searchResultController.stream);
 
         // Act
         refreshChangesController.onInit();
-        mockMailboxDashBoardController.dashBoardAction.value = StartSearchEmailAction();
+        refreshChangesController.searchEmail();
+        await untilCalled(
+          mockSearchEmailInteractor.execute(
+            any,
+            any,
+            limit: anyNamed('limit'),
+            position: anyNamed('position'),
+            sort: anyNamed('sort'),
+            filter: anyNamed('filter'),
+            collapseThreads: anyNamed('collapseThreads'),
+            properties: anyNamed('properties'),
+            needRefreshSearchState: anyNamed('needRefreshSearchState'),
+          ),
+        );
+        PlatformInfo.isTestingForWeb = false;
+        searchResultController.add(Right(SearchEmailSuccess(emailList)));
+        await searchResultController.close();
+        // Wait for the bridge to settle the result rather than sleeping.
+        await _pumpUntil(
+          () => refreshChangesController.viewState.value
+              .getOrElse(() => UIState.idle) is SearchEmailSuccess,
+        );
 
-        await untilCalled(mockSearchEmailInteractor.execute(
-          any,
-          any,
-          limit: anyNamed('limit'),
-          position: anyNamed('position'),
-          sort:anyNamed('sort'),
-          filter: anyNamed('filter'),
-          collapseThreads: anyNamed('collapseThreads'),
-          properties: anyNamed('properties'),
-          needRefreshSearchState: anyNamed('needRefreshSearchState'),
-        ));
-
-        // Assert
-        verify(mockSearchEmailInteractor.execute(
-          SessionFixtures.aliceSession,
-          AccountFixtures.aliceAccountId,
-          limit: ThreadConstants.defaultLimit,
-          position: null,
-          sort: SearchEmailFilter.defaultSortOrder.getSortOrder().toNullable(),
-          filter: SearchEmailFilter.initial().mappingToEmailFilterCondition(),
-          collapseThreads: false,
-          properties: EmailUtils.getPropertiesForEmailGetMethod(
-            SessionFixtures.aliceSession,
-            AccountFixtures.aliceAccountId),
-          needRefreshSearchState: false
-        )).called(1);
-        expect(mockMailboxDashBoardController.emailsInCurrentMailbox.isEmpty, isTrue);
-        expect(mockMailboxDashBoardController.emailsInCurrentMailbox.length, equals(0));
+        // Assert: after results arrive, the searching spinner state is cleared.
+        final settledState = refreshChangesController.viewState.value.getOrElse(
+          () => UIState.idle,
+        );
+        expect(settledState, isA<SearchEmailSuccess>());
+        expect(settledState, isNot(isA<SearchingState>()));
+        PlatformInfo.isTestingForWeb = false;
       });
+    });
+
+    group('web search executor urgent-exception routing (ADR-0103):', () {
+      late ThreadController urgentController;
+
+      final refreshFailureMatcher = predicate<Either<Failure, Success>>(
+        (state) => state.fold((f) => f is RefreshAllEmailFailure, (_) => false),
+      );
+
+      setUp(() {
+        PlatformInfo.isTestingForWeb = true;
+        appProviderContainer.invalidate(searchFilterProvider);
+        appProviderContainer.invalidate(searchEmailProvider);
+        urgentController = ThreadController(
+          mockGetEmailsInMailboxInteractor,
+          mockRefreshChangesEmailsInMailboxInteractor,
+          mockLoadMoreEmailsInMailboxInteractor,
+          mockGetEmailByIdInteractor,
+          mockCleanAndGetEmailsInMailboxInteractor,
+        );
+      });
+
+      tearDown(() {
+        urgentController.onClose();
+        if (Get.isRegistered<UrgentExceptionHandler>()) {
+          Get.delete<UrgentExceptionHandler>();
+        }
+        appProviderContainer.invalidate(searchFilterProvider);
+        appProviderContainer.invalidate(searchEmailProvider);
+        PlatformInfo.isTestingForWeb = false;
+      });
+
+      void stubDashboardForFailedSearch(List<PresentationEmail> seededEmails) {
+        when(
+          mockMailboxDashBoardController.sessionCurrent,
+        ).thenReturn(SessionFixtures.aliceSession);
+        when(
+          mockMailboxDashBoardController.accountId,
+        ).thenReturn(Rxn(AccountFixtures.aliceAccountId));
+        when(
+          mockMailboxDashBoardController.emailsInCurrentMailbox,
+        ).thenReturn(RxList(seededEmails));
+        when(
+          mockMailboxDashBoardController.selectedMailbox,
+        ).thenReturn(Rxn(null));
+        when(
+          mockMailboxDashBoardController.searchController,
+        ).thenReturn(mockSearchController);
+        when(
+          mockMailboxDashBoardController.dashBoardAction,
+        ).thenReturn(Rxn(null));
+        when(
+          mockMailboxDashBoardController.emailUIAction,
+        ).thenReturn(Rxn(null));
+        when(
+          mockMailboxDashBoardController.viewState,
+        ).thenReturn(Rx(Right(UIState.idle)));
+        when(
+          mockMailboxDashBoardController.filterMessageOption,
+        ).thenReturn(Rx(FilterMessageOption.all));
+        when(
+          mockMailboxDashBoardController.currentSelectMode,
+        ).thenReturn(Rx(SelectMode.INACTIVE));
+        when(
+          mockMailboxDashBoardController.listEmailSelected,
+        ).thenReturn(RxList([]));
+        when(
+          mockMailboxDashBoardController.trashSpamMailboxIds,
+        ).thenReturn(null);
+        when(mockMailboxDashBoardController.mapMailboxById).thenReturn({});
+        when(mockSearchController.isSearchEmailRunning).thenReturn(true);
+      }
+
+      void stubSearchInteractorFailure(dynamic exception) {
+        when(
+          mockSearchEmailInteractor.execute(
+            any,
+            any,
+            limit: anyNamed('limit'),
+            position: anyNamed('position'),
+            sort: anyNamed('sort'),
+            filter: anyNamed('filter'),
+            collapseThreads: anyNamed('collapseThreads'),
+            properties: anyNamed('properties'),
+            needRefreshSearchState: anyNamed('needRefreshSearchState'),
+          ),
+        ).thenAnswer(
+          (_) => Stream.value(Left(SearchEmailFailure(exception))),
+        );
+      }
+
+      Future<void> runFailedSearch() async {
+        urgentController.onInit();
+        urgentController.searchEmail();
+        await untilCalled(
+          mockSearchEmailInteractor.execute(
+            any,
+            any,
+            limit: anyNamed('limit'),
+            position: anyNamed('position'),
+            sort: anyNamed('sort'),
+            filter: anyNamed('filter'),
+            collapseThreads: anyNamed('collapseThreads'),
+            properties: anyNamed('properties'),
+            needRefreshSearchState: anyNamed('needRefreshSearchState'),
+          ),
+        );
+        // Wait for the executor to emit `AsyncError` and the bridge to settle the
+        // failure into viewState, rather than sleeping for a fixed duration.
+        await _pumpUntil(() => urgentController.viewState.value.isLeft());
+      }
+
+      test(
+        'GIVEN the executor errors with an urgent exception (BadCredentials)\n'
+        'WHEN the web search result bridge handles it\n'
+        'THEN it routes through the shared UrgentExceptionHandler\n'
+        'AND skips the destructive retry UI (no refresh-failure state)',
+        () async {
+          // Arrange
+          final fakeHandler = _RecordingUrgentExceptionHandler();
+          Get.put<UrgentExceptionHandler>(fakeHandler);
+          stubDashboardForFailedSearch([
+            PresentationEmail(id: EmailId(Id('email1'))),
+          ]);
+          stubSearchInteractorFailure(const BadCredentialsException());
+
+          // Act
+          await runFailedSearch();
+
+          // Assert: urgent exception routed once, retry UI skipped.
+          expect(fakeHandler.handleCallCount, 1);
+          expect(fakeHandler.handledException, isA<BadCredentialsException>());
+          verifyNever(
+            mockMailboxDashBoardController.updateRefreshAllEmailState(
+              argThat(refreshFailureMatcher),
+            ),
+          );
+        },
+      );
+
+      test(
+        'GIVEN the executor errors with a non-urgent exception\n'
+        'WHEN the web search result bridge handles it\n'
+        'THEN the handler declines\n'
+        'AND the destructive retry UI runs (refresh-failure state emitted)',
+        () async {
+          // Arrange
+          final fakeHandler = _RecordingUrgentExceptionHandler();
+          Get.put<UrgentExceptionHandler>(fakeHandler);
+          stubDashboardForFailedSearch([
+            PresentationEmail(id: EmailId(Id('email1'))),
+          ]);
+          stubSearchInteractorFailure(NotFoundSessionException());
+
+          // Act
+          await runFailedSearch();
+
+          // Assert: not routed as urgent, retry UI ran.
+          expect(fakeHandler.handleCallCount, 0);
+          verify(
+            mockMailboxDashBoardController.updateRefreshAllEmailState(
+              argThat(refreshFailureMatcher),
+            ),
+          ).called(1);
+        },
+      );
     });
 
     group('_registerObxStreamListener test:', () {
@@ -476,8 +923,6 @@ void main() {
           mockGetEmailsInMailboxInteractor,
           mockRefreshChangesEmailsInMailboxInteractor,
           mockLoadMoreEmailsInMailboxInteractor,
-          mockSearchEmailInteractor,
-          mockSearchMoreEmailInteractor,
           mockGetEmailByIdInteractor,
           mockCleanAndGetEmailsInMailboxInteractor,
         );
@@ -490,56 +935,84 @@ void main() {
       test(
         'should call _getEmailsInMailboxInteractor.execute with getLatestChanges is false '
         'when mailboxDashBoardController.selectedMailbox updated',
-      () async {
-        // arrange
-        final mailboxBefore = PresentationMailbox(MailboxId(Id('mailbox-before-id')));
-        final mailboxAfter = PresentationMailbox(MailboxId(Id('mailbox-after-id')));
-        final selectedMailbox = Rxn(mailboxBefore);
-        when(mockMailboxDashBoardController.sessionCurrent).thenReturn(SessionFixtures.aliceSession);
-        when(mockMailboxDashBoardController.accountId).thenReturn(Rxn(AccountFixtures.aliceAccountId));
-        when(mockMailboxDashBoardController.selectedMailbox).thenReturn(selectedMailbox);
-        when(mockMailboxDashBoardController.searchController).thenReturn(mockSearchController);
-        when(mockMailboxDashBoardController.dashBoardAction).thenReturn(Rxn());
-        when(mockMailboxDashBoardController.emailUIAction).thenReturn(Rxn());
-        when(mockMailboxDashBoardController.viewState).thenReturn(Rx(Right(UIState.idle)));
-        when(mockMailboxDashBoardController.emailsInCurrentMailbox).thenReturn(RxList());
-        when(mockMailboxDashBoardController.listEmailSelected).thenReturn(RxList());
-        when(mockMailboxDashBoardController.currentSelectMode).thenReturn(Rx(SelectMode.INACTIVE));
-        when(mockMailboxDashBoardController.filterMessageOption).thenReturn(Rx(FilterMessageOption.all));
-        when(mockSearchController.searchState).thenReturn(SearchState(SearchStatus.INACTIVE).obs);
+        () async {
+          // arrange
+          final mailboxBefore = PresentationMailbox(
+            MailboxId(Id('mailbox-before-id')),
+          );
+          final mailboxAfter = PresentationMailbox(
+            MailboxId(Id('mailbox-after-id')),
+          );
+          final selectedMailbox = Rxn(mailboxBefore);
+          when(
+            mockMailboxDashBoardController.sessionCurrent,
+          ).thenReturn(SessionFixtures.aliceSession);
+          when(
+            mockMailboxDashBoardController.accountId,
+          ).thenReturn(Rxn(AccountFixtures.aliceAccountId));
+          when(
+            mockMailboxDashBoardController.selectedMailbox,
+          ).thenReturn(selectedMailbox);
+          when(
+            mockMailboxDashBoardController.searchController,
+          ).thenReturn(mockSearchController);
+          when(
+            mockMailboxDashBoardController.dashBoardAction,
+          ).thenReturn(Rxn());
+          when(mockMailboxDashBoardController.emailUIAction).thenReturn(Rxn());
+          when(
+            mockMailboxDashBoardController.viewState,
+          ).thenReturn(Rx(Right(UIState.idle)));
+          when(
+            mockMailboxDashBoardController.emailsInCurrentMailbox,
+          ).thenReturn(RxList());
+          when(
+            mockMailboxDashBoardController.listEmailSelected,
+          ).thenReturn(RxList());
+          when(
+            mockMailboxDashBoardController.currentSelectMode,
+          ).thenReturn(Rx(SelectMode.INACTIVE));
+          when(
+            mockMailboxDashBoardController.filterMessageOption,
+          ).thenReturn(Rx(FilterMessageOption.all));
 
-        // act
-        obxListenerController.onInit();
-        mockMailboxDashBoardController.selectedMailbox.value = mailboxAfter;
-        await untilCalled(mockGetEmailsInMailboxInteractor.execute(
-          any,
-          any,
-          limit: anyNamed('limit'),
-          sort: anyNamed('sort'),
-          emailFilter: anyNamed('emailFilter'),
-          propertiesCreated: anyNamed('propertiesCreated'),
-          propertiesUpdated: anyNamed('propertiesUpdated'),
-          useCache: anyNamed('useCache'),
-          forceEmailQuery: anyNamed('forceEmailQuery'),
-          collapseThreads: anyNamed('collapseThreads'),
-          getLatestChanges: false,
-        ));
-        
-        // assert
-        verify(mockGetEmailsInMailboxInteractor.execute(
-          any,
-          any,
-          limit: anyNamed('limit'),
-          sort: anyNamed('sort'),
-          emailFilter: anyNamed('emailFilter'),
-          propertiesCreated: anyNamed('propertiesCreated'),
-          propertiesUpdated: anyNamed('propertiesUpdated'),
-          useCache: anyNamed('useCache'),
-          forceEmailQuery: anyNamed('forceEmailQuery'),
-          collapseThreads: anyNamed('collapseThreads'),
-          getLatestChanges: false,
-        ));
-      });
+          // act
+          obxListenerController.onInit();
+          mockMailboxDashBoardController.selectedMailbox.value = mailboxAfter;
+          await untilCalled(
+            mockGetEmailsInMailboxInteractor.execute(
+              any,
+              any,
+              limit: anyNamed('limit'),
+              sort: anyNamed('sort'),
+              emailFilter: anyNamed('emailFilter'),
+              propertiesCreated: anyNamed('propertiesCreated'),
+              propertiesUpdated: anyNamed('propertiesUpdated'),
+              useCache: anyNamed('useCache'),
+              forceEmailQuery: anyNamed('forceEmailQuery'),
+              collapseThreads: anyNamed('collapseThreads'),
+              getLatestChanges: false,
+            ),
+          );
+
+          // assert
+          verify(
+            mockGetEmailsInMailboxInteractor.execute(
+              any,
+              any,
+              limit: anyNamed('limit'),
+              sort: anyNamed('sort'),
+              emailFilter: anyNamed('emailFilter'),
+              propertiesCreated: anyNamed('propertiesCreated'),
+              propertiesUpdated: anyNamed('propertiesUpdated'),
+              useCache: anyNamed('useCache'),
+              forceEmailQuery: anyNamed('forceEmailQuery'),
+              collapseThreads: anyNamed('collapseThreads'),
+              getLatestChanges: false,
+            ),
+          );
+        },
+      );
     });
 
     group('limitEmailFetched::test', () {
@@ -553,22 +1026,33 @@ void main() {
           mockGetEmailsInMailboxInteractor,
           mockRefreshChangesEmailsInMailboxInteractor,
           mockLoadMoreEmailsInMailboxInteractor,
-          mockSearchEmailInteractor,
-          mockSearchMoreEmailInteractor,
           mockGetEmailByIdInteractor,
           mockCleanAndGetEmailsInMailboxInteractor,
         );
 
-        when(mockMailboxDashBoardController.selectedMailbox).thenReturn(Rxn(null));
-        when(mockMailboxDashBoardController.searchController).thenReturn(mockSearchController);
+        when(
+          mockMailboxDashBoardController.selectedMailbox,
+        ).thenReturn(Rxn(null));
+        when(
+          mockMailboxDashBoardController.searchController,
+        ).thenReturn(mockSearchController);
         when(mockMailboxDashBoardController.dashBoardAction).thenReturn(Rxn());
         when(mockMailboxDashBoardController.emailUIAction).thenReturn(Rxn());
-        when(mockMailboxDashBoardController.viewState).thenReturn(Rx(Right(UIState.idle)));
-        when(mockMailboxDashBoardController.emailsInCurrentMailbox).thenReturn(emailsRxList);
-        when(mockMailboxDashBoardController.listEmailSelected).thenReturn(RxList());
-        when(mockMailboxDashBoardController.currentSelectMode).thenReturn(Rx(SelectMode.INACTIVE));
-        when(mockMailboxDashBoardController.filterMessageOption).thenReturn(Rx(FilterMessageOption.all));
-        when(mockSearchController.searchState).thenReturn(SearchState(SearchStatus.INACTIVE).obs);
+        when(
+          mockMailboxDashBoardController.viewState,
+        ).thenReturn(Rx(Right(UIState.idle)));
+        when(
+          mockMailboxDashBoardController.emailsInCurrentMailbox,
+        ).thenReturn(emailsRxList);
+        when(
+          mockMailboxDashBoardController.listEmailSelected,
+        ).thenReturn(RxList());
+        when(
+          mockMailboxDashBoardController.currentSelectMode,
+        ).thenReturn(Rx(SelectMode.INACTIVE));
+        when(
+          mockMailboxDashBoardController.filterMessageOption,
+        ).thenReturn(Rx(FilterMessageOption.all));
 
         limitEmailFetchedController.onInit();
       });
@@ -577,25 +1061,27 @@ void main() {
         limitEmailFetchedController.onClose();
       });
 
-      List<PresentationEmail> generateEmails(int count, {String prefix = 'email'}) {
+      List<PresentationEmail> generateEmails(
+        int count, {
+        String prefix = 'email',
+      }) {
         return List.generate(
           count,
           (i) => PresentationEmail(id: EmailId(Id('$prefix$i'))),
         );
       }
 
-      test(
-        'SHOULD return defaultLimit\n'
-        'WHEN no emails loaded',
-      () {
+      test('SHOULD return defaultLimit\n'
+          'WHEN no emails loaded', () {
         // Assert
-        expect(limitEmailFetchedController.limitEmailFetched, ThreadConstants.defaultLimit);
+        expect(
+          limitEmailFetchedController.limitEmailFetched,
+          ThreadConstants.defaultLimit,
+        );
       });
 
-      test(
-        'SHOULD return email count\n'
-        'WHEN emails are loaded into the list',
-      () {
+      test('SHOULD return email count\n'
+          'WHEN emails are loaded into the list', () {
         // Act
         emailsRxList.addAll(generateEmails(40));
 
@@ -603,10 +1089,8 @@ void main() {
         expect(limitEmailFetchedController.limitEmailFetched, UnsignedInt(40));
       });
 
-      test(
-        'SHOULD retain peak count\n'
-        'WHEN emails are bulk deleted from the list',
-      () {
+      test('SHOULD retain peak count\n'
+          'WHEN emails are bulk deleted from the list', () {
         // Arrange
         emailsRxList.addAll(generateEmails(40));
 
@@ -617,10 +1101,8 @@ void main() {
         expect(limitEmailFetchedController.limitEmailFetched, UnsignedInt(40));
       });
 
-      test(
-        'SHOULD reset to defaultLimit\n'
-        'WHEN resetToOriginalValue is called (mailbox switch)',
-      () {
+      test('SHOULD reset to defaultLimit\n'
+          'WHEN resetToOriginalValue is called (mailbox switch)', () {
         // Arrange
         emailsRxList.addAll(generateEmails(40));
         expect(limitEmailFetchedController.limitEmailFetched, UnsignedInt(40));
@@ -629,30 +1111,38 @@ void main() {
         limitEmailFetchedController.resetToOriginalValue();
 
         // Assert
-        expect(limitEmailFetchedController.limitEmailFetched, ThreadConstants.defaultLimit);
+        expect(
+          limitEmailFetchedController.limitEmailFetched,
+          ThreadConstants.defaultLimit,
+        );
       });
 
       test(
         'SHOULD track peak across load-more then delete\n'
         'WHEN emails are loaded incrementally and then partially deleted',
-      () {
-        // Arrange - simulate initial load + 2 load-mores
-        emailsRxList.addAll(generateEmails(20, prefix: 'init'));
-        emailsRxList.addAll(generateEmails(20, prefix: 'more1'));
-        emailsRxList.addAll(generateEmails(20, prefix: 'more2'));
-        expect(limitEmailFetchedController.limitEmailFetched, UnsignedInt(60));
+        () {
+          // Arrange - simulate initial load + 2 load-mores
+          emailsRxList.addAll(generateEmails(20, prefix: 'init'));
+          emailsRxList.addAll(generateEmails(20, prefix: 'more1'));
+          emailsRxList.addAll(generateEmails(20, prefix: 'more2'));
+          expect(
+            limitEmailFetchedController.limitEmailFetched,
+            UnsignedInt(60),
+          );
 
-        // Act - delete 30 emails
-        emailsRxList.removeRange(0, 30);
+          // Act - delete 30 emails
+          emailsRxList.removeRange(0, 30);
 
-        // Assert - peak was 60
-        expect(limitEmailFetchedController.limitEmailFetched, UnsignedInt(60));
-      });
+          // Assert - peak was 60
+          expect(
+            limitEmailFetchedController.limitEmailFetched,
+            UnsignedInt(60),
+          );
+        },
+      );
 
-      test(
-        'SHOULD reset between mailbox switches\n'
-        'WHEN switching to a mailbox with fewer emails',
-      () {
+      test('SHOULD reset between mailbox switches\n'
+          'WHEN switching to a mailbox with fewer emails', () {
         // Arrange - first mailbox has 40 emails
         emailsRxList.addAll(generateEmails(40));
         expect(limitEmailFetchedController.limitEmailFetched, UnsignedInt(40));
@@ -667,52 +1157,48 @@ void main() {
     });
 
     group('shouldAutoLoadMoreByScrollExtent unit test:', () {
-      test(
-        'GIVEN maxScrollExtent is 0 '
-        'WHEN content exactly fills the viewport '
-        'THEN SHOULD return true',
-      () {
+      test('GIVEN maxScrollExtent is 0 '
+          'WHEN content exactly fills the viewport '
+          'THEN SHOULD return true', () {
         expect(AutoLoadMorePolicy.shouldAutoLoadMoreByScrollExtent(0), isTrue);
       });
 
-      test(
-        'GIVEN maxScrollExtent is positive '
-        'WHEN content overflows the viewport '
-        'THEN SHOULD return false',
-      () {
+      test('GIVEN maxScrollExtent is positive '
+          'WHEN content overflows the viewport '
+          'THEN SHOULD return false', () {
         expect(AutoLoadMorePolicy.shouldAutoLoadMoreByScrollExtent(1), isFalse);
       });
 
-      test(
-        'GIVEN maxScrollExtent is 785 with viewport 816 '
-        'WHEN content fills between 1× and 2× the viewport (large-screen device) '
-        'THEN SHOULD return false to prevent infinite load-more loop',
-      () {
+      test('GIVEN maxScrollExtent is 785 with viewport 816 '
+          'WHEN content fills between 1× and 2× the viewport (large-screen device) '
+          'THEN SHOULD return false to prevent infinite load-more loop', () {
         expect(
-          AutoLoadMorePolicy.shouldAutoLoadMoreByScrollExtent(785.0459770114941),
+          AutoLoadMorePolicy.shouldAutoLoadMoreByScrollExtent(
+            785.0459770114941,
+          ),
           isFalse,
         );
       });
     });
 
     group('shouldAutoLoadMoreByScrollExtent widget test:', () {
-      testWidgets(
-        'GIVEN a ListView whose content overflows the viewport '
-        'THEN maxScrollExtent > 0 and SHOULD return false',
-      (tester) async {
+      testWidgets('GIVEN a ListView whose content overflows the viewport '
+          'THEN maxScrollExtent > 0 and SHOULD return false', (tester) async {
         final scrollController = ScrollController();
         addTearDown(scrollController.dispose);
 
-        await tester.pumpWidget(MaterialApp(
-          home: SizedBox(
-            height: 500,
-            child: ListView.builder(
-              controller: scrollController,
-              itemCount: 20,
-              itemBuilder: (_, __) => const SizedBox(height: 80),
+        await tester.pumpWidget(
+          MaterialApp(
+            home: SizedBox(
+              height: 500,
+              child: ListView.builder(
+                controller: scrollController,
+                itemCount: 20,
+                itemBuilder: (_, __) => const SizedBox(height: 80),
+              ),
             ),
           ),
-        ));
+        );
 
         final maxScroll = scrollController.position.maxScrollExtent;
         expect(maxScroll, greaterThan(0));
@@ -722,23 +1208,23 @@ void main() {
         );
       });
 
-      testWidgets(
-        'GIVEN a ListView whose content does not fill the viewport '
-        'THEN maxScrollExtent == 0 and SHOULD return true',
-      (tester) async {
+      testWidgets('GIVEN a ListView whose content does not fill the viewport '
+          'THEN maxScrollExtent == 0 and SHOULD return true', (tester) async {
         final scrollController = ScrollController();
         addTearDown(scrollController.dispose);
 
-        await tester.pumpWidget(MaterialApp(
-          home: SizedBox(
-            height: 500,
-            child: ListView.builder(
-              controller: scrollController,
-              itemCount: 3,
-              itemBuilder: (_, __) => const SizedBox(height: 80),
+        await tester.pumpWidget(
+          MaterialApp(
+            home: SizedBox(
+              height: 500,
+              child: ListView.builder(
+                controller: scrollController,
+                itemCount: 3,
+                itemBuilder: (_, __) => const SizedBox(height: 80),
+              ),
             ),
           ),
-        ));
+        );
 
         final maxScroll = scrollController.position.maxScrollExtent;
         expect(maxScroll, 0.0);
@@ -762,16 +1248,16 @@ void main() {
 
       void setupMocksForOnDone() {
         PlatformInfo.isTestingForWeb = false;
-        when(mockMailboxDashBoardController.isEmailListDisplayed).thenReturn(false);
+        when(
+          mockMailboxDashBoardController.isEmailListDisplayed,
+        ).thenReturn(false);
       }
 
       tearDown(() => PlatformInfo.isTestingForWeb = false);
 
-      test(
-        'GIVEN server returns fewer than limit emails '
-        'WHEN getAllEmail stream completes (e.g. mailbox with 3 emails) '
-        'THEN canLoadMore SHOULD be false — no Load More button',
-      () {
+      test('GIVEN server returns fewer than limit emails '
+          'WHEN getAllEmail stream completes (e.g. mailbox with 3 emails) '
+          'THEN canLoadMore SHOULD be false — no Load More button', () {
         setupMocksForOnDone();
         final emails = makeEmails(3);
         threadController.viewState.value = Right(
@@ -783,11 +1269,9 @@ void main() {
         expect(threadController.canLoadMore, isFalse);
       });
 
-      test(
-        'GIVEN server returns exactly limit emails '
-        'WHEN getAllEmail stream completes '
-        'THEN canLoadMore SHOULD be true — more may exist',
-      () {
+      test('GIVEN server returns exactly limit emails '
+          'WHEN getAllEmail stream completes '
+          'THEN canLoadMore SHOULD be true — more may exist', () {
         setupMocksForOnDone();
         final emails = makeEmails(ThreadConstants.maxCountEmails);
         threadController.viewState.value = Right(
@@ -799,14 +1283,15 @@ void main() {
         expect(threadController.canLoadMore, isTrue);
       });
 
-      test(
-        'GIVEN server returns an empty list '
-        'WHEN getAllEmail stream completes (empty mailbox) '
-        'THEN canLoadMore SHOULD be false',
-      () {
+      test('GIVEN server returns an empty list '
+          'WHEN getAllEmail stream completes (empty mailbox) '
+          'THEN canLoadMore SHOULD be false', () {
         setupMocksForOnDone();
         threadController.viewState.value = Right(
-          GetAllEmailSuccess(emailList: makeEmails(0), currentMailboxId: mailboxId),
+          GetAllEmailSuccess(
+            emailList: makeEmails(0),
+            currentMailboxId: mailboxId,
+          ),
         );
 
         threadController.onDone();
@@ -814,15 +1299,14 @@ void main() {
         expect(threadController.canLoadMore, isFalse);
       });
 
-      test(
-        'GIVEN getAllEmail fails and auto-load is not active '
-        'WHEN the stream completes with GetAllEmailFailure '
-        'THEN canLoadMore SHOULD be false',
-      () {
+      test('GIVEN getAllEmail fails and auto-load is not active '
+          'WHEN the stream completes with GetAllEmailFailure '
+          'THEN canLoadMore SHOULD be false', () {
         setupMocksForOnDone();
         threadController.canLoadMore = true;
-        threadController.viewState.value =
-            Left(GetAllEmailFailure(Exception('boom')));
+        threadController.viewState.value = Left(
+          GetAllEmailFailure(Exception('boom')),
+        );
 
         threadController.onDone();
 
@@ -843,13 +1327,16 @@ void main() {
 
       void setupMocksForLoadMore() {
         PlatformInfo.isTestingForWeb = false;
-        when(mockMailboxDashBoardController.selectedMailbox)
-            .thenReturn(Rxn(PresentationMailbox(mailboxId)));
+        when(
+          mockMailboxDashBoardController.selectedMailbox,
+        ).thenReturn(Rxn(PresentationMailbox(mailboxId)));
         when(mockMailboxDashBoardController.mapMailboxById).thenReturn({});
-        when(mockMailboxDashBoardController.emailsInCurrentMailbox)
-            .thenReturn(RxList([]));
-        when(mockMailboxDashBoardController.searchController)
-            .thenReturn(mockSearchController);
+        when(
+          mockMailboxDashBoardController.emailsInCurrentMailbox,
+        ).thenReturn(RxList([]));
+        when(
+          mockMailboxDashBoardController.searchController,
+        ).thenReturn(mockSearchController);
         when(mockSearchController.searchQuery).thenReturn(SearchQuery(''));
         when(mockSearchController.isSearchEmailRunning).thenReturn(false);
       }
@@ -860,45 +1347,39 @@ void main() {
         'GIVEN server returns fewer than limit emails in load-more response '
         'WHEN the last page has fewer items (e.g. 5 remaining) '
         'THEN canLoadMore SHOULD be false immediately — no extra empty request needed',
-      () {
-        setupMocksForLoadMore();
-        final emails = makeEmails(5);
+        () {
+          setupMocksForLoadMore();
+          final emails = makeEmails(5);
 
-        threadController.handleSuccessViewState(LoadMoreEmailsSuccess(
-          emails,
-          serverEmailCount: emails.length,
-        ));
+          threadController.handleSuccessViewState(
+            LoadMoreEmailsSuccess(emails, serverEmailCount: emails.length),
+          );
 
-        expect(threadController.canLoadMore, isFalse);
-      });
+          expect(threadController.canLoadMore, isFalse);
+        },
+      );
 
-      test(
-        'GIVEN server returns exactly limit emails in load-more response '
-        'WHEN more pages may exist '
-        'THEN canLoadMore SHOULD be true',
-      () {
+      test('GIVEN server returns exactly limit emails in load-more response '
+          'WHEN more pages may exist '
+          'THEN canLoadMore SHOULD be true', () {
         setupMocksForLoadMore();
         final emails = makeEmails(ThreadConstants.maxCountEmails);
 
-        threadController.handleSuccessViewState(LoadMoreEmailsSuccess(
-          emails,
-          serverEmailCount: emails.length,
-        ));
+        threadController.handleSuccessViewState(
+          LoadMoreEmailsSuccess(emails, serverEmailCount: emails.length),
+        );
 
         expect(threadController.canLoadMore, isTrue);
       });
 
-      test(
-        'GIVEN server returns 0 emails in load-more response '
-        'WHEN all emails have been loaded '
-        'THEN canLoadMore SHOULD be false',
-      () {
+      test('GIVEN server returns 0 emails in load-more response '
+          'WHEN all emails have been loaded '
+          'THEN canLoadMore SHOULD be false', () {
         setupMocksForLoadMore();
 
-        threadController.handleSuccessViewState(LoadMoreEmailsSuccess(
-          [],
-          serverEmailCount: 0,
-        ));
+        threadController.handleSuccessViewState(
+          LoadMoreEmailsSuccess([], serverEmailCount: 0),
+        );
 
         expect(threadController.canLoadMore, isFalse);
       });
@@ -908,17 +1389,20 @@ void main() {
         '(arrives here as limit-1 = 19 all-new emails) '
         'WHEN more pages still exist on the server '
         'THEN canLoadMore SHOULD be true — a 19-item page must NOT be read as end-of-list',
-      () {
-        setupMocksForLoadMore();
-        final emails = makeEmails(ThreadConstants.maxCountEmails - 1);
+        () {
+          setupMocksForLoadMore();
+          final emails = makeEmails(ThreadConstants.maxCountEmails - 1);
 
-        threadController.handleSuccessViewState(LoadMoreEmailsSuccess(
-          emails,
-          serverEmailCount: ThreadConstants.maxCountEmails,
-        ));
+          threadController.handleSuccessViewState(
+            LoadMoreEmailsSuccess(
+              emails,
+              serverEmailCount: ThreadConstants.maxCountEmails,
+            ),
+          );
 
-        expect(threadController.canLoadMore, isTrue);
-      });
+          expect(threadController.canLoadMore, isTrue);
+        },
+      );
     });
 
     group('canLoadMore lifecycle & guard regression:', () {
@@ -926,25 +1410,27 @@ void main() {
         'GIVEN canLoadMore was exhausted (false) '
         'WHEN resetToOriginalValue runs (e.g. switching mailbox) '
         'THEN canLoadMore SHOULD be re-enabled so the new mailbox can paginate',
-      () {
-        when(mockMailboxDashBoardController.emailsInCurrentMailbox)
-            .thenReturn(RxList([]));
-        when(mockMailboxDashBoardController.listEmailSelected)
-            .thenReturn(RxList([]));
-        when(mockMailboxDashBoardController.currentSelectMode)
-            .thenReturn(Rx(SelectMode.INACTIVE));
-        threadController.canLoadMore = false;
+        () {
+          when(
+            mockMailboxDashBoardController.emailsInCurrentMailbox,
+          ).thenReturn(RxList([]));
+          when(
+            mockMailboxDashBoardController.listEmailSelected,
+          ).thenReturn(RxList([]));
+          when(
+            mockMailboxDashBoardController.currentSelectMode,
+          ).thenReturn(Rx(SelectMode.INACTIVE));
+          threadController.canLoadMore = false;
 
-        threadController.resetToOriginalValue();
+          threadController.resetToOriginalValue();
 
-        expect(threadController.canLoadMore, isTrue);
-      });
+          expect(threadController.canLoadMore, isTrue);
+        },
+      );
 
-      test(
-        'GIVEN a load-more request failed '
-        'WHEN handleFailureViewState receives LoadMoreEmailsFailure '
-        'THEN canLoadMore SHOULD be true so the user can retry',
-      () {
+      test('GIVEN a load-more request failed '
+          'WHEN handleFailureViewState receives LoadMoreEmailsFailure '
+          'THEN canLoadMore SHOULD be true so the user can retry', () {
         threadController.canLoadMore = false;
 
         threadController.handleFailureViewState(
@@ -958,32 +1444,128 @@ void main() {
         'GIVEN canLoadMore is false and search is not active '
         'WHEN handleLoadMoreEmailsRequest is invoked '
         'THEN the load-more interactor SHOULD NOT be called — the guard blocks it',
-      () {
-        when(mockMailboxDashBoardController.searchController)
-            .thenReturn(mockSearchController);
-        when(mockSearchController.isSearchEmailRunning).thenReturn(false);
-        threadController.canLoadMore = false;
+        () {
+          when(
+            mockMailboxDashBoardController.searchController,
+          ).thenReturn(mockSearchController);
+          when(mockSearchController.isSearchEmailRunning).thenReturn(false);
+          threadController.canLoadMore = false;
 
-        threadController.handleLoadMoreEmailsRequest();
+          threadController.handleLoadMoreEmailsRequest();
 
-        verifyNever(mockLoadMoreEmailsInMailboxInteractor.execute(any));
-      });
+          verifyNever(mockLoadMoreEmailsInMailboxInteractor.execute(any));
+        },
+      );
 
       test(
-        'GIVEN search is active '
+        'GIVEN search is active with a loaded search page '
         'WHEN handleLoadMoreEmailsRequest is invoked '
-        'THEN it routes to search-more, NOT load-more (canLoadMore is not consulted)',
-      () {
-        when(mockMailboxDashBoardController.searchController)
-            .thenReturn(mockSearchController);
-        when(mockSearchController.isSearchEmailRunning).thenReturn(true);
-        threadController.canSearchMore = false;
-        threadController.canLoadMore = true;
+        'THEN it routes to search-more (SearchMoreEmailInteractor), '
+        'NOT mailbox load-more',
+        () async {
+          final searchPage = [
+            PresentationEmail(id: EmailId(Id('s1'))),
+            PresentationEmail(id: EmailId(Id('s2'))),
+          ];
+          when(
+            mockMailboxDashBoardController.searchController,
+          ).thenReturn(mockSearchController);
+          when(mockSearchController.isSearchEmailRunning).thenReturn(true);
+          when(
+            mockMailboxDashBoardController.sessionCurrent,
+          ).thenReturn(SessionFixtures.aliceSession);
+          when(
+            mockMailboxDashBoardController.accountId,
+          ).thenReturn(Rxn(AccountFixtures.aliceAccountId));
+          when(
+            mockMailboxDashBoardController.emailsInCurrentMailbox,
+          ).thenReturn(RxList(searchPage));
+          when(
+            mockMailboxDashBoardController.trashSpamMailboxIds,
+          ).thenReturn(null);
+          when(
+            mockSearchEmailInteractor.execute(
+              any,
+              any,
+              limit: anyNamed('limit'),
+              position: anyNamed('position'),
+              sort: anyNamed('sort'),
+              filter: anyNamed('filter'),
+              collapseThreads: anyNamed('collapseThreads'),
+              properties: anyNamed('properties'),
+              needRefreshSearchState: anyNamed('needRefreshSearchState'),
+            ),
+          ).thenAnswer(
+            (_) => Stream.value(Right(SearchEmailSuccess(searchPage))),
+          );
+          when(
+            mockSearchMoreEmailInteractor.execute(
+              any,
+              any,
+              limit: anyNamed('limit'),
+              sort: anyNamed('sort'),
+              position: anyNamed('position'),
+              filter: anyNamed('filter'),
+              properties: anyNamed('properties'),
+              collapseThreads: anyNamed('collapseThreads'),
+              lastEmailId: anyNamed('lastEmailId'),
+            ),
+          ).thenAnswer(
+            (_) => const Stream<Either<Failure, Success>>.empty(),
+          );
 
-        threadController.handleLoadMoreEmailsRequest();
+          // Seed the executor with a first page so canSearchMore is true;
+          // a bare clearResult() would let a no-op pass this assertion.
+          appProviderContainer.invalidate(searchEmailProvider);
+          await appProviderContainer.read(searchEmailProvider.notifier).execute(
+                const NewSearchIntent(),
+                session: SessionFixtures.aliceSession,
+                accountId: AccountFixtures.aliceAccountId,
+                properties: EmailUtils.getPropertiesForEmailGetMethod(
+                  SessionFixtures.aliceSession,
+                  AccountFixtures.aliceAccountId,
+                ),
+                collapseThreads: false,
+                trashSpamMailboxIds: null,
+              );
+          expect(
+            appProviderContainer.read(searchEmailProvider.notifier).canLoadMore,
+            isTrue,
+          );
 
-        verifyNever(mockLoadMoreEmailsInMailboxInteractor.execute(any));
-      });
+          // Act
+          threadController.handleLoadMoreEmailsRequest();
+          await untilCalled(
+            mockSearchMoreEmailInteractor.execute(
+              any,
+              any,
+              limit: anyNamed('limit'),
+              sort: anyNamed('sort'),
+              position: anyNamed('position'),
+              filter: anyNamed('filter'),
+              properties: anyNamed('properties'),
+              collapseThreads: anyNamed('collapseThreads'),
+              lastEmailId: anyNamed('lastEmailId'),
+            ),
+          );
+
+          // Assert: search-more ran exactly once; mailbox load-more never did.
+          verify(
+            mockSearchMoreEmailInteractor.execute(
+              any,
+              any,
+              limit: anyNamed('limit'),
+              sort: anyNamed('sort'),
+              position: anyNamed('position'),
+              filter: anyNamed('filter'),
+              properties: anyNamed('properties'),
+              collapseThreads: anyNamed('collapseThreads'),
+              lastEmailId: anyNamed('lastEmailId'),
+            ),
+          ).called(1);
+          verifyNever(mockLoadMoreEmailsInMailboxInteractor.execute(any));
+        },
+      );
     });
 
     group('auto-load-more collapseThreads partial-page edge case test:', () {
@@ -1004,8 +1586,6 @@ void main() {
           mockGetEmailsInMailboxInteractor,
           mockRefreshChangesEmailsInMailboxInteractor,
           mockLoadMoreEmailsInMailboxInteractor,
-          mockSearchEmailInteractor,
-          mockSearchMoreEmailInteractor,
           mockGetEmailByIdInteractor,
           mockCleanAndGetEmailsInMailboxInteractor,
         );
@@ -1022,101 +1602,122 @@ void main() {
         'WHEN getAllEmail stream completes '
         'THEN auto-load-more IS triggered to fill the viewport '
         'AND canLoadMore reflects the subsequent load-more server response',
-      (tester) async {
-        PlatformInfo.isTestingForWeb = false;
+        (tester) async {
+          PlatformInfo.isTestingForWeb = false;
 
-        final partialEmails = makeEmails(15); // fewer than maxCountEmails = 20
+          final partialEmails = makeEmails(
+            15,
+          ); // fewer than maxCountEmails = 20
 
-        when(mockMailboxDashBoardController.isEmailListDisplayed).thenReturn(false);
-        when(mockMailboxDashBoardController.sessionCurrent)
-            .thenReturn(SessionFixtures.aliceSession);
-        when(mockMailboxDashBoardController.accountId)
-            .thenReturn(Rxn(AccountFixtures.aliceAccountId));
-        when(mockMailboxDashBoardController.selectedMailbox)
-            .thenReturn(Rxn(PresentationMailbox(mailboxId)));
-        when(mockMailboxDashBoardController.mapMailboxById).thenReturn({});
-        when(mockMailboxDashBoardController.emailsInCurrentMailbox)
-            .thenReturn(RxList(partialEmails));
-        when(mockMailboxDashBoardController.filterMessageOption)
-            .thenReturn(Rx(FilterMessageOption.all));
-        when(mockMailboxDashBoardController.searchController)
-            .thenReturn(mockSearchController);
-        when(mockSearchController.isSearchEmailRunning).thenReturn(false);
-        when(mockSearchController.searchQuery).thenReturn(SearchQuery(''));
-        when(mockLoadMoreEmailsInMailboxInteractor.execute(any))
-            .thenAnswer((_) => Stream.value(
+          when(
+            mockMailboxDashBoardController.isEmailListDisplayed,
+          ).thenReturn(false);
+          when(
+            mockMailboxDashBoardController.sessionCurrent,
+          ).thenReturn(SessionFixtures.aliceSession);
+          when(
+            mockMailboxDashBoardController.accountId,
+          ).thenReturn(Rxn(AccountFixtures.aliceAccountId));
+          when(
+            mockMailboxDashBoardController.selectedMailbox,
+          ).thenReturn(Rxn(PresentationMailbox(mailboxId)));
+          when(mockMailboxDashBoardController.mapMailboxById).thenReturn({});
+          when(
+            mockMailboxDashBoardController.emailsInCurrentMailbox,
+          ).thenReturn(RxList(partialEmails));
+          when(
+            mockMailboxDashBoardController.filterMessageOption,
+          ).thenReturn(Rx(FilterMessageOption.all));
+          when(
+            mockMailboxDashBoardController.searchController,
+          ).thenReturn(mockSearchController);
+          when(mockSearchController.isSearchEmailRunning).thenReturn(false);
+          when(mockSearchController.searchQuery).thenReturn(SearchQuery(''));
+          when(mockLoadMoreEmailsInMailboxInteractor.execute(any)).thenAnswer(
+            (_) => Stream.value(
               Right(LoadMoreEmailsSuccess([], serverEmailCount: 0)),
-            ));
+            ),
+          );
 
-        // Mount an empty ListView so listEmailController.hasClients = true
-        // and maxScrollExtent = 0 (content does not fill viewport).
-        await tester.pumpWidget(MaterialApp(
-          home: SizedBox(
-            height: 600,
-            child: ListView(controller: collapseController.listEmailController),
-          ),
-        ));
+          // Mount an empty ListView so listEmailController.hasClients = true
+          // and maxScrollExtent = 0 (content does not fill viewport).
+          await tester.pumpWidget(
+            MaterialApp(
+              home: SizedBox(
+                height: 600,
+                child: ListView(
+                  controller: collapseController.listEmailController,
+                ),
+              ),
+            ),
+          );
 
-        expect(
-          collapseController.listEmailController.position.maxScrollExtent,
-          0.0,
-        );
+          expect(
+            collapseController.listEmailController.position.maxScrollExtent,
+            0.0,
+          );
 
-        collapseController.viewState.value = Right(
-          GetAllEmailSuccess(emailList: partialEmails, currentMailboxId: mailboxId),
-        );
+          collapseController.viewState.value = Right(
+            GetAllEmailSuccess(
+              emailList: partialEmails,
+              currentMailboxId: mailboxId,
+            ),
+          );
 
-        collapseController.onDone();
-        await tester.pumpAndSettle();
+          collapseController.onDone();
+          await tester.pumpAndSettle();
 
-        // Load-more interactor MUST be called to attempt filling the viewport.
-        verify(mockLoadMoreEmailsInMailboxInteractor.execute(any)).called(1);
+          // Load-more interactor MUST be called to attempt filling the viewport.
+          verify(mockLoadMoreEmailsInMailboxInteractor.execute(any)).called(1);
 
-        // After the empty load-more response (serverEmailCount = 0 < maxCountEmails),
-        // canLoadMore is set to false by _loadMoreEmailsSuccess.
-        expect(collapseController.canLoadMore, isFalse);
-      });
+          // After the empty load-more response (serverEmailCount = 0 < maxCountEmails),
+          // canLoadMore is set to false by _loadMoreEmailsSuccess.
+          expect(collapseController.canLoadMore, isFalse);
+        },
+      );
 
       test(
         'GIVEN collapseThreads returns a partial page (< maxCountEmails threads) '
         'AND canLoadMore is initially true before the call '
         'WHEN viewport is already full (_isAutoLoadMore = false) '
         'THEN canLoadMore SHOULD be false — no spurious Load More button',
-      () {
-        PlatformInfo.isTestingForWeb = false;
-        // No scroll controller client → _isAutoLoadMore = false
-        when(mockMailboxDashBoardController.isEmailListDisplayed).thenReturn(false);
+        () {
+          PlatformInfo.isTestingForWeb = false;
+          // No scroll controller client → _isAutoLoadMore = false
+          when(
+            mockMailboxDashBoardController.isEmailListDisplayed,
+          ).thenReturn(false);
 
-        final partialEmails = makeEmails(15);
-        threadController.canLoadMore = true;
-        threadController.viewState.value = Right(
-          GetAllEmailSuccess(emailList: partialEmails, currentMailboxId: mailboxId),
-        );
+          final partialEmails = makeEmails(15);
+          threadController.canLoadMore = true;
+          threadController.viewState.value = Right(
+            GetAllEmailSuccess(
+              emailList: partialEmails,
+              currentMailboxId: mailboxId,
+            ),
+          );
 
-        threadController.onDone();
+          threadController.onDone();
 
-        expect(threadController.canLoadMore, isFalse);
-        verifyNever(mockLoadMoreEmailsInMailboxInteractor.execute(any));
-      });
+          expect(threadController.canLoadMore, isFalse);
+          verifyNever(mockLoadMoreEmailsInMailboxInteractor.execute(any));
+        },
+      );
     });
 
     group('shouldAutoLoadMoreByEstimatedHeight unit test:', () {
-      test(
-        'GIVEN totalHeight is 0 (empty list) '
-        'WHEN no emails are loaded '
-        'THEN SHOULD return false — nothing to trigger load from',
-      () {
+      test('GIVEN totalHeight is 0 (empty list) '
+          'WHEN no emails are loaded '
+          'THEN SHOULD return false — nothing to trigger load from', () {
         expect(
           AutoLoadMorePolicy.shouldAutoLoadMoreByEstimatedHeight(0, 816),
           isFalse,
         );
       });
 
-      test(
-        'GIVEN totalHeight is less than viewportHeight '
-        'WHEN content does not fill the viewport '
-        'THEN SHOULD return true',
-      () {
+      test('GIVEN totalHeight is less than viewportHeight '
+          'WHEN content does not fill the viewport '
+          'THEN SHOULD return true', () {
         expect(
           AutoLoadMorePolicy.shouldAutoLoadMoreByEstimatedHeight(800, 816),
           isTrue,
@@ -1127,18 +1728,17 @@ void main() {
         'GIVEN totalHeight equals viewportHeight '
         'WHEN estimated height exactly fills the viewport '
         'THEN SHOULD return false — actual rendered height likely already overflows',
-      () {
-        expect(
-          AutoLoadMorePolicy.shouldAutoLoadMoreByEstimatedHeight(816, 816),
-          isFalse,
-        );
-      });
+        () {
+          expect(
+            AutoLoadMorePolicy.shouldAutoLoadMoreByEstimatedHeight(816, 816),
+            isFalse,
+          );
+        },
+      );
 
-      test(
-        'GIVEN totalHeight exceeds viewportHeight '
-        'WHEN content overflows the viewport '
-        'THEN SHOULD return false',
-      () {
+      test('GIVEN totalHeight exceeds viewportHeight '
+          'WHEN content overflows the viewport '
+          'THEN SHOULD return false', () {
         expect(
           AutoLoadMorePolicy.shouldAutoLoadMoreByEstimatedHeight(1200, 816),
           isFalse,
@@ -1149,24 +1749,57 @@ void main() {
         'GIVEN 20 emails × 40px estimate = 800px with viewport 816px '
         'WHEN actual rendered height is likely larger (e.g. 70px/email = 1400px) '
         'THEN SHOULD return true — one extra load may occur but no infinite loop',
-      () {
-        const estimatedHeight =
-            20 * ThreadConstants.defaultMaxHeightEmailItemOnBrowser;
-        expect(
-          AutoLoadMorePolicy.shouldAutoLoadMoreByEstimatedHeight(estimatedHeight, 816),
-          isTrue,
-        );
-      });
+        () {
+          const estimatedHeight =
+              20 * ThreadConstants.defaultMaxHeightEmailItemOnBrowser;
+          expect(
+            AutoLoadMorePolicy.shouldAutoLoadMoreByEstimatedHeight(
+              estimatedHeight,
+              816,
+            ),
+            isTrue,
+          );
+        },
+      );
 
-      test(
-        'GIVEN 21 emails × 40px estimate = 840px with viewport 816px '
-        'WHEN estimated height exceeds viewport on large-screen browser '
-        'THEN SHOULD return false to prevent infinite load-more loop',
-      () {
+      test('GIVEN 21 emails × 40px estimate = 840px with viewport 816px '
+          'WHEN estimated height exceeds viewport on large-screen browser '
+          'THEN SHOULD return false to prevent infinite load-more loop', () {
         const estimatedHeight =
             21 * ThreadConstants.defaultMaxHeightEmailItemOnBrowser;
         expect(
-          AutoLoadMorePolicy.shouldAutoLoadMoreByEstimatedHeight(estimatedHeight, 816),
+          AutoLoadMorePolicy.shouldAutoLoadMoreByEstimatedHeight(
+            estimatedHeight,
+            816,
+          ),
+          isFalse,
+        );
+      });
+    });
+
+    group('shouldAutoLoadMoreSearchResult (auto-load-more guard):', () {
+      SearchEmailResult resultWith(LoadMoreState loadMore) => SearchEmailResult(
+            emails: const [],
+            canLoadMore: true,
+            loadMore: loadMore,
+          );
+
+      test('GIVEN a failed load-more result THEN SHOULD NOT auto-retry '
+          '(prevents a retry loop on urgent/persistent failure)', () {
+        expect(
+          threadController.shouldAutoLoadMoreSearchResult(
+            resultWith(LoadMoreState.failure),
+          ),
+          isFalse,
+        );
+      });
+
+      test('GIVEN an in-progress load-more result THEN SHOULD NOT auto-fetch again',
+          () {
+        expect(
+          threadController.shouldAutoLoadMoreSearchResult(
+            resultWith(LoadMoreState.inProgress),
+          ),
           isFalse,
         );
       });

--- a/test/features/thread/presentation/extensions/list_presentation_email_extensions_test.dart
+++ b/test/features/thread/presentation/extensions/list_presentation_email_extensions_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/email/presentation_email.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:model/mailbox/select_mode.dart';
+import 'package:tmail_ui_user/features/thread/presentation/extensions/list_presentation_email_extensions.dart';
+
+void main() {
+  final mailboxId = MailboxId(Id('mailbox1'));
+  final mailbox = PresentationMailbox(mailboxId);
+  final syncContext = PresentationEmailSyncContext(
+    mapMailboxById: {mailboxId: mailbox},
+  );
+
+  PresentationEmail email(
+    String id, {
+    SelectMode selectMode = SelectMode.INACTIVE,
+  }) =>
+      PresentationEmail(
+        id: EmailId(Id(id)),
+        mailboxIds: {mailboxId: true},
+        selectMode: selectMode,
+      );
+
+  group('ListPresentationEmailExtensions::toSyncedSearchResults', () {
+    test(
+      'SHOULD return the full mapped list (same length as the input page)\n'
+      'AND NOT append it to previousList — the executor already accumulates',
+      () {
+        final emails = [email('e1'), email('e2'), email('e3')];
+
+        final result = emails.toSyncedSearchResults(
+          context: syncContext,
+          previousList: [email('old')],
+        );
+
+        expect(result.length, 3);
+        expect(
+          result.map((e) => e.id?.id.value).toList(),
+          ['e1', 'e2', 'e3'],
+        );
+      },
+    );
+
+    test(
+      'SHOULD carry the current selection forward by id from previousList',
+      () {
+        final emails = [email('e1'), email('e2'), email('e3')];
+        final previousList = [email('e2', selectMode: SelectMode.ACTIVE)];
+
+        final result = emails.toSyncedSearchResults(
+          context: syncContext,
+          previousList: previousList,
+        );
+
+        final byId = {for (final e in result) e.id?.id.value: e};
+        expect(byId['e2']?.selectMode, SelectMode.ACTIVE);
+        expect(byId['e1']?.selectMode, SelectMode.INACTIVE);
+        expect(byId['e3']?.selectMode, SelectMode.INACTIVE);
+      },
+    );
+
+    test(
+      'SHOULD resolve each row mailboxContain from mapMailboxById',
+      () {
+        final result = [email('e1')].toSyncedSearchResults(
+          context: syncContext,
+          previousList: const [],
+        );
+
+        expect(result.single.mailboxContain, mailbox);
+      },
+    );
+
+    test('SHOULD return an empty list WHEN the page is empty', () {
+      final result = <PresentationEmail>[].toSyncedSearchResults(
+        context: syncContext,
+        previousList: [email('old', selectMode: SelectMode.ACTIVE)],
+      );
+
+      expect(result, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Closes [#4648](https://github.com/linagora/tmail-flutter/issues/4648)

## What this PR does

- Deletes `position` from `SearchEmailFilter`: the field, the constructor param, `positionOption` in `copyWith`,
  and the `props` entry.
- `clearPaginationCursors()` now strips only the `before` / `after` date cursors — `position` no longer exists on
  the model to strip.
- Pagination position keeps living on the transient `SearchRequestSpec` (untouched): the strategies + executor
  already resolve it there per request.

Makes "cursors never live in the committed SSOT" **type-enforced** — a stale position can no longer be written to
the filter at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the obsolete numeric pagination cursor from email search filters.
  * Pagination state now uses only the available load-more cursors.
  * Search, sorting, and filter updates continue to clear and preserve cursor boundaries consistently.

* **Tests**
  * Updated search and mailbox dashboard coverage to reflect the streamlined pagination behavior.
  * Added validation for cursor handling during filtering, sorting, and new searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->