### PR TITLE
Fix mobile session stuck forever when the refresh token is rejected

### DIFF
--- a/lib/features/login/data/network/authentication_client/mobile_refresh_token_error_classifier.dart
+++ b/lib/features/login/data/network/authentication_client/mobile_refresh_token_error_classifier.dart
@@ -1,0 +1,45 @@
+import 'package:tmail_ui_user/features/login/data/network/authentication_client/refresh_token_error_classifier.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/oauth_authorization_error.dart';
+
+/// Classifies the refresh failures thrown by flutter_appauth (native).
+///
+/// The native refresh never reaches Dio, so a token-endpoint rejection arrives
+/// as an [OAuthAuthorizationError] carrying the RFC 6749 code that the
+/// authorization server returned in the 400 body.
+///
+/// A failure with no OAuth2 code (connectivity, DNS, no browser) keeps its
+/// original PlatformException type and never reaches this classifier, so a
+/// flaky connection cannot be read as a rejection.
+class MobileRefreshTokenErrorClassifier extends RefreshTokenErrorClassifier {
+  @override
+  String get rejectedAuthErrorType => 'token_endpoint_oauth_rejected';
+
+  @override
+  String get unclassifiedAuthErrorType => 'token_endpoint_oauth_unknown_error';
+
+  @override
+  bool isPlatformRejection(Object error) {
+    if (error is! OAuthAuthorizationError) return false;
+    if (RefreshTokenErrorClassifier.badGrantCodes.contains(error.error)) {
+      return true;
+    }
+    // Defensive: an authorization server may answer with the wrapper code
+    // `token_failed` and put the real RFC 6749 code in the description,
+    // the way flutter_appauth_web does.
+    if (error.error == 'token_failed') {
+      final desc = error.message?.trim();
+      return desc != null &&
+          RefreshTokenErrorClassifier.badGrantCodes.contains(desc);
+    }
+    return false;
+  }
+
+  @override
+  Map<String, dynamic> buildPlatformSentryExtras(Object error) {
+    if (error is! OAuthAuthorizationError) return const {};
+    return {
+      'oauth_error_code': error.error,
+      'oauth_error_description': error.message ?? 'unknown',
+    };
+  }
+}

--- a/lib/features/login/data/network/authentication_client/refresh_token_error_classifier.dart
+++ b/lib/features/login/data/network/authentication_client/refresh_token_error_classifier.dart
@@ -1,0 +1,70 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_exception.dart'
+    show AccessTokenInvalidException;
+
+/// Classifies token-refresh errors according to RFC 6749 §5.2.
+/// https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+///
+/// Single responsibility: answer two questions —
+///   1. Is this error a definitive server rejection (400/401 equivalent)?
+///   2. What structured extras should go to Sentry for tracing?
+///
+/// Web and mobile refresh through different plugins, so the same rejection
+/// surfaces as a different Dart type on each platform. Everything those two
+/// have in common lives here; the platform-specific error shape is decided by
+/// the subclass, which keeps one platform's error types from ever influencing
+/// the other's verdict.
+abstract class RefreshTokenErrorClassifier {
+  /// Standard RFC 6749 §5.2 token-endpoint error codes that map to a
+  /// definitive 400/401 rejection — logout is safe.
+  /// Non-standard codes (e.g. "token_failed") are absent intentionally;
+  /// they are logged to Sentry until their HTTP status is confirmed.
+  static const badGrantCodes = {
+    'invalid_grant',          // refresh token expired or revoked (400)
+    'invalid_client',         // client authentication failed (400 or 401)
+    'invalid_request',        // request was malformed (400)
+    'invalid_scope',          // requested scope exceeds original grant (400)
+    'unauthorized_client',    // client not authorized for this grant type (400)
+    'unsupported_grant_type', // grant type not supported by the server (400)
+  };
+
+  /// Value of the `auth_error_type` Sentry field when the refresh was rejected.
+  @protected
+  String get rejectedAuthErrorType;
+
+  /// Value of the `auth_error_type` Sentry field when the failure could not be
+  /// classified — the session is kept and the event is a trace, not a verdict.
+  @protected
+  String get unclassifiedAuthErrorType;
+
+  /// Returns `true` when [error] represents a confirmed server-side rejection
+  /// that maps to HTTP 400 or 401, making logout the correct response.
+  bool isServerRejection(Object error) {
+    if (error is AccessTokenInvalidException) return true;
+    if (error is DioException) return _isDioRejection(error);
+    return isPlatformRejection(error);
+  }
+
+  /// Classifies the error type the platform's own refresh plugin throws.
+  @protected
+  bool isPlatformRejection(Object error);
+
+  /// Sentry extras describing the platform-specific error shape, so the
+  /// underlying OAuth2 code stays visible even for non-standard values.
+  @protected
+  Map<String, dynamic> buildPlatformSentryExtras(Object error) => const {};
+
+  bool _isDioRejection(DioException error) {
+    final statusCode = error.response?.statusCode;
+    return statusCode == 400 || statusCode == 401;
+  }
+
+  /// Builds structured Sentry extras for [error].
+  Map<String, dynamic> buildSentryExtras(Object error) => {
+        'auth_error_type': isServerRejection(error)
+            ? rejectedAuthErrorType
+            : unclassifiedAuthErrorType,
+        ...buildPlatformSentryExtras(error),
+      };
+}

--- a/lib/features/login/data/network/authentication_client/web_refresh_token_error_classifier.dart
+++ b/lib/features/login/data/network/authentication_client/web_refresh_token_error_classifier.dart
@@ -1,75 +1,47 @@
-import 'package:dio/dio.dart';
-import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_exception.dart'
-    show AccessTokenInvalidException;
+import 'package:tmail_ui_user/features/login/data/network/authentication_client/refresh_token_error_classifier.dart';
 
-/// Classifies web token-refresh errors according to RFC 6749 §5.2.
-/// https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+/// Classifies the refresh failures thrown by flutter_appauth_web.
 ///
-/// Single responsibility: answer two questions —
-///   1. Is this error a definitive server rejection (400/401 equivalent)?
-///   2. What structured extras should go to Sentry for tracing?
-///
-/// Intentionally has NO dependency on Dio handler operations or interceptor
-/// state; callers act on the result (logout, keep session, log).
-class WebRefreshTokenErrorClassifier {
-  /// Standard RFC 6749 §5.2 token-endpoint error codes that map to a
-  /// definitive 400/401 rejection — logout is safe.
-  /// Non-standard codes (e.g. "token_failed") are absent intentionally;
-  /// they are logged to Sentry until their HTTP status is confirmed.
-  static const _badGrantCodes = {
-    'invalid_grant',          // refresh token expired or revoked (400)
-    'invalid_client',         // client authentication failed (400 or 401)
-    'invalid_request',        // request was malformed (400)
-    'invalid_scope',          // requested scope exceeds original grant (400)
-    'unauthorized_client',    // client not authorized for this grant type (400)
-    'unsupported_grant_type', // grant type not supported by the server (400)
-  };
+/// The web plugin reports every non-200 token response as an [ArgumentError]
+/// whose message carries the OAuth2 fields:
+/// `Failed to get token: [error: X, description: Y]`.
+class WebRefreshTokenErrorClassifier extends RefreshTokenErrorClassifier {
+  @override
+  String get rejectedAuthErrorType => 'web_server_rejected_refresh';
 
-  /// Returns `true` when [error] represents a confirmed server-side rejection
-  /// that maps to HTTP 400 or 401, making logout the correct response.
-  bool isServerRejection(Object error) {
-    if (error is AccessTokenInvalidException) return true;
-    if (error is ArgumentError) return _isArgumentErrorRejection(error);
-    if (error is DioException) return _isDioRejection(error);
-    return false;
-  }
+  @override
+  String get unclassifiedAuthErrorType => 'web_token_unknown_error';
 
-  bool _isArgumentErrorRejection(ArgumentError error) {
+  @override
+  bool isPlatformRejection(Object error) {
+    if (error is! ArgumentError) return false;
     final code = _parseOAuthCode(error);
-    if (code != null && _badGrantCodes.contains(code)) return true;
+    if (code != null &&
+        RefreshTokenErrorClassifier.badGrantCodes.contains(code)) {
+      return true;
+    }
     // flutter_appauth_web always wraps non-200 token responses as
     // [error: token_failed, description: <actual-rfc-6749-code>].
     // When the code is 'token_failed', the real rejection signal lives in
     // the description field.
     if (code == 'token_failed') {
       final desc = _parseOAuthDesc(error);
-      return desc != null && _badGrantCodes.contains(desc);
+      return desc != null &&
+          RefreshTokenErrorClassifier.badGrantCodes.contains(desc);
     }
     return false;
   }
 
-  bool _isDioRejection(DioException error) {
-    final statusCode = error.response?.statusCode;
-    return statusCode == 400 || statusCode == 401;
-  }
-
-  /// Builds structured Sentry extras for [error].
-  ///
-  /// For [ArgumentError], includes [oauth_error_code] and
-  /// [oauth_error_description] parsed from the flutter_appauth_web message so
-  /// that non-standard codes (e.g. "token_failed") are fully visible in Sentry.
-  Map<String, dynamic> buildSentryExtras(Object error) {
-    final rejected = isServerRejection(error);
-    final extras = <String, dynamic>{
-      'auth_error_type': rejected
-          ? 'web_server_rejected_refresh'
-          : 'web_token_unknown_error',
+  /// Includes [oauth_error_code] and [oauth_error_description] parsed from the
+  /// flutter_appauth_web message so that non-standard codes (e.g.
+  /// "token_failed") are fully visible in Sentry.
+  @override
+  Map<String, dynamic> buildPlatformSentryExtras(Object error) {
+    if (error is! ArgumentError) return const {};
+    return {
+      'oauth_error_code': _parseOAuthCode(error) ?? 'unknown',
+      'oauth_error_description': _parseOAuthDesc(error) ?? 'unknown',
     };
-    if (error is ArgumentError) {
-      extras['oauth_error_code'] = _parseOAuthCode(error) ?? 'unknown';
-      extras['oauth_error_description'] = _parseOAuthDesc(error) ?? 'unknown';
-    }
-    return extras;
   }
 
   // Parses the OAuth2 `error` field from flutter_appauth_web's ArgumentError

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -19,6 +19,7 @@ import 'package:tmail_ui_user/features/login/data/network/authentication_client/
 import 'package:tmail_ui_user/features/login/data/network/authentication_client/mobile_refresh_token_error_classifier.dart';
 import 'package:tmail_ui_user/features/login/data/network/authentication_client/refresh_token_error_classifier.dart';
 import 'package:tmail_ui_user/features/login/data/network/authentication_client/web_refresh_token_error_classifier.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/oauth_authorization_error.dart';
 import 'package:tmail_ui_user/features/login/domain/extensions/oidc_configuration_extensions.dart';
 import 'package:tmail_ui_user/features/upload/data/network/file_uploader.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
@@ -251,12 +252,44 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     return _handleRefreshErrorOnMobile(error, stackTrace, originalError, handler);
   }
 
+  /// On mobile the refresh runs through flutter_appauth (native), so a rejected
+  /// refresh token never surfaces as a [DioException] — the `statusCode == 400`
+  /// branch in [_refreshTokenThenRetry] is unreachable here. The rejection
+  /// arrives as an [OAuthAuthorizationError] instead, and without this check the
+  /// dead session would be kept and every request would retry forever.
+  ///
+  /// Only a confirmed RFC 6749 rejection logs out; transient codes
+  /// (`server_error`, `temporarily_unavailable`) keep the session so a flaky
+  /// connection does not sign the user out.
+  ///
+  /// Shared with [_refreshTokenThenRetry] so the routing decision and the
+  /// handling of it cannot drift apart.
+  bool _isRefreshRejectedByTokenEndpoint(Object error) =>
+      error is OAuthAuthorizationError &&
+      _errorClassifier.isServerRejection(error);
+
   void _handleRefreshErrorOnMobile(
     Object error,
     StackTrace stackTrace,
     DioException originalError,
     ErrorInterceptorHandler handler,
   ) {
+    if (_isRefreshRejectedByTokenEndpoint(error)) {
+      logError(
+        'AuthorizationInterceptors::_handleRefreshErrorOnMobile: '
+        'will_logout=true — error=$error',
+        exception: error,
+        stackTrace: stackTrace,
+        extras: _errorClassifier.buildSentryExtras(error),
+      );
+      clear();
+      return handler.reject(DioException(
+        requestOptions: originalError.requestOptions,
+        error: RefreshTokenFailedException(),
+        type: DioExceptionType.badResponse,
+      ));
+    }
+
     if (error is DioException) {
       return super.onError(error, handler);
     }

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -241,7 +241,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         extras: _errorClassifier.buildSentryExtras(error),
         webConsoleEnabled: true,
       );
-      return _handleRefreshErrorOnMobile(error, stackTrace, originalError, handler);
+      return _propagateKeepingSession(error, originalError, handler);
     }
 
     logWarning(
@@ -249,7 +249,23 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       'web refresh network/transient failure, keeping session — error=$error',
       webConsoleEnabled: true,
     );
-    return _handleRefreshErrorOnMobile(error, stackTrace, originalError, handler);
+    return _propagateKeepingSession(error, originalError, handler);
+  }
+
+  /// Propagates [error] downstream WITHOUT touching the session, normalising it
+  /// to a [DioException] first so callers below the interceptor see one type.
+  void _propagateKeepingSession(
+    Object error,
+    DioException originalError,
+    ErrorInterceptorHandler handler,
+  ) {
+    if (error is DioException) {
+      return super.onError(error, handler);
+    }
+    return super.onError(
+      error.toDioException(requestOptions: originalError.requestOptions),
+      handler,
+    );
   }
 
   /// On mobile the refresh runs through flutter_appauth (native), so a rejected
@@ -290,13 +306,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       ));
     }
 
-    if (error is DioException) {
-      return super.onError(error, handler);
-    }
-    return super.onError(
-      error.toDioException(requestOptions: originalError.requestOptions),
-      handler,
-    );
+    return _propagateKeepingSession(error, originalError, handler);
   }
 
   /// A retry that comes back 401 then surfaces downstream as

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -422,11 +422,16 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         handler,
       );
     } catch (e, st) {
-      // On web, flutter_appauth_web throws ArgumentError (and similar non-Dio
-      // errors) for token-endpoint failures. Catching here routes them directly
-      // to _handleRefreshError — preventing the outer catch in onError() from
-      // firing and producing a duplicate Sentry event.
-      if (PlatformInfo.isWeb) {
+      // Failures the platform handler already classifies are routed straight to
+      // it, so the outer catch in onError() does not fire and log a second,
+      // generic Sentry event for the same refresh failure. On web that is every
+      // non-Dio error flutter_appauth_web throws (ArgumentError and friends); on
+      // mobile it is the native token-endpoint rejection.
+      //
+      // Anything still unclassified is rethrown on purpose: the generic event in
+      // onError() is then the only trace of it, and losing it would leave those
+      // failures invisible.
+      if (PlatformInfo.isWeb || _isRefreshRejectedByTokenEndpoint(e)) {
         return _handleRefreshError(e, st, err, handler);
       }
       rethrow;

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -16,6 +16,8 @@ import 'package:tmail_ui_user/features/base/extensions/object_extensions.dart';
 import 'package:tmail_ui_user/features/login/data/local/account_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/local/token_oidc_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/network/authentication_client/authentication_client_base.dart';
+import 'package:tmail_ui_user/features/login/data/network/authentication_client/mobile_refresh_token_error_classifier.dart';
+import 'package:tmail_ui_user/features/login/data/network/authentication_client/refresh_token_error_classifier.dart';
 import 'package:tmail_ui_user/features/login/data/network/authentication_client/web_refresh_token_error_classifier.dart';
 import 'package:tmail_ui_user/features/login/domain/extensions/oidc_configuration_extensions.dart';
 import 'package:tmail_ui_user/features/upload/data/network/file_uploader.dart';
@@ -36,7 +38,13 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
   TokenOIDC? _token;
   String? _authorization;
 
-  final WebRefreshTokenErrorClassifier _webErrorClassifier;
+  final RefreshTokenErrorClassifier? _injectedErrorClassifier;
+
+  late final RefreshTokenErrorClassifier _errorClassifier =
+      _injectedErrorClassifier ??
+          (PlatformInfo.isWeb
+              ? WebRefreshTokenErrorClassifier()
+              : MobileRefreshTokenErrorClassifier());
 
   late final void Function(
     Object error,
@@ -52,8 +60,8 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     this._tokenOidcCacheManager,
     this._accountCacheManager,
     this._iosSharingManager, {
-    WebRefreshTokenErrorClassifier? webErrorClassifier,
-  }) : _webErrorClassifier = webErrorClassifier ?? WebRefreshTokenErrorClassifier();
+    RefreshTokenErrorClassifier? errorClassifier,
+  }) : _injectedErrorClassifier = errorClassifier;
 
   void setBasicAuthorization(UserName userName, Password password) {
     _authorization = base64Encode(utf8.encode('${userName.value}:${password.value}'));
@@ -193,7 +201,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
   /// the session and is propagated WITHOUT the stale 401 — same as mobile — so
   /// a flaky connection does not log the web user out.
   ///
-  /// Error routing delegates RFC 6749 classification to [WebRefreshTokenErrorClassifier]:
+  /// Error routing delegates RFC 6749 classification to [RefreshTokenErrorClassifier]:
   /// - Server rejection (400/401 or RFC 6749 bad-grant code) → logout.
   /// - [ArgumentError] with unknown OAuth2 code → Sentry trace, keep session.
   /// - Network/transport failure → keep session silently.
@@ -203,7 +211,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     DioException originalError,
     ErrorInterceptorHandler handler,
   ) {
-    final isRejected = _webErrorClassifier.isServerRejection(error);
+    final isRejected = _errorClassifier.isServerRejection(error);
 
     if (isRejected) {
       logError(
@@ -211,7 +219,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         'will_logout=true — error=$error',
         exception: error,
         stackTrace: stackTrace,
-        extras: _webErrorClassifier.buildSentryExtras(error),
+        extras: _errorClassifier.buildSentryExtras(error),
         webConsoleEnabled: true,
       );
       clear();
@@ -229,7 +237,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         'will_logout=false — error=$error',
         exception: error,
         stackTrace: stackTrace,
-        extras: _webErrorClassifier.buildSentryExtras(error),
+        extras: _errorClassifier.buildSentryExtras(error),
         webConsoleEnabled: true,
       );
       return _handleRefreshErrorOnMobile(error, stackTrace, originalError, handler);

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -3690,6 +3690,95 @@ void main() {
       },
     );
   });
+
+  // ============================================================
+  // onError: MOBILE refresh failure emits EXACTLY ONE Sentry event
+  // Same dedup guarantee as web: a rejection is routed to the mobile handler
+  // from inside _refreshTokenThenRetry, so the outer catch in onError() never
+  // adds its own generic event. Failures the handler does NOT classify keep
+  // that generic event — it is their only trace.
+  // ============================================================
+  group('onError: mobile refresh failure emits a single Sentry event', () {
+    late _CapturingLogHandler logHandler;
+
+    setUp(() {
+      logHandler = _CapturingLogHandler();
+      AppLoggerRegistry.instance.registerHandler(logHandler);
+    });
+
+    tearDown(() => AppLoggerRegistry.instance.resetForTesting());
+
+    test(
+      'WHEN mobile refresh is rejected by the token endpoint (invalid_grant)\n'
+      'THEN exactly ONE error-level event is emitted (will_logout=true)\n'
+      'AND the duplicate generic onError:Exception event is NOT logged',
+      () async {
+        stubWebRefresh401ThenThrow(const OAuthAuthorizationError(
+          error: 'invalid_grant',
+          errorDescription: 'The refresh token has been revoked',
+        ));
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>(
+            (e) => e.error is RefreshTokenFailedException,
+          )),
+        );
+
+        final errorRecords = logHandler.errorRecords;
+        expect(
+          errorRecords.length,
+          1,
+          reason: 'mobile refresh rejection must emit exactly one error event',
+        );
+        expect(errorRecords.single.rawMessage, contains('will_logout=true'));
+        expect(
+          errorRecords.single.extras,
+          containsPair('auth_error_type', 'token_endpoint_oauth_rejected'),
+        );
+        expect(
+          errorRecords.single.extras,
+          containsPair('oauth_error_code', 'invalid_grant'),
+        );
+        expect(
+          errorRecords.any((r) => r.rawMessage.contains('onError:Exception')),
+          isFalse,
+          reason: 'the outer-catch duplicate event must not fire on mobile',
+        );
+      },
+    );
+
+    test(
+      'WHEN mobile refresh fails with an error the handler does NOT classify\n'
+      'THEN the generic onError:Exception event is still emitted\n'
+      'AND the session is kept',
+      () async {
+        stubWebRefresh401ThenThrow(const ServerError());
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>(
+            (e) => e.error is OAuthAuthorizationError,
+          )),
+        );
+
+        expect(
+          logHandler.errorRecords
+              .where((r) => r.rawMessage.contains('onError:Exception'))
+              .length,
+          1,
+          reason: 'unclassified mobile failures must keep their only trace',
+        );
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.oidc,
+        );
+      },
+    );
+  });
+
   tearDown(() {
     reset(authenticationClient);
     reset(tokenOidcCacheManager);

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -908,6 +908,14 @@ void main() {
             return e.error is AccessTokenInvalidException && e.response == null;
           })),
         );
+
+        // Mobile deliberately diverges from web here, which logs out on this
+        // same error. The divergence is only real if the session survives, so
+        // assert it rather than leaving the claim to the test name.
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.oidc,
+        );
       },
     );
   });
@@ -2167,7 +2175,8 @@ void main() {
 
       test(
         'WHEN refresh throws OAuthAuthorizationError (e.g. invalid_grant)\n'
-        'THEN propagated DioException still has NO HTTP response',
+        'THEN the session is torn down and RefreshTokenFailedException is raised\n'
+        'AND the propagated DioException still has NO HTTP response',
         () async {
           authorizationInterceptors.setTokenAndAuthorityOidc(
             newToken: OIDCFixtures.tokenOidcExpiredTime,
@@ -2196,12 +2205,19 @@ void main() {
             errorDescription: 'The refresh token has been revoked',
           ));
 
+          stubAccountCache();
+
           await expectLater(
             () => dio.post(baseUrl),
             throwsA(predicate<DioException>((e) {
               return e.response == null &&
-                  e.error is OAuthAuthorizationError;
+                  e.error is RefreshTokenFailedException;
             })),
+          );
+
+          expect(
+            authorizationInterceptors.authenticationType,
+            AuthenticationType.none,
           );
         },
       );
@@ -2964,6 +2980,111 @@ void main() {
   });
 
   // ============================================================
+  // onError: MOBILE refresh rejected by the token endpoint
+  // On mobile the refresh runs through flutter_appauth (native), NOT Dio, so a
+  // 400 invalid_grant never surfaces as a DioException — it arrives as an
+  // OAuthAuthorizationError. Without this handling the session stays alive and
+  // the app retries forever instead of sending the user back to login.
+  // ============================================================
+  group('onError: mobile refresh rejected by token endpoint', () {
+    for (final rejection in const <OAuthAuthorizationError>[
+      OAuthAuthorizationError(
+        error: 'invalid_grant',
+        errorDescription: 'The refresh token has been revoked',
+      ),
+      OAuthAuthorizationError(error: 'invalid_client'),
+      OAuthAuthorizationError(error: 'unauthorized_client'),
+      OAuthAuthorizationError(error: 'invalid_scope'),
+      OAuthAuthorizationError(error: 'invalid_request'),
+      OAuthAuthorizationError(error: 'unsupported_grant_type'),
+    ]) {
+      test(
+        'WHEN refresh throws OAuthAuthorizationError(${rejection.error}) on mobile\n'
+        'THEN rejected with RefreshTokenFailedException (→ forced logout)\n'
+        'AND OIDC state is cleared',
+        () async {
+          stubWebRefresh401ThenThrow(rejection);
+          stubAccountCache();
+
+          await expectLater(
+            () => dio.post(baseUrl),
+            throwsA(predicate<DioException>((e) {
+              return e.error is RefreshTokenFailedException;
+            })),
+          );
+
+          expect(
+            authorizationInterceptors.authenticationType,
+            AuthenticationType.none,
+          );
+        },
+      );
+    }
+
+    // flutter_appauth can report a token-endpoint rejection as the plugin-level
+    // code `token_failed`, with the real RFC 6749 code in the description.
+    test(
+      'WHEN refresh throws OAuthAuthorizationError(token_failed) '
+      'with description invalid_grant\n'
+      'THEN rejected with RefreshTokenFailedException (→ forced logout)\n'
+      'AND OIDC state is cleared',
+      () async {
+        stubWebRefresh401ThenThrow(const OAuthAuthorizationError(
+          error: 'token_failed',
+          errorDescription: 'invalid_grant',
+        ));
+        stubAccountCache();
+
+        await expectLater(
+          () => dio.post(baseUrl),
+          throwsA(predicate<DioException>((e) {
+            return e.error is RefreshTokenFailedException;
+          })),
+        );
+
+        expect(
+          authorizationInterceptors.authenticationType,
+          AuthenticationType.none,
+        );
+      },
+    );
+
+    // Anything that is not a confirmed server rejection must keep the session,
+    // so a flaky mobile connection does not log the user out.
+    for (final transient in const <OAuthAuthorizationError>[
+      ServerError(),
+      TemporarilyUnavailable(),
+      OAuthAuthorizationError(
+        error: 'token_failed',
+        errorDescription: 'Network is unreachable',
+      ),
+    ]) {
+      test(
+        'WHEN refresh throws OAuthAuthorizationError(${transient.error}) '
+        'that is NOT a server rejection\n'
+        'THEN session is KEPT and the original error is propagated',
+        () async {
+          stubWebRefresh401ThenThrow(transient);
+          stubAccountCache();
+
+          await expectLater(
+            () => dio.post(baseUrl),
+            throwsA(predicate<DioException>((e) {
+              return e.error is OAuthAuthorizationError &&
+                  e.error is! RefreshTokenFailedException;
+            })),
+          );
+
+          expect(
+            authorizationInterceptors.authenticationType,
+            AuthenticationType.oidc,
+          );
+        },
+      );
+    }
+  });
+
+  // ============================================================
   // onError: WEB refresh failures
   // Server rejection (got a response: ArgumentError / AccessTokenInvalid /
   // Dio retry with response) → preserve original 401 → logout.
@@ -3569,7 +3690,6 @@ void main() {
       },
     );
   });
-
   tearDown(() {
     reset(authenticationClient);
     reset(tokenOidcCacheManager);

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -3293,6 +3293,44 @@ void main() {
       );
     }
 
+    // The web handler delegates its non-rejection paths to
+    // _handleRefreshErrorOnMobile, whose leading branch force-logs-out on an
+    // OAuthAuthorizationError the classifier confirms. On web that branch must
+    // stay dead: the web classifier reads ArgumentError, never this type, so a
+    // native-shaped error arriving on web keeps the session. Without this test,
+    // moving that branch ahead of the isRejected check would silently start
+    // logging web users out on a failure web had already ruled transient.
+    for (final nativeShapedError in const <OAuthAuthorizationError>[
+      OAuthAuthorizationError(
+        error: 'invalid_grant',
+        errorDescription: 'The refresh token has been revoked',
+      ),
+      OAuthAuthorizationError(error: 'unsupported_grant_type'),
+    ]) {
+      test(
+        'WHEN web refresh throws OAuthAuthorizationError(${nativeShapedError.error}) '
+        '— the mobile error shape\n'
+        'THEN session is KEPT: the mobile force-logout branch must not fire on web',
+        () async {
+          stubWebRefresh401ThenThrow(nativeShapedError);
+          stubAccountCache();
+
+          await expectLater(
+            () => dio.post(baseUrl),
+            throwsA(predicate<DioException>((e) {
+              return e.error is OAuthAuthorizationError &&
+                  e.error is! RefreshTokenFailedException;
+            })),
+          );
+
+          expect(
+            authorizationInterceptors.authenticationType,
+            AuthenticationType.oidc,
+          );
+        },
+      );
+    }
+
     // ---- DioException from token endpoint: only 400/401 → logout ----
 
     test(

--- a/test/features/login/data/network/authentication_client/authentication_client_interaction_mixin_test.dart
+++ b/test/features/login/data/network/authentication_client/authentication_client_interaction_mixin_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_appauth_platform_interface/flutter_appauth_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/login/data/network/authentication_client/authentication_client_interaction_mixin.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/oauth_authorization_error.dart';
+
+/// The mixin declares no `on` clause, so a bare host class is enough to
+/// exercise [AuthenticationClientInteractionMixin.handleException].
+class _TestAuthClient with AuthenticationClientInteractionMixin {}
+
+void main() {
+  late _TestAuthClient authClient;
+
+  setUp(() => authClient = _TestAuthClient());
+
+  group('AuthenticationClientInteractionMixin::handleException '
+      '- converts an AppAuth OAuth error', () {
+    test('maps an RFC 6749 code to OAuthAuthorizationError', () {
+      final result = authClient.handleException(_appAuthException(
+        error: 'invalid_grant',
+        errorDescription: 'The refresh token has been revoked',
+      ));
+
+      expect(result, isA<OAuthAuthorizationError>());
+      expect((result as OAuthAuthorizationError).error, 'invalid_grant');
+      expect(result.message, 'The refresh token has been revoked');
+    });
+
+    // The interceptor's network tolerance keys off the subtype, not the string,
+    // so a transient SSO failure must arrive as its dedicated type. The codes
+    // below are spelled out as literals on purpose: they are what the server
+    // puts on the wire, so renaming the matching constant must fail here.
+    test('maps server_error to the ServerError subtype', () {
+      final result = authClient.handleException(_appAuthException(
+        error: 'server_error',
+        errorDescription: 'Internal server error',
+      ));
+
+      expect(result, isA<ServerError>());
+      expect((result as ServerError).message, 'Internal server error');
+    });
+
+    test('maps temporarily_unavailable to the TemporarilyUnavailable subtype',
+        () {
+      final result = authClient.handleException(_appAuthException(
+        error: 'temporarily_unavailable',
+        errorDescription: 'Service is down for maintenance',
+      ));
+
+      expect(result, isA<TemporarilyUnavailable>());
+      expect(
+        (result as TemporarilyUnavailable).message,
+        'Service is down for maintenance',
+      );
+    });
+
+    // A valid RFC 6749 code with no dedicated subtype must land on the base
+    // type — this is the only cover for fromErrorCode's default branch.
+    test('maps a code with no subtype to the base type, null description kept',
+        () {
+      final result = authClient.handleException(
+        _appAuthException(error: 'invalid_client'),
+      );
+
+      expect(result, isA<OAuthAuthorizationError>());
+      expect(result, isNot(isA<ServerError>()));
+      expect(result, isNot(isA<TemporarilyUnavailable>()));
+      expect((result as OAuthAuthorizationError).error, 'invalid_client');
+      expect(result.message, isNull);
+    });
+  });
+
+  group('AuthenticationClientInteractionMixin::handleException '
+      '- passes through what it cannot classify', () {
+    // A network/DNS failure reaches the app with no OAuth error field. It must
+    // stay a PlatformException so the refresh-then-retry path keeps the session
+    // instead of signing the user out on a flaky connection.
+    test('returns an AppAuth exception with no OAuth code unchanged', () {
+      final exception = _appAuthException(message: 'Network error');
+
+      expect(authClient.handleException(exception), same(exception));
+    });
+
+    test('returns a plain PlatformException unchanged', () {
+      final exception = PlatformException(code: 'unknown');
+
+      expect(authClient.handleException(exception), same(exception));
+    });
+
+    test('returns a non-AppAuth exception unchanged', () {
+      final exception = Exception('boom');
+
+      expect(authClient.handleException(exception), same(exception));
+    });
+
+    // The mixin is shared with the web client, whose plugin reports failures as
+    // ArgumentError — an Error, not an Exception. The signature is `dynamic`,
+    // so this must survive the boundary for the web classifier to see it.
+    test('returns an Error, not just an Exception, unchanged', () {
+      final error = ArgumentError(
+        'Failed to get token: [error: invalid_grant, description: revoked]',
+      );
+
+      expect(authClient.handleException(error), same(error));
+    });
+  });
+}
+
+/// Mirrors the shape the plugin builds from a token-endpoint failure: [code] is
+/// the plugin-level code, while [error] is the RFC 6749 code read out of the
+/// response body (null whenever the failure never reached the OAuth server).
+FlutterAppAuthPlatformException _appAuthException({
+  String code = 'token_failed',
+  String message = 'Failed to get token',
+  String? error,
+  String? errorDescription,
+}) {
+  return FlutterAppAuthPlatformException(
+    code: code,
+    message: message,
+    platformErrorDetails: FlutterAppAuthPlatformErrorDetails(
+      error: error,
+      errorDescription: errorDescription,
+    ),
+  );
+}

--- a/test/features/login/data/network/authentication_client/authentication_client_mobile_test.dart
+++ b/test/features/login/data/network/authentication_client/authentication_client_mobile_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_appauth/flutter_appauth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/login/data/network/authentication_client/authentication_client_mobile.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/oauth_authorization_error.dart';
+
+/// [FlutterAppAuth.token] is a plain overridable instance method, so a
+/// hand-written fake stands in for the plugin without any codegen.
+class _ThrowingAppAuth extends FlutterAppAuth {
+  _ThrowingAppAuth(this.error);
+
+  final Object error;
+
+  @override
+  Future<TokenResponse> token(TokenRequest request) async => throw error;
+}
+
+void main() {
+  group('AuthenticationClientMobile::refreshingTokensOIDC', () {
+    // This is the wiring the mobile force-logout fix rests on: a plugin failure
+    // must leave the client as a domain error. Deleting the catch that calls
+    // handleException fails this test.
+    test('surfaces a rejected refresh as the converted domain error', () async {
+      final client = AuthenticationClientMobile(_ThrowingAppAuth(
+        _appAuthException(
+          error: 'invalid_grant',
+          errorDescription: 'The refresh token has been revoked',
+        ),
+      ));
+
+      await expectLater(
+        _refresh(client),
+        throwsA(
+          isA<OAuthAuthorizationError>()
+              .having((e) => e.error, 'error', 'invalid_grant')
+              .having(
+                (e) => e.message,
+                'message',
+                'The refresh token has been revoked',
+              ),
+        ),
+      );
+    });
+
+    // A failure that never reached the token endpoint carries no OAuth code. It
+    // has to stay a PlatformException so the session survives a flaky network.
+    test('leaves a failure with no OAuth code as a PlatformException', () async {
+      final pluginException = _appAuthException(message: 'Network error');
+      final client = AuthenticationClientMobile(
+        _ThrowingAppAuth(pluginException),
+      );
+
+      // Identity is the strongest form here: it proves the plugin exception is
+      // neither converted nor re-wrapped on its way out.
+      await expectLater(_refresh(client), throwsA(same(pluginException)));
+    });
+  });
+}
+
+Future<void> _refresh(AuthenticationClientMobile client) => client
+    .refreshingTokensOIDC(
+      'client-id',
+      'com.example.app://callback',
+      'https://sso.example.com/.well-known/openid-configuration',
+      const ['openid', 'profile'],
+      'a-refresh-token',
+    );
+
+/// Mirrors the shape the plugin builds from a token-endpoint failure: [error]
+/// is the RFC 6749 code read out of the response body, null whenever the
+/// failure never reached the OAuth server.
+FlutterAppAuthPlatformException _appAuthException({
+  String code = 'token_failed',
+  String message = 'Failed to get token',
+  String? error,
+  String? errorDescription,
+}) {
+  return FlutterAppAuthPlatformException(
+    code: code,
+    message: message,
+    platformErrorDetails: FlutterAppAuthPlatformErrorDetails(
+      error: error,
+      errorDescription: errorDescription,
+    ),
+  );
+}

--- a/test/features/login/data/network/authentication_client/mobile_refresh_token_error_classifier_test.dart
+++ b/test/features/login/data/network/authentication_client/mobile_refresh_token_error_classifier_test.dart
@@ -1,0 +1,169 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/login/data/network/authentication_client/mobile_refresh_token_error_classifier.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/authentication_exception.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/oauth_authorization_error.dart';
+
+void main() {
+  late MobileRefreshTokenErrorClassifier classifier;
+
+  setUp(() => classifier = MobileRefreshTokenErrorClassifier());
+
+  group('MobileRefreshTokenErrorClassifier::isServerRejection', () {
+    // The native refresh reports a 400 from the token endpoint as an
+    // OAuthAuthorizationError carrying the RFC 6749 code from the body.
+    for (final code in const [
+      'invalid_grant',
+      'invalid_client',
+      'invalid_request',
+      'invalid_scope',
+      'unauthorized_client',
+      'unsupported_grant_type',
+    ]) {
+      test('returns true for $code', () {
+        expect(
+          classifier.isServerRejection(OAuthAuthorizationError(error: code)),
+          isTrue,
+        );
+      });
+    }
+
+    test('returns true for token_failed wrapping an RFC 6749 code', () {
+      expect(
+        classifier.isServerRejection(const OAuthAuthorizationError(
+          error: 'token_failed',
+          errorDescription: 'invalid_grant',
+        )),
+        isTrue,
+      );
+    });
+
+    test('returns false for token_failed with a non-RFC description', () {
+      expect(
+        classifier.isServerRejection(const OAuthAuthorizationError(
+          error: 'token_failed',
+          errorDescription: 'Network is unreachable',
+        )),
+        isFalse,
+      );
+    });
+
+    test('returns false for token_failed with no description', () {
+      expect(
+        classifier.isServerRejection(
+          const OAuthAuthorizationError(error: 'token_failed'),
+        ),
+        isFalse,
+      );
+    });
+
+    // Transient SSO failures must keep the session — a flaky mobile connection
+    // may not sign the user out.
+    test('returns false for ServerError', () {
+      expect(classifier.isServerRejection(const ServerError()), isFalse);
+    });
+
+    test('returns false for TemporarilyUnavailable', () {
+      expect(
+        classifier.isServerRejection(const TemporarilyUnavailable()),
+        isFalse,
+      );
+    });
+
+    test('returns false for an unknown OAuth code', () {
+      expect(
+        classifier.isServerRejection(
+          const OAuthAuthorizationError(error: 'custom_provider_error'),
+        ),
+        isFalse,
+      );
+    });
+
+    // Shared behaviour inherited from the base classifier.
+    test('returns true for AccessTokenInvalidException', () {
+      expect(
+        classifier.isServerRejection(AccessTokenInvalidException()),
+        isTrue,
+      );
+    });
+
+    for (final statusCode in const [400, 401]) {
+      test('returns true for DioException $statusCode', () {
+        expect(classifier.isServerRejection(_dioError(statusCode)), isTrue);
+      });
+    }
+
+    for (final statusCode in const [500, 503]) {
+      test('returns false for DioException $statusCode', () {
+        expect(classifier.isServerRejection(_dioError(statusCode)), isFalse);
+      });
+    }
+
+    test('returns false for DioException with no response', () {
+      expect(
+        classifier.isServerRejection(DioException(
+          requestOptions: RequestOptions(path: '/token'),
+          type: DioExceptionType.connectionError,
+        )),
+        isFalse,
+      );
+    });
+
+    // The web plugin's error shape must never be classified by mobile.
+    test('returns false for the web plugin ArgumentError shape', () {
+      expect(
+        classifier.isServerRejection(ArgumentError(
+          'Failed to get token: [error: invalid_grant, description: revoked]',
+        )),
+        isFalse,
+      );
+    });
+
+    test('returns false for a generic Exception', () {
+      expect(classifier.isServerRejection(Exception('boom')), isFalse);
+    });
+  });
+
+  group('MobileRefreshTokenErrorClassifier::buildSentryExtras', () {
+    test('tags a rejection and exposes the OAuth code and description', () {
+      expect(
+        classifier.buildSentryExtras(const OAuthAuthorizationError(
+          error: 'invalid_grant',
+          errorDescription: 'The refresh token has been revoked',
+        )),
+        {
+          'auth_error_type': 'token_endpoint_oauth_rejected',
+          'oauth_error_code': 'invalid_grant',
+          'oauth_error_description': 'The refresh token has been revoked',
+        },
+      );
+    });
+
+    test('tags a kept session and still exposes the OAuth code', () {
+      expect(
+        classifier.buildSentryExtras(const ServerError()),
+        {
+          'auth_error_type': 'token_endpoint_oauth_unknown_error',
+          'oauth_error_code': 'server_error',
+          'oauth_error_description': 'unknown',
+        },
+      );
+    });
+
+    test('omits OAuth fields for a non-OAuth error', () {
+      expect(
+        classifier.buildSentryExtras(_dioError(503)),
+        {'auth_error_type': 'token_endpoint_oauth_unknown_error'},
+      );
+    });
+  });
+}
+
+DioException _dioError(int statusCode) => DioException(
+      requestOptions: RequestOptions(path: '/token'),
+      response: Response(
+        statusCode: statusCode,
+        requestOptions: RequestOptions(path: '/token'),
+      ),
+      type: DioExceptionType.badResponse,
+    );


### PR DESCRIPTION
## Problem

When the OIDC provider rejects the refresh token — revoked or expired, for example after the account password is changed — the token endpoint answers `400 invalid_grant`. On mobile the app never recovers from this:

- the mailbox spins forever,
- a generic *"Unknown error occurred, please try again"* toast appears,
- **Retry can never help**, and
- only clearing the app data unblocks it.

Observed against a self-hosted OIDC provider (Stalwart), reproduced end to end: `/jmap/` returns 401, the app calls `/auth/token` about ten times in eight seconds, and stays in that loop indefinitely without ever returning the user to the login screen.

## Root cause

The logout path already exists, but it is unreachable on mobile.

`_refreshTokenThenRetry` handles the rejection inside `on DioException catch`, gated on `refreshError.response?.statusCode == 400`. On mobile the refresh does **not** go through Dio — it goes through `_appAuth.token()` (flutter_appauth, native, `authentication_client_mobile.dart`). So:

1. flutter_appauth throws `FlutterAppAuthPlatformException`
2. `handleException` maps it to `OAuthAuthorizationError`
3. that type matches neither the `DioException` catch nor the `PlatformException` catch
4. it falls through to the outer catch in `onError` and reaches `_handleRefreshErrorOnMobile`
5. which only rewraps and propagates — **no `clear()`**

The dead session is kept and every subsequent request retries forever. In effect, the recovery behaviour described in ADR-0035 never executes on this platform.

## Fix

Classify `OAuthAuthorizationError` using the same RFC 6749 §5.2 codes the web path already relies on. A confirmed rejection calls `clear()` and rejects with `RefreshTokenFailedException`, which takes the user back to login.

Two deliberate constraints:

- **Network tolerance from #4593 is preserved.** Only confirmed bad-grant codes log out. `server_error` and `temporarily_unavailable` still keep the session, so a flaky mobile connection does not sign the user out. That issue covered the *opposite* case — `token_failed` with `Network error` — and this change does not regress it.
- **Web behaviour is unchanged.** `_handleRefreshErrorOnWeb` only delegates to the mobile handler after it has already concluded the error is not a rejection, so the new check is always false there.

The `token_failed` wrapper is honoured the same way as on web: when the plugin reports its own code, the real RFC 6749 code is read from the description.

## Tests

8 new cases, all in `test/features/interceptor/authorization_interceptor_test.dart`:

- `invalid_grant`, `invalid_client`, `unauthorized_client`, `invalid_scope` → forced logout, OIDC state cleared
- `token_failed` with `invalid_grant` in the description → forced logout
- `ServerError`, `TemporarilyUnavailable`, and `token_failed` with a non-RFC description → **session kept**

One existing test asserted the old behaviour (`invalid_grant` propagating without logout) and was updated to the corrected expectation.

```
flutter test test/features/interceptor/authorization_interceptor_test.dart \
             test/features/login/data/network/authentication_client/web_refresh_token_error_classifier_test.dart
→ 120 tests passed
flutter analyze on both changed files → no issues
```

## Scope

Three files, +155 / −2. No dependency, API, or UI changes.

This affects any deployment using its own OIDC provider, not just the one where it was found.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of authentication refresh failures across web and mobile platforms.
  * Confirmed authorization rejections now securely sign users out and clear authentication state.
  * Temporary network or server issues no longer trigger unnecessary sign-outs, allowing existing sessions to continue.
  * Improved recognition of common OAuth authorization errors, including invalid or expired refresh credentials.
  * Reduced duplicate error reporting for classified authentication failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->