### PR TITLE
TF-4750: Webview  wire flutter_assets/ baseUrl into mobile HTML viewers

### DIFF
--- a/android/app/src/main/kotlin/com/linagora/android/tmail/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/linagora/android/tmail/MainActivity.kt
@@ -23,5 +23,6 @@ class MainActivity: FlutterFragmentActivity() {
 
         NotificationGroup().register(flutterEngine, applicationContext)
         AndroidSelectionHandles(this).register(flutterEngine)
+        WebViewAssetBaseUrl().register(flutterEngine)
     }
 }

--- a/android/app/src/main/kotlin/com/linagora/android/tmail/WebViewAssetBaseUrl.kt
+++ b/android/app/src/main/kotlin/com/linagora/android/tmail/WebViewAssetBaseUrl.kt
@@ -25,7 +25,7 @@ class WebViewAssetBaseUrl {
     }
 
     private companion object {
-        const val CHANNEL = "com.linagora.android.tmail/webview_asset_base_url"
+        const val CHANNEL = "com.linagora.tmail/webview_asset_base_url"
         const val FLUTTER_ASSETS_BASE_URL_METHOD = "flutterAssetsBaseUrl"
         const val ANDROID_ASSET_URL_PREFIX = "file:///android_asset/"
     }

--- a/android/app/src/main/kotlin/com/linagora/android/tmail/WebViewAssetBaseUrl.kt
+++ b/android/app/src/main/kotlin/com/linagora/android/tmail/WebViewAssetBaseUrl.kt
@@ -1,0 +1,32 @@
+package com.linagora.android.tmail
+
+import io.flutter.FlutterInjector
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+
+/** Exposes the on-disk `flutter_assets/` URL for Dart to pass as `loadData`'s `baseUrl`. */
+class WebViewAssetBaseUrl {
+
+    fun register(flutterEngine: FlutterEngine) {
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            CHANNEL,
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                FLUTTER_ASSETS_BASE_URL_METHOD -> result.success(flutterAssetsBaseUrl())
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    private fun flutterAssetsBaseUrl(): String {
+        val flutterAssetsDir = FlutterInjector.instance().flutterLoader().findAppBundlePath()
+        return "$ANDROID_ASSET_URL_PREFIX$flutterAssetsDir/"
+    }
+
+    private companion object {
+        const val CHANNEL = "com.linagora.android.tmail/webview_asset_base_url"
+        const val FLUTTER_ASSETS_BASE_URL_METHOD = "flutterAssetsBaseUrl"
+        const val ANDROID_ASSET_URL_PREFIX = "file:///android_asset/"
+    }
+}

--- a/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
+++ b/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
@@ -7,6 +7,7 @@ import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/html/html_interaction.dart';
 import 'package:core/utils/html/html_template.dart';
 import 'package:core/utils/html/html_utils.dart';
+import 'package:core/utils/html/webview_asset_base_url.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -84,6 +85,7 @@ class HtmlContentViewState extends State<HtmlContentViewer> with AutomaticKeepAl
   final _loadingBarNotifier = ValueNotifier(true);
 
   String? _htmlData;
+  WebUri? _assetsBaseUrl;
 
   InAppWebViewController get webViewController => _webViewController;
 
@@ -97,6 +99,7 @@ class HtmlContentViewState extends State<HtmlContentViewer> with AutomaticKeepAl
       disableHorizontalScroll: widget.disableScrolling,
       disableVerticalScroll: widget.disableScrolling,
       horizontalScrollBarEnabled: !widget.disableScrolling,
+      isInspectable: kDebugMode,
     );
 
     _gestureRecognizers = {
@@ -214,7 +217,13 @@ class HtmlContentViewState extends State<HtmlContentViewer> with AutomaticKeepAl
     log('_HtmlContentViewState::_onWebViewCreated:');
     _webViewController = controller;
 
-    await controller.loadData(data: _htmlData ?? '');
+    _assetsBaseUrl = await WebViewAssetBaseUrl.instance.flutterAssetsBaseUrl();
+    // No allowingReadAccessTo: on iOS it triggers a competing loadFileURL
+    // navigation that starves the real page load. baseUrl alone is enough.
+    await controller.loadData(
+      data: _htmlData ?? '',
+      baseUrl: _assetsBaseUrl,
+    );
 
     if (!widget.disableScrolling) {
       controller.addJavaScriptHandler(
@@ -368,6 +377,11 @@ class HtmlContentViewState extends State<HtmlContentViewer> with AutomaticKeepAl
     }
 
     if (navigationAction.isForMainFrame && url == 'about:blank') {
+      return NavigationActionPolicy.ALLOW;
+    }
+
+    // Not a user-followed link — let the baseUrl's own navigation through.
+    if (_assetsBaseUrl != null && url == _assetsBaseUrl.toString()) {
       return NavigationActionPolicy.ALLOW;
     }
 

--- a/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
+++ b/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
@@ -218,6 +218,8 @@ class HtmlContentViewState extends State<HtmlContentViewer> with AutomaticKeepAl
     _webViewController = controller;
 
     _assetsBaseUrl = await WebViewAssetBaseUrl.instance.flutterAssetsBaseUrl();
+    if (!mounted) return;
+
     // No allowingReadAccessTo: on iOS it triggers a competing loadFileURL
     // navigation that starves the real page load. baseUrl alone is enough.
     await controller.loadData(
@@ -376,12 +378,8 @@ class HtmlContentViewState extends State<HtmlContentViewer> with AutomaticKeepAl
       return NavigationActionPolicy.CANCEL;
     }
 
-    if (navigationAction.isForMainFrame && url == 'about:blank') {
-      return NavigationActionPolicy.ALLOW;
-    }
-
-    // Not a user-followed link — let the baseUrl's own navigation through.
-    if (_assetsBaseUrl != null && url == _assetsBaseUrl.toString()) {
+    if (navigationAction.isForMainFrame &&
+        (url == 'about:blank' || url == _assetsBaseUrl?.toString())) {
       return NavigationActionPolicy.ALLOW;
     }
 

--- a/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
+++ b/core/lib/presentation/views/html_viewer/html_content_viewer_widget.dart
@@ -100,6 +100,7 @@ class HtmlContentViewState extends State<HtmlContentViewer> with AutomaticKeepAl
       disableVerticalScroll: widget.disableScrolling,
       horizontalScrollBarEnabled: !widget.disableScrolling,
       isInspectable: kDebugMode,
+      allowFileAccessFromFileURLs: true,
     );
 
     _gestureRecognizers = {
@@ -378,8 +379,7 @@ class HtmlContentViewState extends State<HtmlContentViewer> with AutomaticKeepAl
       return NavigationActionPolicy.CANCEL;
     }
 
-    if (navigationAction.isForMainFrame &&
-        (url == 'about:blank' || url == _assetsBaseUrl?.toString())) {
+    if (isProgrammaticDocumentLoad(navigationAction, _assetsBaseUrl)) {
       return NavigationActionPolicy.ALLOW;
     }
 

--- a/core/lib/presentation/views/html_viewer/ios_html_content_viewer_widget.dart
+++ b/core/lib/presentation/views/html_viewer/ios_html_content_viewer_widget.dart
@@ -4,6 +4,7 @@ import 'package:core/data/constants/constant.dart';
 import 'package:core/presentation/views/html_viewer/html_content_viewer_widget.dart';
 import 'package:core/utils/html/html_interaction.dart';
 import 'package:core/utils/html/html_utils.dart';
+import 'package:core/utils/html/webview_asset_base_url.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -36,10 +37,15 @@ class IosHtmlContentViewerWidget extends StatefulWidget {
 
 class _IosHtmlContentViewerWidgetState extends State<IosHtmlContentViewerWidget> {
 
+  WebUri? _assetsBaseUrl;
+
   @override
   Widget build(BuildContext context) {
     return InAppWebView(
-      initialSettings: InAppWebViewSettings(transparentBackground: true),
+      initialSettings: InAppWebViewSettings(
+        transparentBackground: true,
+        isInspectable: kDebugMode,
+      ),
       onWebViewCreated: _onWebViewCreated,
       shouldOverrideUrlLoading: _shouldOverrideUrlLoading,
       gestureRecognizers: {
@@ -49,13 +55,19 @@ class _IosHtmlContentViewerWidgetState extends State<IosHtmlContentViewerWidget>
   }
 
   Future<void> _onWebViewCreated(InAppWebViewController controller) async {
-    await controller.loadData(data: HtmlUtils.generateHtmlDocument(
-      content: widget.contentHtml,
-      direction: widget.direction,
-      javaScripts: HtmlInteraction.scriptsHandleLazyLoadingBackgroundImage,
-      useDefaultFontStyle: widget.useDefaultFontStyle,
-      fontSize: 16,
-    ));
+    _assetsBaseUrl = await WebViewAssetBaseUrl.instance.flutterAssetsBaseUrl();
+    // No allowingReadAccessTo: on iOS it triggers a competing loadFileURL
+    // navigation that starves the real page load. baseUrl alone is enough.
+    await controller.loadData(
+      data: HtmlUtils.generateHtmlDocument(
+        content: widget.contentHtml,
+        direction: widget.direction,
+        javaScripts: HtmlInteraction.scriptsHandleLazyLoadingBackgroundImage,
+        useDefaultFontStyle: widget.useDefaultFontStyle,
+        fontSize: 16,
+      ),
+      baseUrl: _assetsBaseUrl,
+    );
   }
 
   Future<NavigationActionPolicy?> _shouldOverrideUrlLoading(
@@ -69,6 +81,11 @@ class _IosHtmlContentViewerWidgetState extends State<IosHtmlContentViewerWidget>
     }
 
     if (navigationAction.isForMainFrame && url == 'about:blank') {
+      return NavigationActionPolicy.ALLOW;
+    }
+
+    // Not a user-followed link — let the baseUrl's own navigation through.
+    if (_assetsBaseUrl != null && url == _assetsBaseUrl.toString()) {
       return NavigationActionPolicy.ALLOW;
     }
 

--- a/core/lib/presentation/views/html_viewer/ios_html_content_viewer_widget.dart
+++ b/core/lib/presentation/views/html_viewer/ios_html_content_viewer_widget.dart
@@ -56,6 +56,8 @@ class _IosHtmlContentViewerWidgetState extends State<IosHtmlContentViewerWidget>
 
   Future<void> _onWebViewCreated(InAppWebViewController controller) async {
     _assetsBaseUrl = await WebViewAssetBaseUrl.instance.flutterAssetsBaseUrl();
+    if (!mounted) return;
+
     // No allowingReadAccessTo: on iOS it triggers a competing loadFileURL
     // navigation that starves the real page load. baseUrl alone is enough.
     await controller.loadData(
@@ -80,12 +82,8 @@ class _IosHtmlContentViewerWidgetState extends State<IosHtmlContentViewerWidget>
       return NavigationActionPolicy.CANCEL;
     }
 
-    if (navigationAction.isForMainFrame && url == 'about:blank') {
-      return NavigationActionPolicy.ALLOW;
-    }
-
-    // Not a user-followed link — let the baseUrl's own navigation through.
-    if (_assetsBaseUrl != null && url == _assetsBaseUrl.toString()) {
+    if (navigationAction.isForMainFrame &&
+        (url == 'about:blank' || url == _assetsBaseUrl?.toString())) {
       return NavigationActionPolicy.ALLOW;
     }
 

--- a/core/lib/presentation/views/html_viewer/ios_html_content_viewer_widget.dart
+++ b/core/lib/presentation/views/html_viewer/ios_html_content_viewer_widget.dart
@@ -82,8 +82,7 @@ class _IosHtmlContentViewerWidgetState extends State<IosHtmlContentViewerWidget>
       return NavigationActionPolicy.CANCEL;
     }
 
-    if (navigationAction.isForMainFrame &&
-        (url == 'about:blank' || url == _assetsBaseUrl?.toString())) {
+    if (isProgrammaticDocumentLoad(navigationAction, _assetsBaseUrl)) {
       return NavigationActionPolicy.ALLOW;
     }
 

--- a/core/lib/utils/html/html_template.dart
+++ b/core/lib/utils/html/html_template.dart
@@ -1,12 +1,13 @@
 
 import 'package:core/presentation/constants/constants_ui.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 
 class HtmlTemplate {
-  static const String printDocumentCssStyle = '''
-    <style> 
-      $fontFaceStyle 
-      
+  static String get printDocumentCssStyle => '''
+    <style>
+      $fontFaceStyle
+
       body,td,div,p,a,input {
         font-family: '$fontFamilyApp', sans-serif;
       }
@@ -49,23 +50,20 @@ class HtmlTemplate {
      </style>
   ''';
 
-  /// HTML content is rendered outside Flutter, so the font can only be reached
-  /// by URL and the design system asset path has to be spelled out here. Keep
-  /// it aligned with the family resolved by `ThemeUtils`.
-  ///
-  /// Relative (no leading `/`) so it resolves against `<base href>` on web,
-  /// including non-root preview deploys. On mobile this alone is not enough:
-  /// `InAppWebView.loadData()` has no base URL by default (resolves against
-  /// `about:blank`), so a relative path still 404s there. Fixing that needs
-  /// wiring a base URL into `HtmlContentViewer` / `IosHtmlContentViewerWidget`
-  /// (`WebViewAssetLoader` on Android, `allowingReadAccessTo` on iOS) — not
-  /// done yet, tracked as a follow-up.
-  static const String _fontAssetDirectory =
-      'assets/packages/linagora_design_flutter/assets/fonts';
+  /// Web mounts `flutter_assets/` under an `/assets/` URL prefix; mobile's
+  /// WebView `baseUrl` points directly at `flutter_assets/`, so the same
+  /// prefix there 404s.
+  static String get _fontAssetDirectory {
+    const packageDirectory =
+        'packages/linagora_design_flutter/assets/fonts';
+    return PlatformInfo.isMobile
+        ? packageDirectory
+        : 'assets/$packageDirectory';
+  }
 
   static const String fontFamilyApp = ConstantsUI.fontApp;
 
-  static const String fontFaceStyle = '''
+  static String get fontFaceStyle => '''
     @font-face {
       font-family: '$fontFamilyApp';
       src: url("$_fontAssetDirectory/${ConstantsUI.fontFileRegular}.ttf") format("truetype");
@@ -122,7 +120,7 @@ class HtmlTemplate {
     }
   ''';
 
-  static const String previewEMLFileCssStyle = '''
+  static String get previewEMLFileCssStyle => '''
     <style> 
       $fontFaceStyle
 

--- a/core/lib/utils/html/webview_asset_base_url.dart
+++ b/core/lib/utils/html/webview_asset_base_url.dart
@@ -39,3 +39,43 @@ class WebViewAssetBaseUrl {
     }
   }
 }
+
+/// True when [action] is the WebView's own navigation to [baseUrl] (or
+/// `about:blank`) triggered by `loadData`, as opposed to a user-followed
+/// link. iOS can report this navigation's URL with `/private/var/` instead
+/// of `/var/`, or a mismatched trailing slash, compared to the string
+/// [baseUrl] was built from — so this compares on a normalized path instead
+/// of exact string equality. `hasGesture` is checked so a malicious `file://`
+/// link inside the HTML content can never be auto-allowed just because its
+/// path happens to match.
+bool isProgrammaticDocumentLoad(NavigationAction action, WebUri? baseUrl) {
+  if (!action.isForMainFrame) return false;
+
+  final url = action.request.url?.toString();
+  if (url == 'about:blank') return true;
+
+  if (baseUrl == null ||
+      url == null ||
+      action.request.url?.scheme != 'file' ||
+      action.hasGesture == true) {
+    return false;
+  }
+
+  String normalize(String path) => path
+      .replaceFirst('file:///private/var/', 'file:///var/')
+      .replaceFirst(RegExp(r'/+$'), '');
+
+  final navigatedUrl = normalize(url);
+  final cachedBaseUrl = normalize(baseUrl.toString());
+  return navigatedUrl == cachedBaseUrl ||
+      navigatedUrl.startsWith('$cachedBaseUrl/');
+}
+
+/// Enables `chrome://inspect` access to Android WebViews in debug builds
+/// only. Unlike iOS's per-instance `isInspectable` setting, Android WebView
+/// debugging is a one-time global flag that must be set before any WebView
+/// is created.
+Future<void> enableAndroidWebViewDebuggingInDebugMode() async {
+  if (!kDebugMode) return;
+  await InAppWebViewController.setWebContentsDebuggingEnabled(true);
+}

--- a/core/lib/utils/html/webview_asset_base_url.dart
+++ b/core/lib/utils/html/webview_asset_base_url.dart
@@ -14,7 +14,7 @@ class WebViewAssetBaseUrl {
 
   @visibleForTesting
   static const String channelName =
-      'com.linagora.android.tmail/webview_asset_base_url';
+      'com.linagora.tmail/webview_asset_base_url';
   @visibleForTesting
   static const String flutterAssetsBaseUrlMethod = 'flutterAssetsBaseUrl';
 

--- a/core/lib/utils/html/webview_asset_base_url.dart
+++ b/core/lib/utils/html/webview_asset_base_url.dart
@@ -1,0 +1,46 @@
+import 'package:core/utils/app_logger.dart';
+import 'package:core/utils/platform_info.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+/// Resolves the on-disk `flutter_assets/` URL, used as `loadData`'s `baseUrl`
+/// so relative asset URLs (e.g. the design-system font) can resolve on mobile.
+class WebViewAssetBaseUrl {
+  WebViewAssetBaseUrl({MethodChannel channel = const MethodChannel(channelName)})
+      : _channel = channel;
+
+  static final WebViewAssetBaseUrl instance = WebViewAssetBaseUrl();
+
+  @visibleForTesting
+  static const String channelName =
+      'com.linagora.android.tmail/webview_asset_base_url';
+  @visibleForTesting
+  static const String flutterAssetsBaseUrlMethod = 'flutterAssetsBaseUrl';
+
+  final MethodChannel _channel;
+
+  WebUri? _cachedFlutterAssetsBaseUrl;
+  bool _fetchFailed = false;
+
+  Future<WebUri?> flutterAssetsBaseUrl() async {
+    if (!PlatformInfo.isMobile) return null;
+    if (_cachedFlutterAssetsBaseUrl != null) return _cachedFlutterAssetsBaseUrl;
+    if (_fetchFailed) return null;
+
+    try {
+      final baseUrl = await _channel.invokeMethod<String>(
+        flutterAssetsBaseUrlMethod,
+      );
+      if (baseUrl == null) {
+        _fetchFailed = true;
+        return null;
+      }
+      return _cachedFlutterAssetsBaseUrl = WebUri(baseUrl);
+    } catch (exception) {
+      logWarning('$runtimeType::flutterAssetsBaseUrl:Exception = $exception');
+      _fetchFailed = true;
+      return null;
+    }
+  }
+}

--- a/core/lib/utils/html/webview_asset_base_url.dart
+++ b/core/lib/utils/html/webview_asset_base_url.dart
@@ -53,23 +53,20 @@ bool isProgrammaticDocumentLoad(NavigationAction action, WebUri? baseUrl) {
 
   final url = action.request.url?.toString();
   if (url == 'about:blank') return true;
-
-  if (baseUrl == null ||
-      url == null ||
-      action.request.url?.scheme != 'file' ||
-      action.hasGesture == true) {
+  if (baseUrl == null || url == null) return false;
+  if (action.request.url?.scheme != 'file' || action.hasGesture == true) {
     return false;
   }
 
-  String normalize(String path) => path
-      .replaceFirst('file:///private/var/', 'file:///var/')
-      .replaceFirst(RegExp(r'/+$'), '');
-
-  final navigatedUrl = normalize(url);
-  final cachedBaseUrl = normalize(baseUrl.toString());
+  final navigatedUrl = _normalizeFileUrl(url);
+  final cachedBaseUrl = _normalizeFileUrl(baseUrl.toString());
   return navigatedUrl == cachedBaseUrl ||
       navigatedUrl.startsWith('$cachedBaseUrl/');
 }
+
+String _normalizeFileUrl(String path) => path
+    .replaceFirst('file:///private/var/', 'file:///var/')
+    .replaceFirst(RegExp(r'/+$'), '');
 
 /// Enables `chrome://inspect` access to Android WebViews in debug builds
 /// only. Unlike iOS's per-instance `isInspectable` setting, Android WebView

--- a/core/lib/utils/html/webview_asset_base_url.dart
+++ b/core/lib/utils/html/webview_asset_base_url.dart
@@ -20,26 +20,21 @@ class WebViewAssetBaseUrl {
 
   final MethodChannel _channel;
 
-  WebUri? _cachedFlutterAssetsBaseUrl;
-  bool _fetchFailed = false;
+  Future<WebUri?>? _resolution;
 
-  Future<WebUri?> flutterAssetsBaseUrl() async {
-    if (!PlatformInfo.isMobile) return null;
-    if (_cachedFlutterAssetsBaseUrl != null) return _cachedFlutterAssetsBaseUrl;
-    if (_fetchFailed) return null;
+  Future<WebUri?> flutterAssetsBaseUrl() {
+    if (!PlatformInfo.isMobile) return Future.value(null);
+    return _resolution ??= _resolve();
+  }
 
+  Future<WebUri?> _resolve() async {
     try {
       final baseUrl = await _channel.invokeMethod<String>(
         flutterAssetsBaseUrlMethod,
       );
-      if (baseUrl == null) {
-        _fetchFailed = true;
-        return null;
-      }
-      return _cachedFlutterAssetsBaseUrl = WebUri(baseUrl);
+      return baseUrl != null ? WebUri(baseUrl) : null;
     } catch (exception) {
       logWarning('$runtimeType::flutterAssetsBaseUrl:Exception = $exception');
-      _fetchFailed = true;
       return null;
     }
   }

--- a/core/test/utils/html/html_template_font_test.dart
+++ b/core/test/utils/html/html_template_font_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:core/utils/html/html_template.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linagora_design_flutter/style/linagora_text_theme.dart';
 
@@ -9,14 +10,24 @@ import 'package:linagora_design_flutter/style/linagora_text_theme.dart';
 /// outside Flutter, so its font is referenced by URL instead of through the
 /// theme. Nothing links the two, and a missing file only shows up as a 404 at
 /// runtime — these tests are the link.
+///
+/// `HtmlTemplate.fontFaceStyle` is platform-conditional (web keeps a leading
+/// `assets/` URL segment, mobile does not — see its doc comment), so most
+/// assertions below pin the platform explicitly via `PlatformInfo
+/// .isTestingForWeb` rather than relying on the test harness's ambient
+/// `defaultTargetPlatform` (which defaults to `android`, i.e. "mobile", for
+/// plain VM tests).
 void main() {
-  final fontUrls = RegExp(r'url\("([^"]+)"\)')
+  setUp(() => PlatformInfo.isTestingForWeb = true);
+  tearDown(() => PlatformInfo.isTestingForWeb = false);
+
+  List<String> fontUrls() => RegExp(r'url\("([^"]+)"\)')
       .allMatches(HtmlTemplate.fontFaceStyle)
       .map((match) => match.group(1)!)
       .toList();
 
   test('font-face rules are declared', () {
-    expect(fontUrls, isNotEmpty);
+    expect(fontUrls(), isNotEmpty);
   });
 
   test('uses the same font family as the Flutter theme', () {
@@ -26,7 +37,7 @@ void main() {
     expect(themeFamily, endsWith('/${HtmlTemplate.fontFamilyApp}'));
 
     final package = themeFamily!.split('/')[1];
-    for (final url in fontUrls) {
+    for (final url in fontUrls()) {
       expect(url, startsWith('assets/packages/$package/'),
           reason: '$url does not come from the design system package');
     }
@@ -37,7 +48,7 @@ void main() {
     final packagePubspec =
         File.fromUri(packageRoot.resolve('pubspec.yaml')).readAsStringSync();
 
-    for (final url in fontUrls) {
+    for (final url in fontUrls()) {
       // assets/packages/<package>/<pathInsidePackage>
       final pathInsidePackage = url.split('/').skip(3).join('/');
       final file = File.fromUri(packageRoot.resolve(pathInsidePackage));
@@ -53,10 +64,40 @@ void main() {
 
   test('does not point at app-local font assets', () {
     // The app no longer ships its own font files; the design system does.
-    for (final url in fontUrls) {
+    for (final url in fontUrls()) {
       expect(url, isNot(startsWith('assets/fonts/')),
           reason: '$url expects a font the app no longer bundles');
     }
+  });
+
+  group('mobile vs web asset URL convention', () {
+    // Flutter web serves the `flutter_assets/` bundle mounted under an
+    // `/assets/` URL prefix (see `build/web/assets/packages/...`), so a
+    // relative URL needs that leading `assets/` segment to resolve there.
+    test('web keeps the leading assets/ segment', () {
+      PlatformInfo.isTestingForWeb = true;
+
+      for (final url in fontUrls()) {
+        expect(url, startsWith('assets/packages/'),
+            reason: '$url should keep the web assets/ prefix');
+      }
+    });
+
+    // On mobile there is no such prefix: `InAppWebView`'s baseUrl is rooted
+    // directly at the `flutter_assets/` directory (confirmed against a built
+    // debug APK: `assets/flutter_assets/packages/linagora_design_flutter/...`
+    // inside the APK, with no extra `assets/` segment once that directory is
+    // the WebView's origin). A URL still carrying the web `assets/` prefix
+    // 404s there.
+    test('mobile has no leading assets/ segment', () {
+      PlatformInfo.isTestingForWeb = false;
+
+      for (final url in fontUrls()) {
+        expect(url, startsWith('packages/'),
+            reason: '$url still carries the web-only assets/ prefix and '
+                'will 404 against the mobile flutter_assets/ baseUrl');
+      }
+    });
   });
 }
 

--- a/core/test/utils/html/webview_asset_base_url_test.dart
+++ b/core/test/utils/html/webview_asset_base_url_test.dart
@@ -17,6 +17,17 @@ void main() {
     });
   }
 
+  List<int> mockCountingHandler({dynamic result, Object? error}) {
+    final callCount = [0];
+    binaryMessenger.setMockMethodCallHandler(channel, (call) async {
+      expect(call.method, WebViewAssetBaseUrl.flutterAssetsBaseUrlMethod);
+      callCount[0]++;
+      if (error != null) throw error;
+      return result;
+    });
+    return callCount;
+  }
+
   setUp(() {
     debugDefaultTargetPlatformOverride = TargetPlatform.android;
   });
@@ -59,27 +70,17 @@ void main() {
     });
 
     test('caches the resolved url and only calls the native channel once', () async {
-      var callCount = 0;
-      binaryMessenger.setMockMethodCallHandler(channel, (call) async {
-        expect(call.method, WebViewAssetBaseUrl.flutterAssetsBaseUrlMethod);
-        callCount++;
-        return 'file:///var/app/flutter_assets/';
-      });
+      final callCount = mockCountingHandler(result: 'file:///var/app/flutter_assets/');
       final webViewAssetBaseUrl = WebViewAssetBaseUrl();
 
       await webViewAssetBaseUrl.flutterAssetsBaseUrl();
       await webViewAssetBaseUrl.flutterAssetsBaseUrl();
 
-      expect(callCount, 1);
+      expect(callCount[0], 1);
     });
 
     test('concurrent calls only hit the native channel once', () async {
-      var callCount = 0;
-      binaryMessenger.setMockMethodCallHandler(channel, (call) async {
-        expect(call.method, WebViewAssetBaseUrl.flutterAssetsBaseUrlMethod);
-        callCount++;
-        return 'file:///var/app/flutter_assets/';
-      });
+      final callCount = mockCountingHandler(result: 'file:///var/app/flutter_assets/');
       final webViewAssetBaseUrl = WebViewAssetBaseUrl();
 
       final results = await Future.wait([
@@ -87,18 +88,13 @@ void main() {
         webViewAssetBaseUrl.flutterAssetsBaseUrl(),
       ]);
 
-      expect(callCount, 1);
+      expect(callCount[0], 1);
       expect(results[0].toString(), 'file:///var/app/flutter_assets/');
       expect(results[1].toString(), 'file:///var/app/flutter_assets/');
     });
 
     test('returns null and does not retry when the native channel throws', () async {
-      var callCount = 0;
-      binaryMessenger.setMockMethodCallHandler(channel, (call) async {
-        expect(call.method, WebViewAssetBaseUrl.flutterAssetsBaseUrlMethod);
-        callCount++;
-        throw PlatformException(code: 'error');
-      });
+      final callCount = mockCountingHandler(error: PlatformException(code: 'error'));
       final webViewAssetBaseUrl = WebViewAssetBaseUrl();
 
       final first = await webViewAssetBaseUrl.flutterAssetsBaseUrl();
@@ -106,16 +102,11 @@ void main() {
 
       expect(first, isNull);
       expect(second, isNull);
-      expect(callCount, 1);
+      expect(callCount[0], 1);
     });
 
     test('caches a null result and only calls the native channel once', () async {
-      var callCount = 0;
-      binaryMessenger.setMockMethodCallHandler(channel, (call) async {
-        expect(call.method, WebViewAssetBaseUrl.flutterAssetsBaseUrlMethod);
-        callCount++;
-        return null;
-      });
+      final callCount = mockCountingHandler(result: null);
       final webViewAssetBaseUrl = WebViewAssetBaseUrl();
 
       final first = await webViewAssetBaseUrl.flutterAssetsBaseUrl();
@@ -123,7 +114,7 @@ void main() {
 
       expect(first, isNull);
       expect(second, isNull);
-      expect(callCount, 1);
+      expect(callCount[0], 1);
     });
   });
 }

--- a/core/test/utils/html/webview_asset_base_url_test.dart
+++ b/core/test/utils/html/webview_asset_base_url_test.dart
@@ -1,6 +1,7 @@
 import 'package:core/utils/html/webview_asset_base_url.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -115,6 +116,87 @@ void main() {
       expect(first, isNull);
       expect(second, isNull);
       expect(callCount[0], 1);
+    });
+  });
+
+  group('isProgrammaticDocumentLoad', () {
+    NavigationAction navigationActionFor(
+      String? url, {
+      bool isForMainFrame = true,
+      bool? hasGesture,
+    }) {
+      return NavigationAction(
+        isForMainFrame: isForMainFrame,
+        hasGesture: hasGesture,
+        request: URLRequest(url: url != null ? WebUri(url) : null),
+      );
+    }
+
+    test('allows about:blank regardless of baseUrl', () {
+      final action = navigationActionFor('about:blank');
+
+      expect(isProgrammaticDocumentLoad(action, null), isTrue);
+    });
+
+    test('allows an exact match with the cached base url', () {
+      final baseUrl = WebUri('file:///var/app/flutter_assets/');
+      final action = navigationActionFor('file:///var/app/flutter_assets/');
+
+      expect(isProgrammaticDocumentLoad(action, baseUrl), isTrue);
+    });
+
+    test('allows when iOS reports /private/var/ but the cached url uses /var/', () {
+      final baseUrl = WebUri('file:///var/mobile/flutter_assets/');
+      final action = navigationActionFor('file:///private/var/mobile/flutter_assets/');
+
+      expect(isProgrammaticDocumentLoad(action, baseUrl), isTrue);
+    });
+
+    test('allows a trailing-slash mismatch', () {
+      final baseUrl = WebUri('file:///var/app/flutter_assets/');
+      final action = navigationActionFor('file:///var/app/flutter_assets');
+
+      expect(isProgrammaticDocumentLoad(action, baseUrl), isTrue);
+    });
+
+    test('denies a non-file scheme', () {
+      final baseUrl = WebUri('file:///var/app/flutter_assets/');
+      final action = navigationActionFor('https://example.com');
+
+      expect(isProgrammaticDocumentLoad(action, baseUrl), isFalse);
+    });
+
+    test('denies a matching path when the navigation has a user gesture', () {
+      final baseUrl = WebUri('file:///var/app/flutter_assets/');
+      final action = navigationActionFor(
+        'file:///var/app/flutter_assets/',
+        hasGesture: true,
+      );
+
+      expect(isProgrammaticDocumentLoad(action, baseUrl), isFalse);
+    });
+
+    test('denies an unrelated file path', () {
+      final baseUrl = WebUri('file:///var/app/flutter_assets/');
+      final action = navigationActionFor('file:///var/app/other/');
+
+      expect(isProgrammaticDocumentLoad(action, baseUrl), isFalse);
+    });
+
+    test('denies when not for the main frame', () {
+      final baseUrl = WebUri('file:///var/app/flutter_assets/');
+      final action = navigationActionFor(
+        'file:///var/app/flutter_assets/',
+        isForMainFrame: false,
+      );
+
+      expect(isProgrammaticDocumentLoad(action, baseUrl), isFalse);
+    });
+
+    test('denies when baseUrl is null', () {
+      final action = navigationActionFor('file:///var/app/flutter_assets/');
+
+      expect(isProgrammaticDocumentLoad(action, null), isFalse);
     });
   });
 }

--- a/core/test/utils/html/webview_asset_base_url_test.dart
+++ b/core/test/utils/html/webview_asset_base_url_test.dart
@@ -11,7 +11,10 @@ void main() {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
 
   void mockNativeResult(dynamic result) {
-    binaryMessenger.setMockMethodCallHandler(channel, (call) async => result);
+    binaryMessenger.setMockMethodCallHandler(channel, (call) async {
+      expect(call.method, WebViewAssetBaseUrl.flutterAssetsBaseUrlMethod);
+      return result;
+    });
   }
 
   setUp(() {
@@ -46,9 +49,19 @@ void main() {
       expect(result.toString(), 'file:///var/app/flutter_assets/');
     });
 
+    test('resolves the base url the native side returns on iOS', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      mockNativeResult('file:///var/mobile/flutter_assets/');
+
+      final result = await WebViewAssetBaseUrl().flutterAssetsBaseUrl();
+
+      expect(result.toString(), 'file:///var/mobile/flutter_assets/');
+    });
+
     test('caches the resolved url and only calls the native channel once', () async {
       var callCount = 0;
       binaryMessenger.setMockMethodCallHandler(channel, (call) async {
+        expect(call.method, WebViewAssetBaseUrl.flutterAssetsBaseUrlMethod);
         callCount++;
         return 'file:///var/app/flutter_assets/';
       });
@@ -63,6 +76,7 @@ void main() {
     test('concurrent calls only hit the native channel once', () async {
       var callCount = 0;
       binaryMessenger.setMockMethodCallHandler(channel, (call) async {
+        expect(call.method, WebViewAssetBaseUrl.flutterAssetsBaseUrlMethod);
         callCount++;
         return 'file:///var/app/flutter_assets/';
       });
@@ -81,6 +95,7 @@ void main() {
     test('returns null and does not retry when the native channel throws', () async {
       var callCount = 0;
       binaryMessenger.setMockMethodCallHandler(channel, (call) async {
+        expect(call.method, WebViewAssetBaseUrl.flutterAssetsBaseUrlMethod);
         callCount++;
         throw PlatformException(code: 'error');
       });
@@ -94,12 +109,21 @@ void main() {
       expect(callCount, 1);
     });
 
-    test('returns null when the native channel returns null', () async {
-      mockNativeResult(null);
+    test('caches a null result and only calls the native channel once', () async {
+      var callCount = 0;
+      binaryMessenger.setMockMethodCallHandler(channel, (call) async {
+        expect(call.method, WebViewAssetBaseUrl.flutterAssetsBaseUrlMethod);
+        callCount++;
+        return null;
+      });
+      final webViewAssetBaseUrl = WebViewAssetBaseUrl();
 
-      final result = await WebViewAssetBaseUrl().flutterAssetsBaseUrl();
+      final first = await webViewAssetBaseUrl.flutterAssetsBaseUrl();
+      final second = await webViewAssetBaseUrl.flutterAssetsBaseUrl();
 
-      expect(result, isNull);
+      expect(first, isNull);
+      expect(second, isNull);
+      expect(callCount, 1);
     });
   });
 }

--- a/core/test/utils/html/webview_asset_base_url_test.dart
+++ b/core/test/utils/html/webview_asset_base_url_test.dart
@@ -1,0 +1,87 @@
+import 'package:core/utils/html/webview_asset_base_url.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel(WebViewAssetBaseUrl.channelName);
+  final binaryMessenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  void mockNativeResult(dynamic result) {
+    binaryMessenger.setMockMethodCallHandler(channel, (call) async => result);
+  }
+
+  setUp(() {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+  });
+
+  tearDown(() {
+    binaryMessenger.setMockMethodCallHandler(channel, null);
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  group('WebViewAssetBaseUrl::flutterAssetsBaseUrl', () {
+    test('returns null on desktop/web without calling the native channel', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      var wasCalled = false;
+      binaryMessenger.setMockMethodCallHandler(channel, (call) async {
+        wasCalled = true;
+        return 'file:///should-not-be-used/';
+      });
+
+      final result = await WebViewAssetBaseUrl().flutterAssetsBaseUrl();
+
+      expect(result, isNull);
+      expect(wasCalled, isFalse);
+    });
+
+    test('resolves the base url the native side returns', () async {
+      mockNativeResult('file:///var/app/flutter_assets/');
+
+      final result = await WebViewAssetBaseUrl().flutterAssetsBaseUrl();
+
+      expect(result.toString(), 'file:///var/app/flutter_assets/');
+    });
+
+    test('caches the resolved url and only calls the native channel once', () async {
+      var callCount = 0;
+      binaryMessenger.setMockMethodCallHandler(channel, (call) async {
+        callCount++;
+        return 'file:///var/app/flutter_assets/';
+      });
+      final webViewAssetBaseUrl = WebViewAssetBaseUrl();
+
+      await webViewAssetBaseUrl.flutterAssetsBaseUrl();
+      await webViewAssetBaseUrl.flutterAssetsBaseUrl();
+
+      expect(callCount, 1);
+    });
+
+    test('returns null and does not retry when the native channel throws', () async {
+      var callCount = 0;
+      binaryMessenger.setMockMethodCallHandler(channel, (call) async {
+        callCount++;
+        throw PlatformException(code: 'error');
+      });
+      final webViewAssetBaseUrl = WebViewAssetBaseUrl();
+
+      final first = await webViewAssetBaseUrl.flutterAssetsBaseUrl();
+      final second = await webViewAssetBaseUrl.flutterAssetsBaseUrl();
+
+      expect(first, isNull);
+      expect(second, isNull);
+      expect(callCount, 1);
+    });
+
+    test('returns null when the native channel returns null', () async {
+      mockNativeResult(null);
+
+      final result = await WebViewAssetBaseUrl().flutterAssetsBaseUrl();
+
+      expect(result, isNull);
+    });
+  });
+}

--- a/core/test/utils/html/webview_asset_base_url_test.dart
+++ b/core/test/utils/html/webview_asset_base_url_test.dart
@@ -60,6 +60,24 @@ void main() {
       expect(callCount, 1);
     });
 
+    test('concurrent calls only hit the native channel once', () async {
+      var callCount = 0;
+      binaryMessenger.setMockMethodCallHandler(channel, (call) async {
+        callCount++;
+        return 'file:///var/app/flutter_assets/';
+      });
+      final webViewAssetBaseUrl = WebViewAssetBaseUrl();
+
+      final results = await Future.wait([
+        webViewAssetBaseUrl.flutterAssetsBaseUrl(),
+        webViewAssetBaseUrl.flutterAssetsBaseUrl(),
+      ]);
+
+      expect(callCount, 1);
+      expect(results[0].toString(), 'file:///var/app/flutter_assets/');
+      expect(results[1].toString(), 'file:///var/app/flutter_assets/');
+    });
+
     test('returns null and does not retry when the native channel throws', () async {
       var callCount = 0;
       binaryMessenger.setMockMethodCallHandler(channel, (call) async {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -115,6 +115,8 @@ PODS:
     - Flutter
   - flutter_local_notifications (0.0.1):
     - Flutter
+  - flutter_localization (0.0.1):
+    - Flutter
   - flutter_native_splash (0.0.1):
     - Flutter
   - flutter_secure_storage (6.0.0):
@@ -245,6 +247,7 @@ DEPENDENCIES:
   - flutter_inappwebview_ios (from `.symlinks/plugins/flutter_inappwebview_ios/ios`)
   - flutter_keyboard_visibility (from `.symlinks/plugins/flutter_keyboard_visibility/ios`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
+  - flutter_localization (from `.symlinks/plugins/flutter_localization/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - flutter_web_auth_2 (from `.symlinks/plugins/flutter_web_auth_2/ios`)
@@ -332,6 +335,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_keyboard_visibility/ios"
   flutter_local_notifications:
     :path: ".symlinks/plugins/flutter_local_notifications/ios"
+  flutter_localization:
+    :path: ".symlinks/plugins/flutter_localization/ios"
   flutter_native_splash:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
   flutter_secure_storage:
@@ -402,6 +407,7 @@ SPEC CHECKSUMS:
   flutter_inappwebview_ios: b89ba3482b96fb25e00c967aae065701b66e9b99
   flutter_keyboard_visibility: 4625131e43015dbbe759d9b20daaf77e0e3f6619
   flutter_local_notifications: ad39620c743ea4c15127860f4b5641649a988100
+  flutter_localization: 72299fb6cb4e51cae587bd953ed0b958040b71e6
   flutter_native_splash: 9e672d3818957718ee006a491730c09deeecace9
   flutter_secure_storage: 2c2ff13db9e0a5647389bff88b0ecac56e3f3418
   flutter_web_auth_2: 5c8d9dcd7848b5a9efb086d24e7a9adcae979c80

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		B561AD69C2BE6DF40BF29406 /* Pods_TwakeMailNSE.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA243B93F65E4E3CD7DC0348 /* Pods_TwakeMailNSE.framework */; };
 		C06B95712FAC780E009C15B4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06B95702FAC7800009C15B4 /* SceneDelegate.swift */; };
 		CDFECA8C54311B749F044831 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5810EDDA99BEFEACD742F507 /* Pods_Runner.framework */; };
+		D91B22A6B931C2B9A41A0D6F /* WebViewAssetBaseUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A51B0F1D9ACACBECABDEA9D1 /* WebViewAssetBaseUrl.swift */; };
 		F522E87F2C0EE23400DDA35B /* AuthenticationSSOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F522E87E2C0EE23400DDA35B /* AuthenticationSSOTests.swift */; };
 		F522E8812C0EE3F200DDA35B /* AuthenticationSSO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E7D8832B3877050009BB8A /* AuthenticationSSO.swift */; };
 		F522E8822C0EE48700DDA35B /* AuthenticationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53D1E872B2E4B3B00051FD0 /* AuthenticationType.swift */; };
@@ -145,6 +146,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A51B0F1D9ACACBECABDEA9D1 /* WebViewAssetBaseUrl.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewAssetBaseUrl.swift; sourceTree = "<group>"; };
 		AF31502A83CA492E27C36A7B /* Pods-TwakeMailNSE.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TwakeMailNSE.profile.xcconfig"; path = "Target Support Files/Pods-TwakeMailNSE/Pods-TwakeMailNSE.profile.xcconfig"; sourceTree = "<group>"; };
 		B2EAFF659572E6B9F5AFAAF8 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		BC08294F5AE09BF8CC592AD1 /* Pods-TeamMailShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TeamMailShareExtension.release.xcconfig"; path = "Target Support Files/Pods-TeamMailShareExtension/Pods-TeamMailShareExtension.release.xcconfig"; sourceTree = "<group>"; };
@@ -298,6 +300,7 @@
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 				F5550D2C2B4E90A7003DD2AE /* Localizable.strings */,
+				A51B0F1D9ACACBECABDEA9D1 /* WebViewAssetBaseUrl.swift */,
 			);
 			path = Runner;
 			sourceTree = "<group>";
@@ -843,6 +846,7 @@
 				F5EFC07D2B328B9F00829056 /* TwakeLogger.swift in Sources */,
 				F5E7D8742B3578F90009BB8A /* JmapConstants.swift in Sources */,
 				F522E8832C0EE48C00DDA35B /* Authentication.swift in Sources */,
+				D91B22A6B931C2B9A41A0D6F /* WebViewAssetBaseUrl.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -9,6 +9,7 @@ import flutter_local_notifications
     var notificationInteractionChannel: FlutterMethodChannel?
     var fcmMethodChannel: FlutterMethodChannel?
     var currentEmailId: String?
+    let webViewAssetBaseUrl = WebViewAssetBaseUrl()
     
     override func application(
         _ application: UIApplication,
@@ -40,9 +41,10 @@ import flutter_local_notifications
 
     func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
         GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
-        
+
         createNotificationInteractionChannel(engineBridge.applicationRegistrar.messenger())
         createFcmMethodChannel(engineBridge.applicationRegistrar.messenger())
+        webViewAssetBaseUrl.register(engineBridge.applicationRegistrar.messenger())
     }
     
     override func applicationWillTerminate(_ application: UIApplication) {

--- a/ios/Runner/WebViewAssetBaseUrl.swift
+++ b/ios/Runner/WebViewAssetBaseUrl.swift
@@ -3,7 +3,7 @@ import Flutter
 /// Exposes the on-disk `flutter_assets/` URL for Dart to pass as `loadData`'s `baseUrl`.
 class WebViewAssetBaseUrl {
 
-    private static let channelName = "com.linagora.android.tmail/webview_asset_base_url"
+    private static let channelName = "com.linagora.tmail/webview_asset_base_url"
     private static let flutterAssetsBaseUrlMethod = "flutterAssetsBaseUrl"
 
     func register(_ binaryMessenger: FlutterBinaryMessenger) {

--- a/ios/Runner/WebViewAssetBaseUrl.swift
+++ b/ios/Runner/WebViewAssetBaseUrl.swift
@@ -1,0 +1,40 @@
+import Flutter
+
+/// Exposes the on-disk `flutter_assets/` URL for Dart to pass as `loadData`'s `baseUrl`.
+class WebViewAssetBaseUrl {
+
+    private static let channelName = "com.linagora.android.tmail/webview_asset_base_url"
+    private static let flutterAssetsBaseUrlMethod = "flutterAssetsBaseUrl"
+
+    func register(_ binaryMessenger: FlutterBinaryMessenger) {
+        let channel = FlutterMethodChannel(
+            name: Self.channelName,
+            binaryMessenger: binaryMessenger
+        )
+        channel.setMethodCallHandler { [weak self] call, result in
+            switch call.method {
+            case Self.flutterAssetsBaseUrlMethod:
+                result(self?.flutterAssetsBaseUrl())
+            default:
+                result(FlutterMethodNotImplemented)
+            }
+        }
+    }
+
+    private func flutterAssetsBaseUrl() -> String? {
+        // lookupKey(forAsset:) joins "<flutterAssetsDir>/<asset>"; trimming
+        // the known asset name back off recovers the directory name, since
+        // the underlying flutterAssetsName isn't exposed directly.
+        let probeKey = FlutterDartProject.lookupKey(forAsset: "AssetManifest.json")
+        guard let flutterAssetsDirName = probeKey
+            .range(of: "/AssetManifest.json")
+            .map({ String(probeKey[probeKey.startIndex..<$0.lowerBound]) }) else {
+            return nil
+        }
+        let flutterAssetsUrl = Bundle.main.bundleURL.appendingPathComponent(
+            flutterAssetsDirName,
+            isDirectory: true
+        )
+        return flutterAssetsUrl.absoluteString
+    }
+}

--- a/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
+++ b/lib/features/composer/presentation/widgets/mobile/mobile_editor_widget.dart
@@ -2,6 +2,7 @@ import 'package:core/presentation/constants/constants_ui.dart';
 import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/build_utils.dart';
 import 'package:core/utils/html/html_template.dart';
+import 'package:core/utils/html/webview_asset_base_url.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:core/utils/html/html_utils.dart';
 import 'package:flutter/material.dart';
@@ -171,6 +172,7 @@ class _MobileEditorState extends State<MobileEditorWidget> with TextSelectionMix
       onCreated: _onWebViewCreated,
       onCompleted: _onWebViewCompleted,
       onContentHeightChanged: PlatformInfo.isIOS ? widget.onEditorContentHeightChanged : null,
+      baseUrlResolver: WebViewAssetBaseUrl.instance.flutterAssetsBaseUrl,
     );
   }
 }

--- a/lib/features/identity_creator/presentation/widgets/identity_signature_input_field_widget.dart
+++ b/lib/features/identity_creator/presentation/widgets/identity_signature_input_field_widget.dart
@@ -3,6 +3,7 @@ import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/utils/html/html_template.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:core/utils/html/html_utils.dart';
+import 'package:core/utils/html/webview_asset_base_url.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -233,6 +234,7 @@ class IdentitySignatureInputFieldWidget extends StatelessWidget {
         context,
         editorApi,
       ),
+      baseUrlResolver: WebViewAssetBaseUrl.instance.flutterAssetsBaseUrl,
     );
   }
 }

--- a/lib/features/manage_account/presentation/vacation/vacation_view.dart
+++ b/lib/features/manage_account/presentation/vacation/vacation_view.dart
@@ -7,6 +7,7 @@ import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/presentation/views/responsive/responsive_widget.dart';
 import 'package:core/utils/html/html_template.dart';
 import 'package:core/utils/html/html_utils.dart';
+import 'package:core/utils/html/webview_asset_base_url.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_portal/flutter_portal.dart';
@@ -539,7 +540,8 @@ class VacationView extends GetWidget<VacationController> {
           addDefaultSelectionMenuItems: false,
           initialContent: controller.vacationMessageHtmlText ?? '',
           customStyleCss: HtmlTemplate.mobileCustomInternalStyleCSS(direction: AppUtils.getCurrentDirection(context)),
-          onCreated: (editorApi) => controller.initRichTextForMobile(context, editorApi)
+          onCreated: (editorApi) => controller.initRichTextForMobile(context, editorApi),
+          baseUrlResolver: WebViewAssetBaseUrl.instance.flutterAssetsBaseUrl,
       );
     }
   }

--- a/lib/main/main_entry.dart
+++ b/lib/main/main_entry.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/utils/theme_utils.dart';
 import 'package:core/utils/build_utils.dart';
+import 'package:core/utils/html/webview_asset_base_url.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/widgets.dart';
 import 'package:tmail_ui_user/features/caching/config/hive_cache_config.dart';
@@ -27,6 +28,9 @@ Future<void> runTmailPreload() async {
   if (PlatformInfo.isMobile) {
     await workerManager.init(dynamicSpawning: true);
     workerManager.log = BuildUtils.isDebugMode;
+  }
+  if (PlatformInfo.isAndroid) {
+    await enableAndroidWebViewDebuggingInDebugMode();
   }
   await CozyIntegration.integrateCozy();
   await HiveCacheConfig.instance.initializeEncryptionKey();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -502,8 +502,8 @@ packages:
     dependency: transitive
     description:
       path: "."
-      ref: master
-      resolved-ref: "0d2a6af30721bb88714eee42cc0d48cdfd8011a8"
+      ref: TF-4750-composer-baseurl-strict-match
+      resolved-ref: "0083c474957953a57ab5660c9fa4a6161483e075"
       url: "https://github.com/linagora/enough_html_editor.git"
     source: git
     version: "0.1.7"
@@ -2026,8 +2026,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: main
-      resolved-ref: fad6dc0102d07589c1cc6af97f1d8092749d1185
+      ref: TF-4750-update-enough_html_editor-dependency-reference
+      resolved-ref: f16ac2bf8b3b898135bb203ca07f0fef0d16ea5a
       url: "https://github.com/linagora/rich-text-composer.git"
     source: git
     version: "0.1.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -502,11 +502,11 @@ packages:
     dependency: transitive
     description:
       path: "."
-      ref: master
-      resolved-ref: e1302796a79e8689e09de65544f343db2b798dff
+      ref: TF-4750-update-pass-base-url-to-WebView-load-data
+      resolved-ref: f7013519831be946d0e750dd101eb272013a2ec4
       url: "https://github.com/linagora/enough_html_editor.git"
     source: git
-    version: "0.1.6"
+    version: "0.1.7"
   enough_platform_widgets:
     dependency: transitive
     description:
@@ -2026,8 +2026,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: main
-      resolved-ref: fad6dc0102d07589c1cc6af97f1d8092749d1185
+      ref: TF-4750-update-enough_html_editor-dependency-reference
+      resolved-ref: b48a84bc6138ddbbf3886c8603a4dbf6f639cc69
       url: "https://github.com/linagora/rich-text-composer.git"
     source: git
     version: "0.1.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -502,8 +502,8 @@ packages:
     dependency: transitive
     description:
       path: "."
-      ref: TF-4750-update-pass-base-url-to-WebView-load-data
-      resolved-ref: f7013519831be946d0e750dd101eb272013a2ec4
+      ref: master
+      resolved-ref: "0d2a6af30721bb88714eee42cc0d48cdfd8011a8"
       url: "https://github.com/linagora/enough_html_editor.git"
     source: git
     version: "0.1.7"
@@ -2026,8 +2026,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: TF-4750-update-enough_html_editor-dependency-reference
-      resolved-ref: b48a84bc6138ddbbf3886c8603a4dbf6f639cc69
+      ref: main
+      resolved-ref: fad6dc0102d07589c1cc6af97f1d8092749d1185
       url: "https://github.com/linagora/rich-text-composer.git"
     source: git
     version: "0.1.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -81,7 +81,7 @@ dependencies:
   rich_text_composer:
     git:
       url: https://github.com/linagora/rich-text-composer.git
-      ref: main
+      ref: TF-4750-update-enough_html_editor-dependency-reference
 
   html_editor_enhanced:
     git:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -81,7 +81,7 @@ dependencies:
   rich_text_composer:
     git:
       url: https://github.com/linagora/rich-text-composer.git
-      ref: TF-4750-update-enough_html_editor-dependency-reference
+      ref: main
 
   html_editor_enhanced:
     git:


### PR DESCRIPTION
## Issue
- #4750 

## Desc

Design-system font requests 404 on mobile because InAppWebView.loadData() resolves against about:blank by default. Adds WebViewAssetBaseUrl (native channel on both platforms) to expose the flutter_assets/ directory as loadData's baseUrl, and makes HtmlTemplate's font path platform-conditional since web and mobile mount flutter_assets/ under different URL prefixes.

## Need merge

- https://github.com/linagora/enough_html_editor/pull/43

## Demo


https://github.com/user-attachments/assets/bea42866-41cf-4044-95b1-d07048a8cb15


https://github.com/user-attachments/assets/86056b69-e9dd-4f15-9b6b-e6397eebf1ee



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved HTML and email rendering by resolving bundled assets correctly in mobile WebViews.
  * Updated message, signature, and vacation-response editors to support embedded assets and fonts.
  * Added platform-specific handling for web and mobile font and asset paths.

* **Bug Fixes**
  * Fixed missing or inaccessible fonts and local resources in rendered HTML content.
  * Enabled WebView inspection during debug builds to simplify troubleshooting.
  * Improved navigation handling for locally loaded HTML content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->