### PR TITLE
fix: handle yield* error inside interactor

### DIFF
--- a/core/lib/core.dart
+++ b/core/lib/core.dart
@@ -16,6 +16,7 @@ export 'presentation/extensions/string_extension.dart';
 export 'presentation/extensions/tap_down_details_extension.dart';
 export 'presentation/extensions/map_extensions.dart';
 export 'presentation/extensions/either_view_state_extension.dart';
+export 'presentation/extensions/either_stream_extension.dart';
 export 'presentation/extensions/media_type_extension.dart';
 export 'presentation/extensions/scroll_controller_extension.dart';
 export 'presentation/extensions/hex_color_extension.dart';

--- a/core/lib/presentation/extensions/either_stream_extension.dart
+++ b/core/lib/presentation/extensions/either_stream_extension.dart
@@ -1,0 +1,29 @@
+import 'dart:async';
+
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+
+typedef ToFailureCallback = Failure Function(Object error, StackTrace stackTrace);
+
+extension EitherStreamExtension on Stream<Either<Failure, Success>> {
+  /// Converts an error raised by this stream into a [Left] event.
+  ///
+  /// `yield*` forwards a delegated stream's error straight to the subscriber,
+  /// bypassing the enclosing try/catch of the `async*` function. That kills the
+  /// subscription, so callers never receive a failure state and stay stuck on
+  /// loading. Turning the error into a value keeps everything on the single
+  /// Either channel, which is what consumers already listen for.
+  ///
+  /// The stream is left open afterwards: a source that reports an error and
+  /// keeps going can still deliver later events.
+  Stream<Either<Failure, Success>> mapErrorToLeft(ToFailureCallback toFailure) {
+    return this.cast<Either<Failure, Success>>().transform(
+      StreamTransformer<Either<Failure, Success>, Either<Failure, Success>>.fromHandlers(
+        handleError: (error, stackTrace, sink) => sink.add(
+          Left<Failure, Success>(toFailure(error, stackTrace)),
+        ),
+      ),
+    );
+  }
+}

--- a/core/test/presentation/extensions/either_stream_extension_test.dart
+++ b/core/test/presentation/extensions/either_stream_extension_test.dart
@@ -1,0 +1,167 @@
+import 'dart:async';
+
+import 'package:core/presentation/extensions/either_stream_extension.dart';
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class TestFailure extends Failure {
+  final String message;
+  final StackTrace? stackTrace;
+
+  TestFailure(this.message, {this.stackTrace});
+
+  @override
+  List<Object?> get props => [message];
+}
+
+class TestSuccess extends Success {
+  final String data;
+
+  TestSuccess(this.data);
+
+  @override
+  List<Object?> get props => [data];
+}
+
+/// Mirrors how the interactors delegate to a repository stream: a loading state
+/// is emitted first, then the source stream is forwarded with `yield*` from
+/// inside a try/catch.
+Stream<Either<Failure, Success>> interactorLike(
+  Stream<Either<Failure, Success>> source, {
+  required bool applyExtension,
+}) async* {
+  try {
+    yield Right<Failure, Success>(TestSuccess('loading'));
+    yield* applyExtension
+        ? source.mapErrorToLeft((error, stackTrace) =>
+            TestFailure('$error', stackTrace: stackTrace))
+        : source;
+  } catch (e) {
+    yield Left<Failure, Success>(TestFailure('outer-catch'));
+  }
+}
+
+Stream<Either<Failure, Success>> valueThenError(Object error) async* {
+  yield Right<Failure, Success>(TestSuccess('first'));
+  throw error;
+}
+
+void main() {
+  group('EitherStreamExtension::mapErrorToLeft::test', () {
+    test('Should forward values unchanged when the source raises no error', () async {
+      final source = Stream<Either<Failure, Success>>.fromIterable([
+        Right(TestSuccess('a')),
+        Right(TestSuccess('b')),
+      ]);
+
+      final states = await source
+          .mapErrorToLeft((error, _) => TestFailure('$error'))
+          .toList();
+
+      expect(states, [Right(TestSuccess('a')), Right(TestSuccess('b'))]);
+    });
+
+    test('Should convert an error raised by the source into a Left event', () async {
+      final source = Stream<Either<Failure, Success>>.error(StateError('boom'));
+
+      final states = await source
+          .mapErrorToLeft((error, _) => TestFailure('$error'))
+          .toList();
+
+      expect(states, [Left<Failure, Success>(TestFailure('Bad state: boom'))]);
+    });
+
+    test('Should emit the Left in place, preserving the order of earlier values', () async {
+      final states = await valueThenError(StateError('boom'))
+          .mapErrorToLeft((error, _) => TestFailure('$error'))
+          .toList();
+
+      expect(states, [
+        Right<Failure, Success>(TestSuccess('first')),
+        Left<Failure, Success>(TestFailure('Bad state: boom')),
+      ]);
+    });
+
+    test('Should keep the stream open so a source that errors then continues '
+        'can still deliver later events', () async {
+      final controller = StreamController<Either<Failure, Success>>();
+
+      final future = controller.stream
+          .mapErrorToLeft((error, _) => TestFailure('$error'))
+          .toList();
+
+      controller.add(Right(TestSuccess('before')));
+      controller.addError(StateError('transient'));
+      controller.add(Right(TestSuccess('after')));
+      await controller.close();
+
+      expect(await future, [
+        Right<Failure, Success>(TestSuccess('before')),
+        Left<Failure, Success>(TestFailure('Bad state: transient')),
+        Right<Failure, Success>(TestSuccess('after')),
+      ]);
+    });
+
+    test('Should handle a source whose runtime type is narrower than '
+        'Stream<Either<Failure, Success>>', () async {
+      // A generator yielding only Right values produces a Stream<Right<...>> at
+      // runtime. StreamTransformer is not covariant in its input type, so the
+      // element type has to be pinned before transforming.
+      Stream<Right<Failure, Success>> narrowSource() async* {
+        yield Right<Failure, Success>(TestSuccess('first'));
+        throw StateError('boom');
+      }
+
+      final states = await narrowSource()
+          .mapErrorToLeft((error, _) => TestFailure('$error'))
+          .toList();
+
+      expect(states, [
+        Right<Failure, Success>(TestSuccess('first')),
+        Left<Failure, Success>(TestFailure('Bad state: boom')),
+      ]);
+    });
+
+    test('Should pass the stack trace of the error to the callback', () async {
+      StackTrace? capturedStackTrace;
+
+      await Stream<Either<Failure, Success>>.error(StateError('boom'))
+          .mapErrorToLeft((error, stackTrace) {
+            capturedStackTrace = stackTrace;
+            return TestFailure('$error');
+          })
+          .toList();
+
+      expect(capturedStackTrace, isNotNull);
+    });
+
+    test('Should keep an error raised by a delegated stream from escaping '
+        'the try/catch of the enclosing async* function', () async {
+      final states = await interactorLike(
+        valueThenError(StateError('boom')),
+        applyExtension: true,
+      ).toList();
+
+      expect(states, [
+        Right<Failure, Success>(TestSuccess('loading')),
+        Right<Failure, Success>(TestSuccess('first')),
+        Left<Failure, Success>(TestFailure('Bad state: boom')),
+      ]);
+    });
+
+    test('Should be required for that: without it the delegated error bypasses '
+        'the enclosing try/catch and tears the stream down', () async {
+      // Guards the premise of the extension. `yield*` hands a delegated
+      // stream's error straight to the subscriber, so the catch never runs.
+      expect(
+        () => interactorLike(
+          valueThenError(StateError('boom')),
+          applyExtension: false,
+        ).toList(),
+        throwsStateError,
+      );
+    });
+  });
+}

--- a/docs/adr/0104-indexeddb-dead-connection-recovery.md
+++ b/docs/adr/0104-indexeddb-dead-connection-recovery.md
@@ -1,0 +1,47 @@
+# 104. IndexedDB Dead-Connection Recovery in HiveCacheClient
+
+Date: 2026-07-21
+
+## Status
+
+Proposed
+
+## Context
+
+Issue #4717: on web, `InvalidStateError` from `storage_backend_js.dart getStore` — users stuck on a spinner while JMAP returned 200.
+
+Cause: a 401 makes every pending controller start its own logout; one close lands on another's in-flight write.
+
+Two Hive facts:
+
+- **A close unregisters the box first.** Deliberate close → unregistered; a connection dying alone → still registered; the web backend never tells Hive.
+- **Error text is all we get.** A DOMException stringifies as `"<name>: <message>"` — name fixed by WebIDL, message browser-specific prose.
+
+## Decision
+
+**`TwakeAppManager.runClearDataOnce` serialises logout** — this is what fixes #4717.
+
+**`HiveCacheClient` retries once** for a connection killed from outside while the box stays registered — otherwise every later operation breaks until reload. Closing it unregisters the box, so the retry reopens live.
+
+All must hold:
+
+| Guard | Rule |
+|---|---|
+| Platform | `isWeb` first — elsewhere text matching yields false positives |
+| Error | DOMException name, known messages as fallback |
+| No close since | `closeGeneration` captured before the operation. Changed = logout ran underneath, so a retry would write pre-logout data into the cache it cleared. The registry cannot see this: logout navigates instead of reloading, so the login screen reopens the box, which reads "open" again |
+| Box registered | Secondary: catches a direct `closeBox()`, which bumps no count |
+| Not closed | Never retry Hive's own `Box has already been closed.` |
+
+**One recovery per box, keyed on `tableName`** — bindings share one connection, so otherwise one caller closes what another just reopened. Not the `isolated` flag: on web `IsolatedHive` delegates to `Hive`, one registry.
+
+**Never close a box already replaced.** `_recoveries` keeps each box's latest recovery as a token: same as captured → discard; different → join it.
+
+**Retry safety:** key-addressed operations only — never `box.add()` or read-modify-write.
+
+## Consequences
+
+- Mobile and desktop untouched — the platform gate rethrows first.
+- **Residual leak, outside this ADR:** teardown clears the boxes *then* closes Hive; a write landing in that window succeeds, so no guard applies.
+- **Upgrade tripwire — the reason for this ADR.** On each `hive_ce` upgrade, re-check that DOMExceptions arrive unwrapped (wrapped = recovery stops *silently*) and that web shares one registry.
+- VM tests cover logic, not platform: not error strings, IndexedDB semantics, or the registry.

--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -642,7 +642,12 @@ abstract class BaseController extends GetxController
     removeAllPageAndGoToLogin();
   }
 
-  Future<void> clearAllData() async {
+  /// Several entry points call this, some without awaiting. Overlapping runs
+  /// used to close Hive while another run was still writing to it, so they are
+  /// serialised through a single shared future.
+  Future<void> clearAllData() => twakeAppManager.runClearDataOnce(_clearAllData);
+
+  Future<void> _clearAllData() async {
     try {
       await Future.wait([
         if (isAuthenticatedWithOidc)

--- a/lib/features/caching/config/hive_cache_client.dart
+++ b/lib/features/caching/config/hive_cache_client.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:core/presentation/extensions/map_extensions.dart';
 import 'package:core/utils/app_logger.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:hive_ce/hive.dart';
 import 'package:tmail_ui_user/features/caching/config/hive_cache_config.dart';
 import 'package:tmail_ui_user/features/caching/utils/cache_utils.dart';
@@ -48,13 +49,126 @@ abstract class HiveCacheClient<T> {
     }
   }
 
+  /// The latest recovery of each box, kept after it completes so it doubles as
+  /// the token that says which box a caller started out against.
+  ///
+  /// Keyed on the table
+  static final Map<String, Future<void>> _recoveries = {};
+
+  /// Runs [action], retrying once if the IndexedDB connection died underneath us.
+  ///
+  /// Hive's web backend registers no close listener, so when a connection goes
+  /// away the box stays registered as open and every later operation throws for
+  /// the rest of the session — only a page reload recovers. Closing the stale box
+  /// unregisters it, so re-running [action] opens a live connection instead.
+  ///
+  /// Every caller resolves its box *inside* [action], so the retry picks up
+  /// whatever the recovery reopened.
+  Future<R> _runWithRecovery<R>(bool isolated, Future<R> Function() action) async {
+    final recoveryAtStart = _recoveries[tableName];
+    final closeGeneration = HiveCacheConfig.instance.closeGeneration;
+    try {
+      return await action();
+    } catch (error) {
+      if (!_isRecoverableConnectionLoss(error, isolated, closeGeneration)) {
+        rethrow;
+      }
+
+      logWarning(
+        '$runtimeType::_runWithRecovery: reopening "$tableName" '
+        '(isolated: $isolated) after a closed IndexedDB connection | $error',
+      );
+
+      if (identical(_recoveries[tableName], recoveryAtStart)) {
+        await (_recoveries[tableName] = _discardStaleBox(isolated));
+      } else {
+        await _recoveries[tableName];
+      }
+
+      return _retryAfterRecovery(action);
+    }
+  }
+
+  /// Whether [error] is a dead connection this client may reopen.
+  ///
+  /// [closeGeneration] is what [HiveCacheConfig] reported when the operation
+  /// started, so a teardown that has run since is visible here.
+  bool _isRecoverableConnectionLoss(
+    Object error,
+    bool isolated,
+    int closeGeneration,
+  ) {
+    // Web-only by construction. IndexedDB is the one backend that can lose a
+    // connection while Hive still holds the box
+    if (!PlatformInfo.isWeb) return false;
+
+    if (!_isClosedConnectionError(error)) return false;
+
+    if (HiveCacheConfig.instance.closeGeneration != closeGeneration) {
+      logWarning(
+        '$runtimeType::_isRecoverableConnectionLoss: "$tableName" spans a '
+        'deliberate close, not retrying | $error',
+      );
+      return false;
+    }
+
+    if (!_isBoxRegistered(isolated)) {
+      // Somebody closed this box on purpose
+      logWarning(
+        '$runtimeType::_isRecoverableConnectionLoss: "$tableName" was closed '
+        'deliberately, not reopening | $error',
+      );
+      return false;
+    }
+
+    return true;
+  }
+
+  /// The one retry, run against whatever [_discardStaleBox] left behind.
+  Future<R> _retryAfterRecovery<R>(Future<R> Function() action) async {
+    try {
+      final result = await action();
+      logWarning('$runtimeType::_retryAfterRecovery: "$tableName" recovered');
+      return result;
+    } catch (retryError, retryStackTrace) {
+      logError(
+        '$runtimeType::_retryAfterRecovery: "$tableName" still failing after '
+        'reopen',
+        exception: retryError,
+        stackTrace: retryStackTrace,
+      );
+      rethrow;
+    }
+  }
+
+  bool _isBoxRegistered(bool isolated) => isolated
+      ? IsolatedHive.isBoxOpen(tableName)
+      : Hive.isBoxOpen(tableName);
+
+  bool _isClosedConnectionError(Object error) {
+    final message = error.toString().toLowerCase();
+    return message.contains('invalidstateerror') ||
+        message.contains('connection is closing') ||
+        message.contains('closed database');
+  }
+
+  Future<void> _discardStaleBox(bool isolated) async {
+    try {
+      await closeBox(isolated: isolated);
+    } catch (e) {
+      // Best-effort: the connection is already gone. What matters is that Hive
+      // unregisters the box, which happens before the backend close is attempted.
+      logWarning('$runtimeType::_discardStaleBox: "$tableName" close failed | $e');
+    }
+  }
+
   Future<void> insertItem(
     String key,
     T newObject, {
     bool isolated = true,
   }) {
     log('$runtimeType::insertItem:encryption: $encryption - key = $key - isolated = $isolated');
-    return Future.sync(() async {
+    return _runWithRecovery(isolated, () async {
       if (isolated) {
         final boxItem = await openIsolatedBox();
         return boxItem.put(key, newObject);
@@ -62,8 +176,6 @@ abstract class HiveCacheClient<T> {
         final boxItem = await openBox();
         return boxItem.put(key, newObject);
       }
-    }).catchError((error) {
-      throw error;
     });
   }
 
@@ -71,7 +183,7 @@ abstract class HiveCacheClient<T> {
     Map<String, T> mapObject, {
     bool isolated = true,
   }) {
-    return Future.sync(() async {
+    return _runWithRecovery(isolated, () async {
       if (isolated) {
         final boxItem = await openIsolatedBox();
         return boxItem.putAll(mapObject);
@@ -79,8 +191,6 @@ abstract class HiveCacheClient<T> {
         final boxItem = await openBox();
         return boxItem.putAll(mapObject);
       }
-    }).catchError((error) {
-      throw error;
     });
   }
 
@@ -88,7 +198,7 @@ abstract class HiveCacheClient<T> {
     String key, {
     bool isolated = true,
   }) {
-    return Future.sync(() async {
+    return _runWithRecovery(isolated, () async {
       if (isolated) {
         final boxItem = await openIsolatedBox();
         return boxItem.get(key);
@@ -96,13 +206,11 @@ abstract class HiveCacheClient<T> {
         final boxItem = await openBox();
         return boxItem.get(key);
       }
-    }).catchError((error) {
-      throw error;
     });
   }
 
   Future<List<T>> getAll({bool isolated = true}) {
-    return Future.sync(() async {
+    return _runWithRecovery(isolated, () async {
       Iterable<T> items;
 
       if (isolated) {
@@ -114,13 +222,11 @@ abstract class HiveCacheClient<T> {
       }
       log('$runtimeType::getAll: Length of items is ${items.length}');
       return items.toList();
-    }).catchError((error) {
-      throw error;
     });
   }
 
   Future<Map<String, T>> getMapItems({bool isolated = true}) {
-    return Future.sync(() async {
+    return _runWithRecovery(isolated, () async {
       late Map<dynamic, T> mapItems;
 
       if (isolated) {
@@ -132,8 +238,6 @@ abstract class HiveCacheClient<T> {
       }
       log('$runtimeType::getMapItems: Length of mapItems is ${mapItems.length}');
       return mapItems.map((key, value) => MapEntry(key.toString(), value));
-    }).catchError((error) {
-      throw error;
     });
   }
 
@@ -141,7 +245,7 @@ abstract class HiveCacheClient<T> {
     String nestedKey, {
     bool isolated = true,
   }) {
-    return Future.sync(() async {
+    return _runWithRecovery(isolated, () async {
       late Map<dynamic, T> mapItems;
 
       if (isolated) {
@@ -158,8 +262,6 @@ abstract class HiveCacheClient<T> {
         .toList();
       log('$runtimeType::getListByNestedKey: Length of listItem is ${listItem.length}');
       return listItem;
-    }).catchError((error) {
-      throw error;
     });
   }
 
@@ -167,7 +269,7 @@ abstract class HiveCacheClient<T> {
     List<String> listKeys, {
     bool isolated = true,
   }) {
-    return Future.sync(() async {
+    return _runWithRecovery(isolated, () async {
       late Map<dynamic, T> mapItems;
 
       if (isolated) {
@@ -182,8 +284,6 @@ abstract class HiveCacheClient<T> {
         .where((key, value) => listKeys.contains(key))
         .values
         .toList();
-    }).catchError((error) {
-      throw error;
     });
   }
 
@@ -198,7 +298,7 @@ abstract class HiveCacheClient<T> {
     T newObject, {
     bool isolated = true,
   }) {
-    return Future.sync(() async {
+    return _runWithRecovery(isolated, () async {
       if (isolated) {
         final boxItem = await openIsolatedBox();
         return boxItem.put(key, newObject);
@@ -206,8 +306,6 @@ abstract class HiveCacheClient<T> {
         final boxItem = await openBox();
         return boxItem.put(key, newObject);
       }
-    }).catchError((error) {
-      throw error;
     });
   }
 
@@ -215,7 +313,7 @@ abstract class HiveCacheClient<T> {
     Map<String, T> mapObject, {
     bool isolated = true,
   }) {
-    return Future.sync(() async {
+    return _runWithRecovery(isolated, () async {
       if (isolated) {
         final boxItem = await openIsolatedBox();
         return boxItem.putAll(mapObject);
@@ -223,8 +321,6 @@ abstract class HiveCacheClient<T> {
         final boxItem = await openBox();
         return boxItem.putAll(mapObject);
       }
-    }).catchError((error) {
-      throw error;
     });
   }
 
@@ -232,7 +328,7 @@ abstract class HiveCacheClient<T> {
     String key, {
     bool isolated = true,
   }) {
-    return Future.sync(() async {
+    return _runWithRecovery(isolated, () async {
       if (isolated) {
         final boxItem = await openIsolatedBox();
         return boxItem.delete(key);
@@ -240,8 +336,6 @@ abstract class HiveCacheClient<T> {
         final boxItem = await openBox();
         return boxItem.delete(key);
       }
-    }).catchError((error) {
-      throw error;
     });
   }
 
@@ -249,7 +343,7 @@ abstract class HiveCacheClient<T> {
     List<String> listKey, {
     bool isolated = true,
   }) {
-    return Future.sync(() async {
+    return _runWithRecovery(isolated, () async {
       if (isolated) {
         final boxItem = await openIsolatedBox();
         return boxItem.deleteAll(listKey);
@@ -257,8 +351,6 @@ abstract class HiveCacheClient<T> {
         final boxItem = await openBox();
         return boxItem.deleteAll(listKey);
       }
-    }).catchError((error) {
-      throw error;
     });
   }
 
@@ -266,7 +358,7 @@ abstract class HiveCacheClient<T> {
     String key, {
     bool isolated = true,
   }) {
-    return Future.sync(() async {
+    return _runWithRecovery(isolated, () async {
       if (isolated) {
         final boxItem = await openIsolatedBox();
         return boxItem.containsKey(key);
@@ -274,8 +366,6 @@ abstract class HiveCacheClient<T> {
         final boxItem = await openBox();
         return boxItem.containsKey(key);
       }
-    }).catchError((error) {
-      throw error;
     });
   }
 
@@ -288,16 +378,14 @@ abstract class HiveCacheClient<T> {
   }
 
   Future<void> clearAllData({bool isolated = true}) {
-    return Future.sync(() async {
+    return _runWithRecovery<void>(isolated, () async {
       if (isolated) {
         final boxItem = await openIsolatedBox();
-        return boxItem.clear();
+        await boxItem.clear();
       } else {
         final boxItem = await openBox();
-        return boxItem.clear();
+        await boxItem.clear();
       }
-    }).catchError((error) {
-      throw error;
     });
   }
 
@@ -305,7 +393,7 @@ abstract class HiveCacheClient<T> {
     String nestedKey, {
     bool isolated = true,
   }) {
-    return Future.sync(() async {
+    return _runWithRecovery(isolated, () async {
       if (isolated) {
         final boxItem = await openIsolatedBox();
         final mapItems = await boxItem.toMap();
@@ -322,8 +410,6 @@ abstract class HiveCacheClient<T> {
         log('$runtimeType::clearAllDataContainKey: Length of keys is ${listKeys.length}');
         return boxItem.deleteAll(listKeys);
       }
-    }).catchError((error) {
-      throw error;
     });
   }
 

--- a/lib/features/caching/config/hive_cache_config.dart
+++ b/lib/features/caching/config/hive_cache_config.dart
@@ -40,6 +40,12 @@ class HiveCacheConfig {
   bool _isolatedAdaptersRegistered = false;
   bool _regularAdaptersRegistered = false;
 
+  int _closeGeneration = 0;
+
+  /// Bumped by every deliberate [closeHive], so an operation that started
+  /// before one can tell it happened underneath.
+  int get closeGeneration => _closeGeneration;
+
   Future<void> setUp({String? cachePath, bool isolated = true}) async {
     await initializeDatabase(databasePath: cachePath, isolated: isolated);
     _registerAdapter(isolated: isolated);
@@ -148,6 +154,9 @@ class HiveCacheConfig {
   }
 
   Future<void> closeHive({bool isolated = true}) async {
+    // Bumped before the close, so an operation this very close aborts still
+    // observes it.
+    _closeGeneration++;
     if (isolated) {
       await IsolatedHive.close();
     } else {

--- a/lib/features/mailbox/domain/usecases/get_all_mailbox_interactor.dart
+++ b/lib/features/mailbox/domain/usecases/get_all_mailbox_interactor.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/extensions/either_stream_extension.dart';
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:dartz/dartz.dart';
@@ -21,9 +22,13 @@ class GetAllMailboxInteractor {
       yield* _mailboxRepository
         .getAllMailbox(
           session,
-          accountId, 
+          accountId,
           properties: properties)
-        .map(_toGetMailboxState);
+        .map(_toGetMailboxState)
+        .mapErrorToLeft((error, _) => GetAllMailboxFailure(
+          error,
+          onRetry: execute(session, accountId, properties: properties),
+        ));
     } catch (e) {
       yield Left<Failure, Success>(GetAllMailboxFailure(
         e,

--- a/lib/features/mailbox/domain/usecases/refresh_all_mailbox_interactor.dart
+++ b/lib/features/mailbox/domain/usecases/refresh_all_mailbox_interactor.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/extensions/either_stream_extension.dart';
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:core/utils/app_logger.dart';
@@ -25,9 +26,11 @@ class RefreshAllMailboxInteractor {
     try {
       log('RefreshAllMailboxInteractor::execute:properties: $properties');
       yield Right<Failure, Success>(RefreshChangesAllMailboxLoading());
+
       yield* _mailboxRepository
         .refresh(session, accountId, currentState, properties: properties)
-        .map(_toGetMailboxState);
+        .map(_toGetMailboxState)
+        .mapErrorToLeft((error, _) => RefreshChangesAllMailboxFailure(error));
     } catch (e) {
       yield Left<Failure, Success>(RefreshChangesAllMailboxFailure(e));
     }

--- a/lib/features/thread/domain/usecases/clean_and_get_emails_in_mailbox_interactor.dart
+++ b/lib/features/thread/domain/usecases/clean_and_get_emails_in_mailbox_interactor.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/extensions/either_stream_extension.dart';
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:dartz/dartz.dart';
@@ -38,17 +39,19 @@ class CleanAndGetEmailsInMailboxInteractor {
 
       await _threadRepository.clearEmailCacheAndStateCache();
 
-      yield* _getEmailsInMailboxInteractor.execute(
-        session,
-        accountId,
-        limit: limit,
-        sort: sort,
-        emailFilter: emailFilter,
-        propertiesCreated: propertiesCreated,
-        propertiesUpdated: propertiesUpdated,
-        getLatestChanges: getLatestChanges,
-        useCache: useCache,
-      );
+      yield* _getEmailsInMailboxInteractor
+        .execute(
+          session,
+          accountId,
+          limit: limit,
+          sort: sort,
+          emailFilter: emailFilter,
+          propertiesCreated: propertiesCreated,
+          propertiesUpdated: propertiesUpdated,
+          getLatestChanges: getLatestChanges,
+          useCache: useCache,
+        )
+        .mapErrorToLeft((error, _) => CleanAndGetAllEmailFailure(error));
     } catch (e) {
       yield Left(CleanAndGetAllEmailFailure(e));
     }

--- a/lib/features/thread/domain/usecases/get_emails_in_mailbox_interactor.dart
+++ b/lib/features/thread/domain/usecases/get_emails_in_mailbox_interactor.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/extensions/either_stream_extension.dart';
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:dartz/dartz.dart';
@@ -70,12 +71,14 @@ class GetEmailsInMailboxInteractor {
         );
       }
 
-      yield* sourceStream.map(
-        (emailResponse) => _toGetEmailState(
-          emailResponse: emailResponse,
-          currentMailboxId: emailFilter?.mailboxId,
-        ),
-      );
+      yield* sourceStream
+        .map(
+          (emailResponse) => _toGetEmailState(
+            emailResponse: emailResponse,
+            currentMailboxId: emailFilter?.mailboxId,
+          ),
+        )
+        .mapErrorToLeft((error, _) => GetAllEmailFailure(error));
     } catch (e) {
       yield Left(GetAllEmailFailure(e));
     }

--- a/lib/features/thread/domain/usecases/load_more_emails_in_mailbox_interactor.dart
+++ b/lib/features/thread/domain/usecases/load_more_emails_in_mailbox_interactor.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/extensions/either_stream_extension.dart';
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:dartz/dartz.dart';
@@ -15,7 +16,11 @@ class LoadMoreEmailsInMailboxInteractor {
   Stream<Either<Failure, Success>> execute(GetEmailRequest emailRequest) async* {
     try {
       yield Right<Failure, Success>(LoadingMoreEmails());
-      yield* threadRepository.loadMoreEmails(emailRequest).map(_toGetEmailState);
+
+      yield* threadRepository
+        .loadMoreEmails(emailRequest)
+        .map(_toGetEmailState)
+        .mapErrorToLeft((error, _) => LoadMoreEmailsFailure(error));
     } catch (e) {
       yield Left(LoadMoreEmailsFailure(e));
     }

--- a/lib/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor.dart
+++ b/lib/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor.dart
@@ -48,7 +48,8 @@ class RefreshChangesEmailsInMailboxInteractor {
         .map((emailResponse) => _toGetEmailState(
           emailResponse: emailResponse,
           currentMailboxId: emailFilter?.mailboxId
-        ));
+        ))
+        .mapErrorToLeft((error, _) => RefreshChangesAllEmailFailure(error));
     } catch (e) {
       yield Left(RefreshChangesAllEmailFailure(e));
     }

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -79,6 +79,7 @@ import 'package:tmail_ui_user/features/thread/presentation/model/loading_more_st
 import 'package:tmail_ui_user/features/thread/presentation/model/mail_list_shortcut_action_view_event.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/search_status.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/method_level_exception.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/app_routes.dart';
 import 'package:tmail_ui_user/main/routes/navigation_router.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
@@ -578,7 +579,7 @@ class ThreadController extends BaseController with EmailActionController {
   }
 
   void _handleErrorGetAllOrRefreshChangesEmail(Object error, StackTrace stackTrace) async {
-    logWarning('ThreadController::_handleErrorGetAllOrRefreshChangesEmail():Error: $error');
+    logWarning('ThreadController::_handleErrorGetAllOrRefreshChangesEmail():Error: $error', webConsoleEnabled: true);
     if (error is CannotCalculateChangesMethodResponseException) {
       await cachingManager.clearAllEmailAndStateCache();
       getAllEmailAction(forceEmailQuery: forceEmailQuery);
@@ -590,6 +591,19 @@ class ThreadController extends BaseController with EmailActionController {
         );
       }
       clearState();
+    } else {
+      logError(
+        'ThreadController::_handleErrorGetAllOrRefreshChangesEmail():Error: $error',
+        exception: error,
+        stackTrace: stackTrace
+      );
+      clearState();
+      if (currentOverlayContext != null && currentContext != null) {
+        appToast.showToastErrorMessage(
+          currentOverlayContext!,
+          AppLocalizations.of(currentContext!).unknownError,
+        );
+      }
     }
   }
 

--- a/lib/main/utils/twake_app_manager.dart
+++ b/lib/main/utils/twake_app_manager.dart
@@ -5,6 +5,14 @@ class TwakeAppManager {
   bool _hasComposer = false;
   bool _isExecutingBeforeReconnect = false;
   OidcUserInfo? _oidcUserInfo;
+  Future<void>? _clearingDataFuture;
+
+  /// Serialises cache teardown so only one run is ever in flight.
+  Future<void> runClearDataOnce(Future<void> Function() clearData) {
+    return _clearingDataFuture ??= clearData().whenComplete(() {
+      _clearingDataFuture = null;
+    });
+  }
 
   void setHasComposer(bool value) => _hasComposer = value;
 

--- a/test/features/caching/hive_cache_client_recovery_test.dart
+++ b/test/features/caching/hive_cache_client_recovery_test.dart
@@ -1,0 +1,363 @@
+@TestOn('vm')
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:core/utils/platform_info.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:tmail_ui_user/features/caching/config/hive_cache_client.dart';
+import 'package:tmail_ui_user/features/caching/config/hive_cache_config.dart';
+
+const _tableName = 'RecoveryTestCache';
+const _key = 'key';
+const _value = 'value';
+
+/// Blink's wording when an operation lands on a connection that is mid-close.
+final _blinkClosingError = StateError(
+  "InvalidStateError: Failed to execute 'transaction' on 'IDBDatabase': "
+  'The database connection is closing.',
+);
+
+/// Gecko's wording for the same condition. Sentry groups the two because the
+/// Dart frames are identical, so recovery has to recognise both.
+final _geckoClosedError = StateError(
+  "InvalidStateError: IDBDatabase.transaction: Can't start a transaction on a "
+  'closed database',
+);
+
+/// Drives [HiveCacheClient]'s recovery path without a browser.
+///
+/// `_runWithRecovery` re-acquires the box *inside* the retried closure, so
+/// throwing from [openBox] reproduces a dead IndexedDB connection exactly:
+/// detect -> recover -> retry. Everything else runs the real Hive backend.
+class _RecordingCacheClient extends HiveCacheClient<String> {
+  _RecordingCacheClient({Object? errorToThrow})
+      : errorToThrow = errorToThrow ?? _blinkClosingError;
+
+  final Object errorToThrow;
+
+  int failuresToInject = 0;
+
+  int openAttempts = 0;
+  int closeBoxCalls = 0;
+  final List<Box<String>> openedBoxes = [];
+
+  /// Held by the test to force the destructive interleaving: every close after
+  /// the first waits here, so it can only land *after* another caller has
+  /// already reopened the box. Left null when ordering does not matter.
+  Completer<void>? laterClosesGate;
+
+  /// Completes as soon as a box is opened. Reset when arming so it signals the
+  /// reopen that follows an injected failure, not the one done while seeding.
+  Completer<void> boxOpened = Completer<void>();
+
+  /// Holds back the second injected failure so it can surface *after* another
+  /// caller's recovery has already finished — the only order in which a caller
+  /// can find the box it failed on already replaced. Left null when ordering
+  /// does not matter.
+  Completer<void>? secondFailureGate;
+
+  /// Runs just before an injected failure is thrown, so a test can make the
+  /// world change *underneath* an operation that is already in flight.
+  Future<void> Function()? beforeFailure;
+
+  int _failuresInjected = 0;
+
+  @override
+  String get tableName => _tableName;
+
+  @override
+  Future<Box<String>> openBox() async {
+    openAttempts++;
+    if (failuresToInject > 0) {
+      failuresToInject--;
+      _failuresInjected++;
+      if (_failuresInjected == 2 && secondFailureGate != null) {
+        await secondFailureGate!.future;
+      }
+      await beforeFailure?.call();
+      throw errorToThrow;
+    }
+    final box = await super.openBox();
+    openedBoxes.add(box);
+    if (!boxOpened.isCompleted) boxOpened.complete();
+    return box;
+  }
+
+  @override
+  Future<void> closeBox({bool isolated = true}) async {
+    closeBoxCalls++;
+    if (closeBoxCalls > 1 && laterClosesGate != null) {
+      await laterClosesGate!.future;
+    }
+    return super.closeBox(isolated: isolated);
+  }
+}
+
+void main() {
+  setUpAll(() async {
+    // Recovery is gated on web: IndexedDB is the only backend that can lose a
+    // connection while Hive still holds the box. These tests run on the VM to
+    // get a real Hive backend, so they have to declare the platform they are
+    // standing in for.
+    PlatformInfo.isTestingForWeb = true;
+    await HiveCacheConfig.instance.setUp(
+      cachePath: Directory.current.path,
+      isolated: false,
+    );
+  });
+
+  tearDownAll(() {
+    PlatformInfo.isTestingForWeb = false;
+  });
+
+  tearDown(() async {
+    await Hive.deleteBoxFromDisk(_tableName);
+  });
+
+  /// Seeds the box, then arms [client] so its next operations fail the way a
+  /// dead connection does. Clears the recorded boxes so assertions only see
+  /// what the recovery reopened.
+  Future<void> seedThenArm(
+    _RecordingCacheClient client, {
+    required int failures,
+  }) async {
+    await client.insertItem(_key, _value, isolated: false);
+    client.openedBoxes.clear();
+    client.openAttempts = 0;
+    client.boxOpened = Completer<void>();
+    client.failuresToInject = failures;
+  }
+
+  group('[recovery]', () {
+    test('should reopen the box and return the value '
+        'when the connection closed underneath a read', () async {
+      final client = _RecordingCacheClient();
+      await seedThenArm(client, failures: 1);
+
+      final result = await client.getItem(_key, isolated: false);
+
+      expect(result, equals(_value));
+      expect(client.closeBoxCalls, equals(1));
+      expect(client.openAttempts, equals(2));
+    });
+
+    test('should recover when the browser reports the Gecko wording', () async {
+      final client = _RecordingCacheClient(errorToThrow: _geckoClosedError);
+      await seedThenArm(client, failures: 1);
+
+      final result = await client.getItem(_key, isolated: false);
+
+      expect(result, equals(_value));
+      expect(client.closeBoxCalls, equals(1));
+    });
+
+    test('should recover on the DOMException name alone, '
+        'whatever wording the browser gives the message', () async {
+      // The name is fixed by WebIDL; the message is engine prose we cannot
+      // rely on. This is the generic rendering, with neither known phrase.
+      final client = _RecordingCacheClient(
+        errorToThrow: StateError(
+          'InvalidStateError: The object is in an invalid state.',
+        ),
+      );
+      await seedThenArm(client, failures: 1);
+
+      final result = await client.getItem(_key, isolated: false);
+
+      expect(result, equals(_value));
+      expect(client.closeBoxCalls, equals(1));
+    });
+
+    test('should recover a write the same way as a read', () async {
+      final client = _RecordingCacheClient();
+      await seedThenArm(client, failures: 1);
+
+      await client.insertItem(_key, 'updated', isolated: false);
+
+      expect(await client.getItem(_key, isolated: false), equals('updated'));
+      expect(client.closeBoxCalls, equals(1));
+    });
+  });
+
+  group('[concurrent recovery]', () {
+    test('should run one recovery only, and never close a box '
+        'another caller has just reopened', () async {
+      final client = _RecordingCacheClient();
+      // Every concurrent caller fails once, so each one enters recovery.
+      await seedThenArm(client, failures: 5);
+
+      // Force the damaging order rather than hoping for it: hold back every
+      // close after the first until a caller has already reopened the box. An
+      // unserialised recovery then closes that live box out from under the
+      // callers still using it, which is the production failure.
+      client.laterClosesGate = Completer<void>();
+
+      final pendingReads = [
+        for (var i = 0; i < 5; i++) client.getItem(_key, isolated: false),
+      ];
+      await client.boxOpened.future;
+      client.laterClosesGate!.complete();
+
+      final results = await Future.wait(pendingReads);
+
+      expect(results, everyElement(equals(_value)));
+
+      // Asserted first because it is the property the bug actually violates:
+      // no straggler closed the box the recovery had reopened, so every retry
+      // saw one and the same live connection and it is still open at the end.
+      expect(client.openedBoxes, hasLength(5));
+      expect(
+        client.openedBoxes.every((box) => identical(box, client.openedBoxes.first)),
+        isTrue,
+        reason: 'every retry must see the one box the recovery reopened',
+      );
+      expect(Hive.isBoxOpen(_tableName), isTrue);
+
+      expect(client.closeBoxCalls, equals(1),
+          reason: 'the 5 callers must share a single recovery');
+    });
+
+    test('should not close a box a recovery that already finished '
+        'had just reopened', () async {
+      final client = _RecordingCacheClient();
+      await seedThenArm(client, failures: 2);
+
+      // The shared future only spans the close, so it is empty again by the
+      // time the first caller retries. A straggler failing in that window used
+      // to install a second recovery and close the live box back out.
+      client.secondFailureGate = Completer<void>();
+
+      final firstRead = client.getItem(_key, isolated: false);
+      final stragglerRead = client.getItem(_key, isolated: false);
+
+      // Let the first caller recover and retry before the straggler fails.
+      expect(await firstRead, equals(_value));
+      client.secondFailureGate!.complete();
+
+      expect(await stragglerRead, equals(_value));
+
+      expect(client.closeBoxCalls, equals(1),
+          reason: 'the box was already replaced, so there was nothing to close');
+      expect(
+        client.openedBoxes.every((box) => identical(box, client.openedBoxes.first)),
+        isTrue,
+        reason: 'the straggler must retry against the reopened box',
+      );
+      expect(Hive.isBoxOpen(_tableName), isTrue);
+    });
+  });
+
+  group('[non-recoverable errors]', () {
+    test('should rethrow an unrelated error without touching the box', () async {
+      final client = _RecordingCacheClient(
+        errorToThrow: StateError('some other failure'),
+      );
+      await seedThenArm(client, failures: 1);
+
+      await expectLater(
+        client.getItem(_key, isolated: false),
+        throwsA(isA<StateError>()),
+      );
+      expect(client.closeBoxCalls, equals(0));
+      expect(client.openAttempts, equals(1), reason: 'must not retry');
+    });
+
+    test('should not recover "Box has already been closed", '
+        'which also means a deliberate logout teardown', () async {
+      final client = _RecordingCacheClient(
+        errorToThrow: HiveError('Box has already been closed.'),
+      );
+      await seedThenArm(client, failures: 1);
+
+      await expectLater(
+        client.getItem(_key, isolated: false),
+        throwsA(isA<HiveError>()),
+      );
+      expect(client.closeBoxCalls, equals(0));
+    });
+
+    test('should not reopen a box that logout closed on purpose', () async {
+      final client = _RecordingCacheClient();
+      await seedThenArm(client, failures: 1);
+
+      // What logout does: Hive.close() unregisters every box before closing
+      // its backend, so a write racing the teardown sees an unregistered box.
+      await Hive.close();
+      expect(Hive.isBoxOpen(_tableName), isFalse);
+
+      await expectLater(
+        client.insertItem(_key, 'written after logout', isolated: false),
+        throwsA(isA<StateError>()),
+      );
+
+      // Nothing resurrected the box, so no post-logout data can reach the
+      // next session through it.
+      expect(Hive.isBoxOpen(_tableName), isFalse);
+      expect(client.closeBoxCalls, equals(0));
+      expect(client.openAttempts, equals(1), reason: 'must not retry');
+    });
+
+    test('should not retry a write that spans a logout, even when the box '
+        'was reopened in the meantime', () async {
+      final client = _RecordingCacheClient();
+      await seedThenArm(client, failures: 1);
+
+      // The interleaving the registered/unregistered check cannot see: logout
+      // clears the boxes and closes Hive, and the login page the app navigates
+      // to immediately reopens one. By the time the in-flight write fails, the
+      // box reads as open again — so only the close count still shows what
+      // happened.
+      client.beforeFailure = () async {
+        await Hive.box<String>(_tableName).clear();
+        await HiveCacheConfig.instance.closeHive(isolated: false);
+        await Hive.openBox<String>(_tableName);
+      };
+
+      await expectLater(
+        client.insertItem(_key, 'written before logout', isolated: false),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(client.closeBoxCalls, equals(0));
+      expect(client.openAttempts, equals(1), reason: 'must not retry');
+
+      // The point of the guard: nothing from before the logout survived into
+      // the box the next session will use.
+      expect(Hive.isBoxOpen(_tableName), isTrue);
+      expect(Hive.box<String>(_tableName).get(_key), isNull);
+    });
+
+    test('should not recover off web, where there is no IndexedDB '
+        'to lose a connection', () async {
+      final client = _RecordingCacheClient();
+      await seedThenArm(client, failures: 1);
+      PlatformInfo.isTestingForWeb = false;
+      addTearDown(() => PlatformInfo.isTestingForWeb = true);
+
+      await expectLater(
+        client.getItem(_key, isolated: false),
+        throwsA(isA<StateError>()),
+      );
+
+      // Mobile and desktop keep the pre-recovery behaviour exactly: the error
+      // surfaces, and nothing closes a box the classifier only matched on a
+      // substring.
+      expect(client.closeBoxCalls, equals(0));
+      expect(client.openAttempts, equals(1), reason: 'must not retry');
+    });
+
+    test('should retry once only when the connection stays dead', () async {
+      final client = _RecordingCacheClient();
+      await seedThenArm(client, failures: 99);
+
+      await expectLater(
+        client.getItem(_key, isolated: false),
+        throwsA(isA<StateError>()),
+      );
+      expect(client.openAttempts, equals(2), reason: 'one attempt, one retry');
+      expect(client.closeBoxCalls, equals(1));
+    });
+  });
+}

--- a/test/features/mailbox/domain/usecases/get_all_mailbox_interactor_test.dart
+++ b/test/features/mailbox/domain/usecases/get_all_mailbox_interactor_test.dart
@@ -1,0 +1,163 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/properties/properties.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/extensions/mailbox_extension.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/model/cache_mailbox_response.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/model/jmap_mailbox_response.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/model/mailbox_response.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/repository/mailbox_repository.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/state/get_all_mailboxes_state.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/usecases/get_all_mailbox_interactor.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import '../../../../fixtures/mailbox_fixtures.dart';
+import '../../../../fixtures/session_fixtures.dart';
+import '../../../../fixtures/state_fixtures.dart';
+import 'get_all_mailbox_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<MailboxRepository>()])
+void main() {
+  late MockMailboxRepository mailboxRepository;
+  late GetAllMailboxInteractor interactor;
+
+  setUp(() {
+    mailboxRepository = MockMailboxRepository();
+    interactor = GetAllMailboxInteractor(mailboxRepository);
+  });
+
+  void stubGetAllMailbox(Stream<MailboxResponse> stream) {
+    when(mailboxRepository.getAllMailbox(
+      SessionFixtures.aliceSession,
+      AccountFixtures.aliceAccountId,
+      properties: anyNamed('properties'),
+    )).thenAnswer((_) => stream);
+  }
+
+  Future<List<Either<Failure, Success>>> executeInteractor() => interactor
+      .execute(SessionFixtures.aliceSession, AccountFixtures.aliceAccountId)
+      .toList();
+
+  group('[GetAllMailboxInteractor]', () {
+    test('Should emit loading then a success state per response '
+        'WHEN the repository stream completes normally', () async {
+      stubGetAllMailbox(Stream.fromIterable([
+        CacheMailboxResponse(
+          mailboxes: [MailboxFixtures.inboxMailbox],
+          state: StateFixtures.currentMailboxState,
+        ),
+        JmapMailboxResponse(
+          mailboxes: [MailboxFixtures.inboxMailbox, MailboxFixtures.sentMailbox],
+          state: StateFixtures.newMailboxState,
+        ),
+      ]));
+
+      final states = await executeInteractor();
+
+      expect(states.first, Right<Failure, Success>(GetAllMailboxLoading()));
+
+      final successes = states
+          .whereType<Right>()
+          .map((state) => state.value)
+          .whereType<GetAllMailboxSuccess>()
+          .toList();
+
+      expect(successes.length, 2);
+      expect(successes.first.mailboxList.length, 1);
+      expect(successes.first.currentMailboxState, StateFixtures.currentMailboxState);
+      expect(successes.last.mailboxList.length, 2);
+      expect(successes.last.currentMailboxState, StateFixtures.newMailboxState);
+      expect(states.whereType<Left>(), isEmpty);
+    });
+
+    test('Should map every mailbox to its presentation model and forward the '
+        'requested properties to the repository', () async {
+      final properties = Properties({'id', 'name'});
+
+      stubGetAllMailbox(Stream.fromIterable([
+        JmapMailboxResponse(
+          mailboxes: [MailboxFixtures.inboxMailbox, MailboxFixtures.sentMailbox],
+          state: StateFixtures.newMailboxState,
+        ),
+      ]));
+
+      final states = await interactor
+          .execute(
+            SessionFixtures.aliceSession,
+            AccountFixtures.aliceAccountId,
+            properties: properties,
+          )
+          .toList();
+
+      final success = states
+          .whereType<Right>()
+          .map((state) => state.value)
+          .whereType<GetAllMailboxSuccess>()
+          .single;
+
+      expect(success.mailboxList, [
+        MailboxFixtures.inboxMailbox.toPresentationMailbox(),
+        MailboxFixtures.sentMailbox.toPresentationMailbox(),
+      ]);
+
+      verify(mailboxRepository.getAllMailbox(
+        SessionFixtures.aliceSession,
+        AccountFixtures.aliceAccountId,
+        properties: properties,
+      )).called(1);
+    });
+
+    test('Should emit the values already delivered then GetAllMailboxFailure '
+        'WHEN the repository stream raises an error midway', () async {
+      final exception = StateError('getAllMailbox from JMAP failed');
+
+      stubGetAllMailbox(() async* {
+        yield CacheMailboxResponse(
+          mailboxes: [MailboxFixtures.inboxMailbox],
+          state: StateFixtures.currentMailboxState,
+        );
+        throw exception;
+      }());
+
+      final states = await executeInteractor();
+
+      expect(
+        states
+            .whereType<Right>()
+            .map((state) => state.value)
+            .whereType<GetAllMailboxSuccess>()
+            .length,
+        1,
+      );
+
+      final failure = states
+          .whereType<Left>()
+          .map((state) => state.value)
+          .whereType<GetAllMailboxFailure>()
+          .single;
+
+      expect(failure.exception, exception);
+      expect(failure.onRetry, isNotNull);
+    });
+
+    test('Should emit GetAllMailboxFailure '
+        'WHEN the repository stream raises an error before any value', () async {
+      final exception = StateError('cache unavailable');
+
+      stubGetAllMailbox(Stream<MailboxResponse>.error(exception));
+
+      final states = await executeInteractor();
+
+      final failure = states
+          .whereType<Left>()
+          .map((state) => state.value)
+          .whereType<GetAllMailboxFailure>()
+          .single;
+
+      expect(failure.exception, exception);
+    });
+  });
+}

--- a/test/features/mailbox/domain/usecases/refresh_all_mailbox_interactor_test.dart
+++ b/test/features/mailbox/domain/usecases/refresh_all_mailbox_interactor_test.dart
@@ -1,0 +1,161 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/properties/properties.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/extensions/mailbox_extension.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/model/jmap_mailbox_response.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/model/mailbox_response.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/repository/mailbox_repository.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/state/refresh_changes_all_mailboxes_state.dart';
+import 'package:tmail_ui_user/features/mailbox/domain/usecases/refresh_all_mailbox_interactor.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import '../../../../fixtures/mailbox_fixtures.dart';
+import '../../../../fixtures/session_fixtures.dart';
+import '../../../../fixtures/state_fixtures.dart';
+import 'refresh_all_mailbox_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<MailboxRepository>()])
+void main() {
+  late MockMailboxRepository mailboxRepository;
+  late RefreshAllMailboxInteractor interactor;
+
+  setUp(() {
+    mailboxRepository = MockMailboxRepository();
+    interactor = RefreshAllMailboxInteractor(mailboxRepository);
+  });
+
+  void stubRefresh(Stream<MailboxResponse> stream) {
+    when(mailboxRepository.refresh(
+      SessionFixtures.aliceSession,
+      AccountFixtures.aliceAccountId,
+      StateFixtures.currentMailboxState,
+      properties: anyNamed('properties'),
+    )).thenAnswer((_) => stream);
+  }
+
+  Future<List<Either<Failure, Success>>> executeInteractor() => interactor
+      .execute(
+        SessionFixtures.aliceSession,
+        AccountFixtures.aliceAccountId,
+        StateFixtures.currentMailboxState,
+      )
+      .toList();
+
+  group('[RefreshAllMailboxInteractor]', () {
+    test('Should emit loading then RefreshChangesAllMailboxSuccess '
+        'WHEN the repository stream completes normally', () async {
+      stubRefresh(Stream.fromIterable([
+        JmapMailboxResponse(
+          mailboxes: [MailboxFixtures.inboxMailbox, MailboxFixtures.sentMailbox],
+          state: StateFixtures.newMailboxState,
+        ),
+      ]));
+
+      final states = await executeInteractor();
+
+      expect(states.first, Right<Failure, Success>(RefreshChangesAllMailboxLoading()));
+
+      final success = states
+          .whereType<Right>()
+          .map((state) => state.value)
+          .whereType<RefreshChangesAllMailboxSuccess>()
+          .single;
+
+      expect(success.mailboxList.length, 2);
+      expect(success.currentMailboxState, StateFixtures.newMailboxState);
+      expect(states.whereType<Left>(), isEmpty);
+    });
+
+    test('Should map every mailbox to its presentation model and forward the '
+        'current state and properties to the repository', () async {
+      final properties = Properties({'id', 'name'});
+
+      stubRefresh(Stream.fromIterable([
+        JmapMailboxResponse(
+          mailboxes: [MailboxFixtures.inboxMailbox, MailboxFixtures.sentMailbox],
+          state: StateFixtures.newMailboxState,
+        ),
+      ]));
+
+      final states = await interactor
+          .execute(
+            SessionFixtures.aliceSession,
+            AccountFixtures.aliceAccountId,
+            StateFixtures.currentMailboxState,
+            properties: properties,
+          )
+          .toList();
+
+      final success = states
+          .whereType<Right>()
+          .map((state) => state.value)
+          .whereType<RefreshChangesAllMailboxSuccess>()
+          .single;
+
+      expect(success.mailboxList, [
+        MailboxFixtures.inboxMailbox.toPresentationMailbox(),
+        MailboxFixtures.sentMailbox.toPresentationMailbox(),
+      ]);
+
+      verify(mailboxRepository.refresh(
+        SessionFixtures.aliceSession,
+        AccountFixtures.aliceAccountId,
+        StateFixtures.currentMailboxState,
+        properties: properties,
+      )).called(1);
+    });
+
+    test('Should emit RefreshChangesAllMailboxFailure '
+        'WHEN the repository stream raises an error midway', () async {
+      final exception = StateError('getChanges failed');
+
+      stubRefresh(() async* {
+        yield JmapMailboxResponse(
+          mailboxes: [MailboxFixtures.inboxMailbox],
+          state: StateFixtures.newMailboxState,
+        );
+        throw exception;
+      }());
+
+      final states = await executeInteractor();
+
+      expect(
+        states
+            .whereType<Right>()
+            .map((state) => state.value)
+            .whereType<RefreshChangesAllMailboxSuccess>()
+            .length,
+        1,
+      );
+
+      final failure = states
+          .whereType<Left>()
+          .map((state) => state.value)
+          .whereType<RefreshChangesAllMailboxFailure>()
+          .single;
+
+      expect(failure.exception, exception);
+    });
+
+    test('Should emit RefreshChangesAllMailboxFailure '
+        'WHEN the repository stream raises an error before any value', () async {
+      final exception = StateError('state cache missing');
+
+      stubRefresh(Stream<MailboxResponse>.error(exception));
+
+      final states = await executeInteractor();
+
+      final failure = states
+          .whereType<Left>()
+          .map((state) => state.value)
+          .whereType<RefreshChangesAllMailboxFailure>()
+          .single;
+
+      expect(failure.exception, exception);
+    });
+  });
+}

--- a/test/features/thread/domain/usecases/clean_and_get_emails_in_mailbox_interactor_test.dart
+++ b/test/features/thread/domain/usecases/clean_and_get_emails_in_mailbox_interactor_test.dart
@@ -1,0 +1,181 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
+import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email_comparator.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email_comparator_property.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email_filter_condition.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/extensions/email_extension.dart';
+import 'package:tmail_ui_user/features/thread/domain/constants/thread_constants.dart';
+import 'package:tmail_ui_user/features/thread/domain/model/email_filter.dart';
+import 'package:tmail_ui_user/features/thread/domain/repository/thread_repository.dart';
+import 'package:tmail_ui_user/features/thread/domain/state/clean_and_get_all_email_state.dart';
+import 'package:tmail_ui_user/features/thread/domain/state/get_all_email_state.dart';
+import 'package:tmail_ui_user/features/thread/domain/usecases/clean_and_get_emails_in_mailbox_interactor.dart';
+import 'package:tmail_ui_user/features/thread/domain/usecases/get_emails_in_mailbox_interactor.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import '../../../../fixtures/email_fixtures.dart';
+import '../../../../fixtures/mailbox_fixtures.dart';
+import '../../../../fixtures/session_fixtures.dart';
+import 'clean_and_get_emails_in_mailbox_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<ThreadRepository>(),
+  MockSpec<GetEmailsInMailboxInteractor>(),
+])
+void main() {
+  late MockThreadRepository threadRepository;
+  late MockGetEmailsInMailboxInteractor getEmailsInMailboxInteractor;
+  late CleanAndGetEmailsInMailboxInteractor interactor;
+
+  setUp(() {
+    threadRepository = MockThreadRepository();
+    getEmailsInMailboxInteractor = MockGetEmailsInMailboxInteractor();
+    interactor = CleanAndGetEmailsInMailboxInteractor(
+      threadRepository,
+      getEmailsInMailboxInteractor,
+    );
+  });
+
+  void stubGetEmailsInMailbox(Stream<Either<Failure, Success>> stream) {
+    when(getEmailsInMailboxInteractor.execute(
+      SessionFixtures.aliceSession,
+      AccountFixtures.aliceAccountId,
+      limit: anyNamed('limit'),
+      sort: anyNamed('sort'),
+      emailFilter: anyNamed('emailFilter'),
+      propertiesCreated: anyNamed('propertiesCreated'),
+      propertiesUpdated: anyNamed('propertiesUpdated'),
+      getLatestChanges: true,
+      useCache: true,
+    )).thenAnswer((_) => stream);
+  }
+
+  Future<List<Either<Failure, Success>>> executeInteractor() => interactor
+      .execute(SessionFixtures.aliceSession, AccountFixtures.aliceAccountId)
+      .toList();
+
+  final innerSuccess = Right<Failure, Success>(GetAllEmailSuccess(
+    emailList: [EmailFixtures.email1.toPresentationEmail()],
+    currentEmailState: jmap.State('s1'),
+  ));
+
+  group('[CleanAndGetEmailsInMailboxInteractor]', () {
+    test('Should clear the cache then forward the states of the delegated '
+        'interactor WHEN it completes normally', () async {
+      stubGetEmailsInMailbox(Stream.fromIterable([innerSuccess]));
+
+      final states = await executeInteractor();
+
+      verify(threadRepository.clearEmailCacheAndStateCache()).called(1);
+      expect(states.first, Right<Failure, Success>(CleanAndGetAllEmailLoading()));
+      expect(states.contains(innerSuccess), isTrue);
+      expect(states.whereType<Left>(), isEmpty);
+    });
+
+    test('Should clear the cache before delegating and forward every query '
+        'parameter to the delegated interactor', () async {
+      final sort = <EmailComparator>{
+        EmailComparator(EmailComparatorProperty.sentAt)..setIsAscending(false),
+      };
+      final emailFilter = EmailFilter(
+        filter: EmailFilterCondition(inMailbox: MailboxFixtures.inboxMailbox.id),
+        mailboxId: MailboxFixtures.inboxMailbox.id,
+      );
+
+      when(getEmailsInMailboxInteractor.execute(
+        SessionFixtures.aliceSession,
+        AccountFixtures.aliceAccountId,
+        limit: UnsignedInt(20),
+        sort: sort,
+        emailFilter: emailFilter,
+        propertiesCreated: ThreadConstants.propertiesDefault,
+        propertiesUpdated: ThreadConstants.propertiesUpdatedDefault,
+        getLatestChanges: false,
+        useCache: false,
+      )).thenAnswer((_) => Stream.fromIterable([innerSuccess]));
+
+      final states = await interactor
+          .execute(
+            SessionFixtures.aliceSession,
+            AccountFixtures.aliceAccountId,
+            limit: UnsignedInt(20),
+            sort: sort,
+            emailFilter: emailFilter,
+            propertiesCreated: ThreadConstants.propertiesDefault,
+            propertiesUpdated: ThreadConstants.propertiesUpdatedDefault,
+            getLatestChanges: false,
+            useCache: false,
+          )
+          .toList();
+
+      expect(states, [
+        Right<Failure, Success>(CleanAndGetAllEmailLoading()),
+        innerSuccess,
+      ]);
+
+      // The cache has to be dropped before the delegate refills it, otherwise
+      // the reload would be served from the data this interactor is clearing.
+      verifyInOrder([
+        threadRepository.clearEmailCacheAndStateCache(),
+        getEmailsInMailboxInteractor.execute(
+          SessionFixtures.aliceSession,
+          AccountFixtures.aliceAccountId,
+          limit: UnsignedInt(20),
+          sort: sort,
+          emailFilter: emailFilter,
+          propertiesCreated: ThreadConstants.propertiesDefault,
+          propertiesUpdated: ThreadConstants.propertiesUpdatedDefault,
+          getLatestChanges: false,
+          useCache: false,
+        ),
+      ]);
+    });
+
+    test('Should emit CleanAndGetAllEmailFailure '
+        'WHEN the delegated interactor stream raises an error', () async {
+      final exception = StateError('delegated stream broke');
+
+      stubGetEmailsInMailbox(() async* {
+        yield innerSuccess;
+        throw exception;
+      }());
+
+      final states = await executeInteractor();
+
+      expect(states.contains(innerSuccess), isTrue);
+
+      final failure = states
+          .whereType<Left>()
+          .map((state) => state.value)
+          .whereType<CleanAndGetAllEmailFailure>()
+          .single;
+
+      expect(failure.exception, exception);
+    });
+
+    test('Should emit CleanAndGetAllEmailFailure and never delegate '
+        'WHEN clearing the cache throws', () async {
+      final exception = StateError('cache clear failed');
+
+      when(threadRepository.clearEmailCacheAndStateCache())
+          .thenThrow(exception);
+
+      final states = await executeInteractor();
+
+      final failure = states
+          .whereType<Left>()
+          .map((state) => state.value)
+          .whereType<CleanAndGetAllEmailFailure>()
+          .single;
+
+      expect(failure.exception, exception);
+      verifyNever(getEmailsInMailboxInteractor.execute(any, any));
+    });
+  });
+}

--- a/test/features/thread/domain/usecases/get_emails_in_mailbox_interactor_test.dart
+++ b/test/features/thread/domain/usecases/get_emails_in_mailbox_interactor_test.dart
@@ -437,5 +437,119 @@ void main() {
         propertiesCreated: anyNamed('propertiesCreated'),
       ));
     });
+
+    test(
+        'useCache = false, should call loadAllEmailInFolderWithoutCache() '
+        'and not call getAllEmail()',
+        () async {
+      final sort = <EmailComparator>{
+        EmailComparator(EmailComparatorProperty.sentAt)..setIsAscending(false),
+      };
+
+      final emailFilter = EmailFilter(
+        filter: EmailFilterCondition(inMailbox: MailboxFixtures.inboxMailbox.id),
+        mailboxId: MailboxFixtures.inboxMailbox.id,
+      );
+
+      when(threadRepository.loadAllEmailInFolderWithoutCache(
+        session: SessionFixtures.aliceSession,
+        accountId: AccountFixtures.aliceAccountId,
+        limit: UnsignedInt(20),
+        sort: sort,
+        emailFilter: emailFilter,
+        propertiesCreated: ThreadConstants.propertiesDefault,
+      )).thenAnswer((_) => Stream<EmailsResponse>.fromIterable([
+        EmailsResponse(
+          emailList: [EmailFixtures.email1, EmailFixtures.email2],
+          state: jmap.State('s1'),
+        ),
+      ]));
+
+      final states = await getEmailsInMailboxInteractor.execute(
+        SessionFixtures.aliceSession,
+        AccountFixtures.aliceAccountId,
+        limit: UnsignedInt(20),
+        sort: sort,
+        emailFilter: emailFilter,
+        propertiesCreated: ThreadConstants.propertiesDefault,
+        useCache: false,
+      ).toList();
+
+      expect(states, [
+        Right(GetAllEmailLoading()),
+        Right(GetAllEmailSuccess(
+          emailList: [
+            EmailFixtures.email1.toPresentationEmail(),
+            EmailFixtures.email2.toPresentationEmail(),
+          ],
+          currentEmailState: jmap.State('s1'),
+          currentMailboxId: MailboxFixtures.inboxMailbox.id,
+        )),
+      ]);
+
+      verify(threadRepository.loadAllEmailInFolderWithoutCache(
+        session: SessionFixtures.aliceSession,
+        accountId: AccountFixtures.aliceAccountId,
+        limit: UnsignedInt(20),
+        sort: sort,
+        emailFilter: emailFilter,
+        propertiesCreated: ThreadConstants.propertiesDefault,
+      )).called(1);
+
+      verifyNever(threadRepository.getAllEmail(
+        SessionFixtures.aliceSession,
+        AccountFixtures.aliceAccountId,
+        limit: anyNamed('limit'),
+        sort: anyNamed('sort'),
+        emailFilter: anyNamed('emailFilter'),
+        propertiesCreated: anyNamed('propertiesCreated'),
+        propertiesUpdated: anyNamed('propertiesUpdated'),
+        getLatestChanges: true,
+      ));
+    });
+
+    test('getEmailsInMailboxInteractor should yield GetAllEmailFailure '
+        'when the source stream raises an error, instead of breaking the stream', () async {
+      final exception = StateError('cache read failed');
+
+      when(threadRepository.getAllEmail(
+        SessionFixtures.aliceSession,
+        AccountFixtures.aliceAccountId,
+        limit: anyNamed('limit'),
+        sort: anyNamed('sort'),
+        emailFilter: anyNamed('emailFilter'),
+        propertiesCreated: anyNamed('propertiesCreated'),
+        propertiesUpdated: anyNamed('propertiesUpdated'),
+        getLatestChanges: true,
+      )).thenAnswer((_) async* {
+        yield EmailsResponse(
+          emailList: [EmailFixtures.email1],
+          state: jmap.State('s1'),
+        );
+        throw exception;
+      });
+
+      final states = await getEmailsInMailboxInteractor.execute(
+        SessionFixtures.aliceSession,
+        AccountFixtures.aliceAccountId,
+      ).toList();
+
+      expect(
+        states
+            .whereType<Right>()
+            .map((r) => r.value)
+            .whereType<GetAllEmailSuccess>()
+            .length,
+        1,
+      );
+
+      final failure = states
+          .whereType<Left>()
+          .map((l) => l.value)
+          .whereType<GetAllEmailFailure>()
+          .single;
+
+      expect(failure.exception, exception);
+    });
   });
 }

--- a/test/features/thread/domain/usecases/load_more_emails_in_mailbox_interactor_test.dart
+++ b/test/features/thread/domain/usecases/load_more_emails_in_mailbox_interactor_test.dart
@@ -117,4 +117,61 @@ void main() {
       expect(success.serverEmailCount, emails.length);
     });
   });
+
+  group('LoadMoreEmailsInMailboxInteractor stream error:', () {
+    test(
+      'GIVEN repo stream emits a value then raises an error '
+      'WHEN interactor executes '
+      'THEN it SHOULD emit the mapped success AND a LoadMoreEmailsFailure '
+      'rather than letting the error tear down the stream',
+    () async {
+      final exception = StateError('connection reset');
+      final emails = [Email(id: EmailId(Id('e0')))];
+
+      when(mockThreadRepository.loadMoreEmails(request)).thenAnswer((_) async* {
+        yield EmailsResponse(emailList: emails);
+        throw exception;
+      });
+
+      final states = await interactor.execute(request).toList();
+
+      expect(
+        states
+            .whereType<Right>()
+            .map((r) => r.value)
+            .whereType<LoadMoreEmailsSuccess>()
+            .length,
+        1,
+      );
+
+      final failure = states
+          .whereType<Left>()
+          .map((l) => l.value)
+          .whereType<LoadMoreEmailsFailure>()
+          .single;
+
+      expect(failure.exception, exception);
+    });
+
+    test(
+      'GIVEN repo stream raises an error before emitting anything '
+      'WHEN interactor executes '
+      'THEN it SHOULD complete with a LoadMoreEmailsFailure',
+    () async {
+      final exception = StateError('network down');
+
+      when(mockThreadRepository.loadMoreEmails(request))
+          .thenAnswer((_) => Stream<EmailsResponse>.error(exception));
+
+      final states = await interactor.execute(request).toList();
+
+      final failure = states
+          .whereType<Left>()
+          .map((l) => l.value)
+          .whereType<LoadMoreEmailsFailure>()
+          .single;
+
+      expect(failure.exception, exception);
+    });
+  });
 }

--- a/test/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor_test.dart
+++ b/test/features/thread/domain/usecases/refresh_changes_emails_in_mailbox_interactor_test.dart
@@ -85,5 +85,81 @@ void main() {
         )
       }));
     });
+
+    test('refreshChangesEmailsInMailboxInteractor should emit a success state '
+        'for every response the repository streams, in order', () async {
+      when(threadRepository.refreshChanges(
+        SessionFixtures.aliceSession,
+        AccountFixtures.aliceAccountId,
+        StateFixtures.currentEmailState,
+        sort: anyNamed('sort'),
+        limit: anyNamed('limit'),
+        propertiesCreated: anyNamed('propertiesCreated'),
+        propertiesUpdated: anyNamed('propertiesUpdated'),
+        collapseThreads: anyNamed('collapseThreads'),
+        emailFilter: anyNamed('emailFilter'),
+      )).thenAnswer((_) => Stream.fromIterable([
+        EmailsResponse(
+          emailList: [EmailFixtures.email1],
+          state: jmap.State('s1'),
+        ),
+        EmailsResponse(
+          emailList: [EmailFixtures.email1, EmailFixtures.email2],
+          state: jmap.State('s2'),
+        ),
+      ]));
+
+      final states = await refreshChangesEmailsInMailboxInteractor.execute(
+        SessionFixtures.aliceSession,
+        AccountFixtures.aliceAccountId,
+        StateFixtures.currentEmailState,
+      ).toList();
+
+      expect(states, [
+        Right(RefreshChangesAllEmailLoading()),
+        Right(RefreshChangesAllEmailSuccess(
+          emailList: [EmailFixtures.email1.toPresentationEmail()],
+          currentEmailState: jmap.State('s1'),
+        )),
+        Right(RefreshChangesAllEmailSuccess(
+          emailList: [
+            EmailFixtures.email1.toPresentationEmail(),
+            EmailFixtures.email2.toPresentationEmail(),
+          ],
+          currentEmailState: jmap.State('s2'),
+        )),
+      ]);
+    });
+
+    test('refreshChangesEmailsInMailboxInteractor should yield RefreshChangesAllEmailFailure '
+        'when the source stream raises an error, instead of breaking the stream', () async {
+      final exception = StateError('getChanges failed');
+
+      when(threadRepository.refreshChanges(
+        SessionFixtures.aliceSession,
+        AccountFixtures.aliceAccountId,
+        StateFixtures.currentEmailState,
+        sort: anyNamed('sort'),
+        limit: anyNamed('limit'),
+        propertiesCreated: anyNamed('propertiesCreated'),
+        propertiesUpdated: anyNamed('propertiesUpdated'),
+        collapseThreads: anyNamed('collapseThreads'),
+        emailFilter: anyNamed('emailFilter'),
+      )).thenAnswer((_) => Stream<EmailsResponse>.error(exception));
+
+      final states = await refreshChangesEmailsInMailboxInteractor.execute(
+        SessionFixtures.aliceSession,
+        AccountFixtures.aliceAccountId,
+        StateFixtures.currentEmailState,
+      ).toList();
+
+      final failure = states
+          .whereType<Left>()
+          .map((l) => l.value)
+          .whereType<RefreshChangesAllEmailFailure>()
+          .single;
+
+      expect(failure.exception, exception);
+    });
   });
 }

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -1171,5 +1171,24 @@ void main() {
         );
       });
     });
+
+    group('handleErrorViewState defensive fallback::test', () {
+      test(
+        'GIVEN an unknown error broke the state stream while loading '
+        'WHEN handleErrorViewState is called with an unhandled error '
+        'THEN SHOULD clear the loading state back to idle so the list is not stuck',
+      () {
+        // Arrange: list is currently showing a loading state.
+        threadController.dispatchState(Right(LoadingState()));
+
+        // Act: an interactor forwarded an unexpected error instead of a Left failure.
+        threadController.handleErrorViewState(Exception('boom'), StackTrace.empty);
+
+        // Assert: state cleared back to idle (loading spinner removed).
+        final state = threadController.viewState.value;
+        expect(state.isRight(), isTrue);
+        expect(state.getOrElse(() => LoadingState()), UIState.idle);
+      });
+    });
   });
 }

--- a/test/main/utils/twake_app_manager_test.dart
+++ b/test/main/utils/twake_app_manager_test.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
+
+void main() {
+  late TwakeAppManager twakeAppManager;
+
+  setUp(() {
+    twakeAppManager = TwakeAppManager();
+  });
+
+  group('[runClearDataOnce]', () {
+    test('should run the teardown once when callers arrive concurrently',
+        () async {
+      // A 401 makes every controller with a pending request start its own
+      // logout, and each one clears the Hive boxes then closes Hive.
+      var runs = 0;
+      final gate = Completer<void>();
+
+      final callers = [
+        for (var i = 0; i < 5; i++)
+          twakeAppManager.runClearDataOnce(() async {
+            runs++;
+            await gate.future;
+          }),
+      ];
+      gate.complete();
+      await Future.wait(callers);
+
+      expect(runs, equals(1));
+    });
+
+    test('should give every concurrent caller the same future', () async {
+      final gate = Completer<void>();
+      Future<void> clearData() => gate.future;
+
+      final first = twakeAppManager.runClearDataOnce(clearData);
+      final second = twakeAppManager.runClearDataOnce(clearData);
+
+      expect(identical(first, second), isTrue);
+      gate.complete();
+      await Future.wait([first, second]);
+    });
+
+    test('should run again once the previous teardown has finished', () async {
+      var runs = 0;
+      Future<void> clearData() async => runs++;
+
+      await twakeAppManager.runClearDataOnce(clearData);
+      await twakeAppManager.runClearDataOnce(clearData);
+
+      expect(runs, equals(2), reason: 'the guard is per teardown, not per app');
+    });
+
+    test('should release the guard when the teardown throws', () async {
+      // Otherwise one failed teardown wedges logout for the whole session.
+      var runs = 0;
+      Future<void> failingClearData() async {
+        runs++;
+        throw StateError('cannot clear all data');
+      }
+
+      await expectLater(
+        twakeAppManager.runClearDataOnce(failingClearData),
+        throwsA(isA<StateError>()),
+      );
+      await expectLater(
+        twakeAppManager.runClearDataOnce(failingClearData),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(runs, equals(2));
+    });
+
+    test('should surface the failure to every concurrent caller', () async {
+      final gate = Completer<void>();
+      Future<void> failingClearData() async {
+        await gate.future;
+        throw StateError('cannot clear all data');
+      }
+
+      final first = twakeAppManager.runClearDataOnce(failingClearData);
+      final second = twakeAppManager.runClearDataOnce(failingClearData);
+      gate.complete();
+
+      await expectLater(first, throwsA(isA<StateError>()));
+      await expectLater(second, throwsA(isA<StateError>()));
+    });
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent conversion of streaming errors into in-app failure states across mailbox and email workflows.
  * Streams can continue delivering later results after an error.
  * Unexpected thread errors now display an “Unknown error” notification and are logged with diagnostic details.

* **Bug Fixes**
  * Prevented loading indicators from remaining stuck after unexpected errors.

* **Tests**
  * Added coverage for stream recovery, failure mapping, retry behavior, and error notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->