### PR TITLE
Fix reply-to defaulting to identity email when unset

### DIFF
--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1818,8 +1818,19 @@ class ComposerController extends BaseController
     if (replyToRecipientState.value == PrefixRecipientState.disabled) {
       replyToRecipientState.value = PrefixRecipientState.enabled;
     }
-    listReplyToEmailAddress = listEmailAddress.toList();
+    listReplyToEmailAddress = _normalizeReplyToFromIdentity(listEmailAddress);
     updateStatusEmailSendButton();
+  }
+
+  List<EmailAddress> _normalizeReplyToFromIdentity(Set<EmailAddress> listEmailAddress) {
+    final identity = identitySelected.value;
+    final identityEmail = identity?.email;
+    if (identityEmail?.isNotEmpty == true &&
+        identityEmail != ownEmailAddress &&
+        listEmailAddress.every((address) => address.email == ownEmailAddress)) {
+      return [EmailAddress(identity!.name, identityEmail)];
+    }
+    return listEmailAddress.toList();
   }
 
   void _removeReplyToEmailAddressFromFormerIdentity(Set<EmailAddress> listEmailAddress) {

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1769,27 +1769,40 @@ class ComposerController extends BaseController
       if (formerIdentity.bcc?.isNotEmpty == true) {
         _removeBccEmailAddressFromFormerIdentity(formerIdentity.bcc!);
       }
-      if (formerIdentity.replyTo?.isNotEmpty == true) {
-        _removeReplyToEmailAddressFromFormerIdentity(formerIdentity.replyTo!);
-      }
+      _removeReplyToEmailAddressFromFormerIdentity(formerIdentity);
       await _removeSignature();
     }
+
+    // Identity-change callbacks are not awaited by the UI; a slower earlier
+    // selection must not resume and overwrite a newer selection.
+    if (!_isCurrentlySelectedIdentity(newIdentity)) return;
 
     if (newIdentity.bcc?.isNotEmpty == true) {
       _applyBccEmailAddressFromIdentity(newIdentity.bcc!);
     }
 
-    if (newIdentity.replyTo?.isNotEmpty == true) {
-      _applyReplyToEmailAddressFromIdentity(newIdentity.replyTo!);
-    }
+    // Do not copy identity reply-to into listReplyToEmailAddress. That list is
+    // for user-entered recipients; createReplyToRecipients already defaults from
+    // identity.replyTo / identity.email when the list is empty.
 
     if (newIdentity.signatureAsString.isNotEmpty == true) {
       await applySignature(newIdentity.signatureAsString.asSignatureHtml());
     }
 
+    if (!_isCurrentlySelectedIdentity(newIdentity)) return;
+
     if (PlatformInfo.isMobile) {
       await htmlEditorApi?.onDocumentChanged();
     }
+  }
+
+  bool _isCurrentlySelectedIdentity(Identity identity) {
+    final selected = identitySelected.value;
+    if (selected == null) return false;
+    if (identity.id != null && selected.id != null) {
+      return selected.id == identity.id;
+    }
+    return identical(selected, identity);
   }
 
   void _applyBccEmailAddressFromIdentity(Set<EmailAddress> listEmailAddress) {
@@ -1814,28 +1827,19 @@ class ComposerController extends BaseController
     updateStatusEmailSendButton();
   }
 
-  void _applyReplyToEmailAddressFromIdentity(Set<EmailAddress> listEmailAddress) {
-    if (replyToRecipientState.value == PrefixRecipientState.disabled) {
-      replyToRecipientState.value = PrefixRecipientState.enabled;
-    }
-    listReplyToEmailAddress = _normalizeReplyToFromIdentity(listEmailAddress);
-    updateStatusEmailSendButton();
-  }
+  void _removeReplyToEmailAddressFromFormerIdentity(Identity formerIdentity) {
+    final formerReplyTo = formerIdentity.replyTo;
+    if (formerReplyTo?.isNotEmpty != true) return;
 
-  List<EmailAddress> _normalizeReplyToFromIdentity(Set<EmailAddress> listEmailAddress) {
-    final identity = identitySelected.value;
-    final identityEmail = identity?.email;
-    if (identityEmail?.isNotEmpty == true &&
-        identityEmail != ownEmailAddress &&
-        listEmailAddress.every((address) => address.email == ownEmailAddress)) {
-      return [EmailAddress(identity!.name, identityEmail)];
-    }
-    return listEmailAddress.toList();
-  }
+    final emailsToRemove = formerReplyTo!
+        .map((address) => address.email)
+        .whereType<String>()
+        .where((email) => email.isNotEmpty)
+        .toSet();
+    if (emailsToRemove.isEmpty) return;
 
-  void _removeReplyToEmailAddressFromFormerIdentity(Set<EmailAddress> listEmailAddress) {
     listReplyToEmailAddress = listReplyToEmailAddress
-        .where((address) => !listEmailAddress.contains(address))
+        .where((address) => !emailsToRemove.contains(address.email))
         .toList();
     if (listReplyToEmailAddress.isEmpty) {
       replyToRecipientState.value = PrefixRecipientState.disabled;

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -1769,11 +1769,18 @@ class ComposerController extends BaseController
       if (formerIdentity.bcc?.isNotEmpty == true) {
         _removeBccEmailAddressFromFormerIdentity(formerIdentity.bcc!);
       }
+      if (formerIdentity.replyTo?.isNotEmpty == true) {
+        _removeReplyToEmailAddressFromFormerIdentity(formerIdentity.replyTo!);
+      }
       await _removeSignature();
     }
 
     if (newIdentity.bcc?.isNotEmpty == true) {
       _applyBccEmailAddressFromIdentity(newIdentity.bcc!);
+    }
+
+    if (newIdentity.replyTo?.isNotEmpty == true) {
+      _applyReplyToEmailAddressFromIdentity(newIdentity.replyTo!);
     }
 
     if (newIdentity.signatureAsString.isNotEmpty == true) {
@@ -1803,6 +1810,24 @@ class ComposerController extends BaseController
         .toList();
     if (listBccEmailAddress.isEmpty) {
       bccRecipientState.value = PrefixRecipientState.disabled;
+    }
+    updateStatusEmailSendButton();
+  }
+
+  void _applyReplyToEmailAddressFromIdentity(Set<EmailAddress> listEmailAddress) {
+    if (replyToRecipientState.value == PrefixRecipientState.disabled) {
+      replyToRecipientState.value = PrefixRecipientState.enabled;
+    }
+    listReplyToEmailAddress = listEmailAddress.toList();
+    updateStatusEmailSendButton();
+  }
+
+  void _removeReplyToEmailAddressFromFormerIdentity(Set<EmailAddress> listEmailAddress) {
+    listReplyToEmailAddress = listReplyToEmailAddress
+        .where((address) => !listEmailAddress.contains(address))
+        .toList();
+    if (listReplyToEmailAddress.isEmpty) {
+      replyToRecipientState.value = PrefixRecipientState.disabled;
     }
     updateStatusEmailSendButton();
   }

--- a/lib/features/composer/presentation/extensions/create_email_request_extension.dart
+++ b/lib/features/composer/presentation/extensions/create_email_request_extension.dart
@@ -53,10 +53,6 @@ extension CreateEmailRequestExtension on CreateEmailRequest {
     if (isNotReplyTo) return null;
 
     if (identity?.replyTo?.isNotEmpty == true) {
-      if (_shouldDefaultReplyToIdentityEmail()) {
-        return {EmailAddress(identity!.name, identity!.email)};
-      }
-
       return identity!.replyTo!.map((address) {
         if (address.name?.isNotEmpty == true) return address;
         return EmailAddress(identity!.name, address.email);
@@ -72,16 +68,6 @@ extension CreateEmailRequestExtension on CreateEmailRequest {
     return ownEmailAddress.isNotEmpty
       ? {EmailAddress(null, ownEmailAddress)}
       : null;
-  }
-
-  bool _shouldDefaultReplyToIdentityEmail() {
-    final identityEmail = identity?.email;
-    if (identityEmail?.isNotEmpty != true) return false;
-    if (identityEmail == ownEmailAddress) return false;
-
-    return identity!.replyTo!.every(
-      (address) => address.email == ownEmailAddress,
-    );
   }
 
   Set<EmailBodyPart> createAttachments() => attachments?.toEmailBodyPart() ?? {};

--- a/lib/features/composer/presentation/extensions/create_email_request_extension.dart
+++ b/lib/features/composer/presentation/extensions/create_email_request_extension.dart
@@ -53,6 +53,10 @@ extension CreateEmailRequestExtension on CreateEmailRequest {
     if (isNotReplyTo) return null;
 
     if (identity?.replyTo?.isNotEmpty == true) {
+      if (_shouldDefaultReplyToIdentityEmail()) {
+        return {EmailAddress(identity!.name, identity!.email)};
+      }
+
       return identity!.replyTo!.map((address) {
         if (address.name?.isNotEmpty == true) return address;
         return EmailAddress(identity!.name, address.email);
@@ -70,6 +74,15 @@ extension CreateEmailRequestExtension on CreateEmailRequest {
       : null;
   }
 
+  bool _shouldDefaultReplyToIdentityEmail() {
+    final identityEmail = identity?.email;
+    if (identityEmail?.isNotEmpty != true) return false;
+    if (identityEmail == ownEmailAddress) return false;
+
+    return identity!.replyTo!.every(
+      (address) => address.email == ownEmailAddress,
+    );
+  }
 
   Set<EmailBodyPart> createAttachments() => attachments?.toEmailBodyPart() ?? {};
 

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -1785,6 +1785,7 @@ void main() {
     group('selectIdentity reply-to sync test:', () {
       const bobEmail = 'bob@domain.tld';
       const aliceEmail = 'alice@domain.tld';
+      const accountPrimaryEmail = 'alice@domain.tld';
       final bobReplyTo = EmailAddress('Bob', bobEmail);
       final bobIdentity = Identity(
         id: IdentityId(Id('bob')),
@@ -1798,29 +1799,36 @@ void main() {
         email: aliceEmail,
         replyTo: {},
       );
+      final workIdentity = Identity(
+        id: IdentityId(Id('work')),
+        name: 'Work',
+        email: 'work@domain.tld',
+        replyTo: {EmailAddress(null, accountPrimaryEmail)},
+      );
 
       test(
-        'should apply replyTo from selected identity '
+        'should not copy identity replyTo into composer recipients '
         'when identity has replyTo configured',
         () async {
           await composerController?.selectIdentity(bobIdentity);
 
-          expect(
-            composerController?.listReplyToEmailAddress,
-            [bobReplyTo],
-          );
+          expect(composerController?.listReplyToEmailAddress, isEmpty);
           expect(
             composerController?.replyToRecipientState.value,
-            PrefixRecipientState.enabled,
+            PrefixRecipientState.disabled,
           );
         },
       );
 
       test(
-        'should clear former identity replyTo '
+        'should clear former identity replyTo from composer recipients '
         'when switching to identity without replyTo configured',
         () async {
-          await composerController?.selectIdentity(bobIdentity);
+          composerController?.identitySelected.value = bobIdentity;
+          composerController?.listReplyToEmailAddress = [bobReplyTo];
+          composerController?.replyToRecipientState.value =
+              PrefixRecipientState.enabled;
+
           await composerController?.selectIdentity(aliceIdentity);
 
           expect(composerController?.listReplyToEmailAddress, isEmpty);
@@ -1832,23 +1840,23 @@ void main() {
       );
 
       test(
-        'should store identity email as replyTo '
-        'when identity replyTo only contains account primary address',
+        'should clear account-primary replyTo left by former identity '
+        'when switching to identity with empty replyTo',
         () async {
-          const accountPrimaryEmail = 'alice@domain.tld';
-          final workIdentity = Identity(
-            id: IdentityId(Id('work')),
-            name: 'Work',
-            email: 'work@domain.tld',
-            replyTo: {EmailAddress(null, accountPrimaryEmail)},
-          );
+          final accountPrimaryReplyTo = EmailAddress(null, accountPrimaryEmail);
+          composerController?.identitySelected.value = workIdentity;
+          composerController?.listReplyToEmailAddress = [accountPrimaryReplyTo];
+          composerController?.replyToRecipientState.value =
+              PrefixRecipientState.enabled;
 
-          await composerController?.selectIdentity(workIdentity);
+          await composerController?.selectIdentity(aliceIdentity);
 
+          expect(composerController?.listReplyToEmailAddress, isEmpty);
           expect(
-            composerController?.listReplyToEmailAddress,
-            [EmailAddress('Work', 'work@domain.tld')],
+            composerController?.replyToRecipientState.value,
+            PrefixRecipientState.disabled,
           );
+          expect(composerController?.identitySelected.value, aliceIdentity);
         },
       );
     });

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -56,6 +56,7 @@ import 'package:tmail_ui_user/features/composer/presentation/extensions/setup_em
 import 'package:tmail_ui_user/features/composer/presentation/extensions/setup_selected_identity_extension.dart';
 import 'package:tmail_ui_user/features/composer/presentation/manager/drive_attachment_handler.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/formatting_options_state.dart';
+import 'package:tmail_ui_user/features/composer/presentation/model/prefix_recipient_state.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/saved_composing_email.dart';
 import 'package:tmail_ui_user/features/composer/presentation/model/screen_display_mode.dart';
 import 'package:tmail_ui_user/features/composer/presentation/providers/composer_auto_save_notifier.dart';
@@ -1779,6 +1780,56 @@ void main() {
           }
         });
       }
+    });
+
+    group('selectIdentity reply-to sync test:', () {
+      const bobEmail = 'bob@domain.tld';
+      const aliceEmail = 'alice@domain.tld';
+      final bobReplyTo = EmailAddress('Bob', bobEmail);
+      final bobIdentity = Identity(
+        id: IdentityId(Id('bob')),
+        name: 'Bob',
+        email: bobEmail,
+        replyTo: {bobReplyTo},
+      );
+      final aliceIdentity = Identity(
+        id: IdentityId(Id('alice')),
+        name: 'Alice',
+        email: aliceEmail,
+        replyTo: {},
+      );
+
+      test(
+        'should apply replyTo from selected identity '
+        'when identity has replyTo configured',
+        () async {
+          await composerController?.selectIdentity(bobIdentity);
+
+          expect(
+            composerController?.listReplyToEmailAddress,
+            [bobReplyTo],
+          );
+          expect(
+            composerController?.replyToRecipientState.value,
+            PrefixRecipientState.enabled,
+          );
+        },
+      );
+
+      test(
+        'should clear former identity replyTo '
+        'when switching to identity without replyTo configured',
+        () async {
+          await composerController?.selectIdentity(bobIdentity);
+          await composerController?.selectIdentity(aliceIdentity);
+
+          expect(composerController?.listReplyToEmailAddress, isEmpty);
+          expect(
+            composerController?.replyToRecipientState.value,
+            PrefixRecipientState.disabled,
+          );
+        },
+      );
     });
 
     group('onLocalFileDropZoneListener test:', () {

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -1830,6 +1830,27 @@ void main() {
           );
         },
       );
+
+      test(
+        'should store identity email as replyTo '
+        'when identity replyTo only contains account primary address',
+        () async {
+          const accountPrimaryEmail = 'alice@domain.tld';
+          final workIdentity = Identity(
+            id: IdentityId(Id('work')),
+            name: 'Work',
+            email: 'work@domain.tld',
+            replyTo: {EmailAddress(null, accountPrimaryEmail)},
+          );
+
+          await composerController?.selectIdentity(workIdentity);
+
+          expect(
+            composerController?.listReplyToEmailAddress,
+            [EmailAddress('Work', 'work@domain.tld')],
+          );
+        },
+      );
     });
 
     group('onLocalFileDropZoneListener test:', () {

--- a/test/features/composer/presentation/extensions/create_email_request_extension_test.dart
+++ b/test/features/composer/presentation/extensions/create_email_request_extension_test.dart
@@ -418,8 +418,8 @@ void main() {
     });
 
     test(
-      'should return identity email with display name '
-      'when non-default identity replyTo only contains account primary address',
+      'should preserve explicitly configured replyTo pointing at account primary '
+      'when identity replyTo is set to ownEmailAddress',
     () {
       const bobEmail = 'bob@domain.tld';
       const aliceEmail = 'alice@domain.tld';
@@ -435,7 +435,7 @@ void main() {
 
       final result = request.createReplyToRecipients();
 
-      expect(result, {EmailAddress('Alice Smith', aliceEmail)});
+      expect(result, {EmailAddress('Alice Smith', bobEmail)});
     });
 
     test(

--- a/test/features/composer/presentation/extensions/create_email_request_extension_test.dart
+++ b/test/features/composer/presentation/extensions/create_email_request_extension_test.dart
@@ -418,6 +418,27 @@ void main() {
     });
 
     test(
+      'should return identity email with display name '
+      'when non-default identity replyTo only contains account primary address',
+    () {
+      const bobEmail = 'bob@domain.tld';
+      const aliceEmail = 'alice@domain.tld';
+      final identity = Identity(
+        name: 'Alice Smith',
+        email: aliceEmail,
+        replyTo: {EmailAddress(null, bobEmail)},
+      );
+      final request = buildRequest(
+        identity: identity,
+        ownEmailAddress: bobEmail,
+      );
+
+      final result = request.createReplyToRecipients();
+
+      expect(result, {EmailAddress('Alice Smith', aliceEmail)});
+    });
+
+    test(
       'should supplement identity name on replyTo address '
       'when identity replyTo items have no display name',
     () {


### PR DESCRIPTION
## Summary
- Sync reply-to recipients when switching identities in the composer (mirrors existing BCC behavior)
- Default Reply-To to the selected identity email when a non-default identity inherits the account primary reply-to address
- Add regression tests for identity switching and reply-to header generation

Fixes #2651

## Test plan
- [x] \lutter test test/features/composer/presentation/extensions/create_email_request_extension_test.dart\
- [x] \lutter test test/features/composer/presentation/composer_controller_test.dart\
- [x] \lutter analyze\ on changed files
- [ ] Manual: create non-default identity with reply-to = none, send mail, verify Reply-To header matches identity email

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Switching identities now removes Reply-To addresses associated with the former identity.
  - Selecting a new identity no longer automatically copies its configured Reply-To addresses into the composer.
  - Explicitly configured Reply-To addresses matching the account email are preserved.
  - The Reply-To field is disabled when no addresses remain after switching identities.
  - Identity selection is protected against slower, outdated selections overwriting newer choices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->