### PR TITLE
HOTFIX Remove drive close button

### DIFF
--- a/workplace/lib/presentation/view/drive_intent_web_view_modal_shell.dart
+++ b/workplace/lib/presentation/view/drive_intent_web_view_modal_shell.dart
@@ -12,7 +12,6 @@ class DriveIntentWebViewModalShell extends StatelessWidget {
   final EdgeInsets insetPadding;
   final ShapeBorder? shape;
   final BoxConstraints? constraints;
-  final bool haveCloseButton;
   final AlignmentGeometry? alignment;
   final Widget Function(TMailButtonWidget closeButton)? loadingWidget;
   final String closeIconPath;
@@ -26,7 +25,6 @@ class DriveIntentWebViewModalShell extends StatelessWidget {
     this.insetPadding = const EdgeInsets.all(0),
     this.shape,
     this.constraints,
-    this.haveCloseButton = true,
     this.alignment,
     this.loadingWidget,
   });
@@ -59,20 +57,9 @@ class DriveIntentWebViewModalShell extends StatelessWidget {
           behavior: HitTestBehavior.opaque,
           child: Stack(
             children: [
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  if (haveCloseButton)
-                    Padding(
-                      padding: const EdgeInsetsGeometry.directional(end: 17),
-                      child: closeButton,
-                    ),
-                  // Keep the iframe mounted across responsive changes (#4738).
-                  Expanded(
-                    key: const ValueKey('drive-shell-content'),
-                    child: child,
-                  ),
-                ],
+              KeyedSubtree(
+                key: const ValueKey('drive-shell-content'),
+                child: child,
               ),
               if (loadingWidget != null)
                 Positioned.fill(

--- a/workplace/lib/presentation/view/drive_intent_web_view_modal_web.dart
+++ b/workplace/lib/presentation/view/drive_intent_web_view_modal_web.dart
@@ -107,7 +107,6 @@ class _DriveIntentWebViewModalState extends State<DriveIntentWebViewModal>
               borderRadius: BorderRadius.all(Radius.circular(6)),
             )
           : const RoundedRectangleBorder(),
-      haveCloseButton: !isWideScreen,
       alignment: isWideScreen ? Alignment.center : null,
       closeIconPath: widget.imageAssets.closeIcon,
       onClose: cancel,

--- a/workplace/test/presentation/view/drive_intent_web_view_modal_shell_test.dart
+++ b/workplace/test/presentation/view/drive_intent_web_view_modal_shell_test.dart
@@ -45,7 +45,6 @@ void main() {
   group('DriveIntentWebViewModalShell', () {
     _testLoadingOverlayIsClosable();
     _testLoadingOverlayCloseButtonCallback();
-    _testCloseButtonHoverFeedback();
     _testNoPointerInterceptorWithoutLoadingOverlay();
   });
 }
@@ -102,24 +101,6 @@ void _testLoadingOverlayCloseButtonCallback() {
     // Assert callback wiring without SVG hit-testing.
     received!.onTapActionCallback!();
     expect(closed, 1);
-  });
-}
-
-void _testCloseButtonHoverFeedback() {
-  testWidgets('close button keeps Material hover feedback', (tester) async {
-    await tester.pumpWidget(
-      _shell(
-        haveCloseButton: true,
-        constraints: const BoxConstraints(maxWidth: 800, maxHeight: 677),
-        insetPadding: const EdgeInsets.all(24),
-      ),
-    );
-
-    final button = tester.widget<TMailButtonWidget>(
-      find.byType(TMailButtonWidget),
-    );
-
-    expect(button.hoverColor, const Color(0x14424244));
   });
 }
 

--- a/workplace/test/presentation/view/drive_intent_web_view_modal_shell_test.dart
+++ b/workplace/test/presentation/view/drive_intent_web_view_modal_shell_test.dart
@@ -34,7 +34,6 @@ Widget _modalShell({
   return DriveIntentWebViewModalShell(
     closeIconPath: _closeIcon,
     onClose: onClose ?? () {},
-    haveCloseButton: haveCloseButton,
     constraints: constraints,
     insetPadding: insetPadding,
     loadingWidget: loadingWidget,


### PR DESCRIPTION
## Demo
### Web

https://github.com/user-attachments/assets/4f283ad9-e2a3-4982-8fbb-b9d7cd94fada


### Mobile

[close-button-mobile.webm](https://github.com/user-attachments/assets/3cf05255-34fd-4784-9728-1b57d07a8898)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the web view modal layout so the close button appears only while loading.
  * Removed the close button from the normal content view for a more consistent modal presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->