### PR TITLE
TF-4728 [Part 1] Attach drive files as real attachments on web

### DIFF
--- a/integration_test/scenarios/search/search_email_with_tag_scenario.dart
+++ b/integration_test/scenarios/search/search_email_with_tag_scenario.dart
@@ -50,8 +50,6 @@ class SearchEmailWithTagScenario extends BaseTestScenario
 
       await commonRobot.selectContextMenuItemByName(labelDisplayName);
       await searchRobot.expectEmailListCountAtLeast(emailCount);
-
-      await $.pumpAndSettle(duration: const Duration(seconds: 1));
     }
   }
 

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -128,6 +128,7 @@ import 'package:tmail_ui_user/features/upload/domain/state/local_image_picker_st
 import 'package:tmail_ui_user/features/upload/domain/usecases/local_file_picker_interactor.dart';
 import 'package:tmail_ui_user/features/upload/domain/usecases/local_image_picker_interactor.dart';
 import 'package:tmail_ui_user/features/upload/presentation/controller/upload_controller.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/drive_document_transfer_runner.dart';
 import 'package:tmail_ui_user/features/composer/presentation/manager/drive_transfer_pipeline.dart';
 import 'package:tmail_ui_user/features/upload/data/network/file_uploader.dart';
 import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_upload_validation_service.dart';
@@ -202,12 +203,15 @@ class ComposerController extends BaseController
 
   late final DriveTransferPipeline _driveTransferPipeline = DriveTransferPipeline(
     validationService: attachmentUploadValidationService,
-    uploadController: uploadController,
     fileUploader: Get.find<FileUploader>(),
     uuid: Get.find<Uuid>(),
     strategyFactory: Get.find<DriveTransferStrategyFactory>(),
+    transferRunner: DriveDocumentTransferRunner(
+      uploadController: uploadController,
+      uuid: Get.find<Uuid>(),
+      resolveAuthHeader: () => authorizationInterceptors.currentAuthorizationHeader,
+    ),
     resolveUploadUri: _getCurrentUploadUri,
-    resolveAuthHeader: () => authorizationInterceptors.currentAuthorizationHeader,
   );
 
   GetAllAutoCompleteInteractor? _getAllAutoCompleteInteractor;

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1048,7 +1048,7 @@ class ComposerController extends BaseController
         },
         // Closure, not a tear-off: keeps the pipeline's GetX lookups out of
         // link-only picks, which never reach it.
-        startDriveTransfers: (docs) => _driveTransferPipeline.transfer(docs),
+        transferDriveDocuments: (docs) => _driveTransferPipeline.transfer(docs),
         appLocalizations: currentContext != null ? AppLocalizations.of(currentContext!) : null,
       );
     } catch (e) {

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -128,7 +128,10 @@ import 'package:tmail_ui_user/features/upload/domain/state/local_image_picker_st
 import 'package:tmail_ui_user/features/upload/domain/usecases/local_file_picker_interactor.dart';
 import 'package:tmail_ui_user/features/upload/domain/usecases/local_image_picker_interactor.dart';
 import 'package:tmail_ui_user/features/upload/presentation/controller/upload_controller.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/drive_transfer_pipeline.dart';
+import 'package:tmail_ui_user/features/upload/data/network/file_uploader.dart';
 import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_upload_validation_service.dart';
+import 'package:uuid/uuid.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
@@ -195,6 +198,15 @@ class ComposerController extends BaseController
           maxSizeAttachmentsPerEmail: () => mailboxDashBoardController.maxSizeAttachmentsPerEmail?.value,
         ),
       );
+
+  late final DriveTransferPipeline _driveTransferPipeline = DriveTransferPipeline(
+    validationService: attachmentUploadValidationService,
+    uploadController: uploadController,
+    fileUploader: Get.find<FileUploader>(),
+    uuid: Get.find<Uuid>(),
+    resolveUploadUri: _getCurrentUploadUri,
+    resolveAuthHeader: () => authorizationInterceptors.currentAuthorizationHeader,
+  );
 
   GetAllAutoCompleteInteractor? _getAllAutoCompleteInteractor;
   GetAutoCompleteInteractor? _getAutoCompleteInteractor;
@@ -530,6 +542,13 @@ class ComposerController extends BaseController
     if (createEmailRequest == null) return;
 
     await _saveComposerCacheInteractor.execute(createEmailRequest: createEmailRequest);
+  }
+
+  Uri? _getCurrentUploadUri() {
+    final session = mailboxDashBoardController.sessionCurrent;
+    final accountId = mailboxDashBoardController.accountId.value;
+    if (session == null || accountId == null) return null;
+    return _getUploadUriFromSession(session, accountId);
   }
 
   Uri? _getUploadUriFromSession(Session session, AccountId accountId) {
@@ -1025,6 +1044,9 @@ class ComposerController extends BaseController
             await SchedulerBinding.instance.endOfFrame;
           }
         },
+        // Closure, not a tear-off: keeps the pipeline's GetX lookups out of
+        // link-only picks, which never reach it.
+        startDriveTransfers: (docs) => _driveTransferPipeline.transfer(docs),
         appLocalizations: currentContext != null ? AppLocalizations.of(currentContext!) : null,
       );
     } catch (e) {

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -136,6 +136,7 @@ import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.da
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:tmail_ui_user/main/universal_import/html_stub.dart' as html;
+import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy_factory.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
 import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_handler.dart';
 import 'package:tmail_ui_user/main/utils/app_config.dart';
@@ -204,6 +205,7 @@ class ComposerController extends BaseController
     uploadController: uploadController,
     fileUploader: Get.find<FileUploader>(),
     uuid: Get.find<Uuid>(),
+    strategyFactory: Get.find<DriveTransferStrategyFactory>(),
     resolveUploadUri: _getCurrentUploadUri,
     resolveAuthHeader: () => authorizationInterceptors.currentAuthorizationHeader,
   );

--- a/lib/features/composer/presentation/extensions/drive_document_extension.dart
+++ b/lib/features/composer/presentation/extensions/drive_document_extension.dart
@@ -1,0 +1,21 @@
+import 'package:workplace/domain/entity/drive_document.dart';
+
+/// How a picked drive document can be attached.
+///
+/// The two are exclusive by construction: a document carrying both links is a
+/// link, because a live document is worth more than a static copy.
+extension DriveDocumentExtension on DriveDocument {
+  /// Attachable as a link card pointing back at the live document.
+  bool isAttachableAsLink({required bool requireHttps}) {
+    final link = sharingLink;
+    return link != null && (!requireHttps || link.isScheme('https'));
+  }
+
+  /// Attachable only as a downloaded copy: no sharing link to point at.
+  bool isAttachableAsDownload({required bool requireHttps}) {
+    final link = downloadLink;
+    return sharingLink == null &&
+        link != null &&
+        (!requireHttps || link.isScheme('https'));
+  }
+}

--- a/lib/features/composer/presentation/manager/bounded_concurrency_runner.dart
+++ b/lib/features/composer/presentation/manager/bounded_concurrency_runner.dart
@@ -1,0 +1,24 @@
+import 'dart:async';
+
+/// Runs [task] over [items] with at most [maxConcurrent] in flight.
+///
+/// Workers pull from one shared iterator, so a slot frees the instant its
+/// current item finishes — no "start a batch, wait for all of it, start the
+/// next" stalling. [task] is expected to handle its own failures; an error it
+/// lets escape aborts that worker only, and the others keep draining.
+Future<void> runWithConcurrency<T>(
+  Iterable<T> items,
+  int maxConcurrent,
+  Future<void> Function(T item) task,
+) async {
+  final iterator = items.iterator;
+
+  Future<void> worker() async {
+    while (iterator.moveNext()) {
+      await task(iterator.current);
+    }
+  }
+
+  final workerCount = maxConcurrent < 1 ? 1 : maxConcurrent;
+  await Future.wait(List.generate(workerCount, (_) => worker()));
+}

--- a/lib/features/composer/presentation/manager/bounded_concurrency_runner.dart
+++ b/lib/features/composer/presentation/manager/bounded_concurrency_runner.dart
@@ -6,23 +6,32 @@ import 'dart:async';
 /// current item finishes — no "start a batch, wait for all of it, start the
 /// next" stalling. [task] is expected to handle its own failures; an error it
 /// lets escape aborts that worker only, and the others keep draining.
+///
+/// A worker is only spawned once there is an item for it to own, so an
+/// oversized [maxConcurrent] costs nothing: the worker count never exceeds the
+/// item count.
 Future<void> runWithConcurrency<T>(
   Iterable<T> items,
   int maxConcurrent,
   Future<void> Function(T item) task,
 ) {
   final iterator = items.iterator;
-  final workerCount = maxConcurrent < 1 ? 1 : maxConcurrent;
-  return Future.wait(
-    List.generate(workerCount, (_) => _drainQueue(iterator, task)),
-  );
+  final maxWorkers = maxConcurrent < 1 ? 1 : maxConcurrent;
+  final workers = <Future<void>>[];
+  while (workers.length < maxWorkers && iterator.moveNext()) {
+    workers.add(_drainQueue(iterator.current, iterator, task));
+  }
+  return Future.wait(workers);
 }
 
-/// One worker: pulls from the shared [iterator] until it is exhausted.
+/// One worker: runs [first], then pulls from the shared [iterator] until it is
+/// exhausted.
 Future<void> _drainQueue<T>(
+  T first,
   Iterator<T> iterator,
   Future<void> Function(T item) task,
 ) async {
+  await task(first);
   while (iterator.moveNext()) {
     await task(iterator.current);
   }

--- a/lib/features/composer/presentation/manager/bounded_concurrency_runner.dart
+++ b/lib/features/composer/presentation/manager/bounded_concurrency_runner.dart
@@ -10,18 +10,34 @@ import 'dart:async';
 /// A worker is only spawned once there is an item for it to own, so an
 /// oversized [maxConcurrent] costs nothing: the worker count never exceeds the
 /// item count.
+///
+/// [items] is expected to never throw while spawning (pass a materialised
+/// list, not a lazy source with side effects); if it does, the workers
+/// already started are still drained — not orphaned — before the spawn error
+/// is rethrown.
 Future<void> runWithConcurrency<T>(
   Iterable<T> items,
   int maxConcurrent,
   Future<void> Function(T item) task,
-) {
+) async {
   final iterator = items.iterator;
   final maxWorkers = maxConcurrent < 1 ? 1 : maxConcurrent;
   final workers = <Future<void>>[];
-  while (workers.length < maxWorkers && iterator.moveNext()) {
-    workers.add(_drainQueue(iterator.current, iterator, task));
+  try {
+    while (workers.length < maxWorkers && iterator.moveNext()) {
+      workers.add(_drainQueue(iterator.current, iterator, task));
+    }
+  } catch (spawnError) {
+    // Only one error can surface; a worker's own failure is swallowed here,
+    // not left to escape as an unhandled zone error.
+    try {
+      await Future.wait(workers);
+    } catch (_) {
+      // Swallowed: the spawn error below is what the caller sees.
+    }
+    rethrow;
   }
-  return Future.wait(workers);
+  await Future.wait(workers);
 }
 
 /// One worker: runs [first], then pulls from the shared [iterator] until it is

--- a/lib/features/composer/presentation/manager/bounded_concurrency_runner.dart
+++ b/lib/features/composer/presentation/manager/bounded_concurrency_runner.dart
@@ -10,15 +10,20 @@ Future<void> runWithConcurrency<T>(
   Iterable<T> items,
   int maxConcurrent,
   Future<void> Function(T item) task,
-) async {
+) {
   final iterator = items.iterator;
-
-  Future<void> worker() async {
-    while (iterator.moveNext()) {
-      await task(iterator.current);
-    }
-  }
-
   final workerCount = maxConcurrent < 1 ? 1 : maxConcurrent;
-  await Future.wait(List.generate(workerCount, (_) => worker()));
+  return Future.wait(
+    List.generate(workerCount, (_) => _drainQueue(iterator, task)),
+  );
+}
+
+/// One worker: pulls from the shared [iterator] until it is exhausted.
+Future<void> _drainQueue<T>(
+  Iterator<T> iterator,
+  Future<void> Function(T item) task,
+) async {
+  while (iterator.moveNext()) {
+    await task(iterator.current);
+  }
 }

--- a/lib/features/composer/presentation/manager/drive_attachment_handler.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_handler.dart
@@ -51,23 +51,26 @@ class DriveAttachmentHandler {
         .where((doc) => doc.sharingLink == null && doc.downloadLink != null)
         .toList();
 
+    // A pick with any link doc is handled as a link pick: mixed batches are
+    // not supported.
     if (linkDocs.isNotEmpty) {
       await insertDriveLinkHtml(
         linkDocs,
         insertHtml: insertHtml,
         appLocalizations: appLocalizations,
       );
+      return;
     }
 
-    final transfersStarted = downloadableDocs.isNotEmpty &&
-        await transferDriveDocuments(downloadableDocs);
-
-    if (linkDocs.isEmpty && !transfersStarted) {
-      getBinding<ToastManager>()?.showMessageFailure(DrivePickFailure(
-        Exception(),
-        message: appLocalizations?.driveAttachmentInDevelopment,
-      ));
+    if (downloadableDocs.isNotEmpty &&
+        await transferDriveDocuments(downloadableDocs)) {
+      return;
     }
+
+    getBinding<ToastManager>()?.showMessageFailure(DrivePickFailure(
+      Exception(),
+      message: appLocalizations?.driveAttachmentInDevelopment,
+    ));
   }
 
   Future<void> insertDriveLinkHtml(

--- a/lib/features/composer/presentation/manager/drive_attachment_handler.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_handler.dart
@@ -34,12 +34,7 @@ class DriveAttachmentHandler {
     AppLocalizations? appLocalizations,
   }) async {
     if (result.isEmpty) {
-      getBinding<ToastManager>()?.showMessageFailure(
-        DrivePickFailure(
-          Exception(),
-          message: appLocalizations?.driveNoValidAttachment,
-        ),
-      );
+      _showFailureToast(appLocalizations?.driveNoValidAttachment);
       return;
     }
     final linkDocs = result
@@ -64,10 +59,23 @@ class DriveAttachmentHandler {
 
     if (linkDocs.isNotEmpty || transfersStarted) return;
 
-    getBinding<ToastManager>()?.showMessageFailure(DrivePickFailure(
-      Exception(),
-      message: appLocalizations?.driveAttachmentInDevelopment,
-    ));
+    _showFailureToast(appLocalizations?.driveAttachmentInDevelopment);
+  }
+
+  /// Toasts [message], or logs when there is no [ToastManager] bound: a pick
+  /// that ends with nothing attached must not also end silently.
+  void _showFailureToast(String? message) {
+    final toastManager = getBinding<ToastManager>();
+    if (toastManager == null) {
+      logWarning(
+        'DriveAttachmentHandler::_showFailureToast: no ToastManager bound, '
+        'failure not shown to the user',
+      );
+      return;
+    }
+    toastManager.showMessageFailure(
+      DrivePickFailure(Exception(), message: message),
+    );
   }
 
   Future<void> insertDriveLinkHtml(

--- a/lib/features/composer/presentation/manager/drive_attachment_handler.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_handler.dart
@@ -1,5 +1,6 @@
 import 'package:core/core.dart';
 import 'package:core/utils/html/file_link_card_html_builder.dart';
+import 'package:tmail_ui_user/features/composer/presentation/extensions/drive_document_extension.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
@@ -41,18 +42,12 @@ class DriveAttachmentHandler {
       );
       return;
     }
-    final linkDocs = result.where((doc) {
-      final link = doc.sharingLink;
-      return link != null && (!requireHttps || link.isScheme('https'));
-    }).toList();
-    // Exclusive with linkDocs by construction: a document carrying both links
-    // is a link, because a live document is worth more than a static copy.
-    final downloadableDocs = result.where((doc) {
-      final downloadLink = doc.downloadLink;
-      return doc.sharingLink == null &&
-          downloadLink != null &&
-          (!requireHttps || downloadLink.isScheme('https'));
-    }).toList();
+    final linkDocs = result
+        .where((doc) => doc.isAttachableAsLink(requireHttps: requireHttps))
+        .toList();
+    final downloadableDocs = result
+        .where((doc) => doc.isAttachableAsDownload(requireHttps: requireHttps))
+        .toList();
 
     // Both halves are dispatched: a mixed pick inserts its links and transfers
     // its downloadable docs.
@@ -105,9 +100,8 @@ class DriveAttachmentHandler {
     DriveDocument doc, {
     AppLocalizations? appLocalizations,
   }) {
-    final link = doc.sharingLink;
-    if (link == null) return null;
-    if (requireHttps && !link.isScheme('https')) return null;
+    if (!doc.isAttachableAsLink(requireHttps: requireHttps)) return null;
+    final link = doc.sharingLink!;
 
     final openInDriveLabel =
         appLocalizations?.openInDrive ?? _fallbackOpenInDriveLabel;

--- a/lib/features/composer/presentation/manager/drive_attachment_handler.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_handler.dart
@@ -6,6 +6,12 @@ import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
 import 'package:workplace/presentation/model/drive_pick_state.dart';
 
+/// Inserts [html] into the composer's editor.
+typedef InsertHtmlCallback = Future<void> Function(String html);
+
+/// Starts drive transfers for [docs], returning whether it took them.
+typedef StartDriveTransfersCallback = Future<bool> Function(List<DriveDocument> docs);
+
 class DriveAttachmentHandler {
   DriveAttachmentHandler();
 
@@ -24,8 +30,8 @@ class DriveAttachmentHandler {
   /// transfers existed.
   Future<void> handleDrivePickResult(
     List<DriveDocument> result, {
-    required Future<void> Function(String html) insertHtml,
-    required Future<bool> Function(List<DriveDocument> docs) startDriveTransfers,
+    required InsertHtmlCallback insertHtml,
+    required StartDriveTransfersCallback startDriveTransfers,
     AppLocalizations? appLocalizations,
   }) async {
     if (result.isEmpty) {
@@ -68,7 +74,7 @@ class DriveAttachmentHandler {
 
   Future<void> insertDriveLinkHtml(
     List<DriveDocument> docs, {
-    required Future<void> Function(String html) insertHtml,
+    required InsertHtmlCallback insertHtml,
     AppLocalizations? appLocalizations,
   }) async {
     await insertHtml(

--- a/lib/features/composer/presentation/manager/drive_attachment_handler.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_handler.dart
@@ -47,9 +47,12 @@ class DriveAttachmentHandler {
     }).toList();
     // Exclusive with linkDocs by construction: a document carrying both links
     // is a link, because a live document is worth more than a static copy.
-    final downloadableDocs = result
-        .where((doc) => doc.sharingLink == null && doc.downloadLink != null)
-        .toList();
+    final downloadableDocs = result.where((doc) {
+      final downloadLink = doc.downloadLink;
+      return doc.sharingLink == null &&
+          downloadLink != null &&
+          (!requireHttps || downloadLink.isScheme('https'));
+    }).toList();
 
     // Both halves are dispatched: a mixed pick inserts its links and transfers
     // its downloadable docs.

--- a/lib/features/composer/presentation/manager/drive_attachment_handler.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_handler.dart
@@ -51,21 +51,20 @@ class DriveAttachmentHandler {
         .where((doc) => doc.sharingLink == null && doc.downloadLink != null)
         .toList();
 
-    // A pick with any link doc is handled as a link pick: mixed batches are
-    // not supported.
+    // Both halves are dispatched: a mixed pick inserts its links and transfers
+    // its downloadable docs.
     if (linkDocs.isNotEmpty) {
       await insertDriveLinkHtml(
         linkDocs,
         insertHtml: insertHtml,
         appLocalizations: appLocalizations,
       );
-      return;
     }
 
-    if (downloadableDocs.isNotEmpty &&
-        await transferDriveDocuments(downloadableDocs)) {
-      return;
-    }
+    final transfersStarted = downloadableDocs.isNotEmpty &&
+        await transferDriveDocuments(downloadableDocs);
+
+    if (linkDocs.isNotEmpty || transfersStarted) return;
 
     getBinding<ToastManager>()?.showMessageFailure(DrivePickFailure(
       Exception(),

--- a/lib/features/composer/presentation/manager/drive_attachment_handler.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_handler.dart
@@ -14,9 +14,18 @@ class DriveAttachmentHandler {
   /// Whether non-https sharing/thumbnail links should be rejected.
   bool get requireHttps => BuildUtils.isReleaseMode;
 
+  /// Splits picked documents by how they can be attached and dispatches each
+  /// half.
+  ///
+  /// [startDriveTransfers] downloads and attaches the documents that carry
+  /// only a `downloadLink`, returning whether it took them. It declines on
+  /// platforms with no staging strategy, and those documents then fall back to
+  /// the "not available yet" message — the same behaviour as before drive
+  /// transfers existed.
   Future<void> handleDrivePickResult(
     List<DriveDocument> result, {
     required Future<void> Function(String html) insertHtml,
+    required Future<bool> Function(List<DriveDocument> docs) startDriveTransfers,
     AppLocalizations? appLocalizations,
   }) async {
     if (result.isEmpty) {
@@ -32,19 +41,29 @@ class DriveAttachmentHandler {
       final link = doc.sharingLink;
       return link != null && (!requireHttps || link.isScheme('https'));
     }).toList();
-    // TODO: Update logic here after implement 103. Attach Drive File as Attachment
-    if (linkDocs.isEmpty) {
+    // Exclusive with linkDocs by construction: a document carrying both links
+    // is a link, because a live document is worth more than a static copy.
+    final downloadableDocs = result
+        .where((doc) => doc.sharingLink == null && doc.downloadLink != null)
+        .toList();
+
+    if (linkDocs.isNotEmpty) {
+      await insertDriveLinkHtml(
+        linkDocs,
+        insertHtml: insertHtml,
+        appLocalizations: appLocalizations,
+      );
+    }
+
+    final transfersStarted = downloadableDocs.isNotEmpty &&
+        await startDriveTransfers(downloadableDocs);
+
+    if (linkDocs.isEmpty && !transfersStarted) {
       getBinding<ToastManager>()?.showMessageFailure(DrivePickFailure(
         Exception(),
         message: appLocalizations?.driveAttachmentInDevelopment,
       ));
-      return;
     }
-    await insertDriveLinkHtml(
-      linkDocs,
-      insertHtml: insertHtml,
-      appLocalizations: appLocalizations,
-    );
   }
 
   Future<void> insertDriveLinkHtml(

--- a/lib/features/composer/presentation/manager/drive_attachment_handler.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_handler.dart
@@ -37,12 +37,14 @@ class DriveAttachmentHandler {
       _showFailureToast(appLocalizations?.driveNoValidAttachment);
       return;
     }
-    final linkDocs = result
-        .where((doc) => doc.isAttachableAsLink(requireHttps: requireHttps))
-        .toList();
-    final downloadableDocs = result
-        .where((doc) => doc.isAttachableAsDownload(requireHttps: requireHttps))
-        .toList();
+    final linkDocs = <DriveDocument>[];
+    final downloadableDocs = <DriveDocument>[];
+    for (final doc in result) {
+      if (doc.isAttachableAsLink(requireHttps: requireHttps)) linkDocs.add(doc);
+      if (doc.isAttachableAsDownload(requireHttps: requireHttps)) {
+        downloadableDocs.add(doc);
+      }
+    }
 
     // Both halves are dispatched: a mixed pick inserts its links and transfers
     // its downloadable docs.

--- a/lib/features/composer/presentation/manager/drive_attachment_handler.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_handler.dart
@@ -9,8 +9,8 @@ import 'package:workplace/presentation/model/drive_pick_state.dart';
 /// Inserts [html] into the composer's editor.
 typedef InsertHtmlCallback = Future<void> Function(String html);
 
-/// Starts drive transfers for [docs], returning whether it took them.
-typedef StartDriveTransfersCallback = Future<bool> Function(List<DriveDocument> docs);
+/// Transfers [docs] as real attachments, returning whether it took them.
+typedef TransferDriveDocumentsCallback = Future<bool> Function(List<DriveDocument> docs);
 
 class DriveAttachmentHandler {
   DriveAttachmentHandler();
@@ -23,15 +23,13 @@ class DriveAttachmentHandler {
   /// Splits picked documents by how they can be attached and dispatches each
   /// half.
   ///
-  /// [startDriveTransfers] downloads and attaches the documents that carry
-  /// only a `downloadLink`, returning whether it took them. It declines on
-  /// platforms with no staging strategy, and those documents then fall back to
-  /// the "not available yet" message — the same behaviour as before drive
-  /// transfers existed.
+  /// [transferDriveDocuments] downloads and attaches the documents that carry
+  /// only a `downloadLink`. It declines on platforms with no staging strategy,
+  /// and those documents then fall back to the "not available yet" message.
   Future<void> handleDrivePickResult(
     List<DriveDocument> result, {
     required InsertHtmlCallback insertHtml,
-    required StartDriveTransfersCallback startDriveTransfers,
+    required TransferDriveDocumentsCallback transferDriveDocuments,
     AppLocalizations? appLocalizations,
   }) async {
     if (result.isEmpty) {
@@ -62,7 +60,7 @@ class DriveAttachmentHandler {
     }
 
     final transfersStarted = downloadableDocs.isNotEmpty &&
-        await startDriveTransfers(downloadableDocs);
+        await transferDriveDocuments(downloadableDocs);
 
     if (linkDocs.isEmpty && !transfersStarted) {
       getBinding<ToastManager>()?.showMessageFailure(DrivePickFailure(

--- a/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
@@ -40,7 +40,7 @@ class DriveDocumentTransferRunner {
   }) async {
     final taskId = UploadTaskId(_uuid.v4());
     final cancelToken = CancelToken();
-    var exceededDeclaredSize = false;
+    bool exceededDeclaredSize = false;
 
     _uploadController.addDownloadingPlaceholder(
       taskId: taskId,

--- a/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
@@ -1,0 +1,78 @@
+import 'package:core/utils/app_logger.dart';
+import 'package:dio/dio.dart';
+import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
+import 'package:tmail_ui_user/features/upload/presentation/controller/upload_controller.dart';
+import 'package:uuid/uuid.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
+import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+
+/// Resolves the `Authorization` header for the current session, or null when
+/// there is none to send.
+typedef ResolveAuthHeader = String? Function();
+
+/// Runs one drive document through both legs of its transfer: chip placeholder,
+/// download and upload progress, then completion or failure.
+class DriveDocumentTransferRunner {
+  DriveDocumentTransferRunner({
+    required UploadController uploadController,
+    required Uuid uuid,
+    required ResolveAuthHeader resolveAuthHeader,
+  })  : _uploadController = uploadController,
+        _uuid = uuid,
+        _resolveAuthHeader = resolveAuthHeader;
+
+  final UploadController _uploadController;
+  final Uuid _uuid;
+  final ResolveAuthHeader _resolveAuthHeader;
+
+  Future<void> run({
+    required DriveDocument doc,
+    required Uri uploadUri,
+    required DriveTransferStrategy<StagedDriveFile> strategy,
+  }) async {
+    final taskId = UploadTaskId(_uuid.v4());
+    final cancelToken = CancelToken();
+
+    _uploadController.addDownloadingPlaceholder(
+      taskId: taskId,
+      fileName: doc.name,
+      fileSize: doc.size,
+      mimeType: doc.mimeType,
+      cancelToken: cancelToken,
+    );
+
+    try {
+      final attachment = await strategy.transfer(DriveTransferRequest(
+        doc: doc,
+        uploadUri: uploadUri,
+        authHeader: _resolveAuthHeader() ?? '',
+        onDownloadProgress: (received, total) => _uploadController.updateDownloadProgress(
+          taskId: taskId,
+          received: received,
+          total: total,
+        ),
+        onUploadProgress: (sent, total) => _uploadController.updateUploadProgress(
+          taskId: taskId,
+          sent: sent,
+          total: total,
+        ),
+        cancelToken: cancelToken,
+      ));
+      _uploadController.completeUploadedFile(
+        taskId: taskId,
+        attachment: attachment,
+      );
+    } catch (error) {
+      // A failing file drops its own chip and nothing else: an expired link or
+      // a cancelled transfer must not take its siblings down with it.
+      logWarning('DriveDocumentTransferRunner::run(${doc.name}): $error');
+      if (cancelToken.isCancelled) {
+        // The user asked for this one to stop, so no error toast.
+        _uploadController.deleteFileUploaded(taskId);
+      } else {
+        _uploadController.failDriveTransfer(taskId);
+      }
+    }
+  }
+}

--- a/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
@@ -177,7 +177,11 @@ class DriveDocumentTransferRunner {
 
   /// A stable, PII-free label for a transfer failure: no document name, no
   /// download URI, no error message.
-  String _errorCategory(Object error) => error is DioException
-      ? 'DioException.${error.type.name}(${error.response?.statusCode})'
-      : error.runtimeType.toString();
+  String _errorCategory(Object error) {
+    if (error is! DioException) return error.runtimeType.toString();
+
+    final category = 'DioException.${error.type.name}';
+    final statusCode = error.response?.statusCode;
+    return statusCode == null ? category : '$category($statusCode)';
+  }
 }

--- a/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
@@ -13,6 +13,9 @@ typedef ResolveAuthHeader = String? Function();
 
 /// Runs one drive document through both legs of its transfer: chip placeholder,
 /// download and upload progress, then completion or failure.
+///
+/// Every failure — staging, upload, oversized download — drops that file's chip
+/// and toasts; a user cancel drops the chip silently. Siblings are unaffected.
 class DriveDocumentTransferRunner {
   DriveDocumentTransferRunner({
     required UploadController uploadController,

--- a/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
@@ -31,7 +31,10 @@ class DriveDocumentTransferRunner {
   /// so no file is downloaded only to be rejected by the upload endpoint.
   bool get canAuthenticate => resolveAuthHeader()?.trim().isNotEmpty == true;
 
-  Future<void> run({
+  /// Returns whether the document became an attachment: `false` covers both a
+  /// failed transfer and one the user cancelled, so a batch only reports what
+  /// actually landed.
+  Future<bool> run({
     required DriveDocument doc,
     required Uri uploadUri,
     required DriveTransferStrategy<StagedDriveFile> strategy,
@@ -81,6 +84,7 @@ class DriveDocumentTransferRunner {
         taskId: taskId,
         attachment: attachment,
       );
+      return true;
     } catch (error) {
       _handleTransferFailure(
         taskId: taskId,
@@ -88,6 +92,7 @@ class DriveDocumentTransferRunner {
         exceededDeclaredSize: exceededDeclaredSize,
         error: error,
       );
+      return false;
     }
   }
 

--- a/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
@@ -51,15 +51,10 @@ class DriveDocumentTransferRunner {
     );
 
     try {
-      final authHeader = _resolveAuthHeader();
-      if (authHeader == null || authHeader.isEmpty) {
-        throw StateError('No authorization header for drive transfer');
-      }
-
       final attachment = await strategy.transfer(DriveTransferRequest(
         doc: doc,
         uploadUri: uploadUri,
-        authHeader: authHeader,
+        authHeader: _requireAuthHeader(),
         onDownloadProgress: (received, total) {
           // The link is sending more than the backend declared, so the size
           // the batch was validated against no longer holds: stop now.
@@ -86,15 +81,41 @@ class DriveDocumentTransferRunner {
         attachment: attachment,
       );
     } catch (error) {
-      // A failing file drops its own chip and nothing else: an expired link or
-      // a cancelled transfer must not take its siblings down with it.
-      logWarning('DriveDocumentTransferRunner::run(${doc.name}): $error');
-      if (cancelToken.isCancelled && !exceededDeclaredSize) {
-        // The user asked for this one to stop, so no error toast.
-        _uploadController.deleteFileUploaded(taskId);
-      } else {
-        _uploadController.failDriveTransfer(taskId);
-      }
+      _handleTransferFailure(
+        taskId: taskId,
+        doc: doc,
+        cancelToken: cancelToken,
+        exceededDeclaredSize: exceededDeclaredSize,
+        error: error,
+      );
+    }
+  }
+
+  /// The `Authorization` header for the current session, or a thrown
+  /// [StateError] when there is none to send.
+  String _requireAuthHeader() {
+    final authHeader = _resolveAuthHeader();
+    if (authHeader == null || authHeader.isEmpty) {
+      throw StateError('No authorization header for drive transfer');
+    }
+    return authHeader;
+  }
+
+  /// A failing file drops its own chip and nothing else: an expired link or
+  /// a cancelled transfer must not take its siblings down with it.
+  void _handleTransferFailure({
+    required UploadTaskId taskId,
+    required DriveDocument doc,
+    required CancelToken cancelToken,
+    required bool exceededDeclaredSize,
+    required Object error,
+  }) {
+    logWarning('DriveDocumentTransferRunner::run(${doc.name}): $error');
+    if (cancelToken.isCancelled && !exceededDeclaredSize) {
+      // The user asked for this one to stop, so no error toast.
+      _uploadController.deleteFileUploaded(taskId);
+    } else {
+      _uploadController.failDriveTransfer(taskId);
     }
   }
 }

--- a/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
@@ -53,24 +53,30 @@ class DriveDocumentTransferRunner {
   /// Puts a chip on screen for every [docs] entry at once, before any slot is
   /// free, and returns the handles to transfer them by.
   List<PendingDriveTransfer> enqueue(List<DriveDocument> docs) {
-    final pendingTransfers = docs
-        .map((doc) => PendingDriveTransfer(
-              doc: doc,
-              taskId: UploadTaskId(uuid.v4()),
-              cancelToken: CancelToken(),
-            ))
-        .toList();
+    if (docs.isEmpty) return const [];
 
-    uploadController.addDownloadingPlaceholders(pendingTransfers
-        .map((pending) => DriveTransferPlaceholder(
-              taskId: pending.taskId,
-              fileName: pending.doc.name,
-              fileSize: pending.doc.size,
-              mimeType: pending.doc.mimeType,
-              cancelToken: pending.cancelToken,
-            ))
-        .toList());
+    final pendingTransfers = <PendingDriveTransfer>[];
+    final placeholders = <DriveTransferPlaceholder>[];
 
+    for (final doc in docs) {
+      final taskId = UploadTaskId(uuid.v4());
+      final cancelToken = CancelToken();
+
+      pendingTransfers.add(PendingDriveTransfer(
+        doc: doc,
+        taskId: taskId,
+        cancelToken: cancelToken,
+      ));
+      placeholders.add(DriveTransferPlaceholder(
+        taskId: taskId,
+        fileName: doc.name,
+        fileSize: doc.size,
+        mimeType: doc.mimeType,
+        cancelToken: cancelToken,
+      ));
+    }
+
+    uploadController.addDownloadingPlaceholders(placeholders);
     return pendingTransfers;
   }
 

--- a/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
@@ -12,6 +12,9 @@ import 'package:workplace/domain/entity/drive_document.dart';
 /// there is none to send.
 typedef ResolveAuthHeader = String? Function();
 
+/// How one document's transfer ended.
+enum DriveTransferResult { attached, failed, cancelled }
+
 /// A document whose chip is already on screen while it waits for a concurrency
 /// slot. Its identity is minted at enqueue time, so it can be cancelled before
 /// its transfer ever starts.
@@ -71,10 +74,9 @@ class DriveDocumentTransferRunner {
     return pendingTransfers;
   }
 
-  /// Returns whether the document became an attachment: `false` covers both a
-  /// failed transfer and one the user cancelled, so a batch only reports what
-  /// actually landed.
-  Future<bool> run({
+  /// Returns how the document's transfer ended, so a batch can tell an actual
+  /// failure apart from a user cancel.
+  Future<DriveTransferResult> run({
     required PendingDriveTransfer pending,
     required Uri uploadUri,
     required DriveTransferStrategy<StagedDriveFile> strategy,
@@ -87,7 +89,7 @@ class DriveDocumentTransferRunner {
     // Cancelled while queued, so there is nothing left to download.
     if (cancelToken.isCancelled) {
       uploadController.deleteFileUploaded(taskId);
-      return false;
+      return DriveTransferResult.cancelled;
     }
 
     try {
@@ -123,15 +125,14 @@ class DriveDocumentTransferRunner {
         taskId: taskId,
         attachment: attachment,
       );
-      return true;
+      return DriveTransferResult.attached;
     } catch (error) {
-      _handleTransferFailure(
+      return _handleTransferFailure(
         taskId: taskId,
         cancelToken: cancelToken,
         exceededDeclaredSize: exceededDeclaredSize,
         error: error,
       );
-      return false;
     }
   }
 
@@ -147,7 +148,7 @@ class DriveDocumentTransferRunner {
 
   /// A failing file drops its own chip and nothing else: an expired link or
   /// a cancelled transfer must not take its siblings down with it.
-  void _handleTransferFailure({
+  DriveTransferResult _handleTransferFailure({
     required UploadTaskId taskId,
     required CancelToken cancelToken,
     required bool exceededDeclaredSize,
@@ -156,13 +157,14 @@ class DriveDocumentTransferRunner {
     if (cancelToken.isCancelled && !exceededDeclaredSize) {
       // A user cancel is not a failure, so no warning log and no toast.
       uploadController.deleteFileUploaded(taskId);
-      return;
+      return DriveTransferResult.cancelled;
     }
     logWarning(
       'DriveDocumentTransferRunner::run: transfer failed | '
       'taskId=${taskId.id} | error=${_errorCategory(error)}',
     );
     uploadController.failDriveTransfer(taskId);
+    return DriveTransferResult.failed;
   }
 
   /// A stable, PII-free label for a transfer failure: no document name, no

--- a/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
@@ -153,16 +153,16 @@ class DriveDocumentTransferRunner {
     required bool exceededDeclaredSize,
     required Object error,
   }) {
+    if (cancelToken.isCancelled && !exceededDeclaredSize) {
+      // A user cancel is not a failure, so no warning log and no toast.
+      uploadController.deleteFileUploaded(taskId);
+      return;
+    }
     logWarning(
       'DriveDocumentTransferRunner::run: transfer failed | '
       'taskId=${taskId.id} | error=${_errorCategory(error)}',
     );
-    if (cancelToken.isCancelled && !exceededDeclaredSize) {
-      // The user asked for this one to stop, so no error toast.
-      uploadController.deleteFileUploaded(taskId);
-    } else {
-      uploadController.failDriveTransfer(taskId);
-    }
+    uploadController.failDriveTransfer(taskId);
   }
 
   /// A stable, PII-free label for a transfer failure: no document name, no

--- a/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
@@ -18,31 +18,29 @@ typedef ResolveAuthHeader = String? Function();
 /// and toasts; a user cancel drops the chip silently. Siblings are unaffected.
 class DriveDocumentTransferRunner {
   DriveDocumentTransferRunner({
-    required UploadController uploadController,
-    required Uuid uuid,
-    required ResolveAuthHeader resolveAuthHeader,
-  })  : _uploadController = uploadController,
-        _uuid = uuid,
-        _resolveAuthHeader = resolveAuthHeader;
+    required this.uploadController,
+    required this.uuid,
+    required this.resolveAuthHeader,
+  });
 
-  final UploadController _uploadController;
-  final Uuid _uuid;
-  final ResolveAuthHeader _resolveAuthHeader;
+  final UploadController uploadController;
+  final Uuid uuid;
+  final ResolveAuthHeader resolveAuthHeader;
 
   /// Whether there is a session to upload with. Checked before a batch starts,
   /// so no file is downloaded only to be rejected by the upload endpoint.
-  bool get canAuthenticate => _resolveAuthHeader()?.trim().isNotEmpty == true;
+  bool get canAuthenticate => resolveAuthHeader()?.trim().isNotEmpty == true;
 
   Future<void> run({
     required DriveDocument doc,
     required Uri uploadUri,
     required DriveTransferStrategy<StagedDriveFile> strategy,
   }) async {
-    final taskId = UploadTaskId(_uuid.v4());
+    final taskId = UploadTaskId(uuid.v4());
     final cancelToken = CancelToken();
     bool exceededDeclaredSize = false;
 
-    _uploadController.addDownloadingPlaceholder(
+    uploadController.addDownloadingPlaceholder(
       taskId: taskId,
       fileName: doc.name,
       fileSize: doc.size,
@@ -66,20 +64,20 @@ class DriveDocumentTransferRunner {
             cancelToken.cancel();
             return;
           }
-          _uploadController.updateDownloadProgress(
+          uploadController.updateDownloadProgress(
             taskId: taskId,
             received: received,
             total: total,
           );
         },
-        onUploadProgress: (sent, total) => _uploadController.updateUploadProgress(
+        onUploadProgress: (sent, total) => uploadController.updateUploadProgress(
           taskId: taskId,
           sent: sent,
           total: total,
         ),
         cancelToken: cancelToken,
       ));
-      _uploadController.completeUploadedFile(
+      uploadController.completeUploadedFile(
         taskId: taskId,
         attachment: attachment,
       );
@@ -96,7 +94,7 @@ class DriveDocumentTransferRunner {
   /// The `Authorization` header for the current session, or a thrown
   /// [StateError] when there is none to send.
   String _requireAuthHeader() {
-    final authHeader = _resolveAuthHeader();
+    final authHeader = resolveAuthHeader();
     if (authHeader == null || authHeader.trim().isEmpty) {
       throw StateError('No authorization header for drive transfer');
     }
@@ -117,9 +115,9 @@ class DriveDocumentTransferRunner {
     );
     if (cancelToken.isCancelled && !exceededDeclaredSize) {
       // The user asked for this one to stop, so no error toast.
-      _uploadController.deleteFileUploaded(taskId);
+      uploadController.deleteFileUploaded(taskId);
     } else {
-      _uploadController.failDriveTransfer(taskId);
+      uploadController.failDriveTransfer(taskId);
     }
   }
 

--- a/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
@@ -85,7 +85,10 @@ class DriveDocumentTransferRunner {
     bool exceededDeclaredSize = false;
 
     // Cancelled while queued, so there is nothing left to download.
-    if (cancelToken.isCancelled) return false;
+    if (cancelToken.isCancelled) {
+      uploadController.deleteFileUploaded(taskId);
+      return false;
+    }
 
     try {
       final attachment = await strategy.transfer(DriveTransferRequest(

--- a/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
@@ -31,7 +31,7 @@ class DriveDocumentTransferRunner {
 
   /// Whether there is a session to upload with. Checked before a batch starts,
   /// so no file is downloaded only to be rejected by the upload endpoint.
-  bool get canAuthenticate => _resolveAuthHeader()?.isNotEmpty == true;
+  bool get canAuthenticate => _resolveAuthHeader()?.trim().isNotEmpty == true;
 
   Future<void> run({
     required DriveDocument doc,

--- a/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
@@ -83,7 +83,6 @@ class DriveDocumentTransferRunner {
     } catch (error) {
       _handleTransferFailure(
         taskId: taskId,
-        doc: doc,
         cancelToken: cancelToken,
         exceededDeclaredSize: exceededDeclaredSize,
         error: error,
@@ -105,12 +104,14 @@ class DriveDocumentTransferRunner {
   /// a cancelled transfer must not take its siblings down with it.
   void _handleTransferFailure({
     required UploadTaskId taskId,
-    required DriveDocument doc,
     required CancelToken cancelToken,
     required bool exceededDeclaredSize,
     required Object error,
   }) {
-    logWarning('DriveDocumentTransferRunner::run(${doc.name}): $error');
+    logWarning(
+      'DriveDocumentTransferRunner::run: transfer failed | '
+      'taskId=${taskId.id} | error=${_errorCategory(error)}',
+    );
     if (cancelToken.isCancelled && !exceededDeclaredSize) {
       // The user asked for this one to stop, so no error toast.
       _uploadController.deleteFileUploaded(taskId);
@@ -118,4 +119,10 @@ class DriveDocumentTransferRunner {
       _uploadController.failDriveTransfer(taskId);
     }
   }
+
+  /// A stable, PII-free label for a transfer failure: no document name, no
+  /// download URI, no error message.
+  String _errorCategory(Object error) => error is DioException
+      ? 'DioException.${error.type.name}(${error.response?.statusCode})'
+      : error.runtimeType.toString();
 }

--- a/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
@@ -33,6 +33,7 @@ class DriveDocumentTransferRunner {
   }) async {
     final taskId = UploadTaskId(_uuid.v4());
     final cancelToken = CancelToken();
+    var exceededDeclaredSize = false;
 
     _uploadController.addDownloadingPlaceholder(
       taskId: taskId,
@@ -47,11 +48,20 @@ class DriveDocumentTransferRunner {
         doc: doc,
         uploadUri: uploadUri,
         authHeader: _resolveAuthHeader() ?? '',
-        onDownloadProgress: (received, total) => _uploadController.updateDownloadProgress(
-          taskId: taskId,
-          received: received,
-          total: total,
-        ),
+        onDownloadProgress: (received, total) {
+          // The link is sending more than the backend declared, so the size
+          // the batch was validated against no longer holds: stop now.
+          if (doc.size > 0 && received > doc.size) {
+            exceededDeclaredSize = true;
+            cancelToken.cancel();
+            return;
+          }
+          _uploadController.updateDownloadProgress(
+            taskId: taskId,
+            received: received,
+            total: total,
+          );
+        },
         onUploadProgress: (sent, total) => _uploadController.updateUploadProgress(
           taskId: taskId,
           sent: sent,
@@ -67,7 +77,7 @@ class DriveDocumentTransferRunner {
       // A failing file drops its own chip and nothing else: an expired link or
       // a cancelled transfer must not take its siblings down with it.
       logWarning('DriveDocumentTransferRunner::run(${doc.name}): $error');
-      if (cancelToken.isCancelled) {
+      if (cancelToken.isCancelled && !exceededDeclaredSize) {
         // The user asked for this one to stop, so no error toast.
         _uploadController.deleteFileUploaded(taskId);
       } else {

--- a/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
@@ -2,6 +2,7 @@ import 'package:core/utils/app_logger.dart';
 import 'package:dio/dio.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
 import 'package:tmail_ui_user/features/upload/presentation/controller/upload_controller.dart';
+import 'package:tmail_ui_user/features/upload/presentation/model/drive_transfer_placeholder.dart';
 import 'package:uuid/uuid.dart';
 import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
 import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
@@ -11,8 +12,23 @@ import 'package:workplace/domain/entity/drive_document.dart';
 /// there is none to send.
 typedef ResolveAuthHeader = String? Function();
 
-/// Runs one drive document through both legs of its transfer: chip placeholder,
-/// download and upload progress, then completion or failure.
+/// A document whose chip is already on screen while it waits for a concurrency
+/// slot. Its identity is minted at enqueue time, so it can be cancelled before
+/// its transfer ever starts.
+class PendingDriveTransfer {
+  final DriveDocument doc;
+  final UploadTaskId taskId;
+  final CancelToken cancelToken;
+
+  const PendingDriveTransfer({
+    required this.doc,
+    required this.taskId,
+    required this.cancelToken,
+  });
+}
+
+/// Runs one drive document through both legs of its transfer: download and
+/// upload progress, then completion or failure.
 ///
 /// Every failure — staging, upload, oversized download — drops that file's chip
 /// and toasts; a user cancel drops the chip silently. Siblings are unaffected.
@@ -31,25 +47,45 @@ class DriveDocumentTransferRunner {
   /// so no file is downloaded only to be rejected by the upload endpoint.
   bool get canAuthenticate => resolveAuthHeader()?.trim().isNotEmpty == true;
 
+  /// Puts a chip on screen for every [docs] entry at once, before any slot is
+  /// free, and returns the handles to transfer them by.
+  List<PendingDriveTransfer> enqueue(List<DriveDocument> docs) {
+    final pendingTransfers = docs
+        .map((doc) => PendingDriveTransfer(
+              doc: doc,
+              taskId: UploadTaskId(uuid.v4()),
+              cancelToken: CancelToken(),
+            ))
+        .toList();
+
+    uploadController.addDownloadingPlaceholders(pendingTransfers
+        .map((pending) => DriveTransferPlaceholder(
+              taskId: pending.taskId,
+              fileName: pending.doc.name,
+              fileSize: pending.doc.size,
+              mimeType: pending.doc.mimeType,
+              cancelToken: pending.cancelToken,
+            ))
+        .toList());
+
+    return pendingTransfers;
+  }
+
   /// Returns whether the document became an attachment: `false` covers both a
   /// failed transfer and one the user cancelled, so a batch only reports what
   /// actually landed.
   Future<bool> run({
-    required DriveDocument doc,
+    required PendingDriveTransfer pending,
     required Uri uploadUri,
     required DriveTransferStrategy<StagedDriveFile> strategy,
   }) async {
-    final taskId = UploadTaskId(uuid.v4());
-    final cancelToken = CancelToken();
+    final doc = pending.doc;
+    final taskId = pending.taskId;
+    final cancelToken = pending.cancelToken;
     bool exceededDeclaredSize = false;
 
-    uploadController.addDownloadingPlaceholder(
-      taskId: taskId,
-      fileName: doc.name,
-      fileSize: doc.size,
-      mimeType: doc.mimeType,
-      cancelToken: cancelToken,
-    );
+    // Cancelled while queued, so there is nothing left to download.
+    if (cancelToken.isCancelled) return false;
 
     try {
       final attachment = await strategy.transfer(DriveTransferRequest(

--- a/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
@@ -58,7 +58,10 @@ class DriveDocumentTransferRunner {
         onDownloadProgress: (received, total) {
           // The link is sending more than the backend declared, so the size
           // the batch was validated against no longer holds: stop now.
-          if (doc.size > 0 && received > doc.size) {
+          // `doc.size` is 0 when the backend declared nothing, and the
+          // response's own total is then the only ceiling there is.
+          final declaredSize = doc.size > 0 ? doc.size : total;
+          if (declaredSize > 0 && received > declaredSize) {
             exceededDeclaredSize = true;
             cancelToken.cancel();
             return;

--- a/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
@@ -94,7 +94,7 @@ class DriveDocumentTransferRunner {
   /// [StateError] when there is none to send.
   String _requireAuthHeader() {
     final authHeader = _resolveAuthHeader();
-    if (authHeader == null || authHeader.isEmpty) {
+    if (authHeader == null || authHeader.trim().isEmpty) {
       throw StateError('No authorization header for drive transfer');
     }
     return authHeader;

--- a/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
@@ -26,6 +26,10 @@ class DriveDocumentTransferRunner {
   final Uuid _uuid;
   final ResolveAuthHeader _resolveAuthHeader;
 
+  /// Whether there is a session to upload with. Checked before a batch starts,
+  /// so no file is downloaded only to be rejected by the upload endpoint.
+  bool get canAuthenticate => _resolveAuthHeader()?.isNotEmpty == true;
+
   Future<void> run({
     required DriveDocument doc,
     required Uri uploadUri,
@@ -44,10 +48,15 @@ class DriveDocumentTransferRunner {
     );
 
     try {
+      final authHeader = _resolveAuthHeader();
+      if (authHeader == null || authHeader.isEmpty) {
+        throw StateError('No authorization header for drive transfer');
+      }
+
       final attachment = await strategy.transfer(DriveTransferRequest(
         doc: doc,
         uploadUri: uploadUri,
-        authHeader: _resolveAuthHeader() ?? '',
+        authHeader: authHeader,
         onDownloadProgress: (received, total) {
           // The link is sending more than the backend declared, so the size
           // the batch was validated against no longer holds: stop now.

--- a/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_document_transfer_runner.dart
@@ -48,7 +48,7 @@ class DriveDocumentTransferRunner {
 
   /// Whether there is a session to upload with. Checked before a batch starts,
   /// so no file is downloaded only to be rejected by the upload endpoint.
-  bool get canAuthenticate => resolveAuthHeader()?.trim().isNotEmpty == true;
+  bool get canAuthenticate => _resolveAuthHeader() != null;
 
   /// Puts a chip on screen for every [docs] entry at once, before any slot is
   /// free, and returns the handles to transfer them by.
@@ -142,15 +142,17 @@ class DriveDocumentTransferRunner {
     }
   }
 
+  /// The trimmed `Authorization` header, or null when there is none to send.
+  String? _resolveAuthHeader() {
+    final authHeader = resolveAuthHeader()?.trim();
+    return authHeader?.isNotEmpty == true ? authHeader : null;
+  }
+
   /// The `Authorization` header for the current session, or a thrown
   /// [StateError] when there is none to send.
-  String _requireAuthHeader() {
-    final authHeader = resolveAuthHeader();
-    if (authHeader == null || authHeader.trim().isEmpty) {
-      throw StateError('No authorization header for drive transfer');
-    }
-    return authHeader;
-  }
+  String _requireAuthHeader() =>
+      _resolveAuthHeader() ??
+      (throw StateError('No authorization header for drive transfer'));
 
   /// A failing file drops its own chip and nothing else: an expired link or
   /// a cancelled transfer must not take its siblings down with it.

--- a/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
+++ b/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
@@ -114,6 +114,7 @@ class DriveTransferPipeline {
     DriveTransferStrategy<StagedDriveFile> strategy,
   ) async {
     var attachedCount = 0;
+    var failedCount = 0;
     // Every chip goes up first: what the user sees must match what they picked,
     // not how many files fit through the concurrency limit at once.
     final pendingTransfers = transferRunner.enqueue(docs);
@@ -126,12 +127,19 @@ class DriveTransferPipeline {
           uploadUri: uploadUri,
           strategy: strategy,
         );
-        if (result == DriveTransferResult.attached) attachedCount++;
+        switch (result) {
+          case DriveTransferResult.attached:
+            attachedCount++;
+          case DriveTransferResult.failed:
+            failedCount++;
+          case DriveTransferResult.cancelled:
+            break;
+        }
       },
     );
-    // Nothing landed means every file already toasted its own failure, or the
-    // user cancelled them: a "0 attached" toast would only add noise.
     if (attachedCount > 0) _showSuccessToast(attachedCount);
+    // One toast for the whole batch, not one per file.
+    if (failedCount > 0) transferRunner.uploadController.showDriveTransferFailureToast();
   }
 
   /// Toasts the batch result, or logs when there is no [ToastManager] bound.

--- a/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
+++ b/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
@@ -17,7 +17,16 @@ import 'package:uuid/uuid.dart';
 import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
 import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy_factory.dart';
 import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
+import 'package:workplace/data/model/workplace_type_defs.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
+
+/// Resolves the JMAP upload endpoint for the current session, or null when
+/// there is none yet.
+typedef ResolveUploadUri = Uri? Function();
+
+/// Resolves the `Authorization` header for the current session, or null when
+/// there is none to send.
+typedef ResolveAuthHeader = String? Function();
 
 /// Downloads drive documents into platform temp storage and uploads them as
 /// real attachments, one bounded-concurrency pipeline per batch.
@@ -31,8 +40,8 @@ class DriveTransferPipeline {
     required UploadController uploadController,
     required FileUploader fileUploader,
     required Uuid uuid,
-    required Uri? Function() resolveUploadUri,
-    required String? Function() resolveAuthHeader,
+    required ResolveUploadUri resolveUploadUri,
+    required ResolveAuthHeader resolveAuthHeader,
   })  : _validationService = validationService,
         _uploadController = uploadController,
         _fileUploader = fileUploader,
@@ -44,8 +53,8 @@ class DriveTransferPipeline {
   final UploadController _uploadController;
   final FileUploader _fileUploader;
   final Uuid _uuid;
-  final Uri? Function() _resolveUploadUri;
-  final String? Function() _resolveAuthHeader;
+  final ResolveUploadUri _resolveUploadUri;
+  final ResolveAuthHeader _resolveAuthHeader;
 
   /// Held for this pipeline's lifetime: the factory caches its capability
   /// detection and runs the stale-staging sweep once per instance.
@@ -166,7 +175,7 @@ class DriveTransferPipeline {
   Future<Attachment> _uploadStagedFile({
     required StagedDriveFile staged,
     required Uri uploadUri,
-    required void Function(int sent, int total) onUploadProgress,
+    required OnFileProcessedProgress onUploadProgress,
     required CancelToken cancelToken,
   }) async {
     final fileInfo = switch (staged) {

--- a/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
+++ b/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
@@ -151,7 +151,12 @@ class DriveTransferPipeline {
       // A failing file drops its own chip and nothing else: an expired link or
       // a cancelled transfer must not take its siblings down with it.
       logWarning('DriveTransferPipeline::_transferOne(${doc.name}): $error');
-      _uploadController.deleteFileUploaded(taskId);
+      if (cancelToken.isCancelled) {
+        // The user asked for this one to stop, so no error toast.
+        _uploadController.deleteFileUploaded(taskId);
+      } else {
+        _uploadController.failDriveTransfer(taskId);
+      }
     }
   }
 

--- a/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
+++ b/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
@@ -32,28 +32,23 @@ typedef ResolveUploadUri = Uri? Function();
 /// keeps its link-only behaviour.
 class DriveTransferPipeline {
   DriveTransferPipeline({
-    required AttachmentUploadValidationService validationService,
-    required FileUploader fileUploader,
-    required Uuid uuid,
-    required DriveTransferStrategyFactory strategyFactory,
-    required DriveDocumentTransferRunner transferRunner,
-    required ResolveUploadUri resolveUploadUri,
-  })  : _validationService = validationService,
-        _fileUploader = fileUploader,
-        _uuid = uuid,
-        _strategyFactory = strategyFactory,
-        _transferRunner = transferRunner,
-        _resolveUploadUri = resolveUploadUri;
+    required this.validationService,
+    required this.fileUploader,
+    required this.uuid,
+    required this.strategyFactory,
+    required this.transferRunner,
+    required this.resolveUploadUri,
+  });
 
-  final AttachmentUploadValidationService _validationService;
-  final FileUploader _fileUploader;
-  final Uuid _uuid;
-  final DriveDocumentTransferRunner _transferRunner;
+  final AttachmentUploadValidationService validationService;
+  final FileUploader fileUploader;
+  final Uuid uuid;
+  final DriveDocumentTransferRunner transferRunner;
 
   /// App-wide singleton from `CoreBindings`: it caches capability detection
   /// and sweeps stale staging once, so it outlives any one composer.
-  final DriveTransferStrategyFactory _strategyFactory;
-  final ResolveUploadUri _resolveUploadUri;
+  final DriveTransferStrategyFactory strategyFactory;
+  final ResolveUploadUri resolveUploadUri;
 
   /// Returns whether this pipeline took responsibility for [docs]. `false`
   /// means nothing was attempted — no staging strategy on this platform, or
@@ -68,18 +63,18 @@ class DriveTransferPipeline {
   Future<bool> transfer(List<DriveDocument> docs) async {
     if (docs.isEmpty) return false;
 
-    final uploadUri = _resolveUploadUri();
+    final uploadUri = resolveUploadUri();
     if (uploadUri == null) {
       logWarning('DriveTransferPipeline::transfer: no upload URI available');
       return false;
     }
 
-    if (!_transferRunner.canAuthenticate) {
+    if (!transferRunner.canAuthenticate) {
       logWarning('DriveTransferPipeline::transfer: no authorization header available');
       return false;
     }
 
-    final strategy = _strategyFactory.create(
+    final strategy = strategyFactory.create(
       uploader: ({
         required staged,
         required uploadUri,
@@ -98,7 +93,7 @@ class DriveTransferPipeline {
     final declaredTotalBytes =
         docs.fold<int>(0, (total, doc) => total + doc.size);
 
-    await _validationService.validateBytes(
+    await validationService.validateBytes(
       // Drive documents are never inline, so both totals are the same sum.
       proposedAllAttachmentBytes: declaredTotalBytes,
       proposedRegularAttachmentBytes: declaredTotalBytes,
@@ -115,7 +110,7 @@ class DriveTransferPipeline {
     return runWithConcurrency(
       docs,
       strategy.maxConcurrentTransfers,
-      (doc) => _transferRunner.run(
+      (doc) => transferRunner.run(
         doc: doc,
         uploadUri: uploadUri,
         strategy: strategy,
@@ -159,8 +154,8 @@ class DriveTransferPipeline {
     });
 
     try {
-      return await _fileUploader.uploadAttachment(
-        UploadTaskId(_uuid.v4()),
+      return await fileUploader.uploadAttachment(
+        UploadTaskId(uuid.v4()),
         fileInfo,
         uploadUri,
         cancelToken: cancelToken,

--- a/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
+++ b/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
@@ -40,12 +40,14 @@ class DriveTransferPipeline {
     required UploadController uploadController,
     required FileUploader fileUploader,
     required Uuid uuid,
+    required DriveTransferStrategyFactory strategyFactory,
     required ResolveUploadUri resolveUploadUri,
     required ResolveAuthHeader resolveAuthHeader,
   })  : _validationService = validationService,
         _uploadController = uploadController,
         _fileUploader = fileUploader,
         _uuid = uuid,
+        _strategyFactory = strategyFactory,
         _resolveUploadUri = resolveUploadUri,
         _resolveAuthHeader = resolveAuthHeader;
 
@@ -53,16 +55,12 @@ class DriveTransferPipeline {
   final UploadController _uploadController;
   final FileUploader _fileUploader;
   final Uuid _uuid;
+
+  /// App-wide singleton from `CoreBindings`: it caches capability detection
+  /// and sweeps stale staging once, so it outlives any one composer.
+  final DriveTransferStrategyFactory _strategyFactory;
   final ResolveUploadUri _resolveUploadUri;
   final ResolveAuthHeader _resolveAuthHeader;
-
-  /// Held for this pipeline's lifetime: the factory caches its capability
-  /// detection and runs the stale-staging sweep once per instance.
-  ///
-  /// Not `const`: only the mobile branch of the conditional export has a const
-  /// constructor, which is the only branch the analyzer sees.
-  // ignore: prefer_const_constructors
-  final DriveTransferStrategyFactory _strategyFactory = DriveTransferStrategyFactory();
 
   /// Returns whether this pipeline took responsibility for [docs]. `false`
   /// means nothing was attempted — no staging strategy on this platform, or

--- a/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
+++ b/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
@@ -114,12 +114,15 @@ class DriveTransferPipeline {
     DriveTransferStrategy<StagedDriveFile> strategy,
   ) async {
     var attachedCount = 0;
+    // Every chip goes up first: what the user sees must match what they picked,
+    // not how many files fit through the concurrency limit at once.
+    final pendingTransfers = transferRunner.enqueue(docs);
     await runWithConcurrency(
-      docs,
+      pendingTransfers,
       strategy.maxConcurrentTransfers,
-      (doc) async {
+      (pending) async {
         final attached = await transferRunner.run(
-          doc: doc,
+          pending: pending,
           uploadUri: uploadUri,
           strategy: strategy,
         );

--- a/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
+++ b/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
@@ -121,12 +121,12 @@ class DriveTransferPipeline {
       pendingTransfers,
       strategy.maxConcurrentTransfers,
       (pending) async {
-        final attached = await transferRunner.run(
+        final result = await transferRunner.run(
           pending: pending,
           uploadUri: uploadUri,
           strategy: strategy,
         );
-        if (attached) attachedCount++;
+        if (result == DriveTransferResult.attached) attachedCount++;
       },
     );
     // Nothing landed means every file already toasted its own failure, or the

--- a/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
+++ b/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
@@ -61,6 +61,10 @@ class DriveTransferPipeline {
   ///
   /// A batch the user declines at the size gate still counts as taken: the
   /// documents were handled and the user was told why nothing was attached.
+  ///
+  /// Failure paths:
+  /// - no upload URI / no auth header / no strategy → `false`, caller toasts.
+  /// - staging or upload failure → per-file, see [DriveDocumentTransferRunner].
   Future<bool> transfer(List<DriveDocument> docs) async {
     if (docs.isEmpty) return false;
 

--- a/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
+++ b/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
@@ -8,10 +8,10 @@ import 'package:dio/dio.dart';
 import 'package:model/email/attachment.dart';
 import 'package:model/upload/file_info.dart';
 import 'package:tmail_ui_user/features/composer/presentation/manager/bounded_concurrency_runner.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/drive_document_transfer_runner.dart';
 import 'package:tmail_ui_user/features/upload/data/network/file_uploader.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
 import 'package:tmail_ui_user/features/upload/domain/state/attachment_upload_state.dart';
-import 'package:tmail_ui_user/features/upload/presentation/controller/upload_controller.dart';
 import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_upload_validation_service.dart';
 import 'package:uuid/uuid.dart';
 import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
@@ -24,10 +24,6 @@ import 'package:workplace/domain/entity/drive_document.dart';
 /// there is none yet.
 typedef ResolveUploadUri = Uri? Function();
 
-/// Resolves the `Authorization` header for the current session, or null when
-/// there is none to send.
-typedef ResolveAuthHeader = String? Function();
-
 /// Downloads drive documents into platform temp storage and uploads them as
 /// real attachments, one bounded-concurrency pipeline per batch.
 ///
@@ -37,30 +33,27 @@ typedef ResolveAuthHeader = String? Function();
 class DriveTransferPipeline {
   DriveTransferPipeline({
     required AttachmentUploadValidationService validationService,
-    required UploadController uploadController,
     required FileUploader fileUploader,
     required Uuid uuid,
     required DriveTransferStrategyFactory strategyFactory,
+    required DriveDocumentTransferRunner transferRunner,
     required ResolveUploadUri resolveUploadUri,
-    required ResolveAuthHeader resolveAuthHeader,
   })  : _validationService = validationService,
-        _uploadController = uploadController,
         _fileUploader = fileUploader,
         _uuid = uuid,
         _strategyFactory = strategyFactory,
-        _resolveUploadUri = resolveUploadUri,
-        _resolveAuthHeader = resolveAuthHeader;
+        _transferRunner = transferRunner,
+        _resolveUploadUri = resolveUploadUri;
 
   final AttachmentUploadValidationService _validationService;
-  final UploadController _uploadController;
   final FileUploader _fileUploader;
   final Uuid _uuid;
+  final DriveDocumentTransferRunner _transferRunner;
 
   /// App-wide singleton from `CoreBindings`: it caches capability detection
   /// and sweeps stale staging once, so it outlives any one composer.
   final DriveTransferStrategyFactory _strategyFactory;
   final ResolveUploadUri _resolveUploadUri;
-  final ResolveAuthHeader _resolveAuthHeader;
 
   /// Returns whether this pipeline took responsibility for [docs]. `false`
   /// means nothing was attempted — no staging strategy on this platform, or
@@ -113,58 +106,12 @@ class DriveTransferPipeline {
     return runWithConcurrency(
       docs,
       strategy.maxConcurrentTransfers,
-      (doc) => _transferOne(doc, uploadUri, strategy),
-    );
-  }
-
-  Future<void> _transferOne(
-    DriveDocument doc,
-    Uri uploadUri,
-    DriveTransferStrategy<StagedDriveFile> strategy,
-  ) async {
-    final taskId = UploadTaskId(_uuid.v4());
-    final cancelToken = CancelToken();
-
-    _uploadController.addDownloadingPlaceholder(
-      taskId: taskId,
-      fileName: doc.name,
-      fileSize: doc.size,
-      mimeType: doc.mimeType,
-      cancelToken: cancelToken,
-    );
-
-    try {
-      final attachment = await strategy.transfer(DriveTransferRequest(
+      (doc) => _transferRunner.run(
         doc: doc,
         uploadUri: uploadUri,
-        authHeader: _resolveAuthHeader() ?? '',
-        onDownloadProgress: (received, total) => _uploadController.updateDownloadProgress(
-          taskId: taskId,
-          received: received,
-          total: total,
-        ),
-        onUploadProgress: (sent, total) => _uploadController.updateUploadProgress(
-          taskId: taskId,
-          sent: sent,
-          total: total,
-        ),
-        cancelToken: cancelToken,
-      ));
-      _uploadController.completeUploadedFile(
-        taskId: taskId,
-        attachment: attachment,
-      );
-    } catch (error) {
-      // A failing file drops its own chip and nothing else: an expired link or
-      // a cancelled transfer must not take its siblings down with it.
-      logWarning('DriveTransferPipeline::_transferOne(${doc.name}): $error');
-      if (cancelToken.isCancelled) {
-        // The user asked for this one to stop, so no error toast.
-        _uploadController.deleteFileUploaded(taskId);
-      } else {
-        _uploadController.failDriveTransfer(taskId);
-      }
-    }
+        strategy: strategy,
+      ),
+    );
   }
 
   /// Uploads a staged file whose bytes live in memory or on disk through the

--- a/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
+++ b/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
@@ -1,0 +1,206 @@
+import 'dart:async';
+
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:core/utils/app_logger.dart';
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import 'package:model/email/attachment.dart';
+import 'package:model/upload/file_info.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/bounded_concurrency_runner.dart';
+import 'package:tmail_ui_user/features/upload/data/network/file_uploader.dart';
+import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
+import 'package:tmail_ui_user/features/upload/domain/state/attachment_upload_state.dart';
+import 'package:tmail_ui_user/features/upload/presentation/controller/upload_controller.dart';
+import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_upload_validation_service.dart';
+import 'package:uuid/uuid.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy_factory.dart';
+import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+
+/// Downloads drive documents into platform temp storage and uploads them as
+/// real attachments, one bounded-concurrency pipeline per batch.
+///
+/// Platform capability is the strategy factory's business: when it has no
+/// strategy for this platform, [transfer] declines the batch and the caller
+/// keeps its link-only behaviour.
+class DriveTransferPipeline {
+  DriveTransferPipeline({
+    required AttachmentUploadValidationService validationService,
+    required UploadController uploadController,
+    required FileUploader fileUploader,
+    required Uuid uuid,
+    required Uri? Function() resolveUploadUri,
+    required String? Function() resolveAuthHeader,
+  })  : _validationService = validationService,
+        _uploadController = uploadController,
+        _fileUploader = fileUploader,
+        _uuid = uuid,
+        _resolveUploadUri = resolveUploadUri,
+        _resolveAuthHeader = resolveAuthHeader;
+
+  final AttachmentUploadValidationService _validationService;
+  final UploadController _uploadController;
+  final FileUploader _fileUploader;
+  final Uuid _uuid;
+  final Uri? Function() _resolveUploadUri;
+  final String? Function() _resolveAuthHeader;
+
+  /// Held for this pipeline's lifetime: the factory caches its capability
+  /// detection and runs the stale-staging sweep once per instance.
+  ///
+  /// Not `const`: only the mobile branch of the conditional export has a const
+  /// constructor, which is the only branch the analyzer sees.
+  // ignore: prefer_const_constructors
+  final DriveTransferStrategyFactory _strategyFactory = DriveTransferStrategyFactory();
+
+  /// Returns whether this pipeline took responsibility for [docs]. `false`
+  /// means nothing was attempted — no staging strategy on this platform, or
+  /// no upload endpoint to send to — so the caller should fall back.
+  ///
+  /// A batch the user declines at the size gate still counts as taken: the
+  /// documents were handled and the user was told why nothing was attached.
+  Future<bool> transfer(List<DriveDocument> docs) async {
+    if (docs.isEmpty) return false;
+
+    final uploadUri = _resolveUploadUri();
+    if (uploadUri == null) {
+      logWarning('DriveTransferPipeline::transfer: no upload URI available');
+      return false;
+    }
+
+    final strategy = _strategyFactory.create(
+      uploader: ({
+        required staged,
+        required uploadUri,
+        required onUploadProgress,
+        required cancelToken,
+      }) =>
+          _uploadStagedFile(
+            staged: staged,
+            uploadUri: uploadUri,
+            onUploadProgress: onUploadProgress,
+            cancelToken: cancelToken,
+          ),
+    );
+    if (strategy == null) return false;
+
+    final declaredTotalBytes =
+        docs.fold<int>(0, (total, doc) => total + doc.size);
+
+    await _validationService.validateBytes(
+      // Drive documents are never inline, so both totals are the same sum.
+      proposedAllAttachmentBytes: declaredTotalBytes,
+      proposedRegularAttachmentBytes: declaredTotalBytes,
+      onAllowed: () => unawaited(_runBatch(docs, uploadUri, strategy)),
+    );
+    return true;
+  }
+
+  Future<void> _runBatch(
+    List<DriveDocument> docs,
+    Uri uploadUri,
+    DriveTransferStrategy<StagedDriveFile> strategy,
+  ) {
+    return runWithConcurrency(
+      docs,
+      strategy.maxConcurrentTransfers,
+      (doc) => _transferOne(doc, uploadUri, strategy),
+    );
+  }
+
+  Future<void> _transferOne(
+    DriveDocument doc,
+    Uri uploadUri,
+    DriveTransferStrategy<StagedDriveFile> strategy,
+  ) async {
+    final taskId = UploadTaskId(_uuid.v4());
+    final cancelToken = CancelToken();
+
+    _uploadController.addDownloadingPlaceholder(
+      taskId: taskId,
+      fileName: doc.name,
+      fileSize: doc.size,
+      mimeType: doc.mimeType,
+      cancelToken: cancelToken,
+    );
+
+    try {
+      final attachment = await strategy.transfer(DriveTransferRequest(
+        doc: doc,
+        uploadUri: uploadUri,
+        authHeader: _resolveAuthHeader() ?? '',
+        onDownloadProgress: (received, total) => _uploadController.updateDownloadProgress(
+          taskId: taskId,
+          received: received,
+          total: total,
+        ),
+        onUploadProgress: (sent, total) => _uploadController.updateUploadProgress(
+          taskId: taskId,
+          sent: sent,
+          total: total,
+        ),
+        cancelToken: cancelToken,
+      ));
+      _uploadController.completeUploadedFile(
+        taskId: taskId,
+        attachment: attachment,
+      );
+    } catch (error) {
+      // A failing file drops its own chip and nothing else: an expired link or
+      // a cancelled transfer must not take its siblings down with it.
+      logWarning('DriveTransferPipeline::_transferOne(${doc.name}): $error');
+      _uploadController.deleteFileUploaded(taskId);
+    }
+  }
+
+  /// Uploads a staged file whose bytes live in memory or on disk through the
+  /// shared [FileUploader]. The OPFS strategy never calls this — it streams
+  /// its own raw XHR so the file never reaches the Dart heap.
+  Future<Attachment> _uploadStagedFile({
+    required StagedDriveFile staged,
+    required Uri uploadUri,
+    required void Function(int sent, int total) onUploadProgress,
+    required CancelToken cancelToken,
+  }) async {
+    final fileInfo = switch (staged) {
+      BytesStagedFile(:final bytes) => FileInfo.fromBytes(
+          bytes: bytes,
+          name: staged.fileName,
+          size: staged.fileSize,
+          type: staged.mimeType,
+        ),
+      FileBackedStagedFile(:final filePath) => FileInfo(
+          fileName: staged.fileName,
+          fileSize: staged.fileSize,
+          filePath: filePath,
+          type: staged.mimeType,
+        ),
+      OpfsStagedFile() => throw UnsupportedError(
+          'OPFS staged files upload through their own XHR path'),
+    };
+
+    final progressController = StreamController<Either<Failure, Success>>();
+    final progressSubscription = progressController.stream.listen((state) {
+      state.map((success) {
+        if (success is UploadingAttachmentUploadState) {
+          onUploadProgress(success.progress, success.total);
+        }
+      });
+    });
+
+    try {
+      return await _fileUploader.uploadAttachment(
+        UploadTaskId(_uuid.v4()),
+        fileInfo,
+        uploadUri,
+        cancelToken: cancelToken,
+        onSendController: progressController,
+      );
+    } finally {
+      await progressSubscription.cancel();
+      await progressController.close();
+    }
+  }
+}

--- a/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
+++ b/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
@@ -113,33 +113,40 @@ class DriveTransferPipeline {
     Uri uploadUri,
     DriveTransferStrategy<StagedDriveFile> strategy,
   ) async {
-    var attachedCount = 0;
-    var failedCount = 0;
-    // Every chip goes up first: what the user sees must match what they picked,
-    // not how many files fit through the concurrency limit at once.
-    final pendingTransfers = transferRunner.enqueue(docs);
-    await runWithConcurrency(
-      pendingTransfers,
-      strategy.maxConcurrentTransfers,
-      (pending) async {
-        final result = await transferRunner.run(
-          pending: pending,
-          uploadUri: uploadUri,
-          strategy: strategy,
-        );
-        switch (result) {
-          case DriveTransferResult.attached:
-            attachedCount++;
-          case DriveTransferResult.failed:
-            failedCount++;
-          case DriveTransferResult.cancelled:
-            break;
-        }
-      },
-    );
-    if (attachedCount > 0) _showSuccessToast(attachedCount);
-    // One toast for the whole batch, not one per file.
-    if (failedCount > 0) transferRunner.uploadController.showDriveTransferFailureToast();
+    // Guards the whole batch: runWithConcurrency propagates a worker's escaped
+    // error, and that must not become an unhandled root-zone error under the
+    // caller's unawaited().
+    try {
+      var attachedCount = 0;
+      var failedCount = 0;
+      // Every chip goes up first: what the user sees must match what they
+      // picked, not how many files fit through the concurrency limit at once.
+      final pendingTransfers = transferRunner.enqueue(docs);
+      await runWithConcurrency(
+        pendingTransfers,
+        strategy.maxConcurrentTransfers,
+        (pending) async {
+          final result = await transferRunner.run(
+            pending: pending,
+            uploadUri: uploadUri,
+            strategy: strategy,
+          );
+          switch (result) {
+            case DriveTransferResult.attached:
+              attachedCount++;
+            case DriveTransferResult.failed:
+              failedCount++;
+            case DriveTransferResult.cancelled:
+              break;
+          }
+        },
+      );
+      if (attachedCount > 0) _showSuccessToast(attachedCount);
+      // One toast for the whole batch, not one per file.
+      if (failedCount > 0) transferRunner.uploadController.showDriveTransferFailureToast();
+    } catch (error) {
+      logWarning('DriveTransferPipeline::_runBatch: batch failed: $error');
+    }
   }
 
   /// Toasts the batch result, or logs when there is no [ToastManager] bound.

--- a/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
+++ b/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
@@ -13,12 +13,15 @@ import 'package:tmail_ui_user/features/upload/data/network/file_uploader.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
 import 'package:tmail_ui_user/features/upload/domain/state/attachment_upload_state.dart';
 import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_upload_validation_service.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:uuid/uuid.dart';
 import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
 import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy_factory.dart';
 import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
 import 'package:workplace/data/model/workplace_type_defs.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
+import 'package:workplace/presentation/model/drive_pick_state.dart';
 
 /// Resolves the JMAP upload endpoint for the current session, or null when
 /// there is none yet.
@@ -102,20 +105,43 @@ class DriveTransferPipeline {
     return true;
   }
 
+  /// One toast per pick, not per file: the batch reports itself once every
+  /// transfer has settled. Counting needs no lock — the workers are concurrent
+  /// futures on a single isolate, not parallel threads.
   Future<void> _runBatch(
     List<DriveDocument> docs,
     Uri uploadUri,
     DriveTransferStrategy<StagedDriveFile> strategy,
-  ) {
-    return runWithConcurrency(
+  ) async {
+    var attachedCount = 0;
+    await runWithConcurrency(
       docs,
       strategy.maxConcurrentTransfers,
-      (doc) => transferRunner.run(
-        doc: doc,
-        uploadUri: uploadUri,
-        strategy: strategy,
-      ),
+      (doc) async {
+        final attached = await transferRunner.run(
+          doc: doc,
+          uploadUri: uploadUri,
+          strategy: strategy,
+        );
+        if (attached) attachedCount++;
+      },
     );
+    // Nothing landed means every file already toasted its own failure, or the
+    // user cancelled them: a "0 attached" toast would only add noise.
+    if (attachedCount > 0) _showSuccessToast(attachedCount);
+  }
+
+  /// Toasts the batch result, or logs when there is no [ToastManager] bound.
+  void _showSuccessToast(int attachedCount) {
+    final toastManager = getBinding<ToastManager>();
+    if (toastManager == null) {
+      logWarning(
+        'DriveTransferPipeline::_showSuccessToast: no ToastManager bound, '
+        'success not shown to the user',
+      );
+      return;
+    }
+    toastManager.showMessageSuccess(DriveAttachSuccess(attachedCount));
   }
 
   /// Uploads a staged file whose bytes live in memory or on disk through the

--- a/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
+++ b/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
@@ -70,6 +70,11 @@ class DriveTransferPipeline {
       return false;
     }
 
+    if (!_transferRunner.canAuthenticate) {
+      logWarning('DriveTransferPipeline::transfer: no authorization header available');
+      return false;
+    }
+
     final strategy = _strategyFactory.create(
       uploader: ({
         required staged,

--- a/lib/features/composer/presentation/styles/attachment_progress_loading_composer_widget_style.dart
+++ b/lib/features/composer/presentation/styles/attachment_progress_loading_composer_widget_style.dart
@@ -7,4 +7,8 @@ class AttachmentProgressLoadingComposerWidgetStyle {
 
   static const Color backgroundColor = AppColor.colorProgressLoadingBackground;
   static const Color progressColor = AppColor.primaryColor;
+
+  /// Marks the staging leg of a drive transfer, which fills the first half of
+  /// the same bar [progressColor] then finishes.
+  static const Color downloadProgressColor = AppColor.toastSuccessBackgroundColor;
 }

--- a/lib/features/composer/presentation/styles/attachment_progress_loading_composer_widget_style.dart
+++ b/lib/features/composer/presentation/styles/attachment_progress_loading_composer_widget_style.dart
@@ -7,8 +7,4 @@ class AttachmentProgressLoadingComposerWidgetStyle {
 
   static const Color backgroundColor = AppColor.colorProgressLoadingBackground;
   static const Color progressColor = AppColor.primaryColor;
-
-  /// Marks the staging leg of a drive transfer, which fills the first half of
-  /// the same bar [progressColor] then finishes.
-  static const Color downloadProgressColor = AppColor.toastSuccessBackgroundColor;
 }

--- a/lib/features/composer/presentation/widgets/attachment_progress_loading_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/attachment_progress_loading_composer_widget.dart
@@ -27,7 +27,7 @@ class AttachmentProgressLoadingComposerWidget extends StatelessWidget {
             backgroundColor: AttachmentProgressLoadingComposerWidgetStyle.backgroundColor,
           ),
         );
-      case UploadFileStatus.downloading:
+      case UploadFileStatus.fetching:
         return _buildPercentIndicator(
           AttachmentProgressLoadingComposerWidgetStyle.downloadProgressColor,
         );

--- a/lib/features/composer/presentation/widgets/attachment_progress_loading_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/attachment_progress_loading_composer_widget.dart
@@ -28,22 +28,16 @@ class AttachmentProgressLoadingComposerWidget extends StatelessWidget {
           ),
         );
       case UploadFileStatus.fetching:
-        return _buildPercentIndicator(
-          AttachmentProgressLoadingComposerWidgetStyle.downloadProgressColor,
-        );
       case UploadFileStatus.uploading:
-        return _buildPercentIndicator(
-          AttachmentProgressLoadingComposerWidgetStyle.progressColor,
-        );
+        return _buildPercentIndicator();
       case UploadFileStatus.uploadFailed:
       case UploadFileStatus.succeed:
         return const SizedBox.shrink();
     }
   }
 
-  /// A drive transfer keeps filling one bar across both of its legs — only
-  /// [progressColor] changes at the halfway point.
-  Widget _buildPercentIndicator(Color progressColor) {
+  /// A drive transfer keeps filling one bar across both of its legs.
+  Widget _buildPercentIndicator() {
     return Padding(
       padding: AttachmentItemComposerWidgetStyle.progressLoadingPadding,
       child: LinearPercentIndicator(
@@ -54,7 +48,7 @@ class AttachmentProgressLoadingComposerWidget extends StatelessWidget {
           : percentUploading,
         barRadius: const Radius.circular(AttachmentProgressLoadingComposerWidgetStyle.radius),
         backgroundColor: AttachmentProgressLoadingComposerWidgetStyle.backgroundColor,
-        progressColor: progressColor,
+        progressColor: AttachmentProgressLoadingComposerWidgetStyle.progressColor,
       ),
     );
   }

--- a/lib/features/composer/presentation/widgets/attachment_progress_loading_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/attachment_progress_loading_composer_widget.dart
@@ -27,23 +27,35 @@ class AttachmentProgressLoadingComposerWidget extends StatelessWidget {
             backgroundColor: AttachmentProgressLoadingComposerWidgetStyle.backgroundColor,
           ),
         );
+      case UploadFileStatus.downloading:
+        return _buildPercentIndicator(
+          AttachmentProgressLoadingComposerWidgetStyle.downloadProgressColor,
+        );
       case UploadFileStatus.uploading:
-        return Padding(
-          padding: AttachmentItemComposerWidgetStyle.progressLoadingPadding,
-          child: LinearPercentIndicator(
-            padding: EdgeInsets.zero,
-            lineHeight:AttachmentProgressLoadingComposerWidgetStyle.height,
-            percent: percentUploading > 1.0
-              ? 1.0
-              : percentUploading,
-            barRadius: const Radius.circular(AttachmentProgressLoadingComposerWidgetStyle.radius),
-            backgroundColor: AttachmentProgressLoadingComposerWidgetStyle.backgroundColor,
-            progressColor: AttachmentProgressLoadingComposerWidgetStyle.progressColor,
-          ),
+        return _buildPercentIndicator(
+          AttachmentProgressLoadingComposerWidgetStyle.progressColor,
         );
       case UploadFileStatus.uploadFailed:
       case UploadFileStatus.succeed:
         return const SizedBox.shrink();
     }
+  }
+
+  /// A drive transfer keeps filling one bar across both of its legs — only
+  /// [progressColor] changes at the halfway point.
+  Widget _buildPercentIndicator(Color progressColor) {
+    return Padding(
+      padding: AttachmentItemComposerWidgetStyle.progressLoadingPadding,
+      child: LinearPercentIndicator(
+        padding: EdgeInsets.zero,
+        lineHeight:AttachmentProgressLoadingComposerWidgetStyle.height,
+        percent: percentUploading > 1.0
+          ? 1.0
+          : percentUploading,
+        barRadius: const Radius.circular(AttachmentProgressLoadingComposerWidgetStyle.radius),
+        backgroundColor: AttachmentProgressLoadingComposerWidgetStyle.backgroundColor,
+        progressColor: progressColor,
+      ),
+    );
   }
 }

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -90,21 +90,34 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
   TokenOIDC? get currentToken =>
       _authenticationType == AuthenticationType.oidc ? _token : null;
 
-  @override
-  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
-    switch(_authenticationType) {
+  /// The `Authorization` header value for the current session, or null when
+  /// there is none to send.
+  ///
+  /// [onRequest] applies it to every request on this Dio instance; requests
+  /// made outside Dio — the drive-transfer OPFS upload's raw XHR — read it
+  /// from here, so the header is built in exactly one place.
+  String? get currentAuthorizationHeader {
+    switch (_authenticationType) {
       case AuthenticationType.basic:
         if (_authorization != null) {
-          options.headers[HttpHeaders.authorizationHeader] = _getAuthorizationAsBasicHeader(_authorization);
+          return _getAuthorizationAsBasicHeader(_authorization);
         }
-        break;
+        return null;
       case AuthenticationType.oidc:
         if (_token != null && _token?.isTokenValid() == true) {
-          options.headers[HttpHeaders.authorizationHeader] = _getTokenAsBearerHeader(_token!.token);
+          return _getTokenAsBearerHeader(_token!.token);
         }
-        break;
+        return null;
       case AuthenticationType.none:
-        break;
+        return null;
+    }
+  }
+
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    final authorizationHeader = currentAuthorizationHeader;
+    if (authorizationHeader != null) {
+      options.headers[HttpHeaders.authorizationHeader] = authorizationHeader;
     }
     log('AuthorizationInterceptors::onRequest(): URL = ${options.uri} | DATA = ${options.data}');
     super.onRequest(options, handler);

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -81,7 +81,7 @@ class UploadController extends BaseController {
                 failure.uploadId,
                 (currentState) => currentState?.copyWith(uploadStatus: UploadFileStatus.uploadFailed));
             deleteFileUploaded(failure.uploadId);
-            _showToastMessageWhenUploadAttachmentsFailure(failure);
+            _showToastMessageWhenUploadAttachmentsFailure();
             consumeState(Stream.value((Left(failure))));
           }
         },
@@ -277,6 +277,13 @@ class UploadController extends BaseController {
     _refreshListUploadAttachmentState();
   }
 
+  /// Drops a failed drive transfer's chip and tells the user, mirroring what
+  /// the Dio upload stream does for a failed upload.
+  void failDriveTransfer(UploadTaskId taskId) {
+    deleteFileUploaded(taskId);
+    _showToastMessageWhenUploadAttachmentsFailure();
+  }
+
   void completeUploadedFile({
     required UploadTaskId taskId,
     required Attachment attachment,
@@ -361,7 +368,7 @@ class UploadController extends BaseController {
       .toSet();
   }
 
-  void _showToastMessageWhenUploadAttachmentsFailure(ErrorAttachmentUploadState failure) {
+  void _showToastMessageWhenUploadAttachmentsFailure() {
     if (currentContext != null && currentOverlayContext != null) {
       appToast.showToastErrorMessage(
         currentOverlayContext!,

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -307,10 +307,14 @@ class UploadController extends BaseController {
     _refreshListUploadAttachmentState();
   }
 
-  /// Drops a failed drive transfer's chip and tells the user, mirroring what
-  /// the Dio upload stream does for a failed upload.
+  /// Drops a failed drive transfer's chip. The batch toasts once for every
+  /// failure it collected, not per file — see [showDriveTransferFailureToast].
   void failDriveTransfer(UploadTaskId taskId) {
     deleteFileUploaded(taskId);
+  }
+
+  /// One toast for a whole batch of failed drive transfers.
+  void showDriveTransferFailureToast() {
     _showToastMessageWhenUploadAttachmentsFailure();
   }
 

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -213,6 +213,96 @@ class UploadController extends BaseController {
     _refreshListUploadAttachmentState();
   }
 
+  /// A drive transfer is one operation to the user, so its chip fills a single
+  /// bar across both legs: staging maps onto 0-50, uploading onto 50-100.
+  static const int _downloadProgressCeiling = 50;
+
+  static int _mapProgress(int processed, int total, {required int from, required int to}) {
+    if (total <= 0) return from;
+    final ratio = processed / total;
+    final mapped = from + (ratio * (to - from)).round();
+    return mapped.clamp(from, to);
+  }
+
+  /// Shows a drive file's chip the moment its transfer starts, before any
+  /// bytes arrive. The placeholder carries the document's metadata as a
+  /// [FileInfo] so the chip renders its name, size and icon like any other.
+  void addDownloadingPlaceholder({
+    required UploadTaskId taskId,
+    required String fileName,
+    required int fileSize,
+    String? mimeType,
+    CancelToken? cancelToken,
+  }) {
+    _uploadingStateFiles.add(UploadFileState(
+      taskId,
+      file: FileInfo(
+        fileName: fileName,
+        fileSize: fileSize,
+        type: mimeType,
+      ),
+      uploadStatus: UploadFileStatus.downloading,
+      cancelToken: cancelToken,
+    ));
+    _refreshListUploadAttachmentState();
+  }
+
+  void updateDownloadProgress({
+    required UploadTaskId taskId,
+    required int received,
+    required int total,
+  }) {
+    _uploadingStateFiles.updateElementByUploadTaskId(
+      taskId,
+      (currentState) => currentState?.copyWith(
+        uploadingProgress: _mapProgress(
+          received,
+          total,
+          from: 0,
+          to: _downloadProgressCeiling,
+        ),
+      ),
+    );
+    _refreshListUploadAttachmentState();
+  }
+
+  /// Flips the chip to [UploadFileStatus.uploading] and resumes the bar from
+  /// the halfway mark rather than restarting it.
+  void updateUploadProgress({
+    required UploadTaskId taskId,
+    required int sent,
+    required int total,
+  }) {
+    _uploadingStateFiles.updateElementByUploadTaskId(
+      taskId,
+      (currentState) => currentState?.copyWith(
+        uploadStatus: UploadFileStatus.uploading,
+        uploadingProgress: _mapProgress(
+          sent,
+          total,
+          from: _downloadProgressCeiling,
+          to: 100,
+        ),
+      ),
+    );
+    _refreshListUploadAttachmentState();
+  }
+
+  void completeUploadedFile({
+    required UploadTaskId taskId,
+    required Attachment attachment,
+  }) {
+    _uploadingStateFiles.updateElementByUploadTaskId(
+      taskId,
+      (currentState) => currentState?.copyWith(
+        uploadStatus: UploadFileStatus.succeed,
+        uploadingProgress: 100,
+        attachment: attachment,
+      ),
+    );
+    _refreshListUploadAttachmentState();
+  }
+
   Future<void> justUploadAttachmentsAction({
     required List<FileInfo> uploadFiles,
     required Uri uploadUri,

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -247,6 +247,7 @@ class UploadController extends BaseController {
         uploadingProgress: _mapProgress(
           received,
           total,
+          current: currentState.uploadingProgress,
           from: 0,
           to: _downloadProgressCeiling,
         ),
@@ -269,6 +270,7 @@ class UploadController extends BaseController {
         uploadingProgress: _mapProgress(
           sent,
           total,
+          current: currentState.uploadingProgress,
           from: _downloadProgressCeiling,
           to: 100,
         ),
@@ -545,8 +547,16 @@ class UploadController extends BaseController {
 /// bar across both legs: staging maps onto 0-50, uploading onto 50-100.
 const int _downloadProgressCeiling = 50;
 
-int _mapProgress(int processed, int total, {required int from, required int to}) {
-  if (total <= 0) return from;
+int _mapProgress(
+  int processed,
+  int total, {
+  required int current,
+  required int from,
+  required int to,
+}) {
+  // An unknown content length must not rewind the bar: hold where it stands,
+  // pulled into this leg's band.
+  if (total <= 0) return current.clamp(from, to);
   final ratio = processed / total;
   final mapped = from + (ratio * (to - from)).round();
   return mapped.clamp(from, to);

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -230,7 +230,7 @@ class UploadController extends BaseController {
         fileSize: fileSize,
         type: mimeType,
       ),
-      uploadStatus: UploadFileStatus.downloading,
+      uploadStatus: UploadFileStatus.fetching,
       cancelToken: cancelToken,
     ));
     _refreshListUploadAttachmentState();

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -21,6 +21,7 @@ import 'package:tmail_ui_user/features/composer/domain/usecases/upload_attachmen
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
 import 'package:tmail_ui_user/features/upload/domain/state/attachment_upload_state.dart';
 import 'package:tmail_ui_user/features/upload/presentation/extensions/upload_attachment_extension.dart';
+import 'package:tmail_ui_user/features/upload/presentation/model/drive_transfer_placeholder.dart';
 import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_state.dart';
 import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_state_list.dart';
 import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_status.dart';
@@ -216,26 +217,25 @@ class UploadController extends BaseController {
     _refreshListUploadAttachmentState();
   }
 
-  /// Shows a drive file's chip the moment its transfer starts, before any
-  /// bytes arrive. The placeholder carries the document's metadata as a
-  /// [FileInfo] so the chip renders its name, size and icon like any other.
-  void addDownloadingPlaceholder({
-    required UploadTaskId taskId,
-    required String fileName,
-    required int fileSize,
-    String? mimeType,
-    CancelToken? cancelToken,
-  }) {
-    _uploadingStateFiles.add(UploadFileState(
-      taskId,
+  /// Shows a chip for every picked drive file at once, before any transfer
+  /// starts, so the count on screen matches what the user selected however few
+  /// files are being moved concurrently. Each placeholder carries the
+  /// document's metadata as a [FileInfo] so the chip renders its name, size and
+  /// icon like any other, and starts as [UploadFileStatus.waiting] until its
+  /// first byte lands.
+  void addDownloadingPlaceholders(List<DriveTransferPlaceholder> placeholders) {
+    if (placeholders.isEmpty) return;
+
+    _uploadingStateFiles.addAll(placeholders.map((placeholder) => UploadFileState(
+      placeholder.taskId,
       file: FileInfo(
-        fileName: fileName,
-        fileSize: fileSize,
-        type: mimeType,
+        fileName: placeholder.fileName,
+        fileSize: placeholder.fileSize,
+        type: placeholder.mimeType,
       ),
-      uploadStatus: UploadFileStatus.fetching,
-      cancelToken: cancelToken,
-    ));
+      uploadStatus: UploadFileStatus.waiting,
+      cancelToken: placeholder.cancelToken,
+    )));
     _refreshListUploadAttachmentState();
   }
 

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -213,17 +213,6 @@ class UploadController extends BaseController {
     _refreshListUploadAttachmentState();
   }
 
-  /// A drive transfer is one operation to the user, so its chip fills a single
-  /// bar across both legs: staging maps onto 0-50, uploading onto 50-100.
-  static const int _downloadProgressCeiling = 50;
-
-  static int _mapProgress(int processed, int total, {required int from, required int to}) {
-    if (total <= 0) return from;
-    final ratio = processed / total;
-    final mapped = from + (ratio * (to - from)).round();
-    return mapped.clamp(from, to);
-  }
-
   /// Shows a drive file's chip the moment its transfer starts, before any
   /// bytes arrive. The placeholder carries the document's metadata as a
   /// [FileInfo] so the chip renders its name, size and icon like any other.
@@ -543,4 +532,15 @@ class UploadController extends BaseController {
       super.handleSuccessViewState(success);
     }
   }
+}
+
+/// A drive transfer is one operation to the user, so its chip fills a single
+/// bar across both legs: staging maps onto 0-50, uploading onto 50-100.
+const int _downloadProgressCeiling = 50;
+
+int _mapProgress(int processed, int total, {required int from, required int to}) {
+  if (total <= 0) return from;
+  final ratio = processed / total;
+  final mapped = from + (ratio * (to - from)).round();
+  return mapped.clamp(from, to);
 }

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -55,6 +55,9 @@ class UploadController extends BaseController {
 
   @override
   void onClose() {
+    // Stop the work before dropping the states that hold its cancel tokens.
+    _uploadingStateFiles.cancelAllPending();
+    _uploadingStateInlineFiles.cancelAllPending();
     listUploadAttachments.clear();
     _uploadingStateFiles.clear();
     _uploadingStateInlineFiles.clear();
@@ -324,6 +327,8 @@ class UploadController extends BaseController {
   }
 
   void _refreshListUploadAttachmentState() {
+    // A cancelled transfer still reports back after the composer closed.
+    if (isClosed) return;
     listUploadAttachments.value =
         _uploadingStateFiles.uploadingStateFiles.nonNulls.toList();
     listUploadAttachments.refresh();

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -244,19 +244,14 @@ class UploadController extends BaseController {
     required int received,
     required int total,
   }) {
-    _uploadingStateFiles.updateElementByUploadTaskId(
-      taskId,
-      (currentState) => currentState?.copyWith(
-        uploadingProgress: _mapProgress(
-          received,
-          total,
-          current: currentState.uploadingProgress,
-          from: 0,
-          to: _downloadProgressCeiling,
-        ),
-      ),
+    _applyTransferProgress(
+      taskId: taskId,
+      processed: received,
+      total: total,
+      from: 0,
+      to: _downloadProgressCeiling,
+      status: UploadFileStatus.fetching,
     );
-    _refreshListUploadAttachmentState();
   }
 
   /// Flips the chip to [UploadFileStatus.uploading] and resumes the bar from
@@ -266,17 +261,47 @@ class UploadController extends BaseController {
     required int sent,
     required int total,
   }) {
+    _applyTransferProgress(
+      taskId: taskId,
+      processed: sent,
+      total: total,
+      from: _downloadProgressCeiling,
+      to: 100,
+      status: UploadFileStatus.uploading,
+    );
+  }
+
+  /// Maps one leg's bytes onto its band of the bar. A chunk that moves neither
+  /// the percent nor the status is dropped, so a multi-MB transfer rebuilds the
+  /// chips at most once per percent instead of once per chunk.
+  void _applyTransferProgress({
+    required UploadTaskId taskId,
+    required int processed,
+    required int total,
+    required int from,
+    required int to,
+    required UploadFileStatus status,
+  }) {
+    final currentState = _uploadingStateFiles.getUploadFileStateById(taskId);
+    if (currentState == null) return;
+
+    final progress = _mapProgress(
+      processed,
+      total,
+      current: currentState.uploadingProgress,
+      from: from,
+      to: to,
+    );
+    if (progress == currentState.uploadingProgress &&
+        status == currentState.uploadStatus) {
+      return;
+    }
+
     _uploadingStateFiles.updateElementByUploadTaskId(
       taskId,
-      (currentState) => currentState?.copyWith(
-        uploadStatus: UploadFileStatus.uploading,
-        uploadingProgress: _mapProgress(
-          sent,
-          total,
-          current: currentState.uploadingProgress,
-          from: _downloadProgressCeiling,
-          to: 100,
-        ),
+      (state) => state?.copyWith(
+        uploadStatus: status,
+        uploadingProgress: progress,
       ),
     );
     _refreshListUploadAttachmentState();
@@ -329,9 +354,9 @@ class UploadController extends BaseController {
   void _refreshListUploadAttachmentState() {
     // A cancelled transfer still reports back after the composer closed.
     if (isClosed) return;
+    // A fresh list instance already notifies, so no `refresh()` on top of it.
     listUploadAttachments.value =
         _uploadingStateFiles.uploadingStateFiles.nonNulls.toList();
-    listUploadAttachments.refresh();
   }
 
   List<Attachment> get attachmentsUploaded {

--- a/lib/features/upload/presentation/model/drive_transfer_placeholder.dart
+++ b/lib/features/upload/presentation/model/drive_transfer_placeholder.dart
@@ -1,0 +1,21 @@
+import 'package:dio/dio.dart';
+import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
+
+/// What a queued drive file needs to render its chip before its transfer
+/// starts. The cancel token is minted with it, so a file can be cancelled
+/// while it is still waiting for a slot.
+class DriveTransferPlaceholder {
+  final UploadTaskId taskId;
+  final String fileName;
+  final int fileSize;
+  final String? mimeType;
+  final CancelToken? cancelToken;
+
+  const DriveTransferPlaceholder({
+    required this.taskId,
+    required this.fileName,
+    required this.fileSize,
+    this.mimeType,
+    this.cancelToken,
+  });
+}

--- a/lib/features/upload/presentation/model/upload_file_state_list.dart
+++ b/lib/features/upload/presentation/model/upload_file_state_list.dart
@@ -57,6 +57,15 @@ class UploadFileStateList {
     _uploadingStateFiles.clear();
   }
 
+  /// Cancels every transfer that has not settled yet. Apart from [clear],
+  /// which a re-init calls and must not stop anything.
+  void cancelAllPending() {
+    for (final fileState in _uploadingStateFiles) {
+      if (fileState == null || fileState.uploadStatus.completed) continue;
+      fileState.cancelToken?.cancel();
+    }
+  }
+
   void deleteElementByUploadTaskId(UploadTaskId uploadTaskId) {
     final fileState = _uploadingStateFiles
         .firstWhereOrNull((fileState) => fileState?.uploadTaskId == uploadTaskId);

--- a/lib/features/upload/presentation/model/upload_file_status.dart
+++ b/lib/features/upload/presentation/model/upload_file_status.dart
@@ -1,6 +1,9 @@
 
 enum UploadFileStatus {
   waiting,
+  /// Staging leg of a drive transfer, before its upload starts. Only drive
+  /// attachments enter this state.
+  downloading,
   uploading,
   uploadFailed,
   succeed

--- a/lib/features/upload/presentation/model/upload_file_status.dart
+++ b/lib/features/upload/presentation/model/upload_file_status.dart
@@ -1,9 +1,8 @@
 
 enum UploadFileStatus {
   waiting,
-  /// Staging leg of a drive transfer, before its upload starts. Only drive
-  /// attachments enter this state.
-  downloading,
+  /// Staging leg of a drive transfer, before its upload starts.
+  fetching,
   uploading,
   uploadFailed,
   succeed

--- a/lib/features/upload/presentation/validator/attachment_upload_validation_service.dart
+++ b/lib/features/upload/presentation/validator/attachment_upload_validation_service.dart
@@ -76,6 +76,27 @@ class AttachmentUploadValidationService {
     );
   }
 
+  /// Validates a proposed upload known only by its byte totals — no
+  /// [FileInfo] and no [Attachment] yet — then runs [onAllowed] when the
+  /// upload may proceed. Used by the drive transfer, which gates a batch on
+  /// the sizes the backend declared before downloading anything.
+  Future<void> validateBytes({
+    BuildContext? context,
+    required int proposedAllAttachmentBytes,
+    required int proposedRegularAttachmentBytes,
+    required VoidCallback onAllowed,
+  }) {
+    return _validate(
+      context: context,
+      request: _requestFactory.fromProposedBytes(
+        proposedAllAttachmentBytes: proposedAllAttachmentBytes,
+        proposedRegularAttachmentBytes: proposedRegularAttachmentBytes,
+        state: _stateSource,
+      ),
+      onAllowed: onAllowed,
+    );
+  }
+
   /// Whether what is already attached exceeds the server hard cap, without
   /// showing any dialog.
   bool isExceededMaxSizeAttachmentsPerEmail() {

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -5302,6 +5302,16 @@
     "placeholders_order": [],
     "placeholders": {}
   },
+  "driveFilesAttached": "{count,plural, =1{1 file attached from Drive}other{{count} files attached from Drive}}",
+  "@driveFilesAttached": {
+    "type": "text",
+    "placeholders_order": [
+      "count"
+    ],
+    "placeholders": {
+      "count": {}
+    }
+  },
   "labelAs": "Label as",
   "@labelAs": {
     "type": "text",

--- a/lib/main/bindings/core/core_bindings.dart
+++ b/lib/main/bindings/core/core_bindings.dart
@@ -24,6 +24,7 @@ import 'package:tmail_ui_user/main/utils/ios_notification_manager.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
 import 'package:uuid/uuid.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy_factory.dart';
 
 class CoreBindings extends Bindings {
 
@@ -39,6 +40,7 @@ class CoreBindings extends Bindings {
     _bindingIsolate();
     _bindingStorage();
     _bindingDriveAttachmentHandler();
+    _bindingDriveTransferStrategyFactory();
   }
 
   void _bindingAppImagePaths() {
@@ -51,6 +53,14 @@ class CoreBindings extends Bindings {
 
   void _bindingDriveAttachmentHandler() {
     Get.put(DriveAttachmentHandler());
+  }
+
+  /// One per app: the factory caches capability detection and sweeps stale
+  /// staging once per instance. Not `const`: only the mobile branch of the
+  /// conditional export has a const constructor.
+  void _bindingDriveTransferStrategyFactory() {
+    // ignore: prefer_const_constructors
+    Get.put(DriveTransferStrategyFactory());
   }
 
   Future _bindingSharePreference() async {

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -5632,6 +5632,16 @@ class AppLocalizations {
     );
   }
 
+  String driveFilesAttached(int count) {
+    return Intl.plural(
+      count,
+      one: '1 file attached from Drive',
+      other: '$count files attached from Drive',
+      name: 'driveFilesAttached',
+      args: [count],
+    );
+  }
+
   String get labelAs {
     return Intl.message(
       'Label as',

--- a/lib/main/utils/toast_manager.dart
+++ b/lib/main/utils/toast_manager.dart
@@ -331,6 +331,8 @@ class ToastManager {
       message = appLocalizations.addListLabelToListEmailHasSomeFailureMessage;
     } else if (success is AddListLabelsToListEmailsSuccess) {
       message = appLocalizations.addListLabelToListEmailSuccessfullyMessage;
+    } else if (success is DriveAttachSuccess) {
+      message = appLocalizations.driveFilesAttached(success.attachedCount);
     }
     log('ToastManager::showMessageSuccess: Message: $message');
     if (message?.trim().isNotEmpty == true) {

--- a/test/features/composer/presentation/manager/bounded_concurrency_runner_test.dart
+++ b/test/features/composer/presentation/manager/bounded_concurrency_runner_test.dart
@@ -5,18 +5,23 @@ import 'package:tmail_ui_user/features/composer/presentation/manager/bounded_con
 
 void main() {
   group('runWithConcurrency::', () {
-    test('Should process every item', () async {
+    test('Should process every item exactly once', () async {
       final processed = <int>[];
 
       await runWithConcurrency(
-        List.generate(10, (index) => index),
-        3,
+        List.generate(100, (index) => index),
+        5,
         (item) async {
           processed.add(item);
         },
       );
 
-      expect(processed..sort(), List.generate(10, (index) => index));
+      expect(processed, hasLength(100));
+      expect(processed.toSet(), hasLength(100));
+      expect(
+        processed.toSet(),
+        containsAll(List.generate(100, (index) => index)),
+      );
     });
 
     test('Should never exceed maxConcurrent tasks in flight', () async {

--- a/test/features/composer/presentation/manager/bounded_concurrency_runner_test.dart
+++ b/test/features/composer/presentation/manager/bounded_concurrency_runner_test.dart
@@ -25,36 +25,61 @@ void main() {
     });
 
     test('Should never exceed maxConcurrent tasks in flight', () async {
+      const maxConcurrent = 3;
+      const itemCount = 9;
+
       var inFlight = 0;
       var peakInFlight = 0;
+
       final completers = <Completer<void>>[];
 
       final run = runWithConcurrency(
-        List.generate(9, (index) => index),
-        3,
+        List.generate(itemCount, (index) => index),
+        maxConcurrent,
         (item) async {
           inFlight++;
           peakInFlight = inFlight > peakInFlight ? inFlight : peakInFlight;
+
           final completer = Completer<void>();
           completers.add(completer);
+
           await completer.future;
+
           inFlight--;
         },
       );
 
-      // Release the tasks in waves so the pool has to refill its slots.
-      while (completers.length < 9 || completers.any((c) => !c.isCompleted)) {
-        final pending = completers.where((c) => !c.isCompleted).toList();
-        if (pending.isEmpty) break;
+      // Allow the first wave of workers to start.
+      await Future<void>.delayed(Duration.zero);
+
+      expect(completers, hasLength(maxConcurrent));
+      expect(peakInFlight, maxConcurrent);
+
+      // Release the current tasks so the workers can pick up
+      // the next items.
+      while (completers.length < itemCount) {
+        final pending = completers
+            .where((completer) => !completer.isCompleted)
+            .toList();
+
         for (final completer in pending) {
           completer.complete();
         }
+
         await Future<void>.delayed(Duration.zero);
       }
+
+      // Release the final wave.
+      for (final completer in completers) {
+        if (!completer.isCompleted) {
+          completer.complete();
+        }
+      }
+
       await run;
 
-      expect(peakInFlight, lessThanOrEqualTo(3));
-      expect(completers, hasLength(9));
+      expect(peakInFlight, lessThanOrEqualTo(maxConcurrent));
+      expect(completers, hasLength(itemCount));
     });
 
     test('Should start a queued item as soon as a slot frees', () async {

--- a/test/features/composer/presentation/manager/bounded_concurrency_runner_test.dart
+++ b/test/features/composer/presentation/manager/bounded_concurrency_runner_test.dart
@@ -18,6 +18,29 @@ Future<List<int>> _collectProcessed(List<int> items, int maxConcurrent) async {
   return processed;
 }
 
+/// Yields two items and then fails, so the failure lands while the runner is
+/// still spawning its first wave of workers.
+Iterable<int> _itemsThatFailWhileSpawning() sync* {
+  yield 0;
+  yield 1;
+  throw const FormatException('iterable boom');
+}
+
+/// Runs [body] with its uncaught async errors captured instead of crashing the
+/// test, and returns them. The trailing settle lets a future that failed with
+/// no listener be reported before the zone is torn down.
+Future<List<Object>> _escapedErrorsOf(Future<void> Function() body) async {
+  final escaped = <Object>[];
+  await runZonedGuarded(
+    () async {
+      await body();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    },
+    (error, _) => escaped.add(error),
+  );
+  return escaped;
+}
+
 void main() {
   group('runWithConcurrency::', () {
     test('Should process every item exactly once', () async {
@@ -64,8 +87,16 @@ void main() {
       expect(peakInFlight, maxConcurrent);
 
       // Release the current tasks so the workers can pick up
-      // the next items.
+      // the next items. A regression that stops pulling queued items would
+      // spin here forever, so cap the waves rather than hang the suite.
+      var waves = 0;
       while (completers.length < itemCount) {
+        expect(
+          waves++,
+          lessThan(itemCount),
+          reason: 'workers stopped pulling queued items',
+        );
+
         _completePending(completers);
 
         await Future<void>.delayed(Duration.zero);
@@ -101,32 +132,28 @@ void main() {
       expect(started, [0, 1, 2]);
     });
 
-    test('Should keep other workers running when one task throws', () async {
+    // Workers share one iterator, so a lazy source must be pulled exactly once
+    // per item — never restarted, never double-produced.
+    test('Should pull a lazy iterable once per item', () async {
+      var produced = 0;
+
+      Iterable<int> lazyItems() sync* {
+        for (var index = 0; index < 5; index++) {
+          produced++;
+          yield index;
+        }
+      }
+
       final processed = <int>[];
-      final worker1Started = Completer<void>();
-
-      await expectLater(
-        runWithConcurrency(
-          [0, 1, 2, 3],
-          2,
-          (item) async {
-            if (item == 0) {
-              worker1Started.complete();
-              throw StateError('boom');
-            }
-
-            if (item == 1) {
-              processed.add(item);
-              await worker1Started.future;
-            } else {
-              processed.add(item);
-            }
-          },
-        ),
-        throwsA(isA<StateError>()),
+      await runWithConcurrency(
+        lazyItems(),
+        2,
+        (item) async => processed.add(item),
       );
 
-      expect(processed, containsAll([1, 2, 3]));
+      expect(produced, 5);
+      expect(processed, hasLength(5));
+      expect(processed.toSet(), hasLength(5));
     });
 
     test('Should complete when items are empty', () async {
@@ -162,8 +189,8 @@ void main() {
     }
 
     test('Should drain a large batch under a large concurrency', () async {
-      const itemCount = 100000;
-      const maxConcurrent = 10000;
+      const itemCount = 20000;
+      const maxConcurrent = 2000;
 
       var inFlight = 0;
       var peakInFlight = 0;
@@ -185,7 +212,196 @@ void main() {
 
       expect(processed, hasLength(itemCount));
       expect(processed.toSet(), hasLength(itemCount));
-      expect(peakInFlight, lessThanOrEqualTo(maxConcurrent));
+      // Exactly the cap, not merely under it: the first wave of workers is
+      // spawned synchronously, so a runner that quietly went serial fails here.
+      expect(peakInFlight, maxConcurrent);
+    });
+  });
+
+  // What a failure does to the rest of the batch. These lock in the current
+  // contract — a task is expected to handle its own failures — so a change of
+  // heart about that has to change these tests too.
+  group('runWithConcurrency error contract::', () {
+    test('Should keep the other workers draining when one task throws',
+        () async {
+      final processed = <int>[];
+      final worker1Started = Completer<void>();
+
+      await expectLater(
+        runWithConcurrency(
+          [0, 1, 2, 3],
+          2,
+          (item) async {
+            if (item == 0) {
+              worker1Started.complete();
+              throw StateError('boom');
+            }
+
+            if (item == 1) {
+              processed.add(item);
+              await worker1Started.future;
+            } else {
+              processed.add(item);
+            }
+          },
+        ),
+        throwsA(isA<StateError>()),
+      );
+
+      // The dead worker's share of the queue is picked up by the survivor, and
+      // the item it died on is never retried.
+      expect(processed, [1, 2, 3]);
+    });
+
+    // The runner has no worker of its own to fall back on: once every worker
+    // has thrown, whatever is left in the iterator is silently abandoned. The
+    // caller is what must keep its task from throwing.
+    test('Should abandon the queue when every worker has died', () async {
+      final processed = <int>[];
+
+      await expectLater(
+        runWithConcurrency(
+          [0, 1, 2, 3, 4, 5],
+          2,
+          (item) async {
+            processed.add(item);
+            if (item < 2) throw StateError('boom$item');
+          },
+        ),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(processed, [0, 1], reason: 'items 2..5 are dropped, not retried');
+    });
+
+    // Same rule at its harshest: one worker means one throw ends the batch,
+    // however far in the queue it happens.
+    test('Should abandon the queue when the only worker dies mid-drain',
+        () async {
+      final processed = <int>[];
+
+      await expectLater(
+        runWithConcurrency(
+          [0, 1, 2, 3],
+          1,
+          (item) async {
+            processed.add(item);
+            if (item == 2) throw StateError('boom');
+          },
+        ),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(processed, [0, 1, 2], reason: 'item 3 is dropped, not retried');
+    });
+
+    // Only one failure can come back through a single future. The one that
+    // surfaces is the first to *arrive*, not the first in item order, and the
+    // rest are consumed rather than left to crash the zone.
+    test('Should surface the first error to arrive and consume the rest',
+        () async {
+      final slowItemGate = Completer<void>();
+      Object? surfaced;
+
+      final escaped = await _escapedErrorsOf(() async {
+        final run = runWithConcurrency(
+          [0, 1],
+          2,
+          (item) async {
+            if (item == 0) {
+              await slowItemGate.future;
+              throw StateError('slow failure, first item');
+            }
+            throw const FormatException('fast failure, second item');
+          },
+        );
+
+        // Let the second item fail before the first one is released.
+        await Future<void>.delayed(Duration.zero);
+        slowItemGate.complete();
+
+        try {
+          await run;
+        } catch (error) {
+          surfaced = error;
+        }
+      });
+
+      expect(surfaced, isA<FormatException>());
+      expect(escaped, isEmpty);
+    });
+
+    test('Should report a task that throws synchronously through the future',
+        () async {
+      final processed = <int>[];
+
+      await expectLater(
+        runWithConcurrency(
+          [0, 1, 2],
+          2,
+          // Not an `async` closure: it throws before ever returning a future.
+          (item) {
+            if (item == 0) throw StateError('sync boom');
+            processed.add(item);
+            return Future<void>.value();
+          },
+        ),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(processed, [1, 2]);
+    });
+
+    // A failure raised by the iterable itself (a lazy source, not the
+    // materialised list callers are expected to pass) surfaces through the
+    // returned future like any other spawn-time error, and the workers
+    // already started for the items pulled before it are drained rather than
+    // left to fail into the zone.
+    test(
+        'Should drain already-started workers when the iterable fails while spawning',
+        () async {
+      final processed = <int>[];
+
+      final escaped = await _escapedErrorsOf(() async {
+        await expectLater(
+          runWithConcurrency(
+            _itemsThatFailWhileSpawning(),
+            4,
+            (item) async {
+              processed.add(item);
+              await Future<void>.delayed(Duration.zero);
+              if (item == 0) throw StateError('must not escape');
+            },
+          ),
+          throwsA(isA<FormatException>()),
+        );
+      });
+
+      expect(processed, [0, 1], reason: 'both workers had already started');
+      expect(escaped, isEmpty,
+          reason: 'already-started workers are drained, not orphaned');
+    });
+
+    // The shared iterator is a plain list iterator, so mutating the source
+    // mid-run kills the worker that notices.
+    test('Should surface a concurrent modification of the source list',
+        () async {
+      final items = [0, 1, 2, 3, 4];
+      final processed = <int>[];
+
+      await expectLater(
+        runWithConcurrency(
+          items,
+          1,
+          (item) async {
+            processed.add(item);
+            if (item == 0) items.removeLast();
+          },
+        ),
+        throwsA(isA<ConcurrentModificationError>()),
+      );
+
+      expect(processed, [0]);
     });
   });
 }

--- a/test/features/composer/presentation/manager/bounded_concurrency_runner_test.dart
+++ b/test/features/composer/presentation/manager/bounded_concurrency_runner_test.dart
@@ -105,14 +105,24 @@ void main() {
 
     test('Should keep other workers running when one task throws', () async {
       final processed = <int>[];
+      final worker1Started = Completer<void>();
 
       await expectLater(
         runWithConcurrency(
           [0, 1, 2, 3],
           2,
           (item) async {
-            if (item == 0) throw StateError('boom');
-            processed.add(item);
+            if (item == 0) {
+              worker1Started.complete();
+              throw StateError('boom');
+            }
+
+            if (item == 1) {
+              processed.add(item);
+              await worker1Started.future;
+            } else {
+              processed.add(item);
+            }
           },
         ),
         throwsA(isA<StateError>()),

--- a/test/features/composer/presentation/manager/bounded_concurrency_runner_test.dart
+++ b/test/features/composer/presentation/manager/bounded_concurrency_runner_test.dart
@@ -3,6 +3,14 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tmail_ui_user/features/composer/presentation/manager/bounded_concurrency_runner.dart';
 
+/// Completes every completer that is still pending, on a snapshot of the list
+/// so a task started by one completion cannot mutate it mid-iteration.
+void _completePending(List<Completer<void>> completers) {
+  for (final completer in List.of(completers)) {
+    if (!completer.isCompleted) completer.complete();
+  }
+}
+
 void main() {
   group('runWithConcurrency::', () {
     test('Should process every item exactly once', () async {
@@ -58,23 +66,13 @@ void main() {
       // Release the current tasks so the workers can pick up
       // the next items.
       while (completers.length < itemCount) {
-        final pending = completers
-            .where((completer) => !completer.isCompleted)
-            .toList();
-
-        for (final completer in pending) {
-          completer.complete();
-        }
+        _completePending(completers);
 
         await Future<void>.delayed(Duration.zero);
       }
 
       // Release the final wave.
-      for (final completer in completers) {
-        if (!completer.isCompleted) {
-          completer.complete();
-        }
-      }
+      _completePending(completers);
 
       await run;
 

--- a/test/features/composer/presentation/manager/bounded_concurrency_runner_test.dart
+++ b/test/features/composer/presentation/manager/bounded_concurrency_runner_test.dart
@@ -1,0 +1,102 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/bounded_concurrency_runner.dart';
+
+void main() {
+  group('runWithConcurrency::', () {
+    test('Should process every item', () async {
+      final processed = <int>[];
+
+      await runWithConcurrency(
+        List.generate(10, (index) => index),
+        3,
+        (item) async {
+          processed.add(item);
+        },
+      );
+
+      expect(processed..sort(), List.generate(10, (index) => index));
+    });
+
+    test('Should never exceed maxConcurrent tasks in flight', () async {
+      var inFlight = 0;
+      var peakInFlight = 0;
+      final completers = <Completer<void>>[];
+
+      final run = runWithConcurrency(
+        List.generate(9, (index) => index),
+        3,
+        (item) async {
+          inFlight++;
+          peakInFlight = inFlight > peakInFlight ? inFlight : peakInFlight;
+          final completer = Completer<void>();
+          completers.add(completer);
+          await completer.future;
+          inFlight--;
+        },
+      );
+
+      // Release the tasks in waves so the pool has to refill its slots.
+      while (completers.length < 9 || completers.any((c) => !c.isCompleted)) {
+        final pending = completers.where((c) => !c.isCompleted).toList();
+        if (pending.isEmpty) break;
+        for (final completer in pending) {
+          completer.complete();
+        }
+        await Future<void>.delayed(Duration.zero);
+      }
+      await run;
+
+      expect(peakInFlight, lessThanOrEqualTo(3));
+      expect(completers, hasLength(9));
+    });
+
+    test('Should start a queued item as soon as a slot frees', () async {
+      final started = <int>[];
+      final gate = Completer<void>();
+
+      final run = runWithConcurrency(
+        [0, 1, 2],
+        1,
+        (item) async {
+          started.add(item);
+          if (item == 0) await gate.future;
+        },
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      expect(started, [0], reason: 'the single slot is taken by the first item');
+
+      gate.complete();
+      await run;
+      expect(started, [0, 1, 2]);
+    });
+
+    test('Should keep other workers running when one task throws', () async {
+      final processed = <int>[];
+
+      await expectLater(
+        runWithConcurrency(
+          [0, 1, 2, 3],
+          2,
+          (item) async {
+            if (item == 0) throw StateError('boom');
+            processed.add(item);
+          },
+        ),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(processed, containsAll([1, 2, 3]));
+    });
+
+    test('Should treat a concurrency below one as a single worker', () async {
+      final processed = <int>[];
+
+      await runWithConcurrency([0, 1], 0, (item) async => processed.add(item));
+
+      expect(processed, [0, 1]);
+    });
+  });
+}

--- a/test/features/composer/presentation/manager/bounded_concurrency_runner_test.dart
+++ b/test/features/composer/presentation/manager/bounded_concurrency_runner_test.dart
@@ -138,5 +138,44 @@ void main() {
 
       expect(processed, [0, 1]);
     });
+
+    test('Should complete when items are empty', () async {
+      var taskCalled = false;
+
+      await runWithConcurrency(
+        <int>[],
+        3,
+        (item) async {
+          taskCalled = true;
+        },
+      );
+
+      expect(taskCalled, isFalse);
+    });
+
+    test('Should treat negative concurrency as a single worker', () async {
+      final processed = <int>[];
+
+      await runWithConcurrency(
+        [0, 1, 2],
+        -1,
+        (item) async => processed.add(item),
+      );
+
+      expect(processed, [0, 1, 2]);
+    });
+
+    test('Should process all items when maxConcurrent exceeds item count', () async {
+      final processed = <int>[];
+
+      await runWithConcurrency(
+        [0, 1, 2],
+        100,
+        (item) async => processed.add(item),
+      );
+
+      expect(processed, containsAllInOrder([0, 1, 2]));
+      expect(processed, hasLength(3));
+    });
   });
 }

--- a/test/features/composer/presentation/manager/bounded_concurrency_runner_test.dart
+++ b/test/features/composer/presentation/manager/bounded_concurrency_runner_test.dart
@@ -175,5 +175,45 @@ void main() {
       expect(processed, containsAllInOrder([0, 1, 2]));
       expect(processed, hasLength(3));
     });
+
+    test('Should not spawn a worker per unit of a huge maxConcurrent', () async {
+      final processed = <int>[];
+
+      await runWithConcurrency(
+        [0, 1, 2],
+        1 << 30,
+        (item) async => processed.add(item),
+      );
+
+      expect(processed, containsAllInOrder([0, 1, 2]));
+      expect(processed, hasLength(3));
+    });
+
+    test('Should drain a large batch under a large concurrency', () async {
+      const itemCount = 100000;
+      const maxConcurrent = 10000;
+
+      var inFlight = 0;
+      var peakInFlight = 0;
+      final processed = <int>[];
+
+      await runWithConcurrency(
+        List.generate(itemCount, (index) => index),
+        maxConcurrent,
+        (item) async {
+          inFlight++;
+          peakInFlight = inFlight > peakInFlight ? inFlight : peakInFlight;
+
+          await Future<void>.delayed(Duration.zero);
+          processed.add(item);
+
+          inFlight--;
+        },
+      );
+
+      expect(processed, hasLength(itemCount));
+      expect(processed.toSet(), hasLength(itemCount));
+      expect(peakInFlight, lessThanOrEqualTo(maxConcurrent));
+    });
   });
 }

--- a/test/features/composer/presentation/manager/bounded_concurrency_runner_test.dart
+++ b/test/features/composer/presentation/manager/bounded_concurrency_runner_test.dart
@@ -11,18 +11,18 @@ void _completePending(List<Completer<void>> completers) {
   }
 }
 
+/// Runs [items] at [maxConcurrent] and returns them in completion order.
+Future<List<int>> _collectProcessed(List<int> items, int maxConcurrent) async {
+  final processed = <int>[];
+  await runWithConcurrency(items, maxConcurrent, (item) async => processed.add(item));
+  return processed;
+}
+
 void main() {
   group('runWithConcurrency::', () {
     test('Should process every item exactly once', () async {
-      final processed = <int>[];
-
-      await runWithConcurrency(
-        List.generate(100, (index) => index),
-        5,
-        (item) async {
-          processed.add(item);
-        },
-      );
+      final processed =
+          await _collectProcessed(List.generate(100, (index) => index), 5);
 
       expect(processed, hasLength(100));
       expect(processed.toSet(), hasLength(100));
@@ -129,14 +129,6 @@ void main() {
       expect(processed, containsAll([1, 2, 3]));
     });
 
-    test('Should treat a concurrency below one as a single worker', () async {
-      final processed = <int>[];
-
-      await runWithConcurrency([0, 1], 0, (item) async => processed.add(item));
-
-      expect(processed, [0, 1]);
-    });
-
     test('Should complete when items are empty', () async {
       var taskCalled = false;
 
@@ -151,43 +143,23 @@ void main() {
       expect(taskCalled, isFalse);
     });
 
-    test('Should treat negative concurrency as a single worker', () async {
-      final processed = <int>[];
+    // A concurrency outside [1, itemCount] must still drain the batch exactly
+    // once, whether it is clamped up to one worker or down to one per item.
+    const outOfRangeConcurrencies = {
+      0: 'below one',
+      -1: 'negative',
+      100: 'above the item count',
+      1 << 30: 'huge',
+    };
 
-      await runWithConcurrency(
-        [0, 1, 2],
-        -1,
-        (item) async => processed.add(item),
-      );
+    for (final entry in outOfRangeConcurrencies.entries) {
+      test('Should drain every item when maxConcurrent is ${entry.value}', () async {
+        final processed = await _collectProcessed([0, 1, 2], entry.key);
 
-      expect(processed, [0, 1, 2]);
-    });
-
-    test('Should process all items when maxConcurrent exceeds item count', () async {
-      final processed = <int>[];
-
-      await runWithConcurrency(
-        [0, 1, 2],
-        100,
-        (item) async => processed.add(item),
-      );
-
-      expect(processed, containsAllInOrder([0, 1, 2]));
-      expect(processed, hasLength(3));
-    });
-
-    test('Should not spawn a worker per unit of a huge maxConcurrent', () async {
-      final processed = <int>[];
-
-      await runWithConcurrency(
-        [0, 1, 2],
-        1 << 30,
-        (item) async => processed.add(item),
-      );
-
-      expect(processed, containsAllInOrder([0, 1, 2]));
-      expect(processed, hasLength(3));
-    });
+        expect(processed, containsAllInOrder([0, 1, 2]));
+        expect(processed, hasLength(3));
+      });
+    }
 
     test('Should drain a large batch under a large concurrency', () async {
       const itemCount = 100000;

--- a/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
@@ -164,6 +164,42 @@ void main() {
 
       expect(transferredDocs, isEmpty);
     });
+
+    test('Should not hand a non-https download link to the transfer starter when https is required', () async {
+      transfersAccepted = true;
+      final httpsRequiredHandler = _HttpsRequiredHandler();
+      final httpDownloadDoc = DriveDocument(
+        id: '6',
+        name: 'Insecure.jpg',
+        size: 200,
+        mimeType: 'image/jpeg',
+        downloadLink: Uri.parse('http://drive.example.com/insecure.jpg'),
+      );
+
+      await httpsRequiredHandler.handleDrivePickResult([
+        httpDownloadDoc,
+      ], insertHtml: (html) async => insertedHtml.add(html), transferDriveDocuments: transferDriveDocuments, appLocalizations: appLocalizations);
+
+      expect(transferredDocs, isEmpty);
+      expect(insertedHtml, isEmpty);
+      final captured = verify(
+        mockToastManager.showMessageFailure(captureAny),
+      ).captured;
+      final failure = captured.single as DrivePickFailure;
+      expect(failure.message, equals(appLocalizations.driveAttachmentInDevelopment));
+    });
+
+    test('Should still hand an https download link to the transfer starter when https is required', () async {
+      transfersAccepted = true;
+      final httpsRequiredHandler = _HttpsRequiredHandler();
+
+      await httpsRequiredHandler.handleDrivePickResult([
+        attachmentDoc,
+      ], insertHtml: (html) async => insertedHtml.add(html), transferDriveDocuments: transferDriveDocuments, appLocalizations: appLocalizations);
+
+      expect(transferredDocs.single, [attachmentDoc]);
+      verifyNever(mockToastManager.showMessageFailure(any));
+    });
   });
 
   group('DriveAttachmentHandler::handleDrivePickResult::download-only toast::', () {
@@ -255,4 +291,11 @@ void main() {
       expect(caughtError, isA<StateError>());
     });
   });
+}
+
+/// Stands in for a release build: tests run in debug, where
+/// [DriveAttachmentHandler.requireHttps] is false and the scheme gate never fires.
+class _HttpsRequiredHandler extends DriveAttachmentHandler {
+  @override
+  bool get requireHttps => true;
 }

--- a/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
@@ -16,10 +16,22 @@ void main() {
   late List<String> insertedHtml;
   late DriveAttachmentHandler handler;
   late MockToastManager mockToastManager;
+  late List<List<DriveDocument>> transferredDocs;
+  late bool transfersAccepted;
+
+  /// Stands in for the drive-transfer pipeline: records what it was handed and
+  /// answers whether it took the documents, the way a platform with no staging
+  /// strategy declines them.
+  Future<bool> startDriveTransfers(List<DriveDocument> docs) async {
+    transferredDocs.add(docs);
+    return transfersAccepted;
+  }
   final appLocalizations = AppLocalizations();
 
   setUp(() {
     insertedHtml = [];
+    transferredDocs = [];
+    transfersAccepted = false;
     handler = Get.put(DriveAttachmentHandler());
     mockToastManager = MockToastManager();
     Get.put<ToastManager>(mockToastManager);
@@ -33,7 +45,7 @@ void main() {
     test('Should insert link html for docs with sharingLink', () async {
       await handler.handleDrivePickResult([
         linkDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
+      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers, appLocalizations: appLocalizations);
 
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, contains('https://drive.example.com/report'));
@@ -44,7 +56,7 @@ void main() {
     test('Should still work and fall back to hardcoded English label when appLocalizations is omitted', () async {
       await handler.handleDrivePickResult([
         linkDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html));
+      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers);
 
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, contains('Open in drive'));
@@ -62,7 +74,7 @@ void main() {
 
       await handler.handleDrivePickResult([
         bothLinksDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
+      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers, appLocalizations: appLocalizations);
 
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, contains('https://drive.example.com/both'));
@@ -71,7 +83,7 @@ void main() {
     test('Should show download-only toast and not insert html when doc has neither sharingLink nor downloadLink', () async {
       await handler.handleDrivePickResult([
         noLinkDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
+      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers, appLocalizations: appLocalizations);
 
       expect(insertedHtml, isEmpty);
       verify(mockToastManager.showMessageFailure(any)).called(1);
@@ -82,7 +94,7 @@ void main() {
         linkDoc,
         attachmentDoc,
         noLinkDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
+      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers, appLocalizations: appLocalizations);
 
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, contains('Report'));
@@ -90,11 +102,63 @@ void main() {
     });
   });
 
+  group('DriveAttachmentHandler::handleDrivePickResult::drive transfers::', () {
+    test('Should hand download-only docs to the transfer starter', () async {
+      transfersAccepted = true;
+
+      await handler.handleDrivePickResult([
+        linkDoc,
+        attachmentDoc,
+      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers, appLocalizations: appLocalizations);
+
+      expect(transferredDocs, hasLength(1));
+      expect(transferredDocs.single, [attachmentDoc]);
+    });
+
+    test('Should not show the in-development toast when transfers are taken', () async {
+      transfersAccepted = true;
+
+      await handler.handleDrivePickResult([
+        attachmentDoc,
+      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers, appLocalizations: appLocalizations);
+
+      expect(insertedHtml, isEmpty);
+      verifyNever(mockToastManager.showMessageFailure(any));
+    });
+
+    test('Should never hand a doc carrying both links to the transfer starter', () async {
+      transfersAccepted = true;
+      final bothLinksDoc = DriveDocument(
+        id: '5',
+        name: 'Both',
+        size: 50,
+        mimeType: 'application/pdf',
+        sharingLink: Uri.parse('https://drive.example.com/both'),
+        downloadLink: Uri.parse('https://drive.example.com/both-dl'),
+      );
+
+      await handler.handleDrivePickResult([
+        bothLinksDoc,
+      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers, appLocalizations: appLocalizations);
+
+      expect(insertedHtml, hasLength(1));
+      expect(transferredDocs, isEmpty);
+    });
+
+    test('Should not call the transfer starter when no doc is download-only', () async {
+      await handler.handleDrivePickResult([
+        linkDoc,
+      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers, appLocalizations: appLocalizations);
+
+      expect(transferredDocs, isEmpty);
+    });
+  });
+
   group('DriveAttachmentHandler::handleDrivePickResult::download-only toast::', () {
     test('Should show toast with driveAttachmentInDevelopment message when all docs are download-only', () async {
-      handler.handleDrivePickResult([
+      await handler.handleDrivePickResult([
         attachmentDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
+      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers, appLocalizations: appLocalizations);
 
       expect(insertedHtml, isEmpty);
       final captured = verify(
@@ -106,9 +170,10 @@ void main() {
     });
 
     test('Should show toast when result is empty', () async {
-      handler.handleDrivePickResult(
+      await handler.handleDrivePickResult(
         [],
         insertHtml: (html) async => insertedHtml.add(html),
+        startDriveTransfers: startDriveTransfers,
         appLocalizations: appLocalizations,
       );
 
@@ -117,9 +182,9 @@ void main() {
     });
 
     test('Should show toast with null message when appLocalizations is omitted', () async {
-      handler.handleDrivePickResult([
+      await handler.handleDrivePickResult([
         attachmentDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html));
+      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers);
 
       expect(insertedHtml, isEmpty);
       final captured = verify(
@@ -131,10 +196,10 @@ void main() {
     });
 
     test('Should not show toast when at least one doc has sharingLink', () async {
-      handler.handleDrivePickResult([
+      await handler.handleDrivePickResult([
         attachmentDoc,
         linkDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
+      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers, appLocalizations: appLocalizations);
 
       expect(insertedHtml, hasLength(1));
       verifyNever(mockToastManager.showMessageFailure(any));

--- a/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
@@ -107,6 +107,7 @@ void main() {
       transfersAccepted = true;
 
       await handler.handleDrivePickResult([
+        linkDoc,
         attachmentDoc,
       ], insertHtml: (html) async => insertedHtml.add(html), transferDriveDocuments: transferDriveDocuments, appLocalizations: appLocalizations);
 
@@ -114,7 +115,7 @@ void main() {
       expect(transferredDocs.single, [attachmentDoc]);
     });
 
-    test('Should insert link html and start no transfer for a mixed pick', () async {
+    test('Should insert link html and start transfers for a mixed pick', () async {
       transfersAccepted = true;
 
       await handler.handleDrivePickResult([
@@ -123,7 +124,7 @@ void main() {
       ], insertHtml: (html) async => insertedHtml.add(html), transferDriveDocuments: transferDriveDocuments, appLocalizations: appLocalizations);
 
       expect(insertedHtml, hasLength(1));
-      expect(transferredDocs, isEmpty);
+      expect(transferredDocs.single, [attachmentDoc]);
     });
 
     test('Should not show the in-development toast when transfers are taken', () async {

--- a/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
@@ -22,7 +22,7 @@ void main() {
   /// Stands in for the drive-transfer pipeline: records what it was handed and
   /// answers whether it took the documents, the way a platform with no staging
   /// strategy declines them.
-  Future<bool> startDriveTransfers(List<DriveDocument> docs) async {
+  Future<bool> transferDriveDocuments(List<DriveDocument> docs) async {
     transferredDocs.add(docs);
     return transfersAccepted;
   }
@@ -45,7 +45,7 @@ void main() {
     test('Should insert link html for docs with sharingLink', () async {
       await handler.handleDrivePickResult([
         linkDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers, appLocalizations: appLocalizations);
+      ], insertHtml: (html) async => insertedHtml.add(html), transferDriveDocuments: transferDriveDocuments, appLocalizations: appLocalizations);
 
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, contains('https://drive.example.com/report'));
@@ -56,7 +56,7 @@ void main() {
     test('Should still work and fall back to hardcoded English label when appLocalizations is omitted', () async {
       await handler.handleDrivePickResult([
         linkDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers);
+      ], insertHtml: (html) async => insertedHtml.add(html), transferDriveDocuments: transferDriveDocuments);
 
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, contains('Open in drive'));
@@ -74,7 +74,7 @@ void main() {
 
       await handler.handleDrivePickResult([
         bothLinksDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers, appLocalizations: appLocalizations);
+      ], insertHtml: (html) async => insertedHtml.add(html), transferDriveDocuments: transferDriveDocuments, appLocalizations: appLocalizations);
 
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, contains('https://drive.example.com/both'));
@@ -83,7 +83,7 @@ void main() {
     test('Should show download-only toast and not insert html when doc has neither sharingLink nor downloadLink', () async {
       await handler.handleDrivePickResult([
         noLinkDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers, appLocalizations: appLocalizations);
+      ], insertHtml: (html) async => insertedHtml.add(html), transferDriveDocuments: transferDriveDocuments, appLocalizations: appLocalizations);
 
       expect(insertedHtml, isEmpty);
       verify(mockToastManager.showMessageFailure(any)).called(1);
@@ -94,7 +94,7 @@ void main() {
         linkDoc,
         attachmentDoc,
         noLinkDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers, appLocalizations: appLocalizations);
+      ], insertHtml: (html) async => insertedHtml.add(html), transferDriveDocuments: transferDriveDocuments, appLocalizations: appLocalizations);
 
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, contains('Report'));
@@ -109,7 +109,7 @@ void main() {
       await handler.handleDrivePickResult([
         linkDoc,
         attachmentDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers, appLocalizations: appLocalizations);
+      ], insertHtml: (html) async => insertedHtml.add(html), transferDriveDocuments: transferDriveDocuments, appLocalizations: appLocalizations);
 
       expect(transferredDocs, hasLength(1));
       expect(transferredDocs.single, [attachmentDoc]);
@@ -120,7 +120,7 @@ void main() {
 
       await handler.handleDrivePickResult([
         attachmentDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers, appLocalizations: appLocalizations);
+      ], insertHtml: (html) async => insertedHtml.add(html), transferDriveDocuments: transferDriveDocuments, appLocalizations: appLocalizations);
 
       expect(insertedHtml, isEmpty);
       verifyNever(mockToastManager.showMessageFailure(any));
@@ -139,7 +139,7 @@ void main() {
 
       await handler.handleDrivePickResult([
         bothLinksDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers, appLocalizations: appLocalizations);
+      ], insertHtml: (html) async => insertedHtml.add(html), transferDriveDocuments: transferDriveDocuments, appLocalizations: appLocalizations);
 
       expect(insertedHtml, hasLength(1));
       expect(transferredDocs, isEmpty);
@@ -148,7 +148,7 @@ void main() {
     test('Should not call the transfer starter when no doc is download-only', () async {
       await handler.handleDrivePickResult([
         linkDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers, appLocalizations: appLocalizations);
+      ], insertHtml: (html) async => insertedHtml.add(html), transferDriveDocuments: transferDriveDocuments, appLocalizations: appLocalizations);
 
       expect(transferredDocs, isEmpty);
     });
@@ -158,7 +158,7 @@ void main() {
     test('Should show toast with driveAttachmentInDevelopment message when all docs are download-only', () async {
       await handler.handleDrivePickResult([
         attachmentDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers, appLocalizations: appLocalizations);
+      ], insertHtml: (html) async => insertedHtml.add(html), transferDriveDocuments: transferDriveDocuments, appLocalizations: appLocalizations);
 
       expect(insertedHtml, isEmpty);
       final captured = verify(
@@ -173,7 +173,7 @@ void main() {
       await handler.handleDrivePickResult(
         [],
         insertHtml: (html) async => insertedHtml.add(html),
-        startDriveTransfers: startDriveTransfers,
+        transferDriveDocuments: transferDriveDocuments,
         appLocalizations: appLocalizations,
       );
 
@@ -184,7 +184,7 @@ void main() {
     test('Should show toast with null message when appLocalizations is omitted', () async {
       await handler.handleDrivePickResult([
         attachmentDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers);
+      ], insertHtml: (html) async => insertedHtml.add(html), transferDriveDocuments: transferDriveDocuments);
 
       expect(insertedHtml, isEmpty);
       final captured = verify(
@@ -199,7 +199,7 @@ void main() {
       await handler.handleDrivePickResult([
         attachmentDoc,
         linkDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), startDriveTransfers: startDriveTransfers, appLocalizations: appLocalizations);
+      ], insertHtml: (html) async => insertedHtml.add(html), transferDriveDocuments: transferDriveDocuments, appLocalizations: appLocalizations);
 
       expect(insertedHtml, hasLength(1));
       verifyNever(mockToastManager.showMessageFailure(any));

--- a/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
@@ -107,12 +107,23 @@ void main() {
       transfersAccepted = true;
 
       await handler.handleDrivePickResult([
-        linkDoc,
         attachmentDoc,
       ], insertHtml: (html) async => insertedHtml.add(html), transferDriveDocuments: transferDriveDocuments, appLocalizations: appLocalizations);
 
       expect(transferredDocs, hasLength(1));
       expect(transferredDocs.single, [attachmentDoc]);
+    });
+
+    test('Should insert link html and start no transfer for a mixed pick', () async {
+      transfersAccepted = true;
+
+      await handler.handleDrivePickResult([
+        linkDoc,
+        attachmentDoc,
+      ], insertHtml: (html) async => insertedHtml.add(html), transferDriveDocuments: transferDriveDocuments, appLocalizations: appLocalizations);
+
+      expect(insertedHtml, hasLength(1));
+      expect(transferredDocs, isEmpty);
     });
 
     test('Should not show the in-development toast when transfers are taken', () async {

--- a/test/features/composer/presentation/manager/drive_document_transfer_runner_test.dart
+++ b/test/features/composer/presentation/manager/drive_document_transfer_runner_test.dart
@@ -316,34 +316,26 @@ void main() {
       verify(uploadController.failDriveTransfer(pending.taskId)).called(1);
     });
 
-    test('Should fail the transfer when the session lost its header', () async {
-      final runner = buildRunner();
-      final pending = enqueueOne(runner, docOf());
-      authHeader = null;
+    const unusableHeaders = <String, String?>{
+      'the session lost its header': null,
+      'the header went blank': '   ',
+    };
 
-      final attached = await runner.run(
-        pending: pending,
-        uploadUri: Uri.parse('https://jmap.example.com/upload'),
-        strategy: _ScriptedStrategy((_) async => attachment),
-      );
+    unusableHeaders.forEach((reason, header) {
+      test('Should fail the transfer when $reason', () async {
+        final runner = buildRunner();
+        final pending = enqueueOne(runner, docOf());
+        authHeader = header;
 
-      expect(attached, isFalse);
-      verify(uploadController.failDriveTransfer(pending.taskId)).called(1);
-    });
+        final attached = await runner.run(
+          pending: pending,
+          uploadUri: Uri.parse('https://jmap.example.com/upload'),
+          strategy: _ScriptedStrategy((_) async => attachment),
+        );
 
-    test('Should fail the transfer when the header went blank', () async {
-      final runner = buildRunner();
-      final pending = enqueueOne(runner, docOf());
-      authHeader = '   ';
-
-      final attached = await runner.run(
-        pending: pending,
-        uploadUri: Uri.parse('https://jmap.example.com/upload'),
-        strategy: _ScriptedStrategy((_) async => attachment),
-      );
-
-      expect(attached, isFalse);
-      verify(uploadController.failDriveTransfer(pending.taskId)).called(1);
+        expect(attached, isFalse);
+        verify(uploadController.failDriveTransfer(pending.taskId)).called(1);
+      });
     });
   });
 }

--- a/test/features/composer/presentation/manager/drive_document_transfer_runner_test.dart
+++ b/test/features/composer/presentation/manager/drive_document_transfer_runner_test.dart
@@ -1,0 +1,349 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/email/attachment.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/drive_document_transfer_runner.dart';
+import 'package:tmail_ui_user/features/upload/presentation/controller/upload_controller.dart';
+import 'package:tmail_ui_user/features/upload/presentation/model/drive_transfer_placeholder.dart';
+import 'package:uuid/uuid.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
+import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+
+import 'drive_document_transfer_runner_test.mocks.dart';
+
+/// Drives one transfer from the test: [onTransfer] receives the request the
+/// runner built, so a test can replay progress or throw from either leg.
+class _ScriptedStrategy extends DriveTransferStrategy<StagedDriveFile> {
+  final Future<Attachment> Function(DriveTransferRequest request) onTransfer;
+
+  int transferCalls = 0;
+
+  _ScriptedStrategy(this.onTransfer);
+
+  @override
+  Future<Attachment> transfer(DriveTransferRequest request) {
+    transferCalls++;
+    return onTransfer(request);
+  }
+
+  @override
+  Future<StagedDriveFile> stage({
+    required DriveDocument doc,
+    required onDownloadProgress,
+    required CancelToken cancelToken,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  Future<Attachment> upload(DriveUploadRequest<StagedDriveFile> request) =>
+      throw UnimplementedError();
+}
+
+@GenerateNiceMocks([
+  MockSpec<UploadController>(),
+  MockSpec<Uuid>(),
+])
+void main() {
+  late MockUploadController uploadController;
+  late MockUuid uuid;
+  late String? authHeader;
+  late int nextId;
+
+  final attachment = Attachment(
+    blobId: Id('blob-1'),
+    name: 'Report.pdf',
+    size: UnsignedInt(2000),
+  );
+
+  DriveDocument docOf({int size = 2000}) => DriveDocument(
+        id: 'doc-1',
+        name: 'Report.pdf',
+        size: size,
+        mimeType: 'application/pdf',
+      );
+
+  DriveDocumentTransferRunner buildRunner() => DriveDocumentTransferRunner(
+        uploadController: uploadController,
+        uuid: uuid,
+        resolveAuthHeader: () => authHeader,
+      );
+
+  /// Enqueues [doc] and returns the handle the runner minted for it.
+  PendingDriveTransfer enqueueOne(
+    DriveDocumentTransferRunner runner,
+    DriveDocument doc,
+  ) =>
+      runner.enqueue([doc]).single;
+
+  setUp(() {
+    uploadController = MockUploadController();
+    uuid = MockUuid();
+    authHeader = 'Bearer token';
+    nextId = 0;
+    when(uuid.v4()).thenAnswer((_) => 'task-${nextId++}');
+  });
+
+  group('DriveDocumentTransferRunner::canAuthenticate::', () {
+    test('Should be false when there is no header', () {
+      authHeader = null;
+      expect(buildRunner().canAuthenticate, isFalse);
+    });
+
+    test('Should be false when the header is blank', () {
+      authHeader = '   ';
+      expect(buildRunner().canAuthenticate, isFalse);
+    });
+
+    test('Should be true when there is a header to send', () {
+      expect(buildRunner().canAuthenticate, isTrue);
+    });
+  });
+
+  group('DriveDocumentTransferRunner::enqueue::', () {
+    test('Should put a chip up for every document with its own identity', () {
+      final docs = List.generate(
+        3,
+        (index) => DriveDocument(
+          id: 'doc-$index',
+          name: 'File-$index.pdf',
+          size: 1000,
+          mimeType: 'application/pdf',
+        ),
+      );
+
+      final pendingTransfers = buildRunner().enqueue(docs);
+
+      expect(pendingTransfers, hasLength(3));
+      expect(
+        pendingTransfers.map((pending) => pending.taskId).toSet(),
+        hasLength(3),
+      );
+
+      final placeholders =
+          verify(uploadController.addDownloadingPlaceholders(captureAny))
+              .captured
+              .single as List<DriveTransferPlaceholder>;
+      expect(placeholders, hasLength(3));
+      expect(placeholders.first.fileName, 'File-0.pdf');
+      expect(placeholders.first.fileSize, 1000);
+      expect(placeholders.first.mimeType, 'application/pdf');
+      expect(placeholders.first.cancelToken, pendingTransfers.first.cancelToken);
+    });
+
+    test('Should add the whole batch in one call', () {
+      buildRunner().enqueue(List.generate(
+        10,
+        (index) => DriveDocument(
+          id: 'doc-$index',
+          name: 'File-$index.pdf',
+          size: 1000,
+          mimeType: 'application/pdf',
+        ),
+      ));
+
+      verify(uploadController.addDownloadingPlaceholders(any)).called(1);
+    });
+  });
+
+  group('DriveDocumentTransferRunner::run::', () {
+    test('Should attach the document and complete its chip', () async {
+      final runner = buildRunner();
+      final pending = enqueueOne(runner, docOf());
+      final strategy = _ScriptedStrategy((_) async => attachment);
+
+      final attached = await runner.run(
+        pending: pending,
+        uploadUri: Uri.parse('https://jmap.example.com/upload'),
+        strategy: strategy,
+      );
+
+      expect(attached, isTrue);
+      verify(uploadController.completeUploadedFile(
+        taskId: pending.taskId,
+        attachment: attachment,
+      )).called(1);
+    });
+
+    test('Should forward both legs of progress under the same task', () async {
+      final runner = buildRunner();
+      final pending = enqueueOne(runner, docOf());
+      final strategy = _ScriptedStrategy((request) async {
+        request.onDownloadProgress(1000, 2000);
+        request.onUploadProgress(500, 2000);
+        return attachment;
+      });
+
+      await runner.run(
+        pending: pending,
+        uploadUri: Uri.parse('https://jmap.example.com/upload'),
+        strategy: strategy,
+      );
+
+      verify(uploadController.updateDownloadProgress(
+        taskId: pending.taskId,
+        received: 1000,
+        total: 2000,
+      )).called(1);
+      verify(uploadController.updateUploadProgress(
+        taskId: pending.taskId,
+        sent: 500,
+        total: 2000,
+      )).called(1);
+    });
+
+    test('Should never start a transfer cancelled while it was queued', () async {
+      final runner = buildRunner();
+      final pending = enqueueOne(runner, docOf());
+      final strategy = _ScriptedStrategy((_) async => attachment);
+      pending.cancelToken.cancel();
+
+      final attached = await runner.run(
+        pending: pending,
+        uploadUri: Uri.parse('https://jmap.example.com/upload'),
+        strategy: strategy,
+      );
+
+      expect(attached, isFalse);
+      expect(strategy.transferCalls, 0);
+    });
+  });
+
+  group('DriveDocumentTransferRunner::run::oversize abort::', () {
+    test('Should stop a download that outgrows the declared size', () async {
+      final runner = buildRunner();
+      final pending = enqueueOne(runner, docOf(size: 2000));
+      final strategy = _ScriptedStrategy((request) async {
+        request.onDownloadProgress(3000, 4000);
+        throw DioException.requestCancelled(
+          requestOptions: RequestOptions(),
+          reason: request.cancelToken.cancelError,
+        );
+      });
+
+      final attached = await runner.run(
+        pending: pending,
+        uploadUri: Uri.parse('https://jmap.example.com/upload'),
+        strategy: strategy,
+      );
+
+      expect(attached, isFalse);
+      expect(pending.cancelToken.isCancelled, isTrue);
+      // Not the silent delete: an oversized link is an error the user must see.
+      verify(uploadController.failDriveTransfer(pending.taskId)).called(1);
+      verifyNever(uploadController.updateDownloadProgress(
+        taskId: anyNamed('taskId'),
+        received: anyNamed('received'),
+        total: anyNamed('total'),
+      ));
+    });
+
+    test('Should fall back to the response length when nothing was declared', () async {
+      final runner = buildRunner();
+      final pending = enqueueOne(runner, docOf(size: 0));
+      final strategy = _ScriptedStrategy((request) async {
+        request.onDownloadProgress(1500, 2000);
+        return attachment;
+      });
+
+      final attached = await runner.run(
+        pending: pending,
+        uploadUri: Uri.parse('https://jmap.example.com/upload'),
+        strategy: strategy,
+      );
+
+      expect(attached, isTrue);
+      expect(pending.cancelToken.isCancelled, isFalse);
+      verify(uploadController.updateDownloadProgress(
+        taskId: pending.taskId,
+        received: 1500,
+        total: 2000,
+      )).called(1);
+    });
+  });
+
+  group('DriveDocumentTransferRunner::run::failure paths::', () {
+    Future<bool> runFailing(
+      DriveDocumentTransferRunner runner,
+      PendingDriveTransfer pending,
+      Object error,
+    ) =>
+        runner.run(
+          pending: pending,
+          uploadUri: Uri.parse('https://jmap.example.com/upload'),
+          strategy: _ScriptedStrategy((_) async => throw error),
+        );
+
+    test('Should drop a user-cancelled transfer without a toast', () async {
+      final runner = buildRunner();
+      final pending = enqueueOne(runner, docOf());
+      final strategy = _ScriptedStrategy((request) async {
+        request.cancelToken.cancel();
+        throw DioException.requestCancelled(
+          requestOptions: RequestOptions(),
+          reason: request.cancelToken.cancelError,
+        );
+      });
+
+      final attached = await runner.run(
+        pending: pending,
+        uploadUri: Uri.parse('https://jmap.example.com/upload'),
+        strategy: strategy,
+      );
+
+      expect(attached, isFalse);
+      verify(uploadController.deleteFileUploaded(pending.taskId)).called(1);
+      verifyNever(uploadController.failDriveTransfer(any));
+    });
+
+    test('Should toast a transfer that failed on its own', () async {
+      final runner = buildRunner();
+      final pending = enqueueOne(runner, docOf());
+
+      final attached = await runFailing(
+        runner,
+        pending,
+        DioException.connectionError(
+          requestOptions: RequestOptions(),
+          reason: 'gone',
+        ),
+      );
+
+      expect(attached, isFalse);
+      verify(uploadController.failDriveTransfer(pending.taskId)).called(1);
+    });
+
+    test('Should fail the transfer when the session lost its header', () async {
+      final runner = buildRunner();
+      final pending = enqueueOne(runner, docOf());
+      authHeader = null;
+
+      final attached = await runner.run(
+        pending: pending,
+        uploadUri: Uri.parse('https://jmap.example.com/upload'),
+        strategy: _ScriptedStrategy((_) async => attachment),
+      );
+
+      expect(attached, isFalse);
+      verify(uploadController.failDriveTransfer(pending.taskId)).called(1);
+    });
+
+    test('Should fail the transfer when the header went blank', () async {
+      final runner = buildRunner();
+      final pending = enqueueOne(runner, docOf());
+      authHeader = '   ';
+
+      final attached = await runner.run(
+        pending: pending,
+        uploadUri: Uri.parse('https://jmap.example.com/upload'),
+        strategy: _ScriptedStrategy((_) async => attachment),
+      );
+
+      expect(attached, isFalse);
+      verify(uploadController.failDriveTransfer(pending.taskId)).called(1);
+    });
+  });
+}

--- a/test/features/composer/presentation/manager/drive_document_transfer_runner_test.dart
+++ b/test/features/composer/presentation/manager/drive_document_transfer_runner_test.dart
@@ -155,13 +155,13 @@ void main() {
       final pending = enqueueOne(runner, docOf());
       final strategy = _ScriptedStrategy((_) async => attachment);
 
-      final attached = await runner.run(
+      final result = await runner.run(
         pending: pending,
         uploadUri: Uri.parse('https://jmap.example.com/upload'),
         strategy: strategy,
       );
 
-      expect(attached, isTrue);
+      expect(result, DriveTransferResult.attached);
       verify(uploadController.completeUploadedFile(
         taskId: pending.taskId,
         attachment: attachment,
@@ -201,14 +201,15 @@ void main() {
       final strategy = _ScriptedStrategy((_) async => attachment);
       pending.cancelToken.cancel();
 
-      final attached = await runner.run(
+      final result = await runner.run(
         pending: pending,
         uploadUri: Uri.parse('https://jmap.example.com/upload'),
         strategy: strategy,
       );
 
-      expect(attached, isFalse);
+      expect(result, DriveTransferResult.cancelled);
       expect(strategy.transferCalls, 0);
+      verify(uploadController.deleteFileUploaded(pending.taskId)).called(1);
     });
   });
 
@@ -224,13 +225,13 @@ void main() {
         );
       });
 
-      final attached = await runner.run(
+      final result = await runner.run(
         pending: pending,
         uploadUri: Uri.parse('https://jmap.example.com/upload'),
         strategy: strategy,
       );
 
-      expect(attached, isFalse);
+      expect(result, DriveTransferResult.failed);
       expect(pending.cancelToken.isCancelled, isTrue);
       // Not the silent delete: an oversized link is an error the user must see.
       verify(uploadController.failDriveTransfer(pending.taskId)).called(1);
@@ -249,13 +250,13 @@ void main() {
         return attachment;
       });
 
-      final attached = await runner.run(
+      final result = await runner.run(
         pending: pending,
         uploadUri: Uri.parse('https://jmap.example.com/upload'),
         strategy: strategy,
       );
 
-      expect(attached, isTrue);
+      expect(result, DriveTransferResult.attached);
       expect(pending.cancelToken.isCancelled, isFalse);
       verify(uploadController.updateDownloadProgress(
         taskId: pending.taskId,
@@ -266,7 +267,7 @@ void main() {
   });
 
   group('DriveDocumentTransferRunner::run::failure paths::', () {
-    Future<bool> runFailing(
+    Future<DriveTransferResult> runFailing(
       DriveDocumentTransferRunner runner,
       PendingDriveTransfer pending,
       Object error,
@@ -288,13 +289,13 @@ void main() {
         );
       });
 
-      final attached = await runner.run(
+      final result = await runner.run(
         pending: pending,
         uploadUri: Uri.parse('https://jmap.example.com/upload'),
         strategy: strategy,
       );
 
-      expect(attached, isFalse);
+      expect(result, DriveTransferResult.cancelled);
       verify(uploadController.deleteFileUploaded(pending.taskId)).called(1);
       verifyNever(uploadController.failDriveTransfer(any));
     });
@@ -303,7 +304,7 @@ void main() {
       final runner = buildRunner();
       final pending = enqueueOne(runner, docOf());
 
-      final attached = await runFailing(
+      final result = await runFailing(
         runner,
         pending,
         DioException.connectionError(
@@ -312,7 +313,7 @@ void main() {
         ),
       );
 
-      expect(attached, isFalse);
+      expect(result, DriveTransferResult.failed);
       verify(uploadController.failDriveTransfer(pending.taskId)).called(1);
     });
 
@@ -327,13 +328,13 @@ void main() {
         final pending = enqueueOne(runner, docOf());
         authHeader = header;
 
-        final attached = await runner.run(
+        final result = await runner.run(
           pending: pending,
           uploadUri: Uri.parse('https://jmap.example.com/upload'),
           strategy: _ScriptedStrategy((_) async => attachment),
         );
 
-        expect(attached, isFalse);
+        expect(result, DriveTransferResult.failed);
         verify(uploadController.failDriveTransfer(pending.taskId)).called(1);
       });
     });

--- a/test/features/composer/presentation/manager/drive_transfer_pipeline_test.dart
+++ b/test/features/composer/presentation/manager/drive_transfer_pipeline_test.dart
@@ -196,7 +196,7 @@ void main() {
       )).thenAnswer((_) async {
         if (!firstRunStarted.isCompleted) firstRunStarted.complete();
         await releaseFirstRun.future;
-        return true;
+        return DriveTransferResult.attached;
       });
 
       unawaited(buildPipeline().transfer(docs));
@@ -216,11 +216,13 @@ void main() {
         pending: anyNamed('pending'),
         uploadUri: anyNamed('uploadUri'),
         strategy: anyNamed('strategy'),
-      )).thenAnswer((invocation) async =>
-          (invocation.namedArguments[#pending] as PendingDriveTransfer)
-              .doc
-              .id !=
-          'c');
+      )).thenAnswer((invocation) async {
+        final doc =
+            (invocation.namedArguments[#pending] as PendingDriveTransfer).doc;
+        return doc.id != 'c'
+            ? DriveTransferResult.attached
+            : DriveTransferResult.failed;
+      });
 
       expect(await buildPipeline().transfer(docs), isTrue);
       await settle();
@@ -236,7 +238,7 @@ void main() {
         pending: anyNamed('pending'),
         uploadUri: anyNamed('uploadUri'),
         strategy: anyNamed('strategy'),
-      )).thenAnswer((_) async => false);
+      )).thenAnswer((_) async => DriveTransferResult.failed);
 
       expect(await buildPipeline().transfer([docOf('a')]), isTrue);
       await settle();
@@ -249,7 +251,7 @@ void main() {
         pending: anyNamed('pending'),
         uploadUri: anyNamed('uploadUri'),
         strategy: anyNamed('strategy'),
-      )).thenAnswer((_) async => true);
+      )).thenAnswer((_) async => DriveTransferResult.attached);
 
       await buildPipeline().transfer([docOf('a'), docOf('b')]);
       await settle();

--- a/test/features/composer/presentation/manager/drive_transfer_pipeline_test.dart
+++ b/test/features/composer/presentation/manager/drive_transfer_pipeline_test.dart
@@ -1,0 +1,264 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/email/attachment.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/drive_document_transfer_runner.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/drive_transfer_pipeline.dart';
+import 'package:tmail_ui_user/features/upload/data/network/file_uploader.dart';
+import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
+import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_upload_validation_service.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
+import 'package:uuid/uuid.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy_factory.dart';
+import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
+import 'package:workplace/data/model/workplace_type_defs.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+import 'package:workplace/presentation/model/drive_pick_state.dart';
+
+import 'drive_transfer_pipeline_test.mocks.dart';
+
+/// The pipeline never stages or uploads through the strategy itself — it hands
+/// it to the runner — so only the concurrency it declares matters here.
+class _FakeStrategy extends DriveTransferStrategy<StagedDriveFile> {
+  @override
+  int get maxConcurrentTransfers => 2;
+
+  @override
+  Future<StagedDriveFile> stage({
+    required DriveDocument doc,
+    required OnFileProcessedProgress onDownloadProgress,
+    required CancelToken cancelToken,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  Future<Attachment> upload(DriveUploadRequest<StagedDriveFile> request) =>
+      throw UnimplementedError();
+}
+
+@GenerateNiceMocks([
+  MockSpec<AttachmentUploadValidationService>(),
+  MockSpec<FileUploader>(),
+  MockSpec<DriveTransferStrategyFactory>(),
+  MockSpec<DriveDocumentTransferRunner>(),
+  MockSpec<Uuid>(),
+  MockSpec<ToastManager>(),
+])
+void main() {
+  late MockAttachmentUploadValidationService validationService;
+  late MockDriveTransferStrategyFactory strategyFactory;
+  late MockDriveDocumentTransferRunner transferRunner;
+  late MockToastManager toastManager;
+  late _FakeStrategy strategy;
+  late Uri? uploadUri;
+
+  DriveDocument docOf(String id, {int size = 1000}) => DriveDocument(
+        id: id,
+        name: '$id.pdf',
+        size: size,
+        mimeType: 'application/pdf',
+        downloadLink: Uri.parse('https://drive.example.com/$id'),
+      );
+
+  PendingDriveTransfer pendingOf(DriveDocument doc) => PendingDriveTransfer(
+        doc: doc,
+        taskId: UploadTaskId(doc.id),
+        cancelToken: CancelToken(),
+      );
+
+  DriveTransferPipeline buildPipeline() => DriveTransferPipeline(
+        validationService: validationService,
+        fileUploader: MockFileUploader(),
+        uuid: MockUuid(),
+        strategyFactory: strategyFactory,
+        transferRunner: transferRunner,
+        resolveUploadUri: () => uploadUri,
+      );
+
+  /// Lets the gate through, the way a batch within the size limit passes.
+  void allowValidation() {
+    when(validationService.validateBytes(
+      context: anyNamed('context'),
+      proposedAllAttachmentBytes: anyNamed('proposedAllAttachmentBytes'),
+      proposedRegularAttachmentBytes: anyNamed('proposedRegularAttachmentBytes'),
+      onAllowed: anyNamed('onAllowed'),
+    )).thenAnswer((invocation) async {
+      (invocation.namedArguments[#onAllowed] as VoidCallback)();
+    });
+  }
+
+  setUp(() {
+    validationService = MockAttachmentUploadValidationService();
+    strategyFactory = MockDriveTransferStrategyFactory();
+    transferRunner = MockDriveDocumentTransferRunner();
+    toastManager = MockToastManager();
+    strategy = _FakeStrategy();
+    uploadUri = Uri.parse('https://jmap.example.com/upload');
+
+    Get.testMode = true;
+    Get.put<ToastManager>(toastManager);
+
+    when(transferRunner.canAuthenticate).thenReturn(true);
+    when(strategyFactory.create(uploader: anyNamed('uploader')))
+        .thenReturn(strategy);
+    when(transferRunner.enqueue(any)).thenAnswer((invocation) =>
+        (invocation.positionalArguments.first as List<DriveDocument>)
+            .map(pendingOf)
+            .toList());
+    allowValidation();
+  });
+
+  tearDown(Get.reset);
+
+  group('DriveTransferPipeline::transfer::decline paths::', () {
+    test('Should decline when there is no upload URI', () async {
+      uploadUri = null;
+
+      expect(await buildPipeline().transfer([docOf('a')]), isFalse);
+      verifyNever(transferRunner.enqueue(any));
+      verifyNever(transferRunner.run(
+        pending: anyNamed('pending'),
+        uploadUri: anyNamed('uploadUri'),
+        strategy: anyNamed('strategy'),
+      ));
+    });
+
+    test('Should decline when the session cannot authenticate', () async {
+      when(transferRunner.canAuthenticate).thenReturn(false);
+
+      expect(await buildPipeline().transfer([docOf('a')]), isFalse);
+      verifyNever(strategyFactory.create(uploader: anyNamed('uploader')));
+      verifyNever(transferRunner.enqueue(any));
+    });
+
+    test('Should decline when the platform has no staging strategy', () async {
+      when(strategyFactory.create(uploader: anyNamed('uploader')))
+          .thenReturn(null);
+
+      expect(await buildPipeline().transfer([docOf('a')]), isFalse);
+      verifyNever(transferRunner.enqueue(any));
+    });
+
+    test('Should decline an empty pick before consulting the factory', () async {
+      expect(await buildPipeline().transfer([]), isFalse);
+      verifyNever(strategyFactory.create(uploader: anyNamed('uploader')));
+    });
+  });
+
+  group('DriveTransferPipeline::transfer::size gate::', () {
+    test('Should still take the batch when the user declines at the gate', () async {
+      when(validationService.validateBytes(
+        context: anyNamed('context'),
+        proposedAllAttachmentBytes: anyNamed('proposedAllAttachmentBytes'),
+        proposedRegularAttachmentBytes: anyNamed('proposedRegularAttachmentBytes'),
+        onAllowed: anyNamed('onAllowed'),
+      )).thenAnswer((_) async {});
+
+      // Declined is still handled: the user was told, so no link-only fallback.
+      expect(await buildPipeline().transfer([docOf('a')]), isTrue);
+      verifyNever(transferRunner.enqueue(any));
+    });
+
+    test('Should gate on the declared total, counted as regular attachments', () async {
+      await buildPipeline().transfer([
+        docOf('a', size: 1000),
+        docOf('b', size: 2500),
+      ]);
+
+      verify(validationService.validateBytes(
+        context: anyNamed('context'),
+        proposedAllAttachmentBytes: 3500,
+        proposedRegularAttachmentBytes: 3500,
+        onAllowed: anyNamed('onAllowed'),
+      )).called(1);
+    });
+  });
+
+  group('DriveTransferPipeline::transfer::batch::', () {
+    /// The batch runs unawaited behind the gate, so let it settle.
+    Future<void> settle() => Future<void>.delayed(Duration.zero);
+
+    test('Should show every picked file before the first transfer finishes', () async {
+      final docs = List.generate(10, (index) => docOf('doc-$index'));
+      final firstRunStarted = Completer<void>();
+      final releaseFirstRun = Completer<void>();
+
+      when(transferRunner.run(
+        pending: anyNamed('pending'),
+        uploadUri: anyNamed('uploadUri'),
+        strategy: anyNamed('strategy'),
+      )).thenAnswer((_) async {
+        if (!firstRunStarted.isCompleted) firstRunStarted.complete();
+        await releaseFirstRun.future;
+        return true;
+      });
+
+      unawaited(buildPipeline().transfer(docs));
+      await firstRunStarted.future;
+
+      final enqueued = verify(transferRunner.enqueue(captureAny)).captured.single
+          as List<DriveDocument>;
+      expect(enqueued, hasLength(10));
+
+      releaseFirstRun.complete();
+      await settle();
+    });
+
+    test('Should toast only what actually landed', () async {
+      final docs = [docOf('a'), docOf('b'), docOf('c')];
+      when(transferRunner.run(
+        pending: anyNamed('pending'),
+        uploadUri: anyNamed('uploadUri'),
+        strategy: anyNamed('strategy'),
+      )).thenAnswer((invocation) async =>
+          (invocation.namedArguments[#pending] as PendingDriveTransfer)
+              .doc
+              .id !=
+          'c');
+
+      expect(await buildPipeline().transfer(docs), isTrue);
+      await settle();
+
+      final success = verify(toastManager.showMessageSuccess(captureAny))
+          .captured
+          .single as DriveAttachSuccess;
+      expect(success.attachedCount, 2);
+    });
+
+    test('Should stay quiet when nothing landed', () async {
+      when(transferRunner.run(
+        pending: anyNamed('pending'),
+        uploadUri: anyNamed('uploadUri'),
+        strategy: anyNamed('strategy'),
+      )).thenAnswer((_) async => false);
+
+      expect(await buildPipeline().transfer([docOf('a')]), isTrue);
+      await settle();
+
+      verifyNever(toastManager.showMessageSuccess(any));
+    });
+
+    test('Should run each enqueued transfer against the selected strategy', () async {
+      when(transferRunner.run(
+        pending: anyNamed('pending'),
+        uploadUri: anyNamed('uploadUri'),
+        strategy: anyNamed('strategy'),
+      )).thenAnswer((_) async => true);
+
+      await buildPipeline().transfer([docOf('a'), docOf('b')]);
+      await settle();
+
+      verify(transferRunner.run(
+        pending: anyNamed('pending'),
+        uploadUri: uploadUri!,
+        strategy: strategy,
+      )).called(2);
+    });
+  });
+}

--- a/test/features/composer/presentation/manager/drive_transfer_pipeline_test.dart
+++ b/test/features/composer/presentation/manager/drive_transfer_pipeline_test.dart
@@ -11,6 +11,7 @@ import 'package:tmail_ui_user/features/composer/presentation/manager/drive_docum
 import 'package:tmail_ui_user/features/composer/presentation/manager/drive_transfer_pipeline.dart';
 import 'package:tmail_ui_user/features/upload/data/network/file_uploader.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
+import 'package:tmail_ui_user/features/upload/presentation/controller/upload_controller.dart';
 import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_upload_validation_service.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:uuid/uuid.dart';
@@ -49,12 +50,14 @@ class _FakeStrategy extends DriveTransferStrategy<StagedDriveFile> {
   MockSpec<DriveDocumentTransferRunner>(),
   MockSpec<Uuid>(),
   MockSpec<ToastManager>(),
+  MockSpec<UploadController>(),
 ])
 void main() {
   late MockAttachmentUploadValidationService validationService;
   late MockDriveTransferStrategyFactory strategyFactory;
   late MockDriveDocumentTransferRunner transferRunner;
   late MockToastManager toastManager;
+  late MockUploadController uploadController;
   late _FakeStrategy strategy;
   late Uri? uploadUri;
 
@@ -98,6 +101,7 @@ void main() {
     strategyFactory = MockDriveTransferStrategyFactory();
     transferRunner = MockDriveDocumentTransferRunner();
     toastManager = MockToastManager();
+    uploadController = MockUploadController();
     strategy = _FakeStrategy();
     uploadUri = Uri.parse('https://jmap.example.com/upload');
 
@@ -105,6 +109,7 @@ void main() {
     Get.put<ToastManager>(toastManager);
 
     when(transferRunner.canAuthenticate).thenReturn(true);
+    when(transferRunner.uploadController).thenReturn(uploadController);
     when(strategyFactory.create(uploader: anyNamed('uploader')))
         .thenReturn(strategy);
     when(transferRunner.enqueue(any)).thenAnswer((invocation) =>
@@ -244,6 +249,32 @@ void main() {
       await settle();
 
       verifyNever(toastManager.showMessageSuccess(any));
+    });
+
+    test('Should toast the batch once for every failure, not per file', () async {
+      when(transferRunner.run(
+        pending: anyNamed('pending'),
+        uploadUri: anyNamed('uploadUri'),
+        strategy: anyNamed('strategy'),
+      )).thenAnswer((_) async => DriveTransferResult.failed);
+
+      await buildPipeline().transfer([docOf('a'), docOf('b'), docOf('c')]);
+      await settle();
+
+      verify(uploadController.showDriveTransferFailureToast()).called(1);
+    });
+
+    test('Should not toast a failure when every transfer was cancelled', () async {
+      when(transferRunner.run(
+        pending: anyNamed('pending'),
+        uploadUri: anyNamed('uploadUri'),
+        strategy: anyNamed('strategy'),
+      )).thenAnswer((_) async => DriveTransferResult.cancelled);
+
+      await buildPipeline().transfer([docOf('a')]);
+      await settle();
+
+      verifyNever(uploadController.showDriveTransferFailureToast());
     });
 
     test('Should run each enqueued transfer against the selected strategy', () async {

--- a/test/features/composer/presentation/manager/drive_transfer_pipeline_test.dart
+++ b/test/features/composer/presentation/manager/drive_transfer_pipeline_test.dart
@@ -277,6 +277,18 @@ void main() {
       verifyNever(uploadController.showDriveTransferFailureToast());
     });
 
+    test('Should not let an escaped worker error become unhandled', () async {
+      when(transferRunner.run(
+        pending: anyNamed('pending'),
+        uploadUri: anyNamed('uploadUri'),
+        strategy: anyNamed('strategy'),
+      )).thenAnswer((_) => throw StateError('boom'));
+
+      // No uncaught error means the batch's try/catch swallowed it.
+      await buildPipeline().transfer([docOf('a')]);
+      await settle();
+    });
+
     test('Should run each enqueued transfer against the selected strategy', () async {
       when(transferRunner.run(
         pending: anyNamed('pending'),

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -1,4 +1,5 @@
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:core/data/constants/constant.dart';
@@ -3815,6 +3816,129 @@ void main() {
         );
       },
     );
+  });
+
+  // ============================================================
+  // currentAuthorizationHeader + onRequest
+  // ============================================================
+  group('currentAuthorizationHeader + onRequest', () {
+    const userName = 'alice@domain.tld';
+    const password = '12345';
+    final basicHeaderValue =
+        'Basic ${base64Encode(utf8.encode('$userName:$password'))}';
+
+    /// Captures the headers as they leave the auth interceptor, so a test can
+    /// assert both what is written and what is left untouched.
+    Map<String, dynamic> sendRequestAndCaptureHeaders() {
+      final sentHeaders = <String, dynamic>{};
+      dio.interceptors.add(InterceptorsWrapper(
+        onRequest: (options, handler) {
+          sentHeaders.addAll(options.headers);
+          handler.next(options);
+        },
+      ));
+      dioAdapter.onPost(
+        baseUrl,
+        (server) => server.reply(responseStatusCode200, dataRequestSuccessfully),
+      );
+      return sentHeaders;
+    }
+
+    test('should return the basic header WHEN basic authorization is set', () {
+      authorizationInterceptors.setBasicAuthorization(
+        UserName(userName),
+        Password(password),
+      );
+
+      expect(authorizationInterceptors.currentAuthorizationHeader, basicHeaderValue);
+    });
+
+    test('should return the bearer header WHEN the OIDC token is still valid', () {
+      authorizationInterceptors.setTokenAndAuthorityOidc(
+        newToken: OIDCFixtures.tokenOidcNotExpiredYet,
+        newConfig: OIDCFixtures.oidcConfiguration,
+      );
+
+      expect(
+        authorizationInterceptors.currentAuthorizationHeader,
+        'Bearer ${OIDCFixtures.tokenOidcNotExpiredYet.token}',
+      );
+    });
+
+    test('should return NULL WHEN the OIDC token is empty', () {
+      authorizationInterceptors.setTokenAndAuthorityOidc(
+        newToken: OIDCFixtures.tokenOidcExpiredTimeAndTokenEmpty,
+        newConfig: OIDCFixtures.oidcConfiguration,
+      );
+
+      expect(authorizationInterceptors.currentAuthorizationHeader, isNull);
+    });
+
+    test('should return the bearer header WHEN the OIDC token is expired but not empty', () {
+      authorizationInterceptors.setTokenAndAuthorityOidc(
+        newToken: OIDCFixtures.tokenOidcExpiredTime,
+        newConfig: OIDCFixtures.oidcConfiguration,
+      );
+
+      // Expiry is `onError`'s business: the request goes out with the stale
+      // token and is retried after the refresh it triggers.
+      expect(
+        authorizationInterceptors.currentAuthorizationHeader,
+        'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+      );
+    });
+
+    test('should return NULL WHEN there is no authentication', () {
+      expect(authorizationInterceptors.authenticationType, AuthenticationType.none);
+      expect(authorizationInterceptors.currentAuthorizationHeader, isNull);
+    });
+
+    test('should send the basic header WHEN basic authorization is set', () async {
+      authorizationInterceptors.setBasicAuthorization(
+        UserName(userName),
+        Password(password),
+      );
+      final sentHeaders = sendRequestAndCaptureHeaders();
+
+      await dio.post(baseUrl);
+
+      expect(sentHeaders[HttpHeaders.authorizationHeader], basicHeaderValue);
+    });
+
+    test('should send the bearer header WHEN the OIDC token is still valid', () async {
+      authorizationInterceptors.setTokenAndAuthorityOidc(
+        newToken: OIDCFixtures.tokenOidcNotExpiredYet,
+        newConfig: OIDCFixtures.oidcConfiguration,
+      );
+      final sentHeaders = sendRequestAndCaptureHeaders();
+
+      await dio.post(baseUrl);
+
+      expect(
+        sentHeaders[HttpHeaders.authorizationHeader],
+        'Bearer ${OIDCFixtures.tokenOidcNotExpiredYet.token}',
+      );
+    });
+
+    test('should NOT add the authorization header WHEN there is no authentication', () async {
+      final sentHeaders = sendRequestAndCaptureHeaders();
+
+      await dio.post(baseUrl);
+
+      expect(sentHeaders.containsKey(HttpHeaders.authorizationHeader), isFalse);
+    });
+
+    test('should NOT add the authorization header WHEN the OIDC token is empty', () async {
+      authorizationInterceptors.setTokenAndAuthorityOidc(
+        newToken: OIDCFixtures.tokenOidcExpiredTimeAndTokenEmpty,
+        newConfig: OIDCFixtures.oidcConfiguration,
+      );
+      final sentHeaders = sendRequestAndCaptureHeaders();
+
+      await dio.post(baseUrl);
+
+      expect(sentHeaders.containsKey(HttpHeaders.authorizationHeader), isFalse);
+    });
   });
 
   tearDown(() {

--- a/test/features/upload/presentation/controller/upload_controller_drive_progress_test.dart
+++ b/test/features/upload/presentation/controller/upload_controller_drive_progress_test.dart
@@ -191,6 +191,82 @@ void main() {
     });
   });
 
+  group('UploadController::progress rebuilds::', () {
+    late int emissions;
+
+    setUp(() {
+      emissions = 0;
+      uploadController.listUploadAttachments.listen((_) => emissions++);
+    });
+
+    test('Should rebuild at most once per percent over a chunked download', () async {
+      const total = 100000;
+      for (var received = 0; received <= total; received += 100) {
+        uploadController.updateDownloadProgress(
+          taskId: taskId,
+          received: received,
+          total: total,
+        );
+      }
+      await Future<void>.delayed(Duration.zero);
+
+      expect(progressOf(taskId), 50);
+      // 1000 callbacks, but the download leg only spans 51 distinct percents.
+      expect(emissions, lessThanOrEqualTo(51));
+    });
+
+    test('Should not rebuild when a chunk moves nothing the chip renders', () async {
+      uploadController.updateDownloadProgress(
+        taskId: taskId,
+        received: 1000,
+        total: 2000,
+      );
+      await Future<void>.delayed(Duration.zero);
+      final emissionsAfterFirst = emissions;
+
+      uploadController.updateDownloadProgress(
+        taskId: taskId,
+        received: 1000,
+        total: 2000,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emissions, emissionsAfterFirst);
+    });
+
+    test('Should still rebuild when only the status changes', () async {
+      uploadController.updateDownloadProgress(
+        taskId: taskId,
+        received: 2000,
+        total: 2000,
+      );
+      await Future<void>.delayed(Duration.zero);
+      final emissionsAfterDownload = emissions;
+
+      // Same percent, so only the flip to uploading justifies the rebuild.
+      uploadController.updateUploadProgress(taskId: taskId, sent: 0, total: 2000);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(statusOf(taskId), UploadFileStatus.uploading);
+      expect(progressOf(taskId), 50);
+      expect(emissions, greaterThan(emissionsAfterDownload));
+    });
+
+    test('Should ignore progress for a task that is no longer listed', () {
+      uploadController.deleteFileUploaded(taskId);
+
+      expect(
+        () => uploadController.updateDownloadProgress(
+          taskId: taskId,
+          received: 100,
+          total: 2000,
+        ),
+        returnsNormally,
+      );
+      expect(uploadController.listUploadAttachments, isEmpty);
+    });
+  });
+
   group('UploadController::cancel on close::', () {
     const pendingTaskId = UploadTaskId('pending-task');
     const doneTaskId = UploadTaskId('done-task');

--- a/test/features/upload/presentation/controller/upload_controller_drive_progress_test.dart
+++ b/test/features/upload/presentation/controller/upload_controller_drive_progress_test.dart
@@ -90,7 +90,7 @@ void main() {
 
   group('UploadController::drive transfer chip::', () {
     test('Should show the placeholder as downloading at zero progress', () {
-      expect(statusOf(taskId), UploadFileStatus.downloading);
+      expect(statusOf(taskId), UploadFileStatus.fetching);
       expect(progressOf(taskId), 0);
       expect(uploadController.listUploadAttachments, hasLength(1));
     });
@@ -113,7 +113,7 @@ void main() {
       );
 
       expect(progressOf(taskId), 50);
-      expect(statusOf(taskId), UploadFileStatus.downloading);
+      expect(statusOf(taskId), UploadFileStatus.fetching);
     });
 
     test('Should leave progress untouched when the total length is unknown', () {

--- a/test/features/upload/presentation/controller/upload_controller_drive_progress_test.dart
+++ b/test/features/upload/presentation/controller/upload_controller_drive_progress_test.dart
@@ -126,6 +126,23 @@ void main() {
       expect(progressOf(taskId), 0);
     });
 
+    test('Should hold the bar where it stands when the upload length goes unknown midway', () {
+      uploadController.updateUploadProgress(
+        taskId: taskId,
+        sent: 1200,
+        total: 2000,
+      );
+      expect(progressOf(taskId), 80);
+
+      uploadController.updateUploadProgress(
+        taskId: taskId,
+        sent: 1400,
+        total: 0,
+      );
+
+      expect(progressOf(taskId), 80);
+    });
+
     test('Should resume from the halfway mark when the upload starts', () {
       uploadController.updateDownloadProgress(
         taskId: taskId,

--- a/test/features/upload/presentation/controller/upload_controller_drive_progress_test.dart
+++ b/test/features/upload/presentation/controller/upload_controller_drive_progress_test.dart
@@ -1,4 +1,5 @@
 import 'package:core/data/network/config/dynamic_url_interceptors.dart';
+import 'package:dio/dio.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/app_toast.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
@@ -77,7 +78,7 @@ void main() {
     Get.put<ToastManager>(MockToastManager());
     Get.put<TwakeAppManager>(MockTwakeAppManager());
 
-    uploadController = UploadController(MockUploadAttachmentInteractor());
+    uploadController = Get.put(UploadController(MockUploadAttachmentInteractor()));
     uploadController.addDownloadingPlaceholder(
       taskId: taskId,
       fileName: 'Photo.jpg',
@@ -187,6 +188,64 @@ void main() {
 
       expect(uploadController.getUploadFileId(taskId), isNull);
       expect(uploadController.listUploadAttachments, isEmpty);
+    });
+  });
+
+  group('UploadController::cancel on close::', () {
+    const pendingTaskId = UploadTaskId('pending-task');
+    const doneTaskId = UploadTaskId('done-task');
+
+    late CancelToken pendingToken;
+    late CancelToken doneToken;
+
+    setUp(() {
+      pendingToken = CancelToken();
+      doneToken = CancelToken();
+
+      uploadController.addDownloadingPlaceholder(
+        taskId: pendingTaskId,
+        fileName: 'Pending.pdf',
+        fileSize: 4000,
+        cancelToken: pendingToken,
+      );
+      uploadController.addDownloadingPlaceholder(
+        taskId: doneTaskId,
+        fileName: 'Done.pdf',
+        fileSize: 4000,
+        cancelToken: doneToken,
+      );
+      uploadController.completeUploadedFile(
+        taskId: doneTaskId,
+        attachment: attachmentOf('blob-done'),
+      );
+    });
+
+    test('Should cancel every unfinished transfer when the composer closes', () async {
+      await Get.delete<UploadController>();
+
+      expect(pendingToken.isCancelled, isTrue);
+    });
+
+    test('Should leave a finished transfer alone when the composer closes', () async {
+      await Get.delete<UploadController>();
+
+      expect(doneToken.isCancelled, isFalse);
+    });
+
+    test('Should ignore a transfer reporting back after the composer closed', () async {
+      await Get.delete<UploadController>();
+
+      expect(
+        () {
+          uploadController.updateDownloadProgress(
+            taskId: pendingTaskId,
+            received: 100,
+            total: 4000,
+          );
+          uploadController.deleteFileUploaded(pendingTaskId);
+        },
+        returnsNormally,
+      );
     });
   });
 }

--- a/test/features/upload/presentation/controller/upload_controller_drive_progress_test.dart
+++ b/test/features/upload/presentation/controller/upload_controller_drive_progress_test.dart
@@ -18,6 +18,7 @@ import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_
 import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
 import 'package:tmail_ui_user/features/upload/presentation/controller/upload_controller.dart';
+import 'package:tmail_ui_user/features/upload/presentation/model/drive_transfer_placeholder.dart';
 import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_status.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
@@ -58,6 +59,20 @@ void main() {
   int? progressOf(UploadTaskId id) =>
       uploadController.getUploadFileId(id)?.uploadingProgress;
 
+  DriveTransferPlaceholder placeholderOf(
+    UploadTaskId id, {
+    String fileName = 'Photo.jpg',
+    String? mimeType,
+    CancelToken? cancelToken,
+  }) =>
+      DriveTransferPlaceholder(
+        taskId: id,
+        fileName: fileName,
+        fileSize: 2000,
+        mimeType: mimeType,
+        cancelToken: cancelToken,
+      );
+
   setUp(() {
     Get.testMode = true;
     Get.put<CachingManager>(MockCachingManager());
@@ -79,21 +94,52 @@ void main() {
     Get.put<TwakeAppManager>(MockTwakeAppManager());
 
     uploadController = Get.put(UploadController(MockUploadAttachmentInteractor()));
-    uploadController.addDownloadingPlaceholder(
-      taskId: taskId,
-      fileName: 'Photo.jpg',
-      fileSize: 2000,
-      mimeType: 'image/jpeg',
-    );
+    uploadController.addDownloadingPlaceholders([
+      placeholderOf(taskId, fileName: 'Photo.jpg', mimeType: 'image/jpeg'),
+    ]);
   });
 
   tearDown(Get.reset);
 
   group('UploadController::drive transfer chip::', () {
-    test('Should show the placeholder as downloading at zero progress', () {
-      expect(statusOf(taskId), UploadFileStatus.fetching);
+    test('Should show the placeholder as queued at zero progress', () {
+      expect(statusOf(taskId), UploadFileStatus.waiting);
       expect(progressOf(taskId), 0);
       expect(uploadController.listUploadAttachments, hasLength(1));
+    });
+
+    test('Should flip a queued placeholder to downloading on its first byte', () {
+      uploadController.updateDownloadProgress(
+        taskId: taskId,
+        received: 100,
+        total: 2000,
+      );
+
+      expect(statusOf(taskId), UploadFileStatus.fetching);
+    });
+
+    test('Should show every picked file at once for a single rebuild', () async {
+      var emissions = 0;
+      uploadController.listUploadAttachments.listen((_) => emissions++);
+
+      uploadController.addDownloadingPlaceholders(
+        List.generate(10, (index) => placeholderOf(UploadTaskId('batch-$index'))),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(uploadController.listUploadAttachments, hasLength(11));
+      expect(emissions, 1);
+    });
+
+    test('Should do nothing when the picked batch is empty', () async {
+      var emissions = 0;
+      uploadController.listUploadAttachments.listen((_) => emissions++);
+
+      uploadController.addDownloadingPlaceholders([]);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(uploadController.listUploadAttachments, hasLength(1));
+      expect(emissions, 0);
     });
 
     test('Should map a half-received download onto a quarter of the bar', () {
@@ -278,18 +324,11 @@ void main() {
       pendingToken = CancelToken();
       doneToken = CancelToken();
 
-      uploadController.addDownloadingPlaceholder(
-        taskId: pendingTaskId,
-        fileName: 'Pending.pdf',
-        fileSize: 4000,
-        cancelToken: pendingToken,
-      );
-      uploadController.addDownloadingPlaceholder(
-        taskId: doneTaskId,
-        fileName: 'Done.pdf',
-        fileSize: 4000,
-        cancelToken: doneToken,
-      );
+      uploadController.addDownloadingPlaceholders([
+        placeholderOf(pendingTaskId,
+            fileName: 'Pending.pdf', cancelToken: pendingToken),
+        placeholderOf(doneTaskId, fileName: 'Done.pdf', cancelToken: doneToken),
+      ]);
       uploadController.completeUploadedFile(
         taskId: doneTaskId,
         attachment: attachmentOf('blob-done'),

--- a/test/features/upload/presentation/controller/upload_controller_drive_progress_test.dart
+++ b/test/features/upload/presentation/controller/upload_controller_drive_progress_test.dart
@@ -1,0 +1,175 @@
+import 'package:core/data/network/config/dynamic_url_interceptors.dart';
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/app_toast.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
+import 'package:mockito/annotations.dart';
+import 'package:model/email/attachment.dart';
+import 'package:tmail_ui_user/features/caching/caching_manager.dart';
+import 'package:tmail_ui_user/features/composer/domain/usecases/upload_attachment_interactor.dart';
+import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oidc_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
+import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
+import 'package:tmail_ui_user/features/upload/presentation/controller/upload_controller.dart';
+import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_status.dart';
+import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
+import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
+import 'package:uuid/uuid.dart';
+
+import 'upload_controller_drive_progress_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<UploadAttachmentInteractor>(),
+  MockSpec<CachingManager>(),
+  MockSpec<LanguageCacheManager>(),
+  MockSpec<AuthorizationInterceptors>(),
+  MockSpec<DynamicUrlInterceptors>(),
+  MockSpec<DeleteCredentialInteractor>(),
+  MockSpec<LogoutOidcInteractor>(),
+  MockSpec<DeleteAuthorityOidcInteractor>(),
+  MockSpec<AppToast>(),
+  MockSpec<ImagePaths>(),
+  MockSpec<ResponsiveUtils>(),
+  MockSpec<Uuid>(),
+  MockSpec<ToastManager>(),
+  MockSpec<TwakeAppManager>(),
+])
+void main() {
+  late UploadController uploadController;
+  const taskId = UploadTaskId('drive-task');
+
+  Attachment attachmentOf(String blobId) => Attachment(
+        blobId: Id(blobId),
+        name: 'Photo.jpg',
+        size: UnsignedInt(2000),
+      );
+
+  UploadFileStatus? statusOf(UploadTaskId id) =>
+      uploadController.getUploadFileId(id)?.uploadStatus;
+
+  int? progressOf(UploadTaskId id) =>
+      uploadController.getUploadFileId(id)?.uploadingProgress;
+
+  setUp(() {
+    Get.testMode = true;
+    Get.put<CachingManager>(MockCachingManager());
+    Get.put<LanguageCacheManager>(MockLanguageCacheManager());
+    Get.put<AuthorizationInterceptors>(MockAuthorizationInterceptors());
+    Get.put<AuthorizationInterceptors>(
+      MockAuthorizationInterceptors(),
+      tag: BindingTag.isolateTag,
+    );
+    Get.put<DynamicUrlInterceptors>(MockDynamicUrlInterceptors());
+    Get.put<DeleteCredentialInteractor>(MockDeleteCredentialInteractor());
+    Get.put<LogoutOidcInteractor>(MockLogoutOidcInteractor());
+    Get.put<DeleteAuthorityOidcInteractor>(MockDeleteAuthorityOidcInteractor());
+    Get.put<AppToast>(MockAppToast());
+    Get.put<ImagePaths>(MockImagePaths());
+    Get.put<ResponsiveUtils>(MockResponsiveUtils());
+    Get.put<Uuid>(MockUuid());
+    Get.put<ToastManager>(MockToastManager());
+    Get.put<TwakeAppManager>(MockTwakeAppManager());
+
+    uploadController = UploadController(MockUploadAttachmentInteractor());
+    uploadController.addDownloadingPlaceholder(
+      taskId: taskId,
+      fileName: 'Photo.jpg',
+      fileSize: 2000,
+      mimeType: 'image/jpeg',
+    );
+  });
+
+  tearDown(Get.reset);
+
+  group('UploadController::drive transfer chip::', () {
+    test('Should show the placeholder as downloading at zero progress', () {
+      expect(statusOf(taskId), UploadFileStatus.downloading);
+      expect(progressOf(taskId), 0);
+      expect(uploadController.listUploadAttachments, hasLength(1));
+    });
+
+    test('Should map a half-received download onto a quarter of the bar', () {
+      uploadController.updateDownloadProgress(
+        taskId: taskId,
+        received: 1000,
+        total: 2000,
+      );
+
+      expect(progressOf(taskId), 25);
+    });
+
+    test('Should map a fully received download onto the halfway mark', () {
+      uploadController.updateDownloadProgress(
+        taskId: taskId,
+        received: 2000,
+        total: 2000,
+      );
+
+      expect(progressOf(taskId), 50);
+      expect(statusOf(taskId), UploadFileStatus.downloading);
+    });
+
+    test('Should leave progress untouched when the total length is unknown', () {
+      uploadController.updateDownloadProgress(
+        taskId: taskId,
+        received: 500,
+        total: 0,
+      );
+
+      expect(progressOf(taskId), 0);
+    });
+
+    test('Should resume from the halfway mark when the upload starts', () {
+      uploadController.updateDownloadProgress(
+        taskId: taskId,
+        received: 2000,
+        total: 2000,
+      );
+      uploadController.updateUploadProgress(taskId: taskId, sent: 0, total: 2000);
+
+      expect(statusOf(taskId), UploadFileStatus.uploading);
+      expect(progressOf(taskId), 50);
+    });
+
+    test('Should never drop below the halfway mark while uploading', () {
+      uploadController.updateUploadProgress(
+        taskId: taskId,
+        sent: 500,
+        total: 2000,
+      );
+
+      expect(progressOf(taskId), greaterThanOrEqualTo(50));
+      // A quarter through the upload leg, mapped onto the 50-100 band: 62.5,
+      // which `round()` takes away from zero.
+      expect(progressOf(taskId), 63);
+    });
+
+    test('Should finish at a full bar with the attachment attached', () {
+      final attachment = attachmentOf('blob-1');
+
+      uploadController.completeUploadedFile(
+        taskId: taskId,
+        attachment: attachment,
+      );
+
+      expect(statusOf(taskId), UploadFileStatus.succeed);
+      expect(progressOf(taskId), 100);
+      expect(uploadController.getUploadFileId(taskId)?.attachment, attachment);
+      expect(uploadController.attachmentsUploaded, [attachment]);
+    });
+
+    test('Should drop the chip when the transfer is deleted', () {
+      uploadController.deleteFileUploaded(taskId);
+
+      expect(uploadController.getUploadFileId(taskId), isNull);
+      expect(uploadController.listUploadAttachments, isEmpty);
+    });
+  });
+}

--- a/test/features/upload/presentation/validator/attachment_upload_validation_service_test.dart
+++ b/test/features/upload/presentation/validator/attachment_upload_validation_service_test.dart
@@ -248,6 +248,161 @@ void main() {
     });
   });
 
+  group('AttachmentUploadValidationService::validateBytes', () {
+    testWidgets('Should run onAllowed when the declared total is within limits',
+        (tester) async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      context = tester.element(find.byType(SizedBox));
+      final feedback = _RecordingFeedback();
+      var allowedCalled = false;
+
+      await buildService(
+        stateSource: const _FakeStateSource(hardLimitBytes: 10000),
+        feedback: feedback,
+      ).validateBytes(
+        context: context,
+        proposedAllAttachmentBytes: 300,
+        proposedRegularAttachmentBytes: 300,
+        onAllowed: () => allowedCalled = true,
+      );
+
+      expect(allowedCalled, isTrue);
+      expect(feedback.failureShown, isNull);
+      expect(feedback.promptsAsked, isEmpty);
+    });
+
+    testWidgets('Should show failure and skip onAllowed past the hard limit',
+        (tester) async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      context = tester.element(find.byType(SizedBox));
+      final feedback = _RecordingFeedback();
+      var allowedCalled = false;
+
+      await buildService(
+        stateSource: const _FakeStateSource(hardLimitBytes: 500),
+        feedback: feedback,
+      ).validateBytes(
+        context: context,
+        proposedAllAttachmentBytes: 600,
+        proposedRegularAttachmentBytes: 600,
+        onAllowed: () => allowedCalled = true,
+      );
+
+      expect(allowedCalled, isFalse);
+      expect(feedback.failureShown, isA<MaxEmailAttachmentSizeExceeded>());
+    });
+
+    testWidgets('Should run onAllowed once the user confirms the warning',
+        (tester) async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      context = tester.element(find.byType(SizedBox));
+      final feedback = _RecordingFeedback();
+      var allowedCalled = false;
+
+      await buildService(
+        stateSource: const _FakeStateSource(warningLimitBytes: 500),
+        feedback: feedback,
+      ).validateBytes(
+        context: context,
+        proposedAllAttachmentBytes: 600,
+        proposedRegularAttachmentBytes: 600,
+        onAllowed: () => allowedCalled = true,
+      );
+
+      expect(allowedCalled, isTrue);
+      expect(feedback.promptsAsked, [isA<LargeRegularAttachmentWarning>()]);
+    });
+
+    testWidgets('Should skip onAllowed when the user declines the warning',
+        (tester) async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      context = tester.element(find.byType(SizedBox));
+      final feedback = _RecordingFeedback(confirmed: false);
+      var allowedCalled = false;
+
+      await buildService(
+        stateSource: const _FakeStateSource(warningLimitBytes: 500),
+        feedback: feedback,
+      ).validateBytes(
+        context: context,
+        proposedAllAttachmentBytes: 600,
+        proposedRegularAttachmentBytes: 600,
+        onAllowed: () => allowedCalled = true,
+      );
+
+      expect(allowedCalled, isFalse);
+      expect(feedback.promptsAsked, [isA<LargeRegularAttachmentWarning>()]);
+    });
+
+    testWidgets('Should not warn when only the inline half exceeds the warning limit',
+        (tester) async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      context = tester.element(find.byType(SizedBox));
+      final feedback = _RecordingFeedback();
+      var allowedCalled = false;
+
+      await buildService(
+        stateSource: const _FakeStateSource(warningLimitBytes: 500),
+        feedback: feedback,
+      ).validateBytes(
+        context: context,
+        proposedAllAttachmentBytes: 600,
+        proposedRegularAttachmentBytes: 0,
+        onAllowed: () => allowedCalled = true,
+      );
+
+      expect(allowedCalled, isTrue);
+      expect(feedback.promptsAsked, isEmpty);
+    });
+
+    testWidgets('Should count the proposed bytes on top of what is already attached',
+        (tester) async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      context = tester.element(find.byType(SizedBox));
+      final feedback = _RecordingFeedback();
+      var allowedCalled = false;
+
+      await buildService(
+        stateSource: const _FakeStateSource(
+          currentAllAttachmentBytes: 400,
+          currentRegularAttachmentBytes: 400,
+          warningLimitBytes: 500,
+        ),
+        feedback: feedback,
+      ).validateBytes(
+        context: context,
+        proposedAllAttachmentBytes: 200,
+        proposedRegularAttachmentBytes: 200,
+        onAllowed: () => allowedCalled = true,
+      );
+
+      expect(allowedCalled, isTrue);
+      expect(feedback.promptsAsked, [isA<LargeRegularAttachmentWarning>()]);
+    });
+
+    test('Should run onAllowed with no BuildContext to build feedback from', () async {
+      var feedbackBuilderCalled = false;
+      var allowedCalled = false;
+
+      final service = AttachmentUploadValidationService(
+        stateSource: const _FakeStateSource(hardLimitBytes: 10000),
+        feedbackBuilder: (_) {
+          feedbackBuilderCalled = true;
+          return _RecordingFeedback();
+        },
+      );
+
+      await service.validateBytes(
+        proposedAllAttachmentBytes: 300,
+        proposedRegularAttachmentBytes: 300,
+        onAllowed: () => allowedCalled = true,
+      );
+
+      expect(allowedCalled, isTrue);
+      expect(feedbackBuilderCalled, isFalse);
+    });
+  });
+
   group('AttachmentUploadValidationService without a BuildContext', () {
     test(
         'Should still call onAllowed and never build feedback\n'

--- a/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy.dart
+++ b/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy.dart
@@ -15,6 +15,14 @@ import 'package:workplace/domain/entity/drive_document.dart';
 /// leak temp storage nor hand a strategy a staged file it can't consume. [T]
 /// pins that variant, keeping the pairing a compile-time concern.
 abstract class DriveTransferStrategy<T extends StagedDriveFile> {
+  /// How many transfers may run at once under this strategy. Lives here so
+  /// orchestration never has to name a platform-specific strategy type — the
+  /// cost of a concurrent transfer is the strategy's own business.
+  ///
+  /// The default is the conservative one: a strategy that holds a whole file
+  /// in memory per transfer.
+  int get maxConcurrentTransfers => 2;
+
   Future<Attachment> transfer(DriveTransferRequest request) async {
     final staged = await stage(
       doc: request.doc,

--- a/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy_factory.dart
+++ b/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy_factory.dart
@@ -1,0 +1,7 @@
+/// Selects the drive-transfer strategy for the current platform capability.
+///
+/// `create()` returns `null` when the platform has no staging strategy yet:
+/// callers keep the link-only behaviour for downloadable documents instead of
+/// branching on platform themselves.
+export 'drive_transfer_strategy_factory_mobile.dart'
+    if (dart.library.html) 'drive_transfer_strategy_factory_web.dart';

--- a/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy_factory_mobile.dart
+++ b/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy_factory_mobile.dart
@@ -8,6 +8,11 @@ import 'package:workplace/data/model/workplace_type_defs.dart';
 class DriveTransferStrategyFactory {
   const DriveTransferStrategyFactory();
 
+  /// The single source of truth for whether this platform can stage
+  /// downloadable drive documents — callers must not re-derive it (e.g. via
+  /// `kIsWeb`) independently.
+  bool get canStage => false;
+
   DriveTransferStrategy<StagedDriveFile>? create(
           {required StagedFileUploader uploader}) =>
       null;

--- a/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy_factory_mobile.dart
+++ b/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy_factory_mobile.dart
@@ -1,0 +1,14 @@
+import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy.dart';
+import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
+import 'package:workplace/data/model/workplace_type_defs.dart';
+
+/// Mobile/desktop branch of the conditional export in
+/// `drive_transfer_strategy_factory.dart`. IO temp-file staging is not
+/// available yet, so downloadable documents keep the link-only behaviour.
+class DriveTransferStrategyFactory {
+  const DriveTransferStrategyFactory();
+
+  DriveTransferStrategy<StagedDriveFile>? create(
+          {required StagedFileUploader uploader}) =>
+      null;
+}

--- a/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy_factory_web.dart
+++ b/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy_factory_web.dart
@@ -29,7 +29,11 @@ class DriveTransferStrategyFactory {
 
   /// [uploader] backs the buffered fallback only; the OPFS strategy uploads
   /// through its own raw-XHR path.
-  DriveTransferStrategy<StagedDriveFile> create(
+  ///
+  /// Never null on web: one of the two strategies always applies. The
+  /// nullable return type is the mobile branch's "no staging strategy yet"
+  /// signal, shared so callers have one contract.
+  DriveTransferStrategy<StagedDriveFile>? create(
       {required StagedFileUploader uploader}) {
     _opfsSupported ??= _detectOpfsSupport();
     if (!_opfsSupported!) {

--- a/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy_factory_web.dart
+++ b/workplace/lib/data/datasource/drive_transfer/drive_transfer_strategy_factory_web.dart
@@ -27,6 +27,11 @@ class DriveTransferStrategyFactory {
   bool? _opfsSupported;
   bool _swept = false;
 
+  /// The single source of truth for whether this platform can stage
+  /// downloadable drive documents — callers must not re-derive it (e.g. via
+  /// `kIsWeb`) independently.
+  bool get canStage => true;
+
   /// [uploader] backs the buffered fallback only; the OPFS strategy uploads
   /// through its own raw-XHR path.
   ///

--- a/workplace/lib/data/datasource/drive_transfer/opfs_drive_transfer_strategy.dart
+++ b/workplace/lib/data/datasource/drive_transfer/opfs_drive_transfer_strategy.dart
@@ -22,6 +22,11 @@ class OpfsDriveTransferStrategy extends DriveTransferStrategy<OpfsStagedFile> {
   final DriveFileStager<OpfsStagedFile> _stager;
   final OpfsDriveFileUploader _uploader;
 
+  /// Staging and uploading are both streamed through OPFS, so a concurrent
+  /// transfer costs disk residency rather than heap.
+  @override
+  int get maxConcurrentTransfers => 3;
+
   @protected
   @override
   Future<OpfsStagedFile> stage({

--- a/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
+++ b/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
@@ -1,4 +1,5 @@
 import 'package:core/utils/app_logger.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:workplace/data/model/workplace_intent_request.dart';
 import 'package:workplace/domain/entity/workplace_intent.dart';
@@ -42,13 +43,15 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
       // Captured up front: the caller may pop this context (e.g. a context
       // menu tile) before the intent future settles, disposing this state.
       final failingMessage = l10n.attachFromDriveFailingMessage;
-      const addAsAttachmentTitle = null; // TODO: Add attachment title here after implement 103. Attach Drive File as Attachment
       final theme = _resolveWorkplaceTheme(context);
       final filePickerConfig = WorkplaceFilePickerConfigRequest(
         sharingLink: WorkplaceActionConfigRequest(label: l10n.addAsLink),
-        downloadLink: addAsAttachmentTitle == null
-            ? null
-            : const WorkplaceActionConfigRequest(label: addAsAttachmentTitle),
+        // Web only: it is the one platform with a staging strategy, so
+        // offering the action elsewhere would only ever reach the
+        // "not available yet" message.
+        downloadLink: kIsWeb
+            ? WorkplaceActionConfigRequest(label: l10n.addAsAttachment)
+            : null,
         theme: WorkplaceThemeConfigRequest.fromEntity(theme),
       );
       DrivePickOutcome? outcome;

--- a/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
+++ b/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
@@ -28,6 +28,12 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
 
   OnPickDriveCallback? get pickerOnCallback => null;
 
+  /// Whether this platform can stage a picked download as a real attachment.
+  /// Defaults to the web-only capability; a caller wired to
+  /// `DriveTransferStrategyFactory.canStage` should override this instead of
+  /// deciding it again independently.
+  bool get canStageDownload => kIsWeb;
+
   bool _modalOpen = false;
 
   Future<void> onPickerTap() async {
@@ -46,10 +52,9 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
       final theme = _resolveWorkplaceTheme(context);
       final filePickerConfig = WorkplaceFilePickerConfigRequest(
         sharingLink: WorkplaceActionConfigRequest(label: l10n.addAsLink),
-        // Web only: it is the one platform with a staging strategy, so
-        // offering the action elsewhere would only ever reach the
-        // "not available yet" message.
-        downloadLink: kIsWeb
+        // Offering the action where staging isn't supported would only ever
+        // reach the "not available yet" message.
+        downloadLink: canStageDownload
             ? WorkplaceActionConfigRequest(label: l10n.addAsAttachment)
             : null,
         theme: WorkplaceThemeConfigRequest.fromEntity(theme),

--- a/workplace/lib/presentation/model/drive_pick_state.dart
+++ b/workplace/lib/presentation/model/drive_pick_state.dart
@@ -14,6 +14,16 @@ final class DrivePickResult extends DrivePickState {
   List<Object> get props => [documents];
 }
 
+/// A pick whose downloadable documents finished transferring, carrying how
+/// many of them actually became attachments.
+final class DriveAttachSuccess extends DrivePickState implements Success {
+  final int attachedCount;
+  DriveAttachSuccess(this.attachedCount);
+
+  @override
+  List<Object?> get props => [attachedCount];
+}
+
 final class DrivePickFailure extends DrivePickState implements FeatureFailure {
   final Object error;
   final String? message;


### PR DESCRIPTION
## Issue
- #4728 

## Description
Drive documents picked with only a `downloadLink` are downloaded into OPFS (or buffered, when
OPFS is unavailable) and uploaded as real email attachments, instead of falling back to the
"not available yet" message.

- `DriveAttachmentHandler` partitions a pick by link kind — `sharingLink` wins when a document
  carries both — and hands the download-only half to the new `DriveTransferPipeline`.
- `DriveTransferPipeline` selects a platform strategy through `DriveTransferStrategyFactory`
  and runs one bounded-concurrency pipeline per batch (OPFS 3 at a time, buffered 2). A `null`
  strategy means the platform has no staging support, so the caller keeps link-only behaviour;
  the picker's "Add as attachment" action is gated to web for the same reason, leaving mobile
  behaviour unchanged.
- Each file gets its chip immediately and fills a single bar across both legs: the new
  `downloading` status maps onto 0–50, `uploading` onto 50–100. A failing file drops its own
  chip only; its siblings continue.
- The batch is gated on its declared total through the existing attachment validator before any
  download starts (`AttachmentUploadValidationService.validateBytes`).
- `AuthorizationInterceptors` now exposes `currentAuthorizationHeader`, so the OPFS raw-XHR
  upload builds the same Basic/Bearer header `onRequest` does — built in one place.

## Demo

https://github.com/user-attachments/assets/53b55b9b-b81e-4a1b-91e5-6b1d4ac39b3e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added web support for downloading Drive documents and attaching them directly to composed content.
  * Drive transfers show placeholders with download and upload progress.
  * Multiple documents can transfer concurrently.
  * Drive sharing links continue to insert directly into the composer.
  * Added localized success messages showing attached file counts.
  * Unsupported environments retain link-only behavior.

* **Bug Fixes**
  * Improved attachment validation, cancellation, failure cleanup, authorization, and invalid-link handling.
  * Progress indicators remain accurate and capped at 100%.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->