### PR TITLE
Cherry-pick fix for gray screen when opening composer on tablet  from `maintenance-v0.29.x` branch

### DIFF
--- a/lib/features/composer/presentation/widgets/recipient_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/recipient_composer_widget.dart
@@ -416,10 +416,10 @@ class _RecipientComposerWidgetState extends State<RecipientComposerWidget> {
       _ => false,
     };
 
-    // Native platforms (mobile + tablet) always use the compact expand button;
-    // the inline prefix buttons are a web-only, wide-screen affordance.
-    return shouldCheckPrefix &&
-        (isMobileResponsive || !PlatformInfo.isWeb || widget.isTestingForWeb);
+    // The compact expand button is the exact complement of the inline prefix
+    // buttons (`_isWeb && !isMobileResponsive`): it shows on native platforms
+    // (mobile + tablet) or on a narrow web window.
+    return shouldCheckPrefix && (isMobileResponsive || !_isWeb);
   }
 
   Widget _buildExpandButton() {

--- a/lib/features/composer/presentation/widgets/recipient_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/recipient_composer_widget.dart
@@ -416,7 +416,10 @@ class _RecipientComposerWidgetState extends State<RecipientComposerWidget> {
       _ => false,
     };
 
-    return shouldCheckPrefix && (isMobileResponsive || widget.isTestingForWeb);
+    // Native platforms (mobile + tablet) always use the compact expand button;
+    // the inline prefix buttons are a web-only, wide-screen affordance.
+    return shouldCheckPrefix &&
+        (isMobileResponsive || !PlatformInfo.isWeb || widget.isTestingForWeb);
   }
 
   Widget _buildExpandButton() {

--- a/lib/features/mailbox_dashboard/presentation/extensions/open_and_close_composer_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/open_and_close_composer_extension.dart
@@ -71,7 +71,7 @@ extension OpenAndCloseComposerExtension on MailboxDashBoardController {
 
       result = await Get.to(
         () => const ComposerView(),
-        binding: ComposerBindings(composerId: composerId),
+        binding: ComposerBindings(),
         opaque: false,
         arguments: argsWithId,
       );

--- a/test/features/composer/presentation/composer_bindings_test.dart
+++ b/test/features/composer/presentation/composer_bindings_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_bindings.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
+import 'package:tmail_ui_user/features/composer/presentation/composer_view.dart';
+
+class _MockComposerController extends Mock implements ComposerController {
+  @override
+  InternalFinalCallback<void> get onStart =>
+      InternalFinalCallback<void>(callback: () {});
+
+  @override
+  InternalFinalCallback<void> get onDelete =>
+      InternalFinalCallback<void>(callback: () {});
+}
+
+class _TestComposerView extends ComposerView {
+  const _TestComposerView();
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+void main() {
+  setUp(() {
+    Get.testMode = true;
+  });
+
+  tearDown(Get.reset);
+
+  test(
+    'registers native composer dependencies with the default GetX tag',
+    () {
+      ComposerBindings().dependencies();
+
+      expect(Get.isPrepared<ComposerController>(), isTrue);
+      expect(Get.isPrepared<ComposerController>(tag: 'tablet-composer'), isFalse);
+    },
+  );
+
+  testWidgets(
+    'ComposerView resolves the native composer controller without a tag',
+    (tester) async {
+      final controller = _MockComposerController();
+      const view = _TestComposerView();
+      Get.lazyPut<ComposerController>(() => controller);
+
+      await tester.pumpWidget(const GetMaterialApp(home: view));
+
+      expect(tester.takeException(), isNull);
+      expect(view.controller, same(controller));
+    },
+  );
+}

--- a/test/features/composer/recipient_composer_widget_test.dart
+++ b/test/features/composer/recipient_composer_widget_test.dart
@@ -464,6 +464,7 @@ void main() {
         EmailAddress('test1', 'test1@example.com'),
       ];
 
+      // Native mobile (no isTestingForWeb): compact expand button, no inline buttons.
       final widget = makeTestableWidget(
         child: RecipientComposerWidget(
           prefix: prefix,
@@ -472,7 +473,6 @@ void main() {
           imagePaths: imagePaths,
           maxWidth: 360,
           keyTagEditor: keyEmailTagEditor,
-          isTestingForWeb: true,
           toState: PrefixRecipientState.enabled,
         ),
       );
@@ -557,13 +557,13 @@ void main() {
       expect(recipientFromButtonFinder, findsOneWidget);
       expect(recipientCcButtonFinder, findsOneWidget);
       expect(recipientBccButtonFinder, findsOneWidget);
+      // Web wide is inline-only: the compact expand button must NOT also render
+      // (guards mutual exclusivity between the two recipient-add affordances).
+      expect(find.byKey(Key('prefix_${prefix.name}_recipient_expand_button')), findsNothing);
     });
 
     testWidgets('WHEN on a native (non-web) tablet-width screen (>= 600)\n'
         'To field SHOULD show the expand chevron (same as mobile) and NO inline Cc/Bcc buttons', (tester) async {
-      // Simulate an iPad/tablet-width native screen: no isTestingForWeb, so
-      // PlatformInfo.isWeb == false. Regression guard for the bug where native
-      // tablet rendered neither the inline buttons nor the expand chevron.
       tester.view.physicalSize = const Size(1024, 768);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
@@ -581,6 +581,44 @@ void main() {
           imagePaths: imagePaths,
           maxWidth: 900,
           keyTagEditor: keyEmailTagEditor,
+          toState: PrefixRecipientState.enabled,
+        ),
+      );
+
+      await tester.pumpWidget(widget);
+      await tester.pumpAndSettle();
+
+      final recipientExpandButtonFinder = find.byKey(Key('prefix_${prefix.name}_recipient_expand_button'));
+      final recipientCcButtonFinder = find.byKey(Key('prefix_${prefix.name}_recipient_cc_button'));
+      final recipientBccButtonFinder = find.byKey(Key('prefix_${prefix.name}_recipient_bcc_button'));
+
+      expect(recipientExpandButtonFinder, findsOneWidget);
+      expect(recipientCcButtonFinder, findsNothing);
+      expect(recipientBccButtonFinder, findsNothing);
+    });
+
+    testWidgets('WHEN on web with a narrow (< 600) window (web-responsive)\n'
+        'To field SHOULD show the expand chevron and NO inline Cc/Bcc buttons', (tester) async {
+      // Simulate web (isTestingForWeb) at a phone-width window: the inline
+      // buttons collapse to the compact expand chevron, same as mobile.
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final listEmailAddress = <EmailAddress>[
+        EmailAddress('test1', 'test1@example.com'),
+      ];
+
+      final widget = makeTestableWidget(
+        child: RecipientComposerWidget(
+          prefix: prefix,
+          prefixRootState: prefix,
+          listEmailAddress: listEmailAddress,
+          imagePaths: imagePaths,
+          maxWidth: 360,
+          keyTagEditor: keyEmailTagEditor,
+          isTestingForWeb: true,
           toState: PrefixRecipientState.enabled,
         ),
       );

--- a/test/features/composer/recipient_composer_widget_test.dart
+++ b/test/features/composer/recipient_composer_widget_test.dart
@@ -558,5 +558,43 @@ void main() {
       expect(recipientCcButtonFinder, findsOneWidget);
       expect(recipientBccButtonFinder, findsOneWidget);
     });
+
+    testWidgets('WHEN on a native (non-web) tablet-width screen (>= 600)\n'
+        'To field SHOULD show the expand chevron (same as mobile) and NO inline Cc/Bcc buttons', (tester) async {
+      // Simulate an iPad/tablet-width native screen: no isTestingForWeb, so
+      // PlatformInfo.isWeb == false. Regression guard for the bug where native
+      // tablet rendered neither the inline buttons nor the expand chevron.
+      tester.view.physicalSize = const Size(1024, 768);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final listEmailAddress = <EmailAddress>[
+        EmailAddress('test1', 'test1@example.com'),
+      ];
+
+      final widget = makeTestableWidget(
+        child: RecipientComposerWidget(
+          prefix: prefix,
+          prefixRootState: prefix,
+          listEmailAddress: listEmailAddress,
+          imagePaths: imagePaths,
+          maxWidth: 900,
+          keyTagEditor: keyEmailTagEditor,
+          toState: PrefixRecipientState.enabled,
+        ),
+      );
+
+      await tester.pumpWidget(widget);
+      await tester.pumpAndSettle();
+
+      final recipientExpandButtonFinder = find.byKey(Key('prefix_${prefix.name}_recipient_expand_button'));
+      final recipientCcButtonFinder = find.byKey(Key('prefix_${prefix.name}_recipient_cc_button'));
+      final recipientBccButtonFinder = find.byKey(Key('prefix_${prefix.name}_recipient_bcc_button'));
+
+      expect(recipientExpandButtonFinder, findsOneWidget);
+      expect(recipientCcButtonFinder, findsNothing);
+      expect(recipientBccButtonFinder, findsNothing);
+    });
   });
 }


### PR DESCRIPTION
## Summary

This PR cherry-picks the composer gray-screen fix from #4677, which was previously merged into the `maintenance-v0.29.x` branch.

The fix aligns the native tablet composer binding with `ComposerView`'s default GetX controller lookup, preventing the controller tag mismatch that caused the composer to fail to open.

Additional defensive regression tests are included to ensure:

- Native composer bindings register `ComposerController` with the default GetX tag.
- `ComposerView` resolves the native controller successfully during its real GetX widget lifecycle.
- Future changes do not reintroduce the tablet composer gray-screen issue.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved composer layout behavior across mobile, tablet, and web screen sizes.
  - The compact expand button now appears in appropriate narrow layouts, while wider web layouts retain inline recipient controls.
  - Improved mobile composer opening behavior to ensure the correct composer is displayed.

- **Tests**
  - Added coverage for composer initialization and controller resolution.
  - Expanded responsive layout tests for native and web platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->