### PR TITLE
Add RAG activation setting preference button

### DIFF
--- a/lib/features/manage_account/presentation/preferences/bindings/preferences_bindings.dart
+++ b/lib/features/manage_account/presentation/preferences/bindings/preferences_bindings.dart
@@ -35,6 +35,7 @@ class PreferencesBindings extends Bindings {
         SpamReportPreferenceOption(updateLocal),
         AIScribePreferenceOption(updateLocal),
         AILabelCategorizationPreferenceOption(updateServer),
+        AIRAGPreferenceOption(updateServer),
         LabelPreferenceOption(updateLocal),
         DriveAttachmentPreferenceOption(updateLocal),
       ]);

--- a/lib/features/manage_account/presentation/preferences/model/preference_options.dart
+++ b/lib/features/manage_account/presentation/preferences/model/preference_options.dart
@@ -116,7 +116,9 @@ class AIRAGPreferenceOption extends ServerPreferenceOption {
 
   @override
   bool isAvailable(PreferencesContext context) =>
-      context.serverOptions != null && context.isAICapabilitySupported;
+      context.serverOptions != null &&
+      context.isAICapabilitySupported &&
+      context.serverOptions?.aiRagEnabled != null;
 
   @override
   TMailServerSettingOptions applyTo(

--- a/lib/features/manage_account/presentation/preferences/model/preference_options.dart
+++ b/lib/features/manage_account/presentation/preferences/model/preference_options.dart
@@ -95,6 +95,37 @@ class AILabelCategorizationPreferenceOption extends ServerPreferenceOption {
       current.copyWith(aiLabelCategorizationEnabled: enabled);
 }
 
+class AIRAGPreferenceOption extends ServerPreferenceOption {
+  AIRAGPreferenceOption(super.updateServerSettingInteractor);
+
+  @override
+  String get id => 'ai-rag';
+
+  @override
+  String title(AppLocalizations l) => l.rag;
+
+  @override
+  String explanation(AppLocalizations l) => l.ragSettingExplanation;
+
+  @override
+  String toggleDescription(AppLocalizations l) => l.ragToggleDescription;
+
+  @override
+  bool isEnabled(PreferencesContext context) =>
+      context.serverOptions?.isAIRagEnabled ?? false;
+
+  @override
+  bool isAvailable(PreferencesContext context) =>
+      context.serverOptions != null && context.isAICapabilitySupported;
+
+  @override
+  TMailServerSettingOptions applyTo(
+    TMailServerSettingOptions current, {
+    required bool enabled,
+  }) =>
+      current.copyWith(aiRagEnabled: enabled);
+}
+
 // --- Local-backed options ---
 
 class ThreadPreferenceOption extends LocalPreferenceOption {

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -5641,21 +5641,21 @@ class AppLocalizations {
 
   String get rag {
     return Intl.message(
-      'Activate RAG indexation',
+      'Index my emails with AI',
       name: 'rag',
     );
   }
 
   String get ragSettingExplanation {
     return Intl.message(
-      'Enable RAG (Retrieval-Augmented Generation) indexation for enhanced email search and AI features.',
+      'Allow AI assistant to access and analyze your emails to contextualize its responses.',
       name: 'ragSettingExplanation',
     );
   }
 
   String get ragToggleDescription {
     return Intl.message(
-      'Activate RAG indexation',
+      'Index my emails with AI',
       name: 'ragToggleDescription',
     );
   }

--- a/lib/main/localizations/app_localizations.dart
+++ b/lib/main/localizations/app_localizations.dart
@@ -5639,6 +5639,27 @@ class AppLocalizations {
     );
   }
 
+  String get rag {
+    return Intl.message(
+      'Activate RAG indexation',
+      name: 'rag',
+    );
+  }
+
+  String get ragSettingExplanation {
+    return Intl.message(
+      'Enable RAG (Retrieval-Augmented Generation) indexation for enhanced email search and AI features.',
+      name: 'ragSettingExplanation',
+    );
+  }
+
+  String get ragToggleDescription {
+    return Intl.message(
+      'Activate RAG indexation',
+      name: 'ragToggleDescription',
+    );
+  }
+
   String get labelAs {
     return Intl.message(
       'Label as',

--- a/server_settings/lib/server_settings/tmail_server_settings.dart
+++ b/server_settings/lib/server_settings/tmail_server_settings.dart
@@ -43,11 +43,15 @@ class TMailServerSettingOptions with EquatableMixin {
   @JsonKey(name: 'ai.label-categorization.enabled')
   final bool? aiLabelCategorizationEnabled;
 
+  @JsonKey(name: 'ai.rag.enabled')
+  final bool? aiRagEnabled;
+
   TMailServerSettingOptions({
     this.alwaysReadReceipts,
     this.displaySenderPriority,
     this.language,
     this.aiLabelCategorizationEnabled,
+    this.aiRagEnabled,
   });
 
   factory TMailServerSettingOptions.fromJson(Map<String, dynamic> json) =>
@@ -60,12 +64,14 @@ class TMailServerSettingOptions with EquatableMixin {
     bool? displaySenderPriority,
     String? language,
     bool? aiLabelCategorizationEnabled,
+    bool? aiRagEnabled,
   }) {
     return TMailServerSettingOptions(
       alwaysReadReceipts: alwaysReadReceipts ?? this.alwaysReadReceipts,
       displaySenderPriority: displaySenderPriority ?? this.displaySenderPriority,
       language: language ?? this.language,
       aiLabelCategorizationEnabled: aiLabelCategorizationEnabled ?? this.aiLabelCategorizationEnabled,
+      aiRagEnabled: aiRagEnabled ?? this.aiRagEnabled,
     );
   }
 
@@ -75,5 +81,6 @@ class TMailServerSettingOptions with EquatableMixin {
     displaySenderPriority,
     language,
     aiLabelCategorizationEnabled,
+    aiRagEnabled,
   ];
 }

--- a/server_settings/lib/server_settings/tmail_server_settings_extension.dart
+++ b/server_settings/lib/server_settings/tmail_server_settings_extension.dart
@@ -7,4 +7,6 @@ extension TmailServerSettingsExtension on TMailServerSettingOptions {
   bool get isAlwaysReadReceipts => alwaysReadReceipts ?? false;
 
   bool get isAILabelCategorizationEnabled => aiLabelCategorizationEnabled ?? false;
+
+  bool get isAIRagEnabled => aiRagEnabled ?? false;
 }


### PR DESCRIPTION

- Add ai.rag.enabled to server settings
- Add AIRAGPreferenceOption following existing pattern
- Register in PreferenceOptionRegistry
- Add localization strings

<img width="1801" height="878" alt="Screenshot from 2026-08-28 14-52-16" src="https://github.com/user-attachments/assets/53bd49cc-ce6f-48dc-84f4-5f78a65791ce" />
<img width="1250" height="475" alt="Screenshot from 2026-08-28 10-40-08" src="https://github.com/user-attachments/assets/ca2920a5-451a-4f5e-8e2a-3c7af2f7f1a1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AI email indexing option to Preferences.
  * Users can enable or disable email indexing when supported by their server and AI capabilities.
  * The setting is saved and restored across sessions.
  * Added clearer descriptions explaining that the AI assistant may access and analyze emails to provide more contextual responses.





