### PR TITLE
TF-4728 Drive picker size limit

### DIFF
--- a/lib/features/composer/presentation/providers/composer_attachment_extension_registry_provider.dart
+++ b/lib/features/composer/presentation/providers/composer_attachment_extension_registry_provider.dart
@@ -3,6 +3,7 @@ import 'package:core/utils/app_logger.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
 import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/main/providers/workplace/drive_attachment_uri_value_notifier_provider.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
@@ -18,6 +19,8 @@ ComposerAttachmentExtensionRegistry composerAttachmentExtensionRegistry(Ref ref)
     WorkplaceComposerAttachmentExtension(
       workplaceUri: uriNotifier,
       oidcTokenGetter: () => getBinding<AuthorizationInterceptors>()?.currentOidcIdToken,
+      maxAttachmentSizeBytesGetter: () =>
+          getBinding<MailboxDashBoardController>()?.maxSizeAttachmentsPerEmail?.value,
       onPickState: (composerId, state) async {
         if (state is DrivePickResult) {
           try {

--- a/workplace/lib/data/model/workplace_intent_request.dart
+++ b/workplace/lib/data/model/workplace_intent_request.dart
@@ -8,12 +8,22 @@ part 'workplace_intent_request.g.dart';
 @JsonSerializable(createFactory: false, includeIfNull: false)
 class WorkplaceActionConfigRequest {
   final String? label;
+  final num? maxFileSize;
+  final num? availableSize;
 
-  const WorkplaceActionConfigRequest({this.label});
+  const WorkplaceActionConfigRequest({
+    this.label,
+    this.maxFileSize,
+    this.availableSize,
+  });
 
   factory WorkplaceActionConfigRequest.fromEntity(
     WorkplaceActionConfig config,
-  ) => WorkplaceActionConfigRequest(label: config.label);
+  ) => WorkplaceActionConfigRequest(
+    label: config.label,
+    maxFileSize: config.maxFileSize,
+    availableSize: config.availableSize,
+  );
 
   Map<String, dynamic> toJson() => _$WorkplaceActionConfigRequestToJson(this);
 }

--- a/workplace/lib/domain/entity/workplace_action_config.dart
+++ b/workplace/lib/domain/entity/workplace_action_config.dart
@@ -2,9 +2,15 @@ import 'package:equatable/equatable.dart';
 
 class WorkplaceActionConfig with EquatableMixin {
   final String? label;
+  final num? maxFileSize;
+  final num? availableSize;
 
-  const WorkplaceActionConfig({this.label});
+  const WorkplaceActionConfig({
+    this.label,
+    this.maxFileSize,
+    this.availableSize,
+  });
 
   @override
-  List<Object?> get props => [label];
+  List<Object?> get props => [label, maxFileSize, availableSize];
 }

--- a/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
+++ b/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
@@ -26,6 +26,7 @@ typedef OnDrivePickStateChanged =
 class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
   final ValueListenable<Uri?> workplaceUri;
   final String? Function() oidcTokenGetter;
+  final num? Function() maxAttachmentSizeBytesGetter;
   final OnDrivePickStateChanged? onPickState;
 
   late final _dataSource = WorkplaceDataSourceImpl();
@@ -38,6 +39,7 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
   WorkplaceComposerAttachmentExtension({
     required this.workplaceUri,
     required this.oidcTokenGetter,
+    required this.maxAttachmentSizeBytesGetter,
     this.onPickState,
   });
 
@@ -94,7 +96,11 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
       addAsLink: WorkplaceActionConfig(label: filePickerConfig.sharingLink.label),
       addAsAttachment: filePickerConfig.downloadLink == null
           ? null
-          : WorkplaceActionConfig(label: filePickerConfig.downloadLink!.label),
+          : WorkplaceActionConfig(
+              label: filePickerConfig.downloadLink!.label,
+              maxFileSize: filePickerConfig.downloadLink!.maxFileSize,
+              availableSize: filePickerConfig.downloadLink!.availableSize,
+            ),
       theme: switch (filePickerConfig.theme.type) {
         WorkplaceThemeType.light => WorkplaceTheme.light,
         WorkplaceThemeType.dark => WorkplaceTheme.dark,
@@ -138,6 +144,7 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
             uri,
             filePickerConfig: filePickerConfig,
           ),
+          maxAttachmentSizeBytesGetter: maxAttachmentSizeBytesGetter,
         );
       },
     );
@@ -162,6 +169,7 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
             uri,
             filePickerConfig: filePickerConfig,
           ),
+          maxAttachmentSizeBytesGetter: maxAttachmentSizeBytesGetter,
         );
       },
     );

--- a/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
+++ b/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
@@ -25,6 +25,8 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
 
   DriveIntentImageAssets get driveIntentImageAssets;
 
+  num? get maxAttachmentSizeBytes;
+
   OnPickDriveCallback? get pickerOnCallback => null;
 
   bool _modalOpen = false;
@@ -48,7 +50,11 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
         sharingLink: WorkplaceActionConfigRequest(label: l10n.addAsLink),
         downloadLink: addAsAttachmentTitle == null
             ? null
-            : const WorkplaceActionConfigRequest(label: addAsAttachmentTitle),
+            : WorkplaceActionConfigRequest(
+                label: addAsAttachmentTitle,
+                maxFileSize: maxAttachmentSizeBytes,
+                availableSize: maxAttachmentSizeBytes,
+              ),
         theme: WorkplaceThemeConfigRequest.fromEntity(theme),
       );
       DrivePickOutcome? outcome;

--- a/workplace/lib/presentation/widget/drive_attachment_context_menu_tile.dart
+++ b/workplace/lib/presentation/widget/drive_attachment_context_menu_tile.dart
@@ -12,12 +12,14 @@ class DriveAttachmentContextMenuTile extends StatefulWidget {
   final Uri workplaceUri;
   final OnPickDriveCallback? onPickCallback;
   final FetchDriveIntentCallback onFetchIntent;
+  final num? Function() maxAttachmentSizeBytesGetter;
 
   const DriveAttachmentContextMenuTile({
     super.key,
     required this.imagePaths,
     required this.workplaceUri,
     required this.onFetchIntent,
+    required this.maxAttachmentSizeBytesGetter,
     this.onPickCallback,
   });
 
@@ -34,6 +36,9 @@ class _DriveAttachmentContextMenuTileState
 
   @override
   OnPickDriveCallback? get pickerOnCallback => widget.onPickCallback;
+
+  @override
+  num? get maxAttachmentSizeBytes => widget.maxAttachmentSizeBytesGetter();
 
   @override
   DriveIntentImageAssets get driveIntentImageAssets => DriveIntentImageAssets(

--- a/workplace/lib/presentation/widget/drive_attachment_picker_button.dart
+++ b/workplace/lib/presentation/widget/drive_attachment_picker_button.dart
@@ -12,6 +12,7 @@ class DriveAttachmentPickerButton extends StatefulWidget {
   final ComposerToolbarButtonStyle style;
   final OnPickDriveCallback? onPickCallback;
   final FetchDriveIntentCallback onFetchIntent;
+  final num? Function() maxAttachmentSizeBytesGetter;
 
   const DriveAttachmentPickerButton({
     super.key,
@@ -19,6 +20,7 @@ class DriveAttachmentPickerButton extends StatefulWidget {
     required this.imagePaths,
     required this.workplaceUri,
     required this.onFetchIntent,
+    required this.maxAttachmentSizeBytesGetter,
     this.style = const ComposerToolbarButtonStyle(),
     this.onPickCallback,
   });
@@ -36,6 +38,9 @@ class _DriveAttachmentPickerButtonState
 
   @override
   OnPickDriveCallback? get pickerOnCallback => widget.onPickCallback;
+
+  @override
+  num? get maxAttachmentSizeBytes => widget.maxAttachmentSizeBytesGetter();
 
   @override
   DriveIntentImageAssets get driveIntentImageAssets => DriveIntentImageAssets(

--- a/workplace/test/data/model/workplace_intent_request_test.dart
+++ b/workplace/test/data/model/workplace_intent_request_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:workplace/data/model/workplace_intent_request.dart';
+import 'package:workplace/domain/entity/workplace_action_config.dart';
+
+void main() {
+  group('WorkplaceActionConfigRequest::toJson::', () {
+    test('includes maxFileSize and availableSize when both are set', () {
+      const request = WorkplaceActionConfigRequest(
+        label: 'Attachment',
+        maxFileSize: 100,
+        availableSize: 100,
+      );
+
+      final json = request.toJson();
+
+      expect(json['maxFileSize'], equals(100));
+      expect(json['availableSize'], equals(100));
+    });
+
+    test('omits maxFileSize and availableSize when both are null', () {
+      const request = WorkplaceActionConfigRequest(label: 'Attachment');
+
+      final json = request.toJson();
+
+      expect(json.containsKey('maxFileSize'), isFalse);
+      expect(json.containsKey('availableSize'), isFalse);
+    });
+  });
+
+  group('WorkplaceActionConfigRequest::fromEntity::', () {
+    test('copies maxFileSize and availableSize from the domain entity', () {
+      const entity = WorkplaceActionConfig(
+        label: 'Attachment',
+        maxFileSize: 5000,
+        availableSize: 5000,
+      );
+
+      final request = WorkplaceActionConfigRequest.fromEntity(entity);
+
+      expect(request.label, equals('Attachment'));
+      expect(request.maxFileSize, equals(5000));
+      expect(request.availableSize, equals(5000));
+    });
+
+    test('copies null maxFileSize and availableSize when entity has none', () {
+      const entity = WorkplaceActionConfig(label: 'Attachment');
+
+      final request = WorkplaceActionConfigRequest.fromEntity(entity);
+
+      expect(request.maxFileSize, isNull);
+      expect(request.availableSize, isNull);
+    });
+  });
+}

--- a/workplace/test/data/workplace_datasource_impl_test.dart
+++ b/workplace/test/data/workplace_datasource_impl_test.dart
@@ -341,6 +341,32 @@ void main() {
       expect(theme['type'], equals('dark'));
     });
 
+    test('Should serialize attachment size limits in intent request', () async {
+      final adapter = _MockAdapter(intentResponse);
+      WorkplaceDio.setInstance(Dio()..httpClientAdapter = adapter);
+
+      await datasource.createIntent(
+        platformUrl: Uri.parse('https://platform.example.com'),
+        accessToken: 'test-token',
+        addAsLink: const WorkplaceActionConfig(label: 'https://link.url'),
+        addAsAttachment: const WorkplaceActionConfig(
+          label: 'https://attach.url',
+          maxFileSize: 5000,
+          availableSize: 4500,
+        ),
+        theme: WorkplaceTheme.light,
+      );
+
+      final body = jsonDecode(jsonEncode(adapter.capturedOptions!.data)) as Map<String, dynamic>;
+      final attributes = (body['data'] as Map<String, dynamic>)['attributes'] as Map<String, dynamic>;
+      final config = attributes['data'] as Map<String, dynamic>;
+      final downloadLink = config['downloadLink'] as Map<String, dynamic>;
+
+      expect(downloadLink['label'], equals('https://attach.url'));
+      expect(downloadLink['maxFileSize'], equals(5000));
+      expect(downloadLink['availableSize'], equals(4500));
+    });
+
     test('Should send explicit null downloadLink to hide the attachment button when addAsAttachment is omitted', () async {
       final adapter = _MockAdapter(intentResponse);
       WorkplaceDio.setInstance(Dio()..httpClientAdapter = adapter);

--- a/workplace/test/domain/entity/workplace_action_config_test.dart
+++ b/workplace/test/domain/entity/workplace_action_config_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:workplace/domain/entity/workplace_action_config.dart';
+
+void main() {
+  group('WorkplaceActionConfig::equality::', () {
+    test('two configs with the same label, maxFileSize and availableSize are equal', () {
+      const a = WorkplaceActionConfig(label: 'x', maxFileSize: 100, availableSize: 100);
+      const b = WorkplaceActionConfig(label: 'x', maxFileSize: 100, availableSize: 100);
+
+      expect(a, equals(b));
+    });
+
+    test('configs differing only by maxFileSize are not equal', () {
+      const a = WorkplaceActionConfig(label: 'x', maxFileSize: 100, availableSize: 100);
+      const b = WorkplaceActionConfig(label: 'x', maxFileSize: 200, availableSize: 100);
+
+      expect(a, isNot(equals(b)));
+    });
+
+    test('configs differing only by availableSize are not equal', () {
+      const a = WorkplaceActionConfig(label: 'x', maxFileSize: 100, availableSize: 100);
+      const b = WorkplaceActionConfig(label: 'x', maxFileSize: 100, availableSize: 200);
+
+      expect(a, isNot(equals(b)));
+    });
+  });
+}

--- a/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
+++ b/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
@@ -53,6 +53,36 @@ class _SequentialAdapter implements HttpClientAdapter {
   void close({bool force = false}) {}
 }
 
+// Returns queued responses like _SequentialAdapter, but also records each
+// request body so a test can assert on the outgoing JSON shape.
+class _CapturingAdapter implements HttpClientAdapter {
+  final List<dynamic> _queue;
+  final List<dynamic> capturedBodies = [];
+  int _index = 0;
+
+  _CapturingAdapter(this._queue);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future? cancelFuture,
+  ) async {
+    capturedBodies.add(options.data);
+    final item = _queue[_index++];
+    return ResponseBody.fromString(
+      jsonEncode(item),
+      200,
+      headers: {
+        Headers.contentTypeHeader: ['application/json; charset=utf-8'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
 // Always throws DioException to simulate a network failure.
 class _ErrorAdapter implements HttpClientAdapter {
   @override
@@ -93,11 +123,13 @@ final _intentResponse = {
 WorkplaceComposerAttachmentExtension _makeExtension(
   ValueListenable<Uri?> notifier, {
   String? oidcToken = 'oidc-token',
+  num? maxAttachmentSizeBytes,
   OnDrivePickStateChanged? onPickState,
 }) =>
     WorkplaceComposerAttachmentExtension(
       workplaceUri: notifier,
       oidcTokenGetter: () => oidcToken,
+      maxAttachmentSizeBytesGetter: () => maxAttachmentSizeBytes,
       onPickState: onPickState,
     );
 
@@ -499,6 +531,38 @@ void main() {
       expect(result, isNotNull);
       expect(result!.intentId, equals('intent-xyz'));
       expect(result.intentUrl, equals(Uri.parse('https://drive.example.com/pick')));
+    });
+
+    testWidgets('forwards downloadLink maxFileSize/availableSize from filePickerConfig into the request', (tester) async {
+      final adapter = _CapturingAdapter([_tokenResponse, _intentResponse]);
+      WorkplaceDio.setInstance(Dio()..httpClientAdapter = adapter);
+
+      final notifier = ValueNotifier<Uri?>(_platformUri);
+      final ext = _makeExtension(notifier, maxAttachmentSizeBytes: 5000);
+      final callback = await extractCallback(tester, ext);
+
+      await tester.runAsync(
+        () => callback(
+          filePickerConfig: const WorkplaceFilePickerConfigRequest(
+            sharingLink: WorkplaceActionConfigRequest(label: 'Link'),
+            downloadLink: WorkplaceActionConfigRequest(
+              label: 'Attachment',
+              maxFileSize: 5000,
+              availableSize: 5000,
+            ),
+            theme: WorkplaceThemeConfigRequest(type: WorkplaceThemeType.light),
+          ),
+        ),
+      );
+
+      // `_buildIntentRequest` doesn't fully explicitToJson-serialize nested
+      // request objects (only WorkplaceFilePickerConfigRequest does), so the
+      // captured body still holds the typed request graph at this depth.
+      final intentBody = adapter.capturedBodies[1] as Map<String, dynamic>;
+      final requestData = intentBody['data'] as WorkplaceIntentDataRequest;
+      final downloadLink = requestData.attributes.data.downloadLink;
+      expect(downloadLink!.maxFileSize, equals(5000));
+      expect(downloadLink.availableSize, equals(5000));
     });
   });
 }

--- a/workplace/test/presentation/mixin/drive_picker_state_mixin_test.dart
+++ b/workplace/test/presentation/mixin/drive_picker_state_mixin_test.dart
@@ -27,6 +27,7 @@ class _TestState extends State<_TestWidget>
   final List<DrivePickState> pickStates = [];
   final List<WorkplaceFilePickerConfigRequest> openCalls = [];
   _ModalStub modalStub = () => Future.value();
+  num? maxAttachmentSizeBytesStub;
 
   @override
   FetchDriveIntentCallback get pickerFetchIntent =>
@@ -41,6 +42,9 @@ class _TestState extends State<_TestWidget>
   @override
   DriveIntentImageAssets get driveIntentImageAssets =>
       const DriveIntentImageAssets(driveLogo: '', closeIcon: '', searchIcon: '');
+
+  @override
+  num? get maxAttachmentSizeBytes => maxAttachmentSizeBytesStub;
 
   @override
   Future<DrivePickOutcome?> openDrivePickerModal(
@@ -126,6 +130,22 @@ void main() {
         expect(state.pickStates, hasLength(1));
         final failure = state.pickStates.single as DrivePickFailure;
         expect(failure.error, same(error));
+      });
+    });
+
+    group('maxAttachmentSizeBytes', () {
+      testWidgets('exposes the value returned by the mixer override', (tester) async {
+        final state = await _pumpPicker(tester);
+        state.maxAttachmentSizeBytesStub = 5000;
+
+        expect(state.maxAttachmentSizeBytes, equals(5000));
+      });
+
+      testWidgets('is null when the mixer override returns null', (tester) async {
+        final state = await _pumpPicker(tester);
+        state.maxAttachmentSizeBytesStub = null;
+
+        expect(state.maxAttachmentSizeBytes, isNull);
       });
     });
 

--- a/workplace/test/presentation/mixin/drive_picker_web_message_listener_lifecycle_test.dart
+++ b/workplace/test/presentation/mixin/drive_picker_web_message_listener_lifecycle_test.dart
@@ -284,6 +284,9 @@ class _MenuTileUnderTestState extends State<_MenuTileUnderTest>
       const DriveIntentImageAssets(driveLogo: '', closeIcon: '', searchIcon: '');
 
   @override
+  num? get maxAttachmentSizeBytes => null;
+
+  @override
   Future<DrivePickOutcome?> openDrivePickerModal(
     WorkplaceFilePickerConfigRequest filePickerConfig,
   ) {


### PR DESCRIPTION
## Issue
- #4728 

## ADR
- #4760 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added attachment size limits to workplace composer downloads and pickers.
  * Attachment actions now include maximum and currently available file sizes.
  * Size limits are dynamically retrieved for toolbar and context-menu attachment selections.
  * Attachment size information is included when requesting download-link actions, helping enforce applicable limits.

* **Tests**
  * Added coverage for size-limit serialization, equality, propagation, request payloads, and nullable configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->