### PR TITLE
feat(mail): support shared mailboxes across JMAP accounts

### DIFF
--- a/lib/features/base/action/update_mailbox_properties_action/update_mailbox_name_action.dart
+++ b/lib/features/base/action/update_mailbox_properties_action/update_mailbox_name_action.dart
@@ -5,7 +5,7 @@ import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_tree.d
 class UpdateMailboxNameAction extends UpdateMailboxPropertiesAction {
   const UpdateMailboxNameAction({
     required super.mailboxTrees,
-    required super.mailboxId,
+    required super.mailboxKey,
     required this.mailboxName,
   });
 
@@ -13,6 +13,6 @@ class UpdateMailboxNameAction extends UpdateMailboxPropertiesAction {
   
   @override
   bool updateProperty(MailboxTree mailboxTree) {
-    return mailboxTree.updateMailboxNameById(mailboxId, mailboxName);
+    return mailboxTree.updateMailboxNameByKey(mailboxKey, mailboxName);
   }
 }

--- a/lib/features/base/action/update_mailbox_properties_action/update_mailbox_properties_action.dart
+++ b/lib/features/base/action/update_mailbox_properties_action/update_mailbox_properties_action.dart
@@ -1,15 +1,15 @@
 import 'package:get/get_rx/get_rx.dart';
-import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/mailbox/mailbox_key.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_tree.dart';
 
 abstract class UpdateMailboxPropertiesAction {
   const UpdateMailboxPropertiesAction({
     required this.mailboxTrees,
-    required this.mailboxId,
+    required this.mailboxKey,
   });
 
   final List<Rx<MailboxTree>> mailboxTrees;
-  final MailboxId mailboxId;
+  final MailboxKey mailboxKey;
   
   bool updateProperty(MailboxTree mailboxTree);
 

--- a/lib/features/base/action/update_mailbox_properties_action/update_mailbox_total_emails_count_action.dart
+++ b/lib/features/base/action/update_mailbox_properties_action/update_mailbox_total_emails_count_action.dart
@@ -4,7 +4,7 @@ import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_tree.d
 class UpdateMailboxTotalEmailsCountAction extends UpdateMailboxPropertiesAction {
   const UpdateMailboxTotalEmailsCountAction({
     required super.mailboxTrees,
-    required super.mailboxId,
+    required super.mailboxKey,
     required this.totalEmailsCountChanged,
   });
 
@@ -12,8 +12,8 @@ class UpdateMailboxTotalEmailsCountAction extends UpdateMailboxPropertiesAction 
 
   @override
   bool updateProperty(MailboxTree mailboxTree) {
-    return mailboxTree.updateMailboxTotalEmailsCountById(
-      mailboxId,
+    return mailboxTree.updateMailboxTotalEmailsCountByKey(
+      mailboxKey,
       totalEmailsCountChanged,
     );
   }

--- a/lib/features/base/action/update_mailbox_properties_action/update_mailbox_unread_count_action.dart
+++ b/lib/features/base/action/update_mailbox_properties_action/update_mailbox_unread_count_action.dart
@@ -4,7 +4,7 @@ import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_tree.d
 class UpdateMailboxUnreadCountAction extends UpdateMailboxPropertiesAction {
   const UpdateMailboxUnreadCountAction({
     required super.mailboxTrees,
-    required super.mailboxId,
+    required super.mailboxKey,
     required this.unreadChanges,
   });
 
@@ -12,6 +12,6 @@ class UpdateMailboxUnreadCountAction extends UpdateMailboxPropertiesAction {
 
   @override
   bool updateProperty(MailboxTree mailboxTree) {
-    return mailboxTree.updateMailboxUnreadCountById(mailboxId, unreadChanges);
+    return mailboxTree.updateMailboxUnreadCountByKey(mailboxKey, unreadChanges);
   }
 }

--- a/lib/features/base/base_mailbox_controller.dart
+++ b/lib/features/base/base_mailbox_controller.dart
@@ -273,10 +273,8 @@ abstract class BaseMailboxController extends BaseController
   bool get personalMailboxIsNotEmpty =>
     personalMailboxTree.value.root.childrenItems?.isNotEmpty ?? false;
   
-  bool get teamMailboxesIsNotEmpty {
-    return (teamMailboxesTree.value.root.childrenItems?.isNotEmpty ?? false)
-      && !teamMailboxesTree.value.root.item.isTeamMailboxes;
-  }
+  bool get teamMailboxesIsNotEmpty =>
+    teamMailboxesTree.value.root.childrenItems?.isNotEmpty ?? false;
 
   MailboxNode get defaultRootNode => defaultMailboxTree.value.root;
 

--- a/lib/features/base/base_mailbox_controller.dart
+++ b/lib/features/base/base_mailbox_controller.dart
@@ -13,6 +13,7 @@ import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/extensions/presentation_mailbox_extension.dart';
 import 'package:model/mailbox/expand_mode.dart';
+import 'package:model/mailbox/mailbox_key.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:model/mailbox/select_mode.dart';
 import 'package:tmail_ui_user/features/base/action/update_mailbox_properties_action/update_mailbox_name_action.dart';
@@ -87,6 +88,33 @@ abstract class BaseMailboxController extends BaseController
   final defaultMailboxTree = MailboxTree(MailboxNode.root()).obs;
   final teamMailboxesTree =  MailboxTree(MailboxNode.root()).obs;
 
+  /// Every tree this controller owns.
+  ///
+  /// Operations that are not specific to one section iterate this instead of
+  /// naming each tree.
+  List<Rx<MailboxTree>> get allMailboxTrees => [
+    defaultMailboxTree,
+    personalMailboxTree,
+    teamMailboxesTree,
+  ];
+
+  /// The account this controller is signed in as.
+  ///
+  /// Used to resolve a bare [MailboxId] that arrives without account context,
+  /// such as an id carried by a state-change event on the primary account's
+  /// push channel.
+  AccountId? get primaryAccountId;
+
+  /// Resolves a bare [MailboxId] known to belong to the primary account.
+  ///
+  /// Returns null when there is no id or no signed-in account, so callers can
+  /// bail out with a single check.
+  MailboxKey? primaryMailboxKey(MailboxId? mailboxId) {
+    final accountId = primaryAccountId;
+    if (mailboxId == null || accountId == null) return null;
+    return MailboxKey(accountId, mailboxId);
+  }
+
   List<PresentationMailbox> allMailboxes = <PresentationMailbox>[];
 
   MailboxCollection get currentMailboxCollection => MailboxCollection(
@@ -106,6 +134,7 @@ abstract class BaseMailboxController extends BaseController
       allMailboxes: allMailbox,
       currentCollection: currentMailboxCollection,
       mailboxIdSelected: mailboxIdSelected,
+      primaryAccountId: primaryAccountId,
     );
 
     if (onUpdateMailboxCollectionCallback != null) {
@@ -123,6 +152,7 @@ abstract class BaseMailboxController extends BaseController
         await _treeBuilder.generateMailboxTreeInUIAfterRefreshChanges(
       allMailboxes: allMailbox,
       currentCollection: currentMailboxCollection,
+      primaryAccountId: primaryAccountId,
     );
 
     if (onUpdateMailboxCollectionCallback != null) {
@@ -161,29 +191,11 @@ abstract class BaseMailboxController extends BaseController
   ) {
     final newExpandMode = selectedMailboxNode.expandMode.toggle();
 
-    if (defaultMailboxTree.value.updateExpandedNode(selectedMailboxNode, newExpandMode) != null) {
-      log('toggleMailboxFolder() refresh defaultMailboxTree');
-      defaultMailboxTree.refresh();
-      triggerScrollWhenExpandFolder(
-        selectedMailboxNode.expandMode,
-        itemKey,
-        scrollController,
-      );
-    }
-
-    if (personalMailboxTree.value.updateExpandedNode(selectedMailboxNode, newExpandMode) != null) {
-      log('toggleMailboxFolder() refresh folderMailboxTree');
-      personalMailboxTree.refresh();
-      triggerScrollWhenExpandFolder(
-        selectedMailboxNode.expandMode,
-        itemKey,
-        scrollController,
-      );
-    }
-
-    if (teamMailboxesTree.value.updateExpandedNode(selectedMailboxNode, newExpandMode) != null) {
-      log('toggleMailboxFolder() refresh teamMailboxesTree');
-      teamMailboxesTree.refresh();
+    for (final mailboxTree in allMailboxTrees) {
+      if (mailboxTree.value.updateExpandedNode(selectedMailboxNode, newExpandMode) == null) {
+        continue;
+      }
+      mailboxTree.refresh();
       triggerScrollWhenExpandFolder(
         selectedMailboxNode.expandMode,
         itemKey,
@@ -197,54 +209,41 @@ abstract class BaseMailboxController extends BaseController
         ? SelectMode.ACTIVE
         : SelectMode.INACTIVE;
 
-    if (defaultMailboxTree.value.updateSelectedNode(mailboxNodeSelected, newSelectMode) != null) {
-      log('selectMailboxNode() refresh defaultMailboxTree');
-      defaultMailboxTree.refresh();
-    }
-
-    if (personalMailboxTree.value.updateSelectedNode(mailboxNodeSelected, newSelectMode) != null) {
-      log('selectMailboxNode() refresh folderMailboxTree');
-      personalMailboxTree.refresh();
-    }
-
-    if (teamMailboxesTree.value.updateSelectedNode(mailboxNodeSelected, newSelectMode) != null) {
-      log('selectMailboxNode() refresh folderMailboxTree');
-      teamMailboxesTree.refresh();
+    for (final mailboxTree in allMailboxTrees) {
+      if (mailboxTree.value.updateSelectedNode(mailboxNodeSelected, newSelectMode) != null) {
+        mailboxTree.refresh();
+      }
     }
   }
 
   void unAllSelectedMailboxNode() {
-    defaultMailboxTree.value.updateNodesUIMode(selectMode: SelectMode.INACTIVE);
-    personalMailboxTree.value.updateNodesUIMode(selectMode: SelectMode.INACTIVE);
-    teamMailboxesTree.value.updateNodesUIMode(selectMode: SelectMode.INACTIVE);
-    defaultMailboxTree.refresh();
-    personalMailboxTree.refresh();
-    teamMailboxesTree.refresh();
-  }
-
-  MailboxNode? findMailboxNodeById(MailboxId mailboxId) {
-    final mailboxNode = defaultMailboxTree.value.findNode((node) => node.item.id == mailboxId);
-    if (mailboxNode != null) {
-      return mailboxNode;
+    for (final mailboxTree in allMailboxTrees) {
+      mailboxTree.value.updateNodesUIMode(selectMode: SelectMode.INACTIVE);
+      mailboxTree.refresh();
     }
+  }
 
-    final mailboxPersonal = personalMailboxTree.value.findNode((node) => node.item.id == mailboxId);
-    if (mailboxPersonal != null) {
-      return mailboxPersonal;
+  MailboxNode? findMailboxNodeByKey(MailboxKey mailboxKey) {
+    for (final mailboxTree in allMailboxTrees) {
+      final mailboxNode = mailboxTree.value.findNodeByKey(mailboxKey);
+      if (mailboxNode != null) return mailboxNode;
     }
-    return teamMailboxesTree.value.findNode((node) => node.item.id == mailboxId);
+    return null;
   }
 
-  String? findNodePathWithSeparator(MailboxId mailboxId, String pathSeparator) {
-    var mailboxNodePath = defaultMailboxTree.value.getNodePath(mailboxId, pathSeparator)
-      ?? personalMailboxTree.value.getNodePath(mailboxId, pathSeparator)
-      ?? teamMailboxesTree.value.getNodePath(mailboxId, pathSeparator);
-    log('BaseMailboxController::findNodePath():mailboxNodePath: $mailboxNodePath');
-    return mailboxNodePath;
+  String? findNodePathWithSeparator(MailboxKey mailboxKey, String pathSeparator) {
+    for (final mailboxTree in allMailboxTrees) {
+      final mailboxNodePath = mailboxTree.value.getNodePath(mailboxKey, pathSeparator);
+      if (mailboxNodePath != null) {
+        log('BaseMailboxController::findNodePath():mailboxNodePath: $mailboxNodePath');
+        return mailboxNodePath;
+      }
+    }
+    return null;
   }
 
-  String? findNodePath(MailboxId mailboxId) {
-    return findNodePathWithSeparator(mailboxId, '/');
+  String? findNodePath(MailboxKey mailboxKey) {
+    return findNodePathWithSeparator(mailboxKey, '/');
   }
 
   MailboxNode? findMailboxNodeByRole(Role role) {
@@ -257,7 +256,7 @@ abstract class BaseMailboxController extends BaseController
       if (!presentationMailbox.hasParentId()) {
         return presentationMailbox;
       } else {
-        final mailboxNodePath = findNodePath(presentationMailbox.id);
+        final mailboxNodePath = findNodePath(presentationMailbox.key);
         if (mailboxNodePath != null) {
           return presentationMailbox.toPresentationMailboxWithMailboxPath(mailboxNodePath);
         } else {
@@ -284,9 +283,13 @@ abstract class BaseMailboxController extends BaseController
 
   List<String> getListMailboxNameInParentMailbox(PresentationMailbox parentMailbox) {
     if (parentMailbox.parentId == null) {
-      final allChildrenAtMailboxLocation = (defaultMailboxTree.value.root.childrenItems ?? <MailboxNode>[])
-        + (personalMailboxTree.value.root.childrenItems ?? <MailboxNode>[])
-        + (teamMailboxesTree.value.root.childrenItems ?? <MailboxNode>[]);
+      // Scoped to the target account: a folder named "Projects" in the primary
+      // account must not block creating "Projects" in another user's account.
+      final accountId = parentMailbox.key.accountId;
+      final allChildrenAtMailboxLocation = allMailboxTrees
+        .expand((tree) => tree.value.root.childrenItems ?? <MailboxNode>[])
+        .where((mailboxNode) => mailboxNode.item.key.accountId == accountId)
+        .toList();
       if (allChildrenAtMailboxLocation.isNotEmpty) {
         final listMailboxNameAsStringExist = allChildrenAtMailboxLocation
           .where((mailboxNode) => mailboxNode.nameNotEmpty)
@@ -297,7 +300,9 @@ abstract class BaseMailboxController extends BaseController
         return [];
       }
     } else {
-      final mailboxNodeLocation = findMailboxNodeById(parentMailbox.parentId!);
+      final mailboxNodeLocation = findMailboxNodeByKey(
+        MailboxKey(parentMailbox.key.accountId, parentMailbox.parentId!),
+      );
       if (mailboxNodeLocation != null && mailboxNodeLocation.childrenItems?.isNotEmpty == true) {
         final allChildrenAtMailboxLocation =  mailboxNodeLocation.childrenItems!;
         final listMailboxNameAsStringExist = allChildrenAtMailboxLocation
@@ -401,7 +406,10 @@ abstract class BaseMailboxController extends BaseController
     MailboxDashBoardController dashBoardController, {
     required MovingMailboxActionCallback onMovingMailboxAction
   }) async {
-    final accountId = dashBoardController.accountId.value;
+    // The picker shows destinations in the moved mailbox's own account, since a
+    // move never crosses accounts.
+    final accountId =
+        mailboxSelected.accountId ?? dashBoardController.accountId.value;
     final session = dashBoardController.sessionCurrent;
     if (accountId != null && session != null) {
 
@@ -455,30 +463,32 @@ abstract class BaseMailboxController extends BaseController
   }
 
   List<MailboxNode> getAncestorOfMailboxNode(MailboxNode mailboxNode) {
-    final listAncestor = defaultMailboxTree.value.getAncestorList(mailboxNode)
-      ?? personalMailboxTree.value.getAncestorList(mailboxNode)
-      ?? teamMailboxesTree.value.getAncestorList(mailboxNode);
-    return listAncestor ?? [];
+    for (final mailboxTree in allMailboxTrees) {
+      final listAncestor = mailboxTree.value.getAncestorList(mailboxNode);
+      if (listAncestor != null) return listAncestor;
+    }
+    return [];
   }
 
   SubscribeRequest? generateSubscribeRequest(
-    MailboxId mailboxId,
+    MailboxKey mailboxKey,
     MailboxSubscribeState subscribeState,
     MailboxSubscribeAction subscribeAction
   ) {
     switch(subscribeState) {
       case MailboxSubscribeState.enabled:
-        return _generateSubscribeRequestWhenSubscribeEnabled(mailboxId, subscribeAction);
+        return _generateSubscribeRequestWhenSubscribeEnabled(mailboxKey, subscribeAction);
       case MailboxSubscribeState.disabled:
-        return _generateSubscribeRequestWhenSubscribeDisabled(mailboxId, subscribeAction);
+        return _generateSubscribeRequestWhenSubscribeDisabled(mailboxKey, subscribeAction);
     }
   }
 
   SubscribeRequest? _generateSubscribeRequestWhenSubscribeDisabled(
-    MailboxId mailboxId,
+    MailboxKey mailboxKey,
     MailboxSubscribeAction subscribeAction
   ) {
-    final mailboxNode = findMailboxNodeById(mailboxId);
+    final mailboxId = mailboxKey.mailboxId;
+    final mailboxNode = findMailboxNodeByKey(mailboxKey);
 
     if (mailboxNode == null) return null;
 
@@ -501,10 +511,11 @@ abstract class BaseMailboxController extends BaseController
   }
 
   SubscribeRequest? _generateSubscribeRequestWhenSubscribeEnabled(
-    MailboxId mailboxId,
+    MailboxKey mailboxKey,
     MailboxSubscribeAction subscribeAction
   ) {
-    final mailboxNode = findMailboxNodeById(mailboxId);
+    final mailboxId = mailboxKey.mailboxId;
+    final mailboxNode = findMailboxNodeByKey(mailboxKey);
 
     if (mailboxNode == null) return null;
 
@@ -567,48 +578,44 @@ abstract class BaseMailboxController extends BaseController
     return mailboxNode;
   }
 
-  void updateMailboxNameById(MailboxId mailboxId, MailboxName mailboxName) {
+  void updateMailboxNameByKey(MailboxKey mailboxKey, MailboxName mailboxName) {
     UpdateMailboxNameAction(
-      mailboxTrees: [defaultMailboxTree, personalMailboxTree, teamMailboxesTree],
-      mailboxId: mailboxId,
+      mailboxTrees: allMailboxTrees,
+      mailboxKey: mailboxKey,
       mailboxName: mailboxName,
     ).execute();
   }
 
-  void updateUnreadCountOfMailboxById(
-    MailboxId mailboxId, {
+  void updateUnreadCountOfMailboxByKey(
+    MailboxKey mailboxKey, {
     required int unreadChanges,
   }) {
     UpdateMailboxUnreadCountAction(
-      mailboxTrees: [defaultMailboxTree, personalMailboxTree, teamMailboxesTree],
-      mailboxId: mailboxId,
+      mailboxTrees: allMailboxTrees,
+      mailboxKey: mailboxKey,
       unreadChanges: unreadChanges,
     ).execute();
   }
 
-  void clearUnreadCount(MailboxId mailboxId) {
-    final mailboxTrees = [
-      defaultMailboxTree,
-      personalMailboxTree,
-      teamMailboxesTree,
-    ];
-
-    for (var mailboxTree in mailboxTrees) {
-      final selectedNode = mailboxTree.value.findNode((node) => node.item.id == mailboxId);
+  void clearUnreadCount(MailboxKey mailboxKey) {
+    // No early exit once a tree matches: the same mailbox can be present in
+    // more than one tree, and stopping at the first would leave the others
+    // showing a stale count.
+    for (var mailboxTree in allMailboxTrees) {
+      final selectedNode = mailboxTree.value.findNodeByKey(mailboxKey);
       if (selectedNode == null) continue;
       final currentUnreadCount = selectedNode.item.unreadEmails?.value.value.toInt();
-      mailboxTree.value.updateMailboxUnreadCountById(
-        mailboxId,
+      mailboxTree.value.updateMailboxUnreadCountByKey(
+        mailboxKey,
         -(currentUnreadCount ?? 0));
       mailboxTree.refresh();
-      break;
     }
   }
 
-  void updateMailboxTotalEmailsCountById(MailboxId mailboxId, int totalEmails) {
+  void updateMailboxTotalEmailsCountByKey(MailboxKey mailboxKey, int totalEmails) {
     UpdateMailboxTotalEmailsCountAction(
-      mailboxTrees: [defaultMailboxTree, personalMailboxTree, teamMailboxesTree],
-      mailboxId: mailboxId,
+      mailboxTrees: allMailboxTrees,
+      mailboxKey: mailboxKey,
       totalEmailsCountChanged: totalEmails,
     ).execute();
   }
@@ -674,8 +681,10 @@ abstract class BaseMailboxController extends BaseController
     required PresentationMailbox mailboxSelected,
     required OnMoveFolderContentActionCallback onMoveFolderContentAction,
   }) async {
+    // The picker shows destinations in the source folder's own account.
+    final destinationAccountId = mailboxSelected.accountId ?? accountId;
     final arguments = DestinationPickerArguments(
-      accountId,
+      destinationAccountId,
       MailboxActions.moveFolderContent,
       session,
       mailboxIdSelected: mailboxSelected.id,

--- a/lib/features/base/base_mailbox_controller.dart
+++ b/lib/features/base/base_mailbox_controller.dart
@@ -133,7 +133,7 @@ abstract class BaseMailboxController extends BaseController
         await _treeBuilder.generateMailboxTreeInUI(
       allMailboxes: allMailbox,
       currentCollection: currentMailboxCollection,
-      mailboxIdSelected: mailboxIdSelected,
+      mailboxKeySelected: primaryMailboxKey(mailboxIdSelected),
       primaryAccountId: primaryAccountId,
     );
 
@@ -282,38 +282,29 @@ abstract class BaseMailboxController extends BaseController
   MailboxNode get teamMailboxesRootNode => teamMailboxesTree.value.root;
 
   List<String> getListMailboxNameInParentMailbox(PresentationMailbox parentMailbox) {
-    if (parentMailbox.parentId == null) {
-      // Scoped to the target account: a folder named "Projects" in the primary
-      // account must not block creating "Projects" in another user's account.
+    final siblings = _siblingNodesOf(parentMailbox);
+    return siblings
+      .where((mailboxNode) => mailboxNode.nameNotEmpty)
+      .map((mailboxNode) => mailboxNode.mailboxNameAsString)
+      .toList();
+  }
+
+  /// The nodes that share [parentMailbox]'s location, scoped to its account: a
+  /// folder named "Projects" in the primary account must not block creating
+  /// "Projects" in another user's account. Top-level folders are the account's
+  /// root children across every tree; nested folders are the parent's children.
+  List<MailboxNode> _siblingNodesOf(PresentationMailbox parentMailbox) {
+    final parentId = parentMailbox.parentId;
+    if (parentId == null) {
       final accountId = parentMailbox.key.accountId;
-      final allChildrenAtMailboxLocation = allMailboxTrees
+      return allMailboxTrees
         .expand((tree) => tree.value.root.childrenItems ?? <MailboxNode>[])
         .where((mailboxNode) => mailboxNode.item.key.accountId == accountId)
         .toList();
-      if (allChildrenAtMailboxLocation.isNotEmpty) {
-        final listMailboxNameAsStringExist = allChildrenAtMailboxLocation
-          .where((mailboxNode) => mailboxNode.nameNotEmpty)
-          .map((mailboxNode) => mailboxNode.mailboxNameAsString)
-          .toList();
-        return listMailboxNameAsStringExist;
-      } else {
-        return [];
-      }
-    } else {
-      final mailboxNodeLocation = findMailboxNodeByKey(
-        MailboxKey(parentMailbox.key.accountId, parentMailbox.parentId!),
-      );
-      if (mailboxNodeLocation != null && mailboxNodeLocation.childrenItems?.isNotEmpty == true) {
-        final allChildrenAtMailboxLocation =  mailboxNodeLocation.childrenItems!;
-        final listMailboxNameAsStringExist = allChildrenAtMailboxLocation
-          .where((mailboxNode) => mailboxNode.nameNotEmpty)
-          .map((mailboxNode) => mailboxNode.mailboxNameAsString)
-          .toList();
-        return listMailboxNameAsStringExist;
-      } else {
-        return [];
-      }
     }
+    final parentNode =
+        findMailboxNodeByKey(MailboxKey(parentMailbox.key.accountId, parentId));
+    return parentNode?.childrenItems ?? <MailboxNode>[];
   }
 
   String? verifyMailboxNameAction(

--- a/lib/features/base/mixin/mailbox_account_resolver_mixin.dart
+++ b/lib/features/base/mixin/mailbox_account_resolver_mixin.dart
@@ -1,0 +1,37 @@
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_request_context.dart';
+
+/// Resolves the account a mailbox action must target from the mailbox itself.
+///
+/// Turns "which account" from an implicit read of the primary account into an
+/// explicit value derived from the target mailbox, so an action on a delegated
+/// account's mailbox is dispatched with that account's id.
+mixin MailboxAccountResolverMixin {
+  AccountId? get primaryAccountId;
+  Session? get session;
+
+  /// The account that owns [mailbox]. Falls back to the primary account for
+  /// mailboxes that carry no account (the app-local virtual folders).
+  AccountId? accountIdOf(PresentationMailbox mailbox) =>
+      mailbox.accountId ?? primaryAccountId;
+
+  /// Whether [mailbox] belongs to another user's delegated account.
+  bool isOtherUserMailbox(PresentationMailbox mailbox) =>
+      mailbox.accountId != null && mailbox.accountId != primaryAccountId;
+
+  /// The session and owning account for an action on [mailbox], or null when
+  /// there is no session or the account cannot be resolved.
+  MailboxRequestContext? requestContextOf(PresentationMailbox mailbox) {
+    final currentSession = session;
+    final accountId = accountIdOf(mailbox);
+    if (currentSession == null || accountId == null) return null;
+
+    return MailboxRequestContext(
+      session: currentSession,
+      accountId: accountId,
+      isPrimaryAccount: accountId == primaryAccountId,
+    );
+  }
+}

--- a/lib/features/base/mixin/mailbox_action_handler_mixin.dart
+++ b/lib/features/base/mixin/mailbox_action_handler_mixin.dart
@@ -37,7 +37,9 @@ mixin MailboxActionHandlerMixin {
     }
   ) {
     final session = dashboardController.sessionCurrent;
-    final accountId = dashboardController.accountId.value;
+    // Mark-as-read runs against the account that owns the mailbox.
+    final accountId =
+        presentationMailbox.accountId ?? dashboardController.accountId.value;
     final mailboxId = presentationMailbox.id;
     final countEmailsUnread = presentationMailbox.unreadEmails?.value.value ?? 0;
     if (session != null && accountId != null) {

--- a/lib/features/destination_picker/presentation/destination_picker_controller.dart
+++ b/lib/features/destination_picker/presentation/destination_picker_controller.dart
@@ -56,6 +56,9 @@ class DestinationPickerController extends BaseMailboxController {
   DestinationPickerArguments? arguments;
   Session? _session;
   AccountId? accountId;
+
+  @override
+  AccountId? get primaryAccountId => accountId;
   MailboxId? mailboxIdSelected;
 
   List<String> listMailboxNameAsStringExist = <String>[];
@@ -222,7 +225,7 @@ class DestinationPickerController extends BaseMailboxController {
         listMailboxNameAsStringExist = [];
       }
     } else {
-      final mailboxNodeLocation = findMailboxNodeById(mailboxDestination.value!.id);
+      final mailboxNodeLocation = findMailboxNodeByKey(mailboxDestination.value!.key);
       if (mailboxNodeLocation != null && mailboxNodeLocation.childrenItems?.isNotEmpty == true) {
         final allChildrenAtMailboxLocation =  mailboxNodeLocation.childrenItems!;
         listMailboxNameAsStringExist = allChildrenAtMailboxLocation
@@ -255,7 +258,11 @@ class DestinationPickerController extends BaseMailboxController {
         mailboxAction.value == MailboxActions.moveEmail ||
                 mailboxAction.value == MailboxActions.moveFolderContent
             ? allMailboxes
-            : allMailboxes.listPersonalMailboxes;
+            // Not listPersonalMailboxes: when the picker is opened for a
+            // delegated account, its mailboxes are not isPersonal, so that
+            // filter would return nothing. listSelectableMailboxes keeps them
+            // and drops the synthetic roots and virtual folders.
+            : allMailboxes.listSelectableMailboxes;
 
     final mailboxListWithDisplayName = searchableMailboxList
       .map((mailbox) => mailbox.withDisplayName(mailbox.getDisplayName(context)))
@@ -340,7 +347,7 @@ class DestinationPickerController extends BaseMailboxController {
         unAllSelectedMailboxNode();
         selectMailboxNode(mailboxNode);
       } else {
-        final matchedMailboxNode = findMailboxNodeById(presentationMailbox.id);
+        final matchedMailboxNode = findMailboxNodeByKey(presentationMailbox.key);
         if (matchedMailboxNode != null) {
           unAllSelectedMailboxNode();
           selectMailboxNode(matchedMailboxNode);

--- a/lib/features/destination_picker/presentation/destination_picker_view.dart
+++ b/lib/features/destination_picker/presentation/destination_picker_view.dart
@@ -560,7 +560,7 @@ class DestinationPickerView extends GetWidget<DestinationPickerController>
 
   void _handleOpenMailboxNodeClick(MailboxNode mailboxNode) {
     PresentationMailbox presentationMailbox;
-    final path = controller.findNodePath(mailboxNode.item.id)
+    final path = controller.findNodePath(mailboxNode.item.key)
         ?? mailboxNode.item.name?.name;
     if (path != null) {
       presentationMailbox = mailboxNode.item
@@ -580,7 +580,7 @@ class DestinationPickerView extends GetWidget<DestinationPickerController>
       newPresentationMailbox = presentationMailbox
           .toPresentationMailboxWithMailboxPath(AppLocalizations.of(context).allFolders);
     } else {
-      final path = controller.findNodePath(presentationMailbox.id)
+      final path = controller.findNodePath(presentationMailbox.key)
           ?? presentationMailbox.name?.name;
       if (path != null) {
         newPresentationMailbox = presentationMailbox.toPresentationMailboxWithMailboxPath(path);

--- a/lib/features/mailbox/domain/state/move_mailbox_state.dart
+++ b/lib/features/mailbox/domain/state/move_mailbox_state.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:tmail_ui_user/features/email/domain/model/move_action.dart';
 
@@ -9,6 +10,10 @@ class MoveMailboxSuccess extends UIState {
 
   final MailboxId mailboxIdSelected;
   final MoveAction moveAction;
+  /// The account the move ran against, carried so the undo routes back to the
+  /// same account. JMAP ids collide across accounts, so it cannot be recovered
+  /// from the mailbox id alone.
+  final AccountId accountId;
   final MailboxId? parentId;
   final MailboxId? destinationMailboxId;
   final String? destinationMailboxDisplayName;
@@ -16,6 +21,7 @@ class MoveMailboxSuccess extends UIState {
   MoveMailboxSuccess(
     this.mailboxIdSelected,
     this.moveAction,
+    this.accountId,
     {
       this.parentId,
       this.destinationMailboxId,
@@ -27,6 +33,7 @@ class MoveMailboxSuccess extends UIState {
   List<Object?> get props => [
     mailboxIdSelected,
     moveAction,
+    accountId,
     parentId,
     destinationMailboxId,
     destinationMailboxDisplayName,

--- a/lib/features/mailbox/domain/state/subscribe_mailbox_state.dart
+++ b/lib/features/mailbox/domain/state/subscribe_mailbox_state.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:tmail_ui_user/features/base/state/ui_action_state.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
@@ -10,10 +11,14 @@ class LoadingSubscribeMailbox extends UIState {}
 class SubscribeMailboxSuccess extends UIActionState {
   final MailboxId mailboxId;
   final MailboxSubscribeAction subscribeAction;
+  /// The account the (un)subscribe ran against, carried so the undo routes back
+  /// to the same account instead of resolving by a bare, account-ambiguous id.
+  final AccountId accountId;
 
   SubscribeMailboxSuccess(
-    this.mailboxId, 
+    this.mailboxId,
     this.subscribeAction,
+    this.accountId,
     {
       jmap.State? currentEmailState,
       jmap.State? currentMailboxState,
@@ -24,6 +29,7 @@ class SubscribeMailboxSuccess extends UIActionState {
   List<Object?> get props => [
     mailboxId,
     subscribeAction,
+    accountId,
     ...super.props
   ];
 }

--- a/lib/features/mailbox/domain/state/subscribe_multiple_mailbox_state.dart
+++ b/lib/features/mailbox/domain/state/subscribe_multiple_mailbox_state.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:tmail_ui_user/features/base/state/ui_action_state.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
@@ -12,11 +13,15 @@ class SubscribeMultipleMailboxAllSuccess extends UIActionState {
   final MailboxId parentMailboxId;
   final List<MailboxId> mailboxIdsSubscribe;
   final MailboxSubscribeAction subscribeAction;
+  /// The account the (un)subscribe ran against, carried so the undo routes back
+  /// to the same account instead of resolving by a bare, account-ambiguous id.
+  final AccountId accountId;
 
   SubscribeMultipleMailboxAllSuccess(
     this.parentMailboxId,
     this.mailboxIdsSubscribe,
     this.subscribeAction,
+    this.accountId,
     {
       jmap.State? currentEmailState,
       jmap.State? currentMailboxState,
@@ -28,6 +33,7 @@ class SubscribeMultipleMailboxAllSuccess extends UIActionState {
     parentMailboxId,
     mailboxIdsSubscribe,
     subscribeAction,
+    accountId,
     ...super.props
   ];
 }
@@ -37,11 +43,15 @@ class SubscribeMultipleMailboxHasSomeSuccess extends UIActionState {
   final MailboxId parentMailboxId;
   final List<MailboxId> mailboxIdsSubscribe;
   final MailboxSubscribeAction subscribeAction;
+  /// The account the (un)subscribe ran against, carried so the undo routes back
+  /// to the same account instead of resolving by a bare, account-ambiguous id.
+  final AccountId accountId;
 
   SubscribeMultipleMailboxHasSomeSuccess(
     this.parentMailboxId,
     this.mailboxIdsSubscribe,
     this.subscribeAction,
+    this.accountId,
     {
       jmap.State? currentEmailState,
       jmap.State? currentMailboxState,
@@ -53,6 +63,7 @@ class SubscribeMultipleMailboxHasSomeSuccess extends UIActionState {
     parentMailboxId,
     mailboxIdsSubscribe,
     subscribeAction,
+    accountId,
     ...super.props
   ];
 }

--- a/lib/features/mailbox/domain/usecases/get_all_mailbox_interactor.dart
+++ b/lib/features/mailbox/domain/usecases/get_all_mailbox_interactor.dart
@@ -24,7 +24,7 @@ class GetAllMailboxInteractor {
           session,
           accountId,
           properties: properties)
-        .map(_toGetMailboxState)
+        .map((response) => _toGetMailboxState(response, accountId))
         .mapErrorToLeft((error, _) => GetAllMailboxFailure(
           error,
           onRetry: execute(session, accountId, properties: properties),
@@ -32,14 +32,20 @@ class GetAllMailboxInteractor {
     } catch (e) {
       yield Left<Failure, Success>(GetAllMailboxFailure(
         e,
-        onRetry: execute(session, accountId, properties: properties),  
+        onRetry: execute(session, accountId, properties: properties),
       ));
     }
   }
 
-  Either<Failure, Success> _toGetMailboxState(MailboxResponse mailboxResponse) {
+  Either<Failure, Success> _toGetMailboxState(
+    MailboxResponse mailboxResponse,
+    AccountId accountId,
+  ) {
+    // Stamp the account the mailboxes were fetched from. JMAP ids are only
+    // unique within an account (RFC 8620), so a mailbox is not identifiable
+    // without it once other users' accounts are also loaded.
     final mailboxList = mailboxResponse.mailboxes
-      .map((mailbox) => mailbox.toPresentationMailbox())
+      .map((mailbox) => mailbox.toPresentationMailbox(accountId: accountId))
       .toList();
 
     return Right<Failure, Success>(GetAllMailboxSuccess(

--- a/lib/features/mailbox/domain/usecases/move_mailbox_interactor.dart
+++ b/lib/features/mailbox/domain/usecases/move_mailbox_interactor.dart
@@ -20,6 +20,7 @@ class MoveMailboxInteractor {
         yield Right<Failure, Success>(MoveMailboxSuccess(
             request.mailboxId,
             request.moveAction,
+            accountId,
             parentId: request.parentId,
             destinationMailboxId: request.destinationMailboxId,
             destinationMailboxDisplayName: request.destinationMailboxDisplayName,

--- a/lib/features/mailbox/domain/usecases/refresh_all_mailbox_interactor.dart
+++ b/lib/features/mailbox/domain/usecases/refresh_all_mailbox_interactor.dart
@@ -29,16 +29,21 @@ class RefreshAllMailboxInteractor {
 
       yield* _mailboxRepository
         .refresh(session, accountId, currentState, properties: properties)
-        .map(_toGetMailboxState)
+        .map((response) => _toGetMailboxState(response, accountId))
         .mapErrorToLeft((error, _) => RefreshChangesAllMailboxFailure(error));
     } catch (e) {
       yield Left<Failure, Success>(RefreshChangesAllMailboxFailure(e));
     }
   }
 
-  Either<Failure, Success> _toGetMailboxState(MailboxResponse mailboxResponse) {
+  Either<Failure, Success> _toGetMailboxState(
+    MailboxResponse mailboxResponse,
+    AccountId accountId,
+  ) {
+    // Stamp the account the mailboxes were fetched from. See
+    // GetAllMailboxInteractor for why.
     final mailboxList = mailboxResponse.mailboxes
-      .map((mailbox) => mailbox.toPresentationMailbox())
+      .map((mailbox) => mailbox.toPresentationMailbox(accountId: accountId))
       .toList();
 
     return Right<Failure, Success>(RefreshChangesAllMailboxSuccess(

--- a/lib/features/mailbox/domain/usecases/subscribe_mailbox_interactor.dart
+++ b/lib/features/mailbox/domain/usecases/subscribe_mailbox_interactor.dart
@@ -22,9 +22,10 @@ class SubscribeMailboxInteractor {
 
       if (result) {
         yield Right<Failure, Success>(SubscribeMailboxSuccess(
-          request.mailboxId, 
-          currentMailboxState: currentMailboxState,
-          request.subscribeAction));
+          request.mailboxId,
+          request.subscribeAction,
+          accountId,
+          currentMailboxState: currentMailboxState));
       } else {
         yield Left<Failure, Success>(SubscribeMailboxFailure(null));
       }

--- a/lib/features/mailbox/domain/usecases/subscribe_multiple_mailbox_interactor.dart
+++ b/lib/features/mailbox/domain/usecases/subscribe_multiple_mailbox_interactor.dart
@@ -32,6 +32,7 @@ class SubscribeMultipleMailboxInteractor {
           subscribeRequest.parentMailboxId,
           listResult,
           subscribeRequest.subscribeAction,
+          accountId,
           currentMailboxState: currentMailboxState
         ));
       } else if (listResult.isEmpty) {
@@ -41,6 +42,7 @@ class SubscribeMultipleMailboxInteractor {
           subscribeRequest.parentMailboxId,
           listResult,
           subscribeRequest.subscribeAction,
+          accountId,
           currentMailboxState: currentMailboxState
         ));
       }

--- a/lib/features/mailbox/presentation/extensions/handle_mailbox_action_extension.dart
+++ b/lib/features/mailbox/presentation/extensions/handle_mailbox_action_extension.dart
@@ -18,11 +18,12 @@ extension HandleMailboxActionExtension on MailboxController {
     BuildContext context,
     PresentationMailbox mailbox,
   ) {
+    final mailboxAccountId = accountIdOf(mailbox);
     final deletedMessageVaultSupported =
-      MailboxUtils.isDeletedMessageVaultSupported(session, accountId);
+      MailboxUtils.isDeletedMessageVaultSupported(session, mailboxAccountId);
 
     final isSubAddressingSupported =
-      session?.isSubAddressingSupported(accountId) ?? false;
+      session?.isSubAddressingSupported(mailboxAccountId) ?? false;
 
     final contextMenuActions = listContextMenuItemAction(
       mailbox,
@@ -55,7 +56,7 @@ extension HandleMailboxActionExtension on MailboxController {
     List<PresentationEmail> listEmails,
     PresentationMailbox presentationMailbox,
   ) {
-    final mailboxPath = findNodePath(presentationMailbox.id)
+    final mailboxPath = findNodePath(presentationMailbox.key)
         ?? presentationMailbox.name?.name;
     log('HandleMailboxActionExtension::handleDragItemAccepted():mailboxPath = $mailboxPath');
     final newMailbox = mailboxPath != null
@@ -73,11 +74,12 @@ extension HandleMailboxActionExtension on MailboxController {
     RelativeRect position,
     PresentationMailbox mailbox,
   ) {
+    final mailboxAccountId = accountIdOf(mailbox);
     final deletedMessageVaultSupported =
-      MailboxUtils.isDeletedMessageVaultSupported(session, accountId);
+      MailboxUtils.isDeletedMessageVaultSupported(session, mailboxAccountId);
 
     final isSubAddressingSupported =
-      session?.isSubAddressingSupported(accountId) ?? false;
+      session?.isSubAddressingSupported(mailboxAccountId) ?? false;
 
     final popupMenuActions = getListPopupMenuItemAction(
       AppLocalizations.of(context),

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -14,6 +14,7 @@ import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/namespace.dart';
 import 'package:model/model.dart';
 import 'package:rxdart/transformers.dart';
 import 'package:tmail_ui_user/features/base/base_mailbox_controller.dart';
@@ -122,6 +123,11 @@ class MailboxController extends BaseMailboxController
   final SubaddressingInteractor _subaddressingInteractor;
   final CreateDefaultMailboxInteractor _createDefaultMailboxInteractor;
   final MoveFolderContentInteractor _moveFolderContentInteractor;
+  final GetAllMailboxInteractor _sharedMailboxGetAllMailboxInteractor;
+
+  final Map<AccountId, List<PresentationMailbox>> _sharedMailboxesByAccount = {};
+
+  bool _didLoadSharedMailboxes = false;
 
   IOSSharingManager? _iosSharingManager;
   late MailboxActionReactor mailboxActionReactor;
@@ -161,11 +167,11 @@ class MailboxController extends BaseMailboxController
     VerifyNameInteractor verifyNameInteractor,
     GetAllMailboxInteractor getAllMailboxInteractor,
     RefreshAllMailboxInteractor  refreshAllMailboxInteractor,
-  ) : super(
+  ) : _sharedMailboxGetAllMailboxInteractor = getAllMailboxInteractor, super(
     treeBuilder,
     verifyNameInteractor,
     getAllMailboxInteractor: getAllMailboxInteractor,
-    refreshAllMailboxInteractor: refreshAllMailboxInteractor
+    refreshAllMailboxInteractor: refreshAllMailboxInteractor,
   );
 
   @override
@@ -173,7 +179,7 @@ class MailboxController extends BaseMailboxController
     _registerObxStreamListener();
     _initWebSocketQueueHandler();
     mailboxActionReactor = MailboxActionReactor(
-      _moveFolderContentInteractor,
+      _moveFolderContentInteractor
     );
     super.onInit();
   }
@@ -188,7 +194,7 @@ class MailboxController extends BaseMailboxController
         _handleOpenMailbox(event.buildContext, event.presentationMailbox);
       });
     _initCollapseMailboxCategories();
-    mailboxListScrollController.addListener(_mailboxListScrollControllerListener);
+    mailboxListScrollController.addListener(_mailboxListScrollControllerListener,);
     super.onReady();
   }
 
@@ -211,9 +217,9 @@ class MailboxController extends BaseMailboxController
     } else if (success is CreateNewMailboxSuccess) {
       _createNewMailboxSuccess(success);
     } else if (success is DeleteMultipleMailboxAllSuccess) {
-      _deleteMultipleMailboxSuccess(success.listMailboxIdDeleted, success.currentMailboxState);
+      _deleteMultipleMailboxSuccess(success.listMailboxIdDeleted, success.currentMailboxState,);
     } else if (success is DeleteMultipleMailboxHasSomeSuccess) {
-      _deleteMultipleMailboxSuccess(success.listMailboxIdDeleted, success.currentMailboxState);
+      _deleteMultipleMailboxSuccess(success.listMailboxIdDeleted, success.currentMailboxState,);
     } else if (success is RenameMailboxSuccess) {
       _renameMailboxSuccess(success);
     } else if (success is MoveMailboxSuccess) {
@@ -273,36 +279,119 @@ class MailboxController extends BaseMailboxController
       (failure) {
         if (failure is GetAllMailboxFailure) {
           updateMailboxTree(
-            mailboxCollection: updateMailboxCollection(currentMailboxCollection),
+            mailboxCollection: updateMailboxCollection(currentMailboxCollection,),
             isRefreshTrigger: false,
           );
-          mailboxDashBoardController.updateRefreshAllMailboxState(Left(RefreshAllMailboxFailure()));
+          mailboxDashBoardController.updateRefreshAllMailboxState(Left(RefreshAllMailboxFailure()),);
           showRetryToast(failure);
         }
       },
       (success) {
         if (success is GetAllMailboxSuccess) {
-          mailboxDashBoardController.updateRefreshAllMailboxState(Right(RefreshAllMailboxSuccess()));
-          _handleCreateDefaultFolderIfMissing(mailboxDashBoardController.mapDefaultMailboxIdByRole);
+          mailboxDashBoardController.updateRefreshAllMailboxState(Right(RefreshAllMailboxSuccess()),);
+          _handleCreateDefaultFolderIfMissing(mailboxDashBoardController.mapDefaultMailboxIdByRole,);
           _handleDataFromNavigationRouter();
           mailboxDashBoardController.refreshSpamReportBanner();
           if (PlatformInfo.isIOS) {
             _updateMailboxIdsBlockNotificationToKeychain(success.mailboxList);
           }
         }
-      });
+      },
+    );
+  }
+
+  Future<void> _loadSharedMailboxes(
+    Session currentSession,
+    AccountId primaryAccountId,
+  ) async {
+
+    for (final sharedAccountId in currentSession.accounts.keys) {
+      if (sharedAccountId.asString == primaryAccountId.asString) {
+        continue;
+      }
+
+
+      await for (final result in _sharedMailboxGetAllMailboxInteractor.execute(
+        currentSession,
+        sharedAccountId,
+      )) {
+        result.fold(
+          (failure) {
+            logWarning(
+              'MailboxController::_loadSharedMailboxes: failure '
+              'account=${sharedAccountId.asString} '
+              'failure=$failure',
+            );
+          },
+          (success) {
+            if (success is! GetAllMailboxSuccess) {
+              return;
+            }
+
+            final accountMailboxes = success.mailboxList
+                .map(
+                  (mailbox) => mailbox.copyWith(
+                    accountId: sharedAccountId,
+                    isSharedAccount: true,
+                    namespace: mailbox.namespace ??
+                        Namespace('Shared[${sharedAccountId.asString}]'),
+                  ),
+                )
+                .toList();
+
+            _sharedMailboxesByAccount[sharedAccountId] = accountMailboxes;
+
+
+          },
+        );
+      }
+    }
+
+    final personalMailboxesForUi = allMailboxes
+        .where(
+          (mailbox) => !mailbox.isSharedAccount && !mailbox.isVirtualFolder,
+        )
+        .toList();
+
+    final sharedMailboxesForUi = _sharedMailboxesByAccount.values
+        .expand((mailboxes) => mailboxes)
+        .toList();
+
+    await buildTree([
+      ...personalMailboxesForUi,
+      ...sharedMailboxesForUi,
+    ], onUpdateMailboxCollectionCallback: updateMailboxCollection);
+
+
   }
 
   void _registerObxStreamListener() {
     ever(mailboxDashBoardController.accountId, (accountId) {
-      if (accountId != null && session != null) {
-        getAllMailbox(session!, accountId);
+      final currentSession = session;
+      final currentAccountId =accountId;
+
+      if (currentAccountId != null && currentSession != null) {
+        getAllMailbox(currentSession, currentAccountId);
+
+        if (!_didLoadSharedMailboxes) {
+          _didLoadSharedMailboxes = true;
+
+          unawaited(
+            Future<void>.delayed(
+              const Duration(seconds: 2),
+              () => _loadSharedMailboxes(
+                currentSession,
+                currentAccountId,
+              ),
+            ),
+          );
+        }
       }
     });
 
     ever<Map<String, dynamic>?>(
       mailboxDashBoardController.routerParameters,
-      _handleNavigationRouteParameters
+      _handleNavigationRouteParameters,
     );
 
     ever(mailboxDashBoardController.mailboxUIAction, _handleMailboxUIAction);
@@ -345,7 +434,7 @@ class MailboxController extends BaseMailboxController
         }
       } else if (reactionState is MarkAsMailboxReadAllSuccess) {
         _handleMarkMailboxAsRead(
-          affectedMailboxId: reactionState.mailboxId,
+          affectedMailboxId: reactionState.mailboxId
         );
       } else if (reactionState is MarkAsMailboxReadHasSomeEmailFailure) {
         _handleMarkEmailsAsReadOrUnread(
@@ -488,7 +577,7 @@ class MailboxController extends BaseMailboxController
   }
 
   void _handleMarkMailboxAsRead({
-    required MailboxId? affectedMailboxId,
+    required MailboxId? affectedMailboxId
   }) {
     if (affectedMailboxId == null) return;
 
@@ -503,7 +592,7 @@ class MailboxController extends BaseMailboxController
 
     updateMailboxTotalEmailsCountById(
       affectedMailboxId,
-      totalEmailsChanged,
+      totalEmailsChanged
     );
   }
 
@@ -515,7 +604,7 @@ class MailboxController extends BaseMailboxController
 
     updateMailboxTotalEmailsCountById(
       affectedMailboxId,
-      totalEmailsChanged,
+      totalEmailsChanged
     );
   }
 
@@ -533,7 +622,7 @@ class MailboxController extends BaseMailboxController
           .length;
       updateMailboxTotalEmailsCountById(
         originalMailboxId,
-        -emailsMovedCount,
+        -emailsMovedCount
       );
       updateUnreadCountOfMailboxById(
         originalMailboxId,
@@ -555,7 +644,7 @@ class MailboxController extends BaseMailboxController
         .values
         .fold(
           0,
-          (sum, emails) => sum + emails.where((emailId) => emailIdsWithReadStatus[emailId] == false).length
+          (sum, emails) => sum + emails.where((emailId) => emailIdsWithReadStatus[emailId] == false).length,
         ),
     );
   }
@@ -573,7 +662,7 @@ class MailboxController extends BaseMailboxController
       mailboxCategoriesExpandMode.value = MailboxCategoriesExpandMode(
           defaultMailbox: ExpandMode.COLLAPSE,
           personalFolders: ExpandMode.COLLAPSE,
-          teamMailboxes: ExpandMode.COLLAPSE);
+          teamMailboxes: ExpandMode.COLLAPSE,);
     } else {
       mailboxCategoriesExpandMode.value = MailboxCategoriesExpandMode.initial();
     }
@@ -583,7 +672,7 @@ class MailboxController extends BaseMailboxController
     if (session != null && accountId != null) {
       consumeState(getAllMailboxInteractor!.execute(session!, accountId!));
     } else {
-      consumeState(Stream.value(Left(GetAllMailboxFailure(NotFoundSessionException()))));
+      consumeState(Stream.value(Left(GetAllMailboxFailure(NotFoundSessionException()))),);
     }
   }
 
@@ -621,17 +710,17 @@ class MailboxController extends BaseMailboxController
         }
       }
     } catch (e, stackTrace) {
-      logWarning('MailboxController::_processMailboxStateQueue:Error processing state: $e');
+      logWarning('MailboxController::_processMailboxStateQueue:Error processing state: $e',);
       onError(e, stackTrace);
     }
     if (currentMailboxState != null) {
-      _webSocketQueueHandler?.removeMessagesUpToCurrent(currentMailboxState!.value);
+      _webSocketQueueHandler?.removeMessagesUpToCurrent(currentMailboxState!.value,);
     }
   }
 
-  Future<void> _handleRefreshChangeMailboxSuccess(RefreshChangesAllMailboxSuccess success) async {
+  Future<void> _handleRefreshChangeMailboxSuccess(RefreshChangesAllMailboxSuccess success,) async {
     currentMailboxState = success.currentMailboxState;
-    log('MailboxController::_handleRefreshChangeMailboxSuccess:currentMailboxState: $currentMailboxState');
+    log('MailboxController::_handleRefreshChangeMailboxSuccess:currentMailboxState: $currentMailboxState',);
     final listMailboxDisplayed = success
         .mailboxList
         .listSubscribedMailboxesAndDefaultMailboxes;
@@ -661,15 +750,15 @@ class MailboxController extends BaseMailboxController
   void _setMapMailbox() {
     final mapDefaultMailboxIdByRole = {
       for (var mailboxNode in defaultMailboxTree.value.root.childrenItems ?? List<MailboxNode>.empty())
-        mailboxNode.item.role!: mailboxNode.item.id
+        mailboxNode.item.role!: mailboxNode.item.id,
     };
 
     final mapMailboxById = {
       for (var presentationMailbox in allMailboxes)
-        presentationMailbox.id: presentationMailbox
+        presentationMailbox.id: presentationMailbox,
     };
 
-    mailboxDashBoardController.setMapDefaultMailboxIdByRole(mapDefaultMailboxIdByRole);
+    mailboxDashBoardController.setMapDefaultMailboxIdByRole(mapDefaultMailboxIdByRole,);
     mailboxDashBoardController.setMapMailboxById(mapMailboxById);
   }
 
@@ -677,13 +766,13 @@ class MailboxController extends BaseMailboxController
     try {
       final outboxMailboxIdByRole = mailboxDashBoardController.mapDefaultMailboxIdByRole[PresentationMailbox.roleOutbox];
       if (outboxMailboxIdByRole == null) {
-        final outboxMailboxByName = findNodeByNameOnFirstLevel(PresentationMailbox.outboxRole)?.item;
+        final outboxMailboxByName = findNodeByNameOnFirstLevel(PresentationMailbox.outboxRole,)?.item;
         mailboxDashBoardController.setOutboxMailbox(outboxMailboxByName);
       } else {
-        mailboxDashBoardController.setOutboxMailbox(mailboxDashBoardController.mapMailboxById[outboxMailboxIdByRole]!);
+        mailboxDashBoardController.setOutboxMailbox(mailboxDashBoardController.mapMailboxById[outboxMailboxIdByRole]!,);
       }
     } catch (e) {
-      logWarning('MailboxController::_setOutboxMailbox: Not found outbox mailbox');
+      logWarning('MailboxController::_setOutboxMailbox: Not found outbox mailbox',);
       mailboxDashBoardController.setOutboxMailbox(null);
     }
   }
@@ -692,7 +781,7 @@ class MailboxController extends BaseMailboxController
     final isSearchEmailRunning = mailboxDashBoardController.searchController.isSearchEmailRunning;
     final dashboardRoute = mailboxDashBoardController.dashboardRoute.value;
     if (isSearchEmailRunning || dashboardRoute == DashboardRoutes.sendingQueue) {
-      log('MailboxController::_selectMailboxDefault(): isSearchEmailRunning is $isSearchEmailRunning');
+      log('MailboxController::_selectMailboxDefault(): isSearchEmailRunning is $isSearchEmailRunning',);
       return;
     }
     final mailboxSelected = _getCurrentSelectedMailbox();
@@ -707,7 +796,7 @@ class MailboxController extends BaseMailboxController
 
     if (mailboxCurrent != null) {
       if (mailboxCurrent.hasRole()) {
-        return mapDefaultPresentationMailboxByRole.containsKey(mailboxCurrent.role)
+        return mapDefaultPresentationMailboxByRole.containsKey(mailboxCurrent.role,)
           ? mapDefaultPresentationMailboxByRole[mailboxCurrent.role]
           : mailboxCurrent;
       } else {
@@ -716,7 +805,7 @@ class MailboxController extends BaseMailboxController
           : mailboxCurrent;
       }
     } else if (!isSearchEmailRunning) {
-      if (mapDefaultPresentationMailboxByRole.containsKey(PresentationMailbox.roleInbox)) {
+      if (mapDefaultPresentationMailboxByRole.containsKey(PresentationMailbox.roleInbox,)) {
         return mapDefaultPresentationMailboxByRole[PresentationMailbox.roleInbox];
       } else if (allMailboxes.isNotEmpty) {
         return allMailboxes.first;
@@ -726,9 +815,9 @@ class MailboxController extends BaseMailboxController
     return null;
   }
 
-  void _handleCreateDefaultFolderIfMissing(Map<Role, MailboxId> mapDefaultMailboxRole) {
+  void _handleCreateDefaultFolderIfMissing(Map<Role, MailboxId> mapDefaultMailboxRole,) {
     final listRoleMissing = MailboxConstants.defaultMailboxRoles
-      .whereNot((role) => mapDefaultMailboxRole.containsKey(role) || findNodeByNameOnFirstLevel(role.value) != null)
+      .whereNot((role) => mapDefaultMailboxRole.containsKey(role) || findNodeByNameOnFirstLevel(role.value) != null,)
       .toList();
 
     if (listRoleMissing.isEmpty || accountId == null || session == null) {
@@ -743,15 +832,14 @@ class MailboxController extends BaseMailboxController
       for (var role in listRoleMissing)
         Id(uuid.v1()) : role
     };
-    log('MailboxController::_handleCreateDefaultFolderIfMissing():mapRoles: $mapRoles');
+    log('MailboxController::_handleCreateDefaultFolderIfMissing():mapRoles: $mapRoles',);
     consumeState(_createDefaultMailboxInteractor.execute(
       session!,
       accountId!,
-      mapRoles,
-    ));
+      mapRoles),);
   }
 
-  Future<void> _handleCreateDefaultFolderIfMissingSuccess(CreateDefaultMailboxAllSuccess success) async {
+  Future<void> _handleCreateDefaultFolderIfMissingSuccess(CreateDefaultMailboxAllSuccess success,) async {
     if (success.listMailbox.isEmpty) {
       updateMailboxTree(
         mailboxCollection: updateMailboxCollection(currentMailboxCollection),
@@ -780,10 +868,23 @@ class MailboxController extends BaseMailboxController
     }
     _setMapMailbox();
     _setOutboxMailbox();
+
+    final currentSession = session;
+    final primaryAccountId = accountId;
+
+    if (!_didLoadSharedMailboxes &&
+        currentSession != null &&
+        primaryAccountId != null) {
+      _didLoadSharedMailboxes = true;
+
+      unawaited(
+        _loadSharedMailboxes(currentSession, primaryAccountId),
+      );
+    }
   }
 
   void _handleDataFromNavigationRouter() {
-    log('MailboxController::_handleDataFromNavigationRouter():navigationRouter: $_navigationRouter');
+    log('MailboxController::_handleDataFromNavigationRouter():navigationRouter: $_navigationRouter',);
     if (!PlatformInfo.isWeb || _navigationRouter == null) {
       _selectSelectedMailboxDefault();
       _replaceBrowserHistory();
@@ -797,8 +898,8 @@ class MailboxController extends BaseMailboxController
           cc: _navigationRouter?.cc,
           bcc: _navigationRouter?.bcc,
           subject: _navigationRouter?.subject,
-          body: _navigationRouter?.body
-        )
+          body: _navigationRouter?.body,
+        ),
       );
     }
 
@@ -819,14 +920,14 @@ class MailboxController extends BaseMailboxController
         break;
       case DashboardType.normal:
         if (_navigationRouter!.labelId != null) {
-          handleLabelNavigation(_navigationRouter!, _navigationRouter!.labelId!);
+          handleLabelNavigation(_navigationRouter!, _navigationRouter!.labelId!,);
         } else if (_navigationRouter!.mailboxId != null) {
-          final matchedMailboxNode = findMailboxNodeById(_navigationRouter!.mailboxId!);
+          final matchedMailboxNode = findMailboxNodeById(_navigationRouter!.mailboxId!,);
           if (matchedMailboxNode != null) {
             if (_navigationRouter!.emailId != null) {
               _openEmailInsideMailboxFromLocationBar(
                 matchedMailboxNode.item,
-                _navigationRouter!.emailId!
+                _navigationRouter!.emailId!,
               );
             } else {
               _openMailboxFromLocationBar(matchedMailboxNode.item);
@@ -848,15 +949,15 @@ class MailboxController extends BaseMailboxController
 
   void openEmailInsideMailboxFromLocationBar(
     PresentationMailbox presentationMailbox,
-    EmailId emailId
+    EmailId emailId,
   ) => _openEmailInsideMailboxFromLocationBar(presentationMailbox, emailId);
 
   void _openEmailInsideMailboxFromLocationBar(
     PresentationMailbox presentationMailbox,
-    EmailId emailId
+    EmailId emailId,
   ) {
     mailboxDashBoardController.setSelectedMailbox(presentationMailbox);
-    mailboxDashBoardController.dispatchAction(OpenEmailInsideMailboxFromLocationBar(emailId, presentationMailbox));
+    mailboxDashBoardController.dispatchAction(OpenEmailInsideMailboxFromLocationBar(emailId, presentationMailbox),);
     _clearNavigationRouter();
   }
 
@@ -873,9 +974,9 @@ class MailboxController extends BaseMailboxController
           router: NavigationRouter(
             mailboxId: presentationMailbox.browserRouteMailboxId,
             labelId: presentationMailbox.labelId,
-            dashboardType: DashboardType.normal
-          )
-        )
+            dashboardType: DashboardType.normal,
+          ),
+        ),
       );
     }
     _clearNavigationRouter();
@@ -883,7 +984,7 @@ class MailboxController extends BaseMailboxController
 
   void _openEmailWithoutMailboxFromLocationBar(EmailId emailId) {
     mailboxDashBoardController.dispatchAction(
-      OpenEmailWithoutMailboxFromLocationBar(emailId)
+      OpenEmailWithoutMailboxFromLocationBar(emailId),
     );
     _clearNavigationRouter();
   }
@@ -897,15 +998,14 @@ class MailboxController extends BaseMailboxController
     mailboxDashBoardController.dispatchAction(
       OpenEmailSearchedFromLocationBar(
         emailId,
-        searchQuery: searchQuery,
-      )
+        searchQuery: searchQuery),
     );
     _clearNavigationRouter();
   }
 
   void _searchEmailFromLocationBar(SearchQuery searchQuery) {
     mailboxDashBoardController.dispatchAction(
-      SearchEmailFromLocationBar(searchQuery)
+      SearchEmailFromLocationBar(searchQuery),
     );
     _clearNavigationRouter();
   }
@@ -918,9 +1018,19 @@ class MailboxController extends BaseMailboxController
 
   void _handleOpenMailbox(
     BuildContext context,
-    PresentationMailbox presentationMailboxSelected
+    PresentationMailbox presentationMailboxSelected,
   ) {
-    log('MailboxController::_handleOpenMailbox():MAILBOX_ID = ${presentationMailboxSelected.id.asString} | MAILBOX_NAME: ${presentationMailboxSelected.name?.name}');
+    if (presentationMailboxSelected.isSharedAccountRoot
+  ) {
+    log(
+        'MailboxController::_handleOpenMailbox: '
+        'ignored synthetic shared account root '
+        '${presentationMailboxSelected.accountId?.asString}',
+      );
+      return;
+    }
+
+    log('MailboxController::_handleOpenMailbox():MAILBOX_ID = ${presentationMailboxSelected.id.asString} | MAILBOX_NAME: ${presentationMailboxSelected.name?.name}',);
     KeyboardUtils.hideKeyboard(context);
     mailboxDashBoardController.clearSelectedEmail();
     if (presentationMailboxSelected.id != mailboxDashBoardController.selectedMailbox.value?.id) {
@@ -934,18 +1044,18 @@ class MailboxController extends BaseMailboxController
   }
 
   void _disableAllSearchEmail() {
-    mailboxDashBoardController.dispatchAction(ClearAllFieldOfAdvancedSearchAction());
+    mailboxDashBoardController.dispatchAction(ClearAllFieldOfAdvancedSearchAction(),);
     mailboxDashBoardController.searchController.disableAllSearchEmail();
   }
 
   void openMailbox(
       BuildContext context,
-      PresentationMailbox presentationMailboxSelected
+      PresentationMailbox presentationMailboxSelected,
   ) {
-    _openMailboxEventController.add(OpenMailboxViewEvent(context, presentationMailboxSelected));
+    _openMailboxEventController.add(OpenMailboxViewEvent(context, presentationMailboxSelected),);
   }
 
-  void goToCreateNewMailboxView(BuildContext context, {PresentationMailbox? parentMailbox}) async {
+  void goToCreateNewMailboxView(BuildContext context, {PresentationMailbox? parentMailbox,}) async {
     if (session != null && accountId != null) {
       final arguments = MailboxCreatorArguments(
         allMailboxes.withoutVirtualMailbox,
@@ -953,7 +1063,7 @@ class MailboxController extends BaseMailboxController
       );
 
       final result = PlatformInfo.isWeb
-        ? await DialogRouter().pushGeneralDialog(routeName: AppRoutes.mailboxCreator, arguments: arguments)
+        ? await DialogRouter().pushGeneralDialog(routeName: AppRoutes.mailboxCreator, arguments: arguments,)
         : await push(AppRoutes.mailboxCreator, arguments: arguments);
 
       if (result != null && result is NewMailboxArguments) {
@@ -969,17 +1079,17 @@ class MailboxController extends BaseMailboxController
     }
   }
 
-  void _createNewMailboxAction(Session session, AccountId accountId, CreateNewMailboxRequest request) async {
-    consumeState(_createNewMailboxInteractor.execute(session, accountId, request));
+  void _createNewMailboxAction(Session session, AccountId accountId, CreateNewMailboxRequest request,) async {
+    consumeState(_createNewMailboxInteractor.execute(session, accountId, request),);
   }
 
   void _createNewMailboxSuccess(CreateNewMailboxSuccess success) {
     if (currentOverlayContext != null && currentContext != null) {
       appToast.showToastSuccessMessage(
         currentOverlayContext!,
-        AppLocalizations.of(currentContext!).createFolderSuccessfullyMessage(success.newMailbox.name?.name ?? ''),
+        AppLocalizations.of(currentContext!,).createFolderSuccessfullyMessage(success.newMailbox.name?.name ?? ''),
         leadingSVGIconColor: Colors.white,
-        leadingSVGIcon: imagePaths.icFolderMailbox);
+        leadingSVGIcon: imagePaths.icFolderMailbox,);
 
       _newFolderId = success.newMailbox.id;
     }
@@ -988,7 +1098,7 @@ class MailboxController extends BaseMailboxController
   void _createNewMailboxFailure(CreateNewMailboxFailure failure) {
     if (currentOverlayContext != null && currentContext != null) {
       final exception = failure.exception;
-      var messageError = AppLocalizations.of(currentContext!).createNewFolderFailure;
+      var messageError = AppLocalizations.of(currentContext!,).createNewFolderFailure;
       if (exception is ErrorMethodResponse) {
         messageError = exception.description ?? AppLocalizations.of(currentContext!).createNewFolderFailure;
       }
@@ -1003,11 +1113,11 @@ class MailboxController extends BaseMailboxController
   void _renameMailboxFailure(RenameMailboxFailure failure) {
     if (currentOverlayContext != null && currentContext != null) {
       final exception = failure.exception;
-      var messageError = AppLocalizations.of(currentContext!).renameFolderFailure;
+      var messageError = AppLocalizations.of(currentContext!,).renameFolderFailure;
       if (exception is EmptyMailboxNameException) {
-        messageError = AppLocalizations.of(currentContext!).nameOfFolderIsRequired;
+        messageError = AppLocalizations.of(currentContext!,).nameOfFolderIsRequired;
       } else if (exception is ContainsInvalidCharactersMailboxNameException) {
-        messageError = AppLocalizations.of(currentContext!).folderNameCannotContainSpecialCharacters;
+        messageError = AppLocalizations.of(currentContext!,).folderNameCannotContainSpecialCharacters;
       }
       appToast.showToastErrorMessage(currentOverlayContext!, messageError);
     }
@@ -1035,7 +1145,7 @@ class MailboxController extends BaseMailboxController
           MailboxActions.rename,
           if (currentMailboxesSelected.isAllUnreadMailboxes)
             MailboxActions.markAsRead,
-          MailboxActions.delete
+          MailboxActions.delete,
         ];
       } else {
         return [];
@@ -1050,15 +1160,15 @@ class MailboxController extends BaseMailboxController
 
   List<PresentationMailbox> get listMailboxSelected {
     final defaultMailboxSelected = defaultMailboxTree.value
-      .findNodes((node) => node.selectMode == SelectMode.ACTIVE);
+      .findNodes((node) => node.selectMode == SelectMode.ACTIVE,);
 
     final folderMailboxSelected = personalMailboxTree.value
-      .findNodes((node) => node.selectMode == SelectMode.ACTIVE);
+      .findNodes((node) => node.selectMode == SelectMode.ACTIVE,);
 
     final teamMailboxesSelected = teamMailboxesTree.value
-      .findNodes((node) => node.selectMode == SelectMode.ACTIVE);
+      .findNodes((node) => node.selectMode == SelectMode.ACTIVE,);
 
-    return [defaultMailboxSelected, folderMailboxSelected, teamMailboxesSelected]
+    return [defaultMailboxSelected, folderMailboxSelected, teamMailboxesSelected,]
       .expand((node) => node)
       .map((node) => node.item)
       .toList();
@@ -1069,8 +1179,7 @@ class MailboxController extends BaseMailboxController
       consumeState(_deleteMultipleMailboxInteractor.execute(
         session!,
         accountId!,
-        [presentationMailbox.id],
-      ));
+        [presentationMailbox.id,]),);
     } else {
       _deleteMailboxFailure(DeleteMultipleMailboxFailure(null));
     }
@@ -1080,12 +1189,12 @@ class MailboxController extends BaseMailboxController
 
   void _deleteMultipleMailboxSuccess(
       List<MailboxId> listMailboxIdDeleted,
-      jmap.State? currentMailboxState
+      jmap.State? currentMailboxState,
   ) {
     if (currentOverlayContext != null && currentContext != null) {
       appToast.showToastSuccessMessage(
         currentOverlayContext!,
-        AppLocalizations.of(currentContext!).deleteFoldersSuccessfully);
+        AppLocalizations.of(currentContext!).deleteFoldersSuccessfully,);
     }
 
     if (listMailboxIdDeleted.contains(selectedMailbox?.id)) {
@@ -1106,17 +1215,18 @@ class MailboxController extends BaseMailboxController
       appToast.showToastErrorMessage(
         currentOverlayContext!,
         AppLocalizations.of(currentContext!).deleteFoldersFailure,
-        leadingSVGIcon: imagePaths.icDeleteToast
+        leadingSVGIcon: imagePaths.icDeleteToast,
       );
     }
   }
 
-  void _renameMailboxAction(PresentationMailbox presentationMailbox, MailboxName newMailboxName) {
+  void _renameMailboxAction(PresentationMailbox presentationMailbox, MailboxName newMailboxName,) {
     if (session != null && accountId != null) {
       consumeState(_renameMailboxInteractor.execute(
         session!,
         accountId!,
-        RenameMailboxRequest(presentationMailbox.id, newMailboxName))
+        RenameMailboxRequest(presentationMailbox.id, newMailboxName),
+        ),
       );
     }
   }
@@ -1127,7 +1237,7 @@ class MailboxController extends BaseMailboxController
     AccountId accountId,
     MoveAction moveAction,
     PresentationMailbox mailboxSelected,
-    {PresentationMailbox? destinationMailbox}
+    {PresentationMailbox? destinationMailbox,}
   ) {
     consumeState(_moveMailboxInteractor.execute(
       session,
@@ -1136,8 +1246,10 @@ class MailboxController extends BaseMailboxController
         mailboxSelected.id,
         moveAction,
         destinationMailboxId: destinationMailbox?.id,
-        destinationMailboxDisplayName: destinationMailbox?.getDisplayName(context),
-        parentId: mailboxSelected.parentId)));
+        destinationMailboxDisplayName: destinationMailbox?.getDisplayName(context,),
+        parentId: mailboxSelected.parentId,
+        ),
+      ),);
   }
 
   void _moveMailboxSuccess(MoveMailboxSuccess success) {
@@ -1147,20 +1259,21 @@ class MailboxController extends BaseMailboxController
       appToast.showToastMessage(
           currentOverlayContext!,
           AppLocalizations.of(currentContext!).movedToFolder(
-              success.destinationMailboxDisplayName ?? AppLocalizations.of(currentContext!).allFolders),
+              success.destinationMailboxDisplayName ?? AppLocalizations.of(currentContext!).allFolders,),
           actionName: AppLocalizations.of(currentContext!).undo,
           onActionClick: () {
             _undoMovingMailbox(MoveMailboxRequest(
                 success.mailboxIdSelected,
                 MoveAction.undo,
                 destinationMailboxId: success.parentId,
-                parentId: success.destinationMailboxId));
+                parentId: success.destinationMailboxId,
+            ),);
           },
           leadingSVGIcon: imagePaths.icFolderMailbox,
           leadingSVGIconColor: Colors.white,
           backgroundColor: AppColor.toastSuccessBackgroundColor,
           textColor: Colors.white,
-          actionIcon: SvgPicture.asset(imagePaths.icUndo));
+          actionIcon: SvgPicture.asset(imagePaths.icUndo),);
     }
   }
 
@@ -1169,16 +1282,15 @@ class MailboxController extends BaseMailboxController
       consumeState(_moveMailboxInteractor.execute(
         session!,
         accountId!,
-        newMoveRequest,
-      ));
+        newMoveRequest),);
     }
   }
 
   void _handleNavigationRouteParameters(Map<String, dynamic>? parameters) {
-    log('MailboxController::_handleNavigationRouteParameters(): parameters: $parameters');
+    log('MailboxController::_handleNavigationRouteParameters(): parameters: $parameters',);
     if (parameters != null) {
       final navigationRouter = RouteUtils.parsingRouteParametersToNavigationRouter(parameters);
-      log('MailboxController::_handleNavigationRouteParameters():navigationRouter: $navigationRouter');
+      log('MailboxController::_handleNavigationRouteParameters():navigationRouter: $navigationRouter',);
       _navigationRouter = navigationRouter;
     }
   }
@@ -1186,7 +1298,7 @@ class MailboxController extends BaseMailboxController
   void handleMailboxAction(
       BuildContext context,
       MailboxActions actions,
-      PresentationMailbox mailbox
+      PresentationMailbox mailbox,
   ) {
     switch(actions) {
       case MailboxActions.delete:
@@ -1195,7 +1307,7 @@ class MailboxController extends BaseMailboxController
           responsiveUtils,
           imagePaths,
           mailbox,
-          onDeleteMailboxAction: _deleteMailboxAction
+          onDeleteMailboxAction: _deleteMailboxAction,
         );
         break;
       case MailboxActions.rename:
@@ -1203,7 +1315,7 @@ class MailboxController extends BaseMailboxController
           context,
           mailbox,
           responsiveUtils,
-          onRenameMailboxAction: _renameMailboxAction
+          onRenameMailboxAction: _renameMailboxAction,
         );
         break;
       case MailboxActions.move:
@@ -1211,7 +1323,8 @@ class MailboxController extends BaseMailboxController
           context,
           mailbox,
           mailboxDashBoardController,
-          onMovingMailboxAction: (mailboxSelected, destinationMailbox) => _invokeMovingMailboxAction(context, mailboxSelected, destinationMailbox)
+          onMovingMailboxAction: (mailboxSelected, destinationMailbox) => _invokeMovingMailboxAction(context, mailboxSelected, destinationMailbox,
+          ),
         );
         break;
       case MailboxActions.markAsRead:
@@ -1220,7 +1333,7 @@ class MailboxController extends BaseMailboxController
           context,
           mailbox,
           mailboxDashBoardController,
-          onCallbackAction: closeMailboxScreen
+          onCallbackAction: closeMailboxScreen,
         );
         break;
       case MailboxActions.openInNewTab:
@@ -1234,7 +1347,7 @@ class MailboxController extends BaseMailboxController
           );
           copySubAddressAction(context, subaddress);
         } catch (error) {
-          appToast.showToastErrorMessage(context, AppLocalizations.of(context).errorWhileFetchingSubaddress);
+          appToast.showToastErrorMessage(context, AppLocalizations.of(context).errorWhileFetchingSubaddress,);
         }
         break;
       case MailboxActions.disableSpamReport:
@@ -1259,7 +1372,7 @@ class MailboxController extends BaseMailboxController
               onAllowSubAddressingAction: _handleSubaddressingAction,
           );
         } catch (error) {
-          appToast.showToastErrorMessage(context, AppLocalizations.of(context).errorWhileFetchingSubaddress);
+          appToast.showToastErrorMessage(context, AppLocalizations.of(context).errorWhileFetchingSubaddress,);
         }
         break;
       case MailboxActions.disallowSubaddressing:
@@ -1300,7 +1413,7 @@ class MailboxController extends BaseMailboxController
   void _invokeMovingMailboxAction(
     BuildContext context,
     PresentationMailbox mailboxSelected,
-    PresentationMailbox? destinationMailbox
+    PresentationMailbox? destinationMailbox,
   ) {
     if (session != null && accountId != null) {
       _handleMovingMailbox(
@@ -1309,14 +1422,14 @@ class MailboxController extends BaseMailboxController
         accountId!,
         MoveAction.moving,
         mailboxSelected,
-        destinationMailbox: destinationMailbox
+        destinationMailbox: destinationMailbox,
       );
     }
   }
 
   void _replaceBrowserHistory() {
     final currentMailbox = selectedMailbox;
-    log('MailboxController::_replaceBrowserHistory:selectedMailbox: ${currentMailbox?.id.asString}');
+    log('MailboxController::_replaceBrowserHistory:selectedMailbox: ${currentMailbox?.id.asString}',);
     if (PlatformInfo.isWeb && Get.currentRoute.startsWith(AppRoutes.dashboard)) {
       final route = RouteUtils.createUrlWebLocationBar(
         AppRoutes.dashboard,
@@ -1328,12 +1441,12 @@ class MailboxController extends BaseMailboxController
             : null,
           dashboardType: mailboxDashBoardController.searchController.isSearchEmailRunning
             ? DashboardType.search
-            : DashboardType.normal
-        )
+            : DashboardType.normal,
+        ),
       );
       RouteUtils.replaceBrowserHistory(
         title: currentMailbox?.browserRouteTitle ?? '',
-        url: route
+        url: route,
       );
     }
   }
@@ -1346,26 +1459,26 @@ class MailboxController extends BaseMailboxController
     mailboxListScrollController.animateTo(
       mailboxListScrollController.position.minScrollExtent,
       duration: const Duration(seconds: 1),
-      curve: Curves.easeInToLinear);
+      curve: Curves.easeInToLinear,);
   }
 
   void autoScrollBottom() {
     mailboxListScrollController.animateTo(
       mailboxListScrollController.position.maxScrollExtent,
       duration: const Duration(seconds: 1),
-      curve: Curves.easeInToLinear);
+      curve: Curves.easeInToLinear,);
   }
 
   void stopAutoScroll() {
     mailboxListScrollController.animateTo(
       mailboxListScrollController.offset,
       duration: const Duration(milliseconds: 300),
-      curve: Curves.fastOutSlowIn);
+      curve: Curves.fastOutSlowIn,);
   }
 
   Future<void> _handleGetAllMailboxSuccess(GetAllMailboxSuccess success) async {
     currentMailboxState = success.currentMailboxState;
-    log('MailboxController::_handleGetAllMailboxSuccess:currentMailboxState: $currentMailboxState');
+    log('MailboxController::_handleGetAllMailboxSuccess:currentMailboxState: $currentMailboxState',);
     final listMailboxDisplayed = success.mailboxList.listSubscribedMailboxesAndDefaultMailboxes;
     await buildTree(
       listMailboxDisplayed.withoutVirtualMailbox,
@@ -1378,25 +1491,25 @@ class MailboxController extends BaseMailboxController
     _setOutboxMailbox();
   }
 
-  Future<void> _updateMailboxIdsBlockNotificationToKeychain(List<PresentationMailbox> mailboxes) async {
+  Future<void> _updateMailboxIdsBlockNotificationToKeychain(List<PresentationMailbox> mailboxes,) async {
     _iosSharingManager = getBinding<IOSSharingManager>();
     if (accountId == null || _iosSharingManager == null || mailboxes.isEmpty) {
-      logWarning('MailboxController::_updateMailboxIdsBlockNotificationToKeychain: AccountId = $accountId | IosSharingManager = $_iosSharingManager | Mailboxes = ${mailboxes.length}');
+      logWarning('MailboxController::_updateMailboxIdsBlockNotificationToKeychain: AccountId = $accountId | IosSharingManager = $_iosSharingManager | Mailboxes = ${mailboxes.length}',);
       return;
     }
 
-    if (await _iosSharingManager!.isExistMailboxIdsBlockNotificationInKeyChain(accountId!)) {
+    if (await _iosSharingManager!.isExistMailboxIdsBlockNotificationInKeyChain(accountId!,)) {
       return;
     }
 
     final mailboxIdsBlockNotification = mailboxes
-      .where((presentationMailbox) => presentationMailbox.pushNotificationDeactivated && presentationMailbox.mailboxId != null)
+      .where((presentationMailbox) => presentationMailbox.pushNotificationDeactivated && presentationMailbox.mailboxId != null,)
       .map((presentationMailbox) => presentationMailbox.mailboxId!)
       .toList();
-    log('MailboxController::_updateMailboxIdsBlockNotificationToKeychain:MailboxIdsBlockNotification = $mailboxIdsBlockNotification');
+    log('MailboxController::_updateMailboxIdsBlockNotificationToKeychain:MailboxIdsBlockNotification = $mailboxIdsBlockNotification',);
     _iosSharingManager!.updateMailboxIdsBlockNotificationInKeyChain(
       accountId: accountId!,
-      mailboxIds: mailboxIdsBlockNotification);
+      mailboxIds: mailboxIdsBlockNotification,);
   }
 
   void _unsubscribeMailboxAction(MailboxId mailboxId) {
@@ -1404,7 +1517,7 @@ class MailboxController extends BaseMailboxController
       final subscribeRequest = generateSubscribeRequest(
         mailboxId,
         MailboxSubscribeState.disabled,
-        MailboxSubscribeAction.unSubscribe
+        MailboxSubscribeAction.unSubscribe,
       );
 
       if (subscribeRequest is SubscribeMultipleMailboxRequest) {
@@ -1412,13 +1525,13 @@ class MailboxController extends BaseMailboxController
           session!,
           accountId!,
           subscribeRequest,
-        ));
+        ),);
       } else if (subscribeRequest is SubscribeMailboxRequest) {
         consumeState(_subscribeMailboxInteractor.execute(
           session!,
           accountId!,
           subscribeRequest,
-        ));
+        ),);
       }
     }
   }
@@ -1434,11 +1547,11 @@ class MailboxController extends BaseMailboxController
     }
   }
 
-  void _handleUnsubscribeMultipleMailboxAllSuccess(SubscribeMultipleMailboxAllSuccess success) {
+  void _handleUnsubscribeMultipleMailboxAllSuccess(SubscribeMultipleMailboxAllSuccess success,) {
     if(success.subscribeAction == MailboxSubscribeAction.unSubscribe) {
       _showToastSubscribeMailboxSuccess(
         success.parentMailboxId,
-        listDescendantMailboxIds: success.mailboxIdsSubscribe
+        listDescendantMailboxIds: success.mailboxIdsSubscribe,
       );
 
       if (success.mailboxIdsSubscribe.contains(selectedMailbox?.id)) {
@@ -1448,11 +1561,11 @@ class MailboxController extends BaseMailboxController
     }
   }
 
-  void _handleUnsubscribeMultipleMailboxHasSomeSuccess(SubscribeMultipleMailboxHasSomeSuccess success) {
+  void _handleUnsubscribeMultipleMailboxHasSomeSuccess(SubscribeMultipleMailboxHasSomeSuccess success,) {
     if(success.subscribeAction == MailboxSubscribeAction.unSubscribe) {
       _showToastSubscribeMailboxSuccess(
         success.parentMailboxId,
-        listDescendantMailboxIds: success.mailboxIdsSubscribe
+        listDescendantMailboxIds: success.mailboxIdsSubscribe,
       );
 
       if (success.mailboxIdsSubscribe.contains(selectedMailbox?.id)) {
@@ -1462,12 +1575,12 @@ class MailboxController extends BaseMailboxController
     }
   }
 
-  void _closeEmailViewIfMailboxDisabledOrNotExist(List<MailboxId> mailboxIdsDisabled) {
+  void _closeEmailViewIfMailboxDisabledOrNotExist(List<MailboxId> mailboxIdsDisabled,) {
     if (selectedEmail == null) {
       return;
     }
 
-    final mailboxContain = selectedEmail!.findMailboxContain(mailboxDashBoardController.mapMailboxById);
+    final mailboxContain = selectedEmail!.findMailboxContain(mailboxDashBoardController.mapMailboxById,);
     if (mailboxContain != null && mailboxIdsDisabled.contains(mailboxContain.id)) {
       mailboxDashBoardController.clearSelectedEmail();
       mailboxDashBoardController.dispatchRoute(DashboardRoutes.thread);
@@ -1476,7 +1589,7 @@ class MailboxController extends BaseMailboxController
 
   void _showToastSubscribeMailboxSuccess(
       MailboxId mailboxIdSubscribed,
-      {List<MailboxId>? listDescendantMailboxIds}
+      {List<MailboxId>? listDescendantMailboxIds,}
   ) {
     if (currentOverlayContext != null && currentContext != null) {
       appToast.showToastMessage(
@@ -1485,19 +1598,19 @@ class MailboxController extends BaseMailboxController
         actionName: AppLocalizations.of(currentContext!).undo,
         onActionClick: () => _undoUnsubscribeMailboxAction(
           mailboxIdSubscribed,
-          listDescendantMailboxIds: listDescendantMailboxIds
+          listDescendantMailboxIds: listDescendantMailboxIds,
         ),
         leadingSVGIcon: imagePaths.icFolderMailbox,
         leadingSVGIconColor: Colors.white,
         backgroundColor: AppColor.toastSuccessBackgroundColor,
         textColor: Colors.white,
-        actionIcon: SvgPicture.asset(imagePaths.icUndo));
+        actionIcon: SvgPicture.asset(imagePaths.icUndo),);
     }
   }
 
   void _undoUnsubscribeMailboxAction(
     MailboxId mailboxIdSubscribed,
-    {List<MailboxId>? listDescendantMailboxIds}
+    {List<MailboxId>? listDescendantMailboxIds,}
   ) {
     if (session != null && accountId != null) {
       SubscribeRequest? subscribeRequest;
@@ -1507,13 +1620,13 @@ class MailboxController extends BaseMailboxController
           mailboxIdSubscribed,
           listDescendantMailboxIds,
           MailboxSubscribeState.enabled,
-          MailboxSubscribeAction.undo
+          MailboxSubscribeAction.undo,
         );
       } else {
         subscribeRequest = SubscribeMailboxRequest(
           mailboxIdSubscribed,
           MailboxSubscribeState.enabled,
-          MailboxSubscribeAction.undo
+          MailboxSubscribeAction.undo,
         );
       }
 
@@ -1522,18 +1635,18 @@ class MailboxController extends BaseMailboxController
           session!,
           accountId!,
           subscribeRequest,
-        ));
+        ),);
       } else if (subscribeRequest is SubscribeMailboxRequest) {
         consumeState(_subscribeMailboxInteractor.execute(
           session!,
           accountId!,
           subscribeRequest,
-        ));
+        ),);
       }
     }
   }
 
-  void _handleSubaddressingAction(MailboxId mailboxId, Map<String, List<String>?>? currentRights, MailboxActions subaddressingAction) {
+  void _handleSubaddressingAction(MailboxId mailboxId, Map<String, List<String>?>? currentRights, MailboxActions subaddressingAction,) {
     final accountId = mailboxDashBoardController.accountId.value;
     final session = mailboxDashBoardController.sessionCurrent;
 
@@ -1541,13 +1654,14 @@ class MailboxController extends BaseMailboxController
       final allowSubaddressingRequest = MailboxRightRequest(
           mailboxId,
           currentRights,
-          subaddressingAction == MailboxActions.allowSubaddressing ? MailboxSubaddressingAction.allow : MailboxSubaddressingAction.disallow
+          subaddressingAction == MailboxActions.allowSubaddressing ? MailboxSubaddressingAction.allow : MailboxSubaddressingAction.disallow,
       );
 
-      consumeState(_subaddressingInteractor.execute(session, accountId, allowSubaddressingRequest));
+      consumeState(_subaddressingInteractor.execute(session, accountId, allowSubaddressingRequest,
+        ),);
     } else {
       handleSubAddressingFailure(
-        SubaddressingFailure.withException(const NullSessionOrAccountIdException()),
+        SubaddressingFailure.withException(const NullSessionOrAccountIdException(),),
       );
     }
 
@@ -1599,7 +1713,7 @@ class MailboxController extends BaseMailboxController
 
   void _redirectToNewFolder() {
     final newMailboxNode = findMailboxNodeById(_newFolderId!);
-    log('MailboxController::_redirectToNewFolder:newMailboxNode: $newMailboxNode');
+    log('MailboxController::_redirectToNewFolder:newMailboxNode: $newMailboxNode',);
     if (newMailboxNode != null && currentContext != null) {
       _handleOpenMailbox(currentContext!, newMailboxNode.item);
     }
@@ -1612,14 +1726,14 @@ class MailboxController extends BaseMailboxController
         mailboxListScrollController.animateTo(
           0,
           duration: const Duration(milliseconds: 500),
-          curve: Curves.fastOutSlowIn
+          curve: Curves.fastOutSlowIn,
         );
       }
     });
   }
 
-  void emptyMailboxAction(BuildContext context, PresentationMailbox presentationMailbox) {
-    log('MailboxController::emptyMailboxAction:presentationMailbox: ${presentationMailbox.name}');
+  void emptyMailboxAction(BuildContext context, PresentationMailbox presentationMailbox,) {
+    log('MailboxController::emptyMailboxAction:presentationMailbox: ${presentationMailbox.name}',);
     if (presentationMailbox.isTrash) {
       mailboxDashBoardController.emptyTrashFolderAction(
         trashMailbox: presentationMailbox,
@@ -1627,7 +1741,7 @@ class MailboxController extends BaseMailboxController
     } else if (presentationMailbox.isSpam) {
       mailboxDashBoardController.emptySpamFolderAction(
         spamFolderId: presentationMailbox.id,
-        totalEmails: presentationMailbox.countTotalEmails
+        totalEmails: presentationMailbox.countTotalEmails,
       );
     }
   }

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -345,6 +345,10 @@ class MailboxController extends BaseMailboxController
         _otherUserAccounts.containsKey(accountId)) {
       return;
     }
+    // Capture the primary account this load belongs to. If the user switches
+    // primary account before the stream emits, the result is stale and must be
+    // dropped, otherwise the previous account's delegates reappear.
+    final loadingForPrimary = _lastPrimaryAccountId;
     _otherUserAccountsInFlight.add(accountId);
 
     try {
@@ -364,6 +368,10 @@ class MailboxController extends BaseMailboxController
           (success) => success is GetAllMailboxSuccess ? success : null,
         );
         if (success == null) continue;
+
+        // The primary account changed while this load was in flight: drop the
+        // result so a former account's delegates do not reappear.
+        if (_lastPrimaryAccountId != loadingForPrimary) return;
 
         // Ghost account: the JMAP session lists it but the user has no readable
         // mailbox in it. Skip it so it never appears in the sidebar.

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -14,7 +14,6 @@ import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
-import 'package:jmap_dart_client/jmap/mail/mailbox/namespace.dart';
 import 'package:model/model.dart';
 import 'package:rxdart/transformers.dart';
 import 'package:tmail_ui_user/features/base/base_mailbox_controller.dart';
@@ -77,6 +76,8 @@ import 'package:tmail_ui_user/features/mailbox/presentation/mixin/mailbox_widget
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_actions.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_categories_expand_mode.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_node.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/model/other_user_account_mailboxes.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/utils/mailbox_utils.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_tree_builder.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/open_mailbox_view_event.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/utils/mailbox_action_reactor.dart';
@@ -98,6 +99,7 @@ import 'package:tmail_ui_user/features/thread/domain/state/empty_spam_folder_sta
 import 'package:tmail_ui_user/features/thread/domain/state/empty_trash_folder_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/mark_as_multiple_email_read_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/move_multiple_email_to_mailbox_state.dart';
+import 'package:tmail_ui_user/features/base/mixin/mailbox_account_resolver_mixin.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/app_routes.dart';
 import 'package:tmail_ui_user/main/routes/dialog_router.dart';
@@ -110,9 +112,13 @@ class MailboxController extends BaseMailboxController
     with MailboxActionHandlerMixin,
         ContactSupportMixin,
         LauncherApplicationMixin,
+        MailboxAccountResolverMixin,
         MailboxWidgetMixin {
 
   final mailboxDashBoardController = Get.find<MailboxDashBoardController>();
+
+  @override
+  AccountId? get primaryAccountId => mailboxDashBoardController.accountId.value;
   final isMailboxListScrollable = false.obs;
   final CreateNewMailboxInteractor _createNewMailboxInteractor;
   final DeleteMultipleMailboxInteractor _deleteMultipleMailboxInteractor;
@@ -125,9 +131,23 @@ class MailboxController extends BaseMailboxController
   final MoveFolderContentInteractor _moveFolderContentInteractor;
   final GetAllMailboxInteractor _sharedMailboxGetAllMailboxInteractor;
 
-  final Map<AccountId, List<PresentationMailbox>> _sharedMailboxesByAccount = {};
+  /// Loaded mailboxes for each other user's (delegated) account.
+  final Map<AccountId, OtherUserAccountMailboxes> _otherUserAccounts = {};
 
-  bool _didLoadSharedMailboxes = false;
+  /// Accounts whose mailboxes are being fetched right now. Tracked separately
+  /// from [_otherUserAccounts] so a failed or in-progress load never marks an
+  /// account as loaded, leaving it free to retry.
+  final Set<AccountId> _otherUserAccountsInFlight = {};
+
+  /// The primary account the other-user caches were populated for, so they can
+  /// be cleared when the user switches accounts.
+  AccountId? _lastPrimaryAccountId;
+
+  /// Last known primary-account mailboxes, already filtered (subscribed and
+  /// default, virtual folders removed). The single source of truth for every
+  /// tree rebuild, so a primary refresh never drops the cached other-user
+  /// subtrees.
+  List<PresentationMailbox> _primaryMailboxes = const [];
 
   IOSSharingManager? _iosSharingManager;
   late MailboxActionReactor mailboxActionReactor;
@@ -151,6 +171,7 @@ class MailboxController extends BaseMailboxController
 
   AccountId? get accountId => mailboxDashBoardController.accountId.value;
 
+  @override
   Session? get session => mailboxDashBoardController.sessionCurrent;
 
   MailboxController(
@@ -207,6 +228,7 @@ class MailboxController extends BaseMailboxController
     _webSocketQueueHandler?.dispose();
     isLabelsLoadedWorker?.dispose();
     isLabelsLoadedWorker = null;
+    _resetOtherUserAccounts();
     super.onClose();
   }
 
@@ -263,10 +285,7 @@ class MailboxController extends BaseMailboxController
         toastManager: toastManager,
       );
     } else if (failure is CreateDefaultMailboxFailure) {
-      updateMailboxTree(
-        mailboxCollection: updateMailboxCollection(currentMailboxCollection),
-        isRefreshTrigger: false,
-      );
+      _applyVirtualFoldersOnly();
     } else {
       super.handleFailureViewState(failure);
     }
@@ -278,10 +297,7 @@ class MailboxController extends BaseMailboxController
     viewState.value.fold(
       (failure) {
         if (failure is GetAllMailboxFailure) {
-          updateMailboxTree(
-            mailboxCollection: updateMailboxCollection(currentMailboxCollection,),
-            isRefreshTrigger: false,
-          );
+          _applyVirtualFoldersOnly();
           mailboxDashBoardController.updateRefreshAllMailboxState(Left(RefreshAllMailboxFailure()),);
           showRetryToast(failure);
         }
@@ -300,92 +316,195 @@ class MailboxController extends BaseMailboxController
     );
   }
 
-  Future<void> _loadSharedMailboxes(
-    Session currentSession,
-    AccountId primaryAccountId,
+  /// Clears every other-user cache, e.g. when the primary account changes.
+  void _resetOtherUserAccounts() {
+    _otherUserAccounts.clear();
+    _otherUserAccountsInFlight.clear();
+    _lastPrimaryAccountId = null;
+  }
+
+  /// Loads each delegated account's mailboxes concurrently, rebuilding the
+  /// sidebar as each one arrives so the section fills in progressively.
+  Future<void> _loadOtherUserMailboxes(
+    Session session,
+    AccountId primary,
   ) async {
+    final accountIds =
+        MailboxUtils.resolveOtherUserAccountIds(session, primary);
 
-    for (final sharedAccountId in currentSession.accounts.keys) {
-      if (sharedAccountId.asString == primaryAccountId.asString) {
-        continue;
-      }
+    await Future.wait(
+      accountIds.map((accountId) => _loadOtherUserAccount(session, accountId)),
+    );
+  }
 
+  Future<void> _loadOtherUserAccount(
+    Session session,
+    AccountId accountId,
+  ) async {
+    if (_otherUserAccountsInFlight.contains(accountId) ||
+        _otherUserAccounts.containsKey(accountId)) {
+      return;
+    }
+    _otherUserAccountsInFlight.add(accountId);
 
-      await for (final result in _sharedMailboxGetAllMailboxInteractor.execute(
-        currentSession,
-        sharedAccountId,
-      )) {
-        result.fold(
+    try {
+      // Run the interactor directly rather than through consumeState:
+      // handleSuccessViewState would route its GetAllMailboxSuccess into
+      // _handleGetAllMailboxSuccess and clobber the primary tree.
+      await for (final result
+          in _sharedMailboxGetAllMailboxInteractor.execute(session, accountId)) {
+        final success = result.fold<GetAllMailboxSuccess?>(
           (failure) {
             logWarning(
-              'MailboxController::_loadSharedMailboxes: failure '
-              'account=${sharedAccountId.asString} '
-              'failure=$failure',
+              'MailboxController::_loadOtherUserAccount: failure '
+              'account=${accountId.id.value} failure=$failure',
             );
+            return null;
           },
-          (success) {
-            if (success is! GetAllMailboxSuccess) {
-              return;
-            }
-
-            final accountMailboxes = success.mailboxList
-                .map(
-                  (mailbox) => mailbox.copyWith(
-                    accountId: sharedAccountId,
-                    isSharedAccount: true,
-                    namespace: mailbox.namespace ??
-                        Namespace('Shared[${sharedAccountId.asString}]'),
-                  ),
-                )
-                .toList();
-
-            _sharedMailboxesByAccount[sharedAccountId] = accountMailboxes;
-
-
-          },
+          (success) => success is GetAllMailboxSuccess ? success : null,
         );
+        if (success == null) continue;
+
+        // Ghost account: the JMAP session lists it but the user has no readable
+        // mailbox in it. Skip it so it never appears in the sidebar.
+        final readableMailboxes = success.mailboxList.listReadableMailboxes;
+        if (readableMailboxes.isEmpty) continue;
+
+        // Delegated accounts are filtered strictly by subscription (no isDefault
+        // override), so the user curates exactly which of another user's folders
+        // appear by (un)subscribing to them. Stamp the James-style
+        // `Delegated[owner]` namespace so they fold into Team-mailboxes with the
+        // owner shown as a subtitle; accountId still routes their write actions.
+        final ownerName =
+            session.accounts[accountId]?.name.value ?? accountId.id.value;
+        final mailboxes = readableMailboxes
+            .listSubscribedMailboxes
+            .map((mailbox) => mailbox.copyWith(
+                  accountId: accountId,
+                  isSharedAccount: true,
+                  namespace: MailboxUtils.delegatedNamespace(ownerName),
+                ))
+            .toList();
+
+        _otherUserAccounts[accountId] = OtherUserAccountMailboxes(
+          accountId: accountId,
+          displayName: MailboxName(ownerName),
+          mailboxes: mailboxes,
+          mailboxState: success.currentMailboxState,
+        );
+
+        await _rebuildAllTrees(selectDefaultMailbox: false);
       }
+    } finally {
+      _otherUserAccountsInFlight.remove(accountId);
+    }
+  }
+
+  /// Refreshes the already-loaded delegated accounts off the primary account's
+  /// change signal. The primary Mailbox/changes push says nothing about a
+  /// delegated account's state, so this is a pragmatic approximation until each
+  /// account has its own push subscription.
+  Future<void> _refreshOtherUserMailboxes(Session session) async {
+    var changed = false;
+    for (final account in _otherUserAccounts.values.toList()) {
+      final state = account.mailboxState;
+      if (state == null) continue;
+
+      final refreshViewState = await refreshAllMailboxInteractor!
+          .execute(
+            session,
+            account.accountId,
+            state,
+            properties: MailboxConstants.propertiesDefault,
+          )
+          .last;
+      final refreshState = refreshViewState
+          .foldSuccessWithResult<RefreshChangesAllMailboxSuccess>();
+      if (refreshState is! RefreshChangesAllMailboxSuccess) continue;
+
+      // Delegated accounts are filtered strictly by subscription so an IMAP
+      // unsubscribe hides the folder on the next refresh (see
+      // _loadOtherUserAccount). Unreadable mailboxes are excluded too.
+      final mailboxes = refreshState.mailboxList
+          .listReadableMailboxes
+          .listSubscribedMailboxes
+          .map((mailbox) => mailbox.copyWith(
+                accountId: account.accountId,
+                isSharedAccount: true,
+                namespace:
+                    MailboxUtils.delegatedNamespace(account.displayName.name),
+              ))
+          .toList();
+      _otherUserAccounts[account.accountId] = account.copyWith(
+        mailboxes: mailboxes,
+        mailboxState: refreshState.currentMailboxState,
+      );
+      changed = true;
     }
 
-    final personalMailboxesForUi = allMailboxes
-        .where(
-          (mailbox) => !mailbox.isSharedAccount && !mailbox.isVirtualFolder,
-        )
-        .toList();
+    if (changed) {
+      await _rebuildAllTrees(refreshOnly: true);
+    }
+  }
 
-    final sharedMailboxesForUi = _sharedMailboxesByAccount.values
-        .expand((mailboxes) => mailboxes)
-        .toList();
+  /// Re-fetches every already-loaded delegated account in full and rebuilds.
+  ///
+  /// A subscription toggle does not advance the mailbox modseq that
+  /// Mailbox/changes relies on (IMAP subscriptions are a separate per-user
+  /// list), so [_refreshOtherUserMailboxes] cannot observe an (un)subscribe.
+  /// Only a full Mailbox/get reflects it, so this is used on the manual refresh
+  /// and when returning from the Mailbox visibility settings, where the sidebar
+  /// was otherwise stale until a page reload.
+  Future<void> _reloadOtherUserMailboxesInFull(Session session) async {
+    final accountIds = _otherUserAccounts.keys.toList();
+    if (accountIds.isEmpty) return;
 
-    await buildTree([
-      ...personalMailboxesForUi,
-      ...sharedMailboxesForUi,
-    ], onUpdateMailboxCollectionCallback: updateMailboxCollection);
+    await Future.wait(accountIds.map((accountId) async {
+      final existing = _otherUserAccounts[accountId];
+      if (existing == null) return;
 
+      await for (final result
+          in _sharedMailboxGetAllMailboxInteractor.execute(session, accountId)) {
+        final success = result.fold<GetAllMailboxSuccess?>(
+          (_) => null,
+          (s) => s is GetAllMailboxSuccess ? s : null,
+        );
+        if (success == null) continue;
 
+        final mailboxes = success.mailboxList.listReadableMailboxes
+            .listSubscribedMailboxes
+            .map((mailbox) => mailbox.copyWith(
+                  accountId: accountId,
+                  isSharedAccount: true,
+                  namespace: MailboxUtils.delegatedNamespace(
+                      existing.displayName.name),
+                ))
+            .toList();
+        _otherUserAccounts[accountId] = existing.copyWith(
+          mailboxes: mailboxes,
+          mailboxState: success.currentMailboxState,
+        );
+      }
+    }));
+
+    await _rebuildAllTrees(refreshOnly: true);
   }
 
   void _registerObxStreamListener() {
     ever(mailboxDashBoardController.accountId, (accountId) {
       final currentSession = session;
-      final currentAccountId =accountId;
+      final currentAccountId = accountId;
 
       if (currentAccountId != null && currentSession != null) {
-        getAllMailbox(currentSession, currentAccountId);
-
-        if (!_didLoadSharedMailboxes) {
-          _didLoadSharedMailboxes = true;
-
-          unawaited(
-            Future<void>.delayed(
-              const Duration(seconds: 2),
-              () => _loadSharedMailboxes(
-                currentSession,
-                currentAccountId,
-              ),
-            ),
-          );
+        if (currentAccountId != _lastPrimaryAccountId) {
+          _resetOtherUserAccounts();
+          _lastPrimaryAccountId = currentAccountId;
         }
+
+        getAllMailbox(currentSession, currentAccountId);
+        unawaited(
+          _loadOtherUserMailboxes(currentSession, currentAccountId),
+        );
       }
     });
 
@@ -568,10 +687,11 @@ class MailboxController extends BaseMailboxController
     int? readCount,
     int? unreadCount,
   }) {
-    if (affectedMailboxId == null) return;
+    final mailboxKey = primaryMailboxKey(affectedMailboxId);
+    if (mailboxKey == null) return;
 
-    updateUnreadCountOfMailboxById(
-      affectedMailboxId,
+    updateUnreadCountOfMailboxByKey(
+      mailboxKey,
       unreadChanges: (unreadCount ?? 0) - (readCount ?? 0),
     );
   }
@@ -579,19 +699,21 @@ class MailboxController extends BaseMailboxController
   void _handleMarkMailboxAsRead({
     required MailboxId? affectedMailboxId
   }) {
-    if (affectedMailboxId == null) return;
+    final mailboxKey = primaryMailboxKey(affectedMailboxId);
+    if (mailboxKey == null) return;
 
-    clearUnreadCount(affectedMailboxId);
+    clearUnreadCount(mailboxKey);
   }
 
   void _handleDraftSaved({
     required MailboxId? affectedMailboxId,
     required int totalEmailsChanged,
   }) {
-    if (affectedMailboxId == null) return;
+    final mailboxKey = primaryMailboxKey(affectedMailboxId);
+    if (mailboxKey == null) return;
 
-    updateMailboxTotalEmailsCountById(
-      affectedMailboxId,
+    updateMailboxTotalEmailsCountByKey(
+      mailboxKey,
       totalEmailsChanged
     );
   }
@@ -600,10 +722,11 @@ class MailboxController extends BaseMailboxController
     required MailboxId? affectedMailboxId,
     required int totalEmailsChanged,
   }) {
-    if (affectedMailboxId == null) return;
+    final mailboxKey = primaryMailboxKey(affectedMailboxId);
+    if (mailboxKey == null) return;
 
-    updateMailboxTotalEmailsCountById(
-      affectedMailboxId,
+    updateMailboxTotalEmailsCountByKey(
+      mailboxKey,
       totalEmailsChanged
     );
   }
@@ -620,26 +743,30 @@ class MailboxController extends BaseMailboxController
       final unreadEmailMovedCount = originalMailboxIdWithEmailIds.value
           .where((emailId) => emailIdsWithReadStatus[emailId] == false)
           .length;
-      updateMailboxTotalEmailsCountById(
-        originalMailboxId,
+      final originalMailboxKey = primaryMailboxKey(originalMailboxId);
+      if (originalMailboxKey == null) continue;
+      updateMailboxTotalEmailsCountByKey(
+        originalMailboxKey,
         -emailsMovedCount
       );
-      updateUnreadCountOfMailboxById(
-        originalMailboxId,
+      updateUnreadCountOfMailboxByKey(
+        originalMailboxKey,
         unreadChanges: -unreadEmailMovedCount,
       );
     }
 
     // Update changes in destination mailbox
-    updateMailboxTotalEmailsCountById(
-      destinationMailboxId,
+    final destinationMailboxKey = primaryMailboxKey(destinationMailboxId);
+    if (destinationMailboxKey == null) return;
+    updateMailboxTotalEmailsCountByKey(
+      destinationMailboxKey,
       originalMailboxIdsWithEmailIds.entries.fold(
         0,
         (sum, entry) => sum + entry.value.length,
       ),
     );
-    updateUnreadCountOfMailboxById(
-      destinationMailboxId,
+    updateUnreadCountOfMailboxByKey(
+      destinationMailboxKey,
       unreadChanges: originalMailboxIdsWithEmailIds
         .values
         .fold(
@@ -671,6 +798,11 @@ class MailboxController extends BaseMailboxController
   Future<void> refreshAllMailbox() async {
     if (session != null && accountId != null) {
       consumeState(getAllMailboxInteractor!.execute(session!, accountId!));
+      // Full re-fetch the delegated accounts so an (un)subscribe on another
+      // user's mailbox is reflected. A subscription change does not advance the
+      // mailbox modseq, so the Mailbox/changes based _refreshOtherUserMailboxes
+      // would miss it.
+      unawaited(_reloadOtherUserMailboxesInFull(session!));
     } else {
       consumeState(Stream.value(Left(GetAllMailboxFailure(NotFoundSessionException()))),);
     }
@@ -703,6 +835,9 @@ class MailboxController extends BaseMailboxController
 
       if (refreshState is RefreshChangesAllMailboxSuccess) {
         await _handleRefreshChangeMailboxSuccess(refreshState);
+        // The primary change signal is the only push this app subscribes to, so
+        // opportunistically refresh the delegated accounts alongside it.
+        await _refreshOtherUserMailboxes(session!);
       } else {
         _clearNewFolderId();
         if (refreshState != null) {
@@ -721,22 +856,12 @@ class MailboxController extends BaseMailboxController
   Future<void> _handleRefreshChangeMailboxSuccess(RefreshChangesAllMailboxSuccess success,) async {
     currentMailboxState = success.currentMailboxState;
     log('MailboxController::_handleRefreshChangeMailboxSuccess:currentMailboxState: $currentMailboxState',);
-    final listMailboxDisplayed = success
+    _primaryMailboxes = success
         .mailboxList
-        .listSubscribedMailboxesAndDefaultMailboxes;
+        .listSubscribedMailboxesAndDefaultMailboxes
+        .withoutVirtualMailbox;
 
-    await refreshTree(
-      listMailboxDisplayed.withoutVirtualMailbox,
-      onUpdateMailboxCollectionCallback: updateMailboxCollection,
-    );
-
-    if (currentContext != null) {
-      syncAllMailboxWithDisplayName(currentContext!);
-    }
-    _setMapMailbox();
-    _setOutboxMailbox();
-    _selectSelectedMailboxDefault();
-    mailboxDashBoardController.refreshSpamReportBanner();
+    await _rebuildAllTrees(refreshOnly: true);
 
     if (_newFolderId != null) {
       _redirectToNewFolder();
@@ -747,15 +872,80 @@ class MailboxController extends BaseMailboxController
   bool get isAINeedsActionEnabled =>
       mailboxDashBoardController.isAINeedsActionEnabled;
 
+  /// The one place trees are rebuilt in this controller.
+  ///
+  /// Always composes the primary mailboxes with the cached other-user
+  /// mailboxes, so neither a primary refresh nor a delayed shared load can
+  /// wipe the other section. Every rebuild is followed by the same
+  /// reconciliation, so the dashboard's mailbox maps and the default selection
+  /// stay consistent.
+  Future<void> _rebuildAllTrees({
+    MailboxId? mailboxIdSelected,
+    bool refreshOnly = false,
+    bool selectDefaultMailbox = true,
+  }) async {
+    final sharedMailboxes = _otherUserAccounts.values
+        .expand((account) => account.mailboxes)
+        .toList();
+    final composed = [..._primaryMailboxes, ...sharedMailboxes];
+
+    if (refreshOnly) {
+      await refreshTree(
+        composed,
+        onUpdateMailboxCollectionCallback: updateMailboxCollection,
+      );
+    } else {
+      await buildTree(
+        composed,
+        mailboxIdSelected: mailboxIdSelected,
+        onUpdateMailboxCollectionCallback: updateMailboxCollection,
+      );
+    }
+
+    _reconcileAfterTreeBuild(selectDefaultMailbox: selectDefaultMailbox);
+  }
+
+  /// Reapplies the virtual folders onto the current collection without a full
+  /// rebuild, for the paths that only need to refresh those synthetic entries.
+  void _applyVirtualFoldersOnly() {
+    updateMailboxTree(
+      mailboxCollection: updateMailboxCollection(currentMailboxCollection),
+      isRefreshTrigger: false,
+    );
+  }
+
+  /// Post-build reconciliation run after every [_rebuildAllTrees].
+  void _reconcileAfterTreeBuild({bool selectDefaultMailbox = true}) {
+    if (currentContext != null) {
+      syncAllMailboxWithDisplayName(currentContext!);
+    }
+    _setMapMailbox();
+    _setOutboxMailbox();
+    if (selectDefaultMailbox) {
+      _selectSelectedMailboxDefault();
+    }
+    mailboxDashBoardController.refreshSpamReportBanner();
+  }
+
   void _setMapMailbox() {
     final mapDefaultMailboxIdByRole = {
       for (var mailboxNode in defaultMailboxTree.value.root.childrenItems ?? List<MailboxNode>.empty())
         mailboxNode.item.role!: mailboxNode.item.id,
     };
 
+    // Scoped to the primary account (plus the account-less virtual folders).
+    // JMAP ids collide across accounts, so including other users' mailboxes
+    // here would let one silently overwrite a primary entry and corrupt every
+    // consumer that resolves a mailbox by bare id: spam/trash lookup, the
+    // outbox, and email-to-mailbox resolution. Cross-account lookups use the
+    // account-scoped tree instead.
+    final primary = primaryAccountId;
     final mapMailboxById = {
       for (var presentationMailbox in allMailboxes)
-        presentationMailbox.id: presentationMailbox,
+        if (primary == null ||
+            presentationMailbox.accountId == null ||
+            presentationMailbox.accountId == primary)
+          presentationMailbox.id: presentationMailbox,
     };
 
     mailboxDashBoardController.setMapDefaultMailboxIdByRole(mapDefaultMailboxIdByRole,);
@@ -821,10 +1011,7 @@ class MailboxController extends BaseMailboxController
       .toList();
 
     if (listRoleMissing.isEmpty || accountId == null || session == null) {
-      updateMailboxTree(
-        mailboxCollection: updateMailboxCollection(currentMailboxCollection),
-        isRefreshTrigger: false,
-      );
+      _applyVirtualFoldersOnly();
       return;
     }
 
@@ -833,6 +1020,8 @@ class MailboxController extends BaseMailboxController
         Id(uuid.v1()) : role
     };
     log('MailboxController::_handleCreateDefaultFolderIfMissing():mapRoles: $mapRoles',);
+    // Intentionally the primary account: default system folders are only ever
+    // created for the signed-in user, never in a delegated account.
     consumeState(_createDefaultMailboxInteractor.execute(
       session!,
       accountId!,
@@ -841,46 +1030,24 @@ class MailboxController extends BaseMailboxController
 
   Future<void> _handleCreateDefaultFolderIfMissingSuccess(CreateDefaultMailboxAllSuccess success,) async {
     if (success.listMailbox.isEmpty) {
-      updateMailboxTree(
-        mailboxCollection: updateMailboxCollection(currentMailboxCollection),
-        isRefreshTrigger: false,
-      );
+      _applyVirtualFoldersOnly();
       return;
     }
 
     Set<Role?> existingRoles = {};
     Set<MailboxName> existingNamesWithoutParent = {};
 
+    final createdMailboxes = <PresentationMailbox>[];
     for (var mailbox in success.listMailbox) {
       if (mailbox.role != null && !existingRoles.add(mailbox.role)) continue;
 
       if (mailbox.parentId == null && mailbox.name != null && !existingNamesWithoutParent.add(mailbox.name!)) continue;
 
-      allMailboxes.add(mailbox.toPresentationMailbox());
+      createdMailboxes.add(mailbox.toPresentationMailbox(accountId: accountId));
     }
+    _primaryMailboxes = [..._primaryMailboxes, ...createdMailboxes];
 
-    await buildTree(
-      allMailboxes.withoutVirtualMailbox,
-      onUpdateMailboxCollectionCallback: updateMailboxCollection,
-    );
-    if (currentContext != null) {
-      syncAllMailboxWithDisplayName(currentContext!);
-    }
-    _setMapMailbox();
-    _setOutboxMailbox();
-
-    final currentSession = session;
-    final primaryAccountId = accountId;
-
-    if (!_didLoadSharedMailboxes &&
-        currentSession != null &&
-        primaryAccountId != null) {
-      _didLoadSharedMailboxes = true;
-
-      unawaited(
-        _loadSharedMailboxes(currentSession, primaryAccountId),
-      );
-    }
+    await _rebuildAllTrees(selectDefaultMailbox: false);
   }
 
   void _handleDataFromNavigationRouter() {
@@ -922,7 +1089,18 @@ class MailboxController extends BaseMailboxController
         if (_navigationRouter!.labelId != null) {
           handleLabelNavigation(_navigationRouter!, _navigationRouter!.labelId!,);
         } else if (_navigationRouter!.mailboxId != null) {
-          final matchedMailboxNode = findMailboxNodeById(_navigationRouter!.mailboxId!,);
+          // A delegated-account URL carries its account; a legacy bare-id URL
+          // resolves against the primary account.
+          final routerMailboxId = _navigationRouter!.mailboxId;
+          final routerAccountId =
+              _navigationRouter!.mailboxAccountId ?? primaryAccountId;
+          final matchedMailboxKey =
+              (routerMailboxId != null && routerAccountId != null)
+                  ? MailboxKey(routerAccountId, routerMailboxId)
+                  : null;
+          final matchedMailboxNode = matchedMailboxKey != null
+              ? findMailboxNodeByKey(matchedMailboxKey)
+              : null;
           if (matchedMailboxNode != null) {
             if (_navigationRouter!.emailId != null) {
               _openEmailInsideMailboxFromLocationBar(
@@ -1020,16 +1198,6 @@ class MailboxController extends BaseMailboxController
     BuildContext context,
     PresentationMailbox presentationMailboxSelected,
   ) {
-    if (presentationMailboxSelected.isSharedAccountRoot
-  ) {
-    log(
-        'MailboxController::_handleOpenMailbox: '
-        'ignored synthetic shared account root '
-        '${presentationMailboxSelected.accountId?.asString}',
-      );
-      return;
-    }
-
     log('MailboxController::_handleOpenMailbox():MAILBOX_ID = ${presentationMailboxSelected.id.asString} | MAILBOX_NAME: ${presentationMailboxSelected.name?.name}',);
     KeyboardUtils.hideKeyboard(context);
     mailboxDashBoardController.clearSelectedEmail();
@@ -1056,7 +1224,12 @@ class MailboxController extends BaseMailboxController
   }
 
   void goToCreateNewMailboxView(BuildContext context, {PresentationMailbox? parentMailbox,}) async {
-    if (session != null && accountId != null) {
+    // A subfolder is created in its parent's account; a top-level folder in the
+    // primary account.
+    final currentSession = session;
+    final targetAccountId =
+        parentMailbox != null ? accountIdOf(parentMailbox) : primaryAccountId;
+    if (currentSession != null && targetAccountId != null) {
       final arguments = MailboxCreatorArguments(
         allMailboxes.withoutVirtualMailbox,
         parentMailbox,
@@ -1068,8 +1241,8 @@ class MailboxController extends BaseMailboxController
 
       if (result != null && result is NewMailboxArguments) {
         _createNewMailboxAction(
-          session!,
-          accountId!,
+          currentSession,
+          targetAccountId,
           CreateNewMailboxRequest(
             result.newName,
             parentId: result.mailboxLocation?.id,
@@ -1107,7 +1280,9 @@ class MailboxController extends BaseMailboxController
   }
 
   void _renameMailboxSuccess(RenameMailboxSuccess success) {
-    updateMailboxNameById(success.request.mailboxId, success.request.newName);
+    final mailboxKey = primaryMailboxKey(success.request.mailboxId);
+    if (mailboxKey == null) return;
+    updateMailboxNameByKey(mailboxKey, success.request.newName);
   }
 
   void _renameMailboxFailure(RenameMailboxFailure failure) {
@@ -1168,17 +1343,22 @@ class MailboxController extends BaseMailboxController
     final teamMailboxesSelected = teamMailboxesTree.value
       .findNodes((node) => node.selectMode == SelectMode.ACTIVE,);
 
-    return [defaultMailboxSelected, folderMailboxSelected, teamMailboxesSelected,]
+    return [
+      defaultMailboxSelected,
+      folderMailboxSelected,
+      teamMailboxesSelected,
+    ]
       .expand((node) => node)
       .map((node) => node.item)
       .toList();
   }
 
   void _deleteMailboxAction(PresentationMailbox presentationMailbox) {
-    if (session != null && accountId != null) {
+    final ctx = requestContextOf(presentationMailbox);
+    if (ctx != null) {
       consumeState(_deleteMultipleMailboxInteractor.execute(
-        session!,
-        accountId!,
+        ctx.session,
+        ctx.accountId,
         [presentationMailbox.id,]),);
     } else {
       _deleteMailboxFailure(DeleteMultipleMailboxFailure(null));
@@ -1221,10 +1401,11 @@ class MailboxController extends BaseMailboxController
   }
 
   void _renameMailboxAction(PresentationMailbox presentationMailbox, MailboxName newMailboxName,) {
-    if (session != null && accountId != null) {
+    final ctx = requestContextOf(presentationMailbox);
+    if (ctx != null) {
       consumeState(_renameMailboxInteractor.execute(
-        session!,
-        accountId!,
+        ctx.session,
+        ctx.accountId,
         RenameMailboxRequest(presentationMailbox.id, newMailboxName),
         ),
       );
@@ -1278,12 +1459,27 @@ class MailboxController extends BaseMailboxController
   }
 
   void _undoMovingMailbox(MoveMailboxRequest newMoveRequest) {
-    if (session != null && accountId != null) {
+    // A move never crosses accounts, so the undo runs against the same account
+    // that owns the moved mailbox.
+    final currentSession = session;
+    final owningAccountId =
+        _accountIdOfMailboxId(newMoveRequest.mailboxId) ?? primaryAccountId;
+    if (currentSession != null && owningAccountId != null) {
       consumeState(_moveMailboxInteractor.execute(
-        session!,
-        accountId!,
+        currentSession,
+        owningAccountId,
         newMoveRequest),);
     }
+  }
+
+  /// Resolves the owning account of a mailbox already placed in a tree, by id.
+  AccountId? _accountIdOfMailboxId(MailboxId mailboxId) {
+    for (final mailboxTree in allMailboxTrees) {
+      final node =
+          mailboxTree.value.findNode((node) => node.item.id == mailboxId);
+      if (node != null) return node.item.accountId ?? primaryAccountId;
+    }
+    return null;
   }
 
   void _handleNavigationRouteParameters(Map<String, dynamic>? parameters) {
@@ -1343,7 +1539,7 @@ class MailboxController extends BaseMailboxController
         try{
           final subaddress = getSubAddress(
             mailboxDashBoardController.ownEmailAddress.value,
-            findNodePathWithSeparator(mailbox.id, '.')!,
+            findNodePathWithSeparator(mailbox.key, '.')!,
           );
           copySubAddressAction(context, subaddress);
         } catch (error) {
@@ -1355,13 +1551,13 @@ class MailboxController extends BaseMailboxController
         mailboxDashBoardController.storeSpamReportStateAction();
         break;
       case MailboxActions.disableMailbox:
-        _unsubscribeMailboxAction(mailbox.id);
+        _unsubscribeMailboxAction(mailbox.key);
         break;
       case MailboxActions.allowSubaddressing:
         try{
           final subAddress = getSubAddress(
             mailboxDashBoardController.ownEmailAddress.value,
-            findNodePathWithSeparator(mailbox.id, '.')!,
+            findNodePathWithSeparator(mailbox.key, '.')!,
           );
           openConfirmationDialogSubAddressingAction(
               context,
@@ -1415,16 +1611,31 @@ class MailboxController extends BaseMailboxController
     PresentationMailbox mailboxSelected,
     PresentationMailbox? destinationMailbox,
   ) {
-    if (session != null && accountId != null) {
-      _handleMovingMailbox(
-        context,
-        session!,
-        accountId!,
-        MoveAction.moving,
-        mailboxSelected,
-        destinationMailbox: destinationMailbox,
-      );
+    final ctx = requestContextOf(mailboxSelected);
+    if (ctx == null) return;
+
+    // A cross-account move would need Email/copy plus destroy, which this app
+    // does not implement, so reject it rather than silently move within the
+    // wrong account.
+    if (destinationMailbox != null &&
+        accountIdOf(destinationMailbox) != ctx.accountId) {
+      if (currentOverlayContext != null && currentContext != null) {
+        appToast.showToastErrorMessage(
+          currentOverlayContext!,
+          AppLocalizations.of(currentContext!).moveMailboxAcrossAccountsNotSupported,
+        );
+      }
+      return;
     }
+
+    _handleMovingMailbox(
+      context,
+      ctx.session,
+      ctx.accountId,
+      MoveAction.moving,
+      mailboxSelected,
+      destinationMailbox: destinationMailbox,
+    );
   }
 
   void _replaceBrowserHistory() {
@@ -1435,6 +1646,12 @@ class MailboxController extends BaseMailboxController
         AppRoutes.dashboard,
         router: NavigationRouter(
           mailboxId: currentMailbox?.browserRouteMailboxId,
+          // Carry the account only for a delegated mailbox, so primary-account
+          // URLs stay unchanged.
+          mailboxAccountId:
+              currentMailbox != null && isOtherUserMailbox(currentMailbox)
+                  ? currentMailbox.accountId
+                  : null,
           labelId: currentMailbox?.labelId,
           searchQuery: mailboxDashBoardController.searchController.isSearchEmailRunning
             ? mailboxDashBoardController.searchController.searchQuery
@@ -1479,19 +1696,19 @@ class MailboxController extends BaseMailboxController
   Future<void> _handleGetAllMailboxSuccess(GetAllMailboxSuccess success) async {
     currentMailboxState = success.currentMailboxState;
     log('MailboxController::_handleGetAllMailboxSuccess:currentMailboxState: $currentMailboxState',);
-    final listMailboxDisplayed = success.mailboxList.listSubscribedMailboxesAndDefaultMailboxes;
-    await buildTree(
-      listMailboxDisplayed.withoutVirtualMailbox,
-      onUpdateMailboxCollectionCallback: updateMailboxCollection,
-    );
-    if (currentContext != null) {
-      syncAllMailboxWithDisplayName(currentContext!);
-    }
-    _setMapMailbox();
-    _setOutboxMailbox();
+    _primaryMailboxes = success
+        .mailboxList
+        .listSubscribedMailboxesAndDefaultMailboxes
+        .withoutVirtualMailbox;
+    // onDone -> _handleDataFromNavigationRouter owns the selection here, so this
+    // path must not pick the default itself or it flashes Inbox before the
+    // location-bar mailbox is selected.
+    await _rebuildAllTrees(selectDefaultMailbox: false);
   }
 
   Future<void> _updateMailboxIdsBlockNotificationToKeychain(List<PresentationMailbox> mailboxes,) async {
+    // Intentionally the primary account: the iOS keychain is keyed on the
+    // signed-in account, so only its mailboxes are stored.
     _iosSharingManager = getBinding<IOSSharingManager>();
     if (accountId == null || _iosSharingManager == null || mailboxes.isEmpty) {
       logWarning('MailboxController::_updateMailboxIdsBlockNotificationToKeychain: AccountId = $accountId | IosSharingManager = $_iosSharingManager | Mailboxes = ${mailboxes.length}',);
@@ -1512,24 +1729,28 @@ class MailboxController extends BaseMailboxController
       mailboxIds: mailboxIdsBlockNotification,);
   }
 
-  void _unsubscribeMailboxAction(MailboxId mailboxId) {
-    if (session != null && accountId != null) {
+  void _unsubscribeMailboxAction(MailboxKey mailboxKey) {
+    final currentSession = session;
+    // The key already carries the owning account, so unsubscribe runs against
+    // the account that owns the mailbox.
+    final owningAccountId = mailboxKey.accountId;
+    if (currentSession != null) {
       final subscribeRequest = generateSubscribeRequest(
-        mailboxId,
+        mailboxKey,
         MailboxSubscribeState.disabled,
         MailboxSubscribeAction.unSubscribe,
       );
 
       if (subscribeRequest is SubscribeMultipleMailboxRequest) {
         consumeState(_subscribeMultipleMailboxInteractor.execute(
-          session!,
-          accountId!,
+          currentSession,
+          owningAccountId,
           subscribeRequest,
         ),);
       } else if (subscribeRequest is SubscribeMailboxRequest) {
         consumeState(_subscribeMailboxInteractor.execute(
-          session!,
-          accountId!,
+          currentSession,
+          owningAccountId,
           subscribeRequest,
         ),);
       }
@@ -1612,7 +1833,11 @@ class MailboxController extends BaseMailboxController
     MailboxId mailboxIdSubscribed,
     {List<MailboxId>? listDescendantMailboxIds,}
   ) {
-    if (session != null && accountId != null) {
+    final currentSession = session;
+    // Re-subscribe runs against the account that owns the mailbox.
+    final owningAccountId =
+        _accountIdOfMailboxId(mailboxIdSubscribed) ?? primaryAccountId;
+    if (currentSession != null && owningAccountId != null) {
       SubscribeRequest? subscribeRequest;
 
       if (listDescendantMailboxIds != null) {
@@ -1632,14 +1857,14 @@ class MailboxController extends BaseMailboxController
 
       if (subscribeRequest is SubscribeMultipleMailboxRequest) {
         consumeState(_subscribeMultipleMailboxInteractor.execute(
-          session!,
-          accountId!,
+          currentSession,
+          owningAccountId,
           subscribeRequest,
         ),);
       } else if (subscribeRequest is SubscribeMailboxRequest) {
         consumeState(_subscribeMailboxInteractor.execute(
-          session!,
-          accountId!,
+          currentSession,
+          owningAccountId,
           subscribeRequest,
         ),);
       }
@@ -1647,17 +1872,20 @@ class MailboxController extends BaseMailboxController
   }
 
   void _handleSubaddressingAction(MailboxId mailboxId, Map<String, List<String>?>? currentRights, MailboxActions subaddressingAction,) {
-    final accountId = mailboxDashBoardController.accountId.value;
+    // Sub-addressing runs against the account that owns the mailbox, not the
+    // signed-in account.
+    final owningAccountId =
+        _accountIdOfMailboxId(mailboxId) ?? primaryAccountId;
     final session = mailboxDashBoardController.sessionCurrent;
 
-    if (session != null && accountId != null) {
+    if (session != null && owningAccountId != null) {
       final allowSubaddressingRequest = MailboxRightRequest(
           mailboxId,
           currentRights,
           subaddressingAction == MailboxActions.allowSubaddressing ? MailboxSubaddressingAction.allow : MailboxSubaddressingAction.disallow,
       );
 
-      consumeState(_subaddressingInteractor.execute(session, accountId, allowSubaddressingRequest,
+      consumeState(_subaddressingInteractor.execute(session, owningAccountId, allowSubaddressingRequest,
         ),);
     } else {
       handleSubAddressingFailure(
@@ -1712,7 +1940,9 @@ class MailboxController extends BaseMailboxController
   }
 
   void _redirectToNewFolder() {
-    final newMailboxNode = findMailboxNodeById(_newFolderId!);
+    final newFolderKey = primaryMailboxKey(_newFolderId);
+    final newMailboxNode =
+        newFolderKey != null ? findMailboxNodeByKey(newFolderKey) : null;
     log('MailboxController::_redirectToNewFolder:newMailboxNode: $newMailboxNode',);
     if (newMailboxNode != null && currentContext != null) {
       _handleOpenMailbox(currentContext!, newMailboxNode.item);

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -466,6 +466,11 @@ class MailboxController extends BaseMailboxController
   Future<void> _reloadOtherUserMailboxesInFull(Session session) async {
     final accountIds = _otherUserAccounts.keys.toList();
     if (accountIds.isEmpty) return;
+    // Capture the primary account this reload belongs to. A primary-account
+    // switch clears the caches via _resetOtherUserAccounts; without this guard
+    // the captured `existing` would be written back into the cleared map and the
+    // former account's delegates would reappear in the new account's sidebar.
+    final loadingForPrimary = _lastPrimaryAccountId;
 
     await Future.wait(accountIds.map((accountId) async {
       final existing = _otherUserAccounts[accountId];
@@ -478,6 +483,10 @@ class MailboxController extends BaseMailboxController
           (s) => s is GetAllMailboxSuccess ? s : null,
         );
         if (success == null) continue;
+
+        // The primary account changed while this reload was in flight: drop the
+        // stale result rather than resurrecting a former account's delegates.
+        if (_lastPrimaryAccountId != loadingForPrimary) return;
 
         final mailboxes = success.mailboxList.listReadableMailboxes
             .listSubscribedMailboxes
@@ -495,6 +504,9 @@ class MailboxController extends BaseMailboxController
       }
     }));
 
+    // Primary switched while reloading: the caches were reset, so skip the
+    // rebuild to avoid re-populating the new account's sidebar with stale nodes.
+    if (_lastPrimaryAccountId != loadingForPrimary) return;
     await _rebuildAllTrees(refreshOnly: true);
   }
 
@@ -880,6 +892,16 @@ class MailboxController extends BaseMailboxController
   bool get isAINeedsActionEnabled =>
       mailboxDashBoardController.isAINeedsActionEnabled;
 
+  // Serializes tree rebuilds. Delegated accounts load concurrently and each one
+  // rebuilds the sidebar as it arrives; without serialization an older rebuild
+  // could snapshot the cache first yet finish last, overwriting a newer rebuild
+  // and dropping an account until the next refresh.
+  bool _isRebuilding = false;
+  bool _rebuildRequested = false;
+  MailboxId? _pendingRebuildMailboxIdSelected;
+  bool _pendingRebuildRefreshOnly = false;
+  bool _pendingRebuildSelectDefault = true;
+
   /// The one place trees are rebuilt in this controller.
   ///
   /// Always composes the primary mailboxes with the cached other-user
@@ -887,7 +909,39 @@ class MailboxController extends BaseMailboxController
   /// wipe the other section. Every rebuild is followed by the same
   /// reconciliation, so the dashboard's mailbox maps and the default selection
   /// stay consistent.
+  ///
+  /// Only one rebuild runs at a time. A call made while one is already running
+  /// coalesces onto the latest params and re-runs the loop once the current
+  /// rebuild finishes, so the last cache write always gets a rebuild. When no
+  /// rebuild is in flight the first iteration runs synchronously up to the
+  /// TreeBuilder call, rather than deferring through a Future chain.
   Future<void> _rebuildAllTrees({
+    MailboxId? mailboxIdSelected,
+    bool refreshOnly = false,
+    bool selectDefaultMailbox = true,
+  }) async {
+    _pendingRebuildMailboxIdSelected = mailboxIdSelected;
+    _pendingRebuildRefreshOnly = refreshOnly;
+    _pendingRebuildSelectDefault = selectDefaultMailbox;
+    _rebuildRequested = true;
+
+    if (_isRebuilding) return;
+    _isRebuilding = true;
+    try {
+      while (_rebuildRequested) {
+        _rebuildRequested = false;
+        await _rebuildAllTreesNow(
+          mailboxIdSelected: _pendingRebuildMailboxIdSelected,
+          refreshOnly: _pendingRebuildRefreshOnly,
+          selectDefaultMailbox: _pendingRebuildSelectDefault,
+        );
+      }
+    } finally {
+      _isRebuilding = false;
+    }
+  }
+
+  Future<void> _rebuildAllTreesNow({
     MailboxId? mailboxIdSelected,
     bool refreshOnly = false,
     bool selectDefaultMailbox = true,
@@ -1451,12 +1505,15 @@ class MailboxController extends BaseMailboxController
               success.destinationMailboxDisplayName ?? AppLocalizations.of(currentContext!).allFolders,),
           actionName: AppLocalizations.of(currentContext!).undo,
           onActionClick: () {
-            _undoMovingMailbox(MoveMailboxRequest(
+            _undoMovingMailbox(
+              MoveMailboxRequest(
                 success.mailboxIdSelected,
                 MoveAction.undo,
                 destinationMailboxId: success.parentId,
                 parentId: success.destinationMailboxId,
-            ),);
+              ),
+              success.accountId,
+            );
           },
           leadingSVGIcon: imagePaths.icFolderMailbox,
           leadingSVGIconColor: Colors.white,
@@ -1466,28 +1523,20 @@ class MailboxController extends BaseMailboxController
     }
   }
 
-  void _undoMovingMailbox(MoveMailboxRequest newMoveRequest) {
+  void _undoMovingMailbox(
+    MoveMailboxRequest newMoveRequest,
+    AccountId owningAccountId,
+  ) {
     // A move never crosses accounts, so the undo runs against the same account
-    // that owns the moved mailbox.
+    // the move ran against, carried on MoveMailboxSuccess. Resolving it from the
+    // mailbox id would be wrong: JMAP ids collide across accounts.
     final currentSession = session;
-    final owningAccountId =
-        _accountIdOfMailboxId(newMoveRequest.mailboxId) ?? primaryAccountId;
-    if (currentSession != null && owningAccountId != null) {
+    if (currentSession != null) {
       consumeState(_moveMailboxInteractor.execute(
         currentSession,
         owningAccountId,
         newMoveRequest),);
     }
-  }
-
-  /// Resolves the owning account of a mailbox already placed in a tree, by id.
-  AccountId? _accountIdOfMailboxId(MailboxId mailboxId) {
-    for (final mailboxTree in allMailboxTrees) {
-      final node =
-          mailboxTree.value.findNode((node) => node.item.id == mailboxId);
-      if (node != null) return node.item.accountId ?? primaryAccountId;
-    }
-    return null;
   }
 
   void _handleNavigationRouteParameters(Map<String, dynamic>? parameters) {
@@ -1573,14 +1622,17 @@ class MailboxController extends BaseMailboxController
               mailbox.getDisplayName(context),
               subAddress,
               mailbox.rights,
-              onAllowSubAddressingAction: _handleSubaddressingAction,
+              onAllowSubAddressingAction: (mailboxId, rights, action) =>
+                  _handleSubaddressingAction(
+                      mailboxId, rights, action, accountIdOf(mailbox)),
           );
         } catch (error) {
           appToast.showToastErrorMessage(context, AppLocalizations.of(context).errorWhileFetchingSubaddress,);
         }
         break;
       case MailboxActions.disallowSubaddressing:
-        _handleSubaddressingAction(mailbox.id, mailbox.rights, actions);
+        _handleSubaddressingAction(
+            mailbox.id, mailbox.rights, actions, accountIdOf(mailbox));
         break;
       case MailboxActions.emptyTrash:
         emptyTrashAction(context, mailbox, mailboxDashBoardController);
@@ -1767,7 +1819,7 @@ class MailboxController extends BaseMailboxController
 
   void _handleUnsubscribeMailboxSuccess(SubscribeMailboxSuccess success) {
     if (success.subscribeAction == MailboxSubscribeAction.unSubscribe) {
-      _showToastSubscribeMailboxSuccess(success.mailboxId);
+      _showToastSubscribeMailboxSuccess(success.mailboxId, success.accountId);
 
       if (success.mailboxId == selectedMailbox?.id) {
         _switchBackToMailboxDefault();
@@ -1780,6 +1832,7 @@ class MailboxController extends BaseMailboxController
     if(success.subscribeAction == MailboxSubscribeAction.unSubscribe) {
       _showToastSubscribeMailboxSuccess(
         success.parentMailboxId,
+        success.accountId,
         listDescendantMailboxIds: success.mailboxIdsSubscribe,
       );
 
@@ -1794,6 +1847,7 @@ class MailboxController extends BaseMailboxController
     if(success.subscribeAction == MailboxSubscribeAction.unSubscribe) {
       _showToastSubscribeMailboxSuccess(
         success.parentMailboxId,
+        success.accountId,
         listDescendantMailboxIds: success.mailboxIdsSubscribe,
       );
 
@@ -1818,6 +1872,7 @@ class MailboxController extends BaseMailboxController
 
   void _showToastSubscribeMailboxSuccess(
       MailboxId mailboxIdSubscribed,
+      AccountId owningAccountId,
       {List<MailboxId>? listDescendantMailboxIds,}
   ) {
     if (currentOverlayContext != null && currentContext != null) {
@@ -1827,6 +1882,7 @@ class MailboxController extends BaseMailboxController
         actionName: AppLocalizations.of(currentContext!).undo,
         onActionClick: () => _undoUnsubscribeMailboxAction(
           mailboxIdSubscribed,
+          owningAccountId,
           listDescendantMailboxIds: listDescendantMailboxIds,
         ),
         leadingSVGIcon: imagePaths.icFolderMailbox,
@@ -1839,13 +1895,14 @@ class MailboxController extends BaseMailboxController
 
   void _undoUnsubscribeMailboxAction(
     MailboxId mailboxIdSubscribed,
+    AccountId owningAccountId,
     {List<MailboxId>? listDescendantMailboxIds,}
   ) {
     final currentSession = session;
-    // Re-subscribe runs against the account that owns the mailbox.
-    final owningAccountId =
-        _accountIdOfMailboxId(mailboxIdSubscribed) ?? primaryAccountId;
-    if (currentSession != null && owningAccountId != null) {
+    // Re-subscribe runs against the account the unsubscribe ran against, carried
+    // on the success state. Resolving it from the mailbox id would be wrong:
+    // JMAP ids collide across accounts.
+    if (currentSession != null) {
       SubscribeRequest? subscribeRequest;
 
       if (listDescendantMailboxIds != null) {
@@ -1879,11 +1936,10 @@ class MailboxController extends BaseMailboxController
     }
   }
 
-  void _handleSubaddressingAction(MailboxId mailboxId, Map<String, List<String>?>? currentRights, MailboxActions subaddressingAction,) {
+  void _handleSubaddressingAction(MailboxId mailboxId, Map<String, List<String>?>? currentRights, MailboxActions subaddressingAction, AccountId? owningAccountId,) {
     // Sub-addressing runs against the account that owns the mailbox, not the
-    // signed-in account.
-    final owningAccountId =
-        _accountIdOfMailboxId(mailboxId) ?? primaryAccountId;
+    // signed-in account. The owning account is passed from the call site, which
+    // holds the mailbox: resolving it from the id would be account-ambiguous.
     final session = mailboxDashBoardController.sessionCurrent;
 
     if (session != null && owningAccountId != null) {

--- a/lib/features/mailbox/presentation/mixin/handle_team_mailbox_mixin.dart
+++ b/lib/features/mailbox/presentation/mixin/handle_team_mailbox_mixin.dart
@@ -1,5 +1,5 @@
-import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/namespace.dart';
+import 'package:model/mailbox/mailbox_key.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/mailbox_controller.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_node.dart';
@@ -35,21 +35,20 @@ mixin HandleTeamMailboxMixin {
     return mailboxNode.item;
   }
 
-  MailboxId? findDefaultMailboxIdInTeamMailbox({
+  PresentationMailbox? findDefaultMailboxInTeamMailbox({
     required Namespace namespace,
     required String mailboxName,
   }) {
-    final teamMailbox = _findDefaultMailboxInTeamMailbox(
+    return _findDefaultMailboxInTeamMailbox(
       namespace: namespace,
       mailboxName: mailboxName,
     );
-    return teamMailbox?.id;
   }
 
   String? getTeamMailboxNodePathWithSeparator({
-    required MailboxId mailboxId,
+    required MailboxKey mailboxKey,
     String pathSeparator = '/',
   }) {
-    return _teamMailboxesTree?.getNodePath(mailboxId, pathSeparator);
+    return _teamMailboxesTree?.getNodePath(mailboxKey, pathSeparator);
   }
 }

--- a/lib/features/mailbox/presentation/mixin/mailbox_widget_mixin.dart
+++ b/lib/features/mailbox/presentation/mixin/mailbox_widget_mixin.dart
@@ -89,11 +89,12 @@ mixin MailboxWidgetMixin {
         MailboxActions.openInNewTab,
       if (mailbox.myRights?.mayCreateChild == true)
         MailboxActions.newSubfolder,
-      if (mailbox.countUnReadEmailsAsString.isNotEmpty)
+      if (mailbox.countUnReadEmailsAsString.isNotEmpty &&
+          mailbox.myRights?.mayReadItems != false)
         MailboxActions.markAsRead,
       if (mailbox.myRights?.mayRename == true)
         MailboxActions.rename,
-      if (mailbox.isTeamMailboxes)
+      if (mailbox.isTeamMailboxes || mailbox.isSharedAccount)
         if (mailbox.isSubscribedMailbox)
           MailboxActions.disableMailbox
         else
@@ -111,6 +112,15 @@ mixin MailboxWidgetMixin {
     bool deletedMessageVaultSupported,
     bool isSubAddressingSupported,
   ) {
+    // Every mailbox in another user's account is myRights-gated like a team
+    // mailbox, regardless of whether it carries a role (a shared Inbox would
+    // otherwise fall into the un-gated default-mailbox action list). Move and
+    // createFilter are absent here: cross-account move is unsupported and
+    // filters are a primary-account concept.
+    if (mailbox.isSharedAccount) {
+      return _listActionForTeamMailbox(mailbox);
+    }
+
     if (mailbox.isDefault) {
       return _listActionForDefaultMailbox(
         mailbox,

--- a/lib/features/mailbox/presentation/model/mailbox_request_context.dart
+++ b/lib/features/mailbox/presentation/model/mailbox_request_context.dart
@@ -1,0 +1,20 @@
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+
+/// The session and account a mailbox action must run against.
+///
+/// A mailbox belonging to another user's delegated account has to be acted upon
+/// with that account's id, not the signed-in user's. Resolving this context
+/// makes "which account" an explicit input to every action instead of an
+/// implicit read of the primary account.
+class MailboxRequestContext {
+  final Session session;
+  final AccountId accountId;
+  final bool isPrimaryAccount;
+
+  const MailboxRequestContext({
+    required this.session,
+    required this.accountId,
+    required this.isPrimaryAccount,
+  });
+}

--- a/lib/features/mailbox/presentation/model/mailbox_tree.dart
+++ b/lib/features/mailbox/presentation/model/mailbox_tree.dart
@@ -5,7 +5,9 @@ import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/extensions/presentation_mailbox_extension.dart';
 import 'package:model/mailbox/expand_mode.dart';
+import 'package:model/mailbox/mailbox_key.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:model/mailbox/select_mode.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart';
@@ -52,14 +54,22 @@ class MailboxTree with EquatableMixin {
     return listResult;
   }
 
+  /// Finds the node identified by [mailboxKey].
+  ///
+  /// Always prefer this over a raw [findNode] on `item.id`: the same
+  /// [MailboxId] can legitimately exist in several accounts, so matching on the
+  /// id alone can return another user's mailbox.
+  MailboxNode? findNodeByKey(MailboxKey mailboxKey) =>
+      findNode((node) => node.item.key == mailboxKey);
+
   MailboxNode? updateExpandedNode(MailboxNode selectedNode, ExpandMode newExpandMode) {
-    var matchedNode = findNode((node) => node.item.id == selectedNode.item.id);
+    var matchedNode = findNodeByKey(selectedNode.item.key);
     matchedNode?.expandMode = newExpandMode;
     return matchedNode;
   }
 
   MailboxNode? updateSelectedNode(MailboxNode selectedNode, SelectMode newSelectMode) {
-    var matchedNode = findNode((node) => node.item.id == selectedNode.item.id);
+    var matchedNode = findNodeByKey(selectedNode.item.key);
     matchedNode?.selectMode = newSelectMode;
     return matchedNode;
   }
@@ -84,8 +94,8 @@ class MailboxTree with EquatableMixin {
     }
   }
 
-  bool updateMailboxNameById(MailboxId mailboxId, MailboxName mailboxName) {
-    final matchedNode = findNode((node) => node.item.id == mailboxId);
+  bool updateMailboxNameByKey(MailboxKey mailboxKey, MailboxName mailboxName) {
+    final matchedNode = findNodeByKey(mailboxKey);
     if (matchedNode != null) {
       matchedNode.item = matchedNode.item.copyWith(name: mailboxName);
       return true;
@@ -93,8 +103,8 @@ class MailboxTree with EquatableMixin {
     return false;
   }
 
-  bool updateMailboxUnreadCountById(MailboxId mailboxId, int unreadCount) {
-    final matchedNode = findNode((node) => node.item.id == mailboxId);
+  bool updateMailboxUnreadCountByKey(MailboxKey mailboxKey, int unreadCount) {
+    final matchedNode = findNodeByKey(mailboxKey);
     if (matchedNode != null) {
       final currentUnreadCount = matchedNode.item.unreadEmails?.value.value ?? 0;
       final updatedUnreadCount = currentUnreadCount + unreadCount;
@@ -107,8 +117,8 @@ class MailboxTree with EquatableMixin {
     return false;
   }
 
-  bool updateMailboxTotalEmailsCountById(MailboxId mailboxId, int totalEmailsCount) {
-    final matchedNode = findNode((node) => node.item.id == mailboxId);
+  bool updateMailboxTotalEmailsCountByKey(MailboxKey mailboxKey, int totalEmailsCount) {
+    final matchedNode = findNodeByKey(mailboxKey);
     if (matchedNode != null) {
       final currentTotalEmailsCount = matchedNode.item.totalEmails?.value.value ?? 0;
       final updatedTotalEmailsCount = currentTotalEmailsCount + totalEmailsCount;
@@ -121,8 +131,8 @@ class MailboxTree with EquatableMixin {
     return false;
   }
 
-  String? getNodePath(MailboxId mailboxId, String pathSeparator) {
-    final matchedNode = findNode((node) => node.item.id == mailboxId);
+  String? getNodePath(MailboxKey mailboxKey, String pathSeparator) {
+    final matchedNode = findNodeByKey(mailboxKey);
     if (matchedNode == null) {
       return null;
     }
@@ -133,10 +143,14 @@ class MailboxTree with EquatableMixin {
       path = '${matchedNode.item.name?.name}';
     }
 
+    // A mailbox's parent always belongs to the same account, so the walk stays
+    // inside the starting node's account. Resolving the parent by id alone
+    // would let the path cross into another user's identically numbered folder.
+    final accountId = mailboxKey.accountId;
     var parentId = matchedNode.item.parentId;
 
     while(parentId != null) {
-      var parentNode = findNode((node) => node.item.id == parentId);
+      var parentNode = findNodeByKey(MailboxKey(accountId, parentId));
       if (parentNode == null) {
         break;
       }
@@ -151,10 +165,12 @@ class MailboxTree with EquatableMixin {
   }
 
   List<MailboxNode>? getAncestorList(MailboxNode mailboxNode) {
+    // Same account-scoping reasoning as getNodePath.
+    final accountId = mailboxNode.item.key.accountId;
     var parentId = mailboxNode.item.parentId;
     List<MailboxNode> ancestor = <MailboxNode>[];
     while(parentId != null) {
-      final parentNode = findNode((node) => node.item.id == parentId);
+      final parentNode = findNodeByKey(MailboxKey(accountId, parentId));
       if (parentNode == null) {
         break;
       }

--- a/lib/features/mailbox/presentation/model/mailbox_tree_builder.dart
+++ b/lib/features/mailbox/presentation/model/mailbox_tree_builder.dart
@@ -1,6 +1,8 @@
 import 'dart:collection';
 
 import 'package:collection/collection.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/extensions/mailbox_name_extension.dart';
 import 'package:model/extensions/presentation_mailbox_extension.dart';
@@ -14,13 +16,65 @@ import 'mailbox_node.dart';
 import 'mailbox_tree.dart';
 
 class TreeBuilder {
+  String _mailboxKey(PresentationMailbox mailbox) =>
+      '${mailbox.accountId?.id.value ?? 'primary'}:${mailbox.id.id.value}';
+
+  String _parentMailboxKey(PresentationMailbox mailbox, MailboxId parentId) =>
+      '${mailbox.accountId?.id.value ?? 'primary'}:${parentId.id.value}';
+
+  String _sharedAccountKey(AccountId accountId) => accountId.id.value;
+
+  PresentationMailbox _createSharedAccountRoot(AccountId accountId) {
+    return PresentationMailbox(
+      MailboxId(Id(accountId.id.value)),
+      accountId: accountId,
+      isSharedAccount: true,
+      isSharedAccountRoot: true,
+      name: MailboxName(accountId.id.value),
+    );
+  }
+
+  Map<String, MailboxNode> _createSharedAccountNodes({
+    required List<PresentationMailbox> mailboxes,
+    required Map<String, MailboxNode> nodeLookup,
+  }) {
+    final sharedAccountNodes = <String, MailboxNode>{};
+
+    for (final mailbox in mailboxes) {
+      final accountId = mailbox.accountId;
+      if (!mailbox.isSharedAccount || accountId == null) continue;
+
+      sharedAccountNodes.putIfAbsent(_sharedAccountKey(accountId), () {
+        final accountRoot = _createSharedAccountRoot(accountId);
+        final existingNode = nodeLookup[_mailboxKey(accountRoot)];
+
+        return MailboxNode(
+          accountRoot,
+          expandMode: existingNode?.expandMode ?? ExpandMode.COLLAPSE,
+          selectMode: SelectMode.INACTIVE,
+        );
+      });
+    }
+
+    return sharedAccountNodes;
+  }
+
+  void _attachSharedAccountNodes({
+    required Map<String, MailboxNode> accountNodes,
+    required MailboxTree teamMailboxTree,
+  }) {
+    for (final accountNode in accountNodes.values) {
+      teamMailboxTree.root.addChildNode(accountNode);
+    }
+  }
+
   Future<MailboxCollection> generateMailboxTreeInUI({
     required List<PresentationMailbox> allMailboxes,
     required MailboxCollection currentCollection,
     MailboxId? mailboxIdSelected,
     MailboxId? mailboxIdExpanded,
   }) async {
-    final Map<MailboxId, MailboxNode> mailboxDictionary = HashMap();
+    final Map<String, MailboxNode> mailboxDictionary = HashMap();
 
     final newDefaultTree = MailboxTree(MailboxNode.root());
     final newPersonalTree = MailboxTree(MailboxNode.root());
@@ -28,9 +82,13 @@ class TreeBuilder {
   
     final List<PresentationMailbox> newAllMailboxes = <PresentationMailbox>[];
     final nodeLookup = _buildNodeLookup(currentCollection);
+    final sharedAccountNodes = _createSharedAccountNodes(
+      mailboxes: allMailboxes,
+      nodeLookup: nodeLookup,
+    );
 
     for (var mailbox in allMailboxes) {
-      final currentMailboxNode = nodeLookup[mailbox.id];
+      final currentMailboxNode = nodeLookup[_mailboxKey(mailbox)];
 
       final isDeactivated = mailbox.id == mailboxIdSelected;
       final newMailboxNode = MailboxNode(
@@ -40,17 +98,18 @@ class TreeBuilder {
         selectMode: currentMailboxNode?.selectMode ?? SelectMode.INACTIVE,
       );
 
-      mailboxDictionary[mailbox.id] = newMailboxNode;
+      mailboxDictionary[_mailboxKey(mailbox)] = newMailboxNode;
     }
 
     for (var mailbox in allMailboxes) {
-      final currentNode = mailboxDictionary[mailbox.id];
+      final currentNode = mailboxDictionary[_mailboxKey(mailbox)];
       if (currentNode == null) continue;
 
       _placeNodeInTree(
         mailbox: mailbox,
         currentNode: currentNode,
         mailboxDictionary: mailboxDictionary,
+        sharedAccountNodes: sharedAccountNodes,
         defaultTree: newDefaultTree,
         personalTree: newPersonalTree,
         teamMailboxTree: newTeamMailboxTree,
@@ -60,6 +119,10 @@ class TreeBuilder {
       newAllMailboxes.add(currentNode.item);
     }
 
+    _attachSharedAccountNodes(
+      accountNodes: sharedAccountNodes,
+      teamMailboxTree: newTeamMailboxTree,
+    );
     _finalizeTrees(newDefaultTree, newPersonalTree, newTeamMailboxTree);
 
     return MailboxCollection(
@@ -74,15 +137,19 @@ class TreeBuilder {
     required List<PresentationMailbox> allMailboxes,
     required MailboxCollection currentCollection,
   }) async {
-    final Map<MailboxId, MailboxNode> mailboxDictionary = HashMap();
+    final Map<String, MailboxNode> mailboxDictionary = HashMap();
 
     final newDefaultTree = MailboxTree(MailboxNode.root());
     final newPersonalTree = MailboxTree(MailboxNode.root());
     final newTeamMailboxTree = MailboxTree(MailboxNode.root());
     final nodeLookup = _buildNodeLookup(currentCollection);
+    final sharedAccountNodes = _createSharedAccountNodes(
+      mailboxes: allMailboxes,
+      nodeLookup: nodeLookup,
+    );
 
     for (var mailbox in allMailboxes) {
-      final currentMailboxNode = nodeLookup[mailbox.id];
+      final currentMailboxNode = nodeLookup[_mailboxKey(mailbox)];
 
       final newMailboxNode = MailboxNode(
         mailbox,
@@ -90,23 +157,28 @@ class TreeBuilder {
         selectMode: currentMailboxNode?.selectMode ?? SelectMode.INACTIVE,
       );
 
-      mailboxDictionary[mailbox.id] = newMailboxNode;
+      mailboxDictionary[_mailboxKey(mailbox)] = newMailboxNode;
     }
 
     for (var mailbox in allMailboxes) {
-      final currentNode = mailboxDictionary[mailbox.id];
+      final currentNode = mailboxDictionary[_mailboxKey(mailbox)];
       if (currentNode == null) continue;
 
       _placeNodeInTree(
         mailbox: mailbox,
         currentNode: currentNode,
         mailboxDictionary: mailboxDictionary,
+        sharedAccountNodes: sharedAccountNodes,
         defaultTree: newDefaultTree,
         personalTree: newPersonalTree,
         teamMailboxTree: newTeamMailboxTree,
       );
     }
 
+    _attachSharedAccountNodes(
+      accountNodes: sharedAccountNodes,
+      teamMailboxTree: newTeamMailboxTree,
+    );
     _finalizeTrees(newDefaultTree, newPersonalTree, newTeamMailboxTree);
 
     return MailboxCollection(
@@ -120,20 +192,33 @@ class TreeBuilder {
   void _placeNodeInTree({
     required PresentationMailbox mailbox,
     required MailboxNode currentNode,
-    required Map<MailboxId, MailboxNode> mailboxDictionary,
+    required Map<String, MailboxNode> mailboxDictionary,
+    required Map<String, MailboxNode> sharedAccountNodes,
     required MailboxTree defaultTree,
     required MailboxTree personalTree,
     required MailboxTree teamMailboxTree,
     void Function(MailboxNode parent, MailboxNode child)? onBeforeAddToParent,
   }) {
     final parentId = mailbox.parentId;
-    final parentNode = parentId != null ? mailboxDictionary[parentId] : null;
+    final parentNode = parentId != null
+        ? mailboxDictionary[_parentMailboxKey(mailbox, parentId)]
+        : null;
 
     if (parentNode != null) {
       onBeforeAddToParent?.call(parentNode, currentNode);
       parentNode.addChildNode(currentNode);
+    } else if (mailbox.isSharedAccount && mailbox.accountId != null) {
+      final accountRoot =
+          sharedAccountNodes[_sharedAccountKey(mailbox.accountId!)];
+
+      if (accountRoot != null) {
+        accountRoot.addChildNode(currentNode);
+      } else {
+        teamMailboxTree.root.addChildNode(currentNode);
+      }
     } else {
-      final targetTree = _resolveTargetTree(mailbox, defaultTree, personalTree, teamMailboxTree);
+      final targetTree =
+          _resolveTargetTree(mailbox, defaultTree, personalTree, teamMailboxTree);
       targetTree.root.addChildNode(currentNode);
     }
   }
@@ -210,12 +295,12 @@ class TreeBuilder {
 
   // Traversal strategy by depth:
   //   virtual root (isPersonal=true)  → alphabetical — orders team account roots
-  //   team account root (isTeamMailboxes=true, depth=1) → system folders first, then alphabetical
+  //   shared account root (isSharedAccountRoot=true, depth=1) → system folders first, then alphabetical
   //   children/grandchildren (hasParentId=true) → alphabetical
   void _applyTeamMailboxSorting(MailboxNode node) {
     final children = node.childrenItems;
     if (children == null || children.isEmpty) return;
-    if (node.item.isTeamMailboxes) {
+    if (node.item.isTeamMailboxes || node.item.isSharedAccountRoot) {
       _sortWithSystemFoldersFirst(node);
     } else {
       sortByMailboxNameNodeChildren(node);
@@ -227,8 +312,8 @@ class TreeBuilder {
 
   // Flattens all three trees into a single O(1) lookup map.
   // Avoids repeated O(n) DFS calls when resolving existing nodes for each mailbox.
-  Map<MailboxId, MailboxNode> _buildNodeLookup(MailboxCollection collection) {
-    final lookup = HashMap<MailboxId, MailboxNode>();
+  Map<String, MailboxNode> _buildNodeLookup(MailboxCollection collection) {
+    final lookup = HashMap<String, MailboxNode>();
     final stack = <MailboxNode>[
       ...?collection.defaultTree.root.childrenItems,
       ...?collection.personalTree.root.childrenItems,
@@ -236,7 +321,7 @@ class TreeBuilder {
     ];
     while (stack.isNotEmpty) {
       final node = stack.removeLast();
-      lookup[node.item.id] = node;
+      lookup[_mailboxKey(node.item)] = node;
       final children = node.childrenItems;
       if (children != null) stack.addAll(children);
     }
@@ -249,6 +334,7 @@ class TreeBuilder {
     MailboxTree personalTree,
     MailboxTree teamMailboxTree,
   ) {
+    if (mailbox.isSharedAccount) return teamMailboxTree;
     if (mailbox.hasRole()) return defaultTree;
     return mailbox.isPersonal ? personalTree : teamMailboxTree;
   }

--- a/lib/features/mailbox/presentation/model/mailbox_tree_builder.dart
+++ b/lib/features/mailbox/presentation/model/mailbox_tree_builder.dart
@@ -39,7 +39,7 @@ class TreeBuilder {
   Future<MailboxCollection> generateMailboxTreeInUI({
     required List<PresentationMailbox> allMailboxes,
     required MailboxCollection currentCollection,
-    MailboxId? mailboxIdSelected,
+    MailboxKey? mailboxKeySelected,
     MailboxId? mailboxIdExpanded,
     AccountId? primaryAccountId,
   }) async {
@@ -56,7 +56,7 @@ class TreeBuilder {
     for (var mailbox in allMailboxes) {
       final currentMailboxNode = nodeLookup[mailbox.key];
 
-      final isDeactivated = mailbox.id == mailboxIdSelected;
+      final isDeactivated = mailbox.key == mailboxKeySelected;
       final newMailboxNode = MailboxNode(
         isDeactivated ? mailbox.withMailboxSate(MailboxState.deactivated) : mailbox,
         nodeState: isDeactivated ? MailboxState.deactivated : MailboxState.activated,

--- a/lib/features/mailbox/presentation/model/mailbox_tree_builder.dart
+++ b/lib/features/mailbox/presentation/model/mailbox_tree_builder.dart
@@ -2,11 +2,11 @@ import 'dart:collection';
 
 import 'package:collection/collection.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
-import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/extensions/mailbox_name_extension.dart';
 import 'package:model/extensions/presentation_mailbox_extension.dart';
 import 'package:model/mailbox/expand_mode.dart';
+import 'package:model/mailbox/mailbox_key.dart';
 import 'package:model/mailbox/mailbox_state.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:model/mailbox/select_mode.dart';
@@ -16,56 +16,24 @@ import 'mailbox_node.dart';
 import 'mailbox_tree.dart';
 
 class TreeBuilder {
-  String _mailboxKey(PresentationMailbox mailbox) =>
-      '${mailbox.accountId?.id.value ?? 'primary'}:${mailbox.id.id.value}';
-
-  String _parentMailboxKey(PresentationMailbox mailbox, MailboxId parentId) =>
-      '${mailbox.accountId?.id.value ?? 'primary'}:${parentId.id.value}';
-
-  String _sharedAccountKey(AccountId accountId) => accountId.id.value;
-
-  PresentationMailbox _createSharedAccountRoot(AccountId accountId) {
-    return PresentationMailbox(
-      MailboxId(Id(accountId.id.value)),
-      accountId: accountId,
-      isSharedAccount: true,
-      isSharedAccountRoot: true,
-      name: MailboxName(accountId.id.value),
-    );
-  }
-
-  Map<String, MailboxNode> _createSharedAccountNodes({
-    required List<PresentationMailbox> mailboxes,
-    required Map<String, MailboxNode> nodeLookup,
-  }) {
-    final sharedAccountNodes = <String, MailboxNode>{};
-
-    for (final mailbox in mailboxes) {
-      final accountId = mailbox.accountId;
-      if (!mailbox.isSharedAccount || accountId == null) continue;
-
-      sharedAccountNodes.putIfAbsent(_sharedAccountKey(accountId), () {
-        final accountRoot = _createSharedAccountRoot(accountId);
-        final existingNode = nodeLookup[_mailboxKey(accountRoot)];
-
-        return MailboxNode(
-          accountRoot,
-          expandMode: existingNode?.expandMode ?? ExpandMode.COLLAPSE,
-          selectMode: SelectMode.INACTIVE,
-        );
-      });
-    }
-
-    return sharedAccountNodes;
-  }
-
-  void _attachSharedAccountNodes({
-    required Map<String, MailboxNode> accountNodes,
-    required MailboxTree teamMailboxTree,
-  }) {
-    for (final accountNode in accountNodes.values) {
-      teamMailboxTree.root.addChildNode(accountNode);
-    }
+  /// Guarantees every mailbox carries an owning account before it enters a tree.
+  ///
+  /// Mailboxes fetched from the server are already stamped by the interactor
+  /// that fetched them. This is the safety net for the paths that are not, so
+  /// that a lookup resolving a bare id against the primary account cannot miss
+  /// a node that silently landed under [MailboxKey.localAccount]. Genuinely
+  /// account-less pseudo-mailboxes (the virtual folders) keep a null accountId
+  /// and fall back to that sentinel.
+  List<PresentationMailbox> _normalizeAccounts(
+    List<PresentationMailbox> mailboxes,
+    AccountId? primaryAccountId,
+  ) {
+    if (primaryAccountId == null) return mailboxes;
+    return mailboxes
+        .map((mailbox) => mailbox.accountId != null || mailbox.isVirtualFolder
+            ? mailbox
+            : mailbox.copyWith(accountId: primaryAccountId))
+        .toList();
   }
 
   Future<MailboxCollection> generateMailboxTreeInUI({
@@ -73,22 +41,20 @@ class TreeBuilder {
     required MailboxCollection currentCollection,
     MailboxId? mailboxIdSelected,
     MailboxId? mailboxIdExpanded,
+    AccountId? primaryAccountId,
   }) async {
-    final Map<String, MailboxNode> mailboxDictionary = HashMap();
+    final Map<MailboxKey, MailboxNode> mailboxDictionary = HashMap();
+    allMailboxes = _normalizeAccounts(allMailboxes, primaryAccountId);
 
     final newDefaultTree = MailboxTree(MailboxNode.root());
     final newPersonalTree = MailboxTree(MailboxNode.root());
     final newTeamMailboxTree = MailboxTree(MailboxNode.root());
-  
+
     final List<PresentationMailbox> newAllMailboxes = <PresentationMailbox>[];
     final nodeLookup = _buildNodeLookup(currentCollection);
-    final sharedAccountNodes = _createSharedAccountNodes(
-      mailboxes: allMailboxes,
-      nodeLookup: nodeLookup,
-    );
 
     for (var mailbox in allMailboxes) {
-      final currentMailboxNode = nodeLookup[_mailboxKey(mailbox)];
+      final currentMailboxNode = nodeLookup[mailbox.key];
 
       final isDeactivated = mailbox.id == mailboxIdSelected;
       final newMailboxNode = MailboxNode(
@@ -98,18 +64,17 @@ class TreeBuilder {
         selectMode: currentMailboxNode?.selectMode ?? SelectMode.INACTIVE,
       );
 
-      mailboxDictionary[_mailboxKey(mailbox)] = newMailboxNode;
+      mailboxDictionary[mailbox.key] = newMailboxNode;
     }
 
     for (var mailbox in allMailboxes) {
-      final currentNode = mailboxDictionary[_mailboxKey(mailbox)];
+      final currentNode = mailboxDictionary[mailbox.key];
       if (currentNode == null) continue;
 
       _placeNodeInTree(
         mailbox: mailbox,
         currentNode: currentNode,
         mailboxDictionary: mailboxDictionary,
-        sharedAccountNodes: sharedAccountNodes,
         defaultTree: newDefaultTree,
         personalTree: newPersonalTree,
         teamMailboxTree: newTeamMailboxTree,
@@ -119,10 +84,6 @@ class TreeBuilder {
       newAllMailboxes.add(currentNode.item);
     }
 
-    _attachSharedAccountNodes(
-      accountNodes: sharedAccountNodes,
-      teamMailboxTree: newTeamMailboxTree,
-    );
     _finalizeTrees(newDefaultTree, newPersonalTree, newTeamMailboxTree);
 
     return MailboxCollection(
@@ -136,20 +97,18 @@ class TreeBuilder {
   Future<MailboxCollection> generateMailboxTreeInUIAfterRefreshChanges({
     required List<PresentationMailbox> allMailboxes,
     required MailboxCollection currentCollection,
+    AccountId? primaryAccountId,
   }) async {
-    final Map<String, MailboxNode> mailboxDictionary = HashMap();
+    final Map<MailboxKey, MailboxNode> mailboxDictionary = HashMap();
+    allMailboxes = _normalizeAccounts(allMailboxes, primaryAccountId);
 
     final newDefaultTree = MailboxTree(MailboxNode.root());
     final newPersonalTree = MailboxTree(MailboxNode.root());
     final newTeamMailboxTree = MailboxTree(MailboxNode.root());
     final nodeLookup = _buildNodeLookup(currentCollection);
-    final sharedAccountNodes = _createSharedAccountNodes(
-      mailboxes: allMailboxes,
-      nodeLookup: nodeLookup,
-    );
 
     for (var mailbox in allMailboxes) {
-      final currentMailboxNode = nodeLookup[_mailboxKey(mailbox)];
+      final currentMailboxNode = nodeLookup[mailbox.key];
 
       final newMailboxNode = MailboxNode(
         mailbox,
@@ -157,28 +116,23 @@ class TreeBuilder {
         selectMode: currentMailboxNode?.selectMode ?? SelectMode.INACTIVE,
       );
 
-      mailboxDictionary[_mailboxKey(mailbox)] = newMailboxNode;
+      mailboxDictionary[mailbox.key] = newMailboxNode;
     }
 
     for (var mailbox in allMailboxes) {
-      final currentNode = mailboxDictionary[_mailboxKey(mailbox)];
+      final currentNode = mailboxDictionary[mailbox.key];
       if (currentNode == null) continue;
 
       _placeNodeInTree(
         mailbox: mailbox,
         currentNode: currentNode,
         mailboxDictionary: mailboxDictionary,
-        sharedAccountNodes: sharedAccountNodes,
         defaultTree: newDefaultTree,
         personalTree: newPersonalTree,
         teamMailboxTree: newTeamMailboxTree,
       );
     }
 
-    _attachSharedAccountNodes(
-      accountNodes: sharedAccountNodes,
-      teamMailboxTree: newTeamMailboxTree,
-    );
     _finalizeTrees(newDefaultTree, newPersonalTree, newTeamMailboxTree);
 
     return MailboxCollection(
@@ -192,38 +146,35 @@ class TreeBuilder {
   void _placeNodeInTree({
     required PresentationMailbox mailbox,
     required MailboxNode currentNode,
-    required Map<String, MailboxNode> mailboxDictionary,
-    required Map<String, MailboxNode> sharedAccountNodes,
+    required Map<MailboxKey, MailboxNode> mailboxDictionary,
     required MailboxTree defaultTree,
     required MailboxTree personalTree,
     required MailboxTree teamMailboxTree,
     void Function(MailboxNode parent, MailboxNode child)? onBeforeAddToParent,
   }) {
     final parentId = mailbox.parentId;
+    // The parent is resolved within the mailbox's own account. Looking it up by
+    // id alone would let a mailbox be adopted by an identically numbered folder
+    // belonging to a different account.
     final parentNode = parentId != null
-        ? mailboxDictionary[_parentMailboxKey(mailbox, parentId)]
+        ? mailboxDictionary[MailboxKey(mailbox.key.accountId, parentId)]
         : null;
 
     if (parentNode != null) {
       onBeforeAddToParent?.call(parentNode, currentNode);
       parentNode.addChildNode(currentNode);
-    } else if (mailbox.isSharedAccount && mailbox.accountId != null) {
-      final accountRoot =
-          sharedAccountNodes[_sharedAccountKey(mailbox.accountId!)];
-
-      if (accountRoot != null) {
-        accountRoot.addChildNode(currentNode);
-      } else {
-        teamMailboxTree.root.addChildNode(currentNode);
-      }
     } else {
-      final targetTree =
-          _resolveTargetTree(mailbox, defaultTree, personalTree, teamMailboxTree);
+      final targetTree = _resolveTargetTree(
+        mailbox, defaultTree, personalTree, teamMailboxTree);
       targetTree.root.addChildNode(currentNode);
     }
   }
 
-  void _finalizeTrees(MailboxTree defaultTree, MailboxTree personalTree, MailboxTree teamMailboxTree) {
+  void _finalizeTrees(
+    MailboxTree defaultTree,
+    MailboxTree personalTree,
+    MailboxTree teamMailboxTree,
+  ) {
     sortNodeChildren(defaultTree.root);
     defaultTree.root.childrenItems?.forEach(_sortChildrenAlphabetically);
     _sortChildrenAlphabetically(personalTree.root);
@@ -295,7 +246,7 @@ class TreeBuilder {
 
   // Traversal strategy by depth:
   //   virtual root (isPersonal=true)  → alphabetical — orders team account roots
-  //   shared account root (isSharedAccountRoot=true, depth=1) → system folders first, then alphabetical
+  //   other user account root (isSharedAccountRoot=true, depth=1) → system folders first, then alphabetical
   //   children/grandchildren (hasParentId=true) → alphabetical
   void _applyTeamMailboxSorting(MailboxNode node) {
     final children = node.childrenItems;
@@ -310,10 +261,10 @@ class TreeBuilder {
     }
   }
 
-  // Flattens all three trees into a single O(1) lookup map.
+  // Flattens all trees into a single O(1) lookup map.
   // Avoids repeated O(n) DFS calls when resolving existing nodes for each mailbox.
-  Map<String, MailboxNode> _buildNodeLookup(MailboxCollection collection) {
-    final lookup = HashMap<String, MailboxNode>();
+  Map<MailboxKey, MailboxNode> _buildNodeLookup(MailboxCollection collection) {
+    final lookup = HashMap<MailboxKey, MailboxNode>();
     final stack = <MailboxNode>[
       ...?collection.defaultTree.root.childrenItems,
       ...?collection.personalTree.root.childrenItems,
@@ -321,7 +272,7 @@ class TreeBuilder {
     ];
     while (stack.isNotEmpty) {
       final node = stack.removeLast();
-      lookup[_mailboxKey(node.item)] = node;
+      lookup[node.item.key] = node;
       final children = node.childrenItems;
       if (children != null) stack.addAll(children);
     }
@@ -334,9 +285,11 @@ class TreeBuilder {
     MailboxTree personalTree,
     MailboxTree teamMailboxTree,
   ) {
-    if (mailbox.isSharedAccount) return teamMailboxTree;
-    if (mailbox.hasRole()) return defaultTree;
-    return mailbox.isPersonal ? personalTree : teamMailboxTree;
+    // Team mailboxes and delegated (other users') mailboxes both live here,
+    // rendered identically. Only the signed-in user's own role mailboxes go to
+    // the top default section, so a delegated Inbox is never mixed into it.
+    if (!mailbox.isPersonal) return teamMailboxTree;
+    return mailbox.hasRole() ? defaultTree : personalTree;
   }
 
   void _propagateDeactivationIfNeeded(MailboxNode parentNode, MailboxNode currentNode) {

--- a/lib/features/mailbox/presentation/model/other_user_account_mailboxes.dart
+++ b/lib/features/mailbox/presentation/model/other_user_account_mailboxes.dart
@@ -1,0 +1,36 @@
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+
+/// The loaded mailboxes of one other user's (delegated) account.
+///
+/// [mailboxState] is held per account because a session exposes a single
+/// primary [BaseMailboxController.currentMailboxState], which cannot track the
+/// change state of the delegated accounts. It lets each account be refreshed
+/// with Mailbox/changes independently.
+class OtherUserAccountMailboxes {
+  final AccountId accountId;
+  final MailboxName displayName;
+  final List<PresentationMailbox> mailboxes;
+  final jmap.State? mailboxState;
+
+  const OtherUserAccountMailboxes({
+    required this.accountId,
+    required this.displayName,
+    required this.mailboxes,
+    this.mailboxState,
+  });
+
+  OtherUserAccountMailboxes copyWith({
+    List<PresentationMailbox>? mailboxes,
+    jmap.State? mailboxState,
+  }) {
+    return OtherUserAccountMailboxes(
+      accountId: accountId,
+      displayName: displayName,
+      mailboxes: mailboxes ?? this.mailboxes,
+      mailboxState: mailboxState ?? this.mailboxState,
+    );
+  }
+}

--- a/lib/features/mailbox/presentation/utils/mailbox_utils.dart
+++ b/lib/features/mailbox/presentation/utils/mailbox_utils.dart
@@ -1,13 +1,42 @@
 import 'package:email_recovery/email_recovery/capability_deleted_messages_vault.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/capability/capability_identifier.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/namespace.dart';
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
 
 class MailboxUtils {
+  /// A synthesized namespace matching what James emits for a delegated mailbox,
+  /// so a Cyrus other-user account renders through the same team-mailbox path
+  /// with the owner shown as a subtitle. Cyrus has no namespace of its own; the
+  /// owning account is still carried on the mailbox's accountId for write
+  /// routing. The `[owner]` form is what PresentationMailbox.emailTeamMailBoxes
+  /// parses.
+  static Namespace delegatedNamespace(String ownerName) =>
+      Namespace('Delegated[$ownerName]');
+
   static bool isDeletedMessageVaultSupported(Session? session, AccountId? accountId) {
     if (session == null || accountId == null) {
       return false;
     }
     return capabilityDeletedMessagesVault.isSupported(session, accountId);
+  }
+
+  /// The delegated accounts (other users) in [session], excluding [primary].
+  ///
+  /// A session's accounts also include contacts, calendar or file-storage
+  /// accounts; Mailbox/get on those returns accountNotSupportedByMethod, so the
+  /// JMAP Mail capability filter is mandatory. isPersonal is deliberately not
+  /// used: some deployments mark delegated accounts isPersonal.
+  static List<AccountId> resolveOtherUserAccountIds(
+    Session session,
+    AccountId primary,
+  ) {
+    return session.accounts.entries
+        .where((entry) => entry.key != primary)
+        .where((entry) =>
+            CapabilityIdentifier.jmapMail.isSupported(session, entry.key))
+        .map((entry) => entry.key)
+        .toList();
   }
 }

--- a/lib/features/mailbox/presentation/widgets/mailbox_item_widget.dart
+++ b/lib/features/mailbox/presentation/widgets/mailbox_item_widget.dart
@@ -356,6 +356,7 @@ class _MailboxItemWidgetState extends State<MailboxItemWidget> {
 
   bool get _isIconDisplayed =>
       widget.mailboxNode.item.isPersonal ||
+      widget.mailboxNode.item.isSharedAccount ||
       widget.mailboxNode.item.hasParentId();
 
   String get _iconMailbox =>

--- a/lib/features/mailbox/presentation/widgets/mailbox_item_widget.dart
+++ b/lib/features/mailbox/presentation/widgets/mailbox_item_widget.dart
@@ -320,8 +320,10 @@ class _MailboxItemWidgetState extends State<MailboxItemWidget> {
     }
   }
 
+  // Compared by account-scoped key: selecting the primary Inbox must not
+  // highlight an identically numbered folder in another user's account.
   bool get _isSelected =>
-      widget.mailboxNodeSelected?.id == widget.mailboxNode.item.id;
+      widget.mailboxNodeSelected?.key == widget.mailboxNode.item.key;
 
   Color get backgroundColorItem {
     // Non-mailbox views are always white

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -1483,8 +1483,15 @@ class MailboxDashBoardController extends ReloadableController
   ) {
     // A JMAP move is an Email/set within one account; moving to another user's
     // account would need Email/copy plus destroy, which is not implemented.
-    final sourceAccountId =
-        selectedMailbox.value?.accountId ?? accountId.value;
+    // In search or a virtual folder there is no selected source mailbox, so the
+    // source account is derived from the dragged emails themselves rather than
+    // defaulting to the primary account, which would let a delegated email pass
+    // the guard and then be moved (and silently dropped) against the wrong
+    // account. A null result means the source is unresolved or spans accounts.
+    final selectedSource = selectedMailbox.value;
+    final sourceAccountId = selectedSource != null
+        ? (selectedSource.accountId ?? accountId.value)
+        : _sourceAccountIdOfDraggedEmails(listEmails);
     final destinationAccountId = destinationMailbox.accountId ?? accountId.value;
     if (!destinationMailbox.isFavorite &&
         sourceAccountId != destinationAccountId) {
@@ -1531,6 +1538,23 @@ class MailboxDashBoardController extends ReloadableController
         );
       }
     }
+  }
+
+  /// Resolves the single account the dragged emails belong to, for the cross-
+  /// account move guard when no source mailbox is selected. Each email's account
+  /// is taken from its containing mailbox. Returns null when any email cannot be
+  /// resolved or the emails span more than one account, which the caller treats
+  /// as "not a same-account move" and blocks.
+  AccountId? _sourceAccountIdOfDraggedEmails(List<PresentationEmail> listEmails) {
+    final sourceMailboxes = listEmails
+        .map((email) => email.findMailboxContain(mapMailboxById))
+        .toList();
+    if (sourceMailboxes.any((mailbox) => mailbox == null)) return null;
+
+    final sourceAccountIds = sourceMailboxes
+        .map((mailbox) => mailbox!.accountId ?? accountId.value)
+        .toSet();
+    return sourceAccountIds.length == 1 ? sourceAccountIds.single : null;
   }
 
   void _handleDragSelectedMultipleEmailToFavoriteFolder(

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -1482,16 +1482,12 @@ class MailboxDashBoardController extends ReloadableController
     PresentationMailbox destinationMailbox,
   ) {
     // A JMAP move is an Email/set within one account; moving to another user's
-    // account would need Email/copy plus destroy, which is not implemented.
-    // In search or a virtual folder there is no selected source mailbox, so the
-    // source account is derived from the dragged emails themselves rather than
-    // defaulting to the primary account, which would let a delegated email pass
-    // the guard and then be moved (and silently dropped) against the wrong
-    // account. A null result means the source is unresolved or spans accounts.
-    final selectedSource = selectedMailbox.value;
-    final sourceAccountId = selectedSource != null
-        ? (selectedSource.accountId ?? accountId.value)
-        : _sourceAccountIdOfDraggedEmails(listEmails);
+    // account would need Email/copy plus destroy, which is not implemented. The
+    // thread list only ever holds primary-account emails, so when no source
+    // mailbox is selected (search or a virtual folder) the source is the primary
+    // account; a selected delegated mailbox carries its own account.
+    final sourceAccountId =
+        selectedMailbox.value?.accountId ?? accountId.value;
     final destinationAccountId = destinationMailbox.accountId ?? accountId.value;
     if (!destinationMailbox.isFavorite &&
         sourceAccountId != destinationAccountId) {
@@ -1538,23 +1534,6 @@ class MailboxDashBoardController extends ReloadableController
         );
       }
     }
-  }
-
-  /// Resolves the single account the dragged emails belong to, for the cross-
-  /// account move guard when no source mailbox is selected. Each email's account
-  /// is taken from its containing mailbox. Returns null when any email cannot be
-  /// resolved or the emails span more than one account, which the caller treats
-  /// as "not a same-account move" and blocks.
-  AccountId? _sourceAccountIdOfDraggedEmails(List<PresentationEmail> listEmails) {
-    final sourceMailboxes = listEmails
-        .map((email) => email.findMailboxContain(mapMailboxById))
-        .toList();
-    if (sourceMailboxes.any((mailbox) => mailbox == null)) return null;
-
-    final sourceAccountIds = sourceMailboxes
-        .map((mailbox) => mailbox!.accountId ?? accountId.value)
-        .toSet();
-    return sourceAccountIds.length == 1 ? sourceAccountIds.single : null;
   }
 
   void _handleDragSelectedMultipleEmailToFavoriteFolder(

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -1506,7 +1506,7 @@ class MailboxDashBoardController extends ReloadableController
     );
 
     if (destinationMailbox.isFavorite) {
-      _handleDragSelectedMultipleEmailToFavoriteFolder(listEmails);
+      _handleDragSelectedMultipleEmailToFavoriteFolder(listEmails, sourceAccountId);
     } else {
       if (searchController.isSearchEmailRunning ||
           selectedMailbox.value?.isVirtualFolder == true) {
@@ -1525,12 +1525,14 @@ class MailboxDashBoardController extends ReloadableController
           mapListEmailSelectedByMailBoxId,
           destinationMailbox,
           emailIdsWithReadStatus,
+          sourceAccountId,
         );
       } else if (selectedMailbox.value != null) {
         _handleDragSelectedMultipleEmailToMailboxAction(
           {selectedMailbox.value!.id: listEmails.listEmailIds},
           destinationMailbox,
           emailIdsWithReadStatus,
+          sourceAccountId,
         );
       }
     }
@@ -1538,8 +1540,9 @@ class MailboxDashBoardController extends ReloadableController
 
   void _handleDragSelectedMultipleEmailToFavoriteFolder(
     List<PresentationEmail> listPresentationEmail,
+    AccountId? sourceAccountId,
   ) async {
-    if (accountId.value != null && sessionCurrent != null) {
+    if (sourceAccountId != null && sessionCurrent != null) {
       final listEmailIds = listPresentationEmail
         .where((email) => !email.hasStarred)
         .toList()
@@ -1548,7 +1551,7 @@ class MailboxDashBoardController extends ReloadableController
       consumeState(
         _markAsStarMultipleEmailInteractor.execute(
           sessionCurrent!,
-          accountId.value!,
+          sourceAccountId,
           listEmailIds,
           MarkStarAction.markStar,
         ),
@@ -1571,12 +1574,13 @@ class MailboxDashBoardController extends ReloadableController
     Map<MailboxId, List<EmailId>> mapListEmails,
     PresentationMailbox destinationMailbox,
     Map<EmailId, bool> emailIdsWithReadStatus,
+    AccountId? sourceAccountId,
   ) async {
-    if (accountId.value != null && sessionCurrent != null) {
+    if (sourceAccountId != null && sessionCurrent != null) {
       if (destinationMailbox.isTrash) {
         moveToMailbox(
           sessionCurrent!,
-          accountId.value!,
+          sourceAccountId,
           MoveToMailboxRequest(
             mapListEmails,
             destinationMailbox.id,
@@ -1588,7 +1592,7 @@ class MailboxDashBoardController extends ReloadableController
       } else if (destinationMailbox.isSpam) {
         moveToMailbox(
           sessionCurrent!,
-          accountId.value!,
+          sourceAccountId,
           MoveToMailboxRequest(
             mapListEmails,
             destinationMailbox.id,
@@ -1600,7 +1604,7 @@ class MailboxDashBoardController extends ReloadableController
       } else {
         moveToMailbox(
           sessionCurrent!,
-          accountId.value!,
+          sourceAccountId,
           MoveToMailboxRequest(
             mapListEmails,
             destinationMailbox.id,

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -1481,6 +1481,22 @@ class MailboxDashBoardController extends ReloadableController
     List<PresentationEmail> listEmails,
     PresentationMailbox destinationMailbox,
   ) {
+    // A JMAP move is an Email/set within one account; moving to another user's
+    // account would need Email/copy plus destroy, which is not implemented.
+    final sourceAccountId =
+        selectedMailbox.value?.accountId ?? accountId.value;
+    final destinationAccountId = destinationMailbox.accountId ?? accountId.value;
+    if (!destinationMailbox.isFavorite &&
+        sourceAccountId != destinationAccountId) {
+      if (currentContext != null && currentOverlayContext != null) {
+        appToast.showToastErrorMessage(
+          currentOverlayContext!,
+          AppLocalizations.of(currentContext!).moveEmailAcrossAccountsNotSupported,
+        );
+      }
+      return;
+    }
+
     final emailIdsWithReadStatus = Map.fromEntries(listEmails
       .where((email) => email.id != null)
       .map((e) => MapEntry(e.id!, e.hasRead))
@@ -2139,6 +2155,11 @@ class MailboxDashBoardController extends ReloadableController
     getServerSetting();
     spamReportController.getSpamReportStateAction();
     loadAIScribeConfig();
+    // Reflect any subscription changes made in the Mailbox visibility screen on
+    // the sidebar. This refreshes the primary account and the delegated
+    // accounts, whose subscription state is otherwise only picked up on a
+    // primary websocket push.
+    dispatchMailboxUIAction(RefreshAllMailboxAction());
     if (isLabelCapabilitySupported &&
         accountId.value != null &&
         sessionCurrent != null) {

--- a/lib/features/mailbox_dashboard/presentation/delegates/empty_folder_provider_listener_delegate.dart
+++ b/lib/features/mailbox_dashboard/presentation/delegates/empty_folder_provider_listener_delegate.dart
@@ -76,7 +76,8 @@ class EmptyFolderProviderListenerDelegate
     MailboxDashBoardController dashboardController,
   ) {
     final session = dashboardController.sessionCurrent;
-    final accountId = dashboardController.accountId.value;
+    // Empty-folder runs against the account that owns the mailbox.
+    final accountId = mailbox.accountId ?? dashboardController.accountId.value;
     if (session == null || accountId == null) {
       _showEmptyFolderFailureToast(context, ref);
       return;

--- a/lib/features/mailbox_dashboard/presentation/extensions/get_trash_mailbox_id_and_path_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/get_trash_mailbox_id_and_path_extension.dart
@@ -19,16 +19,16 @@ extension GetTrashMailboxIdAndPathExtension on MailboxDashBoardController {
     final namespace = emailMailbox.namespace;
     if (namespace == null) return defaultResult;
 
-    final trashId = findDefaultMailboxIdInTeamMailbox(
+    final trashMailbox = findDefaultMailboxInTeamMailbox(
       namespace: namespace,
       mailboxName: PresentationMailbox.trashRole,
     );
-    if (trashId == null) return defaultResult;
+    if (trashMailbox == null) return defaultResult;
 
     final trashPath = getTeamMailboxNodePathWithSeparator(
-      mailboxId: trashId,
+      mailboxKey: trashMailbox.key,
     );
-    return (trashId: trashId, trashPath: trashPath);
+    return (trashId: trashMailbox.id, trashPath: trashPath);
   }
 
   void emitMoveToTrashFailure(Exception exception) {

--- a/lib/features/mailbox_dashboard/presentation/extensions/map_mailbox_by_id_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/map_mailbox_by_id_extension.dart
@@ -2,15 +2,12 @@ import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 
 extension MapMailboxByIdExtension on Map<MailboxId, PresentationMailbox> {
-  /// The child mailbox ids of [parent], scoped to the parent's own account.
+  /// The child mailbox ids of [parent].
   ///
-  /// JMAP ids collide across accounts, so matching on `parentId` alone would let
-  /// a delegated parent pick up an identically numbered primary folder's
-  /// children (and vice versa) and empty the wrong subfolders. Comparing the
-  /// account too keeps the cascade within the account the empty runs against.
+  /// This runs against `mapMailboxById`, which `_setMapMailbox()` keeps scoped
+  /// to the primary account plus the account-less virtual folders, so the
+  /// cascade is a primary-account operation and a bare `parentId` match is
+  /// sufficient here.
   List<MailboxId> childMailboxIds(PresentationMailbox parent) =>
-      values
-          .where((m) => m.parentId == parent.id && m.accountId == parent.accountId)
-          .map((m) => m.id)
-          .toList();
+      values.where((m) => m.parentId == parent.id).map((m) => m.id).toList();
 }

--- a/lib/features/mailbox_dashboard/presentation/extensions/map_mailbox_by_id_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/map_mailbox_by_id_extension.dart
@@ -2,6 +2,15 @@ import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 
 extension MapMailboxByIdExtension on Map<MailboxId, PresentationMailbox> {
+  /// The child mailbox ids of [parent], scoped to the parent's own account.
+  ///
+  /// JMAP ids collide across accounts, so matching on `parentId` alone would let
+  /// a delegated parent pick up an identically numbered primary folder's
+  /// children (and vice versa) and empty the wrong subfolders. Comparing the
+  /// account too keeps the cascade within the account the empty runs against.
   List<MailboxId> childMailboxIds(PresentationMailbox parent) =>
-      values.where((m) => m.parentId == parent.id).map((m) => m.id).toList();
+      values
+          .where((m) => m.parentId == parent.id && m.accountId == parent.accountId)
+          .map((m) => m.id)
+          .toList();
 }

--- a/lib/features/manage_account/presentation/mailbox_visibility/mailbox_visibility_controller.dart
+++ b/lib/features/manage_account/presentation/mailbox_visibility/mailbox_visibility_controller.dart
@@ -224,11 +224,14 @@ class MailboxVisibilityController extends BaseMailboxController
     if (subscribeMailboxSuccess.subscribeAction == MailboxSubscribeAction.unSubscribe
         && currentOverlayContext != null
         && currentContext != null) {
-        _showToastSubscribeMailboxSuccess(subscribeMailboxSuccess.mailboxId);
+        _showToastSubscribeMailboxSuccess(
+          subscribeMailboxSuccess.mailboxId,
+          subscribeMailboxSuccess.accountId,
+        );
     }
 
     _reflectSubscribeChange(
-      anchorMailboxId: subscribeMailboxSuccess.mailboxId,
+      owningAccountId: subscribeMailboxSuccess.accountId,
       affectedMailboxIds: {subscribeMailboxSuccess.mailboxId},
       subscribeAction: subscribeMailboxSuccess.subscribeAction,
     );
@@ -238,12 +241,13 @@ class MailboxVisibilityController extends BaseMailboxController
     if(subscribeMailboxSuccess.subscribeAction == MailboxSubscribeAction.unSubscribe) {
       _showToastSubscribeMailboxSuccess(
         subscribeMailboxSuccess.parentMailboxId,
+        subscribeMailboxSuccess.accountId,
         listDescendantMailboxIds: subscribeMailboxSuccess.mailboxIdsSubscribe
       );
     }
 
     _reflectSubscribeChange(
-      anchorMailboxId: subscribeMailboxSuccess.parentMailboxId,
+      owningAccountId: subscribeMailboxSuccess.accountId,
       affectedMailboxIds: {
         subscribeMailboxSuccess.parentMailboxId,
         ...subscribeMailboxSuccess.mailboxIdsSubscribe,
@@ -256,12 +260,13 @@ class MailboxVisibilityController extends BaseMailboxController
     if(subscribeMailboxSuccess.subscribeAction == MailboxSubscribeAction.unSubscribe) {
       _showToastSubscribeMailboxSuccess(
           subscribeMailboxSuccess.parentMailboxId,
+          subscribeMailboxSuccess.accountId,
           listDescendantMailboxIds: subscribeMailboxSuccess.mailboxIdsSubscribe
       );
     }
 
     _reflectSubscribeChange(
-      anchorMailboxId: subscribeMailboxSuccess.parentMailboxId,
+      owningAccountId: subscribeMailboxSuccess.accountId,
       affectedMailboxIds: {
         subscribeMailboxSuccess.parentMailboxId,
         ...subscribeMailboxSuccess.mailboxIdsSubscribe,
@@ -277,17 +282,17 @@ class MailboxVisibilityController extends BaseMailboxController
   /// does not advance the mailbox modseq that Mailbox/changes is based on, so a
   /// server refresh cannot observe it. Flipping isSubscribed in the cached list
   /// keeps Personal Folders and Other Users behaving identically on show/hide.
+  /// The owning account is carried on the success state, not resolved from the
+  /// mailbox id, since JMAP ids collide across accounts.
   void _reflectSubscribeChange({
-    required MailboxId anchorMailboxId,
+    required AccountId owningAccountId,
     required Set<MailboxId> affectedMailboxIds,
     required MailboxSubscribeAction subscribeAction,
   }) async {
-    final owningAccountId = _accountIdOfMailboxId(anchorMailboxId);
     final subscribed = subscribeAction == MailboxSubscribeAction.subscribe;
 
-    final delegated =
-        owningAccountId != null ? _otherUserAccounts[owningAccountId] : null;
-    if (owningAccountId != null && delegated != null) {
+    final delegated = _otherUserAccounts[owningAccountId];
+    if (delegated != null) {
       _otherUserAccounts[owningAccountId] = delegated.copyWith(
         mailboxes:
             _flipSubscribed(delegated.mailboxes, affectedMailboxIds, subscribed),
@@ -312,6 +317,7 @@ class MailboxVisibilityController extends BaseMailboxController
 
   void _showToastSubscribeMailboxSuccess(
       MailboxId mailboxIdSubscribed,
+      AccountId owningAccountId,
       {List<MailboxId>? listDescendantMailboxIds}
   ) {
     if (currentOverlayContext != null && currentContext != null) {
@@ -320,8 +326,6 @@ class MailboxVisibilityController extends BaseMailboxController
         AppLocalizations.of(currentContext!).toastMsgHideFolderSuccess,
         actionName: AppLocalizations.of(currentContext!).undo,
         onActionClick: () {
-          final owningAccountId = _accountIdOfMailboxId(mailboxIdSubscribed);
-          if (owningAccountId == null) return;
           _subscribeMailboxAction(
             SubscribeMailboxRequest(
               mailboxIdSubscribed,
@@ -338,20 +342,6 @@ class MailboxVisibilityController extends BaseMailboxController
         actionIcon: SvgPicture.asset(imagePaths.icUndo),
       );
     }
-  }
-
-  /// Resolves the owning account of a mailbox placed in a tree, by id, falling
-  /// back to the primary account. Returns null when even the primary account is
-  /// unavailable (e.g. a toast-undo callback firing after the account cleared),
-  /// so callers skip the action instead of throwing.
-  AccountId? _accountIdOfMailboxId(MailboxId mailboxId) {
-    for (final mailboxTree in allMailboxTrees) {
-      final node =
-          mailboxTree.value.findNode((node) => node.item.id == mailboxId);
-      final accountId = node?.item.accountId;
-      if (accountId != null) return accountId;
-    }
-    return _accountDashBoardController.accountId.value;
   }
 
   @override

--- a/lib/features/manage_account/presentation/mailbox_visibility/mailbox_visibility_controller.dart
+++ b/lib/features/manage_account/presentation/mailbox_visibility/mailbox_visibility_controller.dart
@@ -285,8 +285,9 @@ class MailboxVisibilityController extends BaseMailboxController
     final owningAccountId = _accountIdOfMailboxId(anchorMailboxId);
     final subscribed = subscribeAction == MailboxSubscribeAction.subscribe;
 
-    final delegated = _otherUserAccounts[owningAccountId];
-    if (delegated != null) {
+    final delegated =
+        owningAccountId != null ? _otherUserAccounts[owningAccountId] : null;
+    if (owningAccountId != null && delegated != null) {
       _otherUserAccounts[owningAccountId] = delegated.copyWith(
         mailboxes:
             _flipSubscribed(delegated.mailboxes, affectedMailboxIds, subscribed),
@@ -318,14 +319,18 @@ class MailboxVisibilityController extends BaseMailboxController
         currentOverlayContext!,
         AppLocalizations.of(currentContext!).toastMsgHideFolderSuccess,
         actionName: AppLocalizations.of(currentContext!).undo,
-        onActionClick: () => _subscribeMailboxAction(
-          SubscribeMailboxRequest(
-            mailboxIdSubscribed,
-            MailboxSubscribeState.enabled,
-            MailboxSubscribeAction.subscribe
-          ),
-          _accountIdOfMailboxId(mailboxIdSubscribed),
-        ),
+        onActionClick: () {
+          final owningAccountId = _accountIdOfMailboxId(mailboxIdSubscribed);
+          if (owningAccountId == null) return;
+          _subscribeMailboxAction(
+            SubscribeMailboxRequest(
+              mailboxIdSubscribed,
+              MailboxSubscribeState.enabled,
+              MailboxSubscribeAction.subscribe
+            ),
+            owningAccountId,
+          );
+        },
         leadingSVGIconColor: Colors.white,
         leadingSVGIcon: imagePaths.icFolderMailbox,
         backgroundColor: AppColor.toastSuccessBackgroundColor,
@@ -336,15 +341,17 @@ class MailboxVisibilityController extends BaseMailboxController
   }
 
   /// Resolves the owning account of a mailbox placed in a tree, by id, falling
-  /// back to the primary account.
-  AccountId _accountIdOfMailboxId(MailboxId mailboxId) {
+  /// back to the primary account. Returns null when even the primary account is
+  /// unavailable (e.g. a toast-undo callback firing after the account cleared),
+  /// so callers skip the action instead of throwing.
+  AccountId? _accountIdOfMailboxId(MailboxId mailboxId) {
     for (final mailboxTree in allMailboxTrees) {
       final node =
           mailboxTree.value.findNode((node) => node.item.id == mailboxId);
       final accountId = node?.item.accountId;
       if (accountId != null) return accountId;
     }
-    return _accountDashBoardController.accountId.value!;
+    return _accountDashBoardController.accountId.value;
   }
 
   @override

--- a/lib/features/manage_account/presentation/mailbox_visibility/mailbox_visibility_controller.dart
+++ b/lib/features/manage_account/presentation/mailbox_visibility/mailbox_visibility_controller.dart
@@ -5,14 +5,16 @@ import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
-import 'package:jmap_dart_client/jmap/core/properties/properties.dart';
-import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:model/mailbox/mailbox_key.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/extensions/list_presentation_mailbox_extension.dart';
 import 'package:model/extensions/presentation_mailbox_extension.dart';
 import 'package:model/mailbox/expand_mode.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:tmail_ui_user/features/base/base_mailbox_controller.dart';
-import 'package:tmail_ui_user/features/mailbox/domain/constants/mailbox_constants.dart';
+import 'package:tmail_ui_user/features/base/mixin/mailbox_account_resolver_mixin.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/model/mailbox_subscribe_action_state.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/model/mailbox_subscribe_state.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/model/subscribe_mailbox_request.dart';
@@ -27,18 +29,34 @@ import 'package:tmail_ui_user/features/mailbox/domain/usecases/subscribe_mailbox
 import 'package:tmail_ui_user/features/mailbox/domain/usecases/subscribe_multiple_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_node.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_tree_builder.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/model/other_user_account_mailboxes.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/utils/mailbox_utils.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/usecases/verify_name_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/mailbox_visibility/state/mailbox_visibility_state.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/manage_account_dashboard_controller.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
-class MailboxVisibilityController extends BaseMailboxController {
+class MailboxVisibilityController extends BaseMailboxController
+    with MailboxAccountResolverMixin {
   SubscribeMailboxInteractor? _subscribeMailboxInteractor;
   SubscribeMultipleMailboxInteractor? _subscribeMultipleMailboxInteractor;
   final _accountDashBoardController = Get.find<ManageAccountDashBoardController>();
   final mailboxListScrollController = ScrollController();
   final foldersExpandMode = Rx(ExpandMode.EXPAND);
+
+  /// Last known primary-account mailboxes, so a delegated-account load or a
+  /// primary refresh can rebuild without dropping the other section.
+  List<PresentationMailbox> _primaryMailboxes = const [];
+
+  /// Loaded mailboxes for each delegated account shown in this screen.
+  final Map<AccountId, OtherUserAccountMailboxes> _otherUserAccounts = {};
+
+  @override
+  AccountId? get primaryAccountId => _accountDashBoardController.accountId.value;
+
+  @override
+  Session? get session => _accountDashBoardController.sessionCurrent;
 
   MailboxVisibilityController(
     TreeBuilder treeBuilder,
@@ -68,10 +86,12 @@ class MailboxVisibilityController extends BaseMailboxController {
     super.handleSuccessViewState(success);
     if (success is GetAllMailboxSuccess)  {
       currentMailboxState = success.currentMailboxState;
-      _handleBuildTree(success.mailboxList);
+      _primaryMailboxes = success.mailboxList;
+      _handleBuildTree();
     } else if (success is RefreshChangesAllMailboxSuccess) {
       currentMailboxState = success.currentMailboxState;
-      await refreshTree(success.mailboxList);
+      _primaryMailboxes = success.mailboxList;
+      await _rebuildVisibilityTrees(refreshOnly: true);
       if (currentContext != null) {
         syncAllMailboxWithDisplayName(currentContext!);
       }
@@ -90,17 +110,74 @@ class MailboxVisibilityController extends BaseMailboxController {
     final accountId = _accountDashBoardController.accountId.value;
     if(session != null && accountId != null) {
       getAllMailbox(session, accountId);
+      _loadOtherUserMailboxes(session, accountId);
     }
     super.onReady();
   }
 
-  void _handleBuildTree(List<PresentationMailbox> mailboxList) async {
+  void _handleBuildTree() async {
     dispatchState(Right(LoadingBuildTreeMailboxVisibility()));
-    await buildTree(mailboxList);
+    await _rebuildVisibilityTrees();
     dispatchState(Right(BuildTreeMailboxVisibilitySuccess()));
     if (currentContext != null) {
       syncAllMailboxWithDisplayName(currentContext!);
     }
+  }
+
+  Future<void> _rebuildVisibilityTrees({bool refreshOnly = false}) async {
+    final sharedMailboxes = _otherUserAccounts.values
+        .expand((account) => account.mailboxes)
+        .toList();
+    final composed = [..._primaryMailboxes, ...sharedMailboxes];
+
+    if (refreshOnly) {
+      await refreshTree(composed);
+    } else {
+      await buildTree(composed);
+    }
+  }
+
+  /// Loads the delegated accounts so their folders can be shown and toggled
+  /// here. Unlike the sidebar this keeps the full folder list (not just
+  /// readable ones), because the point of the screen is to manage visibility.
+  Future<void> _loadOtherUserMailboxes(Session session, AccountId primary) async {
+    final accountIds =
+        MailboxUtils.resolveOtherUserAccountIds(session, primary);
+
+    await Future.wait(accountIds.map((accountId) async {
+      // Run the interactor directly, never via consumeState, so its
+      // GetAllMailboxSuccess is not routed into the primary tree build.
+      await for (final result
+          in getAllMailboxInteractor!.execute(session, accountId)) {
+        final success = result.fold<GetAllMailboxSuccess?>(
+          (_) => null,
+          (s) => s is GetAllMailboxSuccess ? s : null,
+        );
+        if (success == null) continue;
+
+        // Ghost account: listed in the session but with no readable mailbox.
+        // Skip it so it does not appear in the visibility settings either.
+        final readableMailboxes = success.mailboxList.listReadableMailboxes;
+        if (readableMailboxes.isEmpty) continue;
+
+        final ownerName =
+            session.accounts[accountId]?.name.value ?? accountId.id.value;
+        final mailboxes = readableMailboxes
+            .map((mailbox) => mailbox.copyWith(
+                  accountId: accountId,
+                  isSharedAccount: true,
+                  namespace: MailboxUtils.delegatedNamespace(ownerName),
+                ))
+            .toList();
+        _otherUserAccounts[accountId] = OtherUserAccountMailboxes(
+          accountId: accountId,
+          displayName: MailboxName(ownerName),
+          mailboxes: mailboxes,
+          mailboxState: success.currentMailboxState,
+        );
+        await _rebuildVisibilityTrees();
+      }
+    }));
   }
 
   void subscribeMailbox(MailboxNode mailboxNode) {
@@ -108,29 +185,37 @@ class MailboxVisibilityController extends BaseMailboxController {
       ? MailboxSubscribeState.disabled : MailboxSubscribeState.enabled;
     final mailboxSubscribeStateAction = mailboxNode.item.isSubscribedMailbox
       ? MailboxSubscribeAction.unSubscribe : MailboxSubscribeAction.subscribe;
+    // Subscribe runs against the account that owns the mailbox, resolved from
+    // its account-scoped key.
+    // Note: RFC 8621 says isSubscribed defaults to false in shared accounts, so
+    // the subscription model for delegated mailboxes is imperfect; a follow-up
+    // will address it. Here we simply route the toggle to the right account.
     _subscribeMailboxAction(
         SubscribeMailboxRequest(
           mailboxNode.item.id,
           mailboxSubscribeState,
           mailboxSubscribeStateAction,
-        )
+        ),
+        mailboxNode.item.key.accountId,
     );
   }
 
-  void _subscribeMailboxAction(SubscribeMailboxRequest subscribeMailboxRequest) {
-    final accountId = _accountDashBoardController.accountId.value;
+  void _subscribeMailboxAction(
+    SubscribeMailboxRequest subscribeMailboxRequest,
+    AccountId owningAccountId,
+  ) {
     final session = _accountDashBoardController.sessionCurrent;
-    if (session != null && accountId != null) {
+    if (session != null) {
       final subscribeRequest = generateSubscribeRequest(
-        subscribeMailboxRequest.mailboxId,
+        MailboxKey(owningAccountId, subscribeMailboxRequest.mailboxId),
         subscribeMailboxRequest.subscribeState,
         subscribeMailboxRequest.subscribeAction
       );
 
       if (subscribeRequest is SubscribeMultipleMailboxRequest) {
-        consumeState(_subscribeMultipleMailboxInteractor!.execute(session, accountId, subscribeRequest));
+        consumeState(_subscribeMultipleMailboxInteractor!.execute(session, owningAccountId, subscribeRequest));
       } else if (subscribeRequest is SubscribeMailboxRequest) {
-        consumeState(_subscribeMailboxInteractor!.execute(session, accountId, subscribeRequest));
+        consumeState(_subscribeMailboxInteractor!.execute(session, owningAccountId, subscribeRequest));
       }
     }
   }
@@ -142,9 +227,10 @@ class MailboxVisibilityController extends BaseMailboxController {
         _showToastSubscribeMailboxSuccess(subscribeMailboxSuccess.mailboxId);
     }
 
-    _refreshMailboxChanges(
-      newMailboxState: subscribeMailboxSuccess.currentMailboxState,
-      properties: MailboxConstants.propertiesDefault
+    _reflectSubscribeChange(
+      anchorMailboxId: subscribeMailboxSuccess.mailboxId,
+      affectedMailboxIds: {subscribeMailboxSuccess.mailboxId},
+      subscribeAction: subscribeMailboxSuccess.subscribeAction,
     );
   }
 
@@ -156,9 +242,13 @@ class MailboxVisibilityController extends BaseMailboxController {
       );
     }
 
-    _refreshMailboxChanges(
-      newMailboxState: subscribeMailboxSuccess.currentMailboxState,
-      properties: MailboxConstants.propertiesDefault
+    _reflectSubscribeChange(
+      anchorMailboxId: subscribeMailboxSuccess.parentMailboxId,
+      affectedMailboxIds: {
+        subscribeMailboxSuccess.parentMailboxId,
+        ...subscribeMailboxSuccess.mailboxIdsSubscribe,
+      },
+      subscribeAction: subscribeMailboxSuccess.subscribeAction,
     );
   }
 
@@ -170,25 +260,54 @@ class MailboxVisibilityController extends BaseMailboxController {
       );
     }
 
-    _refreshMailboxChanges(
-      newMailboxState: subscribeMailboxSuccess.currentMailboxState,
-      properties: MailboxConstants.propertiesDefault
+    _reflectSubscribeChange(
+      anchorMailboxId: subscribeMailboxSuccess.parentMailboxId,
+      affectedMailboxIds: {
+        subscribeMailboxSuccess.parentMailboxId,
+        ...subscribeMailboxSuccess.mailboxIdsSubscribe,
+      },
+      subscribeAction: subscribeMailboxSuccess.subscribeAction,
     );
   }
 
-  void _refreshMailboxChanges({jmap.State? newMailboxState, Properties? properties}) {
-    final session = _accountDashBoardController.sessionCurrent;
-    final accountId = _accountDashBoardController.accountId.value;
-    final mailboxState = newMailboxState ?? currentMailboxState;
-    if (session != null && accountId != null && mailboxState != null) {
-      refreshMailboxChanges(
-        session,
-        accountId,
-        mailboxState,
-        properties: properties
+  /// Applies a subscribe/unsubscribe result optimistically to the owning
+  /// account, then rebuilds.
+  ///
+  /// The Mailbox/set already persisted the change, and a subscription toggle
+  /// does not advance the mailbox modseq that Mailbox/changes is based on, so a
+  /// server refresh cannot observe it. Flipping isSubscribed in the cached list
+  /// keeps Personal Folders and Other Users behaving identically on show/hide.
+  void _reflectSubscribeChange({
+    required MailboxId anchorMailboxId,
+    required Set<MailboxId> affectedMailboxIds,
+    required MailboxSubscribeAction subscribeAction,
+  }) async {
+    final owningAccountId = _accountIdOfMailboxId(anchorMailboxId);
+    final subscribed = subscribeAction == MailboxSubscribeAction.subscribe;
+
+    final delegated = _otherUserAccounts[owningAccountId];
+    if (delegated != null) {
+      _otherUserAccounts[owningAccountId] = delegated.copyWith(
+        mailboxes:
+            _flipSubscribed(delegated.mailboxes, affectedMailboxIds, subscribed),
       );
+    } else {
+      _primaryMailboxes =
+          _flipSubscribed(_primaryMailboxes, affectedMailboxIds, subscribed);
     }
+    await _rebuildVisibilityTrees();
   }
+
+  List<PresentationMailbox> _flipSubscribed(
+    List<PresentationMailbox> mailboxes,
+    Set<MailboxId> mailboxIds,
+    bool subscribed,
+  ) =>
+      mailboxes
+          .map((mailbox) => mailboxIds.contains(mailbox.id)
+              ? mailbox.copyWith(isSubscribed: IsSubscribed(subscribed))
+              : mailbox)
+          .toList();
 
   void _showToastSubscribeMailboxSuccess(
       MailboxId mailboxIdSubscribed,
@@ -204,7 +323,8 @@ class MailboxVisibilityController extends BaseMailboxController {
             mailboxIdSubscribed,
             MailboxSubscribeState.enabled,
             MailboxSubscribeAction.subscribe
-          )
+          ),
+          _accountIdOfMailboxId(mailboxIdSubscribed),
         ),
         leadingSVGIconColor: Colors.white,
         leadingSVGIcon: imagePaths.icFolderMailbox,
@@ -213,6 +333,18 @@ class MailboxVisibilityController extends BaseMailboxController {
         actionIcon: SvgPicture.asset(imagePaths.icUndo),
       );
     }
+  }
+
+  /// Resolves the owning account of a mailbox placed in a tree, by id, falling
+  /// back to the primary account.
+  AccountId _accountIdOfMailboxId(MailboxId mailboxId) {
+    for (final mailboxTree in allMailboxTrees) {
+      final node =
+          mailboxTree.value.findNode((node) => node.item.id == mailboxId);
+      final accountId = node?.item.accountId;
+      if (accountId != null) return accountId;
+    }
+    return _accountDashBoardController.accountId.value!;
   }
 
   @override

--- a/lib/features/manage_account/presentation/mailbox_visibility/widgets/label_mailbox_visibility_item_widget.dart
+++ b/lib/features/manage_account/presentation/mailbox_visibility/widgets/label_mailbox_visibility_item_widget.dart
@@ -48,8 +48,7 @@ class LabelMailboxVisibilityItemWidget extends StatelessWidget {
             itemKey: itemKey,
             mailboxNode: mailboxNode,
             imagePaths: imagePaths,
-            color: mailboxNode.item.isSubscribedMailbox ||
-                    mailboxNode.item.isDefault
+            color: mailboxNode.item.isDisplayedInSidebar
                 ? AppColor.m3SurfaceBackground
                 : AppColor.steelGray400,
             onExpandFolderActionClick: onClickExpandMailboxNodeAction,
@@ -79,11 +78,9 @@ class LabelMailboxVisibilityItemWidget extends StatelessWidget {
     }
   }
 
-  bool get _isSubscribedMailbox => mailboxNode.item.isSubscribedMailbox;
-
   TextStyle get _displayNameTextStyle {
     return ThemeUtils.textStyleBodyBody3(
-      color: _isSubscribedMailbox || mailboxNode.item.isDefault
+      color: mailboxNode.item.isDisplayedInSidebar
           ? Colors.black
           : AppColor.steelGray400,
     );

--- a/lib/features/manage_account/presentation/mailbox_visibility/widgets/mailbox_visibility_folder_tile_builder.dart
+++ b/lib/features/manage_account/presentation/mailbox_visibility/widgets/mailbox_visibility_folder_tile_builder.dart
@@ -66,7 +66,10 @@ class _MailBoxVisibilityFolderTileBuilderState
                     widget.onClickExpandMailboxNodeAction,
               ),
             ),
-            if (!_mailbox.isDefault)
+            // The Show/Hide button is hidden for the user's own system folders
+            // (their Inbox is always visible), but a delegated account's system
+            // folders ARE subscription-controlled, so they keep the button.
+            if (!_mailbox.isDefault || _mailbox.isSharedAccount)
               MailboxSubscribeButton(
                 imagePaths: _imagePaths,
                 mailboxNode: widget.mailboxNode,
@@ -85,8 +88,7 @@ class _MailBoxVisibilityFolderTileBuilderState
 
   String get _iconMailbox => _mailbox.getMailboxIcon(_imagePaths);
 
-  Color get _iconMailboxColor =>
-      _mailbox.isSubscribedMailbox || _mailbox.isDefault
-          ? AppColor.steelGrayA540
-          : AppColor.steelGray200;
+  Color get _iconMailboxColor => _mailbox.isDisplayedInSidebar
+      ? AppColor.steelGrayA540
+      : AppColor.steelGray200;
 }

--- a/lib/features/rules_filter_creator/presentation/rules_filter_creator_controller.dart
+++ b/lib/features/rules_filter_creator/presentation/rules_filter_creator_controller.dart
@@ -76,6 +76,9 @@ class RulesFilterCreatorController extends BaseMailboxController {
 
   RulesFilterCreatorArguments? arguments;
   AccountId? _accountId;
+
+  @override
+  AccountId? get primaryAccountId => _accountId;
   Session? _session;
   TMailRule? _currentTMailRule;
   EmailAddress? _emailAddress;
@@ -263,8 +266,10 @@ class RulesFilterCreatorController extends BaseMailboxController {
   void _setUpRuleFilterActions() {
     if (_currentTMailRule?.action.appendIn.mailboxIds.isNotEmpty != true) return;
 
-    final mailboxNode = findMailboxNodeById(
+    final mailboxKey = primaryMailboxKey(
       _currentTMailRule!.action.appendIn.mailboxIds.first);
+    final mailboxNode =
+        mailboxKey != null ? findMailboxNodeByKey(mailboxKey) : null;
 
     if (mailboxNode == null) {
       mailboxSelected.value = PresentationMailbox.unifiedMailbox;

--- a/lib/features/search/mailbox/presentation/search_mailbox_controller.dart
+++ b/lib/features/search/mailbox/presentation/search_mailbox_controller.dart
@@ -17,6 +17,8 @@ import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:model/extensions/list_presentation_mailbox_extension.dart';
 import 'package:model/extensions/presentation_email_extension.dart';
+import 'package:model/extensions/presentation_mailbox_extension.dart';
+import 'package:model/mailbox/mailbox_key.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:tmail_ui_user/features/base/base_mailbox_controller.dart';
 import 'package:tmail_ui_user/features/base/extensions/handle_mailbox_action_type_extension.dart';
@@ -105,6 +107,9 @@ class SearchMailboxController extends BaseMailboxController with MailboxActionHa
 
   AccountId? get accountId => dashboardController.accountId.value;
 
+  @override
+  AccountId? get primaryAccountId => accountId;
+
   Session? get session => dashboardController.sessionCurrent;
 
   SearchMailboxController(
@@ -185,7 +190,10 @@ class SearchMailboxController extends BaseMailboxController with MailboxActionHa
     } else if (success is SearchMailboxSuccess) {
       _handleSearchMailboxSuccess(success);
     } else if (success is RenameMailboxSuccess) {
-      updateMailboxNameById(success.request.mailboxId, success.request.newName);
+      final renamedKey = primaryMailboxKey(success.request.mailboxId);
+      if (renamedKey != null) {
+        updateMailboxNameByKey(renamedKey, success.request.newName);
+      }
     } else if (success is MoveMailboxSuccess) {
       _moveMailboxSuccess(success);
     } else if (success is DeleteMultipleMailboxAllSuccess) {
@@ -253,12 +261,16 @@ class SearchMailboxController extends BaseMailboxController with MailboxActionHa
     ever(dashboardController.viewState, (viewState) {
       final reactionState = viewState.getOrElse(() => UIState.idle);
       if (reactionState is MarkAsMailboxReadAllSuccess) {
-        clearUnreadCount(reactionState.mailboxId);
+        final mailboxKey = primaryMailboxKey(reactionState.mailboxId);
+        if (mailboxKey != null) clearUnreadCount(mailboxKey);
       } else if (reactionState is MarkAsMailboxReadHasSomeEmailFailure) {
-        updateUnreadCountOfMailboxById(
-          reactionState.mailboxId,
-          unreadChanges: -reactionState.countEmailsRead,
-        );
+        final mailboxKey = primaryMailboxKey(reactionState.mailboxId);
+        if (mailboxKey != null) {
+          updateUnreadCountOfMailboxByKey(
+            mailboxKey,
+            unreadChanges: -reactionState.countEmailsRead,
+          );
+        }
       }
     });
   }
@@ -425,7 +437,7 @@ class SearchMailboxController extends BaseMailboxController with MailboxActionHa
         try {
           final subAddress = getSubAddress(
             dashboardController.ownEmailAddress.value,
-            findNodePathWithSeparator(mailbox.id, '.')!,
+            findNodePathWithSeparator(mailbox.key, '.')!,
           );
           copySubAddressAction(context, subAddress);
         } catch (error) {
@@ -439,7 +451,7 @@ class SearchMailboxController extends BaseMailboxController with MailboxActionHa
         try{
           final subAddress = getSubAddress(
             dashboardController.ownEmailAddress.value,
-            findNodePathWithSeparator(mailbox.id, '.')!,
+            findNodePathWithSeparator(mailbox.key, '.')!,
           );
           openConfirmationDialogSubAddressingAction(
             context,
@@ -626,7 +638,11 @@ class SearchMailboxController extends BaseMailboxController with MailboxActionHa
     MailboxSubscribeAction subscribeAction
   ) {
     if (session != null && accountId != null) {
-      final subscribeRequest = generateSubscribeRequest(mailboxId, subscribeState, subscribeAction);
+      final subscribeRequest = generateSubscribeRequest(
+        MailboxKey(accountId!, mailboxId),
+        subscribeState,
+        subscribeAction,
+      );
 
       if (subscribeRequest is SubscribeMultipleMailboxRequest) {
         consumeState(_subscribeMultipleMailboxInteractor.execute(

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -123,7 +123,8 @@ class ThreadController extends BaseController with EmailActionController {
   StreamSubscription<html.Event>? _resizeBrowserStreamSubscription;
   ProviderSubscription<PreferencesSetting>? _localSettingsSubscription;
 
-  AccountId? get _accountId => mailboxDashBoardController.accountId.value;
+  AccountId? get _accountId =>
+      selectedMailbox?.accountId ?? mailboxDashBoardController.accountId.value;
 
   Session? get _session => mailboxDashBoardController.sessionCurrent;
 

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -109,7 +109,9 @@ class ThreadController extends BaseController with EmailActionController {
 
   bool canLoadMore = true;
   bool canSearchMore = true;
-  MailboxId? _currentMemoryMailboxId;
+  // Account-scoped: switching between same-id mailboxes in different accounts
+  // must still trigger a reload.
+  MailboxKey? _currentMemoryMailboxKey;
   int _peakEmailCount = 0;
   final ScrollController listEmailController = ScrollController();
   final latestEmailSelectedOrUnselected = Rxn<PresentationEmail>();
@@ -172,7 +174,7 @@ class ThreadController extends BaseController with EmailActionController {
 
   @override
   void onClose() {
-    _currentMemoryMailboxId = null;
+    _currentMemoryMailboxKey = null;
     listEmailController.dispose();
     if (PlatformInfo.isWeb) {
       _resizeBrowserStreamSubscription?.cancel();
@@ -285,10 +287,10 @@ class ThreadController extends BaseController with EmailActionController {
 
   void _registerObxStreamListener() {
     ever(mailboxDashBoardController.selectedMailbox, (mailbox) {
-      log('ThreadController::_registerObxStreamListener:SelectedMailbox: ${mailbox?.id} - ${mailbox?.name} | CurrentMemoryMailboxId: $_currentMemoryMailboxId');
+      log('ThreadController::_registerObxStreamListener:SelectedMailbox: ${mailbox?.id} - ${mailbox?.name} | CurrentMemoryMailboxKey: $_currentMemoryMailboxKey');
       if (mailbox is PresentationMailbox
-          && mailbox.mailboxId != _currentMemoryMailboxId) {
-        _currentMemoryMailboxId = mailbox.id;
+          && mailbox.key != _currentMemoryMailboxKey) {
+        _currentMemoryMailboxKey = mailbox.key;
         consumeState(Stream.value(Right(GetAllEmailLoading())));
         resetToOriginalValue();
         getAllEmailAction(
@@ -297,7 +299,7 @@ class ThreadController extends BaseController with EmailActionController {
         );
         mailboxDashBoardController.setIsFirstSessionLoad(false);
       } else if (mailbox == null) { // disable current mailbox when search active
-        _currentMemoryMailboxId = null;
+        _currentMemoryMailboxKey = null;
         resetToOriginalValue();
       }
     });

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1405,6 +1405,18 @@
     "placeholders_order": [],
     "placeholders": {}
   },
+  "moveMailboxAcrossAccountsNotSupported": "Moving a folder to another account is not supported",
+  "@moveMailboxAcrossAccountsNotSupported": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "moveEmailAcrossAccountsNotSupported": "Moving emails to another account is not supported",
+  "@moveEmailAcrossAccountsNotSupported": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
   "deleteFolder": "Delete folder",
   "@deleteFolder": {
     "type": "text",

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2026-07-15T18:21:15.082129",
+  "@@last_modified": "2026-08-10T00:49:38.555626",
   "initializing_data": "Initializing data...",
   "@initializing_data": {
     "type": "text",
@@ -1480,6 +1480,18 @@
   },
   "moveFolder": "Move folder",
   "@moveFolder": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "moveMailboxAcrossAccountsNotSupported": "Moving a folder to another account is not supported",
+  "@moveMailboxAcrossAccountsNotSupported": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "moveEmailAcrossAccountsNotSupported": "Moving emails to another account is not supported",
+  "@moveEmailAcrossAccountsNotSupported": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -1498,6 +1498,20 @@ class AppLocalizations {
     );
   }
 
+  String get moveMailboxAcrossAccountsNotSupported {
+    return Intl.message(
+      'Moving a folder to another account is not supported',
+      name: 'moveMailboxAcrossAccountsNotSupported',
+    );
+  }
+
+  String get moveEmailAcrossAccountsNotSupported {
+    return Intl.message(
+      'Moving emails to another account is not supported',
+      name: 'moveEmailAcrossAccountsNotSupported',
+    );
+  }
+
   String get deleteFolder {
     return Intl.message(
         'Delete folder',

--- a/lib/main/routes/navigation_router.dart
+++ b/lib/main/routes/navigation_router.dart
@@ -1,5 +1,6 @@
 
 import 'package:equatable/equatable.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
@@ -15,6 +16,9 @@ enum DashboardType {
 class NavigationRouter with EquatableMixin {
   final EmailId? emailId;
   final MailboxId? mailboxId;
+  /// The account that owns [mailboxId], omitted for the primary account so
+  /// existing primary-account URLs stay byte-identical.
+  final AccountId? mailboxAccountId;
   final Id? labelId;
   final DashboardType dashboardType;
   final SearchQuery? searchQuery;
@@ -29,6 +33,7 @@ class NavigationRouter with EquatableMixin {
   NavigationRouter({
     this.emailId,
     this.mailboxId,
+    this.mailboxAccountId,
     this.searchQuery,
     this.dashboardType = DashboardType.normal,
     this.routeName,
@@ -50,6 +55,7 @@ class NavigationRouter with EquatableMixin {
   List<Object?> get props => [
     emailId,
     mailboxId,
+    mailboxAccountId,
     searchQuery,
     dashboardType,
     routeName,

--- a/lib/main/routes/route_utils.dart
+++ b/lib/main/routes/route_utils.dart
@@ -4,6 +4,7 @@ import 'package:core/data/network/config/service_path.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:get/get.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
@@ -20,6 +21,7 @@ abstract class RouteUtils {
   static const String paramID = 'id';
   static const String paramType = 'type';
   static const String paramContext = 'context';
+  static const String paramAccountContext = 'accountId';
   static const String paramLabelId = 'labelId';
   static const String paramQuery = 'q';
   static const String paramRouteName = 'routeName';
@@ -65,6 +67,11 @@ abstract class RouteUtils {
           StringQueryParameter(paramLabelId, router.labelId!.value)
         else if (router.mailboxId != null)
           StringQueryParameter(paramContext, router.mailboxId!.id.value),
+        // Emitted only for a delegated account, so primary-account URLs are
+        // unchanged.
+        if (router.labelId == null && router.mailboxAccountId != null)
+          StringQueryParameter(
+            paramAccountContext, router.mailboxAccountId!.id.value),
         if (router.searchQuery != null)
           StringQueryParameter(paramQuery, router.searchQuery!.value),
       ]);
@@ -127,6 +134,7 @@ abstract class RouteUtils {
     final idParam = parameters[paramID];
     final typeParam = parameters[paramType];
     final contextPram = parameters[paramContext];
+    final accountContextParam = parameters[paramAccountContext];
     final labelIdPram = parameters[paramLabelId];
     final queryParam = parameters[paramQuery];
     final routeName = parameters[paramRouteName];
@@ -141,6 +149,9 @@ abstract class RouteUtils {
     final mailboxId = labelId == null && contextPram != null
         ? MailboxId(Id(contextPram))
         : null;
+    final mailboxAccountId = mailboxId != null && accountContextParam != null
+        ? AccountId(Id(accountContextParam))
+        : null;
     final searchQuery = queryParam != null ? SearchQuery(queryParam) : null;
     final dashboardType = DashboardType.values.firstWhereOrNull((type) => type.name == typeParam) ?? DashboardType.normal;
     final settingType = AccountMenuItem.values.firstWhereOrNull((type) => type.getAliasBrowser() == typeParam) ?? AccountMenuItem.none;
@@ -154,6 +165,7 @@ abstract class RouteUtils {
     return NavigationRouter(
       emailId: emailId,
       mailboxId: mailboxId,
+      mailboxAccountId: mailboxAccountId,
       labelId: labelId,
       searchQuery: searchQuery,
       dashboardType: dashboardType,

--- a/model/lib/extensions/list_presentation_mailbox_extension.dart
+++ b/model/lib/extensions/list_presentation_mailbox_extension.dart
@@ -37,10 +37,13 @@ extension ListPresentationMailboxExtension on List<PresentationMailbox> {
   /// Mailboxes a user can pick as a destination or open from search.
   ///
   /// Unlike [listPersonalMailboxes] this keeps mailboxes from other users'
-  /// accounts, which are never `isPersonal`.
+  /// accounts, which are never `isPersonal`. A synthetic account root is a
+  /// UI-only grouping node with no server-side mailbox, so it is never a valid
+  /// pick even though it satisfies the shared-account condition.
   List<PresentationMailbox> get listSelectableMailboxes =>
     where((mailbox) =>
       !mailbox.isVirtualFolder &&
+      !mailbox.isSharedAccountRoot &&
       (mailbox.isPersonal || mailbox.isSharedAccount)).toList();
 
   bool get isAllPersonalMailboxes => every((mailbox) => mailbox.isPersonal && !mailbox.isDefault);

--- a/model/lib/extensions/list_presentation_mailbox_extension.dart
+++ b/model/lib/extensions/list_presentation_mailbox_extension.dart
@@ -5,11 +5,43 @@ import 'package:model/mailbox/presentation_mailbox.dart';
 
 extension ListPresentationMailboxExtension on List<PresentationMailbox> {
 
+  /// The primary-account sidebar filter: subscribed mailboxes plus the system
+  /// (role) mailboxes, which stay visible even when unsubscribed so the user
+  /// always sees their own Inbox, Sent, Trash and so on.
   List<PresentationMailbox> get listSubscribedMailboxesAndDefaultMailboxes =>
     where((mailbox) => mailbox.isSubscribedMailbox || mailbox.isDefault).toList();
 
+  /// The sidebar filter for another user's (delegated) account: strictly the
+  /// subscribed mailboxes, with no `isDefault` override.
+  ///
+  /// RFC 8621 section 2 on `isSubscribed`: "This SHOULD default to false for
+  /// Mailboxes in shared accounts the user has access to". The user curates
+  /// exactly which delegated folders appear by (un)subscribing to them from the
+  /// Mailbox visibility settings screen (which loads the full unfiltered list).
+  /// Unlike [listSubscribedMailboxesAndDefaultMailboxes] the delegated Inbox,
+  /// Sent and Trash are NOT pinned visible, so unsubscribing any of them hides
+  /// it as expected.
+  List<PresentationMailbox> get listSubscribedMailboxes =>
+    where((mailbox) => mailbox.isSubscribedMailbox).toList();
+
+  /// Mailboxes the user can actually read. A delegated account with none of
+  /// these is a "ghost" (listed in the JMAP session with no usable ACLs) and is
+  /// dropped entirely. `myRights == null` is treated as readable, since not
+  /// every backend returns the property.
+  List<PresentationMailbox> get listReadableMailboxes =>
+    where((mailbox) => mailbox.myRights?.mayReadItems != false).toList();
+
   List<PresentationMailbox> get listPersonalMailboxes =>
     where((mailbox) => mailbox.isPersonal).toList();
+
+  /// Mailboxes a user can pick as a destination or open from search.
+  ///
+  /// Unlike [listPersonalMailboxes] this keeps mailboxes from other users'
+  /// accounts, which are never `isPersonal`.
+  List<PresentationMailbox> get listSelectableMailboxes =>
+    where((mailbox) =>
+      !mailbox.isVirtualFolder &&
+      (mailbox.isPersonal || mailbox.isSharedAccount)).toList();
 
   bool get isAllPersonalMailboxes => every((mailbox) => mailbox.isPersonal && !mailbox.isDefault);
 

--- a/model/lib/extensions/mailbox_extension.dart
+++ b/model/lib/extensions/mailbox_extension.dart
@@ -1,3 +1,4 @@
+import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/properties/properties.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox_rights.dart';
@@ -22,9 +23,15 @@ extension MailboxExtension on Mailbox {
 
   bool get pushNotificationDeactivated => isOutbox || isSent || isDrafts || isTrash || isSpam;
 
-  PresentationMailbox toPresentationMailbox() {
+  /// Converts a JMAP [Mailbox] to its presentation form.
+  ///
+  /// [accountId] is the account the mailbox was fetched from. It defaults to
+  /// null for the primary account, where the tree builder stamps it in during
+  /// normalization. Callers fetching from another user's account must pass it.
+  PresentationMailbox toPresentationMailbox({AccountId? accountId}) {
     return PresentationMailbox(
       id!,
+      accountId: accountId,
       name: name,
       parentId: parentId,
       role: role,

--- a/model/lib/extensions/presentation_mailbox_extension.dart
+++ b/model/lib/extensions/presentation_mailbox_extension.dart
@@ -15,11 +15,15 @@ extension PresentationMailboxExtension on PresentationMailbox {
 
   bool get isDefault => hasRole();
 
-  bool get isPersonal => namespace == null || namespace == Namespace('Personal');
+  bool get isPersonal =>
+      !isSharedAccount &&
+      ( namespace == null || namespace == Namespace('Personal'));
 
-  bool get isTeamMailboxes => !isPersonal && !hasParentId();
+  bool get isTeamMailboxes => !isSharedAccount && !isPersonal && !hasParentId();
 
-  bool get isChildOfTeamMailboxes => !isPersonal && hasParentId();
+  bool get isChildOfTeamMailboxes =>
+      (isSharedAccount && !isSharedAccountRoot) ||
+      ( !isPersonal && hasParentId());
 
   String get countUnReadEmailsAsString {
     if (countUnreadEmails <= 0) return '';
@@ -128,7 +132,8 @@ extension PresentationMailboxExtension on PresentationMailbox {
     return name;
   }
 
-  bool get allowedToDisplay => isSubscribedMailbox || isDefault;
+  bool get allowedToDisplay =>
+      isSharedAccountRoot || isSubscribedMailbox || isDefault;
 
   MailboxId? get mailboxId {
     if (id == PresentationMailbox.unifiedMailbox.id) {
@@ -143,6 +148,9 @@ extension PresentationMailboxExtension on PresentationMailbox {
   PresentationMailbox toPresentationMailboxWithMailboxPath(String mailboxPath) {
     return PresentationMailbox(
       id,
+      accountId: accountId,
+      isSharedAccount: isSharedAccount,
+      isSharedAccountRoot: isSharedAccountRoot,
       name: name,
       parentId: parentId,
       role: role,
@@ -158,13 +166,16 @@ extension PresentationMailboxExtension on PresentationMailbox {
       state: state,
       namespace: namespace,
       displayName: displayName,
-      rights: rights
+      rights: rights,
     );
   }
 
   PresentationMailbox withDisplayName(String? displayName) {
     return PresentationMailbox(
       id,
+      accountId: accountId,
+      isSharedAccount: isSharedAccount,
+      isSharedAccountRoot: isSharedAccountRoot,
       name: name,
       parentId: parentId,
       role: role,
@@ -180,13 +191,16 @@ extension PresentationMailboxExtension on PresentationMailbox {
       state: state,
       namespace: namespace,
       displayName: displayName,
-      rights: rights
+      rights: rights,
     );
   }
 
   PresentationMailbox withMailboxSate(MailboxState newMailboxState) {
     return PresentationMailbox(
       id,
+      accountId: accountId,
+      isSharedAccount: isSharedAccount,
+      isSharedAccountRoot: isSharedAccountRoot,
       name: name,
       parentId: parentId,
       role: role,
@@ -202,7 +216,7 @@ extension PresentationMailboxExtension on PresentationMailbox {
       state: newMailboxState,
       namespace: namespace,
       displayName: displayName,
-      rights: rights
+      rights: rights,
     );
   }
 
@@ -220,13 +234,16 @@ extension PresentationMailboxExtension on PresentationMailbox {
       myRights: myRights,
       isSubscribed: isSubscribed,
       namespace: namespace,
-      rights: rights
+      rights: rights,
     );
   }
 
   PresentationMailbox toggleSelectPresentationMailbox() {
     return PresentationMailbox(
       id,
+      accountId: accountId,
+      isSharedAccount: isSharedAccount,
+      isSharedAccountRoot: isSharedAccountRoot,
       name: name,
       parentId: parentId,
       role: role,
@@ -242,13 +259,16 @@ extension PresentationMailboxExtension on PresentationMailbox {
       state: state,
       namespace: namespace,
       displayName: displayName,
-      rights: rights
+      rights: rights,
     );
   }
 
-  PresentationMailbox toSelectedPresentationMailbox({required SelectMode selectMode}) {
+  PresentationMailbox toSelectedPresentationMailbox({required SelectMode selectMode,}) {
     return PresentationMailbox(
       id,
+      accountId: accountId,
+      isSharedAccount: isSharedAccount,
+      isSharedAccountRoot: isSharedAccountRoot,
       name: name,
       parentId: parentId,
       role: role,
@@ -264,7 +284,7 @@ extension PresentationMailboxExtension on PresentationMailbox {
       state: state,
       namespace: namespace,
       displayName: displayName,
-      rights: rights
+      rights: rights,
     );
   }
 }

--- a/model/lib/extensions/presentation_mailbox_extension.dart
+++ b/model/lib/extensions/presentation_mailbox_extension.dart
@@ -1,11 +1,21 @@
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/namespace.dart';
+import 'package:model/mailbox/mailbox_key.dart';
 import 'package:model/mailbox/mailbox_state.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:model/mailbox/mailbox_constants.dart';
 import 'package:model/mailbox/select_mode.dart';
 
 extension PresentationMailboxExtension on PresentationMailbox {
+
+  /// The account-scoped identity of this mailbox.
+  ///
+  /// Every mailbox that came from the server carries the account it was fetched
+  /// from, stamped on by the interactor that fetched it. The only mailboxes
+  /// with a null [accountId] are app-local pseudo-mailboxes (the virtual
+  /// folders and the tree root sentinel), which fall back to
+  /// [MailboxKey.localAccount], so this never throws.
+  MailboxKey get key => MailboxKey(accountId ?? MailboxKey.localAccount, id);
 
   bool get isActivated => state == MailboxState.activated;
 
@@ -15,15 +25,24 @@ extension PresentationMailboxExtension on PresentationMailbox {
 
   bool get isDefault => hasRole();
 
+  /// Mailboxes owned by the signed-in user.
+  ///
+  /// [namespace] is a James Team-Mailboxes extension field, not RFC 8621, so it
+  /// only ever distinguishes team mailboxes within a single account. Mailboxes
+  /// belonging to another user's account are identified by [isSharedAccount],
+  /// which is set from the JMAP account they were fetched from.
   bool get isPersonal =>
       !isSharedAccount &&
-      ( namespace == null || namespace == Namespace('Personal'));
+      (namespace == null || namespace == Namespace('Personal'));
 
-  bool get isTeamMailboxes => !isSharedAccount && !isPersonal && !hasParentId();
+  /// Team mailboxes and other users' (delegated) mailboxes share the same
+  /// rendering: a top-level row labelled with the owner via [emailTeamMailBoxes].
+  /// A Cyrus delegated account is folded in here too, carrying a synthesized
+  /// `Delegated[owner]` namespace so it looks exactly like a James delegation,
+  /// while [accountId] still routes its write actions to the owning account.
+  bool get isTeamMailboxes => !isPersonal && !hasParentId();
 
-  bool get isChildOfTeamMailboxes =>
-      (isSharedAccount && !isSharedAccountRoot) ||
-      ( !isPersonal && hasParentId());
+  bool get isChildOfTeamMailboxes => !isPersonal && hasParentId();
 
   String get countUnReadEmailsAsString {
     if (countUnreadEmails <= 0) return '';
@@ -106,6 +125,15 @@ extension PresentationMailboxExtension on PresentationMailbox {
 
   bool get isSubscribedMailbox => isSubscribed != null && isSubscribed?.value == true;
 
+  /// Whether this mailbox is currently shown in the sidebar, mirroring the
+  /// per-account sidebar filters: the primary account shows subscribed
+  /// mailboxes plus its system (role) folders, while a delegated account shows
+  /// only subscribed mailboxes with no isDefault override. Used to reflect the
+  /// hidden/shown state in the Mailbox visibility settings, so a delegated
+  /// system folder greys out when unsubscribed.
+  bool get isDisplayedInSidebar =>
+    isSubscribedMailbox || (isDefault && !isSharedAccount);
+
   bool get isSubaddressingAllowed => rights != null && rights?[anyoneIdentifier]?.contains(postingRight) == true;
 
   bool get allowedToDisplayCountOfUnreadEmails => !(isTrash || isSpam || isDrafts || isTemplates || isSent) && countUnreadEmails > 0;
@@ -132,8 +160,7 @@ extension PresentationMailboxExtension on PresentationMailbox {
     return name;
   }
 
-  bool get allowedToDisplay =>
-      isSharedAccountRoot || isSubscribedMailbox || isDefault;
+  bool get allowedToDisplay => isSubscribedMailbox || isDefault;
 
   MailboxId? get mailboxId {
     if (id == PresentationMailbox.unifiedMailbox.id) {

--- a/model/lib/mailbox/mailbox_key.dart
+++ b/model/lib/mailbox/mailbox_key.dart
@@ -1,0 +1,45 @@
+import 'package:equatable/equatable.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+
+/// The real primary key of a mailbox.
+///
+/// RFC 8620 section 1.2: "The id MUST be unique among all records of the same
+/// type within the same account. Ids may clash across accounts or for two
+/// records of different types within the same account."
+///
+/// A bare [MailboxId] is therefore only meaningful alongside the account that
+/// owns it. Anything that looks a mailbox up, selects one, routes to one or
+/// dispatches an action against one must key on this pair, otherwise a mailbox
+/// belonging to another user's account can be mistaken for one of the primary
+/// account's mailboxes.
+class MailboxKey with EquatableMixin {
+
+  /// The account of app-local pseudo-mailboxes: the virtual folders (Starred,
+  /// Needs action, unified inbox) and the root sentinel node.
+  ///
+  /// These are client-side constructs with no server-side counterpart, so they
+  /// genuinely have no owning JMAP account. Giving them one shared namespace
+  /// keeps [PresentationMailbox.key] total, so no caller has to special-case
+  /// them. Mailboxes that came from the server always carry the account they
+  /// were fetched from, stamped on by the interactor that fetched them.
+  ///
+  /// The value has to satisfy the JMAP Id grammar (RFC 8620: leading
+  /// alphanumeric, then alphanumerics, hyphen or underscore), so it cannot be
+  /// marked with a leading underscore.
+  static final AccountId localAccount = AccountId(Id('tmailLocalPseudoAccount'));
+
+  final AccountId accountId;
+  final MailboxId mailboxId;
+
+  const MailboxKey(this.accountId, this.mailboxId);
+
+  String get asString => '${accountId.id.value}:${mailboxId.id.value}';
+
+  @override
+  List<Object?> get props => [accountId, mailboxId];
+
+  @override
+  String toString() => 'MailboxKey($asString)';
+}

--- a/model/lib/mailbox/presentation_mailbox.dart
+++ b/model/lib/mailbox/presentation_mailbox.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox_rights.dart';
@@ -21,7 +22,7 @@ class PresentationMailbox with EquatableMixin {
   static const String favoriteRole = 'favorite';
   static const String actionRequiredRole = 'needs-action';
 
-  static final PresentationMailbox unifiedMailbox = PresentationMailbox(MailboxId(Id('unified')));
+  static final PresentationMailbox unifiedMailbox = PresentationMailbox(MailboxId(Id('unified')),);
   static final PresentationMailbox favoriteFolder = PresentationMailbox(
     MailboxId(Id(favoriteRole)),
     name: MailboxName('Starred'),
@@ -49,6 +50,9 @@ class PresentationMailbox with EquatableMixin {
   static final roleActionRequired = Role(actionRequiredRole);
 
   final MailboxId id;
+  final AccountId? accountId;
+  final bool isSharedAccount;
+  final bool isSharedAccountRoot;
   final MailboxName? name;
   final MailboxId? parentId;
   final Role? role;
@@ -69,7 +73,10 @@ class PresentationMailbox with EquatableMixin {
   PresentationMailbox(
     this.id,
     {
-      this.name,
+      this.accountId,
+    this.isSharedAccount = false,
+    this.isSharedAccountRoot = false,
+    this.name,
       this.parentId,
       this.role,
       this.sortOrder,
@@ -84,13 +91,16 @@ class PresentationMailbox with EquatableMixin {
       this.state = MailboxState.activated,
       this.namespace,
       this.displayName,
-      this.rights
+      this.rights,
     }
   );
 
   @override
   List<Object?> get props => [
     id,
+        accountId,
+        isSharedAccount,
+        isSharedAccountRoot,
     name,
     parentId,
     role,
@@ -106,11 +116,14 @@ class PresentationMailbox with EquatableMixin {
     state,
     namespace,
     displayName,
-    rights
+    rights,
   ];
 
   PresentationMailbox copyWith({
     MailboxId? id,
+    AccountId? accountId,
+    bool? isSharedAccount,
+    bool? isSharedAccountRoot,
     MailboxName? name,
     MailboxId? parentId,
     Role? role,
@@ -126,9 +139,13 @@ class PresentationMailbox with EquatableMixin {
     MailboxState? state,
     Namespace? namespace,
     String? displayName,
+    Map<String, List<String>?>? rights,
   }) {
     return PresentationMailbox(
       id ?? this.id,
+      accountId: accountId ?? this.accountId,
+      isSharedAccount: isSharedAccount ?? this.isSharedAccount,
+      isSharedAccountRoot: isSharedAccountRoot ?? this.isSharedAccountRoot,
       name: name ?? this.name,
       parentId: parentId ?? this.parentId,
       role: role ?? this.role,
@@ -144,6 +161,7 @@ class PresentationMailbox with EquatableMixin {
       state: state ?? this.state,
       namespace: namespace ?? this.namespace,
       displayName: displayName ?? this.displayName,
+      rights: rights ?? this.rights,
     );
   }
 }

--- a/model/lib/model.dart
+++ b/model/lib/model.dart
@@ -67,6 +67,7 @@ export 'extensions/oidc_user_info_extension.dart';
 // Identity
 export 'identity/identity_request_dto.dart';
 export 'mailbox/expand_mode.dart';
+export 'mailbox/mailbox_key.dart';
 export 'mailbox/mailbox_property.dart';
 export 'mailbox/mailbox_state.dart';
 // Mailbox

--- a/model/test/extensions/list_presentation_mailbox_filter_test.dart
+++ b/model/test/extensions/list_presentation_mailbox_filter_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox_rights.dart';
+import 'package:model/extensions/list_presentation_mailbox_extension.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+
+void main() {
+  final accountId = AccountId(Id('otherUser'));
+
+  MailboxRights rights({required bool mayReadItems}) =>
+      MailboxRights(mayReadItems, false, false, false, false, false, false,
+          false, false);
+
+  PresentationMailbox mailbox({
+    required String id,
+    required String name,
+    bool subscribed = false,
+    Role? role,
+    MailboxRights? myRights,
+  }) =>
+      PresentationMailbox(
+        MailboxId(Id(id)),
+        accountId: accountId,
+        name: MailboxName(name),
+        role: role,
+        isSubscribed: IsSubscribed(subscribed),
+        myRights: myRights,
+      );
+
+  // A delegated account: an unsubscribed Inbox (system folder), a subscribed
+  // custom folder, and an unsubscribed custom folder.
+  final mailboxes = [
+    mailbox(id: '1', name: 'Inbox', role: PresentationMailbox.roleInbox),
+    mailbox(id: '2', name: 'Shared Project', subscribed: true),
+    mailbox(id: '3', name: 'Hidden Notes'),
+  ];
+
+  group('list mailbox sidebar filters', () {
+    test('listSubscribedMailboxesAndDefaultMailboxes keeps system folders', () {
+      final names = mailboxes.listSubscribedMailboxesAndDefaultMailboxes
+          .map((m) => m.name?.name)
+          .toList();
+      // The unsubscribed Inbox stays because it is a role (default) mailbox.
+      expect(names, containsAll(['Inbox', 'Shared Project']));
+      expect(names, isNot(contains('Hidden Notes')));
+    });
+
+    test('listSubscribedMailboxes drops the unsubscribed system folder', () {
+      final names = mailboxes.listSubscribedMailboxes
+          .map((m) => m.name?.name)
+          .toList();
+      // Strict subscription: only the subscribed folder survives, the
+      // unsubscribed delegated Inbox is hidden.
+      expect(names, ['Shared Project']);
+    });
+  });
+
+  group('listReadableMailboxes (ghost account detection)', () {
+    test('excludes mailboxes with mayReadItems == false', () {
+      final list = [
+        mailbox(id: '1', name: 'No Access', myRights: rights(mayReadItems: false)),
+        mailbox(id: '2', name: 'Readable', myRights: rights(mayReadItems: true)),
+      ];
+      expect(
+        list.listReadableMailboxes.map((m) => m.name?.name),
+        ['Readable'],
+      );
+    });
+
+    test('treats null myRights as readable', () {
+      final list = [mailbox(id: '1', name: 'Unknown Rights')];
+      expect(list.listReadableMailboxes.map((m) => m.name?.name), ['Unknown Rights']);
+    });
+
+    test('an account with only unreadable mailboxes is a ghost (empty)', () {
+      final ghost = [
+        mailbox(id: '1', name: 'Inbox', role: PresentationMailbox.roleInbox,
+            myRights: rights(mayReadItems: false)),
+      ];
+      expect(ghost.listReadableMailboxes, isEmpty);
+    });
+  });
+}

--- a/test/features/mailbox/domain/usecases/get_all_mailbox_interactor_test.dart
+++ b/test/features/mailbox/domain/usecases/get_all_mailbox_interactor_test.dart
@@ -99,8 +99,10 @@ void main() {
           .single;
 
       expect(success.mailboxList, [
-        MailboxFixtures.inboxMailbox.toPresentationMailbox(),
-        MailboxFixtures.sentMailbox.toPresentationMailbox(),
+        MailboxFixtures.inboxMailbox
+            .toPresentationMailbox(accountId: AccountFixtures.aliceAccountId),
+        MailboxFixtures.sentMailbox
+            .toPresentationMailbox(accountId: AccountFixtures.aliceAccountId),
       ]);
 
       verify(mailboxRepository.getAllMailbox(

--- a/test/features/mailbox/domain/usecases/refresh_all_mailbox_interactor_test.dart
+++ b/test/features/mailbox/domain/usecases/refresh_all_mailbox_interactor_test.dart
@@ -97,8 +97,10 @@ void main() {
           .single;
 
       expect(success.mailboxList, [
-        MailboxFixtures.inboxMailbox.toPresentationMailbox(),
-        MailboxFixtures.sentMailbox.toPresentationMailbox(),
+        MailboxFixtures.inboxMailbox
+            .toPresentationMailbox(accountId: AccountFixtures.aliceAccountId),
+        MailboxFixtures.sentMailbox
+            .toPresentationMailbox(accountId: AccountFixtures.aliceAccountId),
       ]);
 
       verify(mailboxRepository.refresh(

--- a/test/features/mailbox/presentation/model/mailbox_key_test.dart
+++ b/test/features/mailbox/presentation/model/mailbox_key_test.dart
@@ -1,0 +1,47 @@
+import 'dart:collection';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/mailbox/mailbox_key.dart';
+
+void main() {
+  group('MailboxKey', () {
+    final accountA = AccountId(Id('accountA'));
+    final accountB = AccountId(Id('accountB'));
+    final mailbox1 = MailboxId(Id('1'));
+
+    test('keys with the same account and mailbox id are equal', () {
+      expect(
+        MailboxKey(accountA, mailbox1),
+        equals(MailboxKey(accountA, mailbox1)),
+      );
+      expect(
+        MailboxKey(accountA, mailbox1).hashCode,
+        equals(MailboxKey(accountA, mailbox1).hashCode),
+      );
+    });
+
+    test('the same mailbox id in different accounts is not equal', () {
+      expect(
+        MailboxKey(accountA, mailbox1),
+        isNot(equals(MailboxKey(accountB, mailbox1))),
+      );
+    });
+
+    test('distinguishes accounts when used as a HashMap key', () {
+      final map = HashMap<MailboxKey, String>();
+      map[MailboxKey(accountA, mailbox1)] = 'a';
+      map[MailboxKey(accountB, mailbox1)] = 'b';
+
+      expect(map.length, 2);
+      expect(map[MailboxKey(accountA, mailbox1)], 'a');
+      expect(map[MailboxKey(accountB, mailbox1)], 'b');
+    });
+
+    test('asString combines account and mailbox id', () {
+      expect(MailboxKey(accountA, mailbox1).asString, 'accountA:1');
+    });
+  });
+}

--- a/test/features/mailbox/presentation/model/mailbox_tree_account_scope_test.dart
+++ b/test/features/mailbox/presentation/model/mailbox_tree_account_scope_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/mailbox/mailbox_key.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_node.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_tree.dart';
+
+void main() {
+  // getNodePath reads Get.context for display names, which needs the binding.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final primaryAccountId = AccountId(Id('primary'));
+  final otherAccountId = AccountId(Id('otherUser'));
+
+  // Two accounts each own a folder with the same MailboxId('1').
+  PresentationMailbox primaryFolder() => PresentationMailbox(
+        MailboxId(Id('1')),
+        accountId: primaryAccountId,
+        name: MailboxName('PrimaryFolder'),
+      );
+  PresentationMailbox otherFolder() => PresentationMailbox(
+        MailboxId(Id('1')),
+        accountId: otherAccountId,
+        name: MailboxName('OtherFolder'),
+      );
+
+  MailboxTree buildTree() {
+    final root = MailboxNode.root();
+    root.addChildNode(MailboxNode(primaryFolder()));
+    root.addChildNode(MailboxNode(otherFolder()));
+    return MailboxTree(root);
+  }
+
+  group('MailboxTree account-scoped lookups', () {
+    test('findNodeByKey returns the node owned by the requested account', () {
+      final tree = buildTree();
+
+      expect(
+        tree.findNodeByKey(MailboxKey(primaryAccountId, MailboxId(Id('1'))))
+            ?.item.name?.name,
+        'PrimaryFolder',
+      );
+      expect(
+        tree.findNodeByKey(MailboxKey(otherAccountId, MailboxId(Id('1'))))
+            ?.item.name?.name,
+        'OtherFolder',
+      );
+    });
+
+    test('updateMailboxNameByKey only renames the owning account node', () {
+      final tree = buildTree();
+
+      tree.updateMailboxNameByKey(
+        MailboxKey(otherAccountId, MailboxId(Id('1'))),
+        MailboxName('Renamed'),
+      );
+
+      expect(
+        tree.findNodeByKey(MailboxKey(otherAccountId, MailboxId(Id('1'))))
+            ?.item.name?.name,
+        'Renamed',
+      );
+      expect(
+        tree.findNodeByKey(MailboxKey(primaryAccountId, MailboxId(Id('1'))))
+            ?.item.name?.name,
+        'PrimaryFolder',
+        reason: 'the same id in the other account must be untouched',
+      );
+    });
+
+    test('updateMailboxUnreadCountByKey only touches the owning account node', () {
+      final root = MailboxNode.root();
+      root.addChildNode(MailboxNode(primaryFolder().copyWith(
+        unreadEmails: UnreadEmails(UnsignedInt(5)),
+      )));
+      root.addChildNode(MailboxNode(otherFolder().copyWith(
+        unreadEmails: UnreadEmails(UnsignedInt(5)),
+      )));
+      final tree = MailboxTree(root);
+
+      tree.updateMailboxUnreadCountByKey(
+        MailboxKey(otherAccountId, MailboxId(Id('1'))),
+        -5,
+      );
+
+      expect(
+        tree.findNodeByKey(MailboxKey(otherAccountId, MailboxId(Id('1'))))
+            ?.item.unreadEmails?.value.value,
+        0,
+      );
+      expect(
+        tree.findNodeByKey(MailboxKey(primaryAccountId, MailboxId(Id('1'))))
+            ?.item.unreadEmails?.value.value,
+        5,
+      );
+    });
+
+    test('getNodePath does not cross into another account on the parent walk', () {
+      // Each account has a parent id 1 and a child id 2 -> parent 1. The other
+      // account's parent is named differently, so a crossed walk is detectable.
+      final root = MailboxNode.root();
+      root.addChildNode(MailboxNode(PresentationMailbox(
+        MailboxId(Id('1')),
+        accountId: primaryAccountId,
+        name: MailboxName('PrimaryParent'),
+      )));
+      root.addChildNode(MailboxNode(PresentationMailbox(
+        MailboxId(Id('2')),
+        accountId: primaryAccountId,
+        parentId: MailboxId(Id('1')),
+        name: MailboxName('PrimaryChild'),
+      )));
+      root.addChildNode(MailboxNode(PresentationMailbox(
+        MailboxId(Id('1')),
+        accountId: otherAccountId,
+        name: MailboxName('OtherParent'),
+      )));
+      root.addChildNode(MailboxNode(PresentationMailbox(
+        MailboxId(Id('2')),
+        accountId: otherAccountId,
+        parentId: MailboxId(Id('1')),
+        name: MailboxName('OtherChild'),
+      )));
+      final tree = MailboxTree(root);
+
+      expect(
+        tree.getNodePath(MailboxKey(otherAccountId, MailboxId(Id('2'))), '/'),
+        'OtherParent/OtherChild',
+      );
+      expect(
+        tree.getNodePath(MailboxKey(primaryAccountId, MailboxId(Id('2'))), '/'),
+        'PrimaryParent/PrimaryChild',
+      );
+    });
+  });
+}

--- a/test/features/mailbox/presentation/model/mailbox_tree_builder_test.dart
+++ b/test/features/mailbox/presentation/model/mailbox_tree_builder_test.dart
@@ -460,7 +460,7 @@ void main() {
         final result = await TreeBuilder().generateMailboxTreeInUI(
           allMailboxes: [inbox, sent],
           currentCollection: MailboxCollection.empty(),
-          mailboxIdSelected: inbox.id,
+          mailboxKeySelected: inbox.key,
         );
 
         final selectedInResult = result.allMailboxes.firstWhere((m) => m.id == inbox.id);
@@ -811,7 +811,7 @@ void main() {
       final result = await TreeBuilder().generateMailboxTreeInUI(
         allMailboxes: mailboxes,
         currentCollection: MailboxCollection.empty(),
-        mailboxIdSelected: parentId,
+        mailboxKeySelected: mailboxes.first.key,
       );
 
       final parentNode = result.defaultTree.root.childrenItems?.first;

--- a/test/features/mailbox/presentation/model/mailbox_tree_builder_test.dart
+++ b/test/features/mailbox/presentation/model/mailbox_tree_builder_test.dart
@@ -927,6 +927,48 @@ void main() {
 
       expect(result.allMailboxes.single.accountId, equals(primaryAccountId));
     });
+
+    test(
+      'selecting an other-user mailbox deactivates only its node, not a primary '
+      'mailbox sharing the same id',
+      () async {
+        final primaryFolder = PresentationMailbox(
+          MailboxId(Id('5')),
+          name: MailboxName('PrimaryProjects'),
+          isSubscribed: IsSubscribed(true),
+        );
+        final sharedFolder = PresentationMailbox(
+          MailboxId(Id('5')),
+          accountId: otherAccountId,
+          isSharedAccount: true,
+          name: MailboxName('SharedProjects'),
+          myRights: MailboxRights(true, false, false, false, false, false, false, false, false),
+        );
+
+        final result = await TreeBuilder().generateMailboxTreeInUI(
+          allMailboxes: [primaryFolder, sharedFolder],
+          currentCollection: MailboxCollection.empty(),
+          mailboxKeySelected: sharedFolder.key,
+          primaryAccountId: primaryAccountId,
+        );
+
+        final sharedNode =
+            findByName(result.teamMailboxTree.root, 'SharedProjects');
+        final primaryNode =
+            findByName(result.personalTree.root, 'PrimaryProjects');
+
+        expect(
+          sharedNode?.nodeState,
+          equals(MailboxState.deactivated),
+          reason: 'the selected other-user mailbox is deactivated',
+        );
+        expect(
+          primaryNode?.nodeState,
+          equals(MailboxState.activated),
+          reason: 'the same-id primary mailbox must stay activated',
+        );
+      },
+    );
   });
 
   group('other users tree', () {

--- a/test/features/mailbox/presentation/model/mailbox_tree_builder_test.dart
+++ b/test/features/mailbox/presentation/model/mailbox_tree_builder_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox_rights.dart';
@@ -820,6 +821,192 @@ void main() {
       expect(parentNode?.nodeState, equals(MailboxState.deactivated));
       expect(childNode?.nodeState, equals(MailboxState.deactivated));
       expect(grandChildNode?.nodeState, equals(MailboxState.deactivated));
+    });
+  });
+
+  group('account-scoped identity', () {
+    final primaryAccountId = AccountId(Id('primary'));
+    final otherAccountId = AccountId(Id('otherUser'));
+
+    MailboxNode? findByName(MailboxNode root, String name) {
+      for (final child in root.childrenItems ?? <MailboxNode>[]) {
+        if (child.item.name?.name == name) return child;
+        final nested = findByName(child, name);
+        if (nested != null) return nested;
+      }
+      return null;
+    }
+
+    test(
+      'a primary and an other-user mailbox that share a MailboxId both survive',
+      () async {
+        final primaryFolder = PresentationMailbox(
+          MailboxId(Id('5')),
+          name: MailboxName('PrimaryProjects'),
+          isSubscribed: IsSubscribed(true),
+        );
+        final sharedFolder = PresentationMailbox(
+          MailboxId(Id('5')),
+          accountId: otherAccountId,
+          isSharedAccount: true,
+          name: MailboxName('SharedProjects'),
+          myRights: MailboxRights(true, false, false, false, false, false, false, false, false),
+        );
+
+        final result = await TreeBuilder().generateMailboxTreeInUI(
+          allMailboxes: [primaryFolder, sharedFolder],
+          currentCollection: MailboxCollection.empty(),
+          primaryAccountId: primaryAccountId,
+        );
+
+        expect(findByName(result.personalTree.root, 'PrimaryProjects'), isNotNull);
+        // Delegated mailboxes fold into the team-mailbox tree.
+        expect(findByName(result.teamMailboxTree.root, 'SharedProjects'), isNotNull);
+      },
+    );
+
+    test(
+      'an other-user child attaches to its own account parent, not a primary '
+      'mailbox with the same id',
+      () async {
+        final primaryParent = PresentationMailbox(
+          MailboxId(Id('1')),
+          name: MailboxName('PrimaryParent'),
+          isSubscribed: IsSubscribed(true),
+        );
+        final sharedParent = PresentationMailbox(
+          MailboxId(Id('1')),
+          accountId: otherAccountId,
+          isSharedAccount: true,
+          name: MailboxName('SharedParent'),
+        );
+        final sharedChild = PresentationMailbox(
+          MailboxId(Id('2')),
+          accountId: otherAccountId,
+          isSharedAccount: true,
+          parentId: MailboxId(Id('1')),
+          name: MailboxName('SharedChild'),
+        );
+
+        final result = await TreeBuilder().generateMailboxTreeInUI(
+          allMailboxes: [primaryParent, sharedParent, sharedChild],
+          currentCollection: MailboxCollection.empty(),
+          primaryAccountId: primaryAccountId,
+        );
+
+        final sharedParentNode =
+            findByName(result.teamMailboxTree.root, 'SharedParent');
+        final primaryParentNode =
+            findByName(result.personalTree.root, 'PrimaryParent');
+
+        expect(
+          findByName(sharedParentNode!, 'SharedChild'),
+          isNotNull,
+          reason: 'child must attach to its own account parent',
+        );
+        expect(
+          primaryParentNode?.childrenItems ?? const [],
+          isEmpty,
+          reason: 'the primary parent must not steal the other-user child',
+        );
+      },
+    );
+
+    test('a null-account mailbox is normalized to the primary account', () async {
+      final folder = PresentationMailbox(
+        MailboxId(Id('9')),
+        name: MailboxName('Folder'),
+        isSubscribed: IsSubscribed(true),
+      );
+
+      final result = await TreeBuilder().generateMailboxTreeInUI(
+        allMailboxes: [folder],
+        currentCollection: MailboxCollection.empty(),
+        primaryAccountId: primaryAccountId,
+      );
+
+      expect(result.allMailboxes.single.accountId, equals(primaryAccountId));
+    });
+  });
+
+  group('other users tree', () {
+    final primaryAccountId = AccountId(Id('primary'));
+    final accountJohn = AccountId(Id('john'));
+    final accountMary = AccountId(Id('mary'));
+
+    List<PresentationMailbox> sharedMailboxesFor(AccountId accountId) => [
+          PresentationMailbox(
+            MailboxId(Id('inbox-${accountId.id.value}')),
+            accountId: accountId,
+            isSharedAccount: true,
+            role: Role('inbox'),
+            name: MailboxName('Inbox'),
+          ),
+          PresentationMailbox(
+            MailboxId(Id('folder-${accountId.id.value}')),
+            accountId: accountId,
+            isSharedAccount: true,
+            name: MailboxName('AProjects'),
+          ),
+        ];
+
+    test('delegated mailboxes from all accounts fold flat into the team tree, '
+        'with no synthetic account roots', () async {
+      final result = await TreeBuilder().generateMailboxTreeInUI(
+        allMailboxes: [
+          ...sharedMailboxesFor(accountJohn),
+          ...sharedMailboxesFor(accountMary),
+        ],
+        currentCollection: MailboxCollection.empty(),
+        primaryAccountId: primaryAccountId,
+      );
+
+      // No synthetic per-account grouping node any more.
+      final teamNodes = result.teamMailboxTree.root.childrenItems ?? [];
+      expect(teamNodes.any((node) => node.item.isSharedAccountRoot), isFalse);
+
+      final names = <String?>[];
+      void collect(MailboxNode node) {
+        for (final child in node.childrenItems ?? <MailboxNode>[]) {
+          names.add(child.item.name?.name);
+          collect(child);
+        }
+      }
+
+      collect(result.teamMailboxTree.root);
+      // Both accounts' Inbox and AProjects are present, side by side.
+      expect(names.where((name) => name == 'Inbox').length, 2);
+      expect(names.where((name) => name == 'AProjects').length, 2);
+    });
+
+    test('delegated mailboxes sort alphabetically at the team-tree top level, '
+        'exactly like James team mailboxes', () async {
+      final result = await TreeBuilder().generateMailboxTreeInUI(
+        allMailboxes: sharedMailboxesFor(accountJohn),
+        currentCollection: MailboxCollection.empty(),
+        primaryAccountId: primaryAccountId,
+      );
+
+      // Each delegated mailbox is its own top-level team row (the system-first
+      // rule only orders children within a team mailbox), so they sort by name.
+      final childNames = result.teamMailboxTree.root.childrenItems!
+          .map((node) => node.item.name?.name)
+          .toList();
+      expect(childNames, ['AProjects', 'Inbox']);
+    });
+
+    test('an other-user mailbox keeps a null namespace and is not personal', () async {
+      final result = await TreeBuilder().generateMailboxTreeInUI(
+        allMailboxes: sharedMailboxesFor(accountJohn),
+        currentCollection: MailboxCollection.empty(),
+        primaryAccountId: primaryAccountId,
+      );
+
+      final shared = result.allMailboxes
+          .firstWhere((mailbox) => mailbox.name?.name == 'AProjects');
+      expect(shared.namespace, isNull);
+      expect(shared.isPersonal, isFalse);
+      expect(shared.isSharedAccount, isTrue);
     });
   });
 }

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -15,9 +15,11 @@ import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:model/email/presentation_email.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:model/email/email_action_type.dart';
@@ -678,6 +680,84 @@ void main() {
       );
       expect(searchController.sortOrderFiltered, EmailSortOrderType.subjectAscending);
     });
+
+    test(
+      'WHEN dragging emails from a delegated mailbox to another folder in the '
+      'same delegated account\n'
+      'SHOULD route the move through the owning delegated account, not the primary',
+      () {
+        final delegatedAccountId = AccountId(Id('delegated-1'));
+        final delegatedSource = PresentationMailbox(
+          MailboxId(Id('99')),
+          accountId: delegatedAccountId,
+          isSharedAccount: true,
+        );
+        final delegatedDestination = PresentationMailbox(
+          MailboxId(Id('100')),
+          accountId: delegatedAccountId,
+          isSharedAccount: true,
+        );
+        final email = PresentationEmail(
+          id: EmailId(Id('e1')),
+          mailboxIds: {delegatedSource.id: true},
+        );
+
+        mailboxDashboardController.selectedMailbox.value = delegatedSource;
+
+        mailboxDashboardController.dragSelectedMultipleEmailToMailboxAction(
+          [email],
+          delegatedDestination,
+        );
+
+        final captured = verify(moveToMailboxInteractor.execute(
+          captureAny,
+          captureAny,
+          any,
+          any,
+        )).captured;
+        expect(captured[0], testSession);
+        expect(captured[1], delegatedAccountId);
+        expect(captured[1], isNot(testAccountId));
+      },
+    );
+
+    test(
+      'WHEN dragging emails from a delegated mailbox to Favorite\n'
+      'SHOULD star them through the owning delegated account, not the primary',
+      () {
+        final delegatedAccountId = AccountId(Id('delegated-1'));
+        final delegatedSource = PresentationMailbox(
+          MailboxId(Id('99')),
+          accountId: delegatedAccountId,
+          isSharedAccount: true,
+        );
+        final favoriteDestination = PresentationMailbox(
+          MailboxId(Id('favorite')),
+          role: PresentationMailbox.roleFavorite,
+        );
+        final email = PresentationEmail(
+          id: EmailId(Id('e1')),
+          mailboxIds: {delegatedSource.id: true},
+        );
+
+        mailboxDashboardController.selectedMailbox.value = delegatedSource;
+
+        mailboxDashboardController.dragSelectedMultipleEmailToMailboxAction(
+          [email],
+          favoriteDestination,
+        );
+
+        final captured = verify(markAsStarMultipleEmailInteractor.execute(
+          captureAny,
+          captureAny,
+          any,
+          any,
+        )).captured;
+        expect(captured[0], testSession);
+        expect(captured[1], delegatedAccountId);
+        expect(captured[1], isNot(testAccountId));
+      },
+    );
 
     tearDown(Get.deleteAll);
   });

--- a/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
+++ b/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
@@ -282,7 +282,7 @@ void main() {
   final subaddressingInteractor = MockSubaddressingInteractor();
   final createDefaultMailboxInteractor = MockCreateDefaultMailboxInteractor();
   final moveFolderContentInteractor = MockMoveFolderContentInteractor();
-  final treeBuilder = MockTreeBuilder();
+  late MockTreeBuilder treeBuilder;
   final verifyNameInteractor = MockVerifyNameInteractor();
   final getAllMailboxInteractor = MockGetAllMailboxInteractor();
   final refreshAllMailboxInteractor = MockRefreshAllMailboxInteractor();
@@ -329,10 +329,11 @@ void main() {
     setUp(() {
       Get.testMode = true;
 
-      // Reset recorded interactions on shared mocks so a call from a previous
-      // test (e.g. an async mailbox load that resolves after Get.deleteAll)
-      // cannot be counted against this test's verify().
-      clearInteractions(treeBuilder);
+      // A fresh mock per test so a call from a previous test (e.g. an async
+      // mailbox load that resolves after Get.deleteAll) cannot be counted
+      // against this test's verify(). clearInteractions only drops calls made
+      // before setUp, not ones that arrive later on the shared instance.
+      treeBuilder = MockTreeBuilder();
 
       Get.put<RemoveEmailDraftsInteractor>(removeEmailDraftsInteractor);
       Get.put<EmailReceiveManager>(emailReceiveManager);
@@ -827,7 +828,7 @@ void main() {
               currentCollection: anyNamed('currentCollection'),
               mailboxKeySelected: anyNamed('mailboxKeySelected'),
               mailboxIdExpanded: anyNamed('mailboxIdExpanded'),
-              primaryAccountId: anyNamed('primaryAccountId'),
+              primaryAccountId: argThat(equals(AccountFixtures.aliceAccountId), named: 'primaryAccountId'),
             ),
           ).thenAnswer(
             (_) async => MailboxCollection(
@@ -875,7 +876,7 @@ void main() {
               currentCollection: anyNamed('currentCollection'),
               mailboxKeySelected: anyNamed('mailboxKeySelected'),
               mailboxIdExpanded: anyNamed('mailboxIdExpanded'),
-              primaryAccountId: anyNamed('primaryAccountId'),
+              primaryAccountId: argThat(equals(AccountFixtures.aliceAccountId), named: 'primaryAccountId'),
             ),
           ).called(1);
 
@@ -967,7 +968,7 @@ void main() {
               currentCollection: anyNamed('currentCollection'),
               mailboxKeySelected: anyNamed('mailboxKeySelected'),
               mailboxIdExpanded: anyNamed('mailboxIdExpanded'),
-              primaryAccountId: anyNamed('primaryAccountId'),
+              primaryAccountId: argThat(equals(AccountFixtures.aliceAccountId), named: 'primaryAccountId'),
             ),
           ).thenAnswer(
             (_) async => MailboxCollection(
@@ -1016,7 +1017,7 @@ void main() {
               currentCollection: anyNamed('currentCollection'),
               mailboxKeySelected: anyNamed('mailboxKeySelected'),
               mailboxIdExpanded: anyNamed('mailboxIdExpanded'),
-              primaryAccountId: anyNamed('primaryAccountId'),
+              primaryAccountId: argThat(equals(AccountFixtures.aliceAccountId), named: 'primaryAccountId'),
             ),
           ).called(1);
 

--- a/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
+++ b/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
@@ -825,7 +825,7 @@ void main() {
             treeBuilder.generateMailboxTreeInUI(
               allMailboxes: anyNamed('allMailboxes'),
               currentCollection: anyNamed('currentCollection'),
-              mailboxIdSelected: anyNamed('mailboxIdSelected'),
+              mailboxKeySelected: anyNamed('mailboxKeySelected'),
               mailboxIdExpanded: anyNamed('mailboxIdExpanded'),
               primaryAccountId: anyNamed('primaryAccountId'),
             ),
@@ -873,7 +873,7 @@ void main() {
             treeBuilder.generateMailboxTreeInUI(
               allMailboxes: anyNamed('allMailboxes'),
               currentCollection: anyNamed('currentCollection'),
-              mailboxIdSelected: anyNamed('mailboxIdSelected'),
+              mailboxKeySelected: anyNamed('mailboxKeySelected'),
               mailboxIdExpanded: anyNamed('mailboxIdExpanded'),
               primaryAccountId: anyNamed('primaryAccountId'),
             ),
@@ -965,7 +965,7 @@ void main() {
             treeBuilder.generateMailboxTreeInUI(
               allMailboxes: anyNamed('allMailboxes'),
               currentCollection: anyNamed('currentCollection'),
-              mailboxIdSelected: anyNamed('mailboxIdSelected'),
+              mailboxKeySelected: anyNamed('mailboxKeySelected'),
               mailboxIdExpanded: anyNamed('mailboxIdExpanded'),
               primaryAccountId: anyNamed('primaryAccountId'),
             ),
@@ -1014,7 +1014,7 @@ void main() {
             treeBuilder.generateMailboxTreeInUI(
               allMailboxes: anyNamed('allMailboxes'),
               currentCollection: anyNamed('currentCollection'),
-              mailboxIdSelected: anyNamed('mailboxIdSelected'),
+              mailboxKeySelected: anyNamed('mailboxKeySelected'),
               mailboxIdExpanded: anyNamed('mailboxIdExpanded'),
               primaryAccountId: anyNamed('primaryAccountId'),
             ),

--- a/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
+++ b/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
@@ -329,6 +329,11 @@ void main() {
     setUp(() {
       Get.testMode = true;
 
+      // Reset recorded interactions on shared mocks so a call from a previous
+      // test (e.g. an async mailbox load that resolves after Get.deleteAll)
+      // cannot be counted against this test's verify().
+      clearInteractions(treeBuilder);
+
       Get.put<RemoveEmailDraftsInteractor>(removeEmailDraftsInteractor);
       Get.put<EmailReceiveManager>(emailReceiveManager);
       Get.put<DownloadController>(downloadController);
@@ -822,6 +827,7 @@ void main() {
               currentCollection: anyNamed('currentCollection'),
               mailboxIdSelected: anyNamed('mailboxIdSelected'),
               mailboxIdExpanded: anyNamed('mailboxIdExpanded'),
+              primaryAccountId: anyNamed('primaryAccountId'),
             ),
           ).thenAnswer(
             (_) async => MailboxCollection(
@@ -869,6 +875,7 @@ void main() {
               currentCollection: anyNamed('currentCollection'),
               mailboxIdSelected: anyNamed('mailboxIdSelected'),
               mailboxIdExpanded: anyNamed('mailboxIdExpanded'),
+              primaryAccountId: anyNamed('primaryAccountId'),
             ),
           ).called(1);
 
@@ -960,6 +967,7 @@ void main() {
               currentCollection: anyNamed('currentCollection'),
               mailboxIdSelected: anyNamed('mailboxIdSelected'),
               mailboxIdExpanded: anyNamed('mailboxIdExpanded'),
+              primaryAccountId: anyNamed('primaryAccountId'),
             ),
           ).thenAnswer(
             (_) async => MailboxCollection(
@@ -1008,6 +1016,7 @@ void main() {
               currentCollection: anyNamed('currentCollection'),
               mailboxIdSelected: anyNamed('mailboxIdSelected'),
               mailboxIdExpanded: anyNamed('mailboxIdExpanded'),
+              primaryAccountId: anyNamed('primaryAccountId'),
             ),
           ).called(1);
 

--- a/test/features/rule_filter_creator/presentation/rule_filter_creator_controller_test.dart
+++ b/test/features/rule_filter_creator/presentation/rule_filter_creator_controller_test.dart
@@ -174,6 +174,7 @@ void main() {
 
       final spamMailbox = PresentationMailbox(
         MailboxId(Id('SpamId')),
+        accountId: accountId,
         name: MailboxName('Spam'),
         role: PresentationMailbox.roleJunk,
         isSubscribed: IsSubscribed(true),
@@ -213,6 +214,7 @@ void main() {
       when(mockTreeBuilder.generateMailboxTreeInUI(
         allMailboxes: [spamMailbox],
         currentCollection: MailboxCollection.empty(),
+        primaryAccountId: accountId,
       )).thenAnswer((_) async {
         return MailboxCollection(
           allMailboxes: [spamMailbox],
@@ -254,6 +256,7 @@ void main() {
 
       final mailboxA = PresentationMailbox(
         MailboxId(Id('MailboxA')),
+        accountId: accountId,
         name: MailboxName('MailboxA'),
         isSubscribed: IsSubscribed(true),
         namespace: Namespace('Personal'));
@@ -292,6 +295,7 @@ void main() {
       when(mockTreeBuilder.generateMailboxTreeInUI(
         allMailboxes: [mailboxA],
         currentCollection: MailboxCollection.empty(),
+        primaryAccountId: accountId,
       )).thenAnswer((_) async {
         return MailboxCollection(
           allMailboxes: [mailboxA],


### PR DESCRIPTION
## Summary

Add support for shared mailboxes exposed through additional mail-capable
accounts in the JMAP session.

Previously, mailbox loading and message fetching were primarily tied to the
main account. This change allows Twake Mail to discover additional JMAP mail
accounts, display their mailboxes in the mailbox tree, and use the correct
account when loading messages from a shared mailbox.

The implementation was tested against Cyrus JMAP 3.12.3.

## Changes

- Add account information to `PresentationMailbox`
- Distinguish personal mailboxes, shared mailboxes, and synthetic account roots
- Load mailboxes from additional JMAP mail accounts
- Display each additional account as an expandable group under Team Mailboxes
- Preserve the parent/child hierarchy of shared mailboxes
- Use account-aware mailbox keys to avoid mailbox ID collisions across accounts
- Use the selected mailbox account when fetching messages
- Prevent synthetic account roots from being opened as real mailboxes

## Testing

Verified that:

- The personal Inbox continues to load normally
- Team Mailboxes is displayed
- Additional JMAP mail accounts appear as expandable groups
- Shared mailbox hierarchy is preserved
- Messages are loaded from the selected shared mailbox account
- Synthetic account roots only expand and collapse
- Returning to the personal Inbox continues to work
- Static analysis passes with no issues

## Notes

The Cyrus test environment also required `List-Unsubscribe` to be requested as
`header:List-Unsubscribe:asURLs`.

That compatibility fix was used only for local runtime testing and is not
included in this PR because it is unrelated to shared mailbox account support.

Mailbox actions such as move, delete, archive, spam, bulk operations, and
read/starred state changes across shared accounts have not yet been fully
validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for loading, displaying, and managing shared mailboxes from other accounts.
  * Shared mailboxes appear in clearly identified account sections with consistent icons.
  * Mailbox navigation and URLs preserve the owning account context.
  * Mailbox visibility and subscription controls now support shared accounts.

* **Bug Fixes**
  * Improved mailbox selection, paths, counts, and actions when accounts reuse folder IDs.
  * Preserved mailbox permissions and sharing details across actions.
  * Corrected team mailbox empty-state detection.
  * Prevented unsupported cross-account moves with clear messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->