### PR TITLE
TF-4739 Enable mobile drive picker

### DIFF
--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1011,7 +1011,6 @@ class ComposerController extends BaseController
           if (PlatformInfo.isWeb) {
             richTextWebController?.editorController.insertHtml(html);
           } else {
-            popBack();
             await richTextMobileTabletController?.restoreMobileEditorFocus();
             await htmlEditorApi?.insertHtml(html);
             await SchedulerBinding.instance.endOfFrame;

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -49,6 +49,7 @@ import 'package:tmail_ui_user/features/composer/presentation/extensions/handle_m
 import 'package:tmail_ui_user/features/composer/presentation/extensions/refresh_composer_attachments_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/setup_email_content_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/setup_selected_identity_extension.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_handler.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/formatting_options_state.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/saved_composing_email.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/screen_display_mode.dart';
@@ -82,6 +83,7 @@ import 'package:tmail_ui_user/main/utils/app_config.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
 import 'package:uuid/uuid.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
 
 import '../../../fixtures/account_fixtures.dart';
 import '../../../fixtures/session_fixtures.dart';
@@ -1196,6 +1198,66 @@ void main() {
           () => composerController?.tearDownMobileAutoSave(),
           returnsNormally,
         );
+      });
+    });
+
+    group('handleDrivePickResult test:', () {
+      final linkDoc = DriveDocument(
+        id: 'drive-doc-1',
+        name: 'Report',
+        size: 100,
+        mimeType: 'application/pdf',
+        sharingLink: Uri.parse('https://drive.example.com/report'),
+      );
+
+      setUp(() {
+        Get.put(DriveAttachmentHandler());
+        composerController?.richTextMobileTabletController =
+            mockRichTextMobileTabletController;
+        when(mockRichTextMobileTabletController.htmlEditorApi)
+            .thenReturn(mockHtmlEditorApi);
+        when(mockRichTextMobileTabletController.restoreMobileEditorFocus())
+            .thenAnswer((_) async {});
+        when(mockHtmlEditorApi.insertHtml(any)).thenAnswer((_) async {});
+      });
+
+      // handleDrivePickResult awaits SchedulerBinding.instance.endOfFrame on
+      // mobile, which only resolves once a frame is pumped — testWidgets +
+      // tester.pump() drives that, a plain test() would hang forever.
+      testWidgets(
+        'Should restore mobile editor focus and insert the Drive link html\n'
+        'When a file is picked from Drive on mobile',
+      (tester) async {
+        final resultFuture = composerController?.handleDrivePickResult([linkDoc]);
+        await tester.pumpAndSettle();
+        await resultFuture;
+
+        verify(mockRichTextMobileTabletController.restoreMobileEditorFocus())
+            .called(1);
+        final captured =
+            verify(mockHtmlEditorApi.insertHtml(captureAny)).captured;
+        expect(captured, hasLength(1));
+        expect(captured.single as String, contains('https://drive.example.com/report'));
+      });
+
+      testWidgets(
+        'Should restore focus before inserting html\n'
+        'When a file is picked from Drive on mobile',
+      (tester) async {
+        final callOrder = <String>[];
+        when(mockRichTextMobileTabletController.restoreMobileEditorFocus())
+            .thenAnswer((_) async {
+          callOrder.add('restoreFocus');
+        });
+        when(mockHtmlEditorApi.insertHtml(any)).thenAnswer((_) async {
+          callOrder.add('insertHtml');
+        });
+
+        final resultFuture = composerController?.handleDrivePickResult([linkDoc]);
+        await tester.pumpAndSettle();
+        await resultFuture;
+
+        expect(callOrder, ['restoreFocus', 'insertHtml']);
       });
     });
 

--- a/workplace/lib/data/datasource_impl/workplace_datasource_impl.dart
+++ b/workplace/lib/data/datasource_impl/workplace_datasource_impl.dart
@@ -38,6 +38,10 @@ class WorkplaceDataSourceImpl implements WorkplaceDataSource {
           ...platformUrl.pathSegments.where((segment) => segment.isNotEmpty),
           'intents',
         ],
+        queryParameters: {
+          ...platformUrl.queryParameters,
+          'force_session_id': 'true',
+        },
       ).toString(),
       options: Options(
         headers: {'Authorization': 'Bearer $accessToken'},
@@ -67,7 +71,11 @@ class WorkplaceDataSourceImpl implements WorkplaceDataSource {
       throw ArgumentError('Intent URL must use HTTPS, got: $href');
     }
 
-    return WorkplaceIntent(intentId: parsed.data.id, intentUrl: intentUrl);
+    return WorkplaceIntent(
+      intentId: parsed.data.id,
+      intentUrl: intentUrl,
+      client: parsed.data.attributes.client,
+    );
   }
 
   Map<String, dynamic> _buildIntentRequest({

--- a/workplace/lib/data/model/workplace_intent_response.dart
+++ b/workplace/lib/data/model/workplace_intent_response.dart
@@ -9,12 +9,16 @@ final class WorkplaceIntentAttributesResponse {
   final String type;
   final List<WorkplacePermission> permissions;
   final List<WorkplaceIntentServiceResponse> services;
+  final String? client;
+  final List<String>? availableApps;
 
   const WorkplaceIntentAttributesResponse({
     required this.action,
     required this.type,
     required this.permissions,
     required this.services,
+    this.client,
+    this.availableApps,
   });
 
   factory WorkplaceIntentAttributesResponse.fromJson(Map<String, dynamic> json) =>
@@ -32,11 +36,41 @@ final class WorkplaceIntentServiceResponse {
 }
 
 @JsonSerializable(createToJson: false)
+final class WorkplaceIntentMetaResponse {
+  final String? rev;
+
+  const WorkplaceIntentMetaResponse({this.rev});
+
+  factory WorkplaceIntentMetaResponse.fromJson(Map<String, dynamic> json) =>
+      _$WorkplaceIntentMetaResponseFromJson(json);
+}
+
+@JsonSerializable(createToJson: false)
+final class WorkplaceIntentLinksResponse {
+  final String? self;
+  final String? permissions;
+
+  const WorkplaceIntentLinksResponse({this.self, this.permissions});
+
+  factory WorkplaceIntentLinksResponse.fromJson(Map<String, dynamic> json) =>
+      _$WorkplaceIntentLinksResponseFromJson(json);
+}
+
+@JsonSerializable(createToJson: false)
 final class WorkplaceIntentDataResponse {
   final String id;
+  final String? type;
   final WorkplaceIntentAttributesResponse attributes;
+  final WorkplaceIntentMetaResponse? meta;
+  final WorkplaceIntentLinksResponse? links;
 
-  const WorkplaceIntentDataResponse({required this.id, required this.attributes});
+  const WorkplaceIntentDataResponse({
+    required this.id,
+    this.type,
+    required this.attributes,
+    this.meta,
+    this.links,
+  });
 
   factory WorkplaceIntentDataResponse.fromJson(Map<String, dynamic> json) =>
       _$WorkplaceIntentDataResponseFromJson(json);

--- a/workplace/lib/domain/entity/workplace_intent.dart
+++ b/workplace/lib/domain/entity/workplace_intent.dart
@@ -3,9 +3,14 @@ import 'package:equatable/equatable.dart';
 class WorkplaceIntent with EquatableMixin {
   final String intentId;
   final Uri intentUrl;
+  final String? client;
 
-  const WorkplaceIntent({required this.intentId, required this.intentUrl});
+  const WorkplaceIntent({
+    required this.intentId,
+    required this.intentUrl,
+    this.client,
+  });
 
   @override
-  List<Object?> get props => [intentId, intentUrl];
+  List<Object?> get props => [intentId, intentUrl, client];
 }

--- a/workplace/lib/domain/exceptions/workplace_exceptions.dart
+++ b/workplace/lib/domain/exceptions/workplace_exceptions.dart
@@ -14,3 +14,5 @@ class DriveIntentPageLoadException implements Exception {
 }
 
 class DriveIntentTimeoutException implements Exception {}
+
+class WorkplaceNoIntentClientException implements Exception {}

--- a/workplace/lib/presentation/mixin/drive_intent_message_handler_mixin.dart
+++ b/workplace/lib/presentation/mixin/drive_intent_message_handler_mixin.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:workplace/domain/entity/workplace_intent.dart';
 import 'package:workplace/domain/exceptions/workplace_exceptions.dart';
 import 'package:workplace/domain/message/workplace_intent_message.dart';
+import 'package:workplace/presentation/model/drive_origin_validator.dart';
 import 'package:workplace/presentation/model/drive_pick_outcome.dart';
 
 enum _Phase { waiting, loadingPage, interactive, closed }
@@ -16,6 +17,7 @@ typedef DriveIntentLoader = Future<WorkplaceIntent> Function();
 mixin DriveIntentMessageHandlerMixin<T extends StatefulWidget> on State<T> {
   late String _intentId;
   String _intentOrigin = 'null';
+  String? _intentClient;
   Timer? _readyTimeoutTimer;
 
   _Phase _phase = _Phase.waiting;
@@ -35,6 +37,7 @@ mixin DriveIntentMessageHandlerMixin<T extends StatefulWidget> on State<T> {
   }
 
   String get intentOrigin => _intentOrigin;
+  String? get intentClient => _intentClient;
 
   /// Covers silent failures like SSO blocking the page with no postMessage ever sent.
   Duration get readyTimeout => const Duration(seconds: 20);
@@ -101,6 +104,7 @@ mixin DriveIntentMessageHandlerMixin<T extends StatefulWidget> on State<T> {
     _intentOrigin = intent.intentUrl.scheme == 'data'
         ? 'null'
         : intent.intentUrl.origin;
+    _intentClient = intent.client;
     _setPhase(_Phase.loadingPage);
     unawaited(_applyIntent(intent));
   }
@@ -165,13 +169,15 @@ mixin DriveIntentMessageHandlerMixin<T extends StatefulWidget> on State<T> {
     }
   }
 
-  bool _isValidOrigin(String? origin) {
-    if (origin == null) return false;
-    if (origin == _intentOrigin) return true;
-    // On mobile the JS shim forwards targetOrigin as the origin arg. Data URIs
-    // have opaque 'null' origin but the shim receives '*' from postMessage.
-    return _intentOrigin == 'null' && origin == '*';
-  }
+  bool _isValidOrigin(String? origin) => originValidator.isValid(
+        origin,
+        intentOrigin: _intentOrigin,
+        intentClient: _intentClient,
+      );
+
+  /// Platform-specific origin matching rules (web vs mobile JS channel).
+  @protected
+  DriveOriginValidator get originValidator;
 
   Future<void> _handleWorkplaceMessage(WorkplaceIntentMessage msg) async {
     switch (msg) {

--- a/workplace/lib/presentation/model/drive_origin_validator.dart
+++ b/workplace/lib/presentation/model/drive_origin_validator.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/foundation.dart';
+
+bool isValidDriveClient(String? client) =>
+    client != null && client.trim().isNotEmpty && client != '*';
+
+/// Validates a postMessage/JS-channel origin against the resolved intent.
+abstract class DriveOriginValidator {
+  const DriveOriginValidator();
+
+  /// Shared rule set; platform variants only override [matchesClient].
+  bool isValid(
+    String? origin, {
+    required String intentOrigin,
+    required String? intentClient,
+  }) {
+    if (origin == null) return false;
+    if (origin == intentOrigin) return true;
+    if (matchesClient(origin, intentClient)) return true;
+    // Dev/fake intents (data: URI, no server-provided client) — the shim/
+    // postMessage sends '*' as targetOrigin in that case.
+    return intentOrigin == 'null' && origin == '*';
+  }
+
+  /// Extra origin match beyond [intentOrigin]. No-op on web.
+  @protected
+  bool matchesClient(String origin, String? intentClient) => false;
+}
+
+/// Web postMessage origins always equal the intent origin — no extra match.
+class WebDriveOriginValidator extends DriveOriginValidator {
+  const WebDriveOriginValidator();
+}
+
+/// Mobile JS channel additionally allows the intent's declared client id.
+class MobileDriveOriginValidator extends DriveOriginValidator {
+  const MobileDriveOriginValidator();
+
+  @override
+  bool matchesClient(String origin, String? intentClient) =>
+      isValidDriveClient(intentClient) && origin == intentClient;
+}

--- a/workplace/lib/presentation/view/drive_intent_web_view_modal_mobile.dart
+++ b/workplace/lib/presentation/view/drive_intent_web_view_modal_mobile.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import '../mixin/drive_intent_message_handler_mixin.dart';
 import '../mixin/drive_intent_shims.dart';
 import '../model/drive_intent_image_assets.dart';
+import '../model/drive_origin_validator.dart';
 import 'drive_intent_fake_page.dart';
 import 'drive_intent_skeleton_loader.dart';
 import 'drive_intent_web_view_modal_shell.dart';
@@ -33,6 +34,9 @@ class DriveIntentWebViewModal extends StatefulWidget {
 class _DriveIntentWebViewModalState extends State<DriveIntentWebViewModal>
     with DriveIntentMessageHandlerMixin {
   InAppWebViewController? _webViewController;
+
+  @override
+  DriveOriginValidator get originValidator => const MobileDriveOriginValidator();
 
   @override
   void initState() {
@@ -130,6 +134,9 @@ class _DriveIntentWebViewModalState extends State<DriveIntentWebViewModal>
 
   @override
   Future<void> sendAck() async {
+    if (!isValidDriveClient(intentClient)) {
+      throw WorkplaceNoIntentClientException();
+    }
     // Embedded unquoted: JSON object syntax is valid JS object-literal syntax,
     // so `event.data` in the page ends up a real object, not a JSON string —
     // Drive's getFilePickerConfig never calls JSON.parse on it.
@@ -137,7 +144,7 @@ class _DriveIntentWebViewModalState extends State<DriveIntentWebViewModal>
     await _webViewController?.evaluateJavascript(source: '''
       window.dispatchEvent(new MessageEvent('message', {
         data: $payload,
-        origin: '$intentOrigin',
+        origin: ${jsonEncode(intentClient)},
         source: window
       }));
     ''');

--- a/workplace/lib/presentation/view/drive_intent_web_view_modal_web.dart
+++ b/workplace/lib/presentation/view/drive_intent_web_view_modal_web.dart
@@ -9,6 +9,7 @@ import 'package:workplace/domain/entity/workplace_intent.dart';
 import 'package:workplace/presentation/mixin/drive_intent_message_handler_mixin.dart';
 import 'package:workplace/presentation/mixin/web_window_message_mixin.dart';
 import 'package:workplace/presentation/model/drive_intent_image_assets.dart';
+import 'package:workplace/presentation/model/drive_origin_validator.dart';
 import 'package:workplace/presentation/view/drive_intent_skeleton_loader.dart';
 import 'package:workplace/presentation/view/drive_intent_web_view_modal_shell.dart';
 
@@ -32,6 +33,9 @@ class DriveIntentWebViewModal extends StatefulWidget {
 class _DriveIntentWebViewModalState extends State<DriveIntentWebViewModal>
     with DriveIntentMessageHandlerMixin, WebWindowMessageMixin<DriveIntentWebViewModal> {
   html.IFrameElement? _iframeElement;
+
+  @override
+  DriveOriginValidator get originValidator => const WebDriveOriginValidator();
 
   bool wideScreen(BuildContext context) {
     return ResponsiveUtils().isDesktop(context) ||

--- a/workplace/test/data/workplace_datasource_impl_test.dart
+++ b/workplace/test/data/workplace_datasource_impl_test.dart
@@ -163,6 +163,36 @@ void main() {
       }
     });
 
+    test('Should parse client from attributes when present', () {
+      final data = {
+        'data': {
+          'id': 'intent-1',
+          'attributes': {
+            'action': 'PICK',
+            'type': 'files',
+            'permissions': ['GET'],
+            'services': [
+              {'href': 'https://drive.example.com/pick'},
+            ],
+            'client': 'client-abc',
+          },
+        },
+      };
+
+      final result = datasource.parseIntentResponse(data, requireHttps: false);
+
+      expect(result.client, equals('client-abc'));
+    });
+
+    test('Should have null client when attributes omit it', () {
+      final result = datasource.parseIntentResponse(
+        buildResponse(id: 'intent-1', href: 'https://drive.example.com/pick'),
+        requireHttps: false,
+      );
+
+      expect(result.client, isNull);
+    });
+
     test('Should use first service href when multiple services are present', () {
       final data = {
         'data': {
@@ -241,6 +271,24 @@ void main() {
       expect(
         adapter.capturedOptions!.uri.pathSegments.last,
         equals('intents'),
+      );
+    });
+
+    test('Should include force_session_id=true query parameter', () async {
+      final adapter = _MockAdapter(intentResponse);
+      WorkplaceDio.setInstance(Dio()..httpClientAdapter = adapter);
+
+      await datasource.createIntent(
+        platformUrl: Uri.parse('https://platform.example.com'),
+        accessToken: 'test-token',
+        addAsLink: const WorkplaceActionConfig(label: 'https://link.url'),
+        addAsAttachment: const WorkplaceActionConfig(label: 'https://attach.url'),
+        theme: WorkplaceTheme.light,
+      );
+
+      expect(
+        adapter.capturedOptions!.uri.queryParameters['force_session_id'],
+        equals('true'),
       );
     });
 

--- a/workplace/test/presentation/mixin/drive_intent_message_handler_mixin_test.dart
+++ b/workplace/test/presentation/mixin/drive_intent_message_handler_mixin_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:workplace/domain/entity/workplace_intent.dart';
 import 'package:workplace/domain/exceptions/workplace_exceptions.dart';
 import 'package:workplace/presentation/mixin/drive_intent_message_handler_mixin.dart';
+import 'package:workplace/presentation/model/drive_origin_validator.dart';
 import 'package:workplace/presentation/model/drive_pick_outcome.dart';
 
 // Minimal widget harness — no WebView/iframe needed.
@@ -25,6 +26,9 @@ class _TestState extends State<_TestWidget> with DriveIntentMessageHandlerMixin 
   bool throwOnLoad = false;
   bool failLoadAsync = false;
   bool throwOnCleanup = false;
+
+  @override
+  DriveOriginValidator get originValidator => const MobileDriveOriginValidator();
 
   @override
   Future<void> sendAck() {
@@ -57,8 +61,8 @@ class _TestState extends State<_TestWidget> with DriveIntentMessageHandlerMixin 
 const _intentId = 'test-123';
 const _origin = 'https://drive.example.com';
 
-WorkplaceIntent _intent({String intentId = _intentId, String url = '$_origin/pick'}) =>
-    WorkplaceIntent(intentId: intentId, intentUrl: Uri.parse(url));
+WorkplaceIntent _intent({String intentId = _intentId, String url = '$_origin/pick', String? client}) =>
+    WorkplaceIntent(intentId: intentId, intentUrl: Uri.parse(url), client: client);
 
 Future<_TestState> _pumpHarness(WidgetTester tester) async {
   await tester.pumpWidget(const MaterialApp(home: _TestWidget()));
@@ -177,19 +181,17 @@ void _invalidMessageTests() {
 }
 
 void _originFilterTests() {
-  testWidgets('wrong origin → nothing dispatched', (tester) async {
+  testWidgets('mismatched origin → dropped, not dispatched', (tester) async {
     final state = await _buildAndApply(tester);
     state.onMessage(raw: _encode({'type': 'intent-$_intentId:ready'}), origin: 'https://evil.example.com');
     expect(state.ackCalls, isEmpty);
-    expect(state.outcomes, isEmpty);
     state.cancelReadyTimeoutForTesting();
   });
 
-  testWidgets('null origin → nothing dispatched', (tester) async {
+  testWidgets('null origin → dropped, not dispatched', (tester) async {
     final state = await _buildAndApply(tester);
     state.onMessage(raw: _encode({'type': 'intent-$_intentId:ready'}), origin: null);
     expect(state.ackCalls, isEmpty);
-    expect(state.outcomes, isEmpty);
     state.cancelReadyTimeoutForTesting();
   });
 
@@ -453,6 +455,9 @@ class _TimeoutTestState extends State<_TimeoutTestWidget>
   Duration get readyTimeout => const Duration(milliseconds: 50);
 
   @override
+  DriveOriginValidator get originValidator => const MobileDriveOriginValidator();
+
+  @override
   Future<void> sendAck() => Future.value();
 
   @override
@@ -567,6 +572,18 @@ void main() {
     group('ready timeout wiring', _readyTimeoutTests);
     group('finish contract', _finishContractTests);
     group('dispose race safety', _disposeRaceSafetyTests);
+
+    group('intentClient', () {
+      testWidgets('exposes client from resolved intent once applied', (tester) async {
+        final state = await _buildAndApply(tester, intent: _intent(client: 'client-xyz'));
+        expect(state.intentClient, equals('client-xyz'));
+      });
+
+      testWidgets('is null when intent has no client', (tester) async {
+        final state = await _buildAndApply(tester);
+        expect(state.intentClient, isNull);
+      });
+    });
 
     group('multi-state isolation', () {
       testWidgets('two states with different intentIds — only matching state handles done', (tester) async {

--- a/workplace/test/presentation/mixin/drive_picker_web_message_listener_lifecycle_test.dart
+++ b/workplace/test/presentation/mixin/drive_picker_web_message_listener_lifecycle_test.dart
@@ -11,6 +11,7 @@ import 'package:workplace/presentation/mixin/drive_intent_message_handler_mixin.
 import 'package:workplace/presentation/mixin/drive_picker_state_mixin.dart';
 import 'package:workplace/presentation/mixin/web_window_message_mixin.dart';
 import 'package:workplace/presentation/model/drive_intent_image_assets.dart';
+import 'package:workplace/presentation/model/drive_origin_validator.dart';
 import 'package:workplace/presentation/model/drive_pick_outcome.dart';
 
 // Exercises the real `window.postMessage` transport (other tests call
@@ -28,6 +29,7 @@ const _intentId = 'intent-1';
 WorkplaceIntent _intent() => WorkplaceIntent(
       intentId: _intentId,
       intentUrl: Uri.parse('$_origin/pick'),
+      client: _origin,
     );
 
 Future<WorkplaceIntent> _fetchIntentStub({
@@ -141,6 +143,9 @@ class _DriveModalUnderTestState extends State<_DriveModalUnderTest>
   // burn the deadline (production is 20s).
   @override
   Duration get readyTimeout => const Duration(seconds: 5);
+
+  @override
+  DriveOriginValidator get originValidator => const WebDriveOriginValidator();
 
   @override
   void initState() {

--- a/workplace/test/presentation/model/drive_origin_validator_test.dart
+++ b/workplace/test/presentation/model/drive_origin_validator_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:workplace/presentation/model/drive_origin_validator.dart';
+
+const _origin = 'https://drive.example.com';
+const _otherOrigin = 'https://evil.example.com';
+const _client = 'client-xyz';
+
+void main() {
+  group('WebDriveOriginValidator', () {
+    const validator = WebDriveOriginValidator();
+
+    test('null origin → false', () {
+      expect(
+        validator.isValid(null, intentOrigin: _origin, intentClient: null),
+        isFalse,
+      );
+    });
+
+    test('origin matches intentOrigin → true', () {
+      expect(
+        validator.isValid(_origin, intentOrigin: _origin, intentClient: null),
+        isTrue,
+      );
+    });
+
+    test('mismatched origin → false', () {
+      expect(
+        validator.isValid(_otherOrigin, intentOrigin: _origin, intentClient: null),
+        isFalse,
+      );
+    });
+
+    test('origin matches intentClient but not intentOrigin → false (web ignores client)', () {
+      expect(
+        validator.isValid(_client, intentOrigin: _origin, intentClient: _client),
+        isFalse,
+      );
+    });
+
+    test('data: URI intent (intentOrigin "null") accepts "*"', () {
+      expect(
+        validator.isValid('*', intentOrigin: 'null', intentClient: null),
+        isTrue,
+      );
+    });
+
+    test('"*" rejected when intentOrigin is not "null"', () {
+      expect(
+        validator.isValid('*', intentOrigin: _origin, intentClient: null),
+        isFalse,
+      );
+    });
+  });
+
+  group('MobileDriveOriginValidator', () {
+    const validator = MobileDriveOriginValidator();
+
+    test('null origin → false', () {
+      expect(
+        validator.isValid(null, intentOrigin: _origin, intentClient: _client),
+        isFalse,
+      );
+    });
+
+    test('origin matches intentOrigin → true', () {
+      expect(
+        validator.isValid(_origin, intentOrigin: _origin, intentClient: _client),
+        isTrue,
+      );
+    });
+
+    test('origin matches intentClient (not intentOrigin) → true', () {
+      expect(
+        validator.isValid(_client, intentOrigin: _origin, intentClient: _client),
+        isTrue,
+      );
+    });
+
+    test('origin matches neither intentOrigin nor intentClient → false', () {
+      expect(
+        validator.isValid(_otherOrigin, intentOrigin: _origin, intentClient: _client),
+        isFalse,
+      );
+    });
+
+    test('intentClient null → client branch never matches', () {
+      expect(
+        validator.isValid(_otherOrigin, intentOrigin: _origin, intentClient: null),
+        isFalse,
+      );
+    });
+
+    test('data: URI intent (intentOrigin "null") accepts "*"', () {
+      expect(
+        validator.isValid('*', intentOrigin: 'null', intentClient: null),
+        isTrue,
+      );
+    });
+
+    test('wildcard intentClient does not match wildcard origin on HTTPS intent → false', () {
+      expect(
+        validator.isValid('*', intentOrigin: _origin, intentClient: '*'),
+        isFalse,
+      );
+    });
+
+    test('blank/whitespace intentClient never matches → false', () {
+      expect(
+        validator.isValid('   ', intentOrigin: _origin, intentClient: '   '),
+        isFalse,
+      );
+    });
+
+    test('valid non-wildcard intentClient still matches (unchanged behavior)', () {
+      expect(
+        validator.isValid(_client, intentOrigin: _origin, intentClient: _client),
+        isTrue,
+      );
+    });
+  });
+
+  group('isValidDriveClient', () {
+    test('null → false', () {
+      expect(isValidDriveClient(null), isFalse);
+    });
+
+    test('empty string → false', () {
+      expect(isValidDriveClient(''), isFalse);
+    });
+
+    test('whitespace-only → false', () {
+      expect(isValidDriveClient('   '), isFalse);
+    });
+
+    test('wildcard "*" → false', () {
+      expect(isValidDriveClient('*'), isFalse);
+    });
+
+    test('valid client id → true', () {
+      expect(isValidDriveClient(_client), isTrue);
+    });
+  });
+}

--- a/workplace/test/presentation/view/drive_intent_web_view_modal_web_test.dart
+++ b/workplace/test/presentation/view/drive_intent_web_view_modal_web_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:workplace/data/model/workplace_enums.dart';
 import 'package:workplace/data/model/workplace_intent_request.dart';
 import 'package:workplace/domain/entity/workplace_intent.dart';
 import 'package:workplace/presentation/model/drive_intent_image_assets.dart';
@@ -17,6 +18,7 @@ const _imageAssets = DriveIntentImageAssets(
 const _filePickerConfig = WorkplaceFilePickerConfigRequest(
   sharingLink: WorkplaceActionConfigRequest(),
   downloadLink: null,
+  theme: WorkplaceThemeConfigRequest(type: WorkplaceThemeType.light),
 );
 
 Widget _modal(Future<WorkplaceIntent> intent) {


### PR DESCRIPTION
## Issue
- #4739 

## Resolved

[untitled.webm](https://github.com/user-attachments/assets/b0ac6ad3-49fe-4087-8d43-8ad07c745e0e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Drive intent handling by capturing an optional client identifier and exposing it as part of intent metadata.
  * Added session enforcement when creating workplace intents.

* **Bug Fixes**
  * Prevented unintended back navigation during the composer HTML insertion flow.
  * Improved web view acknowledgement by validating and correctly serializing the resolved client/origin value.
  * When no intent client is available, acknowledgement now fails with a clear error; mismatched or null-origin messages are dropped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->