### PR TITLE
Fix mobile Search action state synchronization

### DIFF
--- a/integration_test/robots/abstract/abstract_common_robot.dart
+++ b/integration_test/robots/abstract/abstract_common_robot.dart
@@ -84,7 +84,9 @@ abstract class AbstractCommonRobot extends CoreRobot {
           .last;
     }));
 
-    // Refresh view after provisioning emails
+    // Web e2e browser storage can retain mailbox data from a preceding test.
+    // A normal refresh may return that cache while the server-side provisioning
+    // change is still being reconciled, so force a fresh query on web only.
     if (refreshEmailView) {
       await threadController.refreshAllEmail(
         shouldClearCache: PlatformInfo.isWeb,

--- a/integration_test/robots/abstract/abstract_common_robot.dart
+++ b/integration_test/robots/abstract/abstract_common_robot.dart
@@ -1,4 +1,5 @@
 import 'package:get/get.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:jmap_dart_client/jmap/identities/identity.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
@@ -85,7 +86,9 @@ abstract class AbstractCommonRobot extends CoreRobot {
 
     // Refresh view after provisioning emails
     if (refreshEmailView) {
-      await threadController.refreshAllEmail();
+      await threadController.refreshAllEmail(
+        shouldClearCache: PlatformInfo.isWeb,
+      );
     }
 
     ComposerBindings().dispose();

--- a/integration_test/robots/abstract/abstract_search_email_action_robot.dart
+++ b/integration_test/robots/abstract/abstract_search_email_action_robot.dart
@@ -1,5 +1,6 @@
 abstract class AbstractSearchEmailActionRobot {
   Future<void> selectEmailWithSubject(String subject);
+  Future<void> selectUnreadEmailWithSubject(String subject);
   Future<void> markSelectedEmailsAsRead();
   Future<void> archiveSelectedEmails();
 }

--- a/integration_test/robots/abstract/abstract_search_email_action_robot.dart
+++ b/integration_test/robots/abstract/abstract_search_email_action_robot.dart
@@ -1,0 +1,5 @@
+abstract class AbstractSearchEmailActionRobot {
+  Future<void> selectEmailWithSubject(String subject);
+  Future<void> markSelectedEmailsAsRead();
+  Future<void> archiveSelectedEmails();
+}

--- a/integration_test/robots/abstract/abstract_search_result_assertion_robot.dart
+++ b/integration_test/robots/abstract/abstract_search_result_assertion_robot.dart
@@ -8,6 +8,15 @@ abstract class AbstractSearchResultAssertionRobot {
   /// Asserts no result email carries [subject].
   Future<void> expectEmailSubjectNotPresent(String subject);
 
+  /// Asserts the rendered result shows the unread indicator.
+  Future<void> expectEmailWithSubjectMarkedUnread(String subject);
+
+  /// Asserts the rendered result no longer shows the unread indicator.
+  Future<void> expectEmailWithSubjectMarkedRead(String subject);
+
+  /// Asserts a rendered Search result now belongs to the Archive mailbox.
+  Future<void> expectEmailWithSubjectInArchive(String subject);
+
   /// Asserts the advanced-search attachment checkbox is checked.
   Future<void> expectAdvancedSearchHasAttachmentChecked();
 }

--- a/integration_test/robots/abstract/abstract_search_robot.dart
+++ b/integration_test/robots/abstract/abstract_search_robot.dart
@@ -1,8 +1,10 @@
 import 'abstract_search_assertion_robot.dart';
+import 'abstract_search_email_action_robot.dart';
 import 'abstract_search_filter_robot.dart';
 import 'abstract_search_input_robot.dart';
 import 'abstract_search_result_assertion_robot.dart';
 import 'abstract_search_suggestion_robot.dart';
+import 'abstract_search_viewport_robot.dart';
 
 abstract class AbstractSearchRobot
     implements
@@ -11,6 +13,8 @@ abstract class AbstractSearchRobot
         AbstractSearchAssertionRobot {
   AbstractSearchSuggestionRobot get suggestion;
   AbstractSearchResultAssertionRobot get assertion;
+  AbstractSearchEmailActionRobot get action;
+  AbstractSearchViewportRobot get viewport;
 
   Future<void> openSearch();
   Future<void> searchByLabel(String labelName);

--- a/integration_test/robots/abstract/abstract_search_viewport_robot.dart
+++ b/integration_test/robots/abstract/abstract_search_viewport_robot.dart
@@ -1,0 +1,4 @@
+abstract class AbstractSearchViewportRobot {
+  Future<void> resizeToMobileViewport();
+  Future<void> resizeToTabletViewport();
+}

--- a/integration_test/robots/search_email_action_robot.dart
+++ b/integration_test/robots/search_email_action_robot.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/widgets.dart';
+import 'package:patrol/patrol.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
+import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart'
+    if (dart.library.html) 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_web_builder.dart';
+import 'package:tmail_ui_user/features/thread/presentation/model/email_selection_action_type.dart';
+
+import '../base/core_robot.dart';
+import 'abstract/abstract_search_email_action_robot.dart';
+
+class SearchEmailActionRobot extends CoreRobot
+    implements AbstractSearchEmailActionRobot {
+  SearchEmailActionRobot(super.$);
+
+  @override
+  Future<void> selectEmailWithSubject(String subject) async {
+    final email = $(EmailTileBuilder).which<EmailTileBuilder>(
+      (view) => view.presentationEmail.subject == subject,
+    );
+    await $.waitUntilVisible(email);
+    await email.longPress();
+    await $.waitUntilVisible(
+      selectedEmailActionButton(EmailSelectionActionType.moreAction),
+    );
+  }
+
+  @override
+  Future<void> markSelectedEmailsAsRead() async {
+    await selectedEmailActionButton(EmailSelectionActionType.markAsRead)
+        .tap(settlePolicy: SettlePolicy.noSettle);
+  }
+
+  @override
+  Future<void> archiveSelectedEmails() async {
+    await selectedEmailActionButton(EmailSelectionActionType.archiveMessage)
+        .tap(settlePolicy: SettlePolicy.noSettle);
+  }
+
+  PatrolFinder selectedEmailActionButton(EmailSelectionActionType type) =>
+      $(Key('${type.name}${UiKeys.selectedEmailActionButtonSuffix}'));
+}

--- a/integration_test/robots/search_email_action_robot.dart
+++ b/integration_test/robots/search_email_action_robot.dart
@@ -13,16 +13,30 @@ class SearchEmailActionRobot extends CoreRobot
   SearchEmailActionRobot(super.$);
 
   @override
-  Future<void> selectEmailWithSubject(String subject) async {
-    final email = $(EmailTileBuilder).which<EmailTileBuilder>(
-      (view) => view.presentationEmail.subject == subject,
-    );
+  Future<void> selectEmailWithSubject(String subject) =>
+      _selectEmail(emailWithSubject(subject));
+
+  @override
+  Future<void> selectUnreadEmailWithSubject(String subject) =>
+      _selectEmail(emailWithSubject(subject, unreadOnly: true));
+
+  Future<void> _selectEmail(PatrolFinder email) async {
     await $.waitUntilVisible(email);
     await email.longPress();
     await $.waitUntilVisible(
       selectedEmailActionButton(EmailSelectionActionType.moreAction),
     );
   }
+
+  PatrolFinder emailWithSubject(
+    String subject, {
+    bool unreadOnly = false,
+  }) =>
+      $(EmailTileBuilder).which<EmailTileBuilder>(
+        (view) =>
+            view.presentationEmail.subject == subject &&
+            (!unreadOnly || !view.presentationEmail.hasRead),
+      );
 
   @override
   Future<void> markSelectedEmailsAsRead() async {

--- a/integration_test/robots/search_result_assertion_robot.dart
+++ b/integration_test/robots/search_result_assertion_robot.dart
@@ -55,8 +55,9 @@ class SearchResultAssertionRobot extends CoreRobot
 
     await waitForCondition(() async {
       await $.pump();
-      return unreadIcon.evaluate().isEmpty;
+      return email.evaluate().isNotEmpty && unreadIcon.evaluate().isEmpty;
     });
+    expect(email.exists, isTrue);
     expect(unreadIcon.exists, isFalse);
   }
 

--- a/integration_test/robots/search_result_assertion_robot.dart
+++ b/integration_test/robots/search_result_assertion_robot.dart
@@ -3,12 +3,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/model/search/quick_search_filter.dart';
+import 'package:model/extensions/presentation_mailbox_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_filters/search_filter_button.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_builder.dart'
     if (dart.library.html) 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_web_builder.dart';
 
 import '../base/core_robot.dart';
 import 'abstract/abstract_search_result_assertion_robot.dart';
+import '../utils/wait_for_condition.dart';
 
 /// Widget-property reads; hit-test-independent, so no platform override needed.
 class SearchResultAssertionRobot extends CoreRobot
@@ -28,6 +30,49 @@ class SearchResultAssertionRobot extends CoreRobot
       (view) => view.presentationEmail.subject?.contains(subject) == true,
     );
     expect(match.exists, isFalse);
+  }
+
+  @override
+  Future<void> expectEmailWithSubjectMarkedUnread(String subject) async {
+    final email = $(EmailTileBuilder).which<EmailTileBuilder>(
+      (view) => view.presentationEmail.subject == subject,
+    );
+    final unreadIcon = email.$(const Key(UiKeys.unreadStatusIcon));
+
+    await waitForCondition(() async {
+      await $.pump();
+      return unreadIcon.evaluate().isNotEmpty;
+    });
+    expect(unreadIcon.exists, isTrue);
+  }
+
+  @override
+  Future<void> expectEmailWithSubjectMarkedRead(String subject) async {
+    final email = $(EmailTileBuilder).which<EmailTileBuilder>(
+      (view) => view.presentationEmail.subject == subject,
+    );
+    final unreadIcon = email.$(const Key(UiKeys.unreadStatusIcon));
+
+    await waitForCondition(() async {
+      await $.pump();
+      return unreadIcon.evaluate().isEmpty;
+    });
+    expect(unreadIcon.exists, isFalse);
+  }
+
+  @override
+  Future<void> expectEmailWithSubjectInArchive(String subject) async {
+    final archivedEmail = $(EmailTileBuilder).which<EmailTileBuilder>(
+      (view) =>
+          view.presentationEmail.subject == subject &&
+          view.mailboxContain?.isArchive == true,
+    );
+
+    await waitForCondition(() async {
+      await $.pump();
+      return archivedEmail.evaluate().isNotEmpty;
+    });
+    expect(archivedEmail.exists, isTrue);
   }
 
   @override

--- a/integration_test/robots/search_robot.dart
+++ b/integration_test/robots/search_robot.dart
@@ -22,8 +22,12 @@ import '../utils/wait_for_condition.dart';
 import 'abstract/abstract_search_result_assertion_robot.dart';
 import 'abstract/abstract_search_robot.dart';
 import 'abstract/abstract_search_suggestion_robot.dart';
+import 'abstract/abstract_search_email_action_robot.dart';
+import 'abstract/abstract_search_viewport_robot.dart';
+import 'search_email_action_robot.dart';
 import 'search_result_assertion_robot.dart';
 import 'search_suggestion_robot.dart';
+import 'search_viewport_robot.dart';
 
 class SearchRobot extends CoreRobot implements AbstractSearchRobot {
   @override
@@ -32,12 +36,22 @@ class SearchRobot extends CoreRobot implements AbstractSearchRobot {
   @override
   final AbstractSearchResultAssertionRobot assertion;
 
+  @override
+  final AbstractSearchEmailActionRobot action;
+
+  @override
+  final AbstractSearchViewportRobot viewport;
+
   SearchRobot(
     PatrolIntegrationTester $, {
     AbstractSearchSuggestionRobot? suggestionRobot,
     AbstractSearchResultAssertionRobot? assertionRobot,
+    AbstractSearchEmailActionRobot? actionRobot,
+    AbstractSearchViewportRobot? viewportRobot,
   })  : suggestion = suggestionRobot ?? SearchSuggestionRobot($),
         assertion = assertionRobot ?? SearchResultAssertionRobot($),
+        action = actionRobot ?? SearchEmailActionRobot($),
+        viewport = viewportRobot ?? SearchViewportRobot($),
         super($);
 
   @override

--- a/integration_test/robots/search_viewport_robot.dart
+++ b/integration_test/robots/search_viewport_robot.dart
@@ -1,0 +1,17 @@
+import '../base/core_robot.dart';
+import 'abstract/abstract_search_viewport_robot.dart';
+
+class SearchViewportRobot extends CoreRobot
+    implements AbstractSearchViewportRobot {
+  SearchViewportRobot(super.$);
+
+  @override
+  Future<void> resizeToMobileViewport() async {
+    // Native integration tests already execute in the device's responsive layout.
+  }
+
+  @override
+  Future<void> resizeToTabletViewport() async {
+    // Native integration tests preserve the connected device viewport.
+  }
+}

--- a/integration_test/robots/web/web_responsive_search_robot.dart
+++ b/integration_test/robots/web/web_responsive_search_robot.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/search_email_view.dart';
+
+import '../../extensions/patrol_finder_extension.dart';
+import '../../utils/test_timeouts.dart';
+import '../../utils/wait_for_condition.dart';
+import '../search_robot.dart';
+
+class WebResponsiveSearchRobot extends SearchRobot {
+  WebResponsiveSearchRobot(super.$);
+
+  @override
+  Future<void> tapOnSearchField() async {
+    await super.tapOnSearchField();
+    await waitForCondition(
+      () async => $(SearchEmailView).evaluate().isNotEmpty,
+      timeout: TestTimeouts.short,
+    );
+  }
+
+  @override
+  Future<void> enterKeyword(String keyword) async {
+    final finder = $(SearchEmailView).$(TextField);
+    await finder.tap();
+    return finder.enterTextWithoutTapAction(keyword);
+  }
+}

--- a/integration_test/robots/web/web_search_email_action_robot.dart
+++ b/integration_test/robots/web/web_search_email_action_robot.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/email_selection_action_type.dart';
-import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_web_builder.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/web_tablet_body_email_item_widget.dart';
 
 import '../../utils/wait_for_condition.dart';
@@ -20,15 +19,25 @@ class WebSearchEmailActionRobot extends SearchEmailActionRobot {
       _triggerSelectedEmailAction(EmailSelectionActionType.archiveMessage);
 
   @override
-  Future<void> selectEmailWithSubject(String subject) async {
-    final email = $(EmailTileBuilder).which<EmailTileBuilder>(
-      (view) => view.presentationEmail.subject == subject,
-    );
+  Future<void> selectEmailWithSubject(String subject) =>
+      _selectEmailWithSubject(subject);
+
+  @override
+  Future<void> selectUnreadEmailWithSubject(String subject) =>
+      _selectEmailWithSubject(subject, unreadOnly: true);
+
+  Future<void> _selectEmailWithSubject(
+    String subject, {
+    bool unreadOnly = false,
+  }) async {
+    final email = emailWithSubject(subject, unreadOnly: unreadOnly);
     await waitForCondition(() async => email.evaluate().isNotEmpty);
 
     final tabletEmail = $(WebTabletBodyEmailItemWidget)
         .which<WebTabletBodyEmailItemWidget>(
-      (view) => view.presentationEmail.subject == subject,
+      (view) =>
+          view.presentationEmail.subject == subject &&
+          (!unreadOnly || !view.presentationEmail.hasRead),
     );
     if (tabletEmail.evaluate().isNotEmpty) {
       // Tablet web selects through the avatar; its tile has no long-press handler.

--- a/integration_test/robots/web/web_search_email_action_robot.dart
+++ b/integration_test/robots/web/web_search_email_action_robot.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
+import 'package:tmail_ui_user/features/thread/presentation/model/email_selection_action_type.dart';
+import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_web_builder.dart';
+import 'package:tmail_ui_user/features/thread/presentation/widgets/web_tablet_body_email_item_widget.dart';
+
+import '../../utils/wait_for_condition.dart';
+import '../search_email_action_robot.dart';
+
+class WebSearchEmailActionRobot extends SearchEmailActionRobot {
+  WebSearchEmailActionRobot(super.$);
+
+  @override
+  Future<void> markSelectedEmailsAsRead() =>
+      _triggerSelectedEmailAction(EmailSelectionActionType.markAsRead);
+
+  @override
+  Future<void> archiveSelectedEmails() =>
+      _triggerSelectedEmailAction(EmailSelectionActionType.archiveMessage);
+
+  @override
+  Future<void> selectEmailWithSubject(String subject) async {
+    final email = $(EmailTileBuilder).which<EmailTileBuilder>(
+      (view) => view.presentationEmail.subject == subject,
+    );
+    await waitForCondition(() async => email.evaluate().isNotEmpty);
+
+    final tabletEmail = $(WebTabletBodyEmailItemWidget)
+        .which<WebTabletBodyEmailItemWidget>(
+      (view) => view.presentationEmail.subject == subject,
+    );
+    if (tabletEmail.evaluate().isNotEmpty) {
+      // Tablet web selects through the avatar; its tile has no long-press handler.
+      await tabletEmail
+          .$(const Key(UiKeys.tabletEmailSelectionAvatar))
+          .tap();
+    } else {
+      // Mobile web keeps the native-style long-press selection affordance.
+      await email.longPress();
+    }
+
+    await waitForCondition(
+      () async =>
+          $(Key(
+            '${EmailSelectionActionType.moreAction.name}'
+            '${UiKeys.selectedEmailActionButtonSuffix}',
+          )).evaluate().isNotEmpty,
+    );
+  }
+
+  Future<void> _triggerSelectedEmailAction(
+    EmailSelectionActionType type,
+  ) async {
+    final actionButton = selectedEmailActionButton(type);
+    await waitForCondition(() async => actionButton.evaluate().isNotEmpty);
+
+    // In headless Chrome the responsive toolbar is rendered but not
+    // hit-testable to Patrol, although its button callback is available.
+    final onTap = $.tester
+        .widget<TMailButtonWidget>(actionButton)
+        .onTapActionCallback;
+    if (onTap == null) {
+      throw StateError('Selected email action ${type.name} is unavailable');
+    }
+    onTap();
+    await $.pump();
+  }
+}

--- a/integration_test/robots/web/web_search_robot.dart
+++ b/integration_test/robots/web/web_search_robot.dart
@@ -7,6 +7,8 @@ import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/base/widget/popup_menu/popup_menu_item_action_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/quick_search/email_quick_search_item_tile_widget.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/widgets/search_input_form_widget.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/search_email_view.dart';
+import 'package:core/presentation/views/search/search_bar_view.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/email_tile_web_builder.dart';
 
 import '../../extensions/patrol_finder_extension.dart';
@@ -14,15 +16,31 @@ import '../../utils/test_timeouts.dart';
 import '../../utils/wait_for_condition.dart';
 import '../abstract/abstract_search_robot.dart';
 import '../search_robot.dart';
+import 'web_search_email_action_robot.dart';
 import 'web_search_suggestion_robot.dart';
+import 'web_search_viewport_robot.dart';
 
 class WebSearchRobot extends SearchRobot implements AbstractSearchRobot {
-  // Web suggestion sub-robot; assertions reuse the base (hit-test-independent).
+  // Web-specific sub-robots cover responsive selection and browser resizing.
   WebSearchRobot(PatrolIntegrationTester $)
-      : super($, suggestionRobot: WebSearchSuggestionRobot($));
+      : super(
+          $,
+          suggestionRobot: WebSearchSuggestionRobot($),
+          actionRobot: WebSearchEmailActionRobot($),
+          viewportRobot: WebSearchViewportRobot($),
+        );
 
   @override
   Future<void> tapOnSearchField() async {
+    if ($(SearchBarView).evaluate().isNotEmpty) {
+      // Responsive web uses the mobile search entry point below 1200px.
+      await super.tapOnSearchField();
+      await waitForCondition(
+        () async => $(SearchEmailView).evaluate().isNotEmpty,
+        timeout: TestTimeouts.short,
+      );
+      return;
+    }
     await $(SearchInputFormWidget).$(TextField).tap();
     // Tap the search icon button so isSearchEmailRunning becomes true and filter
     // buttons appear in the dashboard bar before any keyword is entered.
@@ -35,6 +53,12 @@ class WebSearchRobot extends SearchRobot implements AbstractSearchRobot {
 
   @override
   Future<void> enterKeyword(String keyword) async {
+    if ($(SearchEmailView).evaluate().isNotEmpty) {
+      // Responsive web renders the dedicated mobile/tablet SearchEmailView.
+      final finder = $(SearchEmailView).$(TextField);
+      await finder.tap();
+      return finder.enterTextWithoutTapAction(keyword);
+    }
     final finder = $(SearchInputFormWidget).$(TextField);
     await finder.tap();
     await finder.enterTextWithoutTapAction(keyword);
@@ -53,6 +77,15 @@ class WebSearchRobot extends SearchRobot implements AbstractSearchRobot {
 
   @override
   Future<void> tapOnShowAllResultsText() async {
+    if ($(SearchEmailView).evaluate().isNotEmpty) {
+      // Responsive web renders suggestions in the page, so its action remains
+      // hit-testable unlike the desktop overlay.
+      await super.tapOnShowAllResultsText();
+      return waitForCondition(
+        () async => $(EmailTileBuilder).evaluate().isNotEmpty,
+        timeout: TestTimeouts.medium,
+      );
+    }
     // On web the suggestion overlay wraps content in PointerInterceptor, making
     // the "Showing results for:" InkWell unreliable to tap. Pressing Enter on the
     // focused search field triggers onSubmitted → _invokeSearchEmailAction which
@@ -165,7 +198,10 @@ class WebSearchRobot extends SearchRobot implements AbstractSearchRobot {
     final email = $(EmailTileBuilder).which<EmailTileBuilder>(
       (view) => view.presentationEmail.subject?.contains(subject) == true,
     );
-    await $.waitUntilVisible(email);
+    await waitForCondition(
+      () async => email.evaluate().isNotEmpty,
+      timeout: TestTimeouts.medium,
+    );
   }
 
   @override

--- a/integration_test/robots/web/web_search_robot.dart
+++ b/integration_test/robots/web/web_search_robot.dart
@@ -81,20 +81,14 @@ class WebSearchRobot extends SearchRobot implements AbstractSearchRobot {
       // Responsive web renders suggestions in the page, so its action remains
       // hit-testable unlike the desktop overlay.
       await super.tapOnShowAllResultsText();
-      return waitForCondition(
-        () async => $(EmailTileBuilder).evaluate().isNotEmpty,
-        timeout: TestTimeouts.medium,
-      );
+      return _waitForSearchResults();
     }
     // On web the suggestion overlay wraps content in PointerInterceptor, making
     // the "Showing results for:" InkWell unreliable to tap. Pressing Enter on the
     // focused search field triggers onSubmitted → _invokeSearchEmailAction which
     // commits the search and sets isSearchEmailRunning = true.
     await $.platformAutomator.web.pressKeyCombo(keys: ['Enter']);
-    await waitForCondition(
-      () async => $(EmailTileBuilder).evaluate().isNotEmpty,
-      timeout: TestTimeouts.medium,
-    );
+    await _waitForSearchResults();
   }
 
   @override
@@ -199,10 +193,21 @@ class WebSearchRobot extends SearchRobot implements AbstractSearchRobot {
       (view) => view.presentationEmail.subject?.contains(subject) == true,
     );
     await waitForCondition(
-      () async => email.evaluate().isNotEmpty,
+      () async {
+        await $.pump();
+        return email.evaluate().isNotEmpty;
+      },
       timeout: TestTimeouts.medium,
     );
   }
+
+  Future<void> _waitForSearchResults() => waitForCondition(
+        () async {
+          await $.pump();
+          return $(EmailTileBuilder).evaluate().isNotEmpty;
+        },
+        timeout: TestTimeouts.medium,
+      );
 
   @override
   Future<void> expectEmailListCountAtLeast(int count) async {

--- a/integration_test/robots/web/web_search_robot.dart
+++ b/integration_test/robots/web/web_search_robot.dart
@@ -17,10 +17,14 @@ import '../../utils/wait_for_condition.dart';
 import '../abstract/abstract_search_robot.dart';
 import '../search_robot.dart';
 import 'web_search_email_action_robot.dart';
+import 'web_responsive_search_robot.dart';
 import 'web_search_suggestion_robot.dart';
 import 'web_search_viewport_robot.dart';
 
 class WebSearchRobot extends SearchRobot implements AbstractSearchRobot {
+  late final WebResponsiveSearchRobot _responsiveSearchRobot =
+      WebResponsiveSearchRobot($);
+
   // Web-specific sub-robots cover responsive selection and browser resizing.
   WebSearchRobot(PatrolIntegrationTester $)
       : super(
@@ -31,16 +35,12 @@ class WebSearchRobot extends SearchRobot implements AbstractSearchRobot {
         );
 
   @override
-  Future<void> tapOnSearchField() async {
-    if ($(SearchBarView).evaluate().isNotEmpty) {
-      // Responsive web uses the mobile search entry point below 1200px.
-      await super.tapOnSearchField();
-      await waitForCondition(
-        () async => $(SearchEmailView).evaluate().isNotEmpty,
-        timeout: TestTimeouts.short,
+  Future<void> tapOnSearchField() => _runForCurrentSearchLayout(
+        responsiveAction: _responsiveSearchRobot.tapOnSearchField,
+        desktopAction: _tapOnDesktopSearchField,
       );
-      return;
-    }
+
+  Future<void> _tapOnDesktopSearchField() async {
     await $(SearchInputFormWidget).$(TextField).tap();
     // Tap the search icon button so isSearchEmailRunning becomes true and filter
     // buttons appear in the dashboard bar before any keyword is entered.
@@ -52,16 +52,15 @@ class WebSearchRobot extends SearchRobot implements AbstractSearchRobot {
   }
 
   @override
-  Future<void> enterKeyword(String keyword) async {
-    if ($(SearchEmailView).evaluate().isNotEmpty) {
-      // Responsive web renders the dedicated mobile/tablet SearchEmailView.
-      final finder = $(SearchEmailView).$(TextField);
-      await finder.tap();
-      return finder.enterTextWithoutTapAction(keyword);
-    }
+  Future<void> enterKeyword(String keyword) => _runForCurrentSearchLayout(
+        responsiveAction: () => _responsiveSearchRobot.enterKeyword(keyword),
+        desktopAction: () => _enterDesktopKeyword(keyword),
+      );
+
+  Future<void> _enterDesktopKeyword(String keyword) async {
     final finder = $(SearchInputFormWidget).$(TextField);
     await finder.tap();
-    await finder.enterTextWithoutTapAction(keyword);
+    return finder.enterTextWithoutTapAction(keyword);
   }
 
   @override
@@ -77,19 +76,29 @@ class WebSearchRobot extends SearchRobot implements AbstractSearchRobot {
 
   @override
   Future<void> tapOnShowAllResultsText() async {
-    if ($(SearchEmailView).evaluate().isNotEmpty) {
-      // Responsive web renders suggestions in the page, so its action remains
-      // hit-testable unlike the desktop overlay.
-      await super.tapOnShowAllResultsText();
-      return _waitForSearchResults();
-    }
+    await _runForCurrentSearchLayout(
+      responsiveAction: _responsiveSearchRobot.tapOnShowAllResultsText,
+      desktopAction: _submitDesktopSearch,
+    );
+    return _waitForSearchResults();
+  }
+
+  Future<void> _submitDesktopSearch() async {
     // On web the suggestion overlay wraps content in PointerInterceptor, making
     // the "Showing results for:" InkWell unreliable to tap. Pressing Enter on the
     // focused search field triggers onSubmitted → _invokeSearchEmailAction which
     // commits the search and sets isSearchEmailRunning = true.
     await $.platformAutomator.web.pressKeyCombo(keys: ['Enter']);
-    await _waitForSearchResults();
   }
+
+  bool get _isResponsiveSearchLayout =>
+      $(SearchBarView).evaluate().isNotEmpty ||
+      $(SearchEmailView).evaluate().isNotEmpty;
+
+  Future<void> _runForCurrentSearchLayout({
+    required Future<void> Function() responsiveAction,
+    required Future<void> Function() desktopAction,
+  }) => _isResponsiveSearchLayout ? responsiveAction() : desktopAction();
 
   @override
   Future<void> scrollToEndListSearchFilter() async {

--- a/integration_test/robots/web/web_search_viewport_robot.dart
+++ b/integration_test/robots/web/web_search_viewport_robot.dart
@@ -1,0 +1,30 @@
+import 'package:core/presentation/views/search/search_bar_view.dart';
+import 'package:flutter/material.dart';
+import 'package:tmail_ui_user/features/thread/presentation/widgets/web_tablet_body_email_item_widget.dart';
+
+import '../../utils/wait_for_condition.dart';
+import '../search_viewport_robot.dart';
+
+class WebSearchViewportRobot extends SearchViewportRobot {
+  WebSearchViewportRobot(super.$);
+
+  @override
+  Future<void> resizeToMobileViewport() async {
+    await $.platformAutomator.web.resizeWindow(
+      size: const Size(390, 844),
+    );
+    await waitForCondition(
+      () async => $(SearchBarView).evaluate().isNotEmpty,
+    );
+  }
+
+  @override
+  Future<void> resizeToTabletViewport() async {
+    await $.platformAutomator.web.resizeWindow(
+      size: const Size(768, 1024),
+    );
+    await waitForCondition(
+      () async => $(WebTabletBodyEmailItemWidget).evaluate().isNotEmpty,
+    );
+  }
+}

--- a/integration_test/robots/web/web_thread_robot.dart
+++ b/integration_test/robots/web/web_thread_robot.dart
@@ -11,6 +11,7 @@ import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import '../abstract/abstract_thread_robot.dart';
 import '../thread_empty_trash_robot.dart';
 import '../thread_robot.dart';
+import '../../utils/wait_for_condition.dart';
 import 'web_fire_on_tap.dart';
 
 /// Web-specific empty-trash robot: tapping the banner requires firing the
@@ -95,7 +96,12 @@ class WebThreadRobot extends ThreadRobot implements AbstractThreadRobot {
   }
 
   Future<void> _openEmailTile(PatrolFinder emailFinder) async {
-    await $.waitUntilVisible(emailFinder);
+    // Web XHR callbacks need an event-loop yield, which waitUntilVisible's
+    // frame-only retry loop does not provide.
+    await waitForCondition(() async {
+      await $.pump();
+      return emailFinder.evaluate().isNotEmpty;
+    });
     await emailFinder.tap();
     await $.pump(_emailOpenPumpDuration);
   }

--- a/integration_test/scenarios/search/mobile_search_action_state_sync_scenario.dart
+++ b/integration_test/scenarios/search/mobile_search_action_state_sync_scenario.dart
@@ -1,0 +1,41 @@
+import '../../base/base_test_scenario.dart';
+import '../../models/provisioning_email.dart';
+
+class MobileSearchActionStateSyncScenario extends BaseTestScenario {
+  const MobileSearchActionStateSyncScenario(super.$, super.robots);
+
+  static const _subject = 'Mobile Search action state sync';
+  static const _searchKeyword = 'action state sync';
+
+  @override
+  Future<void> runTestLogic() async {
+    const email = String.fromEnvironment('BASIC_AUTH_EMAIL');
+    final commonRobot = robots.commonRobot();
+    final searchRobot = robots.searchRobot();
+
+    await commonRobot.waitForMailboxReady();
+    await commonRobot.provisionEmail([
+      ProvisioningEmail(
+        toEmail: email,
+        subject: _subject,
+        content: _subject,
+      ),
+    ], requestReadReceipt: false);
+
+    await searchRobot.viewport.resizeToMobileViewport();
+    await searchRobot.tapOnSearchField();
+    await searchRobot.enterKeyword(_searchKeyword);
+    await searchRobot.tapOnShowAllResultsText();
+    await searchRobot.expectEmailWithSubjectVisible(_subject);
+    await searchRobot.assertion.expectEmailWithSubjectMarkedUnread(_subject);
+
+    await searchRobot.action.selectEmailWithSubject(_subject);
+    await searchRobot.action.markSelectedEmailsAsRead();
+    await searchRobot.assertion.expectEmailWithSubjectMarkedRead(_subject);
+
+    await searchRobot.viewport.resizeToTabletViewport();
+    await searchRobot.action.selectEmailWithSubject(_subject);
+    await searchRobot.action.archiveSelectedEmails();
+    await searchRobot.assertion.expectEmailWithSubjectInArchive(_subject);
+  }
+}

--- a/integration_test/scenarios/search/mobile_search_action_state_sync_scenario.dart
+++ b/integration_test/scenarios/search/mobile_search_action_state_sync_scenario.dart
@@ -29,7 +29,7 @@ class MobileSearchActionStateSyncScenario extends BaseTestScenario {
     await searchRobot.expectEmailWithSubjectVisible(_subject);
     await searchRobot.assertion.expectEmailWithSubjectMarkedUnread(_subject);
 
-    await searchRobot.action.selectEmailWithSubject(_subject);
+    await searchRobot.action.selectUnreadEmailWithSubject(_subject);
     await searchRobot.action.markSelectedEmailsAsRead();
     await searchRobot.assertion.expectEmailWithSubjectMarkedRead(_subject);
 

--- a/integration_test/tests/search/mobile_search_action_state_sync_test.dart
+++ b/integration_test/tests/search/mobile_search_action_state_sync_test.dart
@@ -1,0 +1,13 @@
+import '../../base/test_base.dart';
+import '../../models/test_tags.dart';
+import '../../scenarios/search/mobile_search_action_state_sync_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description:
+        'Should update Search results immediately when selected emails are marked read and archived',
+    scenarioBuilder: ($, robots) =>
+        MobileSearchActionStateSyncScenario($, robots),
+    tags: [TestTags.android, TestTags.ios, TestTags.web],
+  );
+}

--- a/lib/features/base/model/ui_keys.dart
+++ b/lib/features/base/model/ui_keys.dart
@@ -15,6 +15,10 @@ class UiKeys {
   static const String emptyThreadView = 'empty_thread_view';
   static const String emptySearchEmailView = 'empty_search_email_view';
   static const String searchFilterListView = 'search_filter_list_view';
+  static const String unreadStatusIcon = 'unread_status_icon';
+  static const String selectedEmailActionButtonSuffix = '_selected_email_button';
+  static const String tabletEmailSelectionAvatar =
+      'tablet_email_selection_avatar';
   // Suggestion-overlay chips; compose with the filter name. Distinct from the result-bar keys.
   static const String quickSearchFilterButtonPrefix = 'quick_search_filter_button_';
 

--- a/lib/features/mailbox_dashboard/presentation/extensions/apply_to_visible_email_list_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/apply_to_visible_email_list_extension.dart
@@ -1,0 +1,38 @@
+import 'package:model/email/presentation_email.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/search_email_presentation_owner_extension.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
+
+typedef VisibleEmailListTransformer = List<PresentationEmail> Function(
+  List<PresentationEmail> emails,
+);
+
+extension ApplyToVisibleEmailListExtension on MailboxDashBoardController {
+  void applyToVisibleEmailList(
+    VisibleEmailListTransformer transform, {
+    bool Function()? shouldApplyToMailboxList,
+  }) {
+    final isSearchOwner = isSearchEmailPresentationOwner;
+    if (!isSearchOwner && shouldApplyToMailboxList?.call() == false) {
+      return;
+    }
+
+    final visibleEmails = isSearchOwner
+        ? List<PresentationEmail>.from(
+            appProviderContainer
+                .read(searchEmailPresentationProvider)
+                .listResultSearch,
+          )
+        : List<PresentationEmail>.from(emailsInCurrentMailbox);
+    final updatedEmails = transform(visibleEmails);
+
+    if (isSearchOwner) {
+      appProviderContainer
+          .read(searchEmailPresentationProvider.notifier)
+          .setResultSearches(updatedEmails);
+    } else {
+      updateEmailList(updatedEmails);
+    }
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/extensions/delete_emails_in_mailbox_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/delete_emails_in_mailbox_extension.dart
@@ -1,12 +1,29 @@
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/search_email_presentation_owner_extension.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 
 extension DeleteEmailsInMailboxExtension on MailboxDashBoardController {
   void handleDeleteEmailsInMailbox({
     required List<EmailId> emailIds,
     required MailboxId? affectedMailboxId,
   }) {
+    if (emailIds.isEmpty) return;
+
+    if (isSearchEmailPresentationOwner) {
+      final deletedEmailIds = emailIds.toSet();
+      appProviderContainer
+          .read(searchEmailPresentationProvider.notifier)
+          .updateResultSearches(
+            (emails) => emails
+                .where((email) => !deletedEmailIds.contains(email.id))
+                .toList(),
+          );
+      return;
+    }
+
     if (selectedMailbox.value?.id != affectedMailboxId) {
       return;
     }
@@ -15,6 +32,21 @@ extension DeleteEmailsInMailboxExtension on MailboxDashBoardController {
   }
 
   void handleClearAllEmailsInMailbox(MailboxId mailboxId) {
+    if (isSearchEmailPresentationOwner) {
+      appProviderContainer
+          .read(searchEmailPresentationProvider.notifier)
+          .updateResultSearches(
+            (emails) => emails
+                .where(
+                  (email) =>
+                      email.mailboxIds?.containsKey(mailboxId) != true &&
+                      email.mailboxContain?.id != mailboxId,
+                )
+                .toList(),
+          );
+      return;
+    }
+
     if (selectedMailbox.value?.id != mailboxId) return;
     emailsInCurrentMailbox.clear();
   }

--- a/lib/features/mailbox_dashboard/presentation/extensions/delete_emails_in_mailbox_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/delete_emails_in_mailbox_extension.dart
@@ -1,9 +1,7 @@
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/search_email_presentation_owner_extension.dart';
-import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
-import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/apply_to_visible_email_list_extension.dart';
 
 extension DeleteEmailsInMailboxExtension on MailboxDashBoardController {
   void handleDeleteEmailsInMailbox({
@@ -12,42 +10,26 @@ extension DeleteEmailsInMailboxExtension on MailboxDashBoardController {
   }) {
     if (emailIds.isEmpty) return;
 
-    if (isSearchEmailPresentationOwner) {
-      final deletedEmailIds = emailIds.toSet();
-      appProviderContainer
-          .read(searchEmailPresentationProvider.notifier)
-          .updateResultSearches(
-            (emails) => emails
-                .where((email) => !deletedEmailIds.contains(email.id))
-                .toList(),
-          );
-      return;
-    }
-
-    if (selectedMailbox.value?.id != affectedMailboxId) {
-      return;
-    }
-
-    emailsInCurrentMailbox.removeWhere((email) => emailIds.contains(email.id));
+    final deletedEmailIds = emailIds.toSet();
+    applyToVisibleEmailList(
+      (emails) => emails
+          .where((email) => !deletedEmailIds.contains(email.id))
+          .toList(),
+      shouldApplyToMailboxList: () =>
+          selectedMailbox.value?.id == affectedMailboxId,
+    );
   }
 
   void handleClearAllEmailsInMailbox(MailboxId mailboxId) {
-    if (isSearchEmailPresentationOwner) {
-      appProviderContainer
-          .read(searchEmailPresentationProvider.notifier)
-          .updateResultSearches(
-            (emails) => emails
-                .where(
-                  (email) =>
-                      email.mailboxIds?.containsKey(mailboxId) != true &&
-                      email.mailboxContain?.id != mailboxId,
-                )
-                .toList(),
-          );
-      return;
-    }
-
-    if (selectedMailbox.value?.id != mailboxId) return;
-    emailsInCurrentMailbox.clear();
+    applyToVisibleEmailList(
+      (emails) => emails
+          .where(
+            (email) =>
+                email.mailboxIds?.containsKey(mailboxId) != true &&
+                email.mailboxContain?.id != mailboxId,
+          )
+          .toList(),
+      shouldApplyToMailboxList: () => selectedMailbox.value?.id == mailboxId,
+    );
   }
 }

--- a/lib/features/mailbox_dashboard/presentation/extensions/search_email_presentation_owner_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/search_email_presentation_owner_extension.dart
@@ -1,0 +1,22 @@
+import 'package:core/utils/platform_info.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
+import 'package:tmail_ui_user/main/routes/route_navigation.dart';
+
+extension SearchEmailPresentationOwnerExtension on MailboxDashBoardController {
+  bool get isSearchEmailPresentationOwner {
+    if (!searchController.isSearchEmailRunning) return false;
+
+    if (PlatformInfo.isWeb) {
+      final context = currentContext;
+      if (context != null && responsiveUtils.isWebDesktop(context)) {
+        return false;
+      }
+    }
+
+    return appProviderContainer
+        .read(searchEmailPresentationProvider)
+        .searchIsRunning;
+  }
+}

--- a/lib/features/mailbox_dashboard/presentation/extensions/search_email_presentation_owner_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/search_email_presentation_owner_extension.dart
@@ -1,6 +1,6 @@
-import 'package:core/utils/platform_info.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/utils/search_email_presentation_owner_utils.dart';
 import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 
@@ -8,11 +8,11 @@ extension SearchEmailPresentationOwnerExtension on MailboxDashBoardController {
   bool get isSearchEmailPresentationOwner {
     if (!searchController.isSearchEmailRunning) return false;
 
-    if (PlatformInfo.isWeb) {
-      final context = currentContext;
-      if (context != null && responsiveUtils.isWebDesktop(context)) {
-        return false;
-      }
+    if (!isSearchEmailPresentationLayoutOwner(
+      context: currentContext,
+      responsiveUtils: responsiveUtils,
+    )) {
+      return false;
     }
 
     return appProviderContainer

--- a/lib/features/mailbox_dashboard/presentation/extensions/update_current_emails_flags_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/update_current_emails_flags_extension.dart
@@ -1,10 +1,11 @@
-import 'package:core/utils/platform_info.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
 import 'package:model/email/mark_star_action.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:model/email/read_actions.dart';
+import 'package:model/extensions/presentation_email_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/search_email_presentation_owner_extension.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/action/thread_detail_ui_action.dart';
 import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
@@ -27,51 +28,27 @@ extension UpdateCurrentEmailsFlagsExtension on MailboxDashBoardController {
       return;
     }
 
-    // Mobile search results may be active under Thread Detail.
-    final isSearchEmailRoute =
-        searchController.isSearchEmailRunning && PlatformInfo.isMobile;
+    final isSearchEmailRoute = isSearchEmailPresentationOwner;
     final currentEmails = isSearchEmailRoute
       ? [...appProviderContainer.read(searchEmailPresentationProvider).listResultSearch]
       : emailsInCurrentMailbox;
 
     if (currentEmails.isEmpty) return;
 
-    for (var email in currentEmails) {
-      if (!emailIds.contains(email.id)) continue;
+    final emailIdsSet = emailIds.toSet();
+    for (var index = 0; index < currentEmails.length; index++) {
+      final email = currentEmails[index];
+      if (!emailIdsSet.contains(email.id)) continue;
 
-      switch (readAction) {
-        case ReadActions.markAsRead:
-          _updateKeyword(email, KeyWordIdentifier.emailSeen, true);
-          break;
-        case ReadActions.markAsUnread:
-          _updateKeyword(email, KeyWordIdentifier.emailSeen, false);
-          break;
-        default:
-          break;
-      }
-
-      switch (markStarAction) {
-        case MarkStarAction.markStar:
-          _updateKeyword(email, KeyWordIdentifier.emailFlagged, true);
-          break;
-        case MarkStarAction.unMarkStar:
-          _updateKeyword(email, KeyWordIdentifier.emailFlagged, false);
-          break;
-        default:
-          break;
-      }
-
-      if (markAsAnswered) {
-        _updateKeyword(email, KeyWordIdentifier.emailAnswered, true);
-      }
-
-      if (markAsForwarded) {
-        _updateKeyword(email, KeyWordIdentifier.emailForwarded, true);
-      }
-
-      if (labelKeywords?.isNotEmpty == true) {
-        _updateListKeywords(email, labelKeywords!, isLabelAdded);
-      }
+      currentEmails[index] = _updateEmailKeywords(
+        email,
+        readAction: readAction,
+        markStarAction: markStarAction,
+        markAsAnswered: markAsAnswered,
+        markAsForwarded: markAsForwarded,
+        isLabelAdded: isLabelAdded,
+        labelKeywords: labelKeywords,
+      );
     }
 
     if (isSearchEmailRoute) {
@@ -83,26 +60,35 @@ extension UpdateCurrentEmailsFlagsExtension on MailboxDashBoardController {
     }
   }
 
-  void _updateKeyword(
-    PresentationEmail presentationEmail,
-    KeyWordIdentifier keyword,
-    bool value,
-  ) {
-    if (value) {
-      presentationEmail.keywords?[keyword] = true;
-    } else {
-      presentationEmail.keywords?.remove(keyword);
-    }
-  }
+  PresentationEmail _updateEmailKeywords(
+    PresentationEmail presentationEmail, {
+    ReadActions? readAction,
+    MarkStarAction? markStarAction,
+    required bool markAsAnswered,
+    required bool markAsForwarded,
+    required bool isLabelAdded,
+    List<KeyWordIdentifier>? labelKeywords,
+  }) {
+    final keywordUpdates = <KeyWordIdentifier, bool>{
+      if (readAction == ReadActions.markAsRead)
+        KeyWordIdentifier.emailSeen: true,
+      if (readAction == ReadActions.markAsUnread)
+        KeyWordIdentifier.emailSeen: false,
+      if (markStarAction == MarkStarAction.markStar)
+        KeyWordIdentifier.emailFlagged: true,
+      if (markStarAction == MarkStarAction.unMarkStar)
+        KeyWordIdentifier.emailFlagged: false,
+      if (markAsAnswered) KeyWordIdentifier.emailAnswered: true,
+      if (markAsForwarded) KeyWordIdentifier.emailForwarded: true,
+      for (final keyword in labelKeywords ?? <KeyWordIdentifier>[])
+        keyword: isLabelAdded,
+    };
 
-  void _updateListKeywords(
-    PresentationEmail presentationEmail,
-    List<KeyWordIdentifier> keywords,
-    bool value,
-  ) {
-    for (var keyword in keywords) {
-      _updateKeyword(presentationEmail, keyword, value);
+    if (keywordUpdates.isEmpty) {
+      return presentationEmail;
     }
+
+    return presentationEmail.updateKeywords(keywordUpdates);
   }
 
   void updateEmailAnswered(EmailId emailId) {

--- a/lib/features/mailbox_dashboard/presentation/extensions/update_current_emails_flags_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/update_current_emails_flags_extension.dart
@@ -5,10 +5,8 @@ import 'package:model/email/presentation_email.dart';
 import 'package:model/email/read_actions.dart';
 import 'package:model/extensions/presentation_email_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/search_email_presentation_owner_extension.dart';
-import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/apply_to_visible_email_list_extension.dart';
 import 'package:tmail_ui_user/features/thread_detail/presentation/action/thread_detail_ui_action.dart';
-import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 
 extension UpdateCurrentEmailsFlagsExtension on MailboxDashBoardController {
   void updateEmailFlagByEmailIds(
@@ -28,36 +26,22 @@ extension UpdateCurrentEmailsFlagsExtension on MailboxDashBoardController {
       return;
     }
 
-    final isSearchEmailRoute = isSearchEmailPresentationOwner;
-    final currentEmails = isSearchEmailRoute
-      ? [...appProviderContainer.read(searchEmailPresentationProvider).listResultSearch]
-      : emailsInCurrentMailbox;
-
-    if (currentEmails.isEmpty) return;
-
     final emailIdsSet = emailIds.toSet();
-    for (var index = 0; index < currentEmails.length; index++) {
-      final email = currentEmails[index];
-      if (!emailIdsSet.contains(email.id)) continue;
+    applyToVisibleEmailList(
+      (currentEmails) => currentEmails.map((email) {
+        if (!emailIdsSet.contains(email.id)) return email;
 
-      currentEmails[index] = _updateEmailKeywords(
-        email,
-        readAction: readAction,
-        markStarAction: markStarAction,
-        markAsAnswered: markAsAnswered,
-        markAsForwarded: markAsForwarded,
-        isLabelAdded: isLabelAdded,
-        labelKeywords: labelKeywords,
-      );
-    }
-
-    if (isSearchEmailRoute) {
-      appProviderContainer
-          .read(searchEmailPresentationProvider.notifier)
-          .setResultSearches(currentEmails);
-    } else {
-      emailsInCurrentMailbox.refresh();
-    }
+        return _updateEmailKeywords(
+          email,
+          readAction: readAction,
+          markStarAction: markStarAction,
+          markAsAnswered: markAsAnswered,
+          markAsForwarded: markAsForwarded,
+          isLabelAdded: isLabelAdded,
+          labelKeywords: labelKeywords,
+        );
+      }).toList(),
+    );
   }
 
   PresentationEmail _updateEmailKeywords(

--- a/lib/features/mailbox_dashboard/presentation/extensions/update_emails_with_new_mailbox_id_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/update_emails_with_new_mailbox_id_extension.dart
@@ -2,9 +2,7 @@ import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
-import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/search_email_presentation_owner_extension.dart';
-import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
-import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/apply_to_visible_email_list_extension.dart';
 
 extension UpdateEmailsWithNewMailboxIdExtension on MailboxDashBoardController {
   void handleUpdateEmailsWithNewMailboxId({
@@ -30,15 +28,6 @@ extension UpdateEmailsWithNewMailboxIdExtension on MailboxDashBoardController {
           );
         }).toList();
 
-    if (isSearchEmailPresentationOwner) {
-      appProviderContainer
-          .read(searchEmailPresentationProvider.notifier)
-          .updateResultSearches(updateEmails);
-      return;
-    }
-
-    updateEmailList(updateEmails(List<PresentationEmail>.from(
-      emailsInCurrentMailbox,
-    )));
+    applyToVisibleEmailList(updateEmails);
   }
 }

--- a/lib/features/mailbox_dashboard/presentation/extensions/update_emails_with_new_mailbox_id_extension.dart
+++ b/lib/features/mailbox_dashboard/presentation/extensions/update_emails_with_new_mailbox_id_extension.dart
@@ -2,30 +2,43 @@ import 'package:jmap_dart_client/jmap/mail/email/email.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/search_email_presentation_owner_extension.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 
 extension UpdateEmailsWithNewMailboxIdExtension on MailboxDashBoardController {
-  handleUpdateEmailsWithNewMailboxId({
+  void handleUpdateEmailsWithNewMailboxId({
     required Map<MailboxId,List<EmailId>> originalMailboxIdsWithEmailIds,
     required MailboxId destinationMailboxId,
   }) {
-    final currentEmails = List<PresentationEmail>.from(
-      emailsInCurrentMailbox,
-    );
     final movedEmailIds = originalMailboxIdsWithEmailIds.entries.fold(
       <EmailId>{},
       (emailIds, entry) {
         emailIds.addAll(entry.value);
         return emailIds;
       },
-    ).toList();
-    for (int i = 0; i < currentEmails.length; i++) {
-      if (!movedEmailIds.contains(currentEmails[i].id)) continue;
+    );
+    if (movedEmailIds.isEmpty) return;
 
-      currentEmails[i] = currentEmails[i].copyWith(
-        mailboxIds: {destinationMailboxId: true},
-        mailboxContain: mapMailboxById[destinationMailboxId],
-      );
+    List<PresentationEmail> updateEmails(List<PresentationEmail> emails) =>
+        emails.map((email) {
+          if (!movedEmailIds.contains(email.id)) return email;
+
+          return email.copyWith(
+            mailboxIds: {destinationMailboxId: true},
+            mailboxContain: mapMailboxById[destinationMailboxId],
+          );
+        }).toList();
+
+    if (isSearchEmailPresentationOwner) {
+      appProviderContainer
+          .read(searchEmailPresentationProvider.notifier)
+          .updateResultSearches(updateEmails);
+      return;
     }
-    updateEmailList(currentEmails);
+
+    updateEmailList(updateEmails(List<PresentationEmail>.from(
+      emailsInCurrentMailbox,
+    )));
   }
 }

--- a/lib/features/search/email/presentation/search_email_controller.dart
+++ b/lib/features/search/email/presentation/search_email_controller.dart
@@ -77,6 +77,7 @@ import 'package:tmail_ui_user/features/search/email/presentation/model/search_mo
 import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/search_email_bindings.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/state/search_email_presentation_state.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/utils/search_email_presentation_owner_utils.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/move_multiple_email_to_mailbox_state.dart';
 import 'package:tmail_ui_user/features/thread/domain/state/search_email_state.dart';
 import 'package:tmail_ui_user/features/thread/presentation/extensions/list_presentation_email_extensions.dart';
@@ -190,10 +191,10 @@ class SearchEmailController extends BaseController
   // the thread list renders them inline (ThreadSearchExecutionObserver owns them).
   // Without this guard a desktop search would still populate this view's result
   // list, which then leaks into a later mobile/tablet search after a resize.
-  bool get _ownsSearchResults {
-    final context = currentContext;
-    return context == null || !responsiveUtils.isWebDesktop(context);
-  }
+  bool get _ownsSearchResults => isSearchEmailPresentationLayoutOwner(
+    context: currentContext,
+    responsiveUtils: responsiveUtils,
+  );
 
   SearchEmailController(
       this._quickSearchEmailInteractor,

--- a/lib/features/search/email/presentation/search_email_controller.dart
+++ b/lib/features/search/email/presentation/search_email_controller.dart
@@ -911,6 +911,9 @@ class SearchEmailController extends BaseController
       case EmailActionType.unSpam:
         unSpam(selectedEmail);
         break;
+      case EmailActionType.archiveMessage:
+        moveEmailsToArchive([selectedEmail]);
+        break;
       case EmailActionType.editAsNewEmail:
         editAsNewEmail(selectedEmail);
         break;
@@ -1006,6 +1009,10 @@ class SearchEmailController extends BaseController
       case EmailActionType.unSpam:
         cancelSelectionMode();
         unSpamSelectedMultipleEmail(listEmails);
+        break;
+      case EmailActionType.archiveMessage:
+        cancelSelectionMode();
+        moveEmailsToArchive(listEmails);
         break;
       case EmailActionType.labelAs:
         Get.find<AddListLabelToListEmailsDelegate>().openChooseLabelModal(

--- a/lib/features/search/email/presentation/utils/search_email_presentation_owner_utils.dart
+++ b/lib/features/search/email/presentation/utils/search_email_presentation_owner_utils.dart
@@ -1,0 +1,11 @@
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:flutter/widgets.dart';
+
+/// Whether the dedicated SearchEmailView owns the visible search results.
+///
+/// Web desktop renders search results in the thread list instead. A missing
+/// context keeps SearchEmailView as the safe default while bindings initialize.
+bool isSearchEmailPresentationLayoutOwner({
+  required BuildContext? context,
+  required ResponsiveUtils responsiveUtils,
+}) => context == null || !responsiveUtils.isWebDesktop(context);

--- a/lib/features/thread/presentation/mixin/base_email_item_tile.dart
+++ b/lib/features/thread/presentation/mixin/base_email_item_tile.dart
@@ -14,6 +14,7 @@ import 'package:model/email/presentation_email.dart';
 import 'package:model/extensions/presentation_email_extension.dart';
 import 'package:model/extensions/presentation_mailbox_extension.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/mailbox/presentation/extensions/presentation_mailbox_extension.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
 import 'package:tmail_ui_user/features/thread/presentation/styles/item_email_tile_styles.dart';
@@ -206,7 +207,7 @@ mixin BaseEmailItemTile {
 
   Widget buildIconUnreadStatus() {
     return SvgPicture.asset(
-      key: const Key('unread_status_icon'),
+      key: const Key(UiKeys.unreadStatusIcon),
       imagePaths.icUnreadStatus,
       width: 9,
       height: 9,

--- a/lib/features/thread/presentation/thread_controller.dart
+++ b/lib/features/thread/presentation/thread_controller.dart
@@ -79,6 +79,7 @@ import 'package:tmail_ui_user/features/search/email/presentation/service/search_
 import 'package:tmail_ui_user/features/search/email/presentation/service/search_executor_service.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/providers/search_executor_provider.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/utils/search_email_presentation_owner_utils.dart';
 import 'package:tmail_ui_user/features/thread/presentation/extensions/handle_email_filter_extension.dart';
 import 'package:tmail_ui_user/features/thread/presentation/extensions/handle_keyboard_shortcut_actions_extension.dart';
 import 'package:tmail_ui_user/features/thread/presentation/extensions/list_presentation_email_extensions.dart';

--- a/lib/features/thread/presentation/thread_search_execution_observer.dart
+++ b/lib/features/thread/presentation/thread_search_execution_observer.dart
@@ -11,10 +11,10 @@ class ThreadSearchExecutionObserver implements SearchExecutionObserver {
   // ignore executor events dispatched by SearchEmailController to avoid mutating
   // the off-screen mailbox list and emitting duplicate toasts. This mirrors the
   // layout's own ownership predicate (see MailboxDashBoardView web build).
-  bool get _ownsSearchResults {
-    final context = currentContext;
-    return context != null && _controller.responsiveUtils.isWebDesktop(context);
-  }
+  bool get _ownsSearchResults => !isSearchEmailPresentationLayoutOwner(
+    context: currentContext,
+    responsiveUtils: _controller.responsiveUtils,
+  );
 
   @override
   void onNewSearchStarted() {

--- a/lib/features/thread/presentation/widgets/app_bar/selection_mobile_app_bar_thread_widget.dart
+++ b/lib/features/thread/presentation/widgets/app_bar/selection_mobile_app_bar_thread_widget.dart
@@ -3,6 +3,7 @@ import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:model/email/presentation_email.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/thread/presentation/model/email_selection_action_type.dart';
 import 'package:tmail_ui_user/features/thread/presentation/styles/app_bar/mobile_app_bar_thread_widget_style.dart';
 import 'package:tmail_ui_user/features/thread/presentation/widgets/app_bar/mobile_app_bar_thread_widget.dart';
@@ -64,7 +65,7 @@ class SelectionMobileAppBarThreadWidget extends StatelessWidget {
         ),
         ...emailSelectionActionTypes.map(
           (type) => TMailButtonWidget.fromIcon(
-            key: Key('${type.name}_selected_email_button'),
+            key: Key('${type.name}${UiKeys.selectedEmailActionButtonSuffix}'),
             icon: type.getIcon(imagePaths),
             iconColor: type.getIconColor(),
             iconSize: type.getIconSize(),

--- a/lib/features/thread/presentation/widgets/web_tablet_body_email_item_widget.dart
+++ b/lib/features/thread/presentation/widgets/web_tablet_body_email_item_widget.dart
@@ -10,6 +10,7 @@ import 'package:model/email/presentation_email.dart';
 import 'package:model/extensions/presentation_mailbox_extension.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:model/mailbox/select_mode.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/base/widget/labels/ai_action_tag_widget.dart';
 import 'package:tmail_ui_user/features/labels/presentation/widgets/label_list_widget.dart';
 import 'package:tmail_ui_user/features/thread/domain/model/search_query.dart';
@@ -92,6 +93,7 @@ class _WebTabletBodyEmailItemWidgetState
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   MouseRegion(
+                    key: const Key(UiKeys.tabletEmailSelectionAvatar),
                     cursor: SystemMouseCursors.click,
                     child: GestureDetector(
                         onTap: () => widget.emailActionClick?.call(

--- a/test/features/mailbox_dashboard/presentation/extensions/search_email_result_state_sync_extensions_test.dart
+++ b/test/features/mailbox_dashboard/presentation/extensions/search_email_result_state_sync_extensions_test.dart
@@ -1,0 +1,211 @@
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/utils/platform_info.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+import 'package:get/get.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/email/email.dart';
+import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/email/presentation_email.dart';
+import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/delete_emails_in_mailbox_extension.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/update_emails_with_new_mailbox_id_extension.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
+
+import 'update_current_emails_flags_extension_test.mocks.dart';
+
+class _DesktopResponsiveUtils extends ResponsiveUtils {
+  @override
+  bool isWebDesktop(BuildContext context) => true;
+}
+
+void main() {
+  late MockMailboxDashBoardController mailboxDashBoardController;
+  late MockSearchController searchController;
+  late MailboxId sourceMailboxId;
+  late MailboxId archiveMailboxId;
+  late List<EmailId> emailIds;
+  late List<PresentationEmail> mailboxEmails;
+
+  PresentationEmail email(EmailId id, MailboxId mailboxId) =>
+      PresentationEmail(
+        id: id,
+        mailboxIds: {mailboxId: true},
+        mailboxContain: PresentationMailbox(mailboxId),
+      );
+
+  void setSearchResults(List<PresentationEmail> emails) {
+    appProviderContainer
+        .read(searchEmailPresentationProvider.notifier)
+        .setSearchIsRunning(true);
+    appProviderContainer
+        .read(searchEmailPresentationProvider.notifier)
+        .setResultSearches(emails);
+  }
+
+  setUp(() {
+    appProviderContainer.invalidate(searchEmailPresentationProvider);
+    mailboxDashBoardController = MockMailboxDashBoardController();
+    searchController = MockSearchController();
+    sourceMailboxId = MailboxId(Id('source'));
+    archiveMailboxId = MailboxId(Id('archive'));
+    emailIds = List.generate(
+      3,
+      (index) => EmailId(Id('email-$index')),
+    );
+    mailboxEmails = emailIds
+        .map((emailId) => email(emailId, sourceMailboxId))
+        .toList();
+
+    when(mailboxDashBoardController.searchController).thenReturn(searchController);
+    when(searchController.isSearchEmailRunning).thenReturn(true);
+    when(mailboxDashBoardController.mapMailboxById).thenReturn({
+      archiveMailboxId: PresentationMailbox(archiveMailboxId),
+    });
+    when(mailboxDashBoardController.emailsInCurrentMailbox)
+        .thenReturn(List<PresentationEmail>.from(mailboxEmails).obs);
+  });
+
+  tearDown(() {
+    appProviderContainer.invalidate(searchEmailPresentationProvider);
+  });
+
+  group('search result mailbox move reconciliation', () {
+    test('updates only successfully moved emails in the Riverpod result list', () {
+      setSearchResults(mailboxEmails);
+
+      mailboxDashBoardController.handleUpdateEmailsWithNewMailboxId(
+        originalMailboxIdsWithEmailIds: {
+          sourceMailboxId: [emailIds[1]],
+        },
+        destinationMailboxId: archiveMailboxId,
+      );
+
+      final results = appProviderContainer
+          .read(searchEmailPresentationProvider)
+          .listResultSearch;
+      expect(results[0].mailboxIds, {sourceMailboxId: true});
+      expect(results[1].mailboxIds, {archiveMailboxId: true});
+      expect(results[1].mailboxContain?.id, archiveMailboxId);
+      expect(results[2].mailboxIds, {sourceMailboxId: true});
+      expect(mailboxDashBoardController.emailsInCurrentMailbox[1].mailboxIds,
+          {sourceMailboxId: true});
+    });
+
+    test('combines successful ids from every source mailbox without changing failed emails', () {
+      final secondSourceMailboxId = MailboxId(Id('second-source'));
+      final results = [
+        email(emailIds[0], sourceMailboxId),
+        email(emailIds[1], secondSourceMailboxId),
+        email(emailIds[2], sourceMailboxId),
+      ];
+      setSearchResults(results);
+
+      mailboxDashBoardController.handleUpdateEmailsWithNewMailboxId(
+        originalMailboxIdsWithEmailIds: {
+          sourceMailboxId: [emailIds[0]],
+          secondSourceMailboxId: [emailIds[1]],
+        },
+        destinationMailboxId: archiveMailboxId,
+      );
+
+      final updatedResults = appProviderContainer
+          .read(searchEmailPresentationProvider)
+          .listResultSearch;
+      expect(updatedResults[0].mailboxIds, {archiveMailboxId: true});
+      expect(updatedResults[1].mailboxIds, {archiveMailboxId: true});
+      expect(updatedResults[2].mailboxIds, {sourceMailboxId: true});
+    });
+
+    test('does not update the Riverpod list when the responsive search presentation is inactive', () {
+      appProviderContainer
+          .read(searchEmailPresentationProvider.notifier)
+          .setResultSearches(mailboxEmails);
+      when(searchController.isSearchEmailRunning).thenReturn(false);
+
+      mailboxDashBoardController.handleUpdateEmailsWithNewMailboxId(
+        originalMailboxIdsWithEmailIds: {
+          sourceMailboxId: [emailIds[0]],
+        },
+        destinationMailboxId: archiveMailboxId,
+      );
+
+      final results = appProviderContainer
+          .read(searchEmailPresentationProvider)
+          .listResultSearch;
+      expect(results[0].mailboxIds, {sourceMailboxId: true});
+      verify(mailboxDashBoardController.updateEmailList(any)).called(1);
+    });
+
+    testWidgets('keeps Riverpod results untouched for a web desktop search layout', (tester) async {
+      PlatformInfo.isTestingForWeb = true;
+      addTearDown(() => PlatformInfo.isTestingForWeb = false);
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await tester.binding.setSurfaceSize(const Size(1200, 800));
+      when(mailboxDashBoardController.responsiveUtils)
+          .thenReturn(_DesktopResponsiveUtils());
+      await tester.pumpWidget(const GetMaterialApp(home: SizedBox()));
+      setSearchResults(mailboxEmails);
+
+      mailboxDashBoardController.handleUpdateEmailsWithNewMailboxId(
+        originalMailboxIdsWithEmailIds: {
+          sourceMailboxId: [emailIds[0]],
+        },
+        destinationMailboxId: archiveMailboxId,
+      );
+
+      final results = appProviderContainer
+          .read(searchEmailPresentationProvider)
+          .listResultSearch;
+      expect(results[0].mailboxIds, {sourceMailboxId: true});
+      verify(mailboxDashBoardController.updateEmailList(any)).called(1);
+    });
+  });
+
+  group('search result permanent-delete reconciliation', () {
+    test('removes successful deletion ids from Riverpod results regardless of the selected mailbox', () {
+      setSearchResults(mailboxEmails);
+
+      mailboxDashBoardController.handleDeleteEmailsInMailbox(
+        emailIds: [emailIds[0], emailIds[2]],
+        affectedMailboxId: MailboxId(Id('another-mailbox')),
+      );
+
+      final results = appProviderContainer
+          .read(searchEmailPresentationProvider)
+          .listResultSearch;
+      expect(results.map((email) => email.id), [emailIds[1]]);
+      expect(mailboxDashBoardController.emailsInCurrentMailbox.length, 3);
+    });
+
+    test('does not publish a new result list when no email was deleted', () {
+      setSearchResults(mailboxEmails);
+      final initialState = appProviderContainer.read(searchEmailPresentationProvider);
+
+      mailboxDashBoardController.handleDeleteEmailsInMailbox(
+        emailIds: const [],
+        affectedMailboxId: sourceMailboxId,
+      );
+
+      expect(appProviderContainer.read(searchEmailPresentationProvider), initialState);
+    });
+
+    test('removes only emails from the cleared mailbox in Riverpod results', () {
+      final otherMailboxId = MailboxId(Id('other'));
+      setSearchResults([
+        email(emailIds[0], sourceMailboxId),
+        email(emailIds[1], otherMailboxId),
+        email(emailIds[2], sourceMailboxId),
+      ]);
+
+      mailboxDashBoardController.handleClearAllEmailsInMailbox(sourceMailboxId);
+
+      final results = appProviderContainer
+          .read(searchEmailPresentationProvider)
+          .listResultSearch;
+      expect(results.map((email) => email.id), [emailIds[1]]);
+    });
+  });
+}

--- a/test/features/mailbox_dashboard/presentation/extensions/search_email_result_state_sync_extensions_test.dart
+++ b/test/features/mailbox_dashboard/presentation/extensions/search_email_result_state_sync_extensions_test.dart
@@ -255,4 +255,34 @@ void main() {
       expect(results.map((email) => email.id), [emailIds[1]]);
     });
   });
+
+  group('mailbox list delete reconciliation', () {
+    setUp(() {
+      when(searchController.isSearchEmailRunning).thenReturn(false);
+      when(mailboxDashBoardController.selectedMailbox)
+          .thenReturn(Rxn(PresentationMailbox(sourceMailboxId)));
+    });
+
+    test('does not change the mailbox list when the affected folder is not selected', () {
+      mailboxDashBoardController.handleDeleteEmailsInMailbox(
+        emailIds: [emailIds.first],
+        affectedMailboxId: MailboxId(Id('another-mailbox')),
+      );
+
+      expect(mailboxDashBoardController.emailsInCurrentMailbox.length, 3);
+      verifyNever(mailboxDashBoardController.updateEmailList(any));
+    });
+
+    test('removes deleted ids from the mailbox list when the affected folder is selected', () {
+      mailboxDashBoardController.handleDeleteEmailsInMailbox(
+        emailIds: [emailIds.first],
+        affectedMailboxId: sourceMailboxId,
+      );
+
+      final updatedEmails = verify(
+        mailboxDashBoardController.updateEmailList(captureAny),
+      ).captured.single as List<PresentationEmail>;
+      expect(updatedEmails.map((email) => email.id), emailIds.sublist(1));
+    });
+  });
 }

--- a/test/features/mailbox_dashboard/presentation/extensions/search_email_result_state_sync_extensions_test.dart
+++ b/test/features/mailbox_dashboard/presentation/extensions/search_email_result_state_sync_extensions_test.dart
@@ -9,6 +9,7 @@ import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:mockito/mockito.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/apply_to_visible_email_list_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/delete_emails_in_mailbox_extension.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/extensions/update_emails_with_new_mailbox_id_extension.dart';
 import 'package:tmail_ui_user/features/search/email/presentation/notifier/search_email_presentation_notifier.dart';
@@ -70,6 +71,52 @@ void main() {
 
   tearDown(() {
     appProviderContainer.invalidate(searchEmailPresentationProvider);
+  });
+
+  group('visible email list reconciliation', () {
+    test('publishes a transformed Search result list without changing the mailbox list', () {
+      setSearchResults(mailboxEmails);
+
+      mailboxDashBoardController.applyToVisibleEmailList(
+        (emails) => emails.where((email) => email.id != emailIds.first).toList(),
+      );
+
+      final results = appProviderContainer
+          .read(searchEmailPresentationProvider)
+          .listResultSearch;
+      expect(results.map((email) => email.id), emailIds.sublist(1));
+      expect(mailboxDashBoardController.emailsInCurrentMailbox.length, 3);
+      verifyNever(mailboxDashBoardController.updateEmailList(any));
+    });
+
+    test('publishes a transformed mailbox list when Search is inactive', () {
+      when(searchController.isSearchEmailRunning).thenReturn(false);
+
+      mailboxDashBoardController.applyToVisibleEmailList(
+        (emails) => emails.where((email) => email.id != emailIds.first).toList(),
+      );
+
+      final updatedEmails = verify(
+        mailboxDashBoardController.updateEmailList(captureAny),
+      ).captured.single as List<PresentationEmail>;
+      expect(updatedEmails.map((email) => email.id), emailIds.sublist(1));
+    });
+
+    test('does not transform the mailbox list when its action guard rejects it', () {
+      when(searchController.isSearchEmailRunning).thenReturn(false);
+      var wasTransformed = false;
+
+      mailboxDashBoardController.applyToVisibleEmailList(
+        (emails) {
+          wasTransformed = true;
+          return emails;
+        },
+        shouldApplyToMailboxList: () => false,
+      );
+
+      expect(wasTransformed, isFalse);
+      verifyNever(mailboxDashBoardController.updateEmailList(any));
+    });
   });
 
   group('search result mailbox move reconciliation', () {

--- a/test/features/mailbox_dashboard/presentation/extensions/search_email_result_state_sync_extensions_test.dart
+++ b/test/features/mailbox_dashboard/presentation/extensions/search_email_result_state_sync_extensions_test.dart
@@ -117,6 +117,21 @@ void main() {
       expect(wasTransformed, isFalse);
       verifyNever(mailboxDashBoardController.updateEmailList(any));
     });
+
+    test('still transforms Search results when the mailbox action guard rejects it', () {
+      setSearchResults(mailboxEmails);
+
+      mailboxDashBoardController.applyToVisibleEmailList(
+        (emails) => emails.where((email) => email.id != emailIds.first).toList(),
+        shouldApplyToMailboxList: () => false,
+      );
+
+      final results = appProviderContainer
+          .read(searchEmailPresentationProvider)
+          .listResultSearch;
+      expect(results.map((email) => email.id), emailIds.sublist(1));
+      verifyNever(mailboxDashBoardController.updateEmailList(any));
+    });
   });
 
   group('search result mailbox move reconciliation', () {
@@ -209,6 +224,19 @@ void main() {
       expect(results[0].mailboxIds, {sourceMailboxId: true});
       verify(mailboxDashBoardController.updateEmailList(any)).called(1);
     });
+
+    test('does not publish a move when no email ids were moved', () {
+      setSearchResults(mailboxEmails);
+      final initialState = appProviderContainer.read(searchEmailPresentationProvider);
+
+      mailboxDashBoardController.handleUpdateEmailsWithNewMailboxId(
+        originalMailboxIdsWithEmailIds: const <MailboxId, List<EmailId>>{},
+        destinationMailboxId: archiveMailboxId,
+      );
+
+      expect(appProviderContainer.read(searchEmailPresentationProvider), initialState);
+      verifyNever(mailboxDashBoardController.updateEmailList(any));
+    });
   });
 
   group('search result permanent-delete reconciliation', () {
@@ -254,6 +282,21 @@ void main() {
           .listResultSearch;
       expect(results.map((email) => email.id), [emailIds[1]]);
     });
+
+    test('still removes Search ids when the affected mailbox id is null', () {
+      setSearchResults(mailboxEmails);
+
+      mailboxDashBoardController.handleDeleteEmailsInMailbox(
+        emailIds: [emailIds.first],
+        affectedMailboxId: null,
+      );
+
+      final results = appProviderContainer
+          .read(searchEmailPresentationProvider)
+          .listResultSearch;
+      expect(results.map((email) => email.id), emailIds.sublist(1));
+      expect(mailboxDashBoardController.emailsInCurrentMailbox.length, 3);
+    });
   });
 
   group('mailbox list delete reconciliation', () {
@@ -284,5 +327,87 @@ void main() {
       ).captured.single as List<PresentationEmail>;
       expect(updatedEmails.map((email) => email.id), emailIds.sublist(1));
     });
+
+    test('does not change the mailbox list when the affected mailbox id is null', () {
+      mailboxDashBoardController.handleDeleteEmailsInMailbox(
+        emailIds: [emailIds.first],
+        affectedMailboxId: null,
+      );
+
+      expect(mailboxDashBoardController.emailsInCurrentMailbox.length, 3);
+      verifyNever(mailboxDashBoardController.updateEmailList(any));
+    });
+
+    test('clears the mailbox list when the emptied folder is selected', () {
+      mailboxDashBoardController.handleClearAllEmailsInMailbox(sourceMailboxId);
+
+      final updatedEmails = verify(
+        mailboxDashBoardController.updateEmailList(captureAny),
+      ).captured.single as List<PresentationEmail>;
+      expect(updatedEmails, isEmpty);
+    });
+
+    test('does not clear the mailbox list when emptying another folder', () {
+      mailboxDashBoardController.handleClearAllEmailsInMailbox(
+        MailboxId(Id('other')),
+      );
+
+      expect(mailboxDashBoardController.emailsInCurrentMailbox.length, 3);
+      verifyNever(mailboxDashBoardController.updateEmailList(any));
+    });
+  });
+
+  group('web desktop delete reconciliation', () {
+    Future<void> pumpDesktopSearch(WidgetTester tester) async {
+      PlatformInfo.isTestingForWeb = true;
+      addTearDown(() => PlatformInfo.isTestingForWeb = false);
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await tester.binding.setSurfaceSize(const Size(1200, 800));
+      when(mailboxDashBoardController.responsiveUtils)
+          .thenReturn(_DesktopResponsiveUtils());
+      when(mailboxDashBoardController.selectedMailbox)
+          .thenReturn(Rxn(PresentationMailbox(sourceMailboxId)));
+      await tester.pumpWidget(const GetMaterialApp(home: SizedBox()));
+      setSearchResults(mailboxEmails);
+    }
+
+    testWidgets(
+      'writes deleted ids to the thread list when the affected folder is selected',
+      (tester) async {
+        await pumpDesktopSearch(tester);
+
+        mailboxDashBoardController.handleDeleteEmailsInMailbox(
+          emailIds: [emailIds.first],
+          affectedMailboxId: sourceMailboxId,
+        );
+
+        final searchResults = appProviderContainer
+            .read(searchEmailPresentationProvider)
+            .listResultSearch;
+        expect(searchResults.map((email) => email.id), emailIds);
+        final updatedEmails = verify(
+          mailboxDashBoardController.updateEmailList(captureAny),
+        ).captured.single as List<PresentationEmail>;
+        expect(updatedEmails.map((email) => email.id), emailIds.sublist(1));
+      },
+    );
+
+    testWidgets(
+      'does not change the thread list when the affected folder is not selected',
+      (tester) async {
+        await pumpDesktopSearch(tester);
+
+        mailboxDashBoardController.handleDeleteEmailsInMailbox(
+          emailIds: [emailIds.first],
+          affectedMailboxId: MailboxId(Id('another-mailbox')),
+        );
+
+        final searchResults = appProviderContainer
+            .read(searchEmailPresentationProvider)
+            .listResultSearch;
+        expect(searchResults.map((email) => email.id), emailIds);
+        verifyNever(mailboxDashBoardController.updateEmailList(any));
+      },
+    );
   });
 }

--- a/test/features/mailbox_dashboard/presentation/extensions/update_current_emails_flags_extension_test.dart
+++ b/test/features/mailbox_dashboard/presentation/extensions/update_current_emails_flags_extension_test.dart
@@ -1,3 +1,6 @@
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/utils/platform_info.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
@@ -163,6 +166,9 @@ void main() {
       when(searchController.isSearchEmailRunning).thenReturn(true);
       appProviderContainer
           .read(searchEmailPresentationProvider.notifier)
+          .setSearchIsRunning(true);
+      appProviderContainer
+          .read(searchEmailPresentationProvider.notifier)
           .setResultSearches(
             emailIds
                 .map((emailId) => PresentationEmail(id: emailId, keywords: {}))
@@ -174,7 +180,7 @@ void main() {
         appProviderContainer.invalidate(searchEmailPresentationProvider));
 
     test(
-      'writes the flag change back into searchEmailPresentationProvider',
+      'writes the flag change back into searchEmailPresentationProvider for a responsive search layout',
       () {
         // act
         mailboxDashBoardController.updateEmailFlagByEmailIds(
@@ -189,6 +195,53 @@ void main() {
         expect(result[0].hasRead, false);
         expect(result[1].hasRead, true);
         expect(result[2].hasRead, true);
+      },
+    );
+
+    test(
+      'creates keyword state for a keyword-less search result without mutating the original email',
+      () {
+        final keywordLessEmail = PresentationEmail(id: emailIds.first);
+        appProviderContainer
+            .read(searchEmailPresentationProvider.notifier)
+            .setResultSearches([keywordLessEmail]);
+
+        mailboxDashBoardController.updateEmailFlagByEmailIds(
+          [emailIds.first],
+          markStarAction: MarkStarAction.markStar,
+          markAsAnswered: true,
+        );
+
+        final result = appProviderContainer
+            .read(searchEmailPresentationProvider)
+            .listResultSearch
+            .single;
+        expect(result.hasStarred, true);
+        expect(result.isAnswered, true);
+        expect(keywordLessEmail.keywords, isNull);
+      },
+    );
+
+    testWidgets(
+      'writes flags to Riverpod on a web mobile-width search layout',
+      (tester) async {
+        PlatformInfo.isTestingForWeb = true;
+        addTearDown(() => PlatformInfo.isTestingForWeb = false);
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+        await tester.binding.setSurfaceSize(const Size(375, 800));
+        when(mailboxDashBoardController.responsiveUtils)
+            .thenReturn(ResponsiveUtils());
+        await tester.pumpWidget(const GetMaterialApp(home: SizedBox()));
+
+        mailboxDashBoardController.updateEmailFlagByEmailIds(
+          [emailIds.first],
+          readAction: ReadActions.markAsRead,
+        );
+
+        final result = appProviderContainer
+            .read(searchEmailPresentationProvider)
+            .listResultSearch;
+        expect(result.first.hasRead, true);
       },
     );
   });

--- a/test/features/mailbox_dashboard/presentation/extensions/update_current_emails_flags_extension_test.dart
+++ b/test/features/mailbox_dashboard/presentation/extensions/update_current_emails_flags_extension_test.dart
@@ -36,6 +36,10 @@ void main() {
     );
     when(mailboxDashBoardController.searchController).thenReturn(searchController);
     when(searchController.isSearchEmailRunning).thenReturn(false);
+    when(mailboxDashBoardController.updateEmailList(any)).thenAnswer(
+      (invocation) => mailboxDashBoardController.emailsInCurrentMailbox.value =
+          invocation.positionalArguments.first as List<PresentationEmail>,
+    );
   });
 
   group('updateEmailFlagByEmailIds test:', () {

--- a/test/features/mailbox_dashboard/presentation/extensions/update_current_emails_flags_extension_test.dart
+++ b/test/features/mailbox_dashboard/presentation/extensions/update_current_emails_flags_extension_test.dart
@@ -19,6 +19,11 @@ import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 
 import 'update_current_emails_flags_extension_test.mocks.dart';
 
+class _DesktopResponsiveUtils extends ResponsiveUtils {
+  @override
+  bool isWebDesktop(BuildContext context) => true;
+}
+
 @GenerateNiceMocks([
   MockSpec<MailboxDashBoardController>(),
   MockSpec<SearchController>(),
@@ -246,6 +251,45 @@ void main() {
             .read(searchEmailPresentationProvider)
             .listResultSearch;
         expect(result.first.hasRead, true);
+      },
+    );
+
+    testWidgets(
+      'writes flags to the mailbox list on a web desktop search layout',
+      (tester) async {
+        PlatformInfo.isTestingForWeb = true;
+        addTearDown(() => PlatformInfo.isTestingForWeb = false);
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+        await tester.binding.setSurfaceSize(const Size(1200, 800));
+        when(mailboxDashBoardController.responsiveUtils)
+            .thenReturn(_DesktopResponsiveUtils());
+        when(mailboxDashBoardController.emailsInCurrentMailbox).thenReturn(
+          emailIds
+              .map((emailId) => PresentationEmail(id: emailId, keywords: {}))
+              .toList()
+              .obs,
+        );
+        await tester.pumpWidget(const GetMaterialApp(home: SizedBox()));
+
+        mailboxDashBoardController.updateEmailFlagByEmailIds(
+          [emailIds.first],
+          readAction: ReadActions.markAsRead,
+        );
+
+        final searchResults = appProviderContainer
+            .read(searchEmailPresentationProvider)
+            .listResultSearch;
+        expect(searchResults.every((email) => !email.hasRead), isTrue);
+        expect(
+          mailboxDashBoardController.emailsInCurrentMailbox.first.hasRead,
+          isTrue,
+        );
+        expect(
+          mailboxDashBoardController.emailsInCurrentMailbox
+              .skip(1)
+              .every((email) => !email.hasRead),
+          isTrue,
+        );
       },
     );
   });

--- a/test/features/search/email/presentation/search_email_controller_test.dart
+++ b/test/features/search/email/presentation/search_email_controller_test.dart
@@ -19,12 +19,14 @@ import 'package:jmap_dart_client/jmap/mail/email/keyword_identifier.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox.dart';
 import 'package:labels/model/label.dart';
 import 'package:mockito/mockito.dart';
+import 'package:model/email/email_action_type.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:tmail_ui_user/features/base/action/ui_action.dart';
 import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
 import 'package:tmail_ui_user/features/caching/caching_manager.dart';
 import 'package:tmail_ui_user/features/email/presentation/action/email_ui_action.dart';
+import 'package:tmail_ui_user/features/email/domain/model/move_to_mailbox_request.dart';
 import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oidc_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
@@ -122,7 +124,43 @@ void main() {
     return ref;
   }
 
-  PresentationEmail email(String id) => PresentationEmail(id: EmailId(Id(id)));
+  PresentationEmail email(String id, {MailboxId? mailboxId}) => PresentationEmail(
+        id: EmailId(Id(id)),
+        mailboxIds: mailboxId == null ? null : {mailboxId: true},
+      );
+
+  ({PresentationEmail selectedEmail, MailboxId archiveMailboxId})
+      arrangeArchiveAction() {
+    final sourceMailboxId = MailboxId(Id('source'));
+    final archiveMailboxId = MailboxId(Id('archive'));
+    when(
+      mailboxDashBoardController.getMailboxIdByRole(
+        PresentationMailbox.roleArchive,
+      ),
+    ).thenReturn(archiveMailboxId);
+
+    return (
+      selectedEmail: email('email-to-archive', mailboxId: sourceMailboxId),
+      archiveMailboxId: archiveMailboxId,
+    );
+  }
+
+  void verifyArchiveMove(MailboxId archiveMailboxId) {
+    verify(
+      mailboxDashBoardController.moveSelectedEmailMultipleToMailboxAction(
+        any,
+        any,
+        argThat(
+          predicate<MoveToMailboxRequest>(
+            (request) =>
+                request.destinationMailboxId == archiveMailboxId &&
+                request.emailActionType == EmailActionType.archiveMessage,
+          ),
+        ),
+        any,
+      ),
+    ).called(1);
+  }
 
   List<String?> resultIds() =>
       controller.listResultSearch.map((email) => email.id?.id.value).toList();
@@ -415,6 +453,29 @@ void main() {
 
     expect(controller.textInputSearchController.text, isEmpty);
     expect(controller.currentSearchText, isEmpty);
+  });
+
+  test('archives selected search emails through the archive folder action', () {
+    final archiveAction = arrangeArchiveAction();
+
+    controller.handleSelectionEmailAction(
+      EmailActionType.archiveMessage,
+      [archiveAction.selectedEmail],
+    );
+
+    verifyArchiveMove(archiveAction.archiveMailboxId);
+  });
+
+  test('archives an individual search email through the archive folder action', () {
+    final archiveAction = arrangeArchiveAction();
+
+    controller.pressEmailAction(
+      EmailActionType.archiveMessage,
+      archiveAction.selectedEmail,
+      null,
+    );
+
+    verifyArchiveMove(archiveAction.archiveMailboxId);
   });
 
   test(

--- a/test/features/search/email/presentation/search_email_controller_test.dart
+++ b/test/features/search/email/presentation/search_email_controller_test.dart
@@ -27,7 +27,9 @@ import 'package:tmail_ui_user/features/base/action/ui_action.dart';
 import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
 import 'package:tmail_ui_user/features/caching/caching_manager.dart';
 import 'package:tmail_ui_user/features/email/presentation/action/email_ui_action.dart';
+import 'package:tmail_ui_user/features/email/domain/model/move_action.dart';
 import 'package:tmail_ui_user/features/email/domain/model/move_to_mailbox_request.dart';
+import 'package:tmail_ui_user/features/email/domain/state/move_to_mailbox_state.dart';
 import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oidc_interactor.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
@@ -483,6 +485,43 @@ void main() {
     );
 
     verifyArchiveMove(archiveAction.archiveMailboxId);
+  });
+
+  test('patches search results after a move-to-mailbox success', () {
+    final archiveAction = arrangeArchiveAction();
+    when(mailboxDashBoardController.mapMailboxById).thenReturn({
+      archiveAction.archiveMailboxId: PresentationMailbox(
+        archiveAction.archiveMailboxId,
+      ),
+    });
+    appProviderContainer
+        .read(searchEmailPresentationProvider.notifier)
+        .setSearchIsRunning(true);
+    appProviderContainer
+        .read(searchEmailPresentationProvider.notifier)
+        .setResultSearches([archiveAction.selectedEmail]);
+
+    mailboxDashBoardController.viewState.value = Right(
+      MoveToMailboxSuccess(
+        archiveAction.selectedEmail.id!,
+        archiveAction.selectedEmail.mailboxIds!.keys.first,
+        archiveAction.archiveMailboxId,
+        MoveAction.moving,
+        EmailActionType.archiveMessage,
+        originalMailboxIdsWithEmailIds: {
+          archiveAction.selectedEmail.mailboxIds!.keys.first: [
+            archiveAction.selectedEmail.id!,
+          ],
+        },
+        emailIdsWithReadStatus: {archiveAction.selectedEmail.id!: false},
+      ),
+    );
+
+    final results = appProviderContainer
+        .read(searchEmailPresentationProvider)
+        .listResultSearch;
+    expect(results.single.mailboxIds, {archiveAction.archiveMailboxId: true});
+    expect(results.single.mailboxContain?.id, archiveAction.archiveMailboxId);
   });
 
   test(

--- a/test/features/search/email/presentation/search_email_controller_test.dart
+++ b/test/features/search/email/presentation/search_email_controller_test.dart
@@ -22,6 +22,7 @@ import 'package:mockito/mockito.dart';
 import 'package:model/email/email_action_type.dart';
 import 'package:model/email/presentation_email.dart';
 import 'package:model/mailbox/presentation_mailbox.dart';
+import 'package:model/mailbox/select_mode.dart';
 import 'package:tmail_ui_user/features/base/action/ui_action.dart';
 import 'package:tmail_ui_user/features/base/urgent_exception_handler.dart';
 import 'package:tmail_ui_user/features/caching/caching_manager.dart';
@@ -457,12 +458,18 @@ void main() {
 
   test('archives selected search emails through the archive folder action', () {
     final archiveAction = arrangeArchiveAction();
+    appProviderContainer
+        .read(searchEmailPresentationProvider.notifier)
+        .setResultSearches([archiveAction.selectedEmail]);
+    controller.selectEmail(archiveAction.selectedEmail);
+    expect(controller.selectionMode, SelectMode.ACTIVE);
 
     controller.handleSelectionEmailAction(
       EmailActionType.archiveMessage,
-      [archiveAction.selectedEmail],
+      controller.listResultSearch,
     );
 
+    expect(controller.selectionMode, SelectMode.INACTIVE);
     verifyArchiveMove(archiveAction.archiveMailboxId);
   });
 

--- a/test/features/search/email/presentation/utils/search_email_presentation_owner_utils_test.dart
+++ b/test/features/search/email/presentation/utils/search_email_presentation_owner_utils_test.dart
@@ -1,0 +1,59 @@
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/search/email/presentation/utils/search_email_presentation_owner_utils.dart';
+
+class _WebDesktopResponsiveUtils extends ResponsiveUtils {
+  @override
+  bool isWebDesktop(BuildContext context) => true;
+}
+
+void main() {
+  Future<BuildContext> pumpContext(WidgetTester tester) async {
+    late BuildContext context;
+    await tester.pumpWidget(MaterialApp(
+      home: Builder(
+        builder: (buildContext) {
+          context = buildContext;
+          return const SizedBox();
+        },
+      ),
+    ));
+    return context;
+  }
+
+  test('defaults to SearchEmailView ownership without a context', () {
+    expect(
+      isSearchEmailPresentationLayoutOwner(
+        context: null,
+        responsiveUtils: ResponsiveUtils(),
+      ),
+      isTrue,
+    );
+  });
+
+  testWidgets('keeps SearchEmailView ownership outside web desktop',
+      (tester) async {
+    final context = await pumpContext(tester);
+
+    expect(
+      isSearchEmailPresentationLayoutOwner(
+        context: context,
+        responsiveUtils: ResponsiveUtils(),
+      ),
+      isTrue,
+    );
+  });
+
+  testWidgets('keeps the thread list as owner on web desktop', (tester) async {
+    final context = await pumpContext(tester);
+
+    expect(
+      isSearchEmailPresentationLayoutOwner(
+        context: context,
+        responsiveUtils: _WebDesktopResponsiveUtils(),
+      ),
+      isFalse,
+    );
+  });
+}


### PR DESCRIPTION
## Issue

On mobile Search in v0.35.0, actions on selected emails did not update the visible result list immediately. The UI only refreshed after selecting the email again. The Archive action was also not handled from Search.

## Root cause

Search uses a dedicated Riverpod presentation state, but action-success reconciliation did not update that state correctly. On native mobile, it mutated the existing `PresentationEmail.keywords` map and re-published the same email instances, so no observable immutable state transition was emitted to rebuild the UI. On web mobile/tablet layouts, browser runtime detection routed updates to the mailbox GetX list instead of the Search state. Move, delete and clear reconciliation had the same state-owner gap. Archive was also missing from the single- and multi-selection Search action handlers.

## Solution

- Resolve the active presentation-state owner: Search state on native mobile and web mobile/tablet layouts; mailbox list on web desktop.
- Replace changed Search emails immutably and publish a new result list, rather than mutating existing email instances.
- Route move, delete and clear reconciliation to the active Search presentation state.
- Handle Archive for both single and multi-selected Search emails.
- Add regression tests for mobile, web-mobile, web-desktop, partial move success, delete/clear and Archive flows.

## Demo

https://github.com/user-attachments/assets/a11ad456-47f8-49ff-a640-a5cbf88a9ab5



https://github.com/user-attachments/assets/e97a8f6f-3d07-4413-a05c-a32d0db62d03



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added archive actions for individual emails and multiple selected emails.
- Search results now update immediately after read-status, flag, and archive actions.

## Bug Fixes
- Improved synchronization when emails are moved, deleted, cleared, or updated.
- Empty deletion requests no longer trigger unnecessary updates.
- Email changes now work consistently across mobile, tablet, desktop, and responsive layouts.
- Fixed selection mode behavior after archiving multiple emails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->