### PR TITLE
Handle add as attachment in development

### DIFF
--- a/core/lib/presentation/extensions/composer_attachment_extension_registry.dart
+++ b/core/lib/presentation/extensions/composer_attachment_extension_registry.dart
@@ -27,13 +27,11 @@ class ComposerAttachmentExtensionRegistry {
   List<Widget> buildContextMenuTiles(
     BuildContext context, {
     required ImagePaths imagePaths,
-    required String label,
   }) => extensions
       .map(
         (e) => e.buildContextMenuTile(
           context,
           imagePaths: imagePaths,
-          label: label,
         ),
       )
       .toList();

--- a/core/lib/presentation/extensions/composer_attachment_plugin.dart
+++ b/core/lib/presentation/extensions/composer_attachment_plugin.dart
@@ -13,6 +13,5 @@ abstract class ComposerAttachmentPlugin {
   Widget buildContextMenuTile(
     BuildContext context, {
     required ImagePaths imagePaths,
-    required String label,
   });
 }

--- a/lib/features/composer/presentation/composer_view.dart
+++ b/lib/features/composer/presentation/composer_view.dart
@@ -498,7 +498,6 @@ class ComposerView extends GetWidget<ComposerController> {
           .buildContextMenuTiles(
             context,
             imagePaths: controller.imagePaths,
-            label: AppLocalizations.of(context).attachFromDrive,
           ),
       const SizedBox(height: kIsWeb ? 16 : 30),
     ];

--- a/lib/features/composer/presentation/manager/drive_attachment_handler.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_handler.dart
@@ -19,6 +19,15 @@ class DriveAttachmentHandler {
     required Future<void> Function(String html) insertHtml,
     AppLocalizations? appLocalizations,
   }) async {
+    if (result.isEmpty) {
+      getBinding<ToastManager>()?.showMessageFailure(
+        DrivePickFailure(
+          Exception(),
+          message: appLocalizations?.driveNoValidAttachment,
+        ),
+      );
+      return;
+    }
     final linkDocs = result.where((doc) {
       final link = doc.sharingLink;
       return link != null && (!requireHttps || link.isScheme('https'));

--- a/lib/features/composer/presentation/manager/drive_attachment_handler.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_handler.dart
@@ -1,7 +1,10 @@
 import 'package:core/core.dart';
 import 'package:core/utils/html/file_link_card_html_builder.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
+import 'package:workplace/presentation/model/drive_pick_state.dart';
 
 class DriveAttachmentHandler {
   DriveAttachmentHandler();
@@ -16,7 +19,18 @@ class DriveAttachmentHandler {
     required Future<void> Function(String html) insertHtml,
     AppLocalizations? appLocalizations,
   }) async {
-    final linkDocs = result.where((doc) => doc.sharingLink != null).toList();
+    final linkDocs = result.where((doc) {
+      final link = doc.sharingLink;
+      return link != null && (!requireHttps || link.isScheme('https'));
+    }).toList();
+    // TODO: Update logic here after implement 103. Attach Drive File as Attachment
+    if (linkDocs.isEmpty) {
+      getBinding<ToastManager>()?.showMessageFailure(DrivePickFailure(
+        Exception(),
+        message: appLocalizations?.driveAttachmentInDevelopment,
+      ));
+      return;
+    }
     await insertDriveLinkHtml(
       linkDocs,
       insertHtml: insertHtml,

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -5296,6 +5296,12 @@
     "placeholders_order": [],
     "placeholders": {}
   },
+  "driveNoValidAttachment": "No valid attachment",
+  "@driveNoValidAttachment": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
   "labelAs": "Label as",
   "@labelAs": {
     "type": "text",

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -5290,12 +5290,6 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "attachFromDrive": "Attach from Drive",
-  "@attachFromDrive": {
-    "type": "text",
-    "placeholders_order": [],
-    "placeholders": {}
-  },
   "driveAttachmentInDevelopment": "The add-as-attachment feature is still in development.",
   "@driveAttachmentInDevelopment": {
     "type": "text",

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -5296,6 +5296,12 @@
     "placeholders_order": [],
     "placeholders": {}
   },
+  "driveAttachmentInDevelopment": "The add-as-attachment feature is still in development.",
+  "@driveAttachmentInDevelopment": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
   "labelAs": "Label as",
   "@labelAs": {
     "type": "text",

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -5618,13 +5618,6 @@ class AppLocalizations {
     );
   }
 
-  String get attachFromDrive {
-    return Intl.message(
-      'Attach from Drive',
-      name: 'attachFromDrive',
-    );
-  }
-
   String get driveAttachmentInDevelopment {
     return Intl.message(
       'The add-as-attachment feature is still in development.',

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -5625,6 +5625,13 @@ class AppLocalizations {
     );
   }
 
+  String get driveAttachmentInDevelopment {
+    return Intl.message(
+      'The add-as-attachment feature is still in development.',
+      name: 'driveAttachmentInDevelopment',
+    );
+  }
+
   String get labelAs {
     return Intl.message(
       'Label as',

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -5625,6 +5625,13 @@ class AppLocalizations {
     );
   }
 
+  String get driveNoValidAttachment {
+    return Intl.message(
+      'No valid attachment',
+      name: 'driveNoValidAttachment',
+    );
+  }
+
   String get labelAs {
     return Intl.message(
       'Label as',

--- a/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
@@ -1,23 +1,32 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_handler.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
+import 'package:workplace/presentation/model/drive_pick_state.dart';
 
+import 'drive_attachment_handler_test.mocks.dart';
 import 'drive_attachment_handler_test_helper.dart';
 
+@GenerateNiceMocks([MockSpec<ToastManager>()])
 void main() {
   late List<String> insertedHtml;
   late DriveAttachmentHandler handler;
+  late MockToastManager mockToastManager;
   final appLocalizations = AppLocalizations();
-
-  setUpAll(() {
-    Get.put(DriveAttachmentHandler());
-  });
 
   setUp(() {
     insertedHtml = [];
-    handler = Get.find<DriveAttachmentHandler>();
+    handler = Get.put(DriveAttachmentHandler());
+    mockToastManager = MockToastManager();
+    Get.put<ToastManager>(mockToastManager);
+  });
+
+  tearDown(() {
+    Get.reset();
   });
 
   group('DriveAttachmentHandler::handleDrivePickResult::', () {
@@ -29,6 +38,7 @@ void main() {
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, contains('https://drive.example.com/report'));
       expect(insertedHtml.first, contains('Report'));
+      verifyNever(mockToastManager.showMessageFailure(any));
     });
 
     test('Should still work and fall back to hardcoded English label when appLocalizations is omitted', () async {
@@ -58,16 +68,16 @@ void main() {
       expect(insertedHtml.first, contains('https://drive.example.com/both'));
     });
 
-    test('Should skip docs with neither sharingLink nor downloadLink', () async {
+    test('Should show download-only toast and not insert html when doc has neither sharingLink nor downloadLink', () async {
       await handler.handleDrivePickResult([
         noLinkDoc,
       ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
 
-      expect(insertedHtml, hasLength(1));
-      expect(insertedHtml.first, isEmpty);
+      expect(insertedHtml, isEmpty);
+      verify(mockToastManager.showMessageFailure(any)).called(1);
     });
 
-    test('Should handle mixed docs correctly — only link docs inserted', () async {
+    test('Should handle mixed docs correctly — only link docs inserted, no toast shown', () async {
       await handler.handleDrivePickResult([
         linkDoc,
         attachmentDoc,
@@ -76,6 +86,58 @@ void main() {
 
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, contains('Report'));
+      verifyNever(mockToastManager.showMessageFailure(any));
+    });
+  });
+
+  group('DriveAttachmentHandler::handleDrivePickResult::download-only toast::', () {
+    test('Should show toast with driveAttachmentInDevelopment message when all docs are download-only', () async {
+      handler.handleDrivePickResult([
+        attachmentDoc,
+      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
+
+      expect(insertedHtml, isEmpty);
+      final captured = verify(
+        mockToastManager.showMessageFailure(captureAny),
+      ).captured;
+      expect(captured, hasLength(1));
+      final failure = captured.single as DrivePickFailure;
+      expect(failure.message, equals(appLocalizations.driveAttachmentInDevelopment));
+    });
+
+    test('Should show toast when result is empty', () async {
+      handler.handleDrivePickResult(
+        [],
+        insertHtml: (html) async => insertedHtml.add(html),
+        appLocalizations: appLocalizations,
+      );
+
+      expect(insertedHtml, isEmpty);
+      verify(mockToastManager.showMessageFailure(any)).called(1);
+    });
+
+    test('Should show toast with null message when appLocalizations is omitted', () async {
+      handler.handleDrivePickResult([
+        attachmentDoc,
+      ], insertHtml: (html) async => insertedHtml.add(html));
+
+      expect(insertedHtml, isEmpty);
+      final captured = verify(
+        mockToastManager.showMessageFailure(captureAny),
+      ).captured;
+      expect(captured, hasLength(1));
+      final failure = captured.single as DrivePickFailure;
+      expect(failure.message, isNull);
+    });
+
+    test('Should not show toast when at least one doc has sharingLink', () async {
+      handler.handleDrivePickResult([
+        attachmentDoc,
+        linkDoc,
+      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
+
+      expect(insertedHtml, hasLength(1));
+      verifyNever(mockToastManager.showMessageFailure(any));
     });
 
     test('Should await an async insertHtml callback before insertDriveLinkHtml completes', () async {

--- a/workplace/lib/data/datasource/workplace_datasource.dart
+++ b/workplace/lib/data/datasource/workplace_datasource.dart
@@ -1,11 +1,12 @@
+import '../../domain/entity/workplace_action_config.dart';
 import '../../domain/entity/workplace_intent.dart';
 
 abstract class WorkplaceDataSource {
   Future<WorkplaceIntent> createIntent({
     required Uri platformUrl,
-    required String accessToken, 
-    required String addAsLink,
-    required String addAsAttachment,
+    required String accessToken,
+    required WorkplaceActionConfig addAsLink,
+    WorkplaceActionConfig? addAsAttachment,
   });
   Future<String> exchangeToken(Uri platformUrl, String oidcIdToken);
 }

--- a/workplace/lib/data/datasource_impl/workplace_datasource_impl.dart
+++ b/workplace/lib/data/datasource_impl/workplace_datasource_impl.dart
@@ -9,6 +9,7 @@ import '../model/workplace_enums.dart';
 import '../model/workplace_intent_request.dart';
 import '../model/workplace_intent_response.dart';
 import '../workplace_dio.dart';
+import '../../domain/entity/workplace_action_config.dart';
 import '../../domain/entity/workplace_intent.dart';
 
 class WorkplaceDataSourceImpl implements WorkplaceDataSource {
@@ -25,9 +26,9 @@ class WorkplaceDataSourceImpl implements WorkplaceDataSource {
   @override
   Future<WorkplaceIntent> createIntent({
     required Uri platformUrl,
-    required String accessToken, 
-    required String addAsLink,
-    required String addAsAttachment,
+    required String accessToken,
+    required WorkplaceActionConfig addAsLink,
+    WorkplaceActionConfig? addAsAttachment,
   }) async {
     final response = await WorkplaceDio.instance.post(
       platformUrl.replace(
@@ -67,8 +68,8 @@ class WorkplaceDataSourceImpl implements WorkplaceDataSource {
   }
 
   Map<String, dynamic> _buildIntentRequest({
-    required String addAsLink,
-    required String addAsAttachment,
+    required WorkplaceActionConfig addAsLink,
+    WorkplaceActionConfig? addAsAttachment,
   }) => WorkplaceIntentRequest(
     data: WorkplaceIntentDataRequest(
       type: WorkplaceDataRequestType.intents,
@@ -76,12 +77,12 @@ class WorkplaceDataSourceImpl implements WorkplaceDataSource {
         action: WorkplaceAction.pick,
         type: WorkplaceDocType.files,
         permissions: [WorkplacePermission.get],
-        actions: [
-          WorkplaceIntentActionsRequest(
-            addAsLink: addAsLink,
-            addAsAttachment: addAsAttachment,
-          ),
-        ],
+        data: WorkplaceFilePickerConfigRequest(
+          sharingLink: WorkplaceActionConfigRequest.fromEntity(addAsLink),
+          downloadLink: addAsAttachment == null
+              ? null
+              : WorkplaceActionConfigRequest.fromEntity(addAsAttachment),
+        ),
       ),
     ),
   ).toJson();

--- a/workplace/lib/data/model/workplace_intent_request.dart
+++ b/workplace/lib/data/model/workplace_intent_request.dart
@@ -1,21 +1,34 @@
 import 'workplace_enums.dart';
 import 'package:json_annotation/json_annotation.dart';
+import '../../domain/entity/workplace_action_config.dart';
 
 part 'workplace_intent_request.g.dart';
 
-@JsonSerializable(createFactory: false)
-class WorkplaceIntentActionsRequest {
-  @JsonKey(name: 'sharingLink')
-  final String addAsLink;
-  @JsonKey(name: 'downloadLink')
-  final String addAsAttachment;
+@JsonSerializable(createFactory: false, includeIfNull: false)
+class WorkplaceActionConfigRequest {
+  final String? label;
 
-  const WorkplaceIntentActionsRequest({
-    required this.addAsLink,
-    required this.addAsAttachment,
+  const WorkplaceActionConfigRequest({this.label});
+
+  factory WorkplaceActionConfigRequest.fromEntity(
+    WorkplaceActionConfig config,
+  ) => WorkplaceActionConfigRequest(label: config.label);
+
+  Map<String, dynamic> toJson() => _$WorkplaceActionConfigRequestToJson(this);
+}
+
+@JsonSerializable(createFactory: false, explicitToJson: true)
+class WorkplaceFilePickerConfigRequest {
+  final WorkplaceActionConfigRequest? sharingLink;
+  final WorkplaceActionConfigRequest? downloadLink;
+
+  const WorkplaceFilePickerConfigRequest({
+    required this.sharingLink,
+    required this.downloadLink,
   });
 
-  Map<String, dynamic> toJson() => _$WorkplaceIntentActionsRequestToJson(this);
+  Map<String, dynamic> toJson() =>
+      _$WorkplaceFilePickerConfigRequestToJson(this);
 }
 
 @JsonSerializable(createFactory: false, explicitToJson: true)
@@ -23,13 +36,13 @@ class WorkplaceIntentAttributesRequest {
   final WorkplaceAction action;
   final WorkplaceDocType type;
   final List<WorkplacePermission> permissions;
-  final List<WorkplaceIntentActionsRequest> actions;
+  final WorkplaceFilePickerConfigRequest data;
 
   const WorkplaceIntentAttributesRequest({
     required this.action,
     required this.type,
     required this.permissions,
-    required this.actions,
+    required this.data,
   });
 
   Map<String, dynamic> toJson() => _$WorkplaceIntentAttributesRequestToJson(this);

--- a/workplace/lib/data/model/workplace_intent_request.dart
+++ b/workplace/lib/data/model/workplace_intent_request.dart
@@ -19,7 +19,7 @@ class WorkplaceActionConfigRequest {
 
 @JsonSerializable(createFactory: false, explicitToJson: true)
 class WorkplaceFilePickerConfigRequest {
-  final WorkplaceActionConfigRequest? sharingLink;
+  final WorkplaceActionConfigRequest sharingLink;
   final WorkplaceActionConfigRequest? downloadLink;
 
   const WorkplaceFilePickerConfigRequest({

--- a/workplace/lib/data/repository_impl/workplace_repository_impl.dart
+++ b/workplace/lib/data/repository_impl/workplace_repository_impl.dart
@@ -1,4 +1,5 @@
 import '../datasource/workplace_datasource.dart';
+import '../../domain/entity/workplace_action_config.dart';
 import '../../domain/entity/workplace_intent.dart';
 import '../../domain/repository/workplace_repository.dart';
 
@@ -10,9 +11,9 @@ class WorkplaceRepositoryImpl implements WorkplaceRepository {
   @override
   Future<WorkplaceIntent> createIntent({
     required Uri platformUrl,
-    required String accessToken, 
-    required String addAsLink,
-    required String addAsAttachment,
+    required String accessToken,
+    required WorkplaceActionConfig addAsLink,
+    WorkplaceActionConfig? addAsAttachment,
   }) => _dataSource.createIntent(
     platformUrl: platformUrl,
     accessToken: accessToken,

--- a/workplace/lib/domain/entity/workplace_action_config.dart
+++ b/workplace/lib/domain/entity/workplace_action_config.dart
@@ -1,0 +1,10 @@
+import 'package:equatable/equatable.dart';
+
+class WorkplaceActionConfig with EquatableMixin {
+  final String? label;
+
+  const WorkplaceActionConfig({this.label});
+
+  @override
+  List<Object?> get props => [label];
+}

--- a/workplace/lib/domain/repository/workplace_repository.dart
+++ b/workplace/lib/domain/repository/workplace_repository.dart
@@ -1,11 +1,12 @@
+import '../entity/workplace_action_config.dart';
 import '../entity/workplace_intent.dart';
 
 abstract class WorkplaceRepository {
   Future<WorkplaceIntent> createIntent({
     required Uri platformUrl,
     required String accessToken,
-    required String addAsLink,
-    required String addAsAttachment,
+    required WorkplaceActionConfig addAsLink,
+    WorkplaceActionConfig? addAsAttachment,
   });
   Future<String> exchangeToken(Uri platformUrl, String oidcIdToken);
 }

--- a/workplace/lib/domain/usecase/create_drive_intent_interactor.dart
+++ b/workplace/lib/domain/usecase/create_drive_intent_interactor.dart
@@ -1,6 +1,7 @@
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:dartz/dartz.dart';
+import '../entity/workplace_action_config.dart';
 import '../repository/workplace_repository.dart';
 import '../state/workplace_intent_state.dart';
 
@@ -12,8 +13,8 @@ class CreateDriveIntentInteractor {
   Stream<Either<Failure, Success>> execute(
     Uri platformUrl,
     String accessToken, {
-    required String addAsLink,
-    required String addAsAttachment,
+    required WorkplaceActionConfig addAsLink,
+    WorkplaceActionConfig? addAsAttachment,
   }) async* {
     try {
       yield Right(CreatingWorkplaceIntent());

--- a/workplace/lib/l10n/app_ar.arb
+++ b/workplace/lib/l10n/app_ar.arb
@@ -1,5 +1,6 @@
 {
     "addAsLink": "إضافة كرابط",
     "addAsAttachment": "إضافة كمرفق",
-    "attachFromDriveFailingMessage": "تعذر إرفاق ملف/ملفات من محرك الأقراص"
+    "attachFromDriveFailingMessage": "تعذر إرفاق ملف/ملفات من محرك الأقراص",
+    "attachFromDrive": "إرفاق من Drive"
 }

--- a/workplace/lib/l10n/app_de.arb
+++ b/workplace/lib/l10n/app_de.arb
@@ -1,5 +1,6 @@
 {
     "addAsLink": "Als Link hinzufügen",
     "addAsAttachment": "Als Anhang hinzufügen",
-    "attachFromDriveFailingMessage": "Datei(en) von Drive konnten nicht angehängt werden"
+    "attachFromDriveFailingMessage": "Datei(en) von Drive konnten nicht angehängt werden",
+    "attachFromDrive": "Von Drive anhängen"
 }

--- a/workplace/lib/l10n/app_en.arb
+++ b/workplace/lib/l10n/app_en.arb
@@ -4,5 +4,7 @@
     "addAsAttachment": "Add as attachment",
     "@addAsAttachment": {},
     "attachFromDriveFailingMessage": "Unable to attach file(s) from drive",
-    "@attachFromDriveFailingMessage": {}
+    "@attachFromDriveFailingMessage": {},
+    "attachFromDrive": "Attach from drive",
+    "@attachFromDrive": {}
 }

--- a/workplace/lib/l10n/app_en.arb
+++ b/workplace/lib/l10n/app_en.arb
@@ -5,6 +5,6 @@
     "@addAsAttachment": {},
     "attachFromDriveFailingMessage": "Unable to attach file(s) from drive",
     "@attachFromDriveFailingMessage": {},
-    "attachFromDrive": "Attach from drive",
+    "attachFromDrive": "Attach from Drive",
     "@attachFromDrive": {}
 }

--- a/workplace/lib/l10n/app_fr.arb
+++ b/workplace/lib/l10n/app_fr.arb
@@ -1,5 +1,6 @@
 {
     "addAsLink": "Ajouter comme lien",
     "addAsAttachment": "Ajouter comme pièce jointe",
-    "attachFromDriveFailingMessage": "Impossible de joindre le(s) fichier(s) depuis Drive"
+    "attachFromDriveFailingMessage": "Impossible de joindre le(s) fichier(s) depuis Drive",
+    "attachFromDrive": "Joindre depuis Drive"
 }

--- a/workplace/lib/l10n/app_it.arb
+++ b/workplace/lib/l10n/app_it.arb
@@ -1,5 +1,6 @@
 {
     "addAsLink": "Aggiungi come collegamento",
     "addAsAttachment": "Aggiungi come allegato",
-    "attachFromDriveFailingMessage": "Impossibile allegare file da Drive"
+    "attachFromDriveFailingMessage": "Impossibile allegare file da Drive",
+    "attachFromDrive": "Allega da Drive"
 }

--- a/workplace/lib/l10n/app_mn.arb
+++ b/workplace/lib/l10n/app_mn.arb
@@ -1,5 +1,6 @@
 {
     "addAsLink": "Холбоос болгон нэмэх",
     "addAsAttachment": "Хавсралт болгон нэмэх",
-    "attachFromDriveFailingMessage": "Drive-аас файл(ууд) хавсаргах боломжгүй байна"
+    "attachFromDriveFailingMessage": "Drive-аас файл(ууд) хавсаргах боломжгүй байна",
+    "attachFromDrive": "Drive-аас хавсаргах"
 }

--- a/workplace/lib/l10n/app_ru.arb
+++ b/workplace/lib/l10n/app_ru.arb
@@ -1,5 +1,6 @@
 {
     "addAsLink": "Добавить как ссылку",
     "addAsAttachment": "Добавить как вложение",
-    "attachFromDriveFailingMessage": "Не удалось прикрепить файл(ы) с диска"
+    "attachFromDriveFailingMessage": "Не удалось прикрепить файл(ы) с диска",
+    "attachFromDrive": "Прикрепить с диска"
 }

--- a/workplace/lib/l10n/app_vi.arb
+++ b/workplace/lib/l10n/app_vi.arb
@@ -1,5 +1,6 @@
 {
     "addAsLink": "Thêm dưới dạng liên kết",
     "addAsAttachment": "Thêm dưới dạng tệp đính kèm",
-    "attachFromDriveFailingMessage": "Không thể đính kèm tệp từ drive"
+    "attachFromDriveFailingMessage": "Không thể đính kèm tệp từ drive",
+    "attachFromDrive": "Đính kèm từ Drive"
 }

--- a/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
+++ b/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
@@ -6,6 +6,7 @@ import 'package:core/utils/app_logger.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:workplace/data/datasource_impl/workplace_datasource_impl.dart';
+import 'package:workplace/data/model/workplace_intent_request.dart';
 import 'package:workplace/data/repository_impl/workplace_repository_impl.dart';
 import 'package:workplace/domain/entity/workplace_action_config.dart';
 import 'package:workplace/domain/entity/workplace_intent.dart';
@@ -40,8 +41,7 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
 
   Future<WorkplaceIntent> _fetchIntent(
     Uri platformUrl, {
-    required String addAsLinkTitle,
-    String? addAsAttachmentTitle,
+    required WorkplaceFilePickerConfigRequest filePickerConfig,
   }) async {
     final oidcToken = oidcTokenGetter();
     if (oidcToken == null) throw StateError('OIDC token is unavailable');
@@ -50,8 +50,7 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
     return _createIntent(
       platformUrl,
       accessToken,
-      addAsLinkTitle: addAsLinkTitle,
-      addAsAttachmentTitle: addAsAttachmentTitle,
+      filePickerConfig: filePickerConfig,
     );
   }
 
@@ -84,17 +83,16 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
   Future<WorkplaceIntent> _createIntent(
     Uri platformUrl,
     String accessToken, {
-    required String addAsLinkTitle,
-    String? addAsAttachmentTitle,
+    required WorkplaceFilePickerConfigRequest filePickerConfig,
   }) async {
     WorkplaceIntent? intent;
     await for (final either in _createIntentInteractor.execute(
       platformUrl,
       accessToken,
-      addAsLink: WorkplaceActionConfig(label: addAsLinkTitle),
-      addAsAttachment: addAsAttachmentTitle == null
+      addAsLink: WorkplaceActionConfig(label: filePickerConfig.sharingLink?.label),
+      addAsAttachment: filePickerConfig.downloadLink == null
           ? null
-          : WorkplaceActionConfig(label: addAsAttachmentTitle),
+          : WorkplaceActionConfig(label: filePickerConfig.downloadLink!.label),
     )) {
       either.fold(
         (failure) {
@@ -130,10 +128,9 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
           onPickCallback: onPickState == null
               ? null
               : (state) => onPickState!(composerId, state),
-          onFetchIntent: ({required addAsLinkTitle, addAsAttachmentTitle}) => _fetchIntent(
+          onFetchIntent: ({required filePickerConfig}) => _fetchIntent(
             uri,
-            addAsLinkTitle: addAsLinkTitle,
-            addAsAttachmentTitle: addAsAttachmentTitle,
+            filePickerConfig: filePickerConfig,
           ),
         );
       },
@@ -157,10 +154,9 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
           onPickCallback: onPickState == null
               ? null
               : (state) => onPickState!(null, state),
-          onFetchIntent: ({required addAsLinkTitle, addAsAttachmentTitle}) => _fetchIntent(
+          onFetchIntent: ({required filePickerConfig}) => _fetchIntent(
             uri,
-            addAsLinkTitle: addAsLinkTitle,
-            addAsAttachmentTitle: addAsAttachmentTitle,
+            filePickerConfig: filePickerConfig,
           ),
         );
       },

--- a/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
+++ b/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:workplace/data/datasource_impl/workplace_datasource_impl.dart';
 import 'package:workplace/data/repository_impl/workplace_repository_impl.dart';
+import 'package:workplace/domain/entity/workplace_action_config.dart';
 import 'package:workplace/domain/entity/workplace_intent.dart';
 import 'package:workplace/domain/exceptions/workplace_exceptions.dart';
 import 'package:workplace/presentation/model/drive_pick_state.dart';
@@ -40,7 +41,7 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
   Future<WorkplaceIntent> _fetchIntent(
     Uri platformUrl, {
     required String addAsLinkTitle,
-    required String addAsAttachmentTitle,
+    String? addAsAttachmentTitle,
   }) async {
     final oidcToken = oidcTokenGetter();
     if (oidcToken == null) throw StateError('OIDC token is unavailable');
@@ -84,14 +85,16 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
     Uri platformUrl,
     String accessToken, {
     required String addAsLinkTitle,
-    required String addAsAttachmentTitle,
+    String? addAsAttachmentTitle,
   }) async {
     WorkplaceIntent? intent;
     await for (final either in _createIntentInteractor.execute(
       platformUrl,
       accessToken,
-      addAsLink: addAsLinkTitle,
-      addAsAttachment: addAsAttachmentTitle,
+      addAsLink: WorkplaceActionConfig(label: addAsLinkTitle),
+      addAsAttachment: addAsAttachmentTitle == null
+          ? null
+          : WorkplaceActionConfig(label: addAsAttachmentTitle),
     )) {
       either.fold(
         (failure) {
@@ -127,7 +130,7 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
           onPickCallback: onPickState == null
               ? null
               : (state) => onPickState!(composerId, state),
-          onFetchIntent: ({required addAsLinkTitle, required addAsAttachmentTitle}) => _fetchIntent(
+          onFetchIntent: ({required addAsLinkTitle, addAsAttachmentTitle}) => _fetchIntent(
             uri,
             addAsLinkTitle: addAsLinkTitle,
             addAsAttachmentTitle: addAsAttachmentTitle,
@@ -154,7 +157,7 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
           onPickCallback: onPickState == null
               ? null
               : (state) => onPickState!(null, state),
-          onFetchIntent: ({required addAsLinkTitle, required addAsAttachmentTitle}) => _fetchIntent(
+          onFetchIntent: ({required addAsLinkTitle, addAsAttachmentTitle}) => _fetchIntent(
             uri,
             addAsLinkTitle: addAsLinkTitle,
             addAsAttachmentTitle: addAsAttachmentTitle,

--- a/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
+++ b/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
@@ -89,7 +89,7 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
     await for (final either in _createIntentInteractor.execute(
       platformUrl,
       accessToken,
-      addAsLink: WorkplaceActionConfig(label: filePickerConfig.sharingLink?.label),
+      addAsLink: WorkplaceActionConfig(label: filePickerConfig.sharingLink.label),
       addAsAttachment: filePickerConfig.downloadLink == null
           ? null
           : WorkplaceActionConfig(label: filePickerConfig.downloadLink!.label),
@@ -141,7 +141,6 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
   Widget buildContextMenuTile(
     BuildContext context, {
     required ImagePaths imagePaths,
-    required String label,
   }) {
     return ValueListenableBuilder<Uri?>(
       valueListenable: workplaceUri,
@@ -150,7 +149,6 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
         return DriveAttachmentContextMenuTile(
           imagePaths: imagePaths,
           workplaceUri: uri,
-          label: label,
           onPickCallback: onPickState == null
               ? null
               : (state) => onPickState!(null, state),

--- a/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
+++ b/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
@@ -13,7 +13,7 @@ typedef OnPickDriveCallback = void Function(DrivePickState state);
 typedef FetchDriveIntentCallback =
     Future<WorkplaceIntent> Function({
       required String addAsLinkTitle,
-      required String addAsAttachmentTitle,
+      String? addAsAttachmentTitle,
     });
 
 /// Shared state logic for widgets that open [DriveIntentWebViewModal].
@@ -42,9 +42,10 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
       // Captured up front: the caller may pop this context (e.g. a context
       // menu tile) before the intent future settles, disposing this state.
       final failingMessage = l10n.attachFromDriveFailingMessage;
+      const addAsAttachmentTitle = null; // TODO: Add attachment title here after implement 103. Attach Drive File as Attachment
       final intentFuture = pickerFetchIntent(
         addAsLinkTitle: l10n.addAsLink,
-        addAsAttachmentTitle: l10n.addAsAttachment,
+        addAsAttachmentTitle: addAsAttachmentTitle,
       );
       DrivePickOutcome? outcome;
       try {
@@ -54,6 +55,10 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
           barrierDismissible: false,
           builder: (_) => DriveIntentWebViewModal(
             intentFuture: intentFuture,
+            filePickerConfig: _buildFilePickerConfig(
+              addAsLinkLabel: l10n.addAsLink,
+              addAsAttachmentLabel: addAsAttachmentTitle,
+            ),
             onRegisterExternalHandler: externalHandlerRegistrar,
           ),
         );
@@ -79,6 +84,18 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
         break;
     }
   }
+
+  /// Mirrors the `sharingLink`/`downloadLink` shape Drive expects — must be
+  /// echoed back on the ready handshake, see [DriveIntentMessageHandlerMixin].
+  Map<String, dynamic> _buildFilePickerConfig({
+    required String addAsLinkLabel,
+    String? addAsAttachmentLabel,
+  }) => {
+    'sharingLink': {'label': addAsLinkLabel},
+    'downloadLink': addAsAttachmentLabel == null
+        ? null
+        : {'label': addAsAttachmentLabel},
+  };
 }
 
 /// Web-specific extension of [DrivePickerStateMixin] that wires a single

--- a/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
+++ b/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
@@ -1,5 +1,6 @@
 import 'package:core/utils/app_logger.dart';
 import 'package:flutter/material.dart';
+import 'package:workplace/data/model/workplace_intent_request.dart';
 import 'package:workplace/domain/entity/workplace_intent.dart';
 import 'package:workplace/domain/exceptions/workplace_exceptions.dart';
 import 'package:workplace/l10n/workplace_localizations.dart';
@@ -12,8 +13,7 @@ typedef OnPickDriveCallback = void Function(DrivePickState state);
 
 typedef FetchDriveIntentCallback =
     Future<WorkplaceIntent> Function({
-      required String addAsLinkTitle,
-      String? addAsAttachmentTitle,
+      required WorkplaceFilePickerConfigRequest filePickerConfig,
     });
 
 /// Shared state logic for widgets that open [DriveIntentWebViewModal].
@@ -43,10 +43,13 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
       // menu tile) before the intent future settles, disposing this state.
       final failingMessage = l10n.attachFromDriveFailingMessage;
       const addAsAttachmentTitle = null; // TODO: Add attachment title here after implement 103. Attach Drive File as Attachment
-      final intentFuture = pickerFetchIntent(
-        addAsLinkTitle: l10n.addAsLink,
-        addAsAttachmentTitle: addAsAttachmentTitle,
+      final filePickerConfig = WorkplaceFilePickerConfigRequest(
+        sharingLink: WorkplaceActionConfigRequest(label: l10n.addAsLink),
+        downloadLink: addAsAttachmentTitle == null
+            ? null
+            : const WorkplaceActionConfigRequest(label: addAsAttachmentTitle),
       );
+      final intentFuture = pickerFetchIntent(filePickerConfig: filePickerConfig);
       DrivePickOutcome? outcome;
       try {
         outcome = await showDialog<DrivePickOutcome>(
@@ -55,10 +58,7 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
           barrierDismissible: false,
           builder: (_) => DriveIntentWebViewModal(
             intentFuture: intentFuture,
-            filePickerConfig: _buildFilePickerConfig(
-              addAsLinkLabel: l10n.addAsLink,
-              addAsAttachmentLabel: addAsAttachmentTitle,
-            ),
+            filePickerConfig: filePickerConfig,
             onRegisterExternalHandler: externalHandlerRegistrar,
           ),
         );
@@ -84,18 +84,6 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
         break;
     }
   }
-
-  /// Mirrors the `sharingLink`/`downloadLink` shape Drive expects — must be
-  /// echoed back on the ready handshake, see [DriveIntentMessageHandlerMixin].
-  Map<String, dynamic> _buildFilePickerConfig({
-    required String addAsLinkLabel,
-    String? addAsAttachmentLabel,
-  }) => {
-    'sharingLink': {'label': addAsLinkLabel},
-    'downloadLink': addAsAttachmentLabel == null
-        ? null
-        : {'label': addAsAttachmentLabel},
-  };
 }
 
 /// Web-specific extension of [DrivePickerStateMixin] that wires a single

--- a/workplace/lib/presentation/view/drive_intent_web_view_modal_mobile.dart
+++ b/workplace/lib/presentation/view/drive_intent_web_view_modal_mobile.dart
@@ -12,12 +12,14 @@ import 'package:workplace/domain/entity/workplace_intent.dart';
 
 class DriveIntentWebViewModal extends StatefulWidget {
   final Future<WorkplaceIntent> intentFuture;
+  final Map<String, dynamic> filePickerConfig;
   // Ignored on mobile — only used by the web variant (ADR-93).
   final OnRegisterExternalHandler? onRegisterExternalHandler;
 
   const DriveIntentWebViewModal({
     super.key,
     required this.intentFuture,
+    required this.filePickerConfig,
     this.onRegisterExternalHandler,
   });
 
@@ -97,10 +99,13 @@ class _DriveIntentWebViewModalState extends State<DriveIntentWebViewModal>
 
   @override
   void sendAck() {
-    final payload = jsonEncode({});
+    // Embedded unquoted: JSON object syntax is valid JS object-literal syntax,
+    // so `event.data` in the page ends up a real object, not a JSON string —
+    // Drive's getFilePickerConfig never calls JSON.parse on it.
+    final payload = jsonEncode(widget.filePickerConfig);
     _webViewController?.evaluateJavascript(source: '''
       window.dispatchEvent(new MessageEvent('message', {
-        data: '$payload',
+        data: $payload,
         origin: '$intentOrigin',
         source: window
       }));

--- a/workplace/lib/presentation/view/drive_intent_web_view_modal_mobile.dart
+++ b/workplace/lib/presentation/view/drive_intent_web_view_modal_mobile.dart
@@ -8,11 +8,12 @@ import 'drive_intent_skeleton_loader.dart';
 import 'drive_intent_web_view_modal_shell.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:workplace/data/model/workplace_intent_request.dart';
 import 'package:workplace/domain/entity/workplace_intent.dart';
 
 class DriveIntentWebViewModal extends StatefulWidget {
   final Future<WorkplaceIntent> intentFuture;
-  final Map<String, dynamic> filePickerConfig;
+  final WorkplaceFilePickerConfigRequest filePickerConfig;
   // Ignored on mobile — only used by the web variant (ADR-93).
   final OnRegisterExternalHandler? onRegisterExternalHandler;
 
@@ -102,7 +103,7 @@ class _DriveIntentWebViewModalState extends State<DriveIntentWebViewModal>
     // Embedded unquoted: JSON object syntax is valid JS object-literal syntax,
     // so `event.data` in the page ends up a real object, not a JSON string —
     // Drive's getFilePickerConfig never calls JSON.parse on it.
-    final payload = jsonEncode(widget.filePickerConfig);
+    final payload = jsonEncode(widget.filePickerConfig.toJson());
     _webViewController?.evaluateJavascript(source: '''
       window.dispatchEvent(new MessageEvent('message', {
         data: $payload,

--- a/workplace/lib/presentation/view/drive_intent_web_view_modal_web.dart
+++ b/workplace/lib/presentation/view/drive_intent_web_view_modal_web.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/views/html_viewer/html_iframe_widget.dart';
 import 'package:flutter/material.dart';
@@ -12,6 +10,7 @@ import 'package:workplace/presentation/view/drive_intent_web_view_modal_shell.da
 
 class DriveIntentWebViewModal extends StatefulWidget {
   final Future<WorkplaceIntent> intentFuture;
+  final Map<String, dynamic> filePickerConfig;
   // ADR-93: composer registers the window listener at composer-init time and
   // forwards messages here, so the handler is ready before the iframe loads.
   final OnRegisterExternalHandler? onRegisterExternalHandler;
@@ -19,6 +18,7 @@ class DriveIntentWebViewModal extends StatefulWidget {
   const DriveIntentWebViewModal({
     super.key,
     required this.intentFuture,
+    required this.filePickerConfig,
     this.onRegisterExternalHandler,
   });
 
@@ -127,6 +127,8 @@ class _DriveIntentWebViewModalState extends State<DriveIntentWebViewModal>
   void sendAck() {
     // data: URIs have opaque 'null' origin — postMessage requires '*' for those.
     final targetOrigin = intentOrigin == 'null' ? '*' : intentOrigin;
-    _iframeElement?.contentWindow?.postMessage(jsonEncode({}), targetOrigin);
+    // Pass the Map directly — dart:html's postMessage structured-clones it into
+    // a real JS object, which is what Drive's getFilePickerConfig expects.
+    _iframeElement?.contentWindow?.postMessage(widget.filePickerConfig, targetOrigin);
   }
 }

--- a/workplace/lib/presentation/view/drive_intent_web_view_modal_web.dart
+++ b/workplace/lib/presentation/view/drive_intent_web_view_modal_web.dart
@@ -2,6 +2,7 @@ import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/views/html_viewer/html_iframe_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:universal_html/html.dart' as html;
+import 'package:workplace/data/model/workplace_intent_request.dart';
 import 'package:workplace/domain/entity/workplace_intent.dart';
 import 'package:workplace/presentation/mixin/drive_intent_message_handler_mixin.dart';
 import 'package:workplace/presentation/mixin/web_window_message_mixin.dart';
@@ -10,7 +11,7 @@ import 'package:workplace/presentation/view/drive_intent_web_view_modal_shell.da
 
 class DriveIntentWebViewModal extends StatefulWidget {
   final Future<WorkplaceIntent> intentFuture;
-  final Map<String, dynamic> filePickerConfig;
+  final WorkplaceFilePickerConfigRequest filePickerConfig;
   // ADR-93: composer registers the window listener at composer-init time and
   // forwards messages here, so the handler is ready before the iframe loads.
   final OnRegisterExternalHandler? onRegisterExternalHandler;
@@ -127,8 +128,8 @@ class _DriveIntentWebViewModalState extends State<DriveIntentWebViewModal>
   void sendAck() {
     // data: URIs have opaque 'null' origin — postMessage requires '*' for those.
     final targetOrigin = intentOrigin == 'null' ? '*' : intentOrigin;
-    // Pass the Map directly — dart:html's postMessage structured-clones it into
-    // a real JS object, which is what Drive's getFilePickerConfig expects.
-    _iframeElement?.contentWindow?.postMessage(widget.filePickerConfig, targetOrigin);
+    // dart:html's postMessage structured-clones the Map into a real JS
+    // object, which is what Drive's getFilePickerConfig expects.
+    _iframeElement?.contentWindow?.postMessage(widget.filePickerConfig.toJson(), targetOrigin);
   }
 }

--- a/workplace/lib/presentation/widget/drive_attachment_context_menu_tile.dart
+++ b/workplace/lib/presentation/widget/drive_attachment_context_menu_tile.dart
@@ -4,13 +4,13 @@ import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:workplace/l10n/workplace_localizations.dart';
 import 'package:workplace/presentation/mixin/drive_picker_state_mixin.dart';
 import 'package:workplace/presentation/mixin/web_window_message_mixin.dart';
 
 class DriveAttachmentContextMenuTile extends StatefulWidget {
   final ImagePaths imagePaths;
   final Uri workplaceUri;
-  final String label;
   final OnPickDriveCallback? onPickCallback;
   final FetchDriveIntentCallback onFetchIntent;
 
@@ -18,7 +18,6 @@ class DriveAttachmentContextMenuTile extends StatefulWidget {
     super.key,
     required this.imagePaths,
     required this.workplaceUri,
-    required this.label,
     required this.onFetchIntent,
     this.onPickCallback,
   });
@@ -45,6 +44,8 @@ abstract class _DriveAttachmentContextMenuTileState
 
   @override
   Widget build(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context);
+    final label = appLocalizations?.attachFromDrive ?? 'Attach from Drive';
     return ListTile(
       leading: Padding(
         padding: const EdgeInsets.only(left: 12),
@@ -56,7 +57,7 @@ abstract class _DriveAttachmentContextMenuTileState
         ),
       ),
       title: Text(
-        widget.label,
+        label,
         style: ThemeUtils.defaultTextStyleInterFont.copyWith(
           fontSize: 15,
           color: AppColor.nameUserColor,

--- a/workplace/lib/presentation/widget/drive_attachment_context_menu_tile.dart
+++ b/workplace/lib/presentation/widget/drive_attachment_context_menu_tile.dart
@@ -45,7 +45,7 @@ abstract class _DriveAttachmentContextMenuTileState
   @override
   Widget build(BuildContext context) {
     final appLocalizations = AppLocalizations.of(context);
-    final label = appLocalizations?.attachFromDrive ?? 'Attach from Drive';
+    final label = appLocalizations!.attachFromDrive;
     return ListTile(
       leading: Padding(
         padding: const EdgeInsets.only(left: 12),

--- a/workplace/test/data/workplace_datasource_impl_test.dart
+++ b/workplace/test/data/workplace_datasource_impl_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:workplace/data/datasource_impl/workplace_datasource_impl.dart';
 import 'package:workplace/data/workplace_dio.dart';
+import 'package:workplace/domain/entity/workplace_action_config.dart';
 
 /// Captures the last request and returns a fixed JSON response.
 class _MockAdapter implements HttpClientAdapter {
@@ -215,8 +216,8 @@ void main() {
       final result = await datasource.createIntent(
         platformUrl: Uri.parse('https://platform.example.com'),
         accessToken: 'test-token',
-        addAsLink: 'https://link.url',
-        addAsAttachment: 'https://attach.url',
+        addAsLink: const WorkplaceActionConfig(label: 'https://link.url'),
+        addAsAttachment: const WorkplaceActionConfig(label: 'https://attach.url'),
       );
 
       expect(result.intentId, equals('intent-abc'));
@@ -230,8 +231,8 @@ void main() {
       await datasource.createIntent(
         platformUrl: Uri.parse('https://platform.example.com/api/'),
         accessToken: 'test-token',
-        addAsLink: 'https://link.url',
-        addAsAttachment: 'https://attach.url',
+        addAsLink: const WorkplaceActionConfig(label: 'https://link.url'),
+        addAsAttachment: const WorkplaceActionConfig(label: 'https://attach.url'),
       );
 
       expect(
@@ -247,8 +248,8 @@ void main() {
       await datasource.createIntent(
         platformUrl: Uri.parse('https://platform.example.com'),
         accessToken: 'my-secret-token',
-        addAsLink: 'https://link.url',
-        addAsAttachment: 'https://attach.url',
+        addAsLink: const WorkplaceActionConfig(label: 'https://link.url'),
+        addAsAttachment: const WorkplaceActionConfig(label: 'https://attach.url'),
       );
 
       expect(
@@ -264,8 +265,8 @@ void main() {
       await datasource.createIntent(
         platformUrl: Uri.parse('https://platform.example.com'),
         accessToken: 'test-token',
-        addAsLink: 'https://link.url',
-        addAsAttachment: 'https://attach.url',
+        addAsLink: const WorkplaceActionConfig(label: 'https://link.url'),
+        addAsAttachment: const WorkplaceActionConfig(label: 'https://attach.url'),
       );
 
       // Normalize through jsonEncode so nested Dart objects are fully serialized
@@ -278,11 +279,29 @@ void main() {
       expect(attributes['type'], equals('io.cozy.files'));
       expect(attributes['permissions'], equals(['GET']));
 
-      final actions = attributes['actions'] as List<dynamic>;
-      expect(actions, hasLength(1));
-      final action = actions.first as Map<String, dynamic>;
-      expect(action['sharingLink'], equals('https://link.url'));
-      expect(action['downloadLink'], equals('https://attach.url'));
+      final config = attributes['data'] as Map<String, dynamic>;
+      final sharingLink = config['sharingLink'] as Map<String, dynamic>;
+      expect(sharingLink['label'], equals('https://link.url'));
+      final downloadLink = config['downloadLink'] as Map<String, dynamic>;
+      expect(downloadLink['label'], equals('https://attach.url'));
+    });
+
+    test('Should send explicit null downloadLink to hide the attachment button when addAsAttachment is omitted', () async {
+      final adapter = _MockAdapter(intentResponse);
+      WorkplaceDio.setInstance(Dio()..httpClientAdapter = adapter);
+
+      await datasource.createIntent(
+        platformUrl: Uri.parse('https://platform.example.com'),
+        accessToken: 'test-token',
+        addAsLink: const WorkplaceActionConfig(label: 'https://link.url'),
+      );
+
+      final body = jsonDecode(jsonEncode(adapter.capturedOptions!.data)) as Map<String, dynamic>;
+      final attributes = (body['data'] as Map<String, dynamic>)['attributes'] as Map<String, dynamic>;
+      final config = attributes['data'] as Map<String, dynamic>;
+
+      expect(config.containsKey('downloadLink'), isTrue);
+      expect(config['downloadLink'], isNull);
     });
 
     test('Should propagate DioException on network error', () async {
@@ -292,8 +311,8 @@ void main() {
         () => datasource.createIntent(
           platformUrl: Uri.parse('https://platform.example.com'),
           accessToken: 'test-token',
-          addAsLink: 'https://link.url',
-          addAsAttachment: 'https://attach.url',
+          addAsLink: const WorkplaceActionConfig(label: 'https://link.url'),
+          addAsAttachment: const WorkplaceActionConfig(label: 'https://attach.url'),
         ),
         throwsA(isA<DioException>()),
       );

--- a/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
+++ b/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:workplace/data/model/workplace_intent_request.dart';
 import 'package:workplace/data/workplace_dio.dart';
+import 'package:workplace/l10n/workplace_localizations.dart';
 import 'package:workplace/presentation/extension/workplace_composer_attachment_extension.dart';
 import 'package:workplace/presentation/mixin/drive_picker_state_mixin.dart';
 import 'package:workplace/presentation/model/drive_pick_state.dart';
@@ -243,6 +244,8 @@ void main() {
       final ext = _makeExtension(notifier);
 
       await tester.pumpWidget(MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
         home: Builder(
           builder: (ctx) => ext.buildContextMenuTile(
             ctx,
@@ -259,6 +262,8 @@ void main() {
       final ext = _makeExtension(notifier);
 
       await tester.pumpWidget(MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
           body: Builder(
             builder: (ctx) => ext.buildContextMenuTile(
@@ -277,6 +282,8 @@ void main() {
       final ext = _makeExtension(notifier);
 
       await tester.pumpWidget(MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
           body: Builder(
             builder: (ctx) => ext.buildContextMenuTile(
@@ -299,6 +306,8 @@ void main() {
       final ext = _makeExtension(notifier);
 
       await tester.pumpWidget(MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
           body: Builder(
             builder: (ctx) => ext.buildContextMenuTile(
@@ -317,6 +326,8 @@ void main() {
       final ext = _makeExtension(notifier, onPickState: null);
 
       await tester.pumpWidget(MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
           body: Builder(
             builder: (ctx) => ext.buildContextMenuTile(
@@ -347,6 +358,8 @@ void main() {
       );
 
       await tester.pumpWidget(MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
           body: Builder(
             builder: (ctx) => ext.buildContextMenuTile(

--- a/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
+++ b/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
@@ -5,6 +5,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:workplace/data/model/workplace_intent_request.dart';
 import 'package:workplace/data/workplace_dio.dart';
 import 'package:workplace/presentation/extension/workplace_composer_attachment_extension.dart';
 import 'package:workplace/presentation/mixin/drive_picker_state_mixin.dart';
@@ -413,7 +414,12 @@ void main() {
       final callback = await extractCallback(tester, ext);
 
       await expectLater(
-        callback(addAsLinkTitle: 'Link', addAsAttachmentTitle: 'Attachment'),
+        callback(
+          filePickerConfig: const WorkplaceFilePickerConfigRequest(
+            sharingLink: WorkplaceActionConfigRequest(label: 'Link'),
+            downloadLink: WorkplaceActionConfigRequest(label: 'Attachment'),
+          ),
+        ),
         throwsA(isA<StateError>().having(
           (e) => e.message, 'message', contains('OIDC token'),
         )),
@@ -429,7 +435,12 @@ void main() {
 
       await tester.runAsync(() async {
         await expectLater(
-          callback(addAsLinkTitle: 'Link', addAsAttachmentTitle: 'Attachment'),
+          callback(
+          filePickerConfig: const WorkplaceFilePickerConfigRequest(
+            sharingLink: WorkplaceActionConfigRequest(label: 'Link'),
+            downloadLink: WorkplaceActionConfigRequest(label: 'Attachment'),
+          ),
+        ),
           throwsA(isA<DioException>()),
         );
       });
@@ -447,7 +458,12 @@ void main() {
 
       await tester.runAsync(() async {
         await expectLater(
-          callback(addAsLinkTitle: 'Link', addAsAttachmentTitle: 'Attachment'),
+          callback(
+          filePickerConfig: const WorkplaceFilePickerConfigRequest(
+            sharingLink: WorkplaceActionConfigRequest(label: 'Link'),
+            downloadLink: WorkplaceActionConfigRequest(label: 'Attachment'),
+          ),
+        ),
           throwsA(isA<DioException>()),
         );
       });
@@ -464,7 +480,12 @@ void main() {
       final callback = await extractCallback(tester, ext);
 
       final result = await tester.runAsync(
-        () => callback(addAsLinkTitle: 'Link', addAsAttachmentTitle: 'Attachment'),
+        () => callback(
+          filePickerConfig: const WorkplaceFilePickerConfigRequest(
+            sharingLink: WorkplaceActionConfigRequest(label: 'Link'),
+            downloadLink: WorkplaceActionConfigRequest(label: 'Attachment'),
+          ),
+        ),
       );
       expect(result, isNotNull);
       expect(result!.intentId, equals('intent-xyz'));

--- a/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
+++ b/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
@@ -247,7 +247,6 @@ void main() {
           builder: (ctx) => ext.buildContextMenuTile(
             ctx,
             imagePaths: imagePaths,
-            label: _label,
           ),
         ),
       ));
@@ -265,7 +264,6 @@ void main() {
             builder: (ctx) => ext.buildContextMenuTile(
               ctx,
               imagePaths: imagePaths,
-              label: _label,
             ),
           ),
         ),
@@ -284,7 +282,6 @@ void main() {
             builder: (ctx) => ext.buildContextMenuTile(
               ctx,
               imagePaths: imagePaths,
-              label: _label,
             ),
           ),
         ),
@@ -307,16 +304,12 @@ void main() {
             builder: (ctx) => ext.buildContextMenuTile(
               ctx,
               imagePaths: imagePaths,
-              label: _label,
             ),
           ),
         ),
       ));
 
-      final tile = tester.widget<DriveAttachmentContextMenuTile>(
-        find.byType(DriveAttachmentContextMenuTile),
-      );
-      expect(tile.label, equals(_label));
+      expect(find.text(_label), findsOneWidget);
     });
 
     testWidgets('onPickCallback is null when onPickState is not provided', (tester) async {
@@ -329,7 +322,6 @@ void main() {
             builder: (ctx) => ext.buildContextMenuTile(
               ctx,
               imagePaths: imagePaths,
-              label: _label,
             ),
           ),
         ),
@@ -360,7 +352,6 @@ void main() {
             builder: (ctx) => ext.buildContextMenuTile(
               ctx,
               imagePaths: imagePaths,
-              label: _label,
             ),
           ),
         ),

--- a/workplace/test/presentation/mixin/drive_intent_message_handler_mixin_test.dart
+++ b/workplace/test/presentation/mixin/drive_intent_message_handler_mixin_test.dart
@@ -22,7 +22,9 @@ class _TestState extends State<_TestWidget> with DriveIntentMessageHandlerMixin 
   final List<DrivePickOutcome> outcomes = [];
 
   @override
-  void sendAck() => ackCalls.add('ack');
+  void sendAck() {
+    ackCalls.add('ack');
+  }
 
   @override
   void loadIntent(WorkplaceIntent intent) => loadCalls.add(intent);


### PR DESCRIPTION

https://github.com/user-attachments/assets/fead1606-6c40-4b76-b81d-08f3a665643c

<img width="963" height="767" alt="Screenshot 2026-07-24 at 10 52 23 AM" src="https://github.com/user-attachments/assets/b49b944f-a7a8-4f81-b2dd-a44a1f8f7dbb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When adding a Drive item as an attachment, the app now filters to documents with eligible sharing links and requires HTTPS; if none are eligible, it stops and shows a localized failure toast.
  * Prevented attachment content from being inserted for link-ineligible documents; documents with valid links still generate attachment content.
* **Improvements**
  * Made “add as attachment” details optional during Drive intent creation and composer actions.
* **Localization**
  * Added a localized message noting the “Add as attachment” feature is still in development.
* **Tests**
  * Updated Drive attachment handling coverage for toast failures, link eligibility, and localized vs. nonlocalized messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->