### PR TITLE
Add regression tests for empty identity reply-to fallback

### DIFF
--- a/test/features/composer/presentation/extensions/create_email_request_extension_test.dart
+++ b/test/features/composer/presentation/extensions/create_email_request_extension_test.dart
@@ -418,6 +418,50 @@ void main() {
     });
 
     test(
+      'should return identity email with display name '
+      'when identity has empty replyTo and email differs from ownEmailAddress',
+    () {
+      // Regression for #2651: empty reply-to must prefer the selected identity
+      // email over the account primary / default-identity address.
+      const bobEmail = 'bob@domain.tld';
+      const aliceEmail = 'alice@domain.tld';
+      final identity = Identity(
+        name: 'Alice',
+        email: aliceEmail,
+        replyTo: {},
+      );
+      final request = buildRequest(
+        identity: identity,
+        ownEmailAddress: bobEmail,
+      );
+
+      final result = request.createReplyToRecipients();
+
+      expect(result, {EmailAddress('Alice', aliceEmail)});
+    });
+
+    test(
+      'should preserve explicitly configured replyTo pointing at account primary '
+      'when identity replyTo is set to ownEmailAddress',
+    () {
+      const bobEmail = 'bob@domain.tld';
+      const aliceEmail = 'alice@domain.tld';
+      final identity = Identity(
+        name: 'Alice Smith',
+        email: aliceEmail,
+        replyTo: {EmailAddress(null, bobEmail)},
+      );
+      final request = buildRequest(
+        identity: identity,
+        ownEmailAddress: bobEmail,
+      );
+
+      final result = request.createReplyToRecipients();
+
+      expect(result, {EmailAddress('Alice Smith', bobEmail)});
+    });
+
+    test(
       'should supplement identity name on replyTo address '
       'when identity replyTo items have no display name',
     () {


### PR DESCRIPTION
## Summary
Test-only follow-up suggested by @dab246 on #4801 / #2651.

`createReplyToRecipients` already defaults to the selected identity email when `replyTo` is empty (fixed earlier on master by `9b30b4268`). This PR only adds coverage so that behavior stays locked in.

## Tests added
- Empty `replyTo` with `identity.email != ownEmailAddress` → returns the identity email (real #2651 scenario; existing test used matching emails)
- Explicitly configured reply-to pointing at the account primary is preserved (not rewritten)

## Notes
- No production code changes
- Related implementation PR #4801 was closed as already fixed on master
- Related to #2651

## Test plan
- [x] `flutter test test/features/composer/presentation/extensions/create_email_request_extension_test.dart`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for reply-to recipient handling when an identity has no configured reply-to address.
  - Added coverage ensuring explicitly configured reply-to addresses pointing to the account’s primary address are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->