### PR TITLE
TF-4728 Drive picker data layer (#4764)

### DIFF
--- a/core/lib/utils/sentry/sentry_initializer.dart
+++ b/core/lib/utils/sentry/sentry_initializer.dart
@@ -20,6 +20,7 @@ class SentryInitializer {
     'session',
     'password',
     'token',
+    'content-location',
   ];
 
   /// Initializes Sentry.

--- a/lib/features/home/domain/converter/capability_properties_converter.dart
+++ b/lib/features/home/domain/converter/capability_properties_converter.dart
@@ -13,43 +13,33 @@ import 'package:jmap_dart_client/jmap/core/capability/websocket_capability.dart'
 import 'package:labels/model/labels_capability.dart';
 import 'package:model/saas/saas_account_capability.dart';
 import 'package:model/support/contact_support_capability.dart';
+import 'package:model/upload/upload_from_url_capability.dart';
 import 'package:scribe/scribe/ai/presentation/model/ai_capability.dart';
 
 class CapabilityPropertiesConverter {
 
+  // Dispatch table keyed by runtime type keeps this out of an ever-growing if-else chain.
+  static final Map<Type, Map<String, dynamic>? Function(CapabilityProperties)> _converters = {
+    CoreCapability: (properties) => (properties as CoreCapability).toJson(),
+    MailCapability: (properties) => (properties as MailCapability).toJson(),
+    SubmissionCapability: (properties) => (properties as SubmissionCapability).toJson(),
+    VacationCapability: (properties) => (properties as VacationCapability).toJson(),
+    CalendarEventCapability: (properties) => (properties as CalendarEventCapability).toJson(),
+    WebSocketCapability: (properties) => (properties as WebSocketCapability).toJson(),
+    WebSocketTicketCapability: (properties) => (properties as WebSocketTicketCapability).toJson(),
+    MdnCapability: (properties) => (properties as MdnCapability).toJson(),
+    AutocompleteCapability: (properties) => (properties as AutocompleteCapability).toJson(),
+    ContactSupportCapability: (properties) => (properties as ContactSupportCapability).toJson(),
+    SaaSAccountCapability: (properties) => (properties as SaaSAccountCapability).toJson(),
+    AICapability: (properties) => (properties as AICapability).toJson(),
+    LabelsCapability: (properties) => (properties as LabelsCapability).toJson(),
+    UploadFromUrlCapability: (properties) => (properties as UploadFromUrlCapability).toJson(),
+    DefaultCapability: (properties) => (properties as DefaultCapability).properties,
+    EmptyCapability: (properties) => (properties as EmptyCapability).toJson(),
+  };
+
   Map<String, dynamic>? toJson(CapabilityProperties properties) {
-    if (properties is CoreCapability) {
-      return properties.toJson();
-    } else if (properties is MailCapability) {
-      return properties.toJson();
-    } else if (properties is SubmissionCapability) {
-      return properties.toJson();
-    } else if (properties is VacationCapability) {
-      return properties.toJson();
-    } else if (properties is CalendarEventCapability) {
-      return properties.toJson();
-    } else if (properties is WebSocketCapability) {
-      return properties.toJson();
-    } else if (properties is WebSocketTicketCapability) {
-      return properties.toJson();
-    } else if (properties is MdnCapability) {
-      return properties.toJson();
-    } else if (properties is AutocompleteCapability) {
-      return properties.toJson();
-    } else if (properties is ContactSupportCapability) {
-      return properties.toJson();
-    } else if (properties is SaaSAccountCapability) {
-      return properties.toJson();
-    } else if (properties is AICapability) {
-      return properties.toJson();
-    } else if (properties is LabelsCapability) {
-      return properties.toJson();
-    } else if (properties is DefaultCapability) {
-      return properties.properties;
-    } else if (properties is EmptyCapability) {
-      return properties.toJson();
-    } else {
-      return null;
-    }
+    final converter = _converters[properties.runtimeType];
+    return converter?.call(properties);
   }
 }

--- a/lib/features/home/domain/extensions/session_extensions.dart
+++ b/lib/features/home/domain/extensions/session_extensions.dart
@@ -18,6 +18,7 @@ import 'package:model/ai/ai_capabilities.dart';
 import 'package:model/download_all/download_all_capability.dart';
 import 'package:model/mailbox/mailbox_constants.dart';
 import 'package:model/model.dart';
+import 'package:model/upload/upload_from_url_capability.dart';
 import 'package:scribe/scribe/ai/presentation/model/ai_capability.dart';
 import 'package:server_settings/server_settings/capability_server_settings.dart';
 import 'package:tmail_ui_user/features/home/data/model/session_hive_obj.dart';
@@ -25,11 +26,13 @@ import 'package:tmail_ui_user/features/home/domain/converter/session_account_con
 import 'package:tmail_ui_user/features/home/domain/converter/session_capabilities_converter.dart';
 import 'package:tmail_ui_user/features/home/domain/converter/session_primary_account_converter.dart';
 import 'package:tmail_ui_user/main/error/capability_validator.dart';
+import 'package:uri/uri.dart';
 
 extension SessionExtensions on Session {
   static final CapabilityIdentifier linagoraContactSupportCapability = CapabilityIdentifier(Uri.parse('com:linagora:params:jmap:contact:support'));
   static final CapabilityIdentifier linagoraDownloadAllCapability = CapabilityIdentifier(Uri.parse('com:linagora:params:downloadAll'));
   static final CapabilityIdentifier linagoraSaaSCapability = CapabilityIdentifier(Uri.parse('com:linagora:params:saas'));
+  static final CapabilityIdentifier linagoraUploadFromUrlCapability = CapabilityIdentifier(Uri.parse('com:linagora:params:jmap:upload:from-url'));
 
   static final Map<CapabilityIdentifier, CapabilityProperties Function(Map<String, dynamic>)> customMapCapabilitiesConverter = {
     linagoraContactSupportCapability: ContactSupportCapability.deserialize,
@@ -37,6 +40,7 @@ extension SessionExtensions on Session {
     linagoraDownloadAllCapability: DownloadAllCapability.deserialize,
     capabilityServerSettings: SettingsCapability.deserialize,
     linagoraSaaSCapability: SaaSAccountCapability.deserialize,
+    linagoraUploadFromUrlCapability: UploadFromUrlCapability.deserialize,
     AiCapabilities.aiCapability: AICapability.fromJson,
     LabelsConstants.labelsCapability: LabelsCapability.fromJson,
   };
@@ -123,17 +127,61 @@ extension SessionExtensions on Session {
     return downloadAllCapability?.endpoint?.isNotEmpty ?? false;
   }
 
-  DownloadAllCapability? getDownloadAllCapability(AccountId? accountId) {
+  DownloadAllCapability? getDownloadAllCapability(AccountId? accountId) =>
+      _getSupportedCapability<DownloadAllCapability>(
+        accountId,
+        linagoraDownloadAllCapability,
+      );
+
+  bool isUploadFromUrlSupported(AccountId? accountId, {required String jmapUrl}) {
+    return getUploadFromUrlUri(accountId, jmapUrl: jmapUrl) != null;
+  }
+
+  UploadFromUrlCapability? getUploadFromUrlCapability(AccountId? accountId) =>
+      _getSupportedCapability<UploadFromUrlCapability>(
+        accountId,
+        linagoraUploadFromUrlCapability,
+      );
+
+  // Shared by capability getters that gate on accountId + isSupported before reading properties.
+  T? _getSupportedCapability<T extends CapabilityProperties>(
+    AccountId? accountId,
+    CapabilityIdentifier identifier,
+  ) {
     if (accountId == null) return null;
 
-    if (!linagoraDownloadAllCapability.isSupported(this, accountId)) {
+    if (!identifier.isSupported(this, accountId)) {
       return null;
     }
 
-    return getCapabilityProperties<DownloadAllCapability>(
-      accountId,
-      linagoraDownloadAllCapability,
-    );
+    return getCapabilityProperties<T>(accountId, identifier);
+  }
+
+  /// Resolves the advertised upload-from-url endpoint for [accountId], or null when unavailable.
+  Uri? getUploadFromUrlUri(AccountId? accountId, {required String jmapUrl}) {
+    if (accountId == null) return null;
+
+    final advertisedUrl = getUploadFromUrlCapability(accountId)?.uploadUrl;
+    if (advertisedUrl == null) return null;
+
+    if (!advertisedUrl.hasOrigin && advertisedUrl.host.isNotEmpty) {
+      // Scheme-relative URL ("//host/..."): reject instead of silently gluing it onto jmapUrl.
+      return null;
+    }
+
+    try {
+      final qualifiedUrl = advertisedUrl.toQualifiedUrl(baseUrl: Uri.parse(jmapUrl));
+
+      final normalizedUrl = qualifiedUrl.normalizePathSlashes();
+      // Only unescape the {accountId} delimiters; decoding the whole URI would drop the query string.
+      final uriTemplate = UriTemplate(
+        normalizedUrl.toString().replaceAll('%7B', '{').replaceAll('%7D', '}'),
+      );
+      return Uri.parse(uriTemplate.expand({'accountId': accountId.id.value}));
+    } catch (e) {
+      logWarning('SessionExtensions::getUploadFromUrlUri: failed to build upload uri');
+      return null;
+    }
   }
 
   bool isSubAddressingSupported(AccountId? accountId) {

--- a/lib/features/upload/data/datasource/upload_from_url_datasource.dart
+++ b/lib/features/upload/data/datasource/upload_from_url_datasource.dart
@@ -1,0 +1,6 @@
+import 'package:model/upload/upload_response.dart';
+import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_request.dart';
+
+abstract class UploadFromUrlDataSource {
+  Future<UploadResponse> uploadFromUrl(UploadFromUrlRequest request);
+}

--- a/lib/features/upload/data/datasource_impl/upload_from_url_datasource_impl.dart
+++ b/lib/features/upload/data/datasource_impl/upload_from_url_datasource_impl.dart
@@ -1,0 +1,17 @@
+import 'package:model/upload/upload_response.dart';
+import 'package:tmail_ui_user/features/upload/data/datasource/upload_from_url_datasource.dart';
+import 'package:tmail_ui_user/features/upload/data/network/upload_from_url_api.dart';
+import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_request.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/exception_thrower.dart';
+
+class UploadFromUrlDataSourceImpl implements UploadFromUrlDataSource {
+  const UploadFromUrlDataSourceImpl(this._uploadFromUrlApi, this._exceptionThrower);
+
+  final UploadFromUrlApi _uploadFromUrlApi;
+  final ExceptionThrower _exceptionThrower;
+
+  @override
+  Future<UploadResponse> uploadFromUrl(UploadFromUrlRequest request) =>
+      Future.sync(() => _uploadFromUrlApi.uploadFromUrl(request))
+        .catchError(_exceptionThrower.throwException);
+}

--- a/lib/features/upload/data/extensions/upload_from_url_request_extension.dart
+++ b/lib/features/upload/data/extensions/upload_from_url_request_extension.dart
@@ -1,0 +1,13 @@
+import 'dart:io';
+
+import 'package:core/data/constants/constant.dart';
+import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_request.dart';
+
+extension UploadFromUrlRequestExtension on UploadFromUrlRequest {
+  // BE reads the source URL and mime type from headers, not a JSON body.
+  Map<String, dynamic> get uploadHeaders => {
+        HttpHeaders.contentTypeHeader:
+            mimeType.trim().isEmpty ? Constant.octetStreamMimeType : mimeType.trim(),
+        HttpHeaders.contentLocationHeader: attachmentUrl.toString(),
+      };
+}

--- a/lib/features/upload/data/network/upload_from_url_api.dart
+++ b/lib/features/upload/data/network/upload_from_url_api.dart
@@ -1,0 +1,21 @@
+import 'package:core/data/network/dio_client.dart';
+import 'package:dio/dio.dart';
+import 'package:model/upload/upload_response.dart';
+import 'package:tmail_ui_user/features/upload/data/extensions/upload_from_url_request_extension.dart';
+import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_request.dart';
+
+class UploadFromUrlApi {
+  final DioClient _dioClient;
+
+  const UploadFromUrlApi(this._dioClient);
+
+  Future<UploadResponse> uploadFromUrl(UploadFromUrlRequest request) async {
+    // Empty body: BE reads the source URL/mime type from headers (see uploadHeaders).
+    final responseJson = await _dioClient.post(
+      request.uploadUri.toString(),
+      options: Options(headers: request.uploadHeaders),
+      cancelToken: request.cancelToken,
+    );
+    return UploadResponse.fromJson(responseJson);
+  }
+}

--- a/lib/features/upload/data/repository/upload_from_url_repository_impl.dart
+++ b/lib/features/upload/data/repository/upload_from_url_repository_impl.dart
@@ -1,0 +1,21 @@
+import 'package:model/email/attachment.dart';
+import 'package:model/upload/upload_response.dart';
+import 'package:tmail_ui_user/features/upload/data/datasource/upload_from_url_datasource.dart';
+import 'package:tmail_ui_user/features/upload/domain/exceptions/upload_from_url_account_mismatch_exception.dart';
+import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_repository.dart';
+import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_request.dart';
+
+class UploadFromUrlRepositoryImpl implements UploadFromUrlRepository {
+  final UploadFromUrlDataSource _uploadFromUrlDataSource;
+
+  const UploadFromUrlRepositoryImpl(this._uploadFromUrlDataSource);
+
+  @override
+  Future<Attachment> uploadFromUrl(UploadFromUrlRequest request) async {
+    final uploadResponse = await _uploadFromUrlDataSource.uploadFromUrl(request);
+    if (uploadResponse.accountId != request.accountId) {
+      throw UploadFromUrlAccountMismatchException();
+    }
+    return uploadResponse.toAttachment(nameFile: request.name);
+  }
+}

--- a/lib/features/upload/domain/exceptions/upload_from_url_account_mismatch_exception.dart
+++ b/lib/features/upload/domain/exceptions/upload_from_url_account_mismatch_exception.dart
@@ -1,0 +1,5 @@
+/// Thrown when the upload-from-url response reports a different account than the one requested.
+class UploadFromUrlAccountMismatchException implements Exception {
+  @override
+  String toString() => 'UploadFromUrlAccountMismatchException: response accountId does not match the requested accountId';
+}

--- a/lib/features/upload/domain/repository/upload_from_url_repository.dart
+++ b/lib/features/upload/domain/repository/upload_from_url_repository.dart
@@ -1,0 +1,6 @@
+import 'package:model/email/attachment.dart';
+import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_request.dart';
+
+abstract class UploadFromUrlRepository {
+  Future<Attachment> uploadFromUrl(UploadFromUrlRequest request);
+}

--- a/lib/features/upload/domain/repository/upload_from_url_request.dart
+++ b/lib/features/upload/domain/repository/upload_from_url_request.dart
@@ -1,0 +1,20 @@
+import 'package:dio/dio.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+
+class UploadFromUrlRequest {
+  final AccountId accountId;
+  final Uri uploadUri;
+  final Uri attachmentUrl;
+  final String name;
+  final String mimeType;
+  final CancelToken? cancelToken;
+
+  const UploadFromUrlRequest({
+    required this.accountId,
+    required this.uploadUri,
+    required this.attachmentUrl,
+    required this.name,
+    required this.mimeType,
+    this.cancelToken,
+  });
+}

--- a/lib/features/upload/domain/state/upload_drive_document_from_url_state.dart
+++ b/lib/features/upload/domain/state/upload_drive_document_from_url_state.dart
@@ -1,0 +1,24 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:model/email/attachment.dart';
+
+class UploadDriveDocumentFromUrlSuccess extends UIState {
+
+  final Attachment attachment;
+
+  UploadDriveDocumentFromUrlSuccess(this.attachment);
+
+  @override
+  List<Object?> get props => [attachment];
+}
+
+class UploadDriveDocumentFromUrlFailure extends FeatureFailure {
+
+  UploadDriveDocumentFromUrlFailure(dynamic exception) : super(exception: exception);
+}
+
+class UploadDriveDocumentFromUrlCancelled extends Failure {
+
+  @override
+  List<Object?> get props => [];
+}

--- a/lib/features/upload/domain/usecases/upload_drive_document_from_url_interactor.dart
+++ b/lib/features/upload/domain/usecases/upload_drive_document_from_url_interactor.dart
@@ -1,0 +1,25 @@
+import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/state/success.dart';
+import 'package:dartz/dartz.dart';
+import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_repository.dart';
+import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_request.dart';
+import 'package:tmail_ui_user/features/upload/domain/state/upload_drive_document_from_url_state.dart';
+
+class UploadDriveDocumentFromUrlInteractor {
+  final UploadFromUrlRepository _uploadFromUrlRepository;
+
+  UploadDriveDocumentFromUrlInteractor(this._uploadFromUrlRepository);
+
+  Stream<Either<Failure, Success>> execute(UploadFromUrlRequest request) async* {
+    try {
+      final attachment = await _uploadFromUrlRepository.uploadFromUrl(request);
+      yield Right<Failure, Success>(UploadDriveDocumentFromUrlSuccess(attachment));
+    } catch (e) {
+      yield Left<Failure, Success>(
+        request.cancelToken?.isCancelled == true
+          ? UploadDriveDocumentFromUrlCancelled()
+          : UploadDriveDocumentFromUrlFailure(e),
+      );
+    }
+  }
+}

--- a/lib/features/upload/presentation/providers/upload_from_url_providers.dart
+++ b/lib/features/upload/presentation/providers/upload_from_url_providers.dart
@@ -1,0 +1,31 @@
+import 'package:core/data/network/dio_client.dart';
+import 'package:get/get.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:tmail_ui_user/features/upload/data/datasource/upload_from_url_datasource.dart';
+import 'package:tmail_ui_user/features/upload/data/datasource_impl/upload_from_url_datasource_impl.dart';
+import 'package:tmail_ui_user/features/upload/data/network/upload_from_url_api.dart';
+import 'package:tmail_ui_user/features/upload/data/repository/upload_from_url_repository_impl.dart';
+import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_repository.dart';
+import 'package:tmail_ui_user/features/upload/domain/usecases/upload_drive_document_from_url_interactor.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/remote_exception_thrower.dart';
+
+part 'upload_from_url_providers.g.dart';
+
+@riverpod
+UploadFromUrlApi uploadFromUrlApi(Ref ref) =>
+    UploadFromUrlApi(Get.find<DioClient>());
+
+@riverpod
+UploadFromUrlDataSource uploadFromUrlDataSource(Ref ref) =>
+    UploadFromUrlDataSourceImpl(
+      ref.watch(uploadFromUrlApiProvider),
+      Get.find<RemoteExceptionThrower>(),
+    );
+
+@riverpod
+UploadFromUrlRepository uploadFromUrlRepository(Ref ref) =>
+    UploadFromUrlRepositoryImpl(ref.watch(uploadFromUrlDataSourceProvider));
+
+@riverpod
+UploadDriveDocumentFromUrlInteractor uploadDriveDocumentFromUrlInteractor(Ref ref) =>
+    UploadDriveDocumentFromUrlInteractor(ref.watch(uploadFromUrlRepositoryProvider));

--- a/model/lib/upload/upload_from_url_capability.dart
+++ b/model/lib/upload/upload_from_url_capability.dart
@@ -1,0 +1,21 @@
+import 'package:jmap_dart_client/jmap/core/capability/capability_properties.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'upload_from_url_capability.g.dart';
+
+@JsonSerializable(includeIfNull: false)
+class UploadFromUrlCapability extends CapabilityProperties {
+  UploadFromUrlCapability({this.uploadUrl});
+
+  /// The upload-from-url endpoint advertised by the server, still holding its `{accountId}` template variable.
+  final Uri? uploadUrl;
+
+  factory UploadFromUrlCapability.fromJson(Map<String, dynamic> json) => _$UploadFromUrlCapabilityFromJson(json);
+
+  Map<String, dynamic> toJson() => _$UploadFromUrlCapabilityToJson(this);
+
+  factory UploadFromUrlCapability.deserialize(Map<String, dynamic> json) => _$UploadFromUrlCapabilityFromJson(json);
+
+  @override
+  List<Object?> get props => [uploadUrl];
+}

--- a/model/test/upload/upload_from_url_capability_test.dart
+++ b/model/test/upload/upload_from_url_capability_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/upload/upload_from_url_capability.dart';
+
+void main() {
+  group('UploadFromUrlCapability::json', () {
+    test('SHOULD parse the advertised uploadUrl template', () {
+      final capability = UploadFromUrlCapability.deserialize({
+        'uploadUrl': 'https://mail.example.com/upload-from-url/{accountId}',
+      });
+
+      expect(
+        capability.uploadUrl.toString(),
+        'https://mail.example.com/upload-from-url/%7BaccountId%7D',
+      );
+    });
+
+    test('SHOULD return null uploadUrl WHEN the key is absent', () {
+      final capability = UploadFromUrlCapability.deserialize({});
+
+      expect(capability.uploadUrl, isNull);
+    });
+
+    test('SHOULD round-trip the uploadUrl back to json', () {
+      final capability = UploadFromUrlCapability(
+        uploadUrl: Uri.parse('https://mail.example.com/upload-from-url/alice'),
+      );
+
+      expect(capability.toJson(), {
+        'uploadUrl': 'https://mail.example.com/upload-from-url/alice',
+      });
+    });
+
+    test('SHOULD omit the uploadUrl from json WHEN it is null', () {
+      expect(UploadFromUrlCapability().toJson(), isEmpty);
+    });
+  });
+}

--- a/test/features/session/session_extensions_test.dart
+++ b/test/features/session/session_extensions_test.dart
@@ -1,6 +1,8 @@
 import 'package:contact/contact_module.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/core/account/account.dart';
+import 'package:jmap_dart_client/jmap/core/capability/capability_identifier.dart';
+import 'package:jmap_dart_client/jmap/core/capability/capability_properties.dart';
 import 'package:jmap_dart_client/jmap/core/capability/empty_capability.dart';
 import 'package:jmap_dart_client/jmap/core/session/session.dart';
 import 'package:jmap_dart_client/jmap/core/state.dart';
@@ -8,6 +10,9 @@ import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:model/download_all/download_all_capability.dart';
 import 'package:model/support/contact_support_capability.dart';
+import 'package:model/upload/upload_from_url_capability.dart';
+import 'package:tmail_ui_user/features/home/data/extensions/session_hive_obj_extension.dart';
+import 'package:tmail_ui_user/features/home/domain/converter/capability_properties_converter.dart';
 import 'package:tmail_ui_user/features/home/domain/extensions/session_extensions.dart';
 
 import '../../fixtures/account_fixtures.dart';
@@ -424,6 +429,183 @@ void main() {
 
       // Assert
       expect(result, isNull);
+    });
+  });
+
+  group('uploadFromUrlCapability::test', () {
+    Session sessionWith(Map<CapabilityIdentifier, CapabilityProperties> accountCapabilities) => Session(
+      {},
+      {
+        AccountFixtures.aliceAccountId: Account(
+          AccountName('Alice'),
+          true,
+          false,
+          accountCapabilities,
+        )
+      },
+      {},
+      UserName(''),
+      Uri(),
+      Uri(),
+      Uri(),
+      Uri(),
+      State(''),
+    );
+
+    final capabilityWithTemplate = UploadFromUrlCapability(
+      uploadUrl: Uri.parse('https://mail.example.com/upload-from-url/{accountId}'),
+    );
+
+    test('SHOULD not be supported WHEN AccountId is null', () {
+      final session = sessionWith({
+        SessionExtensions.linagoraUploadFromUrlCapability: capabilityWithTemplate,
+      });
+
+      expect(session.isUploadFromUrlSupported(null, jmapUrl: 'https://mail.example.com'), isFalse);
+      expect(session.getUploadFromUrlUri(null, jmapUrl: 'https://mail.example.com'), isNull);
+    });
+
+    test('SHOULD not be supported WHEN the capability is absent', () {
+      final session = sessionWith({});
+
+      expect(session.isUploadFromUrlSupported(AccountFixtures.aliceAccountId, jmapUrl: 'https://mail.example.com'), isFalse);
+      expect(session.getUploadFromUrlUri(AccountFixtures.aliceAccountId, jmapUrl: 'https://mail.example.com'), isNull);
+    });
+
+    test('SHOULD not be supported WHEN the capability advertises no uploadUrl', () {
+      final session = sessionWith({
+        SessionExtensions.linagoraUploadFromUrlCapability: UploadFromUrlCapability(),
+      });
+
+      expect(session.isUploadFromUrlSupported(AccountFixtures.aliceAccountId, jmapUrl: 'https://mail.example.com'), isFalse);
+      expect(session.getUploadFromUrlUri(AccountFixtures.aliceAccountId, jmapUrl: 'https://mail.example.com'), isNull);
+    });
+
+    test('SHOULD be supported AND expand the accountId template WHEN the capability advertises an absolute url', () {
+      final session = sessionWith({
+        SessionExtensions.linagoraUploadFromUrlCapability: capabilityWithTemplate,
+      });
+
+      expect(session.isUploadFromUrlSupported(AccountFixtures.aliceAccountId, jmapUrl: 'https://mail.example.com'), isTrue);
+      expect(
+        session.getUploadFromUrlUri(AccountFixtures.aliceAccountId, jmapUrl: 'https://mail.example.com').toString(),
+        'https://mail.example.com/upload-from-url/${AccountFixtures.aliceAccountId.id.value}',
+      );
+    });
+
+    test('SHOULD qualify a relative advertised url against the jmapUrl', () {
+      final session = sessionWith({
+        SessionExtensions.linagoraUploadFromUrlCapability: UploadFromUrlCapability(
+          uploadUrl: Uri.parse('/upload-from-url/{accountId}'),
+        ),
+      });
+
+      expect(
+        session.getUploadFromUrlUri(
+          AccountFixtures.aliceAccountId,
+          jmapUrl: 'https://mail.example.com',
+        ).toString(),
+        'https://mail.example.com/upload-from-url/${AccountFixtures.aliceAccountId.id.value}',
+      );
+    });
+
+    test('SHOULD preserve the query string AND an encoded path segment WHEN expanding the template', () {
+      final session = sessionWith({
+        SessionExtensions.linagoraUploadFromUrlCapability: UploadFromUrlCapability(
+          uploadUrl: Uri.parse('https://mail.example.com/upload-from-url%2Fv2/{accountId}?required=true'),
+        ),
+      });
+
+      expect(
+        session.getUploadFromUrlUri(AccountFixtures.aliceAccountId, jmapUrl: 'https://mail.example.com').toString(),
+        'https://mail.example.com/upload-from-url%2Fv2/${AccountFixtures.aliceAccountId.id.value}?required=true',
+      );
+    });
+
+    test('SHOULD qualify a relative advertised url without a leading slash against a jmapUrl with a path', () {
+      final session = sessionWith({
+        SessionExtensions.linagoraUploadFromUrlCapability: UploadFromUrlCapability(
+          uploadUrl: Uri.parse('upload-from-url/{accountId}'),
+        ),
+      });
+
+      expect(
+        session.getUploadFromUrlUri(
+          AccountFixtures.aliceAccountId,
+          jmapUrl: 'https://host/jmap/api',
+        ).toString(),
+        'https://host/jmap/api/upload-from-url/${AccountFixtures.aliceAccountId.id.value}',
+      );
+    });
+
+    test('SHOULD return null WHEN the advertised url is scheme-relative', () {
+      final session = sessionWith({
+        SessionExtensions.linagoraUploadFromUrlCapability: UploadFromUrlCapability(
+          uploadUrl: Uri.parse('//mail.example.com/upload-from-url/{accountId}'),
+        ),
+      });
+
+      expect(
+        session.getUploadFromUrlUri(
+          AccountFixtures.aliceAccountId,
+          jmapUrl: 'https://mail.example.com',
+        ),
+        isNull,
+      );
+    });
+
+    test('SHOULD expand the accountId template WHEN it is located in the query string', () {
+      final session = sessionWith({
+        SessionExtensions.linagoraUploadFromUrlCapability: UploadFromUrlCapability(
+          uploadUrl: Uri.parse('https://mail.example.com/upload-from-url?account={accountId}'),
+        ),
+      });
+
+      expect(
+        session.getUploadFromUrlUri(AccountFixtures.aliceAccountId, jmapUrl: 'https://mail.example.com').toString(),
+        'https://mail.example.com/upload-from-url?account=${AccountFixtures.aliceAccountId.id.value}',
+      );
+    });
+
+    test('SHOULD keep uploadUrl after hive persist and restore', () {
+      final session = Session(
+        {
+          SessionExtensions.linagoraUploadFromUrlCapability: capabilityWithTemplate,
+        },
+        {
+          AccountFixtures.aliceAccountId: Account(
+            AccountName('Alice'),
+            true,
+            false,
+            {
+              SessionExtensions.linagoraUploadFromUrlCapability: capabilityWithTemplate,
+            },
+          )
+        },
+        {},
+        UserName('alice@example.com'),
+        Uri.parse('https://mail.example.com/jmap'),
+        Uri.parse('https://mail.example.com/download'),
+        Uri.parse('https://mail.example.com/upload'),
+        Uri.parse('https://mail.example.com/eventSource'),
+        State('1'),
+      );
+
+      final restored = session.toHiveObj().toSession();
+
+      expect(
+        restored.getUploadFromUrlUri(AccountFixtures.aliceAccountId, jmapUrl: 'https://mail.example.com').toString(),
+        'https://mail.example.com/upload-from-url/${AccountFixtures.aliceAccountId.id.value}',
+      );
+    });
+
+    test('SHOULD serialize UploadFromUrlCapability uploadUrl', () {
+      expect(
+        CapabilityPropertiesConverter().toJson(capabilityWithTemplate),
+        {
+          'uploadUrl': 'https://mail.example.com/upload-from-url/%7BaccountId%7D',
+        },
+      );
     });
   });
 }

--- a/test/features/upload/data/datasource_impl/upload_from_url_datasource_impl_test.dart
+++ b/test/features/upload/data/datasource_impl/upload_from_url_datasource_impl_test.dart
@@ -1,0 +1,86 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http_parser/http_parser.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/upload/upload_response.dart';
+import 'package:tmail_ui_user/features/upload/data/datasource_impl/upload_from_url_datasource_impl.dart';
+import 'package:tmail_ui_user/features/upload/data/network/upload_from_url_api.dart';
+import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_request.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/unknown_remote_exception.dart';
+import 'package:tmail_ui_user/main/exceptions/thrower/exception_thrower.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import 'upload_from_url_datasource_impl_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<UploadFromUrlApi>(),
+  MockSpec<ExceptionThrower>(),
+])
+void main() {
+  final uploadFromUrlApi = MockUploadFromUrlApi();
+  final exceptionThrower = MockExceptionThrower();
+  final uploadFromUrlDataSource = UploadFromUrlDataSourceImpl(
+    uploadFromUrlApi,
+    exceptionThrower,
+  );
+
+  final accountId = AccountFixtures.aliceAccountId;
+
+  final uploadUri = Uri.parse('https://mail.example.com/upload-from-url/${AccountFixtures.aliceAccountId.id.value}');
+  final request = UploadFromUrlRequest(
+    accountId: accountId,
+    uploadUri: uploadUri,
+    attachmentUrl: Uri.parse('https://drive.example.com/secret-token/file.pdf'),
+    name: 'report.pdf',
+    mimeType: 'application/pdf',
+  );
+
+  group('upload from url datasource impl test:', () {
+    test(
+      'should return the UploadResponse from UploadFromUrlApi '
+      'when uploadFromUrl succeeds',
+    () async {
+      // arrange
+      final uploadResponse = UploadResponse(
+        accountId,
+        Id('blob-id-123'),
+        MediaType.parse('application/pdf'),
+        2048,
+      );
+      when(uploadFromUrlApi.uploadFromUrl(request))
+        .thenAnswer((_) async => uploadResponse);
+
+      // act
+      final result = await uploadFromUrlDataSource.uploadFromUrl(request);
+
+      // assert
+      expect(result, uploadResponse);
+    });
+
+    test(
+      'should sanitize the DioException via ExceptionThrower '
+      'instead of letting the tokenized url leak through '
+      'when UploadFromUrlApi throws a DioException',
+    () async {
+      // arrange
+      final dioException = DioException(
+        requestOptions: RequestOptions(
+          path: '/upload-from-url/${accountId.id.value}',
+          data: {'url': request.attachmentUrl.toString()},
+        ),
+      );
+      const sanitizedException = UnknownRemoteException();
+      when(uploadFromUrlApi.uploadFromUrl(request)).thenThrow(dioException);
+      when(exceptionThrower.throwException(dioException, any))
+        .thenThrow(sanitizedException);
+
+      // act & assert
+      await expectLater(
+        uploadFromUrlDataSource.uploadFromUrl(request),
+        throwsA(same(sanitizedException)),
+      );
+    });
+  });
+}

--- a/test/features/upload/data/network/upload_from_url_api_test.dart
+++ b/test/features/upload/data/network/upload_from_url_api_test.dart
@@ -1,0 +1,198 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:core/data/constants/constant.dart';
+import 'package:core/data/network/dio_client.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/upload/data/network/upload_from_url_api.dart';
+import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_request.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import 'upload_from_url_api_test.mocks.dart';
+
+// Captures the RequestOptions Dio actually builds, after merging per-request
+// Options with Dio()'s global defaults - unlike a mocked DioClient, which
+// only sees the Options passed into DioClient.post.
+class _CapturingHttpClientAdapter implements HttpClientAdapter {
+  RequestOptions? capturedRequestOptions;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    capturedRequestOptions = options;
+    return ResponseBody.fromString(
+      '{"accountId":"${AccountFixtures.aliceAccountId.id.value}","blobId":"blob-id-123","type":"application/pdf","size":2048}',
+      200,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+@GenerateNiceMocks([MockSpec<DioClient>()])
+void main() {
+  group('UploadFromUrlApi::uploadFromUrl', () {
+    late MockDioClient dioClient;
+    late UploadFromUrlApi uploadFromUrlApi;
+
+    final accountId = AccountFixtures.aliceAccountId;
+
+    final uploadUri = Uri.parse('https://mail.example.com/upload-from-url/${AccountFixtures.aliceAccountId.id.value}');
+    final downloadLink = Uri.parse('https://drive.example.com/secret-token/file.pdf');
+    const documentName = 'report.pdf';
+    const mimeType = 'application/pdf';
+    final request = UploadFromUrlRequest(
+      accountId: accountId,
+      uploadUri: uploadUri,
+      attachmentUrl: downloadLink,
+      name: documentName,
+      mimeType: mimeType,
+    );
+
+    setUp(() {
+      dioClient = MockDioClient();
+      uploadFromUrlApi = UploadFromUrlApi(dioClient);
+    });
+
+    test('should return UploadResponse when DioClient returns the standard upload contract', () async {
+      when(dioClient.post(
+        any,
+        options: anyNamed('options'),
+        cancelToken: anyNamed('cancelToken'),
+      )).thenAnswer((_) async => {
+        'accountId': accountId.id.value,
+        'blobId': 'blob-id-123',
+        'type': mimeType,
+        'size': 2048,
+      });
+
+      final result = await uploadFromUrlApi.uploadFromUrl(request);
+
+      expect(result.accountId, accountId);
+      expect(result.blobId.value, 'blob-id-123');
+      expect(result.size, 2048);
+    });
+
+    test('should propagate the unmapped DioException on a failed upload', () async {
+      final dioException = DioException(
+        requestOptions: RequestOptions(path: uploadUri.toString()),
+        response: Response(
+          requestOptions: RequestOptions(path: uploadUri.toString()),
+          statusCode: 500,
+        ),
+      );
+      when(dioClient.post(
+        any,
+        options: anyNamed('options'),
+        cancelToken: anyNamed('cancelToken'),
+      )).thenThrow(dioException);
+
+      expect(
+        uploadFromUrlApi.uploadFromUrl(request),
+        throwsA(same(dioException)),
+      );
+    });
+
+    test('should send the url/type as headers with an empty body, and forward the cancelToken', () async {
+      final cancelToken = CancelToken();
+      final requestWithCancelToken = UploadFromUrlRequest(
+        accountId: accountId,
+        uploadUri: uploadUri,
+        attachmentUrl: downloadLink,
+        name: documentName,
+        mimeType: mimeType,
+        cancelToken: cancelToken,
+      );
+      when(dioClient.post(
+        any,
+        options: anyNamed('options'),
+        cancelToken: anyNamed('cancelToken'),
+      )).thenAnswer((_) async => {
+        'accountId': accountId.id.value,
+        'blobId': 'blob-id-123',
+        'type': mimeType,
+        'size': 2048,
+      });
+
+      await uploadFromUrlApi.uploadFromUrl(requestWithCancelToken);
+
+      final captured = verify(dioClient.post(
+        uploadUri.toString(),
+        options: captureAnyNamed('options'),
+        cancelToken: captureAnyNamed('cancelToken'),
+      )).captured;
+      final options = captured[0] as Options;
+      expect(options.headers, {
+        HttpHeaders.contentTypeHeader: mimeType,
+        HttpHeaders.contentLocationHeader: downloadLink.toString(),
+      });
+      expect(captured[1], same(cancelToken));
+    });
+
+    test('should fall back to octet-stream mimeType header on the wire WHEN it is blank', () async {
+      final requestWithBlankMimeType = UploadFromUrlRequest(
+        accountId: accountId,
+        uploadUri: uploadUri,
+        attachmentUrl: downloadLink,
+        name: documentName,
+        mimeType: '',
+      );
+      final adapter = _CapturingHttpClientAdapter();
+      final realDioClient = DioClient(
+        Dio(BaseOptions(contentType: Headers.jsonContentType))
+          ..httpClientAdapter = adapter,
+      );
+
+      await UploadFromUrlApi(realDioClient).uploadFromUrl(requestWithBlankMimeType);
+
+      final sentHeaders = adapter.capturedRequestOptions!.headers;
+      expect(sentHeaders[HttpHeaders.contentTypeHeader], Constant.octetStreamMimeType);
+    });
+
+    test('should override the global JSON content-type on the actual outgoing request', () async {
+      final adapter = _CapturingHttpClientAdapter();
+      final realDioClient = DioClient(Dio()..httpClientAdapter = adapter);
+      final realUploadFromUrlApi = UploadFromUrlApi(realDioClient);
+
+      await realUploadFromUrlApi.uploadFromUrl(request);
+
+      final sentHeaders = adapter.capturedRequestOptions!.headers;
+      expect(sentHeaders[HttpHeaders.contentTypeHeader], mimeType);
+      expect(sentHeaders[HttpHeaders.contentTypeHeader], isNot(Headers.jsonContentType));
+    });
+
+    test('should POST with no body and keep Content-Location on the wire', () async {
+      final adapter = _CapturingHttpClientAdapter();
+      final realDioClient = DioClient(Dio()..httpClientAdapter = adapter);
+
+      await UploadFromUrlApi(realDioClient).uploadFromUrl(request);
+
+      final sent = adapter.capturedRequestOptions!;
+      expect(sent.data, isNull);
+      expect(
+        sent.headers[HttpHeaders.contentLocationHeader],
+        downloadLink.toString(),
+      );
+    });
+
+    test('should throw WHEN the upload response JSON is malformed', () async {
+      when(dioClient.post(
+        any,
+        options: anyNamed('options'),
+        cancelToken: anyNamed('cancelToken'),
+      )).thenAnswer((_) async => <String, dynamic>{});
+
+      expect(uploadFromUrlApi.uploadFromUrl(request), throwsA(isA<TypeError>()));
+    });
+  });
+}

--- a/test/features/upload/data/repository/upload_from_url_repository_impl_test.dart
+++ b/test/features/upload/data/repository/upload_from_url_repository_impl_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http_parser/http_parser.dart';
+import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/upload/upload_response.dart';
+import 'package:tmail_ui_user/features/upload/data/datasource/upload_from_url_datasource.dart';
+import 'package:tmail_ui_user/features/upload/data/repository/upload_from_url_repository_impl.dart';
+import 'package:tmail_ui_user/features/upload/domain/exceptions/upload_from_url_account_mismatch_exception.dart';
+import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_request.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import 'upload_from_url_repository_impl_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<UploadFromUrlDataSource>()])
+void main() {
+  group('UploadFromUrlRepositoryImpl::uploadFromUrl', () {
+    late MockUploadFromUrlDataSource uploadFromUrlDataSource;
+    late UploadFromUrlRepositoryImpl repository;
+
+    final accountId = AccountFixtures.aliceAccountId;
+
+    final uploadUri = Uri.parse('https://mail.example.com/upload-from-url/${AccountFixtures.aliceAccountId.id.value}');
+    final downloadLink = Uri.parse('https://drive.example.com/secret-token/file.pdf');
+    const documentName = 'report.pdf';
+    const mimeType = 'application/pdf';
+    final request = UploadFromUrlRequest(
+      accountId: accountId,
+      uploadUri: uploadUri,
+      attachmentUrl: downloadLink,
+      name: documentName,
+      mimeType: mimeType,
+    );
+
+    setUp(() {
+      uploadFromUrlDataSource = MockUploadFromUrlDataSource();
+      repository = UploadFromUrlRepositoryImpl(uploadFromUrlDataSource);
+    });
+
+    test('should return Attachment built from the datasource UploadResponse', () async {
+      final uploadResponse = UploadResponse(
+        accountId,
+        Id('blob-id-123'),
+        MediaType.parse(mimeType),
+        2048,
+      );
+      when(uploadFromUrlDataSource.uploadFromUrl(request))
+          .thenAnswer((_) async => uploadResponse);
+
+      final attachment = await repository.uploadFromUrl(request);
+
+      expect(attachment.blobId, uploadResponse.blobId);
+      expect(attachment.type, uploadResponse.type);
+      expect(attachment.size, UnsignedInt(uploadResponse.size));
+      expect(attachment.name, documentName);
+    });
+
+    test('should let the underlying datasource exception propagate unmapped', () async {
+      final exception = Exception('upload-from-url failed');
+      when(uploadFromUrlDataSource.uploadFromUrl(request)).thenThrow(exception);
+
+      expect(
+        repository.uploadFromUrl(request),
+        throwsA(same(exception)),
+      );
+    });
+
+    test('should throw UploadFromUrlAccountMismatchException WHEN the response accountId differs from the requested accountId', () async {
+      final otherAccountId = AccountId(Id('other-account-id'));
+      final uploadResponse = UploadResponse(
+        otherAccountId,
+        Id('blob-id-123'),
+        MediaType.parse(mimeType),
+        2048,
+      );
+      when(uploadFromUrlDataSource.uploadFromUrl(request))
+          .thenAnswer((_) async => uploadResponse);
+
+      expect(
+        repository.uploadFromUrl(request),
+        throwsA(isA<UploadFromUrlAccountMismatchException>()),
+      );
+    });
+  });
+}

--- a/test/features/upload/domain/usecases/upload_drive_document_from_url_interactor_test.dart
+++ b/test/features/upload/domain/usecases/upload_drive_document_from_url_interactor_test.dart
@@ -1,0 +1,109 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/email/attachment.dart';
+import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_repository.dart';
+import 'package:tmail_ui_user/features/upload/domain/repository/upload_from_url_request.dart';
+import 'package:tmail_ui_user/features/upload/domain/state/upload_drive_document_from_url_state.dart';
+import 'package:tmail_ui_user/features/upload/domain/usecases/upload_drive_document_from_url_interactor.dart';
+
+import '../../../../fixtures/account_fixtures.dart';
+import 'upload_drive_document_from_url_interactor_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<UploadFromUrlRepository>()])
+void main() {
+  group('UploadDriveDocumentFromUrlInteractor::execute', () {
+    late MockUploadFromUrlRepository uploadFromUrlRepository;
+    late UploadDriveDocumentFromUrlInteractor interactor;
+
+
+    final uploadUri = Uri.parse('https://mail.example.com/upload-from-url/${AccountFixtures.aliceAccountId.id.value}');
+    final downloadLink = Uri.parse('https://drive.example.com/secret-token/file.pdf');
+    const documentName = 'report.pdf';
+    const mimeType = 'application/pdf';
+    final request = UploadFromUrlRequest(
+      accountId: AccountFixtures.aliceAccountId,
+      uploadUri: uploadUri,
+      attachmentUrl: downloadLink,
+      name: documentName,
+      mimeType: mimeType,
+    );
+
+    setUp(() {
+      uploadFromUrlRepository = MockUploadFromUrlRepository();
+      interactor = UploadDriveDocumentFromUrlInteractor(uploadFromUrlRepository);
+    });
+
+    test('should yield Right(UploadDriveDocumentFromUrlSuccess) with the repository\'s Attachment', () async {
+      final attachment = Attachment(blobId: Id('blob-id-123'), name: documentName);
+      when(uploadFromUrlRepository.uploadFromUrl(request))
+          .thenAnswer((_) async => attachment);
+
+      final stream = interactor.execute(request);
+
+      await expectLater(
+        stream,
+        emitsInOrder([
+          predicate<Either>((either) =>
+              either.isRight() &&
+              either.fold((l) => null, (r) => r) is UploadDriveDocumentFromUrlSuccess &&
+              (either.fold((l) => null, (r) => r) as UploadDriveDocumentFromUrlSuccess)
+                      .attachment ==
+                  attachment),
+          emitsDone,
+        ]),
+      );
+    });
+
+    test('should yield Left(UploadDriveDocumentFromUrlFailure) when the repository throws', () async {
+      final exception = Exception('upload-from-url failed');
+      when(uploadFromUrlRepository.uploadFromUrl(request)).thenThrow(exception);
+
+      final stream = interactor.execute(request);
+
+      await expectLater(
+        stream,
+        emitsInOrder([
+          predicate<Either>((either) => either.fold(
+            (failure) =>
+                failure is UploadDriveDocumentFromUrlFailure &&
+                identical(failure.exception, exception),
+            (_) => false,
+          )),
+          emitsDone,
+        ]),
+      );
+    });
+
+    test('should yield Cancelled, not Failure, when the cancelToken was cancelled', () async {
+      final cancelToken = CancelToken();
+      final cancellableRequest = UploadFromUrlRequest(
+        accountId: AccountFixtures.aliceAccountId,
+        uploadUri: uploadUri,
+        attachmentUrl: downloadLink,
+        name: documentName,
+        mimeType: mimeType,
+        cancelToken: cancelToken,
+      );
+      when(uploadFromUrlRepository.uploadFromUrl(cancellableRequest))
+          .thenAnswer((_) async {
+        cancelToken.cancel();
+        throw DioException.requestCancelled(
+          requestOptions: RequestOptions(path: '/upload-from-url'),
+          reason: null);
+      });
+
+      await expectLater(
+        interactor.execute(cancellableRequest),
+        emitsInOrder([
+          predicate<Either>((either) =>
+              either.fold((l) => l, (r) => r) is UploadDriveDocumentFromUrlCancelled),
+          emitsDone,
+        ]),
+      );
+    });
+  });
+}


### PR DESCRIPTION
TF-4728 Drive picker data layer (rebased with master)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for uploading drive documents directly from a remote URL.
  * Automatically detects server support and resolves account-specific upload endpoints.
  * Sends source URL and MIME type with uploads and reports success, failure, or cancellation states.
  * Added validation to prevent mismatched account responses.
* **Bug Fixes**
  * Sensitive `Content-Location` request headers are now removed during error reporting.
* **Tests**
  * Added coverage for capability parsing, URL resolution, request handling, uploads, errors, and cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->