### PR TITLE
TF-4726 Composable validator

### DIFF
--- a/docs/adr/0103-attach-drive-file-as-attachment.md
+++ b/docs/adr/0103-attach-drive-file-as-attachment.md
@@ -35,62 +35,41 @@ A stager yields a sealed result — `FileBackedStagedFile` (IO temp file), `Opfs
 
 **End-to-end flow for `DriveAttachmentHandler`:** partition (sharingLink vs downloadLink) → validate total size of the downloadable set *before any download starts* (declared-size gate, below) → bounded-concurrency per-file pipeline (stage → upload) → chip updated to terminal state.
 
-**Validation — a pure rule/result core, dialog dispatch at the boundary:**
+**Validation — pure rules, dialogs only at the edge:** every "may the user attach this?" question runs through one small kernel (`domain/validator/`). A rule sees a request and gives one of three answers:
+
 ```dart
 sealed class ValidationDecision<Failure, Prompt> {}
-final class ValidationAllowed<Failure, Prompt> extends ValidationDecision<Failure, Prompt> {}
-final class ValidationRejected<Failure, Prompt> extends ValidationDecision<Failure, Prompt> {
-  final Failure failure;
-}
-final class ValidationConfirmationRequired<Failure, Prompt> extends ValidationDecision<Failure, Prompt> {
-  final List<Prompt> prompts;
-}
+final class ValidationAllowed<…> extends ValidationDecision<…> {}
+final class ValidationRejected<…> extends ValidationDecision<…> { final Failure failure; }
+final class ValidationConfirmationRequired<…> extends ValidationDecision<…> { final List<Prompt> prompts; }
 
 abstract interface class ValidationRule<Request, Failure, Prompt> {
   ValidationDecision<Failure, Prompt> validate(Request request);
 }
-
-final class ValidationPipeline<Request, Failure, Prompt> {
-  final List<ValidationRule<Request, Failure, Prompt>> _rules;
-  ValidationPipeline(Iterable<ValidationRule<Request, Failure, Prompt>> rules);
-
-  ValidationDecision<Failure, Prompt> validate(Request request) {
-    final prompts = <Prompt>[];
-    for (final rule in _rules) {
-      switch (rule.validate(request)) {
-        case ValidationAllowed(): break;
-        case ValidationRejected(:final failure): return ValidationRejected(failure); // hard stop
-        case ValidationConfirmationRequired(prompts: final rulePrompts): prompts.addAll(rulePrompts);
-      }
-    }
-    return prompts.isEmpty ? const ValidationAllowed() : ValidationConfirmationRequired(prompts);
-  }
-}
 ```
-Rules are pure and synchronous — no `BuildContext`, no `AppLocalizations`, no dialog side effects, so they unit-test with a plain `test()`. `ValidationRule`/`ValidationDecision`/`ValidationPipeline` (`domain/validator/`) are generic over `Request`/`Failure`/`Prompt`, so a rule's `validate` is typed against its own request shape at compile time — no runtime cast, and no unrelated import leaking into the generic core. `ValidationPipeline.validate()` runs every rule, short-circuits on the first hard rejection, and otherwise collects every rule's confirmation prompts into one list.
 
-Attachment validation instantiates this kernel: `AttachmentUploadRequest` (`sizes: AttachmentUploadSizeSnapshot`, `limits: AttachmentUploadLimits`), `AttachmentUploadFailure`/`MaxEmailAttachmentSizeExceeded`, `AttachmentUploadPrompt`/`LargeRegularAttachmentWarning`, and the typedefs `AttachmentUploadRule`/`AttachmentUploadValidator` (`= ValidationPipeline<AttachmentUploadRequest, AttachmentUploadFailure, AttachmentUploadPrompt>`). `AttachmentUploadSizeSnapshot` tracks *all-attachment* and *regular-attachment* running byte totals separately, each split into `current`/`proposed`; `AttachmentUploadRequestFactory.fromProposedFiles` builds it from a `List<FileInfo>`, filtering by `FileInfo.isInline` so inline images always count toward the hard cap (`allAttachmentBytes`) but never toward the regular-attachment warning (`regularAttachmentBytes`) — a call site that only has raw byte counts (no `FileInfo`, e.g. an already-uploaded attachment being re-attached) uses `AttachmentUploadRequestFactory.fromProposedBytes` instead. The one concrete rule, `AttachmentSizeLimitRule` (`domain/validator/`), evaluates `AttachmentSizeLimitPolicy`'s pure size predicates against `request.sizes`/`request.limits` and returns `ValidationRejected(MaxEmailAttachmentSizeExceeded(...))` on the hard cap, `ValidationConfirmationRequired([LargeRegularAttachmentWarning()])` on the warning threshold, or `ValidationAllowed()`.
+`ValidationPipeline` runs its rules in order: the first rejection wins and stops everything, otherwise all collected prompts are asked together. Rules are pure and synchronous — no `BuildContext`, no localization, no dialogs — so they unit-test with a plain `test()`. The kernel is generic over `Request`/`Failure`/`Prompt`; attachments are one instantiation of it, and today there is exactly one rule, `AttachmentSizeLimitRule`.
 
-**Gate — the single place a decision becomes UI:** `AttachmentUploadGate` (`presentation/validator/attachment_upload_gate.dart`) is the one type every call site (composer local-file/image/paste/drop/share-intent, `DriveAttachmentHandler`) goes through:
+**Two totals, two limits.** A request carries byte totals split two ways, because the thresholds don't measure the same thing:
+
+| Total | Includes inline images? | Limit |
+|---|---|---|
+| all attachments | yes | server `maxSizeAttachmentsPerEmail` → hard reject |
+| regular attachments | no | `AppConfig` warning threshold → ask before continuing |
+
+So pasting an inline image never raises the "large attachment" warning, but can still hit the server cap. `AttachmentUploadRequestFactory` does the split from `FileInfo.isInline`, or straight from byte counts when a call site has no `FileInfo` (re-attaching an already-uploaded attachment).
+
+**The gate is where a decision becomes UI** — one type, every call site goes through it:
+
 ```dart
-final class AttachmentUploadGate {
-  final AttachmentUploadValidator _validator;
-  const AttachmentUploadGate(this._validator);
-
-  Future<bool> permits({required AttachmentUploadRequest request, required AttachmentValidationFeedback feedback}) async {
-    switch (_validator.validate(request)) {
-      case ValidationAllowed(): return true;
-      case ValidationRejected(:final failure): await feedback.showFailure(failure); return false;
-      case ValidationConfirmationRequired(:final prompts): return feedback.confirmAll(prompts);
-    }
-  }
+switch (_validator.validate(request)) {
+  case ValidationAllowed(): return true;
+  case ValidationRejected(:final failure): await feedback.showFailure(failure); return false;
+  case ValidationConfirmationRequired(:final prompts): return feedback.confirmAll(prompts);
 }
 ```
-`AttachmentValidationFeedback` (`showFailure`/`confirmAll`) is the interface the gate talks to; `FlutterAttachmentValidationFeedback` is its only implementation, constructed per call with a `BuildContext` and `mounted`-checked before every dialog call. Composer's five direct UI entry points (file pick, image pick, drop zone, drag/drop, paste) each already have a `BuildContext` in their own call chain and pass it straight through. Two entry points structurally never have one — the composer's share-intent path (`SetupEmailAttachmentsExtension._uploadAttachmentFromFileShare`, invoked from `onReady()`/controller-lifecycle setup, no widget in scope) and `DriveAttachmentHandler` (invoked from `ComposerAttachmentExtensionRegistry`'s `onPickState`, a Riverpod provider callback with no widget in scope) — both resolve the global `currentContext` getter (`main/routes/route_navigation.dart`) themselves, the same pattern every other dialog/toast presenter in the app already uses, so neither needs `BuildContext` plumbing of its own.
 
-`AttachmentValidationFailurePresenter.present` switches on `AttachmentUploadFailure` to pick a dialog (`MaxSizeAttachmentsDialogPresenter` today); `AttachmentConfirmationPresenter.ask` switches on `AttachmentUploadPrompt` and directly `await`s `UploadSizeWarningDialogPresenter.showExceededWarningSize`, which forwards `MessageDialogActionManager.showConfirmDialogAction`'s own `Future<void>` — that future already resolves on every dismissal path (confirm, cancel, close button, outside tap when dismissible, back/programmatic pop) because it awaits `Get.dialog`, which completes when the route pops regardless of how. No `Completer` is written anywhere in this path, so there is no dismissal path that can leave a validation call suspended. Because every confirmation flows through this one function, that guarantee only has to hold once. A new, unrelated condition is one new rule class plus one line in the validator's rule list; a new failure or prompt variant additionally needs one `case` in the corresponding presenter's `switch`.
-
-`UploadController` owns no validation logic — it only exposes the plain upload-state getters (`attachmentsPicked`, `inlineAttachmentsPicked`) that `ComposerController.buildAttachmentUploadRequest`/`AttachmentUploadRequestFactory` read to build an `AttachmentUploadRequest`.
+**Numbers.** `ComposerAttachmentUploadStateSource` adapts `UploadController` totals + limits to the `AttachmentUploadStateSource` port — all getters, so the server cap is re-read per check. Totals prefer `attachment.size`, so forwarded and draft attachments count. Intended.
 
 **Declared vs. actual size:** the pre-download gate sums `DriveDocument.size` — backend-reported metadata, unreliable for export-on-demand documents (e.g. Cozy, which may report `0` up front). A running actual-byte guard runs alongside the declared-size gate: a shared counter updated with each file's progress *delta* — `onDownloadProgress`/`onReceiveProgress` reports bytes received *cumulatively per file*, so each stager tracks its own previous callback value and adds only the difference to the shared counter (summing raw cumulative values would double-count and cancel valid downloads early). The shared counter is checked against budget on every update and cancels that file's transfer once exceeded, caught as a per-file failure. The declared-size gate still fails fast before wasting a download; the hard cap comes from the server `maxSizeAttachmentsPerEmail` capability. When that capability is absent, the guard's budget falls back to a fixed client-side constant — this fallback is local to the actual-byte guard; the size-limit dialog check (`AttachmentSizeLimitPolicy`, driven by `AttachmentSizeLimitRule`) is unchanged and keeps treating an absent capability as unlimited for every attachment source, not only drive.
 

--- a/docs/adr/0103-attach-drive-file-as-attachment.md
+++ b/docs/adr/0103-attach-drive-file-as-attachment.md
@@ -35,29 +35,64 @@ A stager yields a sealed result — `FileBackedStagedFile` (IO temp file), `Opfs
 
 **End-to-end flow for `DriveAttachmentHandler`:** partition (sharingLink vs downloadLink) → validate total size of the downloadable set *before any download starts* (declared-size gate, below) → bounded-concurrency per-file pipeline (stage → upload) → chip updated to terminal state.
 
-**Validation — minimal, condition-agnostic abstraction:**
+**Validation — a pure rule/result core, dialog dispatch at the boundary:**
 ```dart
-abstract class AttachmentUploadValidator {
-  FutureOr<bool> validate();
+sealed class ValidationDecision<Failure, Prompt> {}
+final class ValidationAllowed<Failure, Prompt> extends ValidationDecision<Failure, Prompt> {}
+final class ValidationRejected<Failure, Prompt> extends ValidationDecision<Failure, Prompt> {
+  final Failure failure;
+}
+final class ValidationConfirmationRequired<Failure, Prompt> extends ValidationDecision<Failure, Prompt> {
+  final List<Prompt> prompts;
 }
 
-class CompositeAttachmentUploadValidator implements AttachmentUploadValidator {
-  final List<AttachmentUploadValidator> validators;
-  const CompositeAttachmentUploadValidator(this.validators);
+abstract interface class ValidationRule<Request, Failure, Prompt> {
+  ValidationDecision<Failure, Prompt> validate(Request request);
+}
 
-  @override
-  Future<bool> validate() async {
-    if (validators.isEmpty) return true;
-    for (final v in validators) {
-      if (!await v.validate()) return false;
+final class ValidationPipeline<Request, Failure, Prompt> {
+  final List<ValidationRule<Request, Failure, Prompt>> _rules;
+  ValidationPipeline(Iterable<ValidationRule<Request, Failure, Prompt>> rules);
+
+  ValidationDecision<Failure, Prompt> validate(Request request) {
+    final prompts = <Prompt>[];
+    for (final rule in _rules) {
+      switch (rule.validate(request)) {
+        case ValidationAllowed(): break;
+        case ValidationRejected(:final failure): return ValidationRejected(failure); // hard stop
+        case ValidationConfirmationRequired(prompts: final rulePrompts): prompts.addAll(rulePrompts);
+      }
     }
-    return true;
+    return prompts.isEmpty ? const ValidationAllowed() : ValidationConfirmationRequired(prompts);
   }
 }
 ```
-No size (or other condition-specific data) in the interface. Each concrete validator captures what it needs via its own constructor and is self-contained, including showing its own dialog. Today's only concrete validator, `SizeLimitAttachmentUploadValidator`, wraps the existing size-limit/warning-dialog check (`UploadController.validateTotalSizeAttachmentsBeforeUpload`, whose body moves into it with `UploadController` keeping a thin wrapper). Every attachment entry point (composer local-file/paste/drop, `DriveAttachmentHandler`) constructs the validators it needs and calls `.validate()`. A new, unrelated condition later = one new class + one line in a `CompositeAttachmentUploadValidator([...])` list.
+Rules are pure and synchronous — no `BuildContext`, no `AppLocalizations`, no dialog side effects, so they unit-test with a plain `test()`. `ValidationRule`/`ValidationDecision`/`ValidationPipeline` (`domain/validator/`) are generic over `Request`/`Failure`/`Prompt`, so a rule's `validate` is typed against its own request shape at compile time — no runtime cast, and no unrelated import leaking into the generic core. `ValidationPipeline.validate()` runs every rule, short-circuits on the first hard rejection, and otherwise collects every rule's confirmation prompts into one list.
 
-**Declared vs. actual size:** the pre-download gate sums `DriveDocument.size` — backend-reported metadata, unreliable for export-on-demand documents (e.g. Cozy, which may report `0` up front). A running actual-byte guard runs alongside the declared-size gate: a shared counter updated with each file's progress *delta* — `onDownloadProgress`/`onReceiveProgress` reports bytes received *cumulatively per file*, so each stager tracks its own previous callback value and adds only the difference to the shared counter (summing raw cumulative values would double-count and cancel valid downloads early). The shared counter is checked against budget on every update and cancels that file's transfer once exceeded, caught as a per-file failure. The declared-size gate still fails fast before wasting a download; the hard cap comes from the server `maxSizeAttachmentsPerEmail` capability. When that capability is absent, the guard's budget falls back to a fixed client-side constant — this fallback is local to the actual-byte guard; the pre-existing size-limit dialog check (`validateTotalSizeAttachmentsBeforeUpload`, wrapped by `SizeLimitAttachmentUploadValidator`) is unchanged and keeps treating an absent capability as unlimited for every attachment source, not only drive.
+Attachment validation instantiates this kernel: `AttachmentUploadRequest` (`sizes: AttachmentUploadSizeSnapshot`, `limits: AttachmentUploadLimits`), `AttachmentUploadFailure`/`MaxEmailAttachmentSizeExceeded`, `AttachmentUploadPrompt`/`LargeRegularAttachmentWarning`, and the typedefs `AttachmentUploadRule`/`AttachmentUploadValidator` (`= ValidationPipeline<AttachmentUploadRequest, AttachmentUploadFailure, AttachmentUploadPrompt>`). `AttachmentUploadSizeSnapshot` tracks *all-attachment* and *regular-attachment* running byte totals separately, each split into `current`/`proposed`; `AttachmentUploadRequestFactory.fromProposedFiles` builds it from a `List<FileInfo>`, filtering by `FileInfo.isInline` so inline images always count toward the hard cap (`allAttachmentBytes`) but never toward the regular-attachment warning (`regularAttachmentBytes`) — a call site that only has raw byte counts (no `FileInfo`, e.g. an already-uploaded attachment being re-attached) uses `AttachmentUploadRequestFactory.fromProposedBytes` instead. The one concrete rule, `AttachmentSizeLimitRule` (`domain/validator/`), evaluates `AttachmentSizeLimitPolicy`'s pure size predicates against `request.sizes`/`request.limits` and returns `ValidationRejected(MaxEmailAttachmentSizeExceeded(...))` on the hard cap, `ValidationConfirmationRequired([LargeRegularAttachmentWarning()])` on the warning threshold, or `ValidationAllowed()`.
+
+**Gate — the single place a decision becomes UI:** `AttachmentUploadGate` (`presentation/validator/attachment_upload_gate.dart`) is the one type every call site (composer local-file/image/paste/drop/share-intent, `DriveAttachmentHandler`) goes through:
+```dart
+final class AttachmentUploadGate {
+  final AttachmentUploadValidator _validator;
+  const AttachmentUploadGate(this._validator);
+
+  Future<bool> permits({required AttachmentUploadRequest request, required AttachmentValidationFeedback feedback}) async {
+    switch (_validator.validate(request)) {
+      case ValidationAllowed(): return true;
+      case ValidationRejected(:final failure): await feedback.showFailure(failure); return false;
+      case ValidationConfirmationRequired(:final prompts): return feedback.confirmAll(prompts);
+    }
+  }
+}
+```
+`AttachmentValidationFeedback` (`showFailure`/`confirmAll`) is the interface the gate talks to; `FlutterAttachmentValidationFeedback` is its only implementation, constructed per call with a `BuildContext` and `mounted`-checked before every dialog call. Composer's five direct UI entry points (file pick, image pick, drop zone, drag/drop, paste) each already have a `BuildContext` in their own call chain and pass it straight through. Two entry points structurally never have one — the composer's share-intent path (`SetupEmailAttachmentsExtension._uploadAttachmentFromFileShare`, invoked from `onReady()`/controller-lifecycle setup, no widget in scope) and `DriveAttachmentHandler` (invoked from `ComposerAttachmentExtensionRegistry`'s `onPickState`, a Riverpod provider callback with no widget in scope) — both resolve the global `currentContext` getter (`main/routes/route_navigation.dart`) themselves, the same pattern every other dialog/toast presenter in the app already uses, so neither needs `BuildContext` plumbing of its own.
+
+`AttachmentValidationFailurePresenter.present` switches on `AttachmentUploadFailure` to pick a dialog (`MaxSizeAttachmentsDialogPresenter` today); `AttachmentConfirmationPresenter.ask` switches on `AttachmentUploadPrompt` and directly `await`s `UploadSizeWarningDialogPresenter.showExceededWarningSize`, which forwards `MessageDialogActionManager.showConfirmDialogAction`'s own `Future<void>` — that future already resolves on every dismissal path (confirm, cancel, close button, outside tap when dismissible, back/programmatic pop) because it awaits `Get.dialog`, which completes when the route pops regardless of how. No `Completer` is written anywhere in this path, so there is no dismissal path that can leave a validation call suspended. Because every confirmation flows through this one function, that guarantee only has to hold once. A new, unrelated condition is one new rule class plus one line in the validator's rule list; a new failure or prompt variant additionally needs one `case` in the corresponding presenter's `switch`.
+
+`UploadController` owns no validation logic — it only exposes the plain upload-state getters (`attachmentsPicked`, `inlineAttachmentsPicked`) that `ComposerController.buildAttachmentUploadRequest`/`AttachmentUploadRequestFactory` read to build an `AttachmentUploadRequest`.
+
+**Declared vs. actual size:** the pre-download gate sums `DriveDocument.size` — backend-reported metadata, unreliable for export-on-demand documents (e.g. Cozy, which may report `0` up front). A running actual-byte guard runs alongside the declared-size gate: a shared counter updated with each file's progress *delta* — `onDownloadProgress`/`onReceiveProgress` reports bytes received *cumulatively per file*, so each stager tracks its own previous callback value and adds only the difference to the shared counter (summing raw cumulative values would double-count and cancel valid downloads early). The shared counter is checked against budget on every update and cancels that file's transfer once exceeded, caught as a per-file failure. The declared-size gate still fails fast before wasting a download; the hard cap comes from the server `maxSizeAttachmentsPerEmail` capability. When that capability is absent, the guard's budget falls back to a fixed client-side constant — this fallback is local to the actual-byte guard; the size-limit dialog check (`AttachmentSizeLimitPolicy`, driven by `AttachmentSizeLimitRule`) is unchanged and keeps treating an absent capability as unlimited for every attachment source, not only drive.
 
 The counter's check-then-increment runs synchronously inside each `onDownloadProgress` callback with no `await` in between, so on Dart's single-threaded event loop it cannot interleave across concurrent files — the only possible overshoot is one in-flight progress-chunk per file at the moment the guard fires, not an unbounded race. No chunk-reservation mechanism is needed.
 

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -89,6 +89,7 @@ import 'package:tmail_ui_user/features/composer/presentation/model/prefix_recipi
 import 'package:tmail_ui_user/features/composer/presentation/model/saved_composing_email.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/screen_display_mode.dart';
 import 'package:tmail_ui_user/features/composer/presentation/styles/composer_style.dart';
+import 'package:tmail_ui_user/features/composer/presentation/validator/composer_attachment_upload_state_source.dart';
 import 'package:tmail_ui_user/features/composer/presentation/view/editor_view_mixin.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/mobile/from_composer_bottom_sheet_builder.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/saving_message_dialog_view.dart';
@@ -119,7 +120,6 @@ import 'package:tmail_ui_user/features/network_connection/presentation/network_c
 import 'package:tmail_ui_user/features/server_settings/domain/usecases/get_server_setting_interactor.dart';
 import 'package:tmail_ui_user/features/upload/domain/exceptions/pick_file_exception.dart';
 import 'package:tmail_ui_user/features/upload/domain/extensions/file_info_extension.dart';
-import 'package:tmail_ui_user/features/upload/domain/extensions/list_file_info_extension.dart';
 import 'package:tmail_ui_user/features/upload/domain/extensions/list_file_upload_extension.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
 import 'package:tmail_ui_user/features/upload/domain/state/attachment_upload_state.dart';
@@ -128,6 +128,7 @@ import 'package:tmail_ui_user/features/upload/domain/state/local_image_picker_st
 import 'package:tmail_ui_user/features/upload/domain/usecases/local_file_picker_interactor.dart';
 import 'package:tmail_ui_user/features/upload/domain/usecases/local_image_picker_interactor.dart';
 import 'package:tmail_ui_user/features/upload/presentation/controller/upload_controller.dart';
+import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_upload_validation_service.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
@@ -186,6 +187,14 @@ class ComposerController extends BaseController
   final String? autoSaveComposerId;
   final ComposerArguments? composerArgs;
   final SaveTemplateEmailInteractor _saveTemplateEmailInteractor;
+
+  late AttachmentUploadValidationService attachmentUploadValidationService =
+      AttachmentUploadValidationService(
+        stateSource: ComposerAttachmentUploadStateSource.fromServerCapability(
+          uploadController: uploadController,
+          maxSizeAttachmentsPerEmail: mailboxDashBoardController.maxSizeAttachmentsPerEmail?.value,
+        ),
+      );
 
   GetAllAutoCompleteInteractor? _getAllAutoCompleteInteractor;
   GetAutoCompleteInteractor? _getAutoCompleteInteractor;
@@ -860,7 +869,7 @@ class ComposerController extends BaseController
       return;
     }
 
-    if (uploadController.isExceededMaxSizeAttachmentsPerEmail()) {
+    if (attachmentUploadValidationService.isExceededMaxSizeAttachmentsPerEmail()) {
       MessageDialogActionManager().showConfirmDialogAction(
         context,
         appLocalizations.message_dialog_send_email_exceeds_maximum_size(
@@ -1241,18 +1250,17 @@ class ComposerController extends BaseController
     }
   }
 
-  void _handlePickFileSuccess(LocalFilePickerSuccess success) {
-    uploadController.validateTotalSizeAttachmentsBeforeUpload(
-      totalSizePreparedFiles: success.pickedFiles.totalSize,
-      onValidationSuccess: () => uploadAttachmentsAction(pickedFiles: success.pickedFiles)
-    );
+  Future<void> _handlePickFileSuccess(LocalFilePickerSuccess success) {
+    return attachmentUploadValidationService.validateFiles(
+      files: success.pickedFiles,
+      onAllowed: () => uploadAttachmentsAction(pickedFiles: success.pickedFiles));
   }
 
-  void _handlePickImageSuccess(LocalImagePickerSuccess success) {
-    uploadController.validateTotalSizeInlineAttachmentsBeforeUpload(
-      totalSizePreparedFiles: success.fileInfo.fileSize,
-      onValidationSuccess: () => uploadAttachmentsAction(pickedFiles: [success.fileInfo.withInline()])
-    );
+  Future<void> _handlePickImageSuccess(LocalImagePickerSuccess success) {
+    final inlineFile = success.fileInfo.withInline();
+    return attachmentUploadValidationService.validateFiles(
+      files: [inlineFile],
+      onAllowed: () => uploadAttachmentsAction(pickedFiles: [inlineFile]));
   }
 
   void uploadAttachmentsAction({required List<FileInfo> pickedFiles}) {
@@ -2047,12 +2055,12 @@ class ComposerController extends BaseController
 
   void setSubjectEmail(String subject) => subjectEmail.value = subject;
 
-  void onAttachmentDropZoneListener(Attachment attachment) {
+  Future<void> onAttachmentDropZoneListener(BuildContext context, Attachment attachment) {
     log('ComposerController::onAttachmentDropZoneListener: attachment = $attachment');
-    uploadController.validateTotalSizeAttachmentsBeforeUpload(
-      totalSizePreparedFiles: attachment.size?.value ?? 0,
-      onValidationSuccess: () => uploadController.initializeUploadAttachments([attachment])
-    );
+    return attachmentUploadValidationService.validateAttachment(
+      context: context,
+      attachment: attachment,
+      onAllowed: () => uploadController.initializeUploadAttachments([attachment]));
   }
 
   Future<void> onChangeIdentity(Identity? newIdentity) async {
@@ -2189,7 +2197,9 @@ class ComposerController extends BaseController
 
     final listFileInfo = await onDragDone(context: context, details: details);
 
-    if (listFileInfo.isEmpty && context.mounted) {
+    if (!context.mounted) return;
+
+    if (listFileInfo.isEmpty) {
       appToast.showToastErrorMessage(
         context,
         AppLocalizations.of(context).can_not_upload_this_file_as_attachments
@@ -2197,11 +2207,10 @@ class ComposerController extends BaseController
       return;
     }
 
-    uploadController.validateTotalSizeAttachmentsBeforeUpload(
-      totalSizePreparedFiles: listFileInfo.totalSize,
-      totalSizePreparedFilesWithDispositionAttachment: listFileInfo.listAttachmentFiles.totalSize,
-      onValidationSuccess: () => uploadAttachmentsAction(pickedFiles: listFileInfo)
-    );
+    await attachmentUploadValidationService.validateFiles(
+      context: context,
+      files: listFileInfo,
+      onAllowed: () => uploadAttachmentsAction(pickedFiles: listFileInfo));
   }
 
   void _handleSaveMessageToDraft(BuildContext context) async {
@@ -2473,16 +2482,16 @@ class ComposerController extends BaseController
     required BuildContext context,
     required double maxWidth,
     required List<FileUpload> listFileUpload
-  }) {
+  }) async {
     log('ComposerController::handleOnPasteImageSuccessAction: listFileUpload = ${listFileUpload.length}');
     _setUpMaxWidthInlineImage(context: context, maxWidth: maxWidth);
 
     final listFileInfo = listFileUpload.toListFileInfo();
 
-    uploadController.validateTotalSizeAttachmentsBeforeUpload(
-      totalSizePreparedFiles: listFileInfo.totalSize,
-      onValidationSuccess: () => uploadAttachmentsAction(pickedFiles: listFileInfo)
-    );
+    await attachmentUploadValidationService.validateFiles(
+      context: context,
+      files: listFileInfo,
+      onAllowed: () => uploadAttachmentsAction(pickedFiles: listFileInfo));
   }
 
   void handleOnPasteImageFailureAction({

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1295,6 +1295,20 @@ class ComposerController extends BaseController
     );
   }
 
+  /// Mirrors the bytes reservation [AttachmentUploadValidationService] made
+  /// for a re-attached [attachment] whose bytes are transferred to
+  /// [uploadController]'s state synchronously by
+  /// [initializeUploadAttachments], so there is no later settlement event to
+  /// release it on.
+  void _releaseReservedBytesForAttachment(Attachment attachment) {
+    final attachmentBytes = (attachment.size?.value ?? 0).toInt();
+    attachmentUploadValidationService.releaseReservedBytes(
+      allAttachmentBytes: attachmentBytes,
+      regularAttachmentBytes:
+          attachment.isDispositionInlined() ? 0 : attachmentBytes,
+    );
+  }
+
   void deleteAttachmentUploaded(UploadTaskId uploadId) {
     uploadController.deleteFileUploaded(uploadId);
   }
@@ -2073,7 +2087,10 @@ class ComposerController extends BaseController
     return attachmentUploadValidationService.validateAttachment(
       context: context,
       attachment: attachment,
-      onAllowed: () => uploadController.initializeUploadAttachments([attachment]));
+      onAllowed: () {
+        uploadController.initializeUploadAttachments([attachment]);
+        _releaseReservedBytesForAttachment(attachment);
+      });
   }
 
   Future<void> onChangeIdentity(Identity? newIdentity) async {

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -192,7 +192,7 @@ class ComposerController extends BaseController
       AttachmentUploadValidationService(
         stateSource: ComposerAttachmentUploadStateSource.fromServerCapability(
           uploadController: uploadController,
-          maxSizeAttachmentsPerEmail: mailboxDashBoardController.maxSizeAttachmentsPerEmail?.value,
+          maxSizeAttachmentsPerEmail: () => mailboxDashBoardController.maxSizeAttachmentsPerEmail?.value,
         ),
       );
 

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1272,41 +1272,14 @@ class ComposerController extends BaseController
         uploadController.justUploadAttachmentsAction(
           uploadFiles: pickedFiles,
           uploadUri: uploadUri,
-          onFileSettled: _releaseReservedBytesForFile,
         );
       } catch (e) {
         logWarning('ComposerController::uploadAttachmentsAction: $e');
         uploadController.consumeState(Stream.value(Left(UploadAttachmentFailure(e, pickedFiles[0]))));
-        pickedFiles.forEach(_releaseReservedBytesForFile);
       }
     } else {
       logWarning('ComposerController::uploadAttachmentsAction: SESSION OR ACCOUNT_ID is NULL');
-      pickedFiles.forEach(_releaseReservedBytesForFile);
     }
-  }
-
-  /// Mirrors the bytes reservation [AttachmentUploadValidationService] made
-  /// for [file] when its upload was allowed, now that it has actually
-  /// settled (or will never start).
-  void _releaseReservedBytesForFile(FileInfo file) {
-    attachmentUploadValidationService.releaseReservedBytes(
-      allAttachmentBytes: file.fileSize,
-      regularAttachmentBytes: file.isInline == true ? 0 : file.fileSize,
-    );
-  }
-
-  /// Mirrors the bytes reservation [AttachmentUploadValidationService] made
-  /// for a re-attached [attachment] whose bytes are transferred to
-  /// [uploadController]'s state synchronously by
-  /// [initializeUploadAttachments], so there is no later settlement event to
-  /// release it on.
-  void _releaseReservedBytesForAttachment(Attachment attachment) {
-    final attachmentBytes = (attachment.size?.value ?? 0).toInt();
-    attachmentUploadValidationService.releaseReservedBytes(
-      allAttachmentBytes: attachmentBytes,
-      regularAttachmentBytes:
-          attachment.isDispositionInlined() ? 0 : attachmentBytes,
-    );
   }
 
   void deleteAttachmentUploaded(UploadTaskId uploadId) {
@@ -2087,10 +2060,7 @@ class ComposerController extends BaseController
     return attachmentUploadValidationService.validateAttachment(
       context: context,
       attachment: attachment,
-      onAllowed: () {
-        uploadController.initializeUploadAttachments([attachment]);
-        _releaseReservedBytesForAttachment(attachment);
-      });
+      onAllowed: () => uploadController.initializeUploadAttachments([attachment]));
   }
 
   Future<void> onChangeIdentity(Identity? newIdentity) async {

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1272,14 +1272,27 @@ class ComposerController extends BaseController
         uploadController.justUploadAttachmentsAction(
           uploadFiles: pickedFiles,
           uploadUri: uploadUri,
+          onFileSettled: _releaseReservedBytesForFile,
         );
       } catch (e) {
         logWarning('ComposerController::uploadAttachmentsAction: $e');
         uploadController.consumeState(Stream.value(Left(UploadAttachmentFailure(e, pickedFiles[0]))));
+        pickedFiles.forEach(_releaseReservedBytesForFile);
       }
     } else {
       logWarning('ComposerController::uploadAttachmentsAction: SESSION OR ACCOUNT_ID is NULL');
+      pickedFiles.forEach(_releaseReservedBytesForFile);
     }
+  }
+
+  /// Mirrors the bytes reservation [AttachmentUploadValidationService] made
+  /// for [file] when its upload was allowed, now that it has actually
+  /// settled (or will never start).
+  void _releaseReservedBytesForFile(FileInfo file) {
+    attachmentUploadValidationService.releaseReservedBytes(
+      allAttachmentBytes: file.fileSize,
+      regularAttachmentBytes: file.isInline == true ? 0 : file.fileSize,
+    );
   }
 
   void deleteAttachmentUploaded(UploadTaskId uploadId) {

--- a/lib/features/composer/presentation/composer_view_web.dart
+++ b/lib/features/composer/presentation/composer_view_web.dart
@@ -312,7 +312,8 @@ class ComposerView extends GetWidget<ComposerController> {
                                 child: PointerInterceptor(
                                   child: AttachmentDropZoneWidget(
                                     imagePaths: controller.imagePaths,
-                                    onAttachmentDropZoneListener: controller.onAttachmentDropZoneListener,
+                                    onAttachmentDropZoneListener: (attachment) =>
+                                        controller.onAttachmentDropZoneListener(context, attachment),
                                   )
                                 ),
                               );
@@ -587,8 +588,8 @@ class ComposerView extends GetWidget<ComposerController> {
                               child: PointerInterceptor(
                                 child: AttachmentDropZoneWidget(
                                   imagePaths: controller.imagePaths,
-                                  onAttachmentDropZoneListener:
-                                      controller.onAttachmentDropZoneListener,
+                                  onAttachmentDropZoneListener: (attachment) =>
+                                      controller.onAttachmentDropZoneListener(context, attachment),
                                 )
                               ),
                             );
@@ -865,7 +866,8 @@ class ComposerView extends GetWidget<ComposerController> {
                               child: PointerInterceptor(
                                 child: AttachmentDropZoneWidget(
                                   imagePaths: controller.imagePaths,
-                                  onAttachmentDropZoneListener: controller.onAttachmentDropZoneListener,
+                                  onAttachmentDropZoneListener: (attachment) =>
+                                      controller.onAttachmentDropZoneListener(context, attachment),
                                 )
                               ),
                             );

--- a/lib/features/composer/presentation/extensions/setup_email_attachments_extension.dart
+++ b/lib/features/composer/presentation/extensions/setup_email_attachments_extension.dart
@@ -1,5 +1,4 @@
 
-import 'package:core/utils/list_utils.dart';
 import 'package:model/email/attachment.dart';
 import 'package:model/email/email_action_type.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
@@ -7,7 +6,6 @@ import 'package:tmail_ui_user/features/composer/presentation/composer_controller
 import 'package:tmail_ui_user/features/email/domain/extensions/email_attachment_classifier_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/list_shared_media_file_extension.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/composer_arguments.dart';
-import 'package:tmail_ui_user/features/upload/domain/extensions/list_file_info_extension.dart';
 
 extension SetupEmailAttachmentsExtension on ComposerController {
 
@@ -56,19 +54,11 @@ extension SetupEmailAttachmentsExtension on ComposerController {
     EmailActionType.restoreComposerFromPersistentCache,
   }.contains(currentEmailActionType);
 
-  void _uploadAttachmentFromFileShare(List<SharedMediaFile> listSharedMediaFile) {
+  Future<void> _uploadAttachmentFromFileShare(List<SharedMediaFile> listSharedMediaFile) async {
     final listFileInfo = listSharedMediaFile.toListFileInfo(isShared: true);
 
-    final tupleListFileInfo = partition(
-      listFileInfo,
-      (fileInfo) => fileInfo.isInline == true,
-    );
-    final listAttachments = tupleListFileInfo.value2;
-
-    uploadController.validateTotalSizeAttachmentsBeforeUpload(
-      totalSizePreparedFiles: listFileInfo.totalSize,
-      totalSizePreparedFilesWithDispositionAttachment: listAttachments.totalSize,
-      onValidationSuccess: () => uploadAttachmentsAction(pickedFiles: listFileInfo),
-    );
+    await attachmentUploadValidationService.validateFiles(
+      files: listFileInfo,
+      onAllowed: () => uploadAttachmentsAction(pickedFiles: listFileInfo));
   }
 }

--- a/lib/features/composer/presentation/validator/composer_attachment_upload_state_source.dart
+++ b/lib/features/composer/presentation/validator/composer_attachment_upload_state_source.dart
@@ -12,27 +12,29 @@ class ComposerAttachmentUploadStateSource implements AttachmentUploadStateSource
 
   @override
   final int warningLimitBytes;
-  @override
-  final int? hardLimitBytes;
+  final num? Function() maxSizeAttachmentsPerEmailProvider;
 
   const ComposerAttachmentUploadStateSource({
     required this.uploadController,
     required this.warningLimitBytes,
-    required this.hardLimitBytes,
+    required this.maxSizeAttachmentsPerEmailProvider,
   });
 
   /// Resolves the limits from the raw server capability value.
   factory ComposerAttachmentUploadStateSource.fromServerCapability({
     required UploadController uploadController,
-    required num? maxSizeAttachmentsPerEmail,
+    required num? Function() maxSizeAttachmentsPerEmail,
   }) {
     return ComposerAttachmentUploadStateSource(
       uploadController: uploadController,
       warningLimitBytes: AppConfig.warningAttachmentFileSizeInMegabytes * 1024 * 1024,
-      hardLimitBytes: AttachmentUploadRequestFactory.normalizeServerLimitBytes(
-          maxSizeAttachmentsPerEmail),
+      maxSizeAttachmentsPerEmailProvider: maxSizeAttachmentsPerEmail,
     );
   }
+
+  @override
+  int? get hardLimitBytes => AttachmentUploadRequestFactory
+      .normalizeServerLimitBytes(maxSizeAttachmentsPerEmailProvider());
 
   @override
   int get currentAllAttachmentBytes =>

--- a/lib/features/composer/presentation/validator/composer_attachment_upload_state_source.dart
+++ b/lib/features/composer/presentation/validator/composer_attachment_upload_state_source.dart
@@ -1,0 +1,45 @@
+
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_request_factory.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_state_source.dart';
+import 'package:tmail_ui_user/features/upload/presentation/controller/upload_controller.dart';
+import 'package:tmail_ui_user/main/utils/app_config.dart';
+
+/// Reads the composer's current upload state for the attachment upload
+/// validator.
+class ComposerAttachmentUploadStateSource implements AttachmentUploadStateSource {
+  /// Live reference: byte totals below are read from it on every access.
+  final UploadController uploadController;
+
+  @override
+  final int warningLimitBytes;
+  @override
+  final int? hardLimitBytes;
+
+  const ComposerAttachmentUploadStateSource({
+    required this.uploadController,
+    required this.warningLimitBytes,
+    required this.hardLimitBytes,
+  });
+
+  /// Resolves the limits from the raw server capability value.
+  factory ComposerAttachmentUploadStateSource.fromServerCapability({
+    required UploadController uploadController,
+    required num? maxSizeAttachmentsPerEmail,
+  }) {
+    return ComposerAttachmentUploadStateSource(
+      uploadController: uploadController,
+      warningLimitBytes: AppConfig.warningAttachmentFileSizeInMegabytes * 1024 * 1024,
+      hardLimitBytes: AttachmentUploadRequestFactory.normalizeServerLimitBytes(
+          maxSizeAttachmentsPerEmail),
+    );
+  }
+
+  @override
+  int get currentAllAttachmentBytes =>
+      uploadController.regularAttachmentsTotalBytes +
+      uploadController.inlineAttachmentsTotalBytes;
+
+  @override
+  int get currentRegularAttachmentBytes =>
+      uploadController.regularAttachmentsTotalBytes;
+}

--- a/lib/features/upload/domain/validator/attachment_size_limit_policy.dart
+++ b/lib/features/upload/domain/validator/attachment_size_limit_policy.dart
@@ -1,0 +1,19 @@
+
+class AttachmentSizeLimitPolicy {
+  const AttachmentSizeLimitPolicy._();
+
+  static bool isExceededMaxSizeAttachmentsPerEmail({
+    required int allAttachmentBytes,
+    required int? hardLimitBytes,
+  }) {
+    if (hardLimitBytes == null) return false;
+    return allAttachmentBytes > hardLimitBytes;
+  }
+
+  static bool isExceededWarningAttachmentFileSizeInComposer({
+    required int regularAttachmentBytes,
+    required int warningLimitBytes,
+  }) {
+    return regularAttachmentBytes > warningLimitBytes;
+  }
+}

--- a/lib/features/upload/domain/validator/attachment_size_limit_rule.dart
+++ b/lib/features/upload/domain/validator/attachment_size_limit_rule.dart
@@ -17,9 +17,10 @@ final class AttachmentSizeLimitRule implements AttachmentUploadRule {
       return ValidationRejected(MaxEmailAttachmentSizeExceeded(hardLimit!));
     }
 
-    if (AttachmentSizeLimitPolicy.isExceededWarningAttachmentFileSizeInComposer(
-        regularAttachmentBytes: request.sizes.regularAttachmentBytes,
-        warningLimitBytes: request.limits.warningLimitBytes)) {
+    if (request.sizes.proposedRegularAttachmentBytes > 0 &&
+        AttachmentSizeLimitPolicy.isExceededWarningAttachmentFileSizeInComposer(
+            regularAttachmentBytes: request.sizes.regularAttachmentBytes,
+            warningLimitBytes: request.limits.warningLimitBytes)) {
       return ValidationConfirmationRequired(const [LargeRegularAttachmentWarning()]);
     }
 

--- a/lib/features/upload/domain/validator/attachment_size_limit_rule.dart
+++ b/lib/features/upload/domain/validator/attachment_size_limit_rule.dart
@@ -1,0 +1,28 @@
+
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_size_limit_policy.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_failure.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_prompt.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_request.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/validation_decision.dart';
+
+final class AttachmentSizeLimitRule implements AttachmentUploadRule {
+  const AttachmentSizeLimitRule();
+
+  @override
+  AttachmentUploadDecision validate(AttachmentUploadRequest request) {
+    final hardLimit = request.limits.hardLimitBytes;
+    if (AttachmentSizeLimitPolicy.isExceededMaxSizeAttachmentsPerEmail(
+        allAttachmentBytes: request.sizes.allAttachmentBytes,
+        hardLimitBytes: hardLimit)) {
+      return ValidationRejected(MaxEmailAttachmentSizeExceeded(hardLimit!));
+    }
+
+    if (AttachmentSizeLimitPolicy.isExceededWarningAttachmentFileSizeInComposer(
+        regularAttachmentBytes: request.sizes.regularAttachmentBytes,
+        warningLimitBytes: request.limits.warningLimitBytes)) {
+      return ValidationConfirmationRequired(const [LargeRegularAttachmentWarning()]);
+    }
+
+    return const ValidationAllowed();
+  }
+}

--- a/lib/features/upload/domain/validator/attachment_size_limit_rule.dart
+++ b/lib/features/upload/domain/validator/attachment_size_limit_rule.dart
@@ -1,4 +1,5 @@
 
+import 'package:core/utils/app_logger.dart';
 import 'package:tmail_ui_user/features/upload/domain/validator/attachment_size_limit_policy.dart';
 import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_failure.dart';
 import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_prompt.dart';
@@ -14,6 +15,9 @@ final class AttachmentSizeLimitRule implements AttachmentUploadRule {
     if (AttachmentSizeLimitPolicy.isExceededMaxSizeAttachmentsPerEmail(
         allAttachmentBytes: request.sizes.allAttachmentBytes,
         hardLimitBytes: hardLimit)) {
+      logWarning('AttachmentSizeLimitRule::validate: rejected, '
+          'allAttachmentBytes = ${request.sizes.allAttachmentBytes} | '
+          'hardLimitBytes = $hardLimit');
       return ValidationRejected(MaxEmailAttachmentSizeExceeded(hardLimit!));
     }
 
@@ -21,6 +25,9 @@ final class AttachmentSizeLimitRule implements AttachmentUploadRule {
         AttachmentSizeLimitPolicy.isExceededWarningAttachmentFileSizeInComposer(
             regularAttachmentBytes: request.sizes.regularAttachmentBytes,
             warningLimitBytes: request.limits.warningLimitBytes)) {
+      log('AttachmentSizeLimitRule::validate: confirmation required, '
+          'regularAttachmentBytes = ${request.sizes.regularAttachmentBytes} | '
+          'warningLimitBytes = ${request.limits.warningLimitBytes}');
       return ValidationConfirmationRequired(const [LargeRegularAttachmentWarning()]);
     }
 

--- a/lib/features/upload/domain/validator/attachment_upload_failure.dart
+++ b/lib/features/upload/domain/validator/attachment_upload_failure.dart
@@ -1,0 +1,10 @@
+
+sealed class AttachmentUploadFailure {
+  const AttachmentUploadFailure();
+}
+
+final class MaxEmailAttachmentSizeExceeded extends AttachmentUploadFailure {
+  final int maximumBytes;
+
+  const MaxEmailAttachmentSizeExceeded(this.maximumBytes);
+}

--- a/lib/features/upload/domain/validator/attachment_upload_limits.dart
+++ b/lib/features/upload/domain/validator/attachment_upload_limits.dart
@@ -1,0 +1,10 @@
+
+final class AttachmentUploadLimits {
+  final int warningLimitBytes;
+  final int? hardLimitBytes;
+
+  const AttachmentUploadLimits({
+    required this.warningLimitBytes,
+    this.hardLimitBytes,
+  });
+}

--- a/lib/features/upload/domain/validator/attachment_upload_prompt.dart
+++ b/lib/features/upload/domain/validator/attachment_upload_prompt.dart
@@ -1,0 +1,8 @@
+
+sealed class AttachmentUploadPrompt {
+  const AttachmentUploadPrompt();
+}
+
+final class LargeRegularAttachmentWarning extends AttachmentUploadPrompt {
+  const LargeRegularAttachmentWarning();
+}

--- a/lib/features/upload/domain/validator/attachment_upload_request.dart
+++ b/lib/features/upload/domain/validator/attachment_upload_request.dart
@@ -1,0 +1,19 @@
+
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_failure.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_limits.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_prompt.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_size_snapshot.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/validation_decision.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/validation_pipeline.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/validation_rule.dart';
+
+final class AttachmentUploadRequest {
+  final AttachmentUploadSizeSnapshot sizes;
+  final AttachmentUploadLimits limits;
+
+  const AttachmentUploadRequest({required this.sizes, required this.limits});
+}
+
+typedef AttachmentUploadDecision = ValidationDecision<AttachmentUploadFailure, AttachmentUploadPrompt>;
+typedef AttachmentUploadRule = ValidationRule<AttachmentUploadRequest, AttachmentUploadFailure, AttachmentUploadPrompt>;
+typedef AttachmentUploadValidator = ValidationPipeline<AttachmentUploadRequest, AttachmentUploadFailure, AttachmentUploadPrompt>;

--- a/lib/features/upload/domain/validator/attachment_upload_request_factory.dart
+++ b/lib/features/upload/domain/validator/attachment_upload_request_factory.dart
@@ -1,0 +1,71 @@
+
+import 'package:model/upload/file_info.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_limits.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_request.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_size_snapshot.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_state_source.dart';
+
+final class AttachmentUploadRequestFactory {
+  const AttachmentUploadRequestFactory();
+
+  AttachmentUploadRequest fromProposedFiles({
+    required Iterable<FileInfo> files,
+    required AttachmentUploadStateSource state,
+  }) {
+    final candidate = List<FileInfo>.unmodifiable(files);
+    final proposedAllBytes = candidate.fold<int>(0, (total, file) => total + _byteCount(file));
+    final proposedRegularBytes = candidate
+        .where((file) => file.isInline != true)
+        .fold<int>(0, (total, file) => total + _byteCount(file));
+    return AttachmentUploadRequest(
+      sizes: AttachmentUploadSizeSnapshot(
+        currentAllAttachmentBytes: _requireNonNegative(state.currentAllAttachmentBytes, 'currentAllAttachmentBytes'),
+        proposedAllAttachmentBytes: proposedAllBytes,
+        currentRegularAttachmentBytes: _requireNonNegative(state.currentRegularAttachmentBytes, 'currentRegularAttachmentBytes'),
+        proposedRegularAttachmentBytes: proposedRegularBytes,
+      ),
+      limits: _limitsOf(state),
+    );
+  }
+
+  AttachmentUploadRequest fromProposedBytes({
+    required int proposedAllAttachmentBytes,
+    required int proposedRegularAttachmentBytes,
+    required AttachmentUploadStateSource state,
+  }) {
+    return AttachmentUploadRequest(
+      sizes: AttachmentUploadSizeSnapshot(
+        currentAllAttachmentBytes: _requireNonNegative(state.currentAllAttachmentBytes, 'currentAllAttachmentBytes'),
+        proposedAllAttachmentBytes: _requireNonNegative(proposedAllAttachmentBytes, 'proposedAllAttachmentBytes'),
+        currentRegularAttachmentBytes: _requireNonNegative(state.currentRegularAttachmentBytes, 'currentRegularAttachmentBytes'),
+        proposedRegularAttachmentBytes: _requireNonNegative(proposedRegularAttachmentBytes, 'proposedRegularAttachmentBytes'),
+      ),
+      limits: _limitsOf(state),
+    );
+  }
+
+  AttachmentUploadLimits _limitsOf(AttachmentUploadStateSource state) => AttachmentUploadLimits(
+        warningLimitBytes: state.warningLimitBytes,
+        hardLimitBytes: state.hardLimitBytes,
+      );
+
+  int _byteCount(FileInfo file) {
+    return _requireNonNegative(file.fileSize, 'file.fileSize');
+  }
+
+  int _requireNonNegative(int value, String name) {
+    if (value < 0) throw ArgumentError.value(value, name, 'must be non-negative');
+    return value;
+  }
+
+  static int? normalizeServerLimitBytes(num? value) {
+    if (value == null) return null;
+    if (value is double && !value.isFinite) {
+      throw ArgumentError.value(value, 'value', 'must be finite');
+    }
+    if (value < 0 || value != value.truncate()) {
+      throw ArgumentError.value(value, 'value', 'must be a non-negative integer');
+    }
+    return value.toInt();
+  }
+}

--- a/lib/features/upload/domain/validator/attachment_upload_size_snapshot.dart
+++ b/lib/features/upload/domain/validator/attachment_upload_size_snapshot.dart
@@ -1,0 +1,18 @@
+
+final class AttachmentUploadSizeSnapshot {
+  final int currentAllAttachmentBytes;
+  final int proposedAllAttachmentBytes;
+  final int currentRegularAttachmentBytes;
+  final int proposedRegularAttachmentBytes;
+
+  const AttachmentUploadSizeSnapshot({
+    required this.currentAllAttachmentBytes,
+    required this.proposedAllAttachmentBytes,
+    required this.currentRegularAttachmentBytes,
+    required this.proposedRegularAttachmentBytes,
+  });
+
+  int get allAttachmentBytes => currentAllAttachmentBytes + proposedAllAttachmentBytes;
+
+  int get regularAttachmentBytes => currentRegularAttachmentBytes + proposedRegularAttachmentBytes;
+}

--- a/lib/features/upload/domain/validator/attachment_upload_state_source.dart
+++ b/lib/features/upload/domain/validator/attachment_upload_state_source.dart
@@ -1,0 +1,16 @@
+
+/// Supplies the already-attached byte totals and the size limits the
+/// attachment upload validator needs, without exposing any controller type.
+abstract interface class AttachmentUploadStateSource {
+  /// Bytes of every attachment already picked, inline images included.
+  int get currentAllAttachmentBytes;
+
+  /// Bytes of the already picked attachments that are not inline images.
+  int get currentRegularAttachmentBytes;
+
+  /// Threshold above which the user is warned before uploading.
+  int get warningLimitBytes;
+
+  /// Server side hard cap, `null` when the server does not advertise one.
+  int? get hardLimitBytes;
+}

--- a/lib/features/upload/domain/validator/validation_decision.dart
+++ b/lib/features/upload/domain/validator/validation_decision.dart
@@ -1,0 +1,20 @@
+
+sealed class ValidationDecision<Failure, Prompt> {
+  const ValidationDecision();
+}
+
+final class ValidationAllowed<Failure, Prompt> extends ValidationDecision<Failure, Prompt> {
+  const ValidationAllowed();
+}
+
+final class ValidationRejected<Failure, Prompt> extends ValidationDecision<Failure, Prompt> {
+  final Failure failure;
+
+  const ValidationRejected(this.failure);
+}
+
+final class ValidationConfirmationRequired<Failure, Prompt> extends ValidationDecision<Failure, Prompt> {
+  final List<Prompt> prompts;
+
+  ValidationConfirmationRequired(Iterable<Prompt> prompts) : prompts = List.unmodifiable(prompts);
+}

--- a/lib/features/upload/domain/validator/validation_pipeline.dart
+++ b/lib/features/upload/domain/validator/validation_pipeline.dart
@@ -1,0 +1,27 @@
+
+import 'package:tmail_ui_user/features/upload/domain/validator/validation_decision.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/validation_rule.dart';
+
+final class ValidationPipeline<Request, Failure, Prompt> {
+  final List<ValidationRule<Request, Failure, Prompt>> _rules;
+
+  ValidationPipeline(Iterable<ValidationRule<Request, Failure, Prompt>> rules)
+      : _rules = List.unmodifiable(rules);
+
+  ValidationDecision<Failure, Prompt> validate(Request request) {
+    final prompts = <Prompt>[];
+    for (final rule in _rules) {
+      switch (rule.validate(request)) {
+        case ValidationAllowed():
+          break;
+        case ValidationRejected(:final failure):
+          return ValidationRejected(failure);
+        case ValidationConfirmationRequired(prompts: final rulePrompts):
+          prompts.addAll(rulePrompts);
+      }
+    }
+    return prompts.isEmpty
+        ? const ValidationAllowed()
+        : ValidationConfirmationRequired(prompts);
+  }
+}

--- a/lib/features/upload/domain/validator/validation_rule.dart
+++ b/lib/features/upload/domain/validator/validation_rule.dart
@@ -1,0 +1,6 @@
+
+import 'package:tmail_ui_user/features/upload/domain/validator/validation_decision.dart';
+
+abstract interface class ValidationRule<Request, Failure, Prompt> {
+  ValidationDecision<Failure, Prompt> validate(Request request);
+}

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -7,7 +7,6 @@ import 'package:core/presentation/state/success.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:dartz/dartz.dart';
 import 'package:dio/dio.dart';
-import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_body_part.dart';
@@ -16,12 +15,9 @@ import 'package:model/extensions/attachment_extension.dart';
 import 'package:model/extensions/list_attachment_extension.dart';
 import 'package:model/upload/file_info.dart';
 import 'package:tmail_ui_user/features/base/base_controller.dart';
-import 'package:tmail_ui_user/features/base/mixin/message_dialog_action_manager.dart';
 import 'package:tmail_ui_user/features/base/state/base_ui_state.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/upload_attachment_state.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/upload_attachment_interactor.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
-import 'package:tmail_ui_user/features/upload/domain/extensions/list_file_info_extension.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
 import 'package:tmail_ui_user/features/upload/domain/state/attachment_upload_state.dart';
 import 'package:tmail_ui_user/features/upload/presentation/extensions/upload_attachment_extension.dart';
@@ -30,11 +26,8 @@ import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_sta
 import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_status.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
-import 'package:tmail_ui_user/main/utils/app_config.dart';
 
 class UploadController extends BaseController {
-
-  final _mailboxDashBoardController = Get.find<MailboxDashBoardController>();
 
   final UploadAttachmentInteractor _uploadAttachmentInteractor;
 
@@ -268,6 +261,13 @@ class UploadController extends BaseController {
       .toList();
   }
 
+  /// Bytes of every regular (non-inline) attachment, whether newly picked or
+  /// already attached (e.g. restored from a draft), unlike [attachmentsPicked]
+  /// which only sees entries that still carry a [FileInfo].
+  int get regularAttachmentsTotalBytes => listUploadAttachments
+      .fold<num>(0, (total, fileState) => total + fileState.fileSize)
+      .toInt();
+
   UploadFileState? getUploadFileId(UploadTaskId id) {
     return listUploadAttachments
         .firstWhereOrNull((fileState) => fileState.uploadTaskId == id);
@@ -300,104 +300,6 @@ class UploadController extends BaseController {
         leadingSVGIconColor: Colors.white,
         leadingSVGIcon: imagePaths.icAttachment);
     }
-  }
-
-  bool isExceededMaxSizeAttachmentsPerEmail({num totalSizePreparedFiles = 0}) {
-    final currentTotalSize = attachmentsPicked.totalSize + inlineAttachmentsPicked.totalSize + totalSizePreparedFiles;
-    final maxSizeAttachmentsPerEmail = _mailboxDashBoardController.maxSizeAttachmentsPerEmail?.value;
-    log('UploadController::isExceededMaxSizeAttachmentsPerEmail(): currentTotalSize = $currentTotalSize | maxSizeAttachmentsPerEmail = $maxSizeAttachmentsPerEmail');
-    if (maxSizeAttachmentsPerEmail != null) {
-      return currentTotalSize > maxSizeAttachmentsPerEmail;
-    } else {
-      return false;
-    }
-  }
-
-  bool isExceededWarningAttachmentFileSizeInComposer({num totalSizePreparedFiles = 0}) {
-    final currentTotalSizeAttachments = attachmentsPicked.totalSize + totalSizePreparedFiles;
-    const maximumBytesSizeFileAttachedInComposer = AppConfig.warningAttachmentFileSizeInMegabytes * 1024 * 1024;
-    log('UploadController::isExceededMaxSizeFilesAttachedInComposer(): currentTotalSizeAttachments = $currentTotalSizeAttachments | maximumBytesSizeFileAttachedInComposer = $maximumBytesSizeFileAttachedInComposer');
-    return currentTotalSizeAttachments > maximumBytesSizeFileAttachedInComposer;
-  }
-
-  void validateTotalSizeAttachmentsBeforeUpload({
-    required num totalSizePreparedFiles,
-    num? totalSizePreparedFilesWithDispositionAttachment,
-    VoidCallback? onValidationSuccess
-  }) {
-    log('UploadController::_validateTotalSizeAttachmentsBeforeUpload: totalSizePreparedFiles = $totalSizePreparedFiles');
-    if (isExceededMaxSizeAttachmentsPerEmail(totalSizePreparedFiles: totalSizePreparedFiles)) {
-      if (currentContext == null) {
-        log('UploadController::_validateTotalSizeAttachmentsBeforeUpload: CONTEXT IS NULL');
-        return;
-      }
-
-      _showConfirmDialogWhenExceededMaxSizeAttachmentsPerEmail(context: currentContext!);
-      return;
-    }
-
-    if (isExceededWarningAttachmentFileSizeInComposer(totalSizePreparedFiles: totalSizePreparedFilesWithDispositionAttachment ?? totalSizePreparedFiles)) {
-      if (currentContext == null) {
-        log('UploadController::_validateTotalSizeAttachmentsBeforeUpload: CONTEXT IS NULL');
-        return;
-      }
-
-      _showWarningDialogWhenExceededMaxSizeFilesAttachedInComposer(
-        context: currentContext!,
-        confirmAction: () async {
-          await Future.delayed(
-            const Duration(milliseconds: 100),
-            onValidationSuccess
-          );
-        }
-      );
-      return;
-    }
-
-    onValidationSuccess?.call();
-  }
-
-  void validateTotalSizeInlineAttachmentsBeforeUpload({
-    required num totalSizePreparedFiles,
-    VoidCallback? onValidationSuccess
-  }) {
-    if (isExceededMaxSizeAttachmentsPerEmail(totalSizePreparedFiles: totalSizePreparedFiles)) {
-      if (currentContext == null) {
-        log('UploadController::validateTotalSizeInlineAttachmentsBeforeUpload: CONTEXT IS NULL');
-        return;
-      }
-
-      _showConfirmDialogWhenExceededMaxSizeAttachmentsPerEmail(context: currentContext!);
-      return;
-    }
-
-    onValidationSuccess?.call();
-  }
-
-  void _showConfirmDialogWhenExceededMaxSizeAttachmentsPerEmail({required BuildContext context}) {
-    final maxSizeAttachmentsPerEmail = filesize(_mailboxDashBoardController.maxSizeAttachmentsPerEmail?.value ?? 0, 0);
-    MessageDialogActionManager().showConfirmDialogAction(
-      context,
-      AppLocalizations.of(context).message_dialog_upload_attachments_exceeds_maximum_size(maxSizeAttachmentsPerEmail),
-      AppLocalizations.of(context).got_it,
-      title: AppLocalizations.of(context).maximum_files_size,
-      hasCancelButton: false);
-  }
-
-  void _showWarningDialogWhenExceededMaxSizeFilesAttachedInComposer({
-    required BuildContext context,
-    VoidCallback? confirmAction,
-  }) {
-    final appLocalizations = AppLocalizations.of(context);
-    MessageDialogActionManager().showConfirmDialogAction(
-      context,
-      title: '',
-      appLocalizations.warningMessageWhenExceedGenerallySizeInComposer,
-      appLocalizations.continueAction,
-      cancelTitle: appLocalizations.cancel,
-      alignCenter: true,
-      onConfirmAction: confirmAction,
-    );
   }
 
   bool get allUploadAttachmentsCompleted {
@@ -448,6 +350,14 @@ class UploadController extends BaseController {
       },
     );
   }
+
+  /// Bytes of every inline attachment, whether newly picked or already
+  /// attached, unlike [inlineAttachmentsPicked] which only sees entries that
+  /// still carry a [FileInfo].
+  int get inlineAttachmentsTotalBytes => _uploadingStateInlineFiles.uploadingStateFiles
+      .nonNulls
+      .fold<num>(0, (total, fileState) => total + fileState.fileSize)
+      .toInt();
 
   Map<String, Attachment> get mapInlineAttachments {
     if (_uploadingStateInlineFiles.uploadingStateFiles.isEmpty) {

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -216,22 +216,35 @@ class UploadController extends BaseController {
   Future<void> justUploadAttachmentsAction({
     required List<FileInfo> uploadFiles,
     required Uri uploadUri,
+    void Function(FileInfo uploadFile)? onFileSettled,
   }) {
     return Future.forEach<FileInfo>(uploadFiles, (uploadFile) async {
-      await uploadFileAction(uploadFile: uploadFile, uploadUri: uploadUri);
+      await uploadFileAction(
+        uploadFile: uploadFile,
+        uploadUri: uploadUri,
+        onSettled: onFileSettled == null ? null : () => onFileSettled(uploadFile),
+      );
     });
   }
 
+  /// [onSettled] fires once this file's upload stream truly completes
+  /// (success or failure), unlike the returned [Future] which resolves
+  /// immediately since the stream is only fired off via [consumeState].
   Future<void> uploadFileAction({
     required FileInfo uploadFile,
     required Uri uploadUri,
+    VoidCallback? onSettled,
   }) {
     log('UploadController::_uploadFile():fileName: ${uploadFile.fileName} | mimeType: ${uploadFile.mimeType} | isInline: ${uploadFile.isInline} | fromFileShared: ${uploadFile.isShared}');
-    consumeState(_uploadAttachmentInteractor.execute(
+    final uploadStateStream = _uploadAttachmentInteractor.execute(
       uploadFile,
       uploadUri,
       cancelToken: CancelToken(),
-    ));
+    ).asBroadcastStream();
+    consumeState(uploadStateStream);
+    if (onSettled != null) {
+      uploadStateStream.listen(null, onDone: onSettled);
+    }
     return Future.value();
   }
 

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -243,7 +243,12 @@ class UploadController extends BaseController {
     ).asBroadcastStream();
     consumeState(uploadStateStream);
     if (onSettled != null) {
-      uploadStateStream.listen(null, onDone: onSettled);
+      uploadStateStream.listen(
+        null,
+        onError: (error) => logWarning(
+          'UploadController::uploadFileAction:onError = $error'),
+        onDone: onSettled,
+      );
     }
     return Future.value();
   }

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -216,40 +216,22 @@ class UploadController extends BaseController {
   Future<void> justUploadAttachmentsAction({
     required List<FileInfo> uploadFiles,
     required Uri uploadUri,
-    void Function(FileInfo uploadFile)? onFileSettled,
   }) {
     return Future.forEach<FileInfo>(uploadFiles, (uploadFile) async {
-      await uploadFileAction(
-        uploadFile: uploadFile,
-        uploadUri: uploadUri,
-        onSettled: onFileSettled == null ? null : () => onFileSettled(uploadFile),
-      );
+      await uploadFileAction(uploadFile: uploadFile, uploadUri: uploadUri);
     });
   }
 
-  /// [onSettled] fires once this file's upload stream truly completes
-  /// (success or failure), unlike the returned [Future] which resolves
-  /// immediately since the stream is only fired off via [consumeState].
   Future<void> uploadFileAction({
     required FileInfo uploadFile,
     required Uri uploadUri,
-    VoidCallback? onSettled,
   }) {
     log('UploadController::_uploadFile():fileName: ${uploadFile.fileName} | mimeType: ${uploadFile.mimeType} | isInline: ${uploadFile.isInline} | fromFileShared: ${uploadFile.isShared}');
-    final uploadStateStream = _uploadAttachmentInteractor.execute(
+    consumeState(_uploadAttachmentInteractor.execute(
       uploadFile,
       uploadUri,
       cancelToken: CancelToken(),
-    ).asBroadcastStream();
-    consumeState(uploadStateStream);
-    if (onSettled != null) {
-      uploadStateStream.listen(
-        null,
-        onError: (error) => logWarning(
-          'UploadController::uploadFileAction:onError = $error'),
-        onDone: onSettled,
-      );
-    }
+    ));
     return Future.value();
   }
 

--- a/lib/features/upload/presentation/dialog/attachment_confirmation_presenter.dart
+++ b/lib/features/upload/presentation/dialog/attachment_confirmation_presenter.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_prompt.dart';
+import 'package:tmail_ui_user/features/upload/presentation/dialog/upload_size_warning_dialog_presenter.dart';
+
+class AttachmentConfirmationPresenter {
+  const AttachmentConfirmationPresenter._();
+
+  static Future<bool> ask(BuildContext context, AttachmentUploadPrompt prompt) async {
+    var confirmed = false;
+    switch (prompt) {
+      case LargeRegularAttachmentWarning():
+        await UploadSizeWarningDialogPresenter.showExceededWarningSize(
+          context: context,
+          confirmAction: () => confirmed = true);
+    }
+    return confirmed;
+  }
+}

--- a/lib/features/upload/presentation/dialog/attachment_validation_failure_presenter.dart
+++ b/lib/features/upload/presentation/dialog/attachment_validation_failure_presenter.dart
@@ -5,10 +5,10 @@ import 'package:tmail_ui_user/features/upload/presentation/dialog/max_size_attac
 class AttachmentValidationFailurePresenter {
   const AttachmentValidationFailurePresenter._();
 
-  static void present(BuildContext context, AttachmentUploadFailure failure) {
+  static Future<void> present(BuildContext context, AttachmentUploadFailure failure) {
     switch (failure) {
       case MaxEmailAttachmentSizeExceeded(:final maximumBytes):
-        MaxSizeAttachmentsDialogPresenter.show(
+        return MaxSizeAttachmentsDialogPresenter.show(
           context: context,
           maxSizeAttachmentsPerEmail: maximumBytes);
     }

--- a/lib/features/upload/presentation/dialog/attachment_validation_failure_presenter.dart
+++ b/lib/features/upload/presentation/dialog/attachment_validation_failure_presenter.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_failure.dart';
+import 'package:tmail_ui_user/features/upload/presentation/dialog/max_size_attachments_dialog_presenter.dart';
+
+class AttachmentValidationFailurePresenter {
+  const AttachmentValidationFailurePresenter._();
+
+  static void present(BuildContext context, AttachmentUploadFailure failure) {
+    switch (failure) {
+      case MaxEmailAttachmentSizeExceeded(:final maximumBytes):
+        MaxSizeAttachmentsDialogPresenter.show(
+          context: context,
+          maxSizeAttachmentsPerEmail: maximumBytes);
+    }
+  }
+}

--- a/lib/features/upload/presentation/dialog/max_size_attachments_dialog_presenter.dart
+++ b/lib/features/upload/presentation/dialog/max_size_attachments_dialog_presenter.dart
@@ -1,0 +1,21 @@
+import 'package:filesize/filesize.dart';
+import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/features/base/mixin/message_dialog_action_manager.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+class MaxSizeAttachmentsDialogPresenter {
+  const MaxSizeAttachmentsDialogPresenter._();
+
+  static void show({
+    required BuildContext context,
+    required num? maxSizeAttachmentsPerEmail,
+  }) {
+    final maxSize = filesize(maxSizeAttachmentsPerEmail ?? 0, 0);
+    MessageDialogActionManager().showConfirmDialogAction(
+      context,
+      AppLocalizations.of(context).message_dialog_upload_attachments_exceeds_maximum_size(maxSize),
+      AppLocalizations.of(context).got_it,
+      title: AppLocalizations.of(context).maximum_files_size,
+      hasCancelButton: false);
+  }
+}

--- a/lib/features/upload/presentation/dialog/max_size_attachments_dialog_presenter.dart
+++ b/lib/features/upload/presentation/dialog/max_size_attachments_dialog_presenter.dart
@@ -6,12 +6,12 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 class MaxSizeAttachmentsDialogPresenter {
   const MaxSizeAttachmentsDialogPresenter._();
 
-  static void show({
+  static Future<void> show({
     required BuildContext context,
     required num? maxSizeAttachmentsPerEmail,
   }) {
     final maxSize = filesize(maxSizeAttachmentsPerEmail ?? 0, 0);
-    MessageDialogActionManager().showConfirmDialogAction(
+    return MessageDialogActionManager().showConfirmDialogAction(
       context,
       AppLocalizations.of(context).message_dialog_upload_attachments_exceeds_maximum_size(maxSize),
       AppLocalizations.of(context).got_it,

--- a/lib/features/upload/presentation/dialog/upload_size_warning_dialog_presenter.dart
+++ b/lib/features/upload/presentation/dialog/upload_size_warning_dialog_presenter.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/features/base/mixin/message_dialog_action_manager.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+
+class UploadSizeWarningDialogPresenter {
+  const UploadSizeWarningDialogPresenter._();
+
+  static Future<void> showExceededWarningSize({
+    required BuildContext context,
+    VoidCallback? confirmAction,
+    VoidCallback? cancelAction,
+  }) {
+    final appLocalizations = AppLocalizations.of(context);
+    return MessageDialogActionManager().showConfirmDialogAction(
+      context,
+      title: '',
+      appLocalizations.warningMessageWhenExceedGenerallySizeInComposer,
+      appLocalizations.continueAction,
+      cancelTitle: appLocalizations.cancel,
+      alignCenter: true,
+      outsideDismissible: false,
+      onConfirmAction: confirmAction,
+      onCancelAction: cancelAction,
+      onCloseButtonAction: () {
+        popBack();
+        cancelAction?.call();
+      },
+    );
+  }
+}

--- a/lib/features/upload/presentation/validator/attachment_upload_gate.dart
+++ b/lib/features/upload/presentation/validator/attachment_upload_gate.dart
@@ -1,0 +1,29 @@
+
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_request.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/validation_decision.dart';
+import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_validation_feedback.dart';
+
+final class AttachmentUploadGate {
+  final AttachmentUploadValidator _validator;
+
+  const AttachmentUploadGate(this._validator);
+
+  Future<bool> permits({
+    required AttachmentUploadRequest request,
+    required AttachmentValidationFeedback? Function() feedbackFactory,
+  }) async {
+    switch (_validator.validate(request)) {
+      case ValidationAllowed():
+        return true;
+      case ValidationRejected(:final failure):
+        final feedback = feedbackFactory();
+        if (feedback == null) return false;
+        await feedback.showFailure(failure);
+        return false;
+      case ValidationConfirmationRequired(:final prompts):
+        final feedback = feedbackFactory();
+        if (feedback == null) return false;
+        return feedback.confirmAll(prompts);
+    }
+  }
+}

--- a/lib/features/upload/presentation/validator/attachment_upload_validation_service.dart
+++ b/lib/features/upload/presentation/validator/attachment_upload_validation_service.dart
@@ -1,4 +1,6 @@
 
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'package:model/email/attachment.dart';
 import 'package:model/upload/file_info.dart';
@@ -24,6 +26,12 @@ class AttachmentUploadValidationService {
   final AttachmentUploadGate _gate;
   final AttachmentValidationFeedbackBuilder _feedbackBuilder;
 
+  /// Serializes [_validate] calls so a second concurrent upload request is
+  /// only built/validated once the previous one's [onAllowed] has run,
+  /// preventing two overlapping validations from both passing and jointly
+  /// exceeding the hard cap.
+  Future<void> _lock = Future.value();
+
   AttachmentUploadValidationService({
     required AttachmentUploadStateSource stateSource,
     AttachmentUploadValidator? validator,
@@ -41,7 +49,7 @@ class AttachmentUploadValidationService {
   }) {
     return _validate(
       context: context,
-      request: _requestFactory.fromProposedFiles(
+      requestBuilder: () => _requestFactory.fromProposedFiles(
         files: files,
         state: _stateSource,
       ),
@@ -61,7 +69,7 @@ class AttachmentUploadValidationService {
 
     return _validate(
       context: context,
-      request: _requestFactory.fromProposedBytes(
+      requestBuilder: () => _requestFactory.fromProposedBytes(
         proposedAllAttachmentBytes: attachmentBytes,
         proposedRegularAttachmentBytes: isRegularAttachment ? attachmentBytes : 0,
         state: _stateSource,
@@ -81,16 +89,25 @@ class AttachmentUploadValidationService {
 
   Future<void> _validate({
     BuildContext? context,
-    required AttachmentUploadRequest request,
+    required AttachmentUploadRequest Function() requestBuilder,
     required VoidCallback onAllowed,
-  }) async {
-    final allowed = await _gate.permits(
-      request: request,
-      feedbackFactory: () {
-        final resolvedContext = context ?? currentContext;
-        return resolvedContext == null ? null : _feedbackBuilder(resolvedContext);
-      },
-    );
-    if (allowed) onAllowed();
+  }) {
+    final previous = _lock;
+    final completer = Completer<void>();
+    _lock = completer.future;
+    return previous.then((_) async {
+      try {
+        final allowed = await _gate.permits(
+          request: requestBuilder(),
+          feedbackFactory: () {
+            final resolvedContext = context ?? currentContext;
+            return resolvedContext == null ? null : _feedbackBuilder(resolvedContext);
+          },
+        );
+        if (allowed) onAllowed();
+      } finally {
+        completer.complete();
+      }
+    });
   }
 }

--- a/lib/features/upload/presentation/validator/attachment_upload_validation_service.dart
+++ b/lib/features/upload/presentation/validator/attachment_upload_validation_service.dart
@@ -1,5 +1,6 @@
 
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/widgets.dart';
 import 'package:model/email/attachment.dart';
@@ -26,11 +27,22 @@ class AttachmentUploadValidationService {
   final AttachmentUploadGate _gate;
   final AttachmentValidationFeedbackBuilder _feedbackBuilder;
 
+  /// Reads [_stateSource] with [_reservedAllAttachmentBytes] /
+  /// [_reservedRegularAttachmentBytes] added on top, so a validation request
+  /// built while a previously allowed upload is still in flight (bytes not
+  /// yet reflected by [_stateSource], e.g. real network upload not finished)
+  /// still sees those bytes as already committed.
+  late final AttachmentUploadStateSource _effectiveStateSource =
+      _ReservingStateSource(source: _stateSource, service: this);
+
   /// Serializes [_validate] calls so a second concurrent upload request is
-  /// only built/validated once the previous one's [onAllowed] has run,
+  /// only built/validated once the previous one's gate check has resolved,
   /// preventing two overlapping validations from both passing and jointly
   /// exceeding the hard cap.
   Future<void> _lock = Future.value();
+
+  int _reservedAllAttachmentBytes = 0;
+  int _reservedRegularAttachmentBytes = 0;
 
   AttachmentUploadValidationService({
     required AttachmentUploadStateSource stateSource,
@@ -51,7 +63,7 @@ class AttachmentUploadValidationService {
       context: context,
       requestBuilder: () => _requestFactory.fromProposedFiles(
         files: files,
-        state: _stateSource,
+        state: _effectiveStateSource,
       ),
       onAllowed: onAllowed,
     );
@@ -72,7 +84,7 @@ class AttachmentUploadValidationService {
       requestBuilder: () => _requestFactory.fromProposedBytes(
         proposedAllAttachmentBytes: attachmentBytes,
         proposedRegularAttachmentBytes: isRegularAttachment ? attachmentBytes : 0,
-        state: _stateSource,
+        state: _effectiveStateSource,
       ),
       onAllowed: onAllowed,
     );
@@ -82,9 +94,22 @@ class AttachmentUploadValidationService {
   /// showing any dialog.
   bool isExceededMaxSizeAttachmentsPerEmail() {
     return AttachmentSizeLimitPolicy.isExceededMaxSizeAttachmentsPerEmail(
-      allAttachmentBytes: _stateSource.currentAllAttachmentBytes,
-      hardLimitBytes: _stateSource.hardLimitBytes,
+      allAttachmentBytes: _effectiveStateSource.currentAllAttachmentBytes,
+      hardLimitBytes: _effectiveStateSource.hardLimitBytes,
     );
+  }
+
+  /// Releases bytes reserved by a previously allowed request once its upload
+  /// has actually settled (succeeded or failed) and [_stateSource] reflects
+  /// it. Callers must release exactly the bytes reserved for that request.
+  void releaseReservedBytes({
+    required int allAttachmentBytes,
+    required int regularAttachmentBytes,
+  }) {
+    _reservedAllAttachmentBytes =
+        math.max(0, _reservedAllAttachmentBytes - allAttachmentBytes);
+    _reservedRegularAttachmentBytes =
+        math.max(0, _reservedRegularAttachmentBytes - regularAttachmentBytes);
   }
 
   Future<void> _validate({
@@ -97,17 +122,47 @@ class AttachmentUploadValidationService {
     _lock = completer.future;
     return previous.then((_) async {
       try {
+        final request = requestBuilder();
         final allowed = await _gate.permits(
-          request: requestBuilder(),
+          request: request,
           feedbackFactory: () {
             final resolvedContext = context ?? currentContext;
             return resolvedContext == null ? null : _feedbackBuilder(resolvedContext);
           },
         );
-        if (allowed) onAllowed();
+        if (allowed) {
+          _reservedAllAttachmentBytes += request.sizes.proposedAllAttachmentBytes;
+          _reservedRegularAttachmentBytes += request.sizes.proposedRegularAttachmentBytes;
+          onAllowed();
+        }
       } finally {
         completer.complete();
       }
     });
   }
+}
+
+/// Adds a [AttachmentUploadValidationService]'s in-flight reservation on top
+/// of the real [AttachmentUploadStateSource] byte totals.
+final class _ReservingStateSource implements AttachmentUploadStateSource {
+  const _ReservingStateSource({required AttachmentUploadStateSource source, required AttachmentUploadValidationService service})
+      : _source = source,
+        _service = service;
+
+  final AttachmentUploadStateSource _source;
+  final AttachmentUploadValidationService _service;
+
+  @override
+  int get currentAllAttachmentBytes =>
+      _source.currentAllAttachmentBytes + _service._reservedAllAttachmentBytes;
+
+  @override
+  int get currentRegularAttachmentBytes =>
+      _source.currentRegularAttachmentBytes + _service._reservedRegularAttachmentBytes;
+
+  @override
+  int get warningLimitBytes => _source.warningLimitBytes;
+
+  @override
+  int? get hardLimitBytes => _source.hardLimitBytes;
 }

--- a/lib/features/upload/presentation/validator/attachment_upload_validation_service.dart
+++ b/lib/features/upload/presentation/validator/attachment_upload_validation_service.dart
@@ -1,0 +1,96 @@
+
+import 'package:flutter/widgets.dart';
+import 'package:model/email/attachment.dart';
+import 'package:model/upload/file_info.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_size_limit_policy.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_size_limit_rule.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_request.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_request_factory.dart';
+import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_upload_gate.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_state_source.dart';
+import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_validation_feedback.dart';
+import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_validation_feedback_impl.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+
+typedef AttachmentValidationFeedbackBuilder = AttachmentValidationFeedback Function(BuildContext context);
+
+/// Single entry point for every attachment upload call site: hand it what the
+/// user wants to attach plus the action to run once allowed, and it builds the
+/// validation request, runs the rules and shows the resulting dialogs.
+class AttachmentUploadValidationService {
+  static const AttachmentUploadRequestFactory _requestFactory = AttachmentUploadRequestFactory();
+
+  final AttachmentUploadStateSource _stateSource;
+  final AttachmentUploadGate _gate;
+  final AttachmentValidationFeedbackBuilder _feedbackBuilder;
+
+  AttachmentUploadValidationService({
+    required AttachmentUploadStateSource stateSource,
+    AttachmentUploadValidator? validator,
+    AttachmentValidationFeedbackBuilder? feedbackBuilder,
+  })  : _stateSource = stateSource,
+        _gate = AttachmentUploadGate(
+            validator ?? AttachmentUploadValidator([const AttachmentSizeLimitRule()])),
+        _feedbackBuilder = feedbackBuilder ?? AttachmentValidationFeedbackImpl.new;
+
+  /// Validates the picked [files] then runs [onAllowed] when the upload may proceed.
+  Future<void> validateFiles({
+    BuildContext? context,
+    required List<FileInfo> files,
+    required VoidCallback onAllowed,
+  }) {
+    return _validate(
+      context: context,
+      request: _requestFactory.fromProposedFiles(
+        files: files,
+        state: _stateSource,
+      ),
+      onAllowed: onAllowed,
+    );
+  }
+
+  /// Validates an already uploaded [attachment] being re-attached, then runs
+  /// [onAllowed] when the upload may proceed.
+  Future<void> validateAttachment({
+    BuildContext? context,
+    required Attachment attachment,
+    required VoidCallback onAllowed,
+  }) {
+    final attachmentBytes = (attachment.size?.value ?? 0).toInt();
+    final isRegularAttachment = !attachment.isDispositionInlined();
+
+    return _validate(
+      context: context,
+      request: _requestFactory.fromProposedBytes(
+        proposedAllAttachmentBytes: attachmentBytes,
+        proposedRegularAttachmentBytes: isRegularAttachment ? attachmentBytes : 0,
+        state: _stateSource,
+      ),
+      onAllowed: onAllowed,
+    );
+  }
+
+  /// Whether what is already attached exceeds the server hard cap, without
+  /// showing any dialog.
+  bool isExceededMaxSizeAttachmentsPerEmail() {
+    return AttachmentSizeLimitPolicy.isExceededMaxSizeAttachmentsPerEmail(
+      allAttachmentBytes: _stateSource.currentAllAttachmentBytes,
+      hardLimitBytes: _stateSource.hardLimitBytes,
+    );
+  }
+
+  Future<void> _validate({
+    BuildContext? context,
+    required AttachmentUploadRequest request,
+    required VoidCallback onAllowed,
+  }) async {
+    final allowed = await _gate.permits(
+      request: request,
+      feedbackFactory: () {
+        final resolvedContext = context ?? currentContext;
+        return resolvedContext == null ? null : _feedbackBuilder(resolvedContext);
+      },
+    );
+    if (allowed) onAllowed();
+  }
+}

--- a/lib/features/upload/presentation/validator/attachment_upload_validation_service.dart
+++ b/lib/features/upload/presentation/validator/attachment_upload_validation_service.dart
@@ -1,7 +1,3 @@
-
-import 'dart:async';
-import 'dart:math' as math;
-
 import 'package:flutter/widgets.dart';
 import 'package:model/email/attachment.dart';
 import 'package:model/upload/file_info.dart';
@@ -9,8 +5,8 @@ import 'package:tmail_ui_user/features/upload/domain/validator/attachment_size_l
 import 'package:tmail_ui_user/features/upload/domain/validator/attachment_size_limit_rule.dart';
 import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_request.dart';
 import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_request_factory.dart';
-import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_upload_gate.dart';
 import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_state_source.dart';
+import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_upload_gate.dart';
 import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_validation_feedback.dart';
 import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_validation_feedback_impl.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
@@ -20,29 +16,19 @@ typedef AttachmentValidationFeedbackBuilder = AttachmentValidationFeedback Funct
 /// Single entry point for every attachment upload call site: hand it what the
 /// user wants to attach plus the action to run once allowed, and it builds the
 /// validation request, runs the rules and shows the resulting dialogs.
+///
+/// This is a UX guard, not an enforcement boundary. Each request is evaluated
+/// against the byte totals [_stateSource] reports at call time. Two attachment
+/// actions can overlap while a confirmation dialog is awaiting the user, in
+/// which case neither sees the other's bytes and together they may exceed the
+/// server limit. That is accepted: the composer's send guard rejects it before
+/// sending, and the server enforces the limit regardless.
 class AttachmentUploadValidationService {
   static const AttachmentUploadRequestFactory _requestFactory = AttachmentUploadRequestFactory();
 
   final AttachmentUploadStateSource _stateSource;
   final AttachmentUploadGate _gate;
   final AttachmentValidationFeedbackBuilder _feedbackBuilder;
-
-  /// Reads [_stateSource] with [_reservedAllAttachmentBytes] /
-  /// [_reservedRegularAttachmentBytes] added on top, so a validation request
-  /// built while a previously allowed upload is still in flight (bytes not
-  /// yet reflected by [_stateSource], e.g. real network upload not finished)
-  /// still sees those bytes as already committed.
-  late final AttachmentUploadStateSource _effectiveStateSource =
-      _ReservingStateSource(source: _stateSource, service: this);
-
-  /// Serializes [_validate] calls so a second concurrent upload request is
-  /// only built/validated once the previous one's gate check has resolved,
-  /// preventing two overlapping validations from both passing and jointly
-  /// exceeding the hard cap.
-  Future<void> _lock = Future.value();
-
-  int _reservedAllAttachmentBytes = 0;
-  int _reservedRegularAttachmentBytes = 0;
 
   AttachmentUploadValidationService({
     required AttachmentUploadStateSource stateSource,
@@ -61,9 +47,9 @@ class AttachmentUploadValidationService {
   }) {
     return _validate(
       context: context,
-      requestBuilder: () => _requestFactory.fromProposedFiles(
+      request: _requestFactory.fromProposedFiles(
         files: files,
-        state: _effectiveStateSource,
+        state: _stateSource,
       ),
       onAllowed: onAllowed,
     );
@@ -81,10 +67,10 @@ class AttachmentUploadValidationService {
 
     return _validate(
       context: context,
-      requestBuilder: () => _requestFactory.fromProposedBytes(
+      request: _requestFactory.fromProposedBytes(
         proposedAllAttachmentBytes: attachmentBytes,
         proposedRegularAttachmentBytes: isRegularAttachment ? attachmentBytes : 0,
-        state: _effectiveStateSource,
+        state: _stateSource,
       ),
       onAllowed: onAllowed,
     );
@@ -94,83 +80,25 @@ class AttachmentUploadValidationService {
   /// showing any dialog.
   bool isExceededMaxSizeAttachmentsPerEmail() {
     return AttachmentSizeLimitPolicy.isExceededMaxSizeAttachmentsPerEmail(
-      allAttachmentBytes: _effectiveStateSource.currentAllAttachmentBytes,
-      hardLimitBytes: _effectiveStateSource.hardLimitBytes,
+      allAttachmentBytes: _stateSource.currentAllAttachmentBytes,
+      hardLimitBytes: _stateSource.hardLimitBytes,
     );
-  }
-
-  /// Releases bytes reserved by a previously allowed request once its upload
-  /// has actually settled (succeeded or failed) and [_stateSource] reflects
-  /// it. Callers must release exactly the bytes reserved for that request.
-  void releaseReservedBytes({
-    required int allAttachmentBytes,
-    required int regularAttachmentBytes,
-  }) {
-    _reservedAllAttachmentBytes =
-        math.max(0, _reservedAllAttachmentBytes - allAttachmentBytes);
-    _reservedRegularAttachmentBytes =
-        math.max(0, _reservedRegularAttachmentBytes - regularAttachmentBytes);
   }
 
   Future<void> _validate({
     BuildContext? context,
-    required AttachmentUploadRequest Function() requestBuilder,
+    required AttachmentUploadRequest request,
     required VoidCallback onAllowed,
-  }) {
-    final previous = _lock;
-    final completer = Completer<void>();
-    _lock = completer.future;
-    return previous.then((_) async {
-      try {
-        final request = requestBuilder();
-        final allowed = await _gate.permits(
-          request: request,
-          feedbackFactory: () {
-            final resolvedContext = context ?? currentContext;
-            return resolvedContext == null ? null : _feedbackBuilder(resolvedContext);
-          },
-        );
-        if (allowed) {
-          _reservedAllAttachmentBytes += request.sizes.proposedAllAttachmentBytes;
-          _reservedRegularAttachmentBytes += request.sizes.proposedRegularAttachmentBytes;
-          try {
-            onAllowed();
-          } catch (_) {
-            releaseReservedBytes(
-              allAttachmentBytes: request.sizes.proposedAllAttachmentBytes,
-              regularAttachmentBytes: request.sizes.proposedRegularAttachmentBytes,
-            );
-            rethrow;
-          }
-        }
-      } finally {
-        completer.complete();
-      }
-    });
+  }) async {
+    final allowed = await _gate.permits(
+      request: request,
+      feedbackFactory: () {
+        final resolvedContext = context ?? currentContext;
+        return resolvedContext == null ? null : _feedbackBuilder(resolvedContext);
+      },
+    );
+    if (allowed) {
+      onAllowed();
+    }
   }
-}
-
-/// Adds a [AttachmentUploadValidationService]'s in-flight reservation on top
-/// of the real [AttachmentUploadStateSource] byte totals.
-final class _ReservingStateSource implements AttachmentUploadStateSource {
-  const _ReservingStateSource({required AttachmentUploadStateSource source, required AttachmentUploadValidationService service})
-      : _source = source,
-        _service = service;
-
-  final AttachmentUploadStateSource _source;
-  final AttachmentUploadValidationService _service;
-
-  @override
-  int get currentAllAttachmentBytes =>
-      _source.currentAllAttachmentBytes + _service._reservedAllAttachmentBytes;
-
-  @override
-  int get currentRegularAttachmentBytes =>
-      _source.currentRegularAttachmentBytes + _service._reservedRegularAttachmentBytes;
-
-  @override
-  int get warningLimitBytes => _source.warningLimitBytes;
-
-  @override
-  int? get hardLimitBytes => _source.hardLimitBytes;
 }

--- a/lib/features/upload/presentation/validator/attachment_upload_validation_service.dart
+++ b/lib/features/upload/presentation/validator/attachment_upload_validation_service.dart
@@ -133,7 +133,15 @@ class AttachmentUploadValidationService {
         if (allowed) {
           _reservedAllAttachmentBytes += request.sizes.proposedAllAttachmentBytes;
           _reservedRegularAttachmentBytes += request.sizes.proposedRegularAttachmentBytes;
-          onAllowed();
+          try {
+            onAllowed();
+          } catch (_) {
+            releaseReservedBytes(
+              allAttachmentBytes: request.sizes.proposedAllAttachmentBytes,
+              regularAttachmentBytes: request.sizes.proposedRegularAttachmentBytes,
+            );
+            rethrow;
+          }
         }
       } finally {
         completer.complete();

--- a/lib/features/upload/presentation/validator/attachment_validation_feedback.dart
+++ b/lib/features/upload/presentation/validator/attachment_validation_feedback.dart
@@ -1,0 +1,8 @@
+
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_failure.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_prompt.dart';
+
+abstract interface class AttachmentValidationFeedback {
+  Future<void> showFailure(AttachmentUploadFailure failure);
+  Future<bool> confirmAll(List<AttachmentUploadPrompt> prompts);
+}

--- a/lib/features/upload/presentation/validator/attachment_validation_feedback_impl.dart
+++ b/lib/features/upload/presentation/validator/attachment_validation_feedback_impl.dart
@@ -1,0 +1,28 @@
+
+import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_failure.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_prompt.dart';
+import 'package:tmail_ui_user/features/upload/presentation/dialog/attachment_confirmation_presenter.dart';
+import 'package:tmail_ui_user/features/upload/presentation/dialog/attachment_validation_failure_presenter.dart';
+import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_validation_feedback.dart';
+
+final class AttachmentValidationFeedbackImpl implements AttachmentValidationFeedback {
+  final BuildContext _context;
+
+  const AttachmentValidationFeedbackImpl(this._context);
+
+  @override
+  Future<void> showFailure(AttachmentUploadFailure failure) async {
+    if (!_context.mounted) return;
+    AttachmentValidationFailurePresenter.present(_context, failure);
+  }
+
+  @override
+  Future<bool> confirmAll(List<AttachmentUploadPrompt> prompts) async {
+    for (final prompt in prompts) {
+      if (!_context.mounted) return false;
+      if (!await AttachmentConfirmationPresenter.ask(_context, prompt)) return false;
+    }
+    return true;
+  }
+}

--- a/lib/features/upload/presentation/validator/attachment_validation_feedback_impl.dart
+++ b/lib/features/upload/presentation/validator/attachment_validation_feedback_impl.dart
@@ -14,7 +14,7 @@ final class AttachmentValidationFeedbackImpl implements AttachmentValidationFeed
   @override
   Future<void> showFailure(AttachmentUploadFailure failure) async {
     if (!_context.mounted) return;
-    AttachmentValidationFailurePresenter.present(_context, failure);
+    await AttachmentValidationFailurePresenter.present(_context, failure);
   }
 
   @override

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -42,6 +42,7 @@ import 'package:tmail_ui_user/features/composer/domain/usecases/create_new_and_s
 import 'package:tmail_ui_user/features/composer/domain/usecases/download_image_as_base64_interactor.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/save_composer_cache_interactor.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
+import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_upload_validation_service.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_view_web.dart';
 import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_web_controller.dart';
@@ -213,6 +214,7 @@ class MockMailboxDashBoardController extends Mock implements MailboxDashBoardCon
   MockSpec<PrintEmailInteractor>(),
   MockSpec<ComposerRepository>(),
   MockSpec<SaveTemplateEmailInteractor>(),
+  MockSpec<AttachmentUploadValidationService>(),
 
   // Additional Getx dependencies mock specs
   MockSpec<NetworkConnectionController>(fallbackGenerators: fallbackGenerators),
@@ -1196,6 +1198,74 @@ void main() {
           () => composerController?.tearDownMobileAutoSave(),
           returnsNormally,
         );
+      });
+    });
+
+    group('attachment size validation is injectable:', () {
+      ComposerController buildController({
+        required AttachmentUploadValidationService validationService,
+      }) {
+        return ComposerController(
+          mockLocalFilePickerInteractor,
+          mockLocalImagePickerInteractor,
+          mockGetEmailContentInteractor,
+          mockGetAllIdentitiesInteractor,
+          mockUploadController,
+          mockRemoveComposerCacheByIdInteractor,
+          mockSaveComposerCacheInteractor,
+          mockDownloadImageAsBase64Interactor,
+          mockTransformHtmlEmailContentInteractor,
+          mockGetServerSettingInteractor,
+          mockCreateNewAndSendEmailInteractor,
+          mockCreateNewAndSaveEmailToDraftsInteractor,
+          mockPrintEmailInteractor,
+          mockComposerRepository,
+          mockSaveTemplateEmailInteractor,
+        )..attachmentUploadValidationService = validationService;
+      }
+
+      MockAttachmentUploadValidationService buildValidationService({required bool allowed}) {
+        final validationService = MockAttachmentUploadValidationService();
+        when(validationService.validateAttachment(
+          context: anyNamed('context'),
+          attachment: anyNamed('attachment'),
+          onAllowed: anyNamed('onAllowed'),
+        )).thenAnswer((invocation) async {
+          if (allowed) {
+            (invocation.namedArguments[#onAllowed] as VoidCallback).call();
+          }
+        });
+        return validationService;
+      }
+
+      testWidgets(
+          'Should call uploadController.initializeUploadAttachments\n'
+          'When the injected validation service allows the upload', (tester) async {
+        await tester.pumpWidget(WidgetFixtures.makeTestableWidget(child: const SizedBox.shrink()));
+        await tester.pump();
+        final context = tester.element(find.byType(SizedBox));
+
+        final ctrl = buildController(validationService: buildValidationService(allowed: true));
+        final attachment = Attachment(blobId: Id('allowed-attachment'));
+
+        await ctrl.onAttachmentDropZoneListener(context, attachment);
+
+        verify(mockUploadController.initializeUploadAttachments([attachment])).called(1);
+      });
+
+      testWidgets(
+          'Should NOT call uploadController.initializeUploadAttachments\n'
+          'When the injected validation service rejects the upload', (tester) async {
+        await tester.pumpWidget(WidgetFixtures.makeTestableWidget(child: const SizedBox.shrink()));
+        await tester.pump();
+        final context = tester.element(find.byType(SizedBox));
+
+        final ctrl = buildController(validationService: buildValidationService(allowed: false));
+        final attachment = Attachment(blobId: Id('rejected-attachment'));
+
+        await ctrl.onAttachmentDropZoneListener(context, attachment);
+
+        verifyNever(mockUploadController.initializeUploadAttachments([attachment]));
       });
     });
 

--- a/test/features/composer/presentation/validator/composer_attachment_upload_state_source_test.dart
+++ b/test/features/composer/presentation/validator/composer_attachment_upload_state_source_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/composer/presentation/validator/composer_attachment_upload_state_source.dart';
+import 'package:tmail_ui_user/main/utils/app_config.dart';
+
+import '../composer_controller_test.mocks.dart';
+
+void main() {
+  late MockUploadController mockUploadController;
+
+  setUp(() {
+    mockUploadController = MockUploadController();
+    when(mockUploadController.regularAttachmentsTotalBytes).thenReturn(0);
+    when(mockUploadController.inlineAttachmentsTotalBytes).thenReturn(0);
+  });
+
+  group('ComposerAttachmentUploadStateSource byte totals:', () {
+    test('Should read regularAttachmentsTotalBytes/inlineAttachmentsTotalBytes live on every access', () {
+      final stateSource = ComposerAttachmentUploadStateSource(
+        uploadController: mockUploadController,
+        warningLimitBytes: 1000,
+        hardLimitBytes: null,
+      );
+
+      expect(stateSource.currentAllAttachmentBytes, 0);
+      expect(stateSource.currentRegularAttachmentBytes, 0);
+
+      when(mockUploadController.regularAttachmentsTotalBytes).thenReturn(100);
+      when(mockUploadController.inlineAttachmentsTotalBytes).thenReturn(50);
+
+      expect(stateSource.currentAllAttachmentBytes, 150);
+      expect(stateSource.currentRegularAttachmentBytes, 100);
+    });
+  });
+
+  group('ComposerAttachmentUploadStateSource.fromServerCapability:', () {
+    test('Should normalize a server capability value to an int hard limit', () {
+      final stateSource = ComposerAttachmentUploadStateSource.fromServerCapability(
+        uploadController: mockUploadController,
+        maxSizeAttachmentsPerEmail: 20971520,
+      );
+
+      expect(stateSource.hardLimitBytes, 20971520);
+    });
+
+    test('Should yield a null hard limit when the server advertises no capability', () {
+      final stateSource = ComposerAttachmentUploadStateSource.fromServerCapability(
+        uploadController: mockUploadController,
+        maxSizeAttachmentsPerEmail: null,
+      );
+
+      expect(stateSource.hardLimitBytes, isNull);
+    });
+
+    test('Should resolve the warning limit from AppConfig', () {
+      final stateSource = ComposerAttachmentUploadStateSource.fromServerCapability(
+        uploadController: mockUploadController,
+        maxSizeAttachmentsPerEmail: null,
+      );
+
+      expect(
+        stateSource.warningLimitBytes,
+        AppConfig.warningAttachmentFileSizeInMegabytes * 1024 * 1024,
+      );
+    });
+  });
+}

--- a/test/features/composer/presentation/validator/composer_attachment_upload_state_source_test.dart
+++ b/test/features/composer/presentation/validator/composer_attachment_upload_state_source_test.dart
@@ -19,7 +19,7 @@ void main() {
       final stateSource = ComposerAttachmentUploadStateSource(
         uploadController: mockUploadController,
         warningLimitBytes: 1000,
-        hardLimitBytes: null,
+        maxSizeAttachmentsPerEmailProvider: () => null,
       );
 
       expect(stateSource.currentAllAttachmentBytes, 0);
@@ -37,7 +37,7 @@ void main() {
     test('Should normalize a server capability value to an int hard limit', () {
       final stateSource = ComposerAttachmentUploadStateSource.fromServerCapability(
         uploadController: mockUploadController,
-        maxSizeAttachmentsPerEmail: 20971520,
+        maxSizeAttachmentsPerEmail: () => 20971520,
       );
 
       expect(stateSource.hardLimitBytes, 20971520);
@@ -46,7 +46,7 @@ void main() {
     test('Should yield a null hard limit when the server advertises no capability', () {
       final stateSource = ComposerAttachmentUploadStateSource.fromServerCapability(
         uploadController: mockUploadController,
-        maxSizeAttachmentsPerEmail: null,
+        maxSizeAttachmentsPerEmail: () => null,
       );
 
       expect(stateSource.hardLimitBytes, isNull);
@@ -55,13 +55,27 @@ void main() {
     test('Should resolve the warning limit from AppConfig', () {
       final stateSource = ComposerAttachmentUploadStateSource.fromServerCapability(
         uploadController: mockUploadController,
-        maxSizeAttachmentsPerEmail: null,
+        maxSizeAttachmentsPerEmail: () => null,
       );
 
       expect(
         stateSource.warningLimitBytes,
         AppConfig.warningAttachmentFileSizeInMegabytes * 1024 * 1024,
       );
+    });
+
+    test('Should read the hard limit live on every access', () {
+      num? currentCapability = 1000;
+      final stateSource = ComposerAttachmentUploadStateSource.fromServerCapability(
+        uploadController: mockUploadController,
+        maxSizeAttachmentsPerEmail: () => currentCapability,
+      );
+
+      expect(stateSource.hardLimitBytes, 1000);
+
+      currentCapability = 5000;
+
+      expect(stateSource.hardLimitBytes, 5000);
     });
   });
 }

--- a/test/features/upload/domain/validator/attachment_size_limit_policy_test.dart
+++ b/test/features/upload/domain/validator/attachment_size_limit_policy_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_size_limit_policy.dart';
+import 'package:tmail_ui_user/main/utils/app_config.dart';
+
+void main() {
+  group('AttachmentSizeLimitPolicy.isExceededMaxSizeAttachmentsPerEmail', () {
+    test('should return false when hardLimitBytes is null (unlimited)', () {
+      final result = AttachmentSizeLimitPolicy.isExceededMaxSizeAttachmentsPerEmail(
+        allAttachmentBytes: 2000000000,
+        hardLimitBytes: null);
+
+      expect(result, isFalse);
+    });
+
+    test('should return false when total size is exactly at the cap', () {
+      final result = AttachmentSizeLimitPolicy.isExceededMaxSizeAttachmentsPerEmail(
+        allAttachmentBytes: 100,
+        hardLimitBytes: 100);
+
+      expect(result, isFalse);
+    });
+
+    test('should return true when total size exceeds the cap', () {
+      final result = AttachmentSizeLimitPolicy.isExceededMaxSizeAttachmentsPerEmail(
+        allAttachmentBytes: 101,
+        hardLimitBytes: 100);
+
+      expect(result, isTrue);
+    });
+  });
+
+  group('AttachmentSizeLimitPolicy.isExceededWarningAttachmentFileSizeInComposer', () {
+    const maxWarningBytes = AppConfig.warningAttachmentFileSizeInMegabytes * 1024 * 1024;
+
+    test('should return false when total size is exactly at the warning threshold', () {
+      final result = AttachmentSizeLimitPolicy.isExceededWarningAttachmentFileSizeInComposer(
+        regularAttachmentBytes: maxWarningBytes,
+        warningLimitBytes: maxWarningBytes);
+
+      expect(result, isFalse);
+    });
+
+    test('should return true when total size exceeds the warning threshold', () {
+      final result = AttachmentSizeLimitPolicy.isExceededWarningAttachmentFileSizeInComposer(
+        regularAttachmentBytes: maxWarningBytes + 1,
+        warningLimitBytes: maxWarningBytes);
+
+      expect(result, isTrue);
+    });
+  });
+}

--- a/test/features/upload/domain/validator/attachment_size_limit_rule_test.dart
+++ b/test/features/upload/domain/validator/attachment_size_limit_rule_test.dart
@@ -7,6 +7,7 @@ import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload
 import 'package:tmail_ui_user/features/upload/domain/validator/validation_decision.dart';
 
 AttachmentUploadRequest _request({
+  int currentRegularAttachmentBytes = 0,
   int proposedAllAttachmentBytes = 0,
   int proposedRegularAttachmentBytes = 0,
   int? hardLimitBytes,
@@ -16,7 +17,7 @@ AttachmentUploadRequest _request({
     sizes: AttachmentUploadSizeSnapshot(
       currentAllAttachmentBytes: 0,
       proposedAllAttachmentBytes: proposedAllAttachmentBytes,
-      currentRegularAttachmentBytes: 0,
+      currentRegularAttachmentBytes: currentRegularAttachmentBytes,
       proposedRegularAttachmentBytes: proposedRegularAttachmentBytes,
     ),
     limits: AttachmentUploadLimits(warningLimitBytes: warningLimitBytes, hardLimitBytes: hardLimitBytes),
@@ -58,6 +59,19 @@ void main() {
 
     test('inline-only proposals never trigger the regular-attachment warning', () {
       final request = _request(
+        proposedAllAttachmentBytes: 20000000,
+        proposedRegularAttachmentBytes: 0,
+        hardLimitBytes: 100000000,
+        warningLimitBytes: 1000000);
+
+      final result = rule.validate(request);
+
+      expect(result, isA<ValidationAllowed>());
+    });
+
+    test('should not re-trigger the warning for an inline-only proposal when existing regular attachments already exceed it', () {
+      final request = _request(
+        currentRegularAttachmentBytes: 2000000,
         proposedAllAttachmentBytes: 20000000,
         proposedRegularAttachmentBytes: 0,
         hardLimitBytes: 100000000,

--- a/test/features/upload/domain/validator/attachment_size_limit_rule_test.dart
+++ b/test/features/upload/domain/validator/attachment_size_limit_rule_test.dart
@@ -7,110 +7,111 @@ import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload
 import 'package:tmail_ui_user/features/upload/domain/validator/validation_decision.dart';
 
 AttachmentUploadRequest _request({
-  AttachmentUploadSizeSnapshot sizes = const AttachmentUploadSizeSnapshot(
-    currentAllAttachmentBytes: 0,
-    proposedAllAttachmentBytes: 0,
-    currentRegularAttachmentBytes: 0,
-    proposedRegularAttachmentBytes: 0,
-  ),
-  AttachmentUploadLimits limits = const AttachmentUploadLimits(warningLimitBytes: 1000000000),
+  required AttachmentUploadSizeSnapshot sizes,
+  required AttachmentUploadLimits limits,
 }) {
   return AttachmentUploadRequest(sizes: sizes, limits: limits);
 }
+
+class _RuleCase {
+  const _RuleCase({
+    required this.description,
+    required this.sizes,
+    required this.limits,
+    required this.verify,
+  });
+
+  final String description;
+  final AttachmentUploadSizeSnapshot sizes;
+  final AttachmentUploadLimits limits;
+  final void Function(ValidationDecision result) verify;
+}
+
+final _cases = [
+  _RuleCase(
+    description: 'should return ValidationAllowed when neither the hard limit nor the warning threshold is exceeded',
+    sizes: const AttachmentUploadSizeSnapshot(
+      currentAllAttachmentBytes: 0,
+      proposedAllAttachmentBytes: 10,
+      currentRegularAttachmentBytes: 0,
+      proposedRegularAttachmentBytes: 0,
+    ),
+    limits: const AttachmentUploadLimits(warningLimitBytes: 1000000000, hardLimitBytes: 1000),
+    verify: (result) => expect(result, isA<ValidationAllowed>()),
+  ),
+  _RuleCase(
+    description: 'should return ValidationRejected with MaxEmailAttachmentSizeExceeded when over the hard cap',
+    sizes: const AttachmentUploadSizeSnapshot(
+      currentAllAttachmentBytes: 0,
+      proposedAllAttachmentBytes: 200,
+      currentRegularAttachmentBytes: 0,
+      proposedRegularAttachmentBytes: 0,
+    ),
+    limits: const AttachmentUploadLimits(warningLimitBytes: 1000000000, hardLimitBytes: 100),
+    verify: (result) {
+      final rejected = result as ValidationRejected;
+      expect(rejected.failure, isA<MaxEmailAttachmentSizeExceeded>());
+      expect((rejected.failure as MaxEmailAttachmentSizeExceeded).maximumBytes, 100);
+    },
+  ),
+  _RuleCase(
+    description: 'should return ValidationConfirmationRequired when only the warning threshold is exceeded',
+    sizes: const AttachmentUploadSizeSnapshot(
+      currentAllAttachmentBytes: 0,
+      proposedAllAttachmentBytes: 10,
+      currentRegularAttachmentBytes: 0,
+      proposedRegularAttachmentBytes: 20000000,
+    ),
+    limits: const AttachmentUploadLimits(warningLimitBytes: 1000000, hardLimitBytes: 100000000),
+    verify: (result) => expect(result, isA<ValidationConfirmationRequired>()),
+  ),
+  _RuleCase(
+    description: 'inline-only proposals never trigger the regular-attachment warning',
+    sizes: const AttachmentUploadSizeSnapshot(
+      currentAllAttachmentBytes: 0,
+      proposedAllAttachmentBytes: 20000000,
+      currentRegularAttachmentBytes: 0,
+      proposedRegularAttachmentBytes: 0,
+    ),
+    limits: const AttachmentUploadLimits(warningLimitBytes: 1000000, hardLimitBytes: 100000000),
+    verify: (result) => expect(result, isA<ValidationAllowed>()),
+  ),
+  _RuleCase(
+    description: 'should not re-trigger the warning for an inline-only proposal when existing regular attachments already exceed it',
+    sizes: const AttachmentUploadSizeSnapshot(
+      currentAllAttachmentBytes: 0,
+      proposedAllAttachmentBytes: 20000000,
+      currentRegularAttachmentBytes: 2000000,
+      proposedRegularAttachmentBytes: 0,
+    ),
+    limits: const AttachmentUploadLimits(warningLimitBytes: 1000000, hardLimitBytes: 100000000),
+    verify: (result) => expect(result, isA<ValidationAllowed>()),
+  ),
+  _RuleCase(
+    description: 'hard limit takes priority over the warning threshold',
+    sizes: const AttachmentUploadSizeSnapshot(
+      currentAllAttachmentBytes: 0,
+      proposedAllAttachmentBytes: 200,
+      currentRegularAttachmentBytes: 0,
+      proposedRegularAttachmentBytes: 20000000,
+    ),
+    limits: const AttachmentUploadLimits(warningLimitBytes: 1000000, hardLimitBytes: 100),
+    verify: (result) => expect(result, isA<ValidationRejected>()),
+  ),
+];
 
 void main() {
   const rule = AttachmentSizeLimitRule();
 
   group('AttachmentSizeLimitRule', () {
-    test('should return ValidationAllowed when neither the hard limit nor the warning threshold is exceeded', () {
-      final request = _request(
-        sizes: const AttachmentUploadSizeSnapshot(
-          currentAllAttachmentBytes: 0,
-          proposedAllAttachmentBytes: 10,
-          currentRegularAttachmentBytes: 0,
-          proposedRegularAttachmentBytes: 0,
-        ),
-        limits: const AttachmentUploadLimits(warningLimitBytes: 1000000000, hardLimitBytes: 1000));
+    for (final ruleCase in _cases) {
+      test(ruleCase.description, () {
+        final request = _request(sizes: ruleCase.sizes, limits: ruleCase.limits);
 
-      final result = rule.validate(request);
+        final result = rule.validate(request);
 
-      expect(result, isA<ValidationAllowed>());
-    });
-
-    test('should return ValidationRejected with MaxEmailAttachmentSizeExceeded when over the hard cap', () {
-      final request = _request(
-        sizes: const AttachmentUploadSizeSnapshot(
-          currentAllAttachmentBytes: 0,
-          proposedAllAttachmentBytes: 200,
-          currentRegularAttachmentBytes: 0,
-          proposedRegularAttachmentBytes: 0,
-        ),
-        limits: const AttachmentUploadLimits(warningLimitBytes: 1000000000, hardLimitBytes: 100));
-
-      final result = rule.validate(request) as ValidationRejected;
-
-      expect(result.failure, isA<MaxEmailAttachmentSizeExceeded>());
-      expect((result.failure as MaxEmailAttachmentSizeExceeded).maximumBytes, 100);
-    });
-
-    test('should return ValidationConfirmationRequired when only the warning threshold is exceeded', () {
-      final request = _request(
-        sizes: const AttachmentUploadSizeSnapshot(
-          currentAllAttachmentBytes: 0,
-          proposedAllAttachmentBytes: 10,
-          currentRegularAttachmentBytes: 0,
-          proposedRegularAttachmentBytes: 20000000,
-        ),
-        limits: const AttachmentUploadLimits(warningLimitBytes: 1000000, hardLimitBytes: 100000000));
-
-      final result = rule.validate(request);
-
-      expect(result, isA<ValidationConfirmationRequired>());
-    });
-
-    test('inline-only proposals never trigger the regular-attachment warning', () {
-      final request = _request(
-        sizes: const AttachmentUploadSizeSnapshot(
-          currentAllAttachmentBytes: 0,
-          proposedAllAttachmentBytes: 20000000,
-          currentRegularAttachmentBytes: 0,
-          proposedRegularAttachmentBytes: 0,
-        ),
-        limits: const AttachmentUploadLimits(warningLimitBytes: 1000000, hardLimitBytes: 100000000));
-
-      final result = rule.validate(request);
-
-      expect(result, isA<ValidationAllowed>());
-    });
-
-    test('should not re-trigger the warning for an inline-only proposal when existing regular attachments already exceed it', () {
-      final request = _request(
-        sizes: const AttachmentUploadSizeSnapshot(
-          currentAllAttachmentBytes: 0,
-          proposedAllAttachmentBytes: 20000000,
-          currentRegularAttachmentBytes: 2000000,
-          proposedRegularAttachmentBytes: 0,
-        ),
-        limits: const AttachmentUploadLimits(warningLimitBytes: 1000000, hardLimitBytes: 100000000));
-
-      final result = rule.validate(request);
-
-      expect(result, isA<ValidationAllowed>());
-    });
-
-    test('hard limit takes priority over the warning threshold', () {
-      final request = _request(
-        sizes: const AttachmentUploadSizeSnapshot(
-          currentAllAttachmentBytes: 0,
-          proposedAllAttachmentBytes: 200,
-          currentRegularAttachmentBytes: 0,
-          proposedRegularAttachmentBytes: 20000000,
-        ),
-        limits: const AttachmentUploadLimits(warningLimitBytes: 1000000, hardLimitBytes: 100));
-
-      final result = rule.validate(request);
-
-      expect(result, isA<ValidationRejected>());
-    });
+        ruleCase.verify(result);
+      });
+    }
   });
 }

--- a/test/features/upload/domain/validator/attachment_size_limit_rule_test.dart
+++ b/test/features/upload/domain/validator/attachment_size_limit_rule_test.dart
@@ -7,21 +7,15 @@ import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload
 import 'package:tmail_ui_user/features/upload/domain/validator/validation_decision.dart';
 
 AttachmentUploadRequest _request({
-  int currentRegularAttachmentBytes = 0,
-  int proposedAllAttachmentBytes = 0,
-  int proposedRegularAttachmentBytes = 0,
-  int? hardLimitBytes,
-  int warningLimitBytes = 1000000000,
+  AttachmentUploadSizeSnapshot sizes = const AttachmentUploadSizeSnapshot(
+    currentAllAttachmentBytes: 0,
+    proposedAllAttachmentBytes: 0,
+    currentRegularAttachmentBytes: 0,
+    proposedRegularAttachmentBytes: 0,
+  ),
+  AttachmentUploadLimits limits = const AttachmentUploadLimits(warningLimitBytes: 1000000000),
 }) {
-  return AttachmentUploadRequest(
-    sizes: AttachmentUploadSizeSnapshot(
-      currentAllAttachmentBytes: 0,
-      proposedAllAttachmentBytes: proposedAllAttachmentBytes,
-      currentRegularAttachmentBytes: currentRegularAttachmentBytes,
-      proposedRegularAttachmentBytes: proposedRegularAttachmentBytes,
-    ),
-    limits: AttachmentUploadLimits(warningLimitBytes: warningLimitBytes, hardLimitBytes: hardLimitBytes),
-  );
+  return AttachmentUploadRequest(sizes: sizes, limits: limits);
 }
 
 void main() {
@@ -29,7 +23,14 @@ void main() {
 
   group('AttachmentSizeLimitRule', () {
     test('should return ValidationAllowed when neither the hard limit nor the warning threshold is exceeded', () {
-      final request = _request(proposedAllAttachmentBytes: 10, hardLimitBytes: 1000);
+      final request = _request(
+        sizes: const AttachmentUploadSizeSnapshot(
+          currentAllAttachmentBytes: 0,
+          proposedAllAttachmentBytes: 10,
+          currentRegularAttachmentBytes: 0,
+          proposedRegularAttachmentBytes: 0,
+        ),
+        limits: const AttachmentUploadLimits(warningLimitBytes: 1000000000, hardLimitBytes: 1000));
 
       final result = rule.validate(request);
 
@@ -37,7 +38,14 @@ void main() {
     });
 
     test('should return ValidationRejected with MaxEmailAttachmentSizeExceeded when over the hard cap', () {
-      final request = _request(proposedAllAttachmentBytes: 200, hardLimitBytes: 100);
+      final request = _request(
+        sizes: const AttachmentUploadSizeSnapshot(
+          currentAllAttachmentBytes: 0,
+          proposedAllAttachmentBytes: 200,
+          currentRegularAttachmentBytes: 0,
+          proposedRegularAttachmentBytes: 0,
+        ),
+        limits: const AttachmentUploadLimits(warningLimitBytes: 1000000000, hardLimitBytes: 100));
 
       final result = rule.validate(request) as ValidationRejected;
 
@@ -47,10 +55,13 @@ void main() {
 
     test('should return ValidationConfirmationRequired when only the warning threshold is exceeded', () {
       final request = _request(
-        proposedAllAttachmentBytes: 10,
-        proposedRegularAttachmentBytes: 20000000,
-        hardLimitBytes: 100000000,
-        warningLimitBytes: 1000000);
+        sizes: const AttachmentUploadSizeSnapshot(
+          currentAllAttachmentBytes: 0,
+          proposedAllAttachmentBytes: 10,
+          currentRegularAttachmentBytes: 0,
+          proposedRegularAttachmentBytes: 20000000,
+        ),
+        limits: const AttachmentUploadLimits(warningLimitBytes: 1000000, hardLimitBytes: 100000000));
 
       final result = rule.validate(request);
 
@@ -59,10 +70,13 @@ void main() {
 
     test('inline-only proposals never trigger the regular-attachment warning', () {
       final request = _request(
-        proposedAllAttachmentBytes: 20000000,
-        proposedRegularAttachmentBytes: 0,
-        hardLimitBytes: 100000000,
-        warningLimitBytes: 1000000);
+        sizes: const AttachmentUploadSizeSnapshot(
+          currentAllAttachmentBytes: 0,
+          proposedAllAttachmentBytes: 20000000,
+          currentRegularAttachmentBytes: 0,
+          proposedRegularAttachmentBytes: 0,
+        ),
+        limits: const AttachmentUploadLimits(warningLimitBytes: 1000000, hardLimitBytes: 100000000));
 
       final result = rule.validate(request);
 
@@ -71,11 +85,13 @@ void main() {
 
     test('should not re-trigger the warning for an inline-only proposal when existing regular attachments already exceed it', () {
       final request = _request(
-        currentRegularAttachmentBytes: 2000000,
-        proposedAllAttachmentBytes: 20000000,
-        proposedRegularAttachmentBytes: 0,
-        hardLimitBytes: 100000000,
-        warningLimitBytes: 1000000);
+        sizes: const AttachmentUploadSizeSnapshot(
+          currentAllAttachmentBytes: 0,
+          proposedAllAttachmentBytes: 20000000,
+          currentRegularAttachmentBytes: 2000000,
+          proposedRegularAttachmentBytes: 0,
+        ),
+        limits: const AttachmentUploadLimits(warningLimitBytes: 1000000, hardLimitBytes: 100000000));
 
       final result = rule.validate(request);
 
@@ -84,10 +100,13 @@ void main() {
 
     test('hard limit takes priority over the warning threshold', () {
       final request = _request(
-        proposedAllAttachmentBytes: 200,
-        proposedRegularAttachmentBytes: 20000000,
-        hardLimitBytes: 100,
-        warningLimitBytes: 1000000);
+        sizes: const AttachmentUploadSizeSnapshot(
+          currentAllAttachmentBytes: 0,
+          proposedAllAttachmentBytes: 200,
+          currentRegularAttachmentBytes: 0,
+          proposedRegularAttachmentBytes: 20000000,
+        ),
+        limits: const AttachmentUploadLimits(warningLimitBytes: 1000000, hardLimitBytes: 100));
 
       final result = rule.validate(request);
 

--- a/test/features/upload/domain/validator/attachment_size_limit_rule_test.dart
+++ b/test/features/upload/domain/validator/attachment_size_limit_rule_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_size_limit_rule.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_failure.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_limits.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_request.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_size_snapshot.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/validation_decision.dart';
+
+AttachmentUploadRequest _request({
+  int proposedAllAttachmentBytes = 0,
+  int proposedRegularAttachmentBytes = 0,
+  int? hardLimitBytes,
+  int warningLimitBytes = 1000000000,
+}) {
+  return AttachmentUploadRequest(
+    sizes: AttachmentUploadSizeSnapshot(
+      currentAllAttachmentBytes: 0,
+      proposedAllAttachmentBytes: proposedAllAttachmentBytes,
+      currentRegularAttachmentBytes: 0,
+      proposedRegularAttachmentBytes: proposedRegularAttachmentBytes,
+    ),
+    limits: AttachmentUploadLimits(warningLimitBytes: warningLimitBytes, hardLimitBytes: hardLimitBytes),
+  );
+}
+
+void main() {
+  const rule = AttachmentSizeLimitRule();
+
+  group('AttachmentSizeLimitRule', () {
+    test('should return ValidationAllowed when neither the hard limit nor the warning threshold is exceeded', () {
+      final request = _request(proposedAllAttachmentBytes: 10, hardLimitBytes: 1000);
+
+      final result = rule.validate(request);
+
+      expect(result, isA<ValidationAllowed>());
+    });
+
+    test('should return ValidationRejected with MaxEmailAttachmentSizeExceeded when over the hard cap', () {
+      final request = _request(proposedAllAttachmentBytes: 200, hardLimitBytes: 100);
+
+      final result = rule.validate(request) as ValidationRejected;
+
+      expect(result.failure, isA<MaxEmailAttachmentSizeExceeded>());
+      expect((result.failure as MaxEmailAttachmentSizeExceeded).maximumBytes, 100);
+    });
+
+    test('should return ValidationConfirmationRequired when only the warning threshold is exceeded', () {
+      final request = _request(
+        proposedAllAttachmentBytes: 10,
+        proposedRegularAttachmentBytes: 20000000,
+        hardLimitBytes: 100000000,
+        warningLimitBytes: 1000000);
+
+      final result = rule.validate(request);
+
+      expect(result, isA<ValidationConfirmationRequired>());
+    });
+
+    test('inline-only proposals never trigger the regular-attachment warning', () {
+      final request = _request(
+        proposedAllAttachmentBytes: 20000000,
+        proposedRegularAttachmentBytes: 0,
+        hardLimitBytes: 100000000,
+        warningLimitBytes: 1000000);
+
+      final result = rule.validate(request);
+
+      expect(result, isA<ValidationAllowed>());
+    });
+
+    test('hard limit takes priority over the warning threshold', () {
+      final request = _request(
+        proposedAllAttachmentBytes: 200,
+        proposedRegularAttachmentBytes: 20000000,
+        hardLimitBytes: 100,
+        warningLimitBytes: 1000000);
+
+      final result = rule.validate(request);
+
+      expect(result, isA<ValidationRejected>());
+    });
+  });
+}

--- a/test/features/upload/domain/validator/attachment_upload_request_factory_test.dart
+++ b/test/features/upload/domain/validator/attachment_upload_request_factory_test.dart
@@ -1,0 +1,171 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/upload/file_info.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_request_factory.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_state_source.dart';
+
+class _FakeStateSource implements AttachmentUploadStateSource {
+  @override
+  final int currentAllAttachmentBytes;
+  @override
+  final int currentRegularAttachmentBytes;
+
+  const _FakeStateSource({
+    this.currentAllAttachmentBytes = 0,
+    this.currentRegularAttachmentBytes = 0,
+  });
+  
+  @override
+  int? get hardLimitBytes => 0;
+  
+  @override
+  int get warningLimitBytes => 0;
+}
+
+FileInfo _file({required int fileSize, bool? isInline}) => FileInfo(
+      fileName: 'file-$fileSize',
+      filePath: '/tmp/file-$fileSize',
+      fileSize: fileSize,
+      isInline: isInline,
+    );
+
+void main() {
+  const factory = AttachmentUploadRequestFactory();
+
+  group('AttachmentUploadRequestFactory.fromProposedFiles', () {
+    test('Should yield all-zero proposed bytes when files is empty', () {
+      final request = factory.fromProposedFiles(
+        files: const [],
+        state: const _FakeStateSource(),
+      );
+
+      expect(request.sizes.proposedAllAttachmentBytes, 0);
+      expect(request.sizes.proposedRegularAttachmentBytes, 0);
+    });
+
+    test('Should count a file with isInline null toward both totals', () {
+      final request = factory.fromProposedFiles(
+        files: [_file(fileSize: 100)],
+        state: const _FakeStateSource(),
+      );
+
+      expect(request.sizes.proposedAllAttachmentBytes, 100);
+      expect(request.sizes.proposedRegularAttachmentBytes, 100);
+    });
+
+    test('Should count a file with isInline false toward both totals', () {
+      final request = factory.fromProposedFiles(
+        files: [_file(fileSize: 100, isInline: false)],
+        state: const _FakeStateSource(),
+      );
+
+      expect(request.sizes.proposedAllAttachmentBytes, 100);
+      expect(request.sizes.proposedRegularAttachmentBytes, 100);
+    });
+
+    test('Should count a file with isInline true toward all but exclude it from regular', () {
+      final request = factory.fromProposedFiles(
+        files: [_file(fileSize: 100, isInline: true)],
+        state: const _FakeStateSource(),
+      );
+
+      expect(request.sizes.proposedAllAttachmentBytes, 100);
+      expect(request.sizes.proposedRegularAttachmentBytes, 0);
+    });
+
+    test('Should sum mixed inline and regular files separately', () {
+      final request = factory.fromProposedFiles(
+        files: [
+          _file(fileSize: 100, isInline: true),
+          _file(fileSize: 50, isInline: false),
+        ],
+        state: const _FakeStateSource(),
+      );
+
+      expect(request.sizes.proposedAllAttachmentBytes, 150);
+      expect(request.sizes.proposedRegularAttachmentBytes, 50);
+    });
+
+    test('Should forward the current bytes from the state source unchanged', () {
+      final request = factory.fromProposedFiles(
+        files: const [],
+        state: const _FakeStateSource(
+          currentAllAttachmentBytes: 10,
+          currentRegularAttachmentBytes: 5,
+        ),
+      );
+
+      expect(request.sizes.currentAllAttachmentBytes, 10);
+      expect(request.sizes.currentRegularAttachmentBytes, 5);
+    });
+
+    test('Should throw ArgumentError when currentAllAttachmentBytes is negative', () {
+      expect(
+        () => factory.fromProposedFiles(
+          files: const [],
+          state: const _FakeStateSource(currentAllAttachmentBytes: -1),
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('AttachmentUploadRequestFactory.fromProposedBytes', () {
+    test('Should place proposed and current bytes into the matching snapshot fields', () {
+      final request = factory.fromProposedBytes(
+        proposedAllAttachmentBytes: 100,
+        proposedRegularAttachmentBytes: 60,
+        state: const _FakeStateSource(
+          currentAllAttachmentBytes: 10,
+          currentRegularAttachmentBytes: 5,
+        ),
+      );
+
+      expect(request.sizes.proposedAllAttachmentBytes, 100);
+      expect(request.sizes.proposedRegularAttachmentBytes, 60);
+      expect(request.sizes.currentAllAttachmentBytes, 10);
+      expect(request.sizes.currentRegularAttachmentBytes, 5);
+    });
+
+    test('Should throw ArgumentError when a proposed byte count is negative', () {
+      expect(
+        () => factory.fromProposedBytes(
+          proposedAllAttachmentBytes: -1,
+          proposedRegularAttachmentBytes: 0,
+          state: const _FakeStateSource(),
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('AttachmentUploadRequestFactory.normalizeServerLimitBytes', () {
+    test('Should return null when value is null', () {
+      expect(AttachmentUploadRequestFactory.normalizeServerLimitBytes(null), isNull);
+    });
+
+    test('Should truncate a whole-number double to int', () {
+      expect(AttachmentUploadRequestFactory.normalizeServerLimitBytes(20.0), 20);
+    });
+
+    test('Should throw ArgumentError for a negative value', () {
+      expect(
+        () => AttachmentUploadRequestFactory.normalizeServerLimitBytes(-1),
+        throwsArgumentError,
+      );
+    });
+
+    test('Should throw ArgumentError for a fractional value', () {
+      expect(
+        () => AttachmentUploadRequestFactory.normalizeServerLimitBytes(1.5),
+        throwsArgumentError,
+      );
+    });
+
+    test('Should throw ArgumentError for a non-finite value', () {
+      expect(
+        () => AttachmentUploadRequestFactory.normalizeServerLimitBytes(double.infinity),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/test/features/upload/domain/validator/validation_pipeline_test.dart
+++ b/test/features/upload/domain/validator/validation_pipeline_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_failure.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_limits.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_prompt.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_request.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_size_snapshot.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/validation_decision.dart';
+
+const _request = AttachmentUploadRequest(
+  sizes: AttachmentUploadSizeSnapshot(
+    currentAllAttachmentBytes: 0,
+    proposedAllAttachmentBytes: 0,
+    currentRegularAttachmentBytes: 0,
+    proposedRegularAttachmentBytes: 0,
+  ),
+  limits: AttachmentUploadLimits(warningLimitBytes: 1000000000),
+);
+
+class _StubAttachmentUploadRule implements AttachmentUploadRule {
+  final AttachmentUploadDecision result;
+  int callCount = 0;
+
+  _StubAttachmentUploadRule(this.result);
+
+  @override
+  AttachmentUploadDecision validate(AttachmentUploadRequest request) {
+    callCount++;
+    return result;
+  }
+}
+
+void main() {
+  group('ValidationPipeline (AttachmentUploadValidator)', () {
+    test('should return ValidationAllowed when rules list is empty', () {
+      final validator = AttachmentUploadValidator([]);
+
+      final result = validator.validate(_request);
+
+      expect(result, isA<ValidationAllowed>());
+    });
+
+    final pipelineCases = <({
+      String description,
+      AttachmentUploadDecision firstResult,
+      Matcher expectedResult,
+      int expectedSecondCallCount,
+    })>[
+      (
+        description: 'should return ValidationAllowed when all rules pass',
+        firstResult: const ValidationAllowed(),
+        expectedResult: isA<ValidationAllowed>(),
+        expectedSecondCallCount: 1,
+      ),
+      (
+        description: 'should short-circuit and return ValidationRejected on the first hard reject',
+        firstResult: const ValidationRejected(MaxEmailAttachmentSizeExceeded(100)),
+        expectedResult: isA<ValidationRejected>(),
+        expectedSecondCallCount: 0,
+      ),
+    ];
+    for (final pipelineCase in pipelineCases) {
+      test(pipelineCase.description, () {
+        final first = _StubAttachmentUploadRule(pipelineCase.firstResult);
+        final second = _StubAttachmentUploadRule(const ValidationAllowed());
+        final validator = AttachmentUploadValidator([first, second]);
+
+        final result = validator.validate(_request);
+
+        expect(result, pipelineCase.expectedResult);
+        expect(first.callCount, 1);
+        expect(second.callCount, pipelineCase.expectedSecondCallCount);
+      });
+    }
+
+    test('should return ValidationConfirmationRequired when no rule rejects but one asks to confirm', () {
+      final first = _StubAttachmentUploadRule(const ValidationAllowed());
+      final second = _StubAttachmentUploadRule(
+        ValidationConfirmationRequired(const [LargeRegularAttachmentWarning()]));
+      final third = _StubAttachmentUploadRule(const ValidationAllowed());
+      final validator = AttachmentUploadValidator([first, second, third]);
+
+      final result = validator.validate(_request) as ValidationConfirmationRequired;
+
+      expect(result.prompts, hasLength(1));
+      expect(first.callCount, 1);
+      expect(second.callCount, 1);
+      expect(third.callCount, 1);
+    });
+
+    test('collects prompts from every confirmation-required rule when nothing rejects', () {
+      final first = _StubAttachmentUploadRule(
+        ValidationConfirmationRequired(const [LargeRegularAttachmentWarning()]));
+      final second = _StubAttachmentUploadRule(
+        ValidationConfirmationRequired(const [LargeRegularAttachmentWarning()]));
+      final validator = AttachmentUploadValidator([first, second]);
+
+      final result = validator.validate(_request) as ValidationConfirmationRequired;
+
+      expect(result.prompts, hasLength(2));
+    });
+
+    test('a later hard reject wins over an earlier pending confirmation', () {
+      final first = _StubAttachmentUploadRule(
+        ValidationConfirmationRequired(const [LargeRegularAttachmentWarning()]));
+      final second = _StubAttachmentUploadRule(
+        const ValidationRejected(MaxEmailAttachmentSizeExceeded(100)));
+      final validator = AttachmentUploadValidator([first, second]);
+
+      final result = validator.validate(_request);
+
+      expect(result, isA<ValidationRejected>());
+    });
+  });
+}

--- a/test/features/upload/presentation/dialog/attachment_confirmation_presenter_test.dart
+++ b/test/features/upload/presentation/dialog/attachment_confirmation_presenter_test.dart
@@ -1,0 +1,98 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_prompt.dart';
+import 'package:tmail_ui_user/features/upload/presentation/dialog/attachment_confirmation_presenter.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../../../fixtures/widget_fixtures.dart';
+
+void main() {
+  setUp(() {
+    Get.testMode = true;
+    Get.put<ImagePaths>(ImagePaths());
+    Get.put<ResponsiveUtils>(ResponsiveUtils());
+  });
+
+  tearDown(() {
+    Get.reset();
+  });
+
+  group('AttachmentConfirmationPresenter.ask', () {
+    testWidgets('should resolve true when the user confirms', (tester) async {
+      await tester.pumpWidget(WidgetFixtures.makeTestableWidget(child: const SizedBox.shrink()));
+      await tester.pump();
+
+      final context = tester.element(find.byType(SizedBox));
+      final appLocalizations = AppLocalizations.of(context);
+
+      final future = AttachmentConfirmationPresenter.ask(
+        context,
+        const LargeRegularAttachmentWarning());
+      await tester.pump();
+
+      expect(
+        find.text(appLocalizations.warningMessageWhenExceedGenerallySizeInComposer),
+        findsOneWidget);
+
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+
+      expect(await future, isTrue);
+    });
+
+    testWidgets('should resolve false exactly once when the user taps the close button', (tester) async {
+      await tester.pumpWidget(WidgetFixtures.makeTestableWidget(child: const SizedBox.shrink()));
+      await tester.pump();
+
+      final context = tester.element(find.byType(SizedBox));
+      final appLocalizations = AppLocalizations.of(context);
+
+      final future = AttachmentConfirmationPresenter.ask(
+        context,
+        const LargeRegularAttachmentWarning());
+      await tester.pump();
+
+      expect(
+        find.text(appLocalizations.warningMessageWhenExceedGenerallySizeInComposer),
+        findsOneWidget);
+
+      final closeButton = find.byWidgetPredicate((widget) =>
+        widget is TMailButtonWidget && widget.icon == ImagePaths().icCloseDialog);
+      await tester.tap(closeButton);
+      await tester.pumpAndSettle();
+
+      // Regression: the dialog's barrier must be non-dismissible and the close
+      // button must pop the route, or this future would never resolve.
+      expect(await future, isFalse);
+    });
+
+    testWidgets('should resolve false when the dialog route is popped programmatically', (tester) async {
+      await tester.pumpWidget(WidgetFixtures.makeTestableWidget(child: const SizedBox.shrink()));
+      await tester.pump();
+
+      final context = tester.element(find.byType(SizedBox));
+      final appLocalizations = AppLocalizations.of(context);
+
+      final future = AttachmentConfirmationPresenter.ask(
+        context,
+        const LargeRegularAttachmentWarning());
+      await tester.pump();
+
+      expect(
+        find.text(appLocalizations.warningMessageWhenExceedGenerallySizeInComposer),
+        findsOneWidget);
+
+      // Regression: a Navigator pop that bypasses confirm/cancel/close (e.g. a
+      // back gesture) must still resolve the future, since it relies on
+      // Get.dialog's own future rather than a manually-completed Completer.
+      Navigator.of(context, rootNavigator: true).pop();
+      await tester.pumpAndSettle();
+
+      expect(await future, isFalse);
+    });
+  });
+}

--- a/test/features/upload/presentation/dialog/attachment_validation_failure_presenter_test.dart
+++ b/test/features/upload/presentation/dialog/attachment_validation_failure_presenter_test.dart
@@ -1,0 +1,46 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:filesize/filesize.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_failure.dart';
+import 'package:tmail_ui_user/features/upload/presentation/dialog/attachment_validation_failure_presenter.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../../../fixtures/widget_fixtures.dart';
+
+void main() {
+  setUp(() {
+    Get.testMode = true;
+    Get.put<ImagePaths>(ImagePaths());
+    Get.put<ResponsiveUtils>(ResponsiveUtils());
+  });
+
+  tearDown(() {
+    Get.reset();
+  });
+
+  group('AttachmentValidationFailurePresenter.present', () {
+    testWidgets('should show the max-size dialog for MaxEmailAttachmentSizeExceeded', (tester) async {
+      await tester.pumpWidget(WidgetFixtures.makeTestableWidget(child: const SizedBox.shrink()));
+      await tester.pump();
+
+      final context = tester.element(find.byType(SizedBox));
+      final appLocalizations = AppLocalizations.of(context);
+
+      AttachmentValidationFailurePresenter.present(
+        context,
+        const MaxEmailAttachmentSizeExceeded(1000000));
+      await tester.pump();
+
+      expect(find.byKey(const Key('confirm_dialog_action')), findsOneWidget);
+      expect(find.text(appLocalizations.maximum_files_size), findsOneWidget);
+      expect(
+        find.text(appLocalizations
+            .message_dialog_upload_attachments_exceeds_maximum_size(
+                filesize(1000000, 0))),
+        findsOneWidget);
+    });
+  });
+}

--- a/test/features/upload/presentation/dialog/max_size_attachments_dialog_presenter_test.dart
+++ b/test/features/upload/presentation/dialog/max_size_attachments_dialog_presenter_test.dart
@@ -1,0 +1,49 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:filesize/filesize.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/upload/presentation/dialog/max_size_attachments_dialog_presenter.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../../../fixtures/widget_fixtures.dart';
+
+void main() {
+  setUp(() {
+    Get.testMode = true;
+    Get.put<ImagePaths>(ImagePaths());
+    Get.put<ResponsiveUtils>(ResponsiveUtils());
+  });
+
+  tearDown(() {
+    Get.reset();
+  });
+
+  group('MaxSizeAttachmentsDialogPresenter.show', () {
+    testWidgets(
+      'Should display a confirm dialog\n'
+      'When called with a max size value',
+    (tester) async {
+      await tester.pumpWidget(WidgetFixtures.makeTestableWidget(
+        child: const SizedBox.shrink()));
+      await tester.pump();
+
+      final context = tester.element(find.byType(SizedBox));
+      final appLocalizations = AppLocalizations.of(context);
+
+      MaxSizeAttachmentsDialogPresenter.show(
+        context: context,
+        maxSizeAttachmentsPerEmail: 1000000);
+      await tester.pump();
+
+      expect(find.byKey(const Key('confirm_dialog_action')), findsOneWidget);
+      expect(find.text(appLocalizations.maximum_files_size), findsOneWidget);
+      expect(
+        find.text(appLocalizations
+            .message_dialog_upload_attachments_exceeds_maximum_size(
+                filesize(1000000, 0))),
+        findsOneWidget);
+    });
+  });
+}

--- a/test/features/upload/presentation/dialog/upload_size_warning_dialog_presenter_test.dart
+++ b/test/features/upload/presentation/dialog/upload_size_warning_dialog_presenter_test.dart
@@ -1,0 +1,56 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/upload/presentation/dialog/upload_size_warning_dialog_presenter.dart';
+
+import '../../../../fixtures/widget_fixtures.dart';
+
+void main() {
+  setUp(() {
+    Get.testMode = true;
+    Get.put<ImagePaths>(ImagePaths());
+    Get.put<ResponsiveUtils>(ResponsiveUtils());
+  });
+
+  tearDown(() {
+    Get.reset();
+  });
+
+  group('UploadSizeWarningDialogPresenter.showExceededWarningSize', () {
+    testWidgets(
+      'Should dismiss the dialog and invoke cancelAction exactly once\n'
+      'When user taps the close button',
+    (tester) async {
+      await tester.pumpWidget(WidgetFixtures.makeTestableWidget(
+        child: const SizedBox.shrink()));
+      await tester.pump();
+
+      var confirmCallCount = 0;
+      var cancelCallCount = 0;
+
+      UploadSizeWarningDialogPresenter.showExceededWarningSize(
+        context: tester.element(find.byType(SizedBox)),
+        confirmAction: () => confirmCallCount++,
+        cancelAction: () => cancelCallCount++,
+      );
+      await tester.pump();
+
+      final closeButton = find.byWidgetPredicate((widget) =>
+        widget is TMailButtonWidget && widget.icon == ImagePaths().icCloseDialog);
+      expect(closeButton, findsOneWidget);
+
+      await tester.tap(closeButton);
+      await tester.pumpAndSettle();
+
+      // Dialog must be fully gone, so a stray Confirm/Cancel tap can no
+      // longer reach the caller's callback and invoke it twice.
+      expect(find.byKey(const Key('confirm_dialog_action')), findsNothing);
+      expect(closeButton, findsNothing);
+      expect(cancelCallCount, equals(1));
+      expect(confirmCallCount, equals(0));
+    });
+  });
+}

--- a/test/features/upload/presentation/model/upload_file_state_test.dart
+++ b/test/features/upload/presentation/model/upload_file_state_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
+import 'package:model/email/attachment.dart';
+import 'package:model/upload/file_info.dart';
+import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
+import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_state.dart';
+
+void main() {
+  const taskId = UploadTaskId('task-1');
+
+  FileInfo localFile({required int fileSize}) => FileInfo(
+        fileName: 'file-$fileSize',
+        filePath: '/tmp/file-$fileSize',
+        fileSize: fileSize,
+      );
+
+  Attachment uploadedAttachment({required int size}) => Attachment(
+        blobId: Id('blob-$size'),
+        size: UnsignedInt(size),
+        disposition: ContentDisposition.attachment,
+      );
+
+  group('UploadFileState.fileSize:', () {
+    test('Should report the local file size when only a picked file is present', () {
+      final state = UploadFileState(taskId, file: localFile(fileSize: 1024));
+
+      expect(state.fileSize, 1024);
+    });
+
+    test('Should report the server size when only an attachment is present', () {
+      final state = UploadFileState(taskId, attachment: uploadedAttachment(size: 2048));
+
+      expect(state.fileSize, 2048);
+    });
+
+    test(
+        'Should prefer the attachment size over the local file size when both are present',
+        () {
+      // This precedence is what makes attachments carried into the composer by a
+      // forward, reply or draft restore count toward the size limits: those
+      // states are built from an Attachment with no local FileInfo behind them.
+      final state = UploadFileState(
+        taskId,
+        file: localFile(fileSize: 1024),
+        attachment: uploadedAttachment(size: 2048),
+      );
+
+      expect(state.fileSize, 2048);
+    });
+
+    test('Should report zero when neither a file nor an attachment is present', () {
+      final state = UploadFileState(taskId);
+
+      expect(state.fileSize, 0);
+    });
+
+    test('Should report zero when the attachment advertises no size', () {
+      final state = UploadFileState(
+        taskId,
+        attachment: Attachment(blobId: Id('blob-no-size')),
+      );
+
+      expect(state.fileSize, 0);
+    });
+  });
+}

--- a/test/features/upload/presentation/validator/attachment_upload_gate_test.dart
+++ b/test/features/upload/presentation/validator/attachment_upload_gate_test.dart
@@ -75,6 +75,10 @@ void main() {
         find.text(appLocalizations
             .message_dialog_upload_attachments_exceeds_maximum_size(filesize(100, 0))),
         findsOneWidget);
+
+      await tester.tap(find.text(appLocalizations.got_it));
+      await tester.pumpAndSettle();
+
       expect(await future, isFalse);
     });
 

--- a/test/features/upload/presentation/validator/attachment_upload_gate_test.dart
+++ b/test/features/upload/presentation/validator/attachment_upload_gate_test.dart
@@ -1,0 +1,117 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:filesize/filesize.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_size_limit_rule.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_limits.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_request.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_size_snapshot.dart';
+import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_upload_gate.dart';
+import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_validation_feedback_impl.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+
+import '../../../../fixtures/widget_fixtures.dart';
+
+AttachmentUploadRequest _request({
+  int proposedAllAttachmentBytes = 0,
+  int proposedRegularAttachmentBytes = 0,
+  int? hardLimitBytes,
+}) {
+  return AttachmentUploadRequest(
+    sizes: AttachmentUploadSizeSnapshot(
+      currentAllAttachmentBytes: 0,
+      proposedAllAttachmentBytes: proposedAllAttachmentBytes,
+      currentRegularAttachmentBytes: 0,
+      proposedRegularAttachmentBytes: proposedRegularAttachmentBytes,
+    ),
+    limits: AttachmentUploadLimits(warningLimitBytes: 1000000, hardLimitBytes: hardLimitBytes),
+  );
+}
+
+void main() {
+  setUp(() {
+    Get.testMode = true;
+    Get.put<ImagePaths>(ImagePaths());
+    Get.put<ResponsiveUtils>(ResponsiveUtils());
+  });
+
+  tearDown(() {
+    Get.reset();
+  });
+
+  final gate = AttachmentUploadGate(AttachmentUploadValidator([const AttachmentSizeLimitRule()]));
+
+  group('AttachmentUploadGate.permits', () {
+    testWidgets('should return true directly when validation passes', (tester) async {
+      await tester.pumpWidget(WidgetFixtures.makeTestableWidget(child: const SizedBox.shrink()));
+      await tester.pump();
+
+      final context = tester.element(find.byType(SizedBox));
+
+      final allowed = await gate.permits(
+        request: _request(proposedAllAttachmentBytes: 10, hardLimitBytes: 1000),
+        feedbackFactory: () => AttachmentValidationFeedbackImpl(context));
+
+      expect(allowed, isTrue);
+    });
+
+    testWidgets('should present the failure dialog and return false when rejected', (tester) async {
+      await tester.pumpWidget(WidgetFixtures.makeTestableWidget(child: const SizedBox.shrink()));
+      await tester.pump();
+
+      final context = tester.element(find.byType(SizedBox));
+      final appLocalizations = AppLocalizations.of(context);
+
+      final future = gate.permits(
+        request: _request(proposedAllAttachmentBytes: 200, hardLimitBytes: 100),
+        feedbackFactory: () => AttachmentValidationFeedbackImpl(context));
+      await tester.pump();
+
+      expect(find.byKey(const Key('confirm_dialog_action')), findsOneWidget);
+      expect(
+        find.text(appLocalizations
+            .message_dialog_upload_attachments_exceeds_maximum_size(filesize(100, 0))),
+        findsOneWidget);
+      expect(await future, isFalse);
+    });
+
+    testWidgets('should return true after the user confirms the warning', (tester) async {
+      await tester.pumpWidget(WidgetFixtures.makeTestableWidget(child: const SizedBox.shrink()));
+      await tester.pump();
+
+      final context = tester.element(find.byType(SizedBox));
+
+      final future = gate.permits(
+        request: _request(proposedRegularAttachmentBytes: 20000000),
+        feedbackFactory: () => AttachmentValidationFeedbackImpl(context));
+      await tester.pump();
+
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+
+      expect(await future, isTrue);
+    });
+
+    testWidgets('should return false when the user cancels the warning', (tester) async {
+      await tester.pumpWidget(WidgetFixtures.makeTestableWidget(child: const SizedBox.shrink()));
+      await tester.pump();
+
+      final context = tester.element(find.byType(SizedBox));
+
+      final future = gate.permits(
+        request: _request(proposedRegularAttachmentBytes: 20000000),
+        feedbackFactory: () => AttachmentValidationFeedbackImpl(context));
+      await tester.pump();
+
+      final closeButton = find.byWidgetPredicate((widget) =>
+        widget is TMailButtonWidget && widget.icon == ImagePaths().icCloseDialog);
+      await tester.tap(closeButton);
+      await tester.pumpAndSettle();
+
+      expect(await future, isFalse);
+    });
+  });
+}

--- a/test/features/upload/presentation/validator/attachment_upload_validation_service_test.dart
+++ b/test/features/upload/presentation/validator/attachment_upload_validation_service_test.dart
@@ -1,0 +1,286 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
+import 'package:model/email/attachment.dart';
+import 'package:model/upload/file_info.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_failure.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_prompt.dart';
+import 'package:tmail_ui_user/features/upload/domain/validator/attachment_upload_state_source.dart';
+import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_upload_validation_service.dart';
+import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_validation_feedback.dart';
+
+class _FakeStateSource implements AttachmentUploadStateSource {
+  @override
+  final int currentAllAttachmentBytes;
+  @override
+  final int currentRegularAttachmentBytes;
+  @override
+  final int warningLimitBytes;
+  @override
+  final int? hardLimitBytes;
+
+  const _FakeStateSource({
+    this.currentAllAttachmentBytes = 0,
+    this.currentRegularAttachmentBytes = 0,
+    this.warningLimitBytes = 1000,
+    this.hardLimitBytes,
+  });
+}
+
+class _RecordingFeedback implements AttachmentValidationFeedback {
+  final bool confirmed;
+
+  AttachmentUploadFailure? failureShown;
+  List<AttachmentUploadPrompt> promptsAsked = [];
+
+  _RecordingFeedback({this.confirmed = true});
+
+  @override
+  Future<void> showFailure(AttachmentUploadFailure failure) async {
+    failureShown = failure;
+  }
+
+  @override
+  Future<bool> confirmAll(List<AttachmentUploadPrompt> prompts) async {
+    promptsAsked = prompts;
+    return confirmed;
+  }
+}
+
+FileInfo _file({required int fileSize, bool isInline = false}) => FileInfo(
+      fileName: 'file-$fileSize',
+      filePath: '/tmp/file-$fileSize',
+      fileSize: fileSize,
+      isInline: isInline,
+    );
+
+void main() {
+  late BuildContext context;
+
+  AttachmentUploadValidationService buildService({
+    required AttachmentUploadStateSource stateSource,
+    required AttachmentValidationFeedback feedback,
+  }) {
+    return AttachmentUploadValidationService(
+      stateSource: stateSource,
+      feedbackBuilder: (_) => feedback,
+    );
+  }
+
+  group('AttachmentUploadValidationService::validateFiles', () {
+    testWidgets('Should run onAllowed when no limit is reached', (tester) async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      context = tester.element(find.byType(SizedBox));
+      final feedback = _RecordingFeedback();
+      var allowedCalled = false;
+
+      await buildService(
+        stateSource: const _FakeStateSource(hardLimitBytes: 10000),
+        feedback: feedback,
+      ).validateFiles(
+        context: context,
+        files: [_file(fileSize: 100)],
+        onAllowed: () => allowedCalled = true,
+      );
+
+      expect(allowedCalled, isTrue);
+      expect(feedback.failureShown, isNull);
+      expect(feedback.promptsAsked, isEmpty);
+    });
+
+    testWidgets('Should show failure and skip onAllowed when the hard limit is exceeded',
+        (tester) async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      context = tester.element(find.byType(SizedBox));
+      final feedback = _RecordingFeedback();
+      var allowedCalled = false;
+
+      await buildService(
+        stateSource: const _FakeStateSource(hardLimitBytes: 500),
+        feedback: feedback,
+      ).validateFiles(
+        context: context,
+        files: [_file(fileSize: 600)],
+        onAllowed: () => allowedCalled = true,
+      );
+
+      expect(allowedCalled, isFalse);
+      expect(feedback.failureShown, isA<MaxEmailAttachmentSizeExceeded>());
+    });
+
+    testWidgets(
+        'Should NOT ask for confirmation when only inline files exceed the warning limit',
+        (tester) async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      context = tester.element(find.byType(SizedBox));
+      final feedback = _RecordingFeedback();
+      var allowedCalled = false;
+
+      await buildService(
+        stateSource: const _FakeStateSource(warningLimitBytes: 500),
+        feedback: feedback,
+      ).validateFiles(
+        context: context,
+        files: [_file(fileSize: 600, isInline: true)],
+        onAllowed: () => allowedCalled = true,
+      );
+
+      expect(allowedCalled, isTrue);
+      expect(feedback.promptsAsked, isEmpty);
+    });
+
+    testWidgets(
+        'Should ask for confirmation when already picked attachments push the total\n'
+        'over the warning limit', (tester) async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      context = tester.element(find.byType(SizedBox));
+      final feedback = _RecordingFeedback();
+      var allowedCalled = false;
+
+      await buildService(
+        stateSource: const _FakeStateSource(
+          currentAllAttachmentBytes: 400,
+          currentRegularAttachmentBytes: 400,
+          warningLimitBytes: 500,
+        ),
+        feedback: feedback,
+      ).validateFiles(
+        context: context,
+        files: [_file(fileSize: 200)],
+        onAllowed: () => allowedCalled = true,
+      );
+
+      expect(allowedCalled, isTrue);
+      expect(feedback.promptsAsked, [isA<LargeRegularAttachmentWarning>()]);
+    });
+
+    testWidgets('Should skip onAllowed when the user declines the warning confirmation',
+        (tester) async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      context = tester.element(find.byType(SizedBox));
+      final feedback = _RecordingFeedback(confirmed: false);
+      var allowedCalled = false;
+
+      await buildService(
+        stateSource: const _FakeStateSource(warningLimitBytes: 500),
+        feedback: feedback,
+      ).validateFiles(
+        context: context,
+        files: [_file(fileSize: 600)],
+        onAllowed: () => allowedCalled = true,
+      );
+
+      expect(allowedCalled, isFalse);
+      expect(feedback.promptsAsked, [isA<LargeRegularAttachmentWarning>()]);
+    });
+  });
+
+  group('AttachmentUploadValidationService::validateAttachment', () {
+    testWidgets('Should count an inline attachment toward the hard limit only', (tester) async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      context = tester.element(find.byType(SizedBox));
+      final feedback = _RecordingFeedback();
+      var allowedCalled = false;
+
+      final inlineAttachment = Attachment(
+        blobId: Id('inline-attachment'),
+        size: UnsignedInt(600),
+        disposition: ContentDisposition.inline,
+      );
+
+      await buildService(
+        stateSource: const _FakeStateSource(warningLimitBytes: 500, hardLimitBytes: 10000),
+        feedback: feedback,
+      ).validateAttachment(
+        context: context,
+        attachment: inlineAttachment,
+        onAllowed: () => allowedCalled = true,
+      );
+
+      expect(allowedCalled, isTrue);
+      expect(feedback.promptsAsked, isEmpty);
+    });
+
+    testWidgets('Should show failure when a regular attachment exceeds the hard limit',
+        (tester) async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      context = tester.element(find.byType(SizedBox));
+      final feedback = _RecordingFeedback();
+      var allowedCalled = false;
+
+      final attachment = Attachment(
+        blobId: Id('regular-attachment'),
+        size: UnsignedInt(600),
+        disposition: ContentDisposition.attachment,
+      );
+
+      await buildService(
+        stateSource: const _FakeStateSource(hardLimitBytes: 500),
+        feedback: feedback,
+      ).validateAttachment(
+        context: context,
+        attachment: attachment,
+        onAllowed: () => allowedCalled = true,
+      );
+
+      expect(allowedCalled, isFalse);
+      expect(feedback.failureShown, isA<MaxEmailAttachmentSizeExceeded>());
+    });
+  });
+
+  group('AttachmentUploadValidationService without a BuildContext', () {
+    test(
+        'Should still call onAllowed and never build feedback\n'
+        'When both context and currentContext are null and validation passes',
+        () async {
+      var feedbackBuilderCalled = false;
+      var allowedCalled = false;
+
+      final service = AttachmentUploadValidationService(
+        stateSource: const _FakeStateSource(hardLimitBytes: 10000),
+        feedbackBuilder: (_) {
+          feedbackBuilderCalled = true;
+          return _RecordingFeedback();
+        },
+      );
+
+      await service.validateFiles(
+        files: [_file(fileSize: 100)],
+        onAllowed: () => allowedCalled = true,
+      );
+
+      expect(allowedCalled, isTrue);
+      expect(feedbackBuilderCalled, isFalse);
+    });
+  });
+
+  group('AttachmentUploadValidationService::isExceededMaxSizeAttachmentsPerEmail', () {
+    test('Should return true when the current total exceeds the hard limit', () {
+      final service = buildService(
+        stateSource: const _FakeStateSource(currentAllAttachmentBytes: 600, hardLimitBytes: 500),
+        feedback: _RecordingFeedback(),
+      );
+
+      expect(service.isExceededMaxSizeAttachmentsPerEmail(), isTrue);
+    });
+
+    test('Should return false when the current total is within the hard limit', () {
+      final service = buildService(
+        stateSource: const _FakeStateSource(currentAllAttachmentBytes: 400, hardLimitBytes: 500),
+        feedback: _RecordingFeedback(),
+      );
+
+      expect(service.isExceededMaxSizeAttachmentsPerEmail(), isFalse);
+    });
+
+    test('Should return false when the server advertises no hard limit', () {
+      final service = buildService(
+        stateSource: const _FakeStateSource(currentAllAttachmentBytes: 999999),
+        feedback: _RecordingFeedback(),
+      );
+
+      expect(service.isExceededMaxSizeAttachmentsPerEmail(), isFalse);
+    });
+  });
+}

--- a/test/features/upload/presentation/validator/attachment_upload_validation_service_test.dart
+++ b/test/features/upload/presentation/validator/attachment_upload_validation_service_test.dart
@@ -335,5 +335,67 @@ void main() {
       expect(allowedUploads, 1);
       expect(stateSource.currentAllAttachmentBytes, 600);
     });
+
+    test(
+        'Should not double count an allowed re-attached attachment after it is registered',
+        () async {
+      final stateSource = _MutableStateSource(
+        warningLimitBytes: 10000,
+        hardLimitBytes: 1000,
+      );
+      final service = buildService(
+        stateSource: stateSource,
+        feedback: _RecordingFeedback(),
+      );
+      final attachment = Attachment(
+        blobId: Id('regular-attachment'),
+        size: UnsignedInt(600),
+        disposition: ContentDisposition.attachment,
+      );
+
+      await service.validateAttachment(
+        attachment: attachment,
+        onAllowed: () {
+          stateSource.currentAllAttachmentBytes += 600;
+          stateSource.currentRegularAttachmentBytes += 600;
+          service.releaseReservedBytes(
+            allAttachmentBytes: 600,
+            regularAttachmentBytes: 600,
+          );
+        },
+      );
+
+      expect(stateSource.currentAllAttachmentBytes, 600);
+      expect(service.isExceededMaxSizeAttachmentsPerEmail(), isFalse);
+    });
+
+    test('Should roll back reserved bytes when onAllowed throws', () async {
+      final stateSource = _MutableStateSource(
+        warningLimitBytes: 10000,
+        hardLimitBytes: 1000,
+      );
+      final service = buildService(
+        stateSource: stateSource,
+        feedback: _RecordingFeedback(),
+      );
+
+      await expectLater(
+        service.validateFiles(
+          files: [_file(fileSize: 600)],
+          onAllowed: () => throw StateError('Upload registration failed'),
+        ),
+        throwsA(isA<StateError>()),
+      );
+
+      var secondUploadAllowed = false;
+
+      await service.validateFiles(
+        files: [_file(fileSize: 500)],
+        onAllowed: () => secondUploadAllowed = true,
+      );
+
+      expect(stateSource.currentAllAttachmentBytes, 0);
+      expect(secondUploadAllowed, isTrue);
+    });
   });
 }

--- a/test/features/upload/presentation/validator/attachment_upload_validation_service_test.dart
+++ b/test/features/upload/presentation/validator/attachment_upload_validation_service_test.dart
@@ -28,6 +28,25 @@ class _FakeStateSource implements AttachmentUploadStateSource {
   });
 }
 
+class _MutableStateSource implements AttachmentUploadStateSource {
+  @override
+  int currentAllAttachmentBytes = 0;
+
+  @override
+  int currentRegularAttachmentBytes = 0;
+
+  @override
+  final int warningLimitBytes;
+
+  @override
+  final int? hardLimitBytes;
+
+  _MutableStateSource({
+    this.warningLimitBytes = 10000,
+    this.hardLimitBytes,
+  });
+}
+
 class _RecordingFeedback implements AttachmentValidationFeedback {
   final bool confirmed;
 
@@ -281,6 +300,40 @@ void main() {
       );
 
       expect(service.isExceededMaxSizeAttachmentsPerEmail(), isFalse);
+    });
+  });
+
+  group('AttachmentUploadValidationService concurrency', () {
+    test('Should not allow concurrent uploads to exceed the hard limit', () async {
+      final stateSource = _MutableStateSource(
+        warningLimitBytes: 10000,
+        hardLimitBytes: 1000,
+      );
+      final service = buildService(
+        stateSource: stateSource,
+        feedback: _RecordingFeedback(),
+      );
+      var allowedUploads = 0;
+
+      void registerUpload() {
+        allowedUploads++;
+        stateSource.currentAllAttachmentBytes += 600;
+        stateSource.currentRegularAttachmentBytes += 600;
+      }
+
+      final firstValidation = service.validateFiles(
+        files: [_file(fileSize: 600)],
+        onAllowed: registerUpload,
+      );
+      final secondValidation = service.validateFiles(
+        files: [_file(fileSize: 600)],
+        onAllowed: registerUpload,
+      );
+
+      await Future.wait([firstValidation, secondValidation]);
+
+      expect(allowedUploads, 1);
+      expect(stateSource.currentAllAttachmentBytes, 600);
     });
   });
 }

--- a/test/features/upload/presentation/validator/attachment_upload_validation_service_test.dart
+++ b/test/features/upload/presentation/validator/attachment_upload_validation_service_test.dart
@@ -303,8 +303,10 @@ void main() {
     });
   });
 
-  group('AttachmentUploadValidationService concurrency', () {
-    test('Should not allow concurrent uploads to exceed the hard limit', () async {
+  group('AttachmentUploadValidationService state reads', () {
+    test(
+        'Should reject a second upload that pushes the committed total over the hard limit',
+        () async {
       final stateSource = _MutableStateSource(
         warningLimitBytes: 10000,
         hardLimitBytes: 1000,
@@ -321,24 +323,27 @@ void main() {
         stateSource.currentRegularAttachmentBytes += 600;
       }
 
-      final firstValidation = service.validateFiles(
+      await service.validateFiles(
         files: [_file(fileSize: 600)],
         onAllowed: registerUpload,
       );
-      final secondValidation = service.validateFiles(
+      await service.validateFiles(
         files: [_file(fileSize: 600)],
         onAllowed: registerUpload,
       );
-
-      await Future.wait([firstValidation, secondValidation]);
 
       expect(allowedUploads, 1);
       expect(stateSource.currentAllAttachmentBytes, 600);
     });
 
     test(
-        'Should not double count an allowed re-attached attachment after it is registered',
-        () async {
+        'Should evaluate overlapping validations against uncommitted state, '
+        'letting both proceed past the hard limit', () async {
+      // Documents an accepted limitation rather than a guarantee. Validation is
+      // a UX guard evaluated against what is committed at call time. Two
+      // attachment actions can only overlap while a confirmation dialog awaits
+      // the user; neither then sees the other's bytes. The composer's send
+      // guard and the server both reject the combined total afterwards.
       final stateSource = _MutableStateSource(
         warningLimitBytes: 10000,
         hardLimitBytes: 1000,
@@ -347,55 +352,28 @@ void main() {
         stateSource: stateSource,
         feedback: _RecordingFeedback(),
       );
-      final attachment = Attachment(
-        blobId: Id('regular-attachment'),
-        size: UnsignedInt(600),
-        disposition: ContentDisposition.attachment,
-      );
+      var allowedUploads = 0;
 
-      await service.validateAttachment(
-        attachment: attachment,
-        onAllowed: () {
-          stateSource.currentAllAttachmentBytes += 600;
-          stateSource.currentRegularAttachmentBytes += 600;
-          service.releaseReservedBytes(
-            allAttachmentBytes: 600,
-            regularAttachmentBytes: 600,
-          );
-        },
-      );
+      void registerUpload() {
+        allowedUploads++;
+        stateSource.currentAllAttachmentBytes += 600;
+        stateSource.currentRegularAttachmentBytes += 600;
+      }
 
-      expect(stateSource.currentAllAttachmentBytes, 600);
-      expect(service.isExceededMaxSizeAttachmentsPerEmail(), isFalse);
-    });
-
-    test('Should roll back reserved bytes when onAllowed throws', () async {
-      final stateSource = _MutableStateSource(
-        warningLimitBytes: 10000,
-        hardLimitBytes: 1000,
-      );
-      final service = buildService(
-        stateSource: stateSource,
-        feedback: _RecordingFeedback(),
-      );
-
-      await expectLater(
+      await Future.wait([
         service.validateFiles(
           files: [_file(fileSize: 600)],
-          onAllowed: () => throw StateError('Upload registration failed'),
+          onAllowed: registerUpload,
         ),
-        throwsA(isA<StateError>()),
-      );
+        service.validateFiles(
+          files: [_file(fileSize: 600)],
+          onAllowed: registerUpload,
+        ),
+      ]);
 
-      var secondUploadAllowed = false;
-
-      await service.validateFiles(
-        files: [_file(fileSize: 500)],
-        onAllowed: () => secondUploadAllowed = true,
-      );
-
-      expect(stateSource.currentAllAttachmentBytes, 0);
-      expect(secondUploadAllowed, isTrue);
+      expect(allowedUploads, 2);
+      expect(stateSource.currentAllAttachmentBytes, 1200);
+      expect(service.isExceededMaxSizeAttachmentsPerEmail(), isTrue);
     });
   });
 }


### PR DESCRIPTION
## Issue
- #4726

## Summary
Extracts attachment size-limit validation out of `UploadController` into a composable validator pipeline (`domain/validator/`), fixes a dialog-dismiss deadlock, and routes all composer attachment/inline-image entry points through one validation hook — groundwork for ADR-0103 (drive attachment download/upload).

## Changes
- Add generic `ValidationRule<Request, Failure, Prompt>` / `ValidationPipeline` / `ValidationDecision` (`ValidationAllowed` / `ValidationRejected` / `ValidationConfirmationRequired`) kernel in `domain/validator/`.
- Add `AttachmentUploadRequest` (sizes + limits), `AttachmentSizeLimitPolicy` (pure size-comparison helpers), `AttachmentSizeLimitRule` implementing the hard-limit + warning-limit checks previously duplicated across composer call sites, and `AttachmentUploadRequestFactory` to build requests from picked files or raw byte counts.
- Add `AttachmentUploadGate` (presentation) to run the validator against a request and delegate to `AttachmentValidationFeedback` (implemented by `FlutterAttachmentValidationFeedback`) for failure/confirmation dialogs — exposed via a single overridable `validateAttachmentSize` hook on `ComposerController`, replacing 5 duplicated call sites (pick file/image, drop zone, paste, share).
- `UploadController`: remove `validateTotalSizeAttachmentsBeforeUpload` / `validateTotalSizeInlineAttachmentsBeforeUpload` and their private dialog helpers entirely; validation now lives in the gate + rule, not the controller.
- Dialog fix: `UploadSizeWarningDialogPresenter`'s close button now calls `popBack()` before `cancelAction`, and `outsideDismissible: false`, so `AttachmentConfirmationPresenter`'s awaited result always resolves instead of hanging.
- Docs: update ADR-0103 and the drive-attachment-refactor plan to match the new validator/gate boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized attachment-size validation for file selection, drag-and-drop, paste, and sending.
  * Uploads exceeding server limits are blocked with a clear explanation.
  * Large regular attachments prompt for confirmation before uploading.
  * Validation accounts for existing attachments, inline content, concurrent uploads, and current limits.
  * Added consistent dialogs for size errors and warnings.

* **Bug Fixes**
  * Canceled or dismissed dialogs now reliably prevent uploads.

* **Tests**
  * Expanded coverage for validation, limits, dialogs, confirmations, and upload flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->