### PR TITLE
TF-4728 Drive picker jmap implementation

### DIFF
--- a/core/lib/presentation/views/html_viewer/html_iframe_widget.dart
+++ b/core/lib/presentation/views/html_viewer/html_iframe_widget.dart
@@ -7,12 +7,14 @@ class HtmlIframeWidget extends StatelessWidget {
     this.onIframeCreated,
     this.width,
     this.height,
+    this.borderRadius,
     this.src,
     this.srcdoc,
   });
 
   final void Function(IFrameElement iframe)? onIframeCreated;
   final String? width, height, src, srcdoc;
+  final double? borderRadius;
 
   @override
   Widget build(BuildContext context) {
@@ -29,6 +31,11 @@ class HtmlIframeWidget extends StatelessWidget {
           ..style.overflow = 'hidden'
           ..style.width = '100%'
           ..style.height = '100%';
+
+        if (borderRadius != null) {
+          iframe.style.borderRadius = '${borderRadius}px';
+        }
+
         if (src != null) {
           iframe.src = src;
         } else if (srcdoc != null) {

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -104,6 +104,7 @@ import 'package:tmail_ui_user/features/email/domain/usecases/print_email_interac
 import 'package:tmail_ui_user/features/email/domain/usecases/save_template_email_interactor.dart';
 import 'package:tmail_ui_user/features/email/domain/usecases/transform_html_email_content_interactor.dart';
 import 'package:tmail_ui_user/features/email/presentation/extensions/presentation_email_extension.dart';
+import 'package:tmail_ui_user/features/home/domain/extensions/session_extensions.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/composer_arguments.dart';
 import 'package:tmail_ui_user/features/mailbox/domain/model/create_new_mailbox_request.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/domain/usecases/remove_composer_cache_by_id_interactor.dart';
@@ -128,14 +129,20 @@ import 'package:tmail_ui_user/features/upload/domain/state/local_image_picker_st
 import 'package:tmail_ui_user/features/upload/domain/usecases/local_file_picker_interactor.dart';
 import 'package:tmail_ui_user/features/upload/domain/usecases/local_image_picker_interactor.dart';
 import 'package:tmail_ui_user/features/upload/presentation/controller/upload_controller.dart';
+import 'package:tmail_ui_user/features/upload/presentation/providers/upload_from_url_providers.dart';
 import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_upload_validation_service.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
+import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:tmail_ui_user/main/universal_import/html_stub.dart' as html;
 import 'package:workplace/domain/entity/drive_document.dart';
 import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_handler.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/concurrency_gate.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_transfer_runner.dart';
 import 'package:tmail_ui_user/main/utils/app_config.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
+import 'package:workplace/presentation/model/drive_pick_state.dart';
 
 class ComposerController extends BaseController
     with
@@ -1018,18 +1025,72 @@ class ComposerController extends BaseController
         result,
         insertHtml: (html) async {
           if (PlatformInfo.isWeb) {
-            richTextWebController?.editorController.insertHtml(html);
-          } else {
-            await richTextMobileTabletController?.restoreMobileEditorFocus();
-            await htmlEditorApi?.insertHtml(html);
-            await SchedulerBinding.instance.endOfFrame;
+            final editorController = richTextWebController?.editorController;
+            if (editorController == null) return false;
+            editorController.insertHtml(html);
+            return true;
           }
+          final editorApi = htmlEditorApi;
+          if (editorApi == null) return false;
+          await richTextMobileTabletController?.restoreMobileEditorFocus();
+          await editorApi.insertHtml(html);
+          await SchedulerBinding.instance.endOfFrame;
+          return true;
         },
+        transferDriveDocuments: (docs) => _transferDriveDocuments(docs),
         appLocalizations: currentContext != null ? AppLocalizations.of(currentContext!) : null,
       );
     } catch (e) {
       logWarning('ComposerController::handleDrivePickResult:Exception = $e');
+      // A throw here can strand waiting chips, so the failure must be visible.
+      getBinding<ToastManager>()?.showMessageFailure(DrivePickFailure(
+        e,
+        message: currentContext != null
+            ? AppLocalizations.of(currentContext!).driveAttachmentTransferFailed
+            : null,
+      ));
     }
+  }
+
+  static const _maxConcurrentDriveTransfers = 3;
+
+  /// One gate per composer: reopening the picker mid-transfer queues the new
+  /// batch behind the running one instead of multiplying in-flight requests.
+  late final ConcurrencyGate _driveTransferGate =
+      ConcurrencyGate(_maxConcurrentDriveTransfers);
+
+  Future<DriveTransferOutcome> _transferDriveDocuments(List<DriveDocument> docs) async {
+    final jmapUrl = dynamicUrlInterceptors.jmapUrl;
+    if (jmapUrl == null || jmapUrl.isEmpty) {
+      logWarning('ComposerController::_transferDriveDocuments: jmapUrl is unavailable');
+      return DriveAttachmentTransferRunner.notStartedOutcome;
+    }
+    final session = mailboxDashBoardController.sessionCurrent;
+    final accountId = mailboxDashBoardController.accountId.value;
+    final uploadUri = session?.getUploadFromUrlUri(
+      accountId,
+      jmapUrl: jmapUrl,
+    );
+    if (uploadUri == null || accountId == null) {
+      logWarning('ComposerController::_transferDriveDocuments: upload-from-url endpoint is unavailable');
+      return DriveAttachmentTransferRunner.notStartedOutcome;
+    }
+
+    // Resolved once per batch: each read rebuilds interactor -> repo -> datasource -> dio.
+    final interactor =
+        appProviderContainer.read(uploadDriveDocumentFromUrlInteractorProvider);
+    final runner = DriveAttachmentTransferRunner(
+      uploadFromUrl: (request) => interactor.execute(request),
+      gate: _driveTransferGate,
+    );
+    return runner.transfer((
+      docs: docs,
+      accountId: accountId,
+      uploadUri: uploadUri,
+      onPlaceholdersReady: uploadController.addDownloadingPlaceholders,
+      onSuccess: uploadController.resolveDriveTransferSuccess,
+      onFailure: uploadController.resolveDriveTransferFailure,
+    ));
   }
 
   Future<dynamic> _showSendingMessageDialog({

--- a/lib/features/composer/presentation/extensions/drive_document_extension.dart
+++ b/lib/features/composer/presentation/extensions/drive_document_extension.dart
@@ -1,0 +1,20 @@
+import 'package:workplace/domain/entity/drive_document.dart';
+
+extension DriveDocumentExtension on DriveDocument {
+  /// HTML-embedded link: scheme still validated since the browser follows it directly.
+  bool isAttachableAsLink({required bool requireHttps}) =>
+      sharingLink?.isSafeLinkScheme(requireHttps: requireHttps) ?? false;
+
+  /// Backend fetches this via JMAP, so no scheme gate is needed.
+  /// An empty link is rejected here so it never reaches the backend.
+  /// Link precedence lives at the call site, not here.
+  bool isAttachableAsDownload() =>
+      downloadLink?.toString().trim().isNotEmpty ?? false;
+}
+
+extension _SafeLinkSchemeExtension on Uri {
+  /// Allowlist, not a denylist: anything else (`javascript:`, `data:`, ...) is
+  /// executable once embedded in composer HTML.
+  bool isSafeLinkScheme({required bool requireHttps}) =>
+      isScheme('https') || (!requireHttps && isScheme('http'));
+}

--- a/lib/features/composer/presentation/manager/concurrency_gate.dart
+++ b/lib/features/composer/presentation/manager/concurrency_gate.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+
+/// Counting semaphore: at most [maxConcurrent] actions run at once. The limit
+/// belongs to the instance, so every caller sharing one gate shares one budget
+/// — a second batch queues behind the first instead of doubling the load.
+class ConcurrencyGate {
+  ConcurrencyGate(int maxConcurrent)
+      : maxConcurrent = maxConcurrent < 1 ? 1 : maxConcurrent;
+
+  final int maxConcurrent;
+
+  final Queue<Completer<void>> _waiting = Queue<Completer<void>>();
+  int _inFlight = 0;
+
+  @visibleForTesting
+  int get inFlight => _inFlight;
+
+  Future<T> run<T>(Future<T> Function() action) async {
+    await _acquire();
+    try {
+      return await action();
+    } finally {
+      _release();
+    }
+  }
+
+  Future<void> _acquire() {
+    if (_inFlight < maxConcurrent) {
+      _inFlight++;
+      return Future<void>.value();
+    }
+    final waiter = Completer<void>();
+    _waiting.add(waiter);
+    return waiter.future;
+  }
+
+  /// Hands the slot to the next waiter rather than releasing it, so a queued
+  /// action is never overtaken by a caller arriving later.
+  void _release() {
+    if (_waiting.isNotEmpty) {
+      _waiting.removeFirst().complete();
+      return;
+    }
+    _inFlight--;
+  }
+}

--- a/lib/features/composer/presentation/manager/drive_attachment_handler.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_handler.dart
@@ -1,10 +1,18 @@
 import 'package:core/core.dart';
 import 'package:core/utils/html/file_link_card_html_builder.dart';
+import 'package:tmail_ui_user/features/composer/presentation/extensions/drive_document_extension.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_transfer_runner.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
 import 'package:workplace/presentation/model/drive_pick_state.dart';
+
+/// Transfers [docs] as real attachments, reporting the batch outcome.
+typedef TransferDriveDocumentsCallback = Future<DriveTransferOutcome> Function(List<DriveDocument> docs);
+
+/// Inserts [html] at the caret; false when no editor is bound to insert into.
+typedef InsertHtmlCallback = Future<bool> Function(String html);
 
 class DriveAttachmentHandler {
   DriveAttachmentHandler();
@@ -16,43 +24,120 @@ class DriveAttachmentHandler {
 
   Future<void> handleDrivePickResult(
     List<DriveDocument> result, {
-    required Future<void> Function(String html) insertHtml,
+    required InsertHtmlCallback insertHtml,
+    required TransferDriveDocumentsCallback transferDriveDocuments,
     AppLocalizations? appLocalizations,
   }) async {
     if (result.isEmpty) {
-      getBinding<ToastManager>()?.showMessageFailure(
-        DrivePickFailure(
-          Exception(),
-          message: appLocalizations?.driveNoValidAttachment,
-        ),
+      _showFailureToast(appLocalizations?.driveNoValidAttachment);
+      return;
+    }
+    final (linkDocs, downloadableDocs, droppedCount) =
+        _splitByAttachability(result);
+
+    // A mixed pick inserts its links and transfers its downloadable docs.
+    var linkInserted = false;
+    if (linkDocs.isNotEmpty) {
+      linkInserted = await insertDriveLinkHtml(
+        linkDocs,
+        insertHtml: insertHtml,
+        appLocalizations: appLocalizations,
+      );
+    }
+
+    if (downloadableDocs.isNotEmpty) {
+      await _transferDownloadableDocs(
+        downloadableDocs,
+        linkInserted: linkInserted,
+        transferDriveDocuments: transferDriveDocuments,
+        appLocalizations: appLocalizations,
+      );
+    } else if (linkInserted) {
+      _showSuccessToast(appLocalizations?.driveAttachmentAddedSuccessfully);
+    } else if (linkDocs.isEmpty) {
+      _showFailureToast(appLocalizations?.driveNoValidAttachment);
+    } else {
+      // Docs were linkable but the editor was unbound — nothing reached the body.
+      _showFailureToast(appLocalizations?.driveAttachmentTransferFailed);
+    }
+
+    // Dropped docs would otherwise vanish silently from a pick whose siblings worked.
+    if (droppedCount > 0 && (linkDocs.isNotEmpty || downloadableDocs.isNotEmpty)) {
+      _showFailureToast(appLocalizations?.driveNoValidAttachment);
+    }
+  }
+
+  /// Splits [result] into (linkable docs, downloadable docs, dropped count).
+  (List<DriveDocument>, List<DriveDocument>, int) _splitByAttachability(
+    List<DriveDocument> result,
+  ) {
+    final linkDocs = <DriveDocument>[];
+    final downloadableDocs = <DriveDocument>[];
+    var droppedCount = 0;
+    for (final doc in result) {
+      if (doc.isAttachableAsLink(requireHttps: requireHttps)) {
+        linkDocs.add(doc);
+      } else if (doc.isAttachableAsDownload()) {
+        downloadableDocs.add(doc);
+      } else {
+        droppedCount++;
+      }
+    }
+    return (linkDocs, downloadableDocs, droppedCount);
+  }
+
+  /// Transfers [downloadableDocs], toasting the batch outcome. A partial
+  /// failure stays silent here: each failed chip already toasts its own error.
+  Future<void> _transferDownloadableDocs(
+    List<DriveDocument> downloadableDocs, {
+    required bool linkInserted,
+    required TransferDriveDocumentsCallback transferDriveDocuments,
+    AppLocalizations? appLocalizations,
+  }) async {
+    final outcome = await transferDriveDocuments(downloadableDocs);
+    if (!outcome.started) {
+      _showFailureToast(appLocalizations?.driveAttachmentTransferFailed);
+      return;
+    }
+    if (outcome.failed == 0 && (linkInserted || outcome.succeeded > 0)) {
+      _showSuccessToast(appLocalizations?.driveAttachmentAddedSuccessfully);
+    }
+  }
+
+  /// Toasts [message], or logs if no [ToastManager] is bound.
+  void _showFailureToast(String? message) {
+    final toastManager = getBinding<ToastManager>();
+    if (toastManager == null) {
+      logWarning(
+        'DriveAttachmentHandler::_showFailureToast: no ToastManager bound, '
+        'failure not shown to the user',
       );
       return;
     }
-    final linkDocs = result.where((doc) {
-      final link = doc.sharingLink;
-      return link != null && (!requireHttps || link.isScheme('https'));
-    }).toList();
-    // TODO: Update logic here after implement 103. Attach Drive File as Attachment
-    if (linkDocs.isEmpty) {
-      getBinding<ToastManager>()?.showMessageFailure(DrivePickFailure(
-        Exception(),
-        message: appLocalizations?.driveAttachmentInDevelopment,
-      ));
-      return;
-    }
-    await insertDriveLinkHtml(
-      linkDocs,
-      insertHtml: insertHtml,
-      appLocalizations: appLocalizations,
+    toastManager.showMessageFailure(
+      DrivePickFailure(Exception(), message: message),
     );
   }
 
-  Future<void> insertDriveLinkHtml(
+  /// Toasts [message], or logs if no [ToastManager] is bound.
+  void _showSuccessToast(String? message) {
+    final toastManager = getBinding<ToastManager>();
+    if (toastManager == null) {
+      logWarning(
+        'DriveAttachmentHandler::_showSuccessToast: no ToastManager bound, '
+        'success not shown to the user',
+      );
+      return;
+    }
+    toastManager.showMessageSuccess(DrivePickSuccess(message: message));
+  }
+
+  Future<bool> insertDriveLinkHtml(
     List<DriveDocument> docs, {
-    required Future<void> Function(String html) insertHtml,
+    required InsertHtmlCallback insertHtml,
     AppLocalizations? appLocalizations,
-  }) async {
-    await insertHtml(
+  }) {
+    return insertHtml(
       buildDriveLinksHtml(docs, appLocalizations: appLocalizations),
     );
   }
@@ -77,9 +162,8 @@ class DriveAttachmentHandler {
     DriveDocument doc, {
     AppLocalizations? appLocalizations,
   }) {
-    final link = doc.sharingLink;
-    if (link == null) return null;
-    if (requireHttps && !link.isScheme('https')) return null;
+    if (!doc.isAttachableAsLink(requireHttps: requireHttps)) return null;
+    final link = doc.sharingLink!;
 
     final openInDriveLabel =
         appLocalizations?.openInDrive ?? _fallbackOpenInDriveLabel;

--- a/lib/features/composer/presentation/manager/drive_attachment_handler.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_handler.dart
@@ -36,14 +36,13 @@ class DriveAttachmentHandler {
         _splitByAttachability(result);
 
     // A mixed pick inserts its links and transfers its downloadable docs.
-    var linkInserted = false;
-    if (linkDocs.isNotEmpty) {
-      linkInserted = await insertDriveLinkHtml(
-        linkDocs,
-        insertHtml: insertHtml,
-        appLocalizations: appLocalizations,
-      );
-    }
+    final linkInserted = linkDocs.isEmpty
+        ? false
+        : await insertDriveLinkHtml(
+            linkDocs,
+            insertHtml: insertHtml,
+            appLocalizations: appLocalizations,
+          );
 
     if (downloadableDocs.isNotEmpty) {
       await _transferDownloadableDocs(
@@ -52,19 +51,45 @@ class DriveAttachmentHandler {
         transferDriveDocuments: transferDriveDocuments,
         appLocalizations: appLocalizations,
       );
-    } else if (linkInserted) {
+    } else {
+      _showLinkOnlyOutcome(
+        linkInserted: linkInserted,
+        hasLinkDocs: linkDocs.isNotEmpty,
+        appLocalizations: appLocalizations,
+      );
+    }
+
+    _showDroppedDocsFailure(
+      droppedCount,
+      attachedAny: linkDocs.isNotEmpty || downloadableDocs.isNotEmpty,
+      appLocalizations: appLocalizations,
+    );
+  }
+
+  /// Toasts the outcome of a pick that carried no downloadable docs.
+  void _showLinkOnlyOutcome({
+    required bool linkInserted,
+    required bool hasLinkDocs,
+    AppLocalizations? appLocalizations,
+  }) {
+    if (linkInserted) {
       _showSuccessToast(appLocalizations?.driveAttachmentAddedSuccessfully);
-    } else if (linkDocs.isEmpty) {
+    } else if (!hasLinkDocs) {
       _showFailureToast(appLocalizations?.driveNoValidAttachment);
     } else {
       // Docs were linkable but the editor was unbound — nothing reached the body.
       _showFailureToast(appLocalizations?.driveAttachmentTransferFailed);
     }
+  }
 
-    // Dropped docs would otherwise vanish silently from a pick whose siblings worked.
-    if (droppedCount > 0 && (linkDocs.isNotEmpty || downloadableDocs.isNotEmpty)) {
-      _showFailureToast(appLocalizations?.driveNoValidAttachment);
-    }
+  /// Dropped docs would otherwise vanish silently from a pick whose siblings worked.
+  void _showDroppedDocsFailure(
+    int droppedCount, {
+    required bool attachedAny,
+    AppLocalizations? appLocalizations,
+  }) {
+    if (droppedCount == 0 || !attachedAny) return;
+    _showFailureToast(appLocalizations?.driveNoValidAttachment);
   }
 
   /// Splits [result] into (linkable docs, downloadable docs, dropped count).

--- a/lib/features/composer/presentation/manager/drive_attachment_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_transfer_runner.dart
@@ -132,6 +132,9 @@ class DriveAttachmentTransferRunner {
       request.onFailure(taskId);
       return;
     }
+    // Chip deleted while this upload was in flight: a late response must not
+    // resolve a task the user already dropped.
+    if (task.placeholder.cancelToken?.isCancelled == true) return;
     // fold runs outside the try so a throw from onSuccess/onFailure isn't
     // mistaken for an upload failure and double-reported; the callbacks are
     // guarded by _notify instead, so one bad chip can't abort its siblings.

--- a/lib/features/composer/presentation/manager/drive_attachment_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_transfer_runner.dart
@@ -69,6 +69,9 @@ class DriveAttachmentTransferRunner {
               ),
             ))
         .toList();
+    final placeholdersById = {
+      for (final task in tasks) task.placeholder.taskId: task.placeholder,
+    };
 
     try {
       request.onPlaceholdersReady(tasks.map((task) => task.placeholder).toList());
@@ -92,11 +95,19 @@ class DriveAttachmentTransferRunner {
       onPlaceholdersReady: request.onPlaceholdersReady,
       onSuccess: (UploadTaskId taskId, Attachment attachment) {
         succeeded++;
-        _notify('onSuccess', () => request.onSuccess(taskId, attachment));
+        _notify(
+          'onSuccess',
+          placeholdersById[taskId],
+          () => request.onSuccess(taskId, attachment),
+        );
       },
       onFailure: (UploadTaskId taskId) {
         failed++;
-        _notify('onFailure', () => request.onFailure(taskId));
+        _notify(
+          'onFailure',
+          placeholdersById[taskId],
+          () => request.onFailure(taskId),
+        );
       },
     );
 
@@ -151,7 +162,11 @@ class DriveAttachmentTransferRunner {
   }
 
   /// Runs a caller callback; a throw is logged and contained to this task.
-  void _notify(String label, void Function() callback) {
+  void _notify(
+    String label,
+    DriveTransferPlaceholder? placeholder,
+    void Function() callback,
+  ) {
     try {
       callback();
     } catch (e, s) {
@@ -159,6 +174,12 @@ class DriveAttachmentTransferRunner {
         'DriveAttachmentTransferRunner::_notify: $label failed',
         exception: e,
         stackTrace: s,
+        // File name stays out: extras reach Sentry.
+        extras: {
+          'task_id': placeholder?.taskId.id,
+          'file_size': placeholder?.fileSize,
+          'mime_type': placeholder?.mimeType,
+        },
       );
     }
   }

--- a/lib/features/composer/presentation/manager/drive_attachment_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_transfer_runner.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
+import 'package:core/utils/app_logger.dart';
 import 'package:dartz/dartz.dart';
 import 'package:dio/dio.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
@@ -69,7 +70,17 @@ class DriveAttachmentTransferRunner {
             ))
         .toList();
 
-    request.onPlaceholdersReady(tasks.map((task) => task.placeholder).toList());
+    try {
+      request.onPlaceholdersReady(tasks.map((task) => task.placeholder).toList());
+    } catch (e, s) {
+      // Without chips nothing can resolve, so the batch never starts.
+      logError(
+        'DriveAttachmentTransferRunner::transfer: onPlaceholdersReady failed',
+        exception: e,
+        stackTrace: s,
+      );
+      return notStartedOutcome;
+    }
 
     // Counted here so the caller can tell a fully clean batch from a partial one.
     var succeeded = 0;
@@ -81,11 +92,11 @@ class DriveAttachmentTransferRunner {
       onPlaceholdersReady: request.onPlaceholdersReady,
       onSuccess: (UploadTaskId taskId, Attachment attachment) {
         succeeded++;
-        request.onSuccess(taskId, attachment);
+        _notify('onSuccess', () => request.onSuccess(taskId, attachment));
       },
       onFailure: (UploadTaskId taskId) {
         failed++;
-        request.onFailure(taskId);
+        _notify('onFailure', () => request.onFailure(taskId));
       },
     );
 
@@ -122,7 +133,8 @@ class DriveAttachmentTransferRunner {
       return;
     }
     // fold runs outside the try so a throw from onSuccess/onFailure isn't
-    // mistaken for an upload failure and double-reported.
+    // mistaken for an upload failure and double-reported; the callbacks are
+    // guarded by _notify instead, so one bad chip can't abort its siblings.
     either.fold(
       (failure) {
         // a user-cancelled transfer is not a failure; the chip is already gone.
@@ -133,5 +145,18 @@ class DriveAttachmentTransferRunner {
           ? request.onSuccess(taskId, success.attachment)
           : request.onFailure(taskId),
     );
+  }
+
+  /// Runs a caller callback; a throw is logged and contained to this task.
+  void _notify(String label, void Function() callback) {
+    try {
+      callback();
+    } catch (e, s) {
+      logError(
+        'DriveAttachmentTransferRunner::_notify: $label failed',
+        exception: e,
+        stackTrace: s,
+      );
+    }
   }
 }

--- a/lib/features/composer/presentation/manager/drive_attachment_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_transfer_runner.dart
@@ -1,0 +1,137 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:model/email/attachment.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/concurrency_gate.dart';
+import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
+import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_request.dart';
+import 'package:tmail_ui_user/features/upload/domain/state/upload_drive_document_from_url_state.dart';
+import 'package:tmail_ui_user/features/upload/presentation/model/drive_transfer_placeholder.dart';
+import 'package:uuid/uuid.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+
+/// Runs one gateway call; injected so this class never touches GetX.
+typedef UploadFromUrlCall = Future<Either<Failure, Success>> Function(
+  UploadFromUrlRequest request,
+);
+
+typedef OnPlaceholdersReady = void Function(List<DriveTransferPlaceholder> placeholders);
+typedef OnDriveTransferSuccess = void Function(UploadTaskId taskId, Attachment attachment);
+typedef OnDriveTransferFailure = void Function(UploadTaskId taskId);
+
+/// One batch's input, bundled into a single param for [DriveAttachmentTransferRunner.transfer].
+typedef DriveTransferRequest = ({
+  List<DriveDocument> docs,
+  AccountId accountId,
+  Uri uploadUri,
+  OnPlaceholdersReady onPlaceholdersReady,
+  OnDriveTransferSuccess onSuccess,
+  OnDriveTransferFailure onFailure,
+});
+
+/// One batch's result. [started] is false when the batch never ran; cancelled
+/// tasks resolve neither counter.
+typedef DriveTransferOutcome = ({bool started, int succeeded, int failed});
+
+/// One in-flight unit of work: the doc plus its pre-minted placeholder.
+typedef _DriveTransferTask = ({DriveDocument doc, DriveTransferPlaceholder placeholder});
+
+/// Fans a batch of downloadable drive documents out to [uploadFromUrl] through
+/// [gate]. The gate is owned by the caller, so concurrency stays bounded across
+/// every batch rather than per runner. Pure logic, no GetX — fully unit-testable.
+class DriveAttachmentTransferRunner {
+  DriveAttachmentTransferRunner({
+    required this.uploadFromUrl,
+    required this.gate,
+  });
+
+  final UploadFromUrlCall uploadFromUrl;
+  final ConcurrencyGate gate;
+
+  static const notStartedOutcome =
+      (started: false, succeeded: 0, failed: 0);
+
+  Future<DriveTransferOutcome> transfer(DriveTransferRequest request) async {
+    if (request.docs.isEmpty) return notStartedOutcome;
+
+    final tasks = request.docs
+        .map((doc) => (
+              doc: doc,
+              placeholder: DriveTransferPlaceholder(
+                taskId: UploadTaskId(const Uuid().v4()),
+                fileName: doc.name,
+                fileSize: doc.size,
+                mimeType: doc.mimeType,
+                cancelToken: CancelToken(),
+              ),
+            ))
+        .toList();
+
+    request.onPlaceholdersReady(tasks.map((task) => task.placeholder).toList());
+
+    // Counted here so the caller can tell a fully clean batch from a partial one.
+    var succeeded = 0;
+    var failed = 0;
+    final countingRequest = (
+      docs: request.docs,
+      accountId: request.accountId,
+      uploadUri: request.uploadUri,
+      onPlaceholdersReady: request.onPlaceholdersReady,
+      onSuccess: (UploadTaskId taskId, Attachment attachment) {
+        succeeded++;
+        request.onSuccess(taskId, attachment);
+      },
+      onFailure: (UploadTaskId taskId) {
+        failed++;
+        request.onFailure(taskId);
+      },
+    );
+
+    await Future.wait(
+      tasks.map((task) => gate.run(() => _runOne(task, countingRequest))),
+    );
+    return (started: true, succeeded: succeeded, failed: failed);
+  }
+
+  Future<void> _runOne(_DriveTransferTask task, DriveTransferRequest request) async {
+    // Chip already deleted while this task waited its turn: its request would
+    // only be rejected downstream, and a cancellation is not a failure.
+    if (task.placeholder.cancelToken?.isCancelled == true) return;
+    final taskId = task.placeholder.taskId;
+    final downloadLink = task.doc.downloadLink;
+    // Guarded here too: the runner is injectable, so it can't trust its caller's gate.
+    if (downloadLink == null || downloadLink.toString().trim().isEmpty) {
+      request.onFailure(taskId);
+      return;
+    }
+    final Either<Failure, Success> either;
+    try {
+      either = await uploadFromUrl(UploadFromUrlRequest(
+        accountId: request.accountId,
+        uploadUri: request.uploadUri,
+        attachmentUrl: downloadLink,
+        name: task.doc.name,
+        mimeType: task.doc.mimeType,
+        cancelToken: task.placeholder.cancelToken,
+      ));
+    } catch (_) {
+      // uploadFromUrl must resolve every task; a thrown error still counts as failure.
+      request.onFailure(taskId);
+      return;
+    }
+    // fold runs outside the try so a throw from onSuccess/onFailure isn't
+    // mistaken for an upload failure and double-reported.
+    either.fold(
+      (failure) {
+        // a user-cancelled transfer is not a failure; the chip is already gone.
+        if (failure is UploadDriveDocumentFromUrlCancelled) return;
+        request.onFailure(taskId);
+      },
+      (success) => success is UploadDriveDocumentFromUrlSuccess
+          ? request.onSuccess(taskId, success.attachment)
+          : request.onFailure(taskId),
+    );
+  }
+}

--- a/lib/features/composer/presentation/providers/composer_attachment_extension_registry_provider.dart
+++ b/lib/features/composer/presentation/providers/composer_attachment_extension_registry_provider.dart
@@ -2,6 +2,7 @@ import 'package:core/presentation/extensions/composer_attachment_extension_regis
 import 'package:core/utils/app_logger.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
+import 'package:tmail_ui_user/features/home/domain/extensions/session_extensions.dart';
 import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/main/providers/workplace/drive_attachment_uri_value_notifier_provider.dart';
@@ -18,16 +19,38 @@ ComposerAttachmentExtensionRegistry composerAttachmentExtensionRegistry(Ref ref)
   return ComposerAttachmentExtensionRegistry([
     WorkplaceComposerAttachmentExtension(
       workplaceUri: uriNotifier,
+      // Read at picker-open time, so it's always the current session's answer.
+      uploadFromUrlSupported: () {
+        final dashboard = getBinding<MailboxDashBoardController>();
+        final jmapUrl = dashboard?.dynamicUrlInterceptors.jmapUrl;
+        if (jmapUrl == null || jmapUrl.isEmpty) return false;
+        return dashboard?.sessionCurrent?.isUploadFromUrlSupported(
+              dashboard.accountId.value,
+              jmapUrl: jmapUrl,
+            ) ??
+            false;
+      },
       oidcTokenGetter: () => getBinding<AuthorizationInterceptors>()?.currentOidcIdToken,
       maxAttachmentSizeBytesGetter: () =>
           getBinding<MailboxDashBoardController>()?.maxSizeAttachmentsPerEmail?.value,
+      // Read at picker-open time from the composer that owns the picker.
+      remainingAttachmentCapacityBytesGetter: (composerId) =>
+          getBinding<ComposerController>(tag: composerId)
+              ?.attachmentUploadValidationService
+              .remainingCapacityBytes,
       onPickState: (composerId, state) async {
         if (state is DrivePickResult) {
-          try {
-            await getBinding<ComposerController>(tag: composerId)?.handleDrivePickResult(state.documents);
-          } catch (e) {
-            logWarning('ComposerAttachmentExtensionRegistry::onPickState: $e');
+          final composer = getBinding<ComposerController>(tag: composerId);
+          if (composer == null) {
+            // Composer closed or wrong tag — the pick has nowhere to land.
+            logError('ComposerAttachmentExtensionRegistry::onPickState: no ComposerController for tag=$composerId, drive pick discarded');
+            getBinding<ToastManager>()?.showMessageFailure(
+              DrivePickFailure(Exception('ComposerController unavailable')),
+            );
+            return;
           }
+          // No catch here: handleDrivePickResult swallows and toasts its own errors.
+          await composer.handleDrivePickResult(state.documents);
         } else if (state is DrivePickFailure) {
           getBinding<ToastManager>()?.showMessageFailure(state);
         }

--- a/lib/features/upload/domain/usecases/upload_drive_document_from_url_interactor.dart
+++ b/lib/features/upload/domain/usecases/upload_drive_document_from_url_interactor.dart
@@ -10,12 +10,12 @@ class UploadDriveDocumentFromUrlInteractor {
 
   UploadDriveDocumentFromUrlInteractor(this._uploadFromUrlRepository);
 
-  Stream<Either<Failure, Success>> execute(UploadFromUrlRequest request) async* {
+  Future<Either<Failure, Success>> execute(UploadFromUrlRequest request) async {
     try {
       final attachment = await _uploadFromUrlRepository.uploadFromUrl(request);
-      yield Right<Failure, Success>(UploadDriveDocumentFromUrlSuccess(attachment));
+      return Right<Failure, Success>(UploadDriveDocumentFromUrlSuccess(attachment));
     } catch (e) {
-      yield Left<Failure, Success>(
+      return Left<Failure, Success>(
         request.cancelToken?.isCancelled == true
           ? UploadDriveDocumentFromUrlCancelled()
           : UploadDriveDocumentFromUrlFailure(e),

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -21,6 +21,7 @@ import 'package:tmail_ui_user/features/composer/domain/usecases/upload_attachmen
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
 import 'package:tmail_ui_user/features/upload/domain/state/attachment_upload_state.dart';
 import 'package:tmail_ui_user/features/upload/presentation/extensions/upload_attachment_extension.dart';
+import 'package:tmail_ui_user/features/upload/presentation/model/drive_transfer_placeholder.dart';
 import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_state.dart';
 import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_state_list.dart';
 import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_status.dart';
@@ -56,8 +57,8 @@ class UploadController extends BaseController {
   @override
   void onClose() {
     listUploadAttachments.clear();
-    _uploadingStateFiles.clear();
-    _uploadingStateInlineFiles.clear();
+    _uploadingStateFiles.cancelAll();
+    _uploadingStateInlineFiles.cancelAll();
     uploadInlineViewState.value = Right(UIClosedState());
     dispatchState(Right(UIClosedState()));
     _progressUploadStateStreamGroup.close();
@@ -213,6 +214,44 @@ class UploadController extends BaseController {
     _refreshListUploadAttachmentState();
   }
 
+  /// Shows a chip for every picked drive file up front, before any transfer starts.
+  void addDownloadingPlaceholders(List<DriveTransferPlaceholder> placeholders) {
+    if (placeholders.isEmpty) return;
+    _uploadingStateFiles.addAll(placeholders.map((placeholder) => UploadFileState(
+      placeholder.taskId,
+      file: FileInfo(
+        fileName: placeholder.fileName,
+        fileSize: placeholder.fileSize,
+        type: placeholder.mimeType,
+      ),
+      uploadStatus: UploadFileStatus.waiting,
+      cancelToken: placeholder.cancelToken,
+    )));
+    _refreshListUploadAttachmentState();
+  }
+
+  /// Resolves a drive-transfer chip to succeed with its attachment.
+  void resolveDriveTransferSuccess(UploadTaskId taskId, Attachment attachment) {
+    _uploadingStateFiles.updateElementByUploadTaskId(
+      taskId,
+      (state) => state?.copyWith(
+        uploadingProgress: 100,
+        uploadStatus: UploadFileStatus.succeed,
+        attachment: attachment,
+      ),
+    );
+    _refreshListUploadAttachmentState();
+  }
+
+  /// Resolves a drive-transfer chip to failed by removing it, matching the
+  /// plain-upload failure path.
+  void resolveDriveTransferFailure(UploadTaskId taskId) {
+    deleteFileUploaded(taskId);
+    _showToastMessageWhenUploadAttachmentsFailure(
+      ErrorAttachmentUploadState(uploadId: taskId),
+    );
+  }
+
   Future<void> justUploadAttachmentsAction({
     required List<FileInfo> uploadFiles,
     required Uri uploadUri,
@@ -289,6 +328,9 @@ class UploadController extends BaseController {
         AppLocalizations.of(currentContext!).can_not_upload_this_file_as_attachments,
         leadingSVGIconColor: Colors.white,
         leadingSVGIcon: imagePaths.icAttachment);
+    } else {
+      // The chip is already gone, so an unshowable toast loses the reason entirely.
+      logError('UploadController::_showToastMessageWhenUploadAttachmentsFailure: no context to show failure for ${failure.uploadId}');
     }
   }
 

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -322,6 +322,8 @@ class UploadController extends BaseController {
   }
 
   void _showToastMessageWhenUploadAttachmentsFailure(ErrorAttachmentUploadState failure) {
+    // The chip is removed on failure, so the log is the only durable trace.
+    logError('UploadController::_showToastMessageWhenUploadAttachmentsFailure: upload ${failure.uploadId} failed');
     if (currentContext != null && currentOverlayContext != null) {
       appToast.showToastErrorMessage(
         currentOverlayContext!,
@@ -329,7 +331,6 @@ class UploadController extends BaseController {
         leadingSVGIconColor: Colors.white,
         leadingSVGIcon: imagePaths.icAttachment);
     } else {
-      // The chip is already gone, so an unshowable toast loses the reason entirely.
       logError('UploadController::_showToastMessageWhenUploadAttachmentsFailure: no context to show failure for ${failure.uploadId}');
     }
   }

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -433,15 +433,28 @@ class UploadController extends BaseController {
     final regularAttachments = attachments.getListAttachmentsDisplayedOutside(htmlBodyAttachments);
     final inlineAttachments = attachments.listAttachmentsDisplayedInContent;
 
+    // A still-running upload has no blob yet, so the server response cannot
+    // rebuild it; dropping it would strand the request and lose its chip.
+    final pendingRegularStates = _pendingStatesOf(_uploadingStateFiles);
+    final pendingInlineStates = _pendingStatesOf(_uploadingStateInlineFiles);
+
     _uploadingStateFiles.clear();
     _uploadingStateFiles.addAll(_toUploadFileStates(regularAttachments));
+    _uploadingStateFiles.addAll(pendingRegularStates);
 
     _uploadingStateInlineFiles.clear();
     _uploadingStateInlineFiles.addAll(_toUploadFileStates(inlineAttachments));
+    _uploadingStateInlineFiles.addAll(pendingInlineStates);
 
     _refreshListUploadAttachmentState();
     log('UploadController::refreshAllAttachments(): regular=${regularAttachments.length} | inline=${inlineAttachments.length}');
   }
+
+  List<UploadFileState> _pendingStatesOf(UploadFileStateList stateList) =>
+    stateList.uploadingStateFiles
+      .nonNulls
+      .where((fileState) => !fileState.uploadStatus.completed)
+      .toList();
 
   Iterable<UploadFileState> _toUploadFileStates(List<Attachment> attachments) =>
     attachments

--- a/lib/features/upload/presentation/model/drive_transfer_placeholder.dart
+++ b/lib/features/upload/presentation/model/drive_transfer_placeholder.dart
@@ -1,0 +1,19 @@
+import 'package:dio/dio.dart';
+import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
+
+/// Renders a chip for a queued drive file before its transfer starts.
+class DriveTransferPlaceholder {
+  final UploadTaskId taskId;
+  final String fileName;
+  final int fileSize;
+  final String? mimeType;
+  final CancelToken? cancelToken;
+
+  const DriveTransferPlaceholder({
+    required this.taskId,
+    required this.fileName,
+    required this.fileSize,
+    this.mimeType,
+    this.cancelToken,
+  });
+}

--- a/lib/features/upload/presentation/model/upload_file_state_list.dart
+++ b/lib/features/upload/presentation/model/upload_file_state_list.dart
@@ -12,15 +12,23 @@ class UploadFileStateList {
 
   final List<UploadFileState?> _uploadingStateFiles = <UploadFileState?>[];
 
+  /// Keeps by-id access O(1): a batch of N drive transfers resolves one chip at
+  /// a time, so a linear scan per resolution would make the batch O(N²).
+  /// Holds the first index for a taskId, matching the old scan semantics.
+  final Map<UploadTaskId, int> _indexByTaskId = <UploadTaskId, int>{};
+
   List<UploadFileState?> get uploadingStateFiles => _uploadingStateFiles.toList(growable: false);
 
   UploadFileStateList add(UploadFileState element) {
+    _indexByTaskId.putIfAbsent(element.uploadTaskId, () => _uploadingStateFiles.length);
     _uploadingStateFiles.add(element);
     return this;
   }
 
   UploadFileStateList addAll(Iterable<UploadFileState> elements) {
-    _uploadingStateFiles.addAll(elements);
+    for (final element in elements) {
+      add(element);
+    }
     return this;
   }
 
@@ -30,7 +38,7 @@ class UploadFileStateList {
   ) {
     final matchIndex = _uploadingStateFiles.indexWhere((element) => matchedState(element));
     if (matchIndex >= 0) {
-      _uploadingStateFiles[matchIndex] = updateFileUploadingState(_uploadingStateFiles[matchIndex]);
+      _replaceAt(matchIndex, updateFileUploadingState(_uploadingStateFiles[matchIndex]));
     }
     return this;
   }
@@ -39,10 +47,11 @@ class UploadFileStateList {
     UploadTaskId uploadTaskId,
     UpdateFileUploadingState updateFileUploadingState,
   ) {
-    return updateElementBy(
-      (state) => state?.uploadTaskId == uploadTaskId,
-      updateFileUploadingState
-    );
+    final matchIndex = _indexByTaskId[uploadTaskId];
+    if (matchIndex != null) {
+      _replaceAt(matchIndex, updateFileUploadingState(_uploadingStateFiles[matchIndex]));
+    }
+    return this;
   }
 
   bool get allSuccess {
@@ -55,24 +64,57 @@ class UploadFileStateList {
 
   void clear() {
     _uploadingStateFiles.clear();
+    _indexByTaskId.clear();
+  }
+
+  /// Cancels every pending upload/drive-transfer token before dropping them,
+  /// so in-flight requests don't keep running after the list is torn down.
+  void cancelAll() {
+    for (final fileState in _uploadingStateFiles) {
+      fileState?.cancelToken?.cancel();
+    }
+    clear();
   }
 
   void deleteElementByUploadTaskId(UploadTaskId uploadTaskId) {
-    final fileState = _uploadingStateFiles
-        .firstWhereOrNull((fileState) => fileState?.uploadTaskId == uploadTaskId);
+    final matchIndex = _indexByTaskId[uploadTaskId];
+    if (matchIndex == null) return;
 
-    if (fileState != null) {
-      fileState.cancelToken?.cancel();
-      _uploadingStateFiles.remove(fileState);
-    }
+    _uploadingStateFiles[matchIndex]?.cancelToken?.cancel();
+    _uploadingStateFiles.removeAt(matchIndex);
+    _reindex();
   }
 
   UploadFileState? getUploadFileStateById(UploadTaskId uploadTaskId) {
-    return _uploadingStateFiles.firstWhereOrNull((fileState) => fileState?.uploadTaskId == uploadTaskId);
+    final matchIndex = _indexByTaskId[uploadTaskId];
+    return matchIndex == null ? null : _uploadingStateFiles[matchIndex];
+  }
+
+  /// Swaps in [newState], reindexing only when the swap changes which taskId
+  /// sits at [index].
+  void _replaceAt(int index, UploadFileState? newState) {
+    final previousTaskId = _uploadingStateFiles[index]?.uploadTaskId;
+    _uploadingStateFiles[index] = newState;
+    if (newState?.uploadTaskId != previousTaskId) {
+      _reindex();
+    }
+  }
+
+  void _reindex() {
+    _indexByTaskId.clear();
+    _uploadingStateFiles.forEachIndexed((index, fileState) {
+      if (fileState != null) {
+        _indexByTaskId.putIfAbsent(fileState.uploadTaskId, () => index);
+      }
+    });
   }
 
   @visibleForTesting
   void addNullableForTest(UploadFileState? state) {
-    _uploadingStateFiles.add(state);
+    if (state == null) {
+      _uploadingStateFiles.add(null);
+    } else {
+      add(state);
+    }
   }
 }

--- a/lib/features/upload/presentation/validator/attachment_upload_validation_service.dart
+++ b/lib/features/upload/presentation/validator/attachment_upload_validation_service.dart
@@ -39,6 +39,14 @@ class AttachmentUploadValidationService {
             validator ?? AttachmentUploadValidator([const AttachmentSizeLimitRule()])),
         _feedbackBuilder = feedbackBuilder ?? AttachmentValidationFeedbackImpl.new;
 
+  /// Bytes still attachable under the server cap, `null` when it advertises none.
+  int? get remainingCapacityBytes {
+    final hardLimit = _stateSource.hardLimitBytes;
+    if (hardLimit == null) return null;
+    final remaining = hardLimit - _stateSource.currentAllAttachmentBytes;
+    return remaining < 0 ? 0 : remaining;
+  }
+
   /// Validates the picked [files] then runs [onAllowed] when the upload may proceed.
   Future<void> validateFiles({
     BuildContext? context,

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -5918,8 +5918,8 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "driveAttachmentInDevelopment": "La fonctionnalité d'ajout en pièce jointe est encore en cours de développement.",
-  "@driveAttachmentInDevelopment": {
+  "driveAttachmentTransferFailed": "Échec de l'ajout des fichiers depuis Drive.",
+  "@driveAttachmentTransferFailed": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2026-07-15T18:21:15.082129",
+  "@@last_modified": "2026-08-24T15:11:50.161826",
   "initializing_data": "Initializing data...",
   "@initializing_data": {
     "type": "text",
@@ -5290,8 +5290,14 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "driveAttachmentInDevelopment": "The add-as-attachment feature is still in development.",
-  "@driveAttachmentInDevelopment": {
+  "driveAttachmentAddedSuccessfully": "Files attached from Drive.",
+  "@driveAttachmentAddedSuccessfully": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "driveAttachmentTransferFailed": "Failed to attach files from Drive.",
+  "@driveAttachmentTransferFailed": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/l10n/intl_mn.arb
+++ b/lib/l10n/intl_mn.arb
@@ -5531,8 +5531,8 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "driveAttachmentInDevelopment": "Хавсралт болгон нэмэх боломж хараахан хөгжүүлэлтийн шатанд байна.",
-  "@driveAttachmentInDevelopment": {
+  "driveAttachmentTransferFailed": "Драйваас файл хавсаргахад алдаа гарлаа.",
+  "@driveAttachmentTransferFailed": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -5936,8 +5936,8 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "driveAttachmentInDevelopment": "Функция добавления в качестве вложения ещё находится в разработке.",
-  "@driveAttachmentInDevelopment": {
+  "driveAttachmentTransferFailed": "Не удалось прикрепить файлы из Drive.",
+  "@driveAttachmentTransferFailed": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/l10n/intl_vi.arb
+++ b/lib/l10n/intl_vi.arb
@@ -5924,8 +5924,8 @@
     "placeholders_order": [],
     "placeholders": {}
   },
-  "driveAttachmentInDevelopment": "Tính năng thêm dưới dạng tệp đính kèm vẫn đang được phát triển.",
-  "@driveAttachmentInDevelopment": {
+  "driveAttachmentTransferFailed": "Không thể đính kèm tệp từ Drive.",
+  "@driveAttachmentTransferFailed": {
     "type": "text",
     "placeholders_order": [],
     "placeholders": {}

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -5618,10 +5618,17 @@ class AppLocalizations {
     );
   }
 
-  String get driveAttachmentInDevelopment {
+  String get driveAttachmentAddedSuccessfully {
     return Intl.message(
-      'The add-as-attachment feature is still in development.',
-      name: 'driveAttachmentInDevelopment',
+      'Files attached from Drive.',
+      name: 'driveAttachmentAddedSuccessfully',
+    );
+  }
+
+  String get driveAttachmentTransferFailed {
+    return Intl.message(
+      'Failed to attach files from Drive.',
+      name: 'driveAttachmentTransferFailed',
     );
   }
 

--- a/lib/main/utils/toast_manager.dart
+++ b/lib/main/utils/toast_manager.dart
@@ -331,6 +331,8 @@ class ToastManager {
       message = appLocalizations.addListLabelToListEmailHasSomeFailureMessage;
     } else if (success is AddListLabelsToListEmailsSuccess) {
       message = appLocalizations.addListLabelToListEmailSuccessfullyMessage;
+    } else if (success is DrivePickSuccess) {
+      message = success.message ?? appLocalizations.driveAttachmentAddedSuccessfully;
     }
     log('ToastManager::showMessageSuccess: Message: $message');
     if (message?.trim().isNotEmpty == true) {

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -89,6 +89,7 @@ import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
 import 'package:uuid/uuid.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
+import 'package:workplace/presentation/model/drive_pick_state.dart';
 
 import '../../../fixtures/account_fixtures.dart';
 import '../../../fixtures/session_fixtures.dart';
@@ -1451,6 +1452,52 @@ void main() {
         await resultFuture;
 
         expect(callOrder, ['restoreFocus', 'insertHtml']);
+      });
+
+      final attachmentDoc = DriveDocument(
+        id: 'drive-doc-2',
+        name: 'Report.pdf',
+        size: 100,
+        mimeType: 'application/pdf',
+        downloadLink: Uri.parse('https://drive.example.com/report/download'),
+      );
+
+      Future<void> expectTransferFailedWithoutUpload(WidgetTester tester) async {
+        final resultFuture =
+            composerController?.handleDrivePickResult([attachmentDoc]);
+        await tester.pumpAndSettle();
+        await resultFuture;
+
+        final captured =
+            verify(mockToastManager.showMessageFailure(captureAny)).captured;
+        expect(captured, hasLength(1));
+        final failure = captured.single as DrivePickFailure;
+        // The bare Exception marks the not-started outcome; a thrown error
+        // would have come through handleDrivePickResult's catch instead.
+        expect(failure.error.toString(), 'Exception');
+        // No placeholder means the transfer never reached the runner.
+        verifyNever(mockUploadController.addDownloadingPlaceholders(any));
+      }
+
+      testWidgets(
+        'Should show the transfer failure toast and never start an upload\n'
+        'When jmapUrl is unavailable',
+      (tester) async {
+        when(mockDynamicUrlInterceptors.jmapUrl).thenReturn('');
+
+        await expectTransferFailedWithoutUpload(tester);
+      });
+
+      testWidgets(
+        'Should show the transfer failure toast and never start an upload\n'
+        'When the session exposes no upload-from-url endpoint',
+      (tester) async {
+        // aliceSession carries no upload-from-url capability, so
+        // getUploadFromUrlUri returns null even with a usable jmapUrl.
+        when(mockDynamicUrlInterceptors.jmapUrl)
+            .thenReturn('https://jmap.example.com/jmap');
+
+        await expectTransferFailedWithoutUpload(tester);
       });
     });
 

--- a/test/features/composer/presentation/extensions/drive_document_extension_test.dart
+++ b/test/features/composer/presentation/extensions/drive_document_extension_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/composer/presentation/extensions/drive_document_extension.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+
+DriveDocument _doc({String? sharingLink, String? downloadLink}) => DriveDocument(
+      id: 'doc-1',
+      name: 'file.pdf',
+      size: 100,
+      mimeType: 'application/pdf',
+      sharingLink: sharingLink == null ? null : Uri.parse(sharingLink),
+      downloadLink: downloadLink == null ? null : Uri.parse(downloadLink),
+    );
+
+void main() {
+  group('DriveDocumentExtension::isAttachableAsLink::', () {
+    test('Should accept an https sharingLink whether or not https is required', () {
+      final doc = _doc(sharingLink: 'https://drive.example.com/report');
+
+      expect(doc.isAttachableAsLink(requireHttps: true), isTrue);
+      expect(doc.isAttachableAsLink(requireHttps: false), isTrue);
+    });
+
+    test('Should accept an http sharingLink only when https is not required', () {
+      final doc = _doc(sharingLink: 'http://drive.example.com/report');
+
+      expect(doc.isAttachableAsLink(requireHttps: false), isTrue);
+      expect(doc.isAttachableAsLink(requireHttps: true), isFalse);
+    });
+
+    test('Should reject a javascript sharingLink even when https is not required', () {
+      final doc = _doc(sharingLink: 'javascript:alert(document.cookie)');
+
+      expect(doc.isAttachableAsLink(requireHttps: false), isFalse);
+      expect(doc.isAttachableAsLink(requireHttps: true), isFalse);
+    });
+
+    test('Should reject a data sharingLink even when https is not required', () {
+      final doc = _doc(sharingLink: 'data:text/html;base64,PHNjcmlwdD4=');
+
+      expect(doc.isAttachableAsLink(requireHttps: false), isFalse);
+      expect(doc.isAttachableAsLink(requireHttps: true), isFalse);
+    });
+
+    test('Should reject a null sharingLink', () {
+      expect(_doc().isAttachableAsLink(requireHttps: false), isFalse);
+    });
+  });
+
+  group('DriveDocumentExtension::isAttachableAsDownload::', () {
+    test('Should accept a non-empty downloadLink of any scheme', () {
+      expect(_doc(downloadLink: 'https://drive.example.com/report-dl').isAttachableAsDownload(), isTrue);
+      expect(_doc(downloadLink: 'http://drive.example.com/report-dl').isAttachableAsDownload(), isTrue);
+    });
+
+    test('Should reject a null or empty downloadLink', () {
+      expect(_doc().isAttachableAsDownload(), isFalse);
+      expect(_doc(downloadLink: '').isAttachableAsDownload(), isFalse);
+    });
+
+    test('Should stay independent of sharingLink, precedence is the caller\'s job', () {
+      final doc = _doc(
+        sharingLink: 'https://drive.example.com/report',
+        downloadLink: 'https://drive.example.com/report-dl',
+      );
+
+      expect(doc.isAttachableAsDownload(), isTrue);
+    });
+  });
+}

--- a/test/features/composer/presentation/manager/concurrency_gate_test.dart
+++ b/test/features/composer/presentation/manager/concurrency_gate_test.dart
@@ -1,0 +1,109 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/concurrency_gate.dart';
+
+// Runs [items] through [gate] and asserts every one was processed exactly once.
+Future<void> expectAllItemsProcessed(ConcurrencyGate gate, List<int> items) async {
+  final processed = <int>[];
+
+  await Future.wait(items.map((item) => gate.run(() async {
+        await Future<void>.delayed(Duration.zero);
+        processed.add(item);
+      })));
+
+  expect(processed.toSet(), items.toSet());
+  expect(processed, hasLength(items.length));
+}
+
+// Runs [items] through [gate] while tracking concurrency, returning the peak.
+Future<int> peakInFlight(ConcurrencyGate gate, List<int> items) async {
+  var inFlight = 0;
+  var maxInFlight = 0;
+
+  await Future.wait(items.map((item) => gate.run(() async {
+        inFlight++;
+        maxInFlight = maxInFlight < inFlight ? inFlight : maxInFlight;
+        await Future<void>.delayed(Duration.zero);
+        inFlight--;
+      })));
+
+  return maxInFlight;
+}
+
+void main() {
+  group('ConcurrencyGate::run::', () {
+    test('Should run every action when they outnumber maxConcurrent', () async {
+      await expectAllItemsProcessed(ConcurrencyGate(3), List.generate(10, (index) => index));
+    });
+
+    test('Should run every action when they fit in one wave', () async {
+      await expectAllItemsProcessed(ConcurrencyGate(5), [0, 1]);
+    });
+
+    test('Should return the action result to its own caller', () async {
+      final gate = ConcurrencyGate(1);
+
+      final results = await Future.wait([
+        gate.run(() async => 'a'),
+        gate.run(() async => 'b'),
+      ]);
+
+      expect(results, ['a', 'b']);
+    });
+
+    test('Should never run more than maxConcurrent actions at once', () async {
+      expect(await peakInFlight(ConcurrencyGate(2), List.generate(5, (index) => index)), 2);
+    });
+
+    test('Should clamp a maxConcurrent below 1 to a single slot', () async {
+      expect(ConcurrencyGate(0).maxConcurrent, 1);
+      expect(ConcurrencyGate(-3).maxConcurrent, 1);
+      expect(await peakInFlight(ConcurrencyGate(0), [0, 1, 2]), 1);
+    });
+
+    test('Should hold later actions until a slot frees', () async {
+      final gate = ConcurrencyGate(2);
+      final started = <int>[];
+      final blockers = List.generate(3, (_) => Completer<void>());
+
+      final futures = List.generate(
+        3,
+        (index) => gate.run(() async {
+          started.add(index);
+          await blockers[index].future;
+        }),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      expect(started, [0, 1]);
+
+      blockers[0].complete();
+      await Future<void>.delayed(Duration.zero);
+      expect(started, [0, 1, 2]);
+
+      blockers[1].complete();
+      blockers[2].complete();
+      await Future.wait(futures);
+    });
+
+    test('Should propagate a thrown action error to its caller', () async {
+      await expectLater(
+        ConcurrencyGate(1).run(() async => throw StateError('action blew up')),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('Should release the slot when an action throws', () async {
+      final gate = ConcurrencyGate(1);
+
+      await expectLater(
+        gate.run(() async => throw StateError('action blew up')),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(gate.inFlight, 0);
+      expect(await gate.run(() async => 'still usable'), 'still usable');
+    });
+  });
+}

--- a/test/features/composer/presentation/manager/drive_attachment_handler_insert_link_html_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_insert_link_html_test.dart
@@ -31,7 +31,7 @@ void main() {
 
       handler.insertDriveLinkHtml([
         doc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
+      ], insertHtml: (html) async { insertedHtml.add(html); return true; }, appLocalizations: AppLocalizations());
 
       expect(insertedHtml.first, contains('&amp;'));
       expect(insertedHtml.first, contains('My &lt;Report&gt;'));
@@ -49,7 +49,7 @@ void main() {
 
       handler.insertDriveLinkHtml([
         doc,
-      ], insertHtml: (html) async => insertedHtml.add(html));
+      ], insertHtml: (html) async { insertedHtml.add(html); return true; });
 
       expect(insertedHtml.first, contains('Open in drive'));
     });
@@ -65,7 +65,7 @@ void main() {
 
       handler.insertDriveLinkHtml([
         doc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
+      ], insertHtml: (html) async { insertedHtml.add(html); return true; }, appLocalizations: AppLocalizations());
 
       final html = insertedHtml.first;
       expect('<a '.allMatches(html).length, 1);
@@ -84,7 +84,7 @@ void main() {
       handler.insertDriveLinkHtml([
         linkDoc,
         doc2,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
+      ], insertHtml: (html) async { insertedHtml.add(html); return true; }, appLocalizations: AppLocalizations());
 
       final html = insertedHtml.first;
       expect(html, contains('Report'));
@@ -97,7 +97,7 @@ void main() {
     test('Should produce empty string for docs with null sharingLink', () async {
       handler.insertDriveLinkHtml([
         noLinkDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
+      ], insertHtml: (html) async { insertedHtml.add(html); return true; }, appLocalizations: AppLocalizations());
 
       expect(insertedHtml.first, isEmpty);
     });
@@ -114,7 +114,7 @@ void main() {
 
       handler.insertDriveLinkHtml([
         imageDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
+      ], insertHtml: (html) async { insertedHtml.add(html); return true; }, appLocalizations: AppLocalizations());
 
       expect(insertedHtml.first, contains('<img src="https://cdn.example.com/thumbnails/photo.png"'));
     });
@@ -130,7 +130,7 @@ void main() {
 
       handler.insertDriveLinkHtml([
         xlsDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
+      ], insertHtml: (html) async { insertedHtml.add(html); return true; }, appLocalizations: AppLocalizations());
 
       expect(insertedHtml.first, isNot(contains('<img')));
     });
@@ -147,7 +147,7 @@ void main() {
 
       handler.insertDriveLinkHtml([
         httpThumbnailDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
+      ], insertHtml: (html) async { insertedHtml.add(html); return true; }, appLocalizations: AppLocalizations());
 
       expect(insertedHtml.first, contains('<img src="http://cdn.example.com/thumbnails/photo3.png"'));
     });
@@ -163,7 +163,7 @@ void main() {
 
       handler.insertDriveLinkHtml([
         httpDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: AppLocalizations());
+      ], insertHtml: (html) async { insertedHtml.add(html); return true; }, appLocalizations: AppLocalizations());
 
       expect(insertedHtml.first, contains('http://example.com/file'));
     });

--- a/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_handler.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_transfer_runner.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
@@ -14,12 +15,31 @@ import 'drive_attachment_handler_test_helper.dart';
 @GenerateNiceMocks([MockSpec<ToastManager>()])
 void main() {
   late List<String> insertedHtml;
+  late List<List<DriveDocument>> transferredBatches;
+  late DriveTransferOutcome transferOutcome;
   late DriveAttachmentHandler handler;
   late MockToastManager mockToastManager;
   final appLocalizations = AppLocalizations();
 
+  Future<void> handlePick(
+    List<DriveDocument> result, {
+    AppLocalizations? appLocalizations,
+  }) {
+    return handler.handleDrivePickResult(
+      result,
+      insertHtml: (html) async { insertedHtml.add(html); return true; },
+      transferDriveDocuments: (docs) async {
+        transferredBatches.add(docs);
+        return transferOutcome;
+      },
+      appLocalizations: appLocalizations,
+    );
+  }
+
   setUp(() {
     insertedHtml = [];
+    transferredBatches = [];
+    transferOutcome = (started: true, succeeded: 1, failed: 0);
     handler = Get.put(DriveAttachmentHandler());
     mockToastManager = MockToastManager();
     Get.put<ToastManager>(mockToastManager);
@@ -30,21 +50,41 @@ void main() {
   });
 
   group('DriveAttachmentHandler::handleDrivePickResult::', () {
+    test('Should toast failure for docs dropped alongside a valid sibling', () async {
+      await handlePick([linkDoc, noLinkDoc], appLocalizations: appLocalizations);
+
+      expect(insertedHtml, hasLength(1));
+      verify(mockToastManager.showMessageFailure(any)).called(1);
+    });
+
+    test('Should toast failure instead of success when the editor is unbound', () async {
+      await handler.handleDrivePickResult(
+        [linkDoc],
+        insertHtml: (_) async => false,
+        transferDriveDocuments: (docs) async {
+          transferredBatches.add(docs);
+          return transferOutcome;
+        },
+        appLocalizations: appLocalizations,
+      );
+
+      verify(mockToastManager.showMessageFailure(any)).called(1);
+      verifyNever(mockToastManager.showMessageSuccess(any));
+    });
+
     test('Should insert link html for docs with sharingLink', () async {
-      await handler.handleDrivePickResult([
-        linkDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
+      await handlePick([linkDoc], appLocalizations: appLocalizations);
 
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, contains('https://drive.example.com/report'));
       expect(insertedHtml.first, contains('Report'));
+      expect(transferredBatches, isEmpty);
       verifyNever(mockToastManager.showMessageFailure(any));
+      verify(mockToastManager.showMessageSuccess(any)).called(1);
     });
 
     test('Should still work and fall back to hardcoded English label when appLocalizations is omitted', () async {
-      await handler.handleDrivePickResult([
-        linkDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html));
+      await handlePick([linkDoc]);
 
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, contains('Open in drive'));
@@ -60,68 +100,120 @@ void main() {
         downloadLink: Uri.parse('https://drive.example.com/both-dl'),
       );
 
-      await handler.handleDrivePickResult([
-        bothLinksDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
+      await handlePick([bothLinksDoc], appLocalizations: appLocalizations);
 
       expect(insertedHtml, hasLength(1));
       expect(insertedHtml.first, contains('https://drive.example.com/both'));
+      expect(transferredBatches, isEmpty);
     });
 
-    test('Should show download-only toast and not insert html when doc has neither sharingLink nor downloadLink', () async {
-      await handler.handleDrivePickResult([
-        noLinkDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
+    test('Should show toast and not insert html or transfer when doc has neither sharingLink nor downloadLink', () async {
+      await handlePick([noLinkDoc], appLocalizations: appLocalizations);
 
       expect(insertedHtml, isEmpty);
+      expect(transferredBatches, isEmpty);
       verify(mockToastManager.showMessageFailure(any)).called(1);
     });
 
-    test('Should handle mixed docs correctly — only link docs inserted, no toast shown', () async {
-      await handler.handleDrivePickResult([
-        linkDoc,
-        attachmentDoc,
-        noLinkDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
-
-      expect(insertedHtml, hasLength(1));
-      expect(insertedHtml.first, contains('Report'));
-      verifyNever(mockToastManager.showMessageFailure(any));
-    });
-  });
-
-  group('DriveAttachmentHandler::handleDrivePickResult::download-only toast::', () {
-    test('Should show toast with driveAttachmentInDevelopment message when all docs are download-only', () async {
-      handler.handleDrivePickResult([
-        attachmentDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
+    test('Should not transfer a doc whose downloadLink is empty, and show a toast', () async {
+      await handlePick([emptyDownloadLinkDoc], appLocalizations: appLocalizations);
 
       expect(insertedHtml, isEmpty);
+      expect(transferredBatches, isEmpty);
       final captured = verify(
         mockToastManager.showMessageFailure(captureAny),
       ).captured;
       expect(captured, hasLength(1));
       final failure = captured.single as DrivePickFailure;
-      expect(failure.message, equals(appLocalizations.driveAttachmentInDevelopment));
+      expect(failure.message, equals(appLocalizations.driveNoValidAttachment));
+    });
+
+    test('Should dispatch download-only docs to transferDriveDocuments, link docs to insertHtml', () async {
+      await handlePick([linkDoc, attachmentDoc, noLinkDoc], appLocalizations: appLocalizations);
+
+      expect(insertedHtml, hasLength(1));
+      expect(insertedHtml.first, contains('Report'));
+      expect(transferredBatches, [[attachmentDoc]]);
+      // noLinkDoc is attachable neither way — the drop must be reported.
+      verify(mockToastManager.showMessageFailure(any)).called(1);
+    });
+
+    test('Should show a success toast carrying the localized message for a link-only pick', () async {
+      await handlePick([linkDoc], appLocalizations: appLocalizations);
+
+      final captured = verify(
+        mockToastManager.showMessageSuccess(captureAny),
+      ).captured;
+      expect(captured, hasLength(1));
+      final success = captured.single as DrivePickSuccess;
+      expect(success.message, equals(appLocalizations.driveAttachmentAddedSuccessfully));
+    });
+  });
+
+  group('DriveAttachmentHandler::handleDrivePickResult::download-only transfer::', () {
+    test('Should call transferDriveDocuments with download-only docs and toast success', () async {
+      await handlePick([attachmentDoc], appLocalizations: appLocalizations);
+
+      expect(insertedHtml, isEmpty);
+      expect(transferredBatches, [[attachmentDoc]]);
+      verifyNever(mockToastManager.showMessageFailure(any));
+      verify(mockToastManager.showMessageSuccess(any)).called(1);
+    });
+
+    test('Should show no toast when only some docs of the batch transferred', () async {
+      transferOutcome = (started: true, succeeded: 1, failed: 1);
+
+      await handlePick([attachmentDoc], appLocalizations: appLocalizations);
+
+      verifyNever(mockToastManager.showMessageSuccess(any));
+      verifyNever(mockToastManager.showMessageFailure(any));
+    });
+
+    test('Should show no toast when every transfer of the batch was cancelled', () async {
+      transferOutcome = (started: true, succeeded: 0, failed: 0);
+
+      await handlePick([attachmentDoc], appLocalizations: appLocalizations);
+
+      verifyNever(mockToastManager.showMessageSuccess(any));
+      verifyNever(mockToastManager.showMessageFailure(any));
+    });
+
+    test('Should still toast success when links were inserted and every transfer was cancelled', () async {
+      transferOutcome = (started: true, succeeded: 0, failed: 0);
+
+      await handlePick([attachmentDoc, linkDoc], appLocalizations: appLocalizations);
+
+      expect(insertedHtml, hasLength(1));
+      verify(mockToastManager.showMessageSuccess(any)).called(1);
+      verifyNever(mockToastManager.showMessageFailure(any));
+    });
+
+    test('Should show toast when transferDriveDocuments reports it took nothing', () async {
+      transferOutcome = DriveAttachmentTransferRunner.notStartedOutcome;
+
+      await handlePick([attachmentDoc], appLocalizations: appLocalizations);
+
+      final captured = verify(
+        mockToastManager.showMessageFailure(captureAny),
+      ).captured;
+      expect(captured, hasLength(1));
+      final failure = captured.single as DrivePickFailure;
+      expect(failure.message, equals(appLocalizations.driveAttachmentTransferFailed));
     });
 
     test('Should show toast when result is empty', () async {
-      handler.handleDrivePickResult(
-        [],
-        insertHtml: (html) async => insertedHtml.add(html),
-        appLocalizations: appLocalizations,
-      );
+      await handlePick([], appLocalizations: appLocalizations);
 
       expect(insertedHtml, isEmpty);
+      expect(transferredBatches, isEmpty);
       verify(mockToastManager.showMessageFailure(any)).called(1);
     });
 
     test('Should show toast with null message when appLocalizations is omitted', () async {
-      handler.handleDrivePickResult([
-        attachmentDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html));
+      transferOutcome = DriveAttachmentTransferRunner.notStartedOutcome;
 
-      expect(insertedHtml, isEmpty);
+      await handlePick([attachmentDoc]);
+
       final captured = verify(
         mockToastManager.showMessageFailure(captureAny),
       ).captured;
@@ -130,14 +222,29 @@ void main() {
       expect(failure.message, isNull);
     });
 
-    test('Should not show toast when at least one doc has sharingLink', () async {
-      handler.handleDrivePickResult([
-        attachmentDoc,
-        linkDoc,
-      ], insertHtml: (html) async => insertedHtml.add(html), appLocalizations: appLocalizations);
+    test('Should toast success when a mixed pick fully transfers', () async {
+      await handlePick([attachmentDoc, linkDoc], appLocalizations: appLocalizations);
 
       expect(insertedHtml, hasLength(1));
+      expect(transferredBatches, [[attachmentDoc]]);
       verifyNever(mockToastManager.showMessageFailure(any));
+      verify(mockToastManager.showMessageSuccess(any)).called(1);
+    });
+
+    test('Should toast and still insert links when mixed pick transfer cannot start', () async {
+      transferOutcome = DriveAttachmentTransferRunner.notStartedOutcome;
+
+      await handlePick([attachmentDoc, linkDoc], appLocalizations: appLocalizations);
+
+      expect(insertedHtml, hasLength(1));
+      expect(insertedHtml.first, contains('Report'));
+      expect(transferredBatches, [[attachmentDoc]]);
+      final captured = verify(
+        mockToastManager.showMessageFailure(captureAny),
+      ).captured;
+      expect(captured, hasLength(1));
+      final failure = captured.single as DrivePickFailure;
+      expect(failure.message, equals(appLocalizations.driveAttachmentTransferFailed));
     });
 
     test('Should await an async insertHtml callback before insertDriveLinkHtml completes', () async {
@@ -150,6 +257,7 @@ void main() {
           await Future<void>.delayed(const Duration(milliseconds: 10));
           insertedHtml.add(html);
           callOrder.add('insertHtml-end');
+          return true;
         },
         appLocalizations: appLocalizations,
       );

--- a/test/features/composer/presentation/manager/drive_attachment_handler_test_helper.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_test_helper.dart
@@ -22,3 +22,11 @@ const noLinkDoc = DriveDocument(
   size: 0,
   mimeType: 'application/octet-stream',
 );
+
+final emptyDownloadLinkDoc = DriveDocument(
+  id: '4',
+  name: 'Empty',
+  size: 0,
+  mimeType: 'application/octet-stream',
+  downloadLink: Uri.parse(''),
+);

--- a/test/features/composer/presentation/manager/drive_attachment_transfer_runner_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_transfer_runner_test.dart
@@ -259,7 +259,7 @@ void main() {
       return Right(UploadDriveDocumentFromUrlSuccess(Attachment(name: request.name)));
     });
 
-    final future = runner.transfer((
+    final result = await runner.transfer((
       docs: [doc(downloadLink: 'https://drive.example.com/1')],
       accountId: accountId,
       uploadUri: uploadUri,
@@ -268,8 +268,8 @@ void main() {
       onFailure: (_) => failureCalls++,
     ));
 
-    await expectLater(future, throwsA(isA<StateError>()));
     expect(failureCalls, 0);
+    expect(result, (started: true, succeeded: 1, failed: 0));
   });
 
   test('Should resolve failure when uploadFromUrl throws', () async {
@@ -451,5 +451,73 @@ void main() {
 
     expect(maxInFlight, 3);
     expect(blockers, hasLength(8));
+  });
+
+  test('Should not start the batch when onPlaceholdersReady throws', () async {
+    var uploadCalls = 0;
+    final runner = makeRunner(uploadFromUrl: (request) async {
+      uploadCalls++;
+      return Right(UploadDriveDocumentFromUrlSuccess(Attachment(name: request.name)));
+    });
+
+    final result = await runner.transfer((
+      docs: [doc(downloadLink: 'https://drive.example.com/1')],
+      accountId: accountId,
+      uploadUri: uploadUri,
+      onPlaceholdersReady: (_) => throw StateError('chips unavailable'),
+      onSuccess: (_, __) {},
+      onFailure: (_) {},
+    ));
+
+    expect(result, DriveAttachmentTransferRunner.notStartedOutcome);
+    expect(uploadCalls, 0);
+  });
+
+  test('Should keep resolving siblings and reporting the outcome when onSuccess throws', () async {
+    final succeededNames = <String>[];
+    final runner = makeRunner(uploadFromUrl: (request) async {
+      return Right(UploadDriveDocumentFromUrlSuccess(Attachment(name: request.name)));
+    });
+
+    final result = await runner.transfer((
+      docs: [
+        doc(downloadLink: 'https://drive.example.com/1', name: 'first.pdf'),
+        doc(downloadLink: 'https://drive.example.com/2', name: 'second.pdf'),
+      ],
+      accountId: accountId,
+      uploadUri: uploadUri,
+      onPlaceholdersReady: (_) {},
+      onSuccess: (_, attachment) {
+        succeededNames.add(attachment.name ?? '');
+        if (succeededNames.length == 1) throw StateError('chip update failed');
+      },
+      onFailure: (_) {},
+    ));
+
+    expect(succeededNames, ['first.pdf', 'second.pdf']);
+    expect(result, (started: true, succeeded: 2, failed: 0));
+  });
+
+  test('Should keep resolving siblings when onFailure throws', () async {
+    final failedTaskIds = <UploadTaskId>[];
+    final runner = makeRunner(uploadFromUrl: (request) async => Left(_StubFailure()));
+
+    final result = await runner.transfer((
+      docs: [
+        doc(downloadLink: 'https://drive.example.com/1'),
+        doc(downloadLink: 'https://drive.example.com/2'),
+      ],
+      accountId: accountId,
+      uploadUri: uploadUri,
+      onPlaceholdersReady: (_) {},
+      onSuccess: (_, __) {},
+      onFailure: (taskId) {
+        failedTaskIds.add(taskId);
+        if (failedTaskIds.length == 1) throw StateError('chip removal failed');
+      },
+    ));
+
+    expect(failedTaskIds, hasLength(2));
+    expect(result, (started: true, succeeded: 0, failed: 2));
   });
 }

--- a/test/features/composer/presentation/manager/drive_attachment_transfer_runner_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_transfer_runner_test.dart
@@ -66,6 +66,65 @@ void main() {
     expect(failureCalls, expectedFailureCalls);
   }
 
+  Future<void> expectInFlightSiblingsContinueAfterCancel({
+    required List<String> names,
+    required String cancelledName,
+    required int maxConcurrent,
+  }) async {
+    final succeededNames = <String>[];
+    var failureCalls = 0;
+    final blockers = <String, Completer<void>>{};
+    final runner = makeRunner(
+      maxConcurrent: maxConcurrent,
+      uploadFromUrl: (request) async {
+        final blocker = Completer<void>();
+        blockers[request.name] = blocker;
+        await blocker.future;
+        return Right(UploadDriveDocumentFromUrlSuccess(Attachment(name: request.name)));
+      },
+    );
+
+    late final List<dynamic> placeholders;
+    final future = runner.transfer((
+      docs: [
+        for (var i = 0; i < names.length; i++)
+          doc(
+            downloadLink: 'https://drive.example.com/${i + 1}',
+            name: names[i],
+          ),
+      ],
+      accountId: accountId,
+      uploadUri: uploadUri,
+      onPlaceholdersReady: (received) => placeholders = received,
+      onSuccess: (_, attachment) => succeededNames.add(attachment.name ?? ''),
+      onFailure: (_) => failureCalls++,
+    ));
+
+    await Future<void>.delayed(Duration.zero);
+    expect(blockers.keys, unorderedEquals(names));
+
+    placeholders
+        .firstWhere((placeholder) => placeholder.fileName == cancelledName)
+        .cancelToken
+        ?.cancel();
+    blockers[cancelledName]!.complete();
+    for (final name in names.where((name) => name != cancelledName)) {
+      blockers[name]!.complete();
+    }
+    final result = await future;
+
+    expect(succeededNames, names.where((name) => name != cancelledName).toList());
+    expect(failureCalls, 0);
+    expect(
+      result,
+      (
+        started: true,
+        succeeded: names.length - 1,
+        failed: 0,
+      ),
+    );
+  }
+
   // Shared by the invalid-downloadLink tests: neither shape may reach the gateway.
   Future<void> expectNoUploadForDownloadLink(String? downloadLink) async {
     var uploadCalls = 0;
@@ -549,5 +608,21 @@ void main() {
     expect(successCalls, 0);
     expect(failureCalls, 0);
     expect(result, (started: true, succeeded: 0, failed: 0));
+  });
+
+  test('Should keep a sibling in flight after another chip is cancelled', () async {
+    await expectInFlightSiblingsContinueAfterCancel(
+      names: ['keep.pdf', 'drop.pdf'],
+      cancelledName: 'drop.pdf',
+      maxConcurrent: 2,
+    );
+  });
+
+  test('Should keep every other in-flight sibling running when one chip is cancelled', () async {
+    await expectInFlightSiblingsContinueAfterCancel(
+      names: ['keep-a.pdf', 'drop.pdf', 'keep-b.pdf'],
+      cancelledName: 'drop.pdf',
+      maxConcurrent: 3,
+    );
   });
 }

--- a/test/features/composer/presentation/manager/drive_attachment_transfer_runner_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_transfer_runner_test.dart
@@ -520,4 +520,34 @@ void main() {
     expect(failedTaskIds, hasLength(2));
     expect(result, (started: true, succeeded: 0, failed: 2));
   });
+
+  test('Should resolve neither callback when the chip is cancelled while the upload is in flight', () async {
+    var successCalls = 0;
+    var failureCalls = 0;
+    final uploadBlocker = Completer<void>();
+    final runner = makeRunner(uploadFromUrl: (request) async {
+      await uploadBlocker.future;
+      return Right(UploadDriveDocumentFromUrlSuccess(Attachment(name: request.name)));
+    });
+
+    CancelToken? token;
+    final future = runner.transfer((
+      docs: [doc(downloadLink: 'https://drive.example.com/1')],
+      accountId: accountId,
+      uploadUri: uploadUri,
+      onPlaceholdersReady: (placeholders) => token = placeholders.single.cancelToken,
+      onSuccess: (_, __) => successCalls++,
+      onFailure: (_) => failureCalls++,
+    ));
+
+    await Future<void>.delayed(Duration.zero);
+    // The user removes the chip while the gateway response is still pending.
+    token?.cancel();
+    uploadBlocker.complete();
+    final result = await future;
+
+    expect(successCalls, 0);
+    expect(failureCalls, 0);
+    expect(result, (started: true, succeeded: 0, failed: 0));
+  });
 }

--- a/test/features/composer/presentation/manager/drive_attachment_transfer_runner_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_transfer_runner_test.dart
@@ -1,0 +1,455 @@
+import 'dart:async';
+
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:model/email/attachment.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/concurrency_gate.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_transfer_runner.dart';
+import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
+import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_request.dart';
+import 'package:tmail_ui_user/features/upload/domain/state/upload_drive_document_from_url_state.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+
+class _StubFailure extends FeatureFailure {
+  _StubFailure() : super(exception: Exception('failed'));
+}
+
+void main() {
+  final accountId = AccountId(Id('account-1'));
+  final uploadUri = Uri.parse('https://mail.example.com/upload-from-url/account-1');
+  int taskCounter = 0;
+
+  DriveDocument doc({String? downloadLink, String? name, int? size, String? mimeType}) => DriveDocument(
+        id: 'doc-${taskCounter++}',
+        name: name ?? 'file.pdf',
+        size: size ?? 100,
+        mimeType: mimeType ?? 'application/pdf',
+        downloadLink: downloadLink == null ? null : Uri.parse(downloadLink),
+      );
+
+  DriveAttachmentTransferRunner makeRunner({
+    required UploadFromUrlCall uploadFromUrl,
+    ConcurrencyGate? gate,
+    int maxConcurrent = 3,
+  }) =>
+      DriveAttachmentTransferRunner(
+        uploadFromUrl: uploadFromUrl,
+        gate: gate ?? ConcurrencyGate(maxConcurrent),
+      );
+
+  // Shared by the resolved-outcome tests below; only the uploadFromUrl
+  // stub and the expected callback counts differ between them.
+  Future<void> expectResolvedCallbackCounts({
+    required UploadFromUrlCall uploadFromUrl,
+    required int expectedSuccessCalls,
+    required int expectedFailureCalls,
+  }) async {
+    var successCalls = 0;
+    var failureCalls = 0;
+    final runner = makeRunner(uploadFromUrl: uploadFromUrl);
+
+    await runner.transfer((
+      docs: [doc(downloadLink: 'https://drive.example.com/1')],
+      accountId: accountId,
+      uploadUri: uploadUri,
+      onPlaceholdersReady: (_) {},
+      onSuccess: (_, __) => successCalls++,
+      onFailure: (_) => failureCalls++,
+    ));
+
+    expect(successCalls, expectedSuccessCalls);
+    expect(failureCalls, expectedFailureCalls);
+  }
+
+  // Shared by the invalid-downloadLink tests: neither shape may reach the gateway.
+  Future<void> expectNoUploadForDownloadLink(String? downloadLink) async {
+    var uploadCalls = 0;
+    UploadTaskId? failedTaskId;
+    final runner = makeRunner(uploadFromUrl: (request) async {
+      uploadCalls++;
+      return Left(_StubFailure());
+    });
+
+    await runner.transfer((
+      docs: [doc(downloadLink: downloadLink)],
+      accountId: accountId,
+      uploadUri: uploadUri,
+      onPlaceholdersReady: (_) {},
+      onSuccess: (_, __) {},
+      onFailure: (taskId) => failedTaskId = taskId,
+    ));
+
+    expect(uploadCalls, 0);
+    expect(failedTaskId, isNotNull);
+  }
+
+  setUp(() => taskCounter = 0);
+
+  test('Should report a not-started outcome and call nothing for an empty batch', () async {
+    var uploadCalls = 0;
+    final runner = makeRunner(uploadFromUrl: (request) async {
+      uploadCalls++;
+      return Left(_StubFailure());
+    });
+
+    final result = await runner.transfer((
+      docs: const [],
+      accountId: accountId,
+      uploadUri: uploadUri,
+      onPlaceholdersReady: (_) {},
+      onSuccess: (_, __) {},
+      onFailure: (_) {},
+    ));
+
+    expect(result, DriveAttachmentTransferRunner.notStartedOutcome);
+    expect(uploadCalls, 0);
+  });
+
+  test('Should report placeholders before any success/failure callback fires', () async {
+    final events = <String>[];
+    final runner = makeRunner(uploadFromUrl: (request) async {
+      return Right(UploadDriveDocumentFromUrlSuccess(
+        Attachment(name: request.name),
+      ));
+    });
+
+    await runner.transfer((
+      docs: [doc(downloadLink: 'https://drive.example.com/1')],
+      accountId: accountId,
+      uploadUri: uploadUri,
+      onPlaceholdersReady: (placeholders) => events.add('placeholders:${placeholders.length}'),
+      onSuccess: (_, __) => events.add('success'),
+      onFailure: (_) => events.add('failure'),
+    ));
+
+    expect(events, ['placeholders:1', 'success']);
+  });
+
+  test('Should resolve failure for a doc with a null downloadLink without calling uploadFromUrl', () async {
+    await expectNoUploadForDownloadLink(null);
+  });
+
+  test('Should resolve failure for a doc with an empty downloadLink without calling uploadFromUrl', () async {
+    await expectNoUploadForDownloadLink('');
+  });
+
+  test('Should not call uploadFromUrl for a task cancelled while waiting in the queue', () async {
+    final uploadedNames = <String>[];
+    final failedTaskIds = <UploadTaskId>[];
+    final firstUploadBlocker = Completer<void>();
+    final runner = makeRunner(
+      maxConcurrent: 1,
+      uploadFromUrl: (request) async {
+        uploadedNames.add(request.name);
+        if (uploadedNames.length == 1) await firstUploadBlocker.future;
+        return Right(UploadDriveDocumentFromUrlSuccess(Attachment(name: request.name)));
+      },
+    );
+
+    final future = runner.transfer((
+      docs: [
+        doc(downloadLink: 'https://drive.example.com/1', name: 'first.pdf'),
+        doc(downloadLink: 'https://drive.example.com/2', name: 'queued.pdf'),
+      ],
+      accountId: accountId,
+      uploadUri: uploadUri,
+      // The queued chip is deleted while the first upload still holds the worker.
+      onPlaceholdersReady: (placeholders) => placeholders.last.cancelToken?.cancel(),
+      onSuccess: (_, __) {},
+      onFailure: failedTaskIds.add,
+    ));
+
+    await Future<void>.delayed(Duration.zero);
+    firstUploadBlocker.complete();
+    await future;
+
+    expect(uploadedNames, ['first.pdf']);
+    expect(failedTaskIds, isEmpty);
+  });
+
+  test('Should never run more than maxConcurrent uploads at once', () async {
+    var inFlight = 0;
+    var maxInFlight = 0;
+    final completers = <Completer<void>>[];
+    final runner = makeRunner(
+      maxConcurrent: 2,
+      uploadFromUrl: (request) async {
+        inFlight++;
+        maxInFlight = maxInFlight < inFlight ? inFlight : maxInFlight;
+        final completer = Completer<void>();
+        completers.add(completer);
+        await completer.future;
+        inFlight--;
+        return Right(UploadDriveDocumentFromUrlSuccess(Attachment(name: request.name)));
+      },
+    );
+
+    final docs = List.generate(5, (_) => doc(downloadLink: 'https://drive.example.com/x'));
+    final future = runner.transfer((
+      docs: docs,
+      accountId: accountId,
+      uploadUri: uploadUri,
+      onPlaceholdersReady: (_) {},
+      onSuccess: (_, __) {},
+      onFailure: (_) {},
+    ));
+
+    // Let the first wave of workers spawn and block on their completers.
+    await Future<void>.delayed(Duration.zero);
+    expect(maxInFlight, lessThanOrEqualTo(2));
+
+    while (completers.any((c) => !c.isCompleted)) {
+      completers.firstWhere((c) => !c.isCompleted).complete();
+      await Future<void>.delayed(Duration.zero);
+    }
+    await future;
+
+    expect(maxInFlight, lessThanOrEqualTo(2));
+  });
+
+  test('Should call uploadFromUrl and onSuccess exactly once per doc in a 5-doc batch', () async {
+    var uploadCalls = 0;
+    var successCalls = 0;
+    final runner = makeRunner(
+      maxConcurrent: 2,
+      uploadFromUrl: (request) async {
+        uploadCalls++;
+        return Right(UploadDriveDocumentFromUrlSuccess(Attachment(name: request.name)));
+      },
+    );
+
+    final docs = List.generate(5, (_) => doc(downloadLink: 'https://drive.example.com/x'));
+    await runner.transfer((
+      docs: docs,
+      accountId: accountId,
+      uploadUri: uploadUri,
+      onPlaceholdersReady: (_) {},
+      onSuccess: (_, __) => successCalls++,
+      onFailure: (_) {},
+    ));
+
+    expect(uploadCalls, 5);
+    expect(successCalls, 5);
+  });
+
+  test('Should fold an upload failure into onFailure for the matching task', () async {
+    final failedTaskIds = <UploadTaskId>[];
+    final runner = makeRunner(uploadFromUrl: (request) async => Left(_StubFailure()));
+
+    await runner.transfer((
+      docs: [doc(downloadLink: 'https://drive.example.com/1')],
+      accountId: accountId,
+      uploadUri: uploadUri,
+      onPlaceholdersReady: (_) {},
+      onSuccess: (_, __) {},
+      onFailure: failedTaskIds.add,
+    ));
+
+    expect(failedTaskIds, hasLength(1));
+  });
+
+  test('Should not mask an onSuccess throw as a second onFailure call', () async {
+    var failureCalls = 0;
+    final runner = makeRunner(uploadFromUrl: (request) async {
+      return Right(UploadDriveDocumentFromUrlSuccess(Attachment(name: request.name)));
+    });
+
+    final future = runner.transfer((
+      docs: [doc(downloadLink: 'https://drive.example.com/1')],
+      accountId: accountId,
+      uploadUri: uploadUri,
+      onPlaceholdersReady: (_) {},
+      onSuccess: (_, __) => throw StateError('onSuccess blew up'),
+      onFailure: (_) => failureCalls++,
+    ));
+
+    await expectLater(future, throwsA(isA<StateError>()));
+    expect(failureCalls, 0);
+  });
+
+  test('Should resolve failure when uploadFromUrl throws', () async {
+    await expectResolvedCallbackCounts(
+      uploadFromUrl: (request) async => throw DioException(
+        requestOptions: RequestOptions(path: '/'),
+      ),
+      expectedSuccessCalls: 0,
+      expectedFailureCalls: 1,
+    );
+  });
+
+  test('Should resolve failure when the success payload is not UploadDriveDocumentFromUrlSuccess', () async {
+    await expectResolvedCallbackCounts(
+      uploadFromUrl: (request) async => Right(UIState.idle),
+      expectedSuccessCalls: 0,
+      expectedFailureCalls: 1,
+    );
+  });
+
+  test('Should resolve neither success nor failure when the transfer was cancelled', () async {
+    await expectResolvedCallbackCounts(
+      uploadFromUrl: (request) async => Left(UploadDriveDocumentFromUrlCancelled()),
+      expectedSuccessCalls: 0,
+      expectedFailureCalls: 0,
+    );
+  });
+
+  test('Should forward the request payload to uploadFromUrl unchanged', () async {
+    UploadFromUrlRequest? capturedRequest;
+    final runner = makeRunner(uploadFromUrl: (request) async {
+      capturedRequest = request;
+      return Right(UploadDriveDocumentFromUrlSuccess(Attachment(name: request.name)));
+    });
+
+    await runner.transfer((
+      docs: [doc(
+        downloadLink: 'https://drive.example.com/1',
+        name: 'report.pdf',
+        mimeType: 'application/pdf',
+      )],
+      accountId: accountId,
+      uploadUri: uploadUri,
+      onPlaceholdersReady: (_) {},
+      onSuccess: (_, __) {},
+      onFailure: (_) {},
+    ));
+
+    expect(capturedRequest, isNotNull);
+    expect(capturedRequest!.accountId, accountId);
+    expect(capturedRequest!.uploadUri, uploadUri);
+    expect(capturedRequest!.attachmentUrl, Uri.parse('https://drive.example.com/1'));
+    expect(capturedRequest!.name, 'report.pdf');
+    expect(capturedRequest!.mimeType, 'application/pdf');
+    expect(capturedRequest!.cancelToken, isNotNull);
+  });
+
+  test('Should mint a unique placeholder per doc carrying its own metadata', () async {
+    final placeholderDocs = [
+      doc(downloadLink: 'https://drive.example.com/1', name: 'a.pdf', size: 10),
+      doc(downloadLink: 'https://drive.example.com/2', name: 'b.pdf', size: 20),
+    ];
+    final runner = makeRunner(uploadFromUrl: (request) async {
+      return Right(UploadDriveDocumentFromUrlSuccess(Attachment(name: request.name)));
+    });
+
+    late final List<dynamic> placeholders;
+    await runner.transfer((
+      docs: placeholderDocs,
+      accountId: accountId,
+      uploadUri: uploadUri,
+      onPlaceholdersReady: (received) => placeholders = received,
+      onSuccess: (_, __) {},
+      onFailure: (_) {},
+    ));
+
+    expect(placeholders, hasLength(2));
+    expect(placeholders[0].taskId, isNot(placeholders[1].taskId));
+    expect(placeholders[0].fileName, 'a.pdf');
+    expect(placeholders[0].fileSize, 10);
+    expect(placeholders[0].cancelToken, isNotNull);
+    expect(placeholders[1].fileName, 'b.pdf');
+    expect(placeholders[1].fileSize, 20);
+    expect(placeholders[1].cancelToken, isNotNull);
+  });
+
+  test('Should route each taskId to the right callback in a mixed batch', () async {
+    final successDoc = doc(downloadLink: 'https://drive.example.com/ok');
+    final failDoc = doc(downloadLink: 'https://drive.example.com/fail');
+    final nullLinkDoc = doc();
+
+    final runner = makeRunner(uploadFromUrl: (request) async {
+      if (request.attachmentUrl.toString().endsWith('/ok')) {
+        return Right(UploadDriveDocumentFromUrlSuccess(Attachment(name: request.name)));
+      }
+      return Left(_StubFailure());
+    });
+
+    late final List<dynamic> placeholders;
+    final succeededTaskIds = <UploadTaskId>[];
+    final failedTaskIds = <UploadTaskId>[];
+
+    final result = await runner.transfer((
+      docs: [successDoc, failDoc, nullLinkDoc],
+      accountId: accountId,
+      uploadUri: uploadUri,
+      onPlaceholdersReady: (received) => placeholders = received,
+      onSuccess: (taskId, _) => succeededTaskIds.add(taskId),
+      onFailure: failedTaskIds.add,
+    ));
+
+    final successTaskId = placeholders[0].taskId as UploadTaskId;
+    final failTaskId = placeholders[1].taskId as UploadTaskId;
+    final nullLinkTaskId = placeholders[2].taskId as UploadTaskId;
+
+    expect(succeededTaskIds, [successTaskId]);
+    expect(failedTaskIds, containsAll([failTaskId, nullLinkTaskId]));
+    expect(failedTaskIds, hasLength(2));
+    expect(result, (started: true, succeeded: 1, failed: 2));
+  });
+
+  test('Should report a started outcome with every task failed', () async {
+    final runner = makeRunner(uploadFromUrl: (request) async => Left(_StubFailure()));
+
+    final result = await runner.transfer((
+      docs: [doc(downloadLink: 'https://drive.example.com/1')],
+      accountId: accountId,
+      uploadUri: uploadUri,
+      onPlaceholdersReady: (_) {},
+      onSuccess: (_, __) {},
+      onFailure: (_) {},
+    ));
+
+    expect(result, (started: true, succeeded: 0, failed: 1));
+  });
+
+  test('Should keep two batches sharing one gate under the global limit', () async {
+    var inFlight = 0;
+    var maxInFlight = 0;
+    final blockers = <Completer<void>>[];
+    final gate = ConcurrencyGate(3);
+    DriveAttachmentTransferRunner batchRunner() => makeRunner(
+          gate: gate,
+          uploadFromUrl: (request) async {
+            inFlight++;
+            maxInFlight = maxInFlight < inFlight ? inFlight : maxInFlight;
+            final blocker = Completer<void>();
+            blockers.add(blocker);
+            await blocker.future;
+            inFlight--;
+            return Right(UploadDriveDocumentFromUrlSuccess(Attachment(name: request.name)));
+          },
+        );
+
+    DriveTransferRequest batch() => (
+          docs: List.generate(4, (_) => doc(downloadLink: 'https://drive.example.com/x')),
+          accountId: accountId,
+          uploadUri: uploadUri,
+          onPlaceholdersReady: (_) {},
+          onSuccess: (_, __) {},
+          onFailure: (_) {},
+        );
+
+    // Second picker result arrives while the first batch is still transferring.
+    final firstBatch = batchRunner().transfer(batch());
+    final secondBatch = batchRunner().transfer(batch());
+
+    await Future<void>.delayed(Duration.zero);
+    expect(inFlight, 3);
+
+    for (var released = 0; released < 8; released++) {
+      final pending = blockers.where((blocker) => !blocker.isCompleted).toList();
+      expect(pending, isNotEmpty);
+      pending.first.complete();
+      await Future<void>.delayed(Duration.zero);
+      expect(inFlight, lessThanOrEqualTo(3));
+    }
+    await Future.wait([firstBatch, secondBatch]);
+
+    expect(maxInFlight, 3);
+    expect(blockers, hasLength(8));
+  });
+}

--- a/test/features/upload/domain/usecases/upload_drive_document_from_url_interactor_test.dart
+++ b/test/features/upload/domain/usecases/upload_drive_document_from_url_interactor_test.dart
@@ -1,4 +1,3 @@
-import 'package:dartz/dartz.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
@@ -37,48 +36,34 @@ void main() {
       interactor = UploadDriveDocumentFromUrlInteractor(uploadFromUrlRepository);
     });
 
-    test('should yield Right(UploadDriveDocumentFromUrlSuccess) with the repository\'s Attachment', () async {
+    test('should return Right(UploadDriveDocumentFromUrlSuccess) with the repository\'s Attachment', () async {
       final attachment = Attachment(blobId: Id('blob-id-123'), name: documentName);
       when(uploadFromUrlRepository.uploadFromUrl(request))
           .thenAnswer((_) async => attachment);
 
-      final stream = interactor.execute(request);
+      final result = await interactor.execute(request);
 
-      await expectLater(
-        stream,
-        emitsInOrder([
-          predicate<Either>((either) =>
-              either.isRight() &&
-              either.fold((l) => null, (r) => r) is UploadDriveDocumentFromUrlSuccess &&
-              (either.fold((l) => null, (r) => r) as UploadDriveDocumentFromUrlSuccess)
-                      .attachment ==
-                  attachment),
-          emitsDone,
-        ]),
-      );
+      expect(result.isRight(), isTrue);
+      final success = result.fold((l) => null, (r) => r);
+      expect(success, isA<UploadDriveDocumentFromUrlSuccess>());
+      expect((success as UploadDriveDocumentFromUrlSuccess).attachment, attachment);
     });
 
-    test('should yield Left(UploadDriveDocumentFromUrlFailure) when the repository throws', () async {
+    test('should return Left(UploadDriveDocumentFromUrlFailure) when the repository throws', () async {
       final exception = Exception('upload-from-url failed');
       when(uploadFromUrlRepository.uploadFromUrl(request)).thenThrow(exception);
 
-      final stream = interactor.execute(request);
+      final result = await interactor.execute(request);
 
-      await expectLater(
-        stream,
-        emitsInOrder([
-          predicate<Either>((either) => either.fold(
-            (failure) =>
-                failure is UploadDriveDocumentFromUrlFailure &&
-                identical(failure.exception, exception),
-            (_) => false,
-          )),
-          emitsDone,
-        ]),
+      final failure = result.fold((l) => l, (r) => r);
+      expect(failure, isA<UploadDriveDocumentFromUrlFailure>());
+      expect(
+        identical((failure as UploadDriveDocumentFromUrlFailure).exception, exception),
+        isTrue,
       );
     });
 
-    test('should yield Cancelled, not Failure, when the cancelToken was cancelled', () async {
+    test('should return Cancelled, not Failure, when the cancelToken was cancelled', () async {
       final cancelToken = CancelToken();
       final cancellableRequest = UploadFromUrlRequest(
         accountId: AccountFixtures.aliceAccountId,
@@ -96,13 +81,11 @@ void main() {
           reason: null);
       });
 
-      await expectLater(
-        interactor.execute(cancellableRequest),
-        emitsInOrder([
-          predicate<Either>((either) =>
-              either.fold((l) => l, (r) => r) is UploadDriveDocumentFromUrlCancelled),
-          emitsDone,
-        ]),
+      final result = await interactor.execute(cancellableRequest);
+
+      expect(
+        result.fold((l) => l, (r) => r),
+        isA<UploadDriveDocumentFromUrlCancelled>(),
       );
     });
   });

--- a/test/features/upload/presentation/controller/upload_controller_drive_transfer_test.dart
+++ b/test/features/upload/presentation/controller/upload_controller_drive_transfer_test.dart
@@ -179,4 +179,49 @@ void main() {
       expect(controller.listUploadAttachments, isEmpty);
     });
   });
+
+  group('UploadController::refreshAllAttachments::', () {
+    test('Should keep a waiting drive chip that the server response cannot rebuild', () {
+      final cancelToken = CancelToken();
+      controller.addDownloadingPlaceholders([
+        DriveTransferPlaceholder(
+          taskId: taskId,
+          fileName: 'file.pdf',
+          fileSize: 100,
+          mimeType: 'application/pdf',
+          cancelToken: cancelToken,
+        ),
+      ]);
+      final savedAttachment = Attachment(blobId: Id('blob-1'), size: UnsignedInt(100));
+
+      // Draft saved while the transfer is still running.
+      controller.refreshAllAttachments([savedAttachment], []);
+
+      expect(controller.listUploadAttachments, hasLength(2));
+      final waitingState = controller.getUploadFileId(taskId);
+      expect(waitingState?.uploadStatus, UploadFileStatus.waiting);
+      expect(waitingState?.cancelToken, same(cancelToken));
+      expect(cancelToken.isCancelled, isFalse);
+    });
+
+    test('Should still resolve a chip that survived the refresh', () {
+      controller.addDownloadingPlaceholders([placeholder()]);
+      controller.refreshAllAttachments([], []);
+
+      final attachment = Attachment(blobId: Id('blob-2'), size: UnsignedInt(100));
+      controller.resolveDriveTransferSuccess(taskId, attachment);
+
+      expect(controller.getUploadFileId(taskId)?.uploadStatus, UploadFileStatus.succeed);
+      expect(controller.attachmentsUploaded, contains(attachment));
+    });
+
+    test('Should not duplicate an already completed attachment', () {
+      final attachment = Attachment(blobId: Id('blob-3'), size: UnsignedInt(100));
+      controller.initializeUploadAttachments([attachment]);
+
+      controller.refreshAllAttachments([attachment], []);
+
+      expect(controller.listUploadAttachments, hasLength(1));
+    });
+  });
 }

--- a/test/features/upload/presentation/controller/upload_controller_drive_transfer_test.dart
+++ b/test/features/upload/presentation/controller/upload_controller_drive_transfer_test.dart
@@ -1,0 +1,182 @@
+import 'package:core/data/network/config/dynamic_url_interceptors.dart';
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/app_toast.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
+import 'package:mockito/annotations.dart';
+import 'package:model/email/attachment.dart';
+import 'package:tmail_ui_user/features/caching/caching_manager.dart';
+import 'package:tmail_ui_user/features/composer/domain/repository/composer_repository.dart';
+import 'package:tmail_ui_user/features/composer/domain/usecases/upload_attachment_interactor.dart';
+import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oidc_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
+import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
+import 'package:tmail_ui_user/features/upload/presentation/controller/upload_controller.dart';
+import 'package:tmail_ui_user/features/upload/presentation/model/drive_transfer_placeholder.dart';
+import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_status.dart';
+import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
+import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
+import 'package:uuid/uuid.dart';
+
+import 'upload_controller_drive_transfer_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<CachingManager>(),
+  MockSpec<LanguageCacheManager>(),
+  MockSpec<AuthorizationInterceptors>(),
+  MockSpec<DynamicUrlInterceptors>(),
+  MockSpec<DeleteCredentialInteractor>(),
+  MockSpec<LogoutOidcInteractor>(),
+  MockSpec<DeleteAuthorityOidcInteractor>(),
+  MockSpec<AppToast>(),
+  MockSpec<ImagePaths>(),
+  MockSpec<ResponsiveUtils>(),
+  MockSpec<Uuid>(),
+  MockSpec<ToastManager>(),
+  MockSpec<TwakeAppManager>(),
+  MockSpec<ComposerRepository>(),
+])
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late UploadController controller;
+  const taskId = UploadTaskId('drive-task-1');
+
+  setUp(() {
+    Get.testMode = true;
+    Get.put<CachingManager>(MockCachingManager());
+    Get.put<LanguageCacheManager>(MockLanguageCacheManager());
+    Get.put<AuthorizationInterceptors>(MockAuthorizationInterceptors());
+    Get.put<AuthorizationInterceptors>(
+      MockAuthorizationInterceptors(),
+      tag: BindingTag.isolateTag,
+    );
+    Get.put<DynamicUrlInterceptors>(MockDynamicUrlInterceptors());
+    Get.put<DeleteCredentialInteractor>(MockDeleteCredentialInteractor());
+    Get.put<LogoutOidcInteractor>(MockLogoutOidcInteractor());
+    Get.put<DeleteAuthorityOidcInteractor>(MockDeleteAuthorityOidcInteractor());
+    Get.put<AppToast>(MockAppToast());
+    Get.put<ImagePaths>(MockImagePaths());
+    Get.put<ResponsiveUtils>(MockResponsiveUtils());
+    Get.put<Uuid>(MockUuid());
+    Get.put<ToastManager>(MockToastManager());
+    Get.put<TwakeAppManager>(MockTwakeAppManager());
+
+    controller = UploadController(UploadAttachmentInteractor(MockComposerRepository()));
+  });
+
+  tearDown(() => Get.reset());
+
+  DriveTransferPlaceholder placeholder({UploadTaskId id = taskId}) => DriveTransferPlaceholder(
+        taskId: id,
+        fileName: 'file.pdf',
+        fileSize: 100,
+        mimeType: 'application/pdf',
+      );
+
+  group('UploadController::addDownloadingPlaceholders::', () {
+    test('Should add a waiting chip per placeholder', () {
+      controller.addDownloadingPlaceholders([placeholder()]);
+
+      expect(controller.listUploadAttachments, hasLength(1));
+      expect(controller.listUploadAttachments.single.uploadStatus, UploadFileStatus.waiting);
+      expect(controller.listUploadAttachments.single.uploadTaskId, taskId);
+    });
+
+    test('Should no-op on an empty list', () {
+      controller.addDownloadingPlaceholders([]);
+
+      expect(controller.listUploadAttachments, isEmpty);
+    });
+  });
+
+  group('UploadController::resolveDriveTransferSuccess::', () {
+    test('Should flip the matching chip to succeed with its attachment', () {
+      controller.addDownloadingPlaceholders([placeholder()]);
+      final attachment = Attachment(blobId: Id('blob-1'), size: UnsignedInt(100));
+
+      controller.resolveDriveTransferSuccess(taskId, attachment);
+
+      final state = controller.listUploadAttachments.single;
+      expect(state.uploadStatus, UploadFileStatus.succeed);
+      expect(state.attachment, attachment);
+    });
+  });
+
+  group('UploadController::resolveDriveTransferSuccess after deletion::', () {
+    test('Should not restore a chip whose attachment was already deleted', () {
+      controller.addDownloadingPlaceholders([placeholder()]);
+      controller.deleteFileUploaded(taskId);
+
+      // Transfer completed after the user removed the waiting chip.
+      controller.resolveDriveTransferSuccess(
+        taskId,
+        Attachment(blobId: Id('blob-1'), size: UnsignedInt(100)),
+      );
+
+      expect(controller.listUploadAttachments, isEmpty);
+      expect(controller.attachmentsUploaded, isEmpty);
+    });
+  });
+
+  group('UploadController::resolveDriveTransferFailure::', () {
+    test('Should remove the matching chip, matching the plain-upload failure path', () {
+      controller.addDownloadingPlaceholders([placeholder()]);
+
+      controller.resolveDriveTransferFailure(taskId);
+
+      expect(controller.listUploadAttachments, isEmpty);
+    });
+  });
+
+  group('UploadController::addDownloadingPlaceholders + resolve ordering::', () {
+    test('Should place all placeholders before any resolution', () {
+      const secondTaskId = UploadTaskId('drive-task-2');
+      controller.addDownloadingPlaceholders([
+        placeholder(),
+        placeholder(id: secondTaskId),
+      ]);
+
+      expect(controller.listUploadAttachments, hasLength(2));
+      expect(
+        controller.listUploadAttachments.map((s) => s.uploadStatus),
+        everyElement(UploadFileStatus.waiting),
+      );
+
+      controller.resolveDriveTransferSuccess(
+        taskId,
+        Attachment(blobId: Id('blob-1'), size: UnsignedInt(100)),
+      );
+
+      expect(controller.listUploadAttachments, hasLength(2));
+    });
+  });
+
+  group('UploadController::onClose::', () {
+    test('Should cancel every pending drive-transfer token before clearing', () {
+      final cancelToken = CancelToken();
+      controller.addDownloadingPlaceholders([
+        DriveTransferPlaceholder(
+          taskId: taskId,
+          fileName: 'file.pdf',
+          fileSize: 100,
+          mimeType: 'application/pdf',
+          cancelToken: cancelToken,
+        ),
+      ]);
+
+      controller.onClose();
+
+      expect(cancelToken.isCancelled, isTrue);
+      expect(controller.listUploadAttachments, isEmpty);
+    });
+  });
+}

--- a/test/features/upload/presentation/model/upload_file_state_list_test.dart
+++ b/test/features/upload/presentation/model/upload_file_state_list_test.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
 import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_state.dart';
@@ -46,6 +47,123 @@ void main() {
           () => list.deleteElementByUploadTaskId(const UploadTaskId('any')),
           returnsNormally,
         );
+      });
+    });
+
+    group('by-id lookup index', () {
+      test('finds every entry after an earlier one is deleted', () {
+        const a = UploadTaskId('a');
+        const b = UploadTaskId('b');
+        const c = UploadTaskId('c');
+        final list = makeList([a, b, c]);
+
+        list.deleteElementByUploadTaskId(a);
+
+        expect(list.getUploadFileStateById(a), isNull);
+        expect(list.getUploadFileStateById(b)?.uploadTaskId, b);
+        expect(list.getUploadFileStateById(c)?.uploadTaskId, c);
+      });
+
+      test('updates the right entry after a delete shifts the indices', () {
+        const a = UploadTaskId('a');
+        const b = UploadTaskId('b');
+        final list = makeList([a, b]);
+
+        list.deleteElementByUploadTaskId(a);
+        list.updateElementByUploadTaskId(
+          b,
+          (state) => state?.copyWith(uploadingProgress: 42),
+        );
+
+        expect(list.getUploadFileStateById(b)?.uploadingProgress, 42);
+      });
+
+      test('finds an entry added after a delete', () {
+        const a = UploadTaskId('a');
+        const b = UploadTaskId('b');
+        final list = makeList([a]);
+
+        list.deleteElementByUploadTaskId(a);
+        list.add(UploadFileState(b, uploadStatus: UploadFileStatus.waiting));
+
+        expect(list.getUploadFileStateById(b)?.uploadTaskId, b);
+      });
+
+      test('is empty again after clear', () {
+        const a = UploadTaskId('a');
+        final list = makeList([a]);
+
+        list.clear();
+
+        expect(list.getUploadFileStateById(a), isNull);
+      });
+
+      test('keeps resolving ids when a predicate update replaces an entry', () {
+        const a = UploadTaskId('a');
+        const b = UploadTaskId('b');
+        final list = makeList([a, b]);
+
+        list.updateElementBy(
+          (state) => state?.uploadTaskId == a,
+          (_) => UploadFileState(const UploadTaskId('renamed'), uploadStatus: UploadFileStatus.waiting),
+        );
+
+        expect(list.getUploadFileStateById(a), isNull);
+        expect(list.getUploadFileStateById(const UploadTaskId('renamed')), isNotNull);
+        expect(list.getUploadFileStateById(b)?.uploadTaskId, b);
+      });
+    });
+
+    group('updateElementByUploadTaskId', () {
+      test('is a no-op for an id no longer in the list', () {
+        const a = UploadTaskId('a');
+        final list = makeList([a]);
+        list.deleteElementByUploadTaskId(a);
+
+        list.updateElementByUploadTaskId(
+          a,
+          (state) => UploadFileState(a, uploadStatus: UploadFileStatus.succeed),
+        );
+
+        expect(list.uploadingStateFiles, isEmpty);
+      });
+    });
+
+    group('cancelAll', () {
+      test('cancels every pending token and empties the list', () {
+        final tokenA = CancelToken();
+        final tokenB = CancelToken();
+        final list = UploadFileStateList();
+        list.addAll([
+          UploadFileState(
+            const UploadTaskId('a'),
+            uploadStatus: UploadFileStatus.uploading,
+            cancelToken: tokenA,
+          ),
+          UploadFileState(
+            const UploadTaskId('b'),
+            uploadStatus: UploadFileStatus.uploading,
+            cancelToken: tokenB,
+          ),
+        ]);
+
+        list.cancelAll();
+
+        expect(tokenA.isCancelled, isTrue);
+        expect(tokenB.isCancelled, isTrue);
+        expect(list.uploadingStateFiles, isEmpty);
+      });
+
+      test('skips entries with no token without throwing', () {
+        final list = makeList([const UploadTaskId('no-token')]);
+
+        expect(() => list.cancelAll(), returnsNormally);
+        expect(list.uploadingStateFiles, isEmpty);
+      });
+
+      test('is a no-op on an empty list', () {
+        final list = UploadFileStateList();
+        expect(() => list.cancelAll(), returnsNormally);
       });
     });
   });

--- a/test/features/upload/upload_file_state_list_test.dart
+++ b/test/features/upload/upload_file_state_list_test.dart
@@ -158,6 +158,17 @@ void main() {
 
         expect(result, isNull);
       });
+
+      test('should return state added as a non-null value via addNullableForTest', () {
+        uploadFileStateList.addNullableForTest(UploadFileState(
+          const UploadTaskId('task-3'),
+          uploadStatus: UploadFileStatus.succeed,
+        ));
+
+        final result = uploadFileStateList.getUploadFileStateById(const UploadTaskId('task-3'));
+
+        expect(result?.uploadTaskId, const UploadTaskId('task-3'));
+      });
     });
   });
 }

--- a/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
+++ b/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
@@ -14,6 +14,7 @@ import 'package:workplace/domain/entity/workplace_intent.dart';
 import 'package:workplace/domain/entity/workplace_theme.dart';
 import 'package:workplace/domain/exceptions/workplace_exceptions.dart';
 import 'package:workplace/presentation/model/drive_pick_state.dart';
+import 'package:workplace/presentation/model/drive_picker_session.dart';
 import 'package:workplace/domain/state/workplace_intent_state.dart';
 import 'package:workplace/domain/usecase/create_drive_intent_interactor.dart';
 import 'package:workplace/domain/usecase/exchange_drive_token_interactor.dart';
@@ -25,8 +26,14 @@ typedef OnDrivePickStateChanged =
 
 class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
   final ValueListenable<Uri?> workplaceUri;
+
+  /// Read when the picker opens, so the JMAP capability is always current.
+  final ValueGetter<bool> uploadFromUrlSupported;
   final String? Function() oidcTokenGetter;
   final num? Function() maxAttachmentSizeBytesGetter;
+
+  /// Per-composer: the remainder depends on what that composer already holds.
+  final num? Function(String? composerId) remainingAttachmentCapacityBytesGetter;
   final OnDrivePickStateChanged? onPickState;
 
   late final _dataSource = WorkplaceDataSourceImpl();
@@ -38,8 +45,10 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
 
   WorkplaceComposerAttachmentExtension({
     required this.workplaceUri,
+    required this.uploadFromUrlSupported,
     required this.oidcTokenGetter,
     required this.maxAttachmentSizeBytesGetter,
+    required this.remainingAttachmentCapacityBytesGetter,
     this.onPickState,
   });
 
@@ -135,16 +144,11 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
         return DriveAttachmentPickerButton(
           composerId: composerId,
           imagePaths: imagePaths,
-          workplaceUri: uri,
           style: style,
+          session: _sessionFor(uri, composerId),
           onPickCallback: onPickState == null
               ? null
               : (state) => onPickState!(composerId, state),
-          onFetchIntent: ({required filePickerConfig}) => _fetchIntent(
-            uri,
-            filePickerConfig: filePickerConfig,
-          ),
-          maxAttachmentSizeBytesGetter: maxAttachmentSizeBytesGetter,
         );
       },
     );
@@ -161,17 +165,23 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
         if (uri == null) return const SizedBox.shrink();
         return DriveAttachmentContextMenuTile(
           imagePaths: imagePaths,
-          workplaceUri: uri,
+          session: _sessionFor(uri, null),
           onPickCallback: onPickState == null
               ? null
               : (state) => onPickState!(null, state),
-          onFetchIntent: ({required filePickerConfig}) => _fetchIntent(
-            uri,
-            filePickerConfig: filePickerConfig,
-          ),
-          maxAttachmentSizeBytesGetter: maxAttachmentSizeBytesGetter,
         );
       },
     );
   }
+
+  DrivePickerSession _sessionFor(Uri uri, String? composerId) => DrivePickerSession(
+        uploadFromUrlSupported: uploadFromUrlSupported,
+        maxAttachmentSizeBytesGetter: maxAttachmentSizeBytesGetter,
+        remainingAttachmentCapacityBytesGetter: () =>
+            remainingAttachmentCapacityBytesGetter(composerId),
+        onFetchIntent: ({required filePickerConfig}) => _fetchIntent(
+          uri,
+          filePickerConfig: filePickerConfig,
+        ),
+      );
 }

--- a/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
+++ b/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
@@ -22,7 +22,7 @@ import 'package:workplace/presentation/widget/drive_attachment_context_menu_tile
 import 'package:workplace/presentation/widget/drive_attachment_picker_button.dart';
 
 typedef OnDrivePickStateChanged =
-    void Function(String? composerId, DrivePickState state);
+    Future<void> Function(String? composerId, DrivePickState state);
 
 class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
   final ValueListenable<Uri?> workplaceUri;

--- a/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
+++ b/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
@@ -33,17 +33,33 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
   Future<void> onPickerTap() async {
     if (_modalOpen) return;
     _modalOpen = true;
+    final ({DrivePickOutcome? outcome, String? failingMessage}) pick;
+    try {
+      pick = await _openPicker();
+    } finally {
+      // Guard covers the modal only: the consumer callback can run long (uploads).
+      _modalOpen = false;
+    }
+    await _handleOutcome(pick.outcome, pick.failingMessage);
+  }
+
+  /// Runs the modal phase, never throwing: every failure comes back as an
+  /// outcome so the caller can release the guard before dispatching it.
+  Future<({DrivePickOutcome? outcome, String? failingMessage})>
+      _openPicker() async {
     // Kept outside the try so a failure after localization still toasts it.
     String? failingMessage;
     try {
       if (!mounted) {
-        // Message needs the disposed context, so dispatch without one and let
+        // Message needs the disposed context, so report without one and let
         // the toast fall back to its generic failure text.
         logError('DrivePickerStateMixin::onPickerTap: state disposed before opening modal');
-        await _dispatch(
-          DrivePickFailure(StateError('drive picker state disposed before modal')),
+        return (
+          outcome: DrivePickOutcomeFailed(
+            StateError('drive picker state disposed before modal'),
+          ),
+          failingMessage: null,
         );
-        return;
       }
       final l10n = AppLocalizations.of(context)!;
       // Captured up front: the caller may pop this context (e.g. a context
@@ -67,18 +83,22 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
               ),
         theme: WorkplaceThemeConfigRequest.fromEntity(theme),
       );
-      DrivePickOutcome? outcome;
       try {
-        outcome = await openDrivePickerModal(filePickerConfig);
+        return (
+          outcome: await openDrivePickerModal(filePickerConfig),
+          failingMessage: failingMessage,
+        );
       } catch (e, s) {
         logError(
           'DrivePickerStateMixin::onPickerTap: modal failed',
           exception: e,
           stackTrace: s,
         );
-        outcome = DrivePickOutcomeFailed(e);
+        return (
+          outcome: DrivePickOutcomeFailed(e),
+          failingMessage: failingMessage,
+        );
       }
-      await _handleOutcome(outcome, failingMessage);
     } catch (e, s) {
       // Configuring the picker runs outside the modal's error boundary, so a
       // throw here would leave the tap silently doing nothing.
@@ -87,9 +107,10 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
         exception: e,
         stackTrace: s,
       );
-      await _dispatch(DrivePickFailure(e, message: failingMessage));
-    } finally {
-      _modalOpen = false;
+      return (
+        outcome: DrivePickOutcomeFailed(e),
+        failingMessage: failingMessage,
+      );
     }
   }
 

--- a/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
+++ b/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
@@ -10,7 +10,7 @@ import 'package:workplace/presentation/model/drive_pick_state.dart';
 import 'package:workplace/presentation/model/drive_picker_session.dart';
 import 'package:workplace/presentation/view/drive_intent_web_view_modal.dart';
 
-typedef OnPickDriveCallback = void Function(DrivePickState state);
+typedef OnPickDriveCallback = Future<void> Function(DrivePickState state);
 
 typedef FetchDriveIntentCallback =
     Future<WorkplaceIntent> Function({
@@ -38,7 +38,7 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
         // Message needs the disposed context, so dispatch without one and let
         // the toast fall back to its generic failure text.
         logError('DrivePickerStateMixin::onPickerTap: state disposed before opening modal');
-        pickerOnCallback?.call(
+        await _dispatch(
           DrivePickFailure(StateError('drive picker state disposed before modal')),
         );
         return;
@@ -76,7 +76,7 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
         );
         outcome = DrivePickOutcomeFailed(e);
       }
-      _handleOutcome(outcome, failingMessage);
+      await _handleOutcome(outcome, failingMessage);
     } finally {
       _modalOpen = false;
     }
@@ -104,17 +104,34 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
     );
   }
 
-  void _handleOutcome(DrivePickOutcome? outcome, String? failingMessage) {
+  Future<void> _handleOutcome(
+    DrivePickOutcome? outcome,
+    String? failingMessage,
+  ) async {
     switch (outcome) {
       case DrivePickOutcomePicked(:final documents):
-        pickerOnCallback?.call(DrivePickResult(documents));
+        await _dispatch(DrivePickResult(documents));
       case DrivePickOutcomeFailed(:final error):
         // Already reported to Sentry at the failing stage (modal mixin or the
         // catch above) — only dispatch the UI failure callback here.
-        pickerOnCallback?.call(DrivePickFailure(error, message: failingMessage));
+        await _dispatch(DrivePickFailure(error, message: failingMessage));
       case DrivePickOutcomeCancelled():
       case null:
         break;
+    }
+  }
+
+  /// Awaited so a throw in the consumer's handler is caught here instead of
+  /// escaping as an unhandled zone error.
+  Future<void> _dispatch(DrivePickState state) async {
+    try {
+      await pickerOnCallback?.call(state);
+    } catch (e, s) {
+      logError(
+        'DrivePickerStateMixin::_dispatch: pick callback failed',
+        exception: e,
+        stackTrace: s,
+      );
     }
   }
 

--- a/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
+++ b/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
@@ -33,6 +33,8 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
   Future<void> onPickerTap() async {
     if (_modalOpen) return;
     _modalOpen = true;
+    // Kept outside the try so a failure after localization still toasts it.
+    String? failingMessage;
     try {
       if (!mounted) {
         // Message needs the disposed context, so dispatch without one and let
@@ -46,8 +48,8 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
       final l10n = AppLocalizations.of(context)!;
       // Captured up front: the caller may pop this context (e.g. a context
       // menu tile) before the intent future settles, disposing this state.
+      failingMessage = l10n.attachFromDriveFailingMessage;
       final snapshot = DrivePickerSessionResolver(session).resolve();
-      final failingMessage = l10n.attachFromDriveFailingMessage;
       final addAsAttachmentTitle =
           snapshot.uploadFromUrlSupported ? l10n.addAsAttachment : null;
       final theme = _resolveWorkplaceTheme(context);
@@ -77,6 +79,15 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
         outcome = DrivePickOutcomeFailed(e);
       }
       await _handleOutcome(outcome, failingMessage);
+    } catch (e, s) {
+      // Configuring the picker runs outside the modal's error boundary, so a
+      // throw here would leave the tap silently doing nothing.
+      logError(
+        'DrivePickerStateMixin::onPickerTap: picker configuration failed',
+        exception: e,
+        stackTrace: s,
+      );
+      await _dispatch(DrivePickFailure(e, message: failingMessage));
     } finally {
       _modalOpen = false;
     }

--- a/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
+++ b/workplace/lib/presentation/mixin/drive_picker_state_mixin.dart
@@ -7,6 +7,7 @@ import 'package:workplace/l10n/workplace_localizations.dart';
 import 'package:workplace/presentation/model/drive_intent_image_assets.dart';
 import 'package:workplace/presentation/model/drive_pick_outcome.dart';
 import 'package:workplace/presentation/model/drive_pick_state.dart';
+import 'package:workplace/presentation/model/drive_picker_session.dart';
 import 'package:workplace/presentation/view/drive_intent_web_view_modal.dart';
 
 typedef OnPickDriveCallback = void Function(DrivePickState state);
@@ -21,11 +22,9 @@ typedef FetchDriveIntentCallback =
 /// Consumers must provide [pickerFetchIntent] and [pickerOnCallback], then
 /// call [onPickerTap] from their tap handler.
 mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
-  FetchDriveIntentCallback get pickerFetchIntent;
+  DrivePickerSession get session;
 
   DriveIntentImageAssets get driveIntentImageAssets;
-
-  num? get maxAttachmentSizeBytes;
 
   OnPickDriveCallback? get pickerOnCallback => null;
 
@@ -36,15 +35,21 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
     _modalOpen = true;
     try {
       if (!mounted) {
-        // Tap raced state disposal — nothing to show a modal or toast on.
+        // Message needs the disposed context, so dispatch without one and let
+        // the toast fall back to its generic failure text.
         logError('DrivePickerStateMixin::onPickerTap: state disposed before opening modal');
+        pickerOnCallback?.call(
+          DrivePickFailure(StateError('drive picker state disposed before modal')),
+        );
         return;
       }
       final l10n = AppLocalizations.of(context)!;
       // Captured up front: the caller may pop this context (e.g. a context
       // menu tile) before the intent future settles, disposing this state.
+      final snapshot = DrivePickerSessionResolver(session).resolve();
       final failingMessage = l10n.attachFromDriveFailingMessage;
-      const addAsAttachmentTitle = null; // TODO: Add attachment title here after implement 103. Attach Drive File as Attachment
+      final addAsAttachmentTitle =
+          snapshot.uploadFromUrlSupported ? l10n.addAsAttachment : null;
       final theme = _resolveWorkplaceTheme(context);
       final filePickerConfig = WorkplaceFilePickerConfigRequest(
         sharingLink: WorkplaceActionConfigRequest(label: l10n.addAsLink),
@@ -52,8 +57,11 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
             ? null
             : WorkplaceActionConfigRequest(
                 label: addAsAttachmentTitle,
-                maxFileSize: maxAttachmentSizeBytes,
-                availableSize: maxAttachmentSizeBytes,
+                maxFileSize: snapshot.maxAttachmentSizeBytes,
+                // What is left after the composer's existing attachments, so
+                // the picker can't offer bytes the send guard would reject.
+                availableSize: snapshot.remainingAttachmentCapacityBytes ??
+                    snapshot.maxAttachmentSizeBytes,
               ),
         theme: WorkplaceThemeConfigRequest.fromEntity(theme),
       );
@@ -87,7 +95,7 @@ mixin DrivePickerStateMixin<T extends StatefulWidget> on State<T> {
       builder: (_) => DriveIntentWebViewModal(
         // Must stay lazy so the modal subscribes to failures before the
         // token exchange or intent request starts.
-        intentLoader: () => pickerFetchIntent(
+        intentLoader: () => session.onFetchIntent(
           filePickerConfig: filePickerConfig,
         ),
         filePickerConfig: filePickerConfig,

--- a/workplace/lib/presentation/model/drive_pick_state.dart
+++ b/workplace/lib/presentation/model/drive_pick_state.dart
@@ -28,3 +28,11 @@ final class DrivePickFailure extends DrivePickState implements FeatureFailure {
   @override
   Stream<Either<Failure, Success>>? get onRetry => null;
 }
+
+final class DrivePickSuccess extends DrivePickState implements Success {
+  final String? message;
+  DrivePickSuccess({this.message});
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/workplace/lib/presentation/model/drive_picker_session.dart
+++ b/workplace/lib/presentation/model/drive_picker_session.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/foundation.dart';
+import 'package:workplace/presentation/mixin/drive_picker_state_mixin.dart';
+
+/// Bundles the inputs [DriveAttachmentPickerButton] and
+/// [DriveAttachmentContextMenuTile] both need to open the Drive picker, so
+/// callers thread one object instead of duplicating four constructor params.
+class DrivePickerSession {
+  final ValueGetter<bool> uploadFromUrlSupported;
+  final num? Function() maxAttachmentSizeBytesGetter;
+
+  /// Bytes still attachable once what the composer already holds is deducted.
+  final num? Function() remainingAttachmentCapacityBytesGetter;
+  final FetchDriveIntentCallback onFetchIntent;
+
+  const DrivePickerSession({
+    required this.uploadFromUrlSupported,
+    required this.maxAttachmentSizeBytesGetter,
+    required this.remainingAttachmentCapacityBytesGetter,
+    required this.onFetchIntent,
+  });
+}
+
+/// Snapshot of the capability-gated values a picker tap needs, read once at
+/// tap time rather than through separate getter calls scattered in the mixin.
+class DrivePickerSessionSnapshot {
+  final bool uploadFromUrlSupported;
+  final num? maxAttachmentSizeBytes;
+  final num? remainingAttachmentCapacityBytes;
+
+  const DrivePickerSessionSnapshot({
+    required this.uploadFromUrlSupported,
+    required this.maxAttachmentSizeBytes,
+    required this.remainingAttachmentCapacityBytes,
+  });
+}
+
+/// Resolves a [DrivePickerSession]'s getters on demand, at the point the
+/// picker actually needs them.
+class DrivePickerSessionResolver {
+  final DrivePickerSession session;
+
+  const DrivePickerSessionResolver(this.session);
+
+  DrivePickerSessionSnapshot resolve() => DrivePickerSessionSnapshot(
+        uploadFromUrlSupported: session.uploadFromUrlSupported(),
+        maxAttachmentSizeBytes: session.maxAttachmentSizeBytesGetter(),
+        remainingAttachmentCapacityBytes:
+            session.remainingAttachmentCapacityBytesGetter(),
+      );
+}

--- a/workplace/lib/presentation/view/drive_intent_web_view_modal_shell.dart
+++ b/workplace/lib/presentation/view/drive_intent_web_view_modal_shell.dart
@@ -53,6 +53,7 @@ class DriveIntentWebViewModalShell extends StatelessWidget {
         shape: shape,
         constraints: constraints,
         alignment: alignment,
+        clipBehavior: Clip.antiAlias,
         child: GestureDetector(
           onTap: () {},
           behavior: HitTestBehavior.opaque,

--- a/workplace/lib/presentation/view/drive_intent_web_view_modal_web.dart
+++ b/workplace/lib/presentation/view/drive_intent_web_view_modal_web.dart
@@ -122,6 +122,7 @@ class _DriveIntentWebViewModalState extends State<DriveIntentWebViewModal>
           : null,
       child: HtmlIframeWidget(
         key: const ValueKey('drive-intent-webview'),
+        borderRadius: 6,
         onIframeCreated: (iframe) {
           final viewRecreated = _iframeElement != null &&
               !identical(_iframeElement, iframe);

--- a/workplace/lib/presentation/widget/drive_attachment_context_menu_tile.dart
+++ b/workplace/lib/presentation/widget/drive_attachment_context_menu_tile.dart
@@ -6,20 +6,17 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:workplace/l10n/workplace_localizations.dart';
 import 'package:workplace/presentation/mixin/drive_picker_state_mixin.dart';
 import 'package:workplace/presentation/model/drive_intent_image_assets.dart';
+import 'package:workplace/presentation/model/drive_picker_session.dart';
 
 class DriveAttachmentContextMenuTile extends StatefulWidget {
   final ImagePaths imagePaths;
-  final Uri workplaceUri;
+  final DrivePickerSession session;
   final OnPickDriveCallback? onPickCallback;
-  final FetchDriveIntentCallback onFetchIntent;
-  final num? Function() maxAttachmentSizeBytesGetter;
 
   const DriveAttachmentContextMenuTile({
     super.key,
     required this.imagePaths,
-    required this.workplaceUri,
-    required this.onFetchIntent,
-    required this.maxAttachmentSizeBytesGetter,
+    required this.session,
     this.onPickCallback,
   });
 
@@ -32,13 +29,10 @@ class _DriveAttachmentContextMenuTileState
     extends State<DriveAttachmentContextMenuTile>
     with DrivePickerStateMixin<DriveAttachmentContextMenuTile> {
   @override
-  FetchDriveIntentCallback get pickerFetchIntent => widget.onFetchIntent;
+  DrivePickerSession get session => widget.session;
 
   @override
   OnPickDriveCallback? get pickerOnCallback => widget.onPickCallback;
-
-  @override
-  num? get maxAttachmentSizeBytes => widget.maxAttachmentSizeBytesGetter();
 
   @override
   DriveIntentImageAssets get driveIntentImageAssets => DriveIntentImageAssets(

--- a/workplace/lib/presentation/widget/drive_attachment_picker_button.dart
+++ b/workplace/lib/presentation/widget/drive_attachment_picker_button.dart
@@ -4,23 +4,20 @@ import 'package:core/presentation/views/button/tmail_button_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:workplace/presentation/mixin/drive_picker_state_mixin.dart';
 import 'package:workplace/presentation/model/drive_intent_image_assets.dart';
+import 'package:workplace/presentation/model/drive_picker_session.dart';
 
 class DriveAttachmentPickerButton extends StatefulWidget {
   final String composerId;
   final ImagePaths imagePaths;
-  final Uri workplaceUri;
   final ComposerToolbarButtonStyle style;
+  final DrivePickerSession session;
   final OnPickDriveCallback? onPickCallback;
-  final FetchDriveIntentCallback onFetchIntent;
-  final num? Function() maxAttachmentSizeBytesGetter;
 
   const DriveAttachmentPickerButton({
     super.key,
     required this.composerId,
     required this.imagePaths,
-    required this.workplaceUri,
-    required this.onFetchIntent,
-    required this.maxAttachmentSizeBytesGetter,
+    required this.session,
     this.style = const ComposerToolbarButtonStyle(),
     this.onPickCallback,
   });
@@ -34,13 +31,10 @@ class _DriveAttachmentPickerButtonState
     extends State<DriveAttachmentPickerButton>
     with DrivePickerStateMixin<DriveAttachmentPickerButton> {
   @override
-  FetchDriveIntentCallback get pickerFetchIntent => widget.onFetchIntent;
+  DrivePickerSession get session => widget.session;
 
   @override
   OnPickDriveCallback? get pickerOnCallback => widget.onPickCallback;
-
-  @override
-  num? get maxAttachmentSizeBytes => widget.maxAttachmentSizeBytesGetter();
 
   @override
   DriveIntentImageAssets get driveIntentImageAssets => DriveIntentImageAssets(

--- a/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
+++ b/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
@@ -124,12 +124,16 @@ WorkplaceComposerAttachmentExtension _makeExtension(
   ValueListenable<Uri?> notifier, {
   String? oidcToken = 'oidc-token',
   num? maxAttachmentSizeBytes,
+  num? remainingAttachmentCapacityBytes,
   OnDrivePickStateChanged? onPickState,
+  ValueGetter<bool>? uploadFromUrlSupported,
 }) =>
     WorkplaceComposerAttachmentExtension(
       workplaceUri: notifier,
+      uploadFromUrlSupported: uploadFromUrlSupported ?? () => true,
       oidcTokenGetter: () => oidcToken,
       maxAttachmentSizeBytesGetter: () => maxAttachmentSizeBytes,
+      remainingAttachmentCapacityBytesGetter: (_) => remainingAttachmentCapacityBytes,
       onPickState: onPickState,
     );
 
@@ -442,6 +446,7 @@ void main() {
           .widget<DriveAttachmentPickerButton>(
             find.byType(DriveAttachmentPickerButton),
           )
+          .session
           .onFetchIntent;
     }
 

--- a/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
+++ b/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
@@ -246,7 +246,7 @@ void main() {
 
       final ext = _makeExtension(
         notifier,
-        onPickState: (id, state) {
+        onPickState: (id, state) async {
           receivedId = id;
           receivedState = state;
         },
@@ -388,7 +388,7 @@ void main() {
 
       final ext = _makeExtension(
         notifier,
-        onPickState: (id, state) {
+        onPickState: (id, state) async {
           receivedId = id;
           receivedState = state;
         },

--- a/workplace/test/presentation/mixin/drive_picker_state_mixin_test.dart
+++ b/workplace/test/presentation/mixin/drive_picker_state_mixin_test.dart
@@ -31,13 +31,17 @@ class _TestState extends State<_TestWidget>
   num? maxAttachmentSizeBytesStub;
   num? remainingAttachmentCapacityBytesStub;
   bool uploadFromUrlSupportedOverride = true;
+  bool sessionResolveThrows = false;
   bool pickCallbackThrows = false;
   Completer<void>? pickCallbackBlocker;
 
   @override
   DrivePickerSession get session => DrivePickerSession(
         uploadFromUrlSupported: () => uploadFromUrlSupportedOverride,
-        maxAttachmentSizeBytesGetter: () => maxAttachmentSizeBytesStub,
+        maxAttachmentSizeBytesGetter: () {
+          if (sessionResolveThrows) throw StateError('capability read blew up');
+          return maxAttachmentSizeBytesStub;
+        },
         remainingAttachmentCapacityBytesGetter: () =>
             remainingAttachmentCapacityBytesStub,
         onFetchIntent: ({required filePickerConfig}) async => WorkplaceIntent(
@@ -343,6 +347,34 @@ void main() {
         expect(state.pickStates, hasLength(1));
         final failure = state.pickStates.single as DrivePickFailure;
         expect(failure.message, isNotNull);
+      });
+    });
+
+    group('configuration failures', () {
+      testWidgets('resolver throw → failure callback, no modal, no unhandled error', (tester) async {
+        final state = await _pumpPicker(tester);
+        state.sessionResolveThrows = true;
+
+        await state.onPickerTap();
+
+        expect(state.openCalls, isEmpty);
+        final failure = state.pickStates.single as DrivePickFailure;
+        expect(failure.message, isNotNull, reason: 'localized before the throw');
+        expect(tester.takeException(), isNull);
+      });
+
+      testWidgets('tap allowed again after a configuration failure', (tester) async {
+        final state = await _pumpPicker(tester);
+        state.sessionResolveThrows = true;
+        await state.onPickerTap();
+
+        state.sessionResolveThrows = false;
+        state.modalStub = () => Future.value(DrivePickOutcomePicked([_doc()]));
+        await state.onPickerTap();
+
+        expect(state.openCalls, hasLength(1));
+        expect(state.pickStates.last, isA<DrivePickResult>());
+        expect(tester.takeException(), isNull);
       });
     });
   });

--- a/workplace/test/presentation/mixin/drive_picker_state_mixin_test.dart
+++ b/workplace/test/presentation/mixin/drive_picker_state_mixin_test.dart
@@ -11,6 +11,7 @@ import 'package:workplace/presentation/mixin/drive_picker_state_mixin.dart';
 import 'package:workplace/presentation/model/drive_intent_image_assets.dart';
 import 'package:workplace/presentation/model/drive_pick_outcome.dart';
 import 'package:workplace/presentation/model/drive_pick_state.dart';
+import 'package:workplace/presentation/model/drive_picker_session.dart';
 
 typedef _ModalStub = Future<DrivePickOutcome?> Function();
 
@@ -28,13 +29,20 @@ class _TestState extends State<_TestWidget>
   final List<WorkplaceFilePickerConfigRequest> openCalls = [];
   _ModalStub modalStub = () => Future.value();
   num? maxAttachmentSizeBytesStub;
+  num? remainingAttachmentCapacityBytesStub;
+  bool uploadFromUrlSupportedOverride = true;
 
   @override
-  FetchDriveIntentCallback get pickerFetchIntent =>
-      ({required filePickerConfig}) async => WorkplaceIntent(
-            intentId: 'intent-1',
-            intentUrl: Uri.parse('https://drive.example.com/pick'),
-          );
+  DrivePickerSession get session => DrivePickerSession(
+        uploadFromUrlSupported: () => uploadFromUrlSupportedOverride,
+        maxAttachmentSizeBytesGetter: () => maxAttachmentSizeBytesStub,
+        remainingAttachmentCapacityBytesGetter: () =>
+            remainingAttachmentCapacityBytesStub,
+        onFetchIntent: ({required filePickerConfig}) async => WorkplaceIntent(
+          intentId: 'intent-1',
+          intentUrl: Uri.parse('https://drive.example.com/pick'),
+        ),
+      );
 
   @override
   OnPickDriveCallback? get pickerOnCallback => pickStates.add;
@@ -42,9 +50,6 @@ class _TestState extends State<_TestWidget>
   @override
   DriveIntentImageAssets get driveIntentImageAssets =>
       const DriveIntentImageAssets(driveLogo: '', closeIcon: '', searchIcon: '');
-
-  @override
-  num? get maxAttachmentSizeBytes => maxAttachmentSizeBytesStub;
 
   @override
   Future<DrivePickOutcome?> openDrivePickerModal(
@@ -138,14 +143,61 @@ void main() {
         final state = await _pumpPicker(tester);
         state.maxAttachmentSizeBytesStub = 5000;
 
-        expect(state.maxAttachmentSizeBytes, equals(5000));
+        expect(state.session.maxAttachmentSizeBytesGetter(), equals(5000));
       });
 
       testWidgets('is null when the mixer override returns null', (tester) async {
         final state = await _pumpPicker(tester);
         state.maxAttachmentSizeBytesStub = null;
 
-        expect(state.maxAttachmentSizeBytes, isNull);
+        expect(state.session.maxAttachmentSizeBytesGetter(), isNull);
+      });
+    });
+
+    group('availableSize', () {
+      testWidgets('advertises the remaining capacity, not the full limit', (tester) async {
+        final state = await _pumpPicker(tester);
+        state.maxAttachmentSizeBytesStub = 100 * 1024 * 1024;
+        state.remainingAttachmentCapacityBytesStub = 20 * 1024 * 1024;
+
+        await state.onPickerTap();
+
+        final downloadLink = state.openCalls.single.downloadLink!;
+        expect(downloadLink.availableSize, equals(20 * 1024 * 1024));
+        expect(downloadLink.maxFileSize, equals(100 * 1024 * 1024));
+      });
+
+      testWidgets('falls back to the full limit when no remainder is known', (tester) async {
+        final state = await _pumpPicker(tester);
+        state.maxAttachmentSizeBytesStub = 100 * 1024 * 1024;
+        state.remainingAttachmentCapacityBytesStub = null;
+
+        await state.onPickerTap();
+
+        final downloadLink = state.openCalls.single.downloadLink!;
+        expect(downloadLink.availableSize, equals(100 * 1024 * 1024));
+      });
+    });
+
+    group('capability gating', () {
+      testWidgets('downloadLink is set when uploadFromUrlSupported is true', (tester) async {
+        final state = await _pumpPicker(tester);
+        state.uploadFromUrlSupportedOverride = true;
+        state.modalStub = () => Future.value(const DrivePickOutcomeCancelled());
+
+        await state.onPickerTap();
+
+        expect(state.openCalls.single.downloadLink, isNotNull);
+      });
+
+      testWidgets('downloadLink is null when uploadFromUrlSupported is false', (tester) async {
+        final state = await _pumpPicker(tester);
+        state.uploadFromUrlSupportedOverride = false;
+        state.modalStub = () => Future.value(const DrivePickOutcomeCancelled());
+
+        await state.onPickerTap();
+
+        expect(state.openCalls.single.downloadLink, isNull);
       });
     });
 
@@ -207,14 +259,16 @@ void main() {
         expect(state.openCalls, hasLength(2));
       });
 
-      testWidgets('tap after state disposed → no modal, no callback, no crash', (tester) async {
+      testWidgets('tap after state disposed → no modal, failure callback, no crash', (tester) async {
         final state = await _pumpPicker(tester);
         await tester.pumpWidget(const SizedBox.shrink());
 
         await state.onPickerTap();
 
         expect(state.openCalls, isEmpty);
-        expect(state.pickStates, isEmpty);
+        // Reported rather than dropped: the user tapped and must learn nothing opened.
+        final failure = state.pickStates.single as DrivePickFailure;
+        expect(failure.message, isNull, reason: 'no live context to localize with');
       });
 
       testWidgets('pick delivered even though the opener was disposed mid-flight', (tester) async {

--- a/workplace/test/presentation/mixin/drive_picker_state_mixin_test.dart
+++ b/workplace/test/presentation/mixin/drive_picker_state_mixin_test.dart
@@ -32,6 +32,7 @@ class _TestState extends State<_TestWidget>
   num? remainingAttachmentCapacityBytesStub;
   bool uploadFromUrlSupportedOverride = true;
   bool pickCallbackThrows = false;
+  Completer<void>? pickCallbackBlocker;
 
   @override
   DrivePickerSession get session => DrivePickerSession(
@@ -49,6 +50,7 @@ class _TestState extends State<_TestWidget>
   OnPickDriveCallback? get pickerOnCallback => (state) async {
         pickStates.add(state);
         if (pickCallbackThrows) throw StateError('consumer handler blew up');
+        if (pickCallbackBlocker != null) await pickCallbackBlocker!.future;
       };
 
   @override
@@ -252,6 +254,27 @@ void main() {
 
         completer.complete(const DrivePickOutcomeCancelled());
         await firstTap;
+      });
+
+      testWidgets('second tap while pick callback is in flight → opens another picker', (tester) async {
+        final state = await _pumpPicker(tester);
+        final callbackBlocker = Completer<void>();
+        state.pickCallbackBlocker = callbackBlocker;
+        state.modalStub = () => Future.value(DrivePickOutcomePicked([_doc()]));
+
+        final firstTap = state.onPickerTap();
+        await tester.pump();
+        expect(state.openCalls, hasLength(1));
+        expect(state.pickStates, hasLength(1));
+
+        final secondTap = state.onPickerTap();
+        await tester.pump();
+        expect(state.openCalls, hasLength(2));
+        expect(state.pickStates, hasLength(2));
+
+        callbackBlocker.complete();
+        await firstTap;
+        await secondTap;
       });
 
       testWidgets('tap allowed again after previous modal closed', (tester) async {

--- a/workplace/test/presentation/mixin/drive_picker_state_mixin_test.dart
+++ b/workplace/test/presentation/mixin/drive_picker_state_mixin_test.dart
@@ -31,6 +31,7 @@ class _TestState extends State<_TestWidget>
   num? maxAttachmentSizeBytesStub;
   num? remainingAttachmentCapacityBytesStub;
   bool uploadFromUrlSupportedOverride = true;
+  bool pickCallbackThrows = false;
 
   @override
   DrivePickerSession get session => DrivePickerSession(
@@ -45,7 +46,10 @@ class _TestState extends State<_TestWidget>
       );
 
   @override
-  OnPickDriveCallback? get pickerOnCallback => pickStates.add;
+  OnPickDriveCallback? get pickerOnCallback => (state) async {
+        pickStates.add(state);
+        if (pickCallbackThrows) throw StateError('consumer handler blew up');
+      };
 
   @override
   DriveIntentImageAssets get driveIntentImageAssets =>
@@ -123,6 +127,18 @@ void main() {
         await state.onPickerTap();
 
         expect(state.pickStates, isEmpty);
+      });
+
+      testWidgets('callback throwing → contained, tap allowed again', (tester) async {
+        final state = await _pumpPicker(tester);
+        state.pickCallbackThrows = true;
+        state.modalStub = () => Future.value(DrivePickOutcomePicked([_doc()]));
+
+        await state.onPickerTap();
+        await state.onPickerTap();
+
+        expect(state.pickStates, hasLength(2));
+        expect(state.openCalls, hasLength(2));
       });
 
       testWidgets('modal future fails → DrivePickFailure with the thrown error', (tester) async {

--- a/workplace/test/presentation/mixin/drive_picker_web_message_listener_lifecycle_test.dart
+++ b/workplace/test/presentation/mixin/drive_picker_web_message_listener_lifecycle_test.dart
@@ -13,6 +13,7 @@ import 'package:workplace/presentation/mixin/web_window_message_mixin.dart';
 import 'package:workplace/presentation/model/drive_intent_image_assets.dart';
 import 'package:workplace/presentation/model/drive_origin_validator.dart';
 import 'package:workplace/presentation/model/drive_pick_outcome.dart';
+import 'package:workplace/presentation/model/drive_picker_session.dart';
 
 // Exercises the real `window.postMessage` transport (other tests call
 // onMessage directly). Contract: the modal owns its listener for its own
@@ -277,14 +278,16 @@ class _MenuTileUnderTest extends StatefulWidget {
 class _MenuTileUnderTestState extends State<_MenuTileUnderTest>
     with DrivePickerStateMixin<_MenuTileUnderTest> {
   @override
-  FetchDriveIntentCallback get pickerFetchIntent => _fetchIntentStub;
+  DrivePickerSession get session => DrivePickerSession(
+        uploadFromUrlSupported: () => false,
+        maxAttachmentSizeBytesGetter: () => null,
+        remainingAttachmentCapacityBytesGetter: () => null,
+        onFetchIntent: _fetchIntentStub,
+      );
 
   @override
   DriveIntentImageAssets get driveIntentImageAssets =>
       const DriveIntentImageAssets(driveLogo: '', closeIcon: '', searchIcon: '');
-
-  @override
-  num? get maxAttachmentSizeBytes => null;
 
   @override
   Future<DrivePickOutcome?> openDrivePickerModal(


### PR DESCRIPTION
## Issue
- #4728 

## ADR
- #4760

## Dependency
- https://github.com/linagora/tmail-backend/issues/2556

## Demo

https://github.com/user-attachments/assets/1a8a4e6f-1a9c-4588-96a0-8f8e9ab6ef54



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Attach Drive documents directly in the composer.
  - Pending attachments appear immediately while transfers complete.
  - Uploads support cancellation and clearly show success or failure states.
  - Transfers are limited for improved reliability and performance.
  - Picker availability reflects attachment limits and remaining capacity.
  - Mixed selections support both link attachments and file transfers.
  - Successful Drive attachments display a confirmation message.

- **Bug Fixes**
  - Improved validation blocks unsupported or unsafe links.
  - Transfer and insertion failures show localized feedback.
  - Upload cancellation and cleanup are handled more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->