### PR TITLE
TF-4720 Fix signature is not well displayed

### DIFF
--- a/core/lib/core.dart
+++ b/core/lib/core.dart
@@ -9,6 +9,7 @@ export 'presentation/extensions/list_extensions.dart';
 export 'presentation/extensions/list_nullable_extensions.dart';
 export 'domain/extensions/datetime_extension.dart';
 export 'domain/extensions/list_datetime_extension.dart';
+export 'presentation/extensions/html_document_extension.dart';
 export 'presentation/extensions/html_extension.dart';
 export 'presentation/extensions/compare_string_extension.dart';
 export 'presentation/extensions/compare_list_extensions.dart';

--- a/core/lib/presentation/extensions/html_document_extension.dart
+++ b/core/lib/presentation/extensions/html_document_extension.dart
@@ -1,0 +1,19 @@
+import 'package:html/parser.dart';
+
+/// Helpers for complete HTML documents, e.g. the output of
+/// `HtmlTransform.transformToHtml`, which always serializes a full
+/// `<html><head>…</head><body>…</body></html>` document.
+extension HtmlDocumentExtension on String {
+  /// Converts a complete HTML document into a fragment insertable into an
+  /// editor: the body's inner HTML, prefixed with any `<style>` blocks the
+  /// parser hoisted into `<head>` so a stylesheet survives the conversion.
+  String toHtmlFragment() {
+    final document = parse(this);
+    final headStyles = document.head
+            ?.getElementsByTagName('style')
+            .map((style) => style.outerHtml)
+            .join() ??
+        '';
+    return '$headStyles${document.body?.innerHtml ?? ''}';
+  }
+}

--- a/core/lib/presentation/utils/html_transformer/dom/normalize_line_height_in_style_transformer.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/normalize_line_height_in_style_transformer.dart
@@ -12,13 +12,24 @@ import 'package:html/dom.dart';
 class NormalizeLineHeightInStyleTransformer extends DomTransformer {
   const NormalizeLineHeightInStyleTransformer();
 
-  // Removal bounds. Unitless/em/rem is exclusive, so a normal `line-height:1` is
-  // kept, while `%` and `px`/`pt` are inclusive: `100%` and `1px` are stripped
-  // deliberately (TF-3964 — those exact values broke email-preview rendering).
-  // The unitless-vs-`%` asymmetry is intentional, not an oversight.
-  static const _unitlessRemovalThreshold = 1.0; // unitless / em / rem multiplier
-  static const _percentRemovalThreshold = 100.0; // %
-  static const _absoluteRemovalThreshold = 1.0; // px / pt
+  // Removal bounds. Major mail clients (Gmail, Outlook, Apple Mail) never
+  // rewrite `line-height`, so intervene as narrowly as possible — two classes
+  // of removal only:
+  //  - Degenerate: element-relative values small enough to visibly overlap
+  //    text lines (< 0.8× font-size; the UA default is ~1.2×). Values in
+  //    [0.8, 1) such as `90%`/`0.9em` are tight-but-legitimate typography and
+  //    are preserved for fidelity — especially since reply/draft pipelines
+  //    save and send the transformed style.
+  //  - TF-3964 legacy: exactly `100%` (and `1em`, the same computed length),
+  //    plus absolute values up to `1px`/`1pt`. These shipped as removals and
+  //    must not silently come back.
+  //  `rem` is root-relative, so overlap cannot be judged from the number
+  //  alone (`0.9rem` ≈ 14.4px is fine leading for 12px text) — never removed.
+  static const _degenerateRatioBound = 0.8; // unitless & em, exclusive
+  static const _degeneratePercentBound = 80.0; // %, exclusive
+  static const _legacyRatio = 1.0; // TF-3964: `1em` ≡ `100%`
+  static const _legacyPercent = 100.0; // TF-3964
+  static const _absoluteRemovalThreshold = 1.0; // px / pt, inclusive
 
   /// A CSS number + optional unit. `!important` is stripped beforehand by
   /// [_stripImportant], so the pattern needs no whitespace: keywords,
@@ -120,7 +131,10 @@ class NormalizeLineHeightInStyleTransformer extends DomTransformer {
       } else if (char == '\\') {
         if (next.isEmpty) return null; // trailing backslash → fail-open
         i++; // escaped char is literal data (e.g. `\;`), never a boundary
-      } else if (char == '/' && next == '*') {
+      } else if (char == '/' && next == '*' && parenDepth == 0) {
+        // Inside parentheses `/*` is data, not a comment — an unquoted
+        // `url(https://x/a/*/b.png)` must not poison the whole attribute
+        // (fail-open would keep a degenerate line-height → TF-3964 returns).
         inComment = true;
         i++;
       } else if (char == "'") {
@@ -186,12 +200,16 @@ class NormalizeLineHeightInStyleTransformer extends DomTransformer {
 
     switch (match.group(2)?.toLowerCase()) {
       case '%':
-        return number <= _percentRemovalThreshold;
+        return number < _degeneratePercentBound || number == _legacyPercent;
+      case 'em':
+        return number < _degenerateRatioBound || number == _legacyRatio;
+      case 'rem':
+        return false; // root-relative: overlap cannot be judged from the number
       case 'px':
       case 'pt':
         return number <= _absoluteRemovalThreshold;
-      default: // unitless / em / rem multiplier
-        return number < _unitlessRemovalThreshold;
+      default: // unitless multiplier
+        return number < _degenerateRatioBound;
     }
   }
 }

--- a/core/lib/presentation/utils/html_transformer/dom/normalize_line_height_in_style_transformer.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/normalize_line_height_in_style_transformer.dart
@@ -7,6 +7,8 @@ import 'package:html/dom.dart';
 /// Strips `line-height` values small enough to overlap text lines (e.g. some
 /// signatures ship `line-height:0.1`), letting the renderer fall back to its
 /// default leading. Removed rather than clamped, matching correct clients.
+/// `line-height:0` is left untouched: it is the intentional image-gap/spacer
+/// trick, not an overlap bug.
 class NormalizeLineHeightInStyleTransformer extends DomTransformer {
   const NormalizeLineHeightInStyleTransformer();
 
@@ -176,6 +178,11 @@ class NormalizeLineHeightInStyleTransformer extends DomTransformer {
 
     final number = double.tryParse(match.group(1) ?? '');
     if (number == null || !number.isFinite) return false;
+
+    // `line-height:0` (any unit) is the intentional image-gap/spacer trick used
+    // to collapse whitespace around images; preserve it. Only strip the small
+    // non-zero values that overlap text.
+    if (number <= 0) return false;
 
     switch (match.group(2)?.toLowerCase()) {
       case '%':

--- a/core/lib/presentation/utils/html_transformer/dom/normalize_line_height_in_style_transformer.dart
+++ b/core/lib/presentation/utils/html_transformer/dom/normalize_line_height_in_style_transformer.dart
@@ -4,20 +4,32 @@ import 'package:core/utils/app_logger.dart';
 import 'package:flutter/widgets.dart' show visibleForTesting;
 import 'package:html/dom.dart';
 
+/// Strips `line-height` values small enough to overlap text lines (e.g. some
+/// signatures ship `line-height:0.1`), letting the renderer fall back to its
+/// default leading. Removed rather than clamped, matching correct clients.
 class NormalizeLineHeightInStyleTransformer extends DomTransformer {
   const NormalizeLineHeightInStyleTransformer();
 
-  static const _removableLineHeights = ['1px', '100%'];
-  static final _multipleSpacesRegex = RegExp(r' {2,}');
-  static final _lineHeightPattern = RegExp(
-    r'line-height\s*:\s*(?:' +
-        _removableLineHeights.map(RegExp.escape).join('|') +
-        r')\s*;?',
+  // Removal bounds. Unitless/em/rem is exclusive, so a normal `line-height:1` is
+  // kept, while `%` and `px`/`pt` are inclusive: `100%` and `1px` are stripped
+  // deliberately (TF-3964 — those exact values broke email-preview rendering).
+  // The unitless-vs-`%` asymmetry is intentional, not an oversight.
+  static const _unitlessRemovalThreshold = 1.0; // unitless / em / rem multiplier
+  static const _percentRemovalThreshold = 100.0; // %
+  static const _absoluteRemovalThreshold = 1.0; // px / pt
+
+  /// A CSS number + optional unit. `!important` is stripped beforehand by
+  /// [_stripImportant], so the pattern needs no whitespace: keywords,
+  /// `calc(...)`, negatives, and >9-digit values simply do not match and are
+  /// kept. No whitespace + bounded `\d{1,9}` + `^` anchor make matching
+  /// constant-work — ReDoS-safe (ADR 0069-redos-vulnerability-mitigation).
+  static final _numericValuePattern = RegExp(
+    r'^\+?(\d{1,9}(?:\.\d{0,9})?|\.\d{1,9})(px|pt|em|rem|%)?$',
     caseSensitive: false,
   );
 
   @visibleForTesting
-  static RegExp get lineHeightPattern => _lineHeightPattern;
+  static RegExp get numericValuePattern => _numericValuePattern;
 
   @override
   Future<void> process({
@@ -26,29 +38,153 @@ class NormalizeLineHeightInStyleTransformer extends DomTransformer {
     Map<String, String>? mapUrlDownloadCID,
   }) async {
     try {
-      
-
-      final elements = document.querySelectorAll('[style*="line-height"]');
+      // `[style*=...]` is case-sensitive and would miss `LINE-HEIGHT`; select
+      // all styles and filter case-insensitively.
+      final elements = document.querySelectorAll('[style]');
 
       for (final element in elements) {
         final originalStyle = element.attributes['style'];
         if (originalStyle == null) continue;
+        if (!originalStyle.toLowerCase().contains('line-height')) continue;
 
-        var updatedStyle = originalStyle.replaceAll(_lineHeightPattern, '').trim();
+        final updatedStyle = _stripDegenerateLineHeights(originalStyle);
+        if (updatedStyle == null) continue; // unchanged or malformed → keep
 
-        // Remove extra spaces (>=2 spaces → 1 space)
-        updatedStyle = updatedStyle.replaceAll(_multipleSpacesRegex, ' ');
-
-        if (updatedStyle != originalStyle) {
-          if (updatedStyle.isEmpty) {
-            element.attributes.remove('style');
-          } else {
-            element.attributes['style'] = updatedStyle;
-          }
+        if (updatedStyle.isEmpty) {
+          element.attributes.remove('style');
+        } else {
+          element.attributes['style'] = updatedStyle;
         }
       }
     } catch (e) {
       logWarning('$runtimeType::process: Exception = $e');
+    }
+  }
+
+  /// Returns [style] with degenerate `line-height` declarations removed, or
+  /// `null` when nothing changed or the CSS is malformed (fail-open: keep the
+  /// original). Kept declarations are re-emitted verbatim.
+  String? _stripDegenerateLineHeights(String style) {
+    final declarations = _splitTopLevelDeclarations(style);
+    if (declarations == null) return null; // malformed → fail-open
+
+    var removed = false;
+    final kept = StringBuffer();
+    for (final declaration in declarations) {
+      if (_isRemovableLineHeight(declaration)) {
+        removed = true;
+      } else {
+        kept.write(declaration);
+      }
+    }
+    return removed ? kept.toString().trim() : null;
+  }
+
+  /// Splits [style] at top-level `;`, ignoring semicolons inside quotes,
+  /// comments, or parentheses, and honoring CSS `\` escapes. Each declaration
+  /// keeps its original text (including any trailing `;`). Returns `null` for
+  /// malformed CSS (unterminated quote/comment, unbalanced parenthesis, or a
+  /// trailing backslash). Single linear scan — no backtracking, so ReDoS-immune
+  /// (ADR 0069-redos-vulnerability-mitigation).
+  List<String>? _splitTopLevelDeclarations(String style) {
+    final declarations = <String>[];
+    var start = 0;
+    var inSingleQuote = false;
+    var inDoubleQuote = false;
+    var inComment = false;
+    var parenDepth = 0;
+
+    for (var i = 0; i < style.length; i++) {
+      final char = style[i];
+      final next = i + 1 < style.length ? style[i + 1] : '';
+
+      if (inComment) {
+        if (char == '*' && next == '/') {
+          inComment = false;
+          i++;
+        }
+      } else if (inSingleQuote) {
+        if (char == '\\') {
+          i++; // skip the escaped character
+        } else if (char == "'") {
+          inSingleQuote = false;
+        }
+      } else if (inDoubleQuote) {
+        if (char == '\\') {
+          i++;
+        } else if (char == '"') {
+          inDoubleQuote = false;
+        }
+      } else if (char == '\\') {
+        if (next.isEmpty) return null; // trailing backslash → fail-open
+        i++; // escaped char is literal data (e.g. `\;`), never a boundary
+      } else if (char == '/' && next == '*') {
+        inComment = true;
+        i++;
+      } else if (char == "'") {
+        inSingleQuote = true;
+      } else if (char == '"') {
+        inDoubleQuote = true;
+      } else if (char == '(') {
+        parenDepth++;
+      } else if (char == ')') {
+        if (parenDepth == 0) return null; // unbalanced
+        parenDepth--;
+      } else if (char == ';' && parenDepth == 0) {
+        declarations.add(style.substring(start, i + 1));
+        start = i + 1;
+      }
+    }
+
+    if (inSingleQuote || inDoubleQuote || inComment || parenDepth != 0) {
+      return null; // unterminated
+    }
+    if (start < style.length) declarations.add(style.substring(start));
+    return declarations;
+  }
+
+  bool _isRemovableLineHeight(String declaration) {
+    final body = declaration.endsWith(';')
+        ? declaration.substring(0, declaration.length - 1)
+        : declaration;
+    final colon = body.indexOf(':');
+    if (colon == -1) return false;
+    if (body.substring(0, colon).trim().toLowerCase() != 'line-height') {
+      return false;
+    }
+    return _isDegenerateLineHeight(body.substring(colon + 1).trim());
+  }
+
+  /// Removes a trailing `!important` and any surrounding whitespace so the
+  /// numeric pattern needs no whitespace quantifiers. Linear string ops (no
+  /// backtracking), so every valid CSS spacing is handled without a magic bound.
+  String _stripImportant(String value) {
+    const keyword = 'important';
+    if (value.length < keyword.length) return value;
+    if (value.substring(value.length - keyword.length).toLowerCase() != keyword) {
+      return value;
+    }
+    final beforeKeyword =
+        value.substring(0, value.length - keyword.length).trimRight();
+    if (!beforeKeyword.endsWith('!')) return value;
+    return beforeKeyword.substring(0, beforeKeyword.length - 1).trimRight();
+  }
+
+  bool _isDegenerateLineHeight(String value) {
+    final match = _numericValuePattern.firstMatch(_stripImportant(value));
+    if (match == null) return false;
+
+    final number = double.tryParse(match.group(1) ?? '');
+    if (number == null || !number.isFinite) return false;
+
+    switch (match.group(2)?.toLowerCase()) {
+      case '%':
+        return number <= _percentRemovalThreshold;
+      case 'px':
+      case 'pt':
+        return number <= _absoluteRemovalThreshold;
+      default: // unitless / em / rem multiplier
+        return number < _unitlessRemovalThreshold;
     }
   }
 }

--- a/core/lib/presentation/utils/html_transformer/transform_configuration.dart
+++ b/core/lib/presentation/utils/html_transformer/transform_configuration.dart
@@ -124,8 +124,18 @@ class TransformConfiguration {
        const BlockCodeTransformer(),
        SanitizeHyperLinkTagInHtmlTransformer(),
        const ImageTransformer(),
+       const NormalizeLineHeightInStyleTransformer(),
      ],
    );
+
+  /// Signature HTML inserted into the composer editor. Kept minimal — only
+  /// degenerate `line-height` values are stripped — because the inserted
+  /// signature becomes part of the email that is sent and must not be
+  /// rewritten by display-only transformers.
+  factory TransformConfiguration.forComposerSignature() =>
+      TransformConfiguration.fromDomTransformers([
+        const NormalizeLineHeightInStyleTransformer(),
+      ]);
 
   factory TransformConfiguration.forCalendarEvent() => TransformConfiguration.create(
     customTextTransformers: const [

--- a/core/test/presentation/extensions/html_document_extension_test.dart
+++ b/core/test/presentation/extensions/html_document_extension_test.dart
@@ -1,0 +1,68 @@
+import 'package:core/presentation/extensions/html_document_extension.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('HtmlDocumentExtension::toHtmlFragment test:', () {
+    test(
+      'Should return the body inner HTML\n'
+      'When the document has no <style> in <head>',
+    () {
+      const document = '<html><head></head><body><p>Alice</p></body></html>';
+
+      expect(document.toHtmlFragment(), '<p>Alice</p>');
+    });
+
+    test(
+      'Should prepend the head stylesheet to the body fragment\n'
+      'When the document carries a <style> block in <head>',
+    () {
+      const document = '<html><head><style>.sig{color:#093}</style></head>'
+          '<body><p class="sig">Alice</p></body></html>';
+
+      expect(
+        document.toHtmlFragment(),
+        '<style>.sig{color:#093}</style><p class="sig">Alice</p>',
+      );
+    });
+
+    test(
+      'Should keep every stylesheet in document order\n'
+      'When the document carries multiple <style> blocks in <head>',
+    () {
+      const document =
+          '<html><head><style>.a{}</style><style>.b{}</style></head>'
+          '<body><p>Alice</p></body></html>';
+
+      expect(
+        document.toHtmlFragment(),
+        '<style>.a{}</style><style>.b{}</style><p>Alice</p>',
+      );
+    });
+
+    test(
+      'Should return only the stylesheet\n'
+      'When the document body is empty',
+    () {
+      const document = '<html><head><style>.sig{}</style></head>'
+          '<body></body></html>';
+
+      expect(document.toHtmlFragment(), '<style>.sig{}</style>');
+    });
+
+    test(
+      'Should return the content as a body fragment\n'
+      'When the input is a bare fragment instead of a complete document',
+    () {
+      const fragment = '<p style="line-height:1.5">Alice</p>';
+
+      expect(fragment.toHtmlFragment(), fragment);
+    });
+
+    test(
+      'Should return an empty string\n'
+      'When the input is empty',
+    () {
+      expect(''.toHtmlFragment(), '');
+    });
+  });
+}

--- a/core/test/utils/normalize_line_height_in_style_transformer_test.dart
+++ b/core/test/utils/normalize_line_height_in_style_transformer_test.dart
@@ -48,8 +48,8 @@ void main() {
       );
     });
 
-    test('Should remove small unitless line-height values', () async {
-      for (final value in ['0.1', '0.9']) {
+    test('Should remove degenerate unitless line-height values', () async {
+      for (final value in ['0.1', '0.5', '0.79']) {
         final doc = await run('<p style="line-height:$value;">Hi</p>');
         expect(
           doc.querySelector('p')!.attributes.containsKey('style'),
@@ -59,29 +59,64 @@ void main() {
     });
 
     test(
-      'Should keep normal unitless and relative line-height values',
+      'Should keep tight-but-legitimate and normal relative values',
       () async {
-        for (final value in ['1', '1.5', '1.2em', '2em', '1.2rem']) {
+        // [0.8, 1) is deliberate tight typography (e.g. 90% newsletters);
+        // major clients render it as authored, so preserve for fidelity.
+        for (final value in ['0.8', '0.9', '1', '1.5', '0.8em', '0.9em', '1.2em', '2em']) {
           final doc = await run('<p style="line-height:$value;">Hi</p>');
           expect(
             doc.querySelector('p')!.attributes['style'],
             'line-height:$value;',
+            reason: 'Expected line-height $value to be preserved',
           );
         }
       },
     );
 
-    test('Should remove small percentage line-height values', () async {
-      for (final value in ['10%', '50%', '100%']) {
+    test('Should remove degenerate em values and the legacy 1em', () async {
+      // `1em` computes to the same length as the TF-3964 legacy `100%`.
+      for (final value in ['0.1em', '0.5em', '0.79em', '1em', '1.0em']) {
         final doc = await run('<p style="line-height:$value;">Hi</p>');
         expect(
           doc.querySelector('p')!.attributes.containsKey('style'),
           isFalse,
+          reason: 'Expected line-height $value to be removed',
+        );
+      }
+    });
+
+    test('Should never remove rem line-height values', () async {
+      // rem is root-relative: `0.9rem` ≈ 14.4px is fine leading for 12px
+      // text, so overlap cannot be judged from the number alone.
+      for (final value in ['0.1rem', '0.5rem', '0.9rem', '1rem', '1.2rem']) {
+        final doc = await run('<p style="line-height:$value;">Hi</p>');
+        expect(
+          doc.querySelector('p')!.attributes['style'],
+          'line-height:$value;',
+          reason: 'Expected line-height $value to be preserved',
+        );
+      }
+    });
+
+    test('Should remove degenerate percentages and the legacy 100%', () async {
+      for (final value in ['10%', '50%', '79%', '100%']) {
+        final doc = await run('<p style="line-height:$value;">Hi</p>');
+        expect(
+          doc.querySelector('p')!.attributes.containsKey('style'),
+          isFalse,
+          reason: 'Expected line-height $value to be removed',
         );
       }
 
-      final doc = await run('<p style="line-height:150%;">Hi</p>');
-      expect(doc.querySelector('p')!.attributes['style'], 'line-height:150%;');
+      for (final value in ['80%', '90%', '99.9%', '150%']) {
+        final doc = await run('<p style="line-height:$value;">Hi</p>');
+        expect(
+          doc.querySelector('p')!.attributes['style'],
+          'line-height:$value;',
+          reason: 'Expected line-height $value to be preserved',
+        );
+      }
     });
 
     test(
@@ -106,7 +141,17 @@ void main() {
     );
 
     test('Should enforce exact line-height removal boundaries', () async {
-      for (final value in ['.99', '+0.1', '0.99em', '1.0px', '0.5pt']) {
+      for (final value in [
+        '.79',
+        '+0.1',
+        '0.79em',
+        '1em',
+        '1.0em',
+        '100%',
+        '100.0%',
+        '1.0px',
+        '0.5pt',
+      ]) {
         final doc = await run('<p style="line-height:$value;">Hi</p>');
         expect(
           doc.querySelector('p')!.attributes.containsKey('style'),
@@ -116,12 +161,20 @@ void main() {
       }
 
       for (final value in [
+        '0.8',
+        '.99',
         '1',
         '1.0',
         '1.01',
-        '1.0em',
+        '0.8em',
+        '0.99em',
+        '1.01em',
+        '0.79rem',
+        '1rem',
         '1.01px',
         '2pt',
+        '80%',
+        '99.99%',
         '100.01%',
         '-0.1',
         '1e-1',
@@ -269,6 +322,25 @@ void main() {
         doc.querySelector('p')!.attributes['style'],
         'background-image:url("data:image/svg+xml;a;b"); color:red;',
       );
+    });
+
+    test('Should treat /* inside url() as data, not a comment', () async {
+      // An unquoted URL containing `/*` must not fail-open the whole
+      // attribute, otherwise the degenerate line-height would survive
+      // (TF-3964 regression).
+      final doc = await run(
+        "<p style='background:url(https://example.com/a/*/b.png); line-height:1px; color:red;'>Hi</p>",
+      );
+      expect(
+        doc.querySelector('p')!.attributes['style'],
+        'background:url(https://example.com/a/*/b.png); color:red;',
+      );
+    });
+
+    test('Should still fail-open on a top-level unterminated comment', () async {
+      const style = 'line-height:1px; color:red; /* unclosed';
+      final doc = await run("<p style='$style'>Hi</p>");
+      expect(doc.querySelector('p')!.attributes['style'], style);
     });
 
     test('Should respect escaped quotes while removing line-height', () async {

--- a/core/test/utils/normalize_line_height_in_style_transformer_test.dart
+++ b/core/test/utils/normalize_line_height_in_style_transformer_test.dart
@@ -31,6 +31,13 @@ void main() {
       expect(doc.querySelector('p')!.attributes['style'], 'font-size:14px;');
     });
 
+    test('Should remove line-height regardless of property casing', () async {
+      for (final property in ['LINE-HEIGHT', 'Line-Height', 'lInE-hEiGhT']) {
+        final doc = await run('<p style="$property:1px; color:red;">Hi</p>');
+        expect(doc.querySelector('p')!.attributes['style'], 'color:red;');
+      }
+    });
+
     test('Should keeps other line-height values', () async {
       final doc = await run(
         '<p style="line-height:150%; font-weight:bold;">Hi</p>',
@@ -41,14 +48,264 @@ void main() {
       );
     });
 
-    test('Should removes style attribute if only line-height existed',
-        () async {
-      final doc = await run('<div style="line-height:1px;"></div>');
+    test('Should remove small unitless line-height values', () async {
+      for (final value in ['0.1', '0.9']) {
+        final doc = await run('<p style="line-height:$value;">Hi</p>');
+        expect(
+          doc.querySelector('p')!.attributes.containsKey('style'),
+          isFalse,
+        );
+      }
+    });
+
+    test(
+      'Should keep normal unitless and relative line-height values',
+      () async {
+        for (final value in ['1', '1.5', '1.2em', '2em', '1.2rem']) {
+          final doc = await run('<p style="line-height:$value;">Hi</p>');
+          expect(
+            doc.querySelector('p')!.attributes['style'],
+            'line-height:$value;',
+          );
+        }
+      },
+    );
+
+    test('Should remove small percentage line-height values', () async {
+      for (final value in ['10%', '50%', '100%']) {
+        final doc = await run('<p style="line-height:$value;">Hi</p>');
+        expect(
+          doc.querySelector('p')!.attributes.containsKey('style'),
+          isFalse,
+        );
+      }
+
+      final doc = await run('<p style="line-height:150%;">Hi</p>');
+      expect(doc.querySelector('p')!.attributes['style'], 'line-height:150%;');
+    });
+
+    test(
+      'Should remove small absolute line-height values and keep larger ones',
+      () async {
+        for (final value in ['0px', '1px', '1pt']) {
+          final doc = await run('<p style="line-height:$value;">Hi</p>');
+          expect(
+            doc.querySelector('p')!.attributes.containsKey('style'),
+            isFalse,
+          );
+        }
+
+        for (final value in ['2px', '14px', '2pt']) {
+          final doc = await run('<p style="line-height:$value;">Hi</p>');
+          expect(
+            doc.querySelector('p')!.attributes['style'],
+            'line-height:$value;',
+          );
+        }
+      },
+    );
+
+    test('Should enforce exact line-height removal boundaries', () async {
+      for (final value in ['0', '.99', '+0.1', '0.99em', '1.0px', '0.5pt']) {
+        final doc = await run('<p style="line-height:$value;">Hi</p>');
+        expect(
+          doc.querySelector('p')!.attributes.containsKey('style'),
+          isFalse,
+          reason: 'Expected line-height $value to be removed',
+        );
+      }
+
+      for (final value in [
+        '1',
+        '1.0',
+        '1.01',
+        '1.0em',
+        '1.01px',
+        '2pt',
+        '100.01%',
+        '-0.1',
+        '1e-1',
+      ]) {
+        final doc = await run('<p style="line-height:$value;">Hi</p>');
+        expect(
+          doc.querySelector('p')!.attributes['style'],
+          'line-height:$value;',
+          reason: 'Expected line-height $value to be preserved',
+        );
+      }
+    });
+
+    test(
+      'Should preserve keywords, invalid values, and unrelated styles',
+      () async {
+        for (final value in ['normal', 'auto', 'inherit', 'calc(1em + 2px)']) {
+          final doc = await run(
+            '<p style="color:red; line-height:$value; font-size:14px;">Hi</p>',
+          );
+          expect(
+            doc.querySelector('p')!.attributes['style'],
+            'color:red; line-height:$value; font-size:14px;',
+          );
+        }
+      },
+    );
+
+    test('Should remove a degenerate line-height with !important', () async {
+      final doc = await run(
+        '<p style="color:red; line-height:0.1 !important; font-size:14px;">Hi</p>',
+      );
       expect(
-        doc.querySelector('div')!.attributes.containsKey('style'),
-        isFalse,
+        doc.querySelector('p')!.attributes['style'],
+        'color:red; font-size:14px;',
       );
     });
+
+    test('Should remove degenerate line-height with spaced !important',
+        () async {
+      // Arbitrary whitespace around !important is valid CSS and must not defeat
+      // removal (incl. > any fixed bound, and a space after `!`).
+      for (final value in [
+        '0.1 !important',
+        '0.1 ! important',
+        '0.1${' ' * 20}!important',
+      ]) {
+        final doc = await run('<p style="line-height:$value; color:red;">Hi</p>');
+        final style = doc.querySelector('p')!.attributes['style']!;
+        expect(style, isNot(contains('line-height')), reason: 'value: $value');
+        expect(style, contains('color:red'));
+      }
+    });
+
+    test('Should handle uppercase !IMPORTANT and mixed whitespace', () async {
+      final doc = await run('''
+        <p style="color:red;\n  LiNe-HeIgHt:\t0.5EM !IMPORTANT;\n font-size:14px">Hi</p>
+      ''');
+      final style = doc.querySelector('p')!.attributes['style']!;
+      expect(style.toLowerCase(), isNot(contains('line-height')));
+      expect(style, contains('color:red;'));
+      expect(style, contains('font-size:14px'));
+    });
+
+    test('Should not modify custom properties or quoted CSS values', () async {
+      final customPropertyDoc = await run(
+        '<p style="--line-height:0.1; color:red;">Hi</p>',
+      );
+      expect(
+        customPropertyDoc.querySelector('p')!.attributes['style'],
+        '--line-height:0.1; color:red;',
+      );
+
+      final quotedValueDoc = await run(
+        '<p style=\'line-height:1.5; content:"line-height:0.1;";\'>Hi</p>',
+      );
+      expect(
+        quotedValueDoc.querySelector('p')!.attributes['style'],
+        'line-height:1.5; content:"line-height:0.1;";',
+      );
+    });
+
+    test('Should not touch ";line-height:" embedded in a quoted value',
+        () async {
+      // The semicolons are inside a quoted value, so they are not top-level
+      // declaration boundaries and the property is left intact.
+      const style = '--payload:"x; line-height:0.1; y"; color:red;';
+      final doc = await run("<p style='$style'>Hi</p>");
+      expect(doc.querySelector('p')!.attributes['style'], style);
+    });
+
+    test('Should not touch ";line-height:" inside a single-quoted value',
+        () async {
+      // Semicolons inside a single-quoted value are not top-level boundaries.
+      final doc = await run(
+        '<p style="content:\'a; line-height:0.1; b\'; color:red;">Hi</p>',
+      );
+      expect(
+        doc.querySelector('p')!.attributes['style'],
+        "content:'a; line-height:0.1; b'; color:red;",
+      );
+    });
+
+    test('Should not split on an escaped semicolon', () async {
+      // `\;` is escaped data, not a boundary, so the trailing line-height:0.1 is
+      // part of the --payload value and must be preserved.
+      const style = '--payload:x\\;line-height:0.1; color:red;';
+      final doc = await run("<p style='$style'>Hi</p>");
+      expect(doc.querySelector('p')!.attributes['style'], style);
+    });
+
+    test('Should keep malformed CSS unchanged (fail-open)', () async {
+      for (final style in [
+        'line-height:0.1; content:"unclosed', // unterminated quote
+        'line-height:0.1; /* unclosed comment', // unterminated comment
+        'line-height:0.1 /*/', // unterminated comment (/*/)
+        'line-height:0.1); color:red', // unbalanced parenthesis
+        'line-height:0.1 \\', // trailing backslash
+      ]) {
+        final doc = await run("<p style='$style'>Hi</p>");
+        expect(doc.querySelector('p')!.attributes['style'], style);
+      }
+    });
+
+    test(
+      'Should preserve unrelated whitespace when line-height is kept',
+      () async {
+        const style = 'line-height:1.5; font-family:"A  B"; content:"x  y";';
+        final doc = await run("<p style='$style'>Hi</p>");
+        expect(doc.querySelector('p')!.attributes['style'], style);
+      },
+    );
+
+    test('Should not remove line-height inside a CSS function value', () async {
+      final doc = await run(
+        '<p style=\'background-image:url("data:image/svg+xml;a;b"); line-height:0.1; color:red;\'>Hi</p>',
+      );
+      expect(
+        doc.querySelector('p')!.attributes['style'],
+        'background-image:url("data:image/svg+xml;a;b"); color:red;',
+      );
+    });
+
+    test('Should respect escaped quotes while removing line-height', () async {
+      final doc = await run(
+        r'''<p style='content:"a\";b"; line-height:0.1; color:red;'>Hi</p>''',
+      );
+      expect(
+        doc.querySelector('p')!.attributes['style'],
+        r'''content:"a\";b"; color:red;''',
+      );
+    });
+
+    test(
+      'Should fix a multi-line signature without removing inline styles',
+      () async {
+        final doc = await run('''
+          <div>
+            <p style="color:#333; font-size:14px; line-height:0.1;">Name</p>
+            <p style="color:#333; font-size:12px; line-height:0.1;">Role</p>
+          </div>
+        ''');
+
+        final paragraphs = doc.querySelectorAll('p');
+        expect(paragraphs, hasLength(2));
+        for (final paragraph in paragraphs) {
+          final style = paragraph.attributes['style']!;
+          expect(style, isNot(contains('line-height')));
+          expect(style, contains('color:#333'));
+          expect(style, contains('font-size:'));
+        }
+      },
+    );
+
+    test(
+      'Should removes style attribute if only line-height existed',
+      () async {
+        final doc = await run('<div style="line-height:1px;"></div>');
+        expect(
+          doc.querySelector('div')!.attributes.containsKey('style'),
+          isFalse,
+        );
+      },
+    );
 
     test('Should handles missing style gracefully', () async {
       final doc = await run('<span>No style here</span>');
@@ -66,6 +323,14 @@ void main() {
         doc.querySelector('p')!.attributes['style'],
         'color:blue; font-size:12px;',
       );
+    });
+
+    test('Should remove back-to-back degenerate line-heights', () async {
+      // The boundary between them must survive removal of the first.
+      final doc = await run(
+        '<p style="line-height:0.1;line-height:0.2;color:blue;"></p>',
+      );
+      expect(doc.querySelector('p')!.attributes['style'], 'color:blue;');
     });
 
     test('Should removes line-height even with irregular spacing', () async {

--- a/core/test/utils/normalize_line_height_in_style_transformer_test.dart
+++ b/core/test/utils/normalize_line_height_in_style_transformer_test.dart
@@ -87,7 +87,7 @@ void main() {
     test(
       'Should remove small absolute line-height values and keep larger ones',
       () async {
-        for (final value in ['0px', '1px', '1pt']) {
+        for (final value in ['1px', '1pt']) {
           final doc = await run('<p style="line-height:$value;">Hi</p>');
           expect(
             doc.querySelector('p')!.attributes.containsKey('style'),
@@ -106,7 +106,7 @@ void main() {
     );
 
     test('Should enforce exact line-height removal boundaries', () async {
-      for (final value in ['0', '.99', '+0.1', '0.99em', '1.0px', '0.5pt']) {
+      for (final value in ['.99', '+0.1', '0.99em', '1.0px', '0.5pt']) {
         final doc = await run('<p style="line-height:$value;">Hi</p>');
         expect(
           doc.querySelector('p')!.attributes.containsKey('style'),
@@ -125,6 +125,12 @@ void main() {
         '100.01%',
         '-0.1',
         '1e-1',
+        // Zero is the intentional image-gap/spacer trick — preserved in any unit.
+        '0',
+        '0.0',
+        '0px',
+        '0em',
+        '0%',
       ]) {
         final doc = await run('<p style="line-height:$value;">Hi</p>');
         expect(

--- a/core/test/utils/normalize_line_height_in_style_transformer_test.dart
+++ b/core/test/utils/normalize_line_height_in_style_transformer_test.dart
@@ -255,7 +255,7 @@ void main() {
       },
     );
 
-    test('Should not remove line-height inside a CSS function value', () async {
+    test('Should not split on semicolons inside a CSS function value', () async {
       final doc = await run(
         '<p style=\'background-image:url("data:image/svg+xml;a;b"); line-height:0.1; color:red;\'>Hi</p>',
       );

--- a/core/test/utils/redos_vulnerability_test.dart
+++ b/core/test/utils/redos_vulnerability_test.dart
@@ -93,91 +93,99 @@ void main() {
         mockDioClient = MockDioClient();
       });
 
-      test('should handle very long style strings efficiently', () async {
-        // Create HTML with very long style attribute
-        final longStyle = 'color: red; ' * 10000 + 'line-height: 1px;';
-        final htmlContent = '<div style="$longStyle">Content</div>';
-        final document = html_parser.parse(htmlContent);
-
+      // Runs the transformer over [html] and returns processing time plus the
+      // resulting `style` of the styled element.
+      Future<({int elapsedMs, String style})> runTransformer(String html) async {
+        final document = html_parser.parse(html);
         final stopwatch = Stopwatch()..start();
-        await transformer.process(
-          document: document,
-          dioClient: mockDioClient,
-        );
+        await transformer.process(document: document, dioClient: mockDioClient);
         stopwatch.stop();
+        final element =
+            document.querySelector('div') ?? document.querySelector('p');
+        return (
+          elapsedMs: stopwatch.elapsedMilliseconds,
+          style: element?.attributes['style'] ?? '',
+        );
+      }
 
-        expect(stopwatch.elapsedMilliseconds, lessThan(100));
+      // 500ms: catches ReDoS (which would be seconds) without CI flakiness.
+      const performanceBudgetMs = 500;
 
-        // Verify the transformer removed line-height
-        final divElement = document.querySelector('div');
-        final resultStyle = divElement?.attributes['style'] ?? '';
-        expect(resultStyle, isNot(contains('line-height')));
+      test('should handle very long style strings efficiently', () async {
+        final longStyle = 'color: red; ' * 10000 + 'line-height: 1px;';
+        final result = await runTransformer('<div style="$longStyle">x</div>');
+
+        expect(result.elapsedMs, lessThan(performanceBudgetMs));
+        expect(result.style, isNot(contains('line-height')));
       });
 
       test('should handle many consecutive spaces efficiently', () async {
-        // Create HTML with many spaces in style that includes line-height
         final manySpaces = 'color:${' ' * 10000}red; line-height: 1px;';
-        final htmlContent = '<p style="$manySpaces">Text</p>';
-        final document = html_parser.parse(htmlContent);
+        final result = await runTransformer('<p style="$manySpaces">x</p>');
 
-        final stopwatch = Stopwatch()..start();
-        await transformer.process(
-          document: document,
-          dioClient: mockDioClient,
-        );
-        stopwatch.stop();
-
-        expect(stopwatch.elapsedMilliseconds, lessThan(100));
-
-        // After removing line-height, spaces should be normalized
-        final pElement = document.querySelector('p');
-        final resultStyle = pElement?.attributes['style'] ?? '';
-        expect(resultStyle, isNot(contains('line-height')));
-        // Multiple consecutive spaces should be normalized to single space
-        expect(resultStyle, isNot(matches(r' {2,}')));
+        expect(result.elapsedMs, lessThan(performanceBudgetMs));
+        // Unrelated spaces in the color value are preserved (not collapsed).
+        expect(result.style, isNot(contains('line-height')));
+        expect(result.style, contains('color:${' ' * 10000}red'));
       });
 
+      test('should not backtrack on a very long numeric line-height', () async {
+        // A huge digit run with an invalid tail must not backtrack in the
+        // anchored, bounded _numericValuePattern.
+        final result = await runTransformer(
+          '<p style="line-height:${'9' * 50000}x; color:red;">x</p>',
+        );
+
+        expect(result.elapsedMs, lessThan(performanceBudgetMs));
+        // Non-matching value is left intact (not stripped or corrupted).
+        expect(result.style, contains('line-height'));
+        expect(result.style, contains('color:red'));
+      });
+
+      test('should not backtrack on a moderate numeric line-height', () async {
+        final result = await runTransformer(
+          '<p style="line-height:${'9' * 120}x; color:red;">x</p>',
+        );
+
+        expect(result.elapsedMs, lessThan(performanceBudgetMs));
+        expect(result.style, contains('line-height'));
+        expect(result.style, contains('color:red'));
+      });
+
+      test('should not backtrack on whitespace in a numeric line-height', () async {
+        // Spaces between the number and an invalid tail must not backtrack in
+        // the value pattern's optional !important group.
+        final result = await runTransformer(
+          '<p style="line-height:1${' ' * 50000}x; color:red;">x</p>',
+        );
+
+        expect(result.elapsedMs, lessThan(performanceBudgetMs));
+        expect(result.style, contains('line-height'));
+        expect(result.style, contains('color:red'));
+      });
+
+      Future<void> expectStyles(List<String> styles, Matcher styleMatcher) async {
+        for (final html in styles) {
+          final result = await runTransformer(html);
+          expect(result.style, styleMatcher, reason: 'from: $html');
+        }
+      }
+
       test('should remove line-height: 1px and 100% patterns', () async {
-        final testCases = [
+        await expectStyles(const [
           '<div style="line-height: 1px; color: blue;">Test 1px</div>',
           '<div style="line-height: 100%; color: red;">Test 100%</div>',
           '<div style="line-height:1px">No spaces</div>',
           '<div style="LINE-HEIGHT: 1PX;">Case insensitive</div>',
-        ];
-
-        for (final htmlContent in testCases) {
-          final document = html_parser.parse(htmlContent);
-          await transformer.process(
-            document: document,
-            dioClient: mockDioClient,
-          );
-
-          final divElement = document.querySelector('div');
-          final resultStyle = divElement?.attributes['style'] ?? '';
-          expect(resultStyle, isNot(contains('line-height')),
-              reason: 'Should remove line-height from: $htmlContent');
-        }
+        ], isNot(contains('line-height')));
       });
 
       test('should preserve other line-height values', () async {
-        final testCases = [
+        await expectStyles(const [
           '<div style="line-height: 1.5; color: blue;">Test 1.5</div>',
           '<div style="line-height: 20px; color: red;">Test 20px</div>',
           '<div style="line-height: normal;">Test normal</div>',
-        ];
-
-        for (final htmlContent in testCases) {
-          final document = html_parser.parse(htmlContent);
-          await transformer.process(
-            document: document,
-            dioClient: mockDioClient,
-          );
-
-          final divElement = document.querySelector('div');
-          final resultStyle = divElement?.attributes['style'] ?? '';
-          expect(resultStyle, contains('line-height'),
-              reason: 'Should preserve line-height from: $htmlContent');
-        }
+        ], contains('line-height'));
       });
 
       test('should remove style attribute when empty after transformation', () async {
@@ -194,7 +202,7 @@ void main() {
             reason: 'Should remove empty style attribute');
       });
 
-      test('should normalize multiple spaces after removing line-height', () async {
+      test('should preserve unrelated declarations after removing line-height', () async {
         const htmlContent = '<div style="color: red;   line-height: 1px;   font-size: 12px;">Multi-space</div>';
         final document = html_parser.parse(htmlContent);
 
@@ -205,7 +213,7 @@ void main() {
 
         final divElement = document.querySelector('div');
         final resultStyle = divElement?.attributes['style'] ?? '';
-        expect(resultStyle, isNot(contains('  '))); // No double spaces
+        expect(resultStyle, isNot(contains('line-height')));
         expect(resultStyle, contains('color: red'));
         expect(resultStyle, contains('font-size: 12px'));
       });
@@ -623,31 +631,28 @@ void main() {
         expect(result, isTrue);
       });
 
+      void expectLocalhost(List<String> emails, Matcher matcher) {
+        for (final email in emails) {
+          expect(StringConvert.isEmailLocalhost(email), matcher,
+              reason: 'email: $email');
+        }
+      }
+
       test('should correctly match valid localhost emails', () {
-        const validEmails = [
+        expectLocalhost(const [
           'user@localhost',
           'user.name@localhost',
           '"User Name"@localhost',
-        ];
-
-        for (final email in validEmails) {
-          expect(StringConvert.isEmailLocalhost(email), isTrue,
-              reason: 'Should match: $email');
-        }
+        ], isTrue);
       });
 
       test('should reject invalid localhost emails', () {
-        const invalidEmails = [
+        expectLocalhost(const [
           'user@localhost.com',
           '@localhost',
           'user@',
           'not-an-email',
-        ];
-
-        for (final email in invalidEmails) {
-          expect(StringConvert.isEmailLocalhost(email), isFalse,
-              reason: 'Should not match: $email');
-        }
+        ], isFalse);
       });
     });
 
@@ -706,10 +711,10 @@ void main() {
             reason: 'backgroundImageRegex should be static and reused');
 
         // NormalizeLineHeightInStyleTransformer patterns
-        final lineHeight1 = NormalizeLineHeightInStyleTransformer.lineHeightPattern;
-        final lineHeight2 = NormalizeLineHeightInStyleTransformer.lineHeightPattern;
-        expect(identical(lineHeight1, lineHeight2), true,
-            reason: 'lineHeightPattern should be static and reused');
+        final numericValue1 = NormalizeLineHeightInStyleTransformer.numericValuePattern;
+        final numericValue2 = NormalizeLineHeightInStyleTransformer.numericValuePattern;
+        expect(identical(numericValue1, numericValue2), true,
+            reason: 'numericValuePattern should be static and reused');
 
         // HtmlUtils patterns
         final htmlStartTag1 = HtmlUtils.htmlStartTagRegex;

--- a/core/test/utils/redos_vulnerability_test.dart
+++ b/core/test/utils/redos_vulnerability_test.dart
@@ -10,6 +10,24 @@ import 'package:mockito/mockito.dart';
 
 class MockDioClient extends Mock implements DioClient {}
 
+/// Runs [action], asserts it completes within [budgetMs] milliseconds, and
+/// returns its result. Centralizes the stopwatch + elapsed-time assertion that
+/// every ReDoS performance test shares, so the timing criterion lives in one
+/// place instead of being duplicated per test.
+T expectFastResult<T>(
+  T Function() action, {
+  int budgetMs = 100,
+  String? reason,
+}) {
+  final stopwatch = Stopwatch()..start();
+  try {
+    return action();
+  } finally {
+    stopwatch.stop();
+    expect(stopwatch.elapsedMilliseconds, lessThan(budgetMs), reason: reason);
+  }
+}
+
 /// Tests to verify that ReDoS (Regular Expression Denial of Service) vulnerabilities
 /// have been properly patched. These tests use inputs that would cause catastrophic
 /// backtracking in the old regex patterns.
@@ -23,13 +41,11 @@ void main() {
         // in the old pattern: r'background-image:\s*url\(([^)]+)\).*?'
         final maliciousStyle = 'background-image: url(${'a' * 10000})';
 
-        final stopwatch = Stopwatch()..start();
-        final result = transformer.findImageUrlFromStyleTag(maliciousStyle);
-        stopwatch.stop();
+        final result = expectFastResult(
+          () => transformer.findImageUrlFromStyleTag(maliciousStyle),
+          reason: 'Regex should not cause catastrophic backtracking',
+        );
 
-        // Should complete within a reasonable time (< 100ms)
-        expect(stopwatch.elapsedMilliseconds, lessThan(100),
-            reason: 'Regex should not cause catastrophic backtracking');
         expect(result, isNotNull);
       });
 
@@ -43,13 +59,10 @@ void main() {
         // resilience over strict validation.
         final style = 'background-image: url(${'(' * 1000}example.jpg${')' * 1000})';
 
-        final stopwatch = Stopwatch()..start();
-        final result = transformer.findImageUrlFromStyleTag(style);
-        stopwatch.stop();
-
-        // Performance: Should complete quickly without catastrophic backtracking
-        expect(stopwatch.elapsedMilliseconds, lessThan(100),
-            reason: 'Should process quickly despite nested parentheses');
+        final result = expectFastResult(
+          () => transformer.findImageUrlFromStyleTag(style),
+          reason: 'Should process quickly despite nested parentheses',
+        );
 
         // Functional: Current implementation extracts URL despite malformed nesting
         expect(result, isNotNull,
@@ -60,11 +73,10 @@ void main() {
         // Input with many whitespace and incomplete patterns
         final maliciousInput = 'background-image:${' ' * 10000}url(';
 
-        final stopwatch = Stopwatch()..start();
-        final result = transformer.findImageUrlFromStyleTag(maliciousInput);
-        stopwatch.stop();
+        final result = expectFastResult(
+          () => transformer.findImageUrlFromStyleTag(maliciousInput),
+        );
 
-        expect(stopwatch.elapsedMilliseconds, lessThan(100));
         expect(result, isNull);
       });
 
@@ -102,14 +114,23 @@ void main() {
         stopwatch.stop();
         final element =
             document.querySelector('div') ?? document.querySelector('p');
+        expect(element, isNotNull, reason: 'No styled element found in: $html');
         return (
           elapsedMs: stopwatch.elapsedMilliseconds,
-          style: element?.attributes['style'] ?? '',
+          style: element!.attributes['style'] ?? '',
         );
       }
 
       // 500ms: catches ReDoS (which would be seconds) without CI flakiness.
       const performanceBudgetMs = 500;
+
+      // Asserts a numeric line-height with an invalid tail is processed within
+      // budget and left intact alongside its sibling `color:red` declaration.
+      void expectLineHeightPreserved(({int elapsedMs, String style}) result) {
+        expect(result.elapsedMs, lessThan(performanceBudgetMs));
+        expect(result.style, contains('line-height'));
+        expect(result.style, contains('color:red'));
+      }
 
       test('should handle very long style strings efficiently', () async {
         final longStyle = 'color: red; ' * 10000 + 'line-height: 1px;';
@@ -136,10 +157,8 @@ void main() {
           '<p style="line-height:${'9' * 50000}x; color:red;">x</p>',
         );
 
-        expect(result.elapsedMs, lessThan(performanceBudgetMs));
         // Non-matching value is left intact (not stripped or corrupted).
-        expect(result.style, contains('line-height'));
-        expect(result.style, contains('color:red'));
+        expectLineHeightPreserved(result);
       });
 
       test('should not backtrack on a moderate numeric line-height', () async {
@@ -147,21 +166,17 @@ void main() {
           '<p style="line-height:${'9' * 120}x; color:red;">x</p>',
         );
 
-        expect(result.elapsedMs, lessThan(performanceBudgetMs));
-        expect(result.style, contains('line-height'));
-        expect(result.style, contains('color:red'));
+        expectLineHeightPreserved(result);
       });
 
       test('should not backtrack on whitespace in a numeric line-height', () async {
         // Spaces between the number and an invalid tail must not backtrack in
-        // the value pattern's optional !important group.
+        // the anchored, bounded numeric value pattern.
         final result = await runTransformer(
           '<p style="line-height:1${' ' * 50000}x; color:red;">x</p>',
         );
 
-        expect(result.elapsedMs, lessThan(performanceBudgetMs));
-        expect(result.style, contains('line-height'));
-        expect(result.style, contains('color:red'));
+        expectLineHeightPreserved(result);
       });
 
       Future<void> expectStyles(List<String> styles, Matcher styleMatcher) async {
@@ -224,11 +239,7 @@ void main() {
         // Old pattern: r'<[a-zA-Z][^>]*>' could cause issues with many attributes
         final maliciousTag = '<div${'a' * 10000}>';
 
-        final stopwatch = Stopwatch()..start();
-        HtmlUtils.addQuoteToggle(maliciousTag);
-        stopwatch.stop();
-
-        expect(stopwatch.elapsedMilliseconds, lessThan(100));
+        expectFastResult(() => HtmlUtils.addQuoteToggle(maliciousTag));
       });
 
       test('_htmlEndTagRegex should have bounded quantifier', () {
@@ -236,11 +247,7 @@ void main() {
         // New pattern has max 128 chars: r'</[a-zA-Z][^>]{0,128}>'
         final longEndTag = '</div${'x' * 200}>';
 
-        final stopwatch = Stopwatch()..start();
-        HtmlUtils.addQuoteToggle(longEndTag);
-        stopwatch.stop();
-
-        expect(stopwatch.elapsedMilliseconds, lessThan(100));
+        expectFastResult(() => HtmlUtils.addQuoteToggle(longEndTag));
       });
 
       test('_urlRegex should handle long URLs efficiently', () {
@@ -248,11 +255,10 @@ void main() {
         // had potential for catastrophic backtracking
         final longUrl = 'https://${'a' * 10000}.com${'b' * 10000}';
 
-        final stopwatch = Stopwatch()..start();
-        HtmlUtils.wrapPlainTextLinks('<p>$longUrl</p>');
-        stopwatch.stop();
-
-        expect(stopwatch.elapsedMilliseconds, lessThan(200));
+        expectFastResult(
+          () => HtmlUtils.wrapPlainTextLinks('<p>$longUrl</p>'),
+          budgetMs: 200,
+        );
       });
 
       test('_urlRegex should correctly match valid URLs', () {
@@ -281,12 +287,10 @@ void main() {
 
         for (final url in malformedUrls) {
           final html = '<p>Visit $url today</p>';
-          final stopwatch = Stopwatch()..start();
-          HtmlUtils.wrapPlainTextLinks(html);
-          stopwatch.stop();
-
-          expect(stopwatch.elapsedMilliseconds, lessThan(100),
-              reason: 'Should process quickly: $url');
+          expectFastResult(
+            () => HtmlUtils.wrapPlainTextLinks(html),
+            reason: 'Should process quickly: $url',
+          );
         }
       });
 
@@ -294,11 +298,11 @@ void main() {
         // Test that escaped tag processing doesn't cause issues
         final longHtml = '${'&lt;div&gt;' * 1000}content${'&lt;/div&gt;' * 1000}';
 
-        final stopwatch = Stopwatch()..start();
-        final result = HtmlUtils.extractPlainText(longHtml);
-        stopwatch.stop();
+        final result = expectFastResult(
+          () => HtmlUtils.extractPlainText(longHtml),
+          budgetMs: 500,
+        );
 
-        expect(stopwatch.elapsedMilliseconds, lessThan(500));
         expect(result, contains('content'));
       });
 
@@ -317,19 +321,16 @@ void main() {
         </div>
     ''';
 
-        final stopwatch = Stopwatch()..start();
-
-        // Extract plain text
-        final plainText = HtmlUtils.extractPlainText(gmailHtml);
-
-        // Wrap URLs
-        final linkedHtml = HtmlUtils.wrapPlainTextLinks(gmailHtml);
-
-        stopwatch.stop();
-
-        // Performance check
-        expect(stopwatch.elapsedMilliseconds, lessThan(200),
-            reason: 'Gmail HTML processing should be fast');
+        final (:plainText, :linkedHtml) = expectFastResult(
+          () => (
+            // Extract plain text
+            plainText: HtmlUtils.extractPlainText(gmailHtml),
+            // Wrap URLs
+            linkedHtml: HtmlUtils.wrapPlainTextLinks(gmailHtml),
+          ),
+          budgetMs: 200,
+          reason: 'Gmail HTML processing should be fast',
+        );
 
         // Functional check
         expect(plainText, contains('Hello User'));
@@ -356,13 +357,10 @@ void main() {
         for (final url in complexUrls) {
           final html = '<p>Visit $url for details</p>';
 
-          final stopwatch = Stopwatch()..start();
-          final result = HtmlUtils.wrapPlainTextLinks(html);
-          stopwatch.stop();
-
-          // Performance check
-          expect(stopwatch.elapsedMilliseconds, lessThan(100),
-              reason: 'Should process quickly: $url');
+          final result = expectFastResult(
+            () => HtmlUtils.wrapPlainTextLinks(html),
+            reason: 'Should process quickly: $url',
+          );
 
           // Functional check
           expect(result, contains('<a href='),
@@ -381,24 +379,12 @@ void main() {
         // Very long (1000 chars - malicious)
         final malicious = '</div${'x' * 995}>';
 
-        final stopwatch1 = Stopwatch()..start();
-        HtmlUtils.addQuoteToggle('Text $exactly128 end');
-        stopwatch1.stop();
-
-        final stopwatch2 = Stopwatch()..start();
-        HtmlUtils.addQuoteToggle('Text $over128 end');
-        stopwatch2.stop();
-
-        final stopwatch3 = Stopwatch()..start();
-        HtmlUtils.addQuoteToggle('Text $malicious end');
-        stopwatch3.stop();
-
         // All should complete quickly (bounded quantifier prevents backtracking)
-        expect(stopwatch1.elapsedMilliseconds, lessThan(100),
+        expectFastResult(() => HtmlUtils.addQuoteToggle('Text $exactly128 end'),
             reason: '128 chars (boundary) should be fast');
-        expect(stopwatch2.elapsedMilliseconds, lessThan(100),
+        expectFastResult(() => HtmlUtils.addQuoteToggle('Text $over128 end'),
             reason: '129 chars (over boundary) should be fast');
-        expect(stopwatch3.elapsedMilliseconds, lessThan(100),
+        expectFastResult(() => HtmlUtils.addQuoteToggle('Text $malicious end'),
             reason: '1000 chars (malicious) should be fast');
       });
 
@@ -409,25 +395,27 @@ void main() {
         // 100 levels (extreme)
         final extremeNesting = '${'<span>' * 100}Content${'</span>' * 100}';
 
-        final stopwatch1 = Stopwatch()..start();
-        final plainText1 = HtmlUtils.extractPlainText(deepNesting);
-        final linked1 = HtmlUtils.wrapPlainTextLinks(deepNesting);
-        stopwatch1.stop();
+        final (:plainText, :linked) = expectFastResult(
+          () => (
+            plainText: HtmlUtils.extractPlainText(deepNesting),
+            linked: HtmlUtils.wrapPlainTextLinks(deepNesting),
+          ),
+          budgetMs: 200,
+          reason: '50 levels of nesting should process quickly',
+        );
 
-        final stopwatch2 = Stopwatch()..start();
-        final plainText2 = HtmlUtils.extractPlainText(extremeNesting);
-        final linked2 = HtmlUtils.wrapPlainTextLinks(extremeNesting);
-        stopwatch2.stop();
-
-        // Performance checks
-        expect(stopwatch1.elapsedMilliseconds, lessThan(200),
-            reason: '50 levels of nesting should process quickly');
-        expect(stopwatch2.elapsedMilliseconds, lessThan(300),
-            reason: '100 levels of nesting should process quickly');
+        final (plainText: plainText2, linked: linked2) = expectFastResult(
+          () => (
+            plainText: HtmlUtils.extractPlainText(extremeNesting),
+            linked: HtmlUtils.wrapPlainTextLinks(extremeNesting),
+          ),
+          budgetMs: 300,
+          reason: '100 levels of nesting should process quickly',
+        );
 
         // Functional checks
-        expect(plainText1, contains('Deep content'));
-        expect(linked1, contains('<a href='));
+        expect(plainText, contains('Deep content'));
+        expect(linked, contains('<a href='));
         expect(plainText2, contains('Content'));
 
         // Verify extreme nesting doesn't break link wrapping
@@ -441,11 +429,7 @@ void main() {
         // Test with a very long string that looks like base64 but isn't
         final longInvalidBase64 = 'A' * 10000 + '!'; // Not valid base64
 
-        final stopwatch = Stopwatch()..start();
-        StringConvert.extractEmailAddress(longInvalidBase64);
-        stopwatch.stop();
-
-        expect(stopwatch.elapsedMilliseconds, lessThan(100));
+        expectFastResult(() => StringConvert.extractEmailAddress(longInvalidBase64));
       });
 
       test('_mdSeparatorRegex should handle malicious markdown separators', () {
@@ -453,21 +437,15 @@ void main() {
         // Could cause issues with many repeating patterns
         final maliciousMarkdown = '|${':---:' * 1000}|';
 
-        final stopwatch = Stopwatch()..start();
-        StringConvert.isTextTable('$maliciousMarkdown\n$maliciousMarkdown');
-        stopwatch.stop();
-
-        expect(stopwatch.elapsedMilliseconds, lessThan(100));
+        expectFastResult(
+          () => StringConvert.isTextTable('$maliciousMarkdown\n$maliciousMarkdown'),
+        );
       });
 
       test('_asciiArtRegex should efficiently check long text', () {
         final longText = 'a' * 10000 + '+';
 
-        final stopwatch = Stopwatch()..start();
-        StringConvert.isTextTable('$longText\n$longText');
-        stopwatch.stop();
-
-        expect(stopwatch.elapsedMilliseconds, lessThan(100));
+        expectFastResult(() => StringConvert.isTextTable('$longText\n$longText'));
       });
 
       test('_namedAddressRegex should handle many quoted addresses', () {
@@ -477,11 +455,11 @@ void main() {
           (i) => '"User $i" <user$i@example.com>',
         ).join(', ');
 
-        final stopwatch = Stopwatch()..start();
-        final result = StringConvert.extractNamedAddresses(manyAddresses);
-        stopwatch.stop();
+        final result = expectFastResult(
+          () => StringConvert.extractNamedAddresses(manyAddresses),
+          budgetMs: 500,
+        );
 
-        expect(stopwatch.elapsedMilliseconds, lessThan(500));
         expect(result.length, equals(1000));
       });
 
@@ -489,11 +467,10 @@ void main() {
         // Old pattern could have issues with many mixed separators
         final maliciousInput = 'email@test.com${', ; ' * 10000}another@test.com';
 
-        final stopwatch = Stopwatch()..start();
-        final result = StringConvert.extractEmailAddress(maliciousInput);
-        stopwatch.stop();
+        final result = expectFastResult(
+          () => StringConvert.extractEmailAddress(maliciousInput),
+        );
 
-        expect(stopwatch.elapsedMilliseconds, lessThan(100));
         expect(result, contains('email@test.com'));
         expect(result, contains('another@test.com'));
       });
@@ -520,12 +497,10 @@ void main() {
           final input = entry.key;
           final expectedEmail = entry.value;
 
-          final stopwatch = Stopwatch()..start();
-          final result = StringConvert.extractEmailAddress(input);
-          stopwatch.stop();
-
-          expect(stopwatch.elapsedMilliseconds, lessThan(100),
-              reason: 'Should process quickly: $input');
+          final result = expectFastResult(
+            () => StringConvert.extractEmailAddress(input),
+            reason: 'Should process quickly: $input',
+          );
 
           expect(result, contains(expectedEmail),
               reason: 'Should extract "$expectedEmail" from: $input');
@@ -540,13 +515,10 @@ void main() {
         ];
 
         for (final input in quotedEmails) {
-          final stopwatch = Stopwatch()..start();
-          final result = StringConvert.extractEmailAddress(input);
-          stopwatch.stop();
-
-          // Performance check
-          expect(stopwatch.elapsedMilliseconds, lessThan(100),
-              reason: 'Should process quickly: $input');
+          final result = expectFastResult(
+            () => StringConvert.extractEmailAddress(input),
+            reason: 'Should process quickly: $input',
+          );
 
           // Should extract something (even if split) - no crash
           expect(result, isA<List<String>>(),
@@ -570,13 +542,10 @@ void main() {
         ];
 
         for (final input in edgeCaseInputs) {
-          final stopwatch = Stopwatch()..start();
-          final result = StringConvert.extractEmailAddress(input);
-          stopwatch.stop();
-
-          // Performance check - should handle gracefully without hanging
-          expect(stopwatch.elapsedMilliseconds, lessThan(100),
-              reason: 'Should process quickly even for invalid: $input');
+          final result = expectFastResult(
+            () => StringConvert.extractEmailAddress(input),
+            reason: 'Should process quickly even for invalid: $input',
+          );
 
           // Result should be a list (even if empty) - no crash
           expect(result, isA<List<String>>(),
@@ -623,11 +592,10 @@ void main() {
       test('should handle very long email addresses efficiently', () {
         final longEmail = '${'a' * 10000}@localhost';
 
-        final stopwatch = Stopwatch()..start();
-        final result = StringConvert.isEmailLocalhost(longEmail);
-        stopwatch.stop();
+        final result = expectFastResult(
+          () => StringConvert.isEmailLocalhost(longEmail),
+        );
 
-        expect(stopwatch.elapsedMilliseconds, lessThan(100));
         expect(result, isTrue);
       });
 
@@ -669,21 +637,20 @@ void main() {
         ];
 
         for (final input in edgeCases) {
-          final stopwatch = Stopwatch()..start();
-
-          // Test various functions with edge case input
-          try {
-            StringConvert.extractEmailAddress(input);
-            StringConvert.isTextTable('$input\n$input');
-            HtmlUtils.extractPlainText(input);
-          } catch (_) {
-            // Intentionally ignored - focus is on performance, not correctness
-          }
-
-          stopwatch.stop();
-
-          expect(stopwatch.elapsedMilliseconds, lessThan(1000),
-              reason: 'Should process edge case within 1 second');
+          expectFastResult(
+            () {
+              // Test various functions with edge case input
+              try {
+                StringConvert.extractEmailAddress(input);
+                StringConvert.isTextTable('$input\n$input');
+                HtmlUtils.extractPlainText(input);
+              } catch (_) {
+                // Intentionally ignored - focus is on performance, not correctness
+              }
+            },
+            budgetMs: 1000,
+            reason: 'Should process edge case within 1 second',
+          );
         }
       });
     });

--- a/core/test/utils/redos_vulnerability_test.dart
+++ b/core/test/utils/redos_vulnerability_test.dart
@@ -20,12 +20,16 @@ T expectFastResult<T>(
   String? reason,
 }) {
   final stopwatch = Stopwatch()..start();
+  late final T result;
   try {
-    return action();
+    result = action();
   } finally {
     stopwatch.stop();
-    expect(stopwatch.elapsedMilliseconds, lessThan(budgetMs), reason: reason);
   }
+  // Assert the budget only after a successful return so a throwing [action]
+  // surfaces its own exception instead of the timing matcher's failure.
+  expect(stopwatch.elapsedMilliseconds, lessThan(budgetMs), reason: reason);
+  return result;
 }
 
 /// Tests to verify that ReDoS (Regular Expression Denial of Service) vulnerabilities
@@ -121,14 +125,21 @@ void main() {
         );
       }
 
-      // 500ms: catches ReDoS (which would be seconds) without CI flakiness.
-      const performanceBudgetMs = 500;
+      // 100ms: matches the other ReDoS budgets. These inputs measure single-digit
+      // milliseconds here, so a real perf regression stays visible; a ReDoS would
+      // blow past this by orders of magnitude (seconds).
+      const performanceBudgetMs = 100;
 
       // Asserts a numeric line-height with an invalid tail is processed within
-      // budget and left intact alongside its sibling `color:red` declaration.
-      void expectLineHeightPreserved(({int elapsedMs, String style}) result) {
+      // budget and left byte-for-byte intact (a regression that rewrote or
+      // truncated the value would still contain 'line-height', so compare the
+      // exact declaration) alongside its sibling `color:red` declaration.
+      void expectLineHeightPreserved(
+        ({int elapsedMs, String style}) result,
+        String expectedLineHeight,
+      ) {
         expect(result.elapsedMs, lessThan(performanceBudgetMs));
-        expect(result.style, contains('line-height'));
+        expect(result.style, contains(expectedLineHeight));
         expect(result.style, contains('color:red'));
       }
 
@@ -153,30 +164,33 @@ void main() {
       test('should not backtrack on a very long numeric line-height', () async {
         // A huge digit run with an invalid tail must not backtrack in the
         // anchored, bounded _numericValuePattern.
+        final lineHeight = 'line-height:${'9' * 50000}x';
         final result = await runTransformer(
-          '<p style="line-height:${'9' * 50000}x; color:red;">x</p>',
+          '<p style="$lineHeight; color:red;">x</p>',
         );
 
         // Non-matching value is left intact (not stripped or corrupted).
-        expectLineHeightPreserved(result);
+        expectLineHeightPreserved(result, lineHeight);
       });
 
       test('should not backtrack on a moderate numeric line-height', () async {
+        final lineHeight = 'line-height:${'9' * 120}x';
         final result = await runTransformer(
-          '<p style="line-height:${'9' * 120}x; color:red;">x</p>',
+          '<p style="$lineHeight; color:red;">x</p>',
         );
 
-        expectLineHeightPreserved(result);
+        expectLineHeightPreserved(result, lineHeight);
       });
 
       test('should not backtrack on whitespace in a numeric line-height', () async {
         // Spaces between the number and an invalid tail must not backtrack in
         // the anchored, bounded numeric value pattern.
+        final lineHeight = 'line-height:1${' ' * 50000}x';
         final result = await runTransformer(
-          '<p style="line-height:1${' ' * 50000}x; color:red;">x</p>',
+          '<p style="$lineHeight; color:red;">x</p>',
         );
 
-        expectLineHeightPreserved(result);
+        expectLineHeightPreserved(result, lineHeight);
       });
 
       Future<void> expectStyles(List<String> styles, Matcher styleMatcher) async {
@@ -426,8 +440,11 @@ void main() {
 
     group('StringConvert regex patterns', () {
       test('_base64ValidationRegex should handle long invalid base64', () {
-        // Test with a very long string that looks like base64 but isn't
-        final longInvalidBase64 = 'A' * 10000 + '!'; // Not valid base64
+        // extractStrings only runs _base64ValidationRegex when the input length
+        // is a multiple of 4 and contains no spaces, so the input must satisfy
+        // those gates to actually exercise the regex. The trailing '!' keeps it
+        // invalid base64, forcing hasMatch to scan the whole string.
+        final longInvalidBase64 = 'A' * 9999 + '!'; // length 10000, % 4 == 0
 
         expectFastResult(() => StringConvert.extractEmailAddress(longInvalidBase64));
       });
@@ -639,14 +656,13 @@ void main() {
         for (final input in edgeCases) {
           expectFastResult(
             () {
-              // Test various functions with edge case input
-              try {
-                StringConvert.extractEmailAddress(input);
-                StringConvert.isTextTable('$input\n$input');
-                HtmlUtils.extractPlainText(input);
-              } catch (_) {
-                // Intentionally ignored - focus is on performance, not correctness
-              }
+              // Exercise the regex-backed functions with the edge-case input.
+              // None of these should throw on any input, so we deliberately let
+              // an exception propagate and fail the test rather than swallowing
+              // it and masking a crash or correctness regression.
+              StringConvert.extractEmailAddress(input);
+              StringConvert.isTextTable('$input\n$input');
+              HtmlUtils.extractPlainText(input);
             },
             budgetMs: 1000,
             reason: 'Should process edge case within 1 second',

--- a/core/test/utils/transform_configuration_test.dart
+++ b/core/test/utils/transform_configuration_test.dart
@@ -1,3 +1,4 @@
+import 'package:core/presentation/utils/html_transformer/dom/normalize_line_height_in_style_transformer.dart';
 import 'package:core/presentation/utils/html_transformer/dom/remove_negative_margin_float_transformers.dart';
 import 'package:core/presentation/utils/html_transformer/dom/responsive_table_cell_transformer.dart';
 import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
@@ -8,6 +9,9 @@ bool _hasResponsiveTransformer(List transformers) =>
 
 bool _hasNegativeMarginFloatTransformer(List transformers) =>
     transformers.any((t) => t is RemoveNegativeMarginFloatTransformer);
+
+bool _hasNormalizeLineHeightTransformer(List transformers) =>
+    transformers.any((t) => t is NormalizeLineHeightInStyleTransformer);
 
 void main() {
   group('TransformConfiguration — ResponsiveTableCellTransformer membership', () {
@@ -121,6 +125,33 @@ void main() {
         isFalse,
         reason: 'Print pipeline renders the original email faithfully without layout adjustments',
       );
+    });
+  });
+
+  group('TransformConfiguration — NormalizeLineHeightInStyleTransformer membership', () {
+    test('forSignatureIdentity includes NormalizeLineHeightInStyleTransformer', () {
+      expect(
+        _hasNormalizeLineHeightTransformer(
+          TransformConfiguration.forSignatureIdentity().domTransformers,
+        ),
+        isTrue,
+        reason: 'Settings signature preview must not overlap text lines',
+      );
+    });
+
+    test('forComposerSignature contains ONLY NormalizeLineHeightInStyleTransformer', () {
+      final configuration = TransformConfiguration.forComposerSignature();
+      expect(
+        configuration.domTransformers.length,
+        1,
+        reason: 'Inserted signature is part of the sent email and must not be '
+            'rewritten by display-only transformers',
+      );
+      expect(
+        _hasNormalizeLineHeightTransformer(configuration.domTransformers),
+        isTrue,
+      );
+      expect(configuration.textTransformers, isEmpty);
     });
   });
 }

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -15,6 +15,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
+import 'package:html/parser.dart' show parse;
 import 'package:html_editor_enhanced/html_editor.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/error/method/error_method_response.dart';
@@ -96,6 +97,7 @@ import 'package:tmail_ui_user/features/composer/presentation/widgets/saving_temp
 import 'package:tmail_ui_user/features/composer/presentation/widgets/sending_message_dialog_view.dart';
 import 'package:tmail_ui_user/features/email/domain/state/get_email_content_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/save_template_email_state.dart';
+import 'package:tmail_ui_user/features/email/domain/state/transform_html_email_content_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/update_template_email_state.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/get_email_content_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/print_email_interactor.dart';
@@ -1718,13 +1720,47 @@ class ComposerController extends BaseController
   }
 
   Future<void> applySignature(String signature) async {
+    final normalizedSignature = await _normalizeSignature(signature);
     if (PlatformInfo.isWeb) {
       richTextWebController?.editorController.insertSignature(
-        signature,
+        normalizedSignature,
         allowCollapsed: false,
       );
     } else {
-      await htmlEditorApi?.insertSignature(signature, allowCollapsed: false);
+      await htmlEditorApi?.insertSignature(
+        normalizedSignature,
+        allowCollapsed: false,
+      );
+    }
+  }
+
+  /// Identity signatures are stored raw on the server, so a degenerate
+  /// `line-height` (e.g. `0.1`) would overlap text once inserted into the
+  /// editor. Normalize it like the preview pipeline does. The HTML transform
+  /// returns a complete document, while the editor expects a fragment, so only
+  /// the transformed body is inserted. Fail-open: any failure, unexpected
+  /// state, empty result, or exception falls back to the original signature so
+  /// insertion never breaks.
+  Future<String> _normalizeSignature(String signature) async {
+    try {
+      final resultState = await _transformHtmlEmailContentInteractor
+          .execute(signature, TransformConfiguration.forComposerSignature())
+          .last;
+      return resultState.fold(
+        (failure) => signature,
+        (success) {
+          if (success is! TransformHtmlEmailContentSuccess) return signature;
+
+          final normalizedSignature =
+              parse(success.htmlContent).body?.innerHtml ?? '';
+          return normalizedSignature.trim().isNotEmpty
+              ? normalizedSignature
+              : signature;
+        },
+      );
+    } catch (e) {
+      logWarning('ComposerController::_normalizeSignature: Exception = $e');
+      return signature;
     }
   }
 

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -15,7 +15,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
-import 'package:html/parser.dart' show parse;
 import 'package:html_editor_enhanced/html_editor.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/error/method/error_method_response.dart';
@@ -1736,11 +1735,9 @@ class ComposerController extends BaseController
 
   /// Identity signatures are stored raw on the server, so a degenerate
   /// `line-height` (e.g. `0.1`) would overlap text once inserted into the
-  /// editor. Normalize it like the preview pipeline does. The HTML transform
-  /// returns a complete document, while the editor expects a fragment, so only
-  /// the transformed body is inserted. Fail-open: any failure, unexpected
-  /// state, empty result, or exception falls back to the original signature so
-  /// insertion never breaks.
+  /// editor. Normalize it like the preview pipeline does. Fail-open: any
+  /// failure, unexpected state, empty result, or exception falls back to the
+  /// original signature so insertion never breaks.
   Future<String> _normalizeSignature(String signature) async {
     try {
       final resultState = await _transformHtmlEmailContentInteractor
@@ -1751,8 +1748,9 @@ class ComposerController extends BaseController
         (success) {
           if (success is! TransformHtmlEmailContentSuccess) return signature;
 
-          final normalizedSignature =
-              parse(success.htmlContent).body?.innerHtml ?? '';
+          // The transform returns a complete document while the editor
+          // expects a fragment.
+          final normalizedSignature = success.htmlContent.toHtmlFragment();
           return normalizedSignature.trim().isNotEmpty
               ? normalizedSignature
               : signature;

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -807,6 +807,34 @@ void main() {
       });
 
       test(
+        'Should keep the signature stylesheet when inserting into the editor\n'
+        'When the transformed document carries a <style> block in <head>',
+      () async {
+        // A signature whose first node is a <style> block parses with that
+        // block hoisted into <head> — this is the exact document the
+        // forComposerSignature() pipeline returns for such a signature.
+        const transformedDocument =
+            '<html><head><style>.sig{color:#093}</style></head>'
+            '<body><p class="sig">Alice</p></body></html>';
+        const normalizedSignature =
+            '<style>.sig{color:#093}</style><p class="sig">Alice</p>';
+        composerController?.richTextMobileTabletController =
+            mockRichTextMobileTabletController;
+        when(mockRichTextMobileTabletController.htmlEditorApi)
+            .thenReturn(mockHtmlEditorApi);
+        when(mockTransformHtmlEmailContentInteractor.execute(any, any))
+            .thenAnswer((_) => Stream.value(
+                Right(TransformHtmlEmailContentSuccess(transformedDocument))));
+
+        await composerController?.applySignature(rawSignature);
+
+        verify(mockHtmlEditorApi.insertSignature(
+          normalizedSignature,
+          allowCollapsed: false,
+        )).called(1);
+      });
+
+      test(
         'Should insert the normalized signature fragment into the web editor\n'
         'When TransformHtmlEmailContentInteractor succeeds',
       () async {

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -2,6 +2,8 @@ import 'package:core/data/network/config/dynamic_url_interceptors.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:core/presentation/utils/app_toast.dart';
+import 'package:core/presentation/utils/html_transformer/dom/normalize_line_height_in_style_transformer.dart';
+import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/utils/platform_info.dart';
@@ -33,6 +35,7 @@ import 'package:tmail_ui_user/features/caching/caching_manager.dart';
 import 'package:tmail_ui_user/features/composer/domain/repository/composer_repository.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/save_email_as_drafts_state.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/update_email_drafts_state.dart';
+import 'package:tmail_ui_user/features/email/domain/state/transform_html_email_content_state.dart';
 import 'package:tmail_ui_user/features/email/domain/state/update_template_email_state.dart' show UpdateTemplateEmailSuccess;
 import 'package:tmail_ui_user/features/composer/domain/usecases/create_new_and_save_email_to_drafts_interactor.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/create_new_and_send_email_interactor.dart';
@@ -93,6 +96,8 @@ const fallbackGenerators = {
 };
 
 class MockRichTextWebController extends Mock implements RichTextWebController {
+  final _editorController = MockHtmlEditorController();
+
   @override
   Rx<FormattingOptionsState> get formattingOptionsState => 
     FormattingOptionsState.disabled.obs;
@@ -101,7 +106,7 @@ class MockRichTextWebController extends Mock implements RichTextWebController {
   bool get isFormattingOptionsEnabled => formattingOptionsState.value == FormattingOptionsState.enabled;
 
   @override
-  HtmlEditorController get editorController => MockHtmlEditorController();
+  HtmlEditorController get editorController => _editorController;
 
   @override
   bool get codeViewEnabled => false;
@@ -764,6 +769,161 @@ void main() {
             equals(savedEmailDraft.asString().hashCode),
           );
         });
+      });
+    });
+
+    group('applySignature test:', () {
+      const rawSignature = '<p style="line-height:0.1;">Alice</p>';
+
+      test(
+        'Should insert the normalized signature into the editor\n'
+        'When TransformHtmlEmailContentInteractor succeeds',
+      () async {
+        const transformedDocument =
+            '<html><head></head><body><p>Alice</p></body></html>';
+        const normalizedSignature = '<p>Alice</p>';
+        composerController?.richTextMobileTabletController =
+            mockRichTextMobileTabletController;
+        when(mockRichTextMobileTabletController.htmlEditorApi)
+            .thenReturn(mockHtmlEditorApi);
+        when(mockTransformHtmlEmailContentInteractor.execute(any, any))
+            .thenAnswer((_) => Stream.value(
+                Right(TransformHtmlEmailContentSuccess(transformedDocument))));
+
+        await composerController?.applySignature(rawSignature);
+
+        final captured = verify(mockTransformHtmlEmailContentInteractor
+                .execute(rawSignature, captureAny))
+            .captured;
+        final configuration = captured.single as TransformConfiguration;
+        expect(
+          configuration.domTransformers.single,
+          isA<NormalizeLineHeightInStyleTransformer>(),
+        );
+        verify(mockHtmlEditorApi.insertSignature(
+          normalizedSignature,
+          allowCollapsed: false,
+        )).called(1);
+      });
+
+      test(
+        'Should insert the normalized signature fragment into the web editor\n'
+        'When TransformHtmlEmailContentInteractor succeeds',
+      () async {
+        const transformedDocument =
+            '<html><head></head><body><p>Alice</p></body></html>';
+        const normalizedSignature = '<p>Alice</p>';
+        PlatformInfo.isTestingForWeb = true;
+        addTearDown(() => PlatformInfo.isTestingForWeb = false);
+        composerController?.richTextWebController = mockRichTextWebController;
+        when(mockTransformHtmlEmailContentInteractor.execute(any, any))
+            .thenAnswer((_) => Stream.value(
+                Right(TransformHtmlEmailContentSuccess(transformedDocument))));
+
+        await composerController?.applySignature(rawSignature);
+
+        verify(mockRichTextWebController.editorController.insertSignature(
+          normalizedSignature,
+          allowCollapsed: false,
+        )).called(1);
+      });
+
+      test(
+        'Should insert the original signature into the editor\n'
+        'When TransformHtmlEmailContentInteractor fails',
+      () async {
+        composerController?.richTextMobileTabletController =
+            mockRichTextMobileTabletController;
+        when(mockRichTextMobileTabletController.htmlEditorApi)
+            .thenReturn(mockHtmlEditorApi);
+        when(mockTransformHtmlEmailContentInteractor.execute(any, any))
+            .thenAnswer((_) => Stream.value(
+                Left(TransformHtmlEmailContentFailure(Exception()))));
+
+        await composerController?.applySignature(rawSignature);
+
+        verify(mockHtmlEditorApi.insertSignature(
+          rawSignature,
+          allowCollapsed: false,
+        )).called(1);
+      });
+
+      test(
+        'Should insert the original signature into the editor\n'
+        'When TransformHtmlEmailContentInteractor throws a stream error',
+      () async {
+        composerController?.richTextMobileTabletController =
+            mockRichTextMobileTabletController;
+        when(mockRichTextMobileTabletController.htmlEditorApi)
+            .thenReturn(mockHtmlEditorApi);
+        when(mockTransformHtmlEmailContentInteractor.execute(any, any))
+            .thenAnswer((_) => Stream.error(Exception('transform crashed')));
+
+        await composerController?.applySignature(rawSignature);
+
+        verify(mockHtmlEditorApi.insertSignature(
+          rawSignature,
+          allowCollapsed: false,
+        )).called(1);
+      });
+
+      test(
+        'Should insert the original signature into the editor\n'
+        'When TransformHtmlEmailContentInteractor returns an empty stream',
+      () async {
+        composerController?.richTextMobileTabletController =
+            mockRichTextMobileTabletController;
+        when(mockRichTextMobileTabletController.htmlEditorApi)
+            .thenReturn(mockHtmlEditorApi);
+        when(mockTransformHtmlEmailContentInteractor.execute(any, any))
+            .thenAnswer((_) => const Stream.empty());
+
+        await composerController?.applySignature(rawSignature);
+
+        verify(mockHtmlEditorApi.insertSignature(
+          rawSignature,
+          allowCollapsed: false,
+        )).called(1);
+      });
+
+      test(
+        'Should insert the original signature into the editor\n'
+        'When the transform succeeds but returns blank content',
+      () async {
+        composerController?.richTextMobileTabletController =
+            mockRichTextMobileTabletController;
+        when(mockRichTextMobileTabletController.htmlEditorApi)
+            .thenReturn(mockHtmlEditorApi);
+        when(mockTransformHtmlEmailContentInteractor.execute(any, any))
+            .thenAnswer((_) => Stream.value(
+                Right(TransformHtmlEmailContentSuccess('   '))));
+
+        await composerController?.applySignature(rawSignature);
+
+        verify(mockHtmlEditorApi.insertSignature(
+          rawSignature,
+          allowCollapsed: false,
+        )).called(1);
+      });
+
+      test(
+        'Should insert the original signature into the editor\n'
+        'When the last emitted state is not TransformHtmlEmailContentSuccess',
+      () async {
+        composerController?.richTextMobileTabletController =
+            mockRichTextMobileTabletController;
+        when(mockRichTextMobileTabletController.htmlEditorApi)
+            .thenReturn(mockHtmlEditorApi);
+        when(mockTransformHtmlEmailContentInteractor.execute(any, any))
+            .thenAnswer((_) => Stream.value(
+                Right(TransformHtmlEmailContentLoading())));
+
+        await composerController?.applySignature(rawSignature);
+
+        verify(mockHtmlEditorApi.insertSignature(
+          rawSignature,
+          allowCollapsed: false,
+        )).called(1);
       });
     });
 


### PR DESCRIPTION
Closes #4720 

## Context

Received signatures (e.g. Gmail/Element) ship inline styles like `line-height:0.1` on each `<p>`. A line-height below `1` collapses the line box under the font size, so consecutive lines overlap and the signature is unreadable — even though other clients render it correctly.

## Root cause

`NormalizeLineHeightInStyleTransformer` only stripped two hard-coded values (`1px`, `100%`) and missed general degenerate values such as unitless `0.1`. Generalizing the match naively is unsafe: a regex that splits on `;` corrupts complex inline CSS (quoted values, `url()`, comments, escapes), and unbounded quantifiers risk ReDoS on attacker-controlled email content.

## Solution

- Split inline styles with a linear, fail-open scanner that finds only top-level `;`; semicolons inside quotes, comments, `url()`/`calc()`, and CSS `\` escapes are never treated as boundaries. Malformed CSS (unterminated quote/comment, unbalanced parenthesis, trailing backslash) is left untouched.
- Remove a `line-height` declaration only when its value is degenerate: unitless/`em`/`rem` `< 1`, `%` `<= 100`, `px`/`pt` `<= 1`. Normal values (`1`, `1.5`, `150%`, `20px`, `normal`, `calc(...)`, negatives) are kept. Removing `1px`/`100%` is intentional, pre-existing behavior (TF-3964).
- Strip a trailing `!important` (any whitespace) with a linear helper, then match the number with a whitespace-free, `^`-anchored, bounded regex — O(n), no ReDoS.

## Demo


https://github.com/user-attachments/assets/8697719f-1842-4620-827a-24067f1b6c78



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Composer identity signatures are now normalized before insertion for consistent rendering.
  - Added HTML document-to-editor fragment conversion that preserves `<head>` styles and extracts body content.

- **Bug Fixes**
  - Improved normalization/removal of ineffective `line-height` in inline styles with case-insensitive and unit-aware handling.
  - More reliably preserves `line-height` when it’s meaningful, including `line-height: 0`, and avoids touching custom properties, quoted content, function values, and malformed CSS.
  - Removes the entire `style` attribute when it would otherwise only contain ineffective `line-height`.

- **Performance**
  - Added safeguards and broader coverage to keep style processing fast even with pathological inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->