### PR TITLE
TF-4728 [Part 3] Purge OPFS drive staging on logout, and type quota failures

### DIFF
--- a/.github/workflows/analyze-test.yaml
+++ b/.github/workflows/analyze-test.yaml
@@ -19,6 +19,7 @@ env:
     workplace/test/presentation/view/drive_intent_web_view_modal_web_test.dart
     core/test/utils/html/editor_script/quoted_reply_enter_handler_script_browser_test.dart
     workplace/test/data/datasource/drive_transfer/drive_transfer_strategy_factory_web_test.dart
+    workplace/test/data/datasource/drive_transfer/opfs_file_ops_test.dart
     workplace/test/data/datasource/drive_transfer/opfs_drive_file_stager_test.dart
     workplace/test/data/datasource/drive_transfer/opfs_drive_file_uploader_test.dart
     workplace/test/data/datasource/drive_transfer/opfs_fetch_download_test.dart

--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -64,6 +64,7 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/app_routes.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:tmail_ui_user/main/utils/app_config.dart';
+import 'package:workplace/data/datasource/drive_transfer/drive_staging_purge.dart';
 import 'package:tmail_ui_user/main/universal_import/html_stub.dart' as html;
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
@@ -656,6 +657,9 @@ abstract class BaseController extends GetxController
           deleteCredentialInteractor.execute(),
         cachingManager.clearAll(),
         languageCacheManager.removeLanguage(),
+        // Drive documents staged for upload are persistent and origin-scoped
+        // on web, so they would otherwise carry into the next account.
+        purgeDriveStagingStorage(),
       ]);
       authorizationInterceptors.clear();
       authorizationIsolateInterceptors.clear();

--- a/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
+++ b/lib/features/composer/presentation/manager/drive_transfer_pipeline.dart
@@ -19,6 +19,7 @@ import 'package:workplace/data/datasource/drive_transfer/drive_transfer_strategy
 import 'package:workplace/data/datasource/drive_transfer/staged_drive_file.dart';
 import 'package:workplace/data/model/workplace_type_defs.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
+import 'package:workplace/domain/exceptions/workplace_exceptions.dart';
 
 /// Resolves the JMAP upload endpoint for the current session, or null when
 /// there is none yet.
@@ -156,16 +157,31 @@ class DriveTransferPipeline {
         taskId: taskId,
         attachment: attachment,
       );
-    } catch (error) {
+    } catch (error, stackTrace) {
       // A failing file drops its own chip and nothing else: an expired link or
       // a cancelled transfer must not take its siblings down with it.
-      logWarning('DriveTransferPipeline::_transferOne(${doc.name}): $error');
+      _logTransferFailure(doc, error, stackTrace);
       if (cancelToken.isCancelled) {
         // The user asked for this one to stop, so no error toast.
         _uploadController.deleteFileUploaded(taskId);
       } else {
         _uploadController.failDriveTransfer(taskId);
       }
+    }
+  }
+
+  void _logTransferFailure(DriveDocument doc, Object error, StackTrace stackTrace) {
+    // Running out of browser storage is a condition worth acting on, unlike
+    // an expired link or a cancelled transfer, so it is reported rather than
+    // just logged.
+    if (error is DriveStagingQuotaExceededException) {
+      logError(
+        'DriveTransferPipeline::_transferOne(${doc.name}): staging storage exhausted',
+        exception: error,
+        stackTrace: stackTrace,
+      );
+    } else {
+      logWarning('DriveTransferPipeline::_transferOne(${doc.name}): $error');
     }
   }
 

--- a/workplace/lib/data/datasource/drive_transfer/drive_staging_purge.dart
+++ b/workplace/lib/data/datasource/drive_transfer/drive_staging_purge.dart
@@ -1,0 +1,7 @@
+/// Removes every drive-staging entry this package owns.
+///
+/// The main app cannot import `package:web` code directly, so the web
+/// implementation is reached through this conditional export and is a no-op
+/// everywhere else.
+export 'drive_staging_purge_mobile.dart'
+    if (dart.library.html) 'drive_staging_purge_web.dart';

--- a/workplace/lib/data/datasource/drive_transfer/drive_staging_purge_mobile.dart
+++ b/workplace/lib/data/datasource/drive_transfer/drive_staging_purge_mobile.dart
@@ -1,0 +1,3 @@
+/// Non-web stub: staging storage is per-transfer temp files removed on every
+/// exit path, so there is nothing left to purge.
+Future<void> purgeDriveStagingStorage() async {}

--- a/workplace/lib/data/datasource/drive_transfer/drive_staging_purge_web.dart
+++ b/workplace/lib/data/datasource/drive_transfer/drive_staging_purge_web.dart
@@ -1,0 +1,22 @@
+import 'package:core/utils/app_logger.dart';
+import 'package:workplace/data/datasource/drive_transfer/opfs_feature_detection.dart';
+import 'package:workplace/data/datasource/drive_transfer/opfs_file_ops.dart';
+
+/// Removes every OPFS staging entry, whatever its age.
+///
+/// Staged documents are persistent and origin-scoped, so without this they
+/// outlive a logout and carry into the next account's session. Failures are
+/// logged, never rethrown: a logout must not be blocked by storage cleanup,
+/// and a browser without OPFS has nothing to clean.
+///
+/// Reaches for the implementations directly rather than through an injected
+/// port: purging is a logout concern with one caller, not one of the storage
+/// operations a transfer depends on.
+Future<void> purgeDriveStagingStorage() async {
+  try {
+    if (!OpfsFeatureDetection().isOpfsSupported()) return;
+    await OpfsFileOps().purgeAllTempFiles();
+  } catch (error) {
+    logWarning('purgeDriveStagingStorage: failed to purge staging storage: $error');
+  }
+}

--- a/workplace/lib/data/datasource/drive_transfer/opfs_drive_file_stager.dart
+++ b/workplace/lib/data/datasource/drive_transfer/opfs_drive_file_stager.dart
@@ -88,9 +88,9 @@ class OpfsDriveFileStager implements DriveFileStager<OpfsStagedFile> {
   /// The one place a staging failure is shaped, so callers only ever branch on
   /// [DioExceptionType]. Without it the OPFS half of the pipeline —
   /// `createTempFile`, `openWritable`, `writeChunk`, `closeWritable` — would
-  /// surface raw browser errors (`QuotaExceededError` on a full disk, a bare
-  /// `DOMException`) that no caller can classify. The download half already
-  /// arrives Dio-shaped and passes through untouched.
+  /// surface bare `DOMException`s that no caller can classify. The download
+  /// half already arrives Dio-shaped and passes through untouched, as do the
+  /// domain exceptions below.
   static Object _asDioFailure(Object error, CancelToken cancelToken, Uri url) {
     final requestOptions = RequestOptions(path: url.toString());
     // Checked first: a cancellation reaches here as whatever the browser threw
@@ -103,8 +103,11 @@ class OpfsDriveFileStager implements DriveFileStager<OpfsStagedFile> {
         reason: 'drive staging was cancelled',
       );
     }
-    // Carries its own received/expected counts; flattening it would lose them.
+    // Both carry information a caller acts on, so neither is flattened into a
+    // DioException: the first its received/expected counts, and the second the
+    // one staging failure `DriveTransferPipeline` reports rather than logs.
     if (error is DriveDownloadIncompleteException) return error;
+    if (error is DriveStagingQuotaExceededException) return error;
     if (error is DioException) return error;
     // Spelled out rather than via a `DioException` factory, which hardcodes
     // `error: null` and would drop the browser's own failure — the same reason

--- a/workplace/lib/data/datasource/drive_transfer/opfs_file_ops.dart
+++ b/workplace/lib/data/datasource/drive_transfer/opfs_file_ops.dart
@@ -5,6 +5,7 @@ import 'package:core/utils/app_logger.dart';
 import 'package:web/web.dart' as web;
 import 'package:workplace/data/datasource/drive_transfer/opfs_file_handle.dart';
 import 'package:workplace/data/datasource/drive_transfer/opfs_store.dart';
+import 'package:workplace/domain/exceptions/workplace_exceptions.dart';
 
 /// Marks an OPFS entry as this package's, so [OpfsFileOps.sweepStaleTempFiles]
 /// leaves the origin's other data alone.
@@ -18,6 +19,21 @@ extension type _DirectoryHandleKeys(JSObject _) implements JSObject {
 
 extension type _AsyncStringIterator(JSObject _) implements JSObject {
   external JSPromise<_AsyncIterationResult> next();
+}
+
+/// `package:web`'s `DOMException` is an extension type over [JSObject], so a
+/// caught quota error can only be recognised by reading its `name`.
+extension type _JsErrorName(JSObject _) implements JSObject {
+  external String? get name;
+}
+
+extension on Object {
+  /// True when this is a JS `DOMException` reporting an exhausted quota.
+  bool get isQuotaExceededError {
+    final jsError = this;
+    if (jsError is! JSObject) return false;
+    return _JsErrorName(jsError).name == 'QuotaExceededError';
+  }
 }
 
 extension type _AsyncIterationResult(JSObject _) implements JSObject {
@@ -61,12 +77,27 @@ class OpfsFileOps implements OpfsStore {
 
   @override
   Future<void> writeChunk(
-      web.FileSystemWritableFileStream stream, Uint8List chunk) =>
-      stream.write(chunk.toJS).toDart;
+          web.FileSystemWritableFileStream stream, Uint8List chunk) =>
+      _mappingQuotaError(() => stream.write(chunk.toJS).toDart);
 
   @override
   Future<void> closeWritable(web.FileSystemWritableFileStream stream) =>
-      stream.close().toDart;
+      _mappingQuotaError(() => stream.close().toDart);
+
+  /// A full quota surfaces as a raw JS `DOMException`, indistinguishable at
+  /// every layer above from a CORS or DNS failure unless it is typed here.
+  /// `package:web`'s `DOMException` is an extension type over `JSObject`, so
+  /// this is a name probe rather than a Dart `is` check.
+  Future<void> _mappingQuotaError(Future<void> Function() write) async {
+    try {
+      await write();
+    } catch (error) {
+      if (error.isQuotaExceededError) {
+        throw DriveStagingQuotaExceededException(error);
+      }
+      rethrow;
+    }
+  }
 
   @override
   Future<void> abortWritable(web.FileSystemWritableFileStream stream) =>
@@ -91,17 +122,10 @@ class OpfsFileOps implements OpfsStore {
   }) async {
     final root = await _opfsRoot();
     final cutoff = DateTime.now().subtract(olderThan);
-    final iterator = (root as _DirectoryHandleKeys).keys();
-    // Collected first: removing entries while iterating the same directory is
-    // not guaranteed to leave the iteration stable, which can skip entries.
-    final staleNames = <String>[];
-    while (true) {
-      final step = await iterator.next().toDart;
-      if (step.done) break;
-      final name = step.value;
-      if (name == null || !_isStaleTempFile(name, cutoff)) continue;
-      staleNames.add(name);
-    }
+    final staleNames = await _listTempFileNames(
+      root,
+      where: (name) => _isStaleTempFile(name, cutoff),
+    );
     for (final name in staleNames) {
       try {
         await root.removeEntry(name).toDart;
@@ -110,14 +134,52 @@ class OpfsFileOps implements OpfsStore {
       }
     }
   }
-}
 
-/// Names are `<prefix><microsSinceEpoch>_...`. A name that doesn't parse is
-/// left alone.
-bool _isStaleTempFile(String name, DateTime cutoff) {
-  if (!name.startsWith(opfsTempFilePrefix)) return false;
-  final micros = int.tryParse(
-      name.substring(opfsTempFilePrefix.length).split('_').first);
-  if (micros == null) return false;
-  return DateTime.fromMicrosecondsSinceEpoch(micros).isBefore(cutoff);
+  /// Removes every staging entry regardless of age.
+  ///
+  /// Staged documents are persistent and origin-scoped, so without this they
+  /// outlive a logout and carry into the next account's session. Stays scoped
+  /// to [opfsTempFilePrefix] so it can never touch the origin's other data.
+  /// An entry another tab holds open fails its removal — logged and skipped;
+  /// logout is global by intent.
+  Future<void> purgeAllTempFiles() async {
+    final root = await _opfsRoot();
+    for (final name in await _listTempFileNames(root)) {
+      try {
+        await root.removeEntry(name).toDart;
+      } catch (e) {
+        logWarning('OpfsFileOps: failed to purge temp file $name: $e');
+      }
+    }
+  }
+
+  /// Collected before removing anything: removing entries while iterating the
+  /// same directory is not guaranteed to leave the iteration stable, which can
+  /// skip entries.
+  Future<List<String>> _listTempFileNames(
+    web.FileSystemDirectoryHandle root, {
+    bool Function(String name)? where,
+  }) async {
+    final iterator = (root as _DirectoryHandleKeys).keys();
+    final names = <String>[];
+    while (true) {
+      final step = await iterator.next().toDart;
+      if (step.done) break;
+      final name = step.value;
+      if (name == null || !name.startsWith(opfsTempFilePrefix)) continue;
+      if (where != null && !where(name)) continue;
+      names.add(name);
+    }
+    return names;
+  }
+
+  /// Names are `<prefix><microsSinceEpoch>_...`. A name that doesn't parse is
+  /// left alone.
+  static bool _isStaleTempFile(String name, DateTime cutoff) {
+    if (!name.startsWith(opfsTempFilePrefix)) return false;
+    final micros = int.tryParse(
+        name.substring(opfsTempFilePrefix.length).split('_').first);
+    if (micros == null) return false;
+    return DateTime.fromMicrosecondsSinceEpoch(micros).isBefore(cutoff);
+  }
 }

--- a/workplace/lib/domain/exceptions/workplace_exceptions.dart
+++ b/workplace/lib/domain/exceptions/workplace_exceptions.dart
@@ -23,6 +23,18 @@ class DriveDownloadInsecureLinkException implements Exception {}
 
 class DriveDownloadEmptyResponseException implements Exception {}
 
+/// The browser refused a staging write because the origin's storage quota is
+/// exhausted. Distinguished from a network or CORS failure so it can be
+/// reported rather than lost among ordinary transfer errors.
+class DriveStagingQuotaExceededException implements Exception {
+  final Object? cause;
+
+  DriveStagingQuotaExceededException([this.cause]);
+
+  @override
+  String toString() => 'DriveStagingQuotaExceededException: $cause';
+}
+
 /// The response body ended before the declared `content-length` was reached,
 /// so the staged file is a truncated copy of the document.
 class DriveDownloadIncompleteException implements Exception {

--- a/workplace/test/data/datasource/drive_transfer/opfs_drive_file_stager_test.dart
+++ b/workplace/test/data/datasource/drive_transfer/opfs_drive_file_stager_test.dart
@@ -146,6 +146,30 @@ void main() {
     );
   });
 
+  test('lets a staging quota failure through unwrapped', () async {
+    // `DriveTransferPipeline` branches on this type to report an exhausted
+    // quota rather than log it like any other transfer error, so wrapping it
+    // in a DioException the way an unrecognised browser error is wrapped
+    // would silently downgrade the one staging failure the user can act on.
+    const content = 'hello opfs world';
+    final doc = DriveDocument(
+      id: 'doc-opfs-2c',
+      name: 'quota-exhausted.txt',
+      size: content.length,
+      mimeType: 'text/plain',
+      downloadLink: Uri.dataFromString(content, mimeType: 'text/plain'),
+    );
+
+    await expectLater(
+      OpfsDriveFileStager(store: _QuotaExceededStore()).stage(
+        doc: doc,
+        onDownloadProgress: (_, __) {},
+        cancelToken: CancelToken(),
+      ),
+      throwsA(isA<DriveStagingQuotaExceededException>()),
+    );
+  });
+
   test('removes the OPFS temp entry when the transfer fails mid-stream',
       () async {
     final store = _CountingRemoveStore();
@@ -861,6 +885,16 @@ class _FailingWriteStore extends OpfsFileOps {
   Future<void> writeChunk(
       web.FileSystemWritableFileStream stream, Uint8List chunk) async {
     throw StateError('write failed');
+  }
+}
+
+/// A full origin quota, already typed by [OpfsFileOps] before it reaches the
+/// stager — unlike [_FailingWriteStore], whose failure has no type to keep.
+class _QuotaExceededStore extends OpfsFileOps {
+  @override
+  Future<void> writeChunk(
+      web.FileSystemWritableFileStream stream, Uint8List chunk) async {
+    throw DriveStagingQuotaExceededException('QuotaExceededError');
   }
 }
 

--- a/workplace/test/data/datasource/drive_transfer/opfs_file_ops_test.dart
+++ b/workplace/test/data/datasource/drive_transfer/opfs_file_ops_test.dart
@@ -1,0 +1,84 @@
+@TestOn('chrome')
+library;
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:web/web.dart' as web;
+import 'package:workplace/data/datasource/drive_transfer/opfs_file_ops.dart';
+import 'package:workplace/domain/exceptions/workplace_exceptions.dart';
+
+class _OpfsFileOpsUnderTest extends OpfsFileOps {}
+
+Future<web.FileSystemDirectoryHandle> _opfsRoot() =>
+    web.window.navigator.storage.getDirectory().toDart;
+
+Future<List<String>> _rootEntryNames() async {
+  final root = await _opfsRoot();
+  final iterator = (root as JSObject).callMethod<JSObject>('keys'.toJS);
+  final names = <String>[];
+  while (true) {
+    final step =
+        await (iterator.callMethod<JSPromise<JSObject>>('next'.toJS)).toDart;
+    if ((step['done'] as JSBoolean).toDart) break;
+    names.add((step['value'] as JSString).toDart);
+  }
+  return names;
+}
+
+void main() {
+  late _OpfsFileOpsUnderTest fileOps;
+
+  setUp(() => fileOps = _OpfsFileOpsUnderTest());
+
+  Future<void> createEntry(String name) async {
+    final handle = await fileOps.createTempFile(name);
+    final writable = await fileOps.openWritable(handle);
+    await fileOps.writeChunk(writable, Uint8List.fromList([1, 2, 3]));
+    await fileOps.closeWritable(writable);
+  }
+
+  group('OpfsFileOps.purgeAllTempFiles', () {
+    test('Should remove staging entries whatever their age', () async {
+      final freshName = '$opfsTempFilePrefix${DateTime.now().microsecondsSinceEpoch}_fresh';
+      await createEntry(freshName);
+      expect(await _rootEntryNames(), contains(freshName));
+
+      await fileOps.purgeAllTempFiles();
+
+      expect(await _rootEntryNames(), isNot(contains(freshName)));
+    });
+
+    test('Should leave entries this package does not own alone', () async {
+      const foreignName = 'someone_elses_data';
+      final root = await _opfsRoot();
+      await root
+          .getFileHandle(foreignName, web.FileSystemGetFileOptions(create: true))
+          .toDart;
+      addTearDown(() async => (await _opfsRoot()).removeEntry(foreignName).toDart);
+
+      await fileOps.purgeAllTempFiles();
+
+      expect(await _rootEntryNames(), contains(foreignName));
+    });
+  });
+
+  group('OpfsFileOps quota probe', () {
+    test('Should surface a non-quota write failure unchanged', () async {
+      final handle = await fileOps.createTempFile(
+          '$opfsTempFilePrefix${DateTime.now().microsecondsSinceEpoch}_closed');
+      final writable = await fileOps.openWritable(handle);
+      await fileOps.closeWritable(writable);
+      addTearDown(fileOps.purgeAllTempFiles);
+
+      // Writing to a closed stream is a TypeError, not a quota failure: it
+      // must not be mistaken for exhausted storage.
+      await expectLater(
+        fileOps.writeChunk(writable, Uint8List.fromList([1])),
+        throwsA(isNot(isA<DriveStagingQuotaExceededException>())),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Issue
- #4728

## Description
Two OPFS storage-hygiene fixes that share the same file.

**Logout purge.** OPFS is persistent and origin-scoped, so a document staged for upload outlives
a logout and carries into the next account's session — a privacy problem before it is a quota
one. `purgeAllTempFiles` removes every staging entry regardless of age, scoped to the
`tmail_drive_` prefix so it can never touch the origin's other data. `BaseController` calls it
from the path both logout flows funnel through, reached through a conditional-export facade
since `package:web` cannot be imported outside `workplace`. Failures are logged, never rethrown.

**Typed quota failure.** A full origin quota surfaces as a raw `DOMException`, indistinguishable
from a CORS or DNS failure at every layer above. `writeChunk`/`closeWritable` now probe for it by
name — `package:web`'s `DOMException` is an extension type over `JSObject`, so a Dart `is` check
cannot work — and raise `DriveStagingQuotaExceededException`. The stager passes it through
unwrapped and the pipeline reports it via `logError` (so Sentry sees it) rather than logging it
like an ordinary per-file failure.

Also extracts the entry enumeration shared by the new purge and the existing stale sweep.

## Dependency
- #4751 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic cleanup of temporary Drive staging files during account data removal.
  - Added browser support for clearing all owned staging files, while safely skipping unsupported environments.
  - Added clear detection and reporting for storage quota exhaustion during Drive transfers.

- **Bug Fixes**
  - Improved transfer failure diagnostics and preserved meaningful quota-related errors.
  - Prevented cleanup failures from interrupting broader data removal operations.

- **Tests**
  - Added coverage for staging cleanup, quota errors, and file ownership protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->