### PR TITLE
fix: highlight Bcc recipient field during drag-and-drop

### DIFF
--- a/lib/features/composer/presentation/widgets/recipient_composer_widget.dart
+++ b/lib/features/composer/presentation/widgets/recipient_composer_widget.dart
@@ -127,7 +127,6 @@ class _RecipientComposerWidgetState extends State<RecipientComposerWidget> {
 
   Timer? _gapBetweenTagChangedAndFindSuggestion;
   int _tagIndexFocused = -1;
-  bool _isDragging = false;
   late List<EmailAddress> _currentListEmailAddress;
 
   @override
@@ -194,132 +193,128 @@ class _RecipientComposerWidgetState extends State<RecipientComposerWidget> {
               onKeyEvent: PlatformInfo.isWeb ? _recipientInputOnKeyListener : null,
               child: StatefulBuilder(
                 builder: (context, stateSetter) {
-                  final tagEditor = TagEditor<SuggestionEmailAddress>(
-                    key: widget.keyTagEditor,
-                    length: _currentListEmailAddress.length,
-                    controller: widget.controller,
-                    focusNode: widget.focusNode,
-                    enableBorder: _isDragging,
-                    borderRadius: RecipientComposerWidgetStyle.enableBorderRadius,
-                    enableBorderColor: RecipientComposerWidgetStyle.enableBorderColor,
-                    focusedBorderColor: _isDragging
-                        ? RecipientComposerWidgetStyle.enableBorderColor
-                        : null,
-                    autofocus: PlatformInfo.isWeb
-                        ? widget.prefix != PrefixEmailAddress.to &&
-                        _currentListEmailAddress.isEmpty
-                        : false,
-                    focusNodeKeyboard: widget.focusNodeKeyboard,
-                      keyboardType: PlatformInfo.isMobile
-                          ? TextInputType.emailAddress
-                          : TextInputType.text,
-                    textInputAction: TextInputAction.done,
-                    debounceDuration:
-                    RecipientComposerWidgetStyle.suggestionDebounceDuration,
-                    tagSpacing: RecipientComposerWidgetStyle.tagSpacing,
-                    minTextFieldWidth: RecipientComposerWidgetStyle.minTextFieldWidth,
-                    resetTextOnSubmitted: true,
-                    autoScrollToInput: false,
-                    autoHideTextInputField: true,
-                    cursorColor: RecipientComposerWidgetStyle.cursorColor,
-                    suggestionsBoxElevation:
-                    RecipientComposerWidgetStyle.suggestionsBoxElevation,
-                    suggestionsBoxBackgroundColor:
-                    RecipientComposerWidgetStyle.suggestionsBoxBackgroundColor,
-                    suggestionsBoxRadius:
-                    RecipientComposerWidgetStyle.suggestionsBoxRadius,
-                    suggestionsBoxMaxHeight:
-                    RecipientComposerWidgetStyle.suggestionsBoxMaxHeight,
-                    suggestionItemHeight:
-                    RecipientComposerWidgetStyle.suggestionBoxItemHeight,
-                    suggestionBoxWidth: _getSuggestionBoxWidth(widget.maxWidth),
-                    textStyle: RecipientComposerWidgetStyle.inputTextStyle,
-                    onFocusTagAction: (index) =>
-                        _handleFocusTagAction.call(index, stateSetter),
-                    onDeleteTagAction: (index) =>
-                        _handleDeleteLatestTagAction.call(index, stateSetter),
-                    onSelectOptionAction: (item) =>
-                        _handleSelectOptionAction.call(item, stateSetter),
-                    onSubmitted: (value) =>
-                        _handleSubmitTagAction.call(value, stateSetter),
-                    onTapOutside: (_) {},
-                    onFocusTextInput: () {},
-                    inputDecoration: const InputDecoration(border: InputBorder.none),
-                    tagBuilder: (context, index) {
-                      final currentEmailAddress = _currentListEmailAddress[index];
+                  // Drive drop highlight from DragTarget.candidateData so the
+                  // border updates without setState in onMove/onLeave (that path
+                  // can miss rebuilds, e.g. focused empty Bcc on web).
+                  return DragTarget<DraggableEmailAddress>(
+                    builder: (context, candidateData, rejectedData) {
+                      final isHighlight = candidateData.isNotEmpty;
 
-                      return RecipientTagItemWidget(
-                        index: index,
-                        imagePaths: widget.imagePaths,
-                        prefix: widget.prefix,
-                        composerId: widget.composerId,
-                        currentEmailAddress: currentEmailAddress,
-                        currentListEmailAddress: _currentListEmailAddress,
-                        isTagFocused: _tagIndexFocused == index,
-                        maxWidth: widget.maxWidth,
-                        isMobile: isMobileResponsive,
-                        onDeleteTagAction: (emailAddress) => _handleDeleteTagAction.call(emailAddress, stateSetter),
-                        onEditRecipientAction: widget.onEditRecipientAction,
-                        onClearFocusAction: widget.onClearFocusAction,
-                      );
-                    },
-                    onTagChanged: (value) =>
-                        _handleOnTagChangeAction.call(value, stateSetter),
-                    findSuggestions: (queryString) => _findSuggestions(
-                      queryString,
-                      limit: AppConfig.defaultLimitAutocomplete,
-                    ),
-                    isLoadMoreOnlyOnce: true,
-                    isLoadMoreReplaceAllOld: false,
-                    loadMoreSuggestions: _findSuggestions,
-                    useDefaultHighlight: false,
-                    suggestionBuilder: (
-                      context,
-                      tagEditorState,
-                      suggestionEmailAddress,
-                      index,
-                      length,
-                      highlight,
-                      suggestionValid,
-                    ) {
-                      return RecipientSuggestionItemWidget(
-                        imagePaths: widget.imagePaths,
-                        suggestionState: suggestionEmailAddress.state,
-                        emailAddress: _subAddressingValidatedEmailAddress(
-                            suggestionEmailAddress.emailAddress),
-                        suggestionValid: suggestionValid,
-                        highlight: highlight,
-                        onSelectedAction: (emailAddress) {
-                          if (!_isDuplicatedRecipient(emailAddress.emailAddress)) {
-                            stateSetter(() => _currentListEmailAddress.add(emailAddress));
-                          }
-                          _updateListEmailAddressAction();
-                          tagEditorState.resetTextField();
-                          tagEditorState.closeSuggestionBox();
+                      return TagEditor<SuggestionEmailAddress>(
+                        key: widget.keyTagEditor,
+                        length: _currentListEmailAddress.length,
+                        controller: widget.controller,
+                        focusNode: widget.focusNode,
+                        enableBorder: isHighlight,
+                        borderRadius: RecipientComposerWidgetStyle.enableBorderRadius,
+                        enableBorderColor: RecipientComposerWidgetStyle.enableBorderColor,
+                        // TagEditor applies focusedBorderColor over enableBorder
+                        // while focused; keep the same color so highlight stays visible.
+                        focusedBorderColor: isHighlight
+                            ? RecipientComposerWidgetStyle.enableBorderColor
+                            : null,
+                        autofocus: PlatformInfo.isWeb
+                            ? widget.prefix != PrefixEmailAddress.to &&
+                            _currentListEmailAddress.isEmpty
+                            : false,
+                        focusNodeKeyboard: widget.focusNodeKeyboard,
+                        keyboardType: PlatformInfo.isMobile
+                            ? TextInputType.emailAddress
+                            : TextInputType.text,
+                        textInputAction: TextInputAction.done,
+                        debounceDuration:
+                        RecipientComposerWidgetStyle.suggestionDebounceDuration,
+                        tagSpacing: RecipientComposerWidgetStyle.tagSpacing,
+                        minTextFieldWidth: RecipientComposerWidgetStyle.minTextFieldWidth,
+                        resetTextOnSubmitted: true,
+                        autoScrollToInput: false,
+                        autoHideTextInputField: true,
+                        cursorColor: RecipientComposerWidgetStyle.cursorColor,
+                        suggestionsBoxElevation:
+                        RecipientComposerWidgetStyle.suggestionsBoxElevation,
+                        suggestionsBoxBackgroundColor:
+                        RecipientComposerWidgetStyle.suggestionsBoxBackgroundColor,
+                        suggestionsBoxRadius:
+                        RecipientComposerWidgetStyle.suggestionsBoxRadius,
+                        suggestionsBoxMaxHeight:
+                        RecipientComposerWidgetStyle.suggestionsBoxMaxHeight,
+                        suggestionItemHeight:
+                        RecipientComposerWidgetStyle.suggestionBoxItemHeight,
+                        suggestionBoxWidth: _getSuggestionBoxWidth(widget.maxWidth),
+                        textStyle: RecipientComposerWidgetStyle.inputTextStyle,
+                        onFocusTagAction: (index) =>
+                            _handleFocusTagAction.call(index, stateSetter),
+                        onDeleteTagAction: (index) =>
+                            _handleDeleteLatestTagAction.call(index, stateSetter),
+                        onSelectOptionAction: (item) =>
+                            _handleSelectOptionAction.call(item, stateSetter),
+                        onSubmitted: (value) =>
+                            _handleSubmitTagAction.call(value, stateSetter),
+                        onTapOutside: (_) {},
+                        onFocusTextInput: () {},
+                        inputDecoration: const InputDecoration(border: InputBorder.none),
+                        tagBuilder: (context, index) {
+                          final currentEmailAddress = _currentListEmailAddress[index];
+
+                          return RecipientTagItemWidget(
+                            index: index,
+                            imagePaths: widget.imagePaths,
+                            prefix: widget.prefix,
+                            composerId: widget.composerId,
+                            currentEmailAddress: currentEmailAddress,
+                            currentListEmailAddress: _currentListEmailAddress,
+                            isTagFocused: _tagIndexFocused == index,
+                            maxWidth: widget.maxWidth,
+                            isMobile: isMobileResponsive,
+                            onDeleteTagAction: (emailAddress) => _handleDeleteTagAction.call(emailAddress, stateSetter),
+                            onEditRecipientAction: widget.onEditRecipientAction,
+                            onClearFocusAction: widget.onClearFocusAction,
+                          );
+                        },
+                        onTagChanged: (value) =>
+                            _handleOnTagChangeAction.call(value, stateSetter),
+                        findSuggestions: (queryString) => _findSuggestions(
+                          queryString,
+                          limit: AppConfig.defaultLimitAutocomplete,
+                        ),
+                        isLoadMoreOnlyOnce: true,
+                        isLoadMoreReplaceAllOld: false,
+                        loadMoreSuggestions: _findSuggestions,
+                        useDefaultHighlight: false,
+                        suggestionBuilder: (
+                          context,
+                          tagEditorState,
+                          suggestionEmailAddress,
+                          index,
+                          length,
+                          highlight,
+                          suggestionValid,
+                        ) {
+                          return RecipientSuggestionItemWidget(
+                            imagePaths: widget.imagePaths,
+                            suggestionState: suggestionEmailAddress.state,
+                            emailAddress: _subAddressingValidatedEmailAddress(
+                                suggestionEmailAddress.emailAddress),
+                            suggestionValid: suggestionValid,
+                            highlight: highlight,
+                            onSelectedAction: (emailAddress) {
+                              if (!_isDuplicatedRecipient(emailAddress.emailAddress)) {
+                                stateSetter(() => _currentListEmailAddress.add(emailAddress));
+                              }
+                              _updateListEmailAddressAction();
+                              tagEditorState.resetTextField();
+                              tagEditorState.closeSuggestionBox();
+                            },
+                          );
                         },
                       );
                     },
-                  );
-
-                  return DragTarget<DraggableEmailAddress>(
-                    builder: (context, candidateData, rejectedData) {
-                      return tagEditor;
-                    },
+                    onWillAcceptWithDetails: (_) => true,
                     onAcceptWithDetails: (draggableEmailAddress) =>
                         _handleAcceptDraggableEmailAddressAction(
                             draggableEmailAddress.data,
                             stateSetter,
                         ),
-                    onLeave: (draggableEmailAddress) {
-                      if (_isDragging) {
-                        stateSetter(() => _isDragging = false);
-                      }
-                    },
-                    onMove: (details) {
-                      if (!_isDragging) {
-                        stateSetter(() => _isDragging = true);
-                      }
-                    },
                   );
                 },
               )
@@ -601,31 +596,17 @@ class _RecipientComposerWidgetState extends State<RecipientComposerWidget> {
         if (!_isDuplicatedRecipient(draggableEmailAddress.emailAddress.emailAddress)) {
           stateSetter(() {
             _currentListEmailAddress.add(draggableEmailAddress.emailAddress);
-            _isDragging = false;
           });
           _updateListEmailAddressAction();
-        } else {
-          if (_isDragging) {
-            stateSetter(() => _isDragging = false);
-          }
         }
         widget.onRemoveDraggableEmailAddressAction?.call(draggableEmailAddress);
-      } else {
-        if (_isDragging) {
-          stateSetter(() => _isDragging = false);
-        }
       }
     } else {
       if (!_isDuplicatedRecipient(draggableEmailAddress.emailAddress.emailAddress)) {
         stateSetter(() {
           _currentListEmailAddress.add(draggableEmailAddress.emailAddress);
-          _isDragging = false;
         });
         _updateListEmailAddressAction();
-      } else {
-        if (_isDragging) {
-          stateSetter(() => _isDragging = false);
-        }
       }
       widget.onRemoveDraggableEmailAddressAction?.call(draggableEmailAddress);
     }

--- a/test/features/composer/recipient_composer_widget_test.dart
+++ b/test/features/composer/recipient_composer_widget_test.dart
@@ -10,7 +10,9 @@ import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/mail/email/email_address.dart';
 import 'package:model/email/prefix_email_address.dart';
 import 'package:super_tag_editor/tag_editor.dart';
+import 'package:tmail_ui_user/features/composer/presentation/model/draggable_email_address.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/prefix_recipient_state.dart';
+import 'package:tmail_ui_user/features/composer/presentation/model/suggestion_email_address.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/recipient_composer_widget.dart';
 import 'package:tmail_ui_user/features/composer/presentation/widgets/recipient_tag_item_widget.dart';
 import 'package:tmail_ui_user/main/localizations/app_localizations_delegate.dart';
@@ -634,5 +636,95 @@ void main() {
       expect(recipientCcButtonFinder, findsNothing);
       expect(recipientBccButtonFinder, findsNothing);
     });
+
+    testWidgets(
+      'Bcc TagEditor enableBorder becomes true while a To recipient is dragged over it\n'
+      '(regression for #3074)',
+      (tester) async {
+        const composerId = 'composer-drag-highlight';
+        final toKey = GlobalKey<TagsEditorState>();
+        final bccKey = GlobalKey<TagsEditorState>();
+        final toEmail = EmailAddress('Alice', 'alice@example.com');
+
+        await tester.pumpWidget(
+          makeTestableWidget(
+            child: Column(
+              children: [
+                RecipientComposerWidget(
+                  prefix: PrefixEmailAddress.to,
+                  prefixRootState: PrefixEmailAddress.to,
+                  listEmailAddress: <EmailAddress>[toEmail],
+                  imagePaths: imagePaths,
+                  maxWidth: 600,
+                  keyTagEditor: toKey,
+                  isTestingForWeb: true,
+                  toState: PrefixRecipientState.enabled,
+                  ccState: PrefixRecipientState.enabled,
+                  bccState: PrefixRecipientState.enabled,
+                  composerId: composerId,
+                ),
+                RecipientComposerWidget(
+                  prefix: PrefixEmailAddress.cc,
+                  listEmailAddress: <EmailAddress>[],
+                  imagePaths: imagePaths,
+                  maxWidth: 600,
+                  isTestingForWeb: true,
+                  composerId: composerId,
+                ),
+                RecipientComposerWidget(
+                  prefix: PrefixEmailAddress.bcc,
+                  listEmailAddress: <EmailAddress>[],
+                  imagePaths: imagePaths,
+                  maxWidth: 600,
+                  keyTagEditor: bccKey,
+                  isTestingForWeb: true,
+                  composerId: composerId,
+                ),
+              ],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final bccDragTarget = find.descendant(
+          of: find.byWidgetPredicate(
+            (widget) =>
+                widget is RecipientComposerWidget &&
+                widget.prefix == PrefixEmailAddress.bcc,
+          ),
+          matching: find.byType(DragTarget<DraggableEmailAddress>),
+        );
+        expect(bccDragTarget, findsOneWidget);
+
+        TagEditor getBccTagEditor() {
+          return tester.widget<TagEditor>(
+            find.descendant(
+              of: find.byWidgetPredicate(
+                (widget) =>
+                    widget is RecipientComposerWidget &&
+                    widget.prefix == PrefixEmailAddress.bcc,
+              ),
+              matching: find.byType(TagEditor<SuggestionEmailAddress>),
+            ),
+          );
+        }
+
+        expect(getBccTagEditor().enableBorder, isFalse);
+
+        final draggableFinder = find.byType(Draggable<DraggableEmailAddress>);
+        expect(draggableFinder, findsOneWidget);
+
+        final gesture = await tester.startGesture(
+          tester.getCenter(draggableFinder),
+        );
+        await gesture.moveTo(tester.getCenter(bccDragTarget));
+        await tester.pump();
+
+        expect(getBccTagEditor().enableBorder, isTrue);
+
+        await gesture.cancel();
+        await tester.pump();
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
- Fix [#3074](https://github.com/linagora/tmail-flutter/issues/3074): Bcc recipient field did not show the drop highlight while To/Cc did.
- Drive the highlight from `DragTarget.candidateData` instead of manual `_isDragging` updates in `onMove`/`onLeave`, which could miss rebuilds (especially on a focused empty Bcc field).
- Keep `focusedBorderColor` aligned with the highlight so TagEditor does not clear the border while focused.

## Test plan
- [x] `flutter test test/features/composer/recipient_composer_widget_test.dart` (17 tests, including regression for #3074)
- [x] `flutter analyze` on the changed widget file
- [x] Manual: open composer on web → add a To recipient → enable Cc and Bcc → drag the To chip over Bcc and confirm the Bcc field border highlights the same way as To/Cc

Fixes #3074

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recipient drag-and-drop behavior so the destination field visibly highlights while an address is dragged over it.
  * Fixed highlighting for Bcc recipient fields during address movement.

* **Tests**
  * Added coverage to verify drag-and-drop highlighting appears correctly across recipient fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->