### PR TITLE
TF-4727 [Part-1] Drive-transfer sealed types, stager interfaces, buffered stager

### DIFF
--- a/workplace/lib/data/datasource/drive_transfer/buffered_web_drive_file_stager.dart
+++ b/workplace/lib/data/datasource/drive_transfer/buffered_web_drive_file_stager.dart
@@ -2,13 +2,14 @@ import 'dart:typed_data';
 
 import 'package:core/utils/build_utils.dart';
 import 'package:dio/dio.dart';
+import 'package:model/email/attachment.dart';
 import 'package:workplace/data/datasource/drive_transfer/drive_file_stager.dart';
 import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
-import 'package:workplace/data/datasource/drive_transfer/opfs_drive_file_uploader.dart';
 import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
 import 'package:workplace/data/model/workplace_type_defs.dart';
 import 'package:workplace/data/workplace_dio.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
+import 'package:workplace/domain/entity/drive_document_extension.dart';
 import 'package:workplace/domain/exceptions/workplace_exceptions.dart';
 
 /// Buffers a drive document fully into memory. Explicit, feature-detected
@@ -28,13 +29,8 @@ class BufferedWebDriveFileStager implements DriveFileStager {
     required OnFileProcessedProgress onDownloadProgress,
     required CancelToken cancelToken,
   }) async {
-    final downloadLink = doc.downloadLink;
-    if (downloadLink == null) {
-      throw DriveDownloadNullAttachmentException();
-    }
-    if (_isReleaseMode && !downloadLink.isScheme('https')) {
-      throw DriveDownloadInsecureLinkException();
-    }
+    final downloadLink =
+        doc.resolveDownloadLinkForStaging(isReleaseMode: _isReleaseMode);
     final response = await _dio.getUri<List<int>>(
       downloadLink,
       options: Options(
@@ -59,15 +55,46 @@ class BufferedWebDriveFileStager implements DriveFileStager {
   }
 }
 
-/// Web-buffered strategy: no OPFS-only uploader, `FileUploader` handles the
-/// bytes-backed upload leg.
+/// Web-buffered strategy: buffers the download in memory, then uploads the
+/// bytes-backed staged file through the injected uploader.
 class BufferedWebDriveTransferStrategy implements DriveTransferStrategy {
-  @override
-  final DriveFileStager stager;
+  BufferedWebDriveTransferStrategy({
+    required StagedFileUploader uploader,
+    DriveFileStager? stager,
+  })  : _uploader = uploader,
+        _stager = stager ?? BufferedWebDriveFileStager();
+
+  final StagedFileUploader _uploader;
+  final DriveFileStager _stager;
 
   @override
-  OpfsDriveFileUploader? get opfsUploader => null;
+  Future<StagedDriveFile> stage({
+    required DriveDocument doc,
+    required OnFileProcessedProgress onDownloadProgress,
+    required CancelToken cancelToken,
+  }) {
+    return _stager.stage(
+      doc: doc,
+      onDownloadProgress: onDownloadProgress,
+      cancelToken: cancelToken,
+    );
+  }
 
-  BufferedWebDriveTransferStrategy({DriveFileStager? stager})
-      : stager = stager ?? BufferedWebDriveFileStager();
+  /// [authHeader] is unused: the shared uploader authenticates through the
+  /// app's Dio interceptors. Only the OPFS raw-XHR path needs it.
+  @override
+  Future<Attachment> upload({
+    required StagedDriveFile staged,
+    required Uri uploadUri,
+    required String authHeader,
+    required OnFileProcessedProgress onUploadProgress,
+    required CancelToken cancelToken,
+  }) {
+    return _uploader(
+      staged: staged,
+      uploadUri: uploadUri,
+      onUploadProgress: onUploadProgress,
+      cancelToken: cancelToken,
+    );
+  }
 }

--- a/workplace/lib/data/datasource/drive_transfer/buffered_web_drive_file_stager.dart
+++ b/workplace/lib/data/datasource/drive_transfer/buffered_web_drive_file_stager.dart
@@ -6,6 +6,7 @@ import 'package:workplace/data/datasource/drive_transfer/drive_file_stager.dart'
 import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
 import 'package:workplace/data/datasource/drive_transfer/opfs_drive_file_uploader.dart';
 import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
+import 'package:workplace/data/model/workplace_type_defs.dart';
 import 'package:workplace/data/workplace_dio.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
 import 'package:workplace/domain/exceptions/workplace_exceptions.dart';
@@ -24,7 +25,7 @@ class BufferedWebDriveFileStager implements DriveFileStager {
   @override
   Future<StagedDriveFile> stage({
     required DriveDocument doc,
-    required void Function(int received, int total) onDownloadProgress,
+    required OnFileProcessedProgress onDownloadProgress,
     required CancelToken cancelToken,
   }) async {
     final downloadLink = doc.downloadLink;

--- a/workplace/lib/data/datasource/drive_transfer/buffered_web_drive_file_stager.dart
+++ b/workplace/lib/data/datasource/drive_transfer/buffered_web_drive_file_stager.dart
@@ -1,7 +1,6 @@
-import 'dart:typed_data';
-
 import 'package:core/utils/build_utils.dart';
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:model/email/attachment.dart';
 import 'package:workplace/data/datasource/drive_transfer/drive_file_stager.dart';
 import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
@@ -15,7 +14,7 @@ import 'package:workplace/domain/exceptions/workplace_exceptions.dart';
 /// Buffers a drive document fully into memory. Explicit, feature-detected
 /// fallback for browsers without OPFS `createWritable()` support — checked
 /// (the actual-byte guard still cancels on breach), not memory-flat.
-class BufferedWebDriveFileStager implements DriveFileStager {
+class BufferedWebDriveFileStager implements DriveFileStager<BytesStagedFile> {
   BufferedWebDriveFileStager({Dio? dio, bool? isReleaseMode})
       : _dio = dio ?? WorkplaceDio.instance,
         _isReleaseMode = isReleaseMode ?? BuildUtils.isReleaseMode;
@@ -24,7 +23,7 @@ class BufferedWebDriveFileStager implements DriveFileStager {
   final bool _isReleaseMode;
 
   @override
-  Future<StagedDriveFile> stage({
+  Future<BytesStagedFile> stage({
     required DriveDocument doc,
     required OnFileProcessedProgress onDownloadProgress,
     required CancelToken cancelToken,
@@ -57,18 +56,20 @@ class BufferedWebDriveFileStager implements DriveFileStager {
 
 /// Web-buffered strategy: buffers the download in memory, then uploads the
 /// bytes-backed staged file through the injected uploader.
-class BufferedWebDriveTransferStrategy implements DriveTransferStrategy {
+class BufferedWebDriveTransferStrategy
+    extends DriveTransferStrategy<BytesStagedFile> {
   BufferedWebDriveTransferStrategy({
     required StagedFileUploader uploader,
-    DriveFileStager? stager,
+    DriveFileStager<BytesStagedFile>? stager,
   })  : _uploader = uploader,
         _stager = stager ?? BufferedWebDriveFileStager();
 
   final StagedFileUploader _uploader;
-  final DriveFileStager _stager;
+  final DriveFileStager<BytesStagedFile> _stager;
 
+  @protected
   @override
-  Future<StagedDriveFile> stage({
+  Future<BytesStagedFile> stage({
     required DriveDocument doc,
     required OnFileProcessedProgress onDownloadProgress,
     required CancelToken cancelToken,
@@ -82,8 +83,9 @@ class BufferedWebDriveTransferStrategy implements DriveTransferStrategy {
 
   /// `request.authHeader` is unused: the shared uploader authenticates
   /// through the app's Dio interceptors. Only the OPFS raw-XHR path needs it.
+  @protected
   @override
-  Future<Attachment> upload(DriveUploadRequest request) {
+  Future<Attachment> upload(DriveUploadRequest<BytesStagedFile> request) {
     return _uploader(
       staged: request.staged,
       uploadUri: request.uploadUri,

--- a/workplace/lib/data/datasource/drive_transfer/buffered_web_drive_file_stager.dart
+++ b/workplace/lib/data/datasource/drive_transfer/buffered_web_drive_file_stager.dart
@@ -80,21 +80,15 @@ class BufferedWebDriveTransferStrategy implements DriveTransferStrategy {
     );
   }
 
-  /// [authHeader] is unused: the shared uploader authenticates through the
-  /// app's Dio interceptors. Only the OPFS raw-XHR path needs it.
+  /// `request.authHeader` is unused: the shared uploader authenticates
+  /// through the app's Dio interceptors. Only the OPFS raw-XHR path needs it.
   @override
-  Future<Attachment> upload({
-    required StagedDriveFile staged,
-    required Uri uploadUri,
-    required String authHeader,
-    required OnFileProcessedProgress onUploadProgress,
-    required CancelToken cancelToken,
-  }) {
+  Future<Attachment> upload(DriveUploadRequest request) {
     return _uploader(
-      staged: staged,
-      uploadUri: uploadUri,
-      onUploadProgress: onUploadProgress,
-      cancelToken: cancelToken,
+      staged: request.staged,
+      uploadUri: request.uploadUri,
+      onUploadProgress: request.onUploadProgress,
+      cancelToken: request.cancelToken,
     );
   }
 }

--- a/workplace/lib/data/datasource/drive_transfer/buffered_web_drive_file_stager.dart
+++ b/workplace/lib/data/datasource/drive_transfer/buffered_web_drive_file_stager.dart
@@ -1,0 +1,72 @@
+import 'dart:typed_data';
+
+import 'package:core/utils/build_utils.dart';
+import 'package:dio/dio.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_file_stager.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
+import 'package:workplace/data/datasource/drive_transfer/opfs_drive_file_uploader.dart';
+import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
+import 'package:workplace/data/workplace_dio.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+import 'package:workplace/domain/exceptions/workplace_exceptions.dart';
+
+/// Buffers a drive document fully into memory. Explicit, feature-detected
+/// fallback for browsers without OPFS `createWritable()` support — checked
+/// (the actual-byte guard still cancels on breach), not memory-flat.
+class BufferedWebDriveFileStager implements DriveFileStager {
+  BufferedWebDriveFileStager({Dio? dio, bool? isReleaseMode})
+      : _dio = dio ?? WorkplaceDio.instance,
+        _isReleaseMode = isReleaseMode ?? BuildUtils.isReleaseMode;
+
+  final Dio _dio;
+  final bool _isReleaseMode;
+
+  @override
+  Future<StagedDriveFile> stage({
+    required DriveDocument doc,
+    required void Function(int received, int total) onDownloadProgress,
+    required CancelToken cancelToken,
+  }) async {
+    final downloadLink = doc.downloadLink;
+    if (downloadLink == null) {
+      throw DriveDownloadNullAttachmentException();
+    }
+    if (_isReleaseMode && !downloadLink.isScheme('https')) {
+      throw DriveDownloadInsecureLinkException();
+    }
+    final response = await _dio.getUri<List<int>>(
+      downloadLink,
+      options: Options(
+        responseType: ResponseType.bytes,
+        receiveTimeout: driveTransferReceiveTimeout,
+      ),
+      cancelToken: cancelToken,
+      onReceiveProgress: onDownloadProgress,
+    );
+
+    final data = response.data;
+    if (data == null) {
+      throw DriveDownloadEmptyResponseException();
+    }
+    final bytes = data is Uint8List ? data : Uint8List.fromList(data);
+    return BytesStagedFile(
+      bytes: bytes,
+      fileName: doc.name,
+      fileSize: bytes.length,
+      mimeType: doc.mimeType,
+    );
+  }
+}
+
+/// Web-buffered strategy: no OPFS-only uploader, `FileUploader` handles the
+/// bytes-backed upload leg.
+class BufferedWebDriveTransferStrategy implements DriveTransferStrategy {
+  @override
+  final DriveFileStager stager;
+
+  @override
+  OpfsDriveFileUploader? get opfsUploader => null;
+
+  BufferedWebDriveTransferStrategy({DriveFileStager? stager})
+      : stager = stager ?? BufferedWebDriveFileStager();
+}

--- a/workplace/lib/data/datasource/drive_transfer/drive_file_stager.dart
+++ b/workplace/lib/data/datasource/drive_transfer/drive_file_stager.dart
@@ -1,0 +1,21 @@
+import 'package:dio/dio.dart';
+import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+
+/// Shared receive timeout for the Dio-backed download legs (IO, web-buffered)
+/// — raised from `WorkplaceDio`'s 10s default to tolerate slow-to-first-byte
+/// export-on-demand backends (e.g. Cozy) while still catching a stalled
+/// mid-transfer connection.
+const driveTransferReceiveTimeout = Duration(seconds: 60);
+
+/// Streams a drive document into platform-appropriate temp storage and
+/// yields a [StagedDriveFile] ready for upload. One implementation per
+/// platform capability (IO, web+OPFS, web-buffered); orchestration is
+/// written once against this interface and never branches on platform.
+abstract class DriveFileStager {
+  Future<StagedDriveFile> stage({
+    required DriveDocument doc,
+    required void Function(int received, int total) onDownloadProgress,
+    required CancelToken cancelToken,
+  });
+}

--- a/workplace/lib/data/datasource/drive_transfer/drive_file_stager.dart
+++ b/workplace/lib/data/datasource/drive_transfer/drive_file_stager.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
+import 'package:workplace/data/model/workplace_type_defs.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
 
 /// Shared receive timeout for the Dio-backed download legs (IO, web-buffered)
@@ -15,7 +16,7 @@ const driveTransferReceiveTimeout = Duration(seconds: 60);
 abstract class DriveFileStager {
   Future<StagedDriveFile> stage({
     required DriveDocument doc,
-    required void Function(int received, int total) onDownloadProgress,
+    required OnFileProcessedProgress onDownloadProgress,
     required CancelToken cancelToken,
   });
 }

--- a/workplace/lib/data/datasource/drive_transfer/drive_file_stager.dart
+++ b/workplace/lib/data/datasource/drive_transfer/drive_file_stager.dart
@@ -13,8 +13,11 @@ const driveTransferReceiveTimeout = Duration(seconds: 60);
 /// yields a [StagedDriveFile] ready for upload. One implementation per
 /// platform capability (IO, web+OPFS, web-buffered); orchestration is
 /// written once against this interface and never branches on platform.
-abstract class DriveFileStager {
-  Future<StagedDriveFile> stage({
+///
+/// [T] pins the staged variant an implementation produces, so a stager can
+/// only ever be paired with a strategy that can consume its output.
+abstract class DriveFileStager<T extends StagedDriveFile> {
+  Future<T> stage({
     required DriveDocument doc,
     required OnFileProcessedProgress onDownloadProgress,
     required CancelToken cancelToken,

--- a/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy.dart
+++ b/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy.dart
@@ -1,0 +1,12 @@
+import 'package:workplace/data/datasource/drive_transfer/drive_file_stager.dart';
+import 'package:workplace/data/datasource/drive_transfer/opfs_drive_file_uploader.dart';
+
+/// Bundles the stager for a platform capability plus, for web+OPFS, the
+/// raw-XHR uploader — the only upload path that can't reuse `FileUploader`.
+/// Selected once per batch via `DriveTransferStrategyFactory.create()`.
+abstract class DriveTransferStrategy {
+  DriveFileStager get stager;
+
+  /// Non-null only for the OPFS strategy.
+  OpfsDriveFileUploader? get opfsUploader;
+}

--- a/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy.dart
+++ b/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy.dart
@@ -41,7 +41,7 @@ abstract class DriveTransferStrategy<T extends StagedDriveFile> {
       await staged.dispose();
     } catch (error) {
       logWarning(
-          'DriveTransferStrategy::_disposeQuietly: failed to dispose ${staged.fileName}: $error');
+          'DriveTransferStrategy::_disposeQuietly: failed to dispose staged file: $error');
     }
   }
 

--- a/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy.dart
+++ b/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy.dart
@@ -14,13 +14,27 @@ abstract class DriveTransferStrategy {
     required CancelToken cancelToken,
   });
 
-  /// [authHeader] is only used by the OPFS raw-XHR path; the others
-  /// authenticate through the app's Dio interceptors.
-  Future<Attachment> upload({
-    required StagedDriveFile staged,
-    required Uri uploadUri,
-    required String authHeader,
-    required OnFileProcessedProgress onUploadProgress,
-    required CancelToken cancelToken,
+  Future<Attachment> upload(DriveUploadRequest request);
+}
+
+/// Bundles [DriveTransferStrategy.upload]'s parameters to keep its argument
+/// count low.
+class DriveUploadRequest {
+  final StagedDriveFile staged;
+  final Uri uploadUri;
+
+  /// Only used by the OPFS raw-XHR path; the other strategies authenticate
+  /// through the app's Dio interceptors.
+  final String authHeader;
+
+  final OnFileProcessedProgress onUploadProgress;
+  final CancelToken cancelToken;
+
+  const DriveUploadRequest({
+    required this.staged,
+    required this.uploadUri,
+    required this.authHeader,
+    required this.onUploadProgress,
+    required this.cancelToken,
   });
 }

--- a/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy.dart
+++ b/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy.dart
@@ -1,3 +1,4 @@
+import 'package:core/utils/app_logger.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:model/email/attachment.dart';
@@ -14,29 +15,33 @@ import 'package:workplace/domain/entity/drive_document.dart';
 /// leak temp storage nor hand a strategy a staged file it can't consume. [T]
 /// pins that variant, keeping the pairing a compile-time concern.
 abstract class DriveTransferStrategy<T extends StagedDriveFile> {
-  Future<Attachment> transfer({
-    required DriveDocument doc,
-    required Uri uploadUri,
-    required String authHeader,
-    required OnFileProcessedProgress onDownloadProgress,
-    required OnFileProcessedProgress onUploadProgress,
-    required CancelToken cancelToken,
-  }) async {
+  Future<Attachment> transfer(DriveTransferRequest request) async {
     final staged = await stage(
-      doc: doc,
-      onDownloadProgress: onDownloadProgress,
-      cancelToken: cancelToken,
+      doc: request.doc,
+      onDownloadProgress: request.onDownloadProgress,
+      cancelToken: request.cancelToken,
     );
     try {
       return await upload(DriveUploadRequest(
         staged: staged,
-        uploadUri: uploadUri,
-        authHeader: authHeader,
-        onUploadProgress: onUploadProgress,
-        cancelToken: cancelToken,
+        uploadUri: request.uploadUri,
+        authHeader: request.authHeader,
+        onUploadProgress: request.onUploadProgress,
+        cancelToken: request.cancelToken,
       ));
     } finally {
+      await _disposeQuietly(staged);
+    }
+  }
+
+  /// Best-effort: a cleanup failure must neither replace the error that caused
+  /// it nor turn a completed upload into a failed transfer.
+  Future<void> _disposeQuietly(T staged) async {
+    try {
       await staged.dispose();
+    } catch (error) {
+      logWarning(
+          'DriveTransferStrategy::_disposeQuietly: failed to dispose ${staged.fileName}: $error');
     }
   }
 
@@ -49,6 +54,30 @@ abstract class DriveTransferStrategy<T extends StagedDriveFile> {
 
   @protected
   Future<Attachment> upload(DriveUploadRequest<T> request);
+}
+
+/// Bundles [DriveTransferStrategy.transfer]'s parameters to keep its argument
+/// count low.
+class DriveTransferRequest {
+  final DriveDocument doc;
+  final Uri uploadUri;
+
+  /// Only used by the OPFS raw-XHR path; the other strategies authenticate
+  /// through the app's Dio interceptors.
+  final String authHeader;
+
+  final OnFileProcessedProgress onDownloadProgress;
+  final OnFileProcessedProgress onUploadProgress;
+  final CancelToken cancelToken;
+
+  const DriveTransferRequest({
+    required this.doc,
+    required this.uploadUri,
+    required this.authHeader,
+    required this.onDownloadProgress,
+    required this.onUploadProgress,
+    required this.cancelToken,
+  });
 }
 
 /// Bundles [DriveTransferStrategy.upload]'s parameters to keep its argument

--- a/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy.dart
+++ b/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:model/email/attachment.dart';
 import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
 import 'package:workplace/data/model/workplace_type_defs.dart';
@@ -7,20 +8,53 @@ import 'package:workplace/domain/entity/drive_document.dart';
 /// Both legs of a drive transfer for one platform capability, selected once
 /// per batch via `DriveTransferStrategyFactory.create()`. Orchestration —
 /// stage, upload, dispose — never branches on platform.
-abstract class DriveTransferStrategy {
-  Future<StagedDriveFile> stage({
+///
+/// [transfer] is the only public entry point: it owns the staged file for its
+/// whole lifetime and disposes it on every exit path, so callers can neither
+/// leak temp storage nor hand a strategy a staged file it can't consume. [T]
+/// pins that variant, keeping the pairing a compile-time concern.
+abstract class DriveTransferStrategy<T extends StagedDriveFile> {
+  Future<Attachment> transfer({
+    required DriveDocument doc,
+    required Uri uploadUri,
+    required String authHeader,
+    required OnFileProcessedProgress onDownloadProgress,
+    required OnFileProcessedProgress onUploadProgress,
+    required CancelToken cancelToken,
+  }) async {
+    final staged = await stage(
+      doc: doc,
+      onDownloadProgress: onDownloadProgress,
+      cancelToken: cancelToken,
+    );
+    try {
+      return await upload(DriveUploadRequest(
+        staged: staged,
+        uploadUri: uploadUri,
+        authHeader: authHeader,
+        onUploadProgress: onUploadProgress,
+        cancelToken: cancelToken,
+      ));
+    } finally {
+      await staged.dispose();
+    }
+  }
+
+  @protected
+  Future<T> stage({
     required DriveDocument doc,
     required OnFileProcessedProgress onDownloadProgress,
     required CancelToken cancelToken,
   });
 
-  Future<Attachment> upload(DriveUploadRequest request);
+  @protected
+  Future<Attachment> upload(DriveUploadRequest<T> request);
 }
 
 /// Bundles [DriveTransferStrategy.upload]'s parameters to keep its argument
 /// count low.
-class DriveUploadRequest {
-  final StagedDriveFile staged;
+class DriveUploadRequest<T extends StagedDriveFile> {
+  final T staged;
   final Uri uploadUri;
 
   /// Only used by the OPFS raw-XHR path; the other strategies authenticate

--- a/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy.dart
+++ b/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy.dart
@@ -1,12 +1,26 @@
-import 'package:workplace/data/datasource/drive_transfer/drive_file_stager.dart';
-import 'package:workplace/data/datasource/drive_transfer/opfs_drive_file_uploader.dart';
+import 'package:dio/dio.dart';
+import 'package:model/email/attachment.dart';
+import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
+import 'package:workplace/data/model/workplace_type_defs.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
 
-/// Bundles the stager for a platform capability plus, for web+OPFS, the
-/// raw-XHR uploader — the only upload path that can't reuse `FileUploader`.
-/// Selected once per batch via `DriveTransferStrategyFactory.create()`.
+/// Both legs of a drive transfer for one platform capability, selected once
+/// per batch via `DriveTransferStrategyFactory.create()`. Orchestration —
+/// stage, upload, dispose — never branches on platform.
 abstract class DriveTransferStrategy {
-  DriveFileStager get stager;
+  Future<StagedDriveFile> stage({
+    required DriveDocument doc,
+    required OnFileProcessedProgress onDownloadProgress,
+    required CancelToken cancelToken,
+  });
 
-  /// Non-null only for the OPFS strategy.
-  OpfsDriveFileUploader? get opfsUploader;
+  /// [authHeader] is only used by the OPFS raw-XHR path; the others
+  /// authenticate through the app's Dio interceptors.
+  Future<Attachment> upload({
+    required StagedDriveFile staged,
+    required Uri uploadUri,
+    required String authHeader,
+    required OnFileProcessedProgress onUploadProgress,
+    required CancelToken cancelToken,
+  });
 }

--- a/workplace/lib/data/datasource/drive_transfer/opfs_drive_file_uploader.dart
+++ b/workplace/lib/data/datasource/drive_transfer/opfs_drive_file_uploader.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:model/email/attachment.dart';
+import 'package:workplace/data/datasource/drive_transfer/opfs_file_handle.dart';
 import 'package:workplace/data/model/workplace_type_defs.dart';
 
 /// Uploads an OPFS-staged file via a raw-XHR POST that streams straight from
@@ -7,14 +8,11 @@ import 'package:workplace/data/model/workplace_type_defs.dart';
 /// upload path `FileUploader` can't do. Not refresh-and-retry safe: the
 /// bearer token is read once, up front.
 ///
-/// Declared without any `dart:js_interop`/`package:web` reference so this
-/// file stays part of the platform-agnostic `DriveTransferStrategy` surface;
-/// [fileHandle] is an opaque `web.FileSystemFileHandle`. The concrete
-/// `BrowserOpfsDriveFileUploader` (web-only, `opfs_drive_file_uploader_web.dart`)
-/// is the only place that casts it back.
+/// Held privately by the OPFS strategy, not exposed on
+/// `DriveTransferStrategy`.
 abstract class OpfsDriveFileUploader {
   Future<Attachment> upload({
-    required Object fileHandle,
+    required OpfsFileHandle fileHandle,
     required String fileName,
     required String? mimeType,
     required Uri uploadUri,

--- a/workplace/lib/data/datasource/drive_transfer/opfs_drive_file_uploader.dart
+++ b/workplace/lib/data/datasource/drive_transfer/opfs_drive_file_uploader.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:model/email/attachment.dart';
+import 'package:workplace/data/model/workplace_type_defs.dart';
 
 /// Uploads an OPFS-staged file via a raw-XHR POST that streams straight from
 /// the OPFS-backed file without materializing it in the JS heap — the only
@@ -18,7 +19,7 @@ abstract class OpfsDriveFileUploader {
     required String? mimeType,
     required Uri uploadUri,
     required String authHeader,
-    required void Function(int sent, int total) onUploadProgress,
+    required OnFileProcessedProgress onUploadProgress,
     required CancelToken cancelToken,
   });
 }

--- a/workplace/lib/data/datasource/drive_transfer/opfs_drive_file_uploader.dart
+++ b/workplace/lib/data/datasource/drive_transfer/opfs_drive_file_uploader.dart
@@ -1,0 +1,24 @@
+import 'package:dio/dio.dart';
+import 'package:model/email/attachment.dart';
+
+/// Uploads an OPFS-staged file via a raw-XHR POST that streams straight from
+/// the OPFS-backed file without materializing it in the JS heap — the only
+/// upload path `FileUploader` can't do. Not refresh-and-retry safe: the
+/// bearer token is read once, up front.
+///
+/// Declared without any `dart:js_interop`/`package:web` reference so this
+/// file stays part of the platform-agnostic `DriveTransferStrategy` surface;
+/// [fileHandle] is an opaque `web.FileSystemFileHandle`. The concrete
+/// `BrowserOpfsDriveFileUploader` (web-only, `opfs_drive_file_uploader_web.dart`)
+/// is the only place that casts it back.
+abstract class OpfsDriveFileUploader {
+  Future<Attachment> upload({
+    required Object fileHandle,
+    required String fileName,
+    required String? mimeType,
+    required Uri uploadUri,
+    required String authHeader,
+    required void Function(int sent, int total) onUploadProgress,
+    required CancelToken cancelToken,
+  });
+}

--- a/workplace/lib/data/datasource/drive_transfer/opfs_file_handle.dart
+++ b/workplace/lib/data/datasource/drive_transfer/opfs_file_handle.dart
@@ -1,0 +1,3 @@
+/// `web.FileSystemFileHandle` on web, an opaque [Object] elsewhere.
+export 'opfs_file_handle_mobile.dart'
+    if (dart.library.html) 'opfs_file_handle_web.dart';

--- a/workplace/lib/data/datasource/drive_transfer/opfs_file_handle_mobile.dart
+++ b/workplace/lib/data/datasource/drive_transfer/opfs_file_handle_mobile.dart
@@ -1,0 +1,2 @@
+/// Non-web stub: OPFS has no off-web implementation, nothing produces this.
+typedef OpfsFileHandle = Object;

--- a/workplace/lib/data/datasource/drive_transfer/opfs_file_handle_web.dart
+++ b/workplace/lib/data/datasource/drive_transfer/opfs_file_handle_web.dart
@@ -1,0 +1,3 @@
+import 'package:web/web.dart' as web;
+
+typedef OpfsFileHandle = web.FileSystemFileHandle;

--- a/workplace/lib/data/datasource/drive_transfer/staged_drive_file.dart
+++ b/workplace/lib/data/datasource/drive_transfer/staged_drive_file.dart
@@ -1,0 +1,92 @@
+import 'dart:typed_data';
+
+import 'package:equatable/equatable.dart';
+
+/// Result of staging a drive document into platform-appropriate temp storage,
+/// ready to be uploaded. One variant per platform capability.
+///
+/// Variants inject their [dispose] logic rather than importing `dart:io` or
+/// `dart:js_interop` here, so this file stays compilable on every platform.
+sealed class StagedDriveFile extends Equatable {
+  final String fileName;
+  final int fileSize;
+  final String? mimeType;
+
+  const StagedDriveFile({
+    required this.fileName,
+    required this.fileSize,
+    this.mimeType,
+  });
+
+  /// Removes the underlying temp storage (disk file or OPFS entry).
+  /// No-op for in-memory staged files. Safe to call on every exit path.
+  Future<void> dispose();
+}
+
+/// IO temp file (mobile/desktop).
+final class FileBackedStagedFile extends StagedDriveFile {
+  final String filePath;
+  final Future<void> Function(String filePath) deleteFile;
+
+  const FileBackedStagedFile({
+    required this.filePath,
+    required this.deleteFile,
+    required super.fileName,
+    required super.fileSize,
+    super.mimeType,
+  });
+
+  @override
+  Future<void> dispose() => deleteFile(filePath);
+
+  @override
+  List<Object?> get props => [filePath, fileName, fileSize, mimeType];
+}
+
+/// Web, Origin Private File System temp file handle.
+final class OpfsStagedFile extends StagedDriveFile {
+  /// Opaque `web.FileSystemFileHandle` — typed [Object] so this file never
+  /// imports `package:web`; the web-only uploader casts it back.
+  final Object fileHandle;
+  final Future<void> Function(Object handle) removeEntry;
+
+  const OpfsStagedFile({
+    required this.fileHandle,
+    required this.removeEntry,
+    required super.fileName,
+    required super.fileSize,
+    super.mimeType,
+  });
+
+  @override
+  Future<void> dispose() => removeEntry(fileHandle);
+
+  @override
+  List<Object?> get props => [fileHandle, fileName, fileSize, mimeType];
+}
+
+/// Web, buffered fallback when OPFS is unavailable.
+final class BytesStagedFile extends StagedDriveFile {
+  final Uint8List bytes;
+
+  const BytesStagedFile({
+    required this.bytes,
+    required super.fileName,
+    required super.fileSize,
+    super.mimeType,
+  });
+
+  @override
+  Future<void> dispose() async {}
+
+  /// Compares [bytes] by identity, not content — value equality over a
+  /// potentially large in-memory buffer would make `==`/`hashCode` O(file
+  /// size).
+  @override
+  List<Object?> get props => [
+        identityHashCode(bytes),
+        fileName,
+        fileSize,
+        mimeType,
+      ];
+}

--- a/workplace/lib/data/datasource/drive_transfer/staged_drive_file.dart
+++ b/workplace/lib/data/datasource/drive_transfer/staged_drive_file.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:equatable/equatable.dart';
+import 'package:workplace/data/model/workplace_type_defs.dart';
 
 /// Result of staging a drive document into platform-appropriate temp storage,
 /// ready to be uploaded. One variant per platform capability.
@@ -26,7 +27,7 @@ sealed class StagedDriveFile extends Equatable {
 /// IO temp file (mobile/desktop).
 final class FileBackedStagedFile extends StagedDriveFile {
   final String filePath;
-  final Future<void> Function(String filePath) deleteFile;
+  final OnDeleteIOFile deleteFile;
 
   const FileBackedStagedFile({
     required this.filePath,
@@ -48,7 +49,7 @@ final class OpfsStagedFile extends StagedDriveFile {
   /// Opaque `web.FileSystemFileHandle` — typed [Object] so this file never
   /// imports `package:web`; the web-only uploader casts it back.
   final Object fileHandle;
-  final Future<void> Function(Object handle) removeEntry;
+  final OnDeleteOPFSFile removeEntry;
 
   const OpfsStagedFile({
     required this.fileHandle,

--- a/workplace/lib/data/datasource/drive_transfer/staged_drive_file.dart
+++ b/workplace/lib/data/datasource/drive_transfer/staged_drive_file.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:equatable/equatable.dart';
+import 'package:workplace/data/datasource/drive_transfer/opfs_file_handle.dart';
 import 'package:workplace/data/model/workplace_type_defs.dart';
 
 /// Result of staging a drive document into platform-appropriate temp storage,
@@ -46,9 +47,7 @@ final class FileBackedStagedFile extends StagedDriveFile {
 
 /// Web, Origin Private File System temp file handle.
 final class OpfsStagedFile extends StagedDriveFile {
-  /// Opaque `web.FileSystemFileHandle` — typed [Object] so this file never
-  /// imports `package:web`; the web-only uploader casts it back.
-  final Object fileHandle;
+  final OpfsFileHandle fileHandle;
   final OnDeleteOPFSFile removeEntry;
 
   const OpfsStagedFile({

--- a/workplace/lib/data/model/workplace_type_defs.dart
+++ b/workplace/lib/data/model/workplace_type_defs.dart
@@ -1,6 +1,20 @@
 import 'dart:async';
 
+import 'package:dio/dio.dart';
+import 'package:model/email/attachment.dart';
+import 'package:workplace/data/datasource/drive_transfer/opfs_file_handle.dart';
+import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
+
 typedef OnFileProcessedProgress = void Function(int processed, int total);
 
 typedef OnDeleteIOFile = Future<void> Function(String path);
-typedef OnDeleteOPFSFile = Future<void> Function(Object handle);
+typedef OnDeleteOPFSFile = Future<void> Function(OpfsFileHandle handle);
+
+/// Uploads a staged drive file through the app's `FileUploader`. Injected by
+/// the main app, which `workplace` cannot depend on.
+typedef StagedFileUploader = Future<Attachment> Function({
+  required StagedDriveFile staged,
+  required Uri uploadUri,
+  required OnFileProcessedProgress onUploadProgress,
+  required CancelToken cancelToken,
+});

--- a/workplace/lib/data/model/workplace_type_defs.dart
+++ b/workplace/lib/data/model/workplace_type_defs.dart
@@ -1,0 +1,1 @@
+typedef OnFileProcessedProgress = void Function(int processed, int total);

--- a/workplace/lib/data/model/workplace_type_defs.dart
+++ b/workplace/lib/data/model/workplace_type_defs.dart
@@ -1,1 +1,6 @@
+import 'dart:async';
+
 typedef OnFileProcessedProgress = void Function(int processed, int total);
+
+typedef OnDeleteIOFile = Future<void> Function(String path);
+typedef OnDeleteOPFSFile = Future<void> Function(Object handle);

--- a/workplace/lib/domain/entity/drive_document_extension.dart
+++ b/workplace/lib/domain/entity/drive_document_extension.dart
@@ -1,3 +1,4 @@
+import '../exceptions/workplace_exceptions.dart';
 import 'drive_document.dart';
 
 extension DriveDocumentExtension on DriveDocument {
@@ -35,4 +36,19 @@ extension DriveDocumentExtension on DriveDocument {
   }
 
   Uri? get attachmentUrl => sharingLink ?? downloadLink;
+
+  /// The link a stager downloads from. Throws
+  /// [DriveDownloadNullAttachmentException] when absent, and
+  /// [DriveDownloadInsecureLinkException] for non-https in release mode
+  /// (http stays allowed in dev for local backends).
+  Uri resolveDownloadLinkForStaging({required bool isReleaseMode}) {
+    final link = downloadLink;
+    if (link == null) {
+      throw DriveDownloadNullAttachmentException();
+    }
+    if (isReleaseMode && !link.isScheme('https')) {
+      throw DriveDownloadInsecureLinkException();
+    }
+    return link;
+  }
 }

--- a/workplace/lib/domain/exceptions/workplace_exceptions.dart
+++ b/workplace/lib/domain/exceptions/workplace_exceptions.dart
@@ -14,3 +14,9 @@ class DriveIntentPageLoadException implements Exception {
 }
 
 class DriveIntentTimeoutException implements Exception {}
+
+class DriveDownloadNullAttachmentException implements Exception {}
+
+class DriveDownloadInsecureLinkException implements Exception {}
+
+class DriveDownloadEmptyResponseException implements Exception {}

--- a/workplace/pubspec.yaml
+++ b/workplace/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   dartz: 0.10.1
   flutter_inappwebview: 6.1.0
   universal_html: 2.2.4
+  web: 1.1.1
   flutter_svg:
   flutter_localization:
   intl:

--- a/workplace/test/data/datasource/drive_transfer/buffered_web_drive_file_stager_test.dart
+++ b/workplace/test/data/datasource/drive_transfer/buffered_web_drive_file_stager_test.dart
@@ -5,7 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:model/email/attachment.dart';
 import 'package:workplace/data/datasource/drive_transfer/buffered_web_drive_file_stager.dart';
 import 'package:workplace/data/datasource/drive_transfer/drive_file_stager.dart';
-import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
 import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
 import 'package:workplace/data/model/workplace_type_defs.dart';
 import 'package:workplace/data/workplace_dio.dart';
@@ -98,7 +97,7 @@ void main() {
     );
 
     expect(staged, isA<BytesStagedFile>());
-    expect((staged as BytesStagedFile).bytes, bytes);
+    expect(staged.bytes, bytes);
     expect(progress, isNotEmpty);
     expect(progress.last.first, bytes.length);
 
@@ -113,7 +112,7 @@ void main() {
       doc: _buildDoc(downloadLink: _defaultDownloadLink, mimeType: 'image/png'),
       onDownloadProgress: (_, __) {},
       cancelToken: CancelToken(),
-    ) as BytesStagedFile;
+    );
 
     expect(staged.fileName, 'file.bin');
     expect(staged.mimeType, 'image/png');
@@ -127,7 +126,7 @@ void main() {
       doc: _buildDoc(downloadLink: _defaultDownloadLink),
       onDownloadProgress: (_, __) {},
       cancelToken: CancelToken(),
-    ) as BytesStagedFile;
+    );
 
     expect(staged.bytes, isEmpty);
     expect(staged.fileSize, 0);
@@ -227,69 +226,57 @@ void main() {
   });
 
   group('BufferedWebDriveTransferStrategy', () {
-    test('stage() delegates to the injected stager, passing args through',
+    test('transfer() stages then uploads, passing args through to both',
         () async {
       final stager = _RecordingDriveFileStager();
-      final strategy = BufferedWebDriveTransferStrategy(
-        uploader: _unreachableUploader,
-        stager: stager,
-      );
-      final doc = _buildDoc(downloadLink: _defaultDownloadLink);
-      final cancelToken = CancelToken();
-      void onProgress(int r, int t) {}
-
-      final staged = await strategy.stage(
-        doc: doc,
-        onDownloadProgress: onProgress,
-        cancelToken: cancelToken,
-      );
-
-      expect(staged, same(stager.result));
-      expect(stager.doc, same(doc));
-      expect(stager.onDownloadProgress, same(onProgress));
-      expect(stager.cancelToken, same(cancelToken));
-    });
-
-    test('stage() defaults to a BufferedWebDriveFileStager', () async {
-      WorkplaceDio.setInstance(
-          Dio()..httpClientAdapter = _FakeHttpClientAdapter([1, 2, 3]));
-
-      final staged =
-          await BufferedWebDriveTransferStrategy(uploader: _unreachableUploader)
-              .stage(
-        doc: _buildDoc(downloadLink: _defaultDownloadLink),
-        onDownloadProgress: (_, __) {},
-        cancelToken: CancelToken(),
-      );
-
-      expect(staged, isA<BytesStagedFile>());
-    });
-
-    test('upload() delegates to the injected uploader, ignoring authHeader',
-        () async {
       final uploader = _RecordingStagedFileUploader();
       final strategy = BufferedWebDriveTransferStrategy(
         uploader: uploader.call,
-        stager: _RecordingDriveFileStager(),
+        stager: stager,
       );
-      final staged = _bytesStagedFile();
+      final doc = _buildDoc(downloadLink: _defaultDownloadLink);
       final uploadUri = Uri.parse('https://jmap.example/upload');
       final cancelToken = CancelToken();
-      void onProgress(int r, int t) {}
+      void onDownloadProgress(int r, int t) {}
+      void onUploadProgress(int r, int t) {}
 
-      final attachment = await strategy.upload(DriveUploadRequest(
-        staged: staged,
+      final attachment = await strategy.transfer(
+        doc: doc,
         uploadUri: uploadUri,
         authHeader: 'Bearer token',
-        onUploadProgress: onProgress,
+        onDownloadProgress: onDownloadProgress,
+        onUploadProgress: onUploadProgress,
         cancelToken: cancelToken,
-      ));
+      );
 
+      expect(stager.doc, same(doc));
+      expect(stager.onDownloadProgress, same(onDownloadProgress));
+      expect(stager.cancelToken, same(cancelToken));
+
+      // `authHeader` is deliberately dropped: the shared uploader
+      // authenticates through the app's Dio interceptors.
       expect(attachment, same(uploader.result));
-      expect(uploader.staged, same(staged));
+      expect(uploader.staged, same(stager.result));
       expect(uploader.uploadUri, uploadUri);
-      expect(uploader.onUploadProgress, same(onProgress));
+      expect(uploader.onUploadProgress, same(onUploadProgress));
       expect(uploader.cancelToken, same(cancelToken));
+    });
+
+    test('transfer() defaults to a BufferedWebDriveFileStager', () async {
+      WorkplaceDio.setInstance(
+          Dio()..httpClientAdapter = _FakeHttpClientAdapter([1, 2, 3]));
+      final uploader = _RecordingStagedFileUploader();
+
+      await BufferedWebDriveTransferStrategy(uploader: uploader.call).transfer(
+        doc: _buildDoc(downloadLink: _defaultDownloadLink),
+        uploadUri: Uri.parse('https://jmap.example/upload'),
+        authHeader: 'Bearer token',
+        onDownloadProgress: (_, __) {},
+        onUploadProgress: (_, __) {},
+        cancelToken: CancelToken(),
+      );
+
+      expect(uploader.staged, isA<BytesStagedFile>());
     });
   });
 }
@@ -300,23 +287,15 @@ BytesStagedFile _bytesStagedFile() => BytesStagedFile(
       fileSize: 3,
     );
 
-Future<Attachment> _unreachableUploader({
-  required StagedDriveFile staged,
-  required Uri uploadUri,
-  required OnFileProcessedProgress onUploadProgress,
-  required CancelToken cancelToken,
-}) =>
-    throw UnimplementedError();
-
-class _RecordingDriveFileStager implements DriveFileStager {
-  final StagedDriveFile result = _bytesStagedFile();
+class _RecordingDriveFileStager implements DriveFileStager<BytesStagedFile> {
+  final BytesStagedFile result = _bytesStagedFile();
 
   DriveDocument? doc;
   OnFileProcessedProgress? onDownloadProgress;
   CancelToken? cancelToken;
 
   @override
-  Future<StagedDriveFile> stage({
+  Future<BytesStagedFile> stage({
     required DriveDocument doc,
     required OnFileProcessedProgress onDownloadProgress,
     required CancelToken cancelToken,

--- a/workplace/test/data/datasource/drive_transfer/buffered_web_drive_file_stager_test.dart
+++ b/workplace/test/data/datasource/drive_transfer/buffered_web_drive_file_stager_test.dart
@@ -1,0 +1,252 @@
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:workplace/data/datasource/drive_transfer/buffered_web_drive_file_stager.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_file_stager.dart';
+import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
+import 'package:workplace/data/workplace_dio.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+import 'package:workplace/domain/exceptions/workplace_exceptions.dart';
+
+class _FakeHttpClientAdapter implements HttpClientAdapter {
+  final List<int> bytes;
+  RequestOptions? lastRequestOptions;
+
+  _FakeHttpClientAdapter(this.bytes);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    lastRequestOptions = options;
+    options.onReceiveProgress?.call(bytes.length, bytes.length);
+    return ResponseBody.fromBytes(bytes, 200);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+class _FailingHttpClientAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    throw DioException(
+      requestOptions: options,
+      type: DioExceptionType.connectionError,
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+class _CancellingHttpClientAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    await cancelFuture;
+    throw DioException(requestOptions: options, type: DioExceptionType.cancel);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+final _defaultDownloadLink = Uri.parse('https://drive.example/file');
+
+DriveDocument _buildDoc({
+  required Uri? downloadLink,
+  String mimeType = 'application/octet-stream',
+  int size = 16,
+}) =>
+    DriveDocument(
+      id: 'doc-1',
+      name: 'file.bin',
+      size: size,
+      mimeType: mimeType,
+      downloadLink: downloadLink,
+    );
+
+void main() {
+  late Dio originalDio;
+
+  setUp(() => originalDio = WorkplaceDio.instance);
+  tearDown(() => WorkplaceDio.setInstance(originalDio));
+
+  test('buffers the full response and forwards onReceiveProgress', () async {
+    final bytes = List<int>.generate(16, (i) => i);
+    WorkplaceDio.setInstance(Dio()..httpClientAdapter = _FakeHttpClientAdapter(bytes));
+
+    final progress = <List<int>>[];
+    final staged = await BufferedWebDriveFileStager().stage(
+      doc: _buildDoc(downloadLink: _defaultDownloadLink),
+      onDownloadProgress: (r, t) => progress.add([r, t]),
+      cancelToken: CancelToken(),
+    );
+
+    expect(staged, isA<BytesStagedFile>());
+    expect((staged as BytesStagedFile).bytes, bytes);
+    expect(progress, isNotEmpty);
+    expect(progress.last.first, bytes.length);
+
+    await staged.dispose();
+  });
+
+  test('preserves fileName, mimeType and fileSize metadata', () async {
+    final bytes = List<int>.generate(8, (i) => i);
+    final dio = Dio()..httpClientAdapter = _FakeHttpClientAdapter(bytes);
+
+    final staged = await BufferedWebDriveFileStager(dio: dio).stage(
+      doc: _buildDoc(downloadLink: _defaultDownloadLink, mimeType: 'image/png'),
+      onDownloadProgress: (_, __) {},
+      cancelToken: CancelToken(),
+    ) as BytesStagedFile;
+
+    expect(staged.fileName, 'file.bin');
+    expect(staged.mimeType, 'image/png');
+    expect(staged.fileSize, bytes.length);
+  });
+
+  test('empty response yields a staged file with fileSize 0', () async {
+    final dio = Dio()..httpClientAdapter = _FakeHttpClientAdapter(const []);
+
+    final staged = await BufferedWebDriveFileStager(dio: dio).stage(
+      doc: _buildDoc(downloadLink: _defaultDownloadLink),
+      onDownloadProgress: (_, __) {},
+      cancelToken: CancelToken(),
+    ) as BytesStagedFile;
+
+    expect(staged.bytes, isEmpty);
+    expect(staged.fileSize, 0);
+  });
+
+  test('forwards URI, ResponseType.bytes, receive timeout and cancel token', () async {
+    final adapter = _FakeHttpClientAdapter(const [1, 2, 3]);
+    final dio = Dio()..httpClientAdapter = adapter;
+    final cancelToken = CancelToken();
+    final link = Uri.parse('https://drive.example/other-file');
+
+    await BufferedWebDriveFileStager(dio: dio).stage(
+      doc: _buildDoc(downloadLink: link),
+      onDownloadProgress: (_, __) {},
+      cancelToken: cancelToken,
+    );
+
+    final requestOptions = adapter.lastRequestOptions!;
+    expect(requestOptions.uri, link);
+    expect(requestOptions.responseType, ResponseType.bytes);
+    expect(requestOptions.receiveTimeout, driveTransferReceiveTimeout);
+    expect(requestOptions.cancelToken, cancelToken);
+  });
+
+  test('downloadLink == null throws DriveDownloadNullAttachmentException', () async {
+    expect(
+      () => BufferedWebDriveFileStager().stage(
+        doc: _buildDoc(downloadLink: null),
+        onDownloadProgress: (_, __) {},
+        cancelToken: CancelToken(),
+      ),
+      throwsA(isA<DriveDownloadNullAttachmentException>()),
+    );
+  });
+
+  test('Dio network failures propagate as DioException', () async {
+    final dio = Dio()..httpClientAdapter = _FailingHttpClientAdapter();
+
+    expect(
+      () => BufferedWebDriveFileStager(dio: dio).stage(
+        doc: _buildDoc(downloadLink: _defaultDownloadLink),
+        onDownloadProgress: (_, __) {},
+        cancelToken: CancelToken(),
+      ),
+      throwsA(isA<DioException>()),
+    );
+  });
+
+  test('isReleaseMode true and http downloadLink throws DriveDownloadInsecureLinkException', () async {
+    final insecureLink = Uri.parse('http://drive.example/file');
+
+    expect(
+      () => BufferedWebDriveFileStager(isReleaseMode: true).stage(
+        doc: _buildDoc(downloadLink: insecureLink),
+        onDownloadProgress: (_, __) {},
+        cancelToken: CancelToken(),
+      ),
+      throwsA(isA<DriveDownloadInsecureLinkException>()),
+    );
+  });
+
+  test('isReleaseMode true and https downloadLink succeeds', () async {
+    final bytes = List<int>.generate(4, (i) => i);
+    final dio = Dio()..httpClientAdapter = _FakeHttpClientAdapter(bytes);
+
+    final staged = await BufferedWebDriveFileStager(
+      dio: dio,
+      isReleaseMode: true,
+    ).stage(
+      doc: _buildDoc(downloadLink: _defaultDownloadLink),
+      onDownloadProgress: (_, __) {},
+      cancelToken: CancelToken(),
+    );
+
+    expect(staged, isA<BytesStagedFile>());
+  });
+
+  test('cancellation propagates as a DioException of type cancel', () async {
+    final dio = Dio()..httpClientAdapter = _CancellingHttpClientAdapter();
+    final cancelToken = CancelToken();
+
+    final future = BufferedWebDriveFileStager(dio: dio).stage(
+      doc: _buildDoc(downloadLink: _defaultDownloadLink),
+      onDownloadProgress: (_, __) {},
+      cancelToken: cancelToken,
+    );
+    cancelToken.cancel();
+
+    await expectLater(
+      future,
+      throwsA(isA<DioException>().having(
+        (e) => e.type,
+        'type',
+        DioExceptionType.cancel,
+      )),
+    );
+  });
+
+  group('BufferedWebDriveTransferStrategy', () {
+    test('defaults to a BufferedWebDriveFileStager', () {
+      final strategy = BufferedWebDriveTransferStrategy();
+      expect(strategy.stager, isA<BufferedWebDriveFileStager>());
+    });
+
+    test('uses the injected stager when provided', () {
+      final customStager = _NoopDriveFileStager();
+      final strategy = BufferedWebDriveTransferStrategy(stager: customStager);
+      expect(strategy.stager, same(customStager));
+    });
+
+    test('opfsUploader is always null', () {
+      expect(BufferedWebDriveTransferStrategy().opfsUploader, isNull);
+    });
+  });
+}
+
+class _NoopDriveFileStager implements DriveFileStager {
+  @override
+  Future<StagedDriveFile> stage({
+    required DriveDocument doc,
+    required void Function(int received, int total) onDownloadProgress,
+    required CancelToken cancelToken,
+  }) =>
+      throw UnimplementedError();
+}

--- a/workplace/test/data/datasource/drive_transfer/buffered_web_drive_file_stager_test.dart
+++ b/workplace/test/data/datasource/drive_transfer/buffered_web_drive_file_stager_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:model/email/attachment.dart';
 import 'package:workplace/data/datasource/drive_transfer/buffered_web_drive_file_stager.dart';
 import 'package:workplace/data/datasource/drive_transfer/drive_file_stager.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
 import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
 import 'package:workplace/data/model/workplace_type_defs.dart';
 import 'package:workplace/data/workplace_dio.dart';
@@ -276,13 +277,13 @@ void main() {
       final cancelToken = CancelToken();
       void onProgress(int r, int t) {}
 
-      final attachment = await strategy.upload(
+      final attachment = await strategy.upload(DriveUploadRequest(
         staged: staged,
         uploadUri: uploadUri,
         authHeader: 'Bearer token',
         onUploadProgress: onProgress,
         cancelToken: cancelToken,
-      );
+      ));
 
       expect(attachment, same(uploader.result));
       expect(uploader.staged, same(staged));

--- a/workplace/test/data/datasource/drive_transfer/buffered_web_drive_file_stager_test.dart
+++ b/workplace/test/data/datasource/drive_transfer/buffered_web_drive_file_stager_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:workplace/data/datasource/drive_transfer/buffered_web_drive_file_stager.dart';
 import 'package:workplace/data/datasource/drive_transfer/drive_file_stager.dart';
 import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
+import 'package:workplace/data/model/workplace_type_defs.dart';
 import 'package:workplace/data/workplace_dio.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
 import 'package:workplace/domain/exceptions/workplace_exceptions.dart';
@@ -245,7 +246,7 @@ class _NoopDriveFileStager implements DriveFileStager {
   @override
   Future<StagedDriveFile> stage({
     required DriveDocument doc,
-    required void Function(int received, int total) onDownloadProgress,
+    required OnFileProcessedProgress onDownloadProgress,
     required CancelToken cancelToken,
   }) =>
       throw UnimplementedError();

--- a/workplace/test/data/datasource/drive_transfer/buffered_web_drive_file_stager_test.dart
+++ b/workplace/test/data/datasource/drive_transfer/buffered_web_drive_file_stager_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:model/email/attachment.dart';
 import 'package:workplace/data/datasource/drive_transfer/buffered_web_drive_file_stager.dart';
 import 'package:workplace/data/datasource/drive_transfer/drive_file_stager.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
 import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
 import 'package:workplace/data/model/workplace_type_defs.dart';
 import 'package:workplace/data/workplace_dio.dart';
@@ -240,14 +241,14 @@ void main() {
       void onDownloadProgress(int r, int t) {}
       void onUploadProgress(int r, int t) {}
 
-      final attachment = await strategy.transfer(
+      final attachment = await strategy.transfer(DriveTransferRequest(
         doc: doc,
         uploadUri: uploadUri,
         authHeader: 'Bearer token',
         onDownloadProgress: onDownloadProgress,
         onUploadProgress: onUploadProgress,
         cancelToken: cancelToken,
-      );
+      ));
 
       expect(stager.doc, same(doc));
       expect(stager.onDownloadProgress, same(onDownloadProgress));
@@ -267,14 +268,15 @@ void main() {
           Dio()..httpClientAdapter = _FakeHttpClientAdapter([1, 2, 3]));
       final uploader = _RecordingStagedFileUploader();
 
-      await BufferedWebDriveTransferStrategy(uploader: uploader.call).transfer(
+      await BufferedWebDriveTransferStrategy(uploader: uploader.call)
+          .transfer(DriveTransferRequest(
         doc: _buildDoc(downloadLink: _defaultDownloadLink),
         uploadUri: Uri.parse('https://jmap.example/upload'),
         authHeader: 'Bearer token',
         onDownloadProgress: (_, __) {},
         onUploadProgress: (_, __) {},
         cancelToken: CancelToken(),
-      );
+      ));
 
       expect(uploader.staged, isA<BytesStagedFile>());
     });

--- a/workplace/test/data/datasource/drive_transfer/buffered_web_drive_file_stager_test.dart
+++ b/workplace/test/data/datasource/drive_transfer/buffered_web_drive_file_stager_test.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:model/email/attachment.dart';
 import 'package:workplace/data/datasource/drive_transfer/buffered_web_drive_file_stager.dart';
 import 'package:workplace/data/datasource/drive_transfer/drive_file_stager.dart';
 import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
@@ -225,29 +226,125 @@ void main() {
   });
 
   group('BufferedWebDriveTransferStrategy', () {
-    test('defaults to a BufferedWebDriveFileStager', () {
-      final strategy = BufferedWebDriveTransferStrategy();
-      expect(strategy.stager, isA<BufferedWebDriveFileStager>());
+    test('stage() delegates to the injected stager, passing args through',
+        () async {
+      final stager = _RecordingDriveFileStager();
+      final strategy = BufferedWebDriveTransferStrategy(
+        uploader: _unreachableUploader,
+        stager: stager,
+      );
+      final doc = _buildDoc(downloadLink: _defaultDownloadLink);
+      final cancelToken = CancelToken();
+      void onProgress(int r, int t) {}
+
+      final staged = await strategy.stage(
+        doc: doc,
+        onDownloadProgress: onProgress,
+        cancelToken: cancelToken,
+      );
+
+      expect(staged, same(stager.result));
+      expect(stager.doc, same(doc));
+      expect(stager.onDownloadProgress, same(onProgress));
+      expect(stager.cancelToken, same(cancelToken));
     });
 
-    test('uses the injected stager when provided', () {
-      final customStager = _NoopDriveFileStager();
-      final strategy = BufferedWebDriveTransferStrategy(stager: customStager);
-      expect(strategy.stager, same(customStager));
+    test('stage() defaults to a BufferedWebDriveFileStager', () async {
+      WorkplaceDio.setInstance(
+          Dio()..httpClientAdapter = _FakeHttpClientAdapter([1, 2, 3]));
+
+      final staged =
+          await BufferedWebDriveTransferStrategy(uploader: _unreachableUploader)
+              .stage(
+        doc: _buildDoc(downloadLink: _defaultDownloadLink),
+        onDownloadProgress: (_, __) {},
+        cancelToken: CancelToken(),
+      );
+
+      expect(staged, isA<BytesStagedFile>());
     });
 
-    test('opfsUploader is always null', () {
-      expect(BufferedWebDriveTransferStrategy().opfsUploader, isNull);
+    test('upload() delegates to the injected uploader, ignoring authHeader',
+        () async {
+      final uploader = _RecordingStagedFileUploader();
+      final strategy = BufferedWebDriveTransferStrategy(
+        uploader: uploader.call,
+        stager: _RecordingDriveFileStager(),
+      );
+      final staged = _bytesStagedFile();
+      final uploadUri = Uri.parse('https://jmap.example/upload');
+      final cancelToken = CancelToken();
+      void onProgress(int r, int t) {}
+
+      final attachment = await strategy.upload(
+        staged: staged,
+        uploadUri: uploadUri,
+        authHeader: 'Bearer token',
+        onUploadProgress: onProgress,
+        cancelToken: cancelToken,
+      );
+
+      expect(attachment, same(uploader.result));
+      expect(uploader.staged, same(staged));
+      expect(uploader.uploadUri, uploadUri);
+      expect(uploader.onUploadProgress, same(onProgress));
+      expect(uploader.cancelToken, same(cancelToken));
     });
   });
 }
 
-class _NoopDriveFileStager implements DriveFileStager {
+BytesStagedFile _bytesStagedFile() => BytesStagedFile(
+      bytes: Uint8List.fromList([1, 2, 3]),
+      fileName: 'file.bin',
+      fileSize: 3,
+    );
+
+Future<Attachment> _unreachableUploader({
+  required StagedDriveFile staged,
+  required Uri uploadUri,
+  required OnFileProcessedProgress onUploadProgress,
+  required CancelToken cancelToken,
+}) =>
+    throw UnimplementedError();
+
+class _RecordingDriveFileStager implements DriveFileStager {
+  final StagedDriveFile result = _bytesStagedFile();
+
+  DriveDocument? doc;
+  OnFileProcessedProgress? onDownloadProgress;
+  CancelToken? cancelToken;
+
   @override
   Future<StagedDriveFile> stage({
     required DriveDocument doc,
     required OnFileProcessedProgress onDownloadProgress,
     required CancelToken cancelToken,
-  }) =>
-      throw UnimplementedError();
+  }) async {
+    this.doc = doc;
+    this.onDownloadProgress = onDownloadProgress;
+    this.cancelToken = cancelToken;
+    return result;
+  }
+}
+
+class _RecordingStagedFileUploader {
+  final Attachment result = Attachment(name: 'file.bin');
+
+  StagedDriveFile? staged;
+  Uri? uploadUri;
+  OnFileProcessedProgress? onUploadProgress;
+  CancelToken? cancelToken;
+
+  Future<Attachment> call({
+    required StagedDriveFile staged,
+    required Uri uploadUri,
+    required OnFileProcessedProgress onUploadProgress,
+    required CancelToken cancelToken,
+  }) async {
+    this.staged = staged;
+    this.uploadUri = uploadUri;
+    this.onUploadProgress = onUploadProgress;
+    this.cancelToken = cancelToken;
+    return result;
+  }
 }

--- a/workplace/test/data/datasource/drive_transfer/drive_transfer_strategy_test.dart
+++ b/workplace/test/data/datasource/drive_transfer/drive_transfer_strategy_test.dart
@@ -75,72 +75,57 @@ Future<Attachment> _transfer(_FakeStrategy strategy) =>
       cancelToken: CancelToken(),
     ));
 
-void main() {
-  test('disposes the staged file after a successful upload', () async {
-    final recorder = _RecordingStagedFile();
-    final strategy = _FakeStrategy(staged: recorder.build());
-
-    final attachment = await _transfer(strategy);
-
-    expect(attachment, same(strategy.attachment));
-    expect(recorder.deleted, ['/tmp/file.bin']);
-  });
-
-  test('disposes the staged file when the upload throws, and rethrows',
-      () async {
-    final recorder = _RecordingStagedFile();
-    final error = StateError('upload failed');
-    final strategy = _FakeStrategy(staged: recorder.build(), uploadError: error);
-
-    await expectLater(_transfer(strategy), throwsA(same(error)));
-
-    expect(recorder.deleted, ['/tmp/file.bin']);
-  });
-
-  test('disposes the staged file when the upload is cancelled', () async {
+/// Every path where `transfer()` must dispose the staged file exactly once:
+/// the upload outcome ([uploadError] null means success) is independent of
+/// whether disposal itself fails ([throwOnDelete]).
+void _disposesStagedFileTest(
+  String description, {
+  Object? throwOnDelete,
+  Object? uploadError,
+}) {
+  test(description, () async {
     final recorder = _RecordingStagedFile();
     final strategy = _FakeStrategy(
-      staged: recorder.build(),
-      uploadError: DioException(
-        requestOptions: RequestOptions(path: _uploadUri.toString()),
-        type: DioExceptionType.cancel,
-      ),
-    );
-
-    await expectLater(
-      _transfer(strategy),
-      throwsA(isA<DioException>()
-          .having((e) => e.type, 'type', DioExceptionType.cancel)),
-    );
-
-    expect(recorder.deleted, ['/tmp/file.bin']);
-  });
-
-  test('a failing dispose does not fail an otherwise successful transfer',
-      () async {
-    final recorder = _RecordingStagedFile();
-    final strategy = _FakeStrategy(
-      staged: recorder.build(throwOnDelete: StateError('delete failed')),
-    );
-
-    final attachment = await _transfer(strategy);
-
-    expect(attachment, same(strategy.attachment));
-    expect(recorder.deleted, ['/tmp/file.bin']);
-  });
-
-  test('a failing dispose does not replace the upload error', () async {
-    final recorder = _RecordingStagedFile();
-    final uploadError = StateError('upload failed');
-    final strategy = _FakeStrategy(
-      staged: recorder.build(throwOnDelete: StateError('delete failed')),
+      staged: recorder.build(throwOnDelete: throwOnDelete),
       uploadError: uploadError,
     );
 
-    await expectLater(_transfer(strategy), throwsA(same(uploadError)));
+    if (uploadError == null) {
+      expect(await _transfer(strategy), same(strategy.attachment));
+    } else {
+      await expectLater(_transfer(strategy), throwsA(same(uploadError)));
+    }
 
     expect(recorder.deleted, ['/tmp/file.bin']);
   });
+}
+
+void main() {
+  _disposesStagedFileTest('disposes the staged file after a successful upload');
+
+  _disposesStagedFileTest(
+    'disposes the staged file when the upload throws, and rethrows',
+    uploadError: StateError('upload failed'),
+  );
+
+  _disposesStagedFileTest(
+    'disposes the staged file when the upload is cancelled',
+    uploadError: DioException(
+      requestOptions: RequestOptions(path: _uploadUri.toString()),
+      type: DioExceptionType.cancel,
+    ),
+  );
+
+  _disposesStagedFileTest(
+    'a failing dispose does not fail an otherwise successful transfer',
+    throwOnDelete: StateError('delete failed'),
+  );
+
+  _disposesStagedFileTest(
+    'a failing dispose does not replace the upload error',
+    throwOnDelete: StateError('delete failed'),
+    uploadError: StateError('upload failed'),
+  );
 
   test('does not upload or dispose when staging fails', () async {
     final recorder = _RecordingStagedFile();

--- a/workplace/test/data/datasource/drive_transfer/drive_transfer_strategy_test.dart
+++ b/workplace/test/data/datasource/drive_transfer/drive_transfer_strategy_test.dart
@@ -1,0 +1,125 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/email/attachment.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
+import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
+import 'package:workplace/data/model/workplace_type_defs.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+
+final _doc = DriveDocument(
+  id: 'doc-1',
+  name: 'file.bin',
+  size: 16,
+  mimeType: 'application/octet-stream',
+  downloadLink: Uri.parse('https://drive.example/file'),
+);
+
+final _uploadUri = Uri.parse('https://jmap.example/upload');
+
+/// Records the disposal of the temp file the strategy staged.
+class _RecordingStagedFile {
+  final List<String> deleted = [];
+
+  FileBackedStagedFile build() => FileBackedStagedFile(
+        filePath: '/tmp/file.bin',
+        deleteFile: (path) async => deleted.add(path),
+        fileName: 'file.bin',
+        fileSize: 16,
+      );
+}
+
+/// Exercises the `transfer()` template with both legs fully controllable.
+class _FakeStrategy extends DriveTransferStrategy<FileBackedStagedFile> {
+  _FakeStrategy({
+    required this.staged,
+    this.stageError,
+    this.uploadError,
+  });
+
+  final FileBackedStagedFile staged;
+  final Object? stageError;
+  final Object? uploadError;
+
+  final attachment = Attachment(name: 'file.bin');
+  bool uploadCalled = false;
+
+  @override
+  Future<FileBackedStagedFile> stage({
+    required DriveDocument doc,
+    required OnFileProcessedProgress onDownloadProgress,
+    required CancelToken cancelToken,
+  }) async {
+    if (stageError != null) throw stageError!;
+    return staged;
+  }
+
+  @override
+  Future<Attachment> upload(
+      DriveUploadRequest<FileBackedStagedFile> request) async {
+    uploadCalled = true;
+    if (uploadError != null) throw uploadError!;
+    return attachment;
+  }
+}
+
+Future<Attachment> _transfer(_FakeStrategy strategy) => strategy.transfer(
+      doc: _doc,
+      uploadUri: _uploadUri,
+      authHeader: 'Bearer token',
+      onDownloadProgress: (_, __) {},
+      onUploadProgress: (_, __) {},
+      cancelToken: CancelToken(),
+    );
+
+void main() {
+  test('disposes the staged file after a successful upload', () async {
+    final recorder = _RecordingStagedFile();
+    final strategy = _FakeStrategy(staged: recorder.build());
+
+    final attachment = await _transfer(strategy);
+
+    expect(attachment, same(strategy.attachment));
+    expect(recorder.deleted, ['/tmp/file.bin']);
+  });
+
+  test('disposes the staged file when the upload throws, and rethrows',
+      () async {
+    final recorder = _RecordingStagedFile();
+    final error = StateError('upload failed');
+    final strategy = _FakeStrategy(staged: recorder.build(), uploadError: error);
+
+    await expectLater(_transfer(strategy), throwsA(same(error)));
+
+    expect(recorder.deleted, ['/tmp/file.bin']);
+  });
+
+  test('disposes the staged file when the upload is cancelled', () async {
+    final recorder = _RecordingStagedFile();
+    final strategy = _FakeStrategy(
+      staged: recorder.build(),
+      uploadError: DioException(
+        requestOptions: RequestOptions(path: _uploadUri.toString()),
+        type: DioExceptionType.cancel,
+      ),
+    );
+
+    await expectLater(
+      _transfer(strategy),
+      throwsA(isA<DioException>()
+          .having((e) => e.type, 'type', DioExceptionType.cancel)),
+    );
+
+    expect(recorder.deleted, ['/tmp/file.bin']);
+  });
+
+  test('does not upload or dispose when staging fails', () async {
+    final recorder = _RecordingStagedFile();
+    final error = StateError('stage failed');
+    final strategy = _FakeStrategy(staged: recorder.build(), stageError: error);
+
+    await expectLater(_transfer(strategy), throwsA(same(error)));
+
+    expect(strategy.uploadCalled, isFalse);
+    expect(recorder.deleted, isEmpty);
+  });
+}

--- a/workplace/test/data/datasource/drive_transfer/drive_transfer_strategy_test.dart
+++ b/workplace/test/data/datasource/drive_transfer/drive_transfer_strategy_test.dart
@@ -20,9 +20,12 @@ final _uploadUri = Uri.parse('https://jmap.example/upload');
 class _RecordingStagedFile {
   final List<String> deleted = [];
 
-  FileBackedStagedFile build() => FileBackedStagedFile(
+  FileBackedStagedFile build({Object? throwOnDelete}) => FileBackedStagedFile(
         filePath: '/tmp/file.bin',
-        deleteFile: (path) async => deleted.add(path),
+        deleteFile: (path) async {
+          deleted.add(path);
+          if (throwOnDelete != null) throw throwOnDelete;
+        },
         fileName: 'file.bin',
         fileSize: 16,
       );
@@ -62,14 +65,15 @@ class _FakeStrategy extends DriveTransferStrategy<FileBackedStagedFile> {
   }
 }
 
-Future<Attachment> _transfer(_FakeStrategy strategy) => strategy.transfer(
+Future<Attachment> _transfer(_FakeStrategy strategy) =>
+    strategy.transfer(DriveTransferRequest(
       doc: _doc,
       uploadUri: _uploadUri,
       authHeader: 'Bearer token',
       onDownloadProgress: (_, __) {},
       onUploadProgress: (_, __) {},
       cancelToken: CancelToken(),
-    );
+    ));
 
 void main() {
   test('disposes the staged file after a successful upload', () async {
@@ -108,6 +112,32 @@ void main() {
       throwsA(isA<DioException>()
           .having((e) => e.type, 'type', DioExceptionType.cancel)),
     );
+
+    expect(recorder.deleted, ['/tmp/file.bin']);
+  });
+
+  test('a failing dispose does not fail an otherwise successful transfer',
+      () async {
+    final recorder = _RecordingStagedFile();
+    final strategy = _FakeStrategy(
+      staged: recorder.build(throwOnDelete: StateError('delete failed')),
+    );
+
+    final attachment = await _transfer(strategy);
+
+    expect(attachment, same(strategy.attachment));
+    expect(recorder.deleted, ['/tmp/file.bin']);
+  });
+
+  test('a failing dispose does not replace the upload error', () async {
+    final recorder = _RecordingStagedFile();
+    final uploadError = StateError('upload failed');
+    final strategy = _FakeStrategy(
+      staged: recorder.build(throwOnDelete: StateError('delete failed')),
+      uploadError: uploadError,
+    );
+
+    await expectLater(_transfer(strategy), throwsA(same(uploadError)));
 
     expect(recorder.deleted, ['/tmp/file.bin']);
   });

--- a/workplace/test/data/datasource/drive_transfer/drive_transfer_strategy_test.dart
+++ b/workplace/test/data/datasource/drive_transfer/drive_transfer_strategy_test.dart
@@ -45,6 +45,7 @@ class _FakeStrategy extends DriveTransferStrategy<FileBackedStagedFile> {
 
   final attachment = Attachment(name: 'file.bin');
   bool uploadCalled = false;
+  DriveUploadRequest<FileBackedStagedFile>? uploadRequest;
 
   @override
   Future<FileBackedStagedFile> stage({
@@ -60,6 +61,7 @@ class _FakeStrategy extends DriveTransferStrategy<FileBackedStagedFile> {
   Future<Attachment> upload(
       DriveUploadRequest<FileBackedStagedFile> request) async {
     uploadCalled = true;
+    uploadRequest = request;
     if (uploadError != null) throw uploadError!;
     return attachment;
   }
@@ -126,6 +128,31 @@ void main() {
     throwOnDelete: StateError('delete failed'),
     uploadError: StateError('upload failed'),
   );
+
+  test('transfer() carries every request field onto the upload leg', () async {
+    final recorder = _RecordingStagedFile();
+    final staged = recorder.build();
+    final strategy = _FakeStrategy(staged: staged);
+    // Distinct closure instances, so `same()` also catches the two progress
+    // callbacks being swapped.
+    final request = DriveTransferRequest(
+      doc: _doc,
+      uploadUri: _uploadUri,
+      authHeader: 'Bearer token',
+      onDownloadProgress: (_, __) {},
+      onUploadProgress: (_, __) {},
+      cancelToken: CancelToken(),
+    );
+
+    await strategy.transfer(request);
+
+    final uploaded = strategy.uploadRequest!;
+    expect(uploaded.staged, same(staged));
+    expect(uploaded.uploadUri, same(request.uploadUri));
+    expect(uploaded.authHeader, request.authHeader);
+    expect(uploaded.onUploadProgress, same(request.onUploadProgress));
+    expect(uploaded.cancelToken, same(request.cancelToken));
+  });
 
   test('does not upload or dispose when staging fails', () async {
     final recorder = _RecordingStagedFile();

--- a/workplace/test/data/datasource/drive_transfer/staged_drive_file_test.dart
+++ b/workplace/test/data/datasource/drive_transfer/staged_drive_file_test.dart
@@ -1,0 +1,60 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
+
+void main() {
+  group('StagedDriveFile', () {
+    test('FileBackedStagedFile.dispose calls the injected deleteFile', () async {
+      String? deletedPath;
+      final staged = FileBackedStagedFile(
+        filePath: '/tmp/foo',
+        deleteFile: (path) async => deletedPath = path,
+        fileName: 'foo.txt',
+        fileSize: 10,
+      );
+
+      await staged.dispose();
+
+      expect(deletedPath, '/tmp/foo');
+    });
+
+    test('OpfsStagedFile.dispose calls removeEntry with the handle', () async {
+      Object? removed;
+      final handle = Object();
+      final staged = OpfsStagedFile(
+        fileHandle: handle,
+        removeEntry: (h) async => removed = h,
+        fileName: 'foo.txt',
+        fileSize: 10,
+      );
+
+      await staged.dispose();
+
+      expect(identical(removed, handle), isTrue);
+    });
+
+    test('BytesStagedFile.dispose is a no-op', () async {
+      final staged = BytesStagedFile(
+        bytes: Uint8List.fromList([1, 2, 3]),
+        fileName: 'foo.txt',
+        fileSize: 3,
+      );
+
+      await staged.dispose();
+    });
+
+    test('equality compares bytes by identity, not content', () {
+      final sharedBytes = Uint8List.fromList([1]);
+      final a = BytesStagedFile(
+          bytes: sharedBytes, fileName: 'a', fileSize: 1);
+      final b = BytesStagedFile(
+          bytes: sharedBytes, fileName: 'a', fileSize: 1);
+      final c = BytesStagedFile(
+          bytes: Uint8List.fromList([1]), fileName: 'a', fileSize: 1);
+
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+    });
+  });
+}

--- a/workplace/test/domain/entity/drive_document_extension_test.dart
+++ b/workplace/test/domain/entity/drive_document_extension_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
 import 'package:workplace/domain/entity/drive_document_extension.dart';
+import 'package:workplace/domain/exceptions/workplace_exceptions.dart';
 
 void main() {
   DriveDocument makeDoc({
@@ -241,6 +242,43 @@ void main() {
         final param = splitParams(doc.linkedFileHeader!)[2];
         expect(param, startsWith("type*=UTF-8''"));
       });
+    });
+  });
+
+  group('resolveDownloadLinkForStaging', () {
+    final httpsLink = Uri.parse('https://drive.example/file');
+    final httpLink = Uri.parse('http://drive.example/file');
+
+    test('returns the https link in release mode', () {
+      final doc = makeDoc(downloadLink: httpsLink);
+      expect(
+        doc.resolveDownloadLinkForStaging(isReleaseMode: true),
+        httpsLink,
+      );
+    });
+
+    test('allows http outside release mode', () {
+      final doc = makeDoc(downloadLink: httpLink);
+      expect(
+        doc.resolveDownloadLinkForStaging(isReleaseMode: false),
+        httpLink,
+      );
+    });
+
+    test('throws on http in release mode', () {
+      final doc = makeDoc(downloadLink: httpLink);
+      expect(
+        () => doc.resolveDownloadLinkForStaging(isReleaseMode: true),
+        throwsA(isA<DriveDownloadInsecureLinkException>()),
+      );
+    });
+
+    test('throws when downloadLink is null', () {
+      final doc = makeDoc(sharingLink: httpsLink);
+      expect(
+        () => doc.resolveDownloadLinkForStaging(isReleaseMode: false),
+        throwsA(isA<DriveDownloadNullAttachmentException>()),
+      );
     });
   });
 }


### PR DESCRIPTION
## Issue
- #4727 

## Summary
Foundation for TF-4727 (drive-file-as-attachment download/upload): sealed `StagedDriveFile` result types, `DriveFileStager`/`DriveTransferStrategy` interfaces, and the buffered-web strategy as the first concrete implementation proving the interfaces out.

Isolated to `workplace/`, additive only, no main-app callers yet.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added browser-based Drive downloads with in-memory staging and upload support.
  - Added download and upload progress reporting, cancellation, and a 60-second timeout.
  - Preserved downloaded file names, sizes, and MIME types.
  - Added platform-appropriate temporary storage options and automatic cleanup.
  - Added secure download-link validation and clear errors for missing, insecure, or empty downloads.

- **Bug Fixes**
  - Improved handling of slow, cancelled, failed, and interrupted Drive transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->