### PR TITLE
Allow workplace to refresh jmap token

### DIFF
--- a/docs/adr/0107-workplace-oidc-refresh-via-shared-interceptor.md
+++ b/docs/adr/0107-workplace-oidc-refresh-via-shared-interceptor.md
@@ -1,0 +1,25 @@
+# 0107. Route Workplace's OIDC refresh through the main interceptor
+
+Date: 2026-09-07
+
+## Status
+
+Accepted
+
+## Context
+
+Workplace's Drive `token_exchange` request runs on `WorkplaceDio`, a bare `Dio()` instance with no interceptors. A 401 on that request (a stale OIDC id token) has no refresh-and-retry path, unlike the main app's Dio, which refreshes via `AuthorizationInterceptors`. `AuthorizationInterceptors` lives in the main app package; `workplace` is a separate package that cannot depend on it.
+
+## Decision
+
+- `AuthorizationInterceptors` exposes `requestTokenRefresh()`, a dedup-guarded public entry point backed by an in-flight `Future<TokenOIDC>`. Any caller — the interceptor's own reactive `onError` path or an external caller — joins the same in-flight refresh instead of starting a second one.
+- `AuthorizationInterceptors` exposes `isRefreshFailureFatal()`, reusing the existing web/mobile rejection classifiers, so an external caller can tell a dead session (RFC 6749 400/401-equivalent) from a transient failure and decide whether to call the existing public `clear()`.
+- `ComposerAttachmentExtensionRegistry`'s Workplace wiring passes an `oidcRefreshTrigger` callback into `WorkplaceComposerAttachmentExtension`, alongside the existing `oidcTokenGetter`, mirroring the same callback-injection pattern across the package boundary.
+- `WorkplaceComposerAttachmentExtension._exchangeAccessToken` catches a 401 from the token-exchange call and retries exactly once with a token refreshed via `oidcRefreshTrigger`, guarded by a `refreshAttempted` flag to prevent looping.
+
+## Consequences
+
+- A stale OIDC id token on the Workplace exchange-token request self-heals via one retry instead of surfacing as a generic toast.
+- A 401 on the main Dio and a 401 on Workplace's Dio racing at the same time still trigger exactly one refresh call against the server; both callers resolve to the same new token.
+- `WorkplaceDio` remains a plain, interceptor-free `Dio()`; only the exchange-token call site gains retry logic, not every Workplace request.
+- Workplace's own refresh failures follow the same fatal-vs-transient classification as the main app's reactive path, so a dead refresh token forces logout consistently regardless of which request discovered it.

--- a/docs/adr/0107-workplace-oidc-refresh-via-shared-interceptor.md
+++ b/docs/adr/0107-workplace-oidc-refresh-via-shared-interceptor.md
@@ -13,7 +13,8 @@ Workplace's Drive `token_exchange` request runs on `WorkplaceDio`, a bare `Dio()
 ## Decision
 
 - `AuthorizationInterceptors` exposes `requestTokenRefresh()`, a dedup-guarded public entry point backed by an in-flight `Future<TokenOIDC>`. Any caller — the interceptor's own reactive `onError` path or an external caller — joins the same in-flight refresh instead of starting a second one.
-- `AuthorizationInterceptors` exposes `isRefreshFailureFatal()`, reusing the existing web/mobile rejection classifiers, so an external caller can tell a dead session (RFC 6749 400/401-equivalent) from a transient failure and decide whether to call the existing public `clear()`.
+- `requestTokenRefresh()` owns the outcome of a refresh for every caller: a server rejection (RFC 6749 400/401-equivalent, classified by the existing web/mobile classifiers) clears the session and throws `RefreshTokenFailedException`; a same-token response throws `RefreshTokenDuplicatedException` before anything is persisted; transient failures are rethrown untouched.
+- Callers never classify refresh failures themselves. The Workplace wiring forwards a `DrivePickFailure` carrying an urgent exception into `MailboxDashBoardController`'s `BaseController` handling (`validateUrgentException` / `handleUrgentException`), the same path the interceptor's own rejected requests take.
 - `ComposerAttachmentExtensionRegistry`'s Workplace wiring passes an `oidcRefreshTrigger` callback into `WorkplaceComposerAttachmentExtension`, alongside the existing `oidcTokenGetter`, mirroring the same callback-injection pattern across the package boundary.
 - `WorkplaceComposerAttachmentExtension._exchangeAccessToken` catches a 401 from the token-exchange call and retries exactly once with a token refreshed via `oidcRefreshTrigger`, guarded by a `refreshAttempted` flag to prevent looping.
 
@@ -22,4 +23,4 @@ Workplace's Drive `token_exchange` request runs on `WorkplaceDio`, a bare `Dio()
 - A stale OIDC id token on the Workplace exchange-token request self-heals via one retry instead of surfacing as a generic toast.
 - A 401 on the main Dio and a 401 on Workplace's Dio racing at the same time still trigger exactly one refresh call against the server; both callers resolve to the same new token.
 - `WorkplaceDio` remains a plain, interceptor-free `Dio()`; only the exchange-token call site gains retry logic, not every Workplace request.
-- Workplace's own refresh failures follow the same fatal-vs-transient classification as the main app's reactive path, so a dead refresh token forces logout consistently regardless of which request discovered it.
+- Fatal-vs-transient classification lives in one place, so a dead refresh token forces logout consistently regardless of which request discovered it.

--- a/lib/features/base/base_controller.dart
+++ b/lib/features/base/base_controller.dart
@@ -163,7 +163,8 @@ abstract class BaseController extends GetxController
     return exception is NoNetworkError
       || exception is BadCredentialsException
       || exception is ConnectionError
-      || exception is RefreshTokenFailedException;
+      || exception is RefreshTokenFailedException
+      || exception is RefreshTokenDuplicatedException;
   }
 
   void handleErrorViewState(Object error, StackTrace stackTrace) {}
@@ -185,7 +186,9 @@ abstract class BaseController extends GetxController
       _handleConnectionErrorException();
     } else if (exception is BadCredentialsException) {
       handleBadCredentialsException();
-    } else if (exception is RefreshTokenFailedException) {
+    } else if (exception is RefreshTokenFailedException
+        || exception is RefreshTokenDuplicatedException) {
+      // A refresh that returns the same token cannot clear the 401 either.
       handleRefreshTokenFailedException();
     }
   }
@@ -202,7 +205,9 @@ abstract class BaseController extends GetxController
       _handleConnectionErrorException();
     } else if (exception is BadCredentialsException) {
       handleBadCredentialsException();
-    } else if (exception is RefreshTokenFailedException) {
+    } else if (exception is RefreshTokenFailedException
+        || exception is RefreshTokenDuplicatedException) {
+      // A refresh that returns the same token cannot clear the 401 either.
       handleRefreshTokenFailedException();
     } else {
       logWarning(

--- a/lib/features/composer/presentation/providers/composer_attachment_extension_registry_provider.dart
+++ b/lib/features/composer/presentation/providers/composer_attachment_extension_registry_provider.dart
@@ -19,18 +19,9 @@ ComposerAttachmentExtensionRegistry composerAttachmentExtensionRegistry(Ref ref)
   return ComposerAttachmentExtensionRegistry([
     WorkplaceComposerAttachmentExtension(
       workplaceUri: uriNotifier,
-      // Read at picker-open time, so it's always the current session's answer.
-      uploadFromUrlSupported: () {
-        final dashboard = getBinding<MailboxDashBoardController>();
-        final jmapUrl = dashboard?.dynamicUrlInterceptors.jmapUrl;
-        if (jmapUrl == null || jmapUrl.isEmpty) return false;
-        return dashboard?.sessionCurrent?.isUploadFromUrlSupported(
-              dashboard.accountId.value,
-              jmapUrl: jmapUrl,
-            ) ??
-            false;
-      },
+      uploadFromUrlSupported: _isUploadFromUrlSupported,
       oidcTokenGetter: () => getBinding<AuthorizationInterceptors>()?.currentOidcIdToken,
+      oidcRefreshTrigger: _refreshWorkplaceOidcToken,
       maxAttachmentSizeBytesGetter: () =>
           getBinding<MailboxDashBoardController>()?.maxSizeAttachmentsPerEmail?.value,
       // Read at picker-open time from the composer that owns the picker.
@@ -38,23 +29,50 @@ ComposerAttachmentExtensionRegistry composerAttachmentExtensionRegistry(Ref ref)
           getBinding<ComposerController>(tag: composerId)
               ?.attachmentUploadValidationService
               .remainingCapacityBytes,
-      onPickState: (composerId, state) async {
-        if (state is DrivePickResult) {
-          final composer = getBinding<ComposerController>(tag: composerId);
-          if (composer == null) {
-            // Composer closed or wrong tag — the pick has nowhere to land.
-            logError('ComposerAttachmentExtensionRegistry::onPickState: no ComposerController for tag=$composerId, drive pick discarded');
-            getBinding<ToastManager>()?.showMessageFailure(
-              DrivePickFailure(Exception('ComposerController unavailable')),
-            );
-            return;
-          }
-          // No catch here: handleDrivePickResult swallows and toasts its own errors.
-          await composer.handleDrivePickResult(state.documents);
-        } else if (state is DrivePickFailure) {
-          getBinding<ToastManager>()?.showMessageFailure(state);
-        }
-      },
+      onPickState: _onDrivePickState,
     ),
   ]);
+}
+
+/// Read at picker-open time, so it's always the current session's answer.
+bool _isUploadFromUrlSupported() {
+  final dashboard = getBinding<MailboxDashBoardController>();
+  final jmapUrl = dashboard?.dynamicUrlInterceptors.jmapUrl;
+  if (jmapUrl == null || jmapUrl.isEmpty) return false;
+  return dashboard?.sessionCurrent?.isUploadFromUrlSupported(
+        dashboard.accountId.value,
+        jmapUrl: jmapUrl,
+      ) ??
+      false;
+}
+
+/// Triggers the main app's OIDC refresh for Workplace's own (unwired) Dio.
+Future<String?> _refreshWorkplaceOidcToken() async {
+  final interceptor = getBinding<AuthorizationInterceptors>();
+  if (interceptor == null) return null;
+  try {
+    final newToken = await interceptor.requestTokenRefresh();
+    return newToken.tokenId.uuid;
+  } catch (e) {
+    if (interceptor.isRefreshFailureFatal(e)) interceptor.clear();
+    rethrow;
+  }
+}
+
+Future<void> _onDrivePickState(String? composerId, DrivePickState state) async {
+  if (state is DrivePickResult) {
+    final composer = getBinding<ComposerController>(tag: composerId);
+    if (composer == null) {
+      // Composer closed or wrong tag — the pick has nowhere to land.
+      logError('ComposerAttachmentExtensionRegistry::onPickState: no ComposerController for tag=$composerId, drive pick discarded');
+      getBinding<ToastManager>()?.showMessageFailure(
+        DrivePickFailure(Exception('ComposerController unavailable')),
+      );
+      return;
+    }
+    // No catch here: handleDrivePickResult swallows and toasts its own errors.
+    await composer.handleDrivePickResult(state.documents);
+  } else if (state is DrivePickFailure) {
+    getBinding<ToastManager>()?.showMessageFailure(state);
+  }
 }

--- a/lib/features/composer/presentation/providers/composer_attachment_extension_registry_provider.dart
+++ b/lib/features/composer/presentation/providers/composer_attachment_extension_registry_provider.dart
@@ -5,6 +5,7 @@ import 'package:tmail_ui_user/features/composer/presentation/composer_controller
 import 'package:tmail_ui_user/features/home/domain/extensions/session_extensions.dart';
 import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
 import 'package:tmail_ui_user/main/providers/workplace/drive_attachment_uri_value_notifier_provider.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
@@ -52,8 +53,14 @@ bool _isUploadFromUrlSupported() {
 Future<String?> _refreshWorkplaceOidcToken() async {
   final interceptor = getBinding<AuthorizationInterceptors>();
   if (interceptor == null) return null;
-  final newToken = await interceptor.requestTokenRefresh();
-  return newToken.tokenId.uuid;
+  try {
+    final newToken = await interceptor.requestTokenRefresh();
+    return newToken.tokenId.uuid;
+  } on RefreshTokenFailedException catch (e, st) {
+    // The JMAP path logs its own; without this the Drive journey is silent.
+    interceptor.logFatalRefreshRejection(e, st);
+    rethrow;
+  }
 }
 
 Future<void> _onDrivePickState(String? composerId, DrivePickState state) async {

--- a/lib/features/composer/presentation/providers/composer_attachment_extension_registry_provider.dart
+++ b/lib/features/composer/presentation/providers/composer_attachment_extension_registry_provider.dart
@@ -5,6 +5,7 @@ import 'package:tmail_ui_user/features/composer/presentation/composer_controller
 import 'package:tmail_ui_user/features/home/domain/extensions/session_extensions.dart';
 import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
 import 'package:tmail_ui_user/main/providers/workplace/drive_attachment_uri_value_notifier_provider.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
@@ -54,8 +55,11 @@ Future<String?> _refreshWorkplaceOidcToken() async {
     final newToken = await interceptor.requestTokenRefresh();
     return newToken.tokenId.uuid;
   } catch (e) {
-    if (interceptor.isRefreshFailureFatal(e)) interceptor.clear();
-    rethrow;
+    if (!interceptor.isRefreshFailureFatal(e)) rethrow;
+    interceptor.clear();
+    // Same funnel as the interceptor's own reject(RefreshTokenFailedException) path.
+    getBinding<MailboxDashBoardController>()?.handleRefreshTokenFailedException();
+    throw RefreshTokenFailedException();
   }
 }
 
@@ -73,6 +77,8 @@ Future<void> _onDrivePickState(String? composerId, DrivePickState state) async {
     // No catch here: handleDrivePickResult swallows and toasts its own errors.
     await composer.handleDrivePickResult(state.documents);
   } else if (state is DrivePickFailure) {
+    // Logout already triggered by _refreshWorkplaceOidcToken; no second report.
+    if (state.error is RefreshTokenFailedException) return;
     getBinding<ToastManager>()?.showMessageFailure(state);
   }
 }

--- a/lib/features/composer/presentation/providers/composer_attachment_extension_registry_provider.dart
+++ b/lib/features/composer/presentation/providers/composer_attachment_extension_registry_provider.dart
@@ -5,7 +5,6 @@ import 'package:tmail_ui_user/features/composer/presentation/composer_controller
 import 'package:tmail_ui_user/features/home/domain/extensions/session_extensions.dart';
 import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
-import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
 import 'package:tmail_ui_user/main/providers/workplace/drive_attachment_uri_value_notifier_provider.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
@@ -48,19 +47,13 @@ bool _isUploadFromUrlSupported() {
 }
 
 /// Triggers the main app's OIDC refresh for Workplace's own (unwired) Dio.
-/// The interceptor owns the outcome; a dead session surfaces as
-/// RefreshTokenFailedException and is routed by [_onDrivePickState].
+/// The interceptor owns the outcome, logging included; a dead session surfaces
+/// as RefreshTokenFailedException and is routed by [_onDrivePickState].
 Future<String?> _refreshWorkplaceOidcToken() async {
   final interceptor = getBinding<AuthorizationInterceptors>();
   if (interceptor == null) return null;
-  try {
-    final newToken = await interceptor.requestTokenRefresh();
-    return newToken.tokenId.uuid;
-  } on RefreshTokenFailedException catch (e, st) {
-    // The JMAP path logs its own; without this the Drive journey is silent.
-    interceptor.logFatalRefreshRejection(e, st);
-    rethrow;
-  }
+  final newToken = await interceptor.requestTokenRefresh();
+  return newToken.tokenId.uuid;
 }
 
 Future<void> _onDrivePickState(String? composerId, DrivePickState state) async {

--- a/lib/features/composer/presentation/providers/composer_attachment_extension_registry_provider.dart
+++ b/lib/features/composer/presentation/providers/composer_attachment_extension_registry_provider.dart
@@ -5,7 +5,6 @@ import 'package:tmail_ui_user/features/composer/presentation/composer_controller
 import 'package:tmail_ui_user/features/home/domain/extensions/session_extensions.dart';
 import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
-import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
 import 'package:tmail_ui_user/main/providers/workplace/drive_attachment_uri_value_notifier_provider.dart';
 import 'package:tmail_ui_user/main/routes/route_navigation.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
@@ -48,19 +47,13 @@ bool _isUploadFromUrlSupported() {
 }
 
 /// Triggers the main app's OIDC refresh for Workplace's own (unwired) Dio.
+/// The interceptor owns the outcome; a dead session surfaces as
+/// RefreshTokenFailedException and is routed by [_onDrivePickState].
 Future<String?> _refreshWorkplaceOidcToken() async {
   final interceptor = getBinding<AuthorizationInterceptors>();
   if (interceptor == null) return null;
-  try {
-    final newToken = await interceptor.requestTokenRefresh();
-    return newToken.tokenId.uuid;
-  } catch (e) {
-    if (!interceptor.isRefreshFailureFatal(e)) rethrow;
-    interceptor.clear();
-    // Same funnel as the interceptor's own reject(RefreshTokenFailedException) path.
-    getBinding<MailboxDashBoardController>()?.handleRefreshTokenFailedException();
-    throw RefreshTokenFailedException();
-  }
+  final newToken = await interceptor.requestTokenRefresh();
+  return newToken.tokenId.uuid;
 }
 
 Future<void> _onDrivePickState(String? composerId, DrivePickState state) async {
@@ -77,8 +70,13 @@ Future<void> _onDrivePickState(String? composerId, DrivePickState state) async {
     // No catch here: handleDrivePickResult swallows and toasts its own errors.
     await composer.handleDrivePickResult(state.documents);
   } else if (state is DrivePickFailure) {
-    // Logout already triggered by _refreshWorkplaceOidcToken; no second report.
-    if (state.error is RefreshTokenFailedException) return;
+    final dashboard = getBinding<MailboxDashBoardController>();
+    final error = state.error;
+    if (dashboard != null && error is Exception && dashboard.validateUrgentException(error)) {
+      // Session-level failures take BaseController's standard path (logout, reconnect).
+      dashboard.handleUrgentException(failure: state, exception: error);
+      return;
+    }
     getBinding<ToastManager>()?.showMessageFailure(state);
   }
 }

--- a/lib/features/login/data/extensions/token_oidc_extension.dart
+++ b/lib/features/login/data/extensions/token_oidc_extension.dart
@@ -1,17 +1,8 @@
-import 'package:model/oidc/token_id.dart';
 import 'package:model/oidc/token_oidc.dart';
 import 'package:tmail_ui_user/features/login/data/model/token_oidc_cache.dart';
 
 extension TokenOidcExtension on TokenOIDC {
   TokenOidcCache toTokenOidcCache() {
     return TokenOidcCache(token, tokenId.uuid, refreshToken, expiredTime: expiredTime);
-  }
-
-  // OIDC Core 12.2: a refresh response may omit id_token; keep the one we have.
-  TokenOIDC withIdTokenFallback(TokenId? currentIdToken) {
-    if (tokenId.uuid.isNotEmpty || currentIdToken == null || currentIdToken.uuid.isEmpty) {
-      return this;
-    }
-    return TokenOIDC(token, currentIdToken, refreshToken, expiredTime: expiredTime);
   }
 }

--- a/lib/features/login/data/extensions/token_oidc_extension.dart
+++ b/lib/features/login/data/extensions/token_oidc_extension.dart
@@ -1,8 +1,17 @@
+import 'package:model/oidc/token_id.dart';
 import 'package:model/oidc/token_oidc.dart';
 import 'package:tmail_ui_user/features/login/data/model/token_oidc_cache.dart';
 
 extension TokenOidcExtension on TokenOIDC {
   TokenOidcCache toTokenOidcCache() {
     return TokenOidcCache(token, tokenId.uuid, refreshToken, expiredTime: expiredTime);
+  }
+
+  // OIDC Core 12.2: a refresh response may omit id_token; keep the one we have.
+  TokenOIDC withIdTokenFallback(TokenId? currentIdToken) {
+    if (tokenId.uuid.isNotEmpty || currentIdToken == null || currentIdToken.uuid.isEmpty) {
+      return this;
+    }
+    return TokenOIDC(token, currentIdToken, refreshToken, expiredTime: expiredTime);
   }
 }

--- a/lib/features/login/data/extensions/token_response_extension.dart
+++ b/lib/features/login/data/extensions/token_response_extension.dart
@@ -4,11 +4,17 @@ import 'package:model/model.dart';
 
 extension TokenResponseExtension on TokenResponse {
 
-  TokenOIDC toTokenOIDC({String? maybeAvailableRefreshToken}) {
+  // A refresh response may omit refresh_token, and OIDC Core 12.2 lets it omit
+  // id_token too; keep whichever the current token already holds.
+  TokenOIDC toTokenOIDC({required TokenOIDC currentToken}) {
     return TokenOIDC(
       accessToken ?? '',
-      TokenId(idToken ?? ''),
-      refreshToken ?? maybeAvailableRefreshToken ?? '',
+      TokenId(_orCurrent(idToken, currentToken.tokenId.uuid)),
+      _orCurrent(refreshToken, currentToken.refreshToken),
       expiredTime: accessTokenExpirationDateTime ?? DateTime.now());
   }
+
+  // The plugin returns '' rather than null when a field is absent.
+  String _orCurrent(String? value, String current) =>
+      value?.isNotEmpty == true ? value! : current;
 }

--- a/lib/features/login/data/extensions/token_response_extension.dart
+++ b/lib/features/login/data/extensions/token_response_extension.dart
@@ -9,12 +9,13 @@ extension TokenResponseExtension on TokenResponse {
   TokenOIDC toTokenOIDC({required TokenOIDC currentToken}) {
     return TokenOIDC(
       accessToken ?? '',
-      TokenId(_orCurrent(idToken, currentToken.tokenId.uuid)),
-      _orCurrent(refreshToken, currentToken.refreshToken),
+      TokenId(_idTokenOrCurrent(currentToken.tokenId.uuid)),
+      refreshToken ?? currentToken.refreshToken,
       expiredTime: accessTokenExpirationDateTime ?? DateTime.now());
   }
 
-  // The plugin returns '' rather than null when a field is absent.
-  String _orCurrent(String? value, String current) =>
-      value?.isNotEmpty == true ? value! : current;
+  // flutter_appauth_web stringifies the absent field, so it arrives as "null";
+  // mobile sends '' or null for the same thing.
+  String _idTokenOrCurrent(String current) =>
+      (idToken?.isNotEmpty == true && idToken != 'null') ? idToken! : current;
 }

--- a/lib/features/login/data/network/authentication_client/authentication_client_base.dart
+++ b/lib/features/login/data/network/authentication_client/authentication_client_base.dart
@@ -25,7 +25,7 @@ abstract class AuthenticationClientBase {
       String redirectUrl,
       String discoveryUrl,
       List<String> scopes,
-      String refreshToken);
+      TokenOIDC currentToken);
 
   Future<bool> logoutOidc(TokenId tokenId, OIDCConfiguration config, OIDCDiscoveryResponse oidcRescovery);
 

--- a/lib/features/login/data/network/authentication_client/authentication_client_mobile.dart
+++ b/lib/features/login/data/network/authentication_client/authentication_client_mobile.dart
@@ -71,21 +71,19 @@ class AuthenticationClientMobile with AuthenticationClientInteractionMixin
     String redirectUrl,
     String discoveryUrl,
     List<String> scopes,
-    String refreshToken,
+    TokenOIDC currentToken,
   ) async {
     try {
       final tokenRequest = getRefreshTokenRequest(
         clientId,
         redirectUrl,
         discoveryUrl,
-        refreshToken,
+        currentToken.refreshToken,
         scopes,
       );
       final tokenResponse = await _appAuth.token(tokenRequest);
       log('$runtimeType::refreshingTokensOIDC():Token: ${tokenResponse.accessToken}');
-      final tokenOIDC = tokenResponse.toTokenOIDC(
-        maybeAvailableRefreshToken: refreshToken,
-      );
+      final tokenOIDC = tokenResponse.toTokenOIDC(currentToken: currentToken);
       if (tokenOIDC.isTokenValid()) {
         return tokenOIDC;
       } else {

--- a/lib/features/login/data/network/authentication_client/authentication_client_web.dart
+++ b/lib/features/login/data/network/authentication_client/authentication_client_web.dart
@@ -78,20 +78,18 @@ class AuthenticationClientWeb with AuthenticationClientInteractionMixin
     String redirectUrl,
     String discoveryUrl,
     List<String> scopes,
-    String refreshToken,
+    TokenOIDC currentToken,
   ) async {
     try {
       final tokenRequest = getRefreshTokenRequest(
         clientId,
         redirectUrl,
         discoveryUrl,
-        refreshToken,
+        currentToken.refreshToken,
         scopes,
       );
       final tokenResponse = await _appAuthWeb.token(tokenRequest);
-      final tokenOIDC = tokenResponse.toTokenOIDC(
-        maybeAvailableRefreshToken: refreshToken,
-      );
+      final tokenOIDC = tokenResponse.toTokenOIDC(currentToken: currentToken);
       if (tokenOIDC.isTokenValid()) {
         return tokenOIDC;
       } else {

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -576,8 +576,15 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
 
   String _getTokenAsBearerHeader(String token) => 'Bearer $token';
 
-  Future<PersonalAccount> _updateCurrentAccount({required TokenOIDC tokenOIDC}) async {
+  Future<PersonalAccount> _updateCurrentAccount({
+    required TokenOIDC tokenOIDC,
+    required int generation,
+  }) async {
     final currentAccount = await _accountCacheManager.getCurrentAccount();
+
+    // The session died while we read the account; these writes land between
+    // clearAll() and closeHive(), resurrecting it on the next launch.
+    if (generation != _sessionGeneration) throw const StaleSessionRefreshException();
 
     // Persist the new token BEFORE mutating the account cache. persistOneTokenOidc
     // is crash-safe (write-before-prune), so the token box always holds a usable
@@ -668,7 +675,10 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     }
     _updateNewToken(acquired);
 
-    final personalAccount = await _updateCurrentAccount(tokenOIDC: acquired);
+    final personalAccount = await _updateCurrentAccount(
+      tokenOIDC: acquired,
+      generation: generation,
+    );
     if (PlatformInfo.isIOS) {
       await _iosSharingManager.saveKeyChainSharingSession(personalAccount);
     }

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -365,22 +365,18 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         'AuthorizationInterceptors::onError: Perform get New Token',
         webConsoleEnabled: true,
       );
-      final previousToken = _token?.token;
-      final newTokenOidc = await requestTokenRefresh();
-
-      if (newTokenOidc.token == previousToken) {
-        // Refresh returned the SAME token — retrying cannot clear the 401, so it
-        // propagates to logout. Real auth death, but tag it for forensics.
-        _logForcedLogoutFor401(
-          authErrorType: 'forced_logout_401_refreshed_token_duplicated',
-          err: err,
-          hasAttemptedRefresh: true,
-        );
-        return super.onError(err, handler);
-      }
+      await requestTokenRefresh();
 
       requestOptions.extra[_refreshAttemptedKey] = true;
       return await _performRetry(requestOptions, err, handler);
+    } on RefreshTokenDuplicatedException {
+      // Retrying cannot clear the 401, so it propagates to logout; tag it for forensics.
+      _logForcedLogoutFor401(
+        authErrorType: 'forced_logout_401_refreshed_token_duplicated',
+        err: err,
+        hasAttemptedRefresh: true,
+      );
+      return super.onError(err, handler);
     } on DioException catch (refreshError, st) {
       // Web routes ALL refresh failures (Dio or non-Dio) through the single
       // web handler, so the session decision is uniform regardless of how the
@@ -643,6 +639,9 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     final newTokenOidc = _withCurrentIdTokenIfMissing(PlatformInfo.isIOS
         ? await _getNewTokenForIOSPlatform()
         : await _getNewTokenForOtherPlatform());
+    if (newTokenOidc.token == _token?.token) {
+      throw const RefreshTokenDuplicatedException();
+    }
     _updateNewToken(newTokenOidc);
 
     final personalAccount = await _updateCurrentAccount(tokenOIDC: newTokenOidc);

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -39,6 +39,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
   OIDCConfiguration? _configOIDC;
   TokenOIDC? _token;
   String? _authorization;
+  Future<TokenOIDC>? _refreshInFlight;
 
   final RefreshTokenErrorClassifier? _injectedErrorClassifier;
 
@@ -90,6 +91,19 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
 
   TokenOIDC? get currentToken =>
       _authenticationType == AuthenticationType.oidc ? _token : null;
+
+  /// Triggers a refresh, or joins one already running — dedupes an external
+  /// caller (e.g. Workplace's own Dio) against this interceptor's [onError].
+  Future<TokenOIDC> requestTokenRefresh() {
+    return _refreshInFlight ??= _acquireAndPersistNewToken()
+        .whenComplete(() => _refreshInFlight = null);
+  }
+
+  /// True when [error] is a confirmed server-side refresh rejection (session
+  /// dead). Mirrors [_handleRefreshErrorOnWeb]/[_handleRefreshErrorOnMobile].
+  bool isRefreshFailureFatal(Object error) => PlatformInfo.isWeb
+      ? _errorClassifier.isServerRejection(error)
+      : _isRefreshRejectedByTokenEndpoint(error);
 
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
@@ -351,11 +365,10 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         'AuthorizationInterceptors::onError: Perform get New Token',
         webConsoleEnabled: true,
       );
-      final newTokenOidc = PlatformInfo.isIOS
-        ? await _getNewTokenForIOSPlatform()
-        : await _getNewTokenForOtherPlatform();
+      final previousToken = _token?.token;
+      final newTokenOidc = await requestTokenRefresh();
 
-      if (newTokenOidc.token == _token?.token) {
+      if (newTokenOidc.token == previousToken) {
         // Refresh returned the SAME token — retrying cannot clear the 401, so it
         // propagates to logout. Real auth death, but tag it for forensics.
         _logForcedLogoutFor401(
@@ -364,13 +377,6 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
           hasAttemptedRefresh: true,
         );
         return super.onError(err, handler);
-      }
-      _updateNewToken(newTokenOidc);
-
-      final personalAccount = await _updateCurrentAccount(tokenOIDC: newTokenOidc);
-
-      if (PlatformInfo.isIOS) {
-        await _iosSharingManager.saveKeyChainSharingSession(personalAccount);
       }
 
       requestOptions.extra[_refreshAttemptedKey] = true;
@@ -631,6 +637,20 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
 
   Future<TokenOIDC> _getNewTokenForOtherPlatform() {
     return _invokeRefreshTokenFromServer();
+  }
+
+  Future<TokenOIDC> _acquireAndPersistNewToken() async {
+    final newTokenOidc = PlatformInfo.isIOS
+        ? await _getNewTokenForIOSPlatform()
+        : await _getNewTokenForOtherPlatform();
+    _updateNewToken(newTokenOidc);
+
+    final personalAccount = await _updateCurrentAccount(tokenOIDC: newTokenOidc);
+    if (PlatformInfo.isIOS) {
+      await _iosSharingManager.saveKeyChainSharingSession(personalAccount);
+    }
+
+    return newTokenOidc;
   }
 
   Future<Response> _retryRequest(

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -13,7 +13,6 @@ import 'package:model/account/personal_account.dart';
 import 'package:model/oidc/oidc_configuration.dart';
 import 'package:model/oidc/token_oidc.dart';
 import 'package:tmail_ui_user/features/base/extensions/object_extensions.dart';
-import 'package:tmail_ui_user/features/login/data/extensions/token_oidc_extension.dart';
 import 'package:tmail_ui_user/features/login/data/local/account_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/local/token_oidc_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/network/authentication_client/authentication_client_base.dart';
@@ -609,7 +608,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       _configOIDC!.redirectUrl,
       _configOIDC!.discoveryUrl,
       _configOIDC!.scopes,
-      _token!.refreshToken
+      _token!
     );
   }
 
@@ -644,18 +643,17 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     // logged-out account and re-persist it over wiped caches.
     if (generation != _sessionGeneration) throw RefreshTokenFailedException();
 
-    final newTokenOidc = acquired.withIdTokenFallback(_token?.tokenId);
-    if (newTokenOidc.token == _token?.token) {
+    if (acquired.token == _token?.token) {
       throw const RefreshTokenDuplicatedException();
     }
-    _updateNewToken(newTokenOidc);
+    _updateNewToken(acquired);
 
-    final personalAccount = await _updateCurrentAccount(tokenOIDC: newTokenOidc);
+    final personalAccount = await _updateCurrentAccount(tokenOIDC: acquired);
     if (PlatformInfo.isIOS) {
       await _iosSharingManager.saveKeyChainSharingSession(personalAccount);
     }
 
-    return newTokenOidc;
+    return acquired;
   }
 
   Future<Response> _retryRequest(

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -365,6 +365,14 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         hasAttemptedRefresh: true,
       );
       return super.onError(err, handler);
+    } on StaleSessionRefreshException catch (staleError) {
+      // Another session owns the interceptor now; this answer is not its verdict.
+      logWarning(
+        'AuthorizationInterceptors::onError: '
+        'refresh answered for a replaced session, keeping the current one',
+        webConsoleEnabled: true,
+      );
+      return _propagateKeepingSession(staleError, err, handler);
     } on RefreshTokenFailedException catch (refreshError, st) {
       // Session already cleared by requestTokenRefresh; surface the dead session.
       logFatalRefreshRejection(refreshError, st);
@@ -641,7 +649,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
 
     // The session died while we were away; re-arming it would resurrect a
     // logged-out account and re-persist it over wiped caches.
-    if (generation != _sessionGeneration) throw RefreshTokenFailedException();
+    if (generation != _sessionGeneration) throw const StaleSessionRefreshException();
 
     if (acquired.token == _token?.token) {
       throw const RefreshTokenDuplicatedException();

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -97,9 +97,11 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
 
   /// Triggers a refresh, or joins one already running — dedupes an external
   /// caller (e.g. Workplace's own Dio) against this interceptor's [onError].
-  /// Owns the outcome: throws [RefreshTokenDuplicatedException] on a same-token
-  /// response, clears the session and throws [RefreshTokenFailedException] on a
-  /// server rejection, rethrows transient failures untouched.
+  /// Owns the outcome: throws [RefreshTokenUnavailableException] without sending
+  /// anything when the session has no refresh token, [RefreshTokenDuplicatedException]
+  /// on a same-token response, clears the session and throws
+  /// [RefreshTokenFailedException] on a server rejection, rethrows transient
+  /// failures untouched.
   Future<TokenOIDC> requestTokenRefresh() {
     final inFlight = _refreshInFlight;
     if (inFlight != null) return inFlight;
@@ -107,6 +109,12 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     // Nothing left to refresh with — the session already died elsewhere.
     if (_configOIDC == null || _token == null) {
       return Future.error(RefreshTokenFailedException());
+    }
+
+    // Same bar as validateToRefreshToken: sending a refresh the session cannot
+    // make earns a server rejection that would clear a session still in use.
+    if (!_isAuthenticationOidcValid() || !_isRefreshTokenNotEmpty(_token)) {
+      return Future.error(const RefreshTokenUnavailableException());
     }
 
     late final Future<TokenOIDC> pending;

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -41,6 +41,9 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
   String? _authorization;
   Future<TokenOIDC>? _refreshInFlight;
 
+  /// Bumped by [clear]; a refresh that started on an older generation is stale.
+  int _sessionGeneration = 0;
+
   final RefreshTokenErrorClassifier? _injectedErrorClassifier;
 
   late final RefreshTokenErrorClassifier _errorClassifier =
@@ -98,8 +101,20 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
   /// response, clears the session and throws [RefreshTokenFailedException] on a
   /// server rejection, rethrows transient failures untouched.
   Future<TokenOIDC> requestTokenRefresh() {
-    return _refreshInFlight ??= _acquireAndPersistNewToken()
-        .whenComplete(() => _refreshInFlight = null);
+    final inFlight = _refreshInFlight;
+    if (inFlight != null) return inFlight;
+
+    // Nothing left to refresh with — the session already died elsewhere.
+    if (_configOIDC == null || _token == null) {
+      return Future.error(RefreshTokenFailedException());
+    }
+
+    late final Future<TokenOIDC> pending;
+    pending = _acquireAndPersistNewToken(_sessionGeneration).whenComplete(() {
+      // Only the future still owning the slot may release it.
+      if (identical(_refreshInFlight, pending)) _refreshInFlight = null;
+    });
+    return _refreshInFlight = pending;
   }
 
   bool _isRefreshRejectedByServer(Object error) => PlatformInfo.isWeb
@@ -596,7 +611,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     return _invokeRefreshTokenFromServer();
   }
 
-  Future<TokenOIDC> _acquireAndPersistNewToken() async {
+  Future<TokenOIDC> _acquireAndPersistNewToken(int generation) async {
     final TokenOIDC acquired;
     try {
       acquired = PlatformInfo.isIOS
@@ -615,6 +630,10 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       clear();
       throw RefreshTokenFailedException();
     }
+
+    // The session died while we were away; re-arming it would resurrect a
+    // logged-out account and re-persist it over wiped caches.
+    if (generation != _sessionGeneration) throw RefreshTokenFailedException();
 
     final newTokenOidc = _withCurrentIdTokenIfMissing(acquired);
     if (newTokenOidc.token == _token?.token) {
@@ -715,5 +734,8 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     _token = null;
     _configOIDC = null;
     _authenticationType = AuthenticationType.none;
+    // A refresh still running belongs to the session we just dropped.
+    _sessionGeneration++;
+    _refreshInFlight = null;
   }
 }

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -640,9 +640,9 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
   }
 
   Future<TokenOIDC> _acquireAndPersistNewToken() async {
-    final newTokenOidc = PlatformInfo.isIOS
+    final newTokenOidc = _withCurrentIdTokenIfMissing(PlatformInfo.isIOS
         ? await _getNewTokenForIOSPlatform()
-        : await _getNewTokenForOtherPlatform();
+        : await _getNewTokenForOtherPlatform());
     _updateNewToken(newTokenOidc);
 
     final personalAccount = await _updateCurrentAccount(tokenOIDC: newTokenOidc);
@@ -651,6 +651,20 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     }
 
     return newTokenOidc;
+  }
+
+  // OIDC Core 12.2: a refresh response may omit id_token; keep the one we have.
+  TokenOIDC _withCurrentIdTokenIfMissing(TokenOIDC fresh) {
+    final currentIdToken = _token?.tokenId;
+    if (fresh.tokenId.uuid.isNotEmpty || currentIdToken == null || currentIdToken.uuid.isEmpty) {
+      return fresh;
+    }
+    return TokenOIDC(
+      fresh.token,
+      currentIdToken,
+      fresh.refreshToken,
+      expiredTime: fresh.expiredTime,
+    );
   }
 
   Future<Response> _retryRequest(

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -100,8 +100,9 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
   /// Owns the outcome: throws [RefreshTokenUnavailableException] without sending
   /// anything when the session has no refresh token, [RefreshTokenDuplicatedException]
   /// on a same-token response, clears the session and throws
-  /// [RefreshTokenFailedException] on a server rejection, rethrows transient
-  /// failures untouched.
+  /// [RefreshTokenFailedException] on a server rejection,
+  /// [StaleSessionRefreshException] when the session that started it was
+  /// replaced meanwhile, rethrows transient failures untouched.
   Future<TokenOIDC> requestTokenRefresh() {
     final inFlight = _refreshInFlight;
     if (inFlight != null) return inFlight;
@@ -647,6 +648,9 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
           ? await _getNewTokenForIOSPlatform()
           : await _getNewTokenForOtherPlatform();
     } catch (e, st) {
+      // The session that started this refresh is gone; its answer is not a
+      // verdict on the session that replaced it.
+      if (generation != _sessionGeneration) throw const StaleSessionRefreshException();
       if (!_isRefreshRejectedByServer(e)) rethrow;
       clear();
       // Logged here, not per caller: this one method serves JMAP and Workplace.

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -94,14 +94,15 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
 
   /// Triggers a refresh, or joins one already running — dedupes an external
   /// caller (e.g. Workplace's own Dio) against this interceptor's [onError].
+  /// Owns the outcome: throws [RefreshTokenDuplicatedException] on a same-token
+  /// response, clears the session and throws [RefreshTokenFailedException] on a
+  /// server rejection, rethrows transient failures untouched.
   Future<TokenOIDC> requestTokenRefresh() {
     return _refreshInFlight ??= _acquireAndPersistNewToken()
         .whenComplete(() => _refreshInFlight = null);
   }
 
-  /// True when [error] is a confirmed server-side refresh rejection (session
-  /// dead). Mirrors [_handleRefreshErrorOnWeb]/[_handleRefreshErrorOnMobile].
-  bool isRefreshFailureFatal(Object error) => PlatformInfo.isWeb
+  bool _isRefreshRejectedByServer(Object error) => PlatformInfo.isWeb
       ? _errorClassifier.isServerRejection(error)
       : _isRefreshRejectedByTokenEndpoint(error);
 
@@ -217,8 +218,8 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
   /// the session and is propagated WITHOUT the stale 401 — same as mobile — so
   /// a flaky connection does not log the web user out.
   ///
-  /// Error routing delegates RFC 6749 classification to [RefreshTokenErrorClassifier]:
-  /// - Server rejection (400/401 or RFC 6749 bad-grant code) → logout.
+  /// Server rejections never reach here: [_acquireAndPersistNewToken] already
+  /// turned them into [RefreshTokenFailedException]. What is left:
   /// - [ArgumentError] with unknown OAuth2 code → Sentry trace, keep session.
   /// - Network/transport failure → keep session silently.
   void _handleRefreshErrorOnWeb(
@@ -227,25 +228,6 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     DioException originalError,
     ErrorInterceptorHandler handler,
   ) {
-    final isRejected = _errorClassifier.isServerRejection(error);
-
-    if (isRejected) {
-      logError(
-        'AuthorizationInterceptors::_handleRefreshErrorOnWeb: '
-        'will_logout=true — error=$error',
-        exception: error,
-        stackTrace: stackTrace,
-        extras: _errorClassifier.buildSentryExtras(error),
-        webConsoleEnabled: true,
-      );
-      clear();
-      return handler.reject(DioException(
-        requestOptions: originalError.requestOptions,
-        error: RefreshTokenFailedException(),
-        type: DioExceptionType.badResponse,
-      ));
-    }
-
     if (error is ArgumentError) {
       // Non-standard OAuth2 code — log to Sentry for investigation, keep session.
       logError(
@@ -284,43 +266,20 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
   }
 
   /// On mobile the refresh runs through flutter_appauth (native), so a rejected
-  /// refresh token never surfaces as a [DioException] — the `statusCode == 400`
-  /// branch in [_refreshTokenThenRetry] is unreachable here. The rejection
-  /// arrives as an [OAuthAuthorizationError] instead, and without this check the
-  /// dead session would be kept and every request would retry forever.
-  ///
-  /// Only a confirmed RFC 6749 rejection logs out; transient codes
-  /// (`server_error`, `temporarily_unavailable`) keep the session so a flaky
-  /// connection does not sign the user out.
-  ///
-  /// Shared with [_refreshTokenThenRetry] so the routing decision and the
-  /// handling of it cannot drift apart.
+  /// refresh token arrives as an [OAuthAuthorizationError], never a [DioException].
+  /// Only a confirmed RFC 6749 rejection is fatal; transient codes
+  /// (`server_error`, `temporarily_unavailable`) keep the session.
   bool _isRefreshRejectedByTokenEndpoint(Object error) =>
       error is OAuthAuthorizationError &&
       _errorClassifier.isServerRejection(error);
 
+  /// Server rejections never reach here (see [_acquireAndPersistNewToken]).
   void _handleRefreshErrorOnMobile(
     Object error,
     StackTrace stackTrace,
     DioException originalError,
     ErrorInterceptorHandler handler,
   ) {
-    if (_isRefreshRejectedByTokenEndpoint(error)) {
-      logError(
-        'AuthorizationInterceptors::_handleRefreshErrorOnMobile: '
-        'will_logout=true — error=$error',
-        exception: error,
-        stackTrace: stackTrace,
-        extras: _errorClassifier.buildSentryExtras(error),
-      );
-      clear();
-      return handler.reject(DioException(
-        requestOptions: originalError.requestOptions,
-        error: RefreshTokenFailedException(),
-        type: DioExceptionType.badResponse,
-      ));
-    }
-
     return _propagateKeepingSession(error, originalError, handler);
   }
 
@@ -377,6 +336,13 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         hasAttemptedRefresh: true,
       );
       return super.onError(err, handler);
+    } on RefreshTokenFailedException catch (refreshError) {
+      // Session already cleared by requestTokenRefresh; surface the dead session.
+      return handler.reject(DioException(
+        requestOptions: err.requestOptions,
+        error: refreshError,
+        type: DioExceptionType.badResponse,
+      ));
     } on DioException catch (refreshError, st) {
       // Web routes ALL refresh failures (Dio or non-Dio) through the single
       // web handler, so the session decision is uniform regardless of how the
@@ -435,16 +401,11 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         handler,
       );
     } catch (e, st) {
-      // Failures the platform handler already classifies are routed straight to
-      // it, so the outer catch in onError() does not fire and log a second,
-      // generic Sentry event for the same refresh failure. On web that is every
-      // non-Dio error flutter_appauth_web throws (ArgumentError and friends); on
-      // mobile it is the native token-endpoint rejection.
-      //
-      // Anything still unclassified is rethrown on purpose: the generic event in
-      // onError() is then the only trace of it, and losing it would leave those
-      // failures invisible.
-      if (PlatformInfo.isWeb || _isRefreshRejectedByTokenEndpoint(e)) {
+      // Web routes every non-Dio error flutter_appauth_web throws (ArgumentError
+      // and friends) to its handler so the outer catch in onError() does not log
+      // a second, generic Sentry event. Mobile rethrows on purpose: the generic
+      // event in onError() is then the only trace of an unclassified failure.
+      if (PlatformInfo.isWeb) {
         return _handleRefreshError(e, st, err, handler);
       }
       rethrow;
@@ -636,9 +597,26 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
   }
 
   Future<TokenOIDC> _acquireAndPersistNewToken() async {
-    final newTokenOidc = _withCurrentIdTokenIfMissing(PlatformInfo.isIOS
-        ? await _getNewTokenForIOSPlatform()
-        : await _getNewTokenForOtherPlatform());
+    final TokenOIDC acquired;
+    try {
+      acquired = PlatformInfo.isIOS
+          ? await _getNewTokenForIOSPlatform()
+          : await _getNewTokenForOtherPlatform();
+    } catch (e, st) {
+      if (!_isRefreshRejectedByServer(e)) rethrow;
+      logError(
+        'AuthorizationInterceptors::_acquireAndPersistNewToken: '
+        'will_logout=true — error=$e',
+        exception: e,
+        stackTrace: st,
+        extras: _errorClassifier.buildSentryExtras(e),
+        webConsoleEnabled: true,
+      );
+      clear();
+      throw RefreshTokenFailedException();
+    }
+
+    final newTokenOidc = _withCurrentIdTokenIfMissing(acquired);
     if (newTokenOidc.token == _token?.token) {
       throw const RefreshTokenDuplicatedException();
     }

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -13,6 +13,7 @@ import 'package:model/account/personal_account.dart';
 import 'package:model/oidc/oidc_configuration.dart';
 import 'package:model/oidc/token_oidc.dart';
 import 'package:tmail_ui_user/features/base/extensions/object_extensions.dart';
+import 'package:tmail_ui_user/features/login/data/extensions/token_oidc_extension.dart';
 import 'package:tmail_ui_user/features/login/data/local/account_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/local/token_oidc_cache_manager.dart';
 import 'package:tmail_ui_user/features/login/data/network/authentication_client/authentication_client_base.dart';
@@ -643,7 +644,7 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     // logged-out account and re-persist it over wiped caches.
     if (generation != _sessionGeneration) throw RefreshTokenFailedException();
 
-    final newTokenOidc = _withCurrentIdTokenIfMissing(acquired);
+    final newTokenOidc = acquired.withIdTokenFallback(_token?.tokenId);
     if (newTokenOidc.token == _token?.token) {
       throw const RefreshTokenDuplicatedException();
     }
@@ -655,20 +656,6 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     }
 
     return newTokenOidc;
-  }
-
-  // OIDC Core 12.2: a refresh response may omit id_token; keep the one we have.
-  TokenOIDC _withCurrentIdTokenIfMissing(TokenOIDC fresh) {
-    final currentIdToken = _token?.tokenId;
-    if (fresh.tokenId.uuid.isNotEmpty || currentIdToken == null || currentIdToken.uuid.isEmpty) {
-      return fresh;
-    }
-    return TokenOIDC(
-      fresh.token,
-      currentIdToken,
-      fresh.refreshToken,
-      expiredTime: fresh.expiredTime,
-    );
   }
 
   Future<Response> _retryRequest(

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -117,6 +117,20 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     return _refreshInFlight = pending;
   }
 
+  /// Reports a refresh the server rejected. Public so a direct caller (e.g. the
+  /// Workplace Drive exchange) reports its own journey with the same shape.
+  void logFatalRefreshRejection(RefreshTokenFailedException error, StackTrace st) {
+    final cause = error.cause ?? error;
+    logError(
+      'AuthorizationInterceptors::logFatalRefreshRejection: '
+      'will_logout=true — error=$cause',
+      exception: cause,
+      stackTrace: st,
+      extras: _errorClassifier.buildSentryExtras(cause),
+      webConsoleEnabled: true,
+    );
+  }
+
   bool _isRefreshRejectedByServer(Object error) => PlatformInfo.isWeb
       ? _errorClassifier.isServerRejection(error)
       : _isRefreshRejectedByTokenEndpoint(error);
@@ -351,8 +365,9 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         hasAttemptedRefresh: true,
       );
       return super.onError(err, handler);
-    } on RefreshTokenFailedException catch (refreshError) {
+    } on RefreshTokenFailedException catch (refreshError, st) {
       // Session already cleared by requestTokenRefresh; surface the dead session.
+      logFatalRefreshRejection(refreshError, st);
       return handler.reject(DioException(
         requestOptions: err.requestOptions,
         error: refreshError,
@@ -617,18 +632,11 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       acquired = PlatformInfo.isIOS
           ? await _getNewTokenForIOSPlatform()
           : await _getNewTokenForOtherPlatform();
-    } catch (e, st) {
+    } catch (e) {
       if (!_isRefreshRejectedByServer(e)) rethrow;
-      logError(
-        'AuthorizationInterceptors::_acquireAndPersistNewToken: '
-        'will_logout=true — error=$e',
-        exception: e,
-        stackTrace: st,
-        extras: _errorClassifier.buildSentryExtras(e),
-        webConsoleEnabled: true,
-      );
       clear();
-      throw RefreshTokenFailedException();
+      // Each caller logs it — this one method serves both JMAP and Workplace.
+      throw RefreshTokenFailedException(cause: e);
     }
 
     // The session died while we were away; re-arming it would resurrect a

--- a/lib/features/login/data/network/interceptors/authorization_interceptors.dart
+++ b/lib/features/login/data/network/interceptors/authorization_interceptors.dart
@@ -125,12 +125,11 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
     return _refreshInFlight = pending;
   }
 
-  /// Reports a refresh the server rejected. Public so a direct caller (e.g. the
-  /// Workplace Drive exchange) reports its own journey with the same shape.
-  void logFatalRefreshRejection(RefreshTokenFailedException error, StackTrace st) {
+  /// Reports a refresh the server rejected, once, where the session is cleared.
+  void _logFatalRefreshRejection(RefreshTokenFailedException error, StackTrace st) {
     final cause = error.cause ?? error;
     logError(
-      'AuthorizationInterceptors::logFatalRefreshRejection: '
+      'AuthorizationInterceptors::_logFatalRefreshRejection: '
       'will_logout=true — error=$cause',
       exception: cause,
       stackTrace: st,
@@ -381,9 +380,8 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
         webConsoleEnabled: true,
       );
       return _propagateKeepingSession(staleError, err, handler);
-    } on RefreshTokenFailedException catch (refreshError, st) {
-      // Session already cleared by requestTokenRefresh; surface the dead session.
-      logFatalRefreshRejection(refreshError, st);
+    } on RefreshTokenFailedException catch (refreshError) {
+      // Already cleared and logged by requestTokenRefresh; surface the dead session.
       return handler.reject(DioException(
         requestOptions: err.requestOptions,
         error: refreshError,
@@ -648,11 +646,13 @@ class AuthorizationInterceptors extends QueuedInterceptorsWrapper {
       acquired = PlatformInfo.isIOS
           ? await _getNewTokenForIOSPlatform()
           : await _getNewTokenForOtherPlatform();
-    } catch (e) {
+    } catch (e, st) {
       if (!_isRefreshRejectedByServer(e)) rethrow;
       clear();
-      // Each caller logs it — this one method serves both JMAP and Workplace.
-      throw RefreshTokenFailedException(cause: e);
+      // Logged here, not per caller: this one method serves JMAP and Workplace.
+      final fatal = RefreshTokenFailedException(cause: e);
+      _logFatalRefreshRejection(fatal, st);
+      throw fatal;
     }
 
     // The session died while we were away; re-arming it would resurrect a

--- a/lib/main/exceptions/remote/authentication_exception.dart
+++ b/lib/main/exceptions/remote/authentication_exception.dart
@@ -50,3 +50,13 @@ class StaleSessionRefreshException extends AuthenticationException {
   @override
   String get exceptionName => 'StaleSessionRefreshException';
 }
+
+/// The session holds nothing to refresh with, so no request was sent. Not a
+/// [RefreshTokenFailedException]: the session is untouched, not dead.
+class RefreshTokenUnavailableException extends AuthenticationException {
+  const RefreshTokenUnavailableException()
+      : super(message: 'No refresh token available for the current session.');
+
+  @override
+  String get exceptionName => 'RefreshTokenUnavailableException';
+}

--- a/lib/main/exceptions/remote/authentication_exception.dart
+++ b/lib/main/exceptions/remote/authentication_exception.dart
@@ -39,3 +39,14 @@ class RefreshTokenDuplicatedException extends AuthenticationException {
   @override
   String get exceptionName => 'RefreshTokenDuplicatedException';
 }
+
+/// The refresh answered for a session that no longer exists, so it says nothing
+/// about whichever session is signed in now. Deliberately not a
+/// [RefreshTokenFailedException]: that type forces a logout.
+class StaleSessionRefreshException extends AuthenticationException {
+  const StaleSessionRefreshException()
+      : super(message: 'Refresh answered for a session that has since been replaced.');
+
+  @override
+  String get exceptionName => 'StaleSessionRefreshException';
+}

--- a/lib/main/exceptions/remote/authentication_exception.dart
+++ b/lib/main/exceptions/remote/authentication_exception.dart
@@ -27,3 +27,11 @@ class RefreshTokenFailedException extends AuthenticationException {
   @override
   String get exceptionName => 'RefreshTokenFailedException';
 }
+
+class RefreshTokenDuplicatedException extends AuthenticationException {
+  const RefreshTokenDuplicatedException()
+      : super(message: 'Refresh returned the current token; retry cannot clear the 401.');
+
+  @override
+  String get exceptionName => 'RefreshTokenDuplicatedException';
+}

--- a/lib/main/exceptions/remote/authentication_exception.dart
+++ b/lib/main/exceptions/remote/authentication_exception.dart
@@ -15,9 +15,13 @@ class BadCredentialsException extends AuthenticationException {
 }
 
 class RefreshTokenFailedException extends AuthenticationException {
+  /// The server rejection that killed the session, for the caller to log.
+  final Object? cause;
+
   RefreshTokenFailedException({
     int code = 400,
     String? message,
+    this.cause,
   }) : super(
           code: code,
           message: message ??

--- a/test/features/base/base_controller_test.dart
+++ b/test/features/base/base_controller_test.dart
@@ -5,6 +5,7 @@ import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/utils/app_toast.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:jmap_dart_client/jmap/core/account/account.dart';
@@ -14,7 +15,9 @@ import 'package:jmap_dart_client/jmap/core/state.dart';
 import 'package:jmap_dart_client/jmap/core/unsigned_int.dart';
 import 'package:jmap_dart_client/jmap/core/user_name.dart';
 import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 import 'package:tmail_ui_user/features/base/base_controller.dart';
+import 'package:tmail_ui_user/features/base/before_reconnect_manager.dart';
 import 'package:tmail_ui_user/features/caching/caching_manager.dart';
 import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
 import 'package:tmail_ui_user/features/login/domain/usecases/delete_authority_oidc_interactor.dart';
@@ -37,10 +40,18 @@ class MockBaseController extends BaseController {
 
   bool isUrgentExceptionEnable = false;
   bool isErrorViewStateEnable = false;
+  int logoutCalls = 0;
 
   void resetState() {
      isUrgentExceptionEnable = false;
      isErrorViewStateEnable = false;
+     logoutCalls = 0;
+  }
+
+  // Records the forced logout instead of clearing storage and routing.
+  @override
+  Future<void> clearDataAndGoToLoginPage() async {
+    logoutCalls++;
   }
 
   @override
@@ -77,6 +88,7 @@ class SomeOtherException extends RemoteException {
   MockSpec<Uuid>(),
   MockSpec<ToastManager>(),
   MockSpec<TwakeAppManager>(),
+  MockSpec<BeforeReconnectManager>(),
 ])
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -95,6 +107,7 @@ void main() {
   late MockUuid mockUuid;
   late MockToastManager mockToastManager;
   late MockTwakeAppManager mockTwakeAppManager;
+  late MockBeforeReconnectManager mockBeforeReconnectManager;
 
   setUpAll(() {
     mockCachingManager = MockCachingManager();
@@ -110,6 +123,7 @@ void main() {
     mockUuid = MockUuid();
     mockToastManager = MockToastManager();
     mockTwakeAppManager = MockTwakeAppManager();
+    mockBeforeReconnectManager = MockBeforeReconnectManager();
 
     Get.put<CachingManager>(mockCachingManager);
     Get.put<LanguageCacheManager>(mockLanguageCacheManager);
@@ -128,6 +142,7 @@ void main() {
     Get.put<Uuid>(mockUuid);
     Get.put<ToastManager>(mockToastManager);
     Get.put<TwakeAppManager>(mockTwakeAppManager);
+    Get.put<BeforeReconnectManager>(mockBeforeReconnectManager);
     Get.testMode = true;
 
     mockBaseController = MockBaseController();
@@ -144,6 +159,10 @@ void main() {
 
     test('should return true when exception is ConnectionError', () {
       expect(mockBaseController.validateUrgentException(const ConnectionError()), isTrue);
+    });
+
+    test('should return true when exception is RefreshTokenFailedException', () {
+      expect(mockBaseController.validateUrgentException(RefreshTokenFailedException()), isTrue);
     });
 
     test('should return false when exception is SomeOtherException', () {
@@ -204,6 +223,20 @@ void main() {
       expect(mockBaseController.isErrorViewStateEnable, false);
     });
 
+    test('handleUrgentException should called when error is RefreshTokenFailedException', () {
+      // arrange
+      final error = RefreshTokenFailedException();
+      final stackTrace = StackTrace.current;
+
+      // act
+      mockBaseController.resetState();
+      mockBaseController.onError(error, stackTrace);
+
+      // assert
+      expect(mockBaseController.isUrgentExceptionEnable, true);
+      expect(mockBaseController.isErrorViewStateEnable, false);
+    });
+
     test('handleErrorViewState should called when error is SomeOtherException', () {
       // arrange
       const error = SomeOtherException();
@@ -216,6 +249,59 @@ void main() {
       // assert
       expect(mockBaseController.isErrorViewStateEnable, true);
       expect(mockBaseController.isUrgentExceptionEnable, false);
+    });
+  });
+
+  // Forced logout after a rejected OIDC refresh — the path every
+  // RefreshTokenFailedException ends in, whether it came from the JMAP
+  // interceptor or from a Drive token refresh.
+  group('BaseController::handleRefreshTokenFailedException', () {
+    setUp(() {
+      mockBaseController.resetState();
+      clearInteractions(mockTwakeAppManager);
+      clearInteractions(mockBeforeReconnectManager);
+      addTearDown(() => PlatformInfo.isTestingForWeb = false);
+    });
+
+    test(
+      'web with a composer open: saves via before-reconnect listeners, '
+      'suppresses the browser prompt, then logs out',
+      () async {
+        PlatformInfo.isTestingForWeb = true;
+        when(mockTwakeAppManager.hasComposer).thenReturn(true);
+
+        mockBaseController.handleUrgentException(exception: RefreshTokenFailedException());
+        await pumpEventQueue();
+
+        verifyInOrder([
+          mockTwakeAppManager.setExecutingBeforeReconnect(true),
+          mockBeforeReconnectManager.executeBeforeReconnectListeners(),
+        ]);
+        expect(mockBaseController.logoutCalls, 1);
+      },
+    );
+
+    test('web without a composer: logs out directly, no before-reconnect', () async {
+      PlatformInfo.isTestingForWeb = true;
+      when(mockTwakeAppManager.hasComposer).thenReturn(false);
+
+      mockBaseController.handleUrgentException(exception: RefreshTokenFailedException());
+      await pumpEventQueue();
+
+      verifyNever(mockTwakeAppManager.setExecutingBeforeReconnect(any));
+      verifyNever(mockBeforeReconnectManager.executeBeforeReconnectListeners());
+      expect(mockBaseController.logoutCalls, 1);
+    });
+
+    test('mobile with a composer open: logs out directly, no before-reconnect', () async {
+      when(mockTwakeAppManager.hasComposer).thenReturn(true);
+
+      mockBaseController.handleUrgentException(exception: RefreshTokenFailedException());
+      await pumpEventQueue();
+
+      verifyNever(mockTwakeAppManager.setExecutingBeforeReconnect(any));
+      verifyNever(mockBeforeReconnectManager.executeBeforeReconnectListeners());
+      expect(mockBaseController.logoutCalls, 1);
     });
   });
 

--- a/test/features/base/base_controller_test.dart
+++ b/test/features/base/base_controller_test.dart
@@ -165,6 +165,18 @@ void main() {
       expect(mockBaseController.validateUrgentException(RefreshTokenFailedException()), isTrue);
     });
 
+    // Journey A (JMAP 401): a same-token refresh reaches super.onError, becomes a
+    // BadCredentialsException and forces logout. Journey B (Drive token_exchange
+    // 401) surfaces the RefreshTokenDuplicatedException itself, so it must be
+    // classified urgent here or the dead session only produces a toast.
+    // KNOWN FAILING: RefreshTokenDuplicatedException is not in validateUrgentException.
+    test('should return true when exception is RefreshTokenDuplicatedException', () {
+      expect(
+        mockBaseController.validateUrgentException(const RefreshTokenDuplicatedException()),
+        isTrue,
+      );
+    });
+
     test('should return false when exception is SomeOtherException', () {
       expect(mockBaseController.validateUrgentException(const SomeOtherException()), isFalse);
     });

--- a/test/features/base/base_controller_test.dart
+++ b/test/features/base/base_controller_test.dart
@@ -42,16 +42,21 @@ class MockBaseController extends BaseController {
   bool isErrorViewStateEnable = false;
   int logoutCalls = 0;
 
+  /// Shared with the before-reconnect stub so a test can assert the ordering.
+  final List<String> events = [];
+
   void resetState() {
      isUrgentExceptionEnable = false;
      isErrorViewStateEnable = false;
      logoutCalls = 0;
+     events.clear();
   }
 
   // Records the forced logout instead of clearing storage and routing.
   @override
   Future<void> clearDataAndGoToLoginPage() async {
     logoutCalls++;
+    events.add('logout');
   }
 
   @override
@@ -281,6 +286,14 @@ void main() {
         PlatformInfo.isTestingForWeb = true;
         when(mockTwakeAppManager.hasComposer).thenReturn(true);
 
+        // Yields before recording, so dropping the await in production would
+        // land 'logout' first and fail the ordering assertion below.
+        when(mockBeforeReconnectManager.executeBeforeReconnectListeners())
+            .thenAnswer((_) async {
+          await Future<void>.delayed(Duration.zero);
+          mockBaseController.events.add('listeners');
+        });
+
         mockBaseController.handleUrgentException(exception: RefreshTokenFailedException());
         await pumpEventQueue();
 
@@ -289,6 +302,8 @@ void main() {
           mockBeforeReconnectManager.executeBeforeReconnectListeners(),
         ]);
         expect(mockBaseController.logoutCalls, 1);
+        // Logout must not start before the draft save finishes, or it is lost.
+        expect(mockBaseController.events, ['listeners', 'logout']);
       },
     );
 

--- a/test/features/base/base_controller_test.dart
+++ b/test/features/base/base_controller_test.dart
@@ -169,7 +169,6 @@ void main() {
     // BadCredentialsException and forces logout. Journey B (Drive token_exchange
     // 401) surfaces the RefreshTokenDuplicatedException itself, so it must be
     // classified urgent here or the dead session only produces a toast.
-    // KNOWN FAILING: RefreshTokenDuplicatedException is not in validateUrgentException.
     test('should return true when exception is RefreshTokenDuplicatedException', () {
       expect(
         mockBaseController.validateUrgentException(const RefreshTokenDuplicatedException()),

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -140,10 +140,14 @@ class MockMailboxDashBoardController extends Mock implements MailboxDashBoardCon
   @override
   InternalFinalCallback<void> get onDelete => mockControllerCallback();
 
+  // Overridable so a test can reproduce a session torn down mid-logout.
+  AccountId? currentAccountId = AccountFixtures.aliceAccountId;
+  Session? currentSession = SessionFixtures.aliceSession;
+
   @override
-  Rxn<AccountId> get accountId => Rxn(AccountFixtures.aliceAccountId);
+  Rxn<AccountId> get accountId => Rxn(currentAccountId);
   @override
-  Session? get sessionCurrent => SessionFixtures.aliceSession;
+  Session? get sessionCurrent => currentSession;
 
   bool premiumAvailable = false;
 
@@ -1306,6 +1310,52 @@ void main() {
         'When platform is not web',
       () async {
         PlatformInfo.isTestingForWeb = false;
+        composerController?.composerArguments.value = ComposerArguments();
+
+        await composerController?.onBeforeReconnect();
+
+        verifyNever(mockSaveComposerCacheInteractor.execute(
+          createEmailRequest: anyNamed('createEmailRequest'),
+          isPersistent: anyNamed('isPersistent'),
+        ));
+      });
+
+      // The account/session guard runs on web too. If either is already gone
+      // when the forced logout starts, the draft is not written — logout still
+      // proceeds, so the draft is lost. Locked here so the skip stays a
+      // deliberate choice rather than a silent regression.
+      test(
+        'Should skip the save without throwing\n'
+        'When platform is web but the account is already gone',
+      () async {
+        PlatformInfo.isTestingForWeb = true;
+        addTearDown(() => PlatformInfo.isTestingForWeb = false);
+        mockMailboxDashBoardController.currentAccountId = null;
+        addTearDown(() => mockMailboxDashBoardController.currentAccountId =
+            AccountFixtures.aliceAccountId);
+        composerController?.richTextWebController = mockRichTextWebController;
+        composerController?.setTextEditorWeb(emailContent);
+        composerController?.composerArguments.value = ComposerArguments();
+
+        await composerController?.onBeforeReconnect();
+
+        verifyNever(mockSaveComposerCacheInteractor.execute(
+          createEmailRequest: anyNamed('createEmailRequest'),
+          isPersistent: anyNamed('isPersistent'),
+        ));
+      });
+
+      test(
+        'Should skip the save without throwing\n'
+        'When platform is web but the session is already gone',
+      () async {
+        PlatformInfo.isTestingForWeb = true;
+        addTearDown(() => PlatformInfo.isTestingForWeb = false);
+        mockMailboxDashBoardController.currentSession = null;
+        addTearDown(() => mockMailboxDashBoardController.currentSession =
+            SessionFixtures.aliceSession);
+        composerController?.richTextWebController = mockRichTextWebController;
+        composerController?.setTextEditorWeb(emailContent);
         composerController?.composerArguments.value = ComposerArguments();
 
         await composerController?.onBeforeReconnect();

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -45,6 +45,7 @@ import 'package:tmail_ui_user/features/composer/domain/usecases/create_new_and_s
 import 'package:tmail_ui_user/features/composer/domain/usecases/download_image_as_base64_interactor.dart';
 import 'package:tmail_ui_user/features/composer/domain/usecases/save_composer_cache_interactor.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_controller.dart';
+import 'package:tmail_ui_user/features/composer/presentation/model/create_email_request.dart';
 import 'package:tmail_ui_user/features/upload/presentation/validator/attachment_upload_validation_service.dart';
 import 'package:tmail_ui_user/features/base/model/ui_keys.dart';
 import 'package:tmail_ui_user/features/composer/presentation/composer_view_web.dart';
@@ -1264,6 +1265,55 @@ void main() {
           () => composerController?.markCleanClose(),
           returnsNormally,
         );
+      });
+    });
+
+    // Runs when the app is forced to log out (e.g. rejected OIDC refresh) with
+    // a composer open: web saves the draft to cache before the redirect.
+    group('onBeforeReconnect:', () {
+      const emailContent = '<p>unsent draft</p>';
+
+      test(
+        'Should save the composer cache\n'
+        'When platform is web and account and session are available',
+      () async {
+        PlatformInfo.isTestingForWeb = true;
+        addTearDown(() => PlatformInfo.isTestingForWeb = false);
+        composerController?.richTextWebController = mockRichTextWebController;
+        composerController?.setTextEditorWeb(emailContent);
+        composerController?.composerArguments.value = ComposerArguments();
+        when(mockUploadController.attachmentsUploaded).thenReturn([]);
+        when(mockComposerRepository.removeCollapsedExpandedSignatureEffect(
+          emailContent: anyNamed('emailContent'),
+        )).thenAnswer((_) async => emailContent);
+        when(mockSaveComposerCacheInteractor.execute(
+          createEmailRequest: anyNamed('createEmailRequest'),
+          isPersistent: anyNamed('isPersistent'),
+        )).thenAnswer((_) async => Right(UIState.idle));
+
+        await composerController?.onBeforeReconnect();
+
+        final request = verify(mockSaveComposerCacheInteractor.execute(
+          createEmailRequest: captureAnyNamed('createEmailRequest'),
+          isPersistent: anyNamed('isPersistent'),
+        )).captured.single as CreateEmailRequest;
+        expect(request.emailContent, emailContent);
+        expect(request.accountId, AccountFixtures.aliceAccountId);
+      });
+
+      test(
+        'Should do nothing\n'
+        'When platform is not web',
+      () async {
+        PlatformInfo.isTestingForWeb = false;
+        composerController?.composerArguments.value = ComposerArguments();
+
+        await composerController?.onBeforeReconnect();
+
+        verifyNever(mockSaveComposerCacheInteractor.execute(
+          createEmailRequest: anyNamed('createEmailRequest'),
+          isPersistent: anyNamed('isPersistent'),
+        ));
       });
     });
 

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -141,7 +141,9 @@ class MockMailboxDashBoardController extends Mock implements MailboxDashBoardCon
   InternalFinalCallback<void> get onDelete => mockControllerCallback();
 
   // Overridable so a test can reproduce a session torn down mid-logout.
+  @override
   AccountId? currentAccountId = AccountFixtures.aliceAccountId;
+  @override
   Session? currentSession = SessionFixtures.aliceSession;
 
   @override

--- a/test/features/composer/presentation/providers/composer_attachment_extension_registry_provider_test.dart
+++ b/test/features/composer/presentation/providers/composer_attachment_extension_registry_provider_test.dart
@@ -190,10 +190,13 @@ void main() {
           (e) => e.error, 'error', isA<RefreshTokenFailedException>(),
         )),
       );
-      final workplaceRefresh = expectLater(
-        readExtension().oidcRefreshTrigger!(),
-        throwsA(isA<RefreshTokenFailedException>()),
-      );
+      Object? workplaceError;
+      final workplaceRefresh = readExtension()
+          .oidcRefreshTrigger!()
+          .then<String?>((_) => null, onError: (Object e) {
+            workplaceError = e;
+            return null;
+          });
       // Let both callers reach the in-flight refresh before it is rejected.
       await pumpEventQueue();
       refreshCompleter.completeError(const OAuthAuthorizationError(
@@ -204,6 +207,19 @@ void main() {
 
       verify(authenticationClient.refreshingTokensOIDC(any, any, any, any, any)).called(1);
       expect(realInterceptor.authenticationType, AuthenticationType.none);
+      expect(workplaceError, isA<RefreshTokenFailedException>());
+
+      // The Drive picker reports that rejection as a DrivePickFailure; the
+      // registry must hand it to the dashboard's BaseController path, not toast.
+      final failure = DrivePickFailure(workplaceError!);
+      when(dashboard.validateUrgentException(workplaceError)).thenReturn(true);
+      await readExtension().onPickState!(null, failure);
+
+      verify(dashboard.handleUrgentException(
+        failure: failure,
+        exception: workplaceError as Exception,
+      )).called(1);
+      verifyNever(toastManager.showMessageFailure(any));
     });
 
     test('transient refresh failure racing a JMAP 401 keeps the session', () async {

--- a/test/features/composer/presentation/providers/composer_attachment_extension_registry_provider_test.dart
+++ b/test/features/composer/presentation/providers/composer_attachment_extension_registry_provider_test.dart
@@ -88,23 +88,21 @@ void main() {
       verifyNever(dashboard.handleRefreshTokenFailedException());
     });
 
-    test('fatal rejection triggers the logout handler exactly once and throws RefreshTokenFailedException', () async {
-      final rejection = Exception('invalid_grant');
+    test('rethrows a fatal rejection untouched; the interceptor already owns clear and classification', () async {
+      final rejection = RefreshTokenFailedException();
       when(interceptor.requestTokenRefresh()).thenThrow(rejection);
-      when(interceptor.isRefreshFailureFatal(rejection)).thenReturn(true);
 
       await expectLater(
         readExtension().oidcRefreshTrigger!(),
-        throwsA(isA<RefreshTokenFailedException>()),
+        throwsA(same(rejection)),
       );
 
-      verify(interceptor.clear()).called(1);
-      verify(dashboard.handleRefreshTokenFailedException()).called(1);
+      verifyNever(interceptor.clear());
+      verifyNever(dashboard.handleRefreshTokenFailedException());
     });
 
-    test('transient failure keeps the session and rethrows the original error', () async {
+    test('rethrows a transient failure untouched', () async {
       when(interceptor.requestTokenRefresh()).thenThrow(transientError);
-      when(interceptor.isRefreshFailureFatal(transientError)).thenReturn(false);
 
       await expectLater(
         readExtension().oidcRefreshTrigger!(),
@@ -184,7 +182,7 @@ void main() {
       )).thenAnswer((_) => refreshCompleter.future);
     });
 
-    test('fatal refresh racing a JMAP 401 refreshes once and logs out once', () async {
+    test('fatal refresh racing a JMAP 401 refreshes once and kills the session once', () async {
       // Matchers attach first so neither rejection is reported as unhandled.
       final libRequest = expectLater(
         dio.post(baseUrl),
@@ -205,7 +203,6 @@ void main() {
       await Future.wait([libRequest, workplaceRefresh]);
 
       verify(authenticationClient.refreshingTokensOIDC(any, any, any, any, any)).called(1);
-      verify(dashboard.handleRefreshTokenFailedException()).called(1);
       expect(realInterceptor.authenticationType, AuthenticationType.none);
     });
 
@@ -224,7 +221,6 @@ void main() {
       await Future.wait([libRequest, workplaceRefresh]);
 
       verify(authenticationClient.refreshingTokensOIDC(any, any, any, any, any)).called(1);
-      verifyNever(dashboard.handleRefreshTokenFailedException());
       expect(realInterceptor.authenticationType, AuthenticationType.oidc);
     });
   });
@@ -232,18 +228,25 @@ void main() {
   group('onPickState::', () {
     test('transient Drive failure is reported once by the picker layer', () async {
       final failure = DrivePickFailure(transientError);
+      when(dashboard.validateUrgentException(transientError)).thenReturn(false);
 
       await readExtension().onPickState!(null, failure);
 
       verify(toastManager.showMessageFailure(failure)).called(1);
+      verifyNever(dashboard.handleUrgentException(
+        failure: anyNamed('failure'),
+        exception: anyNamed('exception'),
+      ));
     });
 
-    test('refresh rejection already handled by the refresh layer is not reported again', () async {
-      await readExtension().onPickState!(
-        null,
-        DrivePickFailure(RefreshTokenFailedException()),
-      );
+    test('urgent failure takes the dashboard BaseController path instead of a toast', () async {
+      final rejection = RefreshTokenFailedException();
+      final failure = DrivePickFailure(rejection);
+      when(dashboard.validateUrgentException(rejection)).thenReturn(true);
 
+      await readExtension().onPickState!(null, failure);
+
+      verify(dashboard.handleUrgentException(failure: failure, exception: rejection)).called(1);
       verifyNever(toastManager.showMessageFailure(any));
     });
   });

--- a/test/features/composer/presentation/providers/composer_attachment_extension_registry_provider_test.dart
+++ b/test/features/composer/presentation/providers/composer_attachment_extension_registry_provider_test.dart
@@ -1,27 +1,44 @@
+import 'dart:async';
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:get/get.dart';
+import 'package:get/get.dart' hide Response;
+import 'package:http_mock_adapter/http_mock_adapter.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:model/account/authentication_type.dart';
 import 'package:model/oidc/token_id.dart';
 import 'package:model/oidc/token_oidc.dart';
 import 'package:tmail_ui_user/features/composer/presentation/providers/composer_attachment_extension_registry_provider.dart';
+import 'package:tmail_ui_user/features/login/data/local/account_cache_manager.dart';
+import 'package:tmail_ui_user/features/login/data/local/token_oidc_cache_manager.dart';
+import 'package:tmail_ui_user/features/login/data/network/authentication_client/authentication_client_base.dart';
 import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
+import 'package:tmail_ui_user/features/login/domain/exceptions/oauth_authorization_error.dart';
+import 'package:tmail_ui_user/features/login/domain/extensions/oidc_configuration_extensions.dart';
 import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
 import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
 import 'package:tmail_ui_user/main/providers/workplace/drive_attachment_uri_value_notifier_provider.dart';
+import 'package:tmail_ui_user/main/utils/ios_sharing_manager.dart';
 import 'package:tmail_ui_user/main/utils/toast_manager.dart';
 import 'package:workplace/presentation/extension/workplace_composer_attachment_extension.dart';
 import 'package:workplace/presentation/model/drive_pick_state.dart';
 
+import '../../../../fixtures/oidc_fixtures.dart';
 import 'composer_attachment_extension_registry_provider_test.mocks.dart';
 
 @GenerateNiceMocks([
   MockSpec<AuthorizationInterceptors>(),
   MockSpec<MailboxDashBoardController>(),
   MockSpec<ToastManager>(),
+  MockSpec<AuthenticationClientBase>(),
+  MockSpec<TokenOidcCacheManager>(),
+  MockSpec<AccountCacheManager>(),
+  MockSpec<IOSSharingManager>(),
 ])
 void main() {
   late MockAuthorizationInterceptors interceptor;
@@ -105,6 +122,110 @@ void main() {
 
       expect(token, isNull);
       verifyNever(dashboard.handleRefreshTokenFailedException());
+    });
+  });
+
+  // Real interceptor: proves a server rejection surfaced by the real refresh
+  // path reaches the fatal branch, and that a JMAP 401 racing the Workplace
+  // callback joins the same in-flight refresh.
+  group('oidcRefreshTrigger with real AuthorizationInterceptors::', () {
+    const baseUrl = 'http://domain.com/jmap';
+    late Dio dio;
+    late DioAdapter dioAdapter;
+    late MockAuthenticationClientBase authenticationClient;
+    late AuthorizationInterceptors realInterceptor;
+    late Completer<TokenOIDC> refreshCompleter;
+
+    setUp(() {
+      dotenv.testLoad(mergeWith: {'PLATFORM': 'other'});
+      dio = Dio(BaseOptions(baseUrl: baseUrl));
+      authenticationClient = MockAuthenticationClientBase();
+      realInterceptor = AuthorizationInterceptors(
+        dio,
+        authenticationClient,
+        MockTokenOidcCacheManager(),
+        MockAccountCacheManager(),
+        MockIOSSharingManager(),
+      );
+      dio.interceptors.add(realInterceptor);
+      dioAdapter = DioAdapter(dio: dio);
+      Get.delete<AuthorizationInterceptors>(force: true);
+      Get.put<AuthorizationInterceptors>(realInterceptor);
+
+      realInterceptor.setTokenAndAuthorityOidc(
+        newToken: OIDCFixtures.tokenOidcExpiredTime,
+        newConfig: OIDCFixtures.oidcConfiguration,
+      );
+      dioAdapter.onPost(
+        baseUrl,
+        (server) => server.throws(
+          401,
+          DioException(
+            requestOptions: RequestOptions(path: baseUrl, method: 'POST'),
+            response: Response(
+              statusCode: 401,
+              requestOptions: RequestOptions(path: baseUrl),
+            ),
+            type: DioExceptionType.badResponse,
+          ),
+        ),
+        headers: {
+          HttpHeaders.authorizationHeader:
+              'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+        },
+      );
+      refreshCompleter = Completer<TokenOIDC>();
+      when(authenticationClient.refreshingTokensOIDC(
+        OIDCFixtures.oidcConfiguration.clientId,
+        OIDCFixtures.oidcConfiguration.redirectUrl,
+        OIDCFixtures.oidcConfiguration.discoveryUrl,
+        OIDCFixtures.oidcConfiguration.scopes,
+        OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+      )).thenAnswer((_) => refreshCompleter.future);
+    });
+
+    test('fatal refresh racing a JMAP 401 refreshes once and logs out once', () async {
+      // Matchers attach first so neither rejection is reported as unhandled.
+      final libRequest = expectLater(
+        dio.post(baseUrl),
+        throwsA(isA<DioException>().having(
+          (e) => e.error, 'error', isA<RefreshTokenFailedException>(),
+        )),
+      );
+      final workplaceRefresh = expectLater(
+        readExtension().oidcRefreshTrigger!(),
+        throwsA(isA<RefreshTokenFailedException>()),
+      );
+      // Let both callers reach the in-flight refresh before it is rejected.
+      await pumpEventQueue();
+      refreshCompleter.completeError(const OAuthAuthorizationError(
+        error: 'invalid_grant',
+        errorDescription: 'The refresh token has been revoked',
+      ));
+      await Future.wait([libRequest, workplaceRefresh]);
+
+      verify(authenticationClient.refreshingTokensOIDC(any, any, any, any, any)).called(1);
+      verify(dashboard.handleRefreshTokenFailedException()).called(1);
+      expect(realInterceptor.authenticationType, AuthenticationType.none);
+    });
+
+    test('transient refresh failure racing a JMAP 401 keeps the session', () async {
+      const transient = ServerError();
+      final libRequest = expectLater(
+        dio.post(baseUrl),
+        throwsA(isA<DioException>().having((e) => e.error, 'error', same(transient))),
+      );
+      final workplaceRefresh = expectLater(
+        readExtension().oidcRefreshTrigger!(),
+        throwsA(same(transient)),
+      );
+      await pumpEventQueue();
+      refreshCompleter.completeError(transient);
+      await Future.wait([libRequest, workplaceRefresh]);
+
+      verify(authenticationClient.refreshingTokensOIDC(any, any, any, any, any)).called(1);
+      verifyNever(dashboard.handleRefreshTokenFailedException());
+      expect(realInterceptor.authenticationType, AuthenticationType.oidc);
     });
   });
 

--- a/test/features/composer/presentation/providers/composer_attachment_extension_registry_provider_test.dart
+++ b/test/features/composer/presentation/providers/composer_attachment_extension_registry_provider_test.dart
@@ -88,7 +88,9 @@ void main() {
       verifyNever(dashboard.handleRefreshTokenFailedException());
     });
 
-    test('rethrows a fatal rejection untouched; the interceptor already owns clear and classification', () async {
+    // The trigger adds nothing of its own: requestTokenRefresh clears the
+    // session and emits the fatal event where the rejection is confirmed.
+    test('rethrows a fatal rejection untouched; the interceptor already owns clear, logging and classification', () async {
       final rejection = RefreshTokenFailedException();
       when(interceptor.requestTokenRefresh()).thenThrow(rejection);
 
@@ -97,8 +99,6 @@ void main() {
         throwsA(same(rejection)),
       );
 
-      // Without this the Drive journey reaches logout with nothing in Sentry.
-      verify(interceptor.logFatalRefreshRejection(rejection, any)).called(1);
       verifyNever(interceptor.clear());
       verifyNever(dashboard.handleRefreshTokenFailedException());
     });

--- a/test/features/composer/presentation/providers/composer_attachment_extension_registry_provider_test.dart
+++ b/test/features/composer/presentation/providers/composer_attachment_extension_registry_provider_test.dart
@@ -1,0 +1,129 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:model/oidc/token_id.dart';
+import 'package:model/oidc/token_oidc.dart';
+import 'package:tmail_ui_user/features/composer/presentation/providers/composer_attachment_extension_registry_provider.dart';
+import 'package:tmail_ui_user/features/login/data/network/interceptors/authorization_interceptors.dart';
+import 'package:tmail_ui_user/features/mailbox_dashboard/presentation/controller/mailbox_dashboard_controller.dart';
+import 'package:tmail_ui_user/main/exceptions/remote/authentication_exception.dart';
+import 'package:tmail_ui_user/main/providers/workplace/drive_attachment_uri_value_notifier_provider.dart';
+import 'package:tmail_ui_user/main/utils/toast_manager.dart';
+import 'package:workplace/presentation/extension/workplace_composer_attachment_extension.dart';
+import 'package:workplace/presentation/model/drive_pick_state.dart';
+
+import 'composer_attachment_extension_registry_provider_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<AuthorizationInterceptors>(),
+  MockSpec<MailboxDashBoardController>(),
+  MockSpec<ToastManager>(),
+])
+void main() {
+  late MockAuthorizationInterceptors interceptor;
+  late MockMailboxDashBoardController dashboard;
+  late MockToastManager toastManager;
+  late ProviderContainer container;
+
+  final transientError = DioException(
+    requestOptions: RequestOptions(path: '/token'),
+    type: DioExceptionType.connectionTimeout,
+  );
+
+  WorkplaceComposerAttachmentExtension readExtension() =>
+      container.read(composerAttachmentExtensionRegistryProvider).extensions.single
+          as WorkplaceComposerAttachmentExtension;
+
+  setUp(() {
+    interceptor = MockAuthorizationInterceptors();
+    dashboard = MockMailboxDashBoardController();
+    toastManager = MockToastManager();
+    // Get.put/Get.reset run the GetX lifecycle; the mock's fakes would throw.
+    when(dashboard.onStart).thenReturn(InternalFinalCallback<void>(callback: () {}));
+    when(dashboard.onDelete).thenReturn(InternalFinalCallback<void>(callback: () {}));
+    Get.put<AuthorizationInterceptors>(interceptor);
+    Get.put<MailboxDashBoardController>(dashboard);
+    Get.put<ToastManager>(toastManager);
+    container = ProviderContainer(overrides: [
+      driveAttachmentUriValueProvider.overrideWithValue(ValueNotifier<Uri?>(null)),
+    ]);
+  });
+
+  tearDown(() {
+    container.dispose();
+    Get.reset();
+  });
+
+  group('oidcRefreshTrigger::', () {
+    test('returns the refreshed id token on success', () async {
+      when(interceptor.requestTokenRefresh()).thenAnswer(
+        (_) async => TokenOIDC('access', TokenId('id-token-2'), 'refresh'),
+      );
+
+      final token = await readExtension().oidcRefreshTrigger!();
+
+      expect(token, equals('id-token-2'));
+      verifyNever(interceptor.clear());
+      verifyNever(dashboard.handleRefreshTokenFailedException());
+    });
+
+    test('fatal rejection triggers the logout handler exactly once and throws RefreshTokenFailedException', () async {
+      final rejection = Exception('invalid_grant');
+      when(interceptor.requestTokenRefresh()).thenThrow(rejection);
+      when(interceptor.isRefreshFailureFatal(rejection)).thenReturn(true);
+
+      await expectLater(
+        readExtension().oidcRefreshTrigger!(),
+        throwsA(isA<RefreshTokenFailedException>()),
+      );
+
+      verify(interceptor.clear()).called(1);
+      verify(dashboard.handleRefreshTokenFailedException()).called(1);
+    });
+
+    test('transient failure keeps the session and rethrows the original error', () async {
+      when(interceptor.requestTokenRefresh()).thenThrow(transientError);
+      when(interceptor.isRefreshFailureFatal(transientError)).thenReturn(false);
+
+      await expectLater(
+        readExtension().oidcRefreshTrigger!(),
+        throwsA(same(transientError)),
+      );
+
+      verifyNever(interceptor.clear());
+      verifyNever(dashboard.handleRefreshTokenFailedException());
+    });
+
+    test('returns null without logout when no interceptor is registered', () async {
+      Get.delete<AuthorizationInterceptors>();
+
+      final token = await readExtension().oidcRefreshTrigger!();
+
+      expect(token, isNull);
+      verifyNever(dashboard.handleRefreshTokenFailedException());
+    });
+  });
+
+  group('onPickState::', () {
+    test('transient Drive failure is reported once by the picker layer', () async {
+      final failure = DrivePickFailure(transientError);
+
+      await readExtension().onPickState!(null, failure);
+
+      verify(toastManager.showMessageFailure(failure)).called(1);
+    });
+
+    test('refresh rejection already handled by the refresh layer is not reported again', () async {
+      await readExtension().onPickState!(
+        null,
+        DrivePickFailure(RefreshTokenFailedException()),
+      );
+
+      verifyNever(toastManager.showMessageFailure(any));
+    });
+  });
+}

--- a/test/features/composer/presentation/providers/composer_attachment_extension_registry_provider_test.dart
+++ b/test/features/composer/presentation/providers/composer_attachment_extension_registry_provider_test.dart
@@ -81,7 +81,7 @@ void main() {
         (_) async => TokenOIDC('access', TokenId('id-token-2'), 'refresh'),
       );
 
-      final token = await readExtension().oidcRefreshTrigger!();
+      final token = await readExtension().oidcRefreshTrigger();
 
       expect(token, equals('id-token-2'));
       verifyNever(interceptor.clear());
@@ -93,10 +93,12 @@ void main() {
       when(interceptor.requestTokenRefresh()).thenThrow(rejection);
 
       await expectLater(
-        readExtension().oidcRefreshTrigger!(),
+        readExtension().oidcRefreshTrigger(),
         throwsA(same(rejection)),
       );
 
+      // Without this the Drive journey reaches logout with nothing in Sentry.
+      verify(interceptor.logFatalRefreshRejection(rejection, any)).called(1);
       verifyNever(interceptor.clear());
       verifyNever(dashboard.handleRefreshTokenFailedException());
     });
@@ -111,7 +113,7 @@ void main() {
       when(interceptor.requestTokenRefresh()).thenThrow(duplicated);
 
       await expectLater(
-        readExtension().oidcRefreshTrigger!(),
+        readExtension().oidcRefreshTrigger(),
         throwsA(same(duplicated)),
       );
 
@@ -122,7 +124,7 @@ void main() {
       when(interceptor.requestTokenRefresh()).thenThrow(transientError);
 
       await expectLater(
-        readExtension().oidcRefreshTrigger!(),
+        readExtension().oidcRefreshTrigger(),
         throwsA(same(transientError)),
       );
 
@@ -133,7 +135,7 @@ void main() {
     test('returns null without logout when no interceptor is registered', () async {
       Get.delete<AuthorizationInterceptors>();
 
-      final token = await readExtension().oidcRefreshTrigger!();
+      final token = await readExtension().oidcRefreshTrigger();
 
       expect(token, isNull);
       verifyNever(dashboard.handleRefreshTokenFailedException());
@@ -209,7 +211,7 @@ void main() {
       );
       Object? workplaceError;
       final workplaceRefresh = readExtension()
-          .oidcRefreshTrigger!()
+          .oidcRefreshTrigger()
           .then<String?>((_) => null, onError: (Object e) {
             workplaceError = e;
             return null;
@@ -246,7 +248,7 @@ void main() {
         throwsA(isA<DioException>().having((e) => e.error, 'error', same(transient))),
       );
       final workplaceRefresh = expectLater(
-        readExtension().oidcRefreshTrigger!(),
+        readExtension().oidcRefreshTrigger(),
         throwsA(same(transient)),
       );
       await pumpEventQueue();

--- a/test/features/composer/presentation/providers/composer_attachment_extension_registry_provider_test.dart
+++ b/test/features/composer/presentation/providers/composer_attachment_extension_registry_provider_test.dart
@@ -101,6 +101,23 @@ void main() {
       verifyNever(dashboard.handleRefreshTokenFailedException());
     });
 
+    // Journey B, first half: the duplicate-token verdict must survive the hop
+    // into Workplace so the dashboard gets a chance to classify it. The second
+    // half — that classification returning urgent — is asserted in
+    // base_controller_test (validateUrgentException), where the real
+    // BaseController runs instead of a mock.
+    test('rethrows RefreshTokenDuplicatedException untouched so the dashboard can classify it', () async {
+      const duplicated = RefreshTokenDuplicatedException();
+      when(interceptor.requestTokenRefresh()).thenThrow(duplicated);
+
+      await expectLater(
+        readExtension().oidcRefreshTrigger!(),
+        throwsA(same(duplicated)),
+      );
+
+      verifyNever(interceptor.clear());
+    });
+
     test('rethrows a transient failure untouched', () async {
       when(interceptor.requestTokenRefresh()).thenThrow(transientError);
 

--- a/test/features/composer/presentation/providers/composer_attachment_extension_registry_provider_test.dart
+++ b/test/features/composer/presentation/providers/composer_attachment_extension_registry_provider_test.dart
@@ -197,7 +197,7 @@ void main() {
         OIDCFixtures.oidcConfiguration.redirectUrl,
         OIDCFixtures.oidcConfiguration.discoveryUrl,
         OIDCFixtures.oidcConfiguration.scopes,
-        OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        OIDCFixtures.tokenOidcExpiredTime,
       )).thenAnswer((_) => refreshCompleter.future);
     });
 

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -1750,6 +1750,63 @@ void main() {
   });
 
   // ============================================================
+  // requestTokenRefresh: owns the fatal-vs-transient decision
+  // ============================================================
+  group('requestTokenRefresh: owns the fatal-vs-transient decision', () {
+    void stubRefreshThrowing(Object error) {
+      authorizationInterceptors.setTokenAndAuthorityOidc(
+        newToken: OIDCFixtures.tokenOidcExpiredTime,
+        newConfig: OIDCFixtures.oidcConfiguration,
+      );
+      when(authenticationClient.refreshingTokensOIDC(
+        OIDCFixtures.oidcConfiguration.clientId,
+        OIDCFixtures.oidcConfiguration.redirectUrl,
+        OIDCFixtures.oidcConfiguration.discoveryUrl,
+        OIDCFixtures.oidcConfiguration.scopes,
+        OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+      )).thenThrow(error);
+    }
+
+    test(
+      'GIVEN a direct caller (e.g. Workplace)\n'
+      'WHEN the token endpoint rejects the refresh token (invalid_grant)\n'
+      'THEN the session is cleared and RefreshTokenFailedException is thrown',
+      () async {
+        stubRefreshThrowing(const OAuthAuthorizationError(
+          error: 'invalid_grant',
+          errorDescription: 'The refresh token has been revoked',
+        ));
+
+        await expectLater(
+          authorizationInterceptors.requestTokenRefresh(),
+          throwsA(isA<RefreshTokenFailedException>()),
+        );
+
+        expect(authorizationInterceptors.authenticationType, AuthenticationType.none);
+        verifyNever(tokenOidcCacheManager.persistOneTokenOidc(any));
+      },
+    );
+
+    test(
+      'GIVEN a direct caller (e.g. Workplace)\n'
+      'WHEN the refresh fails transiently\n'
+      'THEN the original error is rethrown and the session is kept',
+      () async {
+        const transient = ServerError();
+        stubRefreshThrowing(transient);
+
+        await expectLater(
+          authorizationInterceptors.requestTokenRefresh(),
+          throwsA(same(transient)),
+        );
+
+        expect(authorizationInterceptors.authenticationType, AuthenticationType.oidc);
+        expect(authorizationInterceptors.currentToken, OIDCFixtures.tokenOidcExpiredTime);
+      },
+    );
+  });
+
+  // ============================================================
   // requestTokenRefresh: id_token omitted from the refresh response
   // ============================================================
   group('requestTokenRefresh: id_token omitted from the refresh response', () {
@@ -3892,7 +3949,7 @@ void main() {
         expect(errorRecords.single.rawMessage, contains('will_logout=true'));
         expect(
           errorRecords.single.rawMessage,
-          contains('_handleRefreshErrorOnWeb'),
+          contains('_acquireAndPersistNewToken'),
         );
         expect(
           errorRecords.any((r) => r.rawMessage.contains('onError:Exception')),

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -1,4 +1,5 @@
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:core/data/constants/constant.dart';
@@ -1640,6 +1641,108 @@ void main() {
         // update _token, so second request can't detect the first's attempt).
         // Key assertion: no infinite loop — each request tries once and stops.
         expect(refreshCallCount, 2);
+      },
+    );
+  });
+
+  // ============================================================
+  // requestTokenRefresh: concurrent callers dedup
+  // ============================================================
+  group('requestTokenRefresh: concurrent callers dedup', () {
+    test(
+      'GIVEN two concurrent direct callers of requestTokenRefresh\n'
+      'WHEN both call before the first refresh resolves\n'
+      'THEN refresh is invoked exactly once\n'
+      'AND both callers receive the same new token',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+        final refreshCompleter = Completer<TokenOIDC>();
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenAnswer((_) => refreshCompleter.future);
+        stubAccountCache();
+
+        final firstCall = authorizationInterceptors.requestTokenRefresh();
+        final secondCall = authorizationInterceptors.requestTokenRefresh();
+        refreshCompleter.complete(OIDCFixtures.newTokenOidc);
+        final results = await Future.wait([firstCall, secondCall]);
+
+        verify(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).called(1);
+        expect(results[0].token, equals(OIDCFixtures.newTokenOidc.token));
+        expect(results[1].token, equals(OIDCFixtures.newTokenOidc.token));
+      },
+    );
+
+    test(
+      'GIVEN a lib request 401s through onError\n'
+      'AND an external caller (e.g. Workplace, on its own unwired Dio) calls\n'
+      '    requestTokenRefresh at the same time\n'
+      'WHEN both race before refresh resolves\n'
+      'THEN refresh is invoked exactly once\n'
+      'AND the external caller resolves to the same token used to retry the lib request',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+          },
+        );
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.reply(responseStatusCode200, dataRequestSuccessfully),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.newTokenOidc.token}',
+          },
+        );
+
+        final refreshCompleter = Completer<TokenOIDC>();
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).thenAnswer((_) => refreshCompleter.future);
+        stubAccountCache();
+
+        // Workplace-style caller races the interceptor's reactive onError path.
+        final workplaceRefresh = authorizationInterceptors.requestTokenRefresh();
+        final libRequest = dio.post(baseUrl);
+        refreshCompleter.complete(OIDCFixtures.newTokenOidc);
+
+        final response = await libRequest;
+        final workplaceToken = await workplaceRefresh;
+
+        verify(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        )).called(1);
+        expect(response.statusCode, equals(HttpStatus.ok));
+        expect(workplaceToken.token, equals(OIDCFixtures.newTokenOidc.token));
       },
     );
   });

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -1874,6 +1874,31 @@ void main() {
     );
 
     test(
+      'GIVEN an OIDC session whose token carries no refresh token\n'
+      'WHEN a caller asks for a refresh\n'
+      'THEN nothing is sent and the session is kept\n'
+      'SO a Drive-only 401 cannot earn a server rejection that logs the user out',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTimeAndRefreshTokenEmpty,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        await expectLater(
+          authorizationInterceptors.requestTokenRefresh(),
+          throwsA(isA<RefreshTokenUnavailableException>()),
+        );
+
+        verifyNever(authenticationClient.refreshingTokensOIDC(any, any, any, any, any));
+        expect(authorizationInterceptors.authenticationType, AuthenticationType.oidc);
+        expect(
+          authorizationInterceptors.currentToken,
+          OIDCFixtures.tokenOidcExpiredTimeAndRefreshTokenEmpty,
+        );
+      },
+    );
+
+    test(
       'GIVEN a refresh in flight\n'
       'WHEN the session is cleared before it resolves\n'
       'THEN the token is dropped instead of re-arming a logged-out interceptor\n'

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -1891,7 +1891,7 @@ void main() {
         authorizationInterceptors.clear();
         gate.complete(OIDCFixtures.tokenOidcNotExpiredYet);
 
-        await expectLater(pending, throwsA(isA<RefreshTokenFailedException>()));
+        await expectLater(pending, throwsA(isA<StaleSessionRefreshException>()));
         expect(authorizationInterceptors.currentToken, isNull);
         expect(authorizationInterceptors.authenticationType, AuthenticationType.none);
         verifyNever(tokenOidcCacheManager.persistOneTokenOidc(any));
@@ -1928,7 +1928,7 @@ void main() {
         final fresh = authorizationInterceptors.requestTokenRefresh();
         gate.complete(OIDCFixtures.tokenOidcNotExpiredYet);
 
-        await expectLater(stale, throwsA(isA<RefreshTokenFailedException>()));
+        await expectLater(stale, throwsA(isA<StaleSessionRefreshException>()));
         expect(await fresh, OIDCFixtures.tokenOidcNotExpiredYet);
         verify(authenticationClient.refreshingTokensOIDC(any, any, any, any, any)).called(2);
         expect(authorizationInterceptors.authenticationType, AuthenticationType.oidc);
@@ -1939,10 +1939,7 @@ void main() {
       'GIVEN a request that 401ed and is awaiting a refresh from its own session\n'
       'WHEN the user logs out and a new session signs in before that refresh lands\n'
       'THEN the leftover request fails without a session verdict\n'
-      'SO it cannot force the freshly signed-in session to log out.\n'
-      'KNOWN FAILING: the generation guard throws RefreshTokenFailedException,\n'
-      'which validateUrgentException treats as urgent, so BaseController runs\n'
-      'handleRefreshTokenFailedException on a session that is perfectly healthy.',
+      'SO it cannot force the freshly signed-in session to log out.',
       () async {
         authorizationInterceptors.setTokenAndAuthorityOidc(
           newToken: OIDCFixtures.tokenOidcExpiredTime,

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -1961,6 +1961,77 @@ void main() {
     );
 
     test(
+      'GIVEN a refresh in flight\n'
+      'WHEN the session is cleared, a new one signs in,\n'
+      '    and only then the token endpoint rejects the old refresh\n'
+      'THEN the rejection is not the new session\'s verdict\n'
+      'SO the freshly signed-in session is neither cleared nor logged out',
+      () async {
+        final gate = Completer<TokenOIDC>();
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+        when(authenticationClient.refreshingTokensOIDC(any, any, any, any, any))
+            .thenAnswer((_) => gate.future);
+
+        final stale = authorizationInterceptors.requestTokenRefresh();
+        authorizationInterceptors.clear();
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.newTokenOidc,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        gate.completeError(const OAuthAuthorizationError(
+          error: 'invalid_grant',
+          errorDescription: 'The refresh token has been revoked',
+        ));
+
+        await expectLater(stale, throwsA(isA<StaleSessionRefreshException>()));
+        expect(authorizationInterceptors.authenticationType, AuthenticationType.oidc);
+        expect(authorizationInterceptors.currentToken, OIDCFixtures.newTokenOidc);
+      },
+    );
+
+    test(
+      'GIVEN a refresh in flight\n'
+      'WHEN the session is cleared, a new one signs in,\n'
+      '    and only then the token endpoint answers 400 as a DioException\n'
+      'THEN the stale answer never reaches the mobile 400 logout mapping\n'
+      'SO the freshly signed-in session survives',
+      () async {
+        final gate = Completer<TokenOIDC>();
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+        when(authenticationClient.refreshingTokensOIDC(any, any, any, any, any))
+            .thenAnswer((_) => gate.future);
+
+        final stale = authorizationInterceptors.requestTokenRefresh();
+        authorizationInterceptors.clear();
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.newTokenOidc,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+
+        gate.completeError(DioException(
+          requestOptions: RequestOptions(path: '/token'),
+          response: Response(
+            requestOptions: RequestOptions(path: '/token'),
+            statusCode: 400,
+            data: {'error': 'invalid_grant'},
+          ),
+          type: DioExceptionType.badResponse,
+        ));
+
+        await expectLater(stale, throwsA(isA<StaleSessionRefreshException>()));
+        expect(authorizationInterceptors.authenticationType, AuthenticationType.oidc);
+        expect(authorizationInterceptors.currentToken, OIDCFixtures.newTokenOidc);
+      },
+    );
+
+    test(
       'GIVEN a request that 401ed and is awaiting a refresh from its own session\n'
       'WHEN the user logs out and a new session signs in before that refresh lands\n'
       'THEN the leftover request fails without a session verdict\n'

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -1804,6 +1804,36 @@ void main() {
         expect(authorizationInterceptors.currentToken, OIDCFixtures.tokenOidcExpiredTime);
       },
     );
+
+    test(
+      'GIVEN a JMAP 401 already cleared the session on a rejected refresh\n'
+      'WHEN a second caller (e.g. Workplace, whose 401 arrived moments later)\n'
+      '    calls requestTokenRefresh on the now-empty session\n'
+      'THEN it fails with RefreshTokenFailedException, not a raw TypeError\n'
+      'SO the Drive failure can be classified urgent and routed to logout.\n'
+      'KNOWN FAILING: clear() nulls _configOIDC, and _invokeRefreshTokenFromServer\n'
+      'dereferences _configOIDC! — the caller currently gets a TypeError, which is\n'
+      'an Error not an Exception, so it falls through to a generic toast.',
+      () async {
+        stubRefreshThrowing(const OAuthAuthorizationError(
+          error: 'invalid_grant',
+          errorDescription: 'The refresh token has been revoked',
+        ));
+
+        // First caller: the JMAP 401 path kills the session.
+        await expectLater(
+          authorizationInterceptors.requestTokenRefresh(),
+          throwsA(isA<RefreshTokenFailedException>()),
+        );
+        expect(authorizationInterceptors.authenticationType, AuthenticationType.none);
+
+        // Second caller races in after the session is already gone.
+        await expectLater(
+          authorizationInterceptors.requestTokenRefresh(),
+          throwsA(isA<RefreshTokenFailedException>()),
+        );
+      },
+    );
   });
 
   // ============================================================

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -1833,6 +1833,47 @@ void main() {
     );
 
     test(
+      'GIVEN a direct caller on web, where Drive attach ships\n'
+      'WHEN flutter_appauth_web rejects the refresh with a non-Dio ArgumentError\n'
+      'THEN the web classifier still calls it a server rejection\n'
+      'AND the session is cleared with RefreshTokenFailedException',
+      () async {
+        PlatformInfo.isTestingForWeb = true;
+        addTearDown(() => PlatformInfo.isTestingForWeb = false);
+        stubRefreshThrowing(ArgumentError(
+          'Failed to get token: [error: token_failed, description: invalid_request]',
+        ));
+
+        await expectLater(
+          authorizationInterceptors.requestTokenRefresh(),
+          throwsA(isA<RefreshTokenFailedException>()),
+        );
+
+        expect(authorizationInterceptors.authenticationType, AuthenticationType.none);
+        verifyNever(tokenOidcCacheManager.persistOneTokenOidc(any));
+      },
+    );
+
+    test(
+      'GIVEN a direct caller on web\n'
+      'WHEN the refresh fails with an error the web classifier does not own\n'
+      'THEN the original error is rethrown and the session is kept',
+      () async {
+        PlatformInfo.isTestingForWeb = true;
+        addTearDown(() => PlatformInfo.isTestingForWeb = false);
+        final transient = ArgumentError('Failed to get token: [error: network_error]');
+        stubRefreshThrowing(transient);
+
+        await expectLater(
+          authorizationInterceptors.requestTokenRefresh(),
+          throwsA(same(transient)),
+        );
+
+        expect(authorizationInterceptors.authenticationType, AuthenticationType.oidc);
+      },
+    );
+
+    test(
       'GIVEN a refresh in flight\n'
       'WHEN the session is cleared before it resolves\n'
       'THEN the token is dropped instead of re-arming a logged-out interceptor\n'

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -150,7 +150,7 @@ void main() {
       OIDCFixtures.oidcConfiguration.redirectUrl,
       OIDCFixtures.oidcConfiguration.discoveryUrl,
       OIDCFixtures.oidcConfiguration.scopes,
-      OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+      OIDCFixtures.tokenOidcExpiredTime,
     )).thenThrow(error);
   }
 
@@ -399,7 +399,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         stubAccountCache();
 
@@ -413,7 +413,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).called(1);
       },
     );
@@ -451,7 +451,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcNotExpiredYet.refreshToken,
+          OIDCFixtures.tokenOidcNotExpiredYet,
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         stubAccountCache();
 
@@ -465,7 +465,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcNotExpiredYet.refreshToken,
+          OIDCFixtures.tokenOidcNotExpiredYet,
         )).called(1);
       },
     );
@@ -489,7 +489,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) async => OIDCFixtures.tokenOidcExpiredTime);
         stubAccountCache();
 
@@ -535,7 +535,7 @@ void main() {
         OIDCFixtures.oidcConfiguration.redirectUrl,
         OIDCFixtures.oidcConfiguration.discoveryUrl,
         OIDCFixtures.oidcConfiguration.scopes,
-        OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        OIDCFixtures.tokenOidcExpiredTime,
       )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
       stubAccountCache();
     }
@@ -628,7 +628,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenThrow(dioErrorRefresh400);
         stubAccountCache();
 
@@ -646,7 +646,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).called(1);
 
         expect(
@@ -689,7 +689,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenThrow(dioErrorRefresh401);
         stubAccountCache();
 
@@ -742,7 +742,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenThrow(dioErrorRefresh403);
         stubAccountCache();
 
@@ -789,7 +789,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenThrow(dioErrorRefresh500);
         stubAccountCache();
 
@@ -832,7 +832,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenThrow(const ServerError());
         stubAccountCache();
 
@@ -864,7 +864,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenThrow(const TemporarilyUnavailable());
         stubAccountCache();
 
@@ -897,7 +897,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenThrow(AccessTokenInvalidException());
         stubAccountCache();
 
@@ -947,7 +947,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenThrow(PlatformException(
           code: 'token_failed',
           message: 'Failed to get token: [error: null, description: Network error]',
@@ -1011,7 +1011,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         ));
       },
     );
@@ -1065,7 +1065,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         ));
       },
     );
@@ -1108,7 +1108,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         ));
       },
     );
@@ -1168,7 +1168,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         stubAccountCache();
 
@@ -1181,7 +1181,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).called(1);
 
         expect(response1.statusCode, equals(HttpStatus.ok));
@@ -1225,7 +1225,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenThrow(AccessTokenInvalidException());
         stubAccountCache();
 
@@ -1241,7 +1241,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).called(1);
       },
     );
@@ -1308,7 +1308,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         stubAccountCache();
 
@@ -1323,7 +1323,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).called(1);
 
         expect(responses[0].statusCode, equals(HttpStatus.ok));
@@ -1382,7 +1382,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         stubAccountCache();
 
@@ -1398,7 +1398,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).called(1);
 
         for (final response in responses) {
@@ -1452,7 +1452,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenThrow(dioErrorRefresh400);
         stubAccountCache();
 
@@ -1519,7 +1519,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenThrow(dioErrorRefresh400);
         stubAccountCache();
 
@@ -1560,7 +1560,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).called(1); // only the first call
       },
     );
@@ -1607,7 +1607,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) async {
           refreshCallCount++;
           return OIDCFixtures.tokenOidcExpiredTime; // same token → duplicate
@@ -1667,7 +1667,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) => refreshCompleter.future);
         stubAccountCache();
 
@@ -1681,7 +1681,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).called(1);
         expect(results[0].token, equals(OIDCFixtures.newTokenOidc.token));
         expect(results[1].token, equals(OIDCFixtures.newTokenOidc.token));
@@ -1724,7 +1724,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) => refreshCompleter.future);
         stubAccountCache();
 
@@ -1741,7 +1741,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).called(1);
         expect(response.statusCode, equals(HttpStatus.ok));
         expect(workplaceToken.token, equals(OIDCFixtures.newTokenOidc.token));
@@ -1763,7 +1763,7 @@ void main() {
         OIDCFixtures.oidcConfiguration.redirectUrl,
         OIDCFixtures.oidcConfiguration.discoveryUrl,
         OIDCFixtures.oidcConfiguration.scopes,
-        OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+        OIDCFixtures.tokenOidcExpiredTime,
       )).thenThrow(error);
     }
 
@@ -1993,70 +1993,6 @@ void main() {
   });
 
   // ============================================================
-  // requestTokenRefresh: id_token omitted from the refresh response
-  // ============================================================
-  group('requestTokenRefresh: id_token omitted from the refresh response', () {
-    void stubRefreshReturning(TokenOIDC refreshed) {
-      authorizationInterceptors.setTokenAndAuthorityOidc(
-        newToken: OIDCFixtures.tokenOidcExpiredTime,
-        newConfig: OIDCFixtures.oidcConfiguration,
-      );
-      when(authenticationClient.refreshingTokensOIDC(
-        OIDCFixtures.oidcConfiguration.clientId,
-        OIDCFixtures.oidcConfiguration.redirectUrl,
-        OIDCFixtures.oidcConfiguration.discoveryUrl,
-        OIDCFixtures.oidcConfiguration.scopes,
-        OIDCFixtures.tokenOidcExpiredTime.refreshToken,
-      )).thenAnswer((_) async => refreshed);
-      when(accountCacheManager.getCurrentAccount())
-          .thenAnswer((_) async => AccountFixtures.aliceAccount);
-    }
-
-    test(
-      'GIVEN the refresh response carries no id_token (OIDC Core 12.2)\n'
-      'THEN the current id token is kept on the new token\n'
-      'AND that token is what gets persisted',
-      () async {
-        final refreshedWithoutId = TokenOIDC(
-          OIDCFixtures.newTokenOidc.token,
-          TokenId(''),
-          OIDCFixtures.newTokenOidc.refreshToken,
-          expiredTime: OIDCFixtures.newTokenOidc.expiredTime,
-        );
-        stubRefreshReturning(refreshedWithoutId);
-
-        final result = await authorizationInterceptors.requestTokenRefresh();
-
-        expect(result.token, equals(OIDCFixtures.newTokenOidc.token));
-        expect(result.tokenId, equals(OIDCFixtures.tokenOidcExpiredTime.tokenId));
-        expect(
-          authorizationInterceptors.currentOidcIdToken,
-          equals(OIDCFixtures.tokenOidcExpiredTime.tokenId.uuid),
-        );
-        final persisted = verify(tokenOidcCacheManager.persistOneTokenOidc(captureAny))
-            .captured.single as TokenOIDC;
-        expect(persisted.tokenId, equals(OIDCFixtures.tokenOidcExpiredTime.tokenId));
-      },
-    );
-
-    test(
-      'GIVEN the refresh response carries a new id_token\n'
-      'THEN the new id token replaces the current one',
-      () async {
-        stubRefreshReturning(OIDCFixtures.newTokenOidc);
-
-        final result = await authorizationInterceptors.requestTokenRefresh();
-
-        expect(result.tokenId, equals(OIDCFixtures.newTokenOidc.tokenId));
-        expect(
-          authorizationInterceptors.currentOidcIdToken,
-          equals(OIDCFixtures.newTokenOidc.tokenId.uuid),
-        );
-      },
-    );
-  });
-
-  // ============================================================
   // onError: retry fails (separate Dio error handling)
   // ============================================================
   group('onError: retry fails (separate Dio error handling)', () {
@@ -2097,7 +2033,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         stubAccountCache();
 
@@ -2112,7 +2048,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).called(1);
       },
     );
@@ -2161,7 +2097,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         stubAccountCache();
 
@@ -2253,7 +2189,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         stubAccountCache();
 
@@ -2298,7 +2234,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcNotExpiredYet.refreshToken,
+          OIDCFixtures.tokenOidcNotExpiredYet,
         )).thenAnswer((_) async {
           refreshCallCount++;
           return OIDCFixtures.tokenOidcNotExpiredYet; // same token → duplicate
@@ -2333,7 +2269,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcNotExpiredYet.refreshToken,
+          OIDCFixtures.tokenOidcNotExpiredYet,
         )).thenAnswer((_) async => OIDCFixtures.tokenOidcNotExpiredYet);
 
         await expectLater(
@@ -2384,7 +2320,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenThrow(refreshTimeoutError);
 
         await expectLater(
@@ -2418,7 +2354,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcNotExpiredYet.refreshToken,
+          OIDCFixtures.tokenOidcNotExpiredYet,
         )).thenThrow(refreshTimeoutError);
 
         await expectLater(
@@ -2472,7 +2408,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         stubAccountCache();
 
@@ -2528,7 +2464,7 @@ void main() {
             OIDCFixtures.oidcConfiguration.redirectUrl,
             OIDCFixtures.oidcConfiguration.discoveryUrl,
             OIDCFixtures.oidcConfiguration.scopes,
-            OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+            OIDCFixtures.tokenOidcExpiredTime,
           )).thenThrow(platformNetworkException);
 
           await expectLater(
@@ -2566,7 +2502,7 @@ void main() {
             OIDCFixtures.oidcConfiguration.redirectUrl,
             OIDCFixtures.oidcConfiguration.discoveryUrl,
             OIDCFixtures.oidcConfiguration.scopes,
-            OIDCFixtures.tokenOidcNotExpiredYet.refreshToken,
+            OIDCFixtures.tokenOidcNotExpiredYet,
           )).thenThrow(platformNetworkException);
 
           await expectLater(
@@ -2604,7 +2540,7 @@ void main() {
             OIDCFixtures.oidcConfiguration.redirectUrl,
             OIDCFixtures.oidcConfiguration.discoveryUrl,
             OIDCFixtures.oidcConfiguration.scopes,
-            OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+            OIDCFixtures.tokenOidcExpiredTime,
           )).thenThrow(PlatformException(
             code: 'network_error',
             message: 'Failed to connect to token endpoint',
@@ -2645,7 +2581,7 @@ void main() {
             OIDCFixtures.oidcConfiguration.redirectUrl,
             OIDCFixtures.oidcConfiguration.discoveryUrl,
             OIDCFixtures.oidcConfiguration.scopes,
-            OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+            OIDCFixtures.tokenOidcExpiredTime,
           )).thenThrow(const OAuthAuthorizationError(
             error: 'invalid_grant',
             errorDescription: 'The refresh token has been revoked',
@@ -2712,7 +2648,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         stubAccountCache();
 
@@ -2728,7 +2664,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).called(1);
 
         for (final response in responses) {
@@ -2777,7 +2713,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenThrow(refreshTimeoutError);
         stubAccountCache();
 
@@ -2835,7 +2771,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenThrow(PlatformException(
           code: 'network_error',
           message: 'Failed to connect to token endpoint',
@@ -2897,7 +2833,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenThrow(dioErrorRefresh400);
         stubAccountCache();
 
@@ -2980,7 +2916,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         stubAccountCache();
 
@@ -3009,7 +2945,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).called(1);
       },
     );
@@ -3060,7 +2996,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         ));
       },
     );
@@ -3090,7 +3026,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         when(accountCacheManager.getCurrentAccount())
             .thenAnswer((_) async => AccountFixtures.aliceAccount);
@@ -3133,7 +3069,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         stubAccountCache();
         final expectedPersonalAccount = PersonalAccount(
@@ -3207,7 +3143,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         stubAccountCache();
 
@@ -3259,7 +3195,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         stubAccountCache();
 
@@ -3341,7 +3277,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         ));
       },
     );
@@ -3409,7 +3345,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         stubAccountCache();
 
@@ -3421,7 +3357,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).called(1);
       },
     );
@@ -3913,7 +3849,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         stubAccountCache();
 
@@ -3969,7 +3905,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         stubAccountCache();
 
@@ -4071,7 +4007,7 @@ void main() {
           OIDCFixtures.oidcConfiguration.redirectUrl,
           OIDCFixtures.oidcConfiguration.discoveryUrl,
           OIDCFixtures.oidcConfiguration.scopes,
-          OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+          OIDCFixtures.tokenOidcExpiredTime,
         )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
         stubAccountCache();
 

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -1748,6 +1748,71 @@ void main() {
   });
 
   // ============================================================
+  // requestTokenRefresh: id_token omitted from the refresh response
+  // ============================================================
+  group('requestTokenRefresh: id_token omitted from the refresh response', () {
+    void stubRefreshReturning(TokenOIDC refreshed) {
+      authorizationInterceptors.setTokenAndAuthorityOidc(
+        newToken: OIDCFixtures.tokenOidcExpiredTime,
+        newConfig: OIDCFixtures.oidcConfiguration,
+      );
+      when(authenticationClient.refreshingTokensOIDC(
+        OIDCFixtures.oidcConfiguration.clientId,
+        OIDCFixtures.oidcConfiguration.redirectUrl,
+        OIDCFixtures.oidcConfiguration.discoveryUrl,
+        OIDCFixtures.oidcConfiguration.scopes,
+        OIDCFixtures.tokenOidcExpiredTime.refreshToken,
+      )).thenAnswer((_) async => refreshed);
+      when(accountCacheManager.getCurrentAccount())
+          .thenAnswer((_) async => AccountFixtures.aliceAccount);
+    }
+
+    test(
+      'GIVEN the refresh response carries no id_token (OIDC Core 12.2)\n'
+      'THEN the current id token is kept on the new token\n'
+      'AND that token is what gets persisted',
+      () async {
+        final refreshedWithoutId = TokenOIDC(
+          OIDCFixtures.newTokenOidc.token,
+          TokenId(''),
+          OIDCFixtures.newTokenOidc.refreshToken,
+          expiredTime: OIDCFixtures.newTokenOidc.expiredTime,
+        );
+        stubRefreshReturning(refreshedWithoutId);
+
+        final result = await authorizationInterceptors.requestTokenRefresh();
+
+        expect(result.token, equals(OIDCFixtures.newTokenOidc.token));
+        expect(result.tokenId, equals(OIDCFixtures.tokenOidcExpiredTime.tokenId));
+        expect(
+          authorizationInterceptors.currentOidcIdToken,
+          equals(OIDCFixtures.tokenOidcExpiredTime.tokenId.uuid),
+        );
+        final persisted = verify((tokenOidcCacheManager as MockTokenOidcCacheManager)
+                .persistOneTokenOidc(captureAny))
+            .captured.single as TokenOIDC;
+        expect(persisted.tokenId, equals(OIDCFixtures.tokenOidcExpiredTime.tokenId));
+      },
+    );
+
+    test(
+      'GIVEN the refresh response carries a new id_token\n'
+      'THEN the new id token replaces the current one',
+      () async {
+        stubRefreshReturning(OIDCFixtures.newTokenOidc);
+
+        final result = await authorizationInterceptors.requestTokenRefresh();
+
+        expect(result.tokenId, equals(OIDCFixtures.newTokenOidc.tokenId));
+        expect(
+          authorizationInterceptors.currentOidcIdToken,
+          equals(OIDCFixtures.newTokenOidc.tokenId.uuid),
+        );
+      },
+    );
+  });
+
+  // ============================================================
   // onError: retry fails (separate Dio error handling)
   // ============================================================
   group('onError: retry fails (separate Dio error handling)', () {

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -4142,6 +4142,50 @@ void main() {
   // adds its own generic event. Failures the handler does NOT classify keep
   // that generic event — it is their only trace.
   // ============================================================
+  // Workplace calls requestTokenRefresh directly, with no onError above it, so
+  // the fatal event has to come from the interceptor rather than the caller.
+  group('requestTokenRefresh: a direct caller gets the fatal event too', () {
+    late CapturingLogHandler logHandler;
+
+    setUp(() {
+      logHandler = CapturingLogHandler();
+      AppLoggerRegistry.instance.registerHandler(logHandler);
+    });
+
+    tearDown(() => AppLoggerRegistry.instance.resetForTesting());
+
+    test(
+      'WHEN a direct refresh is rejected by the token endpoint\n'
+      'THEN exactly ONE error-level event is emitted (will_logout=true)\n'
+      'AND the caller adds none of its own',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+        when(authenticationClient.refreshingTokensOIDC(any, any, any, any, any))
+            .thenThrow(const OAuthAuthorizationError(
+          error: 'invalid_grant',
+          errorDescription: 'The refresh token has been revoked',
+        ));
+
+        await expectLater(
+          authorizationInterceptors.requestTokenRefresh(),
+          throwsA(isA<RefreshTokenFailedException>()),
+        );
+
+        final errorRecords = logHandler.errorRecords;
+        expect(errorRecords.length, 1);
+        expect(errorRecords.single.rawMessage, contains('will_logout=true'));
+        expect(
+          errorRecords.single.extras,
+          containsPair('auth_error_type', 'token_endpoint_oauth_rejected'),
+        );
+        expect(authorizationInterceptors.authenticationType, AuthenticationType.none);
+      },
+    );
+  });
+
   group('onError: mobile refresh failure emits a single Sentry event', () {
     late CapturingLogHandler logHandler;
 

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -4038,7 +4038,7 @@ void main() {
         expect(errorRecords.single.rawMessage, contains('will_logout=true'));
         expect(
           errorRecords.single.rawMessage,
-          contains('_acquireAndPersistNewToken'),
+          contains('logFatalRefreshRejection'),
         );
         expect(
           errorRecords.any((r) => r.rawMessage.contains('onError:Exception')),

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -1934,6 +1934,62 @@ void main() {
         expect(authorizationInterceptors.authenticationType, AuthenticationType.oidc);
       },
     );
+
+    test(
+      'GIVEN a request that 401ed and is awaiting a refresh from its own session\n'
+      'WHEN the user logs out and a new session signs in before that refresh lands\n'
+      'THEN the leftover request fails without a session verdict\n'
+      'SO it cannot force the freshly signed-in session to log out.\n'
+      'KNOWN FAILING: the generation guard throws RefreshTokenFailedException,\n'
+      'which validateUrgentException treats as urgent, so BaseController runs\n'
+      'handleRefreshTokenFailedException on a session that is perfectly healthy.',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+        dioAdapter.onPost(
+          baseUrl,
+          (server) => server.throws(responseStatusCode401, makeDioError401()),
+          headers: {
+            HttpHeaders.authorizationHeader:
+                'Bearer ${OIDCFixtures.tokenOidcExpiredTime.token}',
+          },
+        );
+
+        final gate = Completer<TokenOIDC>();
+        when(authenticationClient.refreshingTokensOIDC(any, any, any, any, any))
+            .thenAnswer((_) => gate.future);
+
+        // The request is now parked inside onError, awaiting the refresh.
+        final leftoverRequest = dio.post(baseUrl).then<Object?>(
+              (_) => null,
+              onError: (Object e) => e,
+            );
+        await pumpEventQueue();
+
+        // The user logs out and someone else signs in on the same interceptor.
+        authorizationInterceptors.clear();
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.newTokenOidc,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+        gate.complete(OIDCFixtures.tokenOidcNotExpiredYet);
+
+        final failure = await leftoverRequest;
+        final surfaced = failure is DioException ? failure.error : failure;
+
+        // Any of these three reaches BaseController.validateUrgentException and
+        // logs the new user out; a stale answer is not a session verdict.
+        expect(surfaced, isNot(isA<RefreshTokenFailedException>()));
+        expect(surfaced, isNot(isA<RefreshTokenDuplicatedException>()));
+        expect(surfaced, isNot(isA<BadCredentialsException>()));
+
+        // The new session must be untouched by the old request's failure.
+        expect(authorizationInterceptors.authenticationType, AuthenticationType.oidc);
+        expect(authorizationInterceptors.currentToken, OIDCFixtures.newTokenOidc);
+      },
+    );
   });
 
   // ============================================================

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -46,9 +46,9 @@ import 'authorization_interceptor_test.mocks.dart';
 void main() {
   late Dio dio;
   late DioAdapter dioAdapter;
-  late AuthenticationClientBase authenticationClient;
-  late TokenOidcCacheManager tokenOidcCacheManager;
-  late AccountCacheManager accountCacheManager;
+  late MockAuthenticationClientBase authenticationClient;
+  late MockTokenOidcCacheManager tokenOidcCacheManager;
+  late MockAccountCacheManager accountCacheManager;
   late IOSSharingManager iosSharingManager;
   late AuthorizationInterceptors authorizationInterceptors;
 
@@ -1641,6 +1641,8 @@ void main() {
         // update _token, so second request can't detect the first's attempt).
         // Key assertion: no infinite loop — each request tries once and stops.
         expect(refreshCallCount, 2);
+        verifyNever(tokenOidcCacheManager.persistOneTokenOidc(any));
+        verifyNever(accountCacheManager.setCurrentAccount(any));
       },
     );
   });
@@ -1788,8 +1790,7 @@ void main() {
           authorizationInterceptors.currentOidcIdToken,
           equals(OIDCFixtures.tokenOidcExpiredTime.tokenId.uuid),
         );
-        final persisted = verify((tokenOidcCacheManager as MockTokenOidcCacheManager)
-                .persistOneTokenOidc(captureAny))
+        final persisted = verify(tokenOidcCacheManager.persistOneTokenOidc(captureAny))
             .captured.single as TokenOIDC;
         expect(persisted.tokenId, equals(OIDCFixtures.tokenOidcExpiredTime.tokenId));
       },
@@ -2069,6 +2070,42 @@ void main() {
         );
 
         expect(refreshCallCount, 1);
+        verifyNever(tokenOidcCacheManager.persistOneTokenOidc(any));
+        verifyNever(accountCacheManager.setCurrentAccount(any));
+      },
+    );
+
+    test(
+      'GIVEN a direct requestTokenRefresh caller\n'
+      'WHEN refresh returns the current token\n'
+      'THEN RefreshTokenDuplicatedException is thrown before anything is persisted\n'
+      'AND the next call refreshes again (in-flight slot released)',
+      () async {
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcNotExpiredYet,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+        when(authenticationClient.refreshingTokensOIDC(
+          OIDCFixtures.oidcConfiguration.clientId,
+          OIDCFixtures.oidcConfiguration.redirectUrl,
+          OIDCFixtures.oidcConfiguration.discoveryUrl,
+          OIDCFixtures.oidcConfiguration.scopes,
+          OIDCFixtures.tokenOidcNotExpiredYet.refreshToken,
+        )).thenAnswer((_) async => OIDCFixtures.tokenOidcNotExpiredYet);
+
+        await expectLater(
+          authorizationInterceptors.requestTokenRefresh(),
+          throwsA(isA<RefreshTokenDuplicatedException>()),
+        );
+        await expectLater(
+          authorizationInterceptors.requestTokenRefresh(),
+          throwsA(isA<RefreshTokenDuplicatedException>()),
+        );
+
+        verify(authenticationClient.refreshingTokensOIDC(any, any, any, any, any)).called(2);
+        verifyNever(tokenOidcCacheManager.persistOneTokenOidc(any));
+        verifyNever(accountCacheManager.setCurrentAccount(any));
+        expect(authorizationInterceptors.authenticationType, AuthenticationType.oidc);
       },
     );
   });

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -1925,6 +1925,33 @@ void main() {
     );
 
     test(
+      'GIVEN a refresh whose new token already arrived\n'
+      'WHEN the session is cleared while the account cache is being read\n'
+      'THEN nothing is written back into the caches logout just wiped\n'
+      'SO the next launch cannot restore the account the user logged out of',
+      () async {
+        final accountGate = Completer<PersonalAccount>();
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+        when(authenticationClient.refreshingTokensOIDC(any, any, any, any, any))
+            .thenAnswer((_) async => OIDCFixtures.tokenOidcNotExpiredYet);
+        when(accountCacheManager.getCurrentAccount())
+            .thenAnswer((_) => accountGate.future);
+
+        final pending = authorizationInterceptors.requestTokenRefresh();
+        await pumpEventQueue();
+        authorizationInterceptors.clear();
+        accountGate.complete(AccountFixtures.aliceAccount);
+
+        await expectLater(pending, throwsA(isA<StaleSessionRefreshException>()));
+        verifyNever(tokenOidcCacheManager.persistOneTokenOidc(any));
+        verifyNever(accountCacheManager.setCurrentAccount(any));
+      },
+    );
+
+    test(
       'GIVEN a refresh in flight\n'
       'WHEN the session is cleared and a new one signs in\n'
       'THEN the next caller starts its own refresh instead of joining the dead one\n'

--- a/test/features/interceptor/authorization_interceptor_test.dart
+++ b/test/features/interceptor/authorization_interceptor_test.dart
@@ -1810,10 +1810,7 @@ void main() {
       'WHEN a second caller (e.g. Workplace, whose 401 arrived moments later)\n'
       '    calls requestTokenRefresh on the now-empty session\n'
       'THEN it fails with RefreshTokenFailedException, not a raw TypeError\n'
-      'SO the Drive failure can be classified urgent and routed to logout.\n'
-      'KNOWN FAILING: clear() nulls _configOIDC, and _invokeRefreshTokenFromServer\n'
-      'dereferences _configOIDC! — the caller currently gets a TypeError, which is\n'
-      'an Error not an Exception, so it falls through to a generic toast.',
+      'SO the Drive failure can be classified urgent and routed to logout',
       () async {
         stubRefreshThrowing(const OAuthAuthorizationError(
           error: 'invalid_grant',
@@ -1832,6 +1829,68 @@ void main() {
           authorizationInterceptors.requestTokenRefresh(),
           throwsA(isA<RefreshTokenFailedException>()),
         );
+      },
+    );
+
+    test(
+      'GIVEN a refresh in flight\n'
+      'WHEN the session is cleared before it resolves\n'
+      'THEN the token is dropped instead of re-arming a logged-out interceptor\n'
+      'AND nothing is persisted over the wiped caches',
+      () async {
+        final gate = Completer<TokenOIDC>();
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+        when(authenticationClient.refreshingTokensOIDC(any, any, any, any, any))
+            .thenAnswer((_) => gate.future);
+
+        final pending = authorizationInterceptors.requestTokenRefresh();
+        authorizationInterceptors.clear();
+        gate.complete(OIDCFixtures.tokenOidcNotExpiredYet);
+
+        await expectLater(pending, throwsA(isA<RefreshTokenFailedException>()));
+        expect(authorizationInterceptors.currentToken, isNull);
+        expect(authorizationInterceptors.authenticationType, AuthenticationType.none);
+        verifyNever(tokenOidcCacheManager.persistOneTokenOidc(any));
+        verifyNever(accountCacheManager.setCurrentAccount(any));
+      },
+    );
+
+    test(
+      'GIVEN a refresh in flight\n'
+      'WHEN the session is cleared and a new one signs in\n'
+      'THEN the next caller starts its own refresh instead of joining the dead one\n'
+      'AND the stale result does not kill the new session',
+      () async {
+        final gate = Completer<TokenOIDC>();
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+        when(authenticationClient.refreshingTokensOIDC(any, any, any, any, any))
+            .thenAnswer((_) => gate.future);
+
+        final stale = authorizationInterceptors.requestTokenRefresh();
+        authorizationInterceptors.clear();
+
+        authorizationInterceptors.setTokenAndAuthorityOidc(
+          newToken: OIDCFixtures.tokenOidcExpiredTime,
+          newConfig: OIDCFixtures.oidcConfiguration,
+        );
+        when(authenticationClient.refreshingTokensOIDC(any, any, any, any, any))
+            .thenAnswer((_) async => OIDCFixtures.tokenOidcNotExpiredYet);
+        when(accountCacheManager.getCurrentAccount())
+            .thenAnswer((_) async => AccountFixtures.aliceAccount);
+
+        final fresh = authorizationInterceptors.requestTokenRefresh();
+        gate.complete(OIDCFixtures.tokenOidcNotExpiredYet);
+
+        await expectLater(stale, throwsA(isA<RefreshTokenFailedException>()));
+        expect(await fresh, OIDCFixtures.tokenOidcNotExpiredYet);
+        verify(authenticationClient.refreshingTokensOIDC(any, any, any, any, any)).called(2);
+        expect(authorizationInterceptors.authenticationType, AuthenticationType.oidc);
       },
     );
   });

--- a/test/features/interceptor/authorization_interceptor_upload_retry_test.dart
+++ b/test/features/interceptor/authorization_interceptor_upload_retry_test.dart
@@ -151,7 +151,7 @@ void main() {
       OIDCFixtures.oidcConfiguration.redirectUrl,
       OIDCFixtures.oidcConfiguration.discoveryUrl,
       OIDCFixtures.oidcConfiguration.scopes,
-      OIDCFixtures.tokenOidcNotExpiredYet.refreshToken,
+      OIDCFixtures.tokenOidcNotExpiredYet,
     )).thenAnswer((_) async => OIDCFixtures.newTokenOidc);
     when(accountCacheManager.getCurrentAccount())
         .thenAnswer((_) async => AccountFixtures.aliceAccount);
@@ -221,7 +221,7 @@ void main() {
       OIDCFixtures.oidcConfiguration.redirectUrl,
       OIDCFixtures.oidcConfiguration.discoveryUrl,
       OIDCFixtures.oidcConfiguration.scopes,
-      OIDCFixtures.tokenOidcNotExpiredYet.refreshToken,
+      OIDCFixtures.tokenOidcNotExpiredYet,
     )).called(1);
   }
 

--- a/test/features/login/data/extensions/token_response_extension_test.dart
+++ b/test/features/login/data/extensions/token_response_extension_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_appauth/flutter_appauth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:model/model.dart';
+import 'package:tmail_ui_user/features/login/data/extensions/token_response_extension.dart';
+
+void main() {
+  final currentToken = TokenOIDC(
+    'current-access-token',
+    TokenId('current-id-token'),
+    'current-refresh-token',
+    expiredTime: DateTime(2026, 1, 1),
+  );
+
+  TokenResponse response({
+    String? accessToken = 'new-access-token',
+    String? refreshToken,
+    String? idToken,
+  }) {
+    return TokenResponse(
+      accessToken,
+      refreshToken,
+      DateTime(2026, 6, 1),
+      idToken,
+      'Bearer',
+      const <String>['openid'],
+      const <String, dynamic>{},
+    );
+  }
+
+  // A refresh response may omit id_token (OIDC Core 12.2). Every shape the two
+  // plugins can produce for an absent field must fall back to the current one.
+  group('toTokenOIDC::id_token fallback', () {
+    test('keeps the current id token when the response omits it (null)', () {
+      final result = response().toTokenOIDC(currentToken: currentToken);
+
+      expect(result.tokenId, currentToken.tokenId);
+    });
+
+    test('keeps the current id token when the response carries an empty string', () {
+      final result = response(idToken: '').toTokenOIDC(currentToken: currentToken);
+
+      expect(result.tokenId, currentToken.tokenId);
+    });
+
+    // flutter_appauth_web builds id_token with jsonResponse["id_token"].toString()
+    // and no null guard, so an absent id_token arrives as the 4-char string
+    // "null" — not '' and not null:
+    // https://github.com/linagora/flutter_appauth_web/blob/0952346bf781bd87b93b8c61619f81a264be52db/lib/flutter_appauth_web.dart#L179
+    // KNOWN FAILING: _orCurrent tests isNotEmpty, and "null" is not empty, so the
+    // sentinel is stored as the id token. tokenIdHash then keys the token cache
+    // by hash("null") and currentOidcIdToken hands "null" to the Drive exchange.
+    test('keeps the current id token when the web plugin yields the "null" sentinel', () {
+      final result = response(idToken: 'null').toTokenOIDC(currentToken: currentToken);
+
+      expect(result.tokenId, currentToken.tokenId);
+    });
+
+    test('takes the new id token when the response carries one', () {
+      final result =
+          response(idToken: 'new-id-token').toTokenOIDC(currentToken: currentToken);
+
+      expect(result.tokenId, TokenId('new-id-token'));
+    });
+  });
+
+  // Locks the semantics master had as `refreshToken ?? maybeAvailableRefreshToken`.
+  // Both call sites passed a non-nullable String, so only null ever fell back.
+  group('toTokenOIDC::refresh_token keeps the pre-existing semantics', () {
+    test('keeps the current refresh token when the response omits it (null)', () {
+      final result = response().toTokenOIDC(currentToken: currentToken);
+
+      expect(result.refreshToken, currentToken.refreshToken);
+    });
+
+    // KNOWN FAILING: _orCurrent widened the fallback to empty strings, which
+    // master never did. Neither plugin can produce '' here — web guards null
+    // explicitly (flutter_appauth_web.dart:177) and mobile passes the native
+    // map value through (method_channel_flutter_appauth.dart:66) — so the
+    // widening only changes semantics, never behaviour.
+    test('keeps an empty refresh token as-is, the way master did', () {
+      final result = response(refreshToken: '').toTokenOIDC(currentToken: currentToken);
+
+      expect(result.refreshToken, '');
+    });
+
+    test('takes the new refresh token when the response carries one', () {
+      final result = response(refreshToken: 'new-refresh-token')
+          .toTokenOIDC(currentToken: currentToken);
+
+      expect(result.refreshToken, 'new-refresh-token');
+    });
+  });
+
+  group('toTokenOIDC::access token and expiry', () {
+    test('takes the new access token and expiry from the response', () {
+      final result = response().toTokenOIDC(currentToken: currentToken);
+
+      expect(result.token, 'new-access-token');
+      expect(result.expiredTime, DateTime(2026, 6, 1));
+    });
+
+    // Empty access token fails isTokenValid(), which the client turns into
+    // AccessTokenInvalidException — the current token must NOT paper over it.
+    test('does not fall back to the current access token when the response omits it', () {
+      final result = response(accessToken: null).toTokenOIDC(currentToken: currentToken);
+
+      expect(result.token, '');
+    });
+  });
+}

--- a/test/features/login/data/extensions/token_response_extension_test.dart
+++ b/test/features/login/data/extensions/token_response_extension_test.dart
@@ -46,9 +46,8 @@ void main() {
     // and no null guard, so an absent id_token arrives as the 4-char string
     // "null" — not '' and not null:
     // https://github.com/linagora/flutter_appauth_web/blob/0952346bf781bd87b93b8c61619f81a264be52db/lib/flutter_appauth_web.dart#L179
-    // KNOWN FAILING: _orCurrent tests isNotEmpty, and "null" is not empty, so the
-    // sentinel is stored as the id token. tokenIdHash then keys the token cache
-    // by hash("null") and currentOidcIdToken hands "null" to the Drive exchange.
+    // Storing the sentinel would key the token cache by hash("null") and hand
+    // "null" to the Drive exchange through currentOidcIdToken.
     test('keeps the current id token when the web plugin yields the "null" sentinel', () {
       final result = response(idToken: 'null').toTokenOIDC(currentToken: currentToken);
 
@@ -72,11 +71,9 @@ void main() {
       expect(result.refreshToken, currentToken.refreshToken);
     });
 
-    // KNOWN FAILING: _orCurrent widened the fallback to empty strings, which
-    // master never did. Neither plugin can produce '' here — web guards null
+    // Only null falls back. Neither plugin can produce '' here — web guards null
     // explicitly (flutter_appauth_web.dart:177) and mobile passes the native
-    // map value through (method_channel_flutter_appauth.dart:66) — so the
-    // widening only changes semantics, never behaviour.
+    // map value through (method_channel_flutter_appauth.dart:66).
     test('keeps an empty refresh token as-is, the way master did', () {
       final result = response(refreshToken: '').toTokenOIDC(currentToken: currentToken);
 

--- a/test/features/login/data/network/authentication_client/authentication_client_mobile_test.dart
+++ b/test/features/login/data/network/authentication_client/authentication_client_mobile_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_appauth/flutter_appauth.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:model/oidc/token_id.dart';
+import 'package:model/oidc/token_oidc.dart';
 import 'package:tmail_ui_user/features/login/data/network/authentication_client/authentication_client_mobile.dart';
 import 'package:tmail_ui_user/features/login/domain/exceptions/oauth_authorization_error.dart';
 
@@ -13,6 +15,21 @@ class _ThrowingAppAuth extends FlutterAppAuth {
   @override
   Future<TokenResponse> token(TokenRequest request) async => throw error;
 }
+
+class _RespondingAppAuth extends FlutterAppAuth {
+  _RespondingAppAuth(this.response);
+
+  final TokenResponse response;
+
+  @override
+  Future<TokenResponse> token(TokenRequest request) async => response;
+}
+
+final _currentToken = TokenOIDC(
+  'the-old-access-token',
+  TokenId('the-current-id-token'),
+  'a-refresh-token',
+);
 
 void main() {
   group('AuthenticationClientMobile::refreshingTokensOIDC', () {
@@ -53,16 +70,58 @@ void main() {
       // neither converted nor re-wrapped on its way out.
       await expectLater(_refresh(client), throwsA(same(pluginException)));
     });
+
+    // OIDC Core 12.2 lets a refresh response omit id_token. Without the fallback
+    // the token fails isTokenValid(), which the classifier reads as a server
+    // rejection — a legal response would log the user out.
+    test('keeps the current id token when the response omits id_token', () async {
+      final client = AuthenticationClientMobile(_RespondingAppAuth(
+        _tokenResponse(accessToken: 'a-new-access-token'),
+      ));
+
+      final refreshed = await _refresh(client);
+
+      expect(refreshed.token, 'a-new-access-token');
+      expect(refreshed.tokenId, _currentToken.tokenId);
+    });
+
+    // Same contract for refresh_token, which the response may also omit.
+    test('keeps the current refresh token when the response omits it', () async {
+      final client = AuthenticationClientMobile(_RespondingAppAuth(
+        _tokenResponse(accessToken: 'a-new-access-token', idToken: 'a-new-id-token'),
+      ));
+
+      final refreshed = await _refresh(client);
+
+      expect(refreshed.tokenId, TokenId('a-new-id-token'));
+      expect(refreshed.refreshToken, _currentToken.refreshToken);
+    });
   });
 }
 
-Future<void> _refresh(AuthenticationClientMobile client) => client
+TokenResponse _tokenResponse({
+  required String accessToken,
+  String? idToken,
+  String? refreshToken,
+}) {
+  return TokenResponse(
+    accessToken,
+    refreshToken,
+    DateTime.now().add(const Duration(hours: 1)),
+    idToken,
+    'Bearer',
+    const <String>['openid'],
+    const <String, dynamic>{},
+  );
+}
+
+Future<TokenOIDC> _refresh(AuthenticationClientMobile client) => client
     .refreshingTokensOIDC(
       'client-id',
       'com.example.app://callback',
       'https://sso.example.com/.well-known/openid-configuration',
       const ['openid', 'profile'],
-      'a-refresh-token',
+      _currentToken,
     );
 
 /// Mirrors the shape the plugin builds from a token-endpoint failure: [error]

--- a/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
+++ b/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
@@ -160,6 +160,7 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
       'WorkplaceComposerAttachmentExtension::_triggerRefreshOIDCToken: '
       'failedIdTokenHash=${failedToken.hashCode} | '
       'refreshedIdTokenHash=${refreshedToken?.hashCode}',
+      webConsoleEnabled: true,
     );
     // The IdP may omit id_token on refresh, in which case the current one is
     // kept — retrying would re-send the token that just 401'd.

--- a/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
+++ b/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
@@ -154,7 +154,14 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
     }
 
     final refreshedToken = await oidcRefreshTrigger!();
-    if (refreshedToken == null) throw failure;
+    logWarning(
+      'WorkplaceComposerAttachmentExtension::_retryAfterRefreshOrThrow: '
+      'failedIdTokenHash=${failedToken.hashCode} | '
+      'refreshedIdTokenHash=${refreshedToken?.hashCode}',
+    );
+    // The IdP may omit id_token on refresh, in which case the current one is
+    // kept — retrying would re-send the token that just 401'd.
+    if (refreshedToken == null || refreshedToken == failedToken) throw failure;
 
     return _exchangeAccessToken(platformUrl, refreshedToken, refreshAttempted: true);
   }

--- a/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
+++ b/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
@@ -3,6 +3,8 @@ import 'package:core/presentation/extensions/composer_toolbar_button_style.dart'
 import 'package:core/presentation/resources/image_paths.dart';
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/utils/app_logger.dart';
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:workplace/data/bridge/cozy_bridge.dart';
@@ -33,6 +35,9 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
   /// Read when the picker opens, so the JMAP capability is always current.
   final ValueGetter<bool> uploadFromUrlSupported;
   final String? Function() oidcTokenGetter;
+
+  /// Triggers the main app's OIDC refresh; returns the refreshed id token.
+  final Future<String?> Function()? oidcRefreshTrigger;
   final num? Function() maxAttachmentSizeBytesGetter;
 
   /// Per-composer: the remainder depends on what that composer already holds.
@@ -50,6 +55,7 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
     required this.workplaceUri,
     required this.uploadFromUrlSupported,
     required this.oidcTokenGetter,
+    this.oidcRefreshTrigger,
     required this.maxAttachmentSizeBytesGetter,
     required this.remainingAttachmentCapacityBytesGetter,
     this.onPickState,
@@ -89,18 +95,34 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
 
   Future<String?> _exchangeAccessToken(
     Uri platformUrl,
+    String oidcToken, {
+    bool refreshAttempted = false,
+  }) async {
+    final result = await _requestAccessToken(platformUrl, oidcToken);
+    return result.fold(
+      (failure) => _retryAfterRefreshOrThrow(
+        platformUrl: platformUrl,
+        failure: failure,
+        refreshAttempted: refreshAttempted,
+      ),
+      (accessToken) => accessToken,
+    );
+  }
+
+  Future<Either<Object, String?>> _requestAccessToken(
+    Uri platformUrl,
     String oidcToken,
   ) async {
     String? accessToken;
+    Object? caughtFailure;
     await for (final either in _exchangeTokenInteractor.execute(
       platformUrl,
       oidcToken,
     )) {
       either.fold(
-        (failure) {
-          // reported by DriveIntentMessageHandlerMixin._failWith, the single funnel.
-          throw failure is FeatureFailure ? failure.exception : WorkplaceExchangeTokenException();
-        },
+        // reported by DriveIntentMessageHandlerMixin._failWith, the single funnel.
+        (failure) => caughtFailure =
+            failure is FeatureFailure ? failure.exception : WorkplaceExchangeTokenException(),
         (success) {
           if (success is ExchangeWorkplaceTokenSuccess) {
             accessToken = success.accessToken;
@@ -108,8 +130,28 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
         },
       );
     }
-    return accessToken;
+    return caughtFailure == null ? Right(accessToken) : Left(caughtFailure!);
   }
+
+  /// Retries once with a refreshed token on a 401 (Workplace's Dio has no
+  /// refresh interceptor of its own).
+  Future<String?> _retryAfterRefreshOrThrow({
+    required Uri platformUrl,
+    required Object failure,
+    required bool refreshAttempted,
+  }) async {
+    if (refreshAttempted || oidcRefreshTrigger == null || !_isUnauthorized(failure)) {
+      throw failure;
+    }
+
+    final refreshedToken = await oidcRefreshTrigger!();
+    if (refreshedToken == null) throw failure;
+
+    return _exchangeAccessToken(platformUrl, refreshedToken, refreshAttempted: true);
+  }
+
+  bool _isUnauthorized(Object failure) =>
+      failure is DioException && failure.response?.statusCode == 401;
 
   Future<WorkplaceIntent> _createIntent(
     Uri platformUrl,

--- a/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
+++ b/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
@@ -143,7 +143,7 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
     required Object failure,
     required bool refreshAttempted,
   }) async {
-    if (refreshAttempted || oidcRefreshTrigger == null || !_isUnauthorized(failure)) {
+    if (refreshAttempted || oidcRefreshTrigger == null || !_isStaleSubjectToken(failure)) {
       throw failure;
     }
 
@@ -166,8 +166,13 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
     return _exchangeAccessToken(platformUrl, refreshedToken, refreshAttempted: true);
   }
 
-  bool _isUnauthorized(Object failure) =>
-      failure is DioException && failure.response?.statusCode == 401;
+  // RFC 8693 says 400 invalid_grant for a bad subject_token; token_exchange has
+  // also been seen answering 401. Both mean the id token needs refreshing.
+  bool _isStaleSubjectToken(Object failure) {
+    if (failure is! DioException) return false;
+    final statusCode = failure.response?.statusCode;
+    return statusCode == 400 || statusCode == 401;
+  }
 
   Future<WorkplaceIntent> _createIntent(
     Uri platformUrl,

--- a/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
+++ b/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
@@ -29,6 +29,9 @@ import 'package:workplace/presentation/widget/drive_attachment_picker_button.dar
 typedef OnDrivePickStateChanged =
     Future<void> Function(String? composerId, DrivePickState state);
 
+/// Triggers the host app's OIDC refresh; returns the refreshed id token.
+typedef OidcRefreshTrigger = Future<String?> Function();
+
 class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
   final ValueListenable<Uri?> workplaceUri;
 
@@ -36,8 +39,7 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
   final ValueGetter<bool> uploadFromUrlSupported;
   final String? Function() oidcTokenGetter;
 
-  /// Triggers the main app's OIDC refresh; returns the refreshed id token.
-  final Future<String?> Function()? oidcRefreshTrigger;
+  final OidcRefreshTrigger oidcRefreshTrigger;
   final num? Function() maxAttachmentSizeBytesGetter;
 
   /// Per-composer: the remainder depends on what that composer already holds.
@@ -55,7 +57,7 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
     required this.workplaceUri,
     required this.uploadFromUrlSupported,
     required this.oidcTokenGetter,
-    this.oidcRefreshTrigger,
+    required this.oidcRefreshTrigger,
     required this.maxAttachmentSizeBytesGetter,
     required this.remainingAttachmentCapacityBytesGetter,
     this.onPickState,
@@ -100,7 +102,7 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
   }) async {
     final result = await _requestAccessToken(platformUrl, oidcToken);
     return result.fold(
-      (failure) => _retryAfterRefreshOrThrow(
+      (failure) => _triggerRefreshOIDCToken(
         platformUrl: platformUrl,
         failedToken: oidcToken,
         failure: failure,
@@ -134,16 +136,16 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
     return caughtFailure == null ? Right(accessToken) : Left(caughtFailure!);
   }
 
-  /// Retries once on a 401 with the current token if another request already
-  /// refreshed it, else with a freshly refreshed one (Workplace's Dio has no
-  /// refresh interceptor of its own).
-  Future<String?> _retryAfterRefreshOrThrow({
+  /// Retries once on a stale-token response with the current token if another
+  /// request already refreshed it, else with a freshly refreshed one
+  /// (Workplace's Dio has no refresh interceptor of its own).
+  Future<String?> _triggerRefreshOIDCToken({
     required Uri platformUrl,
     required String failedToken,
     required Object failure,
     required bool refreshAttempted,
   }) async {
-    if (refreshAttempted || oidcRefreshTrigger == null || !_isStaleSubjectToken(failure)) {
+    if (refreshAttempted || !_isStaleSubjectToken(failure)) {
       throw failure;
     }
 
@@ -153,9 +155,9 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
       return _exchangeAccessToken(platformUrl, currentToken, refreshAttempted: true);
     }
 
-    final refreshedToken = await oidcRefreshTrigger!();
+    final refreshedToken = await oidcRefreshTrigger();
     logWarning(
-      'WorkplaceComposerAttachmentExtension::_retryAfterRefreshOrThrow: '
+      'WorkplaceComposerAttachmentExtension::_triggerRefreshOIDCToken: '
       'failedIdTokenHash=${failedToken.hashCode} | '
       'refreshedIdTokenHash=${refreshedToken?.hashCode}',
     );

--- a/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
+++ b/workplace/lib/presentation/extension/workplace_composer_attachment_extension.dart
@@ -102,6 +102,7 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
     return result.fold(
       (failure) => _retryAfterRefreshOrThrow(
         platformUrl: platformUrl,
+        failedToken: oidcToken,
         failure: failure,
         refreshAttempted: refreshAttempted,
       ),
@@ -133,15 +134,23 @@ class WorkplaceComposerAttachmentExtension implements ComposerAttachmentPlugin {
     return caughtFailure == null ? Right(accessToken) : Left(caughtFailure!);
   }
 
-  /// Retries once with a refreshed token on a 401 (Workplace's Dio has no
+  /// Retries once on a 401 with the current token if another request already
+  /// refreshed it, else with a freshly refreshed one (Workplace's Dio has no
   /// refresh interceptor of its own).
   Future<String?> _retryAfterRefreshOrThrow({
     required Uri platformUrl,
+    required String failedToken,
     required Object failure,
     required bool refreshAttempted,
   }) async {
     if (refreshAttempted || oidcRefreshTrigger == null || !_isUnauthorized(failure)) {
       throw failure;
+    }
+
+    // Mirrors AuthorizationInterceptors.validateToRetryTheRequestWithNewToken.
+    final currentToken = oidcTokenGetter();
+    if (currentToken != null && currentToken != failedToken) {
+      return _exchangeAccessToken(platformUrl, currentToken, refreshAttempted: true);
     }
 
     final refreshedToken = await oidcRefreshTrigger!();

--- a/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
+++ b/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
@@ -29,11 +29,13 @@ class _Fail401 {
 
 const _fail401 = _Fail401();
 
-// Returns responses from a pre-defined queue, one per HTTP request.
+// Returns responses from a pre-defined queue, one per HTTP request, and
+// records each request body so a test can assert on the outgoing JSON.
 // Queue items are a Map (returned as JSON), _Fail (network error, no
 // response), or _Fail401 (401 response, e.g. a stale OIDC id token).
 class _SequentialAdapter implements HttpClientAdapter {
   final List<dynamic> _queue;
+  final List<dynamic> capturedBodies = [];
   int _index = 0;
 
   _SequentialAdapter(this._queue);
@@ -44,6 +46,7 @@ class _SequentialAdapter implements HttpClientAdapter {
     Stream<Uint8List>? requestStream,
     Future? cancelFuture,
   ) async {
+    capturedBodies.add(options.data);
     final item = _queue[_index++];
     if (item is _Fail) {
       throw DioException(requestOptions: options, message: 'Network error');
@@ -55,36 +58,6 @@ class _SequentialAdapter implements HttpClientAdapter {
         type: DioExceptionType.badResponse,
       );
     }
-    return ResponseBody.fromString(
-      jsonEncode(item),
-      200,
-      headers: {
-        Headers.contentTypeHeader: ['application/json; charset=utf-8'],
-      },
-    );
-  }
-
-  @override
-  void close({bool force = false}) {}
-}
-
-// Returns queued responses like _SequentialAdapter, but also records each
-// request body so a test can assert on the outgoing JSON shape.
-class _CapturingAdapter implements HttpClientAdapter {
-  final List<dynamic> _queue;
-  final List<dynamic> capturedBodies = [];
-  int _index = 0;
-
-  _CapturingAdapter(this._queue);
-
-  @override
-  Future<ResponseBody> fetch(
-    RequestOptions options,
-    Stream<Uint8List>? requestStream,
-    Future? cancelFuture,
-  ) async {
-    capturedBodies.add(options.data);
-    final item = _queue[_index++];
     return ResponseBody.fromString(
       jsonEncode(item),
       200,
@@ -557,7 +530,7 @@ void main() {
     });
 
     testWidgets('forwards downloadLink maxFileSize/availableSize from filePickerConfig into the request', (tester) async {
-      final adapter = _CapturingAdapter([_tokenResponse, _intentResponse]);
+      final adapter = _SequentialAdapter([_tokenResponse, _intentResponse]);
       WorkplaceDio.setInstance(Dio()..httpClientAdapter = adapter);
 
       final notifier = ValueNotifier<Uri?>(_platformUri);
@@ -588,14 +561,12 @@ void main() {
     });
 
     testWidgets('retries once via oidcRefreshTrigger after a 401, then succeeds', (tester) async {
-      WorkplaceDio.setInstance(
-        Dio()
-          ..httpClientAdapter = _SequentialAdapter([
-            _fail401, // stale token exchange → 401
-            _tokenResponse, // retry with refreshed token → succeeds
-            _intentResponse,
-          ]),
-      );
+      final adapter = _SequentialAdapter([
+        _fail401, // stale token exchange → 401
+        _tokenResponse, // retry with refreshed token → succeeds
+        _intentResponse,
+      ]);
+      WorkplaceDio.setInstance(Dio()..httpClientAdapter = adapter);
 
       var refreshCallCount = 0;
       final notifier = ValueNotifier<Uri?>(_platformUri);
@@ -621,6 +592,8 @@ void main() {
       expect(refreshCallCount, equals(1));
       expect(result, isNotNull);
       expect(result!.intentId, equals('intent-xyz'));
+      expect(adapter.capturedBodies[0]['id_token'], equals('oidc-token'));
+      expect(adapter.capturedBodies[1]['id_token'], equals('refreshed-oidc-token'));
     });
 
     testWidgets('does not retry twice when the refreshed token also gets a 401', (tester) async {
@@ -657,17 +630,15 @@ void main() {
       expect(refreshCallCount, equals(1));
     });
     testWidgets('reuses the already-refreshed token when a second 401 arrives late, with one refresh', (tester) async {
-      WorkplaceDio.setInstance(
-        Dio()
-          ..httpClientAdapter = _SequentialAdapter([
-            _fail401, // A: old token → 401
-            _tokenResponse, // A: retry with refreshed token
-            _intentResponse,
-            _fail401, // B: still sent the old token → 401
-            _tokenResponse, // B: retry with current token, no refresh
-            _intentResponse,
-          ]),
-      );
+      final adapter = _SequentialAdapter([
+        _fail401, // A: old token → 401
+        _tokenResponse, // A: retry with refreshed token
+        _intentResponse,
+        _fail401, // B: still sent the old token → 401
+        _tokenResponse, // B: retry with current token, no refresh
+        _intentResponse,
+      ]);
+      WorkplaceDio.setInstance(Dio()..httpClientAdapter = adapter);
 
       var refreshCallCount = 0;
       var currentToken = 'old-oidc-token';
@@ -696,6 +667,11 @@ void main() {
       expect(refreshCallCount, equals(1));
       expect(resultA?.intentId, equals('intent-xyz'));
       expect(resultB?.intentId, equals('intent-xyz'));
+      // Bodies: [0] A old, [1] A retry, [2] A intent, [3] B old, [4] B retry, [5] B intent.
+      expect(adapter.capturedBodies[0]['id_token'], equals('old-oidc-token'));
+      expect(adapter.capturedBodies[1]['id_token'], equals('refreshed-oidc-token'));
+      expect(adapter.capturedBodies[3]['id_token'], equals('old-oidc-token'));
+      expect(adapter.capturedBodies[4]['id_token'], equals('refreshed-oidc-token'));
     });
   });
 }

--- a/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
+++ b/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
@@ -22,8 +22,16 @@ class _Fail {
 
 const _fail = _Fail();
 
+// Sentinel used by _SequentialAdapter to throw a 401 DioException.
+class _Fail401 {
+  const _Fail401();
+}
+
+const _fail401 = _Fail401();
+
 // Returns responses from a pre-defined queue, one per HTTP request.
-// Queue items are either a Map (returned as JSON) or _Fail (throws DioException).
+// Queue items are a Map (returned as JSON), _Fail (network error, no
+// response), or _Fail401 (401 response, e.g. a stale OIDC id token).
 class _SequentialAdapter implements HttpClientAdapter {
   final List<dynamic> _queue;
   int _index = 0;
@@ -39,6 +47,13 @@ class _SequentialAdapter implements HttpClientAdapter {
     final item = _queue[_index++];
     if (item is _Fail) {
       throw DioException(requestOptions: options, message: 'Network error');
+    }
+    if (item is _Fail401) {
+      throw DioException(
+        requestOptions: options,
+        response: Response(statusCode: 401, requestOptions: options),
+        type: DioExceptionType.badResponse,
+      );
     }
     return ResponseBody.fromString(
       jsonEncode(item),
@@ -127,11 +142,13 @@ WorkplaceComposerAttachmentExtension _makeExtension(
   num? remainingAttachmentCapacityBytes,
   OnDrivePickStateChanged? onPickState,
   ValueGetter<bool>? uploadFromUrlSupported,
+  Future<String?> Function()? oidcRefreshTrigger,
 }) =>
     WorkplaceComposerAttachmentExtension(
       workplaceUri: notifier,
       uploadFromUrlSupported: uploadFromUrlSupported ?? () => true,
       oidcTokenGetter: () => oidcToken,
+      oidcRefreshTrigger: oidcRefreshTrigger,
       maxAttachmentSizeBytesGetter: () => maxAttachmentSizeBytes,
       remainingAttachmentCapacityBytesGetter: (_) => remainingAttachmentCapacityBytes,
       onPickState: onPickState,
@@ -567,6 +584,76 @@ void main() {
       final downloadLink = filePickerData['downloadLink'] as Map<String, dynamic>;
       expect(downloadLink['maxFileSize'], equals(5000));
       expect(downloadLink['availableSize'], equals(5000));
+    });
+
+    testWidgets('retries once via oidcRefreshTrigger after a 401, then succeeds', (tester) async {
+      WorkplaceDio.setInstance(
+        Dio()
+          ..httpClientAdapter = _SequentialAdapter([
+            _fail401, // stale token exchange → 401
+            _tokenResponse, // retry with refreshed token → succeeds
+            _intentResponse,
+          ]),
+      );
+
+      var refreshCallCount = 0;
+      final notifier = ValueNotifier<Uri?>(_platformUri);
+      final ext = _makeExtension(
+        notifier,
+        oidcRefreshTrigger: () async {
+          refreshCallCount++;
+          return 'refreshed-oidc-token';
+        },
+      );
+      final callback = await extractCallback(tester, ext);
+
+      final result = await tester.runAsync(
+        () => callback(
+          filePickerConfig: const WorkplaceFilePickerConfigRequest(
+            sharingLink: WorkplaceActionConfigRequest(label: 'Link'),
+            downloadLink: WorkplaceActionConfigRequest(label: 'Attachment'),
+            theme: WorkplaceThemeConfigRequest(type: WorkplaceThemeType.light),
+          ),
+        ),
+      );
+
+      expect(refreshCallCount, equals(1));
+      expect(result, isNotNull);
+      expect(result!.intentId, equals('intent-xyz'));
+    });
+
+    testWidgets('does not retry twice when the refreshed token also gets a 401', (tester) async {
+      WorkplaceDio.setInstance(
+        Dio()
+          ..httpClientAdapter = _SequentialAdapter([_fail401, _fail401]),
+      );
+
+      var refreshCallCount = 0;
+      final notifier = ValueNotifier<Uri?>(_platformUri);
+      final ext = _makeExtension(
+        notifier,
+        oidcRefreshTrigger: () async {
+          refreshCallCount++;
+          return 'refreshed-oidc-token';
+        },
+      );
+      final callback = await extractCallback(tester, ext);
+
+      await tester.runAsync(() async {
+        await expectLater(
+          callback(
+            filePickerConfig: const WorkplaceFilePickerConfigRequest(
+              sharingLink: WorkplaceActionConfigRequest(label: 'Link'),
+              downloadLink: WorkplaceActionConfigRequest(label: 'Attachment'),
+              theme: WorkplaceThemeConfigRequest(type: WorkplaceThemeType.light),
+            ),
+          ),
+          throwsA(isA<DioException>()),
+        );
+      });
+
+      // Called once for the first 401, not again after the retry also fails.
+      expect(refreshCallCount, equals(1));
     });
   });
 }

--- a/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
+++ b/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
@@ -629,6 +629,35 @@ void main() {
       // Called once for the first 401, not again after the retry also fails.
       expect(refreshCallCount, equals(1));
     });
+    testWidgets('propagates the oidcRefreshTrigger failure after a 401 with no second exchange', (tester) async {
+      final adapter = _SequentialAdapter([_fail401]);
+      WorkplaceDio.setInstance(Dio()..httpClientAdapter = adapter);
+
+      // Stands in for the app's RefreshTokenFailedException: must reach the
+      // picker failure untouched so the app can route it to logout.
+      final rejection = StateError('refresh rejected by the server');
+      final notifier = ValueNotifier<Uri?>(_platformUri);
+      final ext = _makeExtension(
+        notifier,
+        oidcRefreshTrigger: () async => throw rejection,
+      );
+      final callback = await extractCallback(tester, ext);
+
+      await tester.runAsync(() async {
+        await expectLater(
+          callback(
+            filePickerConfig: const WorkplaceFilePickerConfigRequest(
+              sharingLink: WorkplaceActionConfigRequest(label: 'Link'),
+              downloadLink: WorkplaceActionConfigRequest(label: 'Attachment'),
+              theme: WorkplaceThemeConfigRequest(type: WorkplaceThemeType.light),
+            ),
+          ),
+          throwsA(same(rejection)),
+        );
+      });
+
+      expect(adapter.capturedBodies, hasLength(1));
+    });
     testWidgets('reuses the already-refreshed token when a second 401 arrives late, with one refresh', (tester) async {
       final adapter = _SequentialAdapter([
         _fail401, // A: old token → 401

--- a/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
+++ b/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
@@ -629,6 +629,40 @@ void main() {
       // Called once for the first 401, not again after the retry also fails.
       expect(refreshCallCount, equals(1));
     });
+
+    testWidgets('does not retry when the refresh keeps the id token that just 401ed', (tester) async {
+      final adapter = _SequentialAdapter([_fail401]);
+      WorkplaceDio.setInstance(Dio()..httpClientAdapter = adapter);
+
+      var refreshCallCount = 0;
+      final notifier = ValueNotifier<Uri?>(_platformUri);
+      final ext = _makeExtension(
+        notifier,
+        // The IdP omitted id_token, so the interceptor kept the current one.
+        oidcRefreshTrigger: () async {
+          refreshCallCount++;
+          return 'oidc-token';
+        },
+      );
+      final callback = await extractCallback(tester, ext);
+
+      await tester.runAsync(() async {
+        await expectLater(
+          callback(
+            filePickerConfig: const WorkplaceFilePickerConfigRequest(
+              sharingLink: WorkplaceActionConfigRequest(label: 'Link'),
+              downloadLink: WorkplaceActionConfigRequest(label: 'Attachment'),
+              theme: WorkplaceThemeConfigRequest(type: WorkplaceThemeType.light),
+            ),
+          ),
+          throwsA(isA<DioException>()),
+        );
+      });
+
+      expect(refreshCallCount, equals(1));
+      // No second exchange: the token that just failed is not re-sent.
+      expect(adapter.capturedBodies, hasLength(1));
+    });
     testWidgets('propagates the oidcRefreshTrigger failure after a 401 with no second exchange', (tester) async {
       final adapter = _SequentialAdapter([_fail401]);
       WorkplaceDio.setInstance(Dio()..httpClientAdapter = adapter);

--- a/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
+++ b/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
@@ -138,6 +138,7 @@ final _intentResponse = {
 WorkplaceComposerAttachmentExtension _makeExtension(
   ValueListenable<Uri?> notifier, {
   String? oidcToken = 'oidc-token',
+  String? Function()? oidcTokenGetter,
   num? maxAttachmentSizeBytes,
   num? remainingAttachmentCapacityBytes,
   OnDrivePickStateChanged? onPickState,
@@ -147,7 +148,7 @@ WorkplaceComposerAttachmentExtension _makeExtension(
     WorkplaceComposerAttachmentExtension(
       workplaceUri: notifier,
       uploadFromUrlSupported: uploadFromUrlSupported ?? () => true,
-      oidcTokenGetter: () => oidcToken,
+      oidcTokenGetter: oidcTokenGetter ?? () => oidcToken,
       oidcRefreshTrigger: oidcRefreshTrigger,
       maxAttachmentSizeBytesGetter: () => maxAttachmentSizeBytes,
       remainingAttachmentCapacityBytesGetter: (_) => remainingAttachmentCapacityBytes,
@@ -654,6 +655,47 @@ void main() {
 
       // Called once for the first 401, not again after the retry also fails.
       expect(refreshCallCount, equals(1));
+    });
+    testWidgets('reuses the already-refreshed token when a second 401 arrives late, with one refresh', (tester) async {
+      WorkplaceDio.setInstance(
+        Dio()
+          ..httpClientAdapter = _SequentialAdapter([
+            _fail401, // A: old token → 401
+            _tokenResponse, // A: retry with refreshed token
+            _intentResponse,
+            _fail401, // B: still sent the old token → 401
+            _tokenResponse, // B: retry with current token, no refresh
+            _intentResponse,
+          ]),
+      );
+
+      var refreshCallCount = 0;
+      var currentToken = 'old-oidc-token';
+      var tokenReads = 0;
+      final notifier = ValueNotifier<Uri?>(_platformUri);
+      final ext = _makeExtension(
+        notifier,
+        // Reads 1-2: A start + A retry check; read 3: B start (old); read 4: B retry check.
+        oidcTokenGetter: () => ++tokenReads <= 3 ? 'old-oidc-token' : currentToken,
+        oidcRefreshTrigger: () async {
+          refreshCallCount++;
+          currentToken = 'refreshed-oidc-token';
+          return currentToken;
+        },
+      );
+      final callback = await extractCallback(tester, ext);
+      const config = WorkplaceFilePickerConfigRequest(
+        sharingLink: WorkplaceActionConfigRequest(label: 'Link'),
+        downloadLink: WorkplaceActionConfigRequest(label: 'Attachment'),
+        theme: WorkplaceThemeConfigRequest(type: WorkplaceThemeType.light),
+      );
+
+      final resultA = await tester.runAsync(() => callback(filePickerConfig: config));
+      final resultB = await tester.runAsync(() => callback(filePickerConfig: config));
+
+      expect(refreshCallCount, equals(1));
+      expect(resultA?.intentId, equals('intent-xyz'));
+      expect(resultB?.intentId, equals('intent-xyz'));
     });
   });
 }

--- a/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
+++ b/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
@@ -22,17 +22,20 @@ class _Fail {
 
 const _fail = _Fail();
 
-// Sentinel used by _SequentialAdapter to throw a 401 DioException.
-class _Fail401 {
-  const _Fail401();
+// Sentinel used by _SequentialAdapter to throw a DioException with a status.
+class _FailStatus {
+  final int statusCode;
+
+  const _FailStatus(this.statusCode);
 }
 
-const _fail401 = _Fail401();
+const _fail401 = _FailStatus(401);
+const _fail400 = _FailStatus(400);
 
 // Returns responses from a pre-defined queue, one per HTTP request, and
 // records each request body so a test can assert on the outgoing JSON.
 // Queue items are a Map (returned as JSON), _Fail (network error, no
-// response), or _Fail401 (401 response, e.g. a stale OIDC id token).
+// response), or _FailStatus (a status response, e.g. a stale OIDC id token).
 class _SequentialAdapter implements HttpClientAdapter {
   final List<dynamic> _queue;
   final List<dynamic> capturedBodies = [];
@@ -51,10 +54,10 @@ class _SequentialAdapter implements HttpClientAdapter {
     if (item is _Fail) {
       throw DioException(requestOptions: options, message: 'Network error');
     }
-    if (item is _Fail401) {
+    if (item is _FailStatus) {
       throw DioException(
         requestOptions: options,
-        response: Response(statusCode: 401, requestOptions: options),
+        response: Response(statusCode: item.statusCode, requestOptions: options),
         type: DioExceptionType.badResponse,
       );
     }
@@ -558,6 +561,37 @@ void main() {
       final downloadLink = filePickerData['downloadLink'] as Map<String, dynamic>;
       expect(downloadLink['maxFileSize'], equals(5000));
       expect(downloadLink['availableSize'], equals(5000));
+    });
+
+    testWidgets('retries once via oidcRefreshTrigger after a 400, then succeeds', (tester) async {
+      // RFC 8693's invalid_grant answer for a stale subject_token.
+      final adapter = _SequentialAdapter([_fail400, _tokenResponse, _intentResponse]);
+      WorkplaceDio.setInstance(Dio()..httpClientAdapter = adapter);
+
+      var refreshCallCount = 0;
+      final notifier = ValueNotifier<Uri?>(_platformUri);
+      final ext = _makeExtension(
+        notifier,
+        oidcRefreshTrigger: () async {
+          refreshCallCount++;
+          return 'refreshed-oidc-token';
+        },
+      );
+      final callback = await extractCallback(tester, ext);
+
+      final result = await tester.runAsync(
+        () => callback(
+          filePickerConfig: const WorkplaceFilePickerConfigRequest(
+            sharingLink: WorkplaceActionConfigRequest(label: 'Link'),
+            downloadLink: WorkplaceActionConfigRequest(label: 'Attachment'),
+            theme: WorkplaceThemeConfigRequest(type: WorkplaceThemeType.light),
+          ),
+        ),
+      );
+
+      expect(refreshCallCount, equals(1));
+      expect(result!.intentId, equals('intent-xyz'));
+      expect(adapter.capturedBodies[1]['id_token'], equals('refreshed-oidc-token'));
     });
 
     testWidgets('retries once via oidcRefreshTrigger after a 401, then succeeds', (tester) async {

--- a/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
+++ b/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
@@ -38,10 +38,14 @@ const _fail400 = _FailStatus(400);
 // response), or _FailStatus (a status response, e.g. a stale OIDC id token).
 class _SequentialAdapter implements HttpClientAdapter {
   final List<dynamic> _queue;
+
+  /// Called with each request's queue index before its response is served, so a
+  /// test can move shared state at a named point instead of counting reads.
+  final void Function(int index)? onRequest;
   final List<dynamic> capturedBodies = [];
   int _index = 0;
 
-  _SequentialAdapter(this._queue);
+  _SequentialAdapter(this._queue, {this.onRequest});
 
   @override
   Future<ResponseBody> fetch(
@@ -50,7 +54,9 @@ class _SequentialAdapter implements HttpClientAdapter {
     Future? cancelFuture,
   ) async {
     capturedBodies.add(options.data);
-    final item = _queue[_index++];
+    final index = _index++;
+    onRequest?.call(index);
+    final item = _queue[index];
     if (item is _Fail) {
       throw DioException(requestOptions: options, message: 'Network error');
     }
@@ -110,6 +116,24 @@ final _intentResponse = {
 };
 
 // ── Factory ───────────────────────────────────────────────────────────────────
+
+// Stands in for AuthorizationInterceptors: holds the id token and an explicit
+// flag for whether the caller is still on the one that will get a 401.
+class _FakeOidcTokenSource {
+  static const staleToken = 'old-oidc-token';
+  static const refreshedToken = 'refreshed-oidc-token';
+
+  bool isStale = true;
+  int refreshCount = 0;
+
+  String get currentToken => isStale ? staleToken : refreshedToken;
+
+  Future<String?> refresh() async {
+    refreshCount++;
+    isStale = false;
+    return refreshedToken;
+  }
+}
 
 WorkplaceComposerAttachmentExtension _makeExtension(
   ValueListenable<Uri?> notifier, {
@@ -727,29 +751,29 @@ void main() {
       expect(adapter.capturedBodies, hasLength(1));
     });
     testWidgets('reuses the already-refreshed token when a second 401 arrives late, with one refresh', (tester) async {
-      final adapter = _SequentialAdapter([
-        _fail401, // A: old token → 401
-        _tokenResponse, // A: retry with refreshed token
-        _intentResponse,
-        _fail401, // B: still sent the old token → 401
-        _tokenResponse, // B: retry with current token, no refresh
-        _intentResponse,
-      ]);
+      final source = _FakeOidcTokenSource();
+      final adapter = _SequentialAdapter(
+        [
+          _fail401, // A: stale token → 401
+          _tokenResponse, // A: retry with refreshed token
+          _intentResponse,
+          _fail401, // B: was already in flight with the stale token → 401
+          _tokenResponse, // B: retry with the token A refreshed, no refresh
+          _intentResponse,
+        ],
+        // B's exchange leaves holding the stale token; by the time its 401 comes
+        // back, A's refresh has rotated the source.
+        onRequest: (index) {
+          if (index == 3) source.isStale = false;
+        },
+      );
       WorkplaceDio.setInstance(Dio()..httpClientAdapter = adapter);
 
-      var refreshCallCount = 0;
-      var currentToken = 'old-oidc-token';
-      var tokenReads = 0;
       final notifier = ValueNotifier<Uri?>(_platformUri);
       final ext = _makeExtension(
         notifier,
-        // Reads 1-2: A start + A retry check; read 3: B start (old); read 4: B retry check.
-        oidcTokenGetter: () => ++tokenReads <= 3 ? 'old-oidc-token' : currentToken,
-        oidcRefreshTrigger: () async {
-          refreshCallCount++;
-          currentToken = 'refreshed-oidc-token';
-          return currentToken;
-        },
+        oidcTokenGetter: () => source.currentToken,
+        oidcRefreshTrigger: source.refresh,
       );
       final callback = await extractCallback(tester, ext);
       const config = WorkplaceFilePickerConfigRequest(
@@ -759,16 +783,79 @@ void main() {
       );
 
       final resultA = await tester.runAsync(() => callback(filePickerConfig: config));
+      source.isStale = true; // B started before A's refresh landed.
       final resultB = await tester.runAsync(() => callback(filePickerConfig: config));
 
-      expect(refreshCallCount, equals(1));
+      expect(source.refreshCount, equals(1));
       expect(resultA?.intentId, equals('intent-xyz'));
       expect(resultB?.intentId, equals('intent-xyz'));
-      // Bodies: [0] A old, [1] A retry, [2] A intent, [3] B old, [4] B retry, [5] B intent.
-      expect(adapter.capturedBodies[0]['id_token'], equals('old-oidc-token'));
-      expect(adapter.capturedBodies[1]['id_token'], equals('refreshed-oidc-token'));
-      expect(adapter.capturedBodies[3]['id_token'], equals('old-oidc-token'));
-      expect(adapter.capturedBodies[4]['id_token'], equals('refreshed-oidc-token'));
+      // Bodies: [0] A stale, [1] A retry, [2] A intent, [3] B stale, [4] B retry, [5] B intent.
+      expect(adapter.capturedBodies[0]['id_token'], equals(_FakeOidcTokenSource.staleToken));
+      expect(adapter.capturedBodies[1]['id_token'], equals(_FakeOidcTokenSource.refreshedToken));
+      expect(adapter.capturedBodies[3]['id_token'], equals(_FakeOidcTokenSource.staleToken));
+      expect(adapter.capturedBodies[4]['id_token'], equals(_FakeOidcTokenSource.refreshedToken));
+    });
+
+    testWidgets('never triggers a refresh when the exchange fails without a 4xx response', (tester) async {
+      final adapter = _SequentialAdapter([_fail]);
+      WorkplaceDio.setInstance(Dio()..httpClientAdapter = adapter);
+
+      var refreshCallCount = 0;
+      final notifier = ValueNotifier<Uri?>(_platformUri);
+      final ext = _makeExtension(
+        notifier,
+        oidcRefreshTrigger: () async {
+          refreshCallCount++;
+          return 'refreshed-oidc-token';
+        },
+      );
+      final callback = await extractCallback(tester, ext);
+
+      await tester.runAsync(() async {
+        await expectLater(
+          callback(
+            filePickerConfig: const WorkplaceFilePickerConfigRequest(
+              sharingLink: WorkplaceActionConfigRequest(label: 'Link'),
+              downloadLink: WorkplaceActionConfigRequest(label: 'Attachment'),
+              theme: WorkplaceThemeConfigRequest(type: WorkplaceThemeType.light),
+            ),
+          ),
+          throwsA(isA<DioException>()),
+        );
+      });
+
+      // A network error is not a stale token; refreshing would be pointless.
+      expect(refreshCallCount, equals(0));
+      expect(adapter.capturedBodies, hasLength(1));
+    });
+
+    testWidgets('throws the original 401 when the refresh trigger yields no token', (tester) async {
+      final adapter = _SequentialAdapter([_fail401]);
+      WorkplaceDio.setInstance(Dio()..httpClientAdapter = adapter);
+
+      final notifier = ValueNotifier<Uri?>(_platformUri);
+      final ext = _makeExtension(notifier, oidcRefreshTrigger: () async => null);
+      final callback = await extractCallback(tester, ext);
+
+      await tester.runAsync(() async {
+        await expectLater(
+          callback(
+            filePickerConfig: const WorkplaceFilePickerConfigRequest(
+              sharingLink: WorkplaceActionConfigRequest(label: 'Link'),
+              downloadLink: WorkplaceActionConfigRequest(label: 'Attachment'),
+              theme: WorkplaceThemeConfigRequest(type: WorkplaceThemeType.light),
+            ),
+          ),
+          // Not a StateError from a null access token: the 401 is the real cause.
+          throwsA(isA<DioException>().having(
+            (e) => e.response?.statusCode,
+            'statusCode',
+            401,
+          )),
+        );
+      });
+
+      expect(adapter.capturedBodies, hasLength(1));
     });
   });
 }

--- a/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
+++ b/workplace/test/presentation/extension/workplace_composer_attachment_extension_test.dart
@@ -119,13 +119,13 @@ WorkplaceComposerAttachmentExtension _makeExtension(
   num? remainingAttachmentCapacityBytes,
   OnDrivePickStateChanged? onPickState,
   ValueGetter<bool>? uploadFromUrlSupported,
-  Future<String?> Function()? oidcRefreshTrigger,
+  OidcRefreshTrigger? oidcRefreshTrigger,
 }) =>
     WorkplaceComposerAttachmentExtension(
       workplaceUri: notifier,
       uploadFromUrlSupported: uploadFromUrlSupported ?? () => true,
       oidcTokenGetter: oidcTokenGetter ?? () => oidcToken,
-      oidcRefreshTrigger: oidcRefreshTrigger,
+      oidcRefreshTrigger: oidcRefreshTrigger ?? () async => null,
       maxAttachmentSizeBytesGetter: () => maxAttachmentSizeBytes,
       remainingAttachmentCapacityBytesGetter: (_) => remainingAttachmentCapacityBytes,
       onPickState: onPickState,

--- a/workplace/test/presentation/extension/workplace_composer_attachment_extension_web_test.dart
+++ b/workplace/test/presentation/extension/workplace_composer_attachment_extension_web_test.dart
@@ -93,6 +93,7 @@ WorkplaceComposerAttachmentExtension _makeExtension(ValueListenable<Uri?> notifi
       oidcTokenGetter: () => 'oidc-token',
       maxAttachmentSizeBytesGetter: () => null,
       remainingAttachmentCapacityBytesGetter: (_) => null,
+      oidcRefreshTrigger: () => Future.value(null),
     );
 
 const _filePickerConfig = WorkplaceFilePickerConfigRequest(


### PR DESCRIPTION
## Issue
- Due to workplace (where file picker and other workplace requests are made) does not use the app's common Dio, it does not has access to the refresh token mechanism, hence the exchange token process failing with 401 will forever stuck users in an unauthenticated state, until users trigger other process that require network to jmap.

## Solution

- Expose the refresh token mechanism publicly so other services can trigger it by their own.
- Dedup the refresh token mechanism so concurrent unauthenticated failure does not refresh token multiple times.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workplace attachment requests can refresh authentication and retry once after unauthorized responses.
  * Existing refreshed credentials are reused when available.
  * Token refresh outcomes distinguish duplicate, stale-session, and unavailable-token scenarios.

* **Bug Fixes**
  * Prevented duplicate refreshes during concurrent requests.
  * Improved reliability when attachment and app requests refresh credentials simultaneously.
  * Preserved valid credentials when refresh responses omit token values.
  * Prevented stale refresh results from restoring cleared sessions.
  * Authentication failures now follow consistent recovery handling, including urgent error flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->