### PR TITLE
Optimize Drive link UI

### DIFF
--- a/core/lib/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart
@@ -19,7 +19,7 @@ class StandardizeHtmlSanitizingTransformers extends TextTransformer {
     if (text.isEmpty) return '';
 
     final scopedText = allowAttributes?.contains(_contentEditableAttribute) == true &&
-            text.contains(_contentEditableAttribute)
+            text.toLowerCase().contains(_contentEditableAttribute)
       ? _stripContentEditableOutsideDriveLinkCard(text)
       : text;
 

--- a/core/lib/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart
+++ b/core/lib/presentation/utils/html_transformer/text/standardize_html_sanitizing_transformers.dart
@@ -18,7 +18,8 @@ class StandardizeHtmlSanitizingTransformers extends TextTransformer {
   String process(String text, HtmlEscape htmlEscape) {
     if (text.isEmpty) return '';
 
-    final scopedText = allowAttributes?.contains(_contentEditableAttribute) == true
+    final scopedText = allowAttributes?.contains(_contentEditableAttribute) == true &&
+            text.contains(_contentEditableAttribute)
       ? _stripContentEditableOutsideDriveLinkCard(text)
       : text;
 

--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -643,7 +643,7 @@ class HtmlUtils {
             width: 100% !important;
           }
           
-          a {
+          a:not(.tmail-file-link-card) {
             width: -webkit-fill-available !important;
           }
         }

--- a/core/test/utils/standardize_html_sanitizing_transformers_test.dart
+++ b/core/test/utils/standardize_html_sanitizing_transformers_test.dart
@@ -196,6 +196,15 @@ void main() {
             driveCardTransformer.process(html, htmlEscape).trim(),
             equals('<a href="https://example.com">plain link</a><div>editable island</div>'));
       });
+
+      test('SHOULD strip mixed-case CONTENTEDITABLE FROM non-Drive-card elements WHEN allowAttributes opts in', () {
+        const driveCardTransformer =
+            StandardizeHtmlSanitizingTransformers(allowAttributes: ['contenteditable']);
+        const html = '<div CONTENTEDITABLE="false">editable island</div>';
+        expect(
+            driveCardTransformer.process(html, htmlEscape).trim(),
+            equals('<div>editable island</div>'));
+      });
     });
 
     group('Unknown tags, structural tags – unwrap or preserve safely', () {

--- a/lib/features/composer/presentation/composer_bindings.dart
+++ b/lib/features/composer/presentation/composer_bindings.dart
@@ -20,7 +20,6 @@ import 'package:tmail_ui_user/features/composer/domain/usecases/restore_email_in
 import 'package:tmail_ui_user/features/composer/domain/usecases/save_composer_cache_interactor.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/upload_attachment_interactor.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
-import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_handler.dart';
 import 'package:tmail_ui_user/features/composer/presentation/mobile_composer_bindings.dart';
 import 'package:tmail_ui_user/features/composer/presentation/web_composer_bindings.dart';
 import 'package:tmail_ui_user/features/email/data/datasource/email_datasource.dart';
@@ -344,11 +343,6 @@ abstract class ComposerBindings extends BaseBindings {
 
   @override
   void bindingsController() {
-    Get.put(
-      DriveAttachmentHandler(requireHttps: BuildUtils.isReleaseMode),
-      tag: composerId,
-      permanent: true,
-    );
     bindPlatformRichTextController();
     Get.lazyPut(
       () => UploadController(Get.find<UploadAttachmentInteractor>(tag: composerId)),
@@ -435,7 +429,5 @@ abstract class ComposerBindings extends BaseBindings {
 
     IdentityInteractorsBindings(composerId: composerId).dispose();
     PreferencesInteractorsBindings(composerId: composerId).dispose();
-
-    Get.delete<DriveAttachmentHandler>(tag: composerId, force: true);
   }
 }

--- a/lib/features/composer/presentation/composer_bindings.dart
+++ b/lib/features/composer/presentation/composer_bindings.dart
@@ -344,10 +344,10 @@ abstract class ComposerBindings extends BaseBindings {
 
   @override
   void bindingsController() {
-    Get.lazyPut(
-      () => DriveAttachmentHandler(requireHttps: BuildUtils.isReleaseMode),
+    Get.put(
+      DriveAttachmentHandler(requireHttps: BuildUtils.isReleaseMode),
       tag: composerId,
-      fenix: true,
+      permanent: true,
     );
     bindPlatformRichTextController();
     Get.lazyPut(
@@ -436,6 +436,6 @@ abstract class ComposerBindings extends BaseBindings {
     IdentityInteractorsBindings(composerId: composerId).dispose();
     PreferencesInteractorsBindings(composerId: composerId).dispose();
 
-    Get.delete<DriveAttachmentHandler>(tag: composerId);
+    Get.delete<DriveAttachmentHandler>(tag: composerId, force: true);
   }
 }

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -256,6 +256,7 @@ class ComposerController extends BaseController
   EmailActionType? savedActionType;
   int minInputLengthAutocomplete = AppConfig.defaultMinInputLengthAutocomplete;
   EmailId? currentTemplateEmailId;
+  DriveAttachmentHandler? _driveAttachmentHandler;
 
   AppLifecycleListener? mobileAutoSaveLifecycleListener;
   Timer? periodicSnapshotTimer;
@@ -331,6 +332,9 @@ class ComposerController extends BaseController
     if (PlatformInfo.isAndroid) {
       initMobileAutoSave();
     }
+    _driveAttachmentHandler = DriveAttachmentHandler(
+      requireHttps: BuildUtils.isReleaseMode,
+    );
   }
 
   @override
@@ -347,6 +351,7 @@ class ComposerController extends BaseController
 
   @override
   void onClose() {
+    _driveAttachmentHandler = null;
     _textEditorWeb = null;
     savedActionType = null;
     _savedEmailDraftHash = null;
@@ -1003,7 +1008,7 @@ class ComposerController extends BaseController
 
   Future<void> handleDrivePickResult(List<DriveDocument> result) async {
     try {
-      await getBinding<DriveAttachmentHandler>(tag: composerId)?.handleDrivePickResult(
+      await _driveAttachmentHandler?.handleDrivePickResult(
         result,
         insertHtml: (html) async {
           if (PlatformInfo.isWeb) {

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1003,7 +1003,7 @@ class ComposerController extends BaseController
 
   Future<void> handleDrivePickResult(List<DriveDocument> result) async {
     try {
-      await DriveAttachmentHandler.instance.handleDrivePickResult(
+      await Get.find<DriveAttachmentHandler>().handleDrivePickResult(
         result,
         insertHtml: (html) async {
           if (PlatformInfo.isWeb) {

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -256,7 +256,6 @@ class ComposerController extends BaseController
   EmailActionType? savedActionType;
   int minInputLengthAutocomplete = AppConfig.defaultMinInputLengthAutocomplete;
   EmailId? currentTemplateEmailId;
-  DriveAttachmentHandler? _driveAttachmentHandler;
 
   AppLifecycleListener? mobileAutoSaveLifecycleListener;
   Timer? periodicSnapshotTimer;
@@ -332,9 +331,6 @@ class ComposerController extends BaseController
     if (PlatformInfo.isAndroid) {
       initMobileAutoSave();
     }
-    _driveAttachmentHandler = DriveAttachmentHandler(
-      requireHttps: BuildUtils.isReleaseMode,
-    );
   }
 
   @override
@@ -351,7 +347,6 @@ class ComposerController extends BaseController
 
   @override
   void onClose() {
-    _driveAttachmentHandler = null;
     _textEditorWeb = null;
     savedActionType = null;
     _savedEmailDraftHash = null;
@@ -1008,7 +1003,7 @@ class ComposerController extends BaseController
 
   Future<void> handleDrivePickResult(List<DriveDocument> result) async {
     try {
-      await _driveAttachmentHandler?.handleDrivePickResult(
+      await DriveAttachmentHandler.instance.handleDrivePickResult(
         result,
         insertHtml: (html) async {
           if (PlatformInfo.isWeb) {

--- a/lib/features/composer/presentation/manager/drive_attachment_handler.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_handler.dart
@@ -1,16 +1,17 @@
+import 'package:core/core.dart';
 import 'package:core/utils/html/file_link_card_html_builder.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
 
 class DriveAttachmentHandler {
-  DriveAttachmentHandler({required this.requireHttps});
+  DriveAttachmentHandler._();
+
+  static final DriveAttachmentHandler instance = DriveAttachmentHandler._();
 
   static const _fallbackOpenInDriveLabel = 'Open in drive';
 
   /// Whether non-https sharing/thumbnail links should be rejected.
-  /// Injected by the binding so it reflects the app's build mode
-  /// without this class depending on `BuildUtils` directly.
-  final bool requireHttps;
+  bool get requireHttps => BuildUtils.isReleaseMode;
 
   Future<void> handleDrivePickResult(
     List<DriveDocument> result, {

--- a/lib/features/composer/presentation/manager/drive_attachment_handler.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_handler.dart
@@ -4,9 +4,7 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
 
 class DriveAttachmentHandler {
-  DriveAttachmentHandler._();
-
-  static final DriveAttachmentHandler instance = DriveAttachmentHandler._();
+  DriveAttachmentHandler();
 
   static const _fallbackOpenInDriveLabel = 'Open in drive';
 

--- a/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/presentation/constants/constants_ui.dart';
 import 'package:core/utils/app_logger.dart';
+import 'package:core/utils/build_utils.dart';
 import 'package:core/utils/html/html_template.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:core/utils/html/html_utils.dart';
@@ -119,6 +120,7 @@ class _MobileEditorState extends State<MobileEditorWidget> with TextSelectionMix
 
     final uri = Uri.tryParse(href);
     if (uri == null) return;
+    if (uri.scheme != 'https' && BuildUtils.isReleaseMode) return;
 
     try {
       if (await launcher.canLaunchUrl(uri)) {

--- a/lib/main/bindings/core/core_bindings.dart
+++ b/lib/main/bindings/core/core_bindings.dart
@@ -14,6 +14,7 @@ import 'package:get/get.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tmail_ui_user/features/base/before_reconnect_manager.dart';
 import 'package:tmail_ui_user/features/caching/utils/local_storage_manager.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_handler.dart';
 import 'package:tmail_ui_user/features/caching/utils/session_storage_manager.dart';
 import 'package:tmail_ui_user/features/sending_queue/presentation/utils/sending_queue_isolate_manager.dart';
 import 'package:tmail_ui_user/main/permissions/permission_service.dart';
@@ -37,6 +38,7 @@ class CoreBindings extends Bindings {
     _bindingUtils();
     _bindingIsolate();
     _bindingStorage();
+    _bindingDriveAttachmentHandler();
   }
 
   void _bindingAppImagePaths() {
@@ -45,6 +47,10 @@ class CoreBindings extends Bindings {
 
   void _bindingResponsiveManager() {
     Get.put(ResponsiveUtils());
+  }
+
+  void _bindingDriveAttachmentHandler() {
+    Get.put(DriveAttachmentHandler());
   }
 
   Future _bindingSharePreference() async {

--- a/test/features/composer/presentation/manager/drive_attachment_handler_insert_link_html_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_insert_link_html_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_handler.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
@@ -9,9 +10,13 @@ void main() {
   late List<String> insertedHtml;
   late DriveAttachmentHandler handler;
 
+  setUpAll(() {
+    Get.put(DriveAttachmentHandler());
+  });
+
   setUp(() {
     insertedHtml = [];
-    handler = DriveAttachmentHandler.instance;
+    handler = Get.find<DriveAttachmentHandler>();
   });
 
   group('DriveAttachmentHandler::insertDriveLinkHtml::', () {

--- a/test/features/composer/presentation/manager/drive_attachment_handler_insert_link_html_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_insert_link_html_test.dart
@@ -11,7 +11,7 @@ void main() {
 
   setUp(() {
     insertedHtml = [];
-    handler = DriveAttachmentHandler(requireHttps: false);
+    handler = DriveAttachmentHandler.instance;
   });
 
   group('DriveAttachmentHandler::insertDriveLinkHtml::', () {
@@ -130,24 +130,6 @@ void main() {
       expect(insertedHtml.first, isNot(contains('<img')));
     });
 
-    test('Should omit the img tag when the thumbnail is non-https and requireHttps is true', () async {
-      final untrustedHttpDoc = DriveDocument(
-        id: '9',
-        name: 'Photo2.png',
-        size: 0,
-        mimeType: 'image/png',
-        sharingLink: Uri.parse('https://example.com/photo2.png'),
-        thumbnail: DriveDocumentThumbnail(link: Uri.parse('http://cdn.example.com/thumbnails/photo2.png')),
-      );
-      final strictHandler = DriveAttachmentHandler(requireHttps: true);
-
-      strictHandler.insertDriveLinkHtml([
-        untrustedHttpDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
-
-      expect(insertedHtml.first, isNot(contains('<img')));
-    });
-
     test('Should embed a non-https thumbnail when requireHttps is false', () async {
       final httpThumbnailDoc = DriveDocument(
         id: '10',
@@ -163,23 +145,6 @@ void main() {
       ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
 
       expect(insertedHtml.first, contains('<img src="http://cdn.example.com/thumbnails/photo3.png"'));
-    });
-
-    test('Should skip non-https links when requireHttps is true', () async {
-      final httpDoc = DriveDocument(
-        id: '5',
-        name: 'Insecure',
-        size: 0,
-        mimeType: 'text/plain',
-        sharingLink: Uri.parse('http://example.com/file'),
-      );
-      final strictHandler = DriveAttachmentHandler(requireHttps: true);
-
-      strictHandler.insertDriveLinkHtml([
-        httpDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
-
-      expect(insertedHtml.first, isEmpty);
     });
 
     test('Should allow non-https links when requireHttps is false', () async {

--- a/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
@@ -12,7 +12,7 @@ void main() {
 
   setUp(() {
     insertedHtml = [];
-    handler = DriveAttachmentHandler(requireHttps: false);
+    handler = DriveAttachmentHandler.instance;
   });
 
   group('DriveAttachmentHandler::handleDrivePickResult::', () {

--- a/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
 import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_handler.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
@@ -10,9 +11,13 @@ void main() {
   late DriveAttachmentHandler handler;
   final appLocalizations = AppLocalizations();
 
+  setUpAll(() {
+    Get.put(DriveAttachmentHandler());
+  });
+
   setUp(() {
     insertedHtml = [];
-    handler = DriveAttachmentHandler.instance;
+    handler = Get.find<DriveAttachmentHandler>();
   });
 
   group('DriveAttachmentHandler::handleDrivePickResult::', () {


### PR DESCRIPTION
## Demo
### Web

https://github.com/user-attachments/assets/2328f488-7983-4e92-86ec-cfba28a94100

### Mobile

[untitled.webm](https://github.com/user-attachments/assets/f4dfc4da-08bd-4bb8-a06d-096f8dc6f017)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTML sanitization so `contenteditable` is stripped only when the input actually contains it (including mixed/uppercase like `CONTENTEDITABLE="false"`).
  - Scoped mobile anchor styling so file-link-card links keep the intended layout.
  - Tightened mobile file-link launching in release builds to allow only `https` links.
- **Reliability**
  - Updated Drive attachment handling to use a shared handler with lifecycle cleanup; HTTPS behavior now follows release mode automatically.
- **Tests**
  - Added coverage for mixed-case `CONTENTEDITABLE` sanitization.
  - Updated Drive attachment handler tests to use dependency injection (and adjusted for removed `requireHttps: true` assertions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->