### PR TITLE
Sync `flutter_localization` in `Podfile.lock` for iOS

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -115,6 +115,8 @@ PODS:
     - Flutter
   - flutter_local_notifications (0.0.1):
     - Flutter
+  - flutter_localization (0.0.1):
+    - Flutter
   - flutter_native_splash (0.0.1):
     - Flutter
   - flutter_secure_storage (6.0.0):
@@ -245,6 +247,7 @@ DEPENDENCIES:
   - flutter_inappwebview_ios (from `.symlinks/plugins/flutter_inappwebview_ios/ios`)
   - flutter_keyboard_visibility (from `.symlinks/plugins/flutter_keyboard_visibility/ios`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
+  - flutter_localization (from `.symlinks/plugins/flutter_localization/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - flutter_web_auth_2 (from `.symlinks/plugins/flutter_web_auth_2/ios`)
@@ -332,6 +335,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_keyboard_visibility/ios"
   flutter_local_notifications:
     :path: ".symlinks/plugins/flutter_local_notifications/ios"
+  flutter_localization:
+    :path: ".symlinks/plugins/flutter_localization/ios"
   flutter_native_splash:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
   flutter_secure_storage:
@@ -402,6 +407,7 @@ SPEC CHECKSUMS:
   flutter_inappwebview_ios: b89ba3482b96fb25e00c967aae065701b66e9b99
   flutter_keyboard_visibility: 4625131e43015dbbe759d9b20daaf77e0e3f6619
   flutter_local_notifications: ad39620c743ea4c15127860f4b5641649a988100
+  flutter_localization: 72299fb6cb4e51cae587bd953ed0b958040b71e6
   flutter_native_splash: 9e672d3818957718ee006a491730c09deeecace9
   flutter_secure_storage: 2c2ff13db9e0a5647389bff88b0ecac56e3f3418
   flutter_web_auth_2: 5c8d9dcd7848b5a9efb086d24e7a9adcae979c80


### PR DESCRIPTION
## Summary

Synchronize `ios/Podfile.lock` with the Flutter plugin graph by adding the native iOS pod entry for `flutter_localization`.

## Why this is needed

The internal `workplace` package depends on `flutter_localization`, so the root Flutter dependency graph resolves version `0.3.2` and the generated iOS plugin configuration includes it.

Before this change, `ios/Podfile.lock` did not record the corresponding CocoaPods dependency even though Flutter exposes `flutter_localization` as an iOS plugin.

As a result, running the iOS dependency synchronization locally can modify the tracked lockfile unexpectedly. Keeping the lockfile aligned makes the CocoaPods resolution reproducible across developer machines and CI, and prevents unrelated iOS dependency diffs from being mixed into feature or bug-fix pull requests.
