### PR TITLE
TF-4805 Fix cannot copy subject

### DIFF
--- a/core/lib/presentation/views/html_viewer/html_content_viewer_on_web_widget.dart
+++ b/core/lib/presentation/views/html_viewer/html_content_viewer_on_web_widget.dart
@@ -5,6 +5,7 @@ import 'dart:math' as math;
 import 'package:core/presentation/constants/constants_ui.dart';
 import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/views/html_viewer/html_iframe_widget.dart';
+import 'package:core/presentation/views/html_viewer/html_selection_sync_bus.dart';
 import 'package:core/presentation/views/shortcut/key_shortcut.dart';
 import 'package:core/presentation/views/tooltip/iframe_tooltip_overlay.dart';
 import 'package:core/utils/app_logger.dart';
@@ -118,11 +119,14 @@ class _HtmlContentViewerOnWebState extends State<HtmlContentViewerOnWeb>
   bool _isLoading = true;
   late double minHeight;
   late final StreamSubscription<html.MessageEvent> _onMessageSubscription;
+  StreamSubscription<void>? _flutterSelectionStartedSubscription;
+  html.IFrameElement? _iframeElement;
   bool _iframeLoaded = false;
   static const String iframeOnLoadMessage = 'iframeHasBeenLoaded';
   static const String onClickHyperLinkName = 'onClickHyperLink';
   static const String onScrollChangedEvent = 'onScrollChanged';
   static const String onScrollEndEvent = 'onScrollEnd';
+  static const String onSelectionChangedEvent = 'onSelectionChanged';
 
   IframeTooltipOverlay? _tooltipOverlay;
 
@@ -139,6 +143,18 @@ class _HtmlContentViewerOnWebState extends State<HtmlContentViewerOnWeb>
     }
     _setUpWeb();
     _onMessageSubscription = html.window.onMessage.listen(_handleMessageEvent);
+    _flutterSelectionStartedSubscription = HtmlSelectionSyncBus
+        .instance.flutterSelectionStarted
+        .listen((_) => _clearIframeSelection());
+  }
+
+  /// Clears this iframe's selection and blurs it to restore top-document focus.
+  void _clearIframeSelection() {
+    html.window.postMessage(
+      json.encode({'view': _createdViewId, 'type': 'toIframe: clearSelection'}),
+      '*',
+    );
+    _iframeElement?.blur();
   }
 
   void _handleMessageEvent(html.MessageEvent event) {
@@ -149,42 +165,56 @@ class _HtmlContentViewerOnWebState extends State<HtmlContentViewerOnWeb>
       if (viewId != _createdViewId) return;
 
       final type = data['type'];
-      if (_isScrollingIsAvailable && _isScrollChangedEventTriggered(type)) {
-        _handleIframeOnScrollChangedListener(data, widget.scrollController!);
-        return;
-      } else if (_isScrollingIsAvailable && _isScrollEndEventTriggered(type)) {
-        _handleIframeOnScrollEndListener(data, widget.scrollController!);
-        return;
-      } else if (_isIframeKeyboardEventTriggered(type)) {
-        _handleOnIFrameKeyboardEvent(data);
-        return;
-      } else if (_isIframeClickEventTriggered(type)) {
-        _handleOnIFrameClickEvent(data);
-        return;
-      } else if (_isIframeLinkHoverEventTriggered(type)) {
-        _handleOnIFrameLinkHoverEvent(data);
-        return;
-      } else if (_isIframeLinkOutEventTriggered(type)) {
-        _handleOnIFrameLinkOutEvent(data);
-        return;
-      }
+      if (_tryHandleImmediateEvent(type, data)) return;
 
       if (data['message'] == iframeOnLoadMessage) {
         _iframeLoaded = true;
       }
       if (!_iframeLoaded) return;
 
-      if (_isHtmlContentHeightEventTriggered(type)) {
-        _handleContentHeightEvent(data['height']);
-      } else if (_isHtmlContentWidthEventTriggered(type)) {
-        _handleContentWidthEvent(data['width']);
-      } else if (_isMailtoLinkEventTriggered(type)) {
-        _handleMailtoLinkEvent(data['url']);
-      } else if (_isHyperLinkEventTriggered(type)) {
-        _handleHyperLinkEvent(data['url']);
-      }
+      _handleLoadedContentEvent(type, data);
     } catch (e) {
       logWarning('$runtimeType::_handleMessageEvent:Exception = $e');
+    }
+  }
+
+  /// Handles events independent of iframe load state; true if [type] matched.
+  bool _tryHandleImmediateEvent(String? type, dynamic data) {
+    final matches = [
+      (
+        _isScrollingIsAvailable && _isScrollChangedEventTriggered(type),
+        () => _handleIframeOnScrollChangedListener(data, widget.scrollController!),
+      ),
+      (
+        _isScrollingIsAvailable && _isScrollEndEventTriggered(type),
+        () => _handleIframeOnScrollEndListener(data, widget.scrollController!),
+      ),
+      (_isIframeKeyboardEventTriggered(type), () => _handleOnIFrameKeyboardEvent(data)),
+      (_isIframeClickEventTriggered(type), () => _handleOnIFrameClickEvent(data)),
+      (_isIframeLinkHoverEventTriggered(type), () => _handleOnIFrameLinkHoverEvent(data)),
+      (_isIframeLinkOutEventTriggered(type), () => _handleOnIFrameLinkOutEvent(data)),
+      (_isSelectionChangedEventTriggered(type), () => _handleOnIFrameSelectionChangedEvent(data)),
+    ];
+
+    for (final (matched, handle) in matches) {
+      if (matched) {
+        handle();
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /// Events that require the iframe content to have finished loading.
+  void _handleLoadedContentEvent(String? type, dynamic data) {
+    if (_isHtmlContentHeightEventTriggered(type)) {
+      _handleContentHeightEvent(data['height']);
+    } else if (_isHtmlContentWidthEventTriggered(type)) {
+      _handleContentWidthEvent(data['width']);
+    } else if (_isMailtoLinkEventTriggered(type)) {
+      _handleMailtoLinkEvent(data['url']);
+    } else if (_isHyperLinkEventTriggered(type)) {
+      _handleHyperLinkEvent(data['url']);
     }
   }
 
@@ -355,6 +385,17 @@ class _HtmlContentViewerOnWebState extends State<HtmlContentViewerOnWeb>
     return type?.contains('toDart: iframeLinkOut') == true;
   }
 
+  bool _isSelectionChangedEventTriggered(String? type) {
+    return type?.contains('toDart: $onSelectionChangedEvent') == true;
+  }
+
+  /// Notifies the sync bus so the Flutter-side selection gets cleared.
+  void _handleOnIFrameSelectionChangedEvent(dynamic data) {
+    if (data['hasSelection'] == true) {
+      HtmlSelectionSyncBus.instance.notifyIframeSelectionStarted();
+    }
+  }
+
   void _handleOnIFrameLinkHoverEvent(dynamic data) {
     try {
       log('$runtimeType::_handleOnIFrameLinkHoverEvent: $data');
@@ -415,6 +456,7 @@ class _HtmlContentViewerOnWebState extends State<HtmlContentViewerOnWeb>
         window.addEventListener('pagehide', (event) => {
           window.parent.removeEventListener('message', handleMessage, false);
           window.removeEventListener('load', handleOnLoad);
+          document.removeEventListener('selectionchange', handleSelectionChange);
           ${!widget.autoAdjustHeight ? '''
             clearTimeout(_resizeDebounceTimer);
             if (typeof resizeObserver !== 'undefined') resizeObserver.disconnect();
@@ -440,9 +482,22 @@ class _HtmlContentViewerOnWebState extends State<HtmlContentViewerOnWeb>
                   document.execCommand(data["command"], false, data["argument"]);
                 }
               }
+              if (data["type"].includes("clearSelection")) {
+                window.getSelection().removeAllRanges();
+              }
             }
           }
         }
+
+        // Reports selection changes to Dart to sync with the Flutter side.
+        var _lastSelectionNonEmpty = false;
+        function handleSelectionChange() {
+          var hasSelection = window.getSelection().toString().length > 0;
+          if (hasSelection === _lastSelectionNonEmpty) return;
+          _lastSelectionNonEmpty = hasSelection;
+          window.parent.postMessage(JSON.stringify({"view": "$_createdViewId", "type": "toDart: $onSelectionChangedEvent", "hasSelection": hasSelection}), "*");
+        }
+        document.addEventListener('selectionchange', handleSelectionChange);
 
         ${!widget.autoAdjustHeight ? '''
           var _lastResizeHeight = 0;
@@ -594,6 +649,7 @@ class _HtmlContentViewerOnWebState extends State<HtmlContentViewerOnWeb>
                   srcdoc: _htmlData,
                   width: _actualWidth.toString(),
                   height: _actualHeight.toString(),
+                  onIframeCreated: (iframe) => _iframeElement = iframe,
                 );
 
                 if (widget.viewMaxHeight != null) {
@@ -643,6 +699,7 @@ class _HtmlContentViewerOnWebState extends State<HtmlContentViewerOnWeb>
   void dispose() {
     _htmlData = null;
     _onMessageSubscription.cancel();
+    _flutterSelectionStartedSubscription?.cancel();
     if (PlatformInfo.isWebDesktop) {
       _tooltipOverlay?.hide();
       _tooltipOverlay = null;

--- a/core/lib/presentation/views/html_viewer/html_selection_sync_bus.dart
+++ b/core/lib/presentation/views/html_viewer/html_selection_sync_bus.dart
@@ -9,6 +9,7 @@ class HtmlSelectionSyncBus {
 
   StreamController<void>? _flutterSelectionStartedController;
   StreamController<void>? _iframeSelectionStartedController;
+  int _refCount = 0;
 
   /// A selection started in the Flutter tree (e.g. the email subject).
   Stream<void> get flutterSelectionStarted =>
@@ -30,9 +31,16 @@ class HtmlSelectionSyncBus {
     _iframeSelectionStartedController?.add(null);
   }
 
-  /// Releases both streams when the email view that owns them closes; the
-  /// next view lazily recreates fresh ones on first subscribe.
-  void dispose() {
+  /// Registers one more consumer of the shared bus.
+  void acquire() {
+    _refCount++;
+  }
+
+  /// Closes both streams once every consumer has released; a no-op otherwise.
+  void release() {
+    if (_refCount > 0) _refCount--;
+    if (_refCount > 0) return;
+
     _flutterSelectionStartedController?.close();
     _iframeSelectionStartedController?.close();
     _flutterSelectionStartedController = null;

--- a/core/lib/presentation/views/html_viewer/html_selection_sync_bus.dart
+++ b/core/lib/presentation/views/html_viewer/html_selection_sync_bus.dart
@@ -1,0 +1,30 @@
+import 'dart:async';
+
+/// Keeps Flutter's own text selection and each email body iframe's native
+/// selection mutually exclusive, so only one is ever active at a time.
+class HtmlSelectionSyncBus {
+  HtmlSelectionSyncBus._();
+
+  static final HtmlSelectionSyncBus instance = HtmlSelectionSyncBus._();
+
+  final StreamController<void> _flutterSelectionStartedController =
+      StreamController<void>.broadcast();
+  final StreamController<void> _iframeSelectionStartedController =
+      StreamController<void>.broadcast();
+
+  /// A selection started in the Flutter tree (e.g. the email subject).
+  Stream<void> get flutterSelectionStarted =>
+      _flutterSelectionStartedController.stream;
+
+  /// A selection started inside an email body iframe.
+  Stream<void> get iframeSelectionStarted =>
+      _iframeSelectionStartedController.stream;
+
+  void notifyFlutterSelectionStarted() {
+    _flutterSelectionStartedController.add(null);
+  }
+
+  void notifyIframeSelectionStarted() {
+    _iframeSelectionStartedController.add(null);
+  }
+}

--- a/core/lib/presentation/views/html_viewer/html_selection_sync_bus.dart
+++ b/core/lib/presentation/views/html_viewer/html_selection_sync_bus.dart
@@ -7,24 +7,35 @@ class HtmlSelectionSyncBus {
 
   static final HtmlSelectionSyncBus instance = HtmlSelectionSyncBus._();
 
-  final StreamController<void> _flutterSelectionStartedController =
-      StreamController<void>.broadcast();
-  final StreamController<void> _iframeSelectionStartedController =
-      StreamController<void>.broadcast();
+  StreamController<void>? _flutterSelectionStartedController;
+  StreamController<void>? _iframeSelectionStartedController;
 
   /// A selection started in the Flutter tree (e.g. the email subject).
   Stream<void> get flutterSelectionStarted =>
-      _flutterSelectionStartedController.stream;
+      (_flutterSelectionStartedController ??=
+              StreamController<void>.broadcast())
+          .stream;
 
   /// A selection started inside an email body iframe.
   Stream<void> get iframeSelectionStarted =>
-      _iframeSelectionStartedController.stream;
+      (_iframeSelectionStartedController ??=
+              StreamController<void>.broadcast())
+          .stream;
 
   void notifyFlutterSelectionStarted() {
-    _flutterSelectionStartedController.add(null);
+    _flutterSelectionStartedController?.add(null);
   }
 
   void notifyIframeSelectionStarted() {
-    _iframeSelectionStartedController.add(null);
+    _iframeSelectionStartedController?.add(null);
+  }
+
+  /// Releases both streams when the email view that owns them closes; the
+  /// next view lazily recreates fresh ones on first subscribe.
+  void dispose() {
+    _flutterSelectionStartedController?.close();
+    _iframeSelectionStartedController?.close();
+    _flutterSelectionStartedController = null;
+    _iframeSelectionStartedController = null;
   }
 }

--- a/core/lib/utils/html/html_utils.dart
+++ b/core/lib/utils/html/html_utils.dart
@@ -446,6 +446,15 @@ class HtmlUtils {
         name: 'registerFileLinkCardClickHandler',
       );
 
+  static const clearEditorFocusAndSelection = (
+    script: '''
+      (() => {
+        const selection = window.getSelection();
+        if (selection) selection.removeAllRanges();
+        document.querySelector(".note-editable")?.blur();
+      })();''',
+    name: 'clearEditorFocusAndSelection');
+
   static const collapseSelectionToEnd = (
     script: '''
       (() => {

--- a/core/test/presentation/views/html_viewer/html_selection_sync_bus_test.dart
+++ b/core/test/presentation/views/html_viewer/html_selection_sync_bus_test.dart
@@ -1,49 +1,59 @@
+import 'dart:async';
+
 import 'package:core/presentation/views/html_viewer/html_selection_sync_bus.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+/// Subscribes to both bus streams, tracking how many events each received.
+class _BothSidesListener {
+  _BothSidesListener(HtmlSelectionSyncBus bus)
+      : _flutterSub = bus.flutterSelectionStarted.listen(null),
+        _iframeSub = bus.iframeSelectionStarted.listen(null) {
+    _flutterSub.onData((_) => flutterCount++);
+    _iframeSub.onData((_) => iframeCount++);
+  }
+
+  final StreamSubscription<void> _flutterSub;
+  final StreamSubscription<void> _iframeSub;
+  int flutterCount = 0;
+  int iframeCount = 0;
+
+  Future<void> cancel() async {
+    await _flutterSub.cancel();
+    await _iframeSub.cancel();
+  }
+}
 
 void main() {
   // Locks the mutual-exclusion contract subject/body selection syncing relies on.
   group('HtmlSelectionSyncBus', () {
+    tearDown(() => HtmlSelectionSyncBus.instance.dispose());
+
     test('instance is a singleton', () {
       expect(HtmlSelectionSyncBus.instance, same(HtmlSelectionSyncBus.instance));
     });
 
     test('notifyFlutterSelectionStarted only fires flutterSelectionStarted', () async {
       final bus = HtmlSelectionSyncBus.instance;
-      final flutterEvents = <void>[];
-      final iframeEvents = <void>[];
-      final subs = [
-        bus.flutterSelectionStarted.listen(flutterEvents.add),
-        bus.iframeSelectionStarted.listen(iframeEvents.add),
-      ];
+      final listener = _BothSidesListener(bus);
 
       bus.notifyFlutterSelectionStarted();
       await Future<void>.delayed(Duration.zero);
 
-      expect(flutterEvents, hasLength(1));
-      expect(iframeEvents, isEmpty);
-      for (final sub in subs) {
-        await sub.cancel();
-      }
+      expect(listener.flutterCount, 1);
+      expect(listener.iframeCount, 0);
+      await listener.cancel();
     });
 
     test('notifyIframeSelectionStarted only fires iframeSelectionStarted', () async {
       final bus = HtmlSelectionSyncBus.instance;
-      final flutterEvents = <void>[];
-      final iframeEvents = <void>[];
-      final subs = [
-        bus.flutterSelectionStarted.listen(flutterEvents.add),
-        bus.iframeSelectionStarted.listen(iframeEvents.add),
-      ];
+      final listener = _BothSidesListener(bus);
 
       bus.notifyIframeSelectionStarted();
       await Future<void>.delayed(Duration.zero);
 
-      expect(iframeEvents, hasLength(1));
-      expect(flutterEvents, isEmpty);
-      for (final sub in subs) {
-        await sub.cancel();
-      }
+      expect(listener.iframeCount, 1);
+      expect(listener.flutterCount, 0);
+      await listener.cancel();
     });
 
     test('broadcasts to every listener', () async {
@@ -63,6 +73,42 @@ void main() {
       for (final sub in subs) {
         await sub.cancel();
       }
+    });
+
+    test('notify* before any listener subscribes is a safe no-op', () {
+      expect(HtmlSelectionSyncBus.instance.notifyFlutterSelectionStarted, returnsNormally);
+      expect(HtmlSelectionSyncBus.instance.notifyIframeSelectionStarted, returnsNormally);
+    });
+
+    test('dispose closes the streams and notify* after dispose is a safe no-op', () async {
+      final bus = HtmlSelectionSyncBus.instance;
+      var doneCount = 0;
+      final sub = bus.flutterSelectionStarted.listen(
+        (_) {},
+        onDone: () => doneCount++,
+      );
+
+      bus.dispose();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(doneCount, 1);
+      expect(bus.notifyFlutterSelectionStarted, returnsNormally);
+      expect(bus.notifyIframeSelectionStarted, returnsNormally);
+      await sub.cancel();
+    });
+
+    test('a fresh stream works again after dispose', () async {
+      final bus = HtmlSelectionSyncBus.instance;
+      bus.dispose();
+
+      final events = <void>[];
+      final sub = bus.iframeSelectionStarted.listen(events.add);
+
+      bus.notifyIframeSelectionStarted();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, hasLength(1));
+      await sub.cancel();
     });
   });
 }

--- a/core/test/presentation/views/html_viewer/html_selection_sync_bus_test.dart
+++ b/core/test/presentation/views/html_viewer/html_selection_sync_bus_test.dart
@@ -26,7 +26,7 @@ class _BothSidesListener {
 void main() {
   // Locks the mutual-exclusion contract subject/body selection syncing relies on.
   group('HtmlSelectionSyncBus', () {
-    tearDown(() => HtmlSelectionSyncBus.instance.dispose());
+    tearDown(() => HtmlSelectionSyncBus.instance.release());
 
     test('instance is a singleton', () {
       expect(HtmlSelectionSyncBus.instance, same(HtmlSelectionSyncBus.instance));
@@ -80,7 +80,7 @@ void main() {
       expect(HtmlSelectionSyncBus.instance.notifyIframeSelectionStarted, returnsNormally);
     });
 
-    test('dispose closes the streams and notify* after dispose is a safe no-op', () async {
+    test('release closes the streams and notify* after release is a safe no-op', () async {
       final bus = HtmlSelectionSyncBus.instance;
       var doneCount = 0;
       final sub = bus.flutterSelectionStarted.listen(
@@ -88,7 +88,7 @@ void main() {
         onDone: () => doneCount++,
       );
 
-      bus.dispose();
+      bus.release();
       await Future<void>.delayed(Duration.zero);
 
       expect(doneCount, 1);
@@ -97,9 +97,9 @@ void main() {
       await sub.cancel();
     });
 
-    test('a fresh stream works again after dispose', () async {
+    test('a fresh stream works again after release', () async {
       final bus = HtmlSelectionSyncBus.instance;
-      bus.dispose();
+      bus.release();
 
       final events = <void>[];
       final sub = bus.iframeSelectionStarted.listen(events.add);
@@ -108,6 +108,26 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       expect(events, hasLength(1));
+      await sub.cancel();
+    });
+
+    test('release is a no-op while another consumer still holds the bus', () async {
+      final bus = HtmlSelectionSyncBus.instance;
+      bus.acquire();
+      bus.acquire();
+      var doneCount = 0;
+      final sub = bus.flutterSelectionStarted.listen(
+        (_) {},
+        onDone: () => doneCount++,
+      );
+
+      bus.release();
+      await Future<void>.delayed(Duration.zero);
+      expect(doneCount, 0, reason: 'stream must stay open for the remaining consumer');
+
+      bus.release();
+      await Future<void>.delayed(Duration.zero);
+      expect(doneCount, 1);
       await sub.cancel();
     });
   });

--- a/core/test/presentation/views/html_viewer/html_selection_sync_bus_test.dart
+++ b/core/test/presentation/views/html_viewer/html_selection_sync_bus_test.dart
@@ -1,0 +1,68 @@
+import 'package:core/presentation/views/html_viewer/html_selection_sync_bus.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // Locks the mutual-exclusion contract subject/body selection syncing relies on.
+  group('HtmlSelectionSyncBus', () {
+    test('instance is a singleton', () {
+      expect(HtmlSelectionSyncBus.instance, same(HtmlSelectionSyncBus.instance));
+    });
+
+    test('notifyFlutterSelectionStarted only fires flutterSelectionStarted', () async {
+      final bus = HtmlSelectionSyncBus.instance;
+      final flutterEvents = <void>[];
+      final iframeEvents = <void>[];
+      final subs = [
+        bus.flutterSelectionStarted.listen(flutterEvents.add),
+        bus.iframeSelectionStarted.listen(iframeEvents.add),
+      ];
+
+      bus.notifyFlutterSelectionStarted();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(flutterEvents, hasLength(1));
+      expect(iframeEvents, isEmpty);
+      for (final sub in subs) {
+        await sub.cancel();
+      }
+    });
+
+    test('notifyIframeSelectionStarted only fires iframeSelectionStarted', () async {
+      final bus = HtmlSelectionSyncBus.instance;
+      final flutterEvents = <void>[];
+      final iframeEvents = <void>[];
+      final subs = [
+        bus.flutterSelectionStarted.listen(flutterEvents.add),
+        bus.iframeSelectionStarted.listen(iframeEvents.add),
+      ];
+
+      bus.notifyIframeSelectionStarted();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(iframeEvents, hasLength(1));
+      expect(flutterEvents, isEmpty);
+      for (final sub in subs) {
+        await sub.cancel();
+      }
+    });
+
+    test('broadcasts to every listener', () async {
+      final bus = HtmlSelectionSyncBus.instance;
+      var firstCount = 0;
+      var secondCount = 0;
+      final subs = [
+        bus.iframeSelectionStarted.listen((_) => firstCount++),
+        bus.iframeSelectionStarted.listen((_) => secondCount++),
+      ];
+
+      bus.notifyIframeSelectionStarted();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(firstCount, 1);
+      expect(secondCount, 1);
+      for (final sub in subs) {
+        await sub.cancel();
+      }
+    });
+  });
+}

--- a/docs/adr/0107-mutual-exclusion-subject-body-selection-web.md
+++ b/docs/adr/0107-mutual-exclusion-subject-body-selection-web.md
@@ -1,0 +1,46 @@
+# 0107. Mutual exclusion between subject and email body selection on web
+
+Date: 2026-09-07
+
+## Status
+
+Accepted
+
+## Context
+
+On web, the email subject is selectable through a single app-wide Flutter
+`SelectionArea`, while the email body is a real `srcdoc` `<iframe>` with its
+own native browser selection and its own `document.activeElement`. The two
+selection systems are invisible to each other. Interacting with the iframe
+— even a plain click, with no selection made there — leaves the top
+document's real focus and the `SelectionArea`'s active-selection state
+stale without clearing its visual highlight, so the native right-click
+"Copy" can show disabled, missing, or targeting the wrong region's text
+depending on browser.
+
+## Decision
+
+- A selection starting in either the Flutter `SelectionArea` or an email
+  body iframe clears the other, so only one selection is ever active.
+- `HtmlSelectionSyncBus` (`core/lib/presentation/views/html_viewer/`)
+  broadcasts `flutterSelectionStarted` and `iframeSelectionStarted` events
+  between the two sides.
+- Each email body iframe listens for `document.selectionchange`; a
+  non-empty selection notifies the bus and a `toIframe: clearSelection`
+  message (removeAllRanges) clears it when the other side reports a
+  selection.
+- The thread detail body's `SelectionArea` reports its own selection
+  changes to the bus and clears itself via `SelectionAreaState.selectableRegion.clearSelection()`
+  through a `GlobalKey` held on `ThreadDetailController`.
+- When a Flutter-side selection starts, each iframe also blurs itself
+  (`IFrameElement.blur()`), returning real DOM focus to the top document
+  regardless of whether the iframe ever held a selection.
+
+## Consequences
+
+- Right-click "Copy" always targets whichever region is actually
+  highlighted, on both Chrome and Firefox.
+- Selecting text in one region now visibly deselects the other, matching
+  standard single-selection browser/webmail behavior.
+- Non-web platforms are unaffected — the bus and iframe hooks are gated
+  behind `PlatformInfo.isWeb`.

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:core/core.dart';
+import 'package:core/presentation/views/html_viewer/html_selection_sync_bus.dart';
 import 'package:custom_pop_up_menu/custom_pop_up_menu.dart';
 import 'package:dartz/dartz.dart';
 import 'package:desktop_drop/desktop_drop.dart';
@@ -248,6 +249,7 @@ class ComposerController extends BaseController
   StreamSubscription<html.Event>? _subscriptionOnDrop;
   StreamSubscription<html.Event>? _subscriptionOnBlur;
   StreamSubscription<String>? _composerCacheListener;
+  StreamSubscription<void>? _flutterSelectionStartedSubscription;
 
   RichTextMobileTabletController? richTextMobileTabletController;
   RichTextWebController? richTextWebController;
@@ -338,6 +340,9 @@ class ComposerController extends BaseController
       responsiveContainerKey = GlobalKey();
       richTextWebController = getBinding<RichTextWebController>(tag: composerId);
       menuMoreOptionController = CustomPopupMenuController();
+      _flutterSelectionStartedSubscription = HtmlSelectionSyncBus
+          .instance.flutterSelectionStarted
+          .listen((_) => handleFlutterSelectionStartedWeb());
     } else {
       richTextMobileTabletController = getBinding<RichTextMobileTabletController>(tag: composerId);
     }
@@ -383,6 +388,7 @@ class ComposerController extends BaseController
     _subscriptionOnDragLeave?.cancel();
     _subscriptionOnDrop?.cancel();
     _subscriptionOnBlur?.cancel();
+    _flutterSelectionStartedSubscription?.cancel();
     subjectEmailInputFocusNode?.removeListener(_subjectEmailInputFocusListener);
     _composerCacheListener?.cancel();
     _beforeReconnectManager.removeListener(onBeforeReconnect);
@@ -2038,7 +2044,24 @@ class ComposerController extends BaseController
     _autoFocusFieldWhenLauncher();
   }
 
+  /// A Flutter-side selection (e.g. the email subject) just started — clear
+  /// this composer's own iframe selection and blur it. In-iframe `.blur()`
+  /// only releases focus inside the editor's own document; the top document
+  /// still sees the `<iframe>` element itself as focused until it is blurred
+  /// from here, so copy/selection keeps targeting the editor otherwise.
+  void handleFlutterSelectionStartedWeb() {
+    final activeElement = html.document.activeElement;
+    if (activeElement is html.IFrameElement) {
+      activeElement.blur();
+    }
+    richTextWebController?.editorController
+        .evaluateJavascriptWeb(HtmlUtils.clearEditorFocusAndSelection.name);
+  }
+
   void handleOnFocusHtmlEditorWeb() {
+    // The composer editor is its own iframe taking real DOM focus, same as
+    // an email body iframe — clear any stale subject selection behind it.
+    HtmlSelectionSyncBus.instance.notifyIframeSelectionStarted();
     // This handler only ever runs because the html editor's own native DOM
     // element just gained focus (wired exclusively to the editor widget's
     // `onFocus` callback), so calling editorController.setFocus() again is

--- a/lib/features/composer/presentation/composer_controller.dart
+++ b/lib/features/composer/presentation/composer_controller.dart
@@ -340,6 +340,7 @@ class ComposerController extends BaseController
       responsiveContainerKey = GlobalKey();
       richTextWebController = getBinding<RichTextWebController>(tag: composerId);
       menuMoreOptionController = CustomPopupMenuController();
+      HtmlSelectionSyncBus.instance.acquire();
       _flutterSelectionStartedSubscription = HtmlSelectionSyncBus
           .instance.flutterSelectionStarted
           .listen((_) => handleFlutterSelectionStartedWeb());
@@ -388,7 +389,10 @@ class ComposerController extends BaseController
     _subscriptionOnDragLeave?.cancel();
     _subscriptionOnDrop?.cancel();
     _subscriptionOnBlur?.cancel();
-    _flutterSelectionStartedSubscription?.cancel();
+    if (PlatformInfo.isWeb) {
+      _flutterSelectionStartedSubscription?.cancel();
+      HtmlSelectionSyncBus.instance.release();
+    }
     subjectEmailInputFocusNode?.removeListener(_subjectEmailInputFocusListener);
     _composerCacheListener?.cancel();
     _beforeReconnectManager.removeListener(onBeforeReconnect);

--- a/lib/features/composer/presentation/widgets/web/initial_scripts/web_editor_selection_script_group.dart
+++ b/lib/features/composer/presentation/widgets/web/initial_scripts/web_editor_selection_script_group.dart
@@ -15,6 +15,7 @@ final class WebEditorSelectionScriptGroup
   List<WebEditorScriptDescriptor> build() => [
     WebEditorScriptDescriptor(script: selectionChangeScript, runOnInit: true),
     adapter.fromHtmlUtils(HtmlUtils.collapseSelectionToEnd),
+    adapter.fromHtmlUtils(HtmlUtils.clearEditorFocusAndSelection),
     adapter.fromHtmlUtils(HtmlUtils.deleteSelectionContent),
     adapter.fromHtmlUtils(HtmlUtils.saveSelection),
     adapter.fromHtmlUtils(HtmlUtils.restoreSelection),

--- a/lib/features/thread_detail/presentation/thread_detail_controller.dart
+++ b/lib/features/thread_detail/presentation/thread_detail_controller.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:core/data/network/download/download_manager.dart';
 import 'package:core/presentation/state/failure.dart';
+import 'package:core/presentation/views/html_viewer/html_selection_sync_bus.dart';
+import 'package:core/utils/platform_info.dart';
 import 'package:dartz/dartz.dart';
 import 'package:debounce_throttle/debounce_throttle.dart';
 import 'package:flutter/material.dart';
@@ -133,6 +135,10 @@ class ThreadDetailController extends BaseController {
   StreamController<MailViewShortcutActionViewEvent>? shortcutActionEventController;
   StreamSubscription<MailViewShortcutActionViewEvent>? shortcutActionEventSubscription;
 
+  /// Clears the body selection when an email body iframe starts its own.
+  final GlobalKey<SelectionAreaState> bodySelectionAreaKey = GlobalKey<SelectionAreaState>();
+  StreamSubscription<void>? _iframeSelectionStartedSubscription;
+
   AccountId? get accountId => mailboxDashBoardController.accountId.value;
   Session? get session => mailboxDashBoardController.sessionCurrent;
   MailboxId? get sentMailboxId => mailboxDashBoardController.getMailboxIdByRole(
@@ -162,6 +168,11 @@ class ThreadDetailController extends BaseController {
   @override
   void onInit() {
     super.onInit();
+    if (PlatformInfo.isWeb) {
+      _iframeSelectionStartedSubscription = HtmlSelectionSyncBus
+          .instance.iframeSelectionStarted
+          .listen((_) => bodySelectionAreaKey.currentState?.selectableRegion.clearSelection());
+    }
     ever(mailboxDashBoardController.accountId, (accountId) {
       if (accountId == null) return;
 
@@ -309,6 +320,7 @@ class ThreadDetailController extends BaseController {
   @override
   void onClose() {
     onKeyboardShortcutDispose();
+    _iframeSelectionStartedSubscription?.cancel();
     super.onClose();
   }
 }

--- a/lib/features/thread_detail/presentation/thread_detail_controller.dart
+++ b/lib/features/thread_detail/presentation/thread_detail_controller.dart
@@ -169,6 +169,7 @@ class ThreadDetailController extends BaseController {
   void onInit() {
     super.onInit();
     if (PlatformInfo.isWeb) {
+      HtmlSelectionSyncBus.instance.acquire();
       _iframeSelectionStartedSubscription = HtmlSelectionSyncBus
           .instance.iframeSelectionStarted
           .listen((_) => bodySelectionAreaKey.currentState?.selectableRegion.clearSelection());
@@ -320,8 +321,10 @@ class ThreadDetailController extends BaseController {
   @override
   void onClose() {
     onKeyboardShortcutDispose();
-    _iframeSelectionStartedSubscription?.cancel();
-    HtmlSelectionSyncBus.instance.dispose();
+    if (PlatformInfo.isWeb) {
+      _iframeSelectionStartedSubscription?.cancel();
+      HtmlSelectionSyncBus.instance.release();
+    }
     super.onClose();
   }
 }

--- a/lib/features/thread_detail/presentation/thread_detail_controller.dart
+++ b/lib/features/thread_detail/presentation/thread_detail_controller.dart
@@ -321,6 +321,7 @@ class ThreadDetailController extends BaseController {
   void onClose() {
     onKeyboardShortcutDispose();
     _iframeSelectionStartedSubscription?.cancel();
+    HtmlSelectionSyncBus.instance.dispose();
     super.onClose();
   }
 }

--- a/lib/features/thread_detail/presentation/thread_detail_view.dart
+++ b/lib/features/thread_detail/presentation/thread_detail_view.dart
@@ -2,6 +2,7 @@ import 'package:core/presentation/extensions/color_extension.dart';
 import 'package:core/presentation/state/failure.dart';
 import 'package:core/presentation/state/success.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:core/presentation/views/html_viewer/html_selection_sync_bus.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
@@ -216,7 +217,15 @@ class ThreadDetailView extends GetWidget<ThreadDetailController> {
     }
 
     if (PlatformInfo.isWeb) {
-      bodyWidget = SelectionArea(child: bodyWidget);
+      bodyWidget = SelectionArea(
+        key: controller.bodySelectionAreaKey,
+        onSelectionChanged: (selection) {
+          if (selection != null) {
+            HtmlSelectionSyncBus.instance.notifyFlutterSelectionStarted();
+          }
+        },
+        child: bodyWidget,
+      );
     }
 
     if (controller.responsiveUtils.isDesktop(context)) {

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -1829,7 +1829,7 @@ void main() {
     });
 
     group('handleOnFocusHtmlEditorWeb test:', () {
-      tearDown(() => HtmlSelectionSyncBus.instance.dispose());
+      tearDown(() => HtmlSelectionSyncBus.instance.release());
 
       test(
           'Should notify HtmlSelectionSyncBus.iframeSelectionStarted\n'

--- a/test/features/composer/presentation/composer_controller_test.dart
+++ b/test/features/composer/presentation/composer_controller_test.dart
@@ -7,6 +7,8 @@ import 'package:core/presentation/utils/html_transformer/dom/normalize_line_heig
 import 'package:core/presentation/utils/html_transformer/transform_configuration.dart';
 import 'package:core/presentation/utils/responsive_utils.dart';
 import 'package:core/presentation/views/button/tmail_button_widget.dart';
+import 'package:core/presentation/views/html_viewer/html_selection_sync_bus.dart';
+import 'package:core/utils/html/html_utils.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:dartz/dartz.dart';
 import 'package:desktop_drop/desktop_drop.dart';
@@ -1823,6 +1825,43 @@ void main() {
           // Let the asynchronous drop processing (loading dialog/toast) settle.
           await tester.pump(const Duration(seconds: 1));
         });
+      });
+    });
+
+    group('handleOnFocusHtmlEditorWeb test:', () {
+      tearDown(() => HtmlSelectionSyncBus.instance.dispose());
+
+      test(
+          'Should notify HtmlSelectionSyncBus.iframeSelectionStarted\n'
+          'When the composer editor iframe gains focus', () async {
+        // arrange
+        final events = <void>[];
+        final sub = HtmlSelectionSyncBus.instance.iframeSelectionStarted
+            .listen(events.add);
+        addTearDown(() => sub.cancel());
+
+        // act
+        composerController?.handleOnFocusHtmlEditorWeb();
+        await Future<void>.delayed(Duration.zero);
+
+        // assert
+        expect(events, hasLength(1));
+      });
+    });
+
+    group('handleFlutterSelectionStartedWeb test:', () {
+      test(
+          'Should clear the composer editor selection/focus\n'
+          'When a Flutter-side selection starts', () {
+        // arrange
+        composerController?.richTextWebController = mockRichTextWebController;
+
+        // act
+        composerController?.handleFlutterSelectionStartedWeb();
+
+        // assert
+        verify(mockRichTextWebController.editorController
+            .evaluateJavascriptWeb(HtmlUtils.clearEditorFocusAndSelection.name));
       });
     });
   });

--- a/test/features/composer/presentation/widgets/web/web_editor_script_plan_test.dart
+++ b/test/features/composer/presentation/widgets/web/web_editor_script_plan_test.dart
@@ -59,6 +59,7 @@ void main() {
         HtmlUtils.unregisterDropListener.name,
         selectionChangeScript.name,
         HtmlUtils.collapseSelectionToEnd.name,
+        HtmlUtils.clearEditorFocusAndSelection.name,
         HtmlUtils.deleteSelectionContent.name,
         HtmlUtils.saveSelection.name,
         HtmlUtils.restoreSelection.name,


### PR DESCRIPTION
## Issue
- #4805 

## Reproducing steps
- Open an email, drag to select some subject text, can still see copy, and when clicked, the copied text is expected as selected
- Click somewhere in the email body
- Drag to select some subject text again, the copy button is now greyed out
- While the subject text is still selected, drag some text in the email body, the selected subject text is not deselected, and now there are 2 selected text region on the screen
- While there are 2 selected text region on the screen, right click selected subject text, the copy button is now functional, but the copied text is the highlighted email body.

## Reproducing video

https://github.com/user-attachments/assets/63e0aaad-11c1-410d-92ac-d67683b8c472

## Resolved

https://github.com/user-attachments/assets/e0084114-b1fd-4445-858b-aaf8258930ea



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web users can select text in the email body or surrounding thread content without conflicting selections.
  * Starting a selection in one area automatically clears the active selection and focus in the other.
  * Selection and focus behavior is synchronized between the email viewer, composer, and thread content.
  * Non-web platforms remain unaffected.

* **Documentation**
  * Added documentation describing web text-selection behavior and synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->