### PR TITLE
[Build] Firebase policy changes: upload to specific bucket name

### DIFF
--- a/JenkinsfileMobile
+++ b/JenkinsfileMobile
@@ -11,6 +11,7 @@ pipeline {
     environment {
         FLUTTER_VERSION = '3.38.9'
         FIREBASE_PROJECT_ID = 'twake-195010'
+        RESULTS_BUCKET="twake-195010.firebasestorage.app"
     }
 
     stages {

--- a/scripts/patrol-integration-test-with-docker.sh
+++ b/scripts/patrol-integration-test-with-docker.sh
@@ -149,6 +149,7 @@ gcloud firebase test android run \
     --use-orchestrator \
     --environment-variables clearPackageData=true \
     --no-record-video \
+    --results-bucket="gs://$RESULTS_BUCKET" \
     --results-dir="$RESULTS_DIR" \
     2>&1 | tee "$FTL_OUTPUT"
 TEST_EXIT_CODE=${PIPESTATUS[0]}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Mobile integration test results are now automatically stored in the designated Firebase Storage bucket.
  * Test runs provide a consistent location for accessing generated results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->