### PR TITLE
TF-4742 Drive picker theme

### DIFF
--- a/workplace/lib/data/datasource/workplace_datasource.dart
+++ b/workplace/lib/data/datasource/workplace_datasource.dart
@@ -1,5 +1,6 @@
 import '../../domain/entity/workplace_action_config.dart';
 import '../../domain/entity/workplace_intent.dart';
+import '../../domain/entity/workplace_theme.dart';
 
 abstract class WorkplaceDataSource {
   Future<WorkplaceIntent> createIntent({
@@ -7,6 +8,7 @@ abstract class WorkplaceDataSource {
     required String accessToken,
     required WorkplaceActionConfig addAsLink,
     WorkplaceActionConfig? addAsAttachment,
+    required WorkplaceTheme theme,
   });
   Future<String> exchangeToken(Uri platformUrl, String oidcIdToken);
 }

--- a/workplace/lib/data/datasource_impl/workplace_datasource_impl.dart
+++ b/workplace/lib/data/datasource_impl/workplace_datasource_impl.dart
@@ -11,6 +11,7 @@ import '../model/workplace_intent_response.dart';
 import '../workplace_dio.dart';
 import '../../domain/entity/workplace_action_config.dart';
 import '../../domain/entity/workplace_intent.dart';
+import '../../domain/entity/workplace_theme.dart';
 
 class WorkplaceDataSourceImpl implements WorkplaceDataSource {
   WorkplaceDataSourceImpl();
@@ -29,6 +30,7 @@ class WorkplaceDataSourceImpl implements WorkplaceDataSource {
     required String accessToken,
     required WorkplaceActionConfig addAsLink,
     WorkplaceActionConfig? addAsAttachment,
+    required WorkplaceTheme theme,
   }) async {
     final response = await WorkplaceDio.instance.post(
       platformUrl.replace(
@@ -43,6 +45,7 @@ class WorkplaceDataSourceImpl implements WorkplaceDataSource {
       data: _buildIntentRequest(
         addAsLink: addAsLink,
         addAsAttachment: addAsAttachment,
+        theme: theme,
       ),
     );
     return parseIntentResponse(response.data);
@@ -70,6 +73,7 @@ class WorkplaceDataSourceImpl implements WorkplaceDataSource {
   Map<String, dynamic> _buildIntentRequest({
     required WorkplaceActionConfig addAsLink,
     WorkplaceActionConfig? addAsAttachment,
+    required WorkplaceTheme theme,
   }) => WorkplaceIntentRequest(
     data: WorkplaceIntentDataRequest(
       type: WorkplaceDataRequestType.intents,
@@ -82,6 +86,7 @@ class WorkplaceDataSourceImpl implements WorkplaceDataSource {
           downloadLink: addAsAttachment == null
               ? null
               : WorkplaceActionConfigRequest.fromEntity(addAsAttachment),
+          theme: WorkplaceThemeConfigRequest.fromEntity(theme),
         ),
       ),
     ),

--- a/workplace/lib/data/model/workplace_enums.dart
+++ b/workplace/lib/data/model/workplace_enums.dart
@@ -24,3 +24,10 @@ enum WorkplaceExchangeType {
   admin,
   app;
 }
+
+enum WorkplaceThemeType {
+  @JsonValue('light')
+  light,
+  @JsonValue('dark')
+  dark;
+}

--- a/workplace/lib/data/model/workplace_enums.dart
+++ b/workplace/lib/data/model/workplace_enums.dart
@@ -26,8 +26,6 @@ enum WorkplaceExchangeType {
 }
 
 enum WorkplaceThemeType {
-  @JsonValue('light')
   light,
-  @JsonValue('dark')
   dark;
 }

--- a/workplace/lib/data/model/workplace_intent_request.dart
+++ b/workplace/lib/data/model/workplace_intent_request.dart
@@ -1,6 +1,7 @@
 import 'workplace_enums.dart';
 import 'package:json_annotation/json_annotation.dart';
 import '../../domain/entity/workplace_action_config.dart';
+import '../../domain/entity/workplace_theme.dart';
 
 part 'workplace_intent_request.g.dart';
 
@@ -17,14 +18,33 @@ class WorkplaceActionConfigRequest {
   Map<String, dynamic> toJson() => _$WorkplaceActionConfigRequestToJson(this);
 }
 
+@JsonSerializable(createFactory: false)
+class WorkplaceThemeConfigRequest {
+  final WorkplaceThemeType type;
+
+  const WorkplaceThemeConfigRequest({required this.type});
+
+  factory WorkplaceThemeConfigRequest.fromEntity(WorkplaceTheme theme) =>
+      WorkplaceThemeConfigRequest(
+        type: switch (theme) {
+          WorkplaceTheme.light => WorkplaceThemeType.light,
+          WorkplaceTheme.dark => WorkplaceThemeType.dark,
+        },
+      );
+
+  Map<String, dynamic> toJson() => _$WorkplaceThemeConfigRequestToJson(this);
+}
+
 @JsonSerializable(createFactory: false, explicitToJson: true)
 class WorkplaceFilePickerConfigRequest {
   final WorkplaceActionConfigRequest sharingLink;
   final WorkplaceActionConfigRequest? downloadLink;
+  final WorkplaceThemeConfigRequest theme;
 
   const WorkplaceFilePickerConfigRequest({
     required this.sharingLink,
     required this.downloadLink,
+    required this.theme,
   });
 
   Map<String, dynamic> toJson() =>

--- a/workplace/lib/data/repository_impl/workplace_repository_impl.dart
+++ b/workplace/lib/data/repository_impl/workplace_repository_impl.dart
@@ -1,6 +1,7 @@
 import '../datasource/workplace_datasource.dart';
 import '../../domain/entity/workplace_action_config.dart';
 import '../../domain/entity/workplace_intent.dart';
+import '../../domain/entity/workplace_theme.dart';
 import '../../domain/repository/workplace_repository.dart';
 
 class WorkplaceRepositoryImpl implements WorkplaceRepository {
@@ -14,11 +15,13 @@ class WorkplaceRepositoryImpl implements WorkplaceRepository {
     required String accessToken,
     required WorkplaceActionConfig addAsLink,
     WorkplaceActionConfig? addAsAttachment,
+    required WorkplaceTheme theme,
   }) => _dataSource.createIntent(
     platformUrl: platformUrl,
     accessToken: accessToken,
     addAsLink: addAsLink,
     addAsAttachment: addAsAttachment,
+    theme: theme,
   );
 
   @override

--- a/workplace/lib/domain/entity/workplace_theme.dart
+++ b/workplace/lib/domain/entity/workplace_theme.dart
@@ -1,0 +1,1 @@
+enum WorkplaceTheme { light, dark }

--- a/workplace/lib/domain/repository/workplace_repository.dart
+++ b/workplace/lib/domain/repository/workplace_repository.dart
@@ -1,5 +1,6 @@
 import '../entity/workplace_action_config.dart';
 import '../entity/workplace_intent.dart';
+import '../entity/workplace_theme.dart';
 
 abstract class WorkplaceRepository {
   Future<WorkplaceIntent> createIntent({
@@ -7,6 +8,7 @@ abstract class WorkplaceRepository {
     required String accessToken,
     required WorkplaceActionConfig addAsLink,
     WorkplaceActionConfig? addAsAttachment,
+    required WorkplaceTheme theme,
   });
   Future<String> exchangeToken(Uri platformUrl, String oidcIdToken);
 }

--- a/workplace/lib/domain/usecase/create_drive_intent_interactor.dart
+++ b/workplace/lib/domain/usecase/create_drive_intent_interactor.dart
@@ -2,6 +2,7 @@ import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:dartz/dartz.dart';
 import '../entity/workplace_action_config.dart';
+import '../entity/workplace_theme.dart';
 import '../repository/workplace_repository.dart';
 import '../state/workplace_intent_state.dart';
 
@@ -15,6 +16,7 @@ class CreateDriveIntentInteractor {
     String accessToken, {
     required WorkplaceActionConfig addAsLink,
     WorkplaceActionConfig? addAsAttachment,
+    required WorkplaceTheme theme,
   }) async* {
     try {
       yield Right(CreatingWorkplaceIntent());
@@ -23,6 +25,7 @@ class CreateDriveIntentInteractor {
         accessToken: accessToken,
         addAsLink: addAsLink,
         addAsAttachment: addAsAttachment,
+        theme: theme,
       );
       yield Right(CreateWorkplaceIntentSuccess(intent));
     } catch (e) {

--- a/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
+++ b/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
@@ -6,10 +6,12 @@ import 'package:core/utils/app_logger.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:workplace/data/datasource_impl/workplace_datasource_impl.dart';
+import 'package:workplace/data/model/workplace_enums.dart';
 import 'package:workplace/data/model/workplace_intent_request.dart';
 import 'package:workplace/data/repository_impl/workplace_repository_impl.dart';
 import 'package:workplace/domain/entity/workplace_action_config.dart';
 import 'package:workplace/domain/entity/workplace_intent.dart';
+import 'package:workplace/domain/entity/workplace_theme.dart';
 import 'package:workplace/domain/exceptions/workplace_exceptions.dart';
 import 'package:workplace/presentation/model/drive_pick_state.dart';
 import 'package:workplace/domain/state/workplace_intent_state.dart';
@@ -93,6 +95,10 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
       addAsAttachment: filePickerConfig.downloadLink == null
           ? null
           : WorkplaceActionConfig(label: filePickerConfig.downloadLink!.label),
+      theme: switch (filePickerConfig.theme.type) {
+        WorkplaceThemeType.light => WorkplaceTheme.light,
+        WorkplaceThemeType.dark => WorkplaceTheme.dark,
+      },
     )) {
       either.fold(
         (failure) {

--- a/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
+++ b/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
@@ -2,6 +2,7 @@ import 'package:core/utils/app_logger.dart';
 import 'package:flutter/material.dart';
 import 'package:workplace/data/model/workplace_intent_request.dart';
 import 'package:workplace/domain/entity/workplace_intent.dart';
+import 'package:workplace/domain/entity/workplace_theme.dart';
 import 'package:workplace/l10n/workplace_localizations.dart';
 import 'package:workplace/presentation/model/drive_intent_image_assets.dart';
 import 'package:workplace/presentation/model/drive_pick_outcome.dart';
@@ -42,11 +43,13 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
       // menu tile) before the intent future settles, disposing this state.
       final failingMessage = l10n.attachFromDriveFailingMessage;
       const addAsAttachmentTitle = null; // TODO: Add attachment title here after implement 103. Attach Drive File as Attachment
+      final theme = _resolveWorkplaceTheme(context);
       final filePickerConfig = WorkplaceFilePickerConfigRequest(
         sharingLink: WorkplaceActionConfigRequest(label: l10n.addAsLink),
         downloadLink: addAsAttachmentTitle == null
             ? null
             : const WorkplaceActionConfigRequest(label: addAsAttachmentTitle),
+        theme: WorkplaceThemeConfigRequest.fromEntity(theme),
       );
       DrivePickOutcome? outcome;
       try {
@@ -100,4 +103,9 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
         break;
     }
   }
+
+  WorkplaceTheme _resolveWorkplaceTheme(BuildContext context) =>
+    Theme.of(context).brightness == Brightness.dark
+        ? WorkplaceTheme.dark
+        : WorkplaceTheme.light;
 }

--- a/workplace/test/data/workplace_datasource_impl_test.dart
+++ b/workplace/test/data/workplace_datasource_impl_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:workplace/data/datasource_impl/workplace_datasource_impl.dart';
 import 'package:workplace/data/workplace_dio.dart';
 import 'package:workplace/domain/entity/workplace_action_config.dart';
+import 'package:workplace/domain/entity/workplace_theme.dart';
 
 /// Captures the last request and returns a fixed JSON response.
 class _MockAdapter implements HttpClientAdapter {
@@ -218,6 +219,7 @@ void main() {
         accessToken: 'test-token',
         addAsLink: const WorkplaceActionConfig(label: 'https://link.url'),
         addAsAttachment: const WorkplaceActionConfig(label: 'https://attach.url'),
+        theme: WorkplaceTheme.light,
       );
 
       expect(result.intentId, equals('intent-abc'));
@@ -233,6 +235,7 @@ void main() {
         accessToken: 'test-token',
         addAsLink: const WorkplaceActionConfig(label: 'https://link.url'),
         addAsAttachment: const WorkplaceActionConfig(label: 'https://attach.url'),
+        theme: WorkplaceTheme.light,
       );
 
       expect(
@@ -250,6 +253,7 @@ void main() {
         accessToken: 'my-secret-token',
         addAsLink: const WorkplaceActionConfig(label: 'https://link.url'),
         addAsAttachment: const WorkplaceActionConfig(label: 'https://attach.url'),
+        theme: WorkplaceTheme.light,
       );
 
       expect(
@@ -267,6 +271,7 @@ void main() {
         accessToken: 'test-token',
         addAsLink: const WorkplaceActionConfig(label: 'https://link.url'),
         addAsAttachment: const WorkplaceActionConfig(label: 'https://attach.url'),
+        theme: WorkplaceTheme.dark,
       );
 
       // Normalize through jsonEncode so nested Dart objects are fully serialized
@@ -284,6 +289,8 @@ void main() {
       expect(sharingLink['label'], equals('https://link.url'));
       final downloadLink = config['downloadLink'] as Map<String, dynamic>;
       expect(downloadLink['label'], equals('https://attach.url'));
+      final theme = config['theme'] as Map<String, dynamic>;
+      expect(theme['type'], equals('dark'));
     });
 
     test('Should send explicit null downloadLink to hide the attachment button when addAsAttachment is omitted', () async {
@@ -294,6 +301,7 @@ void main() {
         platformUrl: Uri.parse('https://platform.example.com'),
         accessToken: 'test-token',
         addAsLink: const WorkplaceActionConfig(label: 'https://link.url'),
+        theme: WorkplaceTheme.light,
       );
 
       final body = jsonDecode(jsonEncode(adapter.capturedOptions!.data)) as Map<String, dynamic>;
@@ -313,6 +321,7 @@ void main() {
           accessToken: 'test-token',
           addAsLink: const WorkplaceActionConfig(label: 'https://link.url'),
           addAsAttachment: const WorkplaceActionConfig(label: 'https://attach.url'),
+          theme: WorkplaceTheme.light,
         ),
         throwsA(isA<DioException>()),
       );

--- a/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
+++ b/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
@@ -5,6 +5,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:workplace/data/model/workplace_enums.dart';
 import 'package:workplace/data/model/workplace_intent_request.dart';
 import 'package:workplace/data/workplace_dio.dart';
 import 'package:workplace/l10n/workplace_localizations.dart';
@@ -422,6 +423,7 @@ void main() {
           filePickerConfig: const WorkplaceFilePickerConfigRequest(
             sharingLink: WorkplaceActionConfigRequest(label: 'Link'),
             downloadLink: WorkplaceActionConfigRequest(label: 'Attachment'),
+            theme: WorkplaceThemeConfigRequest(type: WorkplaceThemeType.light),
           ),
         ),
         throwsA(isA<StateError>().having(
@@ -443,6 +445,7 @@ void main() {
           filePickerConfig: const WorkplaceFilePickerConfigRequest(
             sharingLink: WorkplaceActionConfigRequest(label: 'Link'),
             downloadLink: WorkplaceActionConfigRequest(label: 'Attachment'),
+            theme: WorkplaceThemeConfigRequest(type: WorkplaceThemeType.light),
           ),
         ),
           throwsA(isA<DioException>()),
@@ -466,6 +469,7 @@ void main() {
           filePickerConfig: const WorkplaceFilePickerConfigRequest(
             sharingLink: WorkplaceActionConfigRequest(label: 'Link'),
             downloadLink: WorkplaceActionConfigRequest(label: 'Attachment'),
+            theme: WorkplaceThemeConfigRequest(type: WorkplaceThemeType.light),
           ),
         ),
           throwsA(isA<DioException>()),
@@ -488,6 +492,7 @@ void main() {
           filePickerConfig: const WorkplaceFilePickerConfigRequest(
             sharingLink: WorkplaceActionConfigRequest(label: 'Link'),
             downloadLink: WorkplaceActionConfigRequest(label: 'Attachment'),
+            theme: WorkplaceThemeConfigRequest(type: WorkplaceThemeType.light),
           ),
         ),
       );

--- a/workplace/test/presentation/mixin/drive_picker_state_mixin_test.dart
+++ b/workplace/test/presentation/mixin/drive_picker_state_mixin_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:workplace/data/model/workplace_enums.dart';
 import 'package:workplace/data/model/workplace_intent_request.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
 import 'package:workplace/domain/entity/workplace_intent.dart';
@@ -53,11 +54,12 @@ class _TestState extends State<_TestWidget>
   Widget build(BuildContext context) => const SizedBox.shrink();
 }
 
-Future<_TestState> _pumpPicker(WidgetTester tester) async {
-  await tester.pumpWidget(const MaterialApp(
+Future<_TestState> _pumpPicker(WidgetTester tester, {ThemeData? theme}) async {
+  await tester.pumpWidget(MaterialApp(
+    theme: theme,
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
-    home: _TestWidget(),
+    home: const _TestWidget(),
   ));
   return tester.state<_TestState>(find.byType(_TestWidget));
 }
@@ -124,6 +126,29 @@ void main() {
         expect(state.pickStates, hasLength(1));
         final failure = state.pickStates.single as DrivePickFailure;
         expect(failure.error, same(error));
+      });
+    });
+
+    group('theme resolution', () {
+      testWidgets('uses the app declared theme (light) regardless of no explicit theme', (tester) async {
+        final state = await _pumpPicker(tester);
+        state.modalStub = () => Future.value(const DrivePickOutcomeCancelled());
+
+        await state.onPickerTap();
+
+        expect(state.openCalls.single.theme.type, WorkplaceThemeType.light);
+      });
+
+      testWidgets('follows the app theme brightness when dark', (tester) async {
+        final state = await _pumpPicker(
+          tester,
+          theme: ThemeData(brightness: Brightness.dark),
+        );
+        state.modalStub = () => Future.value(const DrivePickOutcomeCancelled());
+
+        await state.onPickerTap();
+
+        expect(state.openCalls.single.theme.type, WorkplaceThemeType.dark);
       });
     });
 


### PR DESCRIPTION
## Issue
- #4742 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added light/dark theme support to Workplace file-picker intent requests.
  * Intent creation now includes the app’s active theme when generating the request payload.
  * The picker automatically detects the app appearance (light or dark) and applies it during intent creation.
* **Tests**
  * Updated and added widget/data-source tests to verify theme resolution and that the generated request includes the correct `theme` type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->