### PR TITLE
TF-4728 Sentry logging drive attachment failure

### DIFF
--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -120,6 +120,7 @@ import 'package:tmail_ui_user/features/network_connection/presentation/network_c
   if (dart.library.html) 'package:tmail_ui_user/features/network_connection/presentation/web_network_connection_controller.dart';
 import 'package:tmail_ui_user/features/server_settings/domain/usecases/get_server_setting_interactor.dart';
 import 'package:tmail_ui_user/features/upload/domain/exceptions/pick_file_exception.dart';
+import 'package:tmail_ui_user/features/upload/domain/exceptions/upload_exception.dart';
 import 'package:tmail_ui_user/features/upload/domain/extensions/file_info_extension.dart';
 import 'package:tmail_ui_user/features/upload/domain/extensions/list_file_upload_extension.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
@@ -1069,6 +1070,8 @@ class ComposerController extends BaseController
     if (jmapUrl == null || jmapUrl.isEmpty) {
       logError(
         'ComposerController::_transferDriveDocuments: jmapUrl is unavailable',
+        exception: const UploadFromUrlEndpointUnavailableException('jmapUrl is unavailable'),
+        stackTrace: StackTrace.current,
         extras: {'docCount': docs.length},
       );
       return DriveAttachmentTransferRunner.notStartedOutcome;
@@ -1082,6 +1085,8 @@ class ComposerController extends BaseController
     if (uploadUri == null || accountId == null) {
       logError(
         'ComposerController::_transferDriveDocuments: upload-from-url endpoint is unavailable',
+        exception: const UploadFromUrlEndpointUnavailableException('upload-from-url uri could not be resolved'),
+        stackTrace: StackTrace.current,
         extras: {
           'docCount': docs.length,
           'accountId': accountId?.id.value,

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1040,8 +1040,13 @@ class ComposerController extends BaseController
         transferDriveDocuments: (docs) => _transferDriveDocuments(docs),
         appLocalizations: currentContext != null ? AppLocalizations.of(currentContext!) : null,
       );
-    } catch (e) {
-      logWarning('ComposerController::handleDrivePickResult:Exception = $e');
+    } catch (e, s) {
+      logError(
+        'ComposerController::handleDrivePickResult failed',
+        exception: e,
+        stackTrace: s,
+        extras: {'docCount': result.length},
+      );
       // A throw here can strand waiting chips, so the failure must be visible.
       getBinding<ToastManager>()?.showMessageFailure(DrivePickFailure(
         e,
@@ -1062,7 +1067,10 @@ class ComposerController extends BaseController
   Future<DriveTransferOutcome> _transferDriveDocuments(List<DriveDocument> docs) async {
     final jmapUrl = dynamicUrlInterceptors.jmapUrl;
     if (jmapUrl == null || jmapUrl.isEmpty) {
-      logWarning('ComposerController::_transferDriveDocuments: jmapUrl is unavailable');
+      logError(
+        'ComposerController::_transferDriveDocuments: jmapUrl is unavailable',
+        extras: {'docCount': docs.length},
+      );
       return DriveAttachmentTransferRunner.notStartedOutcome;
     }
     final session = mailboxDashBoardController.sessionCurrent;
@@ -1072,7 +1080,14 @@ class ComposerController extends BaseController
       jmapUrl: jmapUrl,
     );
     if (uploadUri == null || accountId == null) {
-      logWarning('ComposerController::_transferDriveDocuments: upload-from-url endpoint is unavailable');
+      logError(
+        'ComposerController::_transferDriveDocuments: upload-from-url endpoint is unavailable',
+        extras: {
+          'docCount': docs.length,
+          'accountId': accountId?.id.value,
+          'hasSession': session != null,
+        },
+      );
       return DriveAttachmentTransferRunner.notStartedOutcome;
     }
 

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1087,9 +1087,9 @@ class ComposerController extends BaseController
         'ComposerController::_transferDriveDocuments: upload-from-url endpoint is unavailable',
         exception: const UploadFromUrlEndpointUnavailableException('upload-from-url uri could not be resolved'),
         stackTrace: StackTrace.current,
+        // Account id stays out: extras reach Sentry.
         extras: {
           'docCount': docs.length,
-          'accountId': accountId?.id.value,
           'hasSession': session != null,
         },
       );

--- a/lib/features/composer/presentation/extensions/drive_document_extension.dart
+++ b/lib/features/composer/presentation/extensions/drive_document_extension.dart
@@ -10,6 +10,23 @@ extension DriveDocumentExtension on DriveDocument {
   /// Link precedence lives at the call site, not here.
   bool isAttachableAsDownload() =>
       downloadLink?.toString().trim().isNotEmpty ?? false;
+
+  /// Root cause for why a doc failed both attachability checks; used for Sentry triage.
+  String dropReason({required bool requireHttps}) {
+    final hasSharingLink = sharingLink != null;
+    final downloadLinkText = downloadLink?.toString().trim();
+    final hasDownloadLink = downloadLinkText?.isNotEmpty ?? false;
+
+    if (!hasSharingLink && !hasDownloadLink) return 'missing_links';
+    if (hasSharingLink &&
+        !sharingLink!.isSafeLinkScheme(requireHttps: requireHttps)) {
+      return 'unsafe_sharing_scheme';
+    }
+    if (downloadLinkText != null && downloadLinkText.isEmpty) {
+      return 'blank_download_link';
+    }
+    return 'unsupported_link_scheme';
+  }
 }
 
 extension _SafeLinkSchemeExtension on Uri {

--- a/lib/features/composer/presentation/extensions/drive_document_extension.dart
+++ b/lib/features/composer/presentation/extensions/drive_document_extension.dart
@@ -17,13 +17,13 @@ extension DriveDocumentExtension on DriveDocument {
     final downloadLinkText = downloadLink?.toString().trim();
     final hasDownloadLink = downloadLinkText?.isNotEmpty ?? false;
 
+    if (downloadLinkText != null && downloadLinkText.isEmpty) {
+      return 'blank_download_link';
+    }
     if (!hasSharingLink && !hasDownloadLink) return 'missing_links';
     if (hasSharingLink &&
         !sharingLink!.isSafeLinkScheme(requireHttps: requireHttps)) {
       return 'unsafe_sharing_scheme';
-    }
-    if (downloadLinkText != null && downloadLinkText.isEmpty) {
-      return 'blank_download_link';
     }
     return 'unsupported_link_scheme';
   }

--- a/lib/features/composer/presentation/manager/drive_attachment_handler.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_handler.dart
@@ -2,6 +2,7 @@ import 'package:core/core.dart';
 import 'package:core/utils/html/file_link_card_html_builder.dart';
 import 'package:tmail_ui_user/features/composer/presentation/extensions/drive_document_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_transfer_runner.dart';
+import 'package:tmail_ui_user/features/upload/domain/exceptions/upload_exception.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
@@ -106,6 +107,19 @@ class DriveAttachmentHandler {
         downloadableDocs.add(doc);
       } else {
         droppedCount++;
+        final downloadLink = doc.downloadLink;
+        logError(
+          'DriveAttachmentHandler::_splitByAttachability: document is not attachable',
+          exception: const DriveDocumentNotAttachableException(),
+          stackTrace: StackTrace.current,
+          extras: {
+            'mimeType': doc.mimeType,
+            'hasSharingLink': doc.sharingLink != null,
+            'hasDownloadLink':
+                downloadLink != null && downloadLink.toString().trim().isNotEmpty,
+            'requireHttps': requireHttps,
+          },
+        );
       }
     }
     return (linkDocs, downloadableDocs, droppedCount);

--- a/lib/features/composer/presentation/manager/drive_attachment_handler.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_handler.dart
@@ -118,6 +118,7 @@ class DriveAttachmentHandler {
             'hasDownloadLink':
                 downloadLink != null && downloadLink.toString().trim().isNotEmpty,
             'requireHttps': requireHttps,
+            'dropReason': doc.dropReason(requireHttps: requireHttps),
           },
         );
       }

--- a/lib/features/composer/presentation/manager/drive_attachment_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_transfer_runner.dart
@@ -138,8 +138,18 @@ class DriveAttachmentTransferRunner {
         mimeType: task.doc.mimeType,
         cancelToken: task.placeholder.cancelToken,
       ));
-    } catch (_) {
+    } catch (e, s) {
       // uploadFromUrl must resolve every task; a thrown error still counts as failure.
+      logError(
+        'DriveAttachmentTransferRunner::_runOne: uploadFromUrl threw',
+        exception: e,
+        stackTrace: s,
+        extras: {
+          'taskId': taskId.id,
+          'fileName': task.doc.name,
+          'mimeType': task.doc.mimeType,
+        },
+      );
       request.onFailure(taskId);
       return;
     }
@@ -153,6 +163,15 @@ class DriveAttachmentTransferRunner {
       (failure) {
         // a user-cancelled transfer is not a failure; the chip is already gone.
         if (failure is UploadDriveDocumentFromUrlCancelled) return;
+        logError(
+          'DriveAttachmentTransferRunner::_runOne: upload failed',
+          exception: failure is UploadDriveDocumentFromUrlFailure ? failure.exception : failure,
+          extras: {
+            'taskId': taskId.id,
+            'fileName': task.doc.name,
+            'mimeType': task.doc.mimeType,
+          },
+        );
         request.onFailure(taskId);
       },
       (success) => success is UploadDriveDocumentFromUrlSuccess

--- a/lib/features/composer/presentation/manager/drive_attachment_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_transfer_runner.dart
@@ -163,15 +163,7 @@ class DriveAttachmentTransferRunner {
       (failure) {
         // a user-cancelled transfer is not a failure; the chip is already gone.
         if (failure is UploadDriveDocumentFromUrlCancelled) return;
-        logError(
-          'DriveAttachmentTransferRunner::_runOne: upload failed',
-          exception: failure is UploadDriveDocumentFromUrlFailure ? failure.exception : failure,
-          extras: {
-            'taskId': taskId.id,
-            'fileName': task.doc.name,
-            'mimeType': task.doc.mimeType,
-          },
-        );
+        // not reported here: the interactor is the single funnel for upload failures.
         request.onFailure(taskId);
       },
       (success) => success is UploadDriveDocumentFromUrlSuccess

--- a/lib/features/composer/presentation/manager/drive_attachment_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_transfer_runner.dart
@@ -6,6 +6,7 @@ import 'package:dio/dio.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:model/email/attachment.dart';
 import 'package:tmail_ui_user/features/composer/presentation/manager/concurrency_gate.dart';
+import 'package:tmail_ui_user/features/upload/domain/exceptions/upload_exception.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
 import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_request.dart';
 import 'package:tmail_ui_user/features/upload/domain/state/upload_drive_document_from_url_state.dart';
@@ -125,6 +126,15 @@ class DriveAttachmentTransferRunner {
     final downloadLink = task.doc.downloadLink;
     // Guarded here too: the runner is injectable, so it can't trust its caller's gate.
     if (downloadLink == null || downloadLink.toString().trim().isEmpty) {
+      logError(
+        'DriveAttachmentTransferRunner::_runOne: downloadLink is missing',
+        exception: const DriveDownloadLinkMissingException(),
+        stackTrace: StackTrace.current,
+        extras: {
+          'taskId': taskId.id,
+          'mimeType': task.doc.mimeType,
+        },
+      );
       request.onFailure(taskId);
       return;
     }

--- a/lib/features/composer/presentation/manager/drive_attachment_transfer_runner.dart
+++ b/lib/features/composer/presentation/manager/drive_attachment_transfer_runner.dart
@@ -144,9 +144,9 @@ class DriveAttachmentTransferRunner {
         'DriveAttachmentTransferRunner::_runOne: uploadFromUrl threw',
         exception: e,
         stackTrace: s,
+        // File name stays out: extras reach Sentry.
         extras: {
           'taskId': taskId.id,
-          'fileName': task.doc.name,
           'mimeType': task.doc.mimeType,
         },
       );

--- a/lib/features/upload/domain/exceptions/upload_exception.dart
+++ b/lib/features/upload/domain/exceptions/upload_exception.dart
@@ -27,3 +27,17 @@ class UploadFailureToastContextMissingException extends AppBaseException {
   @override
   String get exceptionName => 'UploadFailureToastContextMissingException';
 }
+
+class DriveDocumentNotAttachableException extends AppBaseException {
+  const DriveDocumentNotAttachableException([super.message]);
+
+  @override
+  String get exceptionName => 'DriveDocumentNotAttachableException';
+}
+
+class DriveDownloadLinkMissingException extends AppBaseException {
+  const DriveDownloadLinkMissingException([super.message]);
+
+  @override
+  String get exceptionName => 'DriveDownloadLinkMissingException';
+}

--- a/lib/features/upload/domain/exceptions/upload_exception.dart
+++ b/lib/features/upload/domain/exceptions/upload_exception.dart
@@ -20,3 +20,10 @@ class DriveTransferTaskNotFoundException extends AppBaseException {
   @override
   String get exceptionName => 'DriveTransferTaskNotFoundException';
 }
+
+class UploadFailureToastContextMissingException extends AppBaseException {
+  const UploadFailureToastContextMissingException([super.message]);
+
+  @override
+  String get exceptionName => 'UploadFailureToastContextMissingException';
+}

--- a/lib/features/upload/domain/exceptions/upload_exception.dart
+++ b/lib/features/upload/domain/exceptions/upload_exception.dart
@@ -13,3 +13,10 @@ class UploadFromUrlEndpointUnavailableException extends AppBaseException {
   @override
   String get exceptionName => 'UploadFromUrlEndpointUnavailableException';
 }
+
+class DriveTransferTaskNotFoundException extends AppBaseException {
+  const DriveTransferTaskNotFoundException([super.message]);
+
+  @override
+  String get exceptionName => 'DriveTransferTaskNotFoundException';
+}

--- a/lib/features/upload/domain/exceptions/upload_exception.dart
+++ b/lib/features/upload/domain/exceptions/upload_exception.dart
@@ -14,20 +14,6 @@ class UploadFromUrlEndpointUnavailableException extends AppBaseException {
   String get exceptionName => 'UploadFromUrlEndpointUnavailableException';
 }
 
-class DriveTransferTaskNotFoundException extends AppBaseException {
-  const DriveTransferTaskNotFoundException([super.message]);
-
-  @override
-  String get exceptionName => 'DriveTransferTaskNotFoundException';
-}
-
-class UploadFailureToastContextMissingException extends AppBaseException {
-  const UploadFailureToastContextMissingException([super.message]);
-
-  @override
-  String get exceptionName => 'UploadFailureToastContextMissingException';
-}
-
 class DriveDocumentNotAttachableException extends AppBaseException {
   const DriveDocumentNotAttachableException([super.message]);
 

--- a/lib/features/upload/domain/exceptions/upload_exception.dart
+++ b/lib/features/upload/domain/exceptions/upload_exception.dart
@@ -6,3 +6,10 @@ class DataResponseIsNullException extends AppBaseException {
   @override
   String get exceptionName => 'DataResponseIsNullException';
 }
+
+class UploadFromUrlEndpointUnavailableException extends AppBaseException {
+  const UploadFromUrlEndpointUnavailableException([super.message]);
+
+  @override
+  String get exceptionName => 'UploadFromUrlEndpointUnavailableException';
+}

--- a/lib/features/upload/domain/model/upload_attachment.dart
+++ b/lib/features/upload/domain/model/upload_attachment.dart
@@ -70,8 +70,8 @@ class UploadAttachment with EquatableMixin {
           'UploadAttachment::upload failed',
           exception: error,
           stackTrace: stackTrace,
+          // File name stays out: extras reach Sentry.
           extras: {
-            'fileName': fileInfo.fileName,
             'mimeType': fileInfo.mimeType,
             'isInline': fileInfo.isInline,
           },

--- a/lib/features/upload/domain/model/upload_attachment.dart
+++ b/lib/features/upload/domain/model/upload_attachment.dart
@@ -61,10 +61,21 @@ class UploadAttachment with EquatableMixin {
 
       _updateEvent(Right(SuccessAttachmentUploadState(uploadTaskId, attachment, fileInfo)));
     } catch (error, stackTrace) {
-      logWarning('UploadAttachment::upload():ERROR: $error');
       if (error is DioException && error.type == DioExceptionType.cancel) {
         _updateEvent(Left(CancelAttachmentUploadState(uploadTaskId)));
       } else {
+        // Single logging point for attachment upload failures; the controller
+        // only shows the toast.
+        logError(
+          'UploadAttachment::upload failed',
+          exception: error,
+          stackTrace: stackTrace,
+          extras: {
+            'fileName': fileInfo.fileName,
+            'mimeType': fileInfo.mimeType,
+            'isInline': fileInfo.isInline,
+          },
+        );
         try {
           exceptionThrower.throwException(error, stackTrace);
         } catch (e) {

--- a/lib/features/upload/domain/usecases/upload_drive_document_from_url_interactor.dart
+++ b/lib/features/upload/domain/usecases/upload_drive_document_from_url_interactor.dart
@@ -26,7 +26,6 @@ class UploadDriveDocumentFromUrlInteractor {
           stackTrace: s,
           extras: {
             'accountId': request.accountId.id.value,
-            'uploadUri': request.uploadUri.toString(),
             'name': request.name,
             'mimeType': request.mimeType,
           },

--- a/lib/features/upload/domain/usecases/upload_drive_document_from_url_interactor.dart
+++ b/lib/features/upload/domain/usecases/upload_drive_document_from_url_interactor.dart
@@ -24,11 +24,8 @@ class UploadDriveDocumentFromUrlInteractor {
           'UploadDriveDocumentFromUrlInteractor::execute failed',
           exception: e,
           stackTrace: s,
-          extras: {
-            'accountId': request.accountId.id.value,
-            'name': request.name,
-            'mimeType': request.mimeType,
-          },
+          // Identifying values stay out: extras reach Sentry.
+          extras: {'mimeType': request.mimeType},
         );
       }
       return Left<Failure, Success>(

--- a/lib/features/upload/domain/usecases/upload_drive_document_from_url_interactor.dart
+++ b/lib/features/upload/domain/usecases/upload_drive_document_from_url_interactor.dart
@@ -1,5 +1,6 @@
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
+import 'package:core/utils/app_logger.dart';
 import 'package:dartz/dartz.dart';
 import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_repository.dart';
 import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_request.dart';
@@ -14,9 +15,25 @@ class UploadDriveDocumentFromUrlInteractor {
     try {
       final attachment = await _uploadFromUrlRepository.uploadFromUrl(request);
       return Right<Failure, Success>(UploadDriveDocumentFromUrlSuccess(attachment));
-    } catch (e) {
+    } catch (e, s) {
+      final isCancelled = request.cancelToken?.isCancelled == true;
+      // Single logging point for everything the repository/datasource/API
+      // layers throw (account mismatch, Dio errors, JSON parse errors).
+      if (!isCancelled) {
+        logError(
+          'UploadDriveDocumentFromUrlInteractor::execute failed',
+          exception: e,
+          stackTrace: s,
+          extras: {
+            'accountId': request.accountId.id.value,
+            'uploadUri': request.uploadUri.toString(),
+            'name': request.name,
+            'mimeType': request.mimeType,
+          },
+        );
+      }
       return Left<Failure, Success>(
-        request.cancelToken?.isCancelled == true
+        isCancelled
           ? UploadDriveDocumentFromUrlCancelled()
           : UploadDriveDocumentFromUrlFailure(e),
       );

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -18,6 +18,7 @@ import 'package:tmail_ui_user/features/base/base_controller.dart';
 import 'package:tmail_ui_user/features/base/state/base_ui_state.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/upload_attachment_state.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/upload_attachment_interactor.dart';
+import 'package:tmail_ui_user/features/upload/domain/exceptions/upload_exception.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
 import 'package:tmail_ui_user/features/upload/domain/state/attachment_upload_state.dart';
 import 'package:tmail_ui_user/features/upload/presentation/extensions/upload_attachment_extension.dart';
@@ -245,6 +246,8 @@ class UploadController extends BaseController {
       // successful upload never reaches the screen - surface it.
       logError(
         'UploadController::resolveDriveTransferSuccess: taskId not found in state list',
+        exception: const DriveTransferTaskNotFoundException('resolveDriveTransferSuccess'),
+        stackTrace: StackTrace.current,
         extras: {'taskId': taskId.id, 'fileName': attachment.name},
       );
     }

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -261,6 +261,8 @@ class UploadController extends BaseController {
     if (!found) {
       logError(
         'UploadController::resolveDriveTransferFailure: taskId not found in state list',
+        exception: const DriveTransferTaskNotFoundException('resolveDriveTransferFailure'),
+        stackTrace: StackTrace.current,
         extras: {'taskId': taskId.id},
       );
     }

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -232,7 +232,7 @@ class UploadController extends BaseController {
 
   /// Resolves a drive-transfer chip to succeed with its attachment.
   void resolveDriveTransferSuccess(UploadTaskId taskId, Attachment attachment) {
-    _uploadingStateFiles.updateElementByUploadTaskId(
+    final found = _uploadingStateFiles.updateElementByUploadTaskId(
       taskId,
       (state) => state?.copyWith(
         uploadingProgress: 100,
@@ -240,13 +240,28 @@ class UploadController extends BaseController {
         attachment: attachment,
       ),
     );
+    if (!found) {
+      // The chip is gone (composer disposed, list cleared) so the
+      // successful upload never reaches the screen - surface it.
+      logError(
+        'UploadController::resolveDriveTransferSuccess: taskId not found in state list',
+        extras: {'taskId': taskId.id, 'fileName': attachment.name},
+      );
+    }
     _refreshListUploadAttachmentState();
   }
 
   /// Resolves a drive-transfer chip to failed by removing it, matching the
   /// plain-upload failure path.
   void resolveDriveTransferFailure(UploadTaskId taskId) {
-    deleteFileUploaded(taskId);
+    final found = _uploadingStateFiles.deleteElementByUploadTaskId(taskId);
+    if (!found) {
+      logError(
+        'UploadController::resolveDriveTransferFailure: taskId not found in state list',
+        extras: {'taskId': taskId.id},
+      );
+    }
+    _refreshListUploadAttachmentState();
     _showToastMessageWhenUploadAttachmentsFailure(
       ErrorAttachmentUploadState(uploadId: taskId),
     );

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -349,7 +349,14 @@ class UploadController extends BaseController {
         leadingSVGIconColor: Colors.white,
         leadingSVGIcon: imagePaths.icAttachment);
     } else {
-      logError('UploadController::_showToastMessageWhenUploadAttachmentsFailure: no context to show failure for ${failure.uploadId}');
+      logError(
+        'UploadController::_showToastMessageWhenUploadAttachmentsFailure: no context to show failure',
+        exception: const UploadFailureToastContextMissingException(
+          '_showToastMessageWhenUploadAttachmentsFailure',
+        ),
+        stackTrace: StackTrace.current,
+        extras: {'uploadId': failure.uploadId.id},
+      );
     }
   }
 

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -18,7 +18,6 @@ import 'package:tmail_ui_user/features/base/base_controller.dart';
 import 'package:tmail_ui_user/features/base/state/base_ui_state.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/upload_attachment_state.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/upload_attachment_interactor.dart';
-import 'package:tmail_ui_user/features/upload/domain/exceptions/upload_exception.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
 import 'package:tmail_ui_user/features/upload/domain/state/attachment_upload_state.dart';
 import 'package:tmail_ui_user/features/upload/presentation/extensions/upload_attachment_extension.dart';
@@ -242,14 +241,8 @@ class UploadController extends BaseController {
       ),
     );
     if (!found) {
-      // The chip is gone (composer disposed, list cleared) so the
-      // successful upload never reaches the screen - surface it.
-      logError(
+      logWarning(
         'UploadController::resolveDriveTransferSuccess: taskId not found in state list',
-        exception: const DriveTransferTaskNotFoundException('resolveDriveTransferSuccess'),
-        stackTrace: StackTrace.current,
-        // File name stays out: extras reach Sentry.
-        extras: {'taskId': taskId.id},
       );
     }
     _refreshListUploadAttachmentState();
@@ -260,11 +253,8 @@ class UploadController extends BaseController {
   void resolveDriveTransferFailure(UploadTaskId taskId) {
     final found = _uploadingStateFiles.deleteElementByUploadTaskId(taskId);
     if (!found) {
-      logError(
+      logWarning(
         'UploadController::resolveDriveTransferFailure: taskId not found in state list',
-        exception: const DriveTransferTaskNotFoundException('resolveDriveTransferFailure'),
-        stackTrace: StackTrace.current,
-        extras: {'taskId': taskId.id},
       );
     }
     _refreshListUploadAttachmentState();
@@ -350,13 +340,8 @@ class UploadController extends BaseController {
         leadingSVGIconColor: Colors.white,
         leadingSVGIcon: imagePaths.icAttachment);
     } else {
-      logError(
+      logWarning(
         'UploadController::_showToastMessageWhenUploadAttachmentsFailure: no context to show failure',
-        exception: const UploadFailureToastContextMissingException(
-          '_showToastMessageWhenUploadAttachmentsFailure',
-        ),
-        stackTrace: StackTrace.current,
-        extras: {'uploadId': failure.uploadId.id},
       );
     }
   }

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -248,7 +248,8 @@ class UploadController extends BaseController {
         'UploadController::resolveDriveTransferSuccess: taskId not found in state list',
         exception: const DriveTransferTaskNotFoundException('resolveDriveTransferSuccess'),
         stackTrace: StackTrace.current,
-        extras: {'taskId': taskId.id, 'fileName': attachment.name},
+        // File name stays out: extras reach Sentry.
+        extras: {'taskId': taskId.id},
       );
     }
     _refreshListUploadAttachmentState();

--- a/lib/features/upload/presentation/controller/upload_controller.dart
+++ b/lib/features/upload/presentation/controller/upload_controller.dart
@@ -342,8 +342,6 @@ class UploadController extends BaseController {
   }
 
   void _showToastMessageWhenUploadAttachmentsFailure(ErrorAttachmentUploadState failure) {
-    // The chip is removed on failure, so the log is the only durable trace.
-    logError('UploadController::_showToastMessageWhenUploadAttachmentsFailure: upload ${failure.uploadId} failed');
     if (currentContext != null && currentOverlayContext != null) {
       appToast.showToastErrorMessage(
         currentOverlayContext!,

--- a/lib/features/upload/presentation/model/upload_file_state_list.dart
+++ b/lib/features/upload/presentation/model/upload_file_state_list.dart
@@ -32,7 +32,8 @@ class UploadFileStateList {
     return this;
   }
 
-  UploadFileStateList updateElementBy(
+  /// Returns whether a matching element was found and updated.
+  bool updateElementBy(
     MatchedState matchedState,
     UpdateFileUploadingState updateFileUploadingState,
   ) {
@@ -40,10 +41,11 @@ class UploadFileStateList {
     if (matchIndex >= 0) {
       _replaceAt(matchIndex, updateFileUploadingState(_uploadingStateFiles[matchIndex]));
     }
-    return this;
+    return matchIndex >= 0;
   }
 
-  UploadFileStateList updateElementByUploadTaskId(
+  /// Returns whether a matching element was found and updated.
+  bool updateElementByUploadTaskId(
     UploadTaskId uploadTaskId,
     UpdateFileUploadingState updateFileUploadingState,
   ) {
@@ -51,7 +53,7 @@ class UploadFileStateList {
     if (matchIndex != null) {
       _replaceAt(matchIndex, updateFileUploadingState(_uploadingStateFiles[matchIndex]));
     }
-    return this;
+    return matchIndex != null;
   }
 
   bool get allSuccess {
@@ -76,13 +78,15 @@ class UploadFileStateList {
     clear();
   }
 
-  void deleteElementByUploadTaskId(UploadTaskId uploadTaskId) {
+  /// Returns whether a matching element was found and removed.
+  bool deleteElementByUploadTaskId(UploadTaskId uploadTaskId) {
     final matchIndex = _indexByTaskId[uploadTaskId];
-    if (matchIndex == null) return;
+    if (matchIndex == null) return false;
 
     _uploadingStateFiles[matchIndex]?.cancelToken?.cancel();
     _uploadingStateFiles.removeAt(matchIndex);
     _reindex();
+    return true;
   }
 
   UploadFileState? getUploadFileStateById(UploadTaskId uploadTaskId) {

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -1,3 +1,4 @@
+import 'package:core/utils/logging/app_logger_registry.dart';
 import 'package:core/data/network/config/dynamic_url_interceptors.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/state/success.dart';
@@ -92,6 +93,7 @@ import 'package:workplace/domain/entity/drive_document.dart';
 import 'package:workplace/presentation/model/drive_pick_state.dart';
 
 import '../../../fixtures/account_fixtures.dart';
+import '../../../fixtures/capturing_log_handler.dart';
 import '../../../fixtures/session_fixtures.dart';
 import '../../../fixtures/widget_fixtures.dart';
 import '../../../mocks/mock_web_view_platform.dart';
@@ -1404,7 +1406,11 @@ void main() {
         sharingLink: Uri.parse('https://drive.example.com/report'),
       );
 
+      late CapturingLogHandler logHandler;
+
       setUp(() {
+        logHandler = CapturingLogHandler();
+        AppLoggerRegistry.instance.registerHandler(logHandler);
         Get.put(DriveAttachmentHandler());
         composerController?.richTextMobileTabletController =
             mockRichTextMobileTabletController;
@@ -1414,6 +1420,8 @@ void main() {
             .thenAnswer((_) async {});
         when(mockHtmlEditorApi.insertHtml(any)).thenAnswer((_) async {});
       });
+
+      tearDown(() => AppLoggerRegistry.instance.resetForTesting());
 
       // handleDrivePickResult awaits SchedulerBinding.instance.endOfFrame on
       // mobile, which only resolves once a frame is pumped — testWidgets +
@@ -1477,6 +1485,16 @@ void main() {
         expect(failure.error.toString(), 'Exception');
         // No placeholder means the transfer never reached the runner.
         verifyNever(mockUploadController.addDownloadingPlaceholders(any));
+
+        // One diagnostic for the batch, and it must not name the account.
+        expect(logHandler.errorRecords, hasLength(1));
+        final record = logHandler.errorRecords.single;
+        expect(record.extras?.keys, isNot(contains('accountId')));
+        expect(
+          record.rawMessage,
+          isNot(contains(AccountFixtures.aliceAccountId.id.value)),
+        );
+        expect(record.extras, containsPair('docCount', 1));
       }
 
       testWidgets(

--- a/test/features/composer/presentation/extensions/drive_document_extension_test.dart
+++ b/test/features/composer/presentation/extensions/drive_document_extension_test.dart
@@ -66,4 +66,28 @@ void main() {
       expect(doc.isAttachableAsDownload(), isTrue);
     });
   });
+
+  group('DriveDocumentExtension::dropReason::', () {
+    test('Should report missing_links when neither link is set', () {
+      expect(_doc().dropReason(requireHttps: false), equals('missing_links'));
+    });
+
+    test('Should report blank_download_link when downloadLink is blank, even without a sharingLink', () {
+      final doc = _doc(downloadLink: '');
+
+      expect(doc.dropReason(requireHttps: false), equals('blank_download_link'));
+    });
+
+    test('Should report unsafe_sharing_scheme when sharingLink fails the scheme check', () {
+      final doc = _doc(sharingLink: 'http://drive.example.com/report');
+
+      expect(doc.dropReason(requireHttps: true), equals('unsafe_sharing_scheme'));
+    });
+
+    test('Should report unsupported_link_scheme as the fallback when only a non-blank downloadLink is set', () {
+      final doc = _doc(downloadLink: 'https://drive.example.com/report-dl');
+
+      expect(doc.dropReason(requireHttps: false), equals('unsupported_link_scheme'));
+    });
+  });
 }

--- a/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_handler_test.dart
@@ -1,14 +1,17 @@
+import 'package:core/utils/logging/app_logger_registry.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_handler.dart';
 import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_transfer_runner.dart';
+import 'package:tmail_ui_user/features/upload/domain/exceptions/upload_exception.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
 import 'package:workplace/presentation/model/drive_pick_state.dart';
 
+import '../../../../fixtures/capturing_log_handler.dart';
 import 'drive_attachment_handler_test.mocks.dart';
 import 'drive_attachment_handler_test_helper.dart';
 
@@ -285,5 +288,62 @@ void main() {
 
       expect(caughtError, isA<StateError>());
     });
+  });
+
+  group('DriveAttachmentHandler::handleDrivePickResult error reporting::', () {
+    late CapturingLogHandler logHandler;
+
+    setUp(() {
+      logHandler = CapturingLogHandler();
+      AppLoggerRegistry.instance.registerHandler(logHandler);
+    });
+
+    tearDown(() => AppLoggerRegistry.instance.resetForTesting());
+
+    test(
+      'WHEN a document is attachable neither as link nor as download\n'
+      'THEN exactly ONE error event is emitted without the file name\n'
+      'AND it records whether sharing/download links were present',
+      () async {
+        const sensitiveName = 'SENSITIVE-PAYSLIP-2026.pdf';
+        final droppedDoc = DriveDocument(
+          id: 'drop-1',
+          name: sensitiveName,
+          size: 0,
+          mimeType: 'application/pdf',
+        );
+
+        await handlePick([droppedDoc], appLocalizations: appLocalizations);
+
+        expect(logHandler.errorRecords, hasLength(1));
+        final record = logHandler.errorRecords.single;
+        expect(record.exception, isA<DriveDocumentNotAttachableException>());
+        expect(record.stackTrace, isNotNull);
+        expect(record.extras?.keys, isNot(contains('fileName')));
+        expect(record.rawMessage, isNot(contains(sensitiveName)));
+        expect(record.extras, containsPair('mimeType', 'application/pdf'));
+        expect(record.extras, containsPair('hasSharingLink', false));
+        expect(record.extras, containsPair('hasDownloadLink', false));
+        expect(record.extras, containsPair('requireHttps', handler.requireHttps));
+      },
+    );
+
+    test(
+      'WHEN one document is dropped beside a valid sibling\n'
+      'THEN exactly ONE drop event is emitted',
+      () async {
+        await handlePick([linkDoc, noLinkDoc], appLocalizations: appLocalizations);
+
+        expect(logHandler.errorRecords, hasLength(1));
+        expect(
+          logHandler.errorRecords.single.exception,
+          isA<DriveDocumentNotAttachableException>(),
+        );
+        expect(
+          logHandler.errorRecords.single.extras,
+          containsPair('mimeType', noLinkDoc.mimeType),
+        );
+      },
+    );
   });
 }

--- a/test/features/composer/presentation/manager/drive_attachment_transfer_runner_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_transfer_runner_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
+import 'package:core/utils/logging/app_logger_registry.dart';
 import 'package:dartz/dartz.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -14,6 +15,8 @@ import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
 import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_request.dart';
 import 'package:tmail_ui_user/features/upload/domain/state/upload_drive_document_from_url_state.dart';
 import 'package:workplace/domain/entity/drive_document.dart';
+
+import '../../../../fixtures/capturing_log_handler.dart';
 
 class _StubFailure extends FeatureFailure {
   _StubFailure() : super(exception: Exception('failed'));
@@ -623,6 +626,52 @@ void main() {
       names: ['keep-a.pdf', 'drop.pdf', 'keep-b.pdf'],
       cancelledName: 'drop.pdf',
       maxConcurrent: 3,
+    );
+  });
+
+  group('DriveAttachmentTransferRunner::_runOne error reporting::', () {
+    late CapturingLogHandler logHandler;
+
+    setUp(() {
+      logHandler = CapturingLogHandler();
+      AppLoggerRegistry.instance.registerHandler(logHandler);
+    });
+
+    tearDown(() => AppLoggerRegistry.instance.resetForTesting());
+
+    test(
+      'WHEN the injected uploadFromUrl callback throws unexpectedly\n'
+      'THEN the matching chip resolves as failed\n'
+      'AND exactly ONE error event is emitted without the file name or URL',
+      () async {
+        const sensitiveName = 'SENSITIVE-CONTRACT-2026.pdf';
+        const sensitiveLink = 'https://drive.example.com/SENSITIVE-TOKEN-1d2e/file.pdf';
+        final failedTaskIds = <UploadTaskId>[];
+        final runner = makeRunner(
+          uploadFromUrl: (_) => throw StateError('uploadFromUrl blew up'),
+        );
+
+        final result = await runner.transfer((
+          docs: [doc(downloadLink: sensitiveLink, name: sensitiveName)],
+          accountId: accountId,
+          uploadUri: uploadUri,
+          onPlaceholdersReady: (_) {},
+          onSuccess: (_, __) {},
+          onFailure: failedTaskIds.add,
+        ));
+
+        expect(failedTaskIds, hasLength(1));
+        expect(result, (started: true, succeeded: 0, failed: 1));
+
+        expect(logHandler.errorRecords, hasLength(1));
+        final record = logHandler.errorRecords.single;
+        expect(record.extras?.keys, isNot(contains('fileName')));
+        expect(record.rawMessage, isNot(contains(sensitiveName)));
+        expect(record.rawMessage, isNot(contains('SENSITIVE-TOKEN-1d2e')));
+        expect(record.extras, containsPair('taskId', failedTaskIds.single.id));
+        expect(record.exception, isA<StateError>());
+        expect(record.stackTrace, isNotNull);
+      },
     );
   });
 }

--- a/test/features/composer/presentation/manager/drive_attachment_transfer_runner_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_transfer_runner_test.dart
@@ -11,6 +11,7 @@ import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:model/email/attachment.dart';
 import 'package:tmail_ui_user/features/composer/presentation/manager/concurrency_gate.dart';
 import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_transfer_runner.dart';
+import 'package:tmail_ui_user/features/upload/domain/exceptions/upload_exception.dart';
 import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
 import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_request.dart';
 import 'package:tmail_ui_user/features/upload/domain/state/upload_drive_document_from_url_state.dart';
@@ -638,6 +639,82 @@ void main() {
     });
 
     tearDown(() => AppLoggerRegistry.instance.resetForTesting());
+
+    test(
+      'WHEN downloadLink is null\n'
+      'THEN the matching chip resolves as failed\n'
+      'AND exactly ONE error event is emitted without the file name',
+      () async {
+        const sensitiveName = 'SENSITIVE-CONTRACT-2026.pdf';
+        final failedTaskIds = <UploadTaskId>[];
+        var uploadCalls = 0;
+        final runner = makeRunner(
+          uploadFromUrl: (_) async {
+            uploadCalls++;
+            return Left(_StubFailure());
+          },
+        );
+
+        final result = await runner.transfer((
+          docs: [doc(name: sensitiveName)],
+          accountId: accountId,
+          uploadUri: uploadUri,
+          onPlaceholdersReady: (_) {},
+          onSuccess: (_, __) {},
+          onFailure: failedTaskIds.add,
+        ));
+
+        expect(uploadCalls, 0);
+        expect(failedTaskIds, hasLength(1));
+        expect(result, (started: true, succeeded: 0, failed: 1));
+
+        expect(logHandler.errorRecords, hasLength(1));
+        final record = logHandler.errorRecords.single;
+        expect(record.exception, isA<DriveDownloadLinkMissingException>());
+        expect(record.stackTrace, isNotNull);
+        expect(record.extras?.keys, isNot(contains('fileName')));
+        expect(record.rawMessage, isNot(contains(sensitiveName)));
+        expect(record.extras, containsPair('taskId', failedTaskIds.single.id));
+        expect(record.extras, containsPair('mimeType', 'application/pdf'));
+      },
+    );
+
+    test(
+      'WHEN downloadLink is empty\n'
+      'THEN the matching chip resolves as failed\n'
+      'AND exactly ONE error event is emitted without the file name or URL',
+      () async {
+        const sensitiveName = 'SENSITIVE-CONTRACT-2026.pdf';
+        final failedTaskIds = <UploadTaskId>[];
+        var uploadCalls = 0;
+        final runner = makeRunner(
+          uploadFromUrl: (_) async {
+            uploadCalls++;
+            return Left(_StubFailure());
+          },
+        );
+
+        final result = await runner.transfer((
+          docs: [doc(downloadLink: '', name: sensitiveName)],
+          accountId: accountId,
+          uploadUri: uploadUri,
+          onPlaceholdersReady: (_) {},
+          onSuccess: (_, __) {},
+          onFailure: failedTaskIds.add,
+        ));
+
+        expect(uploadCalls, 0);
+        expect(failedTaskIds, hasLength(1));
+        expect(result, (started: true, succeeded: 0, failed: 1));
+
+        expect(logHandler.errorRecords, hasLength(1));
+        final record = logHandler.errorRecords.single;
+        expect(record.exception, isA<DriveDownloadLinkMissingException>());
+        expect(record.extras?.keys, isNot(contains('fileName')));
+        expect(record.rawMessage, isNot(contains(sensitiveName)));
+        expect(record.extras, containsPair('taskId', failedTaskIds.single.id));
+      },
+    );
 
     test(
       'WHEN the injected uploadFromUrl callback throws unexpectedly\n'

--- a/test/features/composer/presentation/manager/drive_attachment_transfer_runner_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_transfer_runner_test.dart
@@ -750,5 +750,46 @@ void main() {
         expect(record.stackTrace, isNotNull);
       },
     );
+
+    test(
+      'WHEN the injected uploadFromUrl callback throws a real DioException\n'
+      'THEN the matching chip resolves as failed\n'
+      'AND the logged event carries no sentinel URL/account id outside the raw exception object',
+      () async {
+        const sensitiveName = 'SENSITIVE-CONTRACT-2026.pdf';
+        const sentinelUrl =
+            'https://drive.example.com/upload/accounts/sentinel-account-id?token=sentinel-token';
+        final failedTaskIds = <UploadTaskId>[];
+        final runner = makeRunner(
+          uploadFromUrl: (_) => throw DioException(
+            requestOptions: RequestOptions(path: sentinelUrl),
+          ),
+        );
+
+        final result = await runner.transfer((
+          docs: [doc(downloadLink: 'https://drive.example.com/file.pdf', name: sensitiveName)],
+          accountId: accountId,
+          uploadUri: uploadUri,
+          onPlaceholdersReady: (_) {},
+          onSuccess: (_, __) {},
+          onFailure: failedTaskIds.add,
+        ));
+
+        expect(failedTaskIds, hasLength(1));
+        expect(result, (started: true, succeeded: 0, failed: 1));
+
+        expect(logHandler.errorRecords, hasLength(1));
+        final record = logHandler.errorRecords.single;
+        // The raw DioException is intentionally forwarded as `exception:` so Sentry
+        // can attach it; extras/rawMessage are the only fields this call controls
+        // directly, and neither may carry the sentinel URL. The exception's own
+        // request URL is redacted downstream by
+        // SentryInitializer.sanitizeRequestForTesting, not here.
+        expect(record.exception, isA<DioException>());
+        expect(record.extras?.values, isNot(contains(sentinelUrl)));
+        expect(record.rawMessage, isNot(contains(sentinelUrl)));
+        expect(record.rawMessage, isNot(contains(sensitiveName)));
+      },
+    );
   });
 }

--- a/test/features/composer/presentation/manager/drive_attachment_transfer_runner_test.dart
+++ b/test/features/composer/presentation/manager/drive_attachment_transfer_runner_test.dart
@@ -781,10 +781,8 @@ void main() {
         expect(logHandler.errorRecords, hasLength(1));
         final record = logHandler.errorRecords.single;
         // The raw DioException is intentionally forwarded as `exception:` so Sentry
-        // can attach it; extras/rawMessage are the only fields this call controls
-        // directly, and neither may carry the sentinel URL. The exception's own
-        // request URL is redacted downstream by
-        // SentryInitializer.sanitizeRequestForTesting, not here.
+        // can attach it; this test only asserts the runner-controlled fields
+        // (extras/rawMessage) don't carry the sentinel URL.
         expect(record.exception, isA<DioException>());
         expect(record.extras?.values, isNot(contains(sentinelUrl)));
         expect(record.rawMessage, isNot(contains(sentinelUrl)));

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -4,9 +4,6 @@ import 'dart:io';
 import 'package:core/data/constants/constant.dart';
 import 'package:core/data/network/dio_client.dart';
 import 'package:core/utils/logging/app_logger_registry.dart';
-import 'package:core/utils/logging/log_handler.dart';
-import 'package:core/utils/logging/log_level.dart';
-import 'package:core/utils/logging/log_record.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -35,6 +32,7 @@ import 'package:tmail_ui_user/features/push_notification/data/keychain/keychain_
 import 'package:tmail_ui_user/main/utils/ios_sharing_manager.dart';
 
 import '../../fixtures/account_fixtures.dart';
+import '../../fixtures/capturing_log_handler.dart';
 import '../../fixtures/oidc_fixtures.dart';
 import 'authorization_interceptor_test.mocks.dart';
 
@@ -3648,11 +3646,11 @@ void main() {
   // failure would log twice (generic onError:Exception + the classified event).
   // ============================================================
   group('onError: web refresh failure emits a single Sentry event', () {
-    late _CapturingLogHandler logHandler;
+    late CapturingLogHandler logHandler;
 
     setUp(() {
       PlatformInfo.isTestingForWeb = true;
-      logHandler = _CapturingLogHandler();
+      logHandler = CapturingLogHandler();
       AppLoggerRegistry.instance.registerHandler(logHandler);
     });
 
@@ -3737,10 +3735,10 @@ void main() {
   // that generic event — it is their only trace.
   // ============================================================
   group('onError: mobile refresh failure emits a single Sentry event', () {
-    late _CapturingLogHandler logHandler;
+    late CapturingLogHandler logHandler;
 
     setUp(() {
-      logHandler = _CapturingLogHandler();
+      logHandler = CapturingLogHandler();
       AppLoggerRegistry.instance.registerHandler(logHandler);
     });
 
@@ -3828,14 +3826,4 @@ void main() {
     dioAdapter.close();
     dio.close();
   });
-}
-
-class _CapturingLogHandler extends LogHandler {
-  final List<LogRecord> records = [];
-
-  @override
-  void handle(LogRecord record) => records.add(record);
-
-  List<LogRecord> get errorRecords =>
-      records.where((r) => r.level == Level.error).toList();
 }

--- a/test/features/upload/domain/model/upload_attachment_test.dart
+++ b/test/features/upload/domain/model/upload_attachment_test.dart
@@ -1,0 +1,127 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:core/utils/logging/app_logger_registry.dart';
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/upload/file_info.dart';
+import 'package:tmail_ui_user/features/upload/data/network/file_uploader.dart';
+import 'package:tmail_ui_user/features/upload/domain/model/upload_attachment.dart';
+import 'package:tmail_ui_user/features/upload/domain/model/upload_task_id.dart';
+import 'package:tmail_ui_user/features/upload/domain/state/attachment_upload_state.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/exception_thrower.dart';
+
+import '../../../../fixtures/capturing_log_handler.dart';
+import 'upload_attachment_test.mocks.dart';
+
+/// Mirrors the production thrower closely enough for these tests: it maps the
+/// raw error to a domain exception by throwing it.
+class _RethrowingExceptionThrower extends ExceptionThrower {
+  @override
+  throwException(dynamic error, dynamic stackTrace) => throw error;
+}
+
+@GenerateNiceMocks([MockSpec<FileUploader>()])
+void main() {
+  group('UploadAttachment::upload error reporting::', () {
+    const taskId = UploadTaskId('upload-task-1');
+    const sensitiveName = 'SENSITIVE-PAYSLIP-2026.pdf';
+    final uploadUri = Uri.parse('https://mail.example.com/upload/account-1');
+
+    late MockFileUploader fileUploader;
+    late CapturingLogHandler logHandler;
+
+    final fileInfo = FileInfo(
+      fileName: sensitiveName,
+      fileSize: 100,
+      type: 'application/pdf',
+      isInline: false,
+    );
+
+    setUp(() {
+      fileUploader = MockFileUploader();
+      logHandler = CapturingLogHandler();
+      AppLoggerRegistry.instance.registerHandler(logHandler);
+    });
+
+    tearDown(() => AppLoggerRegistry.instance.resetForTesting());
+
+    UploadAttachment makeUploadAttachment({CancelToken? cancelToken}) => UploadAttachment(
+          taskId,
+          fileInfo,
+          uploadUri,
+          fileUploader,
+          _RethrowingExceptionThrower(),
+          cancelToken: cancelToken,
+        );
+
+    /// Drives [upload] to completion; the stream closes in its finally block.
+    Future<List<Either<Failure, Success>>> runUpload(UploadAttachment attachment) {
+      final events = attachment.progressState.toList();
+      attachment.upload();
+      return events;
+    }
+
+    test(
+      'WHEN the uploader throws\n'
+      'THEN exactly ONE error event is emitted with its exception and stack\n'
+      'AND the file name is not part of it',
+      () async {
+        when(fileUploader.uploadAttachment(
+          any,
+          any,
+          any,
+          cancelToken: anyNamed('cancelToken'),
+          onSendController: anyNamed('onSendController'),
+        )).thenThrow(StateError('backend refused the upload'));
+
+        final events = await runUpload(makeUploadAttachment());
+
+        expect(
+          events.any((e) => e.fold((l) => l is ErrorAttachmentUploadState, (_) => false)),
+          isTrue,
+        );
+
+        expect(logHandler.errorRecords, hasLength(1));
+        final record = logHandler.errorRecords.single;
+        expect(record.exception, isA<StateError>());
+        expect(record.stackTrace, isNotNull);
+        expect(record.extras?.keys, isNot(contains('fileName')));
+        expect(record.rawMessage, isNot(contains(sensitiveName)));
+        expect(record.extras, containsPair('mimeType', fileInfo.mimeType));
+        expect(record.extras, containsPair('isInline', false));
+      },
+    );
+
+    test(
+      'WHEN the upload is cancelled\n'
+      'THEN it emits CancelAttachmentUploadState and NO error event',
+      () async {
+        when(fileUploader.uploadAttachment(
+          any,
+          any,
+          any,
+          cancelToken: anyNamed('cancelToken'),
+          onSendController: anyNamed('onSendController'),
+        )).thenThrow(DioException.requestCancelled(
+          requestOptions: RequestOptions(path: '/upload'),
+          reason: null,
+        ));
+
+        final events = await runUpload(makeUploadAttachment(cancelToken: CancelToken()));
+
+        expect(
+          events.any((e) => e.fold((l) => l is CancelAttachmentUploadState, (_) => false)),
+          isTrue,
+        );
+        expect(
+          logHandler.errorRecords,
+          isEmpty,
+          reason: 'a cancelled upload is not a failure worth reporting',
+        );
+      },
+    );
+  });
+}

--- a/test/features/upload/domain/usecases/upload_drive_document_from_url_interactor_test.dart
+++ b/test/features/upload/domain/usecases/upload_drive_document_from_url_interactor_test.dart
@@ -1,3 +1,4 @@
+import 'package:core/utils/logging/app_logger_registry.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
@@ -10,6 +11,7 @@ import 'package:tmail_ui_user/features/upload/domain/state/upload_drive_document
 import 'package:tmail_ui_user/features/upload/domain/usecases/upload_drive_document_from_url_interactor.dart';
 
 import '../../../../fixtures/account_fixtures.dart';
+import '../../../../fixtures/capturing_log_handler.dart';
 import 'upload_drive_document_from_url_interactor_test.mocks.dart';
 
 @GenerateNiceMocks([MockSpec<UploadFromUrlRepository>()])
@@ -31,10 +33,16 @@ void main() {
       mimeType: mimeType,
     );
 
+    late CapturingLogHandler logHandler;
+
     setUp(() {
       uploadFromUrlRepository = MockUploadFromUrlRepository();
       interactor = UploadDriveDocumentFromUrlInteractor(uploadFromUrlRepository);
+      logHandler = CapturingLogHandler();
+      AppLoggerRegistry.instance.registerHandler(logHandler);
     });
+
+    tearDown(() => AppLoggerRegistry.instance.resetForTesting());
 
     test('should return Right(UploadDriveDocumentFromUrlSuccess) with the repository\'s Attachment', () async {
       final attachment = Attachment(blobId: Id('blob-id-123'), name: documentName);
@@ -87,6 +95,53 @@ void main() {
         result.fold((l) => l, (r) => r),
         isA<UploadDriveDocumentFromUrlCancelled>(),
       );
+      expect(
+        logHandler.errorRecords,
+        isEmpty,
+        reason: 'a user-cancelled transfer is not a failure worth reporting',
+      );
     });
+
+    test(
+      'WHEN the repository throws for a request carrying an upload URL, '
+      'account id and file name\n'
+      'THEN exactly ONE error event is emitted\n'
+      'AND none of those values appear in extras or the message',
+      () async {
+        // Sentinels: distinctive enough that a substring match cannot be a
+        // coincidence if any of them leaks into the event.
+        final sensitiveUploadUri = Uri.parse('https://mail.example.com/upload-from-url/SENSITIVE-ACCOUNT-9f3c');
+        final sensitiveDownloadLink = Uri.parse('https://drive.example.com/SENSITIVE-TOKEN-4b7a/file.pdf');
+        const sensitiveName = 'SENSITIVE-PAYSLIP-2026.pdf';
+        final sensitiveRequest = UploadFromUrlRequest(
+          accountId: AccountFixtures.aliceAccountId,
+          uploadUri: sensitiveUploadUri,
+          attachmentUrl: sensitiveDownloadLink,
+          name: sensitiveName,
+          mimeType: mimeType,
+        );
+        when(uploadFromUrlRepository.uploadFromUrl(sensitiveRequest))
+            .thenThrow(Exception('backend rejected the upload'));
+
+        await interactor.execute(sensitiveRequest);
+
+        expect(logHandler.errorRecords, hasLength(1));
+        final record = logHandler.errorRecords.single;
+
+        expect(record.extras?.keys, isNot(contains('accountId')));
+        expect(record.extras?.keys, isNot(contains('name')));
+        expect(record.extras?.keys, isNot(contains('uploadUri')));
+        // rawMessage concatenates message, exception, extras and stack trace,
+        // so this catches a leak through any of those channels.
+        expect(record.rawMessage, isNot(contains('SENSITIVE-ACCOUNT-9f3c')));
+        expect(record.rawMessage, isNot(contains('SENSITIVE-TOKEN-4b7a')));
+        expect(record.rawMessage, isNot(contains(sensitiveName)));
+        expect(record.rawMessage, isNot(contains(AccountFixtures.aliceAccountId.id.value)));
+        // Allow-listed technical metadata is retained.
+        expect(record.extras, containsPair('mimeType', mimeType));
+        expect(record.exception, isNotNull);
+        expect(record.stackTrace, isNotNull);
+      },
+    );
   });
 }

--- a/test/features/upload/presentation/controller/drive_upload_failure_single_event_test.dart
+++ b/test/features/upload/presentation/controller/drive_upload_failure_single_event_test.dart
@@ -1,0 +1,164 @@
+import 'package:core/data/network/config/dynamic_url_interceptors.dart';
+import 'package:core/presentation/resources/image_paths.dart';
+import 'package:core/presentation/utils/app_toast.dart';
+import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/utils/logging/app_logger_registry.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/caching/caching_manager.dart';
+import 'package:tmail_ui_user/features/composer/domain/repository/composer_repository.dart';
+import 'package:tmail_ui_user/features/composer/domain/usecases/upload_attachment_interactor.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/concurrency_gate.dart';
+import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_transfer_runner.dart';
+import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oidc_interactor.dart';
+import 'package:tmail_ui_user/features/login/domain/usecases/delete_credential_interactor.dart';
+import 'package:tmail_ui_user/features/manage_account/data/local/language_cache_manager.dart';
+import 'package:tmail_ui_user/features/manage_account/domain/usecases/log_out_oidc_interactor.dart';
+import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_repository.dart';
+import 'package:tmail_ui_user/features/upload/domain/usecases/upload_drive_document_from_url_interactor.dart';
+import 'package:tmail_ui_user/features/upload/presentation/controller/upload_controller.dart';
+import 'package:tmail_ui_user/features/upload/presentation/model/drive_transfer_placeholder.dart';
+import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations_delegate.dart';
+import 'package:tmail_ui_user/main/localizations/localization_service.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
+import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
+import 'package:uuid/uuid.dart';
+import 'package:workplace/domain/entity/drive_document.dart';
+
+import '../../../../fixtures/capturing_log_handler.dart';
+import 'drive_upload_failure_single_event_test.mocks.dart';
+
+/// Wires the real interactor -> runner -> controller chain so the "one durable
+/// event per failed upload" invariant is proven across the whole path, not
+/// asserted unit by unit.
+@GenerateNiceMocks([
+  MockSpec<UploadFromUrlRepository>(),
+  MockSpec<CachingManager>(),
+  MockSpec<LanguageCacheManager>(),
+  MockSpec<AuthorizationInterceptors>(),
+  MockSpec<DynamicUrlInterceptors>(),
+  MockSpec<DeleteCredentialInteractor>(),
+  MockSpec<LogoutOidcInteractor>(),
+  MockSpec<DeleteAuthorityOidcInteractor>(),
+  MockSpec<AppToast>(),
+  MockSpec<ImagePaths>(),
+  MockSpec<ResponsiveUtils>(),
+  MockSpec<Uuid>(),
+  MockSpec<ToastManager>(),
+  MockSpec<TwakeAppManager>(),
+  MockSpec<ComposerRepository>(),
+])
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late UploadController controller;
+  late MockUploadFromUrlRepository repository;
+  late CapturingLogHandler logHandler;
+
+  final accountId = AccountId(Id('account-1'));
+  final uploadUri = Uri.parse('https://mail.example.com/upload-from-url/account-1');
+
+  setUp(() {
+    Get.put<CachingManager>(MockCachingManager());
+    Get.put<LanguageCacheManager>(MockLanguageCacheManager());
+    Get.put<AuthorizationInterceptors>(MockAuthorizationInterceptors());
+    Get.put<AuthorizationInterceptors>(
+      MockAuthorizationInterceptors(),
+      tag: BindingTag.isolateTag,
+    );
+    Get.put<DynamicUrlInterceptors>(MockDynamicUrlInterceptors());
+    Get.put<DeleteCredentialInteractor>(MockDeleteCredentialInteractor());
+    Get.put<LogoutOidcInteractor>(MockLogoutOidcInteractor());
+    Get.put<DeleteAuthorityOidcInteractor>(MockDeleteAuthorityOidcInteractor());
+    Get.put<AppToast>(MockAppToast());
+    Get.put<ImagePaths>(MockImagePaths());
+    Get.put<ResponsiveUtils>(MockResponsiveUtils());
+    Get.put<Uuid>(MockUuid());
+    Get.put<ToastManager>(MockToastManager());
+    Get.put<TwakeAppManager>(MockTwakeAppManager());
+
+    repository = MockUploadFromUrlRepository();
+    controller = UploadController(UploadAttachmentInteractor(MockComposerRepository()));
+    logHandler = CapturingLogHandler();
+    AppLoggerRegistry.instance.registerHandler(logHandler);
+  });
+
+  tearDown(() {
+    AppLoggerRegistry.instance.resetForTesting();
+    Get.reset();
+  });
+
+  testWidgets(
+    'WHEN one backend failure travels interactor -> runner -> resolveDriveTransferFailure\n'
+    'THEN exactly ONE durable error event is emitted\n'
+    'AND it carries no file name, account id or URL',
+    (tester) async {
+      const sensitiveName = 'SENSITIVE-PAYSLIP-2026.pdf';
+      const sensitiveLink = 'https://drive.example.com/SENSITIVE-TOKEN-8c1f/file.pdf';
+
+      // A real context, as production always has: the toast branch runs
+      // instead of the no-context fallback, which would add a second event.
+      await tester.pumpWidget(GetMaterialApp(
+        localizationsDelegates: const [
+          AppLocalizationsDelegate(),
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: LocalizationService.supportedLocales,
+        home: Scaffold(body: Container()),
+      ));
+      await tester.pumpAndSettle();
+
+      when(repository.uploadFromUrl(any))
+          .thenThrow(Exception('backend rejected the upload'));
+
+      final interactor = UploadDriveDocumentFromUrlInteractor(repository);
+      final runner = DriveAttachmentTransferRunner(
+        uploadFromUrl: interactor.execute,
+        gate: ConcurrencyGate(3),
+      );
+
+      final outcome = await runner.transfer((
+        docs: [
+          DriveDocument(
+            id: 'doc-1',
+            name: sensitiveName,
+            size: 100,
+            mimeType: 'application/pdf',
+            downloadLink: Uri.parse(sensitiveLink),
+          ),
+        ],
+        accountId: accountId,
+        uploadUri: uploadUri,
+        onPlaceholdersReady: (placeholders) => controller.addDownloadingPlaceholders(
+          placeholders.cast<DriveTransferPlaceholder>(),
+        ),
+        onSuccess: controller.resolveDriveTransferSuccess,
+        onFailure: controller.resolveDriveTransferFailure,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(outcome, (started: true, succeeded: 0, failed: 1));
+      expect(controller.listUploadAttachments, isEmpty);
+
+      expect(
+        logHandler.errorRecords,
+        hasLength(1),
+        reason: 'one failed upload must not raise duplicate Sentry issues',
+      );
+      final record = logHandler.errorRecords.single;
+      expect(record.rawMessage, isNot(contains(sensitiveName)));
+      expect(record.rawMessage, isNot(contains('SENSITIVE-TOKEN-8c1f')));
+      expect(record.rawMessage, isNot(contains('account-1')));
+    },
+  );
+}

--- a/test/features/upload/presentation/controller/upload_controller_drive_transfer_test.dart
+++ b/test/features/upload/presentation/controller/upload_controller_drive_transfer_test.dart
@@ -2,7 +2,10 @@ import 'package:core/data/network/config/dynamic_url_interceptors.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/utils/app_toast.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/utils/logging/app_logger_registry.dart';
 import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
@@ -22,10 +25,13 @@ import 'package:tmail_ui_user/features/upload/presentation/controller/upload_con
 import 'package:tmail_ui_user/features/upload/presentation/model/drive_transfer_placeholder.dart';
 import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_status.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations_delegate.dart';
+import 'package:tmail_ui_user/main/localizations/localization_service.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:tmail_ui_user/main/utils/twake_app_manager.dart';
 import 'package:uuid/uuid.dart';
 
+import '../../../../fixtures/capturing_log_handler.dart';
 import 'upload_controller_drive_transfer_test.mocks.dart';
 
 @GenerateNiceMocks([
@@ -112,19 +118,40 @@ void main() {
   });
 
   group('UploadController::resolveDriveTransferSuccess after deletion::', () {
-    test('Should not restore a chip whose attachment was already deleted', () {
-      controller.addDownloadingPlaceholders([placeholder()]);
-      controller.deleteFileUploaded(taskId);
+    late CapturingLogHandler logHandler;
 
-      // Transfer completed after the user removed the waiting chip.
-      controller.resolveDriveTransferSuccess(
-        taskId,
-        Attachment(blobId: Id('blob-1'), size: UnsignedInt(100)),
-      );
-
-      expect(controller.listUploadAttachments, isEmpty);
-      expect(controller.attachmentsUploaded, isEmpty);
+    setUp(() {
+      logHandler = CapturingLogHandler();
+      AppLoggerRegistry.instance.registerHandler(logHandler);
     });
+
+    tearDown(() => AppLoggerRegistry.instance.resetForTesting());
+
+    test(
+      'WHEN a late success arrives after its placeholder was removed\n'
+      'THEN the chip is not restored\n'
+      'AND the diagnostic event carries no attachment file name',
+      () {
+        const sensitiveName = 'SENSITIVE-OFFER-LETTER.pdf';
+        controller.addDownloadingPlaceholders([placeholder()]);
+        controller.deleteFileUploaded(taskId);
+
+        // Transfer completed after the user removed the waiting chip.
+        controller.resolveDriveTransferSuccess(
+          taskId,
+          Attachment(blobId: Id('blob-1'), size: UnsignedInt(100), name: sensitiveName),
+        );
+
+        expect(controller.listUploadAttachments, isEmpty);
+        expect(controller.attachmentsUploaded, isEmpty);
+
+        expect(logHandler.errorRecords, hasLength(1));
+        final record = logHandler.errorRecords.single;
+        expect(record.extras?.keys, isNot(contains('fileName')));
+        expect(record.rawMessage, isNot(contains(sensitiveName)));
+        expect(record.extras, containsPair('taskId', taskId.id));
+      },
+    );
   });
 
   group('UploadController::resolveDriveTransferFailure::', () {
@@ -135,6 +162,45 @@ void main() {
 
       expect(controller.listUploadAttachments, isEmpty);
     });
+
+    testWidgets(
+      'WHEN the task id is no longer present\n'
+      'THEN it does not throw\n'
+      'AND emits at most one sanitized diagnostic event',
+      (tester) async {
+        final logHandler = CapturingLogHandler();
+        AppLoggerRegistry.instance.registerHandler(logHandler);
+        addTearDown(AppLoggerRegistry.instance.resetForTesting);
+
+        // A real context: production always has one, so the toast branch runs
+        // instead of the no-context fallback that would log a second event.
+        // testMode nulls Get.context, so it is off for this widget test only.
+        Get.testMode = false;
+        addTearDown(() => Get.testMode = true);
+        await tester.pumpWidget(GetMaterialApp(
+          localizationsDelegates: const [
+            AppLocalizationsDelegate(),
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: LocalizationService.supportedLocales,
+          home: Scaffold(body: Container()),
+        ));
+
+        await tester.pumpAndSettle();
+        expect(
+          () => controller.resolveDriveTransferFailure(const UploadTaskId('unknown-task')),
+          returnsNormally,
+        );
+
+        expect(logHandler.errorRecords, hasLength(1));
+        final record = logHandler.errorRecords.single;
+        expect(record.extras, containsPair('taskId', 'unknown-task'));
+        expect(record.extras?.keys, isNot(contains('fileName')));
+        expect(record.stackTrace, isNotNull);
+      },
+    );
   });
 
   group('UploadController::addDownloadingPlaceholders + resolve ordering::', () {

--- a/test/features/upload/presentation/controller/upload_controller_drive_transfer_test.dart
+++ b/test/features/upload/presentation/controller/upload_controller_drive_transfer_test.dart
@@ -145,11 +145,12 @@ void main() {
         expect(controller.listUploadAttachments, isEmpty);
         expect(controller.attachmentsUploaded, isEmpty);
 
-        expect(logHandler.errorRecords, hasLength(1));
-        final record = logHandler.errorRecords.single;
-        expect(record.extras?.keys, isNot(contains('fileName')));
-        expect(record.rawMessage, isNot(contains(sensitiveName)));
-        expect(record.extras, containsPair('taskId', taskId.id));
+        expect(logHandler.errorRecords, isEmpty);
+        expect(logHandler.warningRecords, hasLength(1));
+        expect(
+          logHandler.warningRecords.single.rawMessage,
+          isNot(contains(sensitiveName)),
+        );
       },
     );
   });
@@ -166,15 +167,12 @@ void main() {
     testWidgets(
       'WHEN the task id is no longer present\n'
       'THEN it does not throw\n'
-      'AND emits at most one sanitized diagnostic event',
+      'AND does not emit a Sentry error event',
       (tester) async {
         final logHandler = CapturingLogHandler();
         AppLoggerRegistry.instance.registerHandler(logHandler);
         addTearDown(AppLoggerRegistry.instance.resetForTesting);
 
-        // A real context: production always has one, so the toast branch runs
-        // instead of the no-context fallback that would log a second event.
-        // testMode nulls Get.context, so it is off for this widget test only.
         Get.testMode = false;
         addTearDown(() => Get.testMode = true);
         await tester.pumpWidget(GetMaterialApp(
@@ -194,11 +192,8 @@ void main() {
           returnsNormally,
         );
 
-        expect(logHandler.errorRecords, hasLength(1));
-        final record = logHandler.errorRecords.single;
-        expect(record.extras, containsPair('taskId', 'unknown-task'));
-        expect(record.extras?.keys, isNot(contains('fileName')));
-        expect(record.stackTrace, isNotNull);
+        expect(logHandler.errorRecords, isEmpty);
+        expect(logHandler.warningRecords, hasLength(1));
       },
     );
   });

--- a/test/features/upload/presentation/model/upload_file_state_list_test.dart
+++ b/test/features/upload/presentation/model/upload_file_state_list_test.dart
@@ -129,6 +129,46 @@ void main() {
       });
     });
 
+    group('boolean found/not-found contract', () {
+      const present = UploadTaskId('a');
+      const missing = UploadTaskId('unknown');
+
+      test('updateElementBy returns true for a match and false otherwise', () {
+        final list = makeList([present]);
+
+        expect(
+          list.updateElementBy(
+            (state) => state?.uploadTaskId == present,
+            (state) => state,
+          ),
+          isTrue,
+        );
+        expect(
+          list.updateElementBy(
+            (state) => state?.uploadTaskId == missing,
+            (state) => state,
+          ),
+          isFalse,
+        );
+      });
+
+      test('updateElementByUploadTaskId returns true for a match and false otherwise', () {
+        final list = makeList([present]);
+
+        expect(list.updateElementByUploadTaskId(present, (state) => state), isTrue);
+        expect(list.updateElementByUploadTaskId(missing, (state) => state), isFalse);
+      });
+
+      test('deleteElementByUploadTaskId returns true for a match and false otherwise', () {
+        final list = makeList([present]);
+
+        expect(list.deleteElementByUploadTaskId(present), isTrue);
+        // Already removed by the call above.
+        expect(list.deleteElementByUploadTaskId(present), isFalse);
+        expect(list.deleteElementByUploadTaskId(missing), isFalse);
+      });
+    });
+
     group('cancelAll', () {
       test('cancels every pending token and empties the list', () {
         final tokenA = CancelToken();

--- a/test/fixtures/capturing_log_handler.dart
+++ b/test/fixtures/capturing_log_handler.dart
@@ -14,4 +14,7 @@ class CapturingLogHandler extends LogHandler {
 
   List<LogRecord> get errorRecords =>
       records.where((r) => r.level == Level.error).toList();
+
+  List<LogRecord> get warningRecords =>
+      records.where((r) => r.level == Level.warning).toList();
 }

--- a/test/fixtures/capturing_log_handler.dart
+++ b/test/fixtures/capturing_log_handler.dart
@@ -1,0 +1,17 @@
+import 'package:core/utils/logging/log_handler.dart';
+import 'package:core/utils/logging/log_level.dart';
+import 'package:core/utils/logging/log_record.dart';
+
+/// Captures dispatched [LogRecord]s so tests can assert what reaches Sentry.
+///
+/// Register with `AppLoggerRegistry.instance.registerHandler(...)` in setUp and
+/// clear with `AppLoggerRegistry.instance.resetForTesting()` in tearDown.
+class CapturingLogHandler extends LogHandler {
+  final List<LogRecord> records = [];
+
+  @override
+  void handle(LogRecord record) => records.add(record);
+
+  List<LogRecord> get errorRecords =>
+      records.where((r) => r.level == Level.error).toList();
+}

--- a/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
+++ b/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
@@ -78,8 +78,10 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
     )) {
       either.fold(
         (failure) {
-          logWarning(
-            'WorkplaceComposerAttachmentExtension::_exchangeAccessToken failed: $failure',
+          logError(
+            'WorkplaceComposerAttachmentExtension::_exchangeAccessToken failed',
+            exception: failure is FeatureFailure ? failure.exception : failure,
+            extras: {'platformUrl': platformUrl.toString()},
           );
           throw failure is FeatureFailure ? failure.exception : WorkplaceExchangeTokenException();
         },
@@ -117,8 +119,14 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
     )) {
       either.fold(
         (failure) {
-          logWarning(
-            'WorkplaceComposerAttachmentExtension::_createIntent failed: $failure',
+          logError(
+            'WorkplaceComposerAttachmentExtension::_createIntent failed',
+            exception: failure is FeatureFailure ? failure.exception : failure,
+            extras: {
+              'platformUrl': platformUrl.toString(),
+              'sharingLinkLabel': filePickerConfig.sharingLink.label,
+              'downloadLinkLabel': filePickerConfig.downloadLink?.label,
+            },
           );
           throw failure is FeatureFailure ? failure.exception : WorkplaceCreateIntentException();
         },

--- a/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
+++ b/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
@@ -2,7 +2,6 @@ import 'package:core/presentation/extensions/composer_attachment_plugin.dart';
 import 'package:core/presentation/extensions/composer_toolbar_button_style.dart';
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/state/failure.dart';
-import 'package:core/utils/app_logger.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:workplace/data/datasource_impl/workplace_datasource_impl.dart';
@@ -78,11 +77,7 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
     )) {
       either.fold(
         (failure) {
-          logError(
-            'WorkplaceComposerAttachmentExtension::_exchangeAccessToken failed',
-            exception: failure is FeatureFailure ? failure.exception : failure,
-            extras: {'platformUrl': platformUrl.toString()},
-          );
+          // reported by DriveIntentMessageHandlerMixin._failWith, the single funnel.
           throw failure is FeatureFailure ? failure.exception : WorkplaceExchangeTokenException();
         },
         (success) {
@@ -119,15 +114,7 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
     )) {
       either.fold(
         (failure) {
-          logError(
-            'WorkplaceComposerAttachmentExtension::_createIntent failed',
-            exception: failure is FeatureFailure ? failure.exception : failure,
-            extras: {
-              'platformUrl': platformUrl.toString(),
-              'sharingLinkLabel': filePickerConfig.sharingLink.label,
-              'downloadLinkLabel': filePickerConfig.downloadLink?.label,
-            },
-          );
+          // reported by DriveIntentMessageHandlerMixin._failWith, the single funnel.
           throw failure is FeatureFailure ? failure.exception : WorkplaceCreateIntentException();
         },
         (success) {


### PR DESCRIPTION
## Issue
- #4728

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when adding drive attachments from links.
  * Upload cancellations now stop cleanly when leaving the upload screen.
  * Pending attachments are preserved during attachment-state refreshes.
  * Drive attachment transfers now update correctly on success or failure.
  * Missing or unavailable transfer services are handled more consistently.

* **Improvements**
  * Upload failures now provide more consistent diagnostic information for support and troubleshooting.
  * Attachment transfer state updates are more responsive and reliable.
  * Upload progress is cleaned up correctly when uploads finish or are cancelled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->