### PR TITLE
TF-4727 [Part-2] Web OPFS drive file stager and strategy selection

### DIFF
--- a/.github/workflows/analyze-test.yaml
+++ b/.github/workflows/analyze-test.yaml
@@ -15,6 +15,9 @@ env:
   # "core"). Add more lines here as needed.
   CHROME_TEST_PATHS: |
     core/test/data/network/download/download_manager_test.dart
+    workplace/test/data/datasource/drive_transfer/drive_transfer_strategy_factory_web_test.dart
+    workplace/test/data/datasource/drive_transfer/opfs_drive_file_stager_test.dart
+    workplace/test/data/datasource/drive_transfer/opfs_drive_file_uploader_test.dart
 
 jobs:
   analyze-test:

--- a/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy_factory_web.dart
+++ b/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy_factory_web.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/foundation.dart';
+import 'package:workplace/data/datasource/drive_transfer/buffered_web_drive_file_stager.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
+import 'package:workplace/data/datasource/drive_transfer/opfs_drive_file_stager.dart';
+import 'package:workplace/data/datasource/drive_transfer/opfs_js_bindings.dart';
+
+/// Web branch of the conditional export in
+/// `drive_transfer_strategy_factory.dart`: OPFS detection runs once per
+/// session and is cached (module-level field), so repeated `create()` calls
+/// across a batch never re-probe.
+class DriveTransferStrategyFactory {
+  const DriveTransferStrategyFactory._();
+
+  static bool? _opfsSupported;
+
+  static DriveTransferStrategy create() {
+    _opfsSupported ??= OpfsJsBindings.instance.isOpfsSupported();
+    return _opfsSupported!
+        ? OpfsDriveTransferStrategy()
+        : BufferedWebDriveTransferStrategy();
+  }
+
+  @visibleForTesting
+  static void resetCache() => _opfsSupported = null;
+}

--- a/workplace/lib/data/datasource/drive_transfer/opfs_drive_file_stager.dart
+++ b/workplace/lib/data/datasource/drive_transfer/opfs_drive_file_stager.dart
@@ -1,0 +1,155 @@
+import 'dart:async';
+import 'dart:math' show Random;
+
+import 'package:core/utils/app_logger.dart';
+import 'package:dio/dio.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_file_stager.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
+import 'package:workplace/data/datasource/drive_transfer/opfs_drive_file_uploader.dart';
+import 'package:workplace/data/datasource/drive_transfer/opfs_drive_file_uploader_web.dart';
+import 'package:workplace/data/datasource/drive_transfer/opfs_js_bindings.dart';
+import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+
+/// Streams a drive document into an Origin Private File System temp file.
+/// Web-only: this file (and its `package:web`-touching [OpfsJsBindings]
+/// dependency) is only ever imported by the web branch of
+/// `DriveTransferStrategyFactory`.
+class OpfsDriveFileStager implements DriveFileStager {
+  final OpfsJsBindings _bindings;
+
+  OpfsDriveFileStager({OpfsJsBindings? bindings})
+      : _bindings = bindings ?? OpfsJsBindings.instance;
+
+  @override
+  Future<StagedDriveFile> stage({
+    required DriveDocument doc,
+    required void Function(int received, int total) onDownloadProgress,
+    required CancelToken cancelToken,
+  }) async {
+    final tempFileName = '${doc.id}_${_uniqueSuffix()}_${doc.name}';
+
+    OpfsFetchStream? fetchStream;
+    dynamic handle;
+    dynamic writable;
+    Future<void>? cancelSubscription;
+    // Guards the listener below from firing on a stale reader once stage()
+    // has already returned or thrown — a bare `whenCancel.then(...)` has no
+    // unsubscribe, so it otherwise stays registered for the token's lifetime.
+    var completed = false;
+
+    try {
+      fetchStream = await _bindings.fetchStream(
+        doc.downloadLink!,
+        cancelSignal: cancelToken.whenCancel,
+      );
+      handle = await _bindings.createTempFile(tempFileName);
+      writable = await _bindings.openWritable(handle);
+
+      final reader = fetchStream.reader;
+      cancelSubscription = cancelToken.whenCancel.then((_) {
+        if (!completed) _bindings.cancelReader(reader);
+      });
+
+      final received = await _streamToFile(
+        fetchStream: fetchStream,
+        writable: writable,
+        cancelToken: cancelToken,
+        onDownloadProgress: onDownloadProgress,
+      );
+      await _bindings.closeWritable(writable);
+      completed = true;
+      return OpfsStagedFile(
+        fileHandle: handle,
+        removeEntry: (_) => _bindings.removeTempFile(tempFileName),
+        fileName: doc.name,
+        fileSize: received,
+        mimeType: doc.mimeType,
+      );
+    } catch (e) {
+      completed = true;
+      await _cleanupAfterFailure(
+        tempFileName: tempFileName,
+        fetchStream: fetchStream,
+        writable: writable,
+        handle: handle,
+      );
+      rethrow;
+    } finally {
+      if (cancelSubscription != null) unawaited(cancelSubscription);
+    }
+  }
+
+  Future<int> _streamToFile({
+    required OpfsFetchStream fetchStream,
+    required dynamic writable,
+    required CancelToken cancelToken,
+    required void Function(int received, int total) onDownloadProgress,
+  }) async {
+    final reader = fetchStream.reader;
+    var received = 0;
+    while (true) {
+      if (cancelToken.isCancelled) {
+        throw StateError('OpfsDriveFileStager: transfer cancelled');
+      }
+      final chunk = await _bindings.readChunk(reader);
+      if (chunk == null) break;
+      await _bindings.writeChunk(writable, chunk);
+      received += chunk.length;
+      onDownloadProgress(received, fetchStream.contentLength);
+    }
+    return received;
+  }
+
+  Future<void> _cleanupAfterFailure({
+    required String tempFileName,
+    required OpfsFetchStream? fetchStream,
+    required dynamic writable,
+    required dynamic handle,
+  }) async {
+    if (fetchStream != null) {
+      try {
+        await _bindings.cancelReader(fetchStream.reader);
+      } catch (cleanupError) {
+        logWarning('OpfsDriveFileStager: failed to cancel reader for $tempFileName: $cleanupError');
+      }
+    }
+    if (writable != null) {
+      try {
+        await _bindings.abortWritable(writable);
+      } catch (cleanupError) {
+        logWarning('OpfsDriveFileStager: failed to abort writable for $tempFileName: $cleanupError');
+      }
+    }
+    if (handle != null) {
+      try {
+        await _bindings.removeTempFile(tempFileName);
+      } catch (cleanupError) {
+        logWarning('OpfsDriveFileStager: failed to remove temp file $tempFileName: $cleanupError');
+      }
+    }
+  }
+
+  static final _random = Random();
+
+  /// Distinguishes simultaneous transfers of the same [DriveDocument] so
+  /// they don't collide on the same OPFS entry name.
+  static String _uniqueSuffix() =>
+      '${DateTime.now().microsecondsSinceEpoch}${_random.nextInt(1000000)}';
+}
+
+/// Web+OPFS strategy: flat memory on both legs (streamed download to OPFS,
+/// streamed upload from OPFS via raw XHR).
+class OpfsDriveTransferStrategy implements DriveTransferStrategy {
+  @override
+  final DriveFileStager stager;
+
+  @override
+  final OpfsDriveFileUploader opfsUploader;
+
+  OpfsDriveTransferStrategy({
+    DriveFileStager? stager,
+    OpfsDriveFileUploader? opfsUploader,
+  })  : stager = stager ?? OpfsDriveFileStager(),
+        opfsUploader = opfsUploader ?? BrowserOpfsDriveFileUploader();
+}

--- a/workplace/lib/data/datasource/drive_transfer/opfs_drive_file_uploader.dart
+++ b/workplace/lib/data/datasource/drive_transfer/opfs_drive_file_uploader.dart
@@ -12,12 +12,25 @@ import 'package:model/email/attachment.dart';
 /// `BrowserOpfsDriveFileUploader` (web-only, `opfs_drive_file_uploader_web.dart`)
 /// is the only place that casts it back.
 abstract class OpfsDriveFileUploader {
-  Future<Attachment> upload({
-    required Object fileHandle,
-    required String fileName,
-    required Uri uploadUri,
-    required String authHeader,
-    required void Function(int sent, int total) onUploadProgress,
-    required CancelToken cancelToken,
+  Future<Attachment> upload(OpfsUploadRequest request);
+}
+
+/// Bundles [OpfsDriveFileUploader.upload]'s parameters to keep its argument
+/// count low.
+class OpfsUploadRequest {
+  final Object fileHandle;
+  final String fileName;
+  final Uri uploadUri;
+  final String authHeader;
+  final void Function(int sent, int total) onUploadProgress;
+  final CancelToken cancelToken;
+
+  const OpfsUploadRequest({
+    required this.fileHandle,
+    required this.fileName,
+    required this.uploadUri,
+    required this.authHeader,
+    required this.onUploadProgress,
+    required this.cancelToken,
   });
 }

--- a/workplace/lib/data/datasource/drive_transfer/opfs_drive_file_uploader_web.dart
+++ b/workplace/lib/data/datasource/drive_transfer/opfs_drive_file_uploader_web.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:model/email/attachment.dart';
+import 'package:model/upload/upload_response.dart';
+import 'package:workplace/data/datasource/drive_transfer/opfs_drive_file_uploader.dart';
+import 'package:workplace/data/datasource/drive_transfer/opfs_js_bindings.dart';
+
+/// Web-only implementation of [OpfsDriveFileUploader]. Only ever constructed
+/// from the web branch of `DriveTransferStrategyFactory`, so this file (and
+/// its `package:web` import) never enters an IO/mobile build.
+class BrowserOpfsDriveFileUploader implements OpfsDriveFileUploader {
+  final OpfsJsBindings _bindings;
+
+  BrowserOpfsDriveFileUploader({OpfsJsBindings? bindings})
+      : _bindings = bindings ?? OpfsJsBindings.instance;
+
+  @override
+  Future<Attachment> upload(OpfsUploadRequest request) async {
+    _throwIfCancelled(request.cancelToken);
+    final file = await _bindings.getFile(request.fileHandle);
+    _throwIfCancelled(request.cancelToken);
+
+    final upload = _bindings.uploadFile(XhrUploadFileRequest(
+      file: file,
+      uploadUri: request.uploadUri,
+      authHeader: request.authHeader,
+      onUploadProgress: request.onUploadProgress,
+    ));
+
+    final cancelSubscription =
+        request.cancelToken.whenCancel.then((_) => upload.abort());
+    try {
+      final json = await upload.response;
+      final uploadResponse = UploadResponse.fromJson(json);
+      return uploadResponse.toAttachment(
+          nameFile: request.fileName, charset: null);
+    } finally {
+      unawaited(cancelSubscription);
+    }
+  }
+
+  void _throwIfCancelled(CancelToken cancelToken) {
+    if (cancelToken.isCancelled) {
+      throw cancelToken.cancelError!;
+    }
+  }
+}

--- a/workplace/lib/data/datasource/drive_transfer/opfs_js_bindings.dart
+++ b/workplace/lib/data/datasource/drive_transfer/opfs_js_bindings.dart
@@ -1,0 +1,202 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+import 'package:web/web.dart' as web;
+
+/// Result of [OpfsJsBindings.fetchStream]: a locked reader plus the
+/// declared content-length (0 when the header is absent/unparseable).
+class OpfsFetchStream {
+  final web.ReadableStreamDefaultReader reader;
+  final int contentLength;
+
+  const OpfsFetchStream({required this.reader, required this.contentLength});
+}
+
+/// A raw-XHR upload in flight: [response] resolves with the parsed JSON
+/// body, [abort] can be called any time before that to cancel the request.
+class XhrUploadHandle {
+  final Future<Map<String, dynamic>> response;
+  final void Function() abort;
+
+  const XhrUploadHandle({required this.response, required this.abort});
+}
+
+/// Bundles [OpfsJsBindings.uploadFile]'s parameters to keep its argument
+/// count low.
+class XhrUploadFileRequest {
+  final web.File file;
+  final Uri uploadUri;
+  final String authHeader;
+  final void Function(int sent, int total) onUploadProgress;
+
+  const XhrUploadFileRequest({
+    required this.file,
+    required this.uploadUri,
+    required this.authHeader,
+    required this.onUploadProgress,
+  });
+}
+
+/// Reads the `getDirectory` property off a `StorageManager` without
+/// invoking it, so feature detection never has side effects (no probe
+/// file) and can stay synchronous.
+extension type _StorageManagerFeatureProbe(JSObject _) implements JSObject {
+  external JSAny? get getDirectory;
+}
+
+/// The only file in `workplace` touching `dart:js_interop`/`package:web`.
+/// Wraps OPFS, `fetch`, and raw-XHR calls behind plain Dart methods so
+/// stager/uploader code never touches JS interop directly, and so tests can
+/// substitute a fake via [OpfsJsBindings.setInstance] — the same swap-the-
+/// singleton seam `WorkplaceDio.setInstance` already uses in this package.
+class OpfsJsBindings {
+  static OpfsJsBindings _instance = OpfsJsBindings();
+
+  static void setInstance(OpfsJsBindings bindings) => _instance = bindings;
+
+  static OpfsJsBindings get instance => _instance;
+
+  Future<web.FileSystemDirectoryHandle> _opfsRoot() =>
+      web.window.navigator.storage.getDirectory().toDart;
+
+  /// True when `navigator.storage.getDirectory` is present. `createWritable`
+  /// ships together with it (Baseline across Chrome/Edge, Firefox, and
+  /// Safari as of Safari 26.0), so a single, side-effect-free property read
+  /// is enough — no probe file, no `await`, so callers can cache this once
+  /// per session synchronously.
+  bool isOpfsSupported() {
+    final storage = web.window.navigator.storage;
+    return (storage as _StorageManagerFeatureProbe).getDirectory != null;
+  }
+
+  Future<web.FileSystemFileHandle> createTempFile(String fileName) async {
+    final root = await _opfsRoot();
+    return root
+        .getFileHandle(fileName, web.FileSystemGetFileOptions(create: true))
+        .toDart;
+  }
+
+  /// Resolves an opaque staged-file handle (a `web.FileSystemFileHandle`)
+  /// to the `web.File` snapshot the uploader sends. Kept here, not in the
+  /// uploader, so casting the opaque [Object] is the bindings' job alone.
+  Future<web.File> getFile(Object fileHandle) =>
+      (fileHandle as web.FileSystemFileHandle).getFile().toDart;
+
+  Future<web.FileSystemWritableFileStream> openWritable(
+      web.FileSystemFileHandle handle) =>
+      handle.createWritable().toDart;
+
+  Future<void> writeChunk(
+      web.FileSystemWritableFileStream stream, Uint8List chunk) =>
+      stream.write(chunk.toJS).toDart;
+
+  Future<void> closeWritable(web.FileSystemWritableFileStream stream) =>
+      stream.close().toDart;
+
+  Future<void> abortWritable(web.FileSystemWritableFileStream stream) =>
+      stream.abort().toDart;
+
+  Future<void> removeTempFile(String fileName) async {
+    final root = await _opfsRoot();
+    await root.removeEntry(fileName).toDart;
+  }
+
+  /// Streams [url]'s response body. Caller drives it via [readChunk] and
+  /// must eventually call [cancelReader] or read to completion.
+  ///
+  /// [cancelSignal], when given, aborts the underlying `fetch` if it
+  /// resolves before headers are received — without it, a request stalled
+  /// pre-headers can't be cancelled since no reader exists yet.
+  Future<OpfsFetchStream> fetchStream(Uri url, {Future<void>? cancelSignal}) async {
+    final controller = web.AbortController();
+    if (cancelSignal != null) {
+      unawaited(cancelSignal.then((_) => controller.abort()));
+    }
+    final web.Response response;
+    try {
+      response = await web.window
+          .fetch(url.toString().toJS, web.RequestInit(signal: controller.signal))
+          .toDart;
+    } catch (e) {
+      if (controller.signal.aborted) {
+        throw StateError('OpfsJsBindings.fetchStream: request aborted');
+      }
+      rethrow;
+    }
+    if (!response.ok) {
+      throw StateError('OPFS download failed: HTTP ${response.status}');
+    }
+    final body = response.body;
+    if (body == null) {
+      throw StateError('OpfsJsBindings.fetchStream: response has no body');
+    }
+    final contentLength =
+        int.tryParse(response.headers.get('content-length') ?? '') ?? 0;
+    final reader = body.getReader() as web.ReadableStreamDefaultReader;
+    return OpfsFetchStream(reader: reader, contentLength: contentLength);
+  }
+
+  /// Returns the next chunk, or null once the stream is exhausted.
+  Future<Uint8List?> readChunk(web.ReadableStreamDefaultReader reader) async {
+    final result = await reader.read().toDart;
+    if (result.done) return null;
+    final value = result.value;
+    if (value == null) return Uint8List(0);
+    return (value as JSUint8Array).toDart;
+  }
+
+  Future<void> cancelReader(web.ReadableStreamDefaultReader reader) =>
+      reader.cancel().toDart;
+
+  /// POSTs [file] (an OPFS-backed `File`) to [uploadUri] via a raw XHR,
+  /// streaming the upload directly from the OPFS-backed file so it never
+  /// materializes in the JS heap. Not refresh-and-retry safe: [authHeader]
+  /// is read once, up front.
+  XhrUploadHandle uploadFile(XhrUploadFileRequest request) {
+    final xhr = web.XMLHttpRequest();
+    xhr.open('POST', request.uploadUri.toString());
+    xhr.setRequestHeader('Authorization', request.authHeader);
+
+    final completer = Completer<Map<String, dynamic>>();
+
+    xhr.upload.onprogress = ((web.ProgressEvent event) {
+      request.onUploadProgress(event.loaded, event.total);
+    }).toJS;
+
+    xhr.onload = ((web.Event _) {
+      if (completer.isCompleted) return;
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try {
+          completer.complete(
+              jsonDecode(xhr.responseText) as Map<String, dynamic>);
+        } catch (e) {
+          completer.completeError(e);
+        }
+      } else {
+        completer.completeError(
+            StateError('OPFS upload failed: HTTP ${xhr.status}'));
+      }
+    }).toJS;
+
+    xhr.onerror = ((web.Event _) {
+      if (!completer.isCompleted) {
+        completer.completeError(StateError('OPFS upload network error'));
+      }
+    }).toJS;
+
+    xhr.onabort = ((web.Event _) {
+      if (!completer.isCompleted) {
+        completer.completeError(StateError('OPFS upload cancelled'));
+      }
+    }).toJS;
+
+    xhr.send(request.file);
+
+    return XhrUploadHandle(
+      response: completer.future,
+      abort: () => xhr.abort(),
+    );
+  }
+}

--- a/workplace/pubspec.yaml
+++ b/workplace/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   dartz: 0.10.1
   flutter_inappwebview: 6.1.0
   universal_html: 2.2.4
+  web: 1.1.1
   flutter_svg:
   flutter_localization:
   intl:

--- a/workplace/test/data/datasource/drive_transfer/drive_transfer_strategy_factory_web_test.dart
+++ b/workplace/test/data/datasource/drive_transfer/drive_transfer_strategy_factory_web_test.dart
@@ -1,0 +1,54 @@
+@TestOn('chrome')
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:workplace/data/datasource/drive_transfer/buffered_web_drive_file_stager.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy_factory_web.dart';
+import 'package:workplace/data/datasource/drive_transfer/opfs_drive_file_stager.dart';
+import 'package:workplace/data/datasource/drive_transfer/opfs_js_bindings.dart';
+
+class _FakeOpfsJsBindings extends OpfsJsBindings {
+  final bool supported;
+  int probeCount = 0;
+
+  _FakeOpfsJsBindings(this.supported);
+
+  @override
+  bool isOpfsSupported() {
+    probeCount++;
+    return supported;
+  }
+}
+
+void main() {
+  setUp(DriveTransferStrategyFactory.resetCache);
+
+  group('DriveTransferStrategyFactory (web)', () {
+    test('returns the OPFS strategy when OPFS is detected', () {
+      OpfsJsBindings.setInstance(_FakeOpfsJsBindings(true));
+
+      final strategy = DriveTransferStrategyFactory.create();
+
+      expect(strategy, isA<OpfsDriveTransferStrategy>());
+    });
+
+    test('returns the buffered strategy when OPFS is unavailable', () {
+      OpfsJsBindings.setInstance(_FakeOpfsJsBindings(false));
+
+      final strategy = DriveTransferStrategyFactory.create();
+
+      expect(strategy, isA<BufferedWebDriveTransferStrategy>());
+    });
+
+    test('caches detection across multiple create() calls', () {
+      final fake = _FakeOpfsJsBindings(true);
+      OpfsJsBindings.setInstance(fake);
+
+      DriveTransferStrategyFactory.create();
+      DriveTransferStrategyFactory.create();
+      DriveTransferStrategyFactory.create();
+
+      expect(fake.probeCount, 1);
+    });
+  });
+}

--- a/workplace/test/data/datasource/drive_transfer/opfs_drive_file_stager_test.dart
+++ b/workplace/test/data/datasource/drive_transfer/opfs_drive_file_stager_test.dart
@@ -1,0 +1,62 @@
+@TestOn('chrome')
+library;
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:workplace/data/datasource/drive_transfer/opfs_drive_file_stager.dart';
+import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+
+void main() {
+  test('stages a fetched file into OPFS and reports cumulative progress',
+      () async {
+    const content = 'hello opfs world';
+    final dataUrl = Uri.dataFromString(content, mimeType: 'text/plain');
+
+    final doc = DriveDocument(
+      id: 'doc-opfs-1',
+      name: 'hello.txt',
+      size: content.length,
+      mimeType: 'text/plain',
+      downloadLink: dataUrl,
+    );
+
+    final progress = <int>[];
+    final staged = await OpfsDriveFileStager().stage(
+      doc: doc,
+      onDownloadProgress: (received, total) => progress.add(received),
+      cancelToken: CancelToken(),
+    );
+
+    expect(staged, isA<OpfsStagedFile>());
+    final opfsStaged = staged as OpfsStagedFile;
+    expect(opfsStaged.fileSize, content.length);
+    expect(opfsStaged.fileName, doc.name);
+    expect(progress, isNotEmpty);
+    expect(progress.last, content.length);
+
+    // dispose() must remove the OPFS temp entry on every exit path; a
+    // real `FileSystemDirectoryHandle.removeEntry` call throwing would
+    // surface here.
+    await opfsStaged.dispose();
+  });
+
+  test('cleans up the OPFS temp entry when the transfer fails', () async {
+    final doc = DriveDocument(
+      id: 'doc-opfs-2',
+      name: 'missing.bin',
+      size: 0,
+      mimeType: 'application/octet-stream',
+      downloadLink: Uri.parse('https://127.0.0.1:0/does-not-resolve'),
+    );
+
+    await expectLater(
+      OpfsDriveFileStager().stage(
+        doc: doc,
+        onDownloadProgress: (_, __) {},
+        cancelToken: CancelToken(),
+      ),
+      throwsA(anything),
+    );
+  });
+}

--- a/workplace/test/data/datasource/drive_transfer/opfs_drive_file_uploader_test.dart
+++ b/workplace/test/data/datasource/drive_transfer/opfs_drive_file_uploader_test.dart
@@ -1,0 +1,171 @@
+@TestOn('chrome')
+library;
+
+import 'dart:async';
+import 'dart:js_interop';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:web/web.dart' as web;
+import 'package:workplace/data/datasource/drive_transfer/opfs_drive_file_uploader.dart';
+import 'package:workplace/data/datasource/drive_transfer/opfs_drive_file_uploader_web.dart';
+import 'package:workplace/data/datasource/drive_transfer/opfs_js_bindings.dart';
+
+web.File _fakeFile() => web.File(<web.BlobPart>[].toJS, 'test.txt');
+
+void main() {
+  test('resolves with an Attachment when the upload succeeds', () async {
+    OpfsJsBindings.setInstance(_FakeSuccessfulOpfsJsBindings());
+
+    final attachment = await BrowserOpfsDriveFileUploader().upload(OpfsUploadRequest(
+      fileHandle: Object(),
+      fileName: 'hello.txt',
+      uploadUri: Uri.parse('https://jmap.example/upload'),
+      authHeader: 'Bearer token',
+      onUploadProgress: (_, __) {},
+      cancelToken: CancelToken(),
+    ));
+
+    expect(attachment.name, 'hello.txt');
+    expect(attachment.size?.value, 42);
+  });
+
+  test('propagates an error when the upload fails', () async {
+    OpfsJsBindings.setInstance(_FakeFailingOpfsJsBindings());
+
+    await expectLater(
+      BrowserOpfsDriveFileUploader().upload(OpfsUploadRequest(
+        fileHandle: Object(),
+        fileName: 'hello.txt',
+        uploadUri: Uri.parse('https://jmap.example/upload'),
+        authHeader: 'Bearer token',
+        onUploadProgress: (_, __) {},
+        cancelToken: CancelToken(),
+      )),
+      throwsA(isA<StateError>()),
+    );
+  });
+
+  test('calling cancel aborts the in-flight upload', () async {
+    final bindings = _FakeAbortableOpfsJsBindings();
+    OpfsJsBindings.setInstance(bindings);
+    final cancelToken = CancelToken();
+
+    final upload = BrowserOpfsDriveFileUploader().upload(OpfsUploadRequest(
+      fileHandle: Object(),
+      fileName: 'hello.txt',
+      uploadUri: Uri.parse('https://jmap.example/upload'),
+      authHeader: 'Bearer token',
+      onUploadProgress: (_, __) {},
+      cancelToken: cancelToken,
+    ));
+
+    // Let the upload progress past its own cancellation checks and create
+    // the XHR before cancelling, so this exercises the whenCancel -> abort
+    // wiring rather than the pre-XHR cancellation guard.
+    await Future<void>.delayed(Duration.zero);
+    cancelToken.cancel();
+
+    await expectLater(upload, throwsA(isA<StateError>()));
+    expect(bindings.aborted, isTrue);
+  });
+
+  test('does not create the XHR when cancelled while getFile is pending',
+      () async {
+    final bindings = _FakeDeferredGetFileOpfsJsBindings();
+    OpfsJsBindings.setInstance(bindings);
+    final cancelToken = CancelToken();
+
+    final upload = BrowserOpfsDriveFileUploader().upload(OpfsUploadRequest(
+      fileHandle: Object(),
+      fileName: 'hello.txt',
+      uploadUri: Uri.parse('https://jmap.example/upload'),
+      authHeader: 'Bearer token',
+      onUploadProgress: (_, __) {},
+      cancelToken: cancelToken,
+    ));
+
+    // getFile has started (and is pending) by the time this runs; cancel
+    // here exercises the *second* guard, after getFile resolves, not the
+    // pre-getFile one.
+    await Future<void>.delayed(Duration.zero);
+    cancelToken.cancel();
+    bindings.completeGetFile();
+
+    await expectLater(upload, throwsA(isA<DioException>()));
+    expect(bindings.uploadFileCalled, isFalse);
+  });
+}
+
+class _FakeSuccessfulOpfsJsBindings extends OpfsJsBindings {
+  @override
+  Future<web.File> getFile(Object fileHandle) async => _fakeFile();
+
+  @override
+  XhrUploadHandle uploadFile(XhrUploadFileRequest request) {
+    return XhrUploadHandle(
+      response: Future.value({
+        'accountId': 'account-1',
+        'blobId': 'blob-1',
+        'type': 'text/plain',
+        'size': 42,
+      }),
+      abort: () {},
+    );
+  }
+}
+
+class _FakeFailingOpfsJsBindings extends OpfsJsBindings {
+  @override
+  Future<web.File> getFile(Object fileHandle) async => _fakeFile();
+
+  @override
+  XhrUploadHandle uploadFile(XhrUploadFileRequest request) {
+    return XhrUploadHandle(
+      response: Future.error(StateError('upload failed')),
+      abort: () {},
+    );
+  }
+}
+
+class _FakeDeferredGetFileOpfsJsBindings extends OpfsJsBindings {
+  bool uploadFileCalled = false;
+  final _getFileCompleter = Completer<web.File>();
+
+  void completeGetFile() => _getFileCompleter.complete(_fakeFile());
+
+  @override
+  Future<web.File> getFile(Object fileHandle) => _getFileCompleter.future;
+
+  @override
+  XhrUploadHandle uploadFile(XhrUploadFileRequest request) {
+    uploadFileCalled = true;
+    return XhrUploadHandle(
+      response: Future.value(<String, dynamic>{}),
+      abort: () {},
+    );
+  }
+}
+
+class _FakeAbortableOpfsJsBindings extends OpfsJsBindings {
+  bool aborted = false;
+  bool uploadFileCalled = false;
+
+  @override
+  Future<web.File> getFile(Object fileHandle) async => _fakeFile();
+
+  @override
+  XhrUploadHandle uploadFile(XhrUploadFileRequest request) {
+    uploadFileCalled = true;
+    final completer = Completer<Map<String, dynamic>>();
+    return XhrUploadHandle(
+      response: completer.future,
+      abort: () {
+        aborted = true;
+        if (!completer.isCompleted) {
+          completer.completeError(StateError('OPFS upload cancelled'));
+        }
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Issue
- #4727

## Summary
TF-4727: streams a drive document via `fetch()`/`ReadableStream` into an Origin Private File System temp file, uploaded via raw XHR (the only upload path `FileUploader` can't do). `drive_transfer_strategy_factory_web.dart` picks OPFS vs. the buffered strategy based on cached feature detection.

## Dependencies
- #4731

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved web drive transfers using browser storage when supported.
  - Added a fallback transfer method for browsers without storage support.
  - Added download and upload progress reporting.
  - Added cancellation support for active transfers.
  - Improved temporary-file cleanup after completed or failed transfers.

- **Bug Fixes**
  - Prevented incomplete or cancelled transfers from leaving temporary files behind.
  - Added safer handling for network and upload failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->