### PR TITLE
TF-4805 Fix cannot copy subject (web selection coordinator)

### DIFF
--- a/.github/workflows/analyze-test.yaml
+++ b/.github/workflows/analyze-test.yaml
@@ -22,6 +22,7 @@ env:
     core/test/utils/html/mobile_email_responsive_layout_side_effects_browser_test.dart
     workplace/test/data/workplace_datasource_impl_web_test.dart
     workplace/test/presentation/extension/workplace_composer_attachment_extension_web_test.dart
+    core/test/presentation/utils/web_selection/platform_web_selection_dom_adapter_browser_test.dart
 
 jobs:
   analyze-test:

--- a/core/lib/presentation/utils/flutter_selection_clearer.dart
+++ b/core/lib/presentation/utils/flutter_selection_clearer.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/widgets.dart';
+
+/// Clears the selection of the [SelectableRegion] enclosing a context.
+class FlutterSelectionClearer {
+  FlutterSelectionClearer._();
+
+  /// Returns true when a [SelectableRegion] was found and cleared.
+  static bool clearSelectableRegionOf(BuildContext context) {
+    final selectableRegion = context
+        .findAncestorStateOfType<SelectableRegionState>();
+    if (selectableRegion == null) {
+      return false;
+    }
+
+    selectableRegion.hideToolbar();
+    selectableRegion.clearSelection();
+    FocusManager.instance.primaryFocus?.unfocus();
+    return true;
+  }
+}

--- a/core/lib/presentation/utils/flutter_selection_clearer.dart
+++ b/core/lib/presentation/utils/flutter_selection_clearer.dart
@@ -6,6 +6,7 @@ class FlutterSelectionClearer {
 
   /// Returns true when a [SelectableRegion] was found and cleared.
   static bool clearSelectableRegionOf(BuildContext context) {
+    if (!context.mounted) return false;
     final selectableRegion = context
         .findAncestorStateOfType<SelectableRegionState>();
     if (selectableRegion == null) {

--- a/core/lib/presentation/utils/selection_handles_overlay_guard.dart
+++ b/core/lib/presentation/utils/selection_handles_overlay_guard.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/utils/android_selection_handles_manager.dart';
+import 'package:core/presentation/utils/flutter_selection_clearer.dart';
 import 'package:core/presentation/utils/selection_handles_controller.dart';
 import 'package:core/presentation/utils/selection_handles_guard.dart';
 import 'package:core/utils/platform_info.dart';
@@ -74,13 +75,16 @@ class SelectionHandlesOverlayGuard {
     var clearedSelection = false;
 
     if (context?.mounted == true) {
-      clearedSelection = _clearSelectableRegion(context!) || clearedSelection;
+      clearedSelection =
+          FlutterSelectionClearer.clearSelectableRegionOf(context!) ||
+              clearedSelection;
     }
 
     final focusContext = FocusManager.instance.primaryFocus?.context;
     if (focusContext != null) {
       clearedSelection =
-          _clearSelectableRegion(focusContext) || clearedSelection;
+          FlutterSelectionClearer.clearSelectableRegionOf(focusContext) ||
+              clearedSelection;
     }
 
     final editableTextState = focusContext
@@ -92,18 +96,5 @@ class SelectionHandlesOverlayGuard {
     }
 
     return clearedSelection;
-  }
-
-  static bool _clearSelectableRegion(BuildContext context) {
-    final selectableRegion = context
-        .findAncestorStateOfType<SelectableRegionState>();
-    if (selectableRegion == null) {
-      return false;
-    }
-
-    selectableRegion.hideToolbar();
-    selectableRegion.clearSelection();
-    FocusManager.instance.primaryFocus?.unfocus();
-    return true;
   }
 }

--- a/core/lib/presentation/utils/web_selection/platform_web_selection_dom_adapter.dart
+++ b/core/lib/presentation/utils/web_selection/platform_web_selection_dom_adapter.dart
@@ -1,0 +1,2 @@
+export 'platform_web_selection_dom_adapter_stub.dart'
+    if (dart.library.html) 'platform_web_selection_dom_adapter_web.dart';

--- a/core/lib/presentation/utils/web_selection/platform_web_selection_dom_adapter_stub.dart
+++ b/core/lib/presentation/utils/web_selection/platform_web_selection_dom_adapter_stub.dart
@@ -1,0 +1,18 @@
+import 'package:core/presentation/utils/web_selection/web_selection_dom_adapter.dart';
+
+/// Non-web build: there is no DOM, so every operation is a no-op.
+class PlatformWebSelectionDomAdapter implements WebSelectionDomAdapter {
+  PlatformWebSelectionDomAdapter();
+
+  @override
+  void clearIframeSelections() {}
+
+  @override
+  bool get isIframeFocused => false;
+
+  @override
+  void addTopWindowBlurListener(void Function() handler) {}
+
+  @override
+  void removeTopWindowBlurListener() {}
+}

--- a/core/lib/presentation/utils/web_selection/platform_web_selection_dom_adapter_web.dart
+++ b/core/lib/presentation/utils/web_selection/platform_web_selection_dom_adapter_web.dart
@@ -1,0 +1,62 @@
+import 'dart:js_interop';
+
+import 'package:core/presentation/utils/web_selection/web_selection_dom_adapter.dart';
+import 'package:web/web.dart' as web;
+
+/// Web build: touches every `<iframe>` directly (srcdoc iframes are same-origin).
+class PlatformWebSelectionDomAdapter implements WebSelectionDomAdapter {
+  PlatformWebSelectionDomAdapter();
+
+  static const _flutterViewTag = 'flutter-view';
+
+  JSFunction? _blurListener;
+
+  @override
+  void clearIframeSelections() {
+    final iframes = web.document.getElementsByTagName('iframe');
+    for (var i = 0; i < iframes.length; i++) {
+      final element = iframes.item(i);
+      if (element == null || !element.isA<web.HTMLIFrameElement>()) continue;
+      final iframe = element as web.HTMLIFrameElement;
+      _clearSelectionOf(iframe);
+      if (web.document.activeElement == iframe) _returnFocusToFlutter(iframe);
+    }
+  }
+
+  /// Plain `blur()` lands on `<body>` and makes the engine unfocus the region.
+  void _returnFocusToFlutter(web.HTMLIFrameElement iframe) {
+    final flutterView = iframe.closest(_flutterViewTag);
+    if (flutterView != null && flutterView.isA<web.HTMLElement>()) {
+      (flutterView as web.HTMLElement).focus();
+    } else {
+      iframe.blur();
+    }
+  }
+
+  void _clearSelectionOf(web.HTMLIFrameElement iframe) {
+    try {
+      iframe.contentWindow?.getSelection()?.removeAllRanges();
+    } catch (_) {
+      // Cross-origin iframe.
+    }
+  }
+
+  @override
+  bool get isIframeFocused =>
+      web.document.activeElement?.isA<web.HTMLIFrameElement>() ?? false;
+
+  @override
+  void addTopWindowBlurListener(void Function() handler) {
+    removeTopWindowBlurListener();
+    _blurListener = ((web.Event _) => handler()).toJS;
+    web.window.addEventListener('blur', _blurListener);
+  }
+
+  @override
+  void removeTopWindowBlurListener() {
+    final listener = _blurListener;
+    if (listener == null) return;
+    web.window.removeEventListener('blur', listener);
+    _blurListener = null;
+  }
+}

--- a/core/lib/presentation/utils/web_selection/platform_web_selection_dom_adapter_web.dart
+++ b/core/lib/presentation/utils/web_selection/platform_web_selection_dom_adapter_web.dart
@@ -1,6 +1,7 @@
 import 'dart:js_interop';
 
 import 'package:core/presentation/utils/web_selection/web_selection_dom_adapter.dart';
+import 'package:core/utils/app_logger.dart';
 import 'package:web/web.dart' as web;
 
 /// Web build: touches every `<iframe>` directly (srcdoc iframes are same-origin).
@@ -36,8 +37,11 @@ class PlatformWebSelectionDomAdapter implements WebSelectionDomAdapter {
   void _clearSelectionOf(web.HTMLIFrameElement iframe) {
     try {
       iframe.contentWindow?.getSelection()?.removeAllRanges();
-    } catch (_) {
-      // Cross-origin iframe.
+    } catch (e) {
+      logWarning(
+        'PlatformWebSelectionDomAdapter::_clearSelectionOf: Exception = $e',
+        webConsoleEnabled: true,
+      );
     }
   }
 

--- a/core/lib/presentation/utils/web_selection/web_selection_coordinator.dart
+++ b/core/lib/presentation/utils/web_selection/web_selection_coordinator.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+
+import 'package:core/presentation/utils/flutter_selection_clearer.dart';
+import 'package:core/presentation/utils/web_selection/platform_web_selection_dom_adapter.dart';
+import 'package:core/presentation/utils/web_selection/web_selection_dom_adapter.dart';
+import 'package:flutter/widgets.dart';
+
+/// Keeps Flutter's selection and every iframe's native selection mutually exclusive.
+class WebSelectionCoordinator {
+  WebSelectionCoordinator({WebSelectionDomAdapter? dom})
+      : _dom = dom ?? PlatformWebSelectionDomAdapter();
+
+  static final WebSelectionCoordinator instance = WebSelectionCoordinator();
+
+  final WebSelectionDomAdapter _dom;
+  FocusManager get _focusManager => FocusManager.instance;
+  bool _started = false;
+
+  bool get isStarted => _started;
+
+  void start() {
+    if (_started) return;
+    _started = true;
+    _focusManager.addListener(_handleFlutterFocusChanged);
+    _dom.addTopWindowBlurListener(_handleTopWindowBlur);
+  }
+
+  void stop() {
+    if (!_started) return;
+    _started = false;
+    _focusManager.removeListener(_handleFlutterFocusChanged);
+    _dom.removeTopWindowBlurListener();
+  }
+
+  /// A Flutter selection surface took focus: drop every iframe selection.
+  void _handleFlutterFocusChanged() {
+    final context = _focusManager.primaryFocus?.context;
+    if (context == null || !_isFlutterSelectionSurface(context)) return;
+    _dom.clearIframeSelections();
+  }
+
+  /// The single place to extend if more Flutter surfaces must take part.
+  static bool _isFlutterSelectionSurface(BuildContext context) =>
+      context.findAncestorStateOfType<SelectableRegionState>() != null;
+
+  /// Deferred one tick so `activeElement` already points at the iframe.
+  void _handleTopWindowBlur() {
+    Timer.run(() {
+      if (!_started || !_dom.isIframeFocused) return;
+      final context = _focusManager.primaryFocus?.context;
+      if (context == null) return;
+      FlutterSelectionClearer.clearSelectableRegionOf(context);
+    });
+  }
+}

--- a/core/lib/presentation/utils/web_selection/web_selection_coordinator.dart
+++ b/core/lib/presentation/utils/web_selection/web_selection_coordinator.dart
@@ -34,14 +34,19 @@ class WebSelectionCoordinator {
 
   /// A Flutter selection surface took focus: drop every iframe selection.
   void _handleFlutterFocusChanged() {
-    final context = _focusManager.primaryFocus?.context;
-    if (context == null || !_isFlutterSelectionSurface(context)) return;
+    final focusNode = _focusManager.primaryFocus;
+    if (focusNode == null || !_isSelectionSurfaceFocus(focusNode)) return;
     _dom.clearIframeSelections();
   }
 
-  /// The single place to extend if more Flutter surfaces must take part.
-  static bool _isFlutterSelectionSurface(BuildContext context) =>
-      context.findAncestorStateOfType<SelectableRegionState>() != null;
+  /// Only the region's own node counts; focus on a child inside it is not a selection.
+  static bool _isSelectionSurfaceFocus(FocusNode node) {
+    final region = _enclosingRegionOf(node);
+    return region != null && _enclosingRegionOf(node.parent) != region;
+  }
+
+  static SelectableRegionState? _enclosingRegionOf(FocusNode? node) =>
+      node?.context?.findAncestorStateOfType<SelectableRegionState>();
 
   /// Deferred one tick so `activeElement` already points at the iframe.
   void _handleTopWindowBlur() {

--- a/core/lib/presentation/utils/web_selection/web_selection_dom_adapter.dart
+++ b/core/lib/presentation/utils/web_selection/web_selection_dom_adapter.dart
@@ -1,0 +1,13 @@
+/// Browser-side operations of the selection coordinator, mockable in tests.
+abstract interface class WebSelectionDomAdapter {
+  /// Drops every iframe's native selection and returns DOM focus to Flutter.
+  void clearIframeSelections();
+
+  /// Whether the top document's active element is an iframe.
+  bool get isIframeFocused;
+
+  /// Calls [handler] whenever the top window loses focus.
+  void addTopWindowBlurListener(void Function() handler);
+
+  void removeTopWindowBlurListener();
+}

--- a/core/test/presentation/utils/web_selection/platform_web_selection_dom_adapter_browser_test.dart
+++ b/core/test/presentation/utils/web_selection/platform_web_selection_dom_adapter_browser_test.dart
@@ -1,0 +1,167 @@
+@TestOn('chrome')
+
+import 'dart:async';
+import 'dart:js_interop';
+
+import 'package:core/presentation/utils/web_selection/platform_web_selection_dom_adapter.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:web/web.dart' as web;
+
+void main() {
+  late PlatformWebSelectionDomAdapter adapter;
+  late List<web.Element> fixtures;
+
+  setUp(() {
+    adapter = PlatformWebSelectionDomAdapter();
+    fixtures = [];
+  });
+
+  tearDown(() {
+    adapter.removeTopWindowBlurListener();
+    for (final fixture in fixtures.reversed) {
+      fixture.remove();
+    }
+  });
+
+  Future<web.HTMLIFrameElement> appendIframe({
+    web.Element? parent,
+    bool sandboxed = false,
+  }) async {
+    final iframe = web.HTMLIFrameElement();
+    if (sandboxed) {
+      iframe.setAttribute('sandbox', '');
+    }
+
+    final loaded = Completer<void>();
+    late JSFunction loadListener;
+    loadListener = ((web.Event _) {
+      iframe.removeEventListener('load', loadListener);
+      loaded.complete();
+    }).toJS;
+    iframe.addEventListener('load', loadListener);
+    iframe.srcdoc = '<p id="target">iframe selection</p>'.toJS;
+    (parent ?? web.document.body)!.append(iframe);
+    fixtures.add(iframe);
+    await loaded.future;
+    return iframe;
+  }
+
+  web.Selection selectIframeText(web.HTMLIFrameElement iframe) {
+    final iframeDocument = iframe.contentDocument!;
+    final target = iframeDocument.querySelector('#target')!;
+    final selection = iframe.contentWindow!.getSelection()!;
+    final range = iframeDocument.createRange()..selectNodeContents(target);
+    selection
+      ..removeAllRanges()
+      ..addRange(range);
+    return selection;
+  }
+
+  web.HTMLElement appendFlutterView() {
+    final flutterView =
+        web.document.createElement('flutter-view') as web.HTMLElement;
+    flutterView.tabIndex = 0;
+    web.document.body!.append(flutterView);
+    fixtures.add(flutterView);
+    return flutterView;
+  }
+
+  test('clears a same-origin srcdoc iframe selection', () async {
+    final iframe = await appendIframe();
+    final selection = selectIframeText(iframe);
+    expect(selection.rangeCount, 1);
+
+    adapter.clearIframeSelections();
+
+    expect(selection.rangeCount, 0);
+  });
+
+  test('clears selections from every iframe', () async {
+    final firstIframe = await appendIframe();
+    final secondIframe = await appendIframe();
+    final firstSelection = selectIframeText(firstIframe);
+    final secondSelection = selectIframeText(secondIframe);
+
+    adapter.clearIframeSelections();
+
+    expect(firstSelection.rangeCount, 0);
+    expect(secondSelection.rangeCount, 0);
+  });
+
+  test('returns active iframe focus to its enclosing Flutter view', () async {
+    final flutterView = appendFlutterView();
+    final iframe = await appendIframe(parent: flutterView);
+    iframe.focus();
+    expect(web.document.activeElement, same(iframe));
+
+    adapter.clearIframeSelections();
+
+    expect(web.document.activeElement, same(flutterView));
+  });
+
+  test('blurs an active iframe without an enclosing Flutter view', () async {
+    final iframe = await appendIframe();
+    iframe.focus();
+    expect(web.document.activeElement, same(iframe));
+
+    adapter.clearIframeSelections();
+
+    expect(web.document.activeElement, isNot(same(iframe)));
+  });
+
+  test('reports whether an iframe owns top-level focus', () async {
+    final flutterView = appendFlutterView()..focus();
+    final iframe = await appendIframe(parent: flutterView);
+    expect(adapter.isIframeFocused, isFalse);
+
+    iframe.focus();
+    expect(adapter.isIframeFocused, isTrue);
+
+    flutterView.focus();
+    expect(adapter.isIframeFocused, isFalse);
+  });
+
+  test('defends against cross-origin iframe selection access', () async {
+    final flutterView = appendFlutterView();
+    final iframe = await appendIframe(parent: flutterView, sandboxed: true);
+    iframe.focus();
+    expect(web.document.activeElement, same(iframe));
+    expect(() => iframe.contentWindow!.getSelection(), throwsA(anything));
+
+    expect(adapter.clearIframeSelections, returnsNormally);
+    expect(web.document.activeElement, same(flutterView));
+  });
+
+  test('replaces and removes the top-window blur listener', () {
+    var firstCalls = 0;
+    var secondCalls = 0;
+    adapter.addTopWindowBlurListener(() => firstCalls++);
+    adapter.addTopWindowBlurListener(() => secondCalls++);
+
+    web.window.dispatchEvent(web.Event('blur'));
+
+    expect(firstCalls, 0);
+    expect(secondCalls, 1);
+
+    adapter.removeTopWindowBlurListener();
+    adapter.removeTopWindowBlurListener();
+    web.window.dispatchEvent(web.Event('blur'));
+
+    expect(firstCalls, 0);
+    expect(secondCalls, 1);
+  });
+
+  test('handles an empty or changing iframe collection', () async {
+    expect(adapter.clearIframeSelections, returnsNormally);
+
+    final detachedIframe = await appendIframe();
+    selectIframeText(detachedIframe);
+    detachedIframe.remove();
+
+    final connectedIframe = await appendIframe();
+    final connectedSelection = selectIframeText(connectedIframe);
+
+    expect(adapter.clearIframeSelections, returnsNormally);
+    expect(connectedSelection.rangeCount, 0);
+  });
+}

--- a/core/test/presentation/utils/web_selection/platform_web_selection_dom_adapter_stub_test.dart
+++ b/core/test/presentation/utils/web_selection/platform_web_selection_dom_adapter_stub_test.dart
@@ -1,0 +1,20 @@
+@TestOn('vm')
+
+import 'package:core/presentation/utils/web_selection/platform_web_selection_dom_adapter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('non-web DOM adapter remains a no-op', () {
+    final adapter = PlatformWebSelectionDomAdapter();
+    var blurCalls = 0;
+
+    expect(adapter.isIframeFocused, isFalse);
+    expect(adapter.clearIframeSelections, returnsNormally);
+    expect(
+      () => adapter.addTopWindowBlurListener(() => blurCalls++),
+      returnsNormally,
+    );
+    expect(adapter.removeTopWindowBlurListener, returnsNormally);
+    expect(blurCalls, 0);
+  });
+}

--- a/core/test/presentation/utils/web_selection/web_selection_coordinator_test.dart
+++ b/core/test/presentation/utils/web_selection/web_selection_coordinator_test.dart
@@ -29,6 +29,7 @@ void main() {
   late WebSelectionCoordinator coordinator;
   late FocusNode regionFocusNode;
   late FocusNode textFieldFocusNode;
+  late FocusNode innerFocusNode;
   SelectedContent? lastSelection;
 
   setUp(() {
@@ -36,6 +37,7 @@ void main() {
     coordinator = WebSelectionCoordinator(dom: dom);
     regionFocusNode = FocusNode();
     textFieldFocusNode = FocusNode();
+    innerFocusNode = FocusNode();
     lastSelection = null;
   });
 
@@ -43,6 +45,7 @@ void main() {
     coordinator.stop();
     regionFocusNode.dispose();
     textFieldFocusNode.dispose();
+    innerFocusNode.dispose();
   });
 
   Future<void> pumpApp(WidgetTester tester) async {
@@ -54,7 +57,12 @@ void main() {
               SelectionArea(
                 focusNode: regionFocusNode,
                 onSelectionChanged: (selection) => lastSelection = selection,
-                child: const Text('Subject line to select'),
+                child: Column(
+                  children: [
+                    const Text('Subject line to select'),
+                    TextField(focusNode: innerFocusNode),
+                  ],
+                ),
               ),
               TextField(focusNode: textFieldFocusNode),
             ],
@@ -119,6 +127,33 @@ void main() {
       await tester.pump();
 
       expect(dom.clearIframeSelectionsCalls, 0);
+    });
+
+    testWidgets('ignores focus moving to a widget inside the SelectionArea',
+        (tester) async {
+      await pumpApp(tester);
+      coordinator.start();
+
+      innerFocusNode.requestFocus();
+      await tester.pump();
+
+      expect(innerFocusNode.hasFocus, isTrue);
+      expect(dom.clearIframeSelectionsCalls, 0);
+    });
+
+    testWidgets(
+        'does not clear iframes again when focus moves from the region to a child',
+        (tester) async {
+      await pumpApp(tester);
+      coordinator.start();
+      await selectSubjectWithMouse(tester);
+      expect(dom.clearIframeSelectionsCalls, 1);
+
+      innerFocusNode.requestFocus();
+      await tester.pump();
+
+      expect(innerFocusNode.hasFocus, isTrue);
+      expect(dom.clearIframeSelectionsCalls, 1);
     });
 
     testWidgets('clears the Flutter selection when focus lands in an iframe',

--- a/core/test/presentation/utils/web_selection/web_selection_coordinator_test.dart
+++ b/core/test/presentation/utils/web_selection/web_selection_coordinator_test.dart
@@ -1,0 +1,177 @@
+import 'package:core/presentation/utils/web_selection/web_selection_coordinator.dart';
+import 'package:core/presentation/utils/web_selection/web_selection_dom_adapter.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeDomAdapter implements WebSelectionDomAdapter {
+  int clearIframeSelectionsCalls = 0;
+  bool iframeFocused = false;
+  void Function()? blurHandler;
+
+  @override
+  void clearIframeSelections() => clearIframeSelectionsCalls++;
+
+  @override
+  bool get isIframeFocused => iframeFocused;
+
+  @override
+  void addTopWindowBlurListener(void Function() handler) =>
+      blurHandler = handler;
+
+  @override
+  void removeTopWindowBlurListener() => blurHandler = null;
+}
+
+void main() {
+  late _FakeDomAdapter dom;
+  late WebSelectionCoordinator coordinator;
+  late FocusNode regionFocusNode;
+  late FocusNode textFieldFocusNode;
+  SelectedContent? lastSelection;
+
+  setUp(() {
+    dom = _FakeDomAdapter();
+    coordinator = WebSelectionCoordinator(dom: dom);
+    regionFocusNode = FocusNode();
+    textFieldFocusNode = FocusNode();
+    lastSelection = null;
+  });
+
+  tearDown(() {
+    coordinator.stop();
+    regionFocusNode.dispose();
+    textFieldFocusNode.dispose();
+  });
+
+  Future<void> pumpApp(WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: [
+              SelectionArea(
+                focusNode: regionFocusNode,
+                onSelectionChanged: (selection) => lastSelection = selection,
+                child: const Text('Subject line to select'),
+              ),
+              TextField(focusNode: textFieldFocusNode),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> selectSubjectWithMouse(WidgetTester tester) async {
+    final textRect = tester.getRect(find.text('Subject line to select'));
+    final gesture = await tester.startGesture(
+      textRect.centerLeft + const Offset(2, 0),
+      kind: PointerDeviceKind.mouse,
+    );
+    await tester.pump();
+    await gesture.moveTo(textRect.centerRight - const Offset(2, 0));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+  }
+
+  // Browser moved focus into an iframe and blurred the top window.
+  Future<void> focusIframe(WidgetTester tester) async {
+    dom.iframeFocused = true;
+    dom.blurHandler!();
+    await tester.pump(const Duration(milliseconds: 1));
+  }
+
+  group('WebSelectionCoordinator', () {
+    testWidgets('start registers listeners once and stop removes them',
+        (tester) async {
+      await pumpApp(tester);
+
+      coordinator.start();
+      coordinator.start();
+      expect(coordinator.isStarted, isTrue);
+      expect(dom.blurHandler, isNotNull);
+
+      coordinator.stop();
+      expect(coordinator.isStarted, isFalse);
+      expect(dom.blurHandler, isNull);
+    });
+
+    testWidgets('clears iframe selections when a SelectableRegion takes focus',
+        (tester) async {
+      await pumpApp(tester);
+      coordinator.start();
+
+      await selectSubjectWithMouse(tester);
+
+      expect(lastSelection?.plainText, 'Subject line to select');
+      expect(dom.clearIframeSelectionsCalls, 1);
+    });
+
+    testWidgets('ignores focus moving to a non-selection widget',
+        (tester) async {
+      await pumpApp(tester);
+      coordinator.start();
+
+      textFieldFocusNode.requestFocus();
+      await tester.pump();
+
+      expect(dom.clearIframeSelectionsCalls, 0);
+    });
+
+    testWidgets('clears the Flutter selection when focus lands in an iframe',
+        (tester) async {
+      await pumpApp(tester);
+      coordinator.start();
+      await selectSubjectWithMouse(tester);
+      expect(lastSelection, isNotNull);
+
+      await focusIframe(tester);
+
+      expect(lastSelection, isNull);
+      expect(regionFocusNode.hasFocus, isFalse);
+      // Unfocusing the region must not trigger another iframe clear.
+      expect(dom.clearIframeSelectionsCalls, 1);
+    });
+
+    testWidgets('a second blur while the iframe stays focused is harmless',
+        (tester) async {
+      await pumpApp(tester);
+      coordinator.start();
+      await selectSubjectWithMouse(tester);
+
+      await focusIframe(tester);
+      await focusIframe(tester);
+
+      expect(lastSelection, isNull);
+      expect(regionFocusNode.hasFocus, isFalse);
+      expect(dom.clearIframeSelectionsCalls, 1);
+    });
+
+    testWidgets('keeps the Flutter selection when blur is not an iframe',
+        (tester) async {
+      await pumpApp(tester);
+      coordinator.start();
+      await selectSubjectWithMouse(tester);
+
+      dom.iframeFocused = false;
+      dom.blurHandler!();
+      await tester.pump(const Duration(milliseconds: 1));
+
+      expect(lastSelection, isNotNull);
+      expect(regionFocusNode.hasFocus, isTrue);
+    });
+
+    testWidgets('does nothing after stop', (tester) async {
+      await pumpApp(tester);
+      coordinator.start();
+      coordinator.stop();
+
+      await selectSubjectWithMouse(tester);
+
+      expect(dom.clearIframeSelectionsCalls, 0);
+    });
+  });
+}

--- a/core/test/presentation/utils/web_selection/web_selection_coordinator_test.dart
+++ b/core/test/presentation/utils/web_selection/web_selection_coordinator_test.dart
@@ -173,5 +173,45 @@ void main() {
 
       expect(dom.clearIframeSelectionsCalls, 0);
     });
+
+    testWidgets('keeps Flutter selection when stopped before deferred blur',
+        (tester) async {
+      await pumpApp(tester);
+      coordinator.start();
+      await selectSubjectWithMouse(tester);
+
+      dom.iframeFocused = true;
+      dom.blurHandler!();
+      coordinator.stop();
+      await tester.pump(const Duration(milliseconds: 1));
+
+      expect(lastSelection, isNotNull);
+      expect(regionFocusNode.hasFocus, isTrue);
+    });
+
+    testWidgets('ignores iframe blur without a Flutter focus context',
+        (tester) async {
+      coordinator.start();
+      expect(FocusManager.instance.primaryFocus?.context, isNull);
+
+      await focusIframe(tester);
+
+      expect(lastSelection, isNull);
+      expect(dom.clearIframeSelectionsCalls, 0);
+    });
+
+    testWidgets('ignores deferred blur after the selection region is disposed',
+        (tester) async {
+      await pumpApp(tester);
+      coordinator.start();
+      await selectSubjectWithMouse(tester);
+
+      dom.iframeFocused = true;
+      dom.blurHandler!();
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump(const Duration(milliseconds: 1));
+
+      expect(tester.takeException(), isNull);
+    });
   });
 }

--- a/docs/adr/0107-web-selection-coordinator.md
+++ b/docs/adr/0107-web-selection-coordinator.md
@@ -1,0 +1,45 @@
+# 0107. One coordinator for Flutter and iframe text selection on web
+
+Date: 2026-09-08
+
+## Status
+
+Accepted
+
+## Context
+
+On web, Flutter text such as the email subject is selected through a
+`SelectionArea` in the top document. The email body and the composer editor
+are `srcdoc` iframes with their own native selection and their own DOM focus.
+The two selection systems are invisible to each other, so once an iframe has
+been clicked the native right-click "Copy" can be disabled or copy the wrong
+region's text.
+
+The app's iframes are unsandboxed `srcdoc` documents and therefore
+same-origin with the top document: their selection can be read and cleared
+from Dart directly.
+
+## Decision
+
+- A single app-wide coordinator, started once at web boot, keeps Flutter's
+  selection and every iframe's native selection mutually exclusive.
+- No widget, controller, or iframe registers with it. A `SelectableRegion`
+  requests focus when a selection starts, which is observed through
+  `FocusManager`. Focus moving into any iframe is observed through the top
+  window's `blur` event.
+- When a `SelectableRegion` takes focus, every `<iframe>` in the document,
+  including the composer editor, has its selection ranges removed; an iframe
+  holding DOM focus hands it back to the Flutter view element.
+- When the top window blurs and the active element is an iframe, the
+  `SelectableRegion` holding Flutter focus is cleared and unfocused.
+- Browser access sits behind an adapter interface with a no-op stub on
+  non-web builds and in tests.
+
+## Consequences
+
+- Right-click "Copy" always targets the highlighted region.
+- Clicking or selecting in one region deselects the other, matching standard
+  single-selection browser behaviour.
+- A new iframe or a new `SelectionArea` takes part automatically.
+- A cross-origin iframe only loses DOM focus, since its selection cannot be read.
+- Non-web platforms are unaffected.

--- a/lib/main/main_entry.dart
+++ b/lib/main/main_entry.dart
@@ -1,4 +1,5 @@
 import 'package:core/presentation/utils/theme_utils.dart';
+import 'package:core/presentation/utils/web_selection/web_selection_coordinator.dart';
 import 'package:core/utils/build_utils.dart';
 import 'package:core/utils/platform_info.dart';
 import 'package:flutter/widgets.dart';
@@ -33,5 +34,6 @@ Future<void> runTmailPreload() async {
 
   if (PlatformInfo.isWeb) {
     setPathUrlStrategy();
+    WebSelectionCoordinator.instance.start();
   }
 }


### PR DESCRIPTION
## Issue
- #4805

## Reproducing steps
- Open an email, drag to select some subject text, right-click: Copy works and copies the subject
- Click somewhere in the email body
- Drag to select some subject text again: the Copy button is now greyed out
- While the subject text is still selected, drag some text in the email body: both regions stay highlighted
- Right-click the selected subject: Copy is enabled but copies the email body

## Root cause
The subject is selected by a Flutter `SelectionArea` in the top document, while the email body and the composer editor are `srcdoc` iframes with their own native selection and DOM focus. Neither side knows about the other, so the browser's Copy targets whichever document last held focus.

## Fix
One app-wide `WebSelectionCoordinator` started at web boot. Nothing has to register with it:
- A `SelectableRegion` requests focus when a selection starts; the coordinator sees that through `FocusManager` and removes the selection ranges of every `<iframe>` in the page (they are same-origin `srcdoc` iframes), handing DOM focus back to the Flutter view.
- Focus moving into any iframe fires the top window `blur`; the coordinator then clears and unfocuses the focused `SelectableRegion`.

Any future iframe or `SelectionArea` takes part automatically. Supersedes #4811.

## Demo

https://github.com/user-attachments/assets/e312ba9b-c7c4-4db3-a0e4-3867df204eb2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added web selection coordination to prevent conflicts between Flutter text selections and selections inside embedded iframes.
  - Switching focus between Flutter content and iframe content now clears the competing selection and restores focus appropriately.
  - Added consistent selection-clearing behavior across web and non-web platforms.

- **Documentation**
  - Documented web selection coordination, including iframe and cross-origin scenarios.

- **Tests**
  - Added coverage for iframe selection, focus handling, browser behavior, and non-web platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->