### PR TITLE
Fix: Search list goes blank when resizing across the web desktop breakpoint

### DIFF
--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -105,7 +105,6 @@ import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/localizations/localization_service.dart';
 import 'package:tmail_ui_user/main/routes/app_routes.dart';
-import 'package:tmail_ui_user/main/routes/navigation_router.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:tmail_ui_user/main/routes/route_utils.dart';
 import 'package:tmail_ui_user/main/utils/app_utils.dart';
@@ -1126,17 +1125,10 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
           : selectedMailbox?.browserRouteTitle ?? '',
         url: RouteUtils.createUrlWebLocationBar(
           AppRoutes.dashboard,
-          router: NavigationRouter(
-            mailboxId: isSearchRunning
-              ? null
-              : selectedMailbox?.browserRouteMailboxId,
-            labelId: selectedMailbox?.labelId,
-            dashboardType: isSearchRunning
-              ? DashboardType.search
-              : DashboardType.normal,
-            searchQuery: isSearchRunning
-              ? mailboxDashBoardController.searchController.searchQuery
-              : null
+          router: RouteUtils.dashboardRouterForMailboxOrSearch(
+            isSearchRunning: isSearchRunning,
+            selectedMailbox: selectedMailbox,
+            searchQuery: mailboxDashBoardController.searchController.searchQuery,
           )
         )
       );

--- a/lib/features/email/presentation/controller/single_email_controller.dart
+++ b/lib/features/email/presentation/controller/single_email_controller.dart
@@ -76,7 +76,6 @@ import 'package:tmail_ui_user/features/email/presentation/utils/email_action_rea
 import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
 import 'package:tmail_ui_user/features/home/domain/extensions/session_extensions.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/action/mailbox_ui_action.dart';
-import 'package:tmail_ui_user/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/action/download_ui_action.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/home/data/exceptions/session_exceptions.dart';
@@ -1120,9 +1119,10 @@ class SingleEmailController extends BaseController with AppLoaderMixin {
       final selectedMailbox = mailboxDashBoardController.selectedMailbox.value;
       final isSearchRunning = mailboxDashBoardController.searchController.isSearchEmailRunning;
       RouteUtils.replaceBrowserHistory(
-        title: isSearchRunning
-          ? 'SearchEmail'
-          : selectedMailbox?.browserRouteTitle ?? '',
+        title: RouteUtils.dashboardBrowserRouteTitle(
+          isSearchRunning: isSearchRunning,
+          selectedMailbox: selectedMailbox,
+        ),
         url: RouteUtils.createUrlWebLocationBar(
           AppRoutes.dashboard,
           router: RouteUtils.dashboardRouterForMailboxOrSearch(

--- a/lib/features/mailbox/presentation/base_mailbox_view.dart
+++ b/lib/features/mailbox/presentation/base_mailbox_view.dart
@@ -411,7 +411,7 @@ abstract class BaseMailboxView extends GetWidget<MailboxController>
 
       final labelController = dashboardController.labelController;
 
-      final selectedMailbox = dashboardController.selectedMailbox.value;
+      final selectedMailbox = dashboardController.selectedMailboxForDisplay;
       Id? labelIdSelected;
       if (selectedMailbox?.isLabelMailbox == true) {
         labelIdSelected = selectedMailbox?.labelId;

--- a/lib/features/mailbox/presentation/base_mailbox_view.dart
+++ b/lib/features/mailbox/presentation/base_mailbox_view.dart
@@ -209,8 +209,7 @@ abstract class BaseMailboxView extends GetWidget<MailboxController>
         mailboxNode: mailboxNode,
         mailboxNodeSelected: controller
           .mailboxDashBoardController
-          .selectedMailbox
-          .value,
+          .selectedMailboxForDisplay,
         isDraggingMailbox: controller
             .mailboxDashBoardController
             .isDraggingMailbox,

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -88,6 +88,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_ai_needs_action_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/handle_create_new_rule_filter.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/open_and_close_composer_extension.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/restore_mailbox_email_list_after_search_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/websocket/web_socket_message.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/websocket/web_socket_queue_handler.dart';
@@ -923,12 +924,17 @@ class MailboxController extends BaseMailboxController
     log('MailboxController::_handleOpenMailbox():MAILBOX_ID = ${presentationMailboxSelected.id.asString} | MAILBOX_NAME: ${presentationMailboxSelected.name?.name}');
     KeyboardUtils.hideKeyboard(context);
     mailboxDashBoardController.clearSelectedEmail();
+    final shouldRestoreMailboxEmailList = mailboxDashBoardController
+        .shouldRestoreMailboxEmailListAfterSearch(presentationMailboxSelected);
     if (presentationMailboxSelected.id != mailboxDashBoardController.selectedMailbox.value?.id) {
       mailboxDashBoardController.clearFilterMessageOption();
     }
     _disableAllSearchEmail();
     mailboxDashBoardController.closeMailboxMenuDrawer();
     mailboxDashBoardController.setSelectedMailbox(presentationMailboxSelected);
+    if (shouldRestoreMailboxEmailList) {
+      mailboxDashBoardController.restoreMailboxEmailListAfterSearch();
+    }
     mailboxDashBoardController.dispatchRoute(DashboardRoutes.thread);
     _replaceBrowserHistory();
   }

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -1339,17 +1339,21 @@ class MailboxController extends BaseMailboxController
     final currentMailbox = selectedMailbox;
     log('MailboxController::_replaceBrowserHistory:selectedMailbox: ${currentMailbox?.id.asString}');
     if (PlatformInfo.isWeb && Get.currentRoute.startsWith(AppRoutes.dashboard)) {
+      final isSearchRunning =
+          mailboxDashBoardController.searchController.isSearchEmailRunning;
       final route = RouteUtils.createUrlWebLocationBar(
         AppRoutes.dashboard,
         router: RouteUtils.dashboardRouterForMailboxOrSearch(
-          isSearchRunning:
-            mailboxDashBoardController.searchController.isSearchEmailRunning,
+          isSearchRunning: isSearchRunning,
           selectedMailbox: currentMailbox,
           searchQuery: mailboxDashBoardController.searchController.searchQuery,
         )
       );
       RouteUtils.replaceBrowserHistory(
-        title: currentMailbox?.browserRouteTitle ?? '',
+        title: RouteUtils.dashboardBrowserRouteTitle(
+          isSearchRunning: isSearchRunning,
+          selectedMailbox: currentMailbox,
+        ),
         url: route
       );
     }

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -433,8 +433,7 @@ class MailboxController extends BaseMailboxController
     } else if (action is OpenMailboxAction) {
       _onOpenMailboxAction(action);
     } else if (action is SystemBackToInboxAction) {
-      _disableAllSearchEmail();
-      _switchBackToMailboxDefault();
+      _backToInboxLeavingSearch();
       mailboxDashBoardController.clearMailboxUIAction();
     } else if (action is RefreshAllMailboxAction) {
       refreshAllMailbox();
@@ -1107,6 +1106,22 @@ class MailboxController extends BaseMailboxController
     _autoScrollToTopMailboxList();
   }
 
+  /// Returns to the inbox on a system Back, restoring its list. A search run
+  /// from the inbox re-selects the already-selected inbox, firing no mailbox
+  /// change, so the list must be restored explicitly. Searches from another
+  /// folder change the selection and reload on their own. The decision is read
+  /// before disabling search, which clears the flags it checks.
+  void _backToInboxLeavingSearch() {
+    final restoreNeeded =
+        mailboxDashBoardController.searchController.isSearchEmailRunning &&
+            mailboxDashBoardController.selectedMailbox.value?.isInbox == true;
+    _disableAllSearchEmail();
+    _switchBackToMailboxDefault();
+    if (restoreNeeded) {
+      mailboxDashBoardController.restoreMailboxEmailListAfterSearch();
+    }
+  }
+
   void _deleteMailboxFailure(DeleteMultipleMailboxFailure failure) {
     if (currentOverlayContext != null && currentContext != null) {
       appToast.showToastErrorMessage(
@@ -1326,15 +1341,11 @@ class MailboxController extends BaseMailboxController
     if (PlatformInfo.isWeb && Get.currentRoute.startsWith(AppRoutes.dashboard)) {
       final route = RouteUtils.createUrlWebLocationBar(
         AppRoutes.dashboard,
-        router: NavigationRouter(
-          mailboxId: currentMailbox?.browserRouteMailboxId,
-          labelId: currentMailbox?.labelId,
-          searchQuery: mailboxDashBoardController.searchController.isSearchEmailRunning
-            ? mailboxDashBoardController.searchController.searchQuery
-            : null,
-          dashboardType: mailboxDashBoardController.searchController.isSearchEmailRunning
-            ? DashboardType.search
-            : DashboardType.normal
+        router: RouteUtils.dashboardRouterForMailboxOrSearch(
+          isSearchRunning:
+            mailboxDashBoardController.searchController.isSearchEmailRunning,
+          selectedMailbox: currentMailbox,
+          searchQuery: mailboxDashBoardController.searchController.searchQuery,
         )
       );
       RouteUtils.replaceBrowserHistory(

--- a/lib/features/mailbox_dashboard/presentation/action/dashboard_action.dart
+++ b/lib/features/mailbox_dashboard/presentation/action/dashboard_action.dart
@@ -134,6 +134,15 @@ class QuickSearchEmailByFromAction extends DashBoardAction {
 
 class CloseSearchEmailViewAction extends DashBoardAction {}
 
+class RestoreMailboxEmailListAfterSearchAction extends DashBoardAction {
+  final bool force;
+
+  RestoreMailboxEmailListAfterSearchAction({this.force = false});
+
+  @override
+  List<Object?> get props => [force];
+}
+
 class CancelSelectionSearchEmailAction extends DashBoardAction {}
 
 class OpenAdvancedSearchViewAction extends DashBoardAction {}

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -233,7 +233,6 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/routes/app_routes.dart';
 import 'package:tmail_ui_user/main/routes/dialog_router.dart';
-import 'package:tmail_ui_user/main/routes/navigation_router.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:tmail_ui_user/main/routes/route_utils.dart';
 import 'package:tmail_ui_user/main/universal_import/html_stub.dart' as html;
@@ -3110,18 +3109,11 @@ class MailboxDashBoardController extends ReloadableController
         title: title,
         url: uri ?? RouteUtils.createUrlWebLocationBar(
           AppRoutes.dashboard,
-          router: NavigationRouter(
+          router: RouteUtils.dashboardRouterForMailboxOrSearch(
+            isSearchRunning: isSearchRunning,
             emailId: selectedEmail.value?.id,
-            mailboxId: isSearchRunning
-              ? null
-              : currentMailbox?.browserRouteMailboxId,
-            labelId: currentMailbox?.labelId,
-            dashboardType: isSearchRunning
-              ? DashboardType.search
-              : DashboardType.normal,
-            searchQuery: isSearchRunning
-              ? searchController.searchQuery
-              : null
+            selectedMailbox: currentMailbox,
+            searchQuery: searchController.searchQuery,
           )
         )
       );

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -3097,16 +3097,12 @@ class MailboxDashBoardController extends ReloadableController
       final currentMailbox = selectedMailbox.value;
       final selectedEmailId = selectedEmail.value?.id;
       final isSearchRunning = searchController.isSearchEmailRunning;
-      String title = '';
-      if (selectedEmail.value != null) {
-        title = 'Email-${selectedEmailId?.asString ?? ''}';
-      } else if (isSearchRunning) {
-        title = 'SearchEmail';
-      } else {
-        title = currentMailbox?.browserRouteTitle ?? '';
-      }
       RouteUtils.replaceBrowserHistory(
-        title: title,
+        title: RouteUtils.dashboardBrowserRouteTitle(
+          isSearchRunning: isSearchRunning,
+          selectedEmailId: selectedEmailId,
+          selectedMailbox: currentMailbox,
+        ),
         url: uri ?? RouteUtils.createUrlWebLocationBar(
           AppRoutes.dashboard,
           router: RouteUtils.dashboardRouterForMailboxOrSearch(

--- a/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
+++ b/lib/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart
@@ -312,6 +312,8 @@ class MailboxDashBoardController extends ReloadableController
 
   final scaffoldKey = GlobalKey<ScaffoldState>();
   final selectedMailbox = Rxn<PresentationMailbox>();
+  PresentationMailbox? get selectedMailboxForDisplay =>
+      searchController.isSearchEmailRunning ? null : selectedMailbox.value;
   final selectedEmail = Rxn<PresentationEmail>();
   final accountId = Rxn<AccountId>();
   final dashBoardAction = Rxn<UIAction>();
@@ -1096,7 +1098,6 @@ class MailboxDashBoardController extends ReloadableController
     if (_searchInsideThreadDetailViewIsActive()) {
       _closeEmailDetailedView();
     }
-    _unSelectedMailbox();
     FocusManager.instance.primaryFocus?.unfocus();
     storeEmailSortOrder(searchController.committedSearchFilter.sortOrderType);
     dispatchAction(StartSearchEmailAction());
@@ -1108,7 +1109,6 @@ class MailboxDashBoardController extends ReloadableController
     if (_searchInsideThreadDetailViewIsActive()) {
       _closeEmailDetailedView();
     }
-    _unSelectedMailbox();
     searchController.clearAllFilterSearch();
     FocusManager.instance.primaryFocus?.unfocus();
     dispatchAction(ClearAdvancedSearchFilterEmailAction());
@@ -1120,7 +1120,6 @@ class MailboxDashBoardController extends ReloadableController
     if (_searchInsideThreadDetailViewIsActive()) {
       _closeEmailDetailedView();
     }
-    _unSelectedMailbox();
 
     // A bare email address routes to the `from` filter; clear the live text term
     // so the same string is not also applied as a full-text condition.
@@ -1146,10 +1145,6 @@ class MailboxDashBoardController extends ReloadableController
       && currentContext != null
       && responsiveUtils.isDesktop(currentContext!)
       && dashboardRoute.value == DashboardRoutes.threadDetailed;
-  }
-
-  void _unSelectedMailbox() {
-    selectedMailbox.value = null;
   }
 
   void _closeEmailDetailedView() {
@@ -3046,7 +3041,6 @@ class MailboxDashBoardController extends ReloadableController
     if (_searchInsideThreadDetailViewIsActive()) {
       _closeEmailDetailedView();
     }
-    _unSelectedMailbox();
     dispatchAction(QuickSearchEmailByFromAction(emailAddress));
   }
 

--- a/lib/features/mailbox_dashboard/presentation/extensions/restore_mailbox_email_list_after_search_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/restore_mailbox_email_list_after_search_extension.dart
@@ -1,0 +1,20 @@
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/action/dashboard_action.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+
+extension RestoreMailboxEmailListAfterSearchExtension
+    on MailboxDashBoardController {
+  bool shouldRestoreMailboxEmailListAfterSearch(
+    PresentationMailbox presentationMailbox,
+  ) {
+    final selectedMailboxId = selectedMailbox.value?.id;
+    return presentationMailbox.id == selectedMailboxId &&
+        searchController.isSearchEmailRunning;
+  }
+
+  void restoreMailboxEmailListAfterSearch() {
+    dispatchAction(
+      RestoreMailboxEmailListAfterSearchAction(force: true),
+    );
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart
+++ b/lib/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart
@@ -30,6 +30,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/open_and_close_composer_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/select_search_filter_action_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/desktop_dashboard_route_body.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/profile_setting/profile_setting_action_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
@@ -284,16 +285,10 @@ class MailboxDashBoardView extends BaseMailboxDashBoardView {
                               }),
                               _buildListButtonQuickSearchFilter(context),
                               Expanded(
-                                child: Obx(() {
-                                  switch(controller.dashboardRoute.value) {
-                                    case DashboardRoutes.thread:
-                                      return _buildThreadViewForWebDesktop(context);
-                                    case DashboardRoutes.threadDetailed:
-                                      return const ThreadDetailView();
-                                    default:
-                                      return const SizedBox.shrink();
-                                  }
-                                }),
+                                child: Obx(() => DesktopDashboardRouteBody(
+                                  route: controller.dashboardRoute.value,
+                                  threadListBuilder: _buildThreadViewForWebDesktop,
+                                )),
                               )
                             ],
                           ),

--- a/lib/features/mailbox_dashboard/presentation/widgets/desktop_dashboard_route_body.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/desktop_dashboard_route_body.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/widgets.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
+import 'package:tmail_ui_user/features/thread_detail/presentation/thread_detail_view.dart';
+
+typedef DesktopThreadListBuilder = Widget Function(BuildContext context);
+
+/// Maps the current [DashboardRoutes] to the body shown inside the web-desktop
+/// content pane. [DashboardRoutes.searchEmail] shares the inline thread list
+/// with [DashboardRoutes.thread] so a residual search route left after a
+/// responsive handoff renders results instead of a blank pane.
+class DesktopDashboardRouteBody extends StatelessWidget {
+  const DesktopDashboardRouteBody({
+    super.key,
+    required this.route,
+    required this.threadListBuilder,
+  });
+
+  final DashboardRoutes route;
+  final DesktopThreadListBuilder threadListBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    switch (route) {
+      case DashboardRoutes.thread:
+      case DashboardRoutes.searchEmail:
+        return threadListBuilder(context);
+      case DashboardRoutes.threadDetailed:
+        return const ThreadDetailView();
+      default:
+        return const SizedBox.shrink();
+    }
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
+++ b/lib/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart
@@ -141,7 +141,7 @@ class SearchInputFormWidget extends StatelessWidget with AppLoaderMixin {
         suggestionsCallback: _dashBoardController.quickSearchEmails,
         itemBuilder: (context, email) => EmailQuickSearchItemTileWidget(
             email,
-            _dashBoardController.selectedMailbox.value,
+            _dashBoardController.selectedMailboxForDisplay,
             searchQuery: SearchQuery(currentSearchText.trim())),
         onSuggestionSelected: _invokeSelectSuggestionItem,
         contactItemBuilder: (context, emailAddress) => ContactQuickSearchItem(emailAddress: emailAddress),

--- a/lib/features/search/email/presentation/coordinator/get_search_email_layout_owner_registry.dart
+++ b/lib/features/search/email/presentation/coordinator/get_search_email_layout_owner_registry.dart
@@ -1,0 +1,30 @@
+import 'package:core/utils/app_logger.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/search_email_bindings.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/search_email_controller.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/coordinator/search_email_layout_owner_registry.dart';
+
+class GetSearchEmailLayoutOwnerRegistry
+    implements SearchEmailLayoutOwnerRegistry {
+  const GetSearchEmailLayoutOwnerRegistry();
+
+  @override
+  bool tryPrepareForSearchHandoff() {
+    try {
+      if (!Get.isRegistered<SearchEmailController>()) {
+        SearchEmailBindings().dependencies();
+      }
+      if (!Get.isRegistered<SearchEmailController>()) {
+        return false;
+      }
+      Get.find<SearchEmailController>().prepareForSearchHandoff();
+      return true;
+    } catch (error, stackTrace) {
+      logWarning(
+        'GetSearchEmailLayoutOwnerRegistry::tryPrepareForSearchHandoff: '
+        '$error\n$stackTrace',
+      );
+      return false;
+    }
+  }
+}

--- a/lib/features/search/email/presentation/coordinator/search_email_layout_owner_registry.dart
+++ b/lib/features/search/email/presentation/coordinator/search_email_layout_owner_registry.dart
@@ -1,0 +1,3 @@
+abstract class SearchEmailLayoutOwnerRegistry {
+  bool tryPrepareForSearchHandoff();
+}

--- a/lib/features/search/email/presentation/coordinator/search_layout_callbacks.dart
+++ b/lib/features/search/email/presentation/coordinator/search_layout_callbacks.dart
@@ -1,0 +1,15 @@
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
+
+typedef SearchEngagementResolver = bool Function();
+
+typedef EmailOpenedResolver = bool Function();
+
+typedef DesktopSearchHandoffCallback = void Function();
+
+typedef MobileSearchActivationCallback = void Function();
+
+typedef SearchRouteDispatcher = void Function(DashboardRoutes route);
+
+typedef BrowserResizeCallback = void Function();
+
+typedef ControllerClosedResolver = bool Function();

--- a/lib/features/search/email/presentation/coordinator/search_layout_coordinator.dart
+++ b/lib/features/search/email/presentation/coordinator/search_layout_coordinator.dart
@@ -122,6 +122,9 @@ class SearchLayoutCoordinator {
   bool _handoffToDesktop() {
     _dispatchSearchListRouteIfEmailClosed(DashboardRoutes.thread);
     _prepareDesktopSearchHandoff();
+    // The desktop thread list now owns the presentation, so mailbox restore can
+    // reclaim it via takeDesktopSearchPresentation().
+    _desktopSearchPresentationActive = true;
     _searchService.replayCurrentStateToOwners();
     return true;
   }

--- a/lib/features/search/email/presentation/coordinator/search_layout_coordinator.dart
+++ b/lib/features/search/email/presentation/coordinator/search_layout_coordinator.dart
@@ -25,7 +25,9 @@ class SearchLayoutCoordinator {
   final SearchLayoutTransitionState _transitionState =
       SearchLayoutTransitionState();
 
-  /// Tracks whether the desktop thread list currently owns search results.
+  /// Whether the desktop thread list still holds search results and needs a
+  /// restore when search closes. Survives a desktop-to-mobile handoff, which
+  /// never clears that list.
   bool _desktopSearchPresentationActive = false;
 
   StreamSubscription<html.Event>? _resizeSubscription;
@@ -134,9 +136,8 @@ class SearchLayoutCoordinator {
   bool _handoffToMobile() {
     if (!_mobileOwnerRegistry.tryPrepareForSearchHandoff()) return false;
 
-    // The mobile list now owns the presentation, so mailbox restore must not
-    // treat the previous desktop list as active.
-    _desktopSearchPresentationActive = false;
+    // Mobile now shows the results, but the desktop list still holds them
+    // behind it. Keep desktop ownership so closing search restores that list.
     _activateMobileSearch();
     _dispatchSearchListRouteIfEmailClosed(DashboardRoutes.searchEmail);
     _searchService.replayCurrentStateToOwners();

--- a/lib/features/search/email/presentation/coordinator/search_layout_coordinator.dart
+++ b/lib/features/search/email/presentation/coordinator/search_layout_coordinator.dart
@@ -1,0 +1,148 @@
+import 'dart:async';
+
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:flutter/widgets.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/coordinator/get_search_email_layout_owner_registry.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/coordinator/search_email_layout_owner_registry.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/coordinator/search_layout_callbacks.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/coordinator/search_layout_transition_state.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/service/search_executor_service.dart';
+import 'package:universal_html/html.dart' as html;
+
+/// Coordinates responsive search ownership without owning mailbox/thread data.
+class SearchLayoutCoordinator {
+  final ResponsiveUtils _responsiveUtils;
+  final SearchExecutorService _searchService;
+  final SearchEmailLayoutOwnerRegistry _mobileOwnerRegistry;
+  final SearchEngagementResolver _isSearchEngaged;
+  final EmailOpenedResolver _isEmailOpened;
+  final DesktopSearchHandoffCallback _prepareDesktopSearchHandoff;
+  final MobileSearchActivationCallback _activateMobileSearch;
+  final SearchRouteDispatcher _dispatchRoute;
+  final BrowserResizeCallback? _onBrowserResize;
+  final ControllerClosedResolver _isClosed;
+  final SearchLayoutTransitionState _transitionState =
+      SearchLayoutTransitionState();
+
+  /// Tracks whether the desktop thread list currently owns search results.
+  bool _desktopSearchPresentationActive = false;
+
+  StreamSubscription<html.Event>? _resizeSubscription;
+
+  SearchLayoutCoordinator({
+    required ResponsiveUtils responsiveUtils,
+    required SearchExecutorService searchService,
+    required SearchEngagementResolver isSearchEngaged,
+    required EmailOpenedResolver isEmailOpened,
+    required DesktopSearchHandoffCallback prepareDesktopSearchHandoff,
+    required MobileSearchActivationCallback activateMobileSearch,
+    required SearchRouteDispatcher dispatchRoute,
+    required ControllerClosedResolver isClosed,
+    SearchEmailLayoutOwnerRegistry mobileOwnerRegistry =
+        const GetSearchEmailLayoutOwnerRegistry(),
+    BrowserResizeCallback? onBrowserResize,
+  })  : _responsiveUtils = responsiveUtils,
+        _searchService = searchService,
+        _isSearchEngaged = isSearchEngaged,
+        _isEmailOpened = isEmailOpened,
+        _prepareDesktopSearchHandoff = prepareDesktopSearchHandoff,
+        _activateMobileSearch = activateMobileSearch,
+        _dispatchRoute = dispatchRoute,
+        _isClosed = isClosed,
+        _mobileOwnerRegistry = mobileOwnerRegistry,
+        _onBrowserResize = onBrowserResize;
+
+  double get _currentBrowserWidth => (html.window.innerWidth ?? 0).toDouble();
+
+  void start() {
+    final isDesktop = _responsiveUtils.isMatchedDesktopWidth(
+      _currentBrowserWidth,
+    );
+    _transitionState.initialize(isDesktop);
+    _resizeSubscription = html.window.onResize.listen((_) {
+      handleBrowserWidthChange(_currentBrowserWidth);
+      _onBrowserResize?.call();
+    });
+  }
+
+  void dispose() {
+    _transitionState.invalidateTransitions();
+    _resizeSubscription?.cancel();
+    _resizeSubscription = null;
+  }
+
+  void handleBrowserWidthChange(double width) {
+    final isDesktopNow = _responsiveUtils.isMatchedDesktopWidth(width);
+    final transition = _transitionState.observeBreakpoint(isDesktopNow);
+    if (transition == null) return;
+
+    _scheduleReconciliation(transition);
+  }
+
+  /// Waits for the target layout to settle before replaying search results.
+  void _scheduleReconciliation(SearchLayoutTransition transition) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_transitionState.shouldSkip(
+        transition,
+        isClosed: _isClosed(),
+      )) {
+        return;
+      }
+      _transitionState.complete(
+        transition,
+        succeeded: reconcile(transition.isDesktop),
+      );
+    });
+    WidgetsBinding.instance.scheduleFrame();
+  }
+
+  /// Replays the active search into the list owner for the current layout.
+  bool reconcile(bool isDesktop) {
+    if (!_isSearchEngaged()) return false;
+
+    if (isDesktop) {
+      return _handoffToDesktop();
+    } else {
+      return _handoffToMobile();
+    }
+  }
+
+  void markDesktopSearchPresentation() {
+    _desktopSearchPresentationActive = true;
+  }
+
+  bool takeDesktopSearchPresentation({bool force = false}) {
+    if (!force && !_desktopSearchPresentationActive) return false;
+    _desktopSearchPresentationActive = false;
+    return true;
+  }
+
+  /// Makes the desktop thread list the active search presentation owner.
+  bool _handoffToDesktop() {
+    _dispatchSearchListRouteIfEmailClosed(DashboardRoutes.thread);
+    _prepareDesktopSearchHandoff();
+    _searchService.replayCurrentStateToOwners();
+    return true;
+  }
+
+  /// Prepares the mobile owner before activating it and replaying search data.
+  /// A missing owner is a recoverable failure; the next resize can retry.
+  bool _handoffToMobile() {
+    if (!_mobileOwnerRegistry.tryPrepareForSearchHandoff()) return false;
+
+    // The mobile list now owns the presentation, so mailbox restore must not
+    // treat the previous desktop list as active.
+    _desktopSearchPresentationActive = false;
+    _activateMobileSearch();
+    _dispatchSearchListRouteIfEmailClosed(DashboardRoutes.searchEmail);
+    _searchService.replayCurrentStateToOwners();
+    return true;
+  }
+
+  /// Keeps the email detail route open while switching only the search list.
+  void _dispatchSearchListRouteIfEmailClosed(DashboardRoutes route) {
+    if (_isEmailOpened()) return;
+    _dispatchRoute(route);
+  }
+}

--- a/lib/features/search/email/presentation/coordinator/search_layout_coordinator.dart
+++ b/lib/features/search/email/presentation/coordinator/search_layout_coordinator.dart
@@ -100,8 +100,9 @@ class SearchLayoutCoordinator {
   }
 
   /// Replays the active search into the list owner for the current layout.
+  /// Returns true when no handoff is needed or the handoff succeeds.
   bool reconcile(bool isDesktop) {
-    if (!_isSearchEngaged()) return false;
+    if (!_isSearchEngaged()) return true;
 
     if (isDesktop) {
       return _handoffToDesktop();

--- a/lib/features/search/email/presentation/coordinator/search_layout_transition_state.dart
+++ b/lib/features/search/email/presentation/coordinator/search_layout_transition_state.dart
@@ -1,0 +1,90 @@
+class SearchLayoutTransition {
+  const SearchLayoutTransition({
+    required this.id,
+    required this.isDesktop,
+  });
+
+  /// Identifier used to invalidate callbacks from older resize events.
+  final int id;
+
+  /// Breakpoint mode that this transition is trying to reconcile.
+  final bool isDesktop;
+}
+
+class SearchLayoutTransitionState {
+  /// Latest responsive mode observed from the browser width.
+  bool? _lastObservedDesktop;
+
+  bool? get lastObservedDesktop => _lastObservedDesktop;
+
+  /// Responsive mode for which the latest handoff has been completed.
+  bool? _lastReconciledDesktop;
+
+  bool? get lastReconciledDesktop => _lastReconciledDesktop;
+
+  /// Invalidates callbacks queued for older browser width transitions.
+  int _transitionId = 0;
+
+  int get transitionId => _transitionId;
+
+  /// Initializes the responsive baseline without triggering a handoff.
+  void initialize(bool isDesktop) {
+    _lastObservedDesktop = isDesktop;
+    _lastReconciledDesktop = isDesktop;
+  }
+
+  /// Invalidates callbacks that were scheduled before disposal.
+  void invalidateTransitions() {
+    _transitionId++;
+  }
+
+  /// Records a resize and returns a transition only when reconciliation is
+  /// required for the newly observed breakpoint.
+  SearchLayoutTransition? observeBreakpoint(bool isDesktop) {
+    final wasDesktop = _lastObservedDesktop;
+    _lastObservedDesktop = isDesktop;
+
+    // First observation establishes the baseline only.
+    if (wasDesktop == null) {
+      _lastReconciledDesktop = isDesktop;
+      return null;
+    }
+
+    // A resize inside an already reconciled breakpoint is a no-op.
+    if (wasDesktop == isDesktop && _lastReconciledDesktop == isDesktop) {
+      return null;
+    }
+
+    // Crossing back to the already reconciled mode cancels the pending
+    // transition for the breakpoint we just left.
+    if (wasDesktop != isDesktop && _lastReconciledDesktop == isDesktop) {
+      invalidateTransitions();
+      return null;
+    }
+
+    return SearchLayoutTransition(
+      id: ++_transitionId,
+      isDesktop: isDesktop,
+    );
+  }
+
+  /// Returns whether a queued transition no longer matches the current state.
+  bool shouldSkip(
+    SearchLayoutTransition transition, {
+    required bool isClosed,
+  }) {
+    if (isClosed) return true;
+    if (transition.id != _transitionId) return true;
+    if (_lastObservedDesktop != transition.isDesktop) return true;
+    return _lastReconciledDesktop == transition.isDesktop;
+  }
+
+  /// Commits the result so failed handoffs can be retried on a later resize.
+  void complete(
+    SearchLayoutTransition transition, {
+    required bool succeeded,
+  }) {
+    if (transition.id != _transitionId) return;
+    _lastReconciledDesktop = succeeded ? transition.isDesktop : null;
+  }
+}

--- a/lib/features/search/email/presentation/search_email_controller.dart
+++ b/lib/features/search/email/presentation/search_email_controller.dart
@@ -126,7 +126,8 @@ class SearchEmailController extends BaseController
   /// load-more spinner toggling), so an identity check skips the full rebuild.
   List<PresentationEmail>? _lastAppliedResultEmails;
 
-  PresentationMailbox? get currentMailbox => mailboxDashBoardController.selectedMailbox.value;
+  PresentationMailbox? get currentMailbox =>
+      mailboxDashBoardController.selectedMailboxForDisplay;
 
   AccountId? get accountId => mailboxDashBoardController.accountId.value;
 
@@ -436,9 +437,12 @@ class SearchEmailController extends BaseController
   }
 
   @override
-  void onSearchFailure(Object error) {
+  void onSearchFailure(Object error, {bool isReplay = false}) {
     if (!_ownsSearchResults) return;
-    _searchEmailsFailure(asSearchEmailFailure(error));
+    _searchEmailsFailure(
+      asSearchEmailFailure(error),
+      showToast: !isReplay,
+    );
   }
 
   void _searchEmailAction() {
@@ -510,10 +514,15 @@ class SearchEmailController extends BaseController
     }
   }
 
-  void _searchEmailsFailure(SearchEmailFailure failure) {
+  void _searchEmailsFailure(
+    SearchEmailFailure failure, {
+    bool showToast = true,
+  }) {
     _searchEmailPresentationNotifier.clearResultSearches();
     _searchEmailPresentationNotifier.setResultSearchViewState(Left(failure));
-    showRetryToast(failure);
+    if (showToast) {
+      showRetryToast(failure);
+    }
   }
 
   void searchMoreEmailsAction() {
@@ -801,6 +810,15 @@ class SearchEmailController extends BaseController
     textInputSearchController.text = value;
   }
 
+  void prepareForSearchHandoff() {
+    onNewSearchStarted();
+    final committedSearchText = searchEmailFilter.text?.value ?? '';
+    setTextInputSearchForm(committedSearchText);
+    _searchEmailPresentationNotifier.setCurrentSearchText(
+      committedSearchText,
+    );
+  }
+
   void clearAllTextInputSearchForm({bool requestFocus = false}) {
     textInputSearchController.clear();
     _searchEmailPresentationNotifier.clearAllTextInputSearchState();
@@ -823,6 +841,9 @@ class SearchEmailController extends BaseController
     clearAllResultSearch();
     mailboxDashBoardController.searchController.disableAllSearchEmail();
     mailboxDashBoardController.dispatchRoute(DashboardRoutes.thread);
+    mailboxDashBoardController.dispatchAction(
+      RestoreMailboxEmailListAfterSearchAction(),
+    );
     if (PlatformInfo.isWeb) {
       final currentMailbox = mailboxDashBoardController.selectedMailbox.value;
       RouteUtils.replaceBrowserHistory(

--- a/lib/features/search/email/presentation/search_email_view.dart
+++ b/lib/features/search/email/presentation/search_email_view.dart
@@ -71,24 +71,10 @@ class SearchEmailView extends ConsumerWidget {
       searchFilterProvider.select((filter) => filter.text),
     );
 
-    _dismissSearchOnWebDesktop(context);
-
     return _buildScaffold(
       context,
       _buildBody(ref, context, presentationState, searchQuery),
     );
-  }
-
-  /// Close mobile search on web desktop rebuilds.
-  void _dismissSearchOnWebDesktop(BuildContext context) {
-    if (!controller.responsiveUtils.isWebDesktop(context)) return;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!context.mounted ||
-          !Get.isRegistered<SearchEmailController>()) {
-        return;
-      }
-      Get.find<SearchEmailController>().closeSearchView(context: context);
-    });
   }
 
   Widget _buildBody(

--- a/lib/features/search/email/presentation/service/search_execution_observer.dart
+++ b/lib/features/search/email/presentation/service/search_execution_observer.dart
@@ -16,6 +16,7 @@ abstract class SearchExecutionObserver {
 
   /// The search failed with a non-urgent error. Urgent failures are routed by
   /// the executor's consume seam and filtered by [SearchExecutorService]
-  /// (ADR-0103), so this is never called for them.
-  void onSearchFailure(Object error);
+  /// (ADR-0103), so this is never called for them. [isReplay] hydrates a new
+  /// layout owner and must not repeat one-shot user notifications.
+  void onSearchFailure(Object error, {bool isReplay = false});
 }

--- a/lib/features/search/email/presentation/service/search_executor_service.dart
+++ b/lib/features/search/email/presentation/service/search_executor_service.dart
@@ -41,6 +41,15 @@ class SearchExecutorService {
     if (_observers.isEmpty) _closeSubscription();
   }
 
+  /// Replays the executor's current state to every registered observer.
+  ///
+  /// Used when responsive layouts hand an active search between presentation
+  /// stores without executing the search again.
+  void replayCurrentStateToOwners() {
+    if (_disposed || !_hasDispatchedSearch) return;
+    _notifyObservers(_notifyCurrentState);
+  }
+
   /// Runs [intent] via the executor; a new search first resets its observers.
   /// The returned future completes when the executor finishes (awaited by the
   /// websocket-refresh path to order message-dedup after the refresh).
@@ -123,7 +132,7 @@ class SearchExecutorService {
     } else if (current.hasError) {
       // Urgent failures were already routed by the consume seam (ADR-0103).
       if (isUrgentException(current.error!)) return;
-      observer.onSearchFailure(current.error!);
+      observer.onSearchFailure(current.error!, isReplay: true);
     } else if (current.value != null) {
       observer.onSearchResult(current.value!, isFreshResult: false);
     }

--- a/lib/features/thread/presentation/extensions/list_presentation_email_extensions.dart
+++ b/lib/features/thread/presentation/extensions/list_presentation_email_extensions.dart
@@ -52,7 +52,7 @@ extension ListPresentationEmailExtensions on List<PresentationEmail> {
           mailboxId: isSearchEmailRunning
               ? null
               : selectedMailbox?.browserRouteMailboxId,
-          labelId: selectedMailbox?.labelId,
+          labelId: isSearchEmailRunning ? null : selectedMailbox?.labelId,
           searchQuery: isSearchEmailRunning ? searchQuery : null,
           dashboardType: isSearchEmailRunning ? DashboardType.search : DashboardType.normal
         )

--- a/lib/features/thread/presentation/extensions/list_presentation_email_extensions.dart
+++ b/lib/features/thread/presentation/extensions/list_presentation_email_extensions.dart
@@ -5,11 +5,9 @@ import 'package:model/email/presentation_email.dart';
 import 'package:model/extensions/presentation_email_extension.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:tmail_ui_user/features/email/presentation/extensions/email_extension.dart';
-import 'package:tmail_ui_user/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
 import 'package:tmail_ui_user/features/thread_detail/domain/model/email_in_thread_detail_info.dart';
 import 'package:tmail_ui_user/main/routes/app_routes.dart';
-import 'package:tmail_ui_user/main/routes/navigation_router.dart';
 import 'package:tmail_ui_user/main/routes/route_utils.dart';
 
 extension ListPresentationEmailExtensions on List<PresentationEmail> {
@@ -47,14 +45,11 @@ extension ListPresentationEmailExtensions on List<PresentationEmail> {
     if (PlatformInfo.isWeb) {
       final route = RouteUtils.createUrlWebLocationBar(
         AppRoutes.dashboard,
-        router: NavigationRouter(
+        router: RouteUtils.dashboardRouterForMailboxOrSearch(
+          isSearchRunning: isSearchEmailRunning,
           emailId: currentEmail.id,
-          mailboxId: isSearchEmailRunning
-              ? null
-              : selectedMailbox?.browserRouteMailboxId,
-          labelId: isSearchEmailRunning ? null : selectedMailbox?.labelId,
-          searchQuery: isSearchEmailRunning ? searchQuery : null,
-          dashboardType: isSearchEmailRunning ? DashboardType.search : DashboardType.normal
+          selectedMailbox: selectedMailbox,
+          searchQuery: searchQuery,
         )
       );
       return route;

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -77,7 +77,6 @@ import 'package:tmail_ui_user/features/search/email/presentation/service/search_
 import 'package:tmail_ui_user/features/search/email/presentation/service/search_executor_service.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/providers/search_executor_provider.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/thread/presentation/extensions/handle_email_filter_extension.dart';
 import 'package:tmail_ui_user/features/thread/presentation/extensions/handle_keyboard_shortcut_actions_extension.dart';
 import 'package:tmail_ui_user/features/thread/presentation/extensions/list_presentation_email_extensions.dart';

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -49,6 +49,7 @@ import 'package:tmail_ui_user/features/thread/data/model/email_change_response.d
 import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_bindings.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/coordinator/get_search_email_layout_owner_registry.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/coordinator/search_email_layout_owner_registry.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/coordinator/search_layout_coordinator.dart';
 import 'package:tmail_ui_user/features/thread/data/extensions/email_change_response_extension.dart';
 import 'package:tmail_ui_user/features/thread/domain/constants/thread_constants.dart';
@@ -110,6 +111,7 @@ class ThreadController extends BaseController with EmailActionController {
   final LoadMoreEmailsInMailboxInteractor _loadMoreEmailsInMailboxInteractor;
   final GetEmailByIdInteractor _getEmailByIdInteractor;
   final CleanAndGetEmailsInMailboxInteractor cleanAndGetEmailsInMailboxInteractor;
+  final SearchEmailLayoutOwnerRegistry _searchEmailLayoutOwnerRegistry;
 
   final listEmailDrag = <PresentationEmail>[].obs;
   bool rangeSelectionMode = false;
@@ -132,7 +134,8 @@ class ThreadController extends BaseController with EmailActionController {
   ProviderSubscription<PreferencesSetting>? _localSettingsSubscription;
   late final SearchExecutionObserver _searchExecutionObserver =
       ThreadSearchExecutionObserver(this);
-  late final SearchLayoutCoordinator _searchLayoutCoordinator =
+  @visibleForTesting
+  late final SearchLayoutCoordinator searchLayoutCoordinator =
       _createSearchLayoutCoordinator();
 
   AccountId? get _accountId => mailboxDashBoardController.accountId.value;
@@ -162,8 +165,10 @@ class ThreadController extends BaseController with EmailActionController {
     this._refreshChangesEmailsInMailboxInteractor,
     this._loadMoreEmailsInMailboxInteractor,
     this._getEmailByIdInteractor,
-    this.cleanAndGetEmailsInMailboxInteractor,
-  );
+    this.cleanAndGetEmailsInMailboxInteractor, {
+    SearchEmailLayoutOwnerRegistry searchEmailLayoutOwnerRegistry =
+        const GetSearchEmailLayoutOwnerRegistry(),
+  }) : _searchEmailLayoutOwnerRegistry = searchEmailLayoutOwnerRegistry;
 
   // Lazy so dispatch works before onInit, like the old late-final executor.
   SearchExecutorService get _searchService =>
@@ -182,7 +187,7 @@ class ThreadController extends BaseController with EmailActionController {
   void onInit() {
     _registerObxStreamListener();
     if (PlatformInfo.isWeb) {
-      _searchLayoutCoordinator.start();
+      searchLayoutCoordinator.start();
       onKeyboardShortcutInit();
     }
     _initWebSocketQueueHandler();
@@ -202,7 +207,7 @@ class ThreadController extends BaseController with EmailActionController {
     _currentMemoryMailboxId = null;
     listEmailController.dispose();
     if (PlatformInfo.isWeb) {
-      _searchLayoutCoordinator.dispose();
+      searchLayoutCoordinator.dispose();
       onKeyboardShortcutDispose();
     }
     _webSocketQueueHandler?.dispose();
@@ -541,7 +546,7 @@ class ThreadController extends BaseController with EmailActionController {
       activateMobileSearch: () => searchController.activateSimpleSearch(),
       dispatchRoute: mailboxDashBoardController.dispatchRoute,
       isClosed: () => isClosed,
-      mobileOwnerRegistry: const GetSearchEmailLayoutOwnerRegistry(),
+      mobileOwnerRegistry: _searchEmailLayoutOwnerRegistry,
       onBrowserResize: _validateBrowserHeight,
     );
   }
@@ -645,7 +650,7 @@ class ThreadController extends BaseController with EmailActionController {
 
   @visibleForTesting
   void restoreMailboxEmailListAfterSearch({bool force = false}) {
-    if (!_searchLayoutCoordinator.takeDesktopSearchPresentation(force: force)) {
+    if (!searchLayoutCoordinator.takeDesktopSearchPresentation(force: force)) {
       return;
     }
     resetToOriginalValue();

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -35,6 +35,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/network_connection/presentation/network_connection_controller.dart'
   if (dart.library.html) 'package:tmail_ui_user/features/network_connection/presentation/web_network_connection_controller.dart';
 import 'package:tmail_ui_user/features/push_notification/presentation/websocket/web_socket_message.dart';
@@ -47,6 +48,8 @@ import 'package:tmail_ui_user/main/providers/settings/local_settings_notifier.da
 import 'package:tmail_ui_user/features/thread/data/model/email_change_response.dart';
 import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_bindings.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/coordinator/get_search_email_layout_owner_registry.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/coordinator/search_layout_coordinator.dart';
 import 'package:tmail_ui_user/features/thread/data/extensions/email_change_response_extension.dart';
 import 'package:tmail_ui_user/features/thread/domain/constants/thread_constants.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/filter_message_option.dart';
@@ -127,10 +130,11 @@ class ThreadController extends BaseController with EmailActionController {
   StreamController<MailListShortcutActionViewEvent>? shortcutActionEventController;
   StreamSubscription<MailListShortcutActionViewEvent>? shortcutActionEventSubscription;
 
-  StreamSubscription<html.Event>? _resizeBrowserStreamSubscription;
   ProviderSubscription<PreferencesSetting>? _localSettingsSubscription;
   late final SearchExecutionObserver _searchExecutionObserver =
       ThreadSearchExecutionObserver(this);
+  late final SearchLayoutCoordinator _searchLayoutCoordinator =
+      _createSearchLayoutCoordinator();
 
   AccountId? get _accountId => mailboxDashBoardController.accountId.value;
 
@@ -171,11 +175,15 @@ class ThreadController extends BaseController with EmailActionController {
         collapseThreads: _isCollapseThreadsEnabled,
       );
 
+  bool get _isSearchEngaged =>
+      appProviderContainer.read(searchViewStateProvider).isSearchEngaged ||
+      searchController.isSearchEmailRunning;
+
   @override
   void onInit() {
     _registerObxStreamListener();
     if (PlatformInfo.isWeb) {
-      _registerBrowserResizeListener();
+      _searchLayoutCoordinator.start();
       onKeyboardShortcutInit();
     }
     _initWebSocketQueueHandler();
@@ -195,7 +203,7 @@ class ThreadController extends BaseController with EmailActionController {
     _currentMemoryMailboxId = null;
     listEmailController.dispose();
     if (PlatformInfo.isWeb) {
-      _resizeBrowserStreamSubscription?.cancel();
+      _searchLayoutCoordinator.dispose();
       onKeyboardShortcutDispose();
     }
     _webSocketQueueHandler?.dispose();
@@ -383,6 +391,9 @@ class ThreadController extends BaseController with EmailActionController {
       } else if (action is ClearMailListKeyboardShortcutFocusAction) {
         clearMailShortcutFocus();
         mailboxDashBoardController.clearDashBoardAction();
+      } else if (action is RestoreMailboxEmailListAfterSearchAction) {
+        restoreMailboxEmailListAfterSearch(force: action.force);
+        mailboxDashBoardController.clearDashBoardAction();
       }
     });
 
@@ -520,10 +531,20 @@ class ThreadController extends BaseController with EmailActionController {
     dispatchState(Right(GetAllEmailLoading()));
   }
 
-  void _registerBrowserResizeListener() {
-    _resizeBrowserStreamSubscription = html.window.onResize.listen((_) {
-      _validateBrowserHeight();
-    });
+  SearchLayoutCoordinator _createSearchLayoutCoordinator() {
+    return SearchLayoutCoordinator(
+      responsiveUtils: responsiveUtils,
+      searchService: _searchService,
+      isSearchEngaged: () => _isSearchEngaged,
+      isEmailOpened: () => mailboxDashBoardController.isEmailOpened,
+      prepareDesktopSearchHandoff: () =>
+          _searchExecutionObserver.onNewSearchStarted(),
+      activateMobileSearch: () => searchController.activateSimpleSearch(),
+      dispatchRoute: mailboxDashBoardController.dispatchRoute,
+      isClosed: () => isClosed,
+      mobileOwnerRegistry: const GetSearchEmailLayoutOwnerRegistry(),
+      onBrowserResize: _validateBrowserHeight,
+    );
   }
 
   void _validateBrowserHeight() {
@@ -621,6 +642,19 @@ class ThreadController extends BaseController with EmailActionController {
         .read(searchEmailPresentationProvider.notifier)
         .resetSearchMore();
     loadingMoreStatus.value = LoadingMoreStatus.idle;
+  }
+
+  @visibleForTesting
+  void restoreMailboxEmailListAfterSearch({bool force = false}) {
+    if (!_searchLayoutCoordinator.takeDesktopSearchPresentation(force: force)) {
+      return;
+    }
+    resetToOriginalValue();
+    consumeState(Stream.value(Right(GetAllEmailLoading())));
+    getAllEmailAction(
+      getLatestChanges: false,
+      forceEmailQuery: forceEmailQuery,
+    );
   }
 
   void _getAllEmailSuccess(
@@ -910,7 +944,7 @@ class ThreadController extends BaseController with EmailActionController {
 
   void _loadMoreEmails() {
     log('ThreadController::_loadMoreEmails()::canLoadMore = $canLoadMore');
-    if (!canLoadMore) return;
+    if (!canLoadMore || loadingMoreStatus.value.isRunning) return;
 
     if (_session != null && _accountId != null) {
       final currentListEmail =
@@ -927,6 +961,7 @@ class ThreadController extends BaseController with EmailActionController {
         'filterOption = ${filterOption.name}',
       );
 
+      loadingMoreStatus.value = LoadingMoreStatus.running;
       consumeState(_loadMoreEmailsInMailboxInteractor.execute(
         GetEmailRequest(
           _session!,
@@ -979,11 +1014,13 @@ class ThreadController extends BaseController with EmailActionController {
       mailboxDashBoardController.emailsInCurrentMailbox.addAll(appendableList);
     }
 
-    canLoadMore = success.serverEmailCount >= ThreadConstants.maxCountEmails;
+    // Without an appendable email the oldest-email cursor does not move, so
+    // another automatic request would repeat the same full page forever.
+    canLoadMore = appendableList.isNotEmpty &&
+        success.serverEmailCount >= ThreadConstants.maxCountEmails;
+    loadingMoreStatus.value = LoadingMoreStatus.completed;
     if (_isAutoLoadMore && canLoadMore) {
       _performAutomaticallyLoadMoreEmails();
-    } else {
-      loadingMoreStatus.value = LoadingMoreStatus.completed;
     }
   }
 

--- a/lib/features/thread/presentation/thread_search_execution_observer.dart
+++ b/lib/features/thread/presentation/thread_search_execution_observer.dart
@@ -19,7 +19,7 @@ class ThreadSearchExecutionObserver implements SearchExecutionObserver {
   @override
   void onNewSearchStarted() {
     if (!_ownsSearchResults) return;
-    _controller._searchLayoutCoordinator.markDesktopSearchPresentation();
+    _controller.searchLayoutCoordinator.markDesktopSearchPresentation();
     if (_controller.listEmailController.hasClients) {
       _controller.isListEmailScrollViewJumping = true;
       _controller.listEmailController.jumpTo(0);
@@ -35,7 +35,7 @@ class ThreadSearchExecutionObserver implements SearchExecutionObserver {
   @override
   void onSearchLoading() {
     if (!_ownsSearchResults) return;
-    _controller._searchLayoutCoordinator.markDesktopSearchPresentation();
+    _controller.searchLayoutCoordinator.markDesktopSearchPresentation();
     _controller.dispatchState(Right(SearchingState()));
   }
 
@@ -45,7 +45,7 @@ class ThreadSearchExecutionObserver implements SearchExecutionObserver {
     required bool isFreshResult,
   }) {
     if (!_ownsSearchResults) return;
-    _controller._searchLayoutCoordinator.markDesktopSearchPresentation();
+    _controller.searchLayoutCoordinator.markDesktopSearchPresentation();
     _controller.mailboxDashBoardController
         .updateRefreshAllEmailState(Right(RefreshAllEmailSuccess()));
     final emailList = result.emails;
@@ -87,7 +87,7 @@ class ThreadSearchExecutionObserver implements SearchExecutionObserver {
   @override
   void onSearchFailure(Object error, {bool isReplay = false}) {
     if (!_ownsSearchResults) return;
-    _controller._searchLayoutCoordinator.markDesktopSearchPresentation();
+    _controller.searchLayoutCoordinator.markDesktopSearchPresentation();
     final failure = asSearchEmailFailure(error);
     _controller.mailboxDashBoardController
         .updateRefreshAllEmailState(Left(RefreshAllEmailFailure()));

--- a/lib/features/thread/presentation/thread_search_execution_observer.dart
+++ b/lib/features/thread/presentation/thread_search_execution_observer.dart
@@ -19,6 +19,7 @@ class ThreadSearchExecutionObserver implements SearchExecutionObserver {
   @override
   void onNewSearchStarted() {
     if (!_ownsSearchResults) return;
+    _controller._searchLayoutCoordinator.markDesktopSearchPresentation();
     if (_controller.listEmailController.hasClients) {
       _controller.isListEmailScrollViewJumping = true;
       _controller.listEmailController.jumpTo(0);
@@ -34,6 +35,7 @@ class ThreadSearchExecutionObserver implements SearchExecutionObserver {
   @override
   void onSearchLoading() {
     if (!_ownsSearchResults) return;
+    _controller._searchLayoutCoordinator.markDesktopSearchPresentation();
     _controller.dispatchState(Right(SearchingState()));
   }
 
@@ -43,6 +45,7 @@ class ThreadSearchExecutionObserver implements SearchExecutionObserver {
     required bool isFreshResult,
   }) {
     if (!_ownsSearchResults) return;
+    _controller._searchLayoutCoordinator.markDesktopSearchPresentation();
     _controller.mailboxDashBoardController
         .updateRefreshAllEmailState(Right(RefreshAllEmailSuccess()));
     final emailList = result.emails;
@@ -82,8 +85,9 @@ class ThreadSearchExecutionObserver implements SearchExecutionObserver {
   }
 
   @override
-  void onSearchFailure(Object error) {
+  void onSearchFailure(Object error, {bool isReplay = false}) {
     if (!_ownsSearchResults) return;
+    _controller._searchLayoutCoordinator.markDesktopSearchPresentation();
     final failure = asSearchEmailFailure(error);
     _controller.mailboxDashBoardController
         .updateRefreshAllEmailState(Left(RefreshAllEmailFailure()));
@@ -94,6 +98,8 @@ class ThreadSearchExecutionObserver implements SearchExecutionObserver {
     _controller.mailboxDashBoardController.emailsInCurrentMailbox.clear();
     // Clear the loading state so the spinner stops on a failed search too.
     _controller.dispatchState(Left(failure));
-    _controller.showRetryToast(failure);
+    if (!isReplay) {
+      _controller.showRetryToast(failure);
+    }
   }
 }

--- a/lib/main/routes/route_utils.dart
+++ b/lib/main/routes/route_utils.dart
@@ -8,6 +8,7 @@ import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/extensions/email_id_extensions.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:tmail_ui_user/features/login/data/extensions/service_path_extension.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart';
@@ -141,6 +142,20 @@ abstract class RouteUtils {
       dashboardType:
           isSearchRunning ? DashboardType.search : DashboardType.normal,
     );
+  }
+
+  static String dashboardBrowserRouteTitle({
+    required bool isSearchRunning,
+    EmailId? selectedEmailId,
+    PresentationMailbox? selectedMailbox,
+  }) {
+    if (selectedEmailId != null) {
+      return 'Email-${selectedEmailId.asString}';
+    } else if (isSearchRunning) {
+      return 'SearchEmail';
+    } else {
+      return selectedMailbox?.browserRouteTitle ?? '';
+    }
   }
 
   static NavigationRouter parsingRouteParametersToNavigationRouter(Map<String, dynamic> parameters) {

--- a/lib/main/routes/route_utils.dart
+++ b/lib/main/routes/route_utils.dart
@@ -8,7 +8,9 @@ import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:tmail_ui_user/features/login/data/extensions/service_path_extension.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/model/account_menu_item.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
 import 'package:tmail_ui_user/main/routes/app_routes.dart';
@@ -121,6 +123,24 @@ abstract class RouteUtils {
       final servicePath = _createServicePath('$baseOriginUrl$route');
       return Uri.parse(servicePath.path);
     }
+  }
+
+  /// Dashboard router for a mailbox or an active search. During search it drops
+  /// [mailboxId] and [labelId] so the launching folder never leaks into the URL.
+  static NavigationRouter dashboardRouterForMailboxOrSearch({
+    required bool isSearchRunning,
+    EmailId? emailId,
+    PresentationMailbox? selectedMailbox,
+    SearchQuery? searchQuery,
+  }) {
+    return NavigationRouter(
+      emailId: emailId,
+      mailboxId: isSearchRunning ? null : selectedMailbox?.browserRouteMailboxId,
+      labelId: isSearchRunning ? null : selectedMailbox?.labelId,
+      searchQuery: isSearchRunning ? searchQuery : null,
+      dashboardType:
+          isSearchRunning ? DashboardType.search : DashboardType.normal,
+    );
   }
 
   static NavigationRouter parsingRouteParametersToNavigationRouter(Map<String, dynamic> parameters) {

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -510,6 +510,50 @@ void main() {
       ));
     });
 
+    test(
+      'REGRESSION WHEN search is active and the current mailbox is opened again '
+      'THEN the mailbox list SHOULD be reloaded after search is disabled',
+      () async {
+      when(context.owner).thenReturn(BuildOwner(focusManager: FocusManager()));
+      when(context.mounted).thenReturn(true);
+      final currentMailbox = PresentationMailbox(testMailboxId);
+      mailboxDashboardController.selectedMailbox.value = currentMailbox;
+      await pumpEventQueue();
+      clearInteractions(getEmailsInMailboxInteractor);
+      searchController.activateSimpleSearch();
+
+      mailboxController.openMailbox(context, currentMailbox);
+
+      await untilCalled(getEmailsInMailboxInteractor.execute(
+        any,
+        any,
+        limit: anyNamed('limit'),
+        sort: anyNamed('sort'),
+        emailFilter: anyNamed('emailFilter'),
+        getLatestChanges: anyNamed('getLatestChanges'),
+        propertiesCreated: anyNamed('propertiesCreated'),
+        propertiesUpdated: anyNamed('propertiesUpdated'),
+        useCache: anyNamed('useCache'),
+        forceEmailQuery: anyNamed('forceEmailQuery'),
+        collapseThreads: anyNamed('collapseThreads'),
+      ));
+
+      verify(getEmailsInMailboxInteractor.execute(
+        any,
+        any,
+        limit: anyNamed('limit'),
+        sort: anyNamed('sort'),
+        emailFilter: anyNamed('emailFilter'),
+        getLatestChanges: anyNamed('getLatestChanges'),
+        propertiesCreated: anyNamed('propertiesCreated'),
+        propertiesUpdated: anyNamed('propertiesUpdated'),
+        useCache: anyNamed('useCache'),
+        forceEmailQuery: anyNamed('forceEmailQuery'),
+        collapseThreads: anyNamed('collapseThreads'),
+      )).called(1);
+      },
+    );
+
     test('WHEN user use advanced search/sort/filter feature, '
       'THEN user tap on mail box, '
       'SHOULD reset all advanced search and filter options, '
@@ -625,6 +669,21 @@ void main() {
     expect(filterAfterQuickSearch.before, isNull);
     expect(filterAfterQuickSearch.after, isNull);
   });
+
+    test(
+      'REGRESSION WHEN email search starts from a selected mailbox\n'
+      'THEN the mailbox SHOULD remain selected as the Back navigation context',
+    () {
+      final inbox = PresentationMailbox(
+        testMailboxId,
+        role: PresentationMailbox.roleInbox,
+      );
+      mailboxDashboardController.selectedMailbox.value = inbox;
+
+      mailboxDashboardController.searchEmailByQueryString(queryString);
+
+      expect(mailboxDashboardController.selectedMailbox.value, inbox);
+    });
 
     test(
       'WHEN stored sort order is loaded on app restart\n'

--- a/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
+++ b/test/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller_test.dart
@@ -64,7 +64,10 @@ import 'package:tmail_ui_user/features/mailbox/domain/usecases/rename_mailbox_in
 import 'package:tmail_ui_user/features/mailbox/domain/usecases/subaddressing_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/usecases/subscribe_mailbox_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/usecases/subscribe_multiple_mailbox_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/action/mailbox_ui_action.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/mailbox_controller.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_node.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_tree.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/model/mailbox_tree_builder.dart';
 import 'package:tmail_ui_user/features/mailbox_creator/domain/usecases/verify_name_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/get_all_recent_search_latest_interactor.dart';
@@ -683,6 +686,66 @@ void main() {
       mailboxDashboardController.searchEmailByQueryString(queryString);
 
       expect(mailboxDashboardController.selectedMailbox.value, inbox);
+    });
+
+    test(
+      'REGRESSION WHEN a system Back leaves a search launched from the inbox\n'
+      'THEN the inbox list SHOULD be reloaded even though the inbox stays selected',
+      () async {
+      when(context.owner).thenReturn(BuildOwner(focusManager: FocusManager()));
+      when(context.mounted).thenReturn(true);
+      // onInit registers the mailboxUIAction listener that handles the action
+      // (the harness only calls onReady).
+      mailboxController.onInit();
+      // One inbox instance backs both tree and selection, so switching back
+      // fires no mailbox change: only the restore can reload, making this a
+      // real guard for the fix.
+      final inbox = PresentationMailbox(
+        testMailboxId,
+        role: PresentationMailbox.roleInbox,
+      );
+      mailboxController.defaultMailboxTree.value = MailboxTree(
+        MailboxNode(
+          MailboxNode.rootItem(),
+          childrenItems: [MailboxNode(inbox)],
+        ),
+      );
+      mailboxDashboardController.selectedMailbox.value = inbox;
+      await pumpEventQueue();
+      clearInteractions(getEmailsInMailboxInteractor);
+      searchController.activateSimpleSearch();
+
+      mailboxDashboardController
+          .dispatchMailboxUIAction(SystemBackToInboxAction());
+
+      await untilCalled(getEmailsInMailboxInteractor.execute(
+        any,
+        any,
+        limit: anyNamed('limit'),
+        sort: anyNamed('sort'),
+        emailFilter: anyNamed('emailFilter'),
+        getLatestChanges: anyNamed('getLatestChanges'),
+        propertiesCreated: anyNamed('propertiesCreated'),
+        propertiesUpdated: anyNamed('propertiesUpdated'),
+        useCache: anyNamed('useCache'),
+        forceEmailQuery: anyNamed('forceEmailQuery'),
+        collapseThreads: anyNamed('collapseThreads'),
+      ));
+
+      expect(searchController.isSearchEmailRunning, isFalse);
+      verify(getEmailsInMailboxInteractor.execute(
+        any,
+        any,
+        limit: anyNamed('limit'),
+        sort: anyNamed('sort'),
+        emailFilter: anyNamed('emailFilter'),
+        getLatestChanges: anyNamed('getLatestChanges'),
+        propertiesCreated: anyNamed('propertiesCreated'),
+        propertiesUpdated: anyNamed('propertiesUpdated'),
+        useCache: anyNamed('useCache'),
+        forceEmailQuery: anyNamed('forceEmailQuery'),
+        collapseThreads: anyNamed('collapseThreads'),
+      )).called(1);
     });
 
     test(

--- a/test/features/mailbox_dashboard/presentation/extensions/restore_mailbox_email_list_after_search_extension_test.dart
+++ b/test/features/mailbox_dashboard/presentation/extensions/restore_mailbox_email_list_after_search_extension_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/action/dashboard_action.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/search_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/restore_mailbox_email_list_after_search_extension.dart';
+
+import 'restore_mailbox_email_list_after_search_extension_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<MailboxDashBoardController>(),
+  MockSpec<SearchController>(),
+])
+void main() {
+  final mailboxDashBoardController = MockMailboxDashBoardController();
+  final searchController = MockSearchController();
+  final inboxMailbox = PresentationMailbox(
+    MailboxId(Id('inbox')),
+    role: PresentationMailbox.roleInbox,
+  );
+  final otherMailbox = PresentationMailbox(MailboxId(Id('other')));
+
+  setUp(() {
+    when(mailboxDashBoardController.searchController)
+        .thenReturn(searchController);
+  });
+
+  tearDown(() {
+    reset(mailboxDashBoardController);
+    reset(searchController);
+  });
+
+  group('shouldRestoreMailboxEmailListAfterSearch test:', () {
+    test('returns true when the mailbox is selected and search is running', () {
+      when(mailboxDashBoardController.selectedMailbox)
+          .thenReturn(Rxn(inboxMailbox));
+      when(searchController.isSearchEmailRunning).thenReturn(true);
+
+      expect(
+        mailboxDashBoardController
+            .shouldRestoreMailboxEmailListAfterSearch(inboxMailbox),
+        isTrue,
+      );
+    });
+
+    test('returns false when another mailbox is selected', () {
+      when(mailboxDashBoardController.selectedMailbox)
+          .thenReturn(Rxn(otherMailbox));
+      when(searchController.isSearchEmailRunning).thenReturn(true);
+
+      expect(
+        mailboxDashBoardController
+            .shouldRestoreMailboxEmailListAfterSearch(inboxMailbox),
+        isFalse,
+      );
+    });
+
+    test('returns false when search is not running', () {
+      when(mailboxDashBoardController.selectedMailbox)
+          .thenReturn(Rxn(inboxMailbox));
+      when(searchController.isSearchEmailRunning).thenReturn(false);
+
+      expect(
+        mailboxDashBoardController
+            .shouldRestoreMailboxEmailListAfterSearch(inboxMailbox),
+        isFalse,
+      );
+    });
+  });
+
+  group('restoreMailboxEmailListAfterSearch test:', () {
+    test('dispatches a forced RestoreMailboxEmailListAfterSearchAction', () {
+      mailboxDashBoardController.restoreMailboxEmailListAfterSearch();
+
+      final action = verify(
+        mailboxDashBoardController.dispatchAction(captureAny),
+      ).captured.single;
+      expect(action, isA<RestoreMailboxEmailListAfterSearchAction>());
+      expect(
+        (action as RestoreMailboxEmailListAfterSearchAction).force,
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
+++ b/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
@@ -84,6 +84,8 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/search_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/spam_report_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/mailbox_dashboard_view_web.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/desktop_dashboard_route_body.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/get_all_identities_interactor.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
@@ -446,6 +448,76 @@ void main() {
       mailboxDashboardController.sessionCurrent = SessionFixtures.aliceSession;
       mailboxDashboardController.filterMessageOption.value = FilterMessageOption.all;
       mailboxDashboardController.accountId.value = AccountFixtures.aliceAccountId;
+    });
+
+    testWidgets('mailbox selection is hidden while email search is active',
+        (tester) async {
+      // Flush the MailboxController.onReady scheduled by Get.put in setUp so it
+      // runs on the live controller instead of leaking a post-frame callback
+      // that fires (on a disposed ScrollController) inside the next widget test.
+      await tester.pumpWidget(const SizedBox());
+
+      final inbox = MailboxFixtures.inboxMailbox.toPresentationMailbox();
+      mailboxDashboardController.selectedMailbox.value = inbox;
+
+      expect(mailboxDashboardController.selectedMailboxForDisplay, inbox);
+
+      searchController.activateSimpleSearch();
+
+      expect(mailboxDashboardController.selectedMailboxForDisplay, isNull);
+      expect(mailboxDashboardController.selectedMailbox.value, inbox);
+
+      searchController.disableAllSearchEmail();
+
+      expect(mailboxDashboardController.selectedMailboxForDisplay, inbox);
+      expect(mailboxDashboardController.selectedMailbox.value, inbox);
+    });
+
+    group('DesktopDashboardRouteBody', () {
+      const threadListKey = Key('desktop_thread_list_stub');
+
+      Future<void> pumpRouteBody(
+        WidgetTester tester,
+        DashboardRoutes route,
+      ) async {
+        await tester.pumpWidget(
+          makeTestableWidget(
+            child: DesktopDashboardRouteBody(
+              route: route,
+              threadListBuilder: (_) =>
+                  const SizedBox(key: threadListKey),
+            ),
+          ),
+        );
+        await tester.pump();
+      }
+
+      testWidgets(
+        'renders the inline thread list for the residual searchEmail route',
+        (tester) async {
+          await pumpRouteBody(tester, DashboardRoutes.searchEmail);
+
+          expect(find.byKey(threadListKey), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'renders the inline thread list for the thread route',
+        (tester) async {
+          await pumpRouteBody(tester, DashboardRoutes.thread);
+
+          expect(find.byKey(threadListKey), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'does not render the thread list for non-list routes',
+        (tester) async {
+          await pumpRouteBody(tester, DashboardRoutes.waiting);
+
+          expect(find.byKey(threadListKey), findsNothing);
+        },
+      );
     });
 
     group('ThreadView', () {

--- a/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
+++ b/test/features/mailbox_dashboard/presentation/view/mailbox_dashboard_view_widget_test.dart
@@ -468,6 +468,11 @@ void main() {
       expect(mailboxDashboardController.selectedMailbox.value, inbox);
 
       searchController.disableAllSearchEmail();
+      // resetSearchResultSession invalidates Riverpod providers, which the
+      // ProviderScheduler refreshes via a zero-duration Timer. Pump with a
+      // duration so the fake clock elapses and fires it before the test
+      // framework verifies no timers are pending.
+      await tester.pump(const Duration(milliseconds: 1));
 
       expect(mailboxDashboardController.selectedMailboxForDisplay, inbox);
       expect(mailboxDashboardController.selectedMailbox.value, inbox);

--- a/test/features/mailbox_dashboard/presentation/widgets/email_quick_search_item_tile_widget_test.dart
+++ b/test/features/mailbox_dashboard/presentation/widgets/email_quick_search_item_tile_widget_test.dart
@@ -1,0 +1,71 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:model/email/presentation_email.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/quick_search/email_quick_search_item_tile_widget.dart';
+
+void main() {
+  final sender = EmailAddress('Alice Sender', 'alice@example.com');
+  final recipient = EmailAddress('Bob Recipient', 'bob@example.com');
+  final email = PresentationEmail(
+    id: EmailId(Id('email-1')),
+    subject: 'Subject',
+    from: {sender},
+    to: {recipient},
+  );
+
+  PresentationMailbox mailboxWithRole(Role role) =>
+      PresentationMailbox(MailboxId(Id(role.value)), role: role);
+
+  // The tile keys off the currently-selected folder, not the email itself.
+  Widget wrapTile(PresentationMailbox? selectedMailbox) {
+    return MaterialApp(
+      home: Scaffold(
+        body: EmailQuickSearchItemTileWidget(email, selectedMailbox),
+      ),
+    );
+  }
+
+  Finder senderFinder() =>
+      find.textContaining('Alice Sender', findRichText: true);
+  Finder recipientFinder() =>
+      find.textContaining('Bob Recipient', findRichText: true);
+
+  setUp(() => Get.put(ImagePaths()));
+
+  tearDown(Get.reset);
+
+  for (final role in [
+    PresentationMailbox.roleSent,
+    PresentationMailbox.roleDrafts,
+    PresentationMailbox.roleOutbox,
+  ]) {
+    testWidgets('shows recipients when an outgoing folder ($role) is selected',
+        (tester) async {
+      await tester.pumpWidget(wrapTile(mailboxWithRole(role)));
+
+      expect(recipientFinder(), findsOneWidget);
+      expect(senderFinder(), findsNothing);
+    });
+  }
+
+  testWidgets('shows the sender when a received folder is selected',
+      (tester) async {
+    await tester.pumpWidget(wrapTile(mailboxWithRole(PresentationMailbox.roleInbox)));
+
+    expect(senderFinder(), findsOneWidget);
+    expect(recipientFinder(), findsNothing);
+  });
+
+  testWidgets('shows the sender when no folder is selected', (tester) async {
+    await tester.pumpWidget(wrapTile(null));
+
+    expect(senderFinder(), findsOneWidget);
+  });
+}

--- a/test/features/search/email/presentation/coordinator/search_layout_transition_state_test.dart
+++ b/test/features/search/email/presentation/coordinator/search_layout_transition_state_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/coordinator/search_layout_transition_state.dart';
+
+void main() {
+  group('SearchLayoutTransitionState', () {
+    late SearchLayoutTransitionState state;
+
+    setUp(() {
+      state = SearchLayoutTransitionState();
+    });
+
+    // Starts on desktop and crosses to mobile, returning the pending transition.
+    SearchLayoutTransition arrangePendingMobileTransition() {
+      state.initialize(true);
+      return state.observeBreakpoint(false)!;
+    }
+
+    void expectSkipped(SearchLayoutTransition transition) {
+      expect(state.shouldSkip(transition, isClosed: false), isTrue);
+    }
+
+    test('first observation establishes the responsive baseline', () {
+      expect(state.observeBreakpoint(true), isNull);
+      expect(state.lastObservedDesktop, isTrue);
+      expect(state.lastReconciledDesktop, isTrue);
+      expect(state.transitionId, 0);
+    });
+
+    test('same breakpoint after a successful handoff is ignored', () {
+      state.initialize(true);
+
+      expect(state.observeBreakpoint(true), isNull);
+      expect(state.transitionId, 0);
+    });
+
+    test('breakpoint crossing creates a transition', () {
+      state.initialize(true);
+
+      final transition = state.observeBreakpoint(false);
+
+      expect(transition?.id, 1);
+      expect(transition?.isDesktop, isFalse);
+    });
+
+    test('successful transition marks the target breakpoint as reconciled', () {
+      final transition = arrangePendingMobileTransition();
+
+      state.complete(transition, succeeded: true);
+
+      expect(state.observeBreakpoint(false), isNull);
+      expect(state.lastReconciledDesktop, isFalse);
+    });
+
+    test('crossing back invalidates the pending transition', () {
+      final pendingTransition = arrangePendingMobileTransition();
+
+      expect(state.observeBreakpoint(true), isNull);
+      expectSkipped(pendingTransition);
+    });
+
+    test('failed transition remains retryable in the same breakpoint', () {
+      final transition = arrangePendingMobileTransition();
+      state.complete(transition, succeeded: false);
+
+      final retry = state.observeBreakpoint(false);
+
+      expect(retry?.id, 2);
+      expect(retry?.isDesktop, isFalse);
+    });
+
+    test('disposed state skips its pending transition', () {
+      final transition = arrangePendingMobileTransition();
+
+      state.invalidateTransitions();
+
+      expectSkipped(transition);
+    });
+  });
+}

--- a/test/features/search/email/presentation/coordinator/search_layout_transition_state_test.dart
+++ b/test/features/search/email/presentation/coordinator/search_layout_transition_state_test.dart
@@ -75,5 +75,25 @@ void main() {
 
       expectSkipped(transition);
     });
+
+    test('PROBE failed transition never settles in its own breakpoint', () {
+      final transition = arrangePendingMobileTransition();
+      state.complete(transition, succeeded: false);
+
+      expect(state.observeBreakpoint(false), isNotNull);
+      expect(state.observeBreakpoint(false), isNotNull);
+      expect(state.observeBreakpoint(false), isNotNull);
+      expect(state.transitionId, 4);
+      expect(state.lastReconciledDesktop, isNull);
+    });
+
+    test('PROBE successful transition settles after one crossing', () {
+      final transition = arrangePendingMobileTransition();
+      state.complete(transition, succeeded: true);
+
+      expect(state.observeBreakpoint(false), isNull);
+      expect(state.observeBreakpoint(false), isNull);
+      expect(state.transitionId, 1);
+    });
   });
 }

--- a/test/features/search/email/presentation/search_email_controller_test.dart
+++ b/test/features/search/email/presentation/search_email_controller_test.dart
@@ -35,6 +35,7 @@ import 'package:tmail_ui_user/features/mailbox_dashboard/domain/model/recent_sea
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/action/dashboard_action.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/state/store_email_sort_order_state.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_receive_time_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
@@ -50,6 +51,7 @@ import 'package:tmail_ui_user/features/search/email/presentation/notifier/search
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_controller.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/search_email_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/search_more_email_state.dart';
+import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_more_email_interactor.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
@@ -367,6 +369,53 @@ void main() {
       ]);
     },
   );
+
+  test('closing search requests restoration of the mailbox email list', () {
+    clearInteractions(mailboxDashBoardController);
+    clearInteractions(searchController);
+
+    controller.closeSearchView();
+
+    verifyInOrder([
+      searchController.disableAllSearchEmail(),
+      mailboxDashBoardController.dispatchRoute(DashboardRoutes.thread),
+      mailboxDashBoardController.dispatchAction(
+        argThat(isA<RestoreMailboxEmailListAfterSearchAction>()),
+      ),
+    ]);
+  });
+
+  test(
+    'prepareForSearchHandoff hydrates the input from the committed keyword',
+  () {
+    const committedText = 'responsive search';
+    appProviderContainer.read(searchFilterProvider.notifier).set(
+          SearchEmailFilter(text: SearchQuery(committedText)),
+        );
+    controller.textInputSearchController.text = 'stale text';
+
+    controller.prepareForSearchHandoff();
+
+    expect(controller.textInputSearchController.text, committedText);
+    expect(controller.currentSearchText, committedText);
+  });
+
+  test(
+    'prepareForSearchHandoff clears stale input for filter-only searches',
+  () {
+    appProviderContainer.read(searchFilterProvider.notifier).set(
+          SearchEmailFilter(from: {'alice@example.com'}),
+        );
+    controller.textInputSearchController.text = 'stale text';
+    appProviderContainer
+        .read(searchEmailPresentationProvider.notifier)
+        .setCurrentSearchText('stale text');
+
+    controller.prepareForSearchHandoff();
+
+    expect(controller.textInputSearchController.text, isEmpty);
+    expect(controller.currentSearchText, isEmpty);
+  });
 
   test(
     'searchMoreEmailsAction delegates load-more to central executor and bridges append',
@@ -1044,5 +1093,31 @@ void main() {
 
       expect(resultIds(), ['mobile-1']);
     });
+
+    testWidgets(
+      'replayed failure hydrates mobile state without repeating the toast',
+      (tester) async {
+        await tester.pumpWidget(const GetMaterialApp(home: SizedBox.shrink()));
+        when(Get.find<ResponsiveUtils>().isWebDesktop(Get.context!))
+            .thenReturn(false);
+        final appToast = Get.find<AppToast>() as advanced_mocks.MockAppToast;
+        clearInteractions(appToast);
+
+        controller.onSearchFailure(
+          SearchEmailFailure(Exception('boom')),
+          isReplay: true,
+        );
+
+        expect(controller.resultSearchViewState.isLeft(), isTrue);
+        verifyNever(appToast.showToastMessageWithMultipleActions(
+          any,
+          any,
+          actions: anyNamed('actions'),
+          textColor: anyNamed('textColor'),
+          backgroundColor: anyNamed('backgroundColor'),
+          infinityToast: anyNamed('infinityToast'),
+        ));
+      },
+    );
   });
 }

--- a/test/features/search/email/presentation/service/search_executor_service_test.dart
+++ b/test/features/search/email/presentation/service/search_executor_service_test.dart
@@ -37,6 +37,7 @@ class _RecordingObserver implements SearchExecutionObserver {
   final results = <SearchEmailResult>[];
   final freshFlags = <bool>[];
   final failures = <Object>[];
+  final failureReplayFlags = <bool>[];
 
   @override
   void onNewSearchStarted() => newSearchStarted++;
@@ -51,7 +52,10 @@ class _RecordingObserver implements SearchExecutionObserver {
   }
 
   @override
-  void onSearchFailure(Object error) => failures.add(error);
+  void onSearchFailure(Object error, {bool isReplay = false}) {
+    failures.add(error);
+    failureReplayFlags.add(isReplay);
+  }
 }
 
 @GenerateNiceMocks([
@@ -226,6 +230,7 @@ void main() {
     await dispatchNewSearch(service);
 
     expect(observer.failures, hasLength(1));
+    expect(observer.failureReplayFlags.single, isFalse);
     expect(observer.results, isEmpty);
   });
 
@@ -314,6 +319,7 @@ void main() {
     final lateObserver = registerObserver(service);
 
     expect(lateObserver.failures.single, same(failure));
+    expect(lateObserver.failureReplayFlags.single, isTrue);
     expect(lateObserver.results, isEmpty);
   });
 
@@ -375,6 +381,68 @@ void main() {
 
     expect(observer.results, hasLength(1));
     expect(observer.freshFlags.single, isTrue);
+  });
+
+  group('replayCurrentStateToOwners', () {
+    test('fans the current data snapshot out to every observer', () async {
+      final service = makeService();
+      final first = registerObserver(service);
+      final second = registerObserver(service);
+      await dispatchNewSearch(service);
+      first.results.clear();
+      first.freshFlags.clear();
+      second.results.clear();
+      second.freshFlags.clear();
+
+      service.replayCurrentStateToOwners();
+
+      expect(first.results.single.emails, [email]);
+      expect(second.results.single.emails, [email]);
+      expect(first.freshFlags.single, isFalse);
+      expect(second.freshFlags.single, isFalse);
+    });
+
+    test('replays the current loading snapshot', () async {
+      final (:service, :observer) = registeredService();
+      final pending = Completer<Either<Failure, Success>>();
+      stubSearch((_) => Stream.fromFuture(pending.future));
+      final search = service.dispatch(const NewSearchIntent(), context);
+      await pumpEventQueue();
+      observer.loading = 0;
+
+      service.replayCurrentStateToOwners();
+
+      expect(observer.loading, 1);
+      pending.complete(Right(SearchEmailSuccess([email])));
+      await search;
+    });
+
+    test('replays the current error snapshot', () async {
+      final failure = SearchEmailFailure(Exception('boom'));
+      stubSearch((_) => Stream.value(Left(failure)));
+      final (:service, :observer) = registeredService();
+      await dispatchNewSearch(service);
+      observer.failures.clear();
+      observer.failureReplayFlags.clear();
+
+      service.replayCurrentStateToOwners();
+
+      expect(observer.failures.single, same(failure));
+      expect(observer.failureReplayFlags.single, isTrue);
+    });
+
+    test('is a no-op before dispatch and after disposal', () {
+      final service = makeService();
+      final observer = registerObserver(service);
+
+      service.replayCurrentStateToOwners();
+      service.dispose();
+      service.replayCurrentStateToOwners();
+
+      expect(observer.loading, 0);
+      expect(observer.results, isEmpty);
+      expect(observer.failures, isEmpty);
+    });
   });
 
   test('after the last observer unregisters, no fan-out reaches it', () async {

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -1507,6 +1507,15 @@ void main() {
         expect(coordinator.takeDesktopSearchPresentation(), isFalse);
       });
 
+      test('desktop handoff records desktop presentation ownership', () {
+        stubActiveSearchWithOpenEmail();
+        final coordinator = createSearchLayoutCoordinatorForTest();
+
+        coordinator.reconcile(true);
+
+        expect(coordinator.takeDesktopSearchPresentation(), isTrue);
+      });
+
       test('no active search is a no-op', () {
         when(mockMailboxDashBoardController.searchController)
             .thenReturn(mockSearchController);

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:core/data/network/config/dynamic_url_interceptors.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/state/success.dart';
@@ -9,6 +11,7 @@ import 'package:flutter/material.dart' hide SearchController, State;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/properties/properties.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart' as jmap;
 import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
@@ -23,9 +26,15 @@ import 'package:tmail_ui_user/features/email/presentation/action/email_ui_action
 import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oidc_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/get_all_recent_search_latest_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/quick_search_email_interactor.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/save_recent_search_interactor.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/search_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/dashboard_routes.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/email_sort_order_type.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/search_email_filter.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/notifier/search_view_state_notifier.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
 import 'package:tmail_ui_user/features/network_connection/presentation/network_connection_controller.dart';
@@ -45,8 +54,22 @@ import 'package:tmail_ui_user/features/thread/domain/usecases/refresh_changes_em
 import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_email_interactor.dart';
 import 'package:tmail_ui_user/features/thread/domain/usecases/search_more_email_interactor.dart';
+import 'package:tmail_ui_user/features/search/email/domain/execution/search_execution_intent.dart';
 import 'package:tmail_ui_user/features/search/email/domain/model/search_email_result.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/domain/notifier/search_email_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/providers/search_executor_provider.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/search_email_controller.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/coordinator/get_search_email_layout_owner_registry.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/coordinator/search_email_layout_owner_registry.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/coordinator/search_layout_coordinator.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/service/search_dispatch_context.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/service/search_execution_observer.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/auto_load_more_policy.dart';
+import 'package:tmail_ui_user/features/thread/presentation/model/loading_more_status.dart';
+import 'package:tmail_ui_user/features/thread/presentation/model/search_state.dart';
+import 'package:tmail_ui_user/features/thread/presentation/model/search_status.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
 import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
@@ -63,6 +86,46 @@ const fallbackGenerators = {
   #onStart: mockControllerCallback,
   #onDelete: mockControllerCallback,
 };
+
+class _NoOpSearchObserver implements SearchExecutionObserver {
+  @override
+  void onNewSearchStarted() {}
+
+  @override
+  void onSearchFailure(Object error, {bool isReplay = false}) {}
+
+  @override
+  void onSearchLoading() {}
+
+  @override
+  void onSearchResult(
+    SearchEmailResult result, {
+    required bool isFreshResult,
+  }) {}
+}
+
+class _TestSearchEmailLayoutOwnerRegistry
+    extends SearchEmailLayoutOwnerRegistry {
+  @override
+  bool tryPrepareForSearchHandoff() => true;
+}
+
+class _ConfigurableSearchEmailLayoutOwnerRegistry
+    extends SearchEmailLayoutOwnerRegistry {
+  bool canPrepare = false;
+
+  @override
+  bool tryPrepareForSearchHandoff() => canPrepare;
+}
+
+class _MockQuickSearchEmailInteractor extends Mock
+    implements QuickSearchEmailInteractor {}
+
+class _MockSaveRecentSearchInteractor extends Mock
+    implements SaveRecentSearchInteractor {}
+
+class _MockGetAllRecentSearchLatestInteractor extends Mock
+    implements GetAllRecentSearchLatestInteractor {}
 
 @GenerateNiceMocks([
   // Base controller mock specs
@@ -176,7 +239,7 @@ void main() {
     Get.put<SearchEmailInteractor>(mockSearchEmailInteractor);
     Get.put<SearchMoreEmailInteractor>(mockSearchMoreEmailInteractor);
 
-    threadController = ThreadController(
+  threadController = ThreadController(
       mockGetEmailsInMailboxInteractor,
       mockRefreshChangesEmailsInMailboxInteractor,
       mockLoadMoreEmailsInMailboxInteractor,
@@ -184,6 +247,28 @@ void main() {
       mockCleanAndGetEmailsInMailboxInteractor,
     );
   });
+
+  SearchLayoutCoordinator createSearchLayoutCoordinatorForTest({
+    SearchEmailLayoutOwnerRegistry? mobileOwnerRegistry,
+  }) {
+    final dashboardController = threadController.mailboxDashBoardController;
+    final searchController = threadController.searchController;
+    return SearchLayoutCoordinator(
+      responsiveUtils: threadController.responsiveUtils,
+      searchService: appProviderContainer.read(searchExecutorServiceProvider),
+      isSearchEngaged: () =>
+          appProviderContainer.read(searchViewStateProvider).isSearchEngaged ||
+          searchController.isSearchEmailRunning,
+      isEmailOpened: () => dashboardController.isEmailOpened,
+      prepareDesktopSearchHandoff: () =>
+          ThreadSearchExecutionObserver(threadController).onNewSearchStarted(),
+      activateMobileSearch: () => searchController.activateSimpleSearch(),
+      dispatchRoute: dashboardController.dispatchRoute,
+      isClosed: () => threadController.isClosed,
+      mobileOwnerRegistry: mobileOwnerRegistry ??
+          const GetSearchEmailLayoutOwnerRegistry(),
+    );
+  }
 
   group('ThreadController::test', () {
     group('validateListEmailsLoadMore::test', () {
@@ -885,6 +970,28 @@ void main() {
 
         expect(threadController.canLoadMore, isTrue);
       });
+
+      test(
+        'REGRESSION GIVEN a full server page contains no appendable email '
+        'WHEN the pagination cursor cannot advance '
+        'THEN load more SHOULD stop to prevent repeating the same JMAP request',
+      () {
+        setupMocksForLoadMore();
+        final emails = makeEmails(ThreadConstants.maxCountEmails);
+        when(mockMailboxDashBoardController.emailsInCurrentMailbox)
+            .thenReturn(RxList(emails));
+
+        threadController.handleSuccessViewState(LoadMoreEmailsSuccess(
+          emails,
+          serverEmailCount: ThreadConstants.maxCountEmails,
+        ));
+
+        expect(threadController.canLoadMore, isFalse);
+        expect(
+          threadController.loadingMoreStatus.value,
+          LoadingMoreStatus.completed,
+        );
+      });
     });
 
     group('canLoadMore lifecycle & guard regression:', () {
@@ -1001,6 +1108,53 @@ void main() {
         )).called(1);
         verifyNever(mockLoadMoreEmailsInMailboxInteractor.execute(any));
       });
+
+      test(
+        'REGRESSION GIVEN a mailbox load-more request is still running '
+        'WHEN another scroll notification requests load more '
+        'THEN only one request SHOULD be sent',
+      () async {
+        final pendingRequest = Completer<void>();
+        final controllerUnderTest = ThreadController(
+          mockGetEmailsInMailboxInteractor,
+          mockRefreshChangesEmailsInMailboxInteractor,
+          mockLoadMoreEmailsInMailboxInteractor,
+          mockGetEmailByIdInteractor,
+          mockCleanAndGetEmailsInMailboxInteractor,
+        );
+        addTearDown(controllerUnderTest.onClose);
+        when(mockMailboxDashBoardController.searchController)
+            .thenReturn(mockSearchController);
+        when(mockSearchController.isSearchEmailRunning).thenReturn(false);
+        when(mockMailboxDashBoardController.sessionCurrent)
+            .thenReturn(SessionFixtures.aliceSession);
+        when(mockMailboxDashBoardController.accountId)
+            .thenReturn(Rxn(AccountFixtures.aliceAccountId));
+        when(mockMailboxDashBoardController.selectedMailbox)
+            .thenReturn(Rxn(PresentationMailbox(MailboxId(Id('inbox')))));
+        when(mockMailboxDashBoardController.emailsInCurrentMailbox)
+            .thenReturn(RxList([]));
+        when(mockMailboxDashBoardController.filterMessageOption)
+            .thenReturn(Rx(FilterMessageOption.all));
+        when(mockLoadMoreEmailsInMailboxInteractor.execute(any))
+            .thenAnswer((_) async* {
+          await pendingRequest.future;
+          yield Right(LoadMoreEmailsSuccess([], serverEmailCount: 0));
+        });
+        clearInteractions(mockLoadMoreEmailsInMailboxInteractor);
+
+        controllerUnderTest.handleLoadMoreEmailsRequest();
+        controllerUnderTest.handleLoadMoreEmailsRequest();
+
+        verify(mockLoadMoreEmailsInMailboxInteractor.execute(any)).called(1);
+        expect(
+          controllerUnderTest.loadingMoreStatus.value,
+          LoadingMoreStatus.running,
+        );
+
+        pendingRequest.complete();
+        await pumpEventQueue();
+      });
     });
 
     group('auto-load-more collapseThreads partial-page edge case test:', () {
@@ -1115,6 +1269,583 @@ void main() {
       });
     });
 
+    group('SearchLayoutCoordinator test:', () {
+      final searchEmails = List.generate(
+        30,
+        (index) => PresentationEmail(id: EmailId(Id('search-$index'))),
+      );
+      final dispatchContext = SearchDispatchContext(
+        session: SessionFixtures.aliceSession,
+        accountId: AccountFixtures.aliceAccountId,
+        properties: Properties({'id'}),
+        collapseThreads: false,
+        trashSpamMailboxIds: null,
+      );
+
+      setUp(() {
+        reset(mockResponsiveUtils);
+        reset(mockSearchController);
+        reset(mockMailboxDashBoardController);
+        reset(mockSearchEmailInteractor);
+        appProviderContainer.invalidate(searchExecutorServiceProvider);
+        appProviderContainer.invalidate(searchEmailProvider);
+        appProviderContainer.invalidate(searchEmailPresentationProvider);
+        appProviderContainer.invalidate(searchViewStateProvider);
+      });
+
+      tearDown(() async {
+        if (Get.isRegistered<SearchEmailController>()) {
+          await Get.delete<SearchEmailController>(force: true);
+        }
+        if (Get.isRegistered<QuickSearchEmailInteractor>()) {
+          await Get.delete<QuickSearchEmailInteractor>(force: true);
+        }
+        if (Get.isRegistered<SaveRecentSearchInteractor>()) {
+          await Get.delete<SaveRecentSearchInteractor>(force: true);
+        }
+        if (Get.isRegistered<GetAllRecentSearchLatestInteractor>()) {
+          await Get.delete<GetAllRecentSearchLatestInteractor>(force: true);
+        }
+        appProviderContainer.invalidate(searchExecutorServiceProvider);
+        appProviderContainer.invalidate(searchEmailProvider);
+        appProviderContainer.invalidate(searchEmailPresentationProvider);
+        appProviderContainer.invalidate(searchViewStateProvider);
+        PlatformInfo.isTestingForWeb = false;
+        reset(mockResponsiveUtils);
+        reset(mockSearchController);
+        reset(mockMailboxDashBoardController);
+        reset(mockSearchEmailInteractor);
+      });
+
+      void stubSearchExecution() {
+        when(mockSearchEmailInteractor.execute(
+          any,
+          any,
+          limit: anyNamed('limit'),
+          position: anyNamed('position'),
+          sort: anyNamed('sort'),
+          filter: anyNamed('filter'),
+          collapseThreads: anyNamed('collapseThreads'),
+          properties: anyNamed('properties'),
+          needRefreshSearchState: anyNamed('needRefreshSearchState'),
+        )).thenAnswer(
+          (_) => Stream.value(Right(SearchEmailSuccess(searchEmails))),
+        );
+      }
+
+      void stubActiveSearchWithOpenEmail() {
+        when(mockMailboxDashBoardController.searchController)
+            .thenReturn(mockSearchController);
+        when(mockSearchController.isSearchEmailRunning).thenReturn(true);
+        when(mockMailboxDashBoardController.isEmailOpened).thenReturn(true);
+      }
+
+      testWidgets(
+        'active search handed to desktop replays the SSOT into the thread list',
+        (tester) async {
+          PlatformInfo.isTestingForWeb = true;
+          await tester.pumpWidget(
+            const GetMaterialApp(home: SizedBox.shrink()),
+          );
+          PlatformInfo.isTestingForWeb = false;
+          final displayedEmails = <PresentationEmail>[].obs;
+          when(mockResponsiveUtils.isWebDesktop(any)).thenReturn(true);
+          when(mockMailboxDashBoardController.emailsInCurrentMailbox)
+              .thenReturn(displayedEmails);
+          when(mockMailboxDashBoardController.mapMailboxById).thenReturn({});
+          when(mockMailboxDashBoardController.selectedMailbox)
+              .thenReturn(Rxn(null));
+          when(mockMailboxDashBoardController.searchController)
+              .thenReturn(mockSearchController);
+          when(mockMailboxDashBoardController.isSelectionEnabled())
+              .thenReturn(false);
+          when(mockMailboxDashBoardController.updateEmailList(any)).thenAnswer(
+            (invocation) => displayedEmails.assignAll(
+              invocation.positionalArguments.first
+                  as List<PresentationEmail>,
+            ),
+          );
+          when(mockSearchController.isSearchEmailRunning).thenReturn(true);
+          when(mockSearchController.searchQuery).thenReturn(null);
+          stubSearchExecution();
+          final service =
+              appProviderContainer.read(searchExecutorServiceProvider);
+          final observer = ThreadSearchExecutionObserver(threadController);
+          service.register(observer);
+          addTearDown(() => service.unregister(observer));
+          await service.dispatch(const NewSearchIntent(), dispatchContext);
+          await tester.pump();
+          expect(displayedEmails, hasLength(searchEmails.length));
+          displayedEmails.clear();
+          clearInteractions(mockMailboxDashBoardController);
+
+          createSearchLayoutCoordinatorForTest().reconcile(true);
+
+          expect(displayedEmails, hasLength(searchEmails.length));
+          verify(
+            mockMailboxDashBoardController.dispatchRoute(
+              DashboardRoutes.thread,
+            ),
+          ).called(1);
+        },
+      );
+
+      testWidgets(
+        'active search handed to mobile creates its binding and hydrates it',
+        (tester) async {
+          PlatformInfo.isTestingForWeb = true;
+          await tester.pumpWidget(
+            const GetMaterialApp(home: SizedBox.shrink()),
+          );
+          // Reset so web-only navigation-route generation (Uri.base.origin,
+          // which throws on the VM test host's file:// scheme) is skipped.
+          PlatformInfo.isTestingForWeb = false;
+          when(mockResponsiveUtils.isWebDesktop(any)).thenReturn(false);
+          when(mockMailboxDashBoardController.dashBoardAction)
+              .thenReturn(Rxn(null));
+          when(mockMailboxDashBoardController.viewState)
+              .thenReturn(Rx(Right(UIState.idle)));
+          when(mockMailboxDashBoardController.mapMailboxById).thenReturn({});
+          when(mockMailboxDashBoardController.searchController)
+              .thenReturn(mockSearchController);
+          when(mockMailboxDashBoardController.accountId).thenReturn(Rxn(null));
+          when(mockMailboxDashBoardController.sessionCurrent).thenReturn(null);
+          when(mockMailboxDashBoardController.currentSortOrder)
+              .thenReturn(EmailSortOrderType.mostRecent);
+          when(mockSearchController.isSearchEmailRunning).thenReturn(true);
+          const desktopSearchText = 'responsive search';
+          appProviderContainer.read(searchFilterProvider.notifier).set(
+            SearchEmailFilter(text: SearchQuery(desktopSearchText)),
+          );
+          Get.put<QuickSearchEmailInteractor>(
+            _MockQuickSearchEmailInteractor(),
+          );
+          Get.put<SaveRecentSearchInteractor>(
+            _MockSaveRecentSearchInteractor(),
+          );
+          Get.put<GetAllRecentSearchLatestInteractor>(
+            _MockGetAllRecentSearchLatestInteractor(),
+          );
+          stubSearchExecution();
+          final service =
+              appProviderContainer.read(searchExecutorServiceProvider);
+          final observer = _NoOpSearchObserver();
+          service.register(observer);
+          addTearDown(() => service.unregister(observer));
+          await service.dispatch(const NewSearchIntent(), dispatchContext);
+          await tester.pump();
+
+          createSearchLayoutCoordinatorForTest().reconcile(false);
+          await tester.pump();
+
+          expect(Get.isRegistered<SearchEmailController>(), isTrue);
+          expect(
+            appProviderContainer
+                .read(searchEmailPresentationProvider)
+                .listResultSearch,
+            hasLength(searchEmails.length),
+          );
+          expect(
+            appProviderContainer
+                .read(searchEmailPresentationProvider)
+                .searchIsRunning,
+            isTrue,
+          );
+          expect(
+            Get.find<SearchEmailController>()
+                .textInputSearchController
+                .text,
+            desktopSearchText,
+          );
+          expect(
+            appProviderContainer
+                .read(searchEmailPresentationProvider)
+                .currentSearchText,
+            desktopSearchText,
+          );
+          verify(mockSearchController.activateSimpleSearch()).called(1);
+          verify(
+            mockMailboxDashBoardController.dispatchRoute(
+              DashboardRoutes.searchEmail,
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'REGRESSION active search handed to desktop keeps an open email detail',
+      () {
+        stubActiveSearchWithOpenEmail();
+
+        createSearchLayoutCoordinatorForTest().reconcile(true);
+
+        verifyNever(mockMailboxDashBoardController.dispatchRoute(any));
+      });
+
+      test(
+        'REGRESSION active search handed to mobile keeps an open email detail',
+      () {
+        stubActiveSearchWithOpenEmail();
+
+        createSearchLayoutCoordinatorForTest(
+          mobileOwnerRegistry: _TestSearchEmailLayoutOwnerRegistry(),
+        ).reconcile(false);
+
+        verify(mockSearchController.activateSimpleSearch()).called(1);
+        verifyNever(mockMailboxDashBoardController.dispatchRoute(any));
+      });
+
+      test('mobile handoff clears desktop presentation ownership', () {
+        stubActiveSearchWithOpenEmail();
+        final coordinator = createSearchLayoutCoordinatorForTest(
+          mobileOwnerRegistry: _TestSearchEmailLayoutOwnerRegistry(),
+        );
+
+        coordinator.markDesktopSearchPresentation();
+        coordinator.reconcile(false);
+
+        expect(coordinator.takeDesktopSearchPresentation(), isFalse);
+      });
+
+      test('no active search is a no-op', () {
+        when(mockMailboxDashBoardController.searchController)
+            .thenReturn(mockSearchController);
+        when(mockSearchController.isSearchEmailRunning).thenReturn(false);
+
+        createSearchLayoutCoordinatorForTest().reconcile(true);
+
+        verifyNever(mockMailboxDashBoardController.dispatchRoute(any));
+      });
+
+      test('width changes inside the same breakpoint are a no-op', () {
+        when(mockResponsiveUtils.isMatchedDesktopWidth(any))
+            .thenReturn(false);
+        final coordinator = createSearchLayoutCoordinatorForTest();
+
+        coordinator.handleBrowserWidthChange(800);
+        coordinator.handleBrowserWidthChange(900);
+
+        verifyNever(mockMailboxDashBoardController.dispatchRoute(any));
+      });
+
+      testWidgets(
+        'failed mobile handoff retries after the owner becomes available',
+        (tester) async {
+          PlatformInfo.isTestingForWeb = true;
+          await tester.pumpWidget(
+            const GetMaterialApp(home: SizedBox.shrink()),
+          );
+          when(mockResponsiveUtils.isMatchedDesktopWidth(any)).thenAnswer(
+            (invocation) =>
+                (invocation.positionalArguments.first as double) >= 1200,
+          );
+          when(mockMailboxDashBoardController.searchController)
+              .thenReturn(mockSearchController);
+          when(mockMailboxDashBoardController.isEmailOpened)
+              .thenReturn(false);
+          when(mockSearchController.isSearchEmailRunning).thenReturn(true);
+          final ownerRegistry =
+              _ConfigurableSearchEmailLayoutOwnerRegistry();
+          final coordinator = createSearchLayoutCoordinatorForTest(
+            mobileOwnerRegistry: ownerRegistry,
+          );
+
+          coordinator.handleBrowserWidthChange(1200);
+          await tester.pump();
+          coordinator.handleBrowserWidthChange(900);
+          await tester.pump();
+
+          verifyNever(mockSearchController.activateSimpleSearch());
+          verifyNever(mockMailboxDashBoardController.dispatchRoute(any));
+
+          ownerRegistry.canPrepare = true;
+          clearInteractions(mockSearchController);
+          clearInteractions(mockMailboxDashBoardController);
+          coordinator.handleBrowserWidthChange(900);
+          await tester.pump();
+
+          verify(mockSearchController.activateSimpleSearch()).called(1);
+          verify(
+            mockMailboxDashBoardController.dispatchRoute(
+              DashboardRoutes.searchEmail,
+            ),
+          ).called(1);
+        },
+      );
+
+      testWidgets(
+        'breakpoint crossing reconciles only after the next frame',
+        (tester) async {
+          PlatformInfo.isTestingForWeb = true;
+          await tester.pumpWidget(
+            const GetMaterialApp(home: SizedBox.shrink()),
+          );
+          when(mockResponsiveUtils.isMatchedDesktopWidth(any)).thenAnswer(
+            (invocation) =>
+                (invocation.positionalArguments.first as double) >= 1200,
+          );
+          when(mockResponsiveUtils.isWebDesktop(any)).thenReturn(true);
+          when(mockMailboxDashBoardController.searchController)
+              .thenReturn(mockSearchController);
+          when(mockMailboxDashBoardController.emailsInCurrentMailbox)
+              .thenReturn(RxList([]));
+          when(mockSearchController.isSearchEmailRunning).thenReturn(false);
+          final coordinator = createSearchLayoutCoordinatorForTest();
+          coordinator.handleBrowserWidthChange(900);
+          await tester.pump();
+          clearInteractions(mockMailboxDashBoardController);
+          when(mockSearchController.isSearchEmailRunning).thenReturn(true);
+          coordinator.handleBrowserWidthChange(1200);
+
+          verifyNever(mockMailboxDashBoardController.dispatchRoute(any));
+          await tester.pump();
+          verify(
+            mockMailboxDashBoardController.dispatchRoute(
+              DashboardRoutes.thread,
+            ),
+          ).called(1);
+        },
+      );
+
+      testWidgets(
+        'crossing back before the frame drops the stale handoff',
+        (tester) async {
+          PlatformInfo.isTestingForWeb = true;
+          await tester.pumpWidget(
+            const GetMaterialApp(home: SizedBox.shrink()),
+          );
+          when(mockResponsiveUtils.isMatchedDesktopWidth(any)).thenAnswer(
+            (invocation) =>
+                (invocation.positionalArguments.first as double) >= 1200,
+          );
+          when(mockMailboxDashBoardController.searchController)
+              .thenReturn(mockSearchController);
+          when(mockSearchController.isSearchEmailRunning).thenReturn(false);
+          final coordinator = createSearchLayoutCoordinatorForTest();
+          coordinator.handleBrowserWidthChange(1200);
+          await tester.pump();
+          clearInteractions(mockMailboxDashBoardController);
+          when(mockSearchController.isSearchEmailRunning).thenReturn(true);
+          coordinator.handleBrowserWidthChange(900);
+          coordinator.handleBrowserWidthChange(1200);
+          await tester.pump();
+
+          verifyNever(mockMailboxDashBoardController.dispatchRoute(any));
+        },
+      );
+
+      testWidgets(
+        'separate breakpoint crossings are reconciled independently',
+        (tester) async {
+          PlatformInfo.isTestingForWeb = true;
+          await tester.pumpWidget(
+            const GetMaterialApp(home: SizedBox.shrink()),
+          );
+          when(mockResponsiveUtils.isMatchedDesktopWidth(any)).thenAnswer(
+            (invocation) =>
+                (invocation.positionalArguments.first as double) >= 1200,
+          );
+          when(mockResponsiveUtils.isWebDesktop(any)).thenReturn(true);
+          when(mockMailboxDashBoardController.searchController)
+              .thenReturn(mockSearchController);
+          when(mockMailboxDashBoardController.emailsInCurrentMailbox)
+              .thenReturn(RxList([]));
+          when(mockSearchController.isSearchEmailRunning).thenReturn(false);
+          final coordinator = createSearchLayoutCoordinatorForTest();
+          coordinator.handleBrowserWidthChange(900);
+          await tester.pump();
+          clearInteractions(mockMailboxDashBoardController);
+          when(mockSearchController.isSearchEmailRunning).thenReturn(true);
+          coordinator.handleBrowserWidthChange(1200);
+          await tester.pump();
+          when(mockSearchController.isSearchEmailRunning).thenReturn(false);
+          coordinator.handleBrowserWidthChange(900);
+          await tester.pump();
+          when(mockSearchController.isSearchEmailRunning).thenReturn(true);
+          coordinator.handleBrowserWidthChange(1200);
+          await tester.pump();
+
+          verify(
+            mockMailboxDashBoardController.dispatchRoute(
+              DashboardRoutes.thread,
+            ),
+          ).called(2);
+        },
+      );
+    });
+
+    group('restore mailbox list after responsive search handoff:', () {
+      testWidgets(
+        'desktop search ownership is replaced with the selected mailbox list',
+        (tester) async {
+          PlatformInfo.isTestingForWeb = true;
+          await tester.pumpWidget(
+            const GetMaterialApp(home: SizedBox.shrink()),
+          );
+          PlatformInfo.isTestingForWeb = false;
+          final controllerUnderTest = ThreadController(
+            mockGetEmailsInMailboxInteractor,
+            mockRefreshChangesEmailsInMailboxInteractor,
+            mockLoadMoreEmailsInMailboxInteractor,
+            mockGetEmailByIdInteractor,
+            mockCleanAndGetEmailsInMailboxInteractor,
+          );
+          addTearDown(() {
+            PlatformInfo.isTestingForWeb = false;
+            controllerUnderTest.onClose();
+          });
+          final mailboxId = MailboxId(Id('inbox'));
+          final mailbox = PresentationMailbox(
+            mailboxId,
+            role: PresentationMailbox.roleInbox,
+          );
+          final searchEmail = PresentationEmail(
+            id: EmailId(Id('search-email')),
+          );
+          final mailboxEmail = PresentationEmail(
+            id: EmailId(Id('mailbox-email')),
+            mailboxIds: {mailboxId: true},
+          );
+          final displayedEmails = <PresentationEmail>[searchEmail].obs;
+          when(mockResponsiveUtils.isWebDesktop(any)).thenReturn(true);
+          when(mockMailboxDashBoardController.searchController)
+              .thenReturn(mockSearchController);
+          when(mockMailboxDashBoardController.emailsInCurrentMailbox)
+              .thenReturn(displayedEmails);
+          when(mockMailboxDashBoardController.listEmailSelected)
+              .thenReturn(RxList([]));
+          when(mockMailboxDashBoardController.currentSelectMode)
+              .thenReturn(Rx(SelectMode.INACTIVE));
+          when(mockMailboxDashBoardController.accountId)
+              .thenReturn(Rxn(AccountFixtures.aliceAccountId));
+          when(mockMailboxDashBoardController.sessionCurrent)
+              .thenReturn(SessionFixtures.aliceSession);
+          when(mockMailboxDashBoardController.selectedMailbox)
+              .thenReturn(Rxn(mailbox));
+          when(mockMailboxDashBoardController.filterMessageOption)
+              .thenReturn(Rx(FilterMessageOption.all));
+          when(mockMailboxDashBoardController.mapMailboxById).thenReturn({});
+          when(mockMailboxDashBoardController.isSelectionEnabled())
+              .thenReturn(false);
+          when(mockMailboxDashBoardController.updateEmailList(any)).thenAnswer(
+            (invocation) => displayedEmails.assignAll(
+              invocation.positionalArguments.first as List<PresentationEmail>,
+            ),
+          );
+          when(mockSearchController.isSearchEmailRunning).thenReturn(true);
+          when(mockSearchController.searchQuery).thenReturn(null);
+          when(mockGetEmailsInMailboxInteractor.execute(
+            any,
+            any,
+            limit: anyNamed('limit'),
+            sort: anyNamed('sort'),
+            emailFilter: anyNamed('emailFilter'),
+            propertiesCreated: anyNamed('propertiesCreated'),
+            propertiesUpdated: anyNamed('propertiesUpdated'),
+            getLatestChanges: anyNamed('getLatestChanges'),
+            useCache: anyNamed('useCache'),
+            forceEmailQuery: anyNamed('forceEmailQuery'),
+            collapseThreads: anyNamed('collapseThreads'),
+          )).thenAnswer(
+            (_) => Stream.value(Right(GetAllEmailSuccess(
+              emailList: [mailboxEmail],
+              currentMailboxId: mailboxId,
+            ))),
+          );
+          clearInteractions(mockGetEmailsInMailboxInteractor);
+
+          ThreadSearchExecutionObserver(controllerUnderTest)
+              .onNewSearchStarted();
+          expect(displayedEmails, isEmpty);
+          when(mockSearchController.isSearchEmailRunning).thenReturn(false);
+
+          controllerUnderTest.restoreMailboxEmailListAfterSearch();
+          await tester.pump();
+
+          expect(displayedEmails, [mailboxEmail]);
+          verify(mockGetEmailsInMailboxInteractor.execute(
+            any,
+            any,
+            limit: anyNamed('limit'),
+            sort: anyNamed('sort'),
+            emailFilter: anyNamed('emailFilter'),
+            propertiesCreated: anyNamed('propertiesCreated'),
+            propertiesUpdated: anyNamed('propertiesUpdated'),
+            getLatestChanges: false,
+            useCache: anyNamed('useCache'),
+            forceEmailQuery: anyNamed('forceEmailQuery'),
+            collapseThreads: anyNamed('collapseThreads'),
+          )).called(1);
+
+          final nextPage = List.generate(
+            ThreadConstants.maxCountEmails,
+            (index) => PresentationEmail(
+              id: EmailId(Id('mailbox-more-$index')),
+              mailboxIds: {mailboxId: true},
+            ),
+          );
+          PlatformInfo.isTestingForWeb = false;
+          controllerUnderTest.handleSuccessViewState(
+            LoadMoreEmailsSuccess(
+              nextPage,
+              serverEmailCount: ThreadConstants.maxCountEmails,
+            ),
+          );
+
+          expect(controllerUnderTest.canLoadMore, isTrue);
+          expect(
+            displayedEmails,
+            containsAll(nextPage),
+          );
+        },
+      );
+
+      test('mobile-only search does not reload the mailbox list', () {
+        final controllerUnderTest = ThreadController(
+          mockGetEmailsInMailboxInteractor,
+          mockRefreshChangesEmailsInMailboxInteractor,
+          mockLoadMoreEmailsInMailboxInteractor,
+          mockGetEmailByIdInteractor,
+          mockCleanAndGetEmailsInMailboxInteractor,
+        );
+        addTearDown(controllerUnderTest.onClose);
+        clearInteractions(mockGetEmailsInMailboxInteractor);
+
+        controllerUnderTest.restoreMailboxEmailListAfterSearch();
+
+        verifyNever(mockGetEmailsInMailboxInteractor.execute(
+          any,
+          any,
+          limit: anyNamed('limit'),
+          sort: anyNamed('sort'),
+          emailFilter: anyNamed('emailFilter'),
+          propertiesCreated: anyNamed('propertiesCreated'),
+          propertiesUpdated: anyNamed('propertiesUpdated'),
+          getLatestChanges: anyNamed('getLatestChanges'),
+          useCache: anyNamed('useCache'),
+          forceEmailQuery: anyNamed('forceEmailQuery'),
+          collapseThreads: anyNamed('collapseThreads'),
+        ));
+      });
+
+      test(
+        'mobile handoff skips routing when SearchEmailController cannot be resolved',
+        () {
+          when(mockMailboxDashBoardController.searchController)
+              .thenReturn(mockSearchController);
+          when(mockSearchController.isSearchEmailRunning).thenReturn(true);
+
+          final coordinator = createSearchLayoutCoordinatorForTest();
+
+          expect(
+            () => coordinator.reconcile(false),
+            returnsNormally,
+          );
+          verifyNever(mockMailboxDashBoardController.dispatchRoute(any));
+        },
+      );
+    });
+
     group('ThreadSearchExecutionObserver ownership guard test:', () {
       final mailboxId = MailboxId(Id('inbox'));
       late ThreadSearchExecutionObserver observer;
@@ -1143,6 +1874,34 @@ void main() {
         verifyNever(
           mockMailboxDashBoardController.updateRefreshAllEmailState(any),
         );
+      });
+
+      testWidgets(
+        'GIVEN desktop owns a replayed search failure '
+        'THEN it hydrates failure state without repeating the toast',
+      (tester) async {
+        await tester.pumpWidget(const GetMaterialApp(home: SizedBox.shrink()));
+        when(mockResponsiveUtils.isWebDesktop(any)).thenReturn(true);
+        when(mockMailboxDashBoardController.emailsInCurrentMailbox)
+            .thenReturn(RxList([]));
+        clearInteractions(mockAppToast);
+
+        observer.onSearchFailure(
+          Exception('search failed'),
+          isReplay: true,
+        );
+
+        verify(
+          mockMailboxDashBoardController.updateRefreshAllEmailState(any),
+        ).called(1);
+        verifyNever(mockAppToast.showToastMessageWithMultipleActions(
+          any,
+          any,
+          actions: anyNamed('actions'),
+          textColor: anyNamed('textColor'),
+          backgroundColor: anyNamed('backgroundColor'),
+          infinityToast: anyNamed('infinityToast'),
+        ));
       });
 
       testWidgets(

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -1492,13 +1492,28 @@ void main() {
         verifyNever(mockMailboxDashBoardController.dispatchRoute(any));
       });
 
-      test('mobile handoff clears desktop presentation ownership', () {
+      test(
+        'REGRESSION mobile handoff keeps desktop presentation ownership '
+        'so closing search on mobile restores the mailbox list',
+      () {
         stubActiveSearchWithOpenEmail();
         final coordinator = createSearchLayoutCoordinatorForTest(
           mobileOwnerRegistry: _TestSearchEmailLayoutOwnerRegistry(),
         );
 
         coordinator.markDesktopSearchPresentation();
+        coordinator.reconcile(false);
+
+        expect(coordinator.takeDesktopSearchPresentation(), isTrue);
+      });
+
+      test('mobile handoff without desktop presentation leaves ownership unset',
+      () {
+        stubActiveSearchWithOpenEmail();
+        final coordinator = createSearchLayoutCoordinatorForTest(
+          mobileOwnerRegistry: _TestSearchEmailLayoutOwnerRegistry(),
+        );
+
         coordinator.reconcile(false);
 
         expect(coordinator.takeDesktopSearchPresentation(), isFalse);

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -62,7 +62,6 @@ import 'package:tmail_ui_user/features/search/email/presentation/providers/searc
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_controller.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/coordinator/get_search_email_layout_owner_registry.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/coordinator/search_email_layout_owner_registry.dart';
-import 'package:tmail_ui_user/features/search/email/presentation/coordinator/search_layout_coordinator.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/service/search_dispatch_context.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/service/search_execution_observer.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/auto_load_more_policy.dart';
@@ -245,26 +244,23 @@ void main() {
     );
   });
 
-  SearchLayoutCoordinator createSearchLayoutCoordinatorForTest({
+  ThreadController createThreadControllerForSearchLayoutTest({
     SearchEmailLayoutOwnerRegistry? mobileOwnerRegistry,
   }) {
-    final dashboardController = threadController.mailboxDashBoardController;
-    final searchController = threadController.searchController;
-    return SearchLayoutCoordinator(
-      responsiveUtils: threadController.responsiveUtils,
-      searchService: appProviderContainer.read(searchExecutorServiceProvider),
-      isSearchEngaged: () =>
-          appProviderContainer.read(searchViewStateProvider).isSearchEngaged ||
-          searchController.isSearchEmailRunning,
-      isEmailOpened: () => dashboardController.isEmailOpened,
-      prepareDesktopSearchHandoff: () =>
-          ThreadSearchExecutionObserver(threadController).onNewSearchStarted(),
-      activateMobileSearch: () => searchController.activateSimpleSearch(),
-      dispatchRoute: dashboardController.dispatchRoute,
-      isClosed: () => threadController.isClosed,
-      mobileOwnerRegistry: mobileOwnerRegistry ??
+    final controller = ThreadController(
+      mockGetEmailsInMailboxInteractor,
+      mockRefreshChangesEmailsInMailboxInteractor,
+      mockLoadMoreEmailsInMailboxInteractor,
+      mockGetEmailByIdInteractor,
+      mockCleanAndGetEmailsInMailboxInteractor,
+      searchEmailLayoutOwnerRegistry: mobileOwnerRegistry ??
           const GetSearchEmailLayoutOwnerRegistry(),
     );
+    addTearDown(() {
+      PlatformInfo.isTestingForWeb = false;
+      controller.onClose();
+    });
+    return controller;
   }
 
   group('ThreadController::test', () {
@@ -1367,7 +1363,9 @@ void main() {
           stubSearchExecution();
           final service =
               appProviderContainer.read(searchExecutorServiceProvider);
-          final observer = ThreadSearchExecutionObserver(threadController);
+          final controllerUnderTest =
+              createThreadControllerForSearchLayoutTest();
+          final observer = ThreadSearchExecutionObserver(controllerUnderTest);
           service.register(observer);
           addTearDown(() => service.unregister(observer));
           await service.dispatch(const NewSearchIntent(), dispatchContext);
@@ -1376,7 +1374,7 @@ void main() {
           displayedEmails.clear();
           clearInteractions(mockMailboxDashBoardController);
 
-          createSearchLayoutCoordinatorForTest().reconcile(true);
+          controllerUnderTest.searchLayoutCoordinator.reconcile(true);
 
           expect(displayedEmails, hasLength(searchEmails.length));
           verify(
@@ -1432,7 +1430,9 @@ void main() {
           await service.dispatch(const NewSearchIntent(), dispatchContext);
           await tester.pump();
 
-          createSearchLayoutCoordinatorForTest().reconcile(false);
+          createThreadControllerForSearchLayoutTest()
+              .searchLayoutCoordinator
+              .reconcile(false);
           await tester.pump();
 
           expect(Get.isRegistered<SearchEmailController>(), isTrue);
@@ -1474,7 +1474,9 @@ void main() {
       () {
         stubActiveSearchWithOpenEmail();
 
-        createSearchLayoutCoordinatorForTest().reconcile(true);
+        createThreadControllerForSearchLayoutTest()
+            .searchLayoutCoordinator
+            .reconcile(true);
 
         verifyNever(mockMailboxDashBoardController.dispatchRoute(any));
       });
@@ -1484,9 +1486,9 @@ void main() {
       () {
         stubActiveSearchWithOpenEmail();
 
-        createSearchLayoutCoordinatorForTest(
+        createThreadControllerForSearchLayoutTest(
           mobileOwnerRegistry: _TestSearchEmailLayoutOwnerRegistry(),
-        ).reconcile(false);
+        ).searchLayoutCoordinator.reconcile(false);
 
         verify(mockSearchController.activateSimpleSearch()).called(1);
         verifyNever(mockMailboxDashBoardController.dispatchRoute(any));
@@ -1497,9 +1499,9 @@ void main() {
         'so closing search on mobile restores the mailbox list',
       () {
         stubActiveSearchWithOpenEmail();
-        final coordinator = createSearchLayoutCoordinatorForTest(
+        final coordinator = createThreadControllerForSearchLayoutTest(
           mobileOwnerRegistry: _TestSearchEmailLayoutOwnerRegistry(),
-        );
+        ).searchLayoutCoordinator;
 
         coordinator.markDesktopSearchPresentation();
         coordinator.reconcile(false);
@@ -1510,9 +1512,9 @@ void main() {
       test('mobile handoff without desktop presentation leaves ownership unset',
       () {
         stubActiveSearchWithOpenEmail();
-        final coordinator = createSearchLayoutCoordinatorForTest(
+        final coordinator = createThreadControllerForSearchLayoutTest(
           mobileOwnerRegistry: _TestSearchEmailLayoutOwnerRegistry(),
-        );
+        ).searchLayoutCoordinator;
 
         coordinator.reconcile(false);
 
@@ -1521,7 +1523,8 @@ void main() {
 
       test('desktop handoff records desktop presentation ownership', () {
         stubActiveSearchWithOpenEmail();
-        final coordinator = createSearchLayoutCoordinatorForTest();
+        final coordinator = createThreadControllerForSearchLayoutTest()
+            .searchLayoutCoordinator;
 
         coordinator.reconcile(true);
 
@@ -1533,21 +1536,47 @@ void main() {
             .thenReturn(mockSearchController);
         when(mockSearchController.isSearchEmailRunning).thenReturn(false);
 
-        createSearchLayoutCoordinatorForTest().reconcile(true);
+        createThreadControllerForSearchLayoutTest()
+            .searchLayoutCoordinator
+            .reconcile(true);
 
         verifyNever(mockMailboxDashBoardController.dispatchRoute(any));
       });
 
-      test('width changes inside the same breakpoint are a no-op', () {
-        when(mockResponsiveUtils.isMatchedDesktopWidth(any))
-            .thenReturn(false);
-        final coordinator = createSearchLayoutCoordinatorForTest();
+      testWidgets(
+        'a resize inside the same breakpoint does not redo the handoff',
+        (tester) async {
+          PlatformInfo.isTestingForWeb = true;
+          await tester.pumpWidget(
+            const GetMaterialApp(home: SizedBox.shrink()),
+          );
+          when(mockResponsiveUtils.isMatchedDesktopWidth(any)).thenAnswer(
+            (invocation) =>
+                (invocation.positionalArguments.first as double) >= 1200,
+          );
+          when(mockMailboxDashBoardController.searchController)
+              .thenReturn(mockSearchController);
+          when(mockMailboxDashBoardController.isEmailOpened)
+              .thenReturn(false);
+          when(mockSearchController.isSearchEmailRunning).thenReturn(false);
+          final coordinator = createThreadControllerForSearchLayoutTest()
+              .searchLayoutCoordinator;
 
-        coordinator.handleBrowserWidthChange(800);
-        coordinator.handleBrowserWidthChange(900);
+          coordinator.handleBrowserWidthChange(1400);
+          await tester.pump();
+          coordinator.handleBrowserWidthChange(1100);
+          await tester.pump();
+          coordinator.handleBrowserWidthChange(1400);
+          await tester.pump();
 
-        verifyNever(mockMailboxDashBoardController.dispatchRoute(any));
-      });
+          clearInteractions(mockMailboxDashBoardController);
+          when(mockSearchController.isSearchEmailRunning).thenReturn(true);
+          coordinator.handleBrowserWidthChange(1400);
+          await tester.pump();
+
+          verifyNever(mockMailboxDashBoardController.dispatchRoute(any));
+        },
+      );
 
       testWidgets(
         'failed mobile handoff retries after the owner becomes available',
@@ -1567,9 +1596,9 @@ void main() {
           when(mockSearchController.isSearchEmailRunning).thenReturn(true);
           final ownerRegistry =
               _ConfigurableSearchEmailLayoutOwnerRegistry();
-          final coordinator = createSearchLayoutCoordinatorForTest(
+          final coordinator = createThreadControllerForSearchLayoutTest(
             mobileOwnerRegistry: ownerRegistry,
-          );
+          ).searchLayoutCoordinator;
 
           coordinator.handleBrowserWidthChange(1200);
           await tester.pump();
@@ -1611,7 +1640,8 @@ void main() {
           when(mockMailboxDashBoardController.emailsInCurrentMailbox)
               .thenReturn(RxList([]));
           when(mockSearchController.isSearchEmailRunning).thenReturn(false);
-          final coordinator = createSearchLayoutCoordinatorForTest();
+          final coordinator = createThreadControllerForSearchLayoutTest()
+              .searchLayoutCoordinator;
           coordinator.handleBrowserWidthChange(900);
           await tester.pump();
           clearInteractions(mockMailboxDashBoardController);
@@ -1642,7 +1672,8 @@ void main() {
           when(mockMailboxDashBoardController.searchController)
               .thenReturn(mockSearchController);
           when(mockSearchController.isSearchEmailRunning).thenReturn(false);
-          final coordinator = createSearchLayoutCoordinatorForTest();
+          final coordinator = createThreadControllerForSearchLayoutTest()
+              .searchLayoutCoordinator;
           coordinator.handleBrowserWidthChange(1200);
           await tester.pump();
           clearInteractions(mockMailboxDashBoardController);
@@ -1672,7 +1703,8 @@ void main() {
           when(mockMailboxDashBoardController.emailsInCurrentMailbox)
               .thenReturn(RxList([]));
           when(mockSearchController.isSearchEmailRunning).thenReturn(false);
-          final coordinator = createSearchLayoutCoordinatorForTest();
+          final coordinator = createThreadControllerForSearchLayoutTest()
+              .searchLayoutCoordinator;
           coordinator.handleBrowserWidthChange(900);
           await tester.pump();
           clearInteractions(mockMailboxDashBoardController);
@@ -1856,7 +1888,8 @@ void main() {
               .thenReturn(mockSearchController);
           when(mockSearchController.isSearchEmailRunning).thenReturn(true);
 
-          final coordinator = createSearchLayoutCoordinatorForTest();
+          final coordinator = createThreadControllerForSearchLayoutTest()
+              .searchLayoutCoordinator;
 
           expect(
             () => coordinator.reconcile(false),

--- a/test/features/thread/presentation/controller/thread_controller_test.dart
+++ b/test/features/thread/presentation/controller/thread_controller_test.dart
@@ -58,7 +58,6 @@ import 'package:tmail_ui_user/features/search/email/domain/execution/search_exec
 import 'package:tmail_ui_user/features/search/email/domain/model/search_email_result.dart';
 import 'package:tmail_ui_user/features/search/email/domain/notifier/search_filter_notifier.dart';
 import 'package:tmail_ui_user/features/search/email/domain/notifier/search_email_notifier.dart';
-import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/providers/search_executor_provider.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_controller.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/coordinator/get_search_email_layout_owner_registry.dart';
@@ -68,8 +67,6 @@ import 'package:tmail_ui_user/features/search/email/presentation/service/search_
 import 'package:tmail_ui_user/features/search/email/presentation/service/search_execution_observer.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/auto_load_more_policy.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/loading_more_status.dart';
-import 'package:tmail_ui_user/features/thread/presentation/model/search_state.dart';
-import 'package:tmail_ui_user/features/thread/presentation/model/search_status.dart';
 import 'package:tmail_ui_user/features/thread/presentation/thread_controller.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
 import 'package:tmail_ui_user/main/providers/app_provider_container.dart';

--- a/test/main/routes/route_utils_test.dart
+++ b/test/main/routes/route_utils_test.dart
@@ -44,9 +44,11 @@ void main() {
     NavigationRouter buildRouter({
       required bool isSearchRunning,
       PresentationMailbox? selectedMailbox,
+      EmailId? emailId,
     }) {
       return RouteUtils.dashboardRouterForMailboxOrSearch(
         isSearchRunning: isSearchRunning,
+        emailId: emailId,
         selectedMailbox: selectedMailbox,
         searchQuery: query,
       );
@@ -85,6 +87,20 @@ void main() {
         buildRouter(isSearchRunning: true, selectedMailbox: labelMailbox),
         searchRouter,
       );
+    });
+
+    test('keeps the open email regardless of search state', () {
+      final emailId = EmailId(Id('email-1'));
+      for (final isSearchRunning in [true, false]) {
+        expect(
+          buildRouter(
+            isSearchRunning: isSearchRunning,
+            selectedMailbox: regularMailbox,
+            emailId: emailId,
+          ).emailId,
+          emailId,
+        );
+      }
     });
   });
 

--- a/test/main/routes/route_utils_test.dart
+++ b/test/main/routes/route_utils_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:labels/model/label.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
@@ -83,6 +84,51 @@ void main() {
       expect(
         buildRouter(isSearchRunning: true, selectedMailbox: labelMailbox),
         searchRouter,
+      );
+    });
+  });
+
+  group('dashboardBrowserRouteTitle test', () {
+    final mailbox = PresentationMailbox(
+      MailboxId(Id('mailbox-1')),
+      name: MailboxName('Inbox'),
+    );
+
+    test('uses the selected email before search and mailbox', () {
+      expect(
+        RouteUtils.dashboardBrowserRouteTitle(
+          isSearchRunning: true,
+          selectedEmailId: EmailId(Id('email-1')),
+          selectedMailbox: mailbox,
+        ),
+        'Email-email-1',
+      );
+    });
+
+    test('uses search while search is running', () {
+      expect(
+        RouteUtils.dashboardBrowserRouteTitle(
+          isSearchRunning: true,
+          selectedMailbox: mailbox,
+        ),
+        'SearchEmail',
+      );
+    });
+
+    test('uses the selected mailbox outside search', () {
+      expect(
+        RouteUtils.dashboardBrowserRouteTitle(
+          isSearchRunning: false,
+          selectedMailbox: mailbox,
+        ),
+        mailbox.browserRouteTitle,
+      );
+    });
+
+    test('uses an empty title without a selected mailbox', () {
+      expect(
+        RouteUtils.dashboardBrowserRouteTitle(isSearchRunning: false),
+        isEmpty,
       );
     });
   });

--- a/test/main/routes/route_utils_test.dart
+++ b/test/main/routes/route_utils_test.dart
@@ -1,240 +1,216 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:labels/model/label.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart';
+import 'package:tmail_ui_user/features/mailbox/presentation/model/presentation_label_mailbox.dart';
+import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
 import 'package:tmail_ui_user/main/routes/app_routes.dart';
+import 'package:tmail_ui_user/main/routes/navigation_router.dart';
 import 'package:tmail_ui_user/main/routes/route_utils.dart';
 
-void main() {
-  group('parseMapMailtoFromUri test', () {
-    test('should parse a valid mailto URI', () {
-      const mailtoUri = 'mailto:test@example.com?subject=Hello';
-      final result = RouteUtils.parseMapMailtoFromUri(mailtoUri);
+/// Asserts the route, address and subject of a parsed mailto map, so tests read
+/// in domain terms instead of repeating `expect`s. [address]/[subject] default
+/// to being absent.
+void expectParsedMailto(
+  Map<String, dynamic> result, {
+  Object? address = isNull,
+  Object? subject = isNull,
+}) {
+  expect(result[RouteUtils.paramRouteName], AppRoutes.mailtoURL);
+  expect(result[RouteUtils.paramMailtoAddress], address);
+  expect(result[RouteUtils.paramSubject], subject);
+}
 
-      expect(result[RouteUtils.paramRouteName], equals(AppRoutes.mailtoURL));
-      expect(result[RouteUtils.paramMailtoAddress], equals('test@example.com'));
-      expect(result[RouteUtils.paramSubject], equals('Hello'));
+/// Asserts every equivalent mailto form parses to the same map.
+void expectSameParsing(Iterable<Map<String, dynamic>> results) {
+  for (final result in results.skip(1)) {
+    expect(result, equals(results.first));
+  }
+}
+
+void main() {
+  group('dashboardRouterForMailboxOrSearch test', () {
+    final mailboxId = MailboxId(Id('mailbox-1'));
+    final regularMailbox = PresentationMailbox(mailboxId);
+    final labelMailbox = PresentationLabelMailbox(
+      MailboxId(Id('label-1')),
+      Label(id: Id('label-1'), displayName: 'Work'),
+    );
+    final query = SearchQuery('hello');
+
+    NavigationRouter buildRouter({
+      required bool isSearchRunning,
+      PresentationMailbox? selectedMailbox,
+    }) {
+      return RouteUtils.dashboardRouterForMailboxOrSearch(
+        isSearchRunning: isSearchRunning,
+        selectedMailbox: selectedMailbox,
+        searchQuery: query,
+      );
+    }
+
+    // NavigationRouter is an Equatable, so one expectation over the whole
+    // router covers mailboxId, labelId, searchQuery and dashboardType at once.
+    final searchRouter = NavigationRouter(
+      dashboardType: DashboardType.search,
+      searchQuery: query,
+    );
+
+    test('keeps the folder context off search', () {
+      expect(
+        buildRouter(isSearchRunning: false, selectedMailbox: regularMailbox),
+        NavigationRouter(mailboxId: mailboxId),
+      );
+    });
+
+    test('keeps the label context off search', () {
+      expect(
+        buildRouter(isSearchRunning: false, selectedMailbox: labelMailbox),
+        NavigationRouter(labelId: labelMailbox.labelId),
+      );
+    });
+
+    test('drops the folder context during search', () {
+      expect(
+        buildRouter(isSearchRunning: true, selectedMailbox: regularMailbox),
+        searchRouter,
+      );
+    });
+
+    test('drops the label context during search', () {
+      expect(
+        buildRouter(isSearchRunning: true, selectedMailbox: labelMailbox),
+        searchRouter,
+      );
+    });
+  });
+
+  group('parseMapMailtoFromUri test', () {
+    // Shared fixture for the "every possible parameters" cases.
+    const to1 = 'to1@example.com';
+    const to2 = 'to2@example.com';
+    const to3 = 'to3@example.com';
+    const cc1 = 'cc1@example.com';
+    const cc2 = 'cc2@example.com';
+    const bcc1 = 'bcc1@example.com';
+    const bcc2 = 'bcc2@example.com';
+    const subject = 'Hello';
+    const body = 'Bye';
+    const mailtoSchemeUri = 'mailto:$to1,$to2'
+        '?to=$to2,$to3'
+        '&cc=$cc1,$cc2'
+        '&bcc=$bcc1,$bcc2'
+        '&subject=$subject'
+        '&body=$body';
+    const mailtoPathUri = 'https://example.com/mailto'
+        '?uri=$to1,$to2'
+        '&to=$to2,$to3'
+        '&cc=$cc1,$cc2'
+        '&bcc=$bcc1,$bcc2'
+        '&subject=$subject'
+        '&body=$body';
+    const mailtoPathWithNestedMailtoUri = 'https://example.com/mailto/'
+        '?uri=mailto:$to1,$to2'
+        '&to=$to2,$to3'
+        '&cc=$cc1,$cc2'
+        '&bcc=$bcc1,$bcc2'
+        '&subject=$subject'
+        '&body=$body';
+
+    // Asserts a fully-populated mailto: the shared cc/bcc/subject/body fixture
+    // plus the recipients described by [address].
+    void expectFullyParsedMailto(Map<String, dynamic> result, Object address) {
+      expectParsedMailto(result, address: address, subject: subject);
+      expect(result[RouteUtils.paramCc], containsAll([cc1, cc2]));
+      expect(result[RouteUtils.paramBcc], containsAll([bcc1, bcc2]));
+      expect(result[RouteUtils.paramBody], body);
+    }
+
+    // Parses the scheme/path/nested URI forms (via [transform]) and asserts they
+    // agree and carry every parameter.
+    void expectAllUriFormsMatch(String Function(String uri) transform) {
+      final results = [
+        mailtoSchemeUri,
+        mailtoPathUri,
+        mailtoPathWithNestedMailtoUri,
+      ].map((uri) => RouteUtils.parseMapMailtoFromUri(transform(uri))).toList();
+
+      expectSameParsing(results);
+      expectFullyParsedMailto(results.first, containsAll([to1, to2, to3]));
+    }
+
+    test('should parse a valid mailto URI', () {
+      final result = RouteUtils.parseMapMailtoFromUri(
+        'mailto:test@example.com?subject=Hello');
+
+      expectParsedMailto(result, address: 'test@example.com', subject: 'Hello');
     });
 
     test('should parse a valid mailto URI encoded', () {
-      const mailtoUri = 'mailto:test%40example.com%3Fsubject=Hello';
-      final result = RouteUtils.parseMapMailtoFromUri(mailtoUri);
+      final result = RouteUtils.parseMapMailtoFromUri(
+        'mailto:test%40example.com%3Fsubject=Hello');
 
-      expect(result[RouteUtils.paramRouteName], equals(AppRoutes.mailtoURL));
-      expect(result[RouteUtils.paramMailtoAddress], equals('test@example.com'));
-      expect(result[RouteUtils.paramSubject], equals('Hello'));
+      expectParsedMailto(result, address: 'test@example.com', subject: 'Hello');
     });
 
     test('should handle a mailto URI without subject', () {
-      const mailtoUri = 'mailto:test@example.com';
-      final result = RouteUtils.parseMapMailtoFromUri(mailtoUri);
+      final result = RouteUtils.parseMapMailtoFromUri('mailto:test@example.com');
 
-      expect(result[RouteUtils.paramRouteName], equals(AppRoutes.mailtoURL));
-      expect(result[RouteUtils.paramMailtoAddress], equals('test@example.com'));
-      expect(result[RouteUtils.paramSubject], isNull);
+      expectParsedMailto(result, address: 'test@example.com');
     });
 
     test('should handle a mailto URI without subject encoded', () {
-      const mailtoUri = 'mailto:test%40example.com';
-      final result = RouteUtils.parseMapMailtoFromUri(mailtoUri);
+      final result = RouteUtils.parseMapMailtoFromUri('mailto:test%40example.com');
 
-      expect(result[RouteUtils.paramRouteName], equals(AppRoutes.mailtoURL));
-      expect(result[RouteUtils.paramMailtoAddress], equals('test@example.com'));
-      expect(result[RouteUtils.paramSubject], isNull);
+      expectParsedMailto(result, address: 'test@example.com');
     });
 
     test('should handle a non-mailto URI', () {
-      const nonMailtoUri = 'test@example.com';
-      final result = RouteUtils.parseMapMailtoFromUri(nonMailtoUri);
+      final result = RouteUtils.parseMapMailtoFromUri('test@example.com');
 
-      expect(result[RouteUtils.paramRouteName], equals(AppRoutes.mailtoURL));
-      expect(result[RouteUtils.paramMailtoAddress], equals(nonMailtoUri));
-      expect(result[RouteUtils.paramSubject], isNull);
+      expectParsedMailto(result, address: 'test@example.com');
     });
 
     test('should handle a non-mailto URI encoded', () {
-      const nonMailtoUri = 'test%40example.com';
-      final result = RouteUtils.parseMapMailtoFromUri(nonMailtoUri);
+      final result = RouteUtils.parseMapMailtoFromUri('test%40example.com');
 
-      expect(result[RouteUtils.paramRouteName], equals(AppRoutes.mailtoURL));
-      expect(result[RouteUtils.paramMailtoAddress], equals('test@example.com'));
-      expect(result[RouteUtils.paramSubject], isNull);
+      expectParsedMailto(result, address: 'test@example.com');
     });
 
     test('should handle null input', () {
       final result = RouteUtils.parseMapMailtoFromUri(null);
 
-      expect(result[RouteUtils.paramRouteName], equals(AppRoutes.mailtoURL));
-      expect(result[RouteUtils.paramMailtoAddress], isNull);
-      expect(result[RouteUtils.paramSubject], isNull);
+      expectParsedMailto(result);
     });
 
-    test('should parse a valid mailto URI encoded contains multiple recipients', () {
-      const mailtoUri = 'mailto:test%40example.com%2Ctest2%40example.com%2Ctest3%40example.com%3Fsubject=Hello';
-      final result = RouteUtils.parseMapMailtoFromUri(mailtoUri);
+    test('should parse multiple recipients from encoded and plain mailto URIs', () {
+      final results = [
+        'mailto:test%40example.com%2Ctest2%40example.com'
+            '%2Ctest3%40example.com%3Fsubject=Hello',
+        'mailto:test@example.com,test2@example.com,test3@example.com?subject=Hello',
+      ].map(RouteUtils.parseMapMailtoFromUri).toList();
 
-      expect(result[RouteUtils.paramRouteName], equals(AppRoutes.mailtoURL));
-      expect(result[RouteUtils.paramMailtoAddress], containsAll(['test@example.com', 'test2@example.com', 'test3@example.com']));
-      expect(result[RouteUtils.paramSubject], equals('Hello'));
-    });
-
-    test('should parse a valid mailto URI contains multiple recipients', () {
-      const mailtoUri = 'mailto:test@example.com,test2@example.com,test3@example.com?subject=Hello';
-      final result = RouteUtils.parseMapMailtoFromUri(mailtoUri);
-
-      expect(result[RouteUtils.paramRouteName], equals(AppRoutes.mailtoURL));
-      expect(result[RouteUtils.paramMailtoAddress], containsAll(['test@example.com', 'test2@example.com', 'test3@example.com']));
-      expect(result[RouteUtils.paramSubject], equals('Hello'));
-    });
-
-    test(
-      'should parse a valid mailto URI encoded contains every possible parameters',
-    () {
-      // arrange
-      const to1 = 'to1@example.com';
-      const to2 = 'to2@example.com';
-      const to3 = 'to3@example.com';
-      const cc1 = 'cc1@example.com';
-      const cc2 = 'cc2@example.com';
-      const bcc1 = 'bcc1@example.com';
-      const bcc2 = 'bcc2@example.com';
-      const subject = 'Hello';
-      const body = 'Bye';
-      const mailtoSchemeUri = 'mailto:$to1,$to2'
-        '?to=$to2,$to3'
-        '&cc=$cc1,$cc2'
-        '&bcc=$bcc1,$bcc2'
-        '&subject=$subject'
-        '&body=$body';
-
-      const mailtoPathUri = 'https://example.com/mailto'
-        '?uri=$to1,$to2'
-        '&to=$to2,$to3'
-        '&cc=$cc1,$cc2'
-        '&bcc=$bcc1,$bcc2'
-        '&subject=$subject'
-        '&body=$body';
-
-      const mailtoPathWithNestedMailtoUri = 'https://example.com/mailto/'
-        '?uri=mailto:$to1,$to2'
-        '&to=$to2,$to3'
-        '&cc=$cc1,$cc2'
-        '&bcc=$bcc1,$bcc2'
-        '&subject=$subject'
-        '&body=$body';
-
-      // act
-      final mailtoSchemeResult = RouteUtils.parseMapMailtoFromUri(
-        Uri.encodeFull(mailtoSchemeUri));
-      final mailtoPathResult = RouteUtils.parseMapMailtoFromUri(
-        Uri.encodeFull(mailtoPathUri));
-      final mailtoPathWithNestedMailtoResult = RouteUtils.parseMapMailtoFromUri(
-        Uri.encodeFull(mailtoPathWithNestedMailtoUri));
-
-      // assert
-      expect(mailtoSchemeResult, equals(mailtoPathResult));
-      expect(mailtoSchemeResult, equals(mailtoPathWithNestedMailtoResult));
-      expect(mailtoPathResult, equals(mailtoPathWithNestedMailtoResult));
-
-      expect(
-        mailtoSchemeResult[RouteUtils.paramMailtoAddress],
-        containsAll([to1, to2, to3,])
-      );
-      expect(
-        mailtoSchemeResult[RouteUtils.paramCc],
-        containsAll([cc1, cc2])
-      );
-      expect(
-        mailtoSchemeResult[RouteUtils.paramBcc],
-        containsAll([bcc1, bcc2])
-      );
-      expect(
-        mailtoSchemeResult[RouteUtils.paramSubject],
-        equals(subject)
-      );
-      expect(
-        mailtoSchemeResult[RouteUtils.paramBody],
-        equals(body)
+      expectSameParsing(results);
+      expectParsedMailto(
+        results.first,
+        address: containsAll(
+          ['test@example.com', 'test2@example.com', 'test3@example.com']),
+        subject: 'Hello',
       );
     });
 
-    test(
-      'should parse a valid mailto URI contains every possible parameters',
-    () {
-      // arrange
-      const to1 = 'to1@example.com';
-      const to2 = 'to2@example.com';
-      const to3 = 'to3@example.com';
-      const cc1 = 'cc1@example.com';
-      const cc2 = 'cc2@example.com';
-      const bcc1 = 'bcc1@example.com';
-      const bcc2 = 'bcc2@example.com';
-      const subject = 'Hello';
-      const body = 'Bye';
-      const mailtoSchemeUri = 'mailto:$to1,$to2'
-        '?to=$to2,$to3'
-        '&cc=$cc1,$cc2'
-        '&bcc=$bcc1,$bcc2'
-        '&subject=$subject'
-        '&body=$body';
-
-      const mailtoPathUri = 'https://example.com/mailto'
-        '?uri=$to1,$to2'
-        '&to=$to2,$to3'
-        '&cc=$cc1,$cc2'
-        '&bcc=$bcc1,$bcc2'
-        '&subject=$subject'
-        '&body=$body';
-
-      const mailtoPathWithNestedMailtoUri = 'https://example.com/mailto/'
-        '?uri=mailto:$to1,$to2'
-        '&to=$to2,$to3'
-        '&cc=$cc1,$cc2'
-        '&bcc=$bcc1,$bcc2'
-        '&subject=$subject'
-        '&body=$body';
-
-      // act
-      final mailtoSchemeResult = RouteUtils.parseMapMailtoFromUri(
-        mailtoSchemeUri);
-      final mailtoPathResult = RouteUtils.parseMapMailtoFromUri(mailtoPathUri);
-      final mailtoPathWithNestedMailtoResult = RouteUtils.parseMapMailtoFromUri(
-        mailtoPathWithNestedMailtoUri);
-
-      // assert
-      expect(mailtoSchemeResult, equals(mailtoPathResult));
-      expect(mailtoSchemeResult, equals(mailtoPathWithNestedMailtoResult));
-      expect(mailtoPathResult, equals(mailtoPathWithNestedMailtoResult));
-
-      expect(
-        mailtoSchemeResult[RouteUtils.paramMailtoAddress],
-        containsAll([to1, to2, to3,])
-      );
-      expect(
-        mailtoSchemeResult[RouteUtils.paramCc],
-        containsAll([cc1, cc2])
-      );
-      expect(
-        mailtoSchemeResult[RouteUtils.paramBcc],
-        containsAll([bcc1, bcc2])
-      );
-      expect(
-        mailtoSchemeResult[RouteUtils.paramSubject],
-        equals(subject)
-      );
-      expect(
-        mailtoSchemeResult[RouteUtils.paramBody],
-        equals(body)
-      );
+    test('should parse every possible parameter from encoded and plain URIs', () {
+      expectAllUriFormsMatch(Uri.encodeFull);
+      expectAllUriFormsMatch((uri) => uri);
     });
 
     test(
       'should parse url with mailto uri '
       'when the query parameter belongs to the mailto uri',
     () {
-      // arrange
       const to = 'to@example.com';
-      const cc1 = 'cc1@example.com', cc2 = 'cc2@example.com';
-      const bcc1 = 'bcc1@example.com', bcc2 = 'bcc2@example.com';
-      const subject = 'Hello';
-      const body = 'Bye';
       const mailtoUri = 'https://example.com/mailto/'
         '?uri=mailto:$to'
         '?subject=$subject'
@@ -242,15 +218,9 @@ void main() {
         '&bcc=$bcc1,$bcc2'
         '&body=$body';
 
-      // act
       final result = RouteUtils.parseMapMailtoFromUri(mailtoUri);
-      
-      // assert
-      expect(result[RouteUtils.paramMailtoAddress], equals(to));
-      expect(result[RouteUtils.paramCc], containsAll([cc1, cc2]));
-      expect(result[RouteUtils.paramBcc], containsAll([bcc1, bcc2]));
-      expect(result[RouteUtils.paramSubject], equals(subject));
-      expect(result[RouteUtils.paramBody], equals(body));
+
+      expectFullyParsedMailto(result, to);
     });
   });
 


### PR DESCRIPTION
## Description

When an active search is resized across the web desktop breakpoint, the route and the list store can remain owned by the previous layout. The newly visible layout then renders an empty search list.

The issue affects both directions:

- Mobile/tablet → desktop
- Desktop → mobile/tablet

## Root cause

Search results are kept in the shared Riverpod search state, but each layout renders from its own presentation store. On a breakpoint crossing, the new layout was not reliably mounted, hydrated, or routed to the correct list.

There were also two edge cases:

- Desktop could receive the `searchEmail` route without a desktop list body.
- Mobile handoff could run before `SearchEmailController` was registered.

## Solution

Introduce `SearchLayoutCoordinator` to coordinate only the responsive search presentation. It does not own search or mailbox data.

- Detect real breakpoint crossings and defer reconciliation until the next frame.
- Delegate breakpoint bookkeeping to `SearchLayoutTransitionState`, which handles duplicate resize events, stale callbacks, successful handoffs, and retryable failures.
- Route desktop search to `thread` and mobile/tablet search to `searchEmail`.
- Prepare the target layout owner, then replay the current search state into it.
- Keep an open email detail (`threadDetailed`) route intact during a handoff.
- Fail safely when the mobile owner is unavailable and retry on a later resize.
- Render the desktop thread list defensively for a residual `searchEmail` route.

```mermaid
flowchart TD
    A[Browser resize] --> B{Breakpoint crossed?}
    B -- No --> C[Ignore resize]
    B -- Yes --> D[Schedule next-frame reconciliation]
    D --> E{Search still active?}
    E -- No --> F[Keep state pending for a later retry]
    E -- Yes --> G{Target layout}
    G -- Desktop --> H[Prepare Thread owner + route to thread]
    G -- Mobile/tablet --> I[Ensure SearchEmail owner + route to searchEmail]
    H --> J[Replay current search state]
    I --> J
```

## Demo


https://github.com/user-attachments/assets/2d763bff-a931-487e-9fd0-c3d51da186a9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved search transitions between desktop and mobile layouts.
  * Restores mailbox email lists after closing search or navigating back.
  * Preserves mailbox context during search and thread navigation.
  * Improved desktop routing for thread lists and detailed views.

* **Bug Fixes**
  * Prevented duplicate pagination requests.
  * Prevented repeated error notifications during search restoration.
  * Improved browser history and back-navigation behavior.
  * Corrected mailbox selection display while searching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->