### PR TITLE
feat(labels): render JMAP standard keywords as label chips

### DIFF
--- a/docs/dev/jmap-standard-keywords.md
+++ b/docs/dev/jmap-standard-keywords.md
@@ -1,0 +1,324 @@
+# JMAP Standard Keywords as Label Chips
+
+> **Audience:** integrators and developers building tools that read from or
+> write to a Twake Mail account via JMAP (mail sentinels, filters, custom
+> IMAP/JMAP clients, backfill scripts).
+
+Twake Mail renders any [RFC 8621](https://datatracker.ietf.org/doc/html/rfc8621)
+custom keyword (`Email.keywords`) as a visual **label chip** in the email
+list and detail views, even when no server-side `Label` object exists for
+that keyword. This lets external tools tag messages using the standard
+JMAP API and have those tags immediately visible to the end user.
+
+- [What changed](#what-changed)
+- [How it interacts with the Linagora label extension](#how-it-interacts-with-the-linagora-label-extension)
+- [API — setting a keyword that renders as a chip](#api--setting-a-keyword-that-renders-as-a-chip)
+- [Color management](#color-management)
+- [System keyword deny-list](#system-keyword-deny-list)
+- [Where chips appear](#where-chips-appear)
+- [Feature flag / rollout](#feature-flag--rollout)
+- [Backwards compatibility](#backwards-compatibility)
+- [Limitations](#limitations)
+- [Testing](#testing)
+
+---
+
+## What changed
+
+Before this feature, Twake Mail only displayed labels for keywords that
+had a matching server-side `Label` object (Linagora
+`com:linagora:params:jmap:labels` extension). Any keyword set via a
+standard `Email/set { keywords/… : true }` call by an external tool was
+silently discarded from the UI.
+
+With this feature, `PresentationEmail.getLabelList(labels)` also
+synthesises **orphan** `Label` chips — one per enabled keyword that is:
+
+1. present in `Email.keywords` and enabled (`true`), and
+2. not already covered by a registered `Label` object, and
+3. not in the [system keyword deny-list](#system-keyword-deny-list).
+
+Orphan chips are read-only visualisations. They render using a
+[deterministic color](#color-management) derived from the keyword string,
+so the same keyword always shows in the same color across sessions and
+devices with no server round-trip and no storage.
+
+---
+
+## How it interacts with the Linagora label extension
+
+The proprietary Linagora label extension is untouched.
+
+| Case | Registered `Label` exists? | Result |
+| :--- | :--- | :--- |
+| User creates a "Newsletter" label in the UI, then a rule tags mails with `keywords/newsletter` | yes | Chip renders with the user-chosen `displayName` and `color`. |
+| A mail sentinel sets `keywords/newsletter` via JMAP and no user-created label matches | no | **Orphan chip** renders with `displayName = "newsletter"` and a deterministic hash-based color. |
+| RFC 8621 system keyword (`$seen`, `$flagged`, `$answered`, `$draft`, `$junk`, `$notjunk`, `$forwarded`, `$phishing`, `$mdnsent`) | not applicable | Not rendered as a chip — handled by dedicated UI (star, read/unread badge, draft badge, junk-folder move). |
+| Tmail UI-mapped custom keyword (`$unsubscribe`, `needs-action`, `event`) | not applicable | Not rendered as a chip — handled by feature-specific UI. |
+
+If both a registered `Label` and an orphan chip would apply to the same
+keyword, the registered `Label` wins (retains its custom color and
+display name).
+
+---
+
+## API — setting a keyword that renders as a chip
+
+Any [JMAP](https://jmap.io/) `Email/set` operation that adds a keyword
+outside the [deny-list](#system-keyword-deny-list) will render as a
+chip on the next `Email/get` result the UI receives (typically within
+seconds via the `Email/changes` polling loop).
+
+### Constraints
+
+JMAP keyword values follow [IMAP flag naming rules](https://datatracker.ietf.org/doc/html/rfc9051#name-flags-message-attribute)
+(James enforces them server-side):
+
+- length 1..255 characters,
+- allowed: `A-Z a-z 0-9 - _ $` and non-control ASCII,
+- forbidden: control characters, whitespace, and any of `( ) { ] % * " \\`.
+
+Recommended shape: lowercase, hyphenated, no colon prefix
+(`newsletter`, `github-notif`, `action-required`).
+
+### Set a keyword
+
+```json
+{
+  "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
+  "methodCalls": [
+    ["Email/set", {
+      "accountId": "<accountId>",
+      "update": {
+        "<emailId>": {
+          "keywords/newsletter": true,
+          "keywords/action-required": true
+        }
+      }
+    }, "0"]
+  ]
+}
+```
+
+Response:
+
+```json
+{
+  "methodResponses": [
+    ["Email/set", {
+      "accountId": "<accountId>",
+      "oldState": "…",
+      "newState": "…",
+      "updated": { "<emailId>": null }
+    }, "0"]
+  ]
+}
+```
+
+Both chips appear on the next UI refresh — no `Label/set` call needed.
+
+### Remove a keyword
+
+```json
+{
+  "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
+  "methodCalls": [
+    ["Email/set", {
+      "accountId": "<accountId>",
+      "update": {
+        "<emailId>": {
+          "keywords/newsletter": null
+        }
+      }
+    }, "0"]
+  ]
+}
+```
+
+### Query by keyword
+
+Filter emails carrying a specific keyword:
+
+```json
+{
+  "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
+  "methodCalls": [
+    ["Email/query", {
+      "accountId": "<accountId>",
+      "filter": { "hasKeyword": "newsletter" },
+      "limit": 50
+    }, "0"]
+  ]
+}
+```
+
+The `hasKeyword` filter works for any keyword — registered `Label`,
+orphan, or system.
+
+---
+
+## Color management
+
+Orphan chips receive a deterministic color computed client-side from
+the keyword string; no server-side storage and no round-trip.
+
+### Palette
+
+Twelve colors, selected from the tmail label color picker for
+sufficient contrast against white chip text:
+
+| Slot | Hex | Rough name |
+| :--- | :--- | :--- |
+| 0 | `#273891` | deep blue |
+| 1 | `#7E57E3` | purple |
+| 2 | `#4896E5` | blue |
+| 3 | `#038199` | teal |
+| 4 | `#457D6C` | dark green |
+| 5 | `#51B588` | green |
+| 6 | `#E0465C` | red |
+| 7 | `#ED20A4` | pink |
+| 8 | `#B85B17` | brown |
+| 9 | `#ED916B` | orange |
+| 10 | `#EDA91D` | amber |
+| 11 | `#646580` | slate |
+
+### Hash
+
+Simple FNV-1a variant on the keyword's UTF-16 code units, modulo the
+palette length:
+
+```dart
+var hash = 0x811C9DC5;
+for (final unit in keyword.value.codeUnits) {
+  hash = (hash ^ unit) * 0x01000193 & 0xFFFFFFFF;
+}
+final color = palette[hash % palette.length];
+```
+
+### Guarantees
+
+- **Deterministic** — the same keyword always maps to the same color.
+- **Stable across sessions** — no cookie, cache, or storage required.
+- **Cross-platform** — mobile, desktop, and web produce the same result.
+
+### Overriding the color
+
+To display a keyword with a *custom* color and display name, register
+a `Label` object via the Linagora label extension
+(`com:linagora:params:jmap:labels`, `Label/set create`). Once the
+matching `Label` exists, it takes precedence over the orphan-chip
+synthesis and its color / display name are used instead.
+
+---
+
+## System keyword deny-list
+
+The following keywords are **never** rendered as chips because they
+carry dedicated UI treatment:
+
+| Keyword | Dedicated UI |
+| :--- | :--- |
+| `$seen` (RFC 8621) | Read/unread badge on the email tile. |
+| `$flagged` (RFC 8621) | Star icon on the email tile. |
+| `$answered` (RFC 8621) | Reply arrow icon in the tile action area. |
+| `$forwarded` (RFC 8621) | Forward arrow icon in the tile action area. |
+| `$draft` (RFC 8621) | Drafts folder + tile badge. |
+| `$junk` (RFC 8621) | Spam / Indésirables folder auto-move. |
+| `$notjunk` (RFC 8621) | Ham marker — no chip; feeds spam classifiers. |
+| `$phishing` (RFC 8621) | Phishing warning banner. |
+| `$mdnsent` (RFC 8621) | MDN delivery-receipt indicator. |
+| `$unsubscribe` (tmail) | Unsubscribe button in the email header. |
+| `needs-action` (tmail) | "Action requise" filter + folder view. |
+| `event` (tmail) | Calendar event integration. |
+
+The deny-list is a single source of truth in
+`model/lib/extensions/keyword_identifier_extension.dart::systemKeywords`.
+Adding a keyword that should get dedicated UI treatment means adding it
+here — it will then no longer render as an orphan chip.
+
+---
+
+## Where chips appear
+
+All four view callsites for `getLabelList` benefit automatically:
+
+- **Thread view** — `lib/features/thread/presentation/thread_view.dart`
+- **Single email view** — `lib/features/email/presentation/email_view.dart`
+- **Thread detail view** — `lib/features/thread_detail/presentation/extension/get_thread_details_email_views.dart`
+- **Search results** — `lib/features/search/email/presentation/search_email_view.dart`
+
+No per-callsite change was needed; the synthesis lives in the shared
+extension `PresentationEmailExtension.getLabelList(labels)` in
+`lib/features/email/presentation/extensions/presentation_email_extension.dart`.
+
+---
+
+## Feature flag / rollout
+
+The orphan-chip synthesis is **always on** — no capability negotiation
+and no user preference gate. `Email.keywords` is a standard RFC 8621
+`Email` property, so the change works on any JMAP server (with or
+without the Linagora `com:linagora:params:jmap:labels` capability).
+
+The Linagora label capability gate (`isLabelAvailable`) continues to
+gate the *management* UI (create / edit / delete `Label` objects). The
+orphan-chip *display* path is independent.
+
+---
+
+## Backwards compatibility
+
+- **API surface** — none added on the server side; keyword semantics
+  and JMAP wire format are unchanged.
+- **Existing `Label` objects** — untouched; their color and display
+  name still win over any orphan synthesis for the same keyword.
+- **System keywords** — always suppressed; existing UI icons remain
+  the sole visual representation.
+- **Older client behavior** — clients that predate this change
+  continue to ignore keywords without a registered `Label`. Rolling
+  back the change is a UI-only revert.
+
+---
+
+## Limitations
+
+- **Read-only chips** — orphan chips do not currently expose a "remove"
+  action from the tile. Removing an orphan keyword still requires an
+  `Email/set { keywords/foo: null }` call from an external tool (or
+  registering a matching `Label` and using the standard remove UI).
+- **Display name = keyword value** — orphan chips display the raw
+  keyword. If the raw value is technical (`__spam__`,
+  `mail-sentinel-processed`), consider using human-readable keyword
+  values from the start (`spam-detected`, `sentinel-processed`).
+- **Color drift on palette resize** — the palette size (currently
+  `12`) is stable; if a future release changes it, deterministic
+  color assignments will remap. Palette entries can be reordered
+  without changing individual keyword→color mappings so long as the
+  size stays the same.
+
+---
+
+## Testing
+
+Unit tests live in
+`test/model/lib/extensions/get_label_list_in_keyword_email_test.dart`
+and cover:
+
+- surfacing a keyword as an orphan label when no matching `Label` exists;
+- filtering out the full RFC 8621 system keyword set;
+- registered `Label` wins over orphan synthesis for the same keyword;
+- mixed input (registered + orphan + system-filtered) produces the
+  right chip set;
+- disabled keywords (`keywords/foo: false`) are excluded;
+- deterministic color — same keyword string always resolves to the
+  same hex value.
+
+Run:
+
+```bash
+flutter test test/model/lib/extensions/get_label_list_in_keyword_email_test.dart
+```
+
+Live end-to-end verification: from any JMAP client, set a non-system
+keyword on an inbox message and reload the Twake Mail web/mobile app —
+the chip appears on the affected message tile within seconds.

--- a/lib/features/email/presentation/extensions/presentation_email_extension.dart
+++ b/lib/features/email/presentation/extensions/presentation_email_extension.dart
@@ -3,6 +3,7 @@ import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
 import 'package:labels/model/label.dart';
 import 'package:model/email/email_action_type.dart';
 import 'package:model/email/presentation_email.dart';
+import 'package:model/extensions/keyword_identifier_extension.dart';
 import 'package:model/extensions/list_email_address_extension.dart';
 import 'package:tmail_ui_user/features/email/presentation/utils/email_utils.dart';
 import 'package:tmail_ui_user/features/thread/data/extensions/map_keywords_extension.dart';
@@ -158,16 +159,37 @@ extension PresentationEmailExtension on PresentationEmail {
   }
 
   List<Label> getLabelList(List<Label> labels) {
-    if (keywords?.isNotEmpty != true || labels.isEmpty) return const [];
+    if (keywords?.isNotEmpty != true) return const [];
 
     final enabledKeywords = keywords!.enabledKeywords;
-
     if (enabledKeywords.isEmpty) return const [];
 
-    return labels
+    // 1) Registered labels: keywords that have a server-side `Label` object
+    //    (Linagora `com:linagora:params:jmap:labels` extension) — carry
+    //    displayName + color set by the user.
+    final registered = labels
         .where((label) =>
             label.keyword != null && enabledKeywords.contains(label.keyword))
         .toList();
+
+    // 2) Orphan / standard JMAP keywords: any keyword set via the RFC 8621
+    //    `Email/set keywords` API by an external tool (mail sentinel,
+    //    filter, IMAP client) that is NOT already a registered Label AND is
+    //    NOT a UI-mapped system keyword (star, seen, draft, junk, etc.).
+    //    Rendered as read-only chips with the default primary color so
+    //    keywords from any standards-compliant JMAP producer become visible.
+    final registeredKeywords = <String>{
+      for (final label in registered)
+        if (label.keyword != null) label.keyword!.value,
+    };
+    final orphanLabels = <Label>[];
+    for (final keyword in enabledKeywords) {
+      if (keyword.isSystemKeyword) continue;
+      if (registeredKeywords.contains(keyword.value)) continue;
+      orphanLabels.add(Label(keyword: keyword, displayName: keyword.value));
+    }
+
+    return [...registered, ...orphanLabels];
   }
 
   PresentationEmail toggleKeyword(KeyWordIdentifier keyword, bool remove) {

--- a/lib/features/email/presentation/extensions/presentation_email_extension.dart
+++ b/lib/features/email/presentation/extensions/presentation_email_extension.dart
@@ -1,5 +1,6 @@
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
 import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
+import 'package:labels/model/hex_color.dart';
 import 'package:labels/model/label.dart';
 import 'package:model/email/email_action_type.dart';
 import 'package:model/email/presentation_email.dart';
@@ -186,7 +187,14 @@ extension PresentationEmailExtension on PresentationEmail {
     for (final keyword in enabledKeywords) {
       if (keyword.isSystemKeyword) continue;
       if (registeredKeywords.contains(keyword.value)) continue;
-      orphanLabels.add(Label(keyword: keyword, displayName: keyword.value));
+      orphanLabels.add(Label(
+        keyword: keyword,
+        displayName: keyword.value,
+        // Deterministic hash-based color from the tmail palette so each
+        // orphan keyword renders in a distinct, stable color across
+        // sessions and devices without any server-side storage.
+        color: HexColor(keyword.deterministicHexColor),
+      ));
     }
 
     return [...registered, ...orphanLabels];

--- a/model/lib/extensions/keyword_identifier_extension.dart
+++ b/model/lib/extensions/keyword_identifier_extension.dart
@@ -35,6 +35,38 @@ extension KeyWordIdentifierExtension on KeyWordIdentifier {
   /// (RFC 8621 system keywords + tmail's UI-mapped custom keywords).
   bool get isSystemKeyword => systemKeywords.contains(value);
 
+  /// Palette of 12 well-contrasted colors reused from the label color-picker
+  /// (`core/lib/presentation/views/color/colors_map_widget.dart`), filtered
+  /// to those with sufficient contrast against the widget's white text.
+  static const List<String> _orphanColorPalette = <String>[
+    '#273891', // deep blue
+    '#7E57E3', // purple
+    '#4896E5', // blue
+    '#038199', // teal
+    '#457D6C', // dark green
+    '#51B588', // green
+    '#E0465C', // red
+    '#ED20A4', // pink
+    '#B85B17', // brown
+    '#ED916B', // orange
+    '#EDA91D', // amber
+    '#646580', // slate
+  ];
+
+  /// Deterministic hex color for an unregistered / orphan JMAP keyword
+  /// rendered as a label chip. Same keyword string always maps to the
+  /// same color across sessions and devices — no server round-trip, no
+  /// storage. Suitable as the `Label.color` for chips synthesised from
+  /// standard JMAP keywords that have no server-side `Label` object.
+  String get deterministicHexColor {
+    // Simple FNV-1a-ish digest; deterministic and platform-independent.
+    var hash = 0x811C9DC5;
+    for (final unit in value.codeUnits) {
+      hash = (hash ^ unit) * 0x01000193 & 0xFFFFFFFF;
+    }
+    return _orphanColorPalette[hash % _orphanColorPalette.length];
+  }
+
   String generatePath() => '${PatchObject.keywordsProperty}/$value';
 
   /// General helper to generate a boolean patch.

--- a/model/lib/extensions/keyword_identifier_extension.dart
+++ b/model/lib/extensions/keyword_identifier_extension.dart
@@ -8,6 +8,33 @@ extension KeyWordIdentifierExtension on KeyWordIdentifier {
   static final needsActionMail = KeyWordIdentifier('needs-action');
   static final eventsMail = KeyWordIdentifier('event');
 
+  /// Keywords that carry dedicated UI treatment (star, read/unread badge,
+  /// draft badge, junk folder auto-move, etc.) and therefore MUST NOT
+  /// surface as user-visible label chips.
+  ///
+  /// The set combines the RFC 8621 §2.1.4 system keywords with the three
+  /// UI-mapped custom keywords defined above. Any keyword not listed here
+  /// is treated as a user-visible label — including custom keywords set
+  /// by external JMAP-compliant tools (e.g. mail sentinels, filters).
+  static final systemKeywords = <String>{
+    KeyWordIdentifier.emailDraft.value,
+    KeyWordIdentifier.emailSeen.value,
+    KeyWordIdentifier.emailFlagged.value,
+    KeyWordIdentifier.emailAnswered.value,
+    KeyWordIdentifier.emailForwarded.value,
+    KeyWordIdentifier.emailPhishing.value,
+    KeyWordIdentifier.emailJunk.value,
+    KeyWordIdentifier.emailNotJunk.value,
+    KeyWordIdentifier.mdnSent.value,
+    unsubscribeMail.value,
+    needsActionMail.value,
+    eventsMail.value,
+  };
+
+  /// True when this keyword should NOT be rendered as a label chip
+  /// (RFC 8621 system keywords + tmail's UI-mapped custom keywords).
+  bool get isSystemKeyword => systemKeywords.contains(value);
+
   String generatePath() => '${PatchObject.keywordsProperty}/$value';
 
   /// General helper to generate a boolean patch.

--- a/test/model/lib/extensions/get_label_list_in_keyword_email_test.dart
+++ b/test/model/lib/extensions/get_label_list_in_keyword_email_test.dart
@@ -24,7 +24,7 @@ void main() {
       expect(result, isEmpty);
     });
 
-    test('returns empty when labels is empty', () {
+    test('returns empty when labels is empty AND keywords are system-only', () {
       final email = PresentationEmail(keywords: {
         KeyWordIdentifier.emailFlagged: true,
       });
@@ -94,6 +94,95 @@ void main() {
 
       expect(result.length, 1);
       expect(result.first.keyword, KeyWordIdentifier.emailFlagged);
+    });
+  });
+
+  group('getLabelList — JMAP standard keywords (RFC 8621)', () {
+    // Ensures keywords set via `Email/set keywords` by any JMAP-compliant
+    // tool (mail sentinel, filter, IMAP client) surface as visual chips,
+    // even without a registered server-side `Label` object.
+
+    test('surfaces custom keyword as orphan label when no matching Label exists',
+        () {
+      final newsletter = KeyWordIdentifier('newsletter');
+      final email = PresentationEmail(keywords: {newsletter: true});
+
+      final result = email.getLabelList([]);
+
+      expect(result.length, 1);
+      expect(result.first.keyword, newsletter);
+      expect(result.first.displayName, 'newsletter');
+      expect(result.first.id, isNull);
+      expect(result.first.color, isNull);
+    });
+
+    test('filters out system keywords ($seen, $flagged, $draft, $junk, …)',
+        () {
+      final email = PresentationEmail(keywords: {
+        KeyWordIdentifier.emailSeen: true,
+        KeyWordIdentifier.emailFlagged: true,
+        KeyWordIdentifier.emailDraft: true,
+        KeyWordIdentifier.emailAnswered: true,
+        KeyWordIdentifier.emailForwarded: true,
+        KeyWordIdentifier.emailPhishing: true,
+        KeyWordIdentifier.emailJunk: true,
+        KeyWordIdentifier.emailNotJunk: true,
+        KeyWordIdentifier.mdnSent: true,
+      });
+
+      final result = email.getLabelList([]);
+
+      expect(result, isEmpty);
+    });
+
+    test('registered label wins over orphan synthesis for same keyword', () {
+      final newsletter = KeyWordIdentifier('newsletter');
+      final email = PresentationEmail(keywords: {newsletter: true});
+      final registered = Label(
+        keyword: newsletter,
+        displayName: 'My Newsletter',
+      );
+
+      final result = email.getLabelList([registered]);
+
+      expect(result.length, 1);
+      expect(result.first.displayName, 'My Newsletter'); // not "newsletter"
+    });
+
+    test('mixes registered + orphan + system-filtered', () {
+      final github = KeyWordIdentifier('github');
+      final invoice = KeyWordIdentifier('invoice');
+      final email = PresentationEmail(keywords: {
+        github: true,
+        invoice: true,
+        KeyWordIdentifier.emailFlagged: true, // system, filtered out
+        KeyWordIdentifier.emailSeen: true, // system, filtered out
+      });
+      final registered = Label(keyword: github, displayName: 'GitHub');
+
+      final result = email.getLabelList([registered]);
+
+      // github (registered) + invoice (orphan) = 2
+      expect(result.length, 2);
+      final registeredLabel =
+          result.firstWhere((l) => l.keyword?.value == 'github');
+      expect(registeredLabel.displayName, 'GitHub');
+      final orphanLabel =
+          result.firstWhere((l) => l.keyword?.value == 'invoice');
+      expect(orphanLabel.displayName, 'invoice');
+      expect(orphanLabel.id, isNull);
+    });
+
+    test('orphan labels ignore disabled keywords', () {
+      final email = PresentationEmail(keywords: {
+        KeyWordIdentifier('active-label'): true,
+        KeyWordIdentifier('disabled-label'): false,
+      });
+
+      final result = email.getLabelList([]);
+
+      expect(result.length, 1);
+      expect(result.first.keyword?.value, 'active-label');
     });
   });
 }

--- a/test/model/lib/extensions/get_label_list_in_keyword_email_test.dart
+++ b/test/model/lib/extensions/get_label_list_in_keyword_email_test.dart
@@ -129,7 +129,7 @@ void main() {
       expect(r1.first.color!.value, equals(r2.first.color!.value));
     });
 
-    test('filters out system keywords ($seen, $flagged, $draft, $junk, …)',
+    test(r'filters out system keywords ($seen, $flagged, $draft, $junk, …)',
         () {
       final email = PresentationEmail(keywords: {
         KeyWordIdentifier.emailSeen: true,

--- a/test/model/lib/extensions/get_label_list_in_keyword_email_test.dart
+++ b/test/model/lib/extensions/get_label_list_in_keyword_email_test.dart
@@ -113,7 +113,20 @@ void main() {
       expect(result.first.keyword, newsletter);
       expect(result.first.displayName, 'newsletter');
       expect(result.first.id, isNull);
-      expect(result.first.color, isNull);
+      // Orphan labels get a deterministic hash-based color from the tmail
+      // palette (see KeyWordIdentifierExtension.deterministicHexColor).
+      expect(result.first.color, isNotNull);
+      expect(result.first.color!.value, matches(RegExp(r'^#[0-9A-Fa-f]{6}$')));
+    });
+
+    test('orphan color is deterministic — same keyword always same color', () {
+      final urgent = KeyWordIdentifier('urgent');
+      final email = PresentationEmail(keywords: {urgent: true});
+
+      final r1 = email.getLabelList([]);
+      final r2 = email.getLabelList([]);
+
+      expect(r1.first.color!.value, equals(r2.first.color!.value));
     });
 
     test('filters out system keywords ($seen, $flagged, $draft, $junk, …)',


### PR DESCRIPTION
## Summary

Any [RFC 8621](https://datatracker.ietf.org/doc/html/rfc8621) custom keyword set via `Email/set { keywords/… : true }` by an external tool (mail sentinel, filter, IMAP/JMAP client) is currently silently discarded from the Twake Mail UI — only keywords with a matching server-side `Label` object (`com:linagora:params:jmap:labels`) render as chips.

This PR extends `PresentationEmail.getLabelList(labels)` so that JMAP standard keywords render as read-only label chips even without a registered `Label` object, complementing the existing proprietary Linagora label system without any change to it.

Motivation: I built a companion mail sentinel that tags incoming mail via standard JMAP (`Email/set keywords/newsletter: true`, `keywords/github-notif: true`, etc.). The keywords were correctly stored server-side and returned in `Email/get`, but the UI never surfaced them — the operator had no visibility into the sentinel's classifications.

## What the PR does

1. **Renders orphan keywords as label chips.** In `getLabelList()`, after the existing registered-label collection, synthesise a `Label` chip for every enabled keyword that (a) is not covered by a registered `Label` and (b) is not in the [system-keyword deny-list](#deny-list). The synthesised chip has `id: null`, `displayName: keyword.value`, `color: HexColor(<deterministic hash-based color>)`.

2. **Deterministic hash-based color** from a 12-color palette (subset of the tmail label picker's palette, filtered for good contrast against white chip text). Same keyword string → same color across sessions and devices. No server round-trip, no storage. FNV-1a-ish hash on the keyword's UTF-16 code units modulo the palette length.

3. **System-keyword deny-list** (`KeyWordIdentifierExtension.systemKeywords`) as a single source of truth: RFC 8621 system keywords (`$seen`, `$flagged`, `$answered`, `$forwarded`, `$draft`, `$junk`, `$notjunk`, `$phishing`, `$mdnsent`) + tmail-custom UI-mapped keywords (`\$unsubscribe`, `needs-action`, `event`). System keywords keep their dedicated UI treatment (star icon, read badge, spam-folder move, etc.) and are never rendered as chips.

4. **Interaction with the Linagora label extension** is fully preserved. Registered `Label` objects keep their user-chosen `displayName` and `color`; they take precedence over orphan-chip synthesis for the same keyword. The Linagora capability gate (`isLabelAvailable`) continues to gate the *management* UI unchanged — the orphan-chip *display* path is independent and works on any JMAP server.

5. **All four `getLabelList` callsites benefit automatically** — thread view, single email view, thread detail, search. The synthesis lives in the shared extension in `lib/features/email/presentation/extensions/presentation_email_extension.dart`; no per-callsite change was needed.

## Backwards compatibility

- **Server side:** unchanged. `Email.keywords` is already fetched in every `Email/get` call (`ThreadConstants`).
- **Existing `Label` objects:** untouched — their color and display name still win over any orphan synthesis for the same keyword.
- **System keywords:** always suppressed from chip rendering — dedicated UI icons remain the sole visual representation.
- **Older client behavior:** clients that predate this change continue to ignore orphan keywords. Rolling back the change is a UI-only revert.

## Files changed

| Path | Change |
| :--- | :--- |
| `model/lib/extensions/keyword_identifier_extension.dart` | + `systemKeywords` deny-list, + `isSystemKeyword` getter, + `deterministicHexColor` getter |
| `lib/features/email/presentation/extensions/presentation_email_extension.dart` | `getLabelList()` extended to synthesise orphan chips |
| `test/model/lib/extensions/get_label_list_in_keyword_email_test.dart` | +5 new tests for orphan synthesis, +2 for color determinism |
| `docs/dev/jmap-standard-keywords.md` | New — feature + API + color docs for integrators |

**519 insertions, 4 deletions** across 4 files.

## Tests

Unit tests in `test/model/lib/extensions/get_label_list_in_keyword_email_test.dart` cover:

- orphan keyword surfaces as a chip when no matching `Label` exists,
- the full RFC 8621 system keyword set is filtered out,
- registered `Label` wins over orphan synthesis for the same keyword,
- mixed registered + orphan + system-filtered input produces the right chip set,
- disabled keywords (`keywords/foo: false`) are excluded,
- deterministic color — same keyword string always resolves to the same hex value,
- basic well-formedness (`#RRGGBB`) of the assigned color.

Run:
```bash
flutter test test/model/lib/extensions/get_label_list_in_keyword_email_test.dart
```

## Manual verification

Built with `Dockerfile` unchanged (`FLUTTER_VERSION=3.38.9`) and deployed to a dev Twake Mail instance. Confirmed with the browser:

1. Set several test keywords via JMAP `Email/set` (`jmap-standard-test`, `newsletter`, `action-required`, `urgent`, `project-alpha`).
2. Reloaded the Twake Mail web UI.
3. Verified each keyword rendered as a distinct chip with a deterministic color, on both the thread view and the email detail view.
4. Verified `$seen`, `$flagged`, `$answered` on the same emails did NOT render as chips.
5. Verified an existing user-created `Label` with matching keyword still won (kept its custom color / display name).

## Design doc

See `docs/dev/jmap-standard-keywords.md` for the full feature + API documentation (audience: integrators building tools that read from or write to a Twake Mail account via JMAP).

## Notes

- Marked as **draft** — happy to iterate on any of the design choices before flipping to ready-for-review.
- The palette is a subset of the existing tmail color picker for visual consistency with user-created labels.
- Read-only chips only — removing an orphan keyword still requires an `Email/set { keywords/foo: null }` call or registering a matching `Label` and using the standard remove UI. Adding an in-chip remove action for orphans is a follow-up if desired.

Related: this unblocks external JMAP-compliant mail tooling (mail sentinels, filters, standards-based clients) from surfacing their tags in Twake Mail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom email keywords now appear as visual label chips, even when no registered label exists.
  * Unregistered keyword labels receive consistent colors across the app.
  * Registered labels take precedence, while system keywords remain excluded.
  * Disabled keywords are omitted from displayed labels.

* **Documentation**
  * Added guidance covering keyword labels, compatibility, rollout behavior, limitations, and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->