### PR TITLE
TF-4738 Fix response view while drive picker loading display prevent drive picker

### DIFF
--- a/.github/workflows/analyze-test.yaml
+++ b/.github/workflows/analyze-test.yaml
@@ -16,6 +16,7 @@ env:
   CHROME_TEST_PATHS: |
     core/test/data/network/download/download_manager_test.dart
     workplace/test/presentation/mixin/web_window_message_mixin_web_test.dart
+    workplace/test/presentation/view/drive_intent_web_view_modal_web_test.dart
 
 jobs:
   analyze-test:

--- a/.github/workflows/analyze-test.yaml
+++ b/.github/workflows/analyze-test.yaml
@@ -15,6 +15,7 @@ env:
   # "core"). Add more lines here as needed.
   CHROME_TEST_PATHS: |
     core/test/data/network/download/download_manager_test.dart
+    workplace/test/presentation/mixin/web_window_message_mixin_web_test.dart
 
 jobs:
   analyze-test:

--- a/workplace/lib/presentation/mixin/drive_intent_message_handler_mixin.dart
+++ b/workplace/lib/presentation/mixin/drive_intent_message_handler_mixin.dart
@@ -42,8 +42,7 @@ mixin DriveIntentMessageHandlerMixin<T extends StatefulWidget> on State<T> {
   void startLoading(DriveIntentLoader intentLoader) {
     // Starts the deadline immediately so a platform view that never becomes
     // ready (e.g. WebView/iframe init silently failing) still times out.
-    _readyTimeoutTimer?.cancel();
-    _readyTimeoutTimer = Timer(readyTimeout, _handleReadyTimeout);
+    _restartReadyTimeout();
     unawaited(_loadIntent(intentLoader));
   }
 
@@ -69,8 +68,22 @@ mixin DriveIntentMessageHandlerMixin<T extends StatefulWidget> on State<T> {
     _finish(DrivePickOutcomeFailed(error));
   }
 
-  void notifyPlatformViewReady() {
+  void _restartReadyTimeout() {
+    _readyTimeoutTimer?.cancel();
+    _readyTimeoutTimer = Timer(readyTimeout, _handleReadyTimeout);
+  }
+
+  void notifyPlatformViewReady({bool viewRecreated = false}) {
     _platformViewReady = true;
+    if (viewRecreated && _phase == _Phase.loadingPage) {
+      final intent = _resolvedIntent;
+      if (intent != null) {
+        // A replacement iframe needs the resolved URL and a fresh deadline.
+        _restartReadyTimeout();
+        unawaited(_applyIntent(intent));
+      }
+      return;
+    }
     _tryApplyIntent();
   }
 

--- a/workplace/lib/presentation/view/drive_intent_skeleton_loader.dart
+++ b/workplace/lib/presentation/view/drive_intent_skeleton_loader.dart
@@ -32,7 +32,20 @@ class DriveIntentSkeletonLoader extends StatelessWidget {
         color: Colors.white,
         borderRadius: BorderRadius.all(Radius.circular(6)),
       ),
-      child: mobile ? _buildMobile(context) : _buildWeb(),
+      // Table layout has no close slot (#4738).
+      child: mobile
+          ? _buildMobile(context)
+          : Stack(
+              children: [
+                Positioned.fill(child: _buildWeb()),
+                if (closeButton != null)
+                  Positioned(
+                    top: 12,
+                    right: 17,
+                    child: closeButton!,
+                  ),
+              ],
+            ),
     );
   }
 

--- a/workplace/lib/presentation/view/drive_intent_web_view_modal_shell.dart
+++ b/workplace/lib/presentation/view/drive_intent_web_view_modal_shell.dart
@@ -35,42 +35,51 @@ class DriveIntentWebViewModalShell extends StatelessWidget {
   Widget build(BuildContext context) {
     final closeButton = TMailButtonWidget.fromIcon(
       icon: closeIconPath,
+      width: 40,
+      height: 40,
+      iconSize: 24,
       iconColor: const Color(0xFF424244).withValues(alpha: 0.64),
-      padding: const EdgeInsets.all(12),
+      padding: const EdgeInsets.all(8),
       backgroundColor: Colors.transparent,
-      hoverColor: Colors.transparent,
+      hoverColor: const Color(0x14424244),
       onTapActionCallback: onClose,
     );
-    return PointerInterceptor(
-      child: GestureDetector(
-        onTap: onBarrierTap ?? onClose,
-        behavior: HitTestBehavior.opaque,
-        child: Dialog(
-          backgroundColor: Colors.white,
-          insetPadding: insetPadding,
-          shape: shape,
-          constraints: constraints,
-          alignment: alignment,
-          child: GestureDetector(
-            onTap: () {},
-            behavior: HitTestBehavior.opaque,
-            child: Stack(
-              children: [
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  children: [
-                    if (haveCloseButton)
-                      Padding(
-                        padding: const EdgeInsetsGeometry.directional(end: 17),
-                        child: closeButton,
-                      ),
-                    Expanded(child: child),
-                  ],
+    return GestureDetector(
+      onTap: onBarrierTap ?? onClose,
+      behavior: HitTestBehavior.opaque,
+      child: Dialog(
+        backgroundColor: Colors.white,
+        insetPadding: insetPadding,
+        shape: shape,
+        constraints: constraints,
+        alignment: alignment,
+        child: GestureDetector(
+          onTap: () {},
+          behavior: HitTestBehavior.opaque,
+          child: Stack(
+            children: [
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  if (haveCloseButton)
+                    Padding(
+                      padding: const EdgeInsetsGeometry.directional(end: 17),
+                      child: closeButton,
+                    ),
+                  // Keep the iframe mounted across responsive changes (#4738).
+                  Expanded(
+                    key: const ValueKey('drive-shell-content'),
+                    child: child,
+                  ),
+                ],
+              ),
+              if (loadingWidget != null)
+                Positioned.fill(
+                  child: PointerInterceptor(
+                    child: loadingWidget!(closeButton),
+                  ),
                 ),
-                if (loadingWidget != null)
-                  Positioned.fill(child: loadingWidget!(closeButton)),
-              ],
-            ),
+            ],
           ),
         ),
       ),

--- a/workplace/lib/presentation/view/drive_intent_web_view_modal_web.dart
+++ b/workplace/lib/presentation/view/drive_intent_web_view_modal_web.dart
@@ -2,6 +2,7 @@ import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/presentation/views/html_viewer/html_iframe_widget.dart';
 import 'package:flutter/material.dart';
+import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:universal_html/html.dart' as html;
 import 'package:workplace/data/model/workplace_intent_request.dart';
 import 'package:workplace/domain/entity/workplace_intent.dart';
@@ -38,13 +39,14 @@ class _DriveIntentWebViewModalState extends State<DriveIntentWebViewModal>
   }
 
   Widget _loadingWidget({
-    required bool show,
     required bool wideScreen,
     TMailButtonWidget? closeButton,
   }) {
-    if (!show) return const SizedBox();
     if (wideScreen) {
-      return DriveIntentSkeletonLoader.table(imageAssets: widget.imageAssets);
+      return DriveIntentSkeletonLoader.table(
+        imageAssets: widget.imageAssets,
+        closeButton: closeButton,
+      );
     }
     return DriveIntentSkeletonLoader.list(
       imageAssets: widget.imageAssets,
@@ -57,6 +59,7 @@ class _DriveIntentWebViewModalState extends State<DriveIntentWebViewModal>
     super.initState();
     // The modal owns its listener: bound to its own lifetime, not the opener's
     // (a context menu tile pops its route on tap and would tear it down early).
+    // Registered before the iframe can post its first ready message.
     startWindowMessageListener(_forwardMessage);
     startLoading(widget.intentLoader);
   }
@@ -107,28 +110,37 @@ class _DriveIntentWebViewModalState extends State<DriveIntentWebViewModal>
       onBarrierTap: () {
         if (!showSkeleton) cancel();
       },
-      loadingWidget: (closeButton) => _loadingWidget(
-        show: showSkeleton,
-        wideScreen: isWideScreen,
-        closeButton: closeButton,
-      ),
+      loadingWidget: showSkeleton
+          ? (closeButton) => _loadingWidget(
+              wideScreen: isWideScreen,
+              closeButton: closeButton,
+            )
+          : null,
       child: HtmlIframeWidget(
         key: const ValueKey('drive-intent-webview'),
         onIframeCreated: (iframe) {
+          final viewRecreated = _iframeElement != null &&
+              !identical(_iframeElement, iframe);
           _iframeElement = iframe;
-          notifyPlatformViewReady();
+          notifyPlatformViewReady(viewRecreated: viewRecreated);
         },
       ),
     );
-    return isWideScreen
-        ? shell
-        : SafeArea(
-            top: true,
-            left: false,
-            right: false,
-            bottom: false,
-            child: shell,
-          );
+    // Keep the iframe ancestry stable across resize (#4738).
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: PointerInterceptor(child: const SizedBox.expand()),
+        ),
+        SafeArea(
+          top: !isWideScreen,
+          left: false,
+          right: false,
+          bottom: false,
+          child: shell,
+        ),
+      ],
+    );
   }
 
   @override

--- a/workplace/test/presentation/mixin/drive_intent_message_handler_mixin_test.dart
+++ b/workplace/test/presentation/mixin/drive_intent_message_handler_mixin_test.dart
@@ -237,6 +237,31 @@ void _applyOrderingTests() {
     expect(state.outcomes, isEmpty);
     state.cancelReadyTimeoutForTesting();
   });
+
+  testWidgets('recreated platform view reloads the intent while loading',
+      (tester) async {
+    final state = await _buildAndApply(tester);
+
+    state.notifyPlatformViewReady(viewRecreated: true);
+
+    expect(state.loadCalls, hasLength(2));
+    expect(state.outcomes, isEmpty);
+    state.cancelReadyTimeoutForTesting();
+  });
+
+  testWidgets('recreated platform view does not reload an interactive picker',
+      (tester) async {
+    final state = await _buildAndApply(tester);
+    state.onMessage(
+      raw: _encode({'type': 'intent-$_intentId:readyToUse'}),
+      origin: _origin,
+    );
+
+    state.notifyPlatformViewReady(viewRecreated: true);
+
+    expect(state.loadCalls, hasLength(1));
+    expect(state.outcomes, isEmpty);
+  });
 }
 
 void _intentLoadFailureTests() {
@@ -440,27 +465,38 @@ class _TimeoutTestState extends State<_TimeoutTestWidget>
   Widget build(BuildContext context) => const SizedBox.shrink();
 }
 
-void _readyTimeoutTests() {
+Future<_TimeoutTestState> _buildTimeoutState(
+  WidgetTester tester, {
+  bool notifyReady = true,
+}) async {
+  await tester.pumpWidget(const MaterialApp(home: _TimeoutTestWidget()));
+  final state = tester.state<_TimeoutTestState>(find.byType(_TimeoutTestWidget));
+  state.startLoading(() => Future.value(_intent()));
+  await tester.pump();
+  if (notifyReady) state.notifyPlatformViewReady();
+  return state;
+}
+
+void _expectTimeoutFailure(_TimeoutTestState state) {
+  expect(state.outcomes, hasLength(1));
+  expect(state.outcomes.single, isA<DrivePickOutcomeFailed>());
+  expect(
+    (state.outcomes.single as DrivePickOutcomeFailed).error,
+    isA<DriveIntentTimeoutException>(),
+  );
+}
+
+void _readyTimeoutFiringTests() {
   testWidgets('fires Failed(DriveIntentTimeoutException) if ready never arrives', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: _TimeoutTestWidget()));
-    final state = tester.state<_TimeoutTestState>(find.byType(_TimeoutTestWidget));
-    state.startLoading(() => Future.value(_intent()));
-    await tester.pump();
-    state.notifyPlatformViewReady();
+    final state = await _buildTimeoutState(tester);
 
     await tester.pump(const Duration(milliseconds: 60));
 
-    expect(state.outcomes, hasLength(1));
-    expect(state.outcomes.single, isA<DrivePickOutcomeFailed>());
-    expect((state.outcomes.single as DrivePickOutcomeFailed).error, isA<DriveIntentTimeoutException>());
+    _expectTimeoutFailure(state);
   });
 
   testWidgets('cancelled if readyToUse arrives before timeout', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: _TimeoutTestWidget()));
-    final state = tester.state<_TimeoutTestState>(find.byType(_TimeoutTestWidget));
-    state.startLoading(() => Future.value(_intent()));
-    await tester.pump();
-    state.notifyPlatformViewReady();
+    final state = await _buildTimeoutState(tester);
     state.onMessage(raw: _encode({'type': 'intent-$_intentId:ready'}), origin: _origin);
     state.onMessage(raw: _encode({'type': 'intent-$_intentId:readyToUse'}), origin: _origin);
 
@@ -470,29 +506,53 @@ void _readyTimeoutTests() {
   });
 
   testWidgets('fires Failed(DriveIntentTimeoutException) if readyToUse never arrives, even after ready', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: _TimeoutTestWidget()));
-    final state = tester.state<_TimeoutTestState>(find.byType(_TimeoutTestWidget));
-    state.startLoading(() => Future.value(_intent()));
-    await tester.pump();
-    state.notifyPlatformViewReady();
+    final state = await _buildTimeoutState(tester);
     state.onMessage(raw: _encode({'type': 'intent-$_intentId:ready'}), origin: _origin);
 
     await tester.pump(const Duration(milliseconds: 60));
 
-    expect(state.outcomes, hasLength(1));
-    expect((state.outcomes.single as DrivePickOutcomeFailed).error, isA<DriveIntentTimeoutException>());
+    _expectTimeoutFailure(state);
   });
 
   testWidgets('fires Failed(DriveIntentTimeoutException) if platform view never becomes ready', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: _TimeoutTestWidget()));
-    final state = tester.state<_TimeoutTestState>(find.byType(_TimeoutTestWidget));
-    state.startLoading(() => Future.value(_intent()));
+    final state = await _buildTimeoutState(tester, notifyReady: false);
 
     await tester.pump(const Duration(milliseconds: 60));
 
-    expect(state.outcomes, hasLength(1));
-    expect((state.outcomes.single as DrivePickOutcomeFailed).error, isA<DriveIntentTimeoutException>());
+    _expectTimeoutFailure(state);
   });
+}
+
+void _recreatedViewTimeoutTests() {
+  testWidgets('recreated platform view restarts the ready timeout', (tester) async {
+    final state = await _buildTimeoutState(tester);
+
+    await tester.pump(const Duration(milliseconds: 40));
+    state.notifyPlatformViewReady(viewRecreated: true);
+    await tester.pump(const Duration(milliseconds: 20));
+
+    expect(state.outcomes, isEmpty);
+    await tester.pump(const Duration(milliseconds: 40));
+    expect(state.outcomes, hasLength(1));
+  });
+
+  testWidgets('recreated platform view becomes interactive before its new timeout', (tester) async {
+    final state = await _buildTimeoutState(tester);
+
+    await tester.pump(const Duration(milliseconds: 40));
+    state.notifyPlatformViewReady(viewRecreated: true);
+    state.onMessage(raw: _encode({'type': 'intent-$_intentId:ready'}), origin: _origin);
+    state.onMessage(raw: _encode({'type': 'intent-$_intentId:readyToUse'}), origin: _origin);
+
+    expect(state.showSkeleton, isFalse);
+    await tester.pump(const Duration(milliseconds: 60));
+    expect(state.outcomes, isEmpty);
+  });
+}
+
+void _readyTimeoutTests() {
+  _readyTimeoutFiringTests();
+  _recreatedViewTimeoutTests();
 }
 
 void main() {

--- a/workplace/test/presentation/mixin/web_window_message_mixin_web_test.dart
+++ b/workplace/test/presentation/mixin/web_window_message_mixin_web_test.dart
@@ -1,0 +1,83 @@
+@TestOn('chrome')
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:universal_html/html.dart' as html;
+import 'package:workplace/presentation/mixin/web_window_message_mixin.dart';
+
+class _MessageListenerWidget extends StatefulWidget {
+  final void Function(String data, String? origin) onMessage;
+
+  const _MessageListenerWidget({required this.onMessage});
+
+  @override
+  State<_MessageListenerWidget> createState() => _MessageListenerWidgetState();
+}
+
+class _MessageListenerWidgetState extends State<_MessageListenerWidget>
+    with WebWindowMessageMixin<_MessageListenerWidget> {
+  @override
+  void initState() {
+    super.initState();
+    startWindowMessageListener(widget.onMessage);
+  }
+
+  @override
+  void dispose() {
+    stopWindowMessageListener();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox();
+}
+
+void main() {
+  testWidgets('forwards browser MessageEvents', (tester) async {
+    String? data;
+    String? origin;
+    await tester.pumpWidget(MaterialApp(
+      home: _MessageListenerWidget(
+        onMessage: (message, messageOrigin) {
+          data = message;
+          origin = messageOrigin;
+        },
+      ),
+    ));
+
+    html.window.dispatchEvent(
+      html.MessageEvent(
+        'message',
+        data: jsonEncode({'type': 'intent-test:readyToUse'}),
+        origin: Uri.base.origin,
+      ),
+    );
+    await tester.pump();
+
+    expect(data, jsonEncode({'type': 'intent-test:readyToUse'}));
+    expect(origin, Uri.base.origin);
+  });
+
+  testWidgets('stops forwarding messages after disposal', (tester) async {
+    var callCount = 0;
+    await tester.pumpWidget(MaterialApp(
+      home: _MessageListenerWidget(
+        onMessage: (_, __) => callCount++,
+      ),
+    ));
+
+    await tester.pumpWidget(const SizedBox());
+    html.window.dispatchEvent(
+      html.MessageEvent(
+        'message',
+        data: jsonEncode({'type': 'intent-test:readyToUse'}),
+        origin: Uri.base.origin,
+      ),
+    );
+    await tester.pump();
+
+    expect(callCount, 0);
+  });
+}

--- a/workplace/test/presentation/view/drive_intent_skeleton_loader_test.dart
+++ b/workplace/test/presentation/view/drive_intent_skeleton_loader_test.dart
@@ -1,0 +1,60 @@
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:workplace/presentation/model/drive_intent_image_assets.dart';
+import 'package:workplace/presentation/view/drive_intent_skeleton_loader.dart';
+
+const _closeButtonKey = ValueKey('close-button');
+const _skeletonKey = ValueKey('desktop-skeleton');
+const _imageAssets = DriveIntentImageAssets(
+  driveLogo: 'assets/images/twake-drive-logo.svg',
+  closeIcon: 'assets/images/ic_close.svg',
+  searchIcon: 'assets/images/ic_search_bar.svg',
+);
+
+void main() {
+  testWidgets('desktop loading close button matches the design', (tester) async {
+    var closeCalls = 0;
+    final closeButton = TMailButtonWidget.fromIcon(
+      key: _closeButtonKey,
+      icon: _imageAssets.closeIcon,
+      width: 40,
+      height: 40,
+      iconSize: 24,
+      padding: const EdgeInsets.all(8),
+      backgroundColor: Colors.transparent,
+      onTapActionCallback: () => closeCalls++,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox(
+            key: _skeletonKey,
+            width: 800,
+            height: 500,
+            child: DriveIntentSkeletonLoader.table(
+              imageAssets: _imageAssets,
+              closeButton: closeButton,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final closeButtonFinder = find.byKey(_closeButtonKey);
+    final closeContainerFinder = find.descendant(
+      of: closeButtonFinder,
+      matching: find.byType(Container),
+    );
+    final skeletonRect = tester.getRect(find.byKey(_skeletonKey));
+    final closeRect = tester.getRect(closeContainerFinder);
+
+    expect(closeRect.size, const Size(40, 40));
+    expect(closeRect.top, skeletonRect.top + 12);
+    expect(closeRect.right, skeletonRect.right - 17);
+
+    await tester.tap(closeContainerFinder);
+    expect(closeCalls, 1);
+  });
+}

--- a/workplace/test/presentation/view/drive_intent_web_view_modal_shell_test.dart
+++ b/workplace/test/presentation/view/drive_intent_web_view_modal_shell_test.dart
@@ -4,19 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:workplace/presentation/view/drive_intent_web_view_modal_shell.dart';
 
-// Represents the iframe/platform view across resize.
-class _ProbeChild extends StatefulWidget {
-  const _ProbeChild({super.key});
-
-  @override
-  State<_ProbeChild> createState() => _ProbeChildState();
-}
-
-class _ProbeChildState extends State<_ProbeChild> {
-  @override
-  Widget build(BuildContext context) => const SizedBox.shrink();
-}
-
 const _closeIcon = 'assets/close.svg';
 
 Widget _shell({
@@ -37,32 +24,6 @@ Widget _shell({
   );
 }
 
-Widget _responsiveShell({required bool isWideScreen}) {
-  return MaterialApp(
-    home: Stack(
-      children: [
-        Positioned.fill(
-          child: PointerInterceptor(child: const SizedBox.expand()),
-        ),
-        SafeArea(
-          top: !isWideScreen,
-          left: false,
-          right: false,
-          bottom: false,
-          child: _modalShell(
-            haveCloseButton: !isWideScreen,
-            constraints: isWideScreen
-                ? const BoxConstraints(maxWidth: 800, maxHeight: 677)
-                : const BoxConstraints.expand(),
-            insetPadding:
-                isWideScreen ? const EdgeInsets.all(24) : EdgeInsets.zero,
-          ),
-        ),
-      ],
-    ),
-  );
-}
-
 Widget _modalShell({
   required bool haveCloseButton,
   required BoxConstraints constraints,
@@ -77,45 +38,35 @@ Widget _modalShell({
     constraints: constraints,
     insetPadding: insetPadding,
     loadingWidget: loadingWidget,
-    child: const _ProbeChild(key: ValueKey('probe')),
+    child: const SizedBox.shrink(),
   );
 }
 
 void main() {
   group('DriveIntentWebViewModalShell', () {
-    testWidgets(
-      'preserves platform child in both resize directions (#4738)',
-      (tester) async {
-        await tester.pumpWidget(_responsiveShell(isWideScreen: true));
-        final stateBefore =
-            tester.state<_ProbeChildState>(find.byType(_ProbeChild));
+    _testLoadingOverlayIsClosable();
+    _testLoadingOverlayCloseButtonCallback();
+    _testCloseButtonHoverFeedback();
+    _testNoPointerInterceptorWithoutLoadingOverlay();
+  });
+}
 
-        await tester.pumpWidget(_responsiveShell(isWideScreen: false));
-        final mobileState =
-            tester.state<_ProbeChildState>(find.byType(_ProbeChild));
-
-        expect(identical(stateBefore, mobileState), isTrue);
-
-        await tester.pumpWidget(_responsiveShell(isWideScreen: true));
-        final wideState =
-            tester.state<_ProbeChildState>(find.byType(_ProbeChild));
-
-        expect(identical(stateBefore, wideState), isTrue);
-      },
-    );
-
-    testWidgets('loading overlay is always closable — receives a close button',
-        (tester) async {
+void _testLoadingOverlayIsClosable() {
+  testWidgets(
+    'loading overlay is always closable — receives a close button',
+    (tester) async {
       TMailButtonWidget? received;
-      await tester.pumpWidget(_shell(
-        haveCloseButton: false,
-        constraints: const BoxConstraints(maxWidth: 800, maxHeight: 677),
-        insetPadding: const EdgeInsets.all(24),
-        loadingWidget: (closeButton) {
-          received = closeButton;
-          return closeButton;
-        },
-      ));
+      await tester.pumpWidget(
+        _shell(
+          haveCloseButton: false,
+          constraints: const BoxConstraints(maxWidth: 800, maxHeight: 677),
+          insetPadding: const EdgeInsets.all(24),
+          loadingWidget: (closeButton) {
+            received = closeButton;
+            return closeButton;
+          },
+        ),
+      );
 
       expect(received, isNotNull);
       expect(find.byWidget(received!), findsOneWidget);
@@ -126,13 +77,18 @@ void main() {
         ),
         findsOneWidget,
       );
-    });
+    },
+  );
+}
 
-    testWidgets('loading overlay close button is wired to onClose',
-        (tester) async {
-      var closed = 0;
-      TMailButtonWidget? received;
-      await tester.pumpWidget(_shell(
+void _testLoadingOverlayCloseButtonCallback() {
+  testWidgets('loading overlay close button is wired to onClose', (
+    tester,
+  ) async {
+    var closed = 0;
+    TMailButtonWidget? received;
+    await tester.pumpWidget(
+      _shell(
         haveCloseButton: false,
         constraints: const BoxConstraints(maxWidth: 800, maxHeight: 677),
         insetPadding: const EdgeInsets.all(24),
@@ -141,36 +97,45 @@ void main() {
           received = closeButton;
           return closeButton;
         },
-      ));
+      ),
+    );
 
-      // Assert callback wiring without SVG hit-testing.
-      received!.onTapActionCallback!();
-      expect(closed, 1);
-    });
+    // Assert callback wiring without SVG hit-testing.
+    received!.onTapActionCallback!();
+    expect(closed, 1);
+  });
+}
 
-    testWidgets('close button keeps Material hover feedback', (tester) async {
-      await tester.pumpWidget(_shell(
+void _testCloseButtonHoverFeedback() {
+  testWidgets('close button keeps Material hover feedback', (tester) async {
+    await tester.pumpWidget(
+      _shell(
         haveCloseButton: true,
         constraints: const BoxConstraints(maxWidth: 800, maxHeight: 677),
         insetPadding: const EdgeInsets.all(24),
-      ));
+      ),
+    );
 
-      final button = tester.widget<TMailButtonWidget>(
-        find.byType(TMailButtonWidget),
-      );
+    final button = tester.widget<TMailButtonWidget>(
+      find.byType(TMailButtonWidget),
+    );
 
-      expect(button.hoverColor, const Color(0x14424244));
-    });
+    expect(button.hoverColor, const Color(0x14424244));
+  });
+}
 
-    testWidgets('does not intercept pointers without a loading overlay',
-        (tester) async {
-      await tester.pumpWidget(_shell(
+void _testNoPointerInterceptorWithoutLoadingOverlay() {
+  testWidgets('does not intercept pointers without a loading overlay', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _shell(
         haveCloseButton: false,
         constraints: const BoxConstraints(maxWidth: 800, maxHeight: 677),
         insetPadding: const EdgeInsets.all(24),
-      ));
+      ),
+    );
 
-      expect(find.byType(PointerInterceptor), findsNothing);
-    });
+    expect(find.byType(PointerInterceptor), findsNothing);
   });
 }

--- a/workplace/test/presentation/view/drive_intent_web_view_modal_shell_test.dart
+++ b/workplace/test/presentation/view/drive_intent_web_view_modal_shell_test.dart
@@ -1,0 +1,176 @@
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pointer_interceptor/pointer_interceptor.dart';
+import 'package:workplace/presentation/view/drive_intent_web_view_modal_shell.dart';
+
+// Represents the iframe/platform view across resize.
+class _ProbeChild extends StatefulWidget {
+  const _ProbeChild({super.key});
+
+  @override
+  State<_ProbeChild> createState() => _ProbeChildState();
+}
+
+class _ProbeChildState extends State<_ProbeChild> {
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+const _closeIcon = 'assets/close.svg';
+
+Widget _shell({
+  required bool haveCloseButton,
+  required BoxConstraints constraints,
+  required EdgeInsets insetPadding,
+  Widget Function(TMailButtonWidget closeButton)? loadingWidget,
+  VoidCallback? onClose,
+}) {
+  return MaterialApp(
+    home: _modalShell(
+      haveCloseButton: haveCloseButton,
+      constraints: constraints,
+      insetPadding: insetPadding,
+      loadingWidget: loadingWidget,
+      onClose: onClose,
+    ),
+  );
+}
+
+Widget _responsiveShell({required bool isWideScreen}) {
+  return MaterialApp(
+    home: Stack(
+      children: [
+        Positioned.fill(
+          child: PointerInterceptor(child: const SizedBox.expand()),
+        ),
+        SafeArea(
+          top: !isWideScreen,
+          left: false,
+          right: false,
+          bottom: false,
+          child: _modalShell(
+            haveCloseButton: !isWideScreen,
+            constraints: isWideScreen
+                ? const BoxConstraints(maxWidth: 800, maxHeight: 677)
+                : const BoxConstraints.expand(),
+            insetPadding:
+                isWideScreen ? const EdgeInsets.all(24) : EdgeInsets.zero,
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+Widget _modalShell({
+  required bool haveCloseButton,
+  required BoxConstraints constraints,
+  required EdgeInsets insetPadding,
+  Widget Function(TMailButtonWidget closeButton)? loadingWidget,
+  VoidCallback? onClose,
+}) {
+  return DriveIntentWebViewModalShell(
+    closeIconPath: _closeIcon,
+    onClose: onClose ?? () {},
+    haveCloseButton: haveCloseButton,
+    constraints: constraints,
+    insetPadding: insetPadding,
+    loadingWidget: loadingWidget,
+    child: const _ProbeChild(key: ValueKey('probe')),
+  );
+}
+
+void main() {
+  group('DriveIntentWebViewModalShell', () {
+    testWidgets(
+      'preserves platform child in both resize directions (#4738)',
+      (tester) async {
+        await tester.pumpWidget(_responsiveShell(isWideScreen: true));
+        final stateBefore =
+            tester.state<_ProbeChildState>(find.byType(_ProbeChild));
+
+        await tester.pumpWidget(_responsiveShell(isWideScreen: false));
+        final mobileState =
+            tester.state<_ProbeChildState>(find.byType(_ProbeChild));
+
+        expect(identical(stateBefore, mobileState), isTrue);
+
+        await tester.pumpWidget(_responsiveShell(isWideScreen: true));
+        final wideState =
+            tester.state<_ProbeChildState>(find.byType(_ProbeChild));
+
+        expect(identical(stateBefore, wideState), isTrue);
+      },
+    );
+
+    testWidgets('loading overlay is always closable — receives a close button',
+        (tester) async {
+      TMailButtonWidget? received;
+      await tester.pumpWidget(_shell(
+        haveCloseButton: false,
+        constraints: const BoxConstraints(maxWidth: 800, maxHeight: 677),
+        insetPadding: const EdgeInsets.all(24),
+        loadingWidget: (closeButton) {
+          received = closeButton;
+          return closeButton;
+        },
+      ));
+
+      expect(received, isNotNull);
+      expect(find.byWidget(received!), findsOneWidget);
+      expect(
+        find.ancestor(
+          of: find.byType(PointerInterceptor),
+          matching: find.byType(Positioned),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('loading overlay close button is wired to onClose',
+        (tester) async {
+      var closed = 0;
+      TMailButtonWidget? received;
+      await tester.pumpWidget(_shell(
+        haveCloseButton: false,
+        constraints: const BoxConstraints(maxWidth: 800, maxHeight: 677),
+        insetPadding: const EdgeInsets.all(24),
+        onClose: () => closed++,
+        loadingWidget: (closeButton) {
+          received = closeButton;
+          return closeButton;
+        },
+      ));
+
+      // Assert callback wiring without SVG hit-testing.
+      received!.onTapActionCallback!();
+      expect(closed, 1);
+    });
+
+    testWidgets('close button keeps Material hover feedback', (tester) async {
+      await tester.pumpWidget(_shell(
+        haveCloseButton: true,
+        constraints: const BoxConstraints(maxWidth: 800, maxHeight: 677),
+        insetPadding: const EdgeInsets.all(24),
+      ));
+
+      final button = tester.widget<TMailButtonWidget>(
+        find.byType(TMailButtonWidget),
+      );
+
+      expect(button.hoverColor, const Color(0x14424244));
+    });
+
+    testWidgets('does not intercept pointers without a loading overlay',
+        (tester) async {
+      await tester.pumpWidget(_shell(
+        haveCloseButton: false,
+        constraints: const BoxConstraints(maxWidth: 800, maxHeight: 677),
+        insetPadding: const EdgeInsets.all(24),
+      ));
+
+      expect(find.byType(PointerInterceptor), findsNothing);
+    });
+  });
+}

--- a/workplace/test/presentation/view/drive_intent_web_view_modal_web_test.dart
+++ b/workplace/test/presentation/view/drive_intent_web_view_modal_web_test.dart
@@ -1,0 +1,73 @@
+@TestOn('chrome')
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:workplace/data/model/workplace_intent_request.dart';
+import 'package:workplace/domain/entity/workplace_intent.dart';
+import 'package:workplace/presentation/model/drive_intent_image_assets.dart';
+import 'package:workplace/presentation/view/drive_intent_web_view_modal.dart';
+
+const _imageAssets = DriveIntentImageAssets(
+  driveLogo: 'assets/images/twake-drive-logo.svg',
+  closeIcon: 'assets/images/ic_close.svg',
+  searchIcon: 'assets/images/ic_search_bar.svg',
+);
+
+const _filePickerConfig = WorkplaceFilePickerConfigRequest(
+  sharingLink: WorkplaceActionConfigRequest(),
+  downloadLink: null,
+);
+
+Widget _modal(Future<WorkplaceIntent> intent) {
+  return MaterialApp(
+    home: DriveIntentWebViewModal(
+      intentLoader: () => intent,
+      filePickerConfig: _filePickerConfig,
+      imageAssets: _imageAssets,
+    ),
+  );
+}
+
+void main() {
+  testWidgets(
+    'preserves the iframe platform view in both resize directions (#4738)',
+    (tester) async {
+      // The intent never resolves: the modal stays in its loading phase, which
+      // is exactly the window #4738 regresses in. The iframe lives in the shell
+      // regardless of the skeleton, so it is mounted throughout.
+      final intent = Completer<WorkplaceIntent>();
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1280, 800);
+
+      await tester.pumpWidget(_modal(intent.future));
+      await tester.pump();
+
+      // The flutter_test web embedder does not attach the real <iframe> to the
+      // live DOM, so recreation is asserted at the framework level: a stable
+      // HtmlElementView Element means the platform view — and its iframe — was
+      // never torn down. findsOneWidget additionally rules out an orphaned view
+      // leaking alongside a fresh one.
+      final platformView = find.byType(HtmlElementView);
+      expect(platformView, findsOneWidget);
+      final platformViewElement = tester.element(platformView);
+
+      // Desktop -> mobile crosses the responsive breakpoint (1280 >= 1200 desktop,
+      // 375 < 900 mobile), the transition that used to remount the iframe.
+      tester.view.physicalSize = const Size(375, 800);
+      await tester.pump();
+      expect(platformView, findsOneWidget);
+      expect(identical(platformViewElement, tester.element(platformView)), isTrue);
+
+      // Mobile -> desktop: the reverse transition must be just as stable.
+      tester.view.physicalSize = const Size(1280, 800);
+      await tester.pump();
+      expect(platformView, findsOneWidget);
+      expect(identical(platformViewElement, tester.element(platformView)), isTrue);
+    },
+  );
+}


### PR DESCRIPTION
Closes #4738 

## Context

Resizing the browser across the desktop/mobile breakpoint while the Drive picker iframe was loading left it permanently stuck on the loading skeleton (only the 20s timeout eventually broke it). Related gaps: the desktop loading state had no close button, and once the picker was interactive a backdrop tap over the composer editor iframe was swallowed instead of dismissing the dialog.

## Root cause

Three independent issues, all rooted in web platform-view (iframe) behaviour:

1. **Unstable iframe ancestry → remount.** Crossing the breakpoint swapped a `SafeArea` in/out and restructured the `Column` (close button), changing the iframe's ancestor chain. Flutter then unmounted and recreated the `HtmlElementView`. The new iframe reported ready, but the loading lifecycle only applied the intent URL during its initial `waiting` phase, so the replacement stayed blank until the ready timeout fired.
2. **Listener owned by a transient widget.** The `window` message listener was registered by the Drive toolbar/context-menu widget (`DrivePickerWebStateMixin`). A responsive composer rebuild can dispose that widget while the modal is still open, orphaning the listener so `ready`/`readyToUse` never reach the picker.
3. **No pointer interceptor in the modal route.** The composer editor is itself a platform view, so backdrop taps over it were consumed by the browser instead of reaching Flutter. The loading close button also sat over the Drive iframe, which swallowed its clicks.

## Solution

- **Keep the iframe mounted.** Make the `SafeArea` unconditional (toggle `top` only), give the iframe's content slot a stable key, and keep a stable root `Stack` — the ancestry no longer changes across layouts, so the platform view is preserved.
- **Self-heal if it still remounts.** If the iframe is genuinely recreated *during loading*, reapply the resolved intent URL and restart the ready timeout. Never reapply after `readyToUse`, so an active picker session is never reloaded.
- **Own the listener in the modal.** Register the `window` message listener in the web modal's `initState` (before the iframe is created — no race) and remove it on close/dispose. Uses `addEventListener`, so it coexists with the editor's own listener. This removes `DrivePickerWebStateMixin` and the platform-specific entry-widget State subclasses.
- **Pointer interception.** A full-screen `PointerInterceptor` behind the dialog routes backdrop taps to Flutter while the Drive iframe stays directly interactive; the loading overlay is wrapped in a `PointerInterceptor` above the iframe so its close button is clickable.
- **Always-closable loading.** A 40×40 close button is shown during loading on both desktop and mobile.

## Demo


https://github.com/user-attachments/assets/db9ccff4-14ec-4ae9-a6e9-af68c625c6c6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of workplace intent loading, including correct handling of platform-view recreation, ready-timeout restarts, acknowledgements, and safer modal cleanup.
  - Kept the embedded iframe mounted across responsive breakpoint changes, preventing unnecessary remounts.
  - Refined web modal pointer/tap handling and improved close-button placement/behavior, including during loading overlays.

- **Tests**
  - Expanded Chrome/web widget coverage for browser window messaging, modal shell overlays, iframe reuse on resize, and additional intent-loading/timeout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->