### PR TITLE
Hide Twake Calendar visio section when rendering ICS description

### DIFF
--- a/core/lib/core.dart
+++ b/core/lib/core.dart
@@ -52,6 +52,7 @@ export 'utils/benchmark.dart';
 export 'utils/fps_manager.dart';
 export 'utils/build_utils.dart';
 export 'utils/string_convert.dart';
+export 'utils/video_conference_section_utils.dart';
 export 'utils/config/app_config_loader.dart';
 export 'utils/config/app_config_parser.dart';
 export 'utils/config/errors.dart';

--- a/core/lib/utils/video_conference_section_utils.dart
+++ b/core/lib/utils/video_conference_section_utils.dart
@@ -1,9 +1,9 @@
 /// Removes the video-conference section that Twake Calendar appends to event
-/// descriptions, delimited by [VideoConferenceSectionUtils.separator]:
+/// descriptions, delimited by [separator]:
 ///
 /// ```
 /// -::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-
-/// Join Visio : https://meet.example.com/abc-defg-hij
+/// Join visio : https://meet.example.com/abc-defg-hij
 ///
 /// Please do not edit this section.
 /// -::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-
@@ -18,24 +18,139 @@ class VideoConferenceSectionUtils {
   static const String separator =
       '-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-';
 
-  static final String _escapedSeparator = RegExp.escape(separator);
-
-  /// Whitespace or `<br>` tags surrounding the section, so removing it does
-  /// not leave blank lines behind.
-  static const String _surroundingBreaks = r'(?:\s|<br\s*/?>)*';
-
-  static final RegExp _sectionRegex = RegExp(
-    '$_surroundingBreaks$_escapedSeparator.*?$_escapedSeparator$_surroundingBreaks',
-    dotAll: true,
-    caseSensitive: false,
-  );
-
-  static bool containsSection(String description) =>
-      description.contains(separator);
-
   static String removeSection(String description) {
-    if (!containsSection(description)) return description;
+    const markerLength = separator.length;
+    var cursor = 0;
+    var removedPair = false;
+    StringBuffer? result;
 
-    return description.replaceAll(_sectionRegex, '\n').trim();
+    while (true) {
+      final open = description.indexOf(separator, cursor);
+      if (open == -1) break;
+
+      final close = description.indexOf(separator, open + markerLength);
+      if (close == -1) break;
+
+      result ??= StringBuffer();
+      _writeKept(
+        result,
+        description.substring(cursor, open),
+        stripLeading: removedPair,
+        stripTrailing: true,
+      );
+      removedPair = true;
+      cursor = close + markerLength;
+    }
+
+    if (result == null) return description;
+
+    _writeKept(
+      result,
+      description.substring(cursor),
+      stripLeading: true,
+      stripTrailing: false,
+    );
+    return result.toString();
   }
+
+  /// Writes [chunk] into [buffer] without the breaks that hugged a removed
+  /// section, separated from what came before by exactly one newline.
+  ///
+  /// The separator is written whatever the dropped section looked like: a pair
+  /// with no break on either side would otherwise weld the surrounding text
+  /// into a single token.
+  static void _writeKept(
+    StringBuffer buffer,
+    String chunk, {
+    required bool stripLeading,
+    required bool stripTrailing,
+  }) {
+    var kept = chunk;
+    if (stripTrailing) kept = _stripTrailingBreaks(kept);
+    if (stripLeading) kept = _stripLeadingBreaks(kept);
+    if (kept.isEmpty) return;
+
+    if (buffer.isNotEmpty) buffer.write('\n');
+    buffer.write(kept);
+  }
+
+  static String _stripLeadingBreaks(String text) {
+    var start = 0;
+    while (start < text.length) {
+      final length = _breakLengthStartingAt(text, start);
+      if (length == 0) break;
+      start += length;
+    }
+    return start == 0 ? text : text.substring(start);
+  }
+
+  static String _stripTrailingBreaks(String text) {
+    var end = text.length;
+    while (end > 0) {
+      final length = _breakLengthEndingAt(text, end);
+      if (length == 0) break;
+      end -= length;
+    }
+    return end == text.length ? text : text.substring(0, end);
+  }
+
+  static int _breakLengthStartingAt(String text, int index) {
+    if (index >= text.length) return 0;
+    if (text.startsWith('\r\n', index)) return 2;
+    if (text[index] == '\n' || text[index] == '\r') return 1;
+    return _brTagLengthAt(text, index);
+  }
+
+  static int _breakLengthEndingAt(String text, int end) {
+    if (end <= 0) return 0;
+    if (end >= 2 && text.startsWith('\r\n', end - 2)) return 2;
+    if (text[end - 1] == '\n' || text[end - 1] == '\r') return 1;
+    return _brTagLengthEndingAt(text, end);
+  }
+
+  /// Length of the `<br>` tag starting at [index], or 0 when there is none.
+  /// Accepts `<br>`, `<br/>` and any casing, with whitespace before the slash.
+  static int _brTagLengthAt(String text, int index) {
+    if (index + 3 >= text.length || text[index] != '<') return 0;
+    if (!_isLetter(text.codeUnitAt(index + 1), _letterB)) return 0;
+    if (!_isLetter(text.codeUnitAt(index + 2), _letterR)) return 0;
+
+    var cursor = index + 3;
+    while (cursor < text.length && _isTagWhitespace(text[cursor])) {
+      cursor++;
+    }
+    if (cursor < text.length && text[cursor] == '/') cursor++;
+    if (cursor < text.length && text[cursor] == '>') {
+      return cursor - index + 1;
+    }
+    return 0;
+  }
+
+  /// Right-to-left mirror of [_brTagLengthAt], so both directions accept the
+  /// same tags instead of a backward scan guessing at candidate lengths.
+  static int _brTagLengthEndingAt(String text, int end) {
+    if (text[end - 1] != '>') return 0;
+
+    var cursor = end - 2;
+    if (cursor >= 0 && text[cursor] == '/') cursor--;
+    while (cursor >= 0 && _isTagWhitespace(text[cursor])) {
+      cursor--;
+    }
+    if (cursor < 2) return 0;
+    if (!_isLetter(text.codeUnitAt(cursor), _letterR)) return 0;
+    if (!_isLetter(text.codeUnitAt(cursor - 1), _letterB)) return 0;
+    if (text[cursor - 2] != '<') return 0;
+
+    return end - (cursor - 2);
+  }
+
+  static const int _letterB = 0x62;
+  static const int _letterR = 0x72;
+
+  /// Case-insensitive match against a lowercase ASCII [letter].
+  static bool _isLetter(int codeUnit, int letter) =>
+      (codeUnit | 0x20) == letter;
+
+  static bool _isTagWhitespace(String char) =>
+      char == ' ' || char == '\t' || char == '\n' || char == '\r';
 }

--- a/core/lib/utils/video_conference_section_utils.dart
+++ b/core/lib/utils/video_conference_section_utils.dart
@@ -1,0 +1,41 @@
+/// Removes the video-conference section that Twake Calendar appends to event
+/// descriptions, delimited by [VideoConferenceSectionUtils.separator]:
+///
+/// ```
+/// -::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-
+/// Join Visio : https://meet.example.com/abc-defg-hij
+///
+/// Please do not edit this section.
+/// -::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-
+/// ```
+///
+/// The meeting link is already rendered by the invitation email body, so the
+/// section is pure noise when the ICS description is displayed on its own.
+/// Mirrors `removeVideoConferenceFromDescription` in twake-calendar-frontend.
+class VideoConferenceSectionUtils {
+  VideoConferenceSectionUtils._();
+
+  static const String separator =
+      '-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-';
+
+  static final String _escapedSeparator = RegExp.escape(separator);
+
+  /// Whitespace or `<br>` tags surrounding the section, so removing it does
+  /// not leave blank lines behind.
+  static const String _surroundingBreaks = r'(?:\s|<br\s*/?>)*';
+
+  static final RegExp _sectionRegex = RegExp(
+    '$_surroundingBreaks$_escapedSeparator.*?$_escapedSeparator$_surroundingBreaks',
+    dotAll: true,
+    caseSensitive: false,
+  );
+
+  static bool containsSection(String description) =>
+      description.contains(separator);
+
+  static String removeSection(String description) {
+    if (!containsSection(description)) return description;
+
+    return description.replaceAll(_sectionRegex, '\n').trim();
+  }
+}

--- a/core/lib/utils/video_conference_section_utils.dart
+++ b/core/lib/utils/video_conference_section_utils.dart
@@ -33,9 +33,10 @@ class _EventDescription {
 
   static const String _marker = VideoConferenceSectionUtils.separator;
 
-  /// One run of line breaks, written either literally or as `<br>` tags in any
-  /// casing. The whitespace a tag may hold before its slash is bounded, so a
-  /// malformed `<br` fails within one pass instead of backtracking (ADR 0069).
+  /// One run of line breaks: `\r\n` / `\n` / `\r`, or `<br>` / `<br/>` in any
+  /// casing. Tag-internal whitespace before the optional slash is at most 32
+  /// HTML whitespace characters (space, tab, LF, FF, CR — Dart/JS `\s`). A
+  /// malformed `<br` then fails in one pass instead of backtracking (ADR 0069).
   static final RegExp _breakRunPattern = RegExp(
     r'(?:\r\n|[\n\r]|<br\s{0,32}/?>)+',
     caseSensitive: false,

--- a/core/lib/utils/video_conference_section_utils.dart
+++ b/core/lib/utils/video_conference_section_utils.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 /// Removes the video-conference section that Twake Calendar appends to event
 /// descriptions, delimited by [separator]:
 ///
@@ -18,139 +20,104 @@ class VideoConferenceSectionUtils {
   static const String separator =
       '-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-';
 
-  static String removeSection(String description) {
-    const markerLength = separator.length;
+  static String removeSection(String description) =>
+      _EventDescription(description).withoutVideoConferenceSections();
+}
+
+/// The description being cleaned, held as a whole so every step below works on
+/// offsets into [text] instead of on `(text, offset)` argument pairs.
+class _EventDescription {
+  _EventDescription(this.text);
+
+  final String text;
+
+  static const String _marker = VideoConferenceSectionUtils.separator;
+
+  /// One run of line breaks, written either literally or as `<br>` tags in any
+  /// casing. The whitespace a tag may hold before its slash is bounded, so a
+  /// malformed `<br` fails within one pass instead of backtracking (ADR 0069).
+  static final RegExp _breakRunPattern = RegExp(
+    r'(?:\r\n|[\n\r]|<br\s{0,32}/?>)+',
+    caseSensitive: false,
+  );
+
+  /// Every break run of [text], collected in the single pass both indexes below
+  /// share.
+  late final List<RegExpMatch> _breakRuns =
+      _breakRunPattern.allMatches(text).toList();
+
+  /// Where the break run ending at a given offset starts.
+  late final Map<int, int> _runStartByEnd = {
+    for (final run in _breakRuns) run.end: run.start,
+  };
+
+  /// Where the break run starting at a given offset ends.
+  late final Map<int, int> _runEndByStart = {
+    for (final run in _breakRuns) run.start: run.end,
+  };
+
+  String withoutVideoConferenceSections() {
+    final sections = _sections(_markerOffsets());
+    if (sections.isEmpty) return text;
+
+    return _render(_keptRanges(sections));
+  }
+
+  /// Every separator occurrence, in order, searched without overlap.
+  List<int> _markerOffsets() {
+    final offsets = <int>[];
+    var at = text.indexOf(_marker);
+    while (at != -1) {
+      offsets.add(at);
+      at = text.indexOf(_marker, at + _marker.length);
+    }
+    return offsets;
+  }
+
+  /// The ranges to drop: each pair of markers grown over the break run hugging
+  /// it on either side, so a removed section leaves neither a blank line nor a
+  /// half-open one. A separator without a closing partner delimits nothing and
+  /// stays in the text.
+  List<_Range> _sections(List<int> markerOffsets) {
+    final sections = <_Range>[];
+    for (var pair = 0; pair + 1 < markerOffsets.length; pair += 2) {
+      final open = markerOffsets[pair];
+      final afterClose = markerOffsets[pair + 1] + _marker.length;
+      sections.add(_Range(
+        _runStartByEnd[open] ?? open,
+        _runEndByStart[afterClose] ?? afterClose,
+      ));
+    }
+    return sections;
+  }
+
+  /// The ranges left around [sections]. Two sections parted by nothing but a
+  /// break run both grow over that run, hence the clamp: a kept range never
+  /// starts before the section ahead of it ended.
+  List<_Range> _keptRanges(List<_Range> sections) {
+    final kept = <_Range>[];
     var cursor = 0;
-    var removedPair = false;
-    StringBuffer? result;
-
-    while (true) {
-      final open = description.indexOf(separator, cursor);
-      if (open == -1) break;
-
-      final close = description.indexOf(separator, open + markerLength);
-      if (close == -1) break;
-
-      result ??= StringBuffer();
-      _writeKept(
-        result,
-        description.substring(cursor, open),
-        stripLeading: removedPair,
-        stripTrailing: true,
-      );
-      removedPair = true;
-      cursor = close + markerLength;
+    for (final section in sections) {
+      kept.add(_Range(cursor, max(cursor, section.start)));
+      cursor = section.end;
     }
-
-    if (result == null) return description;
-
-    _writeKept(
-      result,
-      description.substring(cursor),
-      stripLeading: true,
-      stripTrailing: false,
-    );
-    return result.toString();
+    kept.add(_Range(cursor, text.length));
+    return kept;
   }
 
-  /// Writes [chunk] into [buffer] without the breaks that hugged a removed
-  /// section, separated from what came before by exactly one newline.
-  ///
-  /// The separator is written whatever the dropped section looked like: a pair
-  /// with no break on either side would otherwise weld the surrounding text
-  /// into a single token.
-  static void _writeKept(
-    StringBuffer buffer,
-    String chunk, {
-    required bool stripLeading,
-    required bool stripTrailing,
-  }) {
-    var kept = chunk;
-    if (stripTrailing) kept = _stripTrailingBreaks(kept);
-    if (stripLeading) kept = _stripLeadingBreaks(kept);
-    if (kept.isEmpty) return;
+  /// Renders [ranges] separated by exactly one newline, whatever the dropped
+  /// sections looked like: a pair with no break on either side would otherwise
+  /// weld the surrounding text into a single token.
+  String _render(List<_Range> ranges) => ranges
+      .map((range) => text.substring(range.start, range.end))
+      .where((slice) => slice.isNotEmpty)
+      .join('\n');
+}
 
-    if (buffer.isNotEmpty) buffer.write('\n');
-    buffer.write(kept);
-  }
+/// A `[start, end)` slice of a description.
+class _Range {
+  const _Range(this.start, this.end);
 
-  static String _stripLeadingBreaks(String text) {
-    var start = 0;
-    while (start < text.length) {
-      final length = _breakLengthStartingAt(text, start);
-      if (length == 0) break;
-      start += length;
-    }
-    return start == 0 ? text : text.substring(start);
-  }
-
-  static String _stripTrailingBreaks(String text) {
-    var end = text.length;
-    while (end > 0) {
-      final length = _breakLengthEndingAt(text, end);
-      if (length == 0) break;
-      end -= length;
-    }
-    return end == text.length ? text : text.substring(0, end);
-  }
-
-  static int _breakLengthStartingAt(String text, int index) {
-    if (index >= text.length) return 0;
-    if (text.startsWith('\r\n', index)) return 2;
-    if (text[index] == '\n' || text[index] == '\r') return 1;
-    return _brTagLengthAt(text, index);
-  }
-
-  static int _breakLengthEndingAt(String text, int end) {
-    if (end <= 0) return 0;
-    if (end >= 2 && text.startsWith('\r\n', end - 2)) return 2;
-    if (text[end - 1] == '\n' || text[end - 1] == '\r') return 1;
-    return _brTagLengthEndingAt(text, end);
-  }
-
-  /// Length of the `<br>` tag starting at [index], or 0 when there is none.
-  /// Accepts `<br>`, `<br/>` and any casing, with whitespace before the slash.
-  static int _brTagLengthAt(String text, int index) {
-    if (index + 3 >= text.length || text[index] != '<') return 0;
-    if (!_isLetter(text.codeUnitAt(index + 1), _letterB)) return 0;
-    if (!_isLetter(text.codeUnitAt(index + 2), _letterR)) return 0;
-
-    var cursor = index + 3;
-    while (cursor < text.length && _isTagWhitespace(text[cursor])) {
-      cursor++;
-    }
-    if (cursor < text.length && text[cursor] == '/') cursor++;
-    if (cursor < text.length && text[cursor] == '>') {
-      return cursor - index + 1;
-    }
-    return 0;
-  }
-
-  /// Right-to-left mirror of [_brTagLengthAt], so both directions accept the
-  /// same tags instead of a backward scan guessing at candidate lengths.
-  static int _brTagLengthEndingAt(String text, int end) {
-    if (text[end - 1] != '>') return 0;
-
-    var cursor = end - 2;
-    if (cursor >= 0 && text[cursor] == '/') cursor--;
-    while (cursor >= 0 && _isTagWhitespace(text[cursor])) {
-      cursor--;
-    }
-    if (cursor < 2) return 0;
-    if (!_isLetter(text.codeUnitAt(cursor), _letterR)) return 0;
-    if (!_isLetter(text.codeUnitAt(cursor - 1), _letterB)) return 0;
-    if (text[cursor - 2] != '<') return 0;
-
-    return end - (cursor - 2);
-  }
-
-  static const int _letterB = 0x62;
-  static const int _letterR = 0x72;
-
-  /// Case-insensitive match against a lowercase ASCII [letter].
-  static bool _isLetter(int codeUnit, int letter) =>
-      (codeUnit | 0x20) == letter;
-
-  static bool _isTagWhitespace(String char) =>
-      char == ' ' || char == '\t' || char == '\n' || char == '\r';
+  final int start;
+  final int end;
 }

--- a/core/test/utils/redos_test_utils.dart
+++ b/core/test/utils/redos_test_utils.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+
+/// Runs [action], asserts it completes within [budgetMs] milliseconds, and
+/// returns its result. Centralizes the stopwatch + elapsed-time assertion that
+/// every ReDoS performance test shares, so the timing criterion lives in one
+/// place instead of being duplicated per test.
+T expectFastResult<T>(
+  T Function() action, {
+  int budgetMs = 100,
+  String? reason,
+}) {
+  final stopwatch = Stopwatch()..start();
+  late final T result;
+  try {
+    result = action();
+  } finally {
+    stopwatch.stop();
+  }
+  // Assert the budget only after a successful return so a throwing [action]
+  // surfaces its own exception instead of the timing matcher's failure.
+  expect(stopwatch.elapsedMilliseconds, lessThan(budgetMs), reason: reason);
+  return result;
+}

--- a/core/test/utils/redos_vulnerability_test.dart
+++ b/core/test/utils/redos_vulnerability_test.dart
@@ -8,29 +8,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:html/parser.dart' as html_parser;
 import 'package:mockito/mockito.dart';
 
-class MockDioClient extends Mock implements DioClient {}
+import 'redos_test_utils.dart';
 
-/// Runs [action], asserts it completes within [budgetMs] milliseconds, and
-/// returns its result. Centralizes the stopwatch + elapsed-time assertion that
-/// every ReDoS performance test shares, so the timing criterion lives in one
-/// place instead of being duplicated per test.
-T expectFastResult<T>(
-  T Function() action, {
-  int budgetMs = 100,
-  String? reason,
-}) {
-  final stopwatch = Stopwatch()..start();
-  late final T result;
-  try {
-    result = action();
-  } finally {
-    stopwatch.stop();
-  }
-  // Assert the budget only after a successful return so a throwing [action]
-  // surfaces its own exception instead of the timing matcher's failure.
-  expect(stopwatch.elapsedMilliseconds, lessThan(budgetMs), reason: reason);
-  return result;
-}
+class MockDioClient extends Mock implements DioClient {}
 
 /// Tests to verify that ReDoS (Regular Expression Denial of Service) vulnerabilities
 /// have been properly patched. These tests use inputs that would cause catastrophic

--- a/core/test/utils/video_conference_section_utils_test.dart
+++ b/core/test/utils/video_conference_section_utils_test.dart
@@ -1,0 +1,101 @@
+import 'package:core/utils/video_conference_section_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const separator = VideoConferenceSectionUtils.separator;
+  const visioSection =
+      '$separator\n'
+      'Participer via Visio : https://meet.linagora.com/apw-gxwg-naw\n'
+      '\n'
+      'Veuillez ne pas modifier cette section.\n'
+      '$separator';
+
+  group('VideoConferenceSectionUtils.removeSection', () {
+    test('SHOULD return description unchanged when it has no separator', () {
+      const description = 'Agenda:\n1. Intro\n2. Demo';
+
+      expect(VideoConferenceSectionUtils.removeSection(description), description);
+    });
+
+    test('SHOULD return empty string when description is empty', () {
+      expect(VideoConferenceSectionUtils.removeSection(''), '');
+    });
+
+    test('SHOULD return empty string when description only contains the visio section', () {
+      expect(VideoConferenceSectionUtils.removeSection(visioSection), '');
+    });
+
+    test('SHOULD strip a visio section appended after the user description', () {
+      const description = 'Sprint planning\n\n$visioSection';
+
+      expect(
+        VideoConferenceSectionUtils.removeSection(description),
+        'Sprint planning',
+      );
+    });
+
+    test('SHOULD strip a visio section placed before the user description', () {
+      const description = '$visioSection\n\nSprint planning';
+
+      expect(
+        VideoConferenceSectionUtils.removeSection(description),
+        'Sprint planning',
+      );
+    });
+
+    test('SHOULD strip a visio section in the middle without leaving blank lines', () {
+      const description = 'Before\n\n$visioSection\n\nAfter';
+
+      expect(
+        VideoConferenceSectionUtils.removeSection(description),
+        'Before\nAfter',
+      );
+    });
+
+    test('SHOULD strip a visio section surrounded by <br> tags', () {
+      const description = 'Before<br><br>$separator<br>Join Visio : https://meet.example.com/a-b-c<br>$separator<br>After';
+
+      expect(
+        VideoConferenceSectionUtils.removeSection(description),
+        'Before\nAfter',
+      );
+    });
+
+    test('SHOULD strip every visio section when several are present', () {
+      const description = 'A\n$visioSection\nB\n$visioSection\nC';
+
+      expect(
+        VideoConferenceSectionUtils.removeSection(description),
+        'A\nB\nC',
+      );
+    });
+
+    test('SHOULD keep a lone separator that does not delimit a section', () {
+      const description = 'Header\n$separator\nBody';
+
+      expect(
+        VideoConferenceSectionUtils.removeSection(description),
+        description,
+      );
+    });
+
+    test('SHOULD keep a legacy "Visio:" line outside of any section', () {
+      const description = 'Visio: https://meet.example.com/a-b-c\nAgenda';
+
+      expect(
+        VideoConferenceSectionUtils.removeSection(description),
+        description,
+      );
+    });
+  });
+
+  group('VideoConferenceSectionUtils.containsSection', () {
+    test('SHOULD be true when the separator is present', () {
+      expect(VideoConferenceSectionUtils.containsSection(visioSection), isTrue);
+    });
+
+    test('SHOULD be false when the separator is absent', () {
+      expect(VideoConferenceSectionUtils.containsSection('plain text'), isFalse);
+    });
+  });
+}

--- a/core/test/utils/video_conference_section_utils_test.dart
+++ b/core/test/utils/video_conference_section_utils_test.dart
@@ -4,13 +4,18 @@ import 'package:flutter_test/flutter_test.dart';
 import 'redos_test_utils.dart';
 
 void main() {
-  const separator = VideoConferenceSectionUtils.separator;
+  const separator =
+      '-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-';
   const visioSection =
       '$separator\n'
       'Participer via Visio : https://meet.linagora.com/apw-gxwg-naw\n'
       '\n'
       'Veuillez ne pas modifier cette section.\n'
       '$separator';
+
+  test('separator SHOULD match the Twake Calendar delimiter used in production', () {
+    expect(VideoConferenceSectionUtils.separator, separator);
+  });
 
   group('VideoConferenceSectionUtils.removeSection', () {
     test('SHOULD return description unchanged when it has no separator', () {
@@ -250,6 +255,16 @@ void main() {
     test('SHOULD strip <br> tags holding whitespace before the slash', () {
       const description =
           'Before<br  />$separator<br\t/>Join Visio : https://meet.example.com/a-b-c<br \n/>$separator<br  />After';
+
+      expect(
+        VideoConferenceSectionUtils.removeSection(description),
+        'Before\nAfter',
+      );
+    });
+
+    test('SHOULD strip <br> tags holding a form feed before the slash', () {
+      const description =
+          'Before<br\f/>$separator<br\f/>Join Visio : https://meet.example.com/a-b-c<br\f/>$separator<br\f/>After';
 
       expect(
         VideoConferenceSectionUtils.removeSection(description),

--- a/core/test/utils/video_conference_section_utils_test.dart
+++ b/core/test/utils/video_conference_section_utils_test.dart
@@ -1,6 +1,8 @@
 import 'package:core/utils/video_conference_section_utils.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'redos_test_utils.dart';
+
 void main() {
   const separator = VideoConferenceSectionUtils.separator;
   const visioSection =
@@ -14,25 +16,34 @@ void main() {
     test('SHOULD return description unchanged when it has no separator', () {
       const description = 'Agenda:\n1. Intro\n2. Demo';
 
-      expect(VideoConferenceSectionUtils.removeSection(description), description);
+      expect(
+        VideoConferenceSectionUtils.removeSection(description),
+        description,
+      );
     });
 
     test('SHOULD return empty string when description is empty', () {
       expect(VideoConferenceSectionUtils.removeSection(''), '');
     });
 
-    test('SHOULD return empty string when description only contains the visio section', () {
-      expect(VideoConferenceSectionUtils.removeSection(visioSection), '');
-    });
+    test(
+      'SHOULD return empty string when description only contains the visio section',
+      () {
+        expect(VideoConferenceSectionUtils.removeSection(visioSection), '');
+      },
+    );
 
-    test('SHOULD strip a visio section appended after the user description', () {
-      const description = 'Sprint planning\n\n$visioSection';
+    test(
+      'SHOULD strip a visio section appended after the user description',
+      () {
+        const description = 'Sprint planning\n\n$visioSection';
 
-      expect(
-        VideoConferenceSectionUtils.removeSection(description),
-        'Sprint planning',
-      );
-    });
+        expect(
+          VideoConferenceSectionUtils.removeSection(description),
+          'Sprint planning',
+        );
+      },
+    );
 
     test('SHOULD strip a visio section placed before the user description', () {
       const description = '$visioSection\n\nSprint planning';
@@ -43,8 +54,21 @@ void main() {
       );
     });
 
-    test('SHOULD strip a visio section in the middle without leaving blank lines', () {
-      const description = 'Before\n\n$visioSection\n\nAfter';
+    test(
+      'SHOULD strip a visio section in the middle without leaving blank lines',
+      () {
+        const description = 'Before\n\n$visioSection\n\nAfter';
+
+        expect(
+          VideoConferenceSectionUtils.removeSection(description),
+          'Before\nAfter',
+        );
+      },
+    );
+
+    test('SHOULD strip a visio section surrounded by <br> tags', () {
+      const description =
+          'Before<br><br>$separator<br>Join Visio : https://meet.example.com/a-b-c<br>$separator<br>After';
 
       expect(
         VideoConferenceSectionUtils.removeSection(description),
@@ -52,22 +76,228 @@ void main() {
       );
     });
 
-    test('SHOULD strip a visio section surrounded by <br> tags', () {
-      const description = 'Before<br><br>$separator<br>Join Visio : https://meet.example.com/a-b-c<br>$separator<br>After';
+    test('SHOULD strip a visio section surrounded by <br /> tags', () {
+      const description =
+          'Before<br />$separator<br />Join Visio : https://meet.example.com/a-b-c<br />$separator<br />After';
 
       expect(
         VideoConferenceSectionUtils.removeSection(description),
         'Before\nAfter',
+      );
+    });
+
+    test('SHOULD strip a visio section surrounded by uppercase <BR> tags', () {
+      const description =
+          'Before<BR>$separator<BR>Join Visio : https://meet.example.com/a-b-c<BR>$separator<BR>After';
+
+      expect(
+        VideoConferenceSectionUtils.removeSection(description),
+        'Before\nAfter',
+      );
+    });
+
+    test('SHOULD strip a visio section that uses CRLF line endings', () {
+      const description =
+          'Sprint planning\r\n\r\n'
+          '$separator\r\n'
+          'Join Visio : https://meet.example.com/a-b-c\r\n'
+          '\r\n'
+          'Please do not edit this section.\r\n'
+          '$separator';
+
+      expect(
+        VideoConferenceSectionUtils.removeSection(description),
+        'Sprint planning',
+      );
+    });
+
+    test(
+      'SHOULD leave wrapping HTML tags when the visio section is the only content inside them',
+      () {
+        const description = '<p>$visioSection</p>';
+
+        expect(
+          VideoConferenceSectionUtils.removeSection(description),
+          '<p>\n</p>',
+        );
+      },
+    );
+
+    test('SHOULD preserve user-authored leading and trailing whitespace', () {
+      const description = '  Sprint planning  \n\n$visioSection';
+
+      expect(
+        VideoConferenceSectionUtils.removeSection(description),
+        '  Sprint planning  ',
+      );
+    });
+
+    test(
+      'SHOULD return a large malformed payload unchanged within the ReDoS budget',
+      () {
+        final description = '${'\n' * 10000}$separator';
+
+        final result = expectFastResult(
+          () => VideoConferenceSectionUtils.removeSection(description),
+          reason:
+              'Malformed visio markers must stay linear (ADR 0069 ReDoS budget)',
+        );
+
+        expect(result, description);
+      },
+    );
+
+    test(
+      'SHOULD strip a pair buried in a huge break run within the ReDoS budget',
+      () {
+        final description =
+            'Before${'<br>' * 50000}$visioSection${'<br>' * 50000}After';
+
+        final result = expectFastResult(
+          () => VideoConferenceSectionUtils.removeSection(description),
+          reason:
+              'Break stripping around a removed pair must stay linear '
+              '(ADR 0069 ReDoS budget)',
+        );
+
+        expect(result, 'Before\nAfter');
+      },
+    );
+
+    test(
+      'SHOULD reject an unterminated <br> run adjacent to a pair within the '
+      'ReDoS budget',
+      () {
+        final description =
+            'Before$visioSection<br${' ' * 100000}After';
+
+        final result = expectFastResult(
+          () => VideoConferenceSectionUtils.removeSection(description),
+          reason:
+              'A malformed tag must fail in one pass, not per offset '
+              '(ADR 0069 ReDoS budget)',
+        );
+
+        expect(result, description.replaceFirst(visioSection, '\n'));
+      },
+    );
+
+    test(
+      'SHOULD return the same instance when no complete visio pair exists',
+      () {
+        const description = 'Header\n$separator\nBody';
+
+        expect(
+          identical(
+            VideoConferenceSectionUtils.removeSection(description),
+            description,
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test('SHOULD strip an empty visio pair with no interior text', () {
+      const description = 'Hello$separator${separator}World';
+
+      expect(
+        VideoConferenceSectionUtils.removeSection(description),
+        'Hello\nWorld',
+      );
+    });
+
+    test(
+      'SHOULD NOT splice text across a removed section into one autolinkable URL',
+      () {
+        const description =
+            'Join here: https://meet.linagora.com'
+            '$visioSection'
+            '.attacker.tld/login';
+
+        expect(
+          VideoConferenceSectionUtils.removeSection(description),
+          'Join here: https://meet.linagora.com\n.attacker.tld/login',
+        );
+      },
+    );
+
+    test(
+      'SHOULD join the surrounding lines when only the text before the section '
+      'ends with a line break',
+      () {
+        const description = 'Before\n$visioSection' 'After';
+
+        expect(
+          VideoConferenceSectionUtils.removeSection(description),
+          'Before\nAfter',
+        );
+      },
+    );
+
+    test(
+      'SHOULD join the surrounding lines when only the text before the section '
+      'ends with a <br> tag',
+      () {
+        const description = 'Before<br>$visioSection' 'After';
+
+        expect(
+          VideoConferenceSectionUtils.removeSection(description),
+          'Before\nAfter',
+        );
+      },
+    );
+
+    test('SHOULD strip <br> tags holding whitespace before the slash', () {
+      const description =
+          'Before<br  />$separator<br\t/>Join Visio : https://meet.example.com/a-b-c<br \n/>$separator<br  />After';
+
+      expect(
+        VideoConferenceSectionUtils.removeSection(description),
+        'Before\nAfter',
+      );
+    });
+
+    test('SHOULD strip a <br> tag broken by a newline', () {
+      const description = 'Before<br\n>$visioSection' 'After';
+
+      expect(
+        VideoConferenceSectionUtils.removeSection(description),
+        'Before\nAfter',
+      );
+    });
+
+    test('SHOULD keep a non-<br> tag adjacent to the section', () {
+      const description = 'Before<b>$visioSection</b>After';
+
+      expect(
+        VideoConferenceSectionUtils.removeSection(description),
+        'Before<b>\n</b>After',
+      );
+    });
+
+    test('SHOULD strip a visio section surrounded by mixed-case <Br> tags', () {
+      const description =
+          'Before<Br>$separator<bR>Join Visio : https://meet.example.com/a-b-c<br/>$separator<BR />After';
+
+      expect(
+        VideoConferenceSectionUtils.removeSection(description),
+        'Before\nAfter',
+      );
+    });
+
+    test('SHOULD keep leftover text after an unpaired third separator', () {
+      const description = 'Notes\n$visioSection\nMore\n$separator\nTail';
+
+      expect(
+        VideoConferenceSectionUtils.removeSection(description),
+        'Notes\nMore\n$separator\nTail',
       );
     });
 
     test('SHOULD strip every visio section when several are present', () {
       const description = 'A\n$visioSection\nB\n$visioSection\nC';
 
-      expect(
-        VideoConferenceSectionUtils.removeSection(description),
-        'A\nB\nC',
-      );
+      expect(VideoConferenceSectionUtils.removeSection(description), 'A\nB\nC');
     });
 
     test('SHOULD keep a lone separator that does not delimit a section', () {
@@ -86,16 +316,6 @@ void main() {
         VideoConferenceSectionUtils.removeSection(description),
         description,
       );
-    });
-  });
-
-  group('VideoConferenceSectionUtils.containsSection', () {
-    test('SHOULD be true when the separator is present', () {
-      expect(VideoConferenceSectionUtils.containsSection(visioSection), isTrue);
-    });
-
-    test('SHOULD be false when the separator is absent', () {
-      expect(VideoConferenceSectionUtils.containsSection('plain text'), isFalse);
     });
   });
 }

--- a/lib/features/email/data/repository/calendar_event_repository_impl.dart
+++ b/lib/features/email/data/repository/calendar_event_repository_impl.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/data/model/source_type/data_source_type.dart';
 import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
+import 'package:core/utils/video_conference_section_utils.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/mail/calendar/calendar_event.dart';
@@ -76,14 +77,25 @@ class CalendarEventRepositoryImpl extends CalendarEventRepository {
     CalendarEvent calendarEvent,
     TransformConfiguration transformConfiguration,
   ) async {
+    final description = _removeVideoConferenceSection(calendarEvent.description);
+
     return calendarEvent.copyWith(
-      description: calendarEvent.description?.trim().isNotEmpty == true
+      description: description?.trim().isNotEmpty == true
         ? await _htmlDataSource.transformHtmlEmailContent(
-            calendarEvent.description!,
+            description!,
             transformConfiguration,
           )
-        : calendarEvent.description,
+        : description,
     );
+  }
+
+  /// The visio link is already part of the invitation email body, so the
+  /// "do not edit" section Twake Calendar appends to the ICS description is
+  /// dropped before rendering (see linagora/tmail-flutter#4802).
+  String? _removeVideoConferenceSection(String? description) {
+    if (description == null) return null;
+
+    return VideoConferenceSectionUtils.removeSection(description);
   }
   
   @override

--- a/lib/features/email/data/repository/calendar_event_repository_impl.dart
+++ b/lib/features/email/data/repository/calendar_event_repository_impl.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/data/model/source_type/data_source_type.dart';
 import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
+import 'package:core/utils/html/html_utils.dart';
 import 'package:core/utils/video_conference_section_utils.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
@@ -56,16 +57,14 @@ class CalendarEventRepositoryImpl extends CalendarEventRepository {
       .rejectEventInvitation(accountId, blobIds, language);
   }
 
-  /// [sanitizeDescription] cleans the raw ICS description before it is
-  /// rendered. It defaults to dropping the "do not edit" section Twake Calendar
-  /// appends to the description, because the visio link it holds is already
-  /// rendered by the invitation email body.
   @override
   Future<List<BlobCalendarEvent>> transformCalendarEventDescription(
     List<BlobCalendarEvent> blobCalendarEvents,
     TransformConfiguration transformConfiguration, {
-    String Function(String) sanitizeDescription = VideoConferenceSectionUtils.removeSection,
+    String Function(String)? sanitizeDescription,
   }) async {
+    final sanitize =
+        sanitizeDescription ?? VideoConferenceSectionUtils.removeSection;
     return Future.wait(blobCalendarEvents.map((blobCalendarEvent) async {
       return BlobCalendarEvent(
         blobId: blobCalendarEvent.blobId,
@@ -73,7 +72,7 @@ class CalendarEventRepositoryImpl extends CalendarEventRepository {
           return _transformCalendarEventDescription(
             calendarEvent,
             transformConfiguration,
-            sanitizeDescription,
+            sanitize,
           );
         })),
         isFree: blobCalendarEvent.isFree,
@@ -89,7 +88,9 @@ class CalendarEventRepositoryImpl extends CalendarEventRepository {
   ) async {
     final description = calendarEvent.description == null
         ? null
-        : sanitizeDescription(calendarEvent.description!);
+        : _visibleCalendarDescription(
+            sanitizeDescription(calendarEvent.description!),
+          );
 
     return calendarEvent.copyWith(
       description: description?.trim().isNotEmpty == true
@@ -100,7 +101,21 @@ class CalendarEventRepositoryImpl extends CalendarEventRepository {
         : description,
     );
   }
-  
+
+  static final _mediaTagRegex = RegExp(
+    r'<(?:img|video|audio|canvas|svg|iframe)\b',
+    caseSensitive: false,
+  );
+
+  String _visibleCalendarDescription(String html) {
+    final plainText = HtmlUtils.extractPlainText(
+      html,
+      removeQuotes: false,
+    ).trim();
+    if (plainText.isNotEmpty || _mediaTagRegex.hasMatch(html)) return html;
+    return '';
+  }
+
   @override
   Future<CalendarEventAcceptResponse> acceptCounterEvent(
     AccountId accountId,

--- a/lib/features/email/data/repository/calendar_event_repository_impl.dart
+++ b/lib/features/email/data/repository/calendar_event_repository_impl.dart
@@ -1,6 +1,7 @@
 
 import 'package:core/data/model/source_type/data_source_type.dart';
 import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
+import 'package:core/utils/app_logger.dart';
 import 'package:core/utils/html/html_utils.dart';
 import 'package:core/utils/video_conference_section_utils.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
@@ -89,7 +90,10 @@ class CalendarEventRepositoryImpl extends CalendarEventRepository {
     final description = calendarEvent.description == null
         ? null
         : _visibleCalendarDescription(
-            sanitizeDescription(calendarEvent.description!),
+            _sanitizeDescription(
+              calendarEvent.description!,
+              sanitizeDescription,
+            ),
           );
 
     return calendarEvent.copyWith(
@@ -100,6 +104,20 @@ class CalendarEventRepositoryImpl extends CalendarEventRepository {
           )
         : description,
     );
+  }
+
+  String _sanitizeDescription(
+    String description,
+    SanitizeCalendarEventDescription sanitizeDescription,
+  ) {
+    try {
+      return sanitizeDescription(description);
+    } catch (e) {
+      logWarning(
+        'CalendarEventRepositoryImpl::_sanitizeDescription:Exception $e',
+      );
+      return description;
+    }
   }
 
   static final _mediaTagRegex = RegExp(

--- a/lib/features/email/data/repository/calendar_event_repository_impl.dart
+++ b/lib/features/email/data/repository/calendar_event_repository_impl.dart
@@ -61,7 +61,7 @@ class CalendarEventRepositoryImpl extends CalendarEventRepository {
   Future<List<BlobCalendarEvent>> transformCalendarEventDescription(
     List<BlobCalendarEvent> blobCalendarEvents,
     TransformConfiguration transformConfiguration, {
-    String Function(String)? sanitizeDescription,
+    SanitizeCalendarEventDescription? sanitizeDescription,
   }) async {
     final sanitize =
         sanitizeDescription ?? VideoConferenceSectionUtils.removeSection;
@@ -84,7 +84,7 @@ class CalendarEventRepositoryImpl extends CalendarEventRepository {
   Future<CalendarEvent> _transformCalendarEventDescription(
     CalendarEvent calendarEvent,
     TransformConfiguration transformConfiguration,
-    String Function(String) sanitizeDescription,
+    SanitizeCalendarEventDescription sanitizeDescription,
   ) async {
     final description = calendarEvent.description == null
         ? null

--- a/lib/features/email/data/repository/calendar_event_repository_impl.dart
+++ b/lib/features/email/data/repository/calendar_event_repository_impl.dart
@@ -56,16 +56,25 @@ class CalendarEventRepositoryImpl extends CalendarEventRepository {
       .rejectEventInvitation(accountId, blobIds, language);
   }
 
+  /// [sanitizeDescription] cleans the raw ICS description before it is
+  /// rendered. It defaults to dropping the "do not edit" section Twake Calendar
+  /// appends to the description, because the visio link it holds is already
+  /// rendered by the invitation email body.
   @override
   Future<List<BlobCalendarEvent>> transformCalendarEventDescription(
     List<BlobCalendarEvent> blobCalendarEvents,
-    TransformConfiguration transformConfiguration,
-  ) async {
+    TransformConfiguration transformConfiguration, {
+    String Function(String) sanitizeDescription = VideoConferenceSectionUtils.removeSection,
+  }) async {
     return Future.wait(blobCalendarEvents.map((blobCalendarEvent) async {
       return BlobCalendarEvent(
         blobId: blobCalendarEvent.blobId,
         calendarEventList: await Future.wait(blobCalendarEvent.calendarEventList.map((calendarEvent) {
-          return _transformCalendarEventDescription(calendarEvent, transformConfiguration);
+          return _transformCalendarEventDescription(
+            calendarEvent,
+            transformConfiguration,
+            sanitizeDescription,
+          );
         })),
         isFree: blobCalendarEvent.isFree,
         attendanceStatus: blobCalendarEvent.attendanceStatus,
@@ -76,8 +85,11 @@ class CalendarEventRepositoryImpl extends CalendarEventRepository {
   Future<CalendarEvent> _transformCalendarEventDescription(
     CalendarEvent calendarEvent,
     TransformConfiguration transformConfiguration,
+    String Function(String) sanitizeDescription,
   ) async {
-    final description = _removeVideoConferenceSection(calendarEvent.description);
+    final description = calendarEvent.description == null
+        ? null
+        : sanitizeDescription(calendarEvent.description!);
 
     return calendarEvent.copyWith(
       description: description?.trim().isNotEmpty == true
@@ -87,15 +99,6 @@ class CalendarEventRepositoryImpl extends CalendarEventRepository {
           )
         : description,
     );
-  }
-
-  /// The visio link is already part of the invitation email body, so the
-  /// "do not edit" section Twake Calendar appends to the ICS description is
-  /// dropped before rendering (see linagora/tmail-flutter#4802).
-  String? _removeVideoConferenceSection(String? description) {
-    if (description == null) return null;
-
-    return VideoConferenceSectionUtils.removeSection(description);
   }
   
   @override

--- a/lib/features/email/domain/repository/calendar_event_repository.dart
+++ b/lib/features/email/domain/repository/calendar_event_repository.dart
@@ -7,6 +7,8 @@ import 'package:tmail_ui_user/features/email/presentation/model/blob_calendar_ev
 import 'package:jmap_dart_client/jmap/mail/calendar/reply/calendar_event_maybe_response.dart';
 import 'package:jmap_dart_client/jmap/mail/calendar/reply/calendar_event_reject_response.dart';
 
+typedef SanitizeCalendarEventDescription = String Function(String);
+
 abstract class CalendarEventRepository {
   Future<List<BlobCalendarEvent>> parse(AccountId accountId, Set<Id> blobIds);
 
@@ -28,7 +30,7 @@ abstract class CalendarEventRepository {
   Future<List<BlobCalendarEvent>> transformCalendarEventDescription(
     List<BlobCalendarEvent> blobCalendarEvents,
     TransformConfiguration transformConfiguration, {
-    String Function(String)? sanitizeDescription,
+    SanitizeCalendarEventDescription? sanitizeDescription,
   });
 
   Future<CalendarEventAcceptResponse> acceptCounterEvent(

--- a/lib/features/email/domain/repository/calendar_event_repository.dart
+++ b/lib/features/email/domain/repository/calendar_event_repository.dart
@@ -27,7 +27,9 @@ abstract class CalendarEventRepository {
 
   Future<List<BlobCalendarEvent>> transformCalendarEventDescription(
     List<BlobCalendarEvent> blobCalendarEvents,
-    TransformConfiguration transformConfiguration);
+    TransformConfiguration transformConfiguration, {
+    String Function(String)? sanitizeDescription,
+  });
 
   Future<CalendarEventAcceptResponse> acceptCounterEvent(
     AccountId accountId,

--- a/lib/features/email/presentation/widgets/calendar_event/calendar_event_detail_widget.dart
+++ b/lib/features/email/presentation/widgets/calendar_event/calendar_event_detail_widget.dart
@@ -39,7 +39,10 @@ class CalendarEventDetailWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final eventDesc = _generateEventDescriptionAsHtml();
+    final eventDesc = generateEventDescriptionAsHtml(
+      description: calendarEvent.description,
+      emailContent: emailContent,
+    );
 
     return Container(
       clipBehavior: Clip.antiAlias,
@@ -78,19 +81,23 @@ class CalendarEventDetailWidget extends StatelessWidget {
       ),
     );
   }
+}
 
-  String _generateEventDescriptionAsHtml() {
-    final descriptions = calendarEvent.description?.trimmed ?? '';
-    final emailContentTrimmed = emailContent.trimmed;
+@visibleForTesting
+String generateEventDescriptionAsHtml({
+  required String? description,
+  required String emailContent,
+}) {
+  final descriptions = description?.trimmed ?? '';
+  final emailContentTrimmed = emailContent.trimmed;
 
-    if (descriptions.isEmpty && emailContentTrimmed.isEmpty) {
-      return '';
-    }
+  if (descriptions.isEmpty && emailContentTrimmed.isEmpty) {
+    return '';
+  }
 
-    return '''
+  return '''
       $descriptions
       <br>
       $emailContentTrimmed
     ''';
-  }
 }

--- a/test/features/email/data/repository/calendar_event_repository_impl_sanitize_test.dart
+++ b/test/features/email/data/repository/calendar_event_repository_impl_sanitize_test.dart
@@ -1,0 +1,181 @@
+import 'package:core/data/model/source_type/data_source_type.dart';
+import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/calendar/calendar_event.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/email/data/repository/calendar_event_repository_impl.dart';
+import 'package:tmail_ui_user/features/email/domain/repository/calendar_event_repository.dart';
+import 'package:tmail_ui_user/features/email/presentation/model/blob_calendar_event.dart';
+
+import 'calendar_event_repository_impl_test.mocks.dart';
+
+void main() {
+  final htmlDatasource = MockHtmlDataSource();
+  final calendarEventRepository = CalendarEventRepositoryImpl(
+    {DataSourceType.network: MockCalendarEventDataSource()},
+    htmlDatasource,
+  );
+  final blobId = Id('blobId');
+  final transformConfiguration = TransformConfiguration.forCalendarEvent();
+  const separator =
+      '-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-';
+  const visioSection =
+      '$separator\n'
+      'Participer via Visio : https://meet.linagora.com/apw-gxwg-naw\n'
+      '\n'
+      'Veuillez ne pas modifier cette section.\n'
+      '$separator';
+
+  setUp(() => reset(htmlDatasource));
+
+  Future<List<BlobCalendarEvent>> transformSingle(
+    CalendarEvent event, {
+    SanitizeCalendarEventDescription? sanitizeDescription,
+  }) =>
+      calendarEventRepository.transformCalendarEventDescription(
+        [BlobCalendarEvent(blobId: blobId, calendarEventList: [event])],
+        transformConfiguration,
+        sanitizeDescription: sanitizeDescription,
+      );
+
+  Future<void> expectSkipped(
+    String description, {
+    SanitizeCalendarEventDescription? sanitizeDescription,
+    required String reason,
+  }) async {
+    final result = await transformSingle(
+      CalendarEvent(description: description),
+      sanitizeDescription: sanitizeDescription,
+    );
+    verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
+    expect(
+      result.first.calendarEventList.first.description,
+      isEmpty,
+      reason: reason,
+    );
+  }
+
+  Future<void> expectForwardedToHtml({
+    required String description,
+    required String forwarded,
+    required String htmlResult,
+    SanitizeCalendarEventDescription? sanitizeDescription,
+    required String reason,
+  }) async {
+    when(htmlDatasource.transformHtmlEmailContent(any, any))
+      .thenAnswer((_) async => htmlResult);
+    final result = await transformSingle(
+      CalendarEvent(description: description),
+      sanitizeDescription: sanitizeDescription,
+    );
+    verify(htmlDatasource.transformHtmlEmailContent(forwarded, transformConfiguration))
+      .called(1);
+    expect(
+      result.first.calendarEventList.first.description,
+      htmlResult,
+      reason: reason,
+    );
+  }
+
+  test('should keep null description and never call htmlDataSource', () async {
+    final result = await transformSingle(
+      CalendarEvent(description: null, title: 'Meeting'),
+    );
+
+    verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
+    expect(result.first.calendarEventList.first.description, isNull);
+    expect(result.first.calendarEventList.first.title, 'Meeting');
+  });
+
+  test('should skip htmlDataSource when leftover is empty', () async {
+    final skipped = <({
+      String name,
+      String description,
+      SanitizeCalendarEventDescription? sanitizeDescription,
+    })>[
+      (name: 'empty description', description: '', sanitizeDescription: null),
+      (name: 'whitespace-only description', description: '   ', sanitizeDescription: null),
+      (name: 'visio-only description', description: visioSection, sanitizeDescription: null),
+      (
+        name: 'visio-only wrapped in HTML tags',
+        description: '<p>$visioSection</p>',
+        sanitizeDescription: null,
+      ),
+      (
+        name: 'leftover wrappers that only hold NBSP',
+        description: '<p>\u00a0$visioSection</p>',
+        sanitizeDescription: null,
+      ),
+      (
+        name: 'leftover wrappers with a long attribute',
+        description: '<p style="${'x' * 140}">$visioSection</p>',
+        sanitizeDescription: null,
+      ),
+      (
+        name: 'sanitizeDescription returns blank',
+        description: 'any visio block',
+        sanitizeDescription: (_) => '',
+      ),
+    ];
+
+    for (final example in skipped) {
+      reset(htmlDatasource);
+      await expectSkipped(
+        example.description,
+        sanitizeDescription: example.sanitizeDescription,
+        reason: example.name,
+      );
+    }
+  });
+
+  test('should forward leftover description to htmlDataSource', () async {
+    final forwarded = <({
+      String name,
+      String description,
+      String forwarded,
+      String htmlResult,
+      SanitizeCalendarEventDescription? sanitizeDescription,
+    })>[
+      (
+        name: 'default visio strip before htmlDataSource',
+        description: 'Sprint planning\n\n$visioSection',
+        forwarded: 'Sprint planning',
+        htmlResult: '<body>Sprint planning</body>',
+        sanitizeDescription: null,
+      ),
+      (
+        name: 'sanitizeDescription output',
+        description: 'Sprint planning with visio block',
+        forwarded: 'Sprint planning',
+        htmlResult: '<body>Sprint planning</body>',
+        sanitizeDescription: (_) => 'Sprint planning',
+      ),
+      (
+        name: 'original description when sanitizeDescription throws',
+        description: 'Sprint planning with visio block',
+        forwarded: 'Sprint planning with visio block',
+        htmlResult: '<body>Sprint planning with visio block</body>',
+        sanitizeDescription: (_) => throw StateError('strip failed'),
+      ),
+      (
+        name: 'image-only leftover after visio strip',
+        description: '<img src="x">$visioSection',
+        forwarded: '<img src="x">',
+        htmlResult: '<body><img src="x"></body>',
+        sanitizeDescription: null,
+      ),
+    ];
+
+    for (final example in forwarded) {
+      reset(htmlDatasource);
+      await expectForwardedToHtml(
+        description: example.description,
+        forwarded: example.forwarded,
+        htmlResult: example.htmlResult,
+        sanitizeDescription: example.sanitizeDescription,
+        reason: example.name,
+      );
+    }
+  });
+}

--- a/test/features/email/data/repository/calendar_event_repository_impl_test.dart
+++ b/test/features/email/data/repository/calendar_event_repository_impl_test.dart
@@ -1,6 +1,5 @@
 import 'package:core/data/model/source_type/data_source_type.dart';
 import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
-import 'package:core/utils/video_conference_section_utils.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
@@ -129,12 +128,20 @@ void main() {
 
   group('transformCalendarEventDescription:', () {
     final transformConfiguration = TransformConfiguration.forCalendarEvent();
+    const separator =
+        '-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-';
+    const visioSection =
+        '$separator\n'
+        'Participer via Visio : https://meet.linagora.com/apw-gxwg-naw\n'
+        '\n'
+        'Veuillez ne pas modifier cette section.\n'
+        '$separator';
 
     setUp(() => reset(htmlDatasource));
 
     Future<List<BlobCalendarEvent>> transformSingle(
       CalendarEvent event, {
-      String Function(String) sanitizeDescription = VideoConferenceSectionUtils.removeSection,
+      String Function(String)? sanitizeDescription,
     }) =>
       calendarEventRepository.transformCalendarEventDescription(
         [BlobCalendarEvent(blobId: blobId, calendarEventList: [event])],
@@ -173,89 +180,17 @@ void main() {
         expect(result.first.calendarEventList.first.description, isEmpty);
       });
 
-      test('should keep whitespace-only description and never call htmlDataSource', () async {
+      test('should collapse whitespace-only description to empty and never call htmlDataSource', () async {
         // act
         final result = await transformSingle(CalendarEvent(description: '   '));
 
         // assert
         verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
-        expect(result.first.calendarEventList.first.description, '   ');
+        expect(result.first.calendarEventList.first.description, isEmpty);
       });
     });
 
     group('_transformCalendarEventDescription — description sanitizing:', () {
-      const visioSection =
-          '${VideoConferenceSectionUtils.separator}\n'
-          'Participer via Visio : https://meet.linagora.com/apw-gxwg-naw\n'
-          '\n'
-          'Veuillez ne pas modifier cette section.\n'
-          '${VideoConferenceSectionUtils.separator}';
-
-      test('should skip htmlDataSource when sanitizeDescription returns blank', () async {
-        final result = await transformSingle(
-          CalendarEvent(description: 'any visio block'),
-          sanitizeDescription: (_) => '',
-        );
-
-        verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
-        expect(result.first.calendarEventList.first.description, isEmpty);
-      });
-
-      test('should skip htmlDataSource when sanitizeDescription returns whitespace', () async {
-        final result = await transformSingle(
-          CalendarEvent(description: 'any visio block'),
-          sanitizeDescription: (_) => '   ',
-        );
-
-        verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
-        expect(result.first.calendarEventList.first.description, '   ');
-      });
-
-      test('should not call sanitizeDescription when description is null', () async {
-        var sanitized = false;
-
-        final result = await transformSingle(
-          CalendarEvent(description: null, title: 'Meeting'),
-          sanitizeDescription: (description) {
-            sanitized = true;
-            return description;
-          },
-        );
-
-        expect(sanitized, isFalse);
-        verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
-        expect(result.first.calendarEventList.first.description, isNull);
-      });
-
-      test('should pass the raw description into sanitizeDescription', () async {
-        when(htmlDatasource.transformHtmlEmailContent(any, any))
-          .thenAnswer((_) async => '<body>Sprint planning</body>');
-        late String capturedRaw;
-
-        await transformSingle(
-          CalendarEvent(description: 'Sprint planning with visio block'),
-          sanitizeDescription: (raw) {
-            capturedRaw = raw;
-            return 'Sprint planning';
-          },
-        );
-
-        expect(capturedRaw, 'Sprint planning with visio block');
-      });
-
-      test('should send sanitizeDescription output to htmlDataSource', () async {
-        when(htmlDatasource.transformHtmlEmailContent(any, any))
-          .thenAnswer((_) async => '<body>Sprint planning</body>');
-
-        final result = await transformSingle(
-          CalendarEvent(description: 'Sprint planning with visio block'),
-          sanitizeDescription: (_) => 'Sprint planning',
-        );
-
-        verify(htmlDatasource.transformHtmlEmailContent('Sprint planning', transformConfiguration)).called(1);
-        expect(result.first.calendarEventList.first.description, '<body>Sprint planning</body>');
-      });
-
       test('should use VideoConferenceSectionUtils by default for a visio-only description', () async {
         final result = await transformSingle(CalendarEvent(description: visioSection));
 
@@ -275,18 +210,67 @@ void main() {
         expect(result.first.calendarEventList.first.description, '<body>Sprint planning</body>');
       });
 
-      test('should still call htmlDataSource when a visio-only section is wrapped in HTML tags', () async {
-        const wrappedDescription = '<p>$visioSection</p>';
-        const leftover = '<p>\n</p>';
-        when(htmlDatasource.transformHtmlEmailContent(any, any))
-          .thenAnswer((_) async => '<body><p></p></body>');
-
+      test('should skip htmlDataSource when a visio-only section is wrapped in HTML tags', () async {
         final result = await transformSingle(
-          CalendarEvent(description: wrappedDescription),
+          CalendarEvent(description: '<p>$visioSection</p>'),
         );
 
-        verify(htmlDatasource.transformHtmlEmailContent(leftover, transformConfiguration)).called(1);
-        expect(result.first.calendarEventList.first.description, '<body><p></p></body>');
+        verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
+        expect(result.first.calendarEventList.first.description, isEmpty);
+      });
+
+      test('should skip htmlDataSource when leftover wrappers only hold NBSP', () async {
+        final result = await transformSingle(
+          CalendarEvent(description: '<p>\u00a0$visioSection</p>'),
+        );
+
+        verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
+        expect(result.first.calendarEventList.first.description, isEmpty);
+      });
+
+      test('should skip htmlDataSource when leftover wrappers have a long attribute', () async {
+        final style = 'x' * 140;
+        final result = await transformSingle(
+          CalendarEvent(description: '<p style="$style">$visioSection</p>'),
+        );
+
+        verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
+        expect(result.first.calendarEventList.first.description, isEmpty);
+      });
+
+      test('should skip htmlDataSource when sanitizeDescription returns blank', () async {
+        final result = await transformSingle(
+          CalendarEvent(description: 'any visio block'),
+          sanitizeDescription: (_) => '',
+        );
+
+        verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
+        expect(result.first.calendarEventList.first.description, isEmpty);
+      });
+
+      test('should send sanitizeDescription output to htmlDataSource', () async {
+        when(htmlDatasource.transformHtmlEmailContent(any, any))
+          .thenAnswer((_) async => '<body>Sprint planning</body>');
+
+        final result = await transformSingle(
+          CalendarEvent(description: 'Sprint planning with visio block'),
+          sanitizeDescription: (_) => 'Sprint planning',
+        );
+
+        verify(htmlDatasource.transformHtmlEmailContent('Sprint planning', transformConfiguration)).called(1);
+        expect(result.first.calendarEventList.first.description, '<body>Sprint planning</body>');
+      });
+
+      test('should keep an image-only leftover after visio strip', () async {
+        when(htmlDatasource.transformHtmlEmailContent(any, any))
+          .thenAnswer((_) async => '<body><img src="x"></body>');
+
+        final result = await transformSingle(
+          CalendarEvent(description: '<img src="x">$visioSection'),
+        );
+
+        verify(htmlDatasource.transformHtmlEmailContent('<img src="x">', transformConfiguration)).called(1);
+        expect(result.first.calendarEventList.first.description, '<body><img src="x"></body>');
       });
     });
 
@@ -447,7 +431,7 @@ void main() {
           blobId: blobId,
           calendarEventList: [
             CalendarEvent(description: 'keep me'),
-            CalendarEvent(description: 'drop me'),
+            CalendarEvent(description: visioSection),
             CalendarEvent(description: null),
           ],
         );
@@ -455,11 +439,10 @@ void main() {
         final result = await calendarEventRepository.transformCalendarEventDescription(
           [blob],
           transformConfiguration,
-          sanitizeDescription: (text) => text == 'drop me' ? '' : text,
         );
 
         verify(htmlDatasource.transformHtmlEmailContent('keep me', transformConfiguration)).called(1);
-        verifyNever(htmlDatasource.transformHtmlEmailContent('drop me', transformConfiguration));
+        verifyNever(htmlDatasource.transformHtmlEmailContent(visioSection, transformConfiguration));
         expect(result.first.calendarEventList[0].description, '<body>keep me</body>');
         expect(result.first.calendarEventList[1].description, isEmpty);
         expect(result.first.calendarEventList[2].description, isNull);

--- a/test/features/email/data/repository/calendar_event_repository_impl_test.dart
+++ b/test/features/email/data/repository/calendar_event_repository_impl_test.dart
@@ -1,5 +1,6 @@
 import 'package:core/data/model/source_type/data_source_type.dart';
 import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
+import 'package:core/utils/video_conference_section_utils.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
@@ -175,6 +176,40 @@ void main() {
         // assert
         verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
         expect(result.first.calendarEventList.first.description, '   ');
+      });
+    });
+
+    group('_transformCalendarEventDescription — video conference section removal:', () {
+      const separator = VideoConferenceSectionUtils.separator;
+      const visioSection =
+          '$separator\n'
+          'Participer via Visio : https://meet.linagora.com/apw-gxwg-naw\n'
+          '\n'
+          'Veuillez ne pas modifier cette section.\n'
+          '$separator';
+
+      test('should blank out a description made only of the visio section and never call htmlDataSource', () async {
+        // act
+        final result = await transformSingle(CalendarEvent(description: visioSection));
+
+        // assert
+        verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
+        expect(result.first.calendarEventList.first.description, isEmpty);
+      });
+
+      test('should strip the visio section before delegating to htmlDataSource', () async {
+        // arrange
+        when(htmlDatasource.transformHtmlEmailContent(any, any))
+          .thenAnswer((_) async => '<body>Sprint planning</body>');
+
+        // act
+        final result = await transformSingle(
+          CalendarEvent(description: 'Sprint planning\n\n$visioSection'),
+        );
+
+        // assert
+        verify(htmlDatasource.transformHtmlEmailContent('Sprint planning', transformConfiguration)).called(1);
+        expect(result.first.calendarEventList.first.description, '<body>Sprint planning</body>');
       });
     });
 

--- a/test/features/email/data/repository/calendar_event_repository_impl_test.dart
+++ b/test/features/email/data/repository/calendar_event_repository_impl_test.dart
@@ -132,10 +132,14 @@ void main() {
 
     setUp(() => reset(htmlDatasource));
 
-    Future<List<BlobCalendarEvent>> transformSingle(CalendarEvent event) =>
+    Future<List<BlobCalendarEvent>> transformSingle(
+      CalendarEvent event, {
+      String Function(String) sanitizeDescription = VideoConferenceSectionUtils.removeSection,
+    }) =>
       calendarEventRepository.transformCalendarEventDescription(
         [BlobCalendarEvent(blobId: blobId, calendarEventList: [event])],
         transformConfiguration,
+        sanitizeDescription: sanitizeDescription,
       );
 
     Future<void> expectDelegated({
@@ -179,37 +183,110 @@ void main() {
       });
     });
 
-    group('_transformCalendarEventDescription — video conference section removal:', () {
-      const separator = VideoConferenceSectionUtils.separator;
+    group('_transformCalendarEventDescription — description sanitizing:', () {
       const visioSection =
-          '$separator\n'
+          '${VideoConferenceSectionUtils.separator}\n'
           'Participer via Visio : https://meet.linagora.com/apw-gxwg-naw\n'
           '\n'
           'Veuillez ne pas modifier cette section.\n'
-          '$separator';
+          '${VideoConferenceSectionUtils.separator}';
 
-      test('should blank out a description made only of the visio section and never call htmlDataSource', () async {
-        // act
-        final result = await transformSingle(CalendarEvent(description: visioSection));
+      test('should skip htmlDataSource when sanitizeDescription returns blank', () async {
+        final result = await transformSingle(
+          CalendarEvent(description: 'any visio block'),
+          sanitizeDescription: (_) => '',
+        );
 
-        // assert
         verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
         expect(result.first.calendarEventList.first.description, isEmpty);
       });
 
-      test('should strip the visio section before delegating to htmlDataSource', () async {
-        // arrange
+      test('should skip htmlDataSource when sanitizeDescription returns whitespace', () async {
+        final result = await transformSingle(
+          CalendarEvent(description: 'any visio block'),
+          sanitizeDescription: (_) => '   ',
+        );
+
+        verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
+        expect(result.first.calendarEventList.first.description, '   ');
+      });
+
+      test('should not call sanitizeDescription when description is null', () async {
+        var sanitized = false;
+
+        final result = await transformSingle(
+          CalendarEvent(description: null, title: 'Meeting'),
+          sanitizeDescription: (description) {
+            sanitized = true;
+            return description;
+          },
+        );
+
+        expect(sanitized, isFalse);
+        verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
+        expect(result.first.calendarEventList.first.description, isNull);
+      });
+
+      test('should pass the raw description into sanitizeDescription', () async {
+        when(htmlDatasource.transformHtmlEmailContent(any, any))
+          .thenAnswer((_) async => '<body>Sprint planning</body>');
+        late String capturedRaw;
+
+        await transformSingle(
+          CalendarEvent(description: 'Sprint planning with visio block'),
+          sanitizeDescription: (raw) {
+            capturedRaw = raw;
+            return 'Sprint planning';
+          },
+        );
+
+        expect(capturedRaw, 'Sprint planning with visio block');
+      });
+
+      test('should send sanitizeDescription output to htmlDataSource', () async {
         when(htmlDatasource.transformHtmlEmailContent(any, any))
           .thenAnswer((_) async => '<body>Sprint planning</body>');
 
-        // act
+        final result = await transformSingle(
+          CalendarEvent(description: 'Sprint planning with visio block'),
+          sanitizeDescription: (_) => 'Sprint planning',
+        );
+
+        verify(htmlDatasource.transformHtmlEmailContent('Sprint planning', transformConfiguration)).called(1);
+        expect(result.first.calendarEventList.first.description, '<body>Sprint planning</body>');
+      });
+
+      test('should use VideoConferenceSectionUtils by default for a visio-only description', () async {
+        final result = await transformSingle(CalendarEvent(description: visioSection));
+
+        verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
+        expect(result.first.calendarEventList.first.description, isEmpty);
+      });
+
+      test('should use VideoConferenceSectionUtils by default before htmlDataSource', () async {
+        when(htmlDatasource.transformHtmlEmailContent(any, any))
+          .thenAnswer((_) async => '<body>Sprint planning</body>');
+
         final result = await transformSingle(
           CalendarEvent(description: 'Sprint planning\n\n$visioSection'),
         );
 
-        // assert
         verify(htmlDatasource.transformHtmlEmailContent('Sprint planning', transformConfiguration)).called(1);
         expect(result.first.calendarEventList.first.description, '<body>Sprint planning</body>');
+      });
+
+      test('should still call htmlDataSource when a visio-only section is wrapped in HTML tags', () async {
+        const wrappedDescription = '<p>$visioSection</p>';
+        const leftover = '<p>\n</p>';
+        when(htmlDatasource.transformHtmlEmailContent(any, any))
+          .thenAnswer((_) async => '<body><p></p></body>');
+
+        final result = await transformSingle(
+          CalendarEvent(description: wrappedDescription),
+        );
+
+        verify(htmlDatasource.transformHtmlEmailContent(leftover, transformConfiguration)).called(1);
+        expect(result.first.calendarEventList.first.description, '<body><p></p></body>');
       });
     });
 
@@ -357,6 +434,35 @@ void main() {
         // assert
         verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
         expect(result, isEmpty);
+      });
+
+      test('should sanitize each CalendarEvent independently', () async {
+        when(htmlDatasource.transformHtmlEmailContent(any, any))
+          .thenAnswer((invocation) async {
+            final raw = invocation.positionalArguments.first as String;
+            return '<body>$raw</body>';
+          });
+
+        final blob = BlobCalendarEvent(
+          blobId: blobId,
+          calendarEventList: [
+            CalendarEvent(description: 'keep me'),
+            CalendarEvent(description: 'drop me'),
+            CalendarEvent(description: null),
+          ],
+        );
+
+        final result = await calendarEventRepository.transformCalendarEventDescription(
+          [blob],
+          transformConfiguration,
+          sanitizeDescription: (text) => text == 'drop me' ? '' : text,
+        );
+
+        verify(htmlDatasource.transformHtmlEmailContent('keep me', transformConfiguration)).called(1);
+        verifyNever(htmlDatasource.transformHtmlEmailContent('drop me', transformConfiguration));
+        expect(result.first.calendarEventList[0].description, '<body>keep me</body>');
+        expect(result.first.calendarEventList[1].description, isEmpty);
+        expect(result.first.calendarEventList[2].description, isNull);
       });
 
       test('should process all CalendarEvents within a single BlobCalendarEvent', () async {

--- a/test/features/email/data/repository/calendar_event_repository_impl_test.dart
+++ b/test/features/email/data/repository/calendar_event_repository_impl_test.dart
@@ -1,10 +1,7 @@
 import 'package:core/data/model/source_type/data_source_type.dart';
-import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
-import 'package:jmap_dart_client/jmap/mail/calendar/attendance/calendar_event_attendance.dart';
-import 'package:jmap_dart_client/jmap/mail/calendar/calendar_event.dart';
 import 'package:jmap_dart_client/jmap/mail/calendar/properties/event_id.dart';
 import 'package:jmap_dart_client/jmap/mail/calendar/reply/calendar_event_accept_response.dart';
 import 'package:jmap_dart_client/jmap/mail/calendar/reply/calendar_event_maybe_response.dart';
@@ -14,9 +11,7 @@ import 'package:mockito/mockito.dart';
 import 'package:tmail_ui_user/features/email/data/datasource/calendar_event_datasource.dart';
 import 'package:tmail_ui_user/features/email/data/datasource/html_datasource.dart';
 import 'package:tmail_ui_user/features/email/data/repository/calendar_event_repository_impl.dart';
-import 'package:tmail_ui_user/features/email/domain/repository/calendar_event_repository.dart';
 import 'package:tmail_ui_user/features/email/domain/exceptions/calendar_event_exceptions.dart';
-import 'package:tmail_ui_user/features/email/presentation/model/blob_calendar_event.dart';
 
 import 'calendar_event_repository_impl_test.mocks.dart';
 
@@ -26,12 +21,9 @@ import 'calendar_event_repository_impl_test.mocks.dart';
 ])
 void main() {
   final calendarEventNetworkDataSource = MockCalendarEventDataSource();
-  final htmlDatasource = MockHtmlDataSource();
-  final calendarEventDataSource = {
-    DataSourceType.network: calendarEventNetworkDataSource};
   final calendarEventRepository = CalendarEventRepositoryImpl(
-    calendarEventDataSource,
-    htmlDatasource,
+    {DataSourceType.network: calendarEventNetworkDataSource},
+    MockHtmlDataSource(),
   );
   final accountId = AccountId(Id('123'));
   final blobId = Id('blobId');
@@ -44,23 +36,18 @@ void main() {
       accepted: [EventId(blobId.value)]);
 
     test('should return response when data source return response', () async {
-      // arrange
       when(calendarEventNetworkDataSource.acceptEventInvitation(any, any, any))
         .thenAnswer((_) async => calendarEventAcceptResponseresponse);
 
-      // act
       final response = await calendarEventRepository.acceptEventInvitation(accountId, {blobId}, language);
-      
-      // assert
+
       expect(response, calendarEventAcceptResponseresponse);
     });
 
     test('should throw exception when data source throw exception', () {
-      // arrange
       when(calendarEventNetworkDataSource.acceptEventInvitation(any, any, any))
         .thenThrow(NotAcceptableCalendarEventException());
-      
-      // assert
+
       expect(
         () => calendarEventRepository.acceptEventInvitation(accountId, {blobId}, language),
         throwsA(isA<NotAcceptableCalendarEventException>()));
@@ -74,23 +61,18 @@ void main() {
       maybe: [EventId(blobId.value)]);
 
     test('should return response when data source return response', () async {
-      // arrange
       when(calendarEventNetworkDataSource.maybeEventInvitation(any, any, any))
         .thenAnswer((_) async => calendarEventMaybeResponse);
 
-      // act
       final response = await calendarEventRepository.maybeEventInvitation(accountId, {blobId}, language);
-      
-      // assert
+
       expect(response, calendarEventMaybeResponse);
     });
 
     test('should throw exception when data source throw exception', () {
-      // arrange
       when(calendarEventNetworkDataSource.maybeEventInvitation(any, any, any))
         .thenThrow(NotMaybeableCalendarEventException());
-      
-      // assert
+
       expect(
         () => calendarEventRepository.maybeEventInvitation(accountId, {blobId}, language),
         throwsA(isA<NotMaybeableCalendarEventException>()));
@@ -104,427 +86,21 @@ void main() {
       rejected: [EventId(blobId.value)]);
 
     test('should return response when data source return response', () async {
-      // arrange
       when(calendarEventNetworkDataSource.rejectEventInvitation(any, any, any))
         .thenAnswer((_) async => calendarEventRejectResponseresponse);
 
-      // act
       final response = await calendarEventRepository.rejectEventInvitation(accountId, {blobId}, language);
-      
-      // assert
+
       expect(response, calendarEventRejectResponseresponse);
     });
 
     test('should throw exception when data source throw exception', () {
-      // arrange
       when(calendarEventNetworkDataSource.rejectEventInvitation(any, any, any))
         .thenThrow(NotRejectableCalendarEventException());
-      
-      // assert
+
       expect(
         () => calendarEventRepository.rejectEventInvitation(accountId, {blobId}, language),
         throwsA(isA<NotRejectableCalendarEventException>()));
-    });
-  });
-
-  group('transformCalendarEventDescription:', () {
-    final transformConfiguration = TransformConfiguration.forCalendarEvent();
-    const separator =
-        '-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-';
-    const visioSection =
-        '$separator\n'
-        'Participer via Visio : https://meet.linagora.com/apw-gxwg-naw\n'
-        '\n'
-        'Veuillez ne pas modifier cette section.\n'
-        '$separator';
-
-    setUp(() => reset(htmlDatasource));
-
-    Future<List<BlobCalendarEvent>> transformSingle(
-      CalendarEvent event, {
-      SanitizeCalendarEventDescription? sanitizeDescription,
-    }) =>
-      calendarEventRepository.transformCalendarEventDescription(
-        [BlobCalendarEvent(blobId: blobId, calendarEventList: [event])],
-        transformConfiguration,
-        sanitizeDescription: sanitizeDescription,
-      );
-
-    Future<void> expectDelegated({
-      required String raw,
-      required String sanitized,
-    }) async {
-      when(htmlDatasource.transformHtmlEmailContent(any, any))
-        .thenAnswer((_) async => sanitized);
-      final result = await transformSingle(CalendarEvent(description: raw));
-      verify(htmlDatasource.transformHtmlEmailContent(raw, transformConfiguration)).called(1);
-      expect(result.first.calendarEventList.first.description, sanitized);
-    }
-
-    group('_transformCalendarEventDescription — description skipping:', () {
-      test('should keep null description and never call htmlDataSource', () async {
-        // act
-        final result = await transformSingle(CalendarEvent(description: null, title: 'Meeting'));
-
-        // assert
-        verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
-        expect(result.first.calendarEventList.first.description, isNull);
-        expect(result.first.calendarEventList.first.title, 'Meeting');
-      });
-
-      test('should keep empty description and never call htmlDataSource', () async {
-        // act
-        final result = await transformSingle(CalendarEvent(description: ''));
-
-        // assert
-        verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
-        expect(result.first.calendarEventList.first.description, isEmpty);
-      });
-
-      test('should collapse whitespace-only description to empty and never call htmlDataSource', () async {
-        // act
-        final result = await transformSingle(CalendarEvent(description: '   '));
-
-        // assert
-        verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
-        expect(result.first.calendarEventList.first.description, isEmpty);
-      });
-    });
-
-    group('_transformCalendarEventDescription — description sanitizing:', () {
-      test('should use VideoConferenceSectionUtils by default for a visio-only description', () async {
-        final result = await transformSingle(CalendarEvent(description: visioSection));
-
-        verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
-        expect(result.first.calendarEventList.first.description, isEmpty);
-      });
-
-      test('should use VideoConferenceSectionUtils by default before htmlDataSource', () async {
-        when(htmlDatasource.transformHtmlEmailContent(any, any))
-          .thenAnswer((_) async => '<body>Sprint planning</body>');
-
-        final result = await transformSingle(
-          CalendarEvent(description: 'Sprint planning\n\n$visioSection'),
-        );
-
-        verify(htmlDatasource.transformHtmlEmailContent('Sprint planning', transformConfiguration)).called(1);
-        expect(result.first.calendarEventList.first.description, '<body>Sprint planning</body>');
-      });
-
-      test('should skip htmlDataSource when a visio-only section is wrapped in HTML tags', () async {
-        final result = await transformSingle(
-          CalendarEvent(description: '<p>$visioSection</p>'),
-        );
-
-        verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
-        expect(result.first.calendarEventList.first.description, isEmpty);
-      });
-
-      test('should skip htmlDataSource when leftover wrappers only hold NBSP', () async {
-        final result = await transformSingle(
-          CalendarEvent(description: '<p>\u00a0$visioSection</p>'),
-        );
-
-        verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
-        expect(result.first.calendarEventList.first.description, isEmpty);
-      });
-
-      test('should skip htmlDataSource when leftover wrappers have a long attribute', () async {
-        final style = 'x' * 140;
-        final result = await transformSingle(
-          CalendarEvent(description: '<p style="$style">$visioSection</p>'),
-        );
-
-        verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
-        expect(result.first.calendarEventList.first.description, isEmpty);
-      });
-
-      test('should skip htmlDataSource when sanitizeDescription returns blank', () async {
-        final result = await transformSingle(
-          CalendarEvent(description: 'any visio block'),
-          sanitizeDescription: (_) => '',
-        );
-
-        verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
-        expect(result.first.calendarEventList.first.description, isEmpty);
-      });
-
-      test('should send sanitizeDescription output to htmlDataSource', () async {
-        when(htmlDatasource.transformHtmlEmailContent(any, any))
-          .thenAnswer((_) async => '<body>Sprint planning</body>');
-
-        final result = await transformSingle(
-          CalendarEvent(description: 'Sprint planning with visio block'),
-          sanitizeDescription: (_) => 'Sprint planning',
-        );
-
-        verify(htmlDatasource.transformHtmlEmailContent('Sprint planning', transformConfiguration)).called(1);
-        expect(result.first.calendarEventList.first.description, '<body>Sprint planning</body>');
-      });
-
-      test('should keep an image-only leftover after visio strip', () async {
-        when(htmlDatasource.transformHtmlEmailContent(any, any))
-          .thenAnswer((_) async => '<body><img src="x"></body>');
-
-        final result = await transformSingle(
-          CalendarEvent(description: '<img src="x">$visioSection'),
-        );
-
-        verify(htmlDatasource.transformHtmlEmailContent('<img src="x">', transformConfiguration)).called(1);
-        expect(result.first.calendarEventList.first.description, '<body><img src="x"></body>');
-      });
-    });
-
-    group('_transformCalendarEventDescription — description transformation:', () {
-      test('should call htmlDataSource with the raw description', () async {
-        // arrange
-        const rawDescription = 'Join the meeting at https://meet.example.com';
-        when(htmlDatasource.transformHtmlEmailContent(any, any))
-          .thenAnswer((_) async => '<body>transformed</body>');
-
-        // act
-        await transformSingle(CalendarEvent(description: rawDescription));
-
-        // assert
-        verify(htmlDatasource.transformHtmlEmailContent(rawDescription, transformConfiguration)).called(1);
-      });
-
-      test('should replace description with the result returned by htmlDataSource', () async {
-        // arrange
-        const transformed = '<body><p>Team standup</p></body>';
-        when(htmlDatasource.transformHtmlEmailContent(any, any))
-          .thenAnswer((_) async => transformed);
-
-        // act
-        final result = await transformSingle(CalendarEvent(description: 'Team standup'));
-
-        // assert
-        expect(result.first.calendarEventList.first.description, transformed);
-      });
-
-      test('should preserve non-description CalendarEvent fields after transformation', () async {
-        // arrange
-        when(htmlDatasource.transformHtmlEmailContent(any, any))
-          .thenAnswer((_) async => '<body>Quarterly review</body>');
-
-        // act
-        final result = await transformSingle(CalendarEvent(
-          description: 'Quarterly review',
-          title: 'Q4 Review',
-          location: 'Conference Room A',
-        ));
-
-        // assert
-        final resultEvent = result.first.calendarEventList.first;
-        expect(resultEvent.title, 'Q4 Review');
-        expect(resultEvent.location, 'Conference Room A');
-      });
-    });
-
-    group('_transformCalendarEventDescription — XSS and nested HTML descriptions:', () {
-      // Sanitization correctness is covered in calendar_event_description_transform_test.dart.
-
-      test('should delegate <script> injection to htmlDataSource and store sanitized result', () async {
-        await expectDelegated(
-          raw: 'Notes: <script>document.cookie</script>',
-          sanitized: '<body>Notes: </body>',
-        );
-      });
-
-      test('should delegate event-handler injection to htmlDataSource and store sanitized result', () async {
-        await expectDelegated(
-          raw: '<img src="x" onerror="alert(1)"> Team photo',
-          sanitized: '<body>Team photo</body>',
-        );
-      });
-
-      test('should delegate javascript: href to htmlDataSource and store sanitized result', () async {
-        await expectDelegated(
-          raw: '<a href="javascript:alert(1)">click here</a>',
-          sanitized: '<body><a href="">click here</a></body>',
-        );
-      });
-
-      test('should delegate deeply nested HTML to htmlDataSource and store result', () async {
-        await expectDelegated(
-          raw: '<div><p><span><b>Important:</b> quarterly budget</span></p></div>',
-          sanitized: '<body><div><p><span><b>Important:</b> quarterly budget</span></p></div></body>',
-        );
-      });
-
-      test('should delegate mixed XSS + plain text to htmlDataSource and store sanitized result', () async {
-        await expectDelegated(
-          raw: 'Agenda:\n1. Budget <script>stealData()</script>\n2. Planning <img src=x onerror="xss()">',
-          sanitized: '<body>Agenda:<br>1. Budget <br>2. Planning </body>',
-        );
-      });
-
-      test('should delegate description with HTML entities to htmlDataSource and store result', () async {
-        await expectDelegated(
-          raw: 'Status: a &lt; b &amp;&amp; b &gt; 0',
-          sanitized: '<body>Status: a &lt; b &amp;&amp; b &gt; 0</body>',
-        );
-      });
-    });
-
-    group('_transformCalendarEventDescription — ADR-0089 backslash-hex regression:', () {
-      // ADR-0089 documents a bug in dart-neats/sanitize_html: the regex
-      // RegExp(r'\\[0-9a-f]{2}') matches any single \XX pair (e.g. \DA in
-      // \Sabre\DAV), stripping the entire text node and producing blank output.
-      // Non-blank output for these inputs is verified in calendar_event_description_transform_test.dart.
-
-      test('should forward PHP namespace path description to htmlDataSource and store result', () async {
-        // \Corp\DAV\Server\Exception\Forbidden — \DA triggers unicodeEscapeReg
-        await expectDelegated(
-          raw: r'Meeting exception: \Corp\DAV\Server\Exception\Forbidden — contact IT',
-          sanitized: r'<body>Meeting exception: \Corp\DAV\Server\Exception\Forbidden — contact IT</body>',
-        );
-      });
-
-      test('should forward Windows file path description to htmlDataSource and store result', () async {
-        // C:\Users\Admin\Documents — \Us, \Ad, \Do each match \XX
-        await expectDelegated(
-          raw: r'Attachment saved at: C:\Users\Admin\Documents\invite.pdf',
-          sanitized: r'<body>Attachment saved at: C:\Users\Admin\Documents\invite.pdf</body>',
-        );
-      });
-
-      test('should forward Go package path description to htmlDataSource and store result', () async {
-        // \github.com\org\repo\pkg\handler\main.go — multiple \XX pairs
-        await expectDelegated(
-          raw: r'Build error in \github.com\org\repo\pkg\handler\main.go line 42',
-          sanitized: r'<body>Build error in \github.com\org\repo\pkg\handler\main.go line 42</body>',
-        );
-      });
-
-      test('should forward mixed backslash-hex path + URL + newline description and store result', () async {
-        // Combines the three ADR-0089 trigger scenarios in one description.
-        await expectDelegated(
-          raw: r'Error \App\DB\Exception\AuthFailed' '\n'
-              r'See https://jira.example.com/ISSUE-99',
-          sanitized: r'<body>Error \App\DB\Exception\AuthFailed<br>'
-              '<a href="https://jira.example.com/ISSUE-99">https://jira.example.com/ISSUE-99</a></body>',
-        );
-      });
-    });
-
-    group('transformCalendarEventDescription — list handling:', () {
-      test('should return empty list when input is empty', () async {
-        // act
-        final result = await calendarEventRepository.transformCalendarEventDescription(
-          [],
-          transformConfiguration,
-        );
-
-        // assert
-        verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
-        expect(result, isEmpty);
-      });
-
-      test('should sanitize each CalendarEvent independently', () async {
-        when(htmlDatasource.transformHtmlEmailContent(any, any))
-          .thenAnswer((invocation) async {
-            final raw = invocation.positionalArguments.first as String;
-            return '<body>$raw</body>';
-          });
-
-        final blob = BlobCalendarEvent(
-          blobId: blobId,
-          calendarEventList: [
-            CalendarEvent(description: 'keep me'),
-            CalendarEvent(description: visioSection),
-            CalendarEvent(description: null),
-          ],
-        );
-
-        final result = await calendarEventRepository.transformCalendarEventDescription(
-          [blob],
-          transformConfiguration,
-        );
-
-        verify(htmlDatasource.transformHtmlEmailContent('keep me', transformConfiguration)).called(1);
-        verifyNever(htmlDatasource.transformHtmlEmailContent(visioSection, transformConfiguration));
-        expect(result.first.calendarEventList[0].description, '<body>keep me</body>');
-        expect(result.first.calendarEventList[1].description, isEmpty);
-        expect(result.first.calendarEventList[2].description, isNull);
-      });
-
-      test('should process all CalendarEvents within a single BlobCalendarEvent', () async {
-        // arrange
-        const transformed = '<body>transformed</body>';
-        final blob = BlobCalendarEvent(
-          blobId: blobId,
-          calendarEventList: [
-            CalendarEvent(description: 'Event A'),
-            CalendarEvent(description: 'Event B'),
-            CalendarEvent(description: null),
-          ],
-        );
-
-        when(htmlDatasource.transformHtmlEmailContent(any, any))
-          .thenAnswer((_) async => transformed);
-
-        // act
-        final result = await calendarEventRepository.transformCalendarEventDescription(
-          [blob],
-          transformConfiguration,
-        );
-
-        // assert — only the two non-null descriptions trigger a call
-        verify(htmlDatasource.transformHtmlEmailContent(any, any)).called(2);
-        expect(result.first.calendarEventList.length, 3);
-        expect(result.first.calendarEventList[2].description, isNull);
-      });
-
-      test('should process all BlobCalendarEvents in the list', () async {
-        // arrange
-        const transformed = '<body>transformed</body>';
-        final blob1 = BlobCalendarEvent(
-          blobId: Id('blob1'),
-          calendarEventList: [CalendarEvent(description: 'Description 1')],
-        );
-        final blob2 = BlobCalendarEvent(
-          blobId: Id('blob2'),
-          calendarEventList: [CalendarEvent(description: 'Description 2')],
-        );
-
-        when(htmlDatasource.transformHtmlEmailContent(any, any))
-          .thenAnswer((_) async => transformed);
-
-        // act
-        final result = await calendarEventRepository.transformCalendarEventDescription(
-          [blob1, blob2],
-          transformConfiguration,
-        );
-
-        // assert
-        expect(result.length, 2);
-        verify(htmlDatasource.transformHtmlEmailContent(any, any)).called(2);
-      });
-
-      test('should preserve BlobCalendarEvent metadata fields', () async {
-        // arrange
-        final blob = BlobCalendarEvent(
-          blobId: blobId,
-          calendarEventList: [CalendarEvent(description: 'Some description')],
-          isFree: false,
-          attendanceStatus: AttendanceStatus.accepted,
-        );
-
-        when(htmlDatasource.transformHtmlEmailContent(any, any))
-          .thenAnswer((_) async => '<body>Some description</body>');
-
-        // act
-        final result = await calendarEventRepository.transformCalendarEventDescription(
-          [blob],
-          transformConfiguration,
-        );
-
-        // assert
-        expect(result.first.blobId, blobId);
-        expect(result.first.isFree, false);
-        expect(result.first.attendanceStatus, AttendanceStatus.accepted);
-      });
     });
   });
 }

--- a/test/features/email/data/repository/calendar_event_repository_impl_test.dart
+++ b/test/features/email/data/repository/calendar_event_repository_impl_test.dart
@@ -14,6 +14,7 @@ import 'package:mockito/mockito.dart';
 import 'package:tmail_ui_user/features/email/data/datasource/calendar_event_datasource.dart';
 import 'package:tmail_ui_user/features/email/data/datasource/html_datasource.dart';
 import 'package:tmail_ui_user/features/email/data/repository/calendar_event_repository_impl.dart';
+import 'package:tmail_ui_user/features/email/domain/repository/calendar_event_repository.dart';
 import 'package:tmail_ui_user/features/email/domain/exceptions/calendar_event_exceptions.dart';
 import 'package:tmail_ui_user/features/email/presentation/model/blob_calendar_event.dart';
 
@@ -141,7 +142,7 @@ void main() {
 
     Future<List<BlobCalendarEvent>> transformSingle(
       CalendarEvent event, {
-      String Function(String)? sanitizeDescription,
+      SanitizeCalendarEventDescription? sanitizeDescription,
     }) =>
       calendarEventRepository.transformCalendarEventDescription(
         [BlobCalendarEvent(blobId: blobId, calendarEventList: [event])],

--- a/test/features/email/data/repository/calendar_event_repository_impl_transform_test.dart
+++ b/test/features/email/data/repository/calendar_event_repository_impl_transform_test.dart
@@ -1,0 +1,207 @@
+import 'package:core/data/model/source_type/data_source_type.dart';
+import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jmap_dart_client/jmap/core/id.dart';
+import 'package:jmap_dart_client/jmap/mail/calendar/attendance/calendar_event_attendance.dart';
+import 'package:jmap_dart_client/jmap/mail/calendar/calendar_event.dart';
+import 'package:mockito/mockito.dart';
+import 'package:tmail_ui_user/features/email/data/repository/calendar_event_repository_impl.dart';
+import 'package:tmail_ui_user/features/email/presentation/model/blob_calendar_event.dart';
+
+import 'calendar_event_repository_impl_test.mocks.dart';
+
+void main() {
+  final htmlDatasource = MockHtmlDataSource();
+  final calendarEventRepository = CalendarEventRepositoryImpl(
+    {DataSourceType.network: MockCalendarEventDataSource()},
+    htmlDatasource,
+  );
+  final blobId = Id('blobId');
+  final transformConfiguration = TransformConfiguration.forCalendarEvent();
+  const visioSection =
+      '-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-\n'
+      'Participer via Visio : https://meet.linagora.com/apw-gxwg-naw\n'
+      '\n'
+      'Veuillez ne pas modifier cette section.\n'
+      '-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-';
+
+  setUp(() => reset(htmlDatasource));
+
+  Future<List<BlobCalendarEvent>> transformSingle(CalendarEvent event) =>
+      calendarEventRepository.transformCalendarEventDescription(
+        [BlobCalendarEvent(blobId: blobId, calendarEventList: [event])],
+        transformConfiguration,
+      );
+
+  Future<void> expectDelegated({
+    required String raw,
+    required String sanitized,
+  }) async {
+    when(htmlDatasource.transformHtmlEmailContent(any, any))
+      .thenAnswer((_) async => sanitized);
+    final result = await transformSingle(CalendarEvent(description: raw));
+    verify(htmlDatasource.transformHtmlEmailContent(raw, transformConfiguration)).called(1);
+    expect(result.first.calendarEventList.first.description, sanitized);
+  }
+
+  group('html transformation:', () {
+    test('should call htmlDataSource with the raw description', () async {
+      const rawDescription = 'Join the meeting at https://meet.example.com';
+      when(htmlDatasource.transformHtmlEmailContent(any, any))
+        .thenAnswer((_) async => '<body>transformed</body>');
+
+      await transformSingle(CalendarEvent(description: rawDescription));
+
+      verify(htmlDatasource.transformHtmlEmailContent(rawDescription, transformConfiguration)).called(1);
+    });
+
+    test('should replace description with the result returned by htmlDataSource', () async {
+      const transformed = '<body><p>Team standup</p></body>';
+      when(htmlDatasource.transformHtmlEmailContent(any, any))
+        .thenAnswer((_) async => transformed);
+
+      final result = await transformSingle(CalendarEvent(description: 'Team standup'));
+
+      expect(result.first.calendarEventList.first.description, transformed);
+    });
+
+    test('should preserve non-description CalendarEvent fields after transformation', () async {
+      when(htmlDatasource.transformHtmlEmailContent(any, any))
+        .thenAnswer((_) async => '<body>Quarterly review</body>');
+
+      final result = await transformSingle(CalendarEvent(
+        description: 'Quarterly review',
+        title: 'Q4 Review',
+        location: 'Conference Room A',
+      ));
+
+      final resultEvent = result.first.calendarEventList.first;
+      expect(resultEvent.title, 'Q4 Review');
+      expect(resultEvent.location, 'Conference Room A');
+    });
+
+    test('should delegate XSS payload to htmlDataSource and store sanitized result', () async {
+      await expectDelegated(
+        raw: 'Notes: <script>document.cookie</script>',
+        sanitized: '<body>Notes: </body>',
+      );
+    });
+
+    test('should forward ADR-0089 backslash-hex description to htmlDataSource', () async {
+      await expectDelegated(
+        raw: r'Error \App\DB\Exception\AuthFailed' '\n'
+            r'See https://jira.example.com/ISSUE-99',
+        sanitized: r'<body>Error \App\DB\Exception\AuthFailed<br>'
+            '<a href="https://jira.example.com/ISSUE-99">https://jira.example.com/ISSUE-99</a></body>',
+      );
+    });
+  });
+
+  group('list handling:', () {
+    test('should return empty list when input is empty', () async {
+      final result = await calendarEventRepository.transformCalendarEventDescription(
+        [],
+        transformConfiguration,
+      );
+
+      verifyNever(htmlDatasource.transformHtmlEmailContent(any, any));
+      expect(result, isEmpty);
+    });
+
+    test('should sanitize each CalendarEvent independently', () async {
+      when(htmlDatasource.transformHtmlEmailContent(any, any))
+        .thenAnswer((invocation) async {
+          final raw = invocation.positionalArguments.first as String;
+          return '<body>$raw</body>';
+        });
+
+      final blob = BlobCalendarEvent(
+        blobId: blobId,
+        calendarEventList: [
+          CalendarEvent(description: 'keep me'),
+          CalendarEvent(description: visioSection),
+          CalendarEvent(description: null),
+        ],
+      );
+
+      final result = await calendarEventRepository.transformCalendarEventDescription(
+        [blob],
+        transformConfiguration,
+      );
+
+      verify(htmlDatasource.transformHtmlEmailContent('keep me', transformConfiguration)).called(1);
+      verifyNever(htmlDatasource.transformHtmlEmailContent(visioSection, transformConfiguration));
+      expect(result.first.calendarEventList[0].description, '<body>keep me</body>');
+      expect(result.first.calendarEventList[1].description, isEmpty);
+      expect(result.first.calendarEventList[2].description, isNull);
+    });
+
+    test('should process all CalendarEvents within a single BlobCalendarEvent', () async {
+      const transformed = '<body>transformed</body>';
+      final blob = BlobCalendarEvent(
+        blobId: blobId,
+        calendarEventList: [
+          CalendarEvent(description: 'Event A'),
+          CalendarEvent(description: 'Event B'),
+          CalendarEvent(description: null),
+        ],
+      );
+
+      when(htmlDatasource.transformHtmlEmailContent(any, any))
+        .thenAnswer((_) async => transformed);
+
+      final result = await calendarEventRepository.transformCalendarEventDescription(
+        [blob],
+        transformConfiguration,
+      );
+
+      verify(htmlDatasource.transformHtmlEmailContent(any, any)).called(2);
+      expect(result.first.calendarEventList.length, 3);
+      expect(result.first.calendarEventList[2].description, isNull);
+    });
+
+    test('should process all BlobCalendarEvents in the list', () async {
+      const transformed = '<body>transformed</body>';
+      final blob1 = BlobCalendarEvent(
+        blobId: Id('blob1'),
+        calendarEventList: [CalendarEvent(description: 'Description 1')],
+      );
+      final blob2 = BlobCalendarEvent(
+        blobId: Id('blob2'),
+        calendarEventList: [CalendarEvent(description: 'Description 2')],
+      );
+
+      when(htmlDatasource.transformHtmlEmailContent(any, any))
+        .thenAnswer((_) async => transformed);
+
+      final result = await calendarEventRepository.transformCalendarEventDescription(
+        [blob1, blob2],
+        transformConfiguration,
+      );
+
+      expect(result.length, 2);
+      verify(htmlDatasource.transformHtmlEmailContent(any, any)).called(2);
+    });
+
+    test('should preserve BlobCalendarEvent metadata fields', () async {
+      final blob = BlobCalendarEvent(
+        blobId: blobId,
+        calendarEventList: [CalendarEvent(description: 'Some description')],
+        isFree: false,
+        attendanceStatus: AttendanceStatus.accepted,
+      );
+
+      when(htmlDatasource.transformHtmlEmailContent(any, any))
+        .thenAnswer((_) async => '<body>Some description</body>');
+
+      final result = await calendarEventRepository.transformCalendarEventDescription(
+        [blob],
+        transformConfiguration,
+      );
+
+      expect(result.first.blobId, blobId);
+      expect(result.first.isFree, false);
+      expect(result.first.attendanceStatus, AttendanceStatus.accepted);
+    });
+  });
+}

--- a/test/features/email/presentation/widgets/calendar_event/calendar_event_detail_widget_test.dart
+++ b/test/features/email/presentation/widgets/calendar_event/calendar_event_detail_widget_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tmail_ui_user/features/email/presentation/widgets/calendar_event/calendar_event_detail_widget.dart';
+
+void main() {
+  group('generateEventDescriptionAsHtml', () {
+    test('SHOULD return empty when description and email body are empty', () {
+      expect(
+        generateEventDescriptionAsHtml(description: '', emailContent: ''),
+        isEmpty,
+      );
+    });
+
+    test('SHOULD return empty when description is null and email body is empty', () {
+      expect(
+        generateEventDescriptionAsHtml(description: null, emailContent: ''),
+        isEmpty,
+      );
+    });
+
+    test('SHOULD return empty when description is whitespace and email body is empty', () {
+      expect(
+        generateEventDescriptionAsHtml(description: '   ', emailContent: '  '),
+        isEmpty,
+      );
+    });
+
+    test('SHOULD keep the card when description has text and email body is empty', () {
+      final html = generateEventDescriptionAsHtml(
+        description: 'Sprint planning',
+        emailContent: '',
+      );
+
+      expect(html, isNotEmpty);
+      expect(html, contains('Sprint planning'));
+    });
+
+    test('SHOULD keep the card when description is empty and email body has HTML', () {
+      final html = generateEventDescriptionAsHtml(
+        description: '',
+        emailContent: '<p>Invitation body</p>',
+      );
+
+      expect(html, isNotEmpty);
+      expect(html, contains('<p>Invitation body</p>'));
+    });
+  });
+}


### PR DESCRIPTION
Closes #4802

## Problem

Twake Calendar appends a "please do not edit this section" block to the event `DESCRIPTION`, delimited by `-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-` markers and holding the visio link. The HTML body of the invitation email already hides that block and renders the link in its own "Lien" row, but tmail renders the ICS description itself on top of the email body, so the block shows up (see screenshot in the issue). Same topic as linagora/twake-calendar-side-service#1044.

## Fix

- New `VideoConferenceSectionUtils` in `core` that strips every marker-delimited section (including surrounding blank lines / `<br>` tags) from a description. Mirrors `removeVideoConferenceFromDescription` from twake-calendar-frontend (linagora/twake-calendar-frontend#1185). A lone marker that does not delimit a section, and the legacy single `Visio: <url>` line, are left untouched.
- `CalendarEventRepositoryImpl._transformCalendarEventDescription` strips the section before the emptiness check, so a description made only of the visio block is blanked out and skips the HTML transform entirely (no empty `<body>` skeleton left in the rendered card).

## Tests

- `core/test/utils/video_conference_section_utils_test.dart`: section only / trailing / leading / middle / `<br>`-separated / multiple sections / lone separator / legacy line.
- `test/features/email/data/repository/calendar_event_repository_impl_test.dart`: visio-only description is blanked without calling `HtmlDataSource`; a description with a trailing visio block is delegated already stripped.

Note: the Flutter toolchain could not be executed from the automated environment that produced this PR, so the tests were reviewed by hand but not run locally — CI will exercise them.

---
*Generated automatically*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar event descriptions no longer display redundant Twake Calendar video-conference sections.
  * Sections are handled reliably across repeated occurrences, HTML line breaks, newline formats, mixed-case tags, malformed content, and unusual surrounding text.
  * Remaining description content, including media-only content such as images or videos, is preserved and displayed correctly.
  * Video-conference-only or whitespace-only descriptions now appear empty instead of showing unnecessary formatting.
  * Description processing now safely preserves the original content if sanitization fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->