### PR TITLE
TF-4758 Enable drive integration by default

### DIFF
--- a/lib/features/manage_account/domain/model/preferences/drive_attachment_config.dart
+++ b/lib/features/manage_account/domain/model/preferences/drive_attachment_config.dart
@@ -10,7 +10,7 @@ class DriveAttachmentConfig extends PreferencesConfig {
   final bool isEnabled;
 
   DriveAttachmentConfig({
-    this.isEnabled = false,
+    this.isEnabled = true,
   });
 
   @override

--- a/lib/features/manage_account/presentation/preferences/model/preference_options/drive_attachment_preference_option.dart
+++ b/lib/features/manage_account/presentation/preferences/model/preference_options/drive_attachment_preference_option.dart
@@ -13,9 +13,6 @@ class DriveAttachmentPreferenceOption extends LocalPreferenceOption {
   String get id => 'drive-attachment';
 
   @override
-  bool get isExperimental => true;
-
-  @override
   String title(AppLocalizations l) => l.driveAttachment;
 
   @override

--- a/test/features/manage_account/data/local/preferences_setting_manager_test.dart
+++ b/test/features/manage_account/data/local/preferences_setting_manager_test.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tmail_ui_user/features/manage_account/data/local/preferences_setting_manager.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/ai_scribe_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/default_preferences_config.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/drive_attachment_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/label_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/spam_report_config.dart';
@@ -146,6 +147,89 @@ void main() {
         final secondLoadSetting = await manager.loadPreferences();
 
         expect(firstLoadSetting, equals(secondLoadSetting));
+      },
+    );
+  });
+
+  // Drive attachment shipped disabled-by-default behind a 7-tap reveal, so the
+  // only installs holding a stored value are those that used that reveal.
+  // These cover what an upgrade sees, without any cache migration.
+  group('loadPreferences drive attachment upgrade path', () {
+    test(
+      'WHEN an old install stored other configs but never revealed the drive toggle\n'
+      'THEN drive attachment comes back enabled',
+      () async {
+        await sharedPreferences.setString(
+          storageKey(ThreadDetailConfig.keySuffix),
+          jsonEncode(ThreadDetailConfig(isEnabled: true).toJson()),
+        );
+
+        final result = await manager.loadPreferences();
+
+        expect(result.configs.whereType<DriveAttachmentConfig>(), isEmpty);
+        expect(result.driveAttachmentConfig.isEnabled, isTrue);
+      },
+    );
+
+    test(
+      'WHEN an old install explicitly turned drive attachment off\n'
+      'THEN that opt-out survives the upgrade',
+      () async {
+        await sharedPreferences.setString(
+          storageKey(DriveAttachmentConfig.keySuffix),
+          jsonEncode(DriveAttachmentConfig(isEnabled: false).toJson()),
+        );
+
+        final result = await manager.loadPreferences();
+
+        expect(result.driveAttachmentConfig.isEnabled, isFalse);
+      },
+    );
+
+    test(
+      'WHEN an old install that opted out toggles drive attachment back on\n'
+      'THEN the new value is persisted and reloaded',
+      () async {
+        await sharedPreferences.setString(
+          storageKey(DriveAttachmentConfig.keySuffix),
+          jsonEncode(DriveAttachmentConfig(isEnabled: false).toJson()),
+        );
+
+        await manager.savePreferences(DriveAttachmentConfig(isEnabled: true));
+        final result = await manager.loadPreferences();
+
+        expect(result.driveAttachmentConfig.isEnabled, isTrue);
+      },
+    );
+
+    test(
+      'WHEN the stored drive config is malformed JSON\n'
+      'THEN it is dropped and drive attachment falls back to enabled',
+      () async {
+        await sharedPreferences.setString(
+          storageKey(DriveAttachmentConfig.keySuffix),
+          'not-valid-json',
+        );
+
+        final result = await manager.loadPreferences();
+
+        expect(result.configs.whereType<DriveAttachmentConfig>(), isEmpty);
+        expect(result.driveAttachmentConfig.isEnabled, isTrue);
+      },
+    );
+
+    test(
+      'WHEN the stored drive config json lost its isEnabled key\n'
+      'THEN drive attachment falls back to enabled',
+      () async {
+        await sharedPreferences.setString(
+          storageKey(DriveAttachmentConfig.keySuffix),
+          jsonEncode(<String, dynamic>{}),
+        );
+
+        final result = await manager.loadPreferences();
+
+        expect(result.driveAttachmentConfig.isEnabled, isTrue);
       },
     );
   });

--- a/test/features/manage_account/domain/model/preferences/drive_attachment_config_test.dart
+++ b/test/features/manage_account/domain/model/preferences/drive_attachment_config_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/drive_attachment_config.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/thread_detail_config.dart';
+
+void main() {
+  _testDefaultValue();
+  _testSerialization();
+  _testPreferencesSettingAccessor();
+}
+
+void _testDefaultValue() {
+  group('DriveAttachmentConfig default', () {
+    test(
+      'WHEN no value is supplied\n'
+      'THEN drive attachment is enabled',
+      () {
+        expect(DriveAttachmentConfig().isEnabled, isTrue);
+        expect(DriveAttachmentConfig.initial().isEnabled, isTrue);
+      },
+    );
+
+    test(
+      'WHEN stored json has no isEnabled key\n'
+      'THEN drive attachment falls back to enabled',
+      () {
+        expect(DriveAttachmentConfig.fromJson({}).isEnabled, isTrue);
+      },
+    );
+  });
+}
+
+void _testSerialization() {
+  group('DriveAttachmentConfig serialization', () {
+    test(
+      'WHEN the user explicitly opted out\n'
+      'THEN the stored value wins over the new default',
+      () {
+        expect(
+          DriveAttachmentConfig.fromJson({'isEnabled': false}).isEnabled,
+          isFalse,
+        );
+      },
+    );
+
+    test(
+      'WHEN a config is serialized and read back\n'
+      'THEN isEnabled survives the round trip',
+      () {
+        final disabled = DriveAttachmentConfig(isEnabled: false);
+
+        expect(DriveAttachmentConfig.fromJson(disabled.toJson()), disabled);
+      },
+    );
+  });
+}
+
+void _testPreferencesSettingAccessor() {
+  group('PreferencesSetting.driveAttachmentConfig', () {
+    test(
+      'WHEN settings are freshly initialized\n'
+      'THEN drive attachment is enabled',
+      () {
+        expect(
+          PreferencesSetting.initial().driveAttachmentConfig.isEnabled,
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'WHEN an existing install stores other configs but no drive config\n'
+      'THEN drive attachment defaults to enabled',
+      () {
+        final settings = PreferencesSetting([ThreadDetailConfig(isEnabled: true)]);
+
+        expect(settings.driveAttachmentConfig.isEnabled, isTrue);
+      },
+    );
+
+    test(
+      'WHEN a stored drive config disables the feature\n'
+      'THEN the stored value is returned',
+      () {
+        final settings = PreferencesSetting([
+          DriveAttachmentConfig(isEnabled: false),
+        ]);
+
+        expect(settings.driveAttachmentConfig.isEnabled, isFalse);
+      },
+    );
+  });
+}

--- a/test/features/manage_account/presentation/preferences/model/preference_option_registry_test.dart
+++ b/test/features/manage_account/presentation/preferences/model/preference_option_registry_test.dart
@@ -1,69 +1,21 @@
-import 'package:core/presentation/state/failure.dart';
-import 'package:core/presentation/state/success.dart';
-import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:jmap_dart_client/jmap/account_id.dart';
-import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:server_settings/server_settings/tmail_server_settings.dart';
-import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_config.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
 import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/thread_detail_config.dart';
-import 'package:tmail_ui_user/features/manage_account/domain/usecases/update_local_settings_interactor.dart';
-import 'package:tmail_ui_user/features/manage_account/presentation/preferences/model/preference_option.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/preferences/model/preference_option_registry.dart';
 import 'package:tmail_ui_user/features/manage_account/presentation/preferences/model/preference_options.dart';
 import 'package:tmail_ui_user/features/server_settings/domain/state/update_server_setting_state.dart';
-import 'package:tmail_ui_user/features/server_settings/domain/usecases/update_server_setting_interactor.dart';
 
-class _FakeUpdateLocalSettingsInteractor implements UpdateLocalSettingsInteractor {
-  PreferencesConfig? captured;
-
-  @override
-  Stream<Either<Failure, Success>> execute(PreferencesConfig preferencesConfig) {
-    captured = preferencesConfig;
-    return const Stream<Either<Failure, Success>>.empty();
-  }
-}
-
-class _FakeUpdateServerSettingInteractor implements UpdateServerSettingInteractor {
-  TMailServerSettingOptions? captured;
-
-  @override
-  Stream<Either<Failure, Success>> execute(
-    Session session,
-    AccountId accountId,
-    TMailServerSettingOptions newSettingOption,
-  ) {
-    captured = newSettingOption;
-    return const Stream<Either<Failure, Success>>.empty();
-  }
-}
-
-PreferencesContext _context({
-  TMailServerSettingOptions? serverOptions,
-  PreferencesSetting? localSettings,
-  bool isAIScribeAvailable = false,
-  bool isAICapabilitySupported = false,
-  bool isLabelVisibilityEnabled = false,
-}) =>
-    (
-      session: null,
-      accountId: null,
-      serverOptions: serverOptions,
-      localSettings: localSettings ?? PreferencesSetting([]),
-      isAIScribeAvailable: isAIScribeAvailable,
-      isAICapabilitySupported: isAICapabilitySupported,
-      isLabelVisibilityEnabled: isLabelVisibilityEnabled,
-    );
+import '../../../../../fixtures/preference_option_fixtures.dart';
 
 void main() {
-  late _FakeUpdateLocalSettingsInteractor fakeLocal;
-  late _FakeUpdateServerSettingInteractor fakeServer;
+  late FakeUpdateLocalSettingsInteractor fakeLocal;
+  late FakeUpdateServerSettingInteractor fakeServer;
   late PreferenceOptionRegistry registry;
 
   setUp(() {
-    fakeLocal = _FakeUpdateLocalSettingsInteractor();
-    fakeServer = _FakeUpdateServerSettingInteractor();
+    fakeLocal = FakeUpdateLocalSettingsInteractor();
+    fakeServer = FakeUpdateServerSettingInteractor();
     registry = PreferenceOptionRegistry([
       ReadReceiptPreferenceOption(fakeServer),
       SenderPriorityPreferenceOption(fakeServer),
@@ -94,25 +46,25 @@ void main() {
 
   group('availability', () {
     test('server options need a non-null server settings snapshot', () {
-      final visible = registry.available(_context()).map((o) => o.id);
+      final visible = registry.available(preferencesContext()).map((o) => o.id);
       expect(visible, isNot(contains('read-receipt')));
       expect(visible, isNot(contains('sender-priority')));
     });
 
     test('read-receipt & sender-priority show once server settings exist', () {
       final visible = registry
-          .available(_context(serverOptions: TMailServerSettingOptions()))
+          .available(preferencesContext(serverOptions: TMailServerSettingOptions()))
           .map((o) => o.id);
       expect(visible, containsAll(['read-receipt', 'sender-priority']));
     });
 
     test('thread & spam-report need local configs', () {
       final hidden =
-          registry.available(_context(localSettings: PreferencesSetting([])));
+          registry.available(preferencesContext(localSettings: PreferencesSetting([])));
       expect(hidden.map((o) => o.id), isNot(contains('thread')));
 
       final shown = registry
-          .available(_context(localSettings: PreferencesSetting.initial()))
+          .available(preferencesContext(localSettings: PreferencesSetting.initial()))
           .map((o) => o.id);
       expect(shown, containsAll(['thread', 'spam-report']));
     });
@@ -120,12 +72,12 @@ void main() {
     test('ai-scribe needs the scribe capability on top of local configs', () {
       final local = PreferencesSetting.initial();
       expect(
-        registry.available(_context(localSettings: local)).map((o) => o.id),
+        registry.available(preferencesContext(localSettings: local)).map((o) => o.id),
         isNot(contains('ai-scribe')),
       );
       expect(
         registry
-            .available(_context(localSettings: local, isAIScribeAvailable: true))
+            .available(preferencesContext(localSettings: local, isAIScribeAvailable: true))
             .map((o) => o.id),
         contains('ai-scribe'),
       );
@@ -134,12 +86,12 @@ void main() {
     test('ai-label-categorization needs server settings AND the AI capability', () {
       final server = TMailServerSettingOptions();
       expect(
-        registry.available(_context(serverOptions: server)).map((o) => o.id),
+        registry.available(preferencesContext(serverOptions: server)).map((o) => o.id),
         isNot(contains('ai-label-categorization')),
       );
       expect(
         registry
-            .available(_context(
+            .available(preferencesContext(
               serverOptions: server,
               isAICapabilitySupported: true,
             ))
@@ -150,12 +102,12 @@ void main() {
 
     test('label is gated only on label visibility', () {
       expect(
-        registry.available(_context()).map((o) => o.id),
+        registry.available(preferencesContext()).map((o) => o.id),
         isNot(contains('label')),
       );
       expect(
         registry
-            .available(_context(isLabelVisibilityEnabled: true))
+            .available(preferencesContext(isLabelVisibilityEnabled: true))
             .map((o) => o.id),
         contains('label'),
       );
@@ -165,7 +117,7 @@ void main() {
   group('write behaviour', () {
     test('local toggle persists the negation of the current value', () {
       ThreadPreferenceOption(fakeLocal)
-          .toggle(currentValue: false, context: _context());
+          .toggle(currentValue: false, context: preferencesContext());
 
       expect(fakeLocal.captured, isA<ThreadDetailConfig>());
       expect((fakeLocal.captured as ThreadDetailConfig).isEnabled, isTrue);
@@ -180,7 +132,7 @@ void main() {
 
     test('server toggle fails fast when session/account are missing', () async {
       final result = await ReadReceiptPreferenceOption(fakeServer)
-          .toggle(currentValue: false, context: _context(
+          .toggle(currentValue: false, context: preferencesContext(
             serverOptions: TMailServerSettingOptions(),
           ))
           .first;

--- a/test/features/manage_account/presentation/preferences/model/preference_options/drive_attachment_preference_option_test.dart
+++ b/test/features/manage_account/presentation/preferences/model/preference_options/drive_attachment_preference_option_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/drive_attachment_config.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/preferences/model/preference_options/drive_attachment_preference_option.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
+import 'package:tmail_ui_user/main/providers/workplace/drive_attachment_enabled_notifier.dart';
+import 'package:tmail_ui_user/main/providers/workplace/workplace_fqdn_notifier.dart';
+
+import '../../../../../../fixtures/preference_option_fixtures.dart';
+
+void main() {
+  late FakeUpdateLocalSettingsInteractor fakeLocal;
+  late DriveAttachmentPreferenceOption option;
+
+  setUp(() {
+    fakeLocal = FakeUpdateLocalSettingsInteractor();
+    option = DriveAttachmentPreferenceOption(fakeLocal);
+    _setDriveAttachmentEnabled(null);
+    _setWorkplaceFqdn(null);
+  });
+
+  tearDown(() {
+    _setDriveAttachmentEnabled(null);
+    _setWorkplaceFqdn(null);
+  });
+
+  test(
+    'WHEN the preferences list is rendered\n'
+    'THEN drive attachment is no longer hidden behind the 7-tap reveal',
+    () {
+      expect(option.isExperimental, isFalse);
+    },
+  );
+
+  test(
+    'WHEN no drive config has been stored yet\n'
+    'THEN the toggle reads as on',
+    () {
+      final context = preferencesContext(
+        localSettings: PreferencesSetting.initial(),
+      );
+
+      expect(option.isEnabled(context), isTrue);
+    },
+  );
+
+  test(
+    'WHEN the user turned drive attachment off\n'
+    'THEN the toggle reads as off',
+    () {
+      final context = preferencesContext(
+        localSettings: PreferencesSetting([
+          DriveAttachmentConfig(isEnabled: false),
+        ]),
+      );
+
+      expect(option.isEnabled(context), isFalse);
+    },
+  );
+
+  test(
+    'WHEN the toggle is switched off\n'
+    'THEN a disabled drive config is persisted',
+    () {
+      option.toggle(
+        currentValue: true,
+        context: preferencesContext(
+          localSettings: PreferencesSetting.initial(),
+        ),
+      );
+
+      expect(fakeLocal.captured, isA<DriveAttachmentConfig>());
+      expect((fakeLocal.captured as DriveAttachmentConfig).isEnabled, isFalse);
+    },
+  );
+
+  group('availability', () {
+    test(
+      'WHEN the ecosystem disables drive attachment\n'
+      'THEN the setting is hidden',
+      () {
+        _setWorkplaceFqdn('https://workplace.example.com');
+        _setDriveAttachmentEnabled(false);
+
+        expect(option.isAvailable(preferencesContext()), isFalse);
+      },
+    );
+
+    test(
+      'WHEN Workplace has no FQDN\n'
+      'THEN the setting is hidden',
+      () {
+        _setDriveAttachmentEnabled(true);
+        _setWorkplaceFqdn('');
+
+        expect(option.isAvailable(preferencesContext()), isFalse);
+      },
+    );
+
+    test(
+      'WHEN the ecosystem enables drive attachment and Workplace has a FQDN\n'
+      'THEN the setting is visible',
+      () {
+        _setDriveAttachmentEnabled(true);
+        _setWorkplaceFqdn('https://workplace.example.com');
+
+        expect(option.isAvailable(preferencesContext()), isTrue);
+      },
+    );
+  });
+}
+
+void _setDriveAttachmentEnabled(bool? enabled) => appProviderContainer
+    .read(driveAttachmentEnabledProvider.notifier)
+    .setEnabled(enabled);
+
+void _setWorkplaceFqdn(String? fqdn) =>
+    appProviderContainer.read(workplaceFqdnProvider.notifier).setFqdn(fqdn);

--- a/test/features/manage_account/presentation/preferences/widgets/preferences_option_item_test.dart
+++ b/test/features/manage_account/presentation/preferences/widgets/preferences_option_item_test.dart
@@ -1,0 +1,101 @@
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/base/widget/default_switch_icon_widget.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/drive_attachment_config.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/preferences/model/preference_option.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/preferences/model/preference_options/drive_attachment_preference_option.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/preferences/widgets/preferences_option_item.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/providers/experimental_preferences_revealed_provider.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations_delegate.dart';
+import 'package:tmail_ui_user/main/localizations/localization_service.dart';
+
+import '../../../../../fixtures/preference_option_fixtures.dart';
+
+/// [revealed] is pinned to false throughout, so these cover what a plain user
+/// sees without ever triggering the 7-tap reveal: the drive row is rendered,
+/// and it is already switched on.
+void main() {
+  late PreferenceOption option;
+
+  /// Matches only the option item's own switch, since the widget forwards its
+  /// key down to the inner [SvgPicture] as well.
+  Finder switchWithKey(String key) => find.byWidgetPredicate(
+        (widget) =>
+            widget is DefaultSwitchIconWidget && widget.key == ValueKey(key),
+      );
+
+  Future<void> pumpOptionItem(
+    WidgetTester tester, {
+    required PreferencesSetting localSettings,
+  }) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          experimentalPreferencesRevealedProvider.overrideWith((ref) async => false),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizationsDelegate(),
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: LocalizationService.supportedLocales,
+          locale: LocalizationService.defaultLocale,
+          home: Scaffold(
+            body: PreferencesOptionItem(
+              imagePaths: ImagePaths(),
+              option: option,
+              preferencesContext: preferencesContext(localSettings: localSettings),
+              onTapPreferencesOptionAction: (_, __) {},
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  setUp(() {
+    option = DriveAttachmentPreferenceOption(FakeUpdateLocalSettingsInteractor());
+  });
+
+  testWidgets(
+    'WHEN experimental preferences were never revealed\n'
+    'THEN the drive attachment row is still rendered',
+    (tester) async {
+      await pumpOptionItem(tester, localSettings: PreferencesSetting.initial());
+
+      expect(find.byType(DefaultSwitchIconWidget), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'WHEN no drive preference was ever stored\n'
+    'THEN the switch is rendered in the on state',
+    (tester) async {
+      await pumpOptionItem(tester, localSettings: PreferencesSetting.initial());
+
+      expect(switchWithKey('setting_option_switch_on'), findsOneWidget);
+      expect(switchWithKey('setting_option_switch_off'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'WHEN the user previously turned drive attachment off\n'
+    'THEN the switch is rendered in the off state',
+    (tester) async {
+      await pumpOptionItem(
+        tester,
+        localSettings: PreferencesSetting([DriveAttachmentConfig(isEnabled: false)]),
+      );
+
+      expect(switchWithKey('setting_option_switch_off'), findsOneWidget);
+      expect(switchWithKey('setting_option_switch_on'), findsNothing);
+    },
+  );
+}

--- a/test/fixtures/preference_option_fixtures.dart
+++ b/test/fixtures/preference_option_fixtures.dart
@@ -1,0 +1,54 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/session/session.dart';
+import 'package:server_settings/server_settings/tmail_server_settings.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_config.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/model/preferences/preferences_setting.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/update_local_settings_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/presentation/preferences/model/preference_option.dart';
+import 'package:tmail_ui_user/features/server_settings/domain/usecases/update_server_setting_interactor.dart';
+
+/// Records the config a [LocalPreferenceOption] tried to persist.
+class FakeUpdateLocalSettingsInteractor implements UpdateLocalSettingsInteractor {
+  PreferencesConfig? captured;
+
+  @override
+  Stream<Either<Failure, Success>> execute(PreferencesConfig preferencesConfig) {
+    captured = preferencesConfig;
+    return const Stream<Either<Failure, Success>>.empty();
+  }
+}
+
+/// Records the payload a [ServerPreferenceOption] tried to persist.
+class FakeUpdateServerSettingInteractor implements UpdateServerSettingInteractor {
+  TMailServerSettingOptions? captured;
+
+  @override
+  Stream<Either<Failure, Success>> execute(
+    Session session,
+    AccountId accountId,
+    TMailServerSettingOptions newSettingOption,
+  ) {
+    captured = newSettingOption;
+    return const Stream<Either<Failure, Success>>.empty();
+  }
+}
+
+PreferencesContext preferencesContext({
+  TMailServerSettingOptions? serverOptions,
+  PreferencesSetting? localSettings,
+  bool isAIScribeAvailable = false,
+  bool isAICapabilitySupported = false,
+  bool isLabelVisibilityEnabled = false,
+}) =>
+    (
+      session: null,
+      accountId: null,
+      serverOptions: serverOptions,
+      localSettings: localSettings ?? PreferencesSetting([]),
+      isAIScribeAvailable: isAIScribeAvailable,
+      isAICapabilitySupported: isAICapabilitySupported,
+      isLabelVisibilityEnabled: isLabelVisibilityEnabled,
+    );

--- a/test/main/providers/workplace/drive_attachment_enabled_notifier_test.dart
+++ b/test/main/providers/workplace/drive_attachment_enabled_notifier_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/main/providers/workplace/drive_attachment_enabled_notifier.dart';
+
+void main() {
+  late ProviderContainer container;
+
+  setUp(() => container = ProviderContainer());
+  tearDown(() => container.dispose());
+
+  bool currentState() => container.read(driveAttachmentEnabledProvider);
+
+  void setEnabled(bool? value) =>
+      container.read(driveAttachmentEnabledProvider.notifier).setEnabled(value);
+
+  test(
+    'WHEN no ecosystem has been loaded yet\n'
+    'THEN drive attachment is enabled',
+    () {
+      expect(currentState(), isTrue);
+    },
+  );
+
+  test(
+    'WHEN the ecosystem explicitly disables drive attachment\n'
+    'THEN it is disabled',
+    () {
+      setEnabled(false);
+
+      expect(currentState(), isFalse);
+    },
+  );
+
+  test(
+    'WHEN the ecosystem carries no drive attachment config\n'
+    'THEN it stays enabled',
+    () {
+      setEnabled(null);
+
+      expect(currentState(), isTrue);
+    },
+  );
+
+  test(
+    'WHEN the ecosystem is cleared on reload after having disabled drive\n'
+    'THEN it returns to enabled',
+    () {
+      setEnabled(false);
+      setEnabled(null);
+
+      expect(currentState(), isTrue);
+    },
+  );
+
+  test(
+    'WHEN the ecosystem explicitly enables drive attachment\n'
+    'THEN it is enabled',
+    () {
+      setEnabled(false);
+      setEnabled(true);
+
+      expect(currentState(), isTrue);
+    },
+  );
+}


### PR DESCRIPTION
## Issue

Closes #4758 

## Demo

- Web:

https://github.com/user-attachments/assets/11caaef8-6412-4305-a6d2-4b2bda1bb29d


- Mobile:

[demo-mobile.webm](https://github.com/user-attachments/assets/4f9a5931-fde1-4625-94f2-0ba30a1a5ae1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drive attachments are now enabled by default.
  * Users can still disable and re-enable drive attachments, with their preference preserved.
  * Drive attachments are no longer marked as experimental.

* **Bug Fixes**
  * Missing or invalid saved settings now safely fall back to enabled.
  * Clearing the configuration resets drive attachments to enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->