### PR TITLE
Fix Drive picker stuck 20s on readyTimeout when token_exchange or page load fails

### DIFF
--- a/workplace/lib/domain/exceptions/workplace_exceptions.dart
+++ b/workplace/lib/domain/exceptions/workplace_exceptions.dart
@@ -1,9 +1,16 @@
 class WorkplaceCreateIntentException implements Exception {}
 
-class WorkplaceUIDisposedException implements Exception {}
-
 class WorkplaceExchangeTokenException implements Exception {}
 
 class DriveIntentErrorException implements Exception {}
+
+class DriveIntentPageLoadException implements Exception {
+  final String reason;
+
+  DriveIntentPageLoadException(this.reason);
+
+  @override
+  String toString() => 'DriveIntentPageLoadException: $reason';
+}
 
 class DriveIntentTimeoutException implements Exception {}

--- a/workplace/lib/presentation/mixin/drive_intent_message_handler_mixin.dart
+++ b/workplace/lib/presentation/mixin/drive_intent_message_handler_mixin.dart
@@ -202,13 +202,20 @@ mixin DriveIntentMessageHandlerMixin<T extends StatefulWidget> on State<T> {
     _readyTimeoutTimer?.cancel();
     // Once closed, the timeout is cancelled and _finish won't run again, so
     // the pop must happen even if a subclass hook throws — otherwise the
-    // modal hangs with no fallback.
+    // modal hangs with no fallback. Each hook is guarded independently so a
+    // throwing onCleanup still runs onFinished, and neither escapes into the
+    // unawaited futures that call _finish as an unobserved async error.
     try {
       onCleanup();
-      onFinished(outcome);
-    } finally {
-      if (mounted) Navigator.of(context).pop(outcome);
+    } catch (e, s) {
+      logError('driveIntent: onCleanup failed', exception: e, stackTrace: s);
     }
+    try {
+      onFinished(outcome);
+    } catch (e, s) {
+      logError('driveIntent: onFinished failed', exception: e, stackTrace: s);
+    }
+    if (mounted) Navigator.of(context).pop(outcome);
   }
 
   /// Async so ack-delivery failures (e.g. evaluateJavascript) reject the

--- a/workplace/lib/presentation/mixin/drive_intent_message_handler_mixin.dart
+++ b/workplace/lib/presentation/mixin/drive_intent_message_handler_mixin.dart
@@ -9,6 +9,9 @@ import 'package:workplace/presentation/model/drive_pick_outcome.dart';
 
 enum _Phase { waiting, loadingPage, interactive, closed }
 
+/// Lazy so the modal starts the request only after its error handling is live.
+typedef DriveIntentLoader = Future<WorkplaceIntent> Function();
+
 /// Shared loading/messaging lifecycle for the mobile and web Drive picker modals.
 mixin DriveIntentMessageHandlerMixin<T extends StatefulWidget> on State<T> {
   late String _intentId;
@@ -36,20 +39,34 @@ mixin DriveIntentMessageHandlerMixin<T extends StatefulWidget> on State<T> {
   /// Covers silent failures like SSO blocking the page with no postMessage ever sent.
   Duration get readyTimeout => const Duration(seconds: 20);
 
-  void startLoading(Future<WorkplaceIntent> intentFuture) {
+  void startLoading(DriveIntentLoader intentLoader) {
     // Starts the deadline immediately so a platform view that never becomes
     // ready (e.g. WebView/iframe init silently failing) still times out.
     _readyTimeoutTimer?.cancel();
     _readyTimeoutTimer = Timer(readyTimeout, _handleReadyTimeout);
-    intentFuture
-        .then((intent) {
-          if (!mounted) return;
-          _resolvedIntent = intent;
-          _tryApplyIntent();
-        })
-        .catchError((Object e) {
-          _finish(DrivePickOutcomeFailed(e));
-        });
+    unawaited(_loadIntent(intentLoader));
+  }
+
+  Future<void> _loadIntent(DriveIntentLoader intentLoader) async {
+    try {
+      final intent = await intentLoader();
+      if (!mounted) return;
+      _resolvedIntent = intent;
+      _tryApplyIntent();
+    } catch (e, s) {
+      _failWith('intent loader failed', e, s);
+    }
+  }
+
+  /// Single Sentry funnel for every failure path: reports the failing stage
+  /// with the original exception and stack, then closes the modal.
+  void _failWith(String stage, Object error, [StackTrace? stackTrace]) {
+    logError(
+      'driveIntent: $stage',
+      exception: error,
+      stackTrace: stackTrace,
+    );
+    _finish(DrivePickOutcomeFailed(error));
   }
 
   void notifyPlatformViewReady() {
@@ -57,28 +74,62 @@ mixin DriveIntentMessageHandlerMixin<T extends StatefulWidget> on State<T> {
     _tryApplyIntent();
   }
 
+  /// The intent can only be applied once: after both the intent resolved and
+  /// the platform view reported ready, and before leaving [_Phase.waiting].
+  bool get _canApplyIntent =>
+      _resolvedIntent != null &&
+      _platformViewReady &&
+      _phase == _Phase.waiting;
+
   void _tryApplyIntent() {
-    final intent = _resolvedIntent;
-    if (intent == null || !_platformViewReady || _phase != _Phase.waiting) {
-      return;
-    }
+    if (!_canApplyIntent) return;
+    final intent = _resolvedIntent!;
     _intentId = intent.intentId;
     _intentOrigin = intent.intentUrl.scheme == 'data'
         ? 'null'
         : intent.intentUrl.origin;
     _setPhase(_Phase.loadingPage);
-    loadIntent(intent);
+    unawaited(_applyIntent(intent));
   }
 
-  void loadIntent(WorkplaceIntent intent);
+  Future<void> _applyIntent(WorkplaceIntent intent) async {
+    try {
+      await loadIntent(intent);
+    } catch (e, s) {
+      _failWith('loading intent into platform view failed', e, s);
+    }
+  }
+
+  /// Async so platform-channel failures (e.g. WebView loadUrl) reject the
+  /// returned future and are funneled instead of becoming uncaught errors.
+  Future<void> loadIntent(WorkplaceIntent intent);
+
+  /// Fails fast on a main-frame page load failure instead of waiting for
+  /// [readyTimeout]. Only honored while the Drive page is loading: earlier
+  /// errors cannot be ours, later ones belong to the page's error protocol.
+  void notifyPageLoadFailed(Object error) {
+    if (_phase != _Phase.loadingPage) {
+      log('driveIntent: ignored page load failure in phase $_phase: $error');
+      return;
+    }
+    _failWith('platform view failed to load page', error);
+  }
 
   void _handleReadyTimeout() {
-    log('driveIntent: timed out waiting for ready after $readyTimeout');
-    _finish(DrivePickOutcomeFailed(DriveIntentTimeoutException()));
+    _failWith(
+      'timed out waiting for ready after $readyTimeout',
+      DriveIntentTimeoutException(),
+    );
   }
 
+  /// Protocol messages only make sense while the Drive page is loaded:
+  /// before that [_intentId]/[_intentOrigin] are unset, after close the
+  /// outcome is already delivered.
+  bool get _acceptsMessages =>
+      _phase == _Phase.loadingPage || _phase == _Phase.interactive;
+
   void onMessage({required String raw, required String? origin}) {
-    if (_phase.index < _Phase.loadingPage.index) return;
+    if (!_acceptsMessages) return;
     if (!_isValidOrigin(origin)) {
       log('driveIntent: dropped message from unexpected origin: $origin');
       return;
@@ -90,7 +141,15 @@ mixin DriveIntentMessageHandlerMixin<T extends StatefulWidget> on State<T> {
       log('driveIntent: failed to parse message: $raw');
       return;
     }
-    _handleWorkplaceMessage(msg);
+    unawaited(_dispatchWorkplaceMessage(msg));
+  }
+
+  Future<void> _dispatchWorkplaceMessage(WorkplaceIntentMessage msg) async {
+    try {
+      await _handleWorkplaceMessage(msg);
+    } catch (e, s) {
+      _failWith('handling workplace message failed', e, s);
+    }
   }
 
   bool _isValidOrigin(String? origin) {
@@ -101,11 +160,11 @@ mixin DriveIntentMessageHandlerMixin<T extends StatefulWidget> on State<T> {
     return _intentOrigin == 'null' && origin == '*';
   }
 
-  void _handleWorkplaceMessage(WorkplaceIntentMessage msg) {
+  Future<void> _handleWorkplaceMessage(WorkplaceIntentMessage msg) async {
     switch (msg) {
       case WorkplaceIntentReadyMessage():
         log('driveIntent: ready received, sending ack');
-        sendAck();
+        await sendAck();
         break;
       case WorkplaceIntentReadyToUseMessage():
         log('driveIntent: readyToUse received, hiding loading');
@@ -117,8 +176,7 @@ mixin DriveIntentMessageHandlerMixin<T extends StatefulWidget> on State<T> {
         _finish(DrivePickOutcomePicked(msg.documents));
         break;
       case WorkplaceIntentErrorMessage():
-        log('driveIntent: error received, closing modal');
-        _finish(DrivePickOutcomeFailed(DriveIntentErrorException()));
+        _failWith('drive page reported error', DriveIntentErrorException());
         break;
       case WorkplaceIntentCancelMessage():
         log('driveIntent: cancel received, closing modal');
@@ -142,12 +200,20 @@ mixin DriveIntentMessageHandlerMixin<T extends StatefulWidget> on State<T> {
     if (_phase == _Phase.closed) return;
     _setPhase(_Phase.closed);
     _readyTimeoutTimer?.cancel();
-    onCleanup();
-    onFinished(outcome);
-    if (mounted) Navigator.of(context).pop(outcome);
+    // Once closed, the timeout is cancelled and _finish won't run again, so
+    // the pop must happen even if a subclass hook throws — otherwise the
+    // modal hangs with no fallback.
+    try {
+      onCleanup();
+      onFinished(outcome);
+    } finally {
+      if (mounted) Navigator.of(context).pop(outcome);
+    }
   }
 
-  void sendAck();
+  /// Async so ack-delivery failures (e.g. evaluateJavascript) reject the
+  /// returned future and are funneled instead of becoming uncaught errors.
+  Future<void> sendAck();
 
   void onCleanup() {}
 

--- a/workplace/lib/presentation/mixin/drive_intent_message_handler_mixin.dart
+++ b/workplace/lib/presentation/mixin/drive_intent_message_handler_mixin.dart
@@ -215,7 +215,13 @@ mixin DriveIntentMessageHandlerMixin<T extends StatefulWidget> on State<T> {
     } catch (e, s) {
       logError('driveIntent: onFinished failed', exception: e, stackTrace: s);
     }
-    if (mounted) Navigator.of(context).pop(outcome);
+    // Guarded like the hooks above: _finish runs from Timer/unawaited paths, so
+    // a throwing pop must not escape as an uncaught async error.
+    try {
+      if (mounted) Navigator.of(context).pop(outcome);
+    } catch (e, s) {
+      logError('driveIntent: pop failed', exception: e, stackTrace: s);
+    }
   }
 
   /// Async so ack-delivery failures (e.g. evaluateJavascript) reject the

--- a/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
+++ b/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:workplace/data/model/workplace_intent_request.dart';
 import 'package:workplace/domain/entity/workplace_intent.dart';
 import 'package:workplace/l10n/workplace_localizations.dart';
-import 'package:workplace/presentation/mixin/web_window_message_mixin.dart';
 import 'package:workplace/presentation/model/drive_intent_image_assets.dart';
 import 'package:workplace/presentation/model/drive_pick_outcome.dart';
 import 'package:workplace/presentation/model/drive_pick_state.dart';
@@ -26,10 +25,6 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
   DriveIntentImageAssets get driveIntentImageAssets;
 
   OnPickDriveCallback? get pickerOnCallback => null;
-
-  void Function(void Function(String raw, String? origin))?
-  get externalHandlerRegistrar => null;
-  void clearExternalHandler() {}
 
   bool _modalOpen = false;
 
@@ -66,7 +61,6 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
       }
       _handleOutcome(outcome, failingMessage);
     } finally {
-      clearExternalHandler();
       _modalOpen = false;
     }
   }
@@ -89,7 +83,6 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
         ),
         filePickerConfig: filePickerConfig,
         imageAssets: driveIntentImageAssets,
-        onRegisterExternalHandler: externalHandlerRegistrar,
       ),
     );
   }
@@ -106,34 +99,5 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
       case null:
         break;
     }
-  }
-}
-
-/// Web-specific extension of [DrivePickerStateMixin] that wires a single
-/// `window.onmessage` listener (ADR-93) into the modal handler slot.
-mixin DrivePickerWebStateMixin<T extends StatefulWidget>
-    on State<T>, DrivePickerStateMixin<T>, WebWindowMessageMixin<T> {
-  void Function(String raw, String? origin)? _webModalHandler;
-
-  @override
-  void Function(void Function(String raw, String? origin))?
-  get externalHandlerRegistrar =>
-      (handler) => _webModalHandler = handler;
-
-  @override
-  void clearExternalHandler() => _webModalHandler = null;
-
-  @override
-  void initState() {
-    super.initState();
-    startWindowMessageListener(
-      (data, origin) => _webModalHandler?.call(data, origin),
-    );
-  }
-
-  @override
-  void dispose() {
-    stopWindowMessageListener();
-    super.dispose();
   }
 }

--- a/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
+++ b/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
@@ -2,7 +2,6 @@ import 'package:core/utils/app_logger.dart';
 import 'package:flutter/material.dart';
 import 'package:workplace/data/model/workplace_intent_request.dart';
 import 'package:workplace/domain/entity/workplace_intent.dart';
-import 'package:workplace/domain/exceptions/workplace_exceptions.dart';
 import 'package:workplace/l10n/workplace_localizations.dart';
 import 'package:workplace/presentation/mixin/web_window_message_mixin.dart';
 import 'package:workplace/presentation/model/drive_intent_image_assets.dart';
@@ -39,7 +38,9 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
     _modalOpen = true;
     try {
       if (!mounted) {
-        throw WorkplaceUIDisposedException();
+        // Tap raced state disposal — nothing to show a modal or toast on.
+        logError('DrivePickerStateMixin::onPickerTap: state disposed before opening modal');
+        return;
       }
       final l10n = AppLocalizations.of(context)!;
       // Captured up front: the caller may pop this context (e.g. a context
@@ -52,21 +53,15 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
             ? null
             : const WorkplaceActionConfigRequest(label: addAsAttachmentTitle),
       );
-      final intentFuture = pickerFetchIntent(filePickerConfig: filePickerConfig);
       DrivePickOutcome? outcome;
       try {
-        outcome = await showDialog<DrivePickOutcome>(
-          context: context,
-          useSafeArea: false,
-          barrierDismissible: false,
-          builder: (_) => DriveIntentWebViewModal(
-            intentFuture: intentFuture,
-            filePickerConfig: filePickerConfig,
-            imageAssets: driveIntentImageAssets,
-            onRegisterExternalHandler: externalHandlerRegistrar,
-          ),
+        outcome = await openDrivePickerModal(filePickerConfig);
+      } catch (e, s) {
+        logError(
+          'DrivePickerStateMixin::onPickerTap: modal failed',
+          exception: e,
+          stackTrace: s,
         );
-      } catch (e) {
         outcome = DrivePickOutcomeFailed(e);
       }
       _handleOutcome(outcome, failingMessage);
@@ -76,12 +71,36 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
     }
   }
 
+  /// Overridable seam so tests can stub the modal instead of pumping a real
+  /// WebView/iframe.
+  @protected
+  Future<DrivePickOutcome?> openDrivePickerModal(
+    WorkplaceFilePickerConfigRequest filePickerConfig,
+  ) {
+    return showDialog<DrivePickOutcome>(
+      context: context,
+      useSafeArea: false,
+      barrierDismissible: false,
+      builder: (_) => DriveIntentWebViewModal(
+        // Must stay lazy so the modal subscribes to failures before the
+        // token exchange or intent request starts.
+        intentLoader: () => pickerFetchIntent(
+          filePickerConfig: filePickerConfig,
+        ),
+        filePickerConfig: filePickerConfig,
+        imageAssets: driveIntentImageAssets,
+        onRegisterExternalHandler: externalHandlerRegistrar,
+      ),
+    );
+  }
+
   void _handleOutcome(DrivePickOutcome? outcome, String? failingMessage) {
     switch (outcome) {
       case DrivePickOutcomePicked(:final documents):
         pickerOnCallback?.call(DrivePickResult(documents));
       case DrivePickOutcomeFailed(:final error):
-        logError('DrivePickerStateMixin::onPickerTap: $error');
+        // Already reported to Sentry at the failing stage (modal mixin or the
+        // catch above) — only dispatch the UI failure callback here.
         pickerOnCallback?.call(DrivePickFailure(error, message: failingMessage));
       case DrivePickOutcomeCancelled():
       case null:

--- a/workplace/lib/presentation/view/drive_intent_web_view_modal_mobile.dart
+++ b/workplace/lib/presentation/view/drive_intent_web_view_modal_mobile.dart
@@ -11,9 +11,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:workplace/data/model/workplace_intent_request.dart';
 import 'package:workplace/domain/entity/workplace_intent.dart';
+import 'package:workplace/domain/exceptions/workplace_exceptions.dart';
 
 class DriveIntentWebViewModal extends StatefulWidget {
-  final Future<WorkplaceIntent> intentFuture;
+  final DriveIntentLoader intentLoader;
   final WorkplaceFilePickerConfigRequest filePickerConfig;
   final DriveIntentImageAssets imageAssets;
   // Ignored on mobile — only used by the web variant (ADR-93).
@@ -21,7 +22,7 @@ class DriveIntentWebViewModal extends StatefulWidget {
 
   const DriveIntentWebViewModal({
     super.key,
-    required this.intentFuture,
+    required this.intentLoader,
     required this.filePickerConfig,
     required this.imageAssets,
     this.onRegisterExternalHandler,
@@ -39,20 +40,46 @@ class _DriveIntentWebViewModalState extends State<DriveIntentWebViewModal>
   @override
   void initState() {
     super.initState();
-    startLoading(widget.intentFuture);
+    startLoading(widget.intentLoader);
   }
 
   @override
-  void loadIntent(WorkplaceIntent intent) {
+  Future<void> loadIntent(WorkplaceIntent intent) {
     if (intent.intentUrl.scheme == 'data') {
-      _webViewController!.loadData(
+      return _webViewController!.loadData(
         data: DriveIntentFakePage.buildHtml(intent.intentId),
       );
-    } else {
-      _webViewController!.loadUrl(
-        urlRequest: URLRequest(url: WebUri.uri(intent.intentUrl)),
-      );
     }
+    return _webViewController!.loadUrl(
+      urlRequest: URLRequest(url: WebUri.uri(intent.intentUrl)),
+    );
+  }
+
+  // Only main-frame failures mean the page is unusable; subframe errors
+  // (favicons, trackers) must not kill the picker. Unknown (null) counts as
+  // subframe — worst case is falling back to the ready timeout.
+  bool _isMainFrame(WebResourceRequest request) => request.isForMainFrame == true;
+
+  void _handleLoadError(
+    InAppWebViewController controller,
+    WebResourceRequest request,
+    WebResourceError error,
+  ) {
+    if (!_isMainFrame(request)) return;
+    notifyPageLoadFailed(
+      DriveIntentPageLoadException('${error.type}: ${error.description}'),
+    );
+  }
+
+  void _handleHttpError(
+    InAppWebViewController controller,
+    WebResourceRequest request,
+    WebResourceResponse errorResponse,
+  ) {
+    if (!_isMainFrame(request)) return;
+    notifyPageLoadFailed(
+      DriveIntentPageLoadException('HTTP ${errorResponse.statusCode}'),
+    );
   }
 
   @override
@@ -97,18 +124,20 @@ class _DriveIntentWebViewModalState extends State<DriveIntentWebViewModal>
             );
             notifyPlatformViewReady();
           },
+          onReceivedError: _handleLoadError,
+          onReceivedHttpError: _handleHttpError,
         ),
       ),
     );
   }
 
   @override
-  void sendAck() {
+  Future<void> sendAck() async {
     // Embedded unquoted: JSON object syntax is valid JS object-literal syntax,
     // so `event.data` in the page ends up a real object, not a JSON string —
     // Drive's getFilePickerConfig never calls JSON.parse on it.
     final payload = jsonEncode(widget.filePickerConfig.toJson());
-    _webViewController?.evaluateJavascript(source: '''
+    await _webViewController?.evaluateJavascript(source: '''
       window.dispatchEvent(new MessageEvent('message', {
         data: $payload,
         origin: '$intentOrigin',

--- a/workplace/lib/presentation/view/drive_intent_web_view_modal_mobile.dart
+++ b/workplace/lib/presentation/view/drive_intent_web_view_modal_mobile.dart
@@ -17,15 +17,12 @@ class DriveIntentWebViewModal extends StatefulWidget {
   final DriveIntentLoader intentLoader;
   final WorkplaceFilePickerConfigRequest filePickerConfig;
   final DriveIntentImageAssets imageAssets;
-  // Ignored on mobile — only used by the web variant (ADR-93).
-  final OnRegisterExternalHandler? onRegisterExternalHandler;
 
   const DriveIntentWebViewModal({
     super.key,
     required this.intentLoader,
     required this.filePickerConfig,
     required this.imageAssets,
-    this.onRegisterExternalHandler,
   });
 
   @override

--- a/workplace/lib/presentation/view/drive_intent_web_view_modal_shell.dart
+++ b/workplace/lib/presentation/view/drive_intent_web_view_modal_shell.dart
@@ -2,9 +2,6 @@ import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 
-typedef DriveMessageHandler = void Function(String raw, String? origin);
-typedef OnRegisterExternalHandler = void Function(DriveMessageHandler handler);
-
 class DriveIntentWebViewModalShell extends StatelessWidget {
   final Widget child;
   final VoidCallback onClose;

--- a/workplace/lib/presentation/view/drive_intent_web_view_modal_web.dart
+++ b/workplace/lib/presentation/view/drive_intent_web_view_modal_web.dart
@@ -12,7 +12,7 @@ import 'package:workplace/presentation/view/drive_intent_skeleton_loader.dart';
 import 'package:workplace/presentation/view/drive_intent_web_view_modal_shell.dart';
 
 class DriveIntentWebViewModal extends StatefulWidget {
-  final Future<WorkplaceIntent> intentFuture;
+  final DriveIntentLoader intentLoader;
   final WorkplaceFilePickerConfigRequest filePickerConfig;
   final DriveIntentImageAssets imageAssets;
   // ADR-93: composer registers the window listener at composer-init time and
@@ -21,7 +21,7 @@ class DriveIntentWebViewModal extends StatefulWidget {
 
   const DriveIntentWebViewModal({
     super.key,
-    required this.intentFuture,
+    required this.intentLoader,
     required this.filePickerConfig,
     required this.imageAssets,
     this.onRegisterExternalHandler,
@@ -68,11 +68,14 @@ class _DriveIntentWebViewModalState extends State<DriveIntentWebViewModal>
       // the composer context).
       startWindowMessageListener(_forwardMessage);
     }
-    startLoading(widget.intentFuture);
+    startLoading(widget.intentLoader);
   }
 
   @override
-  void loadIntent(WorkplaceIntent intent) {
+  Future<void> loadIntent(WorkplaceIntent intent) async {
+    // No web equivalent of mobile's onReceivedError: cross-origin iframes
+    // expose no navigation-failure signal, and probing the URL first could
+    // false-close on CSP mismatches — readyTimeout is the only safe fallback.
     _iframeElement!.src = intent.intentUrl.toString();
   }
 
@@ -140,7 +143,7 @@ class _DriveIntentWebViewModalState extends State<DriveIntentWebViewModal>
   }
 
   @override
-  void sendAck() {
+  Future<void> sendAck() async {
     // data: URIs have opaque 'null' origin — postMessage requires '*' for those.
     final targetOrigin = intentOrigin == 'null' ? '*' : intentOrigin;
     // dart:html's postMessage structured-clones the Map into a real JS

--- a/workplace/lib/presentation/view/drive_intent_web_view_modal_web.dart
+++ b/workplace/lib/presentation/view/drive_intent_web_view_modal_web.dart
@@ -15,16 +15,12 @@ class DriveIntentWebViewModal extends StatefulWidget {
   final DriveIntentLoader intentLoader;
   final WorkplaceFilePickerConfigRequest filePickerConfig;
   final DriveIntentImageAssets imageAssets;
-  // ADR-93: composer registers the window listener at composer-init time and
-  // forwards messages here, so the handler is ready before the iframe loads.
-  final OnRegisterExternalHandler? onRegisterExternalHandler;
 
   const DriveIntentWebViewModal({
     super.key,
     required this.intentLoader,
     required this.filePickerConfig,
     required this.imageAssets,
-    this.onRegisterExternalHandler,
   });
 
   @override
@@ -59,15 +55,9 @@ class _DriveIntentWebViewModalState extends State<DriveIntentWebViewModal>
   @override
   void initState() {
     super.initState();
-    if (widget.onRegisterExternalHandler != null) {
-      // ADR-93: composer registered window listener at composer-init; it
-      // forwards raw messages here so we don't need our own window listener.
-      widget.onRegisterExternalHandler!(_forwardMessage);
-    } else {
-      // Fallback: modal owns its own window listener (e.g. when used outside
-      // the composer context).
-      startWindowMessageListener(_forwardMessage);
-    }
+    // The modal owns its listener: bound to its own lifetime, not the opener's
+    // (a context menu tile pops its route on tap and would tear it down early).
+    startWindowMessageListener(_forwardMessage);
     startLoading(widget.intentLoader);
   }
 
@@ -89,9 +79,8 @@ class _DriveIntentWebViewModalState extends State<DriveIntentWebViewModal>
 
   @override
   void dispose() {
-    // Guard against routes popped without going through the mixin's finish
-    // path (system back, parent nav, etc.) — onCleanup is idempotent so
-    // double-call is safe.
+    // Guards routes popped outside the finish path (system back, parent nav);
+    // onCleanup is idempotent.
     onCleanup();
     super.dispose();
   }

--- a/workplace/lib/presentation/widget/drive_attachment_context_menu_tile.dart
+++ b/workplace/lib/presentation/widget/drive_attachment_context_menu_tile.dart
@@ -1,12 +1,10 @@
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/theme_utils.dart';
-import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:workplace/l10n/workplace_localizations.dart';
 import 'package:workplace/presentation/mixin/drive_picker_state_mixin.dart';
-import 'package:workplace/presentation/mixin/web_window_message_mixin.dart';
 import 'package:workplace/presentation/model/drive_intent_image_assets.dart';
 
 class DriveAttachmentContextMenuTile extends StatefulWidget {
@@ -25,18 +23,12 @@ class DriveAttachmentContextMenuTile extends StatefulWidget {
 
   @override
   State<DriveAttachmentContextMenuTile> createState() =>
-      _DriveAttachmentContextMenuTileState.create();
+      _DriveAttachmentContextMenuTileState();
 }
 
-abstract class _DriveAttachmentContextMenuTileState
+class _DriveAttachmentContextMenuTileState
     extends State<DriveAttachmentContextMenuTile>
     with DrivePickerStateMixin<DriveAttachmentContextMenuTile> {
-  _DriveAttachmentContextMenuTileState();
-
-  factory _DriveAttachmentContextMenuTileState.create() => PlatformInfo.isWeb
-      ? _WebDriveAttachmentContextMenuTileState()
-      : _MobileDriveAttachmentContextMenuTileState();
-
   @override
   FetchDriveIntentCallback get pickerFetchIntent => widget.onFetchIntent;
 
@@ -78,11 +70,3 @@ abstract class _DriveAttachmentContextMenuTileState
     );
   }
 }
-
-class _MobileDriveAttachmentContextMenuTileState
-    extends _DriveAttachmentContextMenuTileState {}
-
-class _WebDriveAttachmentContextMenuTileState
-    extends _DriveAttachmentContextMenuTileState
-    with WebWindowMessageMixin<DriveAttachmentContextMenuTile>,
-         DrivePickerWebStateMixin<DriveAttachmentContextMenuTile> {}

--- a/workplace/lib/presentation/widget/drive_attachment_picker_button.dart
+++ b/workplace/lib/presentation/widget/drive_attachment_picker_button.dart
@@ -1,10 +1,8 @@
 import 'package:core/presentation/extensions/composer_toolbar_button_style.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
-import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 import 'package:workplace/presentation/mixin/drive_picker_state_mixin.dart';
-import 'package:workplace/presentation/mixin/web_window_message_mixin.dart';
 import 'package:workplace/presentation/model/drive_intent_image_assets.dart';
 
 class DriveAttachmentPickerButton extends StatefulWidget {
@@ -27,18 +25,12 @@ class DriveAttachmentPickerButton extends StatefulWidget {
 
   @override
   State<DriveAttachmentPickerButton> createState() =>
-      _DriveAttachmentPickerButtonState.create();
+      _DriveAttachmentPickerButtonState();
 }
 
-abstract class _DriveAttachmentPickerButtonState
+class _DriveAttachmentPickerButtonState
     extends State<DriveAttachmentPickerButton>
     with DrivePickerStateMixin<DriveAttachmentPickerButton> {
-  _DriveAttachmentPickerButtonState();
-
-  factory _DriveAttachmentPickerButtonState.create() => PlatformInfo.isWeb
-      ? _WebDriveAttachmentPickerButtonState()
-      : _MobileDriveAttachmentPickerButtonState();
-
   @override
   FetchDriveIntentCallback get pickerFetchIntent => widget.onFetchIntent;
 
@@ -67,11 +59,3 @@ abstract class _DriveAttachmentPickerButtonState
     );
   }
 }
-
-class _MobileDriveAttachmentPickerButtonState
-    extends _DriveAttachmentPickerButtonState {}
-
-class _WebDriveAttachmentPickerButtonState
-    extends _DriveAttachmentPickerButtonState
-    with WebWindowMessageMixin<DriveAttachmentPickerButton>,
-         DrivePickerWebStateMixin<DriveAttachmentPickerButton> {}

--- a/workplace/test/presentation/mixin/drive_intent_message_handler_mixin_test.dart
+++ b/workplace/test/presentation/mixin/drive_intent_message_handler_mixin_test.dart
@@ -348,13 +348,14 @@ Future<_TestState> _pumpOnPushedRoute(
 }
 
 void _finishContractTests() {
-  testWidgets('onCleanup throws → route still pops', (tester) async {
+  testWidgets('onCleanup throws → swallowed, onFinished still runs, route still pops', (tester) async {
     final state = await _pumpOnPushedRoute(tester);
     state.throwOnCleanup = true;
 
-    expect(state.cancel, throwsStateError);
+    state.cancel();
     await tester.pumpAndSettle();
 
+    expect(state.outcomes.single, isA<DrivePickOutcomeCancelled>());
     expect(find.byType(_TestWidget), findsNothing);
   });
 

--- a/workplace/test/presentation/mixin/drive_intent_message_handler_mixin_test.dart
+++ b/workplace/test/presentation/mixin/drive_intent_message_handler_mixin_test.dart
@@ -20,14 +20,32 @@ class _TestState extends State<_TestWidget> with DriveIntentMessageHandlerMixin 
   final List<String> ackCalls = [];
   final List<WorkplaceIntent> loadCalls = [];
   final List<DrivePickOutcome> outcomes = [];
+  bool throwOnAck = false;
+  bool failAckAsync = false;
+  bool throwOnLoad = false;
+  bool failLoadAsync = false;
+  bool throwOnCleanup = false;
 
   @override
-  void sendAck() {
+  Future<void> sendAck() {
+    if (throwOnAck) throw StateError('send ack failed');
+    if (failAckAsync) return Future.error(StateError('send ack failed async'));
     ackCalls.add('ack');
+    return Future.value();
   }
 
   @override
-  void loadIntent(WorkplaceIntent intent) => loadCalls.add(intent);
+  Future<void> loadIntent(WorkplaceIntent intent) {
+    if (throwOnLoad) throw StateError('load intent failed');
+    if (failLoadAsync) return Future.error(StateError('load intent failed async'));
+    loadCalls.add(intent);
+    return Future.value();
+  }
+
+  @override
+  void onCleanup() {
+    if (throwOnCleanup) throw StateError('cleanup failed');
+  }
 
   @override
   void onFinished(DrivePickOutcome outcome) => outcomes.add(outcome);
@@ -42,10 +60,14 @@ const _origin = 'https://drive.example.com';
 WorkplaceIntent _intent({String intentId = _intentId, String url = '$_origin/pick'}) =>
     WorkplaceIntent(intentId: intentId, intentUrl: Uri.parse(url));
 
-Future<_TestState> _buildAndApply(WidgetTester tester, {WorkplaceIntent? intent}) async {
+Future<_TestState> _pumpHarness(WidgetTester tester) async {
   await tester.pumpWidget(const MaterialApp(home: _TestWidget()));
-  final s = tester.state<_TestState>(find.byType(_TestWidget));
-  s.startLoading(Future.value(intent ?? _intent()));
+  return tester.state<_TestState>(find.byType(_TestWidget));
+}
+
+Future<_TestState> _buildAndApply(WidgetTester tester, {WorkplaceIntent? intent}) async {
+  final s = await _pumpHarness(tester);
+  s.startLoading(() => Future.value(intent ?? _intent()));
   await tester.pump();
   s.notifyPlatformViewReady();
   return s;
@@ -53,13 +75,33 @@ Future<_TestState> _buildAndApply(WidgetTester tester, {WorkplaceIntent? intent}
 
 String _encode(Map<String, dynamic> map) => jsonEncode(map);
 
-void _messageTypeTests() {
+void _handshakeMessageTests() {
   testWidgets('ready → sendAck called, no outcome yet, skeleton still shown', (tester) async {
     final state = await _buildAndApply(tester);
     state.onMessage(raw: _encode({'type': 'intent-$_intentId:ready'}), origin: _origin);
     expect(state.ackCalls, hasLength(1));
     expect(state.outcomes, isEmpty);
     expect(state.showSkeleton, isTrue);
+  });
+
+  testWidgets('sendAck throws → Failed outcome', (tester) async {
+    final state = await _buildAndApply(tester);
+    state.throwOnAck = true;
+    state.onMessage(raw: _encode({'type': 'intent-$_intentId:ready'}), origin: _origin);
+    await tester.pump();
+
+    expect(state.outcomes, hasLength(1));
+    expect(state.outcomes.single, isA<DrivePickOutcomeFailed>());
+  });
+
+  testWidgets('sendAck fails asynchronously → Failed outcome', (tester) async {
+    final state = await _buildAndApply(tester);
+    state.failAckAsync = true;
+    state.onMessage(raw: _encode({'type': 'intent-$_intentId:ready'}), origin: _origin);
+    await tester.pump();
+
+    expect(state.outcomes, hasLength(1));
+    expect(state.outcomes.single, isA<DrivePickOutcomeFailed>());
   });
 
   testWidgets('readyToUse → hides skeleton, no ack, no outcome', (tester) async {
@@ -69,7 +111,9 @@ void _messageTypeTests() {
     expect(state.outcomes, isEmpty);
     expect(state.showSkeleton, isFalse);
   });
+}
 
+void _terminalMessageTests() {
   testWidgets('done → Picked outcome with documents, no ack', (tester) async {
     final state = await _buildAndApply(tester);
     state.onMessage(
@@ -104,7 +148,9 @@ void _messageTypeTests() {
     expect(state.outcomes.single, isA<DrivePickOutcomeCancelled>());
     expect(state.ackCalls, isEmpty);
   });
+}
 
+void _invalidMessageTests() {
   testWidgets('malformed JSON → no crash, nothing dispatched', (tester) async {
     final state = await _buildAndApply(tester);
     state.onMessage(raw: '{not valid json{{', origin: _origin);
@@ -156,13 +202,12 @@ void _originFilterTests() {
 
 void _applyOrderingTests() {
   testWidgets('platform view ready before intent resolves — still applies once both are ready', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: _TestWidget()));
-    final state = tester.state<_TestState>(find.byType(_TestWidget));
+    final state = await _pumpHarness(tester);
     state.notifyPlatformViewReady();
     expect(state.loadCalls, isEmpty);
 
     final completer = Completer<WorkplaceIntent>();
-    state.startLoading(completer.future);
+    state.startLoading(() => completer.future);
     completer.complete(_intent());
     await tester.pump();
 
@@ -171,9 +216,8 @@ void _applyOrderingTests() {
   });
 
   testWidgets('intent resolves before platform view ready — applies once view is ready', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: _TestWidget()));
-    final state = tester.state<_TestState>(find.byType(_TestWidget));
-    state.startLoading(Future.value(_intent()));
+    final state = await _pumpHarness(tester);
+    state.startLoading(() => Future.value(_intent()));
     await tester.pump();
     expect(state.loadCalls, isEmpty);
 
@@ -182,15 +226,189 @@ void _applyOrderingTests() {
     state.cancelReadyTimeoutForTesting();
   });
 
+  testWidgets('message arriving before the intent is applied → dropped', (tester) async {
+    final state = await _pumpHarness(tester);
+    state.startLoading(() => Future.value(_intent()));
+    // Platform view never becomes ready — still in the waiting phase.
+    state.onMessage(raw: _encode({'type': 'intent-$_intentId:ready'}), origin: _origin);
+    await tester.pump();
+
+    expect(state.ackCalls, isEmpty);
+    expect(state.outcomes, isEmpty);
+    state.cancelReadyTimeoutForTesting();
+  });
+}
+
+void _intentLoadFailureTests() {
   testWidgets('intent fetch fails → Failed outcome, no load attempted', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: _TestWidget()));
-    final state = tester.state<_TestState>(find.byType(_TestWidget));
-    state.startLoading(Future.error(StateError('token exchange failed')));
+    final state = await _pumpHarness(tester);
+    state.startLoading(() => Future.error(StateError('token exchange failed')));
     await tester.pump();
 
     expect(state.loadCalls, isEmpty);
     expect(state.outcomes, hasLength(1));
     expect(state.outcomes.single, isA<DrivePickOutcomeFailed>());
+  });
+
+  testWidgets('intent loader throws synchronously → Failed outcome, no load attempted', (tester) async {
+    final state = await _pumpHarness(tester);
+    state.startLoading(() => throw StateError('token exchange failed'));
+    await tester.pump();
+
+    expect(state.loadCalls, isEmpty);
+    expect(state.outcomes, hasLength(1));
+    expect(state.outcomes.single, isA<DrivePickOutcomeFailed>());
+  });
+
+  testWidgets('loading the intent throws → Failed outcome', (tester) async {
+    final state = await _pumpHarness(tester);
+    state.throwOnLoad = true;
+    state.startLoading(() => Future.value(_intent()));
+    await tester.pump();
+    state.notifyPlatformViewReady();
+    await tester.pump();
+
+    expect(state.outcomes, hasLength(1));
+    expect(state.outcomes.single, isA<DrivePickOutcomeFailed>());
+  });
+
+  testWidgets('loading the intent fails asynchronously → Failed outcome', (tester) async {
+    final state = await _pumpHarness(tester);
+    state.failLoadAsync = true;
+    state.startLoading(() => Future.value(_intent()));
+    await tester.pump();
+    state.notifyPlatformViewReady();
+    await tester.pump();
+
+    expect(state.outcomes, hasLength(1));
+    expect(state.outcomes.single, isA<DrivePickOutcomeFailed>());
+  });
+}
+
+void _pageLoadFailureTests() {
+  testWidgets('notifyPageLoadFailed → Failed outcome without waiting for timeout', (tester) async {
+    final state = await _buildAndApply(tester);
+    state.notifyPageLoadFailed(DriveIntentPageLoadException('net::ERR_NAME_NOT_RESOLVED'));
+
+    expect(state.outcomes, hasLength(1));
+    final outcome = state.outcomes.single as DrivePickOutcomeFailed;
+    expect(outcome.error, isA<DriveIntentPageLoadException>());
+  });
+
+  testWidgets('page load failure before intent applied → ignored, modal stays', (tester) async {
+    final state = await _pumpHarness(tester);
+    state.startLoading(() => Future.value(_intent()));
+    // Platform view never becomes ready — still in the waiting phase; a
+    // WebView error here cannot be the Drive page (nothing was loaded yet).
+    state.notifyPageLoadFailed(DriveIntentPageLoadException('spurious init error'));
+
+    expect(state.outcomes, isEmpty);
+    expect(state.showSkeleton, isTrue);
+    state.cancelReadyTimeoutForTesting();
+  });
+
+  testWidgets('page load failure after interactive → ignored, picker keeps working', (tester) async {
+    final state = await _buildAndApply(tester);
+    state.onMessage(raw: _encode({'type': 'intent-$_intentId:readyToUse'}), origin: _origin);
+    state.notifyPageLoadFailed(DriveIntentPageLoadException('in-page navigation error'));
+
+    expect(state.outcomes, isEmpty);
+    expect(state.showSkeleton, isFalse);
+  });
+
+  testWidgets('notifyPageLoadFailed after finish → no second outcome', (tester) async {
+    final state = await _buildAndApply(tester);
+    state.onMessage(raw: _encode({'type': 'intent-$_intentId:cancel'}), origin: _origin);
+    state.notifyPageLoadFailed(DriveIntentPageLoadException('HTTP 500'));
+
+    expect(state.outcomes, hasLength(1));
+    expect(state.outcomes.single, isA<DrivePickOutcomeCancelled>());
+  });
+}
+
+Future<_TestState> _pumpOnPushedRoute(
+  WidgetTester tester, {
+  void Function(DrivePickOutcome?)? onResult,
+}) async {
+  await tester.pumpWidget(MaterialApp(
+    home: Builder(
+      builder: (context) => TextButton(
+        onPressed: () => Navigator.of(context)
+            .push<DrivePickOutcome>(
+              MaterialPageRoute(builder: (_) => const _TestWidget()),
+            )
+            .then((result) => onResult?.call(result)),
+        child: const Text('open'),
+      ),
+    ),
+  ));
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+  return tester.state<_TestState>(find.byType(_TestWidget));
+}
+
+void _finishContractTests() {
+  testWidgets('onCleanup throws → route still pops', (tester) async {
+    final state = await _pumpOnPushedRoute(tester);
+    state.throwOnCleanup = true;
+
+    expect(state.cancel, throwsStateError);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(_TestWidget), findsNothing);
+  });
+
+  testWidgets('finish pops the route with the outcome as dialog result', (tester) async {
+    DrivePickOutcome? result;
+    final state = await _pumpOnPushedRoute(tester, onResult: (r) => result = r);
+
+    state.cancel();
+    await tester.pumpAndSettle();
+
+    expect(result, const DrivePickOutcomeCancelled());
+  });
+}
+
+void _disposeRaceSafetyTests() {
+  testWidgets('intent resolves after dispose → no load, no outcome, no crash', (tester) async {
+    final state = await _pumpHarness(tester);
+    final completer = Completer<WorkplaceIntent>();
+    state.startLoading(() => completer.future);
+    state.notifyPlatformViewReady();
+    await tester.pumpWidget(const SizedBox.shrink());
+
+    completer.complete(_intent());
+    await tester.pump();
+
+    expect(state.loadCalls, isEmpty);
+    expect(state.outcomes, isEmpty);
+  });
+
+  testWidgets('intent fails after dispose → Failed outcome, no setState/pop crash', (tester) async {
+    final state = await _pumpHarness(tester);
+    final completer = Completer<WorkplaceIntent>();
+    state.startLoading(() => completer.future);
+    await tester.pumpWidget(const SizedBox.shrink());
+
+    completer.completeError(StateError('token exchange failed'));
+    await tester.pump();
+
+    expect(state.outcomes, hasLength(1));
+    expect(state.outcomes.single, isA<DrivePickOutcomeFailed>());
+  });
+
+  testWidgets('cancel while loader pending → later failure adds no second outcome', (tester) async {
+    final state = await _pumpHarness(tester);
+    final completer = Completer<WorkplaceIntent>();
+    state.startLoading(() => completer.future);
+    state.notifyPlatformViewReady();
+    state.cancel();
+
+    completer.completeError(StateError('token exchange failed'));
+    await tester.pump();
+
+    expect(state.outcomes, hasLength(1));
+    expect(state.outcomes.single, isA<DrivePickOutcomeCancelled>());
   });
 }
 
@@ -209,10 +427,10 @@ class _TimeoutTestState extends State<_TimeoutTestWidget>
   Duration get readyTimeout => const Duration(milliseconds: 50);
 
   @override
-  void sendAck() {}
+  Future<void> sendAck() => Future.value();
 
   @override
-  void loadIntent(WorkplaceIntent intent) {}
+  Future<void> loadIntent(WorkplaceIntent intent) => Future.value();
 
   @override
   void onFinished(DrivePickOutcome outcome) => outcomes.add(outcome);
@@ -225,7 +443,7 @@ void _readyTimeoutTests() {
   testWidgets('fires Failed(DriveIntentTimeoutException) if ready never arrives', (tester) async {
     await tester.pumpWidget(const MaterialApp(home: _TimeoutTestWidget()));
     final state = tester.state<_TimeoutTestState>(find.byType(_TimeoutTestWidget));
-    state.startLoading(Future.value(_intent()));
+    state.startLoading(() => Future.value(_intent()));
     await tester.pump();
     state.notifyPlatformViewReady();
 
@@ -239,7 +457,7 @@ void _readyTimeoutTests() {
   testWidgets('cancelled if readyToUse arrives before timeout', (tester) async {
     await tester.pumpWidget(const MaterialApp(home: _TimeoutTestWidget()));
     final state = tester.state<_TimeoutTestState>(find.byType(_TimeoutTestWidget));
-    state.startLoading(Future.value(_intent()));
+    state.startLoading(() => Future.value(_intent()));
     await tester.pump();
     state.notifyPlatformViewReady();
     state.onMessage(raw: _encode({'type': 'intent-$_intentId:ready'}), origin: _origin);
@@ -253,7 +471,7 @@ void _readyTimeoutTests() {
   testWidgets('fires Failed(DriveIntentTimeoutException) if readyToUse never arrives, even after ready', (tester) async {
     await tester.pumpWidget(const MaterialApp(home: _TimeoutTestWidget()));
     final state = tester.state<_TimeoutTestState>(find.byType(_TimeoutTestWidget));
-    state.startLoading(Future.value(_intent()));
+    state.startLoading(() => Future.value(_intent()));
     await tester.pump();
     state.notifyPlatformViewReady();
     state.onMessage(raw: _encode({'type': 'intent-$_intentId:ready'}), origin: _origin);
@@ -267,7 +485,7 @@ void _readyTimeoutTests() {
   testWidgets('fires Failed(DriveIntentTimeoutException) if platform view never becomes ready', (tester) async {
     await tester.pumpWidget(const MaterialApp(home: _TimeoutTestWidget()));
     final state = tester.state<_TimeoutTestState>(find.byType(_TimeoutTestWidget));
-    state.startLoading(Future.value(_intent()));
+    state.startLoading(() => Future.value(_intent()));
 
     await tester.pump(const Duration(milliseconds: 60));
 
@@ -278,10 +496,16 @@ void _readyTimeoutTests() {
 
 void main() {
   group('DriveIntentMessageHandlerMixin', () {
-    group('message types', _messageTypeTests);
+    group('handshake messages', _handshakeMessageTests);
+    group('terminal messages', _terminalMessageTests);
+    group('invalid messages', _invalidMessageTests);
     group('origin filtering', _originFilterTests);
     group('apply ordering (intent resolution vs platform view ready)', _applyOrderingTests);
+    group('intent load failures', _intentLoadFailureTests);
+    group('page load failure', _pageLoadFailureTests);
     group('ready timeout wiring', _readyTimeoutTests);
+    group('finish contract', _finishContractTests);
+    group('dispose race safety', _disposeRaceSafetyTests);
 
     group('multi-state isolation', () {
       testWidgets('two states with different intentIds — only matching state handles done', (tester) async {
@@ -292,8 +516,8 @@ void main() {
         final stateA = states[0];
         final stateB = states[1];
 
-        stateA.startLoading(Future.value(_intent(intentId: 'intent-a')));
-        stateB.startLoading(Future.value(_intent(intentId: 'intent-b')));
+        stateA.startLoading(() => Future.value(_intent(intentId: 'intent-a')));
+        stateB.startLoading(() => Future.value(_intent(intentId: 'intent-b')));
         await tester.pump();
         stateA.notifyPlatformViewReady();
         stateB.notifyPlatformViewReady();

--- a/workplace/test/presentation/mixin/drive_picker_state_mixin_test.dart
+++ b/workplace/test/presentation/mixin/drive_picker_state_mixin_test.dart
@@ -171,6 +171,41 @@ void main() {
         expect(state.openCalls, isEmpty);
         expect(state.pickStates, isEmpty);
       });
+
+      testWidgets('pick delivered even though the opener was disposed mid-flight', (tester) async {
+        final state = await _pumpPicker(tester);
+        final completer = Completer<DrivePickOutcome?>();
+        state.modalStub = () => completer.future;
+
+        final tap = state.onPickerTap();
+        await tester.pumpWidget(const SizedBox.shrink());
+        expect(state.mounted, isFalse, reason: 'sanity: opener really is gone');
+
+        completer.complete(DrivePickOutcomePicked([_doc()]));
+        await tap;
+
+        expect(state.pickStates, hasLength(1));
+        final result = state.pickStates.single as DrivePickResult;
+        expect(result.documents.single.id, 'doc1');
+      });
+
+      // Pins the up-front capture of the toast text: localizations need a live
+      // context, so reading them after the await would lose the message.
+      testWidgets('failure after opener disposal keeps the localized message', (tester) async {
+        final state = await _pumpPicker(tester);
+        final completer = Completer<DrivePickOutcome?>();
+        state.modalStub = () => completer.future;
+
+        final tap = state.onPickerTap();
+        await tester.pumpWidget(const SizedBox.shrink());
+
+        completer.complete(DrivePickOutcomeFailed(StateError('intent failed')));
+        await tap;
+
+        expect(state.pickStates, hasLength(1));
+        final failure = state.pickStates.single as DrivePickFailure;
+        expect(failure.message, isNotNull);
+      });
     });
   });
 }

--- a/workplace/test/presentation/mixin/drive_picker_state_mixin_test.dart
+++ b/workplace/test/presentation/mixin/drive_picker_state_mixin_test.dart
@@ -7,6 +7,7 @@ import 'package:workplace/domain/entity/drive_document.dart';
 import 'package:workplace/domain/entity/workplace_intent.dart';
 import 'package:workplace/l10n/workplace_localizations.dart';
 import 'package:workplace/presentation/mixin/drive_picker_state_mixin.dart';
+import 'package:workplace/presentation/model/drive_intent_image_assets.dart';
 import 'package:workplace/presentation/model/drive_pick_outcome.dart';
 import 'package:workplace/presentation/model/drive_pick_state.dart';
 
@@ -25,10 +26,6 @@ class _TestState extends State<_TestWidget>
   final List<DrivePickState> pickStates = [];
   final List<WorkplaceFilePickerConfigRequest> openCalls = [];
   _ModalStub modalStub = () => Future.value();
-  int clearHandlerCalls = 0;
-
-  @override
-  void clearExternalHandler() => clearHandlerCalls++;
 
   @override
   FetchDriveIntentCallback get pickerFetchIntent =>
@@ -39,6 +36,10 @@ class _TestState extends State<_TestWidget>
 
   @override
   OnPickDriveCallback? get pickerOnCallback => pickStates.add;
+
+  @override
+  DriveIntentImageAssets get driveIntentImageAssets =>
+      const DriveIntentImageAssets(driveLogo: '', closeIcon: '', searchIcon: '');
 
   @override
   Future<DrivePickOutcome?> openDrivePickerModal(
@@ -159,15 +160,6 @@ void main() {
         await state.onPickerTap();
 
         expect(state.openCalls, hasLength(2));
-      });
-
-      testWidgets('external handler cleared even when modal fails', (tester) async {
-        final state = await _pumpPicker(tester);
-        state.modalStub = () => Future.error(StateError('modal crashed'));
-
-        await state.onPickerTap();
-
-        expect(state.clearHandlerCalls, 1);
       });
 
       testWidgets('tap after state disposed → no modal, no callback, no crash', (tester) async {

--- a/workplace/test/presentation/mixin/drive_picker_state_mixin_test.dart
+++ b/workplace/test/presentation/mixin/drive_picker_state_mixin_test.dart
@@ -1,0 +1,184 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:workplace/data/model/workplace_intent_request.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+import 'package:workplace/domain/entity/workplace_intent.dart';
+import 'package:workplace/l10n/workplace_localizations.dart';
+import 'package:workplace/presentation/mixin/drive_picker_state_mixin.dart';
+import 'package:workplace/presentation/model/drive_pick_outcome.dart';
+import 'package:workplace/presentation/model/drive_pick_state.dart';
+
+typedef _ModalStub = Future<DrivePickOutcome?> Function();
+
+// Harness overriding the modal seam — no real WebView/iframe is pumped.
+class _TestWidget extends StatefulWidget {
+  const _TestWidget();
+
+  @override
+  _TestState createState() => _TestState();
+}
+
+class _TestState extends State<_TestWidget>
+    with DrivePickerStateMixin<_TestWidget> {
+  final List<DrivePickState> pickStates = [];
+  final List<WorkplaceFilePickerConfigRequest> openCalls = [];
+  _ModalStub modalStub = () => Future.value();
+  int clearHandlerCalls = 0;
+
+  @override
+  void clearExternalHandler() => clearHandlerCalls++;
+
+  @override
+  FetchDriveIntentCallback get pickerFetchIntent =>
+      ({required filePickerConfig}) async => WorkplaceIntent(
+            intentId: 'intent-1',
+            intentUrl: Uri.parse('https://drive.example.com/pick'),
+          );
+
+  @override
+  OnPickDriveCallback? get pickerOnCallback => pickStates.add;
+
+  @override
+  Future<DrivePickOutcome?> openDrivePickerModal(
+    WorkplaceFilePickerConfigRequest filePickerConfig,
+  ) {
+    openCalls.add(filePickerConfig);
+    return modalStub();
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+Future<_TestState> _pumpPicker(WidgetTester tester) async {
+  await tester.pumpWidget(const MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: _TestWidget(),
+  ));
+  return tester.state<_TestState>(find.byType(_TestWidget));
+}
+
+DriveDocument _doc() => const DriveDocument(
+      id: 'doc1',
+      name: 'file.pdf',
+      size: 512,
+      mimeType: 'application/pdf',
+    );
+
+void main() {
+  group('DrivePickerStateMixin', () {
+    group('outcome dispatch', () {
+      testWidgets('Picked → DrivePickResult with documents', (tester) async {
+        final state = await _pumpPicker(tester);
+        state.modalStub = () => Future.value(DrivePickOutcomePicked([_doc()]));
+
+        await state.onPickerTap();
+
+        expect(state.pickStates, hasLength(1));
+        final result = state.pickStates.single as DrivePickResult;
+        expect(result.documents.single.id, 'doc1');
+      });
+
+      testWidgets('Failed → DrivePickFailure with error and message', (tester) async {
+        final state = await _pumpPicker(tester);
+        final error = StateError('token exchange failed');
+        state.modalStub = () => Future.value(DrivePickOutcomeFailed(error));
+
+        await state.onPickerTap();
+
+        expect(state.pickStates, hasLength(1));
+        final failure = state.pickStates.single as DrivePickFailure;
+        expect(failure.error, same(error));
+        expect(failure.message, isNotNull);
+      });
+
+      testWidgets('Cancelled → no callback', (tester) async {
+        final state = await _pumpPicker(tester);
+        state.modalStub = () => Future.value(const DrivePickOutcomeCancelled());
+
+        await state.onPickerTap();
+
+        expect(state.pickStates, isEmpty);
+      });
+
+      testWidgets('null outcome (route popped externally) → no callback', (tester) async {
+        final state = await _pumpPicker(tester);
+        state.modalStub = () => Future.value(null);
+
+        await state.onPickerTap();
+
+        expect(state.pickStates, isEmpty);
+      });
+
+      testWidgets('modal future fails → DrivePickFailure with the thrown error', (tester) async {
+        final state = await _pumpPicker(tester);
+        final error = StateError('showDialog failed');
+        state.modalStub = () => Future.error(error);
+
+        await state.onPickerTap();
+
+        expect(state.pickStates, hasLength(1));
+        final failure = state.pickStates.single as DrivePickFailure;
+        expect(failure.error, same(error));
+      });
+    });
+
+    group('re-entrancy and lifecycle', () {
+      testWidgets('second tap while modal is open → ignored', (tester) async {
+        final state = await _pumpPicker(tester);
+        final completer = Completer<DrivePickOutcome?>();
+        state.modalStub = () => completer.future;
+
+        final firstTap = state.onPickerTap();
+        await state.onPickerTap();
+        expect(state.openCalls, hasLength(1));
+
+        completer.complete(const DrivePickOutcomeCancelled());
+        await firstTap;
+      });
+
+      testWidgets('tap allowed again after previous modal closed', (tester) async {
+        final state = await _pumpPicker(tester);
+        state.modalStub = () => Future.value(const DrivePickOutcomeCancelled());
+
+        await state.onPickerTap();
+        await state.onPickerTap();
+
+        expect(state.openCalls, hasLength(2));
+      });
+
+      testWidgets('tap allowed again after modal failure', (tester) async {
+        final state = await _pumpPicker(tester);
+        state.modalStub = () => Future.error(StateError('modal crashed'));
+        await state.onPickerTap();
+
+        state.modalStub = () => Future.value(const DrivePickOutcomeCancelled());
+        await state.onPickerTap();
+
+        expect(state.openCalls, hasLength(2));
+      });
+
+      testWidgets('external handler cleared even when modal fails', (tester) async {
+        final state = await _pumpPicker(tester);
+        state.modalStub = () => Future.error(StateError('modal crashed'));
+
+        await state.onPickerTap();
+
+        expect(state.clearHandlerCalls, 1);
+      });
+
+      testWidgets('tap after state disposed → no modal, no callback, no crash', (tester) async {
+        final state = await _pumpPicker(tester);
+        await tester.pumpWidget(const SizedBox.shrink());
+
+        await state.onPickerTap();
+
+        expect(state.openCalls, isEmpty);
+        expect(state.pickStates, isEmpty);
+      });
+    });
+  });
+}

--- a/workplace/test/presentation/mixin/drive_picker_web_message_listener_lifecycle_test.dart
+++ b/workplace/test/presentation/mixin/drive_picker_web_message_listener_lifecycle_test.dart
@@ -1,0 +1,389 @@
+import 'dart:convert';
+
+import 'package:core/utils/platform_info.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:universal_html/html.dart' as html;
+import 'package:workplace/data/model/workplace_intent_request.dart';
+import 'package:workplace/domain/entity/workplace_intent.dart';
+import 'package:workplace/l10n/workplace_localizations.dart';
+import 'package:workplace/presentation/mixin/drive_intent_message_handler_mixin.dart';
+import 'package:workplace/presentation/mixin/drive_picker_state_mixin.dart';
+import 'package:workplace/presentation/mixin/web_window_message_mixin.dart';
+import 'package:workplace/presentation/model/drive_intent_image_assets.dart';
+import 'package:workplace/presentation/model/drive_pick_outcome.dart';
+
+// Exercises the real `window.postMessage` transport (other tests call
+// onMessage directly). Contract: the modal owns its listener for its own
+// lifetime and must not depend on the opener's — the context-menu tile pops
+// its route on tap and disposes before the handshake arrives.
+//
+// universal_html gives the VM an in-memory DOM, so dispatchEvent reaches
+// addEventListener under `flutter test`. The real web modal can't be pumped
+// (HtmlIframeWidget needs a browser), so these harnesses mirror its wiring.
+
+const _origin = 'https://drive.example.com';
+const _intentId = 'intent-1';
+
+WorkplaceIntent _intent() => WorkplaceIntent(
+      intentId: _intentId,
+      intentUrl: Uri.parse('$_origin/pick'),
+    );
+
+Future<WorkplaceIntent> _fetchIntentStub({
+  required WorkplaceFilePickerConfigRequest filePickerConfig,
+}) async =>
+    _intent();
+
+/// Mimics the Drive iframe calling `parent.postMessage(...)`.
+void _driveIframePosts(String type, {String origin = _origin}) {
+  html.window.dispatchEvent(html.MessageEvent(
+    'message',
+    data: jsonEncode({'type': 'intent-$_intentId:$type'}),
+    origin: origin,
+  ));
+}
+
+Widget _app(Widget home) => MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: home,
+    );
+
+// ---------------------------------------------------------------------------
+// Group A — WebWindowMessageMixin: the start/stop primitive.
+// ---------------------------------------------------------------------------
+
+class _ListenerProbe extends StatefulWidget {
+  final List<String> received;
+  const _ListenerProbe(this.received);
+
+  @override
+  State<_ListenerProbe> createState() => _ListenerProbeState();
+}
+
+class _ListenerProbeState extends State<_ListenerProbe>
+    with WebWindowMessageMixin<_ListenerProbe> {
+  @override
+  void initState() {
+    super.initState();
+    startWindowMessageListener((raw, _) => widget.received.add(raw));
+  }
+
+  @override
+  void dispose() {
+    stopWindowMessageListener();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+void _listenerPrimitiveTests() {
+  testWidgets('registers a window listener on initState', (tester) async {
+    final received = <String>[];
+    await tester.pumpWidget(_app(_ListenerProbe(received)));
+
+    _driveIframePosts('ready');
+
+    expect(received, hasLength(1));
+  });
+
+  testWidgets('removes the window listener on dispose', (tester) async {
+    final received = <String>[];
+    await tester.pumpWidget(_app(_ListenerProbe(received)));
+    await tester.pumpWidget(_app(const SizedBox.shrink()));
+
+    _driveIframePosts('ready');
+
+    expect(received, isEmpty);
+  });
+
+  testWidgets('a disposed listener does not block a later one', (tester) async {
+    final first = <String>[];
+    await tester.pumpWidget(_app(_ListenerProbe(first)));
+    await tester.pumpWidget(_app(const SizedBox.shrink()));
+
+    final second = <String>[];
+    await tester.pumpWidget(_app(_ListenerProbe(second)));
+    _driveIframePosts('ready');
+
+    expect(first, isEmpty);
+    expect(second, hasLength(1));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Group B & C harnesses — a stand-in for the web modal that owns its listener.
+// Same initState/onCleanup wiring as DriveIntentWebViewModal (web), minus the
+// iframe platform view, which is unavailable on the VM.
+// ---------------------------------------------------------------------------
+
+class _DriveModalUnderTest extends StatefulWidget {
+  const _DriveModalUnderTest();
+
+  @override
+  State<_DriveModalUnderTest> createState() => _DriveModalUnderTestState();
+}
+
+class _DriveModalUnderTestState extends State<_DriveModalUnderTest>
+    with
+        DriveIntentMessageHandlerMixin<_DriveModalUnderTest>,
+        WebWindowMessageMixin<_DriveModalUnderTest> {
+  final List<DrivePickOutcome> outcomes = [];
+  final List<String> ackCalls = [];
+  // Records forwarded messages, so a listener leaked after close is observable
+  // independently of the phase-closed guard.
+  final List<String> forwarded = [];
+
+  // Fast, but clear of the dialog's entry animation so pumpAndSettle can't
+  // burn the deadline (production is 20s).
+  @override
+  Duration get readyTimeout => const Duration(seconds: 5);
+
+  @override
+  void initState() {
+    super.initState();
+    startWindowMessageListener(_forwardMessage);
+    startLoading(() async => _intent());
+    // Stands in for HtmlIframeWidget.onIframeCreated.
+    notifyPlatformViewReady();
+  }
+
+  void _forwardMessage(String raw, String? origin) {
+    forwarded.add(raw);
+    onMessage(raw: raw, origin: origin);
+  }
+
+  @override
+  Future<void> loadIntent(WorkplaceIntent intent) async {}
+
+  @override
+  Future<void> sendAck() async => ackCalls.add('ack');
+
+  @override
+  void onCleanup() => stopWindowMessageListener();
+
+  @override
+  void onFinished(DrivePickOutcome outcome) => outcomes.add(outcome);
+
+  @override
+  void dispose() {
+    onCleanup();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => Text(
+        showSkeleton ? 'skeleton' : 'drive-picker',
+        textDirection: TextDirection.ltr,
+      );
+}
+
+Future<_DriveModalUnderTestState> _openModalInDialog(WidgetTester tester) async {
+  late BuildContext hostContext;
+  await tester.pumpWidget(_app(Builder(builder: (ctx) {
+    hostContext = ctx;
+    return const Scaffold();
+  })));
+
+  showDialog<DrivePickOutcome>(
+    context: hostContext,
+    barrierDismissible: false,
+    builder: (_) => const _DriveModalUnderTest(),
+  );
+  await tester.pumpAndSettle();
+
+  return tester.state<_DriveModalUnderTestState>(
+    find.byType(_DriveModalUnderTest),
+  );
+}
+
+void _modalOwnsListenerTests() {
+  testWidgets('while open, a window message drives the handshake', (tester) async {
+    final modal = await _openModalInDialog(tester);
+
+    _driveIframePosts('ready');
+    _driveIframePosts('readyToUse');
+    await tester.pump();
+
+    expect(modal.ackCalls, hasLength(1));
+    expect(modal.showSkeleton, isFalse);
+    expect(find.text('drive-picker'), findsOneWidget);
+  });
+
+  testWidgets('a message is delivered once, not once per live listener',
+      (tester) async {
+    final modal = await _openModalInDialog(tester);
+
+    _driveIframePosts('ready');
+    await tester.pump();
+
+    expect(modal.ackCalls, hasLength(1));
+  });
+
+  testWidgets('the modal detaches its window listener when it closes',
+      (tester) async {
+    final modal = await _openModalInDialog(tester);
+    _driveIframePosts('ready');
+    expect(modal.forwarded, hasLength(1), reason: 'sanity: live while open');
+
+    modal.cancel();
+    await tester.pumpAndSettle();
+    expect(find.byType(_DriveModalUnderTest), findsNothing);
+
+    final beforeCount = modal.forwarded.length;
+    _driveIframePosts('readyToUse');
+
+    expect(
+      modal.forwarded,
+      hasLength(beforeCount),
+      reason: 'a closed modal must not keep a live window listener',
+    );
+  });
+
+  testWidgets('no handshake → the modal times out (timeout wiring intact)',
+      (tester) async {
+    final modal = await _openModalInDialog(tester);
+
+    await tester.pump(const Duration(seconds: 6));
+
+    expect(modal.outcomes, hasLength(1));
+    expect(modal.outcomes.single, isA<DrivePickOutcomeFailed>());
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Group C — end-to-end via the attachment context menu. This is the
+// regression: the tile pops its own route on tap, so if the modal ever leaned
+// on the tile's listener the handshake would be lost and the pick would fail.
+// ---------------------------------------------------------------------------
+
+/// Same shape as the real context-menu tile state: pops its own route in
+/// onTap, then opens the picker modal.
+class _MenuTileUnderTest extends StatefulWidget {
+  const _MenuTileUnderTest();
+
+  @override
+  State<_MenuTileUnderTest> createState() => _MenuTileUnderTestState();
+}
+
+class _MenuTileUnderTestState extends State<_MenuTileUnderTest>
+    with DrivePickerStateMixin<_MenuTileUnderTest> {
+  @override
+  FetchDriveIntentCallback get pickerFetchIntent => _fetchIntentStub;
+
+  @override
+  DriveIntentImageAssets get driveIntentImageAssets =>
+      const DriveIntentImageAssets(driveLogo: '', closeIcon: '', searchIcon: '');
+
+  @override
+  Future<DrivePickOutcome?> openDrivePickerModal(
+    WorkplaceFilePickerConfigRequest filePickerConfig,
+  ) {
+    return showDialog<DrivePickOutcome>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => const _DriveModalUnderTest(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) => ListTile(
+        title: const Text('Attach from Drive'),
+        onTap: () {
+          Navigator.pop(context);
+          onPickerTap();
+        },
+      );
+}
+
+Future<_DriveModalUnderTestState> _openPickerFromContextMenu(
+  WidgetTester tester,
+) async {
+  late BuildContext hostContext;
+  await tester.pumpWidget(_app(Builder(builder: (ctx) {
+    hostContext = ctx;
+    return const Scaffold();
+  })));
+
+  showModalBottomSheet<void>(
+    context: hostContext,
+    builder: (_) => const _MenuTileUnderTest(),
+  );
+  await tester.pumpAndSettle();
+
+  await tester.tap(find.text('Attach from Drive'));
+  await tester.pumpAndSettle();
+
+  return tester.state<_DriveModalUnderTestState>(
+    find.byType(_DriveModalUnderTest),
+  );
+}
+
+void _contextMenuEndToEndTests() {
+  testWidgets(
+    'after the tile pops its route, the Drive handshake still reaches the '
+    'modal — skeleton hides, no timeout',
+    (tester) async {
+      final modal = await _openPickerFromContextMenu(tester);
+      expect(find.byType(_MenuTileUnderTest), findsNothing,
+          reason: 'the tile route was popped before the modal opened');
+
+      _driveIframePosts('ready');
+      _driveIframePosts('readyToUse');
+      await tester.pump();
+
+      expect(modal.ackCalls, hasLength(1));
+      expect(modal.showSkeleton, isFalse);
+
+      await tester.pump(const Duration(seconds: 6));
+      expect(modal.outcomes, isEmpty);
+    },
+  );
+
+  testWidgets('a "done" pick from the context-menu flow resolves as Picked',
+      (tester) async {
+    final modal = await _openPickerFromContextMenu(tester);
+
+    // Handshake over the real window transport proves the listener reaches the
+    // modal after the tile is gone.
+    _driveIframePosts('ready');
+    await tester.pump();
+    expect(modal.ackCalls, hasLength(1));
+
+    // Terminal `done` goes via onMessage, not dispatchEvent: on the VM,
+    // universal_html throws ConcurrentModificationError when onCleanup removes
+    // the listener mid-dispatch (real browsers allow this).
+    modal.onMessage(
+      raw: jsonEncode({
+        'type': 'intent-$_intentId:done',
+        'document': [
+          {
+            'id': 'doc1',
+            'name': 'file.pdf',
+            'size': 512,
+            'mimeType': 'application/pdf',
+          }
+        ],
+      }),
+      origin: _origin,
+    );
+    await tester.pumpAndSettle();
+
+    expect(modal.outcomes, hasLength(1));
+    expect(modal.outcomes.single, isA<DrivePickOutcomePicked>());
+  });
+}
+
+void main() {
+  setUp(() => PlatformInfo.isTestingForWeb = true);
+  tearDown(() => PlatformInfo.isTestingForWeb = false);
+
+  group('Drive picker web message-listener lifecycle', () {
+    group('listener primitive', _listenerPrimitiveTests);
+    group('modal owns its listener', _modalOwnsListenerTests);
+    group('context-menu end to end', _contextMenuEndToEndTests);
+  });
+}


### PR DESCRIPTION
## Context

"Attach from Drive" opens a modal with a skeleton loader while the application exchanges the OIDC token, creates a Workplace intent, and loads the Drive picker page into a WebView or iframe. On staging, the CORS preflight for `POST /auth/token_exchange` returns 403, but the modal keeps showing the skeleton for the full 20-second `readyTimeout` before displaying the error toast instead of failing immediately.

https://github.com/user-attachments/assets/a38dbdce-3813-48f4-b489-9df4033c4855




## Root cause

The intent `Future` was created **before** the modal was mounted, while the modal attached its failure handler later in `initState`. A CORS preflight rejection can fail almost immediately, so the `Future` completed with an error before the modal started observing it. The error was reported as an **uncaught zone error**, the modal's cleanup path (`_finish`) never ran, and the 20-second timeout became the only remaining exit.

```mermaid
sequenceDiagram
    participant User
    participant Picker as onPickerTap
    participant TokenX as token_exchange
    participant Modal

    User->>Picker: tap "Attach from Drive"
    Picker->>TokenX: create intentFuture (eager)
    TokenX--xPicker: CORS 403 (instant)
    Note over Picker: no handler attached yet → uncaught error
    Picker->>Modal: showDialog (next frame)
    Modal->>Modal: attach .catchError — too late
    Note over Modal: skeleton shown… readyTimeout fires after 20s
```

The audit found the same "error with no handler → wait for timeout" pattern in three additional mobile failure paths: WebView page-load failures were not observed, and rejected futures from `loadUrl` and `evaluateJavascript` escaped synchronous error handling.

## Solution

Every observable failure between the button tap and the interactive picker now reaches a single funnel that records the failing stage, exception, and stack trace in Sentry before closing the modal immediately.

```mermaid
flowchart LR
    A[intent loader] --> F
    B[loadIntent into platform view] --> F
    C[main-frame page load error] --> F
    D[ack / message handling] --> F
    E[ready timeout - last resort] --> F
    F[_failWith: Sentry log + close modal + error toast]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Drive picker reliability by lazily loading intents and standardizing modal failure handling across lifecycle/handshake stages.
  * Prevented modal hangs/crashes from failing cleanup/finish hooks and handled async acknowledgement failures.
  * Treats only main-frame web page-load errors as fatal while ignoring subframe noise; tightened “ready” timeout behavior.
* **New Features**
  * Page-load failures now include a specific reason for easier diagnosis.
* **Refactor**
  * Simplified attachment picker/context-menu widgets by consolidating mobile/web state handling.
* **Tests**
  * Expanded async failure-mode, lifecycle, and real window message transport coverage for the picker flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->