### PR TITLE
TF-4727 [Part-2] IO drive file stager for mobile/desktop drive-transfer

### DIFF
--- a/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy_factory_mobile.dart
+++ b/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy_factory_mobile.dart
@@ -1,0 +1,10 @@
+import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
+import 'package:workplace/data/datasource/drive_transfer/io_drive_file_stager.dart';
+
+/// Mobile/desktop branch of the conditional export in
+/// `drive_transfer_strategy_factory.dart`: always IO temp-file staging.
+class DriveTransferStrategyFactory {
+  const DriveTransferStrategyFactory._();
+
+  static DriveTransferStrategy create() => IoDriveTransferStrategy();
+}

--- a/workplace/lib/data/datasource/drive_transfer/io_drive_file_stager.dart
+++ b/workplace/lib/data/datasource/drive_transfer/io_drive_file_stager.dart
@@ -1,0 +1,221 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:core/utils/build_utils.dart';
+import 'package:dio/dio.dart';
+import 'package:path_provider/path_provider.dart' as path_provider;
+import 'package:workplace/data/datasource/drive_transfer/drive_file_stager.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
+import 'package:workplace/data/datasource/drive_transfer/opfs_drive_file_uploader.dart';
+import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
+import 'package:workplace/data/workplace_dio.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+import 'package:workplace/domain/exceptions/workplace_exceptions.dart';
+
+/// Streams a drive document into a temp file on disk (mobile/desktop).
+/// Mirrors the pause/resume/cancel technique used in
+/// `core`'s `DownloadManager.downloadFile`, against [WorkplaceDio.instance]
+/// instead of the main app's authenticated Dio client — the public
+/// `downloadLink` must never carry the session's auth header.
+class IoDriveFileStager implements DriveFileStager {
+  IoDriveFileStager({
+    Dio? dio,
+    Future<Directory> Function()? getTemporaryDirectory,
+  })  : _dio = dio ?? WorkplaceDio.instance,
+        _getTemporaryDirectory =
+            getTemporaryDirectory ?? path_provider.getTemporaryDirectory;
+
+  final Dio _dio;
+  final Future<Directory> Function() _getTemporaryDirectory;
+
+  @override
+  Future<StagedDriveFile> stage({
+    required DriveDocument doc,
+    required void Function(int received, int total) onDownloadProgress,
+    required CancelToken cancelToken,
+  }) async {
+    final downloadLink = doc.downloadLink;
+    if (downloadLink == null) {
+      throw DriveDownloadNullAttachmentException();
+    }
+    if (BuildUtils.isReleaseMode && !downloadLink.isScheme('https')) {
+      throw DriveDownloadInsecureLinkException();
+    }
+
+    final response = await _dio.getUri<ResponseBody>(
+      downloadLink,
+      options: Options(
+        responseType: ResponseType.stream,
+        receiveTimeout: driveTransferReceiveTimeout,
+      ),
+      cancelToken: cancelToken,
+    );
+
+    final responseBody = response.data!;
+    final total = _resolveTotalSize(responseBody, doc);
+
+    final directory = await _getTemporaryDirectory();
+    // Generated, not derived from `doc.id`/`doc.name` — those are
+    // server-supplied and must never be interpolated into a filesystem path.
+    final file = File('${directory.path}/${_generateTempFileName()}');
+
+    int received;
+    try {
+      received = await _streamToFile(_StreamToFileRequest(
+        responseBody: responseBody,
+        file: file,
+        total: total,
+        cancelToken: cancelToken,
+        onDownloadProgress: onDownloadProgress,
+      ));
+    } catch (error) {
+      // Covers both a failed `file.open()` and a failed/cancelled transfer —
+      // either way nothing partially written should survive.
+      await _deleteIfExists(file);
+      rethrow;
+    }
+
+    return FileBackedStagedFile(
+      filePath: file.path,
+      deleteFile: (path) => _deleteIfExists(File(path)),
+      fileName: doc.name,
+      fileSize: received,
+      mimeType: doc.mimeType,
+    );
+  }
+
+  int _resolveTotalSize(ResponseBody responseBody, DriveDocument doc) {
+    final contentLengthHeader = responseBody.headers['content-length'];
+    final contentLength =
+        (contentLengthHeader != null && contentLengthHeader.isNotEmpty)
+            ? int.tryParse(contentLengthHeader.first)
+            : null;
+    return (contentLength != null && contentLength > 0)
+        ? contentLength
+        : doc.size;
+  }
+
+  String _generateTempFileName() {
+    final random = Random();
+    final suffix =
+        List.generate(8, (_) => random.nextInt(16).toRadixString(16)).join();
+    return 'drive_${DateTime.now().microsecondsSinceEpoch}_$suffix';
+  }
+
+  // `takeWhile` stops the subscription from consuming further chunks the
+  // moment `cancelToken` flips, without waiting on Dio's own teardown of
+  // the underlying HTTP stream to reach this listener. `cancelToken.whenCancel`
+  // below is what actually unblocks `completer` if the stream itself never
+  // emits another event (or closes) after cancellation.
+  Future<int> _streamToFile(_StreamToFileRequest request) async {
+    final responseBody = request.responseBody;
+    final file = request.file;
+    final total = request.total;
+    final cancelToken = request.cancelToken;
+    final onDownloadProgress = request.onDownloadProgress;
+
+    // FileMode.write creates the file if it doesn't exist yet — no separate
+    // createSync step needed, and a failure here surfaces before any bytes
+    // are written.
+    var randomAccessFile = await file.open(mode: FileMode.write);
+    final completer = Completer<int>();
+    var received = 0;
+    // Guards against `onError`/`onDone`/`whenCancel` all racing to settle the
+    // same subscription, which would otherwise close the already-closed
+    // `RandomAccessFile` twice or complete the `completer` more than once.
+    var settled = false;
+    late StreamSubscription<List<int>> subscription;
+
+    Future<void> closeQuietly() async {
+      try {
+        await randomAccessFile.close();
+      } catch (_) {
+        // Best-effort close: cleanup/completion below must still run even if
+        // the underlying handle is already invalid.
+      }
+    }
+
+    Future<void> abortWith(Object error) async {
+      if (settled) return;
+      settled = true;
+      await closeQuietly();
+      await _deleteIfExists(file);
+      if (!completer.isCompleted) completer.completeError(error);
+    }
+
+    Future<void> finish() async {
+      if (settled) return;
+      settled = true;
+      await closeQuietly();
+      if (!completer.isCompleted) completer.complete(received);
+    }
+
+    unawaited(cancelToken.whenCancel.then(
+      (_) => abortWith(cancelToken.cancelError ??
+          StateError('IoDriveFileStager: transfer cancelled')),
+    ));
+
+    subscription = responseBody.stream
+        .takeWhile((_) => !cancelToken.isCancelled)
+        .listen(
+      (chunk) {
+        subscription.pause();
+        randomAccessFile.writeFrom(chunk).then((updated) {
+          randomAccessFile = updated;
+          received += chunk.length;
+          onDownloadProgress(received, total);
+          subscription.resume();
+        }).catchError((Object error) async {
+          await subscription.cancel();
+          await abortWith(error);
+        });
+      },
+      onDone: () async {
+        if (cancelToken.isCancelled) {
+          await abortWith(cancelToken.cancelError ??
+              StateError('IoDriveFileStager: transfer cancelled'));
+        } else {
+          await finish();
+        }
+      },
+      onError: (Object error) async => abortWith(error),
+    );
+
+    return completer.future;
+  }
+}
+
+Future<void> _deleteIfExists(File file) async {
+  if (await file.exists()) await file.delete();
+}
+
+/// Bundles `_streamToFile`'s parameters to keep its argument count low.
+class _StreamToFileRequest {
+  final ResponseBody responseBody;
+  final File file;
+  final int total;
+  final CancelToken cancelToken;
+  final void Function(int received, int total) onDownloadProgress;
+
+  const _StreamToFileRequest({
+    required this.responseBody,
+    required this.file,
+    required this.total,
+    required this.cancelToken,
+    required this.onDownloadProgress,
+  });
+}
+
+/// IO strategy: `FileUploader` handles the upload leg, so there's no
+/// OPFS-only uploader.
+class IoDriveTransferStrategy implements DriveTransferStrategy {
+  @override
+  final DriveFileStager stager;
+
+  @override
+  OpfsDriveFileUploader? get opfsUploader => null;
+
+  IoDriveTransferStrategy({DriveFileStager? stager})
+      : stager = stager ?? IoDriveFileStager();
+}

--- a/workplace/pubspec.yaml
+++ b/workplace/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   dartz: 0.10.1
   flutter_inappwebview: 6.1.0
   universal_html: 2.2.4
+  path_provider: 2.1.5
   flutter_svg:
   flutter_localization:
   intl:
@@ -37,6 +38,7 @@ dev_dependencies:
   build_runner: ^2.15.0
   json_serializable: ^6.11.3
   flutter_lints: 2.0.1
+  path_provider_platform_interface: 2.1.1
 
 flutter:
   uses-material-design: true

--- a/workplace/test/data/datasource/drive_transfer/io_drive_file_stager_test.dart
+++ b/workplace/test/data/datasource/drive_transfer/io_drive_file_stager_test.dart
@@ -1,0 +1,380 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_file_stager.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy_factory_mobile.dart';
+import 'package:workplace/data/datasource/drive_transfer/io_drive_file_stager.dart';
+import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
+import 'package:workplace/data/workplace_dio.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+import 'package:workplace/domain/exceptions/workplace_exceptions.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  final String path;
+  _FakePathProviderPlatform(this.path);
+
+  @override
+  Future<String?> getTemporaryPath() async => path;
+}
+
+class _FakeHttpClientAdapter implements HttpClientAdapter {
+  static const _chunkSize = 4;
+
+  final List<int> bytes;
+  final Map<String, List<String>>? headersOverride;
+  RequestOptions? lastRequestOptions;
+
+  _FakeHttpClientAdapter(this.bytes, {this.headersOverride});
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    lastRequestOptions = options;
+    final controller = StreamController<Uint8List>();
+    unawaited(() async {
+      for (var i = 0; i < bytes.length; i += _chunkSize) {
+        final end = (i + _chunkSize).clamp(0, bytes.length);
+        controller.add(Uint8List.fromList(bytes.sublist(i, end)));
+      }
+      await controller.close();
+    }());
+    return ResponseBody(
+      controller.stream,
+      200,
+      headers: headersOverride ??
+          {
+            'content-length': ['${bytes.length}']
+          },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+/// Emits one chunk then never adds more data and never closes — used to
+/// prove cancellation resolves the transfer even when the stream stalls.
+class _StallingHttpClientAdapter implements HttpClientAdapter {
+  final StreamController<Uint8List> controller = StreamController<Uint8List>();
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    controller.add(Uint8List.fromList([1, 2, 3, 4]));
+    return ResponseBody(controller.stream, 200, headers: {
+      'content-length': ['999']
+    });
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+const _unset = Object();
+
+void main() {
+  late Directory tempDir;
+  late Dio originalDio;
+  late PathProviderPlatform originalPathProviderPlatform;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('io_drive_file_stager_test');
+    originalPathProviderPlatform = PathProviderPlatform.instance;
+    PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+    originalDio = WorkplaceDio.instance;
+  });
+
+  tearDown(() async {
+    WorkplaceDio.setInstance(originalDio);
+    PathProviderPlatform.instance = originalPathProviderPlatform;
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  DriveDocument buildDoc({Object? downloadLink = _unset, int size = 8}) =>
+      DriveDocument(
+        id: 'doc-1',
+        name: 'file.bin',
+        size: size,
+        mimeType: 'application/octet-stream',
+        downloadLink: identical(downloadLink, _unset)
+            ? Uri.parse('https://drive.example/file')
+            : downloadLink as Uri?,
+      );
+
+  test('streams chunks to a temp file and reports cumulative progress',
+      () async {
+    final bytes = List<int>.generate(8, (i) => i);
+    final dio = Dio()..httpClientAdapter = _FakeHttpClientAdapter(bytes);
+    WorkplaceDio.setInstance(dio);
+
+    final received = <int>[];
+    final staged = await IoDriveFileStager().stage(
+      doc: buildDoc(),
+      onDownloadProgress: (r, t) => received.add(r),
+      cancelToken: CancelToken(),
+    );
+
+    expect(staged, isA<FileBackedStagedFile>());
+    final filePath = (staged as FileBackedStagedFile).filePath;
+    final writtenBytes = await File(filePath).readAsBytes();
+    expect(writtenBytes, bytes);
+    expect(received.last, bytes.length);
+
+    await staged.dispose();
+    expect(await File(filePath).exists(), isFalse);
+  });
+
+  test('dispose() is idempotent when called twice', () async {
+    final bytes = List<int>.generate(8, (i) => i);
+    final dio = Dio()..httpClientAdapter = _FakeHttpClientAdapter(bytes);
+    WorkplaceDio.setInstance(dio);
+
+    final staged = await IoDriveFileStager().stage(
+      doc: buildDoc(),
+      onDownloadProgress: (_, __) {},
+      cancelToken: CancelToken(),
+    );
+
+    await staged.dispose();
+    await staged.dispose();
+  });
+
+  test('deletes the temp file on transfer failure', () async {
+    final dio = Dio()..httpClientAdapter = _ThrowingHttpClientAdapter();
+    WorkplaceDio.setInstance(dio);
+
+    await expectLater(
+      IoDriveFileStager().stage(
+        doc: buildDoc(),
+        onDownloadProgress: (_, __) {},
+        cancelToken: CancelToken(),
+      ),
+      throwsA(anything),
+    );
+    expect(tempDir.listSync(), isEmpty);
+  });
+
+  test(
+      'closes and deletes the temp file when the stream errors after it was created',
+      () async {
+    final dio = Dio()
+      ..httpClientAdapter = _FailingMidStreamHttpClientAdapter();
+    WorkplaceDio.setInstance(dio);
+
+    await expectLater(
+      IoDriveFileStager().stage(
+        doc: buildDoc(),
+        onDownloadProgress: (_, __) {},
+        cancelToken: CancelToken(),
+      ),
+      throwsA(anything),
+    );
+
+    final leftoverFiles = tempDir.listSync();
+    expect(leftoverFiles, isEmpty);
+  });
+
+  test('downloadLink == null throws DriveDownloadNullAttachmentException',
+      () async {
+    expect(
+      () => IoDriveFileStager().stage(
+        doc: buildDoc(downloadLink: null),
+        onDownloadProgress: (_, __) {},
+        cancelToken: CancelToken(),
+      ),
+      throwsA(isA<DriveDownloadNullAttachmentException>()),
+    );
+  });
+
+  test('missing content-length falls back to document.size', () async {
+    final bytes = List<int>.generate(8, (i) => i);
+    final dio = Dio()
+      ..httpClientAdapter =
+          _FakeHttpClientAdapter(bytes, headersOverride: const {});
+    WorkplaceDio.setInstance(dio);
+
+    final totals = <int>[];
+    await IoDriveFileStager().stage(
+      doc: buildDoc(size: 8),
+      onDownloadProgress: (r, t) => totals.add(t),
+      cancelToken: CancelToken(),
+    );
+
+    expect(totals, everyElement(8));
+  });
+
+  test('invalid content-length falls back to document.size', () async {
+    final bytes = List<int>.generate(8, (i) => i);
+    final dio = Dio()
+      ..httpClientAdapter = _FakeHttpClientAdapter(bytes, headersOverride: {
+        'content-length': ['not-a-number']
+      });
+    WorkplaceDio.setInstance(dio);
+
+    final totals = <int>[];
+    await IoDriveFileStager().stage(
+      doc: buildDoc(size: 8),
+      onDownloadProgress: (r, t) => totals.add(t),
+      cancelToken: CancelToken(),
+    );
+
+    expect(totals, everyElement(8));
+  });
+
+  test('forwards URI, ResponseType.stream, receive timeout and cancel token',
+      () async {
+    final adapter = _FakeHttpClientAdapter(const [1, 2, 3, 4]);
+    final dio = Dio()..httpClientAdapter = adapter;
+    final cancelToken = CancelToken();
+    final link = Uri.parse('https://drive.example/other-file');
+
+    await IoDriveFileStager(dio: dio).stage(
+      doc: buildDoc(downloadLink: link),
+      onDownloadProgress: (_, __) {},
+      cancelToken: cancelToken,
+    );
+
+    final requestOptions = adapter.lastRequestOptions!;
+    expect(requestOptions.uri, link);
+    expect(requestOptions.responseType, ResponseType.stream);
+    expect(requestOptions.receiveTimeout, driveTransferReceiveTimeout);
+    expect(requestOptions.cancelToken, cancelToken);
+  });
+
+  test(
+      'cancelling after the first chunk resolves even when the stream never sends more events',
+      () async {
+    final adapter = _StallingHttpClientAdapter();
+    final dio = Dio()..httpClientAdapter = adapter;
+    WorkplaceDio.setInstance(dio);
+    final cancelToken = CancelToken();
+
+    final future = IoDriveFileStager(dio: dio).stage(
+      doc: buildDoc(),
+      onDownloadProgress: (_, __) {},
+      cancelToken: cancelToken,
+    );
+
+    // Let the first chunk land, then cancel — the fake never emits another
+    // event or closes, so only `cancelToken.whenCancel` can unblock this.
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    cancelToken.cancel();
+
+    await expectLater(
+      future,
+      throwsA(isA<DioException>().having(
+        (e) => e.type,
+        'type',
+        DioExceptionType.cancel,
+      )),
+    );
+    expect(tempDir.listSync(), isEmpty);
+    await adapter.controller.close();
+  });
+
+  test('fails and cleans up when the temp directory does not exist',
+      () async {
+    PathProviderPlatform.instance =
+        _FakePathProviderPlatform('${tempDir.path}/missing-parent');
+    final bytes = List<int>.generate(8, (i) => i);
+    final dio = Dio()..httpClientAdapter = _FakeHttpClientAdapter(bytes);
+    WorkplaceDio.setInstance(dio);
+
+    await expectLater(
+      IoDriveFileStager(dio: dio).stage(
+        doc: buildDoc(),
+        onDownloadProgress: (_, __) {},
+        cancelToken: CancelToken(),
+      ),
+      throwsA(isA<FileSystemException>()),
+    );
+  });
+
+  group('IoDriveTransferStrategy', () {
+    test('defaults to an IoDriveFileStager', () {
+      final strategy = IoDriveTransferStrategy();
+      expect(strategy.stager, isA<IoDriveFileStager>());
+    });
+
+    test('uses the injected stager when provided', () {
+      final customStager = _NoopDriveFileStager();
+      final strategy = IoDriveTransferStrategy(stager: customStager);
+      expect(strategy.stager, same(customStager));
+    });
+
+    test('opfsUploader is always null', () {
+      expect(IoDriveTransferStrategy().opfsUploader, isNull);
+    });
+  });
+
+  group('DriveTransferStrategyFactory', () {
+    test('creates an IoDriveTransferStrategy', () {
+      expect(DriveTransferStrategyFactory.create(), isA<IoDriveTransferStrategy>());
+    });
+  });
+}
+
+class _NoopDriveFileStager implements DriveFileStager {
+  @override
+  Future<StagedDriveFile> stage({
+    required DriveDocument doc,
+    required void Function(int received, int total) onDownloadProgress,
+    required CancelToken cancelToken,
+  }) =>
+      throw UnimplementedError();
+}
+
+class _ThrowingHttpClientAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) {
+    throw DioException(requestOptions: options, error: 'boom');
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+/// Returns a successful response — the temp file is created and opened —
+/// then errors mid-stream, exercising the post-creation cleanup path.
+class _FailingMidStreamHttpClientAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final controller = StreamController<Uint8List>();
+    unawaited(() async {
+      controller.add(Uint8List.fromList([1, 2, 3, 4]));
+      await Future<void>.delayed(Duration.zero);
+      controller.addError(DioException(requestOptions: options, error: 'boom'));
+      await controller.close();
+    }());
+    return ResponseBody(
+      controller.stream,
+      200,
+      headers: {
+        'content-length': ['8']
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}


### PR DESCRIPTION
## Issue
- #4727 

## Summary
TF-4727: streams a picked drive document's `downloadLink` into a temp file via `WorkplaceDio` + `RandomAccessFile`, yielding a `FileBackedStagedFile`.

## Dependencies
- #4731 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mobile/desktop drive transfer strategy using temp local files.
  * Implemented IO-based file staging with streamed download, download progress, and cancellation handling.
* **Bug Fixes**
  * Improved cleanup of partially written temp files on failure or cancellation.
* **Tests**
  * Added integration-style tests covering successful staging, progress updates, error handling, and temp-file deletion.
* **Chores**
  * Added required path provider dependencies for temp-path support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->