### PR TITLE
HOTFIX ComposerAutoSaveState memory leak

### DIFF
--- a/lib/features/composer/presentation/providers/composer_auto_save_notifier.dart
+++ b/lib/features/composer/presentation/providers/composer_auto_save_notifier.dart
@@ -95,7 +95,10 @@ class ComposerAutoSaveNotifier extends _$ComposerAutoSaveNotifier {
       (failure) => log('ComposerAutoSaveNotifier::clearCache: failure=${failure.runtimeType}'),
       (_) {
         if (!mounted) return;
-        state = state.copyWith(hasRecoverableSnapshot: false);
+        state = state.copyWith(
+          hasRecoverableSnapshot: false,
+          lastKnownHtmlContent: '',
+        );
         log('ComposerAutoSaveNotifier::clearCache: cleared');
       },
     );


### PR DESCRIPTION
## Related
- https://github.com/linagora/tmail-flutter/issues/4748#issuecomment-5351046333

## Before

<img width="4064" height="2384" alt="Image" src="https://github.com/user-attachments/assets/f87138cd-37a8-495b-8dd4-5ab2bf384cb8" />

## After

<img width="3976" height="2296" alt="Screenshot 2026-08-20 at 10 46 49 AM" src="https://github.com/user-attachments/assets/cdc0d686-93fa-4811-a8ae-63f58ad72103" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clearing cached composer data now also resets the tracked recoverable snapshot and last known content, preventing stale recovery information from being displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->