### PR TITLE
TF-4472: Do not offer to close composer when saving a draft fails

### DIFF
--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1402,6 +1402,7 @@ class ComposerController extends BaseController
         await _showConfirmDialogWhenSaveMessageToDraftsFailure(
           context: context,
           failure: resultState,
+          shouldOfferCloseComposer: false,
           onConfirmAction: (needIncreaseMySpace) {
             _saveToDraftButtonState = ButtonState.enabled;
             popBack();
@@ -2396,6 +2397,7 @@ class ComposerController extends BaseController
   Future<void> _showConfirmDialogWhenSaveMessageToDraftsFailure({
     required BuildContext context,
     required FeatureFailure failure,
+    bool shouldOfferCloseComposer = true,
     Function(bool)? onConfirmAction,
     Function(bool)? onCancelAction,
   }) async {
@@ -2422,6 +2424,7 @@ class ComposerController extends BaseController
       cancelTitle: needIncreaseMySpace
         ? AppLocalizations.of(context).edit
         : AppLocalizations.of(context).closeAnyway,
+      hasCancelButton: shouldOfferCloseComposer || needIncreaseMySpace,
       alignCenter: true,
       outsideDismissible: false,
       autoPerformPopBack: false,
@@ -2445,7 +2448,7 @@ class ComposerController extends BaseController
         } else {
           _closeComposerButtonState = ButtonState.enabled;
 
-          if (needIncreaseMySpace) {
+          if (needIncreaseMySpace || !shouldOfferCloseComposer) {
             popBack();
             _autoFocusFieldWhenLauncher();
           } else {

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -45,6 +45,7 @@ import 'package:tmail_ui_user/features/composer/domain/usecases/download_image_a
 import 'package:tmail_ui_user/features/composer/domain/usecases/save_composer_cache_interactor.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
 import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_upload_validation_service.dart';
+import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_view_web.dart';
 import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_mobile_tablet_controller.dart';
 import 'package:tmail_ui_user/features/composer/presentation/controller/rich_text_web_controller.dart';
@@ -116,6 +117,9 @@ class MockRichTextWebController extends Mock implements RichTextWebController {
 
   @override
   bool get codeViewEnabled => false;
+
+  @override
+  Future<void> setEnableCodeView() async {}
 }
 
 class MockLabelController extends Mock implements LabelController {
@@ -699,6 +703,61 @@ void main() {
 
             expect(find.byType(ComposerView), findsOneWidget);
             expect(find.text(appLocalizations.increaseYourSpace), findsNothing);
+
+            PlatformInfo.isTestingForWeb = false;
+          });
+        });
+
+        testWidgets(
+          'Should still offer to close the composer\n'
+          'When save as draft fails after user closes the composer',
+        (tester) async {
+          await tester.runAsync(() async {
+            PlatformInfo.isTestingForWeb = true;
+            InAppWebViewPlatform.instance = MockWebViewPlatform();
+
+            when(mockUploadController.uploadInlineViewState).thenReturn(
+              Rx(Right(UIState.idle)));
+            when(mockUploadController.listUploadAttachments).thenReturn(
+              RxList<UploadFileState>());
+
+            Get.put(composerController!);
+            composerController?.richTextWebController = mockRichTextWebController;
+
+            composerController?.setTextEditorWeb(emailContent);
+            composerController?.composerArguments.value = ComposerArguments();
+            when(mockUploadController.attachmentsUploaded).thenReturn([attachment]);
+            when(mockComposerRepository.removeCollapsedExpandedSignatureEffect(
+              emailContent: anyNamed('emailContent'),
+            )).thenAnswer((_) async => emailContent);
+            when(
+              mockCreateNewAndSaveEmailToDraftsInteractor.execute(
+                createEmailRequest: anyNamed('createEmailRequest'),
+                cancelToken: anyNamed('cancelToken')))
+              .thenAnswer((_) => Stream.value(
+                Left(SaveEmailAsDraftsFailure(Exception()))));
+
+            await tester.pumpWidget(WidgetFixtures.makeTestableWidget(
+              child: const Stack(children: [ComposerView()])));
+            await tester.pump();
+            composerController?.handleInitHtmlEditorWeb(emailContent);
+
+            await tester.tap(find.byKey(const Key(UiKeys.closeComposerButton)));
+            await tester.pumpAndSettle();
+
+            final appLocalizations = AppLocalizations.of(
+              tester.element(find.byType(ComposerView)));
+            await tester.tap(find.text(appLocalizations.save));
+            await tester.pump();
+            await untilCalled(
+              mockCreateNewAndSaveEmailToDraftsInteractor.execute(
+                createEmailRequest: anyNamed('createEmailRequest'),
+                cancelToken: anyNamed('cancelToken')));
+            await tester.pumpAndSettle();
+
+            expect(find.text(appLocalizations.closeAnyway), findsOneWidget);
+            expect(find.text(appLocalizations.edit), findsOneWidget);
+            expect(find.byType(ComposerView), findsOneWidget);
 
             PlatformInfo.isTestingForWeb = false;
           });

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -79,6 +79,7 @@ import 'package:tmail_ui_user/features/upload/presentation/controller/upload_con
 import 'package:tmail_ui_user/features/upload/presentation/model/upload_file_state.dart';
 import 'package:tmail_ui_user/main/bindings/network/binding_tag.dart';
 import 'package:tmail_ui_user/main/exceptions/thrower/cache_exception_thrower.dart';
+import 'package:tmail_ui_user/main/localizations/app_localizations.dart';
 import 'package:tmail_ui_user/main/providers/app_provider_container.dart';
 import 'package:tmail_ui_user/main/utils/app_config.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
@@ -133,6 +134,12 @@ class MockMailboxDashBoardController extends Mock implements MailboxDashBoardCon
   Rxn<AccountId> get accountId => Rxn(AccountFixtures.aliceAccountId);
   @override
   Session? get sessionCurrent => SessionFixtures.aliceSession;
+
+  @override
+  bool isPremiumAvailable({Session? session, AccountId? accountId}) => false;
+
+  @override
+  bool isAlreadyHighestSubscription({Session? session, AccountId? accountId}) => false;
 
   @override
   RxString get ownEmailAddress => SessionFixtures.aliceSession.getOwnEmailAddressOrEmpty().obs;
@@ -568,6 +575,61 @@ void main() {
             );
 
             // tear down
+            PlatformInfo.isTestingForWeb = false;
+          });
+        });
+
+        testWidgets(
+          'Should not offer to close the composer\n'
+          'When save as draft fails',
+        (tester) async {
+          await tester.runAsync(() async {
+            PlatformInfo.isTestingForWeb = true;
+            InAppWebViewPlatform.instance = MockWebViewPlatform();
+
+            when(mockUploadController.uploadInlineViewState).thenReturn(
+              Rx(Right(UIState.idle)));
+            when(mockUploadController.listUploadAttachments).thenReturn(
+              RxList<UploadFileState>());
+
+            Get.put(composerController!);
+            composerController?.richTextWebController = mockRichTextWebController;
+
+            composerController?.setTextEditorWeb(emailContent);
+            composerController?.composerArguments.value = ComposerArguments();
+            when(mockUploadController.attachmentsUploaded).thenReturn([attachment]);
+            when(mockComposerRepository.removeCollapsedExpandedSignatureEffect(
+              emailContent: anyNamed('emailContent'),
+            )).thenAnswer((_) async => emailContent);
+            when(
+              mockCreateNewAndSaveEmailToDraftsInteractor.execute(
+                createEmailRequest: anyNamed('createEmailRequest'),
+                cancelToken: anyNamed('cancelToken')))
+              .thenAnswer((_) => Stream.value(
+                Left(SaveEmailAsDraftsFailure(Exception()))));
+
+            await tester.pumpWidget(WidgetFixtures.makeTestableWidget(
+              child: const Stack(children: [ComposerView()])));
+            await tester.pump();
+
+            final saveAsDraftButton = find.ancestor(
+              of: find.byType(InkWell),
+              matching: find.byWidgetPredicate(
+                (widget) => widget is TMailButtonWidget
+                  && widget.icon == ImagePaths().icSaveToDraft));
+            await tester.tap(saveAsDraftButton);
+            await tester.pump();
+            await untilCalled(
+              mockCreateNewAndSaveEmailToDraftsInteractor.execute(
+                createEmailRequest: anyNamed('createEmailRequest'),
+                cancelToken: anyNamed('cancelToken')));
+            await tester.pumpAndSettle();
+
+            final appLocalizations = AppLocalizations.of(
+              tester.element(find.byType(ComposerView)));
+            expect(find.text(appLocalizations.closeAnyway), findsNothing);
+            expect(find.text(appLocalizations.edit), findsOneWidget);
+
             PlatformInfo.isTestingForWeb = false;
           });
         });

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:html_editor_enhanced/html_editor.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/error/set_error.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/identities/identity.dart';
@@ -32,6 +33,7 @@ import 'package:model/mailbox/presentation_mailbox.dart';
 import 'package:rich_text_composer/rich_text_composer.dart';
 import 'package:tmail_ui_user/features/base/before_reconnect_manager.dart';
 import 'package:tmail_ui_user/features/caching/caching_manager.dart';
+import 'package:tmail_ui_user/features/composer/domain/exceptions/set_method_exception.dart';
 import 'package:tmail_ui_user/features/composer/domain/repository/composer_repository.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/save_email_as_drafts_state.dart';
 import 'package:tmail_ui_user/features/composer/domain/state/update_email_drafts_state.dart';
@@ -135,8 +137,10 @@ class MockMailboxDashBoardController extends Mock implements MailboxDashBoardCon
   @override
   Session? get sessionCurrent => SessionFixtures.aliceSession;
 
+  bool premiumAvailable = false;
+
   @override
-  bool isPremiumAvailable({Session? session, AccountId? accountId}) => false;
+  bool isPremiumAvailable({Session? session, AccountId? accountId}) => premiumAvailable;
 
   @override
   bool isAlreadyHighestSubscription({Session? session, AccountId? accountId}) => false;
@@ -317,6 +321,7 @@ void main() {
     // Mock Getx controllers
     // Reset the shared drag state so it does not leak between tests.
     mockMailboxDashBoardController.localFileDraggableAppState.value = DraggableAppState.inActive;
+    mockMailboxDashBoardController.premiumAvailable = false;
     Get.put<MailboxDashBoardController>(mockMailboxDashBoardController);
     Get.put<NetworkConnectionController>(mockNetworkConnectionController);
     Get.put<BeforeReconnectManager>(mockBeforeReconnectManager);
@@ -629,6 +634,71 @@ void main() {
               tester.element(find.byType(ComposerView)));
             expect(find.text(appLocalizations.closeAnyway), findsNothing);
             expect(find.text(appLocalizations.edit), findsOneWidget);
+
+            PlatformInfo.isTestingForWeb = false;
+          });
+        });
+
+        testWidgets(
+          'Should still offer increase space and edit\n'
+          'When save as draft fails because of over quota',
+        (tester) async {
+          await tester.runAsync(() async {
+            PlatformInfo.isTestingForWeb = true;
+            InAppWebViewPlatform.instance = MockWebViewPlatform();
+            mockMailboxDashBoardController.premiumAvailable = true;
+
+            when(mockUploadController.uploadInlineViewState).thenReturn(
+              Rx(Right(UIState.idle)));
+            when(mockUploadController.listUploadAttachments).thenReturn(
+              RxList<UploadFileState>());
+
+            Get.put(composerController!);
+            composerController?.richTextWebController = mockRichTextWebController;
+
+            composerController?.setTextEditorWeb(emailContent);
+            composerController?.composerArguments.value = ComposerArguments();
+            when(mockUploadController.attachmentsUploaded).thenReturn([attachment]);
+            when(mockComposerRepository.removeCollapsedExpandedSignatureEffect(
+              emailContent: anyNamed('emailContent'),
+            )).thenAnswer((_) async => emailContent);
+            when(
+              mockCreateNewAndSaveEmailToDraftsInteractor.execute(
+                createEmailRequest: anyNamed('createEmailRequest'),
+                cancelToken: anyNamed('cancelToken')))
+              .thenAnswer((_) => Stream.value(
+                Left(SaveEmailAsDraftsFailure(SetMethodException({
+                  Id('draft'): SetError(SetError.overQuota),
+                })))));
+
+            await tester.pumpWidget(WidgetFixtures.makeTestableWidget(
+              child: const Stack(children: [ComposerView()])));
+            await tester.pump();
+
+            final saveAsDraftButton = find.ancestor(
+              of: find.byType(InkWell),
+              matching: find.byWidgetPredicate(
+                (widget) => widget is TMailButtonWidget
+                  && widget.icon == ImagePaths().icSaveToDraft));
+            await tester.tap(saveAsDraftButton);
+            await tester.pump();
+            await untilCalled(
+              mockCreateNewAndSaveEmailToDraftsInteractor.execute(
+                createEmailRequest: anyNamed('createEmailRequest'),
+                cancelToken: anyNamed('cancelToken')));
+            await tester.pumpAndSettle();
+
+            final appLocalizations = AppLocalizations.of(
+              tester.element(find.byType(ComposerView)));
+            expect(find.text(appLocalizations.increaseYourSpace), findsOneWidget);
+            expect(find.text(appLocalizations.edit), findsOneWidget);
+            expect(find.text(appLocalizations.closeAnyway), findsNothing);
+
+            await tester.tap(find.text(appLocalizations.edit));
+            await tester.pumpAndSettle();
+
+            expect(find.byType(ComposerView), findsOneWidget);
+            expect(find.text(appLocalizations.increaseYourSpace), findsNothing);
 
             PlatformInfo.isTestingForWeb = false;
           });


### PR DESCRIPTION
Closes #4472 

## Description

When a user manually saves an email as a draft and the save fails (for example, after cancelling while offline), the failure dialog no longer offers `Close anyway` / `Ignore and close`. This keeps the composer open and preserves the user's input.

The existing close-composer flow is unchanged: it can still offer to close the composer because closing was explicitly requested by the user.

## Changes

- Hide the close-composer action for failures triggered by the explicit **Save as draft** action.
- Keep the **Edit** action so the user can continue editing their email.
- Add a regression widget test covering the draft-save failure dialog.

## Demo

<img width="297" height="640" alt="Screenshot 2026-08-24 at 15 41 05" src="https://github.com/user-attachments/assets/d78b37c2-5a10-4a93-bb72-c8a62c681d44" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved draft-save failure dialogs by removing the misleading “close anyway” option when the composer should remain open.
  * Updated subscription-related recovery options, including prompts to increase storage when applicable.
  * Preserved the option to close the composer when saving fails after it has already been closed.

* **Tests**
  * Added coverage for draft-save failures, storage-limit messaging, and composer-close behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->